### PR TITLE
[master < ] Fix RETURN true, false query

### DIFF
--- a/src/query/frontend/stripped.cpp
+++ b/src/query/frontend/stripped.cpp
@@ -124,9 +124,9 @@ StrippedQuery::StrippedQuery(const std::string &query) : original_(query) {
         // We don't strip NULL, since it can appear in special expressions
         // like IS NULL and IS NOT NULL, but we strip true and false keywords.
         if (utils::IEquals(token.second, "true")) {
-          replace_stripped(token_index, true, kStrippedBooleanToken);
+          replace_stripped(token_index, true, kStrippedBooleanTrueToken);
         } else if (utils::IEquals(token.second, "false")) {
-          replace_stripped(token_index, false, kStrippedBooleanToken);
+          replace_stripped(token_index, false, kStrippedBooleanFalseToken);
         } else {
           token_strings.push_back(token.second);
         }

--- a/src/query/frontend/stripped.hpp
+++ b/src/query/frontend/stripped.hpp
@@ -24,7 +24,8 @@ namespace memgraph::query::frontend {
 const std::string kStrippedIntToken = "0";
 const std::string kStrippedDoubleToken = "0.0";
 const std::string kStrippedStringToken = "\"a\"";
-const std::string kStrippedBooleanToken = "true";
+const std::string kStrippedBooleanTrueToken = "true";
+const std::string kStrippedBooleanFalseToken = "false";
 
 /**
  * StrippedQuery contains:

--- a/tests/unit/stripped.cpp
+++ b/tests/unit/stripped.cpp
@@ -166,14 +166,14 @@ TEST(QueryStripper, TrueLiteral) {
   StrippedQuery stripped("RETURN trUE");
   EXPECT_EQ(stripped.literals().size(), 1);
   EXPECT_PROP_EQ(stripped.literals().At(0).second, TypedValue(true));
-  EXPECT_EQ(stripped.query(), "RETURN " + kStrippedBooleanToken);
+  EXPECT_EQ(stripped.query(), "RETURN " + kStrippedBooleanTrueToken);
 }
 
 TEST(QueryStripper, FalseLiteral) {
   StrippedQuery stripped("RETURN fAlse");
   EXPECT_EQ(stripped.literals().size(), 1);
   EXPECT_PROP_EQ(stripped.literals().At(0).second, TypedValue(false));
-  EXPECT_EQ(stripped.query(), "RETURN " + kStrippedBooleanToken);
+  EXPECT_EQ(stripped.query(), "RETURN " + kStrippedBooleanFalseToken);
 }
 
 TEST(QueryStripper, NullLiteral) {


### PR DESCRIPTION
[master < Task] PR
- [ ] Update [changelog](https://docs.memgraph.com/memgraph/changelog)
- [x] Provide the full content or a guide for the final git message -> `Fix RETURN true, false query`

Fixes #470

The fix only applies to this specific case. To solve the problem in general, some additional alias logic is required. It's possible to solve a problem by manually giving aliases to the expressions that boil down to the same stripped value, e.g.:
* `RETURN 1+2, 3+4;           // fails because that's replaced during the query stripping with 0+0, 0+0`
* `RETURN 1+2 AS x, 3+4 AS y; // OK` 