### PR TITLE
[master < T1213] Match not allowed on replica

### DIFF
--- a/src/query/plan/read_write_type_checker.cpp
+++ b/src/query/plan/read_write_type_checker.cpp
@@ -101,7 +101,7 @@ void ReadWriteTypeChecker::UpdateType(RWType op_type) {
   // if op_type is NONE, type doesn't change.
   if (op_type == RWType::NONE) {
     return;
-  }  
+  }
 
   // Update type only if it's not the NONE type and the current operator's type
   // is different than the one that's currently inferred.
@@ -109,7 +109,7 @@ void ReadWriteTypeChecker::UpdateType(RWType op_type) {
     type = RWType::RW;
   }
 
-  if (type == RWType::NONE && op_type != RWType::NONE) {
+  if (type == RWType::NONE) {
     type = op_type;
   }
 }

--- a/src/query/plan/read_write_type_checker.cpp
+++ b/src/query/plan/read_write_type_checker.cpp
@@ -91,17 +91,24 @@ bool ReadWriteTypeChecker::PreVisit([[maybe_unused]] Foreach &op) {
 bool ReadWriteTypeChecker::Visit(Once &) { return false; }  // NOLINT(hicpp-named-parameter)
 
 void ReadWriteTypeChecker::UpdateType(RWType op_type) {
-  // Update type only if it's not the NONE type and the current operator's type
-  // is different than the one that's currently inferred.
-  if (type != RWType::NONE && type != op_type) {
-    type = RWType::RW;
-  }
   // Stop inference because RW is the most "dominant" type, i.e. it isn't
   // affected by the type of nodes in the plan appearing after the node for
   // which the type is set to RW.
   if (type == RWType::RW) {
     return;
   }
+
+  // if op_type is NONE, type doesn't change.
+  if (op_type == RWType::NONE) {
+    return;
+  }  
+
+  // Update type only if it's not the NONE type and the current operator's type
+  // is different than the one that's currently inferred.
+  if (type != RWType::NONE && type != op_type) {
+    type = RWType::RW;
+  }
+
   if (type == RWType::NONE && op_type != RWType::NONE) {
     type = op_type;
   }

--- a/src/query/plan/read_write_type_checker.hpp
+++ b/src/query/plan/read_write_type_checker.hpp
@@ -15,7 +15,7 @@
 
 namespace memgraph::query::plan {
 
-class ReadWriteTypeChecker : public virtual HierarchicalLogicalOperatorVisitor {
+struct ReadWriteTypeChecker : public virtual HierarchicalLogicalOperatorVisitor {
  public:
   ReadWriteTypeChecker() = default;
 
@@ -89,7 +89,6 @@ class ReadWriteTypeChecker : public virtual HierarchicalLogicalOperatorVisitor {
 
   bool Visit(Once &) override;
 
- private:
   void UpdateType(RWType op_type);
 };
 

--- a/tests/unit/query_plan_read_write_typecheck.cpp
+++ b/tests/unit/query_plan_read_write_typecheck.cpp
@@ -253,3 +253,23 @@ TEST_F(ReadWriteTypeCheckTest, Foreach) {
   std::shared_ptr<LogicalOperator> foreach = std::make_shared<plan::Foreach>(nullptr, nullptr, nullptr, x);
   CheckPlanType(foreach.get(), RWType::RW);
 }
+
+TEST_F(ReadWriteTypeCheckTest, CheckUpdateType) {
+  RWType scenarios[16][3] = {
+      {RWType::NONE, RWType::NONE, RWType::NONE}, {RWType::NONE, RWType::R, RWType::R},
+      {RWType::NONE, RWType::W, RWType::W},       {RWType::NONE, RWType::RW, RWType::RW},
+      {RWType::R, RWType::NONE, RWType::R},       {RWType::R, RWType::R, RWType::R},
+      {RWType::R, RWType::W, RWType::RW},         {RWType::R, RWType::RW, RWType::RW},
+      {RWType::W, RWType::NONE, RWType::W},       {RWType::W, RWType::R, RWType::RW},
+      {RWType::W, RWType::W, RWType::W},          {RWType::W, RWType::RW, RWType::RW},
+      {RWType::RW, RWType::NONE, RWType::RW},     {RWType::RW, RWType::R, RWType::RW},
+      {RWType::RW, RWType::W, RWType::RW},        {RWType::RW, RWType::RW, RWType::RW},
+  };
+
+  auto rw_type_checker = ReadWriteTypeChecker();
+  for (auto scenario : scenarios) {
+    rw_type_checker.type = scenario[0];
+    rw_type_checker.UpdateType(scenario[1]);
+    EXPECT_EQ(scenario[2], rw_type_checker.type);
+  }
+}

--- a/tests/unit/query_plan_read_write_typecheck.cpp
+++ b/tests/unit/query_plan_read_write_typecheck.cpp
@@ -255,16 +255,24 @@ TEST_F(ReadWriteTypeCheckTest, Foreach) {
 }
 
 TEST_F(ReadWriteTypeCheckTest, CheckUpdateType) {
-  RWType scenarios[16][3] = {
-      {RWType::NONE, RWType::NONE, RWType::NONE}, {RWType::NONE, RWType::R, RWType::R},
-      {RWType::NONE, RWType::W, RWType::W},       {RWType::NONE, RWType::RW, RWType::RW},
-      {RWType::R, RWType::NONE, RWType::R},       {RWType::R, RWType::R, RWType::R},
-      {RWType::R, RWType::W, RWType::RW},         {RWType::R, RWType::RW, RWType::RW},
-      {RWType::W, RWType::NONE, RWType::W},       {RWType::W, RWType::R, RWType::RW},
-      {RWType::W, RWType::W, RWType::W},          {RWType::W, RWType::RW, RWType::RW},
-      {RWType::RW, RWType::NONE, RWType::RW},     {RWType::RW, RWType::R, RWType::RW},
-      {RWType::RW, RWType::W, RWType::RW},        {RWType::RW, RWType::RW, RWType::RW},
-  };
+  std::array<std::array<RWType, 3>, 16> scenarios = {{
+      {RWType::NONE, RWType::NONE, RWType::NONE},
+      {RWType::NONE, RWType::R, RWType::R},
+      {RWType::NONE, RWType::W, RWType::W},
+      {RWType::NONE, RWType::RW, RWType::RW},
+      {RWType::R, RWType::NONE, RWType::R},
+      {RWType::R, RWType::R, RWType::R},
+      {RWType::R, RWType::W, RWType::RW},
+      {RWType::R, RWType::RW, RWType::RW},
+      {RWType::W, RWType::NONE, RWType::W},
+      {RWType::W, RWType::R, RWType::RW},
+      {RWType::W, RWType::W, RWType::W},
+      {RWType::W, RWType::RW, RWType::RW},
+      {RWType::RW, RWType::NONE, RWType::RW},
+      {RWType::RW, RWType::R, RWType::RW},
+      {RWType::RW, RWType::W, RWType::RW},
+      {RWType::RW, RWType::RW, RWType::RW},
+  }};
 
   auto rw_type_checker = ReadWriteTypeChecker();
   for (auto scenario : scenarios) {


### PR DESCRIPTION
Closes #705 
^ wrote my view on the problem in the issue. I believe the bug is in the updating of query `rw_type` which I amended here using my own logic and experience from that issue.


[master < Epic] PR
- [ ] Check, and update documentation if necessary
- [ ] Update [changelog](https://docs.memgraph.com/memgraph/changelog)
- [ ] Write E2E tests
- [ ] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch and the Epic branch
- [ ] Provide the full content or a guide for the final git message

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Update [changelog](https://docs.memgraph.com/memgraph/changelog)
- [ ] Provide the full content or a guide for the final git message
