### PR TITLE
[master < MG] Declare `mgp_func_context` outside the callback funciton

### DIFF
--- a/include/mg_procedure.h
+++ b/include/mg_procedure.h
@@ -1512,6 +1512,10 @@ enum mgp_error mgp_module_add_transformation(struct mgp_module *module, const ch
 ///
 ///@{
 
+/// State of the database that is exposed to magic functions. Currently it is unused, but it enables extending the
+/// functionalities of magic functions in future without breaking the API.
+struct mgp_func_context;
+
 /// Add a required argument to a function.
 ///
 /// The order of the added arguments corresponds to the signature of the openCypher function.


### PR DESCRIPTION
[master < Task] PR
- [ ] Check, and update documentation if necessary - **NOT NECESSARY**
- [ ] Update [changelog](https://docs.memgraph.com/memgraph/changelog) - **NOT NECESSARY**
- [X] Provide the full content or a guide for the final git message

> Declare `mgp_func_context` outside the callback function

We missed to declare this struct, so it was implicitly declared in the type definition of `mg_func_cb`, but we introduced this for future improvements, currently it doesn't have any value (apart from making sure we can add new functionalities to functions without breaking the API). I added the declaration just to be 100% correct.

As this didn't mean any error to the users, because the struct is currently unused, I am not sure whether we should add this to the changelog or not. What do you think?