### PR TITLE
Add plan for label+property indexed node where property is not null

### DIFF
--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -235,6 +235,11 @@ class DbAccessor final {
   }
 
   VerticesIterable Vertices(storage::View view, storage::LabelId label,
+                            storage::PropertyId property) {
+    return VerticesIterable(accessor_->Vertices(label, property, view));
+  }
+
+  VerticesIterable Vertices(storage::View view, storage::LabelId label,
                             storage::PropertyId property,
                             const storage::PropertyValue &value) {
     return VerticesIterable(accessor_->Vertices(label, property, value, view));

--- a/src/query/plan/cost_estimator.hpp
+++ b/src/query/plan/cost_estimator.hpp
@@ -44,6 +44,7 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
     static constexpr double kScanAllByLabel{1.1};
     static constexpr double MakeScanAllByLabelPropertyValue{1.1};
     static constexpr double MakeScanAllByLabelPropertyRange{1.1};
+    static constexpr double MakeScanAllByLabelProperty{1.1};
     static constexpr double kExpand{2.0};
     static constexpr double kExpandVariable{3.0};
     static constexpr double kFilter{1.5};
@@ -131,6 +132,14 @@ class CostEstimator : public HierarchicalLogicalOperatorVisitor {
 
     // ScanAll performs some work for every element that is produced
     IncrementCost(CostParam::MakeScanAllByLabelPropertyRange);
+    return true;
+  }
+
+  bool PostVisit(ScanAllByLabelProperty &logical_op) override {
+    const auto factor =
+        db_accessor_->VerticesCount(logical_op.label_, logical_op.property_);
+    cardinality_ *= factor;
+    IncrementCost(CostParam::MakeScanAllByLabelProperty);
     return true;
   }
 

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -499,6 +499,28 @@ UniqueCursorPtr ScanAllByLabelPropertyValue::MakeCursor(
       mem, output_symbol_, input_->MakeCursor(mem), std::move(vertices));
 }
 
+ScanAllByLabelProperty::ScanAllByLabelProperty(
+    const std::shared_ptr<LogicalOperator> &input, Symbol output_symbol,
+    storage::LabelId label, storage::PropertyId property,
+    const std::string &property_name, storage::View view)
+    : ScanAll(input, output_symbol, view),
+      label_(label),
+      property_(property),
+      property_name_(property_name) {}
+
+ACCEPT_WITH_INPUT(ScanAllByLabelProperty)
+
+UniqueCursorPtr ScanAllByLabelProperty::MakeCursor(
+    utils::MemoryResource *mem) const {
+  auto vertices = [this](Frame &frame, ExecutionContext &context) {
+    auto *db = context.db_accessor;
+    return std::make_optional(db->Vertices(view_, label_, property_));
+  };
+  return MakeUniqueCursorPtr<ScanAllCursor<decltype(vertices)>>(
+      mem, output_symbol_, input_->MakeCursor(mem), std::move(vertices));
+}
+
+
 ScanAllById::ScanAllById(const std::shared_ptr<LogicalOperator> &input,
                          Symbol output_symbol, Expression *expression,
                          storage::View view)

--- a/src/query/plan/operator.lcp
+++ b/src/query/plan/operator.lcp
@@ -90,6 +90,7 @@ class ScanAll;
 class ScanAllByLabel;
 class ScanAllByLabelPropertyRange;
 class ScanAllByLabelPropertyValue;
+class ScanAllByLabelProperty;
 class ScanAllById;
 class Expand;
 class ExpandVariable;
@@ -118,7 +119,8 @@ class CallProcedure;
 
 using LogicalOperatorCompositeVisitor = ::utils::CompositeVisitor<
     Once, CreateNode, CreateExpand, ScanAll, ScanAllByLabel,
-    ScanAllByLabelPropertyRange, ScanAllByLabelPropertyValue, ScanAllById,
+    ScanAllByLabelPropertyRange, ScanAllByLabelPropertyValue,
+    ScanAllByLabelProperty, ScanAllById,
     Expand, ExpandVariable, ConstructNamedPath, Filter, Produce, Delete,
     SetProperty, SetProperties, SetLabels, RemoveProperty, RemoveLabels,
     EdgeUniquenessFilter, Accumulate, Aggregate, Skip, Limit, OrderBy, Merge,
@@ -731,6 +733,37 @@ property value.
    cpp<#)
   (:serialize (:slk))
   (:clone))
+
+(lcp:define-class scan-all-by-label-property (scan-all)
+  ((label "::storage::LabelId" :scope :public)
+   (property "::storage::PropertyId" :scope :public)
+   (property-name "std::string" :scope :public)
+   (expression "Expression *" :scope :public
+               :slk-save #'slk-save-ast-pointer
+               :slk-load (slk-load-ast-pointer "Expression")))
+
+  (:documentation
+   "Behaves like @c ScanAll, but this operator produces only vertices with
+given label and property.
+
+@sa ScanAll
+@sa ScanAllByLabelPropertyRange
+@sa ScanAllByLabelPropertyValue")
+  (:public
+   #>cpp
+   ScanAllByLabelProperty() {}
+   ScanAllByLabelProperty(const std::shared_ptr<LogicalOperator> &input,
+                          Symbol output_symbol, storage::LabelId label,
+                          storage::PropertyId property,
+                          const std::string &property_name,
+                          storage::View view = storage::View::OLD);
+   bool Accept(HierarchicalLogicalOperatorVisitor &visitor) override;
+   UniqueCursorPtr MakeCursor(utils::MemoryResource *) const override;
+   cpp<#)
+  (:serialize (:slk))
+  (:clone))
+
+
 
 (lcp:define-class scan-all-by-id (scan-all)
   ((expression "Expression *" :scope :public

--- a/src/query/plan/preprocess.hpp
+++ b/src/query/plan/preprocess.hpp
@@ -96,7 +96,7 @@ class PropertyFilter {
 
   /// Depending on type, this PropertyFilter may be a value equality, regex
   /// matched value or a range with lower and (or) upper bounds, IN list filter.
-  enum class Type { EQUAL, REGEX_MATCH, RANGE, IN };
+  enum class Type { EQUAL, REGEX_MATCH, RANGE, IN, IS_NOT_NULL };
 
   /// Construct with Expression being the equality or regex match check.
   PropertyFilter(const SymbolTable &, const Symbol &, PropertyIx, Expression *,
@@ -104,6 +104,11 @@ class PropertyFilter {
   /// Construct the range based filter.
   PropertyFilter(const SymbolTable &, const Symbol &, PropertyIx,
                  const std::optional<Bound> &, const std::optional<Bound> &);
+  /// Construct a filter without an expression that produces a value.
+  /// Used for the "PROP IS NOT NULL" filter, and can be used for any
+  /// property filter that doesn't need to use an expression to produce
+  /// values that should be filtered further.
+  PropertyFilter(const Symbol &, PropertyIx, Type);
 
   /// Symbol whose property is looked up.
   Symbol symbol_;

--- a/src/query/plan/pretty_print.cpp
+++ b/src/query/plan/pretty_print.cpp
@@ -70,6 +70,16 @@ bool PlanPrinter::PreVisit(query::plan::ScanAllByLabelPropertyRange &op) {
   return true;
 }
 
+bool PlanPrinter::PreVisit(query::plan::ScanAllByLabelProperty &op) {
+  WithPrintLn([&](auto &out) {
+    out << "* ScanAllByLabelProperty"
+        << " (" << op.output_symbol_.name() << " :"
+        << dba_->LabelToName(op.label_) << " {"
+        << dba_->PropertyToName(op.property_) << "})";
+  });
+  return true;
+}
+
 bool PlanPrinter::PreVisit(ScanAllById &op) {
   WithPrintLn([&](auto &out) {
     out << "* ScanAllById"
@@ -457,6 +467,20 @@ bool PlanToJsonVisitor::PreVisit(ScanAllByLabelPropertyValue &op) {
   self["label"] = ToJson(op.label_, *dba_);
   self["property"] = ToJson(op.property_, *dba_);
   self["expression"] = ToJson(op.expression_);
+  self["output_symbol"] = ToJson(op.output_symbol_);
+
+  op.input_->Accept(*this);
+  self["input"] = PopOutput();
+
+  output_ = std::move(self);
+  return false;
+}
+
+bool PlanToJsonVisitor::PreVisit(ScanAllByLabelProperty &op) {
+  json self;
+  self["name"] = "ScanAllByLabelProperty";
+  self["label"] = ToJson(op.label_, *dba_);
+  self["property"] = ToJson(op.property_, *dba_);
   self["output_symbol"] = ToJson(op.output_symbol_);
 
   op.input_->Accept(*this);

--- a/src/query/plan/pretty_print.hpp
+++ b/src/query/plan/pretty_print.hpp
@@ -58,6 +58,7 @@ class PlanPrinter : public virtual HierarchicalLogicalOperatorVisitor {
   bool PreVisit(ScanAllByLabel &) override;
   bool PreVisit(ScanAllByLabelPropertyValue &) override;
   bool PreVisit(ScanAllByLabelPropertyRange &) override;
+  bool PreVisit(ScanAllByLabelProperty &) override;
   bool PreVisit(ScanAllById &) override;
 
   bool PreVisit(Expand &) override;
@@ -183,6 +184,7 @@ class PlanToJsonVisitor : public virtual HierarchicalLogicalOperatorVisitor {
   bool PreVisit(ScanAllByLabel &) override;
   bool PreVisit(ScanAllByLabelPropertyRange &) override;
   bool PreVisit(ScanAllByLabelPropertyValue &) override;
+  bool PreVisit(ScanAllByLabelProperty &) override;
   bool PreVisit(ScanAllById &) override;
 
   bool PreVisit(Produce &) override;

--- a/tests/unit/query_plan_checker.hpp
+++ b/tests/unit/query_plan_checker.hpp
@@ -51,6 +51,7 @@ class PlanChecker : public virtual HierarchicalLogicalOperatorVisitor {
   PRE_VISIT(ScanAllByLabel);
   PRE_VISIT(ScanAllByLabelPropertyValue);
   PRE_VISIT(ScanAllByLabelPropertyRange);
+  PRE_VISIT(ScanAllByLabelProperty);
   PRE_VISIT(ScanAllById);
   PRE_VISIT(Expand);
   PRE_VISIT(ExpandVariable);
@@ -308,6 +309,26 @@ class ExpectScanAllByLabelPropertyRange
   std::optional<ScanAllByLabelPropertyRange::Bound> lower_bound_;
   std::optional<ScanAllByLabelPropertyRange::Bound> upper_bound_;
 };
+
+class ExpectScanAllByLabelProperty : public OpChecker<ScanAllByLabelProperty> {
+ public:
+  ExpectScanAllByLabelProperty(
+      storage::LabelId label,
+      const std::pair<std::string, storage::PropertyId> &prop_pair)
+      : label_(label), property_(prop_pair.second) {}
+
+  void ExpectOp(ScanAllByLabelProperty &scan_all,
+                const SymbolTable &) override {
+    EXPECT_EQ(scan_all.label_, label_);
+    EXPECT_EQ(scan_all.property_, property_);
+  }
+
+ private:
+  storage::LabelId label_;
+  storage::PropertyId property_;
+};
+
+
 
 class ExpectCartesian : public OpChecker<Cartesian> {
  public:


### PR DESCRIPTION
Summary:
Replace ScanAll + Filter with a ScanAll variant performing label and
         property lookup

Reviewers: mferencevic, buda

Differential Revision: https://phabricator.memgraph.io/D2819