### PR TITLE
Memory leak fix in interpreter

### DIFF
--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -1162,11 +1162,13 @@ void Interpreter::BeginTransaction() {
 void Interpreter::CommitTransaction() {
   const auto prepared_query = PrepareTransactionQuery("COMMIT");
   prepared_query.query_handler(nullptr, {});
+  query_executions_.clear();
 }
 
 void Interpreter::RollbackTransaction() {
   const auto prepared_query = PrepareTransactionQuery("ROLLBACK");
   prepared_query.query_handler(nullptr, {});
+  query_executions_.clear();
 }
 
 Interpreter::PrepareResult Interpreter::Prepare(


### PR DESCRIPTION
This PR clears the query executions when the exposed Commit and Rollback functions are called.