### PR TITLE
Update build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Build modern, graph-based applications on top of your streaming data in minutes.
 
 <p align="center">
   <a href="https://github.com/memgraph/memgraph">
-    <img src="https://img.shields.io/github/workflow/status/memgraph/memgraph/Release%20Ubuntu%2020.04/master" alt="build" title="build"/>
+     <img src="https://img.shields.io/github/actions/workflow/status/memgraph/memgraph/release_debian10.yaml?branch=master&label=build%20and%20test&logo=github"/>
   </a>
   <a href="https://memgraph.com/docs/" alt="Documentation">
     <img src="https://img.shields.io/badge/documentation-Memgraph-orange" />


### PR DESCRIPTION
I updated the build badge because of the shields [issue](https://github.com/badges/shields/issues/8671).
Release Ubuntu which we had, was failing, so I changed it to Debian. Why is that?