### PR TITLE
[master < T0405-MG] Update GHA jobs tags

### DIFF
--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   community_build:
     name: "Community build"
-    runs-on: [self-hosted, Linux, X64, Debian10]
+    runs-on: [self-hosted, General, Linux, X64, Debian10]
     env:
       THREADS: 24
 
@@ -50,7 +50,7 @@ jobs:
 
   coverage_build:
     name: "Coverage build"
-    runs-on: [self-hosted, Linux, X64, Debian10]
+    runs-on: [self-hosted, General, Linux, X64, Debian10]
     env:
       THREADS: 24
 
@@ -105,7 +105,7 @@ jobs:
 
   debug_build:
     name: "Debug build"
-    runs-on: [self-hosted, Linux, X64, Debian10]
+    runs-on: [self-hosted, General, Linux, X64, Debian10]
     env:
       THREADS: 24
 
@@ -179,7 +179,7 @@ jobs:
 
   release_build:
     name: "Release build"
-    runs-on: [self-hosted, Linux, X64, Debian10]
+    runs-on: [self-hosted, General, Linux, X64, Debian10]
     env:
       THREADS: 24
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   community_build:
     name: "Community build"
-    runs-on: [self-hosted, Linux, X64, Debian10]
+    runs-on: [self-hosted, General, Linux, X64, Debian10]
     env:
       THREADS: 24
     timeout-minutes: 960
@@ -71,7 +71,7 @@ jobs:
 
   coverage_build:
     name: "Coverage build"
-    runs-on: [self-hosted, Linux, X64, Debian10]
+    runs-on: [self-hosted, General, Linux, X64, Debian10]
     env:
       THREADS: 24
 
@@ -126,7 +126,7 @@ jobs:
 
   debug_build:
     name: "Debug build"
-    runs-on: [self-hosted, Linux, X64, Debian10]
+    runs-on: [self-hosted, General, Linux, X64, Debian10]
     env:
       THREADS: 24
 
@@ -200,7 +200,7 @@ jobs:
 
   release_build:
     name: "Release build"
-    runs-on: [self-hosted, Linux, X64, Debian10]
+    runs-on: [self-hosted, General, Linux, X64, Debian10]
     env:
       THREADS: 24
     timeout-minutes: 960

--- a/.github/workflows/release_centos.yaml
+++ b/.github/workflows/release_centos.yaml
@@ -5,7 +5,7 @@ on: [workflow_dispatch]
 jobs:
   community_build:
     name: "Community build"
-    runs-on: [self-hosted, Linux, X64, CentOS7]
+    runs-on: [self-hosted, General, Linux, X64, CentOS7]
     env:
       THREADS: 24
     timeout-minutes: 960
@@ -69,7 +69,7 @@ jobs:
 
   coverage_build:
     name: "Coverage build"
-    runs-on: [self-hosted, Linux, X64, CentOS7]
+    runs-on: [self-hosted, General, Linux, X64, CentOS7]
     env:
       THREADS: 24
 
@@ -124,7 +124,7 @@ jobs:
 
   debug_build:
     name: "Debug build"
-    runs-on: [self-hosted, Linux, X64, CentOS7]
+    runs-on: [self-hosted, General, Linux, X64, CentOS7]
     env:
       THREADS: 24
 
@@ -198,7 +198,7 @@ jobs:
 
   release_build:
     name: "Release build"
-    runs-on: [self-hosted, Linux, X64, CentOS7]
+    runs-on: [self-hosted, General, Linux, X64, CentOS7]
     env:
       THREADS: 24
     timeout-minutes: 960


### PR DESCRIPTION
This has to be merged to master, and then epic branches have to be rebased to
run jobs only on `General` workers. Once this is integrated, the work related
to set up the `JepsenControl` worker can be continued here #53 because the
rest of the builds won't be executed on the `JepsenControl` worker, and the #53
will only contain Jepsen related config.