### PR TITLE
[master < T1201] Run mgbench diff under 30 min

### DIFF
--- a/tests/mgbench/benchmark.py
+++ b/tests/mgbench/benchmark.py
@@ -142,7 +142,7 @@ parser.add_argument(
     with the presence of 300 write queries from write type or 30%""",
 )
 
-parser.add_argument("--tail-latency", type=int, default=100, help="Number of queries for the tail latency statistics")
+parser.add_argument("--tail-latency", type=int, default=30, help="Number of queries for the tail latency statistics")
 
 parser.add_argument(
     "--performance-tracking",

--- a/tests/mgbench/benchmark.py
+++ b/tests/mgbench/benchmark.py
@@ -223,13 +223,14 @@ def filter_benchmarks(generators, patterns):
                         patterns,
                     ):
                         current[group].append((query_name, query_func))
-            if len(current) > 0:
+            if len(current) == 0:
+              continue
                 # Ignore benchgraph "basic" queries in standard CI/CD run
                 for pattern in patterns:
                     res = pattern.count("*")
                     key = "basic"
                     if res >= 2 and key in current.keys():
-                        del current[key]
+                        current.pop(key)
 
                 filtered.append((generator(variant, args.vendor_name), dict(current)))
     return filtered
@@ -249,7 +250,7 @@ def warmup(client):
 
 def tail_latency(vendor, client, func):
     iteration = args.tail_latency
-    if iteration != 0 and iteration >= 10:
+    if iteration >= 10:
         vendor.start_benchmark("tail_latency")
         if args.warmup_run:
             warmup(client)

--- a/tests/mgbench/benchmark.py
+++ b/tests/mgbench/benchmark.py
@@ -224,15 +224,16 @@ def filter_benchmarks(generators, patterns):
                     ):
                         current[group].append((query_name, query_func))
             if len(current) == 0:
-              continue
-                # Ignore benchgraph "basic" queries in standard CI/CD run
-                for pattern in patterns:
-                    res = pattern.count("*")
-                    key = "basic"
-                    if res >= 2 and key in current.keys():
-                        current.pop(key)
+                continue
 
-                filtered.append((generator(variant, args.vendor_name), dict(current)))
+            # Ignore benchgraph "basic" queries in standard CI/CD run
+            for pattern in patterns:
+                res = pattern.count("*")
+                key = "basic"
+                if res >= 2 and key in current.keys():
+                    current.pop(key)
+
+            filtered.append((generator(variant, args.vendor_name), dict(current)))
     return filtered
 
 

--- a/tests/mgbench/benchmark.py
+++ b/tests/mgbench/benchmark.py
@@ -142,7 +142,7 @@ parser.add_argument(
     with the presence of 300 write queries from write type or 30%""",
 )
 
-parser.add_argument("--tail-latency", type=int, default=30, help="Number of queries for the tail latency statistics")
+parser.add_argument("--tail-latency", type=int, default=10, help="Number of queries for the tail latency statistics")
 
 parser.add_argument(
     "--performance-tracking",

--- a/tests/mgbench/benchmark.py
+++ b/tests/mgbench/benchmark.py
@@ -224,6 +224,13 @@ def filter_benchmarks(generators, patterns):
                     ):
                         current[group].append((query_name, query_func))
             if len(current) > 0:
+                # Ignore benchgraph "basic" queries in standard CI/CD run
+                for pattern in patterns:
+                    res = pattern.count("*")
+                    key = "basic"
+                    if res >= 2 and key in current.keys():
+                        del current[key]
+
                 filtered.append((generator(variant, args.vendor_name), dict(current)))
     return filtered
 

--- a/tests/mgbench/graph_bench.py
+++ b/tests/mgbench/graph_bench.py
@@ -147,6 +147,8 @@ def run_full_benchmarks(vendor, binary, dataset_size, dataset_group, realistic, 
         "12",
         "--no-authorization",
         "pokec/" + dataset_size + "/" + dataset_group + "/*",
+        "--tail-latency",
+        "100",
     ]
 
     for config in configurations:


### PR DESCRIPTION
[master < Task] PR
- [x] Provide the full content or a guide for the final git message

The bench graph basic queries are ignored in standard CI/CD call `pokec/medium/*/*.` Tail latency has been turned off by default. Since latency is not present at the grafana at the moment.  