### PR TITLE
Optimize simulator RNG usage

### DIFF
--- a/src/io/simulator/simulator_handle.cpp
+++ b/src/io/simulator/simulator_handle.cpp
@@ -73,8 +73,7 @@ bool SimulatorHandle::MaybeTickSimulator() {
 
     // We tick the clock forward when all servers are blocked but
     // there are no in-flight messages to schedule delivery of.
-    std::poisson_distribution<> time_distrib(50);
-    Duration clock_advance = std::chrono::microseconds{time_distrib(rng_)};
+    const Duration clock_advance = std::chrono::microseconds{time_distrib_(rng_)};
     cluster_wide_time_microseconds_ += clock_advance;
 
     MG_ASSERT(cluster_wide_time_microseconds_ < config_.abort_time,
@@ -93,8 +92,7 @@ bool SimulatorHandle::MaybeTickSimulator() {
   auto [to_address, opaque_message] = std::move(in_flight_.back());
   in_flight_.pop_back();
 
-  std::uniform_int_distribution<int> drop_distrib(0, 99);
-  const int drop_threshold = drop_distrib(rng_);
+  const int drop_threshold = drop_distrib_(rng_);
   const bool should_drop = drop_threshold < config_.drop_percent;
 
   if (should_drop) {

--- a/src/io/simulator/simulator_handle.hpp
+++ b/src/io/simulator/simulator_handle.hpp
@@ -51,6 +51,8 @@ class SimulatorHandle {
   std::set<Address> blocked_on_receive_;
   std::set<Address> server_addresses_;
   std::mt19937 rng_;
+  std::uniform_int_distribution<int> time_distrib_{5, 50};
+  std::uniform_int_distribution<int> drop_distrib_{0, 99};
   SimulatorConfig config_;
 
   void TimeoutPromisesPastDeadline() {


### PR DESCRIPTION
This causes instructions for basic_request.cpp to drop from 281 million to 28 million

[master < Epic] PR
- [ ] Check, and update documentation if necessary
- [ ] Update [changelog](https://docs.memgraph.com/memgraph/changelog)
- [ ] Write E2E tests
- [ ] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch and the Epic branch
- [ ] Provide the full content or a guide for the final git message

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Update [changelog](https://docs.memgraph.com/memgraph/changelog)
- [ ] Provide the full content or a guide for the final git message
