### PR TITLE
[E112-MG < T0848-MG] Add initial schema implementation

### DIFF
--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -356,6 +356,8 @@ class DbAccessor final {
   storage::IndicesInfo ListAllIndices() const { return accessor_->ListAllIndices(); }
 
   storage::ConstraintsInfo ListAllConstraints() const { return accessor_->ListAllConstraints(); }
+
+  storage::SchemasInfo ListAllSchemas() const { return accessor_->ListAllSchemas(); }
 };
 
 }  // namespace memgraph::query

--- a/src/storage/v2/CMakeLists.txt
+++ b/src/storage/v2/CMakeLists.txt
@@ -10,6 +10,7 @@ set(storage_v2_src_files
     indices.cpp
     property_store.cpp
     vertex_accessor.cpp
+    schemas.cpp
     storage.cpp)
 
 ##### Replication #####

--- a/src/storage/v2/schemas.cpp
+++ b/src/storage/v2/schemas.cpp
@@ -9,7 +9,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -19,40 +18,53 @@
 
 namespace memgraph::storage {
 
-Schemas::CreationStatus Schemas::CreateSchema(
-    const LabelId label, const std::vector<std::pair<PropertyId, PropertyValue::Type>> &property_types) {
-  auto res = schemas_.insert({label, property_types}).second;
+SchemaViolation::SchemaViolation(ValidationStatus status, LabelId label) : status{status}, label{label} {}
+
+SchemaViolation::SchemaViolation(ValidationStatus status, LabelId label, SchemaType violated_type)
+    : status{status}, label{label}, violated_type{violated_type} {}
+
+SchemaViolation::SchemaViolation(ValidationStatus status, LabelId label, SchemaType violated_type,
+                                 PropertyValue violated_property_value)
+    : status{status}, label{label}, violated_type{violated_type}, violated_property_value{violated_property_value} {}
+
+Schemas::CreationStatus Schemas::CreateSchema(const LabelId primary_label,
+                                              const std::vector<SchemaType> &schemas_types) {
+  auto res = schemas_.insert({primary_label, schemas_types}).second;
   return res ? Schemas::CreationStatus::SUCCESS : Schemas::CreationStatus::FAIL;
 }
 
-Schemas::DeletionStatus Schemas::DeleteSchema(const LabelId label) {
-  auto res = schemas_.erase(label);
+Schemas::DeletionStatus Schemas::DeleteSchema(const LabelId primary_label) {
+  auto res = schemas_.erase(primary_label);
   return res != 0 ? Schemas::DeletionStatus::SUCCESS : Schemas::DeletionStatus::FAIL;
 }
 
-Schemas::ValidationStatus Schemas::ValidateVertex(const LabelId primary_label, const Vertex &vertex) {
+[[nodiscard]] std::optional<SchemaViolation> Schemas::ValidateVertex(const LabelId primary_label,
+                                                                     const Vertex &vertex) {
+  // TODO Check for multiple defined primary labels
+  std::vector<std::pair<SchemaType, PropertyValue>> type_violations;
   if (!schemas_.contains(primary_label)) {
-    return Schemas::ValidationStatus::NO_SCHEMA_DEFINED_FOR_LABEL;
+    return SchemaViolation(SchemaViolation::ValidationStatus::NO_SCHEMA_DEFINED_FOR_LABEL, primary_label);
   }
   if (!utils::Contains(vertex.labels, primary_label)) {
-    return Schemas::ValidationStatus::VERTEX_HAS_NO_PRIMARY_LABEL;
+    return SchemaViolation(SchemaViolation::ValidationStatus::VERTEX_HAS_NO_PRIMARY_LABEL, primary_label);
   }
 
-  for (auto &[property_id, property_type] : schemas_[primary_label]) {
-    // Property existence check
-    if (!vertex.properties.HasProperty(property_id)) {
-      return Schemas::ValidationStatus::VERTEX_HAS_NO_PROPERTY;
+  for (auto &schema_type : schemas_[primary_label]) {
+    if (!vertex.properties.HasProperty(schema_type.property_id)) {
+      return SchemaViolation(SchemaViolation::ValidationStatus::VERTEX_HAS_NO_PROPERTY, primary_label, schema_type);
     }
     // Property type check
-    if (vertex.properties.GetProperty(property_id).type() != property_type) {
-      return Schemas::ValidationStatus::VERTEX_PROPERTY_WRONG_TYPE;
+    //  TODO Can this be replaced with just property id check?
+    if (auto vertex_property = vertex.properties.GetProperty(schema_type.property_id);
+        PropertyValueTypeToSchemaType(vertex_property) != schema_type.type) {
+      return SchemaViolation(SchemaViolation::ValidationStatus::VERTEX_PROPERTY_WRONG_TYPE, primary_label, schema_type,
+                             vertex_property);
     }
   }
-
   // TODO after the introduction of vertex hashing introduce check for vertex
   // primary key uniqueness
 
-  return Schemas::ValidationStatus::SUCCESS;
+  return std::nullopt;
 }
 
 Schemas::SchemasList Schemas::ListSchemas() const {

--- a/src/storage/v2/schemas.cpp
+++ b/src/storage/v2/schemas.cpp
@@ -1,0 +1,41 @@
+// Copyright 2022 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "storage/v2/schemas.hpp"
+
+namespace memgraph::storage {
+
+Schemas::CreationStatus Schemas::AddSchema(const LabelId label, const std::vector<PropertyId> &property_ids) {
+  auto res = schemas_.insert({std::move(label), property_ids}).second;
+  return res ? Schemas::CreationStatus::SUCCESS : Schemas::CreationStatus::FAIL;
+}
+
+Schemas::DeletionStatus Schemas::DeleteSchema(const LabelId label) {
+  auto res = schemas_.erase(label);
+  return res != 0 ? Schemas::DeletionStatus::SUCCESS : Schemas::DeletionStatus::FAIL;
+}
+
+Schemas::ValidationStatus ValidateVertex(const LabelId primary_label, const Vertex &vertex, const Transaction &tx,
+                                         const uint64_t commit_timestamp) {
+  if (!schemas_.contains(primary_label)) {
+    return Schemas::ValidationStatus::NO_SCHEMA_DEFINED_FOR_LABEL;
+  }
+  auto &[schema_label, schema_properties] = schemas_[primary_label];
+
+  return Schemas::ValidationStatus::SUCCESS;
+}
+
+}  // namespace memgraph::storage

--- a/src/storage/v2/schemas.cpp
+++ b/src/storage/v2/schemas.cpp
@@ -27,13 +27,11 @@ SchemaViolation::SchemaViolation(ValidationStatus status, LabelId label, SchemaP
     : status{status}, label{label}, violated_type{violated_type}, violated_property_value{violated_property_value} {}
 
 bool Schemas::CreateSchema(const LabelId primary_label, const std::vector<SchemaProperty> &schemas_types) {
-  const auto res = schemas_.insert({primary_label, schemas_types}).second;
-  return res;
+  return schemas_.insert({primary_label, schemas_types}).second;
 }
 
 bool Schemas::DeleteSchema(const LabelId primary_label) {
-  const auto res = schemas_.erase(primary_label);
-  return res;
+  return schemas_.erase(primary_label);
 }
 
 std::optional<SchemaViolation> Schemas::ValidateVertex(const LabelId primary_label, const Vertex &vertex) {

--- a/src/storage/v2/schemas.cpp
+++ b/src/storage/v2/schemas.cpp
@@ -29,12 +29,12 @@ SchemaViolation::SchemaViolation(ValidationStatus status, LabelId label, SchemaT
 
 Schemas::CreationStatus Schemas::CreateSchema(const LabelId primary_label,
                                               const std::vector<SchemaType> &schemas_types) {
-  auto res = schemas_.insert({primary_label, schemas_types}).second;
+  const auto res = schemas_.insert({primary_label, schemas_types}).second;
   return res ? Schemas::CreationStatus::SUCCESS : Schemas::CreationStatus::FAIL;
 }
 
 Schemas::DeletionStatus Schemas::DeleteSchema(const LabelId primary_label) {
-  auto res = schemas_.erase(primary_label);
+  const auto res = schemas_.erase(primary_label);
   return res != 0 ? Schemas::DeletionStatus::SUCCESS : Schemas::DeletionStatus::FAIL;
 }
 
@@ -49,7 +49,7 @@ Schemas::DeletionStatus Schemas::DeleteSchema(const LabelId primary_label) {
     return SchemaViolation(SchemaViolation::ValidationStatus::VERTEX_HAS_NO_PRIMARY_LABEL, primary_label);
   }
 
-  for (auto &schema_type : schemas_[primary_label]) {
+  for (const auto &schema_type : schemas_[primary_label]) {
     if (!vertex.properties.HasProperty(schema_type.property_id)) {
       return SchemaViolation(SchemaViolation::ValidationStatus::VERTEX_HAS_NO_PROPERTY, primary_label, schema_type);
     }

--- a/src/storage/v2/schemas.hpp
+++ b/src/storage/v2/schemas.hpp
@@ -28,6 +28,9 @@ namespace memgraph::storage {
 /// Schema can be mapped under only one label => primary label
 class Schemas {
  public:
+  using SchemasStructure = std::unordered_map<LabelId, std::vector<std::pair<PropertyId, PropertyValue::Type>>>;
+  using SchemasList = std::vector<std::pair<LabelId, std::vector<std::pair<PropertyId, PropertyValue::Type>>>>;
+
   Schemas() = default;
   Schemas(const Schemas &) = delete;
   Schemas(Schemas &&) = delete;
@@ -46,16 +49,17 @@ class Schemas {
     VERTEX_PROPERTY_WRONG_TYPE
   };
 
-  CreationStatus CreateSchema(LabelId label, const std::vector<PropertyId> &property_ids);
+  CreationStatus CreateSchema(LabelId label,
+                              const std::vector<std::pair<PropertyId, PropertyValue::Type>> &property_types);
 
   DeletionStatus DeleteSchema(LabelId label);
 
-  ValidationStatus ValidateVertex(LabelId primary_label, const Vertex &vertex, const Transaction &tx,
-                                  uint64_t commit_timestamp);
+  ValidationStatus ValidateVertex(LabelId primary_label, const Vertex &vertex);
+
+  SchemasList ListSchemas() const;
 
  private:
-  std::unordered_map<LabelId, std::pair<PropertyId, PropertyValue::Type>> schemas_;
-  std::unordered_map<LabelId, LabelPropertyIndex> label_property_indices_;
+  SchemasStructure schemas_;
 };
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/schemas.hpp
+++ b/src/storage/v2/schemas.hpp
@@ -77,13 +77,13 @@ class Schemas {
   enum class CreationStatus : uint8_t { SUCCESS, FAIL };
   enum class DeletionStatus : uint8_t { SUCCESS, FAIL };
 
-  CreationStatus CreateSchema(LabelId label, const std::vector<SchemaType> &schemas_types);
+  [[nodiscard]] CreationStatus CreateSchema(LabelId label, const std::vector<SchemaType> &schemas_types);
 
-  DeletionStatus DeleteSchema(LabelId label);
+  [[nodiscard]] DeletionStatus DeleteSchema(LabelId label);
 
-  std::optional<SchemaViolation> ValidateVertex(LabelId primary_label, const Vertex &vertex);
+  [[nodiscard]] std::optional<SchemaViolation> ValidateVertex(LabelId primary_label, const Vertex &vertex);
 
-  SchemasList ListSchemas() const;
+  [[nodiscard]] SchemasList ListSchemas() const;
 
  private:
   SchemasStructure schemas_;

--- a/src/storage/v2/schemas.hpp
+++ b/src/storage/v2/schemas.hpp
@@ -32,11 +32,10 @@ class SchemaViolationException : public utils::BasicException {
 };
 
 struct SchemaProperty {
-  enum class Type : uint8_t { Bool, Int, Double, String, List, Map, Date, LocalTime, LocalDateTime, Duration };
+  enum class Type : uint8_t { Bool, Int, Double, String, Date, LocalTime, LocalDateTime, Duration };
 
   Type type;
   PropertyId property_id;
-  std::shared_ptr<SchemaProperty> nested_value;
 };
 
 struct SchemaViolation {
@@ -100,12 +99,6 @@ inline std::optional<SchemaProperty::Type> PropertyValueTypeToSchemaProperty(con
     case PropertyValue::Type::String: {
       return SchemaProperty::Type::String;
     }
-    case PropertyValue::Type::List: {
-      return SchemaProperty::Type::List;
-    }
-    case PropertyValue::Type::Map: {
-      return SchemaProperty::Type::Map;
-    }
     case PropertyValue::Type::TemporalData: {
       switch (property_value.ValueTemporalData().type) {
         case TemporalType::Date: {
@@ -122,7 +115,9 @@ inline std::optional<SchemaProperty::Type> PropertyValueTypeToSchemaProperty(con
         }
       }
     }
-    case PropertyValue::Type::Null: {
+    case PropertyValue::Type::Null:
+    case PropertyValue::Type::Map:
+    case PropertyValue::Type::List: {
       return std::nullopt;
     }
   }
@@ -141,12 +136,6 @@ inline std::string SchemaPropertyToString(const SchemaProperty::Type type) {
     }
     case SchemaProperty::Type::String: {
       return "String";
-    }
-    case SchemaProperty::Type::List: {
-      return "List";
-    }
-    case SchemaProperty::Type::Map: {
-      return "Map";
     }
     case SchemaProperty::Type::Date: {
       return "Date";

--- a/src/storage/v2/schemas.hpp
+++ b/src/storage/v2/schemas.hpp
@@ -11,25 +11,61 @@
 
 #pragma once
 
+#include <memory>
+#include <optional>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 
+#include "storage/v2/id_types.hpp"
 #include "storage/v2/indices.hpp"
 #include "storage/v2/property_value.hpp"
+#include "storage/v2/temporal.hpp"
 #include "storage/v2/transaction.hpp"
 #include "storage/v2/vertex.hpp"
 #include "utils/result.hpp"
 
 namespace memgraph::storage {
 
-///
+class SchemaViolationException : public utils::BasicException {
+  using utils::BasicException::BasicException;
+};
+
+struct SchemaType {
+  enum class Type : uint8_t { Bool, Int, Double, String, List, Map, Date, LocalTime, LocalDateTime, Duration };
+
+  Type type;
+  PropertyId property_id;
+  std::shared_ptr<SchemaType> nested_value;
+};
+
+struct SchemaViolation {
+  enum class ValidationStatus : uint8_t {
+    VERTEX_HAS_NO_PRIMARY_LABEL,
+    VERTEX_HAS_NO_PROPERTY,
+    NO_SCHEMA_DEFINED_FOR_LABEL,
+    VERTEX_PROPERTY_WRONG_TYPE
+  };
+
+  SchemaViolation(ValidationStatus status, LabelId label);
+
+  SchemaViolation(ValidationStatus status, LabelId label, SchemaType violated_type);
+
+  SchemaViolation(ValidationStatus status, LabelId label, SchemaType violated_type,
+                  PropertyValue violated_property_value);
+
+  ValidationStatus status;
+  LabelId label;
+  std::optional<SchemaType> violated_type;
+  std::optional<PropertyValue> violated_property_value;
+};
+
 /// Structure that represents a collection of schemas
 /// Schema can be mapped under only one label => primary label
 class Schemas {
  public:
-  using SchemasStructure = std::unordered_map<LabelId, std::vector<std::pair<PropertyId, PropertyValue::Type>>>;
-  using SchemasList = std::vector<std::pair<LabelId, std::vector<std::pair<PropertyId, PropertyValue::Type>>>>;
+  using SchemasStructure = std::unordered_map<LabelId, std::vector<SchemaType>>;
+  using SchemasList = std::vector<std::pair<LabelId, std::vector<SchemaType>>>;
 
   Schemas() = default;
   Schemas(const Schemas &) = delete;
@@ -40,26 +76,101 @@ class Schemas {
 
   enum class CreationStatus : uint8_t { SUCCESS, FAIL };
   enum class DeletionStatus : uint8_t { SUCCESS, FAIL };
-  enum class ValidationStatus : uint8_t {
-    SUCCESS,
-    VERTEX_DELETED,
-    VERTEX_HAS_NO_PRIMARY_LABEL,
-    VERTEX_HAS_NO_PROPERTY,
-    NO_SCHEMA_DEFINED_FOR_LABEL,
-    VERTEX_PROPERTY_WRONG_TYPE
-  };
 
-  CreationStatus CreateSchema(LabelId label,
-                              const std::vector<std::pair<PropertyId, PropertyValue::Type>> &property_types);
+  CreationStatus CreateSchema(LabelId label, const std::vector<SchemaType> &schemas_types);
 
   DeletionStatus DeleteSchema(LabelId label);
 
-  ValidationStatus ValidateVertex(LabelId primary_label, const Vertex &vertex);
+  std::optional<SchemaViolation> ValidateVertex(LabelId primary_label, const Vertex &vertex);
 
   SchemasList ListSchemas() const;
 
  private:
   SchemasStructure schemas_;
 };
+
+inline std::optional<SchemaType::Type> PropertyValueTypeToSchemaType(const PropertyValue &property_value) {
+  switch (property_value.type()) {
+    case PropertyValue::Type::Bool: {
+      return SchemaType::Type::Bool;
+    }
+    case PropertyValue::Type::Int: {
+      return SchemaType::Type::Int;
+    }
+    case PropertyValue::Type::Double: {
+      return SchemaType::Type::Double;
+    }
+    case PropertyValue::Type::String: {
+      return SchemaType::Type::String;
+    }
+    case PropertyValue::Type::List: {
+      return SchemaType::Type::List;
+    }
+    case PropertyValue::Type::Map: {
+      return SchemaType::Type::Map;
+    }
+    case PropertyValue::Type::TemporalData: {
+      switch (property_value.ValueTemporalData().type) {
+        case TemporalType::Date: {
+          return SchemaType::Type::Date;
+        }
+        case TemporalType::LocalDateTime: {
+          return SchemaType::Type::LocalDateTime;
+        }
+        case TemporalType::LocalTime: {
+          return SchemaType::Type::LocalTime;
+        }
+        case TemporalType::Duration: {
+          return SchemaType::Type::Duration;
+        }
+      }
+    }
+    default: {
+      return std::nullopt;
+    }
+  }
+}
+
+inline std::string SchemaTypeToString(const SchemaType::Type type) {
+  switch (type) {
+    case SchemaType::Type::Bool: {
+      return "Bool";
+    }
+    case SchemaType::Type::Int: {
+      return "Integer";
+    }
+    case SchemaType::Type::Double: {
+      return "Double";
+    }
+    case SchemaType::Type::String: {
+      return "String";
+    }
+    case SchemaType::Type::List: {
+      return "List";
+    }
+    case SchemaType::Type::Map: {
+      return "Map";
+    }
+    case SchemaType::Type::Date: {
+      return "Date";
+    }
+    case SchemaType::Type::LocalTime: {
+      return "LocalTime";
+    }
+    case SchemaType::Type::LocalDateTime: {
+      return "LocalDateTime";
+    }
+    case SchemaType::Type::Duration: {
+      return "Duration";
+    }
+  }
+}
+
+inline std::string PropertyTypeToString(const PropertyValue &property_value) {
+  if (const auto schema_type = PropertyValueTypeToSchemaType(property_value); schema_type) {
+    return SchemaTypeToString(*schema_type);
+  }
+  return "Unknown";
+}
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/schemas.hpp
+++ b/src/storage/v2/schemas.hpp
@@ -1,0 +1,54 @@
+// Copyright 2022 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+
+#include "storage/v2/property_value.hpp"
+#include "storage/v2/transaction.hpp"
+#include "storage/v2/vertex.hpp"
+#include "utils/result.hpp"
+
+namespace memgraph::storage {
+
+///
+/// Structure that represents a collection of schemas
+/// Schema can be mapped under only one label => primary label
+class Schemas {
+ public:
+  Schemas() = default;
+  Schemas(const Schemas &) = delete;
+  Schemas(Schemas &&) = delete;
+  Schemas &operator=(const Schemas &) = delete;
+  Schemas &operator=(Schemas &&) = delete;
+  ~Schemas() = default;
+
+  enum class CreationStatus : uint8_t { SUCCESS, FAIL };
+  enum class DeletionStatus : uint8_t { SUCCESS, FAIL };
+  enum class ValidationStatus : uint8_t {
+    SUCCESS,
+    VERTEX_DELETED,
+    NO_SCHEMA_DEFINED_FOR_LABEL,
+    VERTEX_HAS_NO_PRIMARY_LABEL
+  };
+
+  CreationStatus AddSchema(LabelId label, const std::vector<PropertyId> &property_ids);
+  DeletionStatus DeleteSchema(LabelId label);
+  ValidationStatus ValidateVertex(LabelId primary_label, const Vertex &vertex, const Transaction &tx,
+                                  uint64_t commit_timestamp);
+
+ private:
+  std::unordered_map<LabelId, std::vector<PropertyId>> schemas_;
+};
+
+}  // namespace memgraph::storage

--- a/src/storage/v2/schemas.hpp
+++ b/src/storage/v2/schemas.hpp
@@ -12,8 +12,10 @@
 #pragma once
 
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
+#include "storage/v2/indices.hpp"
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/transaction.hpp"
 #include "storage/v2/vertex.hpp"
@@ -38,17 +40,22 @@ class Schemas {
   enum class ValidationStatus : uint8_t {
     SUCCESS,
     VERTEX_DELETED,
+    VERTEX_HAS_NO_PRIMARY_LABEL,
+    VERTEX_HAS_NO_PROPERTY,
     NO_SCHEMA_DEFINED_FOR_LABEL,
-    VERTEX_HAS_NO_PRIMARY_LABEL
+    VERTEX_PROPERTY_WRONG_TYPE
   };
 
-  CreationStatus AddSchema(LabelId label, const std::vector<PropertyId> &property_ids);
+  CreationStatus CreateSchema(LabelId label, const std::vector<PropertyId> &property_ids);
+
   DeletionStatus DeleteSchema(LabelId label);
+
   ValidationStatus ValidateVertex(LabelId primary_label, const Vertex &vertex, const Transaction &tx,
                                   uint64_t commit_timestamp);
 
  private:
-  std::unordered_map<LabelId, std::vector<PropertyId>> schemas_;
+  std::unordered_map<LabelId, std::pair<PropertyId, PropertyValue::Type>> schemas_;
+  std::unordered_map<LabelId, LabelPropertyIndex> label_property_indices_;
 };
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -1227,6 +1227,11 @@ ConstraintsInfo Storage::ListAllConstraints() const {
   return {ListExistenceConstraints(constraints_), constraints_.unique_constraints.ListConstraints()};
 }
 
+SchemasInfo Storage::ListAllSchemas() const {
+  std::shared_lock<utils::RWLock> storage_guard_(main_lock_);
+  return {schemas_.ListSchemas()};
+}
+
 StorageInfo Storage::GetInfo() const {
   auto vertex_count = vertices_.size();
   auto edge_count = edge_count_.load(std::memory_order_acquire);

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -28,6 +28,7 @@
 #include "storage/v2/indices.hpp"
 #include "storage/v2/mvcc.hpp"
 #include "storage/v2/replication/config.hpp"
+#include "storage/v2/schemas.hpp"
 #include "storage/v2/transaction.hpp"
 #include "storage/v2/vertex_accessor.hpp"
 #include "utils/file.hpp"
@@ -456,12 +457,13 @@ VertexAccessor Storage::Accessor::CreateVertex() {
   OOMExceptionEnabler oom_exception;
   auto gid = storage_->vertex_id_.fetch_add(1, std::memory_order_acq_rel);
   auto acc = storage_->vertices_.access();
-  auto delta = CreateDeleteObjectDelta(&transaction_);
+  auto *delta = CreateDeleteObjectDelta(&transaction_);
   auto [it, inserted] = acc.insert(Vertex{storage::Gid::FromUint(gid), delta});
   MG_ASSERT(inserted, "The vertex must be inserted here!");
   MG_ASSERT(it != acc.end(), "Invalid Vertex accessor!");
+
   delta->prev.Set(&*it);
-  return VertexAccessor(&*it, &transaction_, &storage_->indices_, &storage_->constraints_, config_);
+  return {&*it, &transaction_, &storage_->indices_, &storage_->constraints_, config_};
 }
 
 VertexAccessor Storage::Accessor::CreateVertex(storage::Gid gid) {

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -414,7 +414,7 @@ class Storage final {
 
   ConstraintsInfo ListAllConstraints() const;
 
-  bool CreateSchema(LabelId primary_label, std::vector<SchemaType> &schemas_types);
+  bool CreateSchema(LabelId primary_label, std::vector<SchemaProperty> &schemas_types);
 
   bool DeleteSchema(LabelId primary_label);
 

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -30,6 +30,7 @@
 #include "storage/v2/mvcc.hpp"
 #include "storage/v2/name_id_mapper.hpp"
 #include "storage/v2/result.hpp"
+#include "storage/v2/schemas.hpp"
 #include "storage/v2/transaction.hpp"
 #include "storage/v2/vertex.hpp"
 #include "storage/v2/vertex_accessor.hpp"
@@ -364,7 +365,7 @@ class Storage final {
   IndicesInfo ListAllIndices() const;
 
   /// Creates an existence constraint. Returns true if the constraint was
-  /// successfuly added, false if it already exists and a `ConstraintViolation`
+  /// successfully added, false if it already exists and a `ConstraintViolation`
   /// if there is an existing vertex violating the constraint.
   ///
   /// @throw std::bad_alloc
@@ -491,6 +492,7 @@ class Storage final {
 
   Constraints constraints_;
   Indices indices_;
+  Schemas schemas_;
 
   // Transaction engine
   utils::SpinLock engine_lock_;

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -414,10 +414,8 @@ class Storage final {
 
   ConstraintsInfo ListAllConstraints() const;
 
-  /// @throw std::bad_alloc
   bool CreateSchema(LabelId primary_label, std::vector<SchemaType> &schemas_types);
 
-  /// @throw std::bad_alloc
   bool DeleteSchema(LabelId primary_label);
 
   SchemasInfo ListAllSchemas() const;

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -414,6 +414,12 @@ class Storage final {
 
   ConstraintsInfo ListAllConstraints() const;
 
+  /// @throw std::bad_alloc
+  bool CreateSchema(LabelId primary_label, std::vector<SchemaType> &schemas_types);
+
+  /// @throw std::bad_alloc
+  bool DeleteSchema(LabelId primary_label);
+
   SchemasInfo ListAllSchemas() const;
 
   StorageInfo GetInfo() const;

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -16,6 +16,7 @@
 #include <optional>
 #include <shared_mutex>
 #include <variant>
+#include <vector>
 
 #include "io/network/endpoint.hpp"
 #include "storage/v2/commit_log.hpp"
@@ -25,15 +26,18 @@
 #include "storage/v2/durability/wal.hpp"
 #include "storage/v2/edge.hpp"
 #include "storage/v2/edge_accessor.hpp"
+#include "storage/v2/id_types.hpp"
 #include "storage/v2/indices.hpp"
 #include "storage/v2/isolation_level.hpp"
 #include "storage/v2/mvcc.hpp"
 #include "storage/v2/name_id_mapper.hpp"
+#include "storage/v2/property_value.hpp"
 #include "storage/v2/result.hpp"
 #include "storage/v2/schemas.hpp"
 #include "storage/v2/transaction.hpp"
 #include "storage/v2/vertex.hpp"
 #include "storage/v2/vertex_accessor.hpp"
+#include "utils/exceptions.hpp"
 #include "utils/file_locker.hpp"
 #include "utils/on_scope_exit.hpp"
 #include "utils/rw_lock.hpp"
@@ -174,6 +178,11 @@ struct ConstraintsInfo {
   std::vector<std::pair<LabelId, std::set<PropertyId>>> unique;
 };
 
+/// Structure used to return information about existing schemas in the storage
+struct SchemasInfo {
+  Schemas::SchemasList schemas;
+};
+
 /// Structure used to return information about the storage.
 struct StorageInfo {
   uint64_t vertex_count;
@@ -307,6 +316,8 @@ class Storage final {
               storage_->constraints_.unique_constraints.ListConstraints()};
     }
 
+    SchemasInfo ListAllSchemas() const { return {storage_->schemas_.ListSchemas()}; }
+
     void AdvanceCommand();
 
     /// Commit returns `ConstraintViolation` if the changes made by this
@@ -402,6 +413,8 @@ class Storage final {
                                                          std::optional<uint64_t> desired_commit_timestamp = {});
 
   ConstraintsInfo ListAllConstraints() const;
+
+  SchemasInfo ListAllSchemas() const;
 
   StorageInfo GetInfo() const;
 


### PR DESCRIPTION
Introducing only in-memory representation of schema, without any support for creating or validating schema against vertices.

[epic < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Update [changelog](https://docs.memgraph.com/memgraph/changelog)
