### PR TITLE
[master < T0876-MG] Add an uncatchable kill method to the python MemgraphInstanceRunner 

### DIFF
--- a/tests/e2e/memgraph.py
+++ b/tests/e2e/memgraph.py
@@ -106,3 +106,10 @@ class MemgraphInstanceRunner:
         self.proc_mg.terminate()
         code = self.proc_mg.wait()
         assert code == 0, "The Memgraph process exited with non-zero!"
+
+    def kill(self):
+        if not self.is_running():
+            return
+        self.proc_mg.kill()
+        code = self.proc_mg.wait()
+        assert code == 9, "The killed Memgraph process exited with non-nine!"


### PR DESCRIPTION
This adds a simple python test method for killing instances under test in a way that is impossible for the process to catch and gracefully clean up, in the way that the existing `stop` method may lead to graceful handling if the subprocess implements a SIGTERM handler.