### PR TITLE
Add logarithmically bucketing histogram and measure response latencies for each request response type

### DIFF
--- a/src/io/local_transport/local_transport_handle.hpp
+++ b/src/io/local_transport/local_transport_handle.hpp
@@ -19,6 +19,7 @@
 
 #include "io/errors.hpp"
 #include "io/message_conversion.hpp"
+#include "io/message_histogram_collector.hpp"
 #include "io/time.hpp"
 #include "io/transport.hpp"
 
@@ -28,6 +29,7 @@ class LocalTransportHandle {
   mutable std::mutex mu_{};
   mutable std::condition_variable cv_;
   bool should_shut_down_ = false;
+  MessageHistogramCollector histograms_;
 
   // the responses to requests that are being waited on
   std::map<PromiseKey, DeadlineAndOpaquePromise> promises_;
@@ -52,6 +54,11 @@ class LocalTransportHandle {
   bool ShouldShutDown() const {
     std::unique_lock<std::mutex> lock(mu_);
     return should_shut_down_;
+  }
+
+  std::unordered_map<std::string, LatencyHistogramSummary> ResponseLatencies() {
+    std::unique_lock<std::mutex> lock(mu_);
+    return histograms_.ResponseLatencies();
   }
 
   static Time Now() {
@@ -118,6 +125,7 @@ class LocalTransportHandle {
         Duration response_latency = Now() - dop.requested_at;
 
         dop.promise.Fill(std::move(opaque_message), response_latency);
+        histograms_.Measure(dop.response_type_id, response_latency);
       } else {
         spdlog::info("placing message in can_receive_");
         can_receive_.emplace_back(std::move(opaque_message));
@@ -144,7 +152,10 @@ class LocalTransportHandle {
       PromiseKey promise_key{
           .requester_address = from_address, .request_id = request_id, .replier_address = to_address};
       OpaquePromise opaque_promise(std::move(promise).ToUnique());
-      DeadlineAndOpaquePromise dop{.requested_at = now, .deadline = deadline, .promise = std::move(opaque_promise)};
+      DeadlineAndOpaquePromise dop{.requested_at = now,
+                                   .deadline = deadline,
+                                   .promise = std::move(opaque_promise),
+                                   .response_type_id = typeid(ResponseT)};
       promises_.emplace(std::move(promise_key), std::move(dop));
     }  // lock dropped
 

--- a/src/io/message_conversion.hpp
+++ b/src/io/message_conversion.hpp
@@ -199,6 +199,7 @@ struct DeadlineAndOpaquePromise {
   Time requested_at;
   Time deadline;
   OpaquePromise promise;
+  const std::type_info &response_type_id;
 };
 
 template <class From>

--- a/src/io/message_histogram_collector.hpp
+++ b/src/io/message_histogram_collector.hpp
@@ -1,0 +1,152 @@
+// Copyright 2022 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <chrono>
+#include <cmath>
+#include <functional>
+#include <typeinfo>
+#include <unordered_map>
+
+#include <boost/core/demangle.hpp>
+
+#include "io/time.hpp"
+
+namespace memgraph::io {
+
+constexpr auto sample_limit = (16 * 1024) - 1;
+constexpr auto precision = 100.0;
+
+struct LatencyHistogramSummary {
+  Duration p0;
+  Duration p50;
+  Duration p75;
+  Duration p90;
+  Duration p95;
+  Duration p975;
+  Duration p99;
+  Duration p999;
+  Duration p9999;
+  Duration p100;
+
+  friend std::ostream &operator<<(std::ostream &in, const LatencyHistogramSummary &histo) {
+    in << "LatencyHistogramSummary { p0: " << histo.p0.count();
+    in << ", p50: " << histo.p50.count();
+    in << ", p75: " << histo.p75.count();
+    in << ", p90: " << histo.p90.count();
+    in << ", p95: " << histo.p95.count();
+    in << ", p975: " << histo.p975.count();
+    in << ", p99: " << histo.p99.count();
+    in << ", p999: " << histo.p999.count();
+    in << ", p9999: " << histo.p9999.count();
+    in << ", p100: " << histo.p100.count();
+    in << " }";
+
+    return in;
+  }
+};
+
+struct Histogram {
+  uint64_t count = 0;
+  uint64_t sum = 0;
+  std::vector<uint64_t> samples = {};
+
+  Histogram() {
+    // set samples_ to 16k 0's
+    samples.resize(sample_limit, 0);
+  }
+
+  Duration Percentile(double percentile) const {
+    MG_ASSERT(percentile <= 100.0, "percentiles must not exceed 100.0");
+
+    if (count == 0) {
+      return Duration::min();
+    }
+
+    const auto floated_count = static_cast<double>(count);
+    const auto target = std::max(floated_count * percentile / 100.0, 1.0);
+
+    auto scanned = 0.0;
+
+    for (int i = 0; i <= sample_limit; i++) {
+      const auto samples_at_index = samples[i];
+      scanned += static_cast<double>(samples_at_index);
+      if (scanned >= target) {
+        auto floated = static_cast<double>(i);
+        auto unboosted = floated / precision;
+        auto microseconds = static_cast<int64_t>(std::exp(unboosted) - 1.0);
+
+        return Duration(microseconds);
+      }
+    }
+
+    return Duration::min();
+  }
+};
+
+using TypeInfoRef = std::reference_wrapper<const std::type_info>;
+struct Hasher {
+  std::size_t operator()(TypeInfoRef code) const { return code.get().hash_code(); }
+};
+
+struct EqualTo {
+  bool operator()(TypeInfoRef lhs, TypeInfoRef rhs) const { return lhs.get() == rhs.get(); }
+};
+
+class MessageHistogramCollector {
+  std::unordered_map<TypeInfoRef, Histogram, Hasher, EqualTo> histograms_;
+
+ public:
+  void Measure(const std::type_info &type_info, const Duration &duration) {
+    // TODO(tyler)
+    auto count = duration.count();
+    double floated = static_cast<double>(count);
+    auto boosted = 1.0 + floated;
+    auto ln = std::log(boosted);
+    auto compressed = precision * ln + 0.5;
+    auto sample_index = static_cast<uint16_t>(compressed);
+    MG_ASSERT(sample_index < sample_limit);
+
+    auto &histo = histograms_[type_info];
+
+    histo.count++;
+    histo.samples[sample_index]++;
+    histo.sum += count;
+  }
+
+  std::unordered_map<std::string, LatencyHistogramSummary> ResponseLatencies() {
+    std::unordered_map<std::string, LatencyHistogramSummary> ret{};
+
+    for (const auto &[type_id, histo] : histograms_) {
+      std::string demangled_name = boost::core::demangle(type_id.get().name());
+
+      LatencyHistogramSummary latency_histogram_summary{
+          .p0 = histo.Percentile(0.0),
+          .p50 = histo.Percentile(50.0),
+          .p75 = histo.Percentile(75.0),
+          .p90 = histo.Percentile(90.0),
+          .p95 = histo.Percentile(95.0),
+          .p975 = histo.Percentile(97.5),
+          .p99 = histo.Percentile(99.0),
+          .p999 = histo.Percentile(99.9),
+          .p9999 = histo.Percentile(99.99),
+          .p100 = histo.Percentile(100.0),
+      };
+
+      ret.emplace(demangled_name, latency_histogram_summary);
+    }
+
+    return ret;
+  }
+};
+
+}  // namespace memgraph::io

--- a/src/io/simulator/simulator_handle.cpp
+++ b/src/io/simulator/simulator_handle.cpp
@@ -115,7 +115,8 @@ bool SimulatorHandle::MaybeTickSimulator() {
       dop.promise.TimeOut();
     } else {
       stats_.total_responses++;
-      dop.promise.Fill(std::move(opaque_message));
+      Duration response_latency = cluster_wide_time_microseconds_ - dop.requested_at;
+      dop.promise.Fill(std::move(opaque_message), response_latency);
     }
   } else if (should_drop) {
     // don't add it anywhere, let it drop

--- a/src/io/simulator/simulator_handle.hpp
+++ b/src/io/simulator/simulator_handle.hpp
@@ -104,7 +104,8 @@ class SimulatorHandle {
 
     PromiseKey promise_key{.requester_address = from_address, .request_id = request_id, .replier_address = to_address};
     OpaquePromise opaque_promise(std::move(promise).ToUnique());
-    DeadlineAndOpaquePromise dop{.deadline = deadline, .promise = std::move(opaque_promise)};
+    DeadlineAndOpaquePromise dop{
+        .requested_at = cluster_wide_time_microseconds_, .deadline = deadline, .promise = std::move(opaque_promise)};
     promises_.emplace(std::move(promise_key), std::move(dop));
 
     stats_.total_messages++;

--- a/src/io/simulator/simulator_transport.hpp
+++ b/src/io/simulator/simulator_transport.hpp
@@ -63,5 +63,9 @@ class SimulatorTransport {
   Return Rand(D distrib) {
     return distrib(rng_);
   }
+
+  std::unordered_map<std::string, LatencyHistogramSummary> ResponseLatencies() {
+    return simulator_handle_->ResponseLatencies();
+  }
 };
 };  // namespace memgraph::io::simulator

--- a/src/io/transport.hpp
+++ b/src/io/transport.hpp
@@ -19,6 +19,7 @@
 #include "io/address.hpp"
 #include "io/errors.hpp"
 #include "io/future.hpp"
+#include "io/message_histogram_collector.hpp"
 #include "io/time.hpp"
 #include "utils/result.hpp"
 
@@ -141,5 +142,9 @@ class Io {
   void SetAddress(Address address) { address_ = address; }
 
   Io<I> ForkLocal() { return Io(implementation_, address_.ForkUniqueAddress()); }
+
+  std::unordered_map<std::string, LatencyHistogramSummary> ResponseLatencies() {
+    return implementation_.ResponseLatencies();
+  }
 };
 };  // namespace memgraph::io

--- a/src/io/transport.hpp
+++ b/src/io/transport.hpp
@@ -40,6 +40,7 @@ struct ResponseEnvelope {
   RequestId request_id;
   Address to_address;
   Address from_address;
+  Duration response_latency;
 };
 
 template <Message M>

--- a/src/utils/print_helpers.hpp
+++ b/src/utils/print_helpers.hpp
@@ -13,6 +13,7 @@
 
 #include <map>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 namespace memgraph::utils::print_helpers {
@@ -34,6 +35,23 @@ std::ostream &operator<<(std::ostream &in, const std::vector<T> &vector) {
 
 template <typename K, typename V>
 std::ostream &operator<<(std::ostream &in, const std::map<K, V> &map) {
+  in << "{";
+  bool first = true;
+  for (const auto &[a, b] : map) {
+    if (!first) {
+      in << ", ";
+    }
+    first = false;
+    in << a;
+    in << ": ";
+    in << b;
+  }
+  in << "}";
+  return in;
+}
+
+template <typename K, typename V>
+std::ostream &operator<<(std::ostream &in, const std::unordered_map<K, V> &map) {
   in << "{";
   bool first = true;
   for (const auto &[a, b] : map) {

--- a/tests/simulation/basic_request.cpp
+++ b/tests/simulation/basic_request.cpp
@@ -12,6 +12,7 @@
 #include <thread>
 
 #include "io/simulator/simulator.hpp"
+#include "utils/print_helpers.hpp"
 
 using memgraph::io::Address;
 using memgraph::io::Io;
@@ -82,6 +83,9 @@ int main() {
       std::cout << "[CLIENT] Got an error" << std::endl;
     }
   }
+
+  using memgraph::utils::print_helpers::operator<<;
+  std::cout << "response latencies: " << cli_io.ResponseLatencies() << std::endl;
 
   simulator.ShutDown();
   return 0;

--- a/tests/simulation/basic_request.cpp
+++ b/tests/simulation/basic_request.cpp
@@ -77,6 +77,7 @@ int main() {
       std::cout << "[CLIENT] Got a valid response" << std::endl;
       auto env = res_rez.GetValue();
       MG_ASSERT(env.message.highest_seen == i);
+      std::cout << "response latency: " << env.response_latency.count() << " microseconds" << std::endl;
     } else {
       std::cout << "[CLIENT] Got an error" << std::endl;
     }


### PR DESCRIPTION
This measures response latencies per request response message type. Here is what it collects for the new cluster property test:
`response latencies: {memgraph::io::rsm::ReadResponse<std::variant<memgraph::coordinator::GetShardMapResponse> >: LatencyHistogramSummary { p0: 114, p50: 7404, p75: 34890, p90: 40133, p95: 53102, p975: 53102, p99: 53102, p999: 53102, p9999: 53102, p100: 53102 }, memgraph::io::rsm::WriteResponse<std::variant<memgraph::coordinator::HlcResponse, memgraph::coordinator::AllocateEdgeIdBatchResponse, memgraph::coordinator::SplitShardResponse, memgraph::coordinator::RegisterStorageEngineResponse, memgraph::coordinator::DeregisterStorageEngineResponse, memgraph::coordinator::InitializeLabelResponse, memgraph::coordinator::AllocatePropertyIdsResponse, memgraph::coordinator::HeartbeatResponse> >: LatencyHistogramSummary { p0: 0, p50: 23, p75: 6567, p90: 40133, p95: 56953, p975: 56953, p99: 56953, p999: 56953, p9999: 56953, p100: 56953 }, memgraph::io::rsm::WriteResponse<std::variant<memgraph::msgs::CreateVerticesResponse, memgraph::msgs::DeleteVerticesResponse, memgraph::msgs::UpdateVerticesResponse, memgraph::msgs::CreateExpandResponse, memgraph::msgs::DeleteEdgesResponse, memgraph::msgs::UpdateEdgesResponse, memgraph::msgs::CommitResponse> >: LatencyHistogramSummary { p0: 0, p50: 20129, p75: 33859, p90: 51020, p95: 56386, p975: 68870, p99: 68870, p999: 68870, p9999: 68870, p100: 68870 }, memgraph::io::rsm::ReadResponse<std::variant<memgraph::msgs::ExpandOneResponse, memgraph::msgs::GetPropertiesResponse, memgraph::msgs::ScanVerticesResponse> >: LatencyHistogramSummary { p0: 0, p50: 10508, p75: 30030, p90: 49512, p95: 51533, p975: 362216, p99: 369533, p999: 369533, p9999: 369533, p100: 369533 }}
`

It will be nicer to avoid the big std::variant output and have a finer grained message type output so I'll look at that shortly.

[master < Epic] PR
- [ ] Check, and update documentation if necessary
- [ ] Update [changelog](https://docs.memgraph.com/memgraph/changelog)
- [ ] Write E2E tests
- [ ] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch and the Epic branch
- [ ] Provide the full content or a guide for the final git message

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Update [changelog](https://docs.memgraph.com/memgraph/changelog)
- [ ] Provide the full content or a guide for the final git message
