### PR TITLE
Thread pool fix

### DIFF
--- a/src/utils/thread_pool.hpp
+++ b/src/utils/thread_pool.hpp
@@ -29,7 +29,7 @@ class ThreadPool {
   ThreadPool &operator=(const ThreadPool &) = delete;
   ThreadPool &operator=(ThreadPool &&) = delete;
 
-  size_t IdleThreadNum() const;
+  size_t UnfinishedTasksNum() const;
 
  private:
   std::unique_ptr<TaskSignature> PopTask();
@@ -38,7 +38,7 @@ class ThreadPool {
 
   std::vector<std::thread> thread_pool_;
 
-  std::atomic<size_t> idle_thread_num_{0};
+  std::atomic<size_t> unfinished_tasks_num_{0};
   std::atomic<bool> terminate_pool_{false};
   std::atomic<bool> stopped_{false};
   utils::Synchronized<std::queue<std::unique_ptr<TaskSignature>>,

--- a/tests/unit/utils_thread_pool.cpp
+++ b/tests/unit/utils_thread_pool.cpp
@@ -9,8 +9,8 @@
 using namespace std::chrono_literals;
 
 TEST(ThreadPool, Basic) {
-  constexpr size_t adder_count = 100'000;
-  constexpr std::array<size_t, 5> pool_sizes{1, 2, 4, 8, 100};
+  constexpr size_t adder_count =
+      500'000; constexpr std::array<size_t, 5> pool_sizes{1, 2, 4, 8, 100};
 
   for (const auto pool_size : pool_sizes) {
     utils::ThreadPool pool{pool_size};
@@ -20,7 +20,7 @@ TEST(ThreadPool, Basic) {
       pool.AddTask([&] { count.fetch_add(1); });
     }
 
-    while (pool.IdleThreadNum() != pool_size) {
+    while (pool.UnfinishedTasksNum() != 0) {
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
 


### PR DESCRIPTION
Idle thread number can have unexpected values because it's not acquiring lock while fetching it. 
Unfinished tasks number should be much safer for the test because we add all the tasks at the beginning so it can have value 0 **only** when every task finished.