### PR TITLE
[master <- ] Add support for -h to show help in addition to --help

### DIFF
--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -135,6 +135,7 @@ std::optional<Enum> StringToEnum(const auto &value, const auto &mappings) {
 }  // namespace
 
 // Short help flag.
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_bool(h, false, "Print usage and exit.");
 
 // Bolt server flags.

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -136,7 +136,7 @@ std::optional<Enum> StringToEnum(const auto &value, const auto &mappings) {
 
 // Short help flag.
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_bool(h, false, "Print usage and exit.");
+DEFINE_HIDDEN_bool(h, false, "Print usage and exit.");
 
 // Bolt server flags.
 DEFINE_string(bolt_address, "0.0.0.0", "IP address on which the Bolt server should listen.");

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -134,6 +134,9 @@ std::optional<Enum> StringToEnum(const auto &value, const auto &mappings) {
 }
 }  // namespace
 
+// Short help flag.
+DEFINE_bool(h, false, "Print usage and exit.");
+
 // Bolt server flags.
 DEFINE_string(bolt_address, "0.0.0.0", "IP address on which the Bolt server should listen.");
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
@@ -686,6 +689,11 @@ int main(int argc, char **argv) {
   // overwrite the config.
   LoadConfig("memgraph");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  if (FLAGS_h) {
+    gflags::ShowUsageWithFlags(argv[0]);
+    exit(1);
+  }
 
   InitializeLogger();
 

--- a/tests/e2e/configuration/configuration_check.py
+++ b/tests/e2e/configuration/configuration_check.py
@@ -10,10 +10,10 @@
 # licenses/APL.txt.
 
 import sys
-import mgclient
-import pytest
 
 import default_config
+import mgclient
+import pytest
 
 
 def test_does_default_config_match():
@@ -24,7 +24,15 @@ def test_does_default_config_match():
     cursor.execute("SHOW CONFIG")
     config = cursor.fetchall()
 
-    assert len(config) == len(default_config.startup_config_dict)
+    define_msg = """
+        If this test fails after adding a new DEFINE_* flag,
+        you should decide whether your new flag needs to be
+        returned in the SHOW CONFIG command. If not, please
+        use the DEFINE_HIDDEN_* macro instead of DEFINE_* to
+        prevent SHOW CONFIG from returning it.
+    """
+
+    assert len(config) == len(default_config.startup_config_dict), define_msg
 
     for flag in config:
         flag_name = flag[0]


### PR DESCRIPTION
before:
```
λ ./memgraph -h
ERROR: unknown command line flag 'h'
```

after is same as --help