### PR TITLE
[E004 <T0423] Avoid crashing the db when an invalid ip address is given in a REGISTER REPLICA query

### DIFF
--- a/tests/unit/network_endpoint.cpp
+++ b/tests/unit/network_endpoint.cpp
@@ -17,7 +17,7 @@ TEST(Endpoint, IPv4) {
   EXPECT_EQ(endpoint.family, endpoint_t::IpFamily::IP4);
 
   // test address invalid
-  EXPECT_DEATH(endpoint_t("invalid", 12345), "address");
+  EXPECT_THROW(endpoint_t("invalid", 12345), io::network::NetworkError);
 }
 
 TEST(Endpoint, IPv6) {
@@ -30,7 +30,7 @@ TEST(Endpoint, IPv6) {
   EXPECT_EQ(endpoint.family, endpoint_t::IpFamily::IP6);
 
   // test address invalid
-  EXPECT_DEATH(endpoint_t("::g", 12345), "address");
+  EXPECT_THROW(endpoint_t("::g", 12345), io::network::NetworkError);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
* all the changes are in endpoint.cpp
* replaced a `CHECK` with a `throw NetworkError` in the Endpoint constructor
* added ip address validity checks to the `ParseSocketOrIpAddress` method