### PR TITLE
load spdlog env in tests

### DIFF
--- a/tests/unit/main.cpp
+++ b/tests/unit/main.cpp
@@ -10,11 +10,13 @@
 // licenses/APL.txt.
 
 #include <gtest/gtest.h>
+#include <spdlog/cfg/env.h>
 #include <utils/logging.hpp>
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   memgraph::logging::RedirectToStderr();
   spdlog::set_level(spdlog::level::trace);
+  spdlog::cfg::load_env_levels();
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
allows test log verbosity to be overridden when running individual unit tests by setting the `SPDLOG_LEVEL` env var:

```
SPDLOG_LEVEL=error tests/unit/machine_manager
# executes without default trace logging output
```