### PR TITLE
[🍍  <-] Improve simulator determinism

### DIFF
--- a/src/coordinator/shard_map.cpp
+++ b/src/coordinator/shard_map.cpp
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+#include <cstdint>
 #include <optional>
 #include <unordered_map>
 #include <vector>
@@ -257,13 +258,13 @@ boost::uuids::uuid NewShardUuid(uint64_t shard_id) {
                             0,
                             0,
                             0,
-                            static_cast<unsigned char>(shard_id >> 56),
-                            static_cast<unsigned char>(shard_id >> 48),
-                            static_cast<unsigned char>(shard_id >> 40),
-                            static_cast<unsigned char>(shard_id >> 32),
-                            static_cast<unsigned char>(shard_id >> 24),
-                            static_cast<unsigned char>(shard_id >> 16),
-                            static_cast<unsigned char>(shard_id >> 8),
+                            static_cast<unsigned char>(shard_id >> UINT8_C(56)),
+                            static_cast<unsigned char>(shard_id >> UINT8_C(48)),
+                            static_cast<unsigned char>(shard_id >> UINT8_C(40)),
+                            static_cast<unsigned char>(shard_id >> UINT8_C(32)),
+                            static_cast<unsigned char>(shard_id >> UINT8_C(24)),
+                            static_cast<unsigned char>(shard_id >> UINT8_C(16)),
+                            static_cast<unsigned char>(shard_id >> UINT8_C(8)),
                             static_cast<unsigned char>(shard_id)};
 }
 

--- a/src/coordinator/shard_map.cpp
+++ b/src/coordinator/shard_map.cpp
@@ -9,7 +9,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-#include <cstdint>
 #include <optional>
 #include <unordered_map>
 #include <vector>
@@ -258,13 +257,13 @@ boost::uuids::uuid NewShardUuid(uint64_t shard_id) {
                             0,
                             0,
                             0,
-                            static_cast<unsigned char>(shard_id >> UINT8_C(56)),
-                            static_cast<unsigned char>(shard_id >> UINT8_C(48)),
-                            static_cast<unsigned char>(shard_id >> UINT8_C(40)),
-                            static_cast<unsigned char>(shard_id >> UINT8_C(32)),
-                            static_cast<unsigned char>(shard_id >> UINT8_C(24)),
-                            static_cast<unsigned char>(shard_id >> UINT8_C(16)),
-                            static_cast<unsigned char>(shard_id >> UINT8_C(8)),
+                            static_cast<unsigned char>(shard_id >> 56u),
+                            static_cast<unsigned char>(shard_id >> 48u),
+                            static_cast<unsigned char>(shard_id >> 40u),
+                            static_cast<unsigned char>(shard_id >> 32u),
+                            static_cast<unsigned char>(shard_id >> 24u),
+                            static_cast<unsigned char>(shard_id >> 16u),
+                            static_cast<unsigned char>(shard_id >> 8u),
                             static_cast<unsigned char>(shard_id)};
 }
 

--- a/src/coordinator/shard_map.cpp
+++ b/src/coordinator/shard_map.cpp
@@ -228,7 +228,7 @@ Hlc ShardMap::IncrementShardMapVersion() noexcept {
   return shard_map_version;
 }
 
-// TODO(antaljanosbenjamin) use a single map for all name id 
+// TODO(antaljanosbenjamin) use a single map for all name id
 // mapping and a single counter to maintain the next id
 std::unordered_map<uint64_t, std::string> ShardMap::IdToNames() {
   std::unordered_map<uint64_t, std::string> id_to_names;
@@ -247,6 +247,25 @@ std::unordered_map<uint64_t, std::string> ShardMap::IdToNames() {
 }
 
 Hlc ShardMap::GetHlc() const noexcept { return shard_map_version; }
+
+boost::uuids::uuid NewShardUuid(uint64_t shard_id) {
+  return boost::uuids::uuid{0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            static_cast<unsigned char>(shard_id >> 56),
+                            static_cast<unsigned char>(shard_id >> 48),
+                            static_cast<unsigned char>(shard_id >> 40),
+                            static_cast<unsigned char>(shard_id >> 32),
+                            static_cast<unsigned char>(shard_id >> 24),
+                            static_cast<unsigned char>(shard_id >> 16),
+                            static_cast<unsigned char>(shard_id >> 8),
+                            static_cast<unsigned char>(shard_id)};
+}
 
 std::vector<ShardToInitialize> ShardMap::AssignShards(Address storage_manager,
                                                       std::set<boost::uuids::uuid> initialized) {
@@ -268,6 +287,7 @@ std::vector<ShardToInitialize> ShardMap::AssignShards(Address storage_manager,
         if (initialized.contains(aas.address.unique_id)) {
           machine_contains_shard = true;
           if (aas.status != Status::CONSENSUS_PARTICIPANT) {
+            mutated = true;
             spdlog::info("marking shard as full consensus participant: {}", aas.address.unique_id);
             aas.status = Status::CONSENSUS_PARTICIPANT;
           }
@@ -292,10 +312,13 @@ std::vector<ShardToInitialize> ShardMap::AssignShards(Address storage_manager,
       }
 
       if (!machine_contains_shard && shard.size() < label_space.replication_factor) {
+        // increment version for each new uuid for deterministic creation
+        IncrementShardMapVersion();
+
         Address address = storage_manager;
 
         // TODO(tyler) use deterministic UUID so that coordinators don't diverge here
-        address.unique_id = boost::uuids::uuid{boost::uuids::random_generator()()},
+        address.unique_id = NewShardUuid(shard_map_version.logical_id);
 
         spdlog::info("assigning shard manager to shard");
 
@@ -383,6 +406,7 @@ std::optional<LabelId> ShardMap::InitializeNewLabel(std::string label_name, std:
 void ShardMap::AddServer(Address server_address) {
   // Find a random place for the server to plug in
 }
+
 std::optional<LabelId> ShardMap::GetLabelId(const std::string &label) const {
   if (const auto it = labels.find(label); it != labels.end()) {
     return it->second;

--- a/src/coordinator/shard_map.cpp
+++ b/src/coordinator/shard_map.cpp
@@ -257,13 +257,13 @@ boost::uuids::uuid NewShardUuid(uint64_t shard_id) {
                             0,
                             0,
                             0,
-                            static_cast<unsigned char>(shard_id >> 56u),
-                            static_cast<unsigned char>(shard_id >> 48u),
-                            static_cast<unsigned char>(shard_id >> 40u),
-                            static_cast<unsigned char>(shard_id >> 32u),
-                            static_cast<unsigned char>(shard_id >> 24u),
-                            static_cast<unsigned char>(shard_id >> 16u),
-                            static_cast<unsigned char>(shard_id >> 8u),
+                            static_cast<unsigned char>(shard_id >> 56U),
+                            static_cast<unsigned char>(shard_id >> 48U),
+                            static_cast<unsigned char>(shard_id >> 40U),
+                            static_cast<unsigned char>(shard_id >> 32U),
+                            static_cast<unsigned char>(shard_id >> 24U),
+                            static_cast<unsigned char>(shard_id >> 16U),
+                            static_cast<unsigned char>(shard_id >> 8U),
                             static_cast<unsigned char>(shard_id)};
 }
 

--- a/src/io/address.hpp
+++ b/src/io/address.hpp
@@ -58,6 +58,8 @@ struct Address {
   uint16_t last_known_port;
 
   static Address TestAddress(uint16_t port) {
+    MG_ASSERT(port <= 255);
+
     return Address{
         .unique_id = boost::uuids::uuid{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, static_cast<unsigned char>(port)},
         .last_known_port = port,

--- a/src/io/address.hpp
+++ b/src/io/address.hpp
@@ -20,6 +20,8 @@
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
+#include "utils/logging.hpp"
+
 namespace memgraph::io {
 
 struct PartialAddress {

--- a/src/io/address.hpp
+++ b/src/io/address.hpp
@@ -68,9 +68,28 @@ struct Address {
     };
   }
 
+  // NB: don't use this in test code because it is non-deterministic
   static Address UniqueLocalAddress() {
     return Address{
         .unique_id = boost::uuids::uuid{boost::uuids::random_generator()()},
+    };
+  }
+
+  /// `Coordinator`s have constant UUIDs because there is at most one per ip/port pair.
+  Address ForkLocalCoordinator() {
+    return Address{
+        .unique_id = boost::uuids::uuid{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+        .last_known_ip = last_known_ip,
+        .last_known_port = last_known_port,
+    };
+  }
+
+  /// `ShardManager`s have constant UUIDs because there is at most one per ip/port pair.
+  Address ForkLocalShardManager() {
+    return Address{
+        .unique_id = boost::uuids::uuid{2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+        .last_known_ip = last_known_ip,
+        .last_known_port = last_known_port,
     };
   }
 

--- a/src/io/address.hpp
+++ b/src/io/address.hpp
@@ -59,7 +59,7 @@ struct Address {
 
   static Address TestAddress(uint16_t port) {
     return Address{
-        .unique_id = boost::uuids::uuid{boost::uuids::random_generator()()},
+        .unique_id = boost::uuids::uuid{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, static_cast<unsigned char>(port)},
         .last_known_port = port,
     };
   }

--- a/src/io/future.hpp
+++ b/src/io/future.hpp
@@ -64,7 +64,6 @@ class Shared {
     waiting_ = true;
 
     while (!item_) {
-      bool simulator_progressed = false;
       if (simulator_notifier_) [[unlikely]] {
         // We can't hold our own lock while notifying
         // the simulator because notifying the simulator
@@ -77,7 +76,7 @@ class Shared {
         // so we have to get out of its way to avoid
         // a cyclical deadlock.
         lock.unlock();
-        simulator_progressed = std::invoke(simulator_notifier_);
+        std::invoke(simulator_notifier_);
         lock.lock();
         if (item_) {
           // item may have been filled while we
@@ -85,8 +84,7 @@ class Shared {
           // the simulator of our waiting_ status.
           break;
         }
-      }
-      if (!simulator_progressed) [[likely]] {
+      } else {
         cv_.wait(lock);
       }
       MG_ASSERT(!consumed_, "Future consumed twice!");

--- a/src/io/message_histogram_collector.hpp
+++ b/src/io/message_histogram_collector.hpp
@@ -39,6 +39,8 @@ struct LatencyHistogramSummary {
   Duration p100;
   Duration sum;
 
+  friend bool operator==(const LatencyHistogramSummary &lhs, const LatencyHistogramSummary &rhs) = default;
+
   friend std::ostream &operator<<(std::ostream &in, const LatencyHistogramSummary &histo) {
     in << "{ \"count\": " << histo.count;
     in << ", \"p0\": " << histo.p0.count();
@@ -79,6 +81,8 @@ struct LatencyHistogramSummaries {
     output += "\n";
     return output;
   }
+
+  friend bool operator==(const LatencyHistogramSummaries &lhs, const LatencyHistogramSummaries &rhs) = default;
 
   friend std::ostream &operator<<(std::ostream &in, const LatencyHistogramSummaries &histo) {
     using memgraph::utils::print_helpers::operator<<;

--- a/src/io/message_histogram_collector.hpp
+++ b/src/io/message_histogram_collector.hpp
@@ -13,6 +13,7 @@
 
 #include <chrono>
 #include <cmath>
+#include <compare>
 #include <unordered_map>
 
 #include <boost/core/demangle.hpp>

--- a/src/io/rsm/raft.hpp
+++ b/src/io/rsm/raft.hpp
@@ -19,7 +19,6 @@
 #include <map>
 #include <set>
 #include <thread>
-#include <unordered_map>
 #include <vector>
 
 #include <boost/core/demangle.hpp>
@@ -182,7 +181,7 @@ struct PendingClientRequest {
 
 struct Leader {
   std::map<Address, FollowerTracker> followers;
-  std::unordered_map<LogIndex, PendingClientRequest> pending_client_requests;
+  std::map<LogIndex, PendingClientRequest> pending_client_requests;
   Time last_broadcast = Time::min();
 
   std::string static ToString() { return "\tLeader   \t"; }
@@ -683,7 +682,7 @@ class Raft {
 
       return Leader{
           .followers = std::move(followers),
-          .pending_client_requests = std::unordered_map<LogIndex, PendingClientRequest>(),
+          .pending_client_requests = std::map<LogIndex, PendingClientRequest>(),
       };
     }
 

--- a/src/io/simulator/simulator_handle.cpp
+++ b/src/io/simulator/simulator_handle.cpp
@@ -101,6 +101,7 @@ bool SimulatorHandle::MaybeTickSimulator() {
 
   const Duration clock_advance = std::chrono::microseconds{time_distrib_(rng_)};
   cluster_wide_time_microseconds_ += clock_advance;
+  stats_.elapsed_time = cluster_wide_time_microseconds_ - config_.start_time;
 
   spdlog::info("simulator progressing: clock advanced by {}", clock_advance.count());
 

--- a/src/io/simulator/simulator_handle.cpp
+++ b/src/io/simulator/simulator_handle.cpp
@@ -118,7 +118,8 @@ bool SimulatorHandle::MaybeTickSimulator() {
   if (cluster_wide_time_microseconds_ >= config_.abort_time) {
     spdlog::error(
         "Cluster has executed beyond its configured abort_time, and something may be failing to make progress "
-        "in an expected amount of time.");
+        "in an expected amount of time. The SimulatorConfig.rng_seed for this run is {}",
+        config_.rng_seed);
     throw utils::BasicException{"Cluster has executed beyond its configured abort_time"};
   }
 

--- a/src/io/simulator/simulator_handle.hpp
+++ b/src/io/simulator/simulator_handle.hpp
@@ -171,12 +171,15 @@ class SimulatorHandle {
       }
 
       if (!should_shut_down_) {
-        blocked_on_receive_.emplace(receiver);
-        cv_.notify_all();
-        spdlog::info("blocking receiver {}", receiver.ToPartialAddress().port);
+        if (!blocked_on_receive_.contains(receiver)) {
+          blocked_on_receive_.emplace(receiver);
+          spdlog::info("blocking receiver {}", receiver.ToPartialAddress().port);
+          cv_.notify_all();
+        }
         cv_.wait(lock);
       }
     }
+    spdlog::info("timing out receiver {}", receiver.ToPartialAddress().port);
 
     return TimedOut{};
   }

--- a/src/io/simulator/simulator_handle.hpp
+++ b/src/io/simulator/simulator_handle.hpp
@@ -52,7 +52,7 @@ class SimulatorHandle {
   std::set<Address> blocked_on_receive_;
   std::set<Address> server_addresses_;
   std::mt19937 rng_;
-  std::uniform_int_distribution<int> time_distrib_{0, 50};
+  std::uniform_int_distribution<int> time_distrib_{0, 1000};
   std::uniform_int_distribution<int> drop_distrib_{0, 99};
   SimulatorConfig config_;
   MessageHistogramCollector histograms_;

--- a/src/io/simulator/simulator_handle.hpp
+++ b/src/io/simulator/simulator_handle.hpp
@@ -52,7 +52,7 @@ class SimulatorHandle {
   std::set<Address> blocked_on_receive_;
   std::set<Address> server_addresses_;
   std::mt19937 rng_;
-  std::uniform_int_distribution<int> time_distrib_{5, 50};
+  std::uniform_int_distribution<int> time_distrib_{0, 50};
   std::uniform_int_distribution<int> drop_distrib_{0, 99};
   SimulatorConfig config_;
   MessageHistogramCollector histograms_;

--- a/src/io/simulator/simulator_handle.hpp
+++ b/src/io/simulator/simulator_handle.hpp
@@ -64,7 +64,7 @@ class SimulatorHandle {
     for (auto it = promises_.begin(); it != promises_.end();) {
       auto &[promise_key, dop] = *it;
       if (dop.deadline < now && config_.perform_timeouts) {
-        spdlog::info("timing out request from requester {}.", promise_key.requester_address.ToString());
+        spdlog::trace("timing out request from requester {}.", promise_key.requester_address.ToString());
         std::move(dop).promise.TimeOut();
         it = promises_.erase(it);
 
@@ -106,7 +106,7 @@ class SimulatorHandle {
   template <Message Request, Message Response>
   ResponseFuture<Response> SubmitRequest(Address to_address, Address from_address, Request &&request, Duration timeout,
                                          std::function<bool()> &&maybe_tick_simulator) {
-    spdlog::info("submitting request to {}", to_address.last_known_port);
+    spdlog::trace("submitting request to {}", to_address.last_known_port);
     auto type_info = TypeInfoFor(request);
 
     auto [future, promise] = memgraph::io::FuturePromisePairWithNotifier<ResponseResult<Response>>(
@@ -173,20 +173,20 @@ class SimulatorHandle {
       if (!should_shut_down_) {
         if (!blocked_on_receive_.contains(receiver)) {
           blocked_on_receive_.emplace(receiver);
-          spdlog::info("blocking receiver {}", receiver.ToPartialAddress().port);
+          spdlog::trace("blocking receiver {}", receiver.ToPartialAddress().port);
           cv_.notify_all();
         }
         cv_.wait(lock);
       }
     }
-    spdlog::info("timing out receiver {}", receiver.ToPartialAddress().port);
+    spdlog::trace("timing out receiver {}", receiver.ToPartialAddress().port);
 
     return TimedOut{};
   }
 
   template <Message M>
   void Send(Address to_address, Address from_address, RequestId request_id, M message) {
-    spdlog::info("sending message from {} to {}", from_address.last_known_port, to_address.last_known_port);
+    spdlog::trace("sending message from {} to {}", from_address.last_known_port, to_address.last_known_port);
     auto type_info = TypeInfoFor(message);
     {
       std::unique_lock<std::mutex> lock(mu_);

--- a/src/io/simulator/simulator_handle.hpp
+++ b/src/io/simulator/simulator_handle.hpp
@@ -52,7 +52,7 @@ class SimulatorHandle {
   std::set<Address> blocked_on_receive_;
   std::set<Address> server_addresses_;
   std::mt19937 rng_;
-  std::uniform_int_distribution<int> time_distrib_{0, 1000};
+  std::uniform_int_distribution<int> time_distrib_{0, 30000};
   std::uniform_int_distribution<int> drop_distrib_{0, 99};
   SimulatorConfig config_;
   MessageHistogramCollector histograms_;

--- a/src/io/simulator/simulator_handle.hpp
+++ b/src/io/simulator/simulator_handle.hpp
@@ -170,12 +170,7 @@ class SimulatorHandle {
         }
       }
 
-      lock.unlock();
-      spdlog::info("server calling MaybeTickSimulator");
-      bool made_progress = MaybeTickSimulator();
-      spdlog::info("server returned from MaybeTickSimulator");
-      lock.lock();
-      if (!should_shut_down_ && !made_progress) {
+      if (!should_shut_down_) {
         blocked_on_receive_.emplace(receiver);
         cv_.notify_all();
         spdlog::info("blocking receiver {}", receiver.ToPartialAddress().port);
@@ -202,10 +197,6 @@ class SimulatorHandle {
 
       stats_.total_messages++;
     }  // lock dropped before cv notification
-
-    spdlog::info("sender calling MaybeTickSimulator");
-    MaybeTickSimulator();
-    spdlog::info("sender returned from MaybeTickSimulator");
 
     cv_.notify_all();
   }

--- a/src/io/simulator/simulator_stats.hpp
+++ b/src/io/simulator/simulator_stats.hpp
@@ -30,7 +30,7 @@ struct SimulatorStats {
   friend bool operator==(const SimulatorStats & /* lhs */, const SimulatorStats & /* rhs */) = default;
 
   friend std::ostream &operator<<(std::ostream &in, const SimulatorStats &stats) {
-    auto elapsed_ms = stats.elapsed_time.count() / 1000;
+    auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(stats.elapsed_time).count() / 1000;
 
     std::string formated = fmt::format(
         "SimulatorStats {{ total_messages: {}, dropped_messages: {}, timed_out_requests: {}, total_requests: {}, "

--- a/src/io/simulator/simulator_stats.hpp
+++ b/src/io/simulator/simulator_stats.hpp
@@ -30,7 +30,7 @@ struct SimulatorStats {
   friend bool operator==(const SimulatorStats & /* lhs */, const SimulatorStats & /* rhs */) = default;
 
   friend std::ostream &operator<<(std::ostream &in, const SimulatorStats &stats) {
-    auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(stats.elapsed_time).count() / 1000;
+    auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(stats.elapsed_time).count();
 
     std::string formated = fmt::format(
         "SimulatorStats {{ total_messages: {}, dropped_messages: {}, timed_out_requests: {}, total_requests: {}, "

--- a/src/io/simulator/simulator_stats.hpp
+++ b/src/io/simulator/simulator_stats.hpp
@@ -13,6 +13,8 @@
 
 #include <cstdint>
 
+#include <fmt/format.h>
+
 namespace memgraph::io::simulator {
 struct SimulatorStats {
   uint64_t total_messages = 0;
@@ -22,7 +24,7 @@ struct SimulatorStats {
   uint64_t total_responses = 0;
   uint64_t simulator_ticks = 0;
 
-  friend bool operator==(const SimulatorStats &lhs, const SimulatorStats &rhs) = default;
+  friend bool operator==(const SimulatorStats & /* lhs */, const SimulatorStats & /* rhs */) = default;
 
   friend std::ostream &operator<<(std::ostream &in, const SimulatorStats &stats) {
     std::string formated = fmt::format(

--- a/src/io/simulator/simulator_stats.hpp
+++ b/src/io/simulator/simulator_stats.hpp
@@ -15,6 +15,8 @@
 
 #include <fmt/format.h>
 
+#include "io/time.hpp"
+
 namespace memgraph::io::simulator {
 struct SimulatorStats {
   uint64_t total_messages = 0;
@@ -23,15 +25,18 @@ struct SimulatorStats {
   uint64_t total_requests = 0;
   uint64_t total_responses = 0;
   uint64_t simulator_ticks = 0;
+  Duration elapsed_time;
 
   friend bool operator==(const SimulatorStats & /* lhs */, const SimulatorStats & /* rhs */) = default;
 
   friend std::ostream &operator<<(std::ostream &in, const SimulatorStats &stats) {
+    auto elapsed_ms = stats.elapsed_time.count() / 1000;
+
     std::string formated = fmt::format(
         "SimulatorStats {{ total_messages: {}, dropped_messages: {}, timed_out_requests: {}, total_requests: {}, "
-        "total_responses: {}, simulator_ticks: {} }}",
+        "total_responses: {}, simulator_ticks: {}, elapsed_time: {}ms }}",
         stats.total_messages, stats.dropped_messages, stats.timed_out_requests, stats.total_requests,
-        stats.total_responses, stats.simulator_ticks);
+        stats.total_responses, stats.simulator_ticks, elapsed_ms);
 
     in << formated;
 

--- a/src/io/simulator/simulator_stats.hpp
+++ b/src/io/simulator/simulator_stats.hpp
@@ -21,5 +21,19 @@ struct SimulatorStats {
   uint64_t total_requests = 0;
   uint64_t total_responses = 0;
   uint64_t simulator_ticks = 0;
+
+  friend bool operator==(const SimulatorStats &lhs, const SimulatorStats &rhs) = default;
+
+  friend std::ostream &operator<<(std::ostream &in, const SimulatorStats &stats) {
+    std::string formated = fmt::format(
+        "SimulatorStats {{ total_messages: {}, dropped_messages: {}, timed_out_requests: {}, total_requests: {}, "
+        "total_responses: {}, simulator_ticks: {} }}",
+        stats.total_messages, stats.dropped_messages, stats.timed_out_requests, stats.total_requests,
+        stats.total_responses, stats.simulator_ticks);
+
+    in << formated;
+
+    return in;
+  }
 };
 };  // namespace memgraph::io::simulator

--- a/src/io/simulator/simulator_transport.hpp
+++ b/src/io/simulator/simulator_transport.hpp
@@ -34,12 +34,7 @@ class SimulatorTransport {
 
   template <Message RequestT, Message ResponseT>
   ResponseFuture<ResponseT> Request(Address to_address, Address from_address, RequestT request, Duration timeout) {
-    std::function<bool()> maybe_tick_simulator = [this] {
-      spdlog::info("client calling MaybeTickSimulator");
-      bool ret = simulator_handle_->MaybeTickSimulator();
-      spdlog::info("client returned from MaybeTickSimulator");
-      return ret;
-    };
+    std::function<bool()> maybe_tick_simulator = [this] { return simulator_handle_->MaybeTickSimulator(); };
 
     return simulator_handle_->template SubmitRequest<RequestT, ResponseT>(to_address, from_address, std::move(request),
                                                                           timeout, std::move(maybe_tick_simulator));

--- a/src/io/simulator/simulator_transport.hpp
+++ b/src/io/simulator/simulator_transport.hpp
@@ -34,7 +34,12 @@ class SimulatorTransport {
 
   template <Message RequestT, Message ResponseT>
   ResponseFuture<ResponseT> Request(Address to_address, Address from_address, RequestT request, Duration timeout) {
-    std::function<bool()> maybe_tick_simulator = [this] { return simulator_handle_->MaybeTickSimulator(); };
+    std::function<bool()> maybe_tick_simulator = [this] {
+      spdlog::info("client calling MaybeTickSimulator");
+      bool ret = simulator_handle_->MaybeTickSimulator();
+      spdlog::info("client returned from MaybeTickSimulator");
+      return ret;
+    };
 
     return simulator_handle_->template SubmitRequest<RequestT, ResponseT>(to_address, from_address, std::move(request),
                                                                           timeout, std::move(maybe_tick_simulator));

--- a/src/io/transport.hpp
+++ b/src/io/transport.hpp
@@ -137,7 +137,14 @@ class Io {
   Address GetAddress() { return address_; }
   void SetAddress(Address address) { address_ = address; }
 
-  Io<I> ForkLocal() { return Io(implementation_, address_.ForkUniqueAddress()); }
+  Io<I> ForkLocal(boost::uuids::uuid uuid) {
+    Address new_address{
+        .unique_id = uuid,
+        .last_known_ip = address_.last_known_ip,
+        .last_known_port = address_.last_known_port,
+    };
+    return Io(implementation_, new_address);
+  }
 
   LatencyHistogramSummaries ResponseLatencies() { return implementation_.ResponseLatencies(); }
 };

--- a/src/machine_manager/machine_config.hpp
+++ b/src/machine_manager/machine_config.hpp
@@ -42,6 +42,7 @@ struct MachineConfig {
   boost::asio::ip::address listen_ip;
   uint16_t listen_port;
   size_t shard_worker_threads = std::max(static_cast<unsigned int>(1), std::thread::hardware_concurrency());
+  bool sync_message_handling = false;
 };
 
 }  // namespace memgraph::machine_manager

--- a/src/query/v2/interpreter.cpp
+++ b/src/query/v2/interpreter.cpp
@@ -800,7 +800,11 @@ InterpreterContext::InterpreterContext(storage::v3::Shard *db, const Interpreter
 
 Interpreter::Interpreter(InterpreterContext *interpreter_context) : interpreter_context_(interpreter_context) {
   MG_ASSERT(interpreter_context_, "Interpreter context must not be NULL");
-  auto query_io = interpreter_context_->io.ForkLocal();
+
+  // TODO(tyler) make this deterministic so that it can be tested.
+  auto random_uuid = boost::uuids::uuid{boost::uuids::random_generator()()};
+  auto query_io = interpreter_context_->io.ForkLocal(random_uuid);
+
   shard_request_manager_ = std::make_unique<msgs::ShardRequestManager<io::local_transport::LocalTransport>>(
       coordinator::CoordinatorClient<io::local_transport::LocalTransport>(
           query_io, interpreter_context_->coordinator_address, std::vector{interpreter_context_->coordinator_address}),

--- a/src/storage/v3/shard_manager.hpp
+++ b/src/storage/v3/shard_manager.hpp
@@ -190,6 +190,12 @@ class ShardManager {
                                      });
   }
 
+  void BlockOnQuiescence() {
+    for (const auto &worker : workers_) {
+      worker.BlockOnQuiescence();
+    }
+  }
+
  private:
   io::Io<IoImpl> io_;
   std::vector<shard_worker::Queue> workers_;

--- a/tests/simulation/basic_request.cpp
+++ b/tests/simulation/basic_request.cpp
@@ -109,11 +109,11 @@ int main() {
   auto [sim_stats_2, latency_stats_2] = RunWorkload(config);
 
   if (sim_stats_1 != sim_stats_2 || latency_stats_1 != latency_stats_2) {
-    spdlog::info("simulator stats diverged across runs");
-    spdlog::info("run 1 simulator stats: {}", sim_stats_1);
-    spdlog::info("run 2 simulator stats: {}", sim_stats_2);
-    spdlog::info("run 1 latency:\n{}", latency_stats_1.SummaryTable());
-    spdlog::info("run 2 latency:\n{}", latency_stats_2.SummaryTable());
+    spdlog::error("simulator stats diverged across runs");
+    spdlog::error("run 1 simulator stats: {}", sim_stats_1);
+    spdlog::error("run 2 simulator stats: {}", sim_stats_2);
+    spdlog::error("run 1 latency:\n{}", latency_stats_1.SummaryTable());
+    spdlog::error("run 2 latency:\n{}", latency_stats_2.SummaryTable());
     std::terminate();
   }
 

--- a/tests/simulation/basic_request.cpp
+++ b/tests/simulation/basic_request.cpp
@@ -9,17 +9,25 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+#include <memory>
 #include <thread>
 
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <spdlog/cfg/env.h>
+
+#include "io/message_histogram_collector.hpp"
 #include "io/simulator/simulator.hpp"
 #include "utils/print_helpers.hpp"
 
 using memgraph::io::Address;
 using memgraph::io::Io;
+using memgraph::io::LatencyHistogramSummaries;
 using memgraph::io::ResponseFuture;
 using memgraph::io::ResponseResult;
 using memgraph::io::simulator::Simulator;
 using memgraph::io::simulator::SimulatorConfig;
+using memgraph::io::simulator::SimulatorStats;
 using memgraph::io::simulator::SimulatorTransport;
 
 struct CounterRequest {
@@ -40,6 +48,7 @@ void run_server(Io<SimulatorTransport> io) {
       std::cout << "[SERVER] Error, continue" << std::endl;
       continue;
     }
+    std::cout << "[SERVER] Got message" << std::endl;
     auto request_envelope = request_result.GetValue();
     auto req = std::get<CounterRequest>(request_envelope.message);
 
@@ -50,13 +59,7 @@ void run_server(Io<SimulatorTransport> io) {
   }
 }
 
-int main() {
-  auto config = SimulatorConfig{
-      .drop_percent = 0,
-      .perform_timeouts = true,
-      .scramble_messages = true,
-      .rng_seed = 0,
-  };
+std::pair<SimulatorStats, LatencyHistogramSummaries> RunWorkload(SimulatorConfig &config) {
   auto simulator = Simulator(config);
 
   auto cli_addr = Address::TestAddress(1);
@@ -72,21 +75,47 @@ int main() {
     // send request
     CounterRequest cli_req;
     cli_req.proposal = i;
+    spdlog::info("[CLIENT] calling Request");
     auto res_f = cli_io.Request<CounterRequest, CounterResponse>(srv_addr, cli_req);
+    spdlog::info("[CLIENT] calling Wait");
     auto res_rez = std::move(res_f).Wait();
+    spdlog::info("[CLIENT] Wait returned");
     if (!res_rez.HasError()) {
-      std::cout << "[CLIENT] Got a valid response" << std::endl;
+      spdlog::info("[CLIENT] Got a valid response");
       auto env = res_rez.GetValue();
       MG_ASSERT(env.message.highest_seen == i);
-      std::cout << "response latency: " << env.response_latency.count() << " microseconds" << std::endl;
+      spdlog::info("response latency: {} microseconds", env.response_latency.count());
     } else {
-      std::cout << "[CLIENT] Got an error" << std::endl;
+      spdlog::info("[CLIENT] Got an error");
     }
   }
 
-  using memgraph::utils::print_helpers::operator<<;
-  std::cout << "response latencies: " << cli_io.ResponseLatencies() << std::endl;
-
   simulator.ShutDown();
+
+  return std::make_pair(simulator.Stats(), cli_io.ResponseLatencies());
+}
+
+int main() {
+  spdlog::cfg::load_env_levels();
+
+  auto config = SimulatorConfig{
+      .drop_percent = 0,
+      .perform_timeouts = true,
+      .scramble_messages = true,
+      .rng_seed = 0,
+  };
+
+  auto [sim_stats_1, latency_stats_1] = RunWorkload(config);
+  auto [sim_stats_2, latency_stats_2] = RunWorkload(config);
+
+  if (sim_stats_1 != sim_stats_2 || latency_stats_1 != latency_stats_2) {
+    spdlog::info("simulator stats diverged across runs");
+    spdlog::info("run 1 simulator stats: {}", sim_stats_1);
+    spdlog::info("run 2 simulator stats: {}", sim_stats_2);
+    spdlog::info("run 1 latency:\n{}", latency_stats_1.SummaryTable());
+    spdlog::info("run 2 latency:\n{}", latency_stats_2.SummaryTable());
+    std::terminate();
+  }
+
   return 0;
 }

--- a/tests/simulation/raft.cpp
+++ b/tests/simulation/raft.cpp
@@ -275,8 +275,6 @@ int main() {
       spdlog::error("run 2 latency:\n{}", latency_stats_2.SummaryTable());
       std::terminate();
     }
-    spdlog::info("run 1 simulator stats: {}", sim_stats_1);
-    spdlog::info("run 2 simulator stats: {}", sim_stats_2);
   }
 
   spdlog::info("passed {} tests!", n_tests);

--- a/tests/simulation/raft.cpp
+++ b/tests/simulation/raft.cpp
@@ -185,6 +185,7 @@ std::pair<SimulatorStats, LatencyHistogramSummaries> RunSimulation(SimulatorConf
 
     auto write_cas_response_result = client.SendWriteRequest(cas_req);
     if (write_cas_response_result.HasError()) {
+      spdlog::debug("timed out");
       // timed out
       continue;
     }

--- a/tests/simulation/raft.cpp
+++ b/tests/simulation/raft.cpp
@@ -240,13 +240,6 @@ std::pair<SimulatorStats, LatencyHistogramSummaries> RunSimulation(SimulatorConf
   spdlog::info("========================== SUCCESS :) ==========================");
 
   return std::make_pair(simulator.Stats(), cli_io.ResponseLatencies());
-
-  /*
-  this is implicit in jthread's dtor
-  srv_thread_1.join();
-  srv_thread_2.join();
-  srv_thread_3.join();
-  */
 }
 
 int main() {
@@ -264,25 +257,26 @@ int main() {
   };
 
   for (int i = 0; i < n_tests; i++) {
-    spdlog::error("========================== NEW SIMULATION SEED {} ==========================", i);
     spdlog::info("\tTime\t\tTerm\tPort\tRole\t\tMessage\n");
 
     // this is vital to cause tests to behave differently across runs
     config.rng_seed = i;
 
+    spdlog::info("========================== NEW SIMULATION SEED {} ==========================", i);
     auto [sim_stats_1, latency_stats_1] = RunSimulation(config);
+    spdlog::info("========================== NEW SIMULATION SEED {} ==========================", i);
     auto [sim_stats_2, latency_stats_2] = RunSimulation(config);
 
     if (sim_stats_1 != sim_stats_2 || latency_stats_1 != latency_stats_2) {
-      spdlog::error("simulator stats diverged across runs");
+      spdlog::error("simulator stats diverged across runs for test rng_seed {}", i);
       spdlog::error("run 1 simulator stats: {}", sim_stats_1);
       spdlog::error("run 2 simulator stats: {}", sim_stats_2);
       spdlog::error("run 1 latency:\n{}", latency_stats_1.SummaryTable());
       spdlog::error("run 2 latency:\n{}", latency_stats_2.SummaryTable());
       std::terminate();
     }
-    spdlog::error("run 1 simulator stats: {}", sim_stats_1);
-    spdlog::error("run 2 simulator stats: {}", sim_stats_2);
+    spdlog::info("run 1 simulator stats: {}", sim_stats_1);
+    spdlog::info("run 2 simulator stats: {}", sim_stats_2);
   }
 
   spdlog::info("passed {} tests!", n_tests);

--- a/tests/simulation/raft.cpp
+++ b/tests/simulation/raft.cpp
@@ -250,7 +250,7 @@ void RunWithSeed(uint64_t seed) {
       .scramble_messages = true,
       .rng_seed = seed,
       .start_time = Time::min() + std::chrono::microseconds{256 * 1024},
-      .abort_time = Time::max(),
+      .abort_time = Time::min() + std::chrono::seconds{3600},
   };
 
   spdlog::error("========================== NEW SIMULATION, replay with RunWithSeed({}) ==========================",

--- a/tests/simulation/raft.cpp
+++ b/tests/simulation/raft.cpp
@@ -253,8 +253,8 @@ void RunWithSeed(uint64_t seed) {
       .abort_time = Time::max(),
   };
 
-  spdlog::info("========================== NEW SIMULATION, replay with RunWithSeed({}) ==========================",
-               seed);
+  spdlog::error("========================== NEW SIMULATION, replay with RunWithSeed({}) ==========================",
+                seed);
   spdlog::info("\tTime\t\tTerm\tPort\tRole\t\tMessage\n");
   auto [sim_stats_1, latency_stats_1] = RunSimulation(config);
 

--- a/tests/simulation/raft.cpp
+++ b/tests/simulation/raft.cpp
@@ -224,6 +224,10 @@ std::pair<SimulatorStats, LatencyHistogramSummaries> RunSimulation(SimulatorConf
 
   simulator.ShutDown();
 
+  srv_thread_1.join();
+  srv_thread_2.join();
+  srv_thread_3.join();
+
   SimulatorStats stats = simulator.Stats();
 
   spdlog::info("total messages:     {}", stats.total_messages);

--- a/tests/simulation/shard_rsm.cpp
+++ b/tests/simulation/shard_rsm.cpp
@@ -1115,11 +1115,12 @@ int TestMessages() {
   ConcreteShardRsm shard_server3(std::move(shard_server_io_3), address_for_3, ShardRsm(std::move(shard_ptr3)));
 
   auto server_thread1 = std::jthread([&shard_server1]() { shard_server1.Run(); });
-  auto server_thread2 = std::jthread([&shard_server2]() { shard_server2.Run(); });
-  auto server_thread3 = std::jthread([&shard_server3]() { shard_server3.Run(); });
-
   simulator.IncrementServerCountAndWaitForQuiescentState(shard_server_1_address);
+
+  auto server_thread2 = std::jthread([&shard_server2]() { shard_server2.Run(); });
   simulator.IncrementServerCountAndWaitForQuiescentState(shard_server_2_address);
+
+  auto server_thread3 = std::jthread([&shard_server3]() { shard_server3.Run(); });
   simulator.IncrementServerCountAndWaitForQuiescentState(shard_server_3_address);
 
   std::cout << "Beginning test after servers have become quiescent." << std::endl;


### PR DESCRIPTION
This makes the simulated tests deterministic for basic_request, multithreaded raft tests, and the cluster property tests. 

Determinism is tested explicitly by running tests twice and asserting that the simulator stats and latency histograms are identical, so if we accidentally add non-deterministic behavior, the tests will hopefully flag it quickly. There are cases where threads will behave slightly differently in-between simulator ticks, but this is fine, because the actual cross-thread communication points are fully controlled now, which is the extent of the partial order that we must impose to achieve the goal of replayable tests.