### PR TITLE
[E086-MG < T0678-MG] Change the timestamp function to return microseconds instead of milliseconds

### DIFF
--- a/src/query/common.cpp
+++ b/src/query/common.cpp
@@ -45,7 +45,7 @@ bool TypedValueCompare(const TypedValue &a, const TypedValue &b) {
 
 }  // namespace impl
 
-int64_t SystemClockNowAsMicroseconds() {
+int64_t QueryTimestamp() {
   return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch())
       .count();
 }

--- a/src/query/common.hpp
+++ b/src/query/common.hpp
@@ -95,5 +95,5 @@ storage::PropertyValue PropsSetChecked(T *record, const storage::PropertyId &key
   }
 }
 
-int64_t SystemClockNowAsMicroseconds();
+int64_t QueryTimestamp();
 }  // namespace query

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -217,7 +217,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, AuthQueryHandler *auth, const Pa
   EvaluationContext evaluation_context;
   // TODO: MemoryResource for EvaluationContext, it should probably be passed as
   // the argument to Callback.
-  evaluation_context.timestamp = SystemClockNowAsMicroseconds();
+  evaluation_context.timestamp = QueryTimestamp();
   evaluation_context.parameters = parameters;
   ExpressionEvaluator evaluator(&frame, symbol_table, evaluation_context, db_accessor, storage::View::OLD);
 
@@ -363,7 +363,7 @@ Callback HandleReplicationQuery(ReplicationQuery *repl_query, const Parameters &
   EvaluationContext evaluation_context;
   // TODO: MemoryResource for EvaluationContext, it should probably be passed as
   // the argument to Callback.
-  evaluation_context.timestamp = SystemClockNowAsMicroseconds();
+  evaluation_context.timestamp = QueryTimestamp();
   evaluation_context.parameters = parameters;
   ExpressionEvaluator evaluator(&frame, symbol_table, evaluation_context, db_accessor, storage::View::OLD);
 
@@ -466,7 +466,7 @@ Callback HandleStreamQuery(StreamQuery *stream_query, const Parameters &paramete
   EvaluationContext evaluation_context;
   // TODO: MemoryResource for EvaluationContext, it should probably be passed as
   // the argument to Callback.
-  evaluation_context.timestamp = SystemClockNowAsMicroseconds();
+  evaluation_context.timestamp = QueryTimestamp();
   evaluation_context.parameters = parameters;
   ExpressionEvaluator evaluator(&frame, symbol_table, evaluation_context, db_accessor, storage::View::OLD);
 
@@ -647,7 +647,7 @@ PullPlan::PullPlan(const std::shared_ptr<CachedPlan> plan, const Parameters &par
       memory_limit_(memory_limit) {
   ctx_.db_accessor = dba;
   ctx_.symbol_table = plan->symbol_table();
-  ctx_.evaluation_context.timestamp = SystemClockNowAsMicroseconds();
+  ctx_.evaluation_context.timestamp = QueryTimestamp();
   ctx_.evaluation_context.parameters = parameters;
   ctx_.evaluation_context.properties = NamesToProperties(plan->ast_storage().properties_, dba);
   ctx_.evaluation_context.labels = NamesToLabels(plan->ast_storage().labels_, dba);
@@ -822,7 +822,7 @@ PreparedQuery PrepareCypherQuery(ParsedQuery parsed_query, std::map<std::string,
   Frame frame(0);
   SymbolTable symbol_table;
   EvaluationContext evaluation_context;
-  evaluation_context.timestamp = SystemClockNowAsMicroseconds();
+  evaluation_context.timestamp = QueryTimestamp();
   evaluation_context.parameters = parsed_query.parameters;
   ExpressionEvaluator evaluator(&frame, symbol_table, evaluation_context, dba, storage::View::OLD);
   const auto memory_limit = EvaluateMemoryLimit(&evaluator, cypher_query->memory_limit_, cypher_query->memory_scale_);
@@ -953,7 +953,7 @@ PreparedQuery PrepareProfileQuery(ParsedQuery parsed_query, bool in_explicit_tra
   Frame frame(0);
   SymbolTable symbol_table;
   EvaluationContext evaluation_context;
-  evaluation_context.timestamp = SystemClockNowAsMicroseconds();
+  evaluation_context.timestamp = QueryTimestamp();
   evaluation_context.parameters = parsed_inner_query.parameters;
   ExpressionEvaluator evaluator(&frame, symbol_table, evaluation_context, dba, storage::View::OLD);
   const auto memory_limit = EvaluateMemoryLimit(&evaluator, cypher_query->memory_limit_, cypher_query->memory_scale_);

--- a/src/query/trigger.cpp
+++ b/src/query/trigger.cpp
@@ -193,7 +193,7 @@ void Trigger::Execute(DbAccessor *dba, utils::MonotonicBufferResource *execution
   ExecutionContext ctx;
   ctx.db_accessor = dba;
   ctx.symbol_table = plan.symbol_table();
-  ctx.evaluation_context.timestamp = SystemClockNowAsMicroseconds();
+  ctx.evaluation_context.timestamp = QueryTimestamp();
   ctx.evaluation_context.parameters = parsed_statements_.parameters;
   ctx.evaluation_context.properties = NamesToProperties(plan.ast_storage().properties_, dba);
   ctx.evaluation_context.labels = NamesToLabels(plan.ast_storage().labels_, dba);


### PR DESCRIPTION
[master < Epic] PR
- [x] Check, and update documentation if necessary
- [ ] Update [changelog](https://docs.memgraph.com/memgraph/changelog)
- [ ] Write E2E tests
- [ ] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch and the Epic branch

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Update [changelog](https://docs.memgraph.com/memgraph/changelog)
