### PR TITLE
[master < T1220-MG] Fix bug on properties in c++ api

### DIFF
--- a/include/_mgp.hpp
+++ b/include/_mgp.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -378,6 +378,10 @@ inline mgp_value *vertex_get_property(mgp_vertex *v, const char *property_name, 
   return MgInvoke<mgp_value *>(mgp_vertex_get_property, v, property_name, memory);
 }
 
+inline void vertex_set_property(mgp_vertex *v, const char *property_name, mgp_value *property_value) {
+  MgInvokeVoid(mgp_vertex_set_property, v, property_name, property_value);
+}
+
 inline mgp_properties_iterator *vertex_iter_properties(mgp_vertex *v, mgp_memory *memory) {
   return MgInvoke<mgp_properties_iterator *>(mgp_vertex_iter_properties, v, memory);
 }
@@ -408,6 +412,10 @@ inline mgp_vertex *edge_get_to(mgp_edge *e) { return MgInvoke<mgp_vertex *>(mgp_
 
 inline mgp_value *edge_get_property(mgp_edge *e, const char *property_name, mgp_memory *memory) {
   return MgInvoke<mgp_value *>(mgp_edge_get_property, e, property_name, memory);
+}
+
+inline void edge_set_property(mgp_edge *e, const char *property_name, mgp_value *property_value) {
+  MgInvokeVoid(mgp_edge_set_property, e, property_name, property_value);
 }
 
 inline mgp_properties_iterator *edge_iter_properties(mgp_edge *e, mgp_memory *memory) {

--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -564,7 +564,7 @@ class Node {
   /// @brief Returns an iterable & indexable structure of the node’s properties.
   std::map<std::string, Value> Properties() const;
 
-  void SetProperty(std::string property, Value value) const;
+  void SetProperty(std::string property, Value value);
 
   Value GetProperty(const std::string &property) const;
 
@@ -619,7 +619,7 @@ class Relationship {
   /// @brief Returns an std::map of the relationship’s properties.
   std::map<std::string, Value> Properties() const;
 
-  void SetProperty(std::string property, Value value) const;
+  void SetProperty(std::string property, Value value);
 
   Value GetProperty(const std::string &property) const;
 
@@ -2324,17 +2324,16 @@ inline void Node::AddLabel(const std::string_view label) {
 
 inline std::map<std::string, Value> Node::Properties() const {
   mgp_properties_iterator *properties_iterator = mgp::vertex_iter_properties(ptr_, memory);
-  std::map<std::string, Value> property_map_;
+  std::map<std::string, Value> property_map;
   for (auto *property = mgp::properties_iterator_get(properties_iterator); property;
        property = mgp::properties_iterator_next(properties_iterator)) {
-    auto value = Value(property->value);
-    property_map_.emplace(std::string(property->name), value);
+    property_map.emplace(std::string(property->name), Value(property->value));
   }
   mgp::properties_iterator_destroy(properties_iterator);
-  return property_map_;
+  return property_map;
 }
 
-inline void Node::SetProperty(std::string property, Value value) const {
+inline void Node::SetProperty(std::string property, Value value) {
   mgp::vertex_set_property(ptr_, property.data(), value.ptr());
 }
 
@@ -2391,22 +2390,22 @@ inline std::string_view Relationship::Type() const { return mgp::edge_get_type(p
 
 inline std::map<std::string, Value> Relationship::Properties() const {
   mgp_properties_iterator *properties_iterator = mgp::edge_iter_properties(ptr_, memory);
-  std::map<std::string, Value> property_map_;
+  std::map<std::string, Value> property_map;
   for (mgp_property *property = mgp::properties_iterator_get(properties_iterator); property;
        property = mgp::properties_iterator_next(properties_iterator)) {
-    Value value = Value(property->value);
-    property_map_.emplace(property->name, value);
+    property_map.emplace(property->name, Value(property->value));
   }
   mgp::properties_iterator_destroy(properties_iterator);
-  return property_map_;
+  return property_map;
 }
 
-inline void Relationship::SetProperty(std::string property, Value value) const {
+inline void Relationship::SetProperty(std::string property, Value value) {
   mgp::edge_set_property(ptr_, property.data(), value.ptr());
 }
 
 inline Value Relationship::GetProperty(const std::string &property) const {
-  return Value(mgp::edge_get_property(ptr_, property.data(), memory));
+  mgp_value *edge_prop = mgp::edge_get_property(ptr_, property.data(), memory);
+  return Value(&edge_prop);
 }
 
 inline Node Relationship::From() const { return Node(mgp::edge_get_from(ptr_)); }

--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -2331,7 +2331,7 @@ inline std::map<std::string, Value> Node::Properties() const {
     property_map_.emplace(std::string(property->name), value);
   }
   mgp::properties_iterator_destroy(properties_iterator);
-  return std::move(property_map_);
+  return property_map_;
 }
 
 inline void Node::SetProperty(std::string property, Value value) const {
@@ -2398,7 +2398,7 @@ inline std::map<std::string, Value> Relationship::Properties() const {
     property_map_.emplace(property->name, value);
   }
   mgp::properties_iterator_destroy(properties_iterator);
-  return std::move(property_map_);
+  return property_map_;
 }
 
 inline void Relationship::SetProperty(std::string property, Value value) const {

--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -66,6 +66,9 @@ struct MapItem;
 class Duration;
 class Value;
 
+struct StealType {};
+inline constexpr StealType steal{};
+
 inline mgp_memory *memory{nullptr};
 
 /* #region Graph (Id, Graph, Nodes, GraphRelationships, Relationships & Labels) */
@@ -954,7 +957,6 @@ class Value {
 
   explicit Value(mgp_value *ptr);
 
-  struct StealType {};
   explicit Value(StealType /*steal*/, mgp_value *ptr);
 
   // Null constructor:
@@ -1544,8 +1546,6 @@ inline Type ToAPIType(mgp_value_type type) {
 /* #region Graph (Id, Graph, Nodes, GraphRelationships, Relationships, Properties & Labels) */
 
 // Id:
-
-inline constexpr Value::StealType steal{};
 
 inline Id Id::FromUint(uint64_t id) { return Id(util::MemcpyCast<int64_t>(id)); }
 
@@ -2343,7 +2343,7 @@ inline void Node::SetProperty(std::string property, Value value) {
 
 inline Value Node::GetProperty(const std::string &property) const {
   mgp_value *vertex_prop = mgp::vertex_get_property(ptr_, property.data(), memory);
-  return Value(mgp::steal, vertex_prop);
+  return Value(steal, vertex_prop);
 }
 
 inline bool Node::operator<(const Node &other) const { return Id() < other.Id(); }
@@ -2409,7 +2409,7 @@ inline void Relationship::SetProperty(std::string property, Value value) {
 
 inline Value Relationship::GetProperty(const std::string &property) const {
   mgp_value *edge_prop = mgp::edge_get_property(ptr_, property.data(), memory);
-  return Value(mgp::steal, edge_prop);
+  return Value(steal, edge_prop);
 }
 
 inline Node Relationship::From() const { return Node(mgp::edge_get_from(ptr_)); }
@@ -2885,7 +2885,7 @@ inline bool Duration::operator<(const Duration &other) const {
 /* #region Value */
 
 inline Value::Value(mgp_value *ptr) : ptr_(mgp::value_copy(ptr, memory)) {}
-inline Value::Value(StealType /*steal*/, mgp_value *ptr) : ptr_{ptr} {};
+inline Value::Value(StealType /*steal*/, mgp_value *ptr) : ptr_{ptr} {}
 
 inline Value::Value() : ptr_(mgp::value_make_null(memory)) {}
 

--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -293,18 +293,18 @@ class Properties {
 
   /// @brief Returns the value associated with the given `key`. If there’s no such value, the behavior is undefined.
   /// @note Each key-value pair needs to be checked, ensuing O(n) time complexity.
-  Value operator[](const std::string_view key) const;
+  Value operator[](const std::string &key) const;
 
-  std::map<std::string_view, Value>::const_iterator begin() const;
-  std::map<std::string_view, Value>::const_iterator end() const;
+  std::map<std::string, Value>::const_iterator begin() const;
+  std::map<std::string, Value>::const_iterator end() const;
 
-  std::map<std::string_view, Value>::const_iterator cbegin() const;
-  std::map<std::string_view, Value>::const_iterator cend() const;
+  std::map<std::string, Value>::const_iterator cbegin() const;
+  std::map<std::string, Value>::const_iterator cend() const;
 
   /// @brief Returns the key-value iterator for the given `key`. If there’s no such pair, returns the end of the
   /// iterator.
   /// @note Each key-value pair needs to be checked, ensuing O(n) time complexity.
-  std::map<std::string_view, Value>::const_iterator find(const std::string_view key) const;
+  std::map<std::string, Value>::const_iterator find(const std::string &key) const;
 
   /// @exception std::runtime_error Map contains value(s) of unknown type.
   bool operator==(const Properties &other) const;
@@ -312,7 +312,7 @@ class Properties {
   bool operator!=(const Properties &other) const;
 
  private:
-  std::map<const std::string_view, Value> property_map_;
+  std::map<const std::string, Value> property_map_;
 };
 
 /// @brief View of node labels.
@@ -599,7 +599,7 @@ class Node {
   class Properties Properties() const;
 
   /// @brief Returns the value of the node’s `property_name` property.
-  Value operator[](const std::string_view property_name) const;
+  Value operator[](const std::string &property_name) const;
 
   /// @brief Returns an iterable structure of the node’s inbound relationships.
   Relationships InRelationships() const;
@@ -653,7 +653,7 @@ class Relationship {
   class Properties Properties() const;
 
   /// @brief Returns the value of the relationship’s `property_name` property.
-  Value operator[](const std::string_view property_name) const;
+  Value operator[](const std::string &property_name) const;
 
   /// @brief Returns the relationship’s source node.
   Node From() const;
@@ -1966,10 +1966,10 @@ inline Relationships::Iterator Relationships::cend() const { return Iterator(nul
 // Properties:
 
 inline Properties::Properties(mgp_properties_iterator *properties_iterator) {
-  for (auto property = mgp::properties_iterator_get(properties_iterator); property;
+  for (auto *property = mgp::properties_iterator_get(properties_iterator); property;
        property = mgp::properties_iterator_next(properties_iterator)) {
     auto value = Value(property->value);
-    property_map_.emplace(property->name, value);
+    property_map_.emplace(std::string(property->name), value);
   }
   mgp::properties_iterator_destroy(properties_iterator);
 }
@@ -1978,15 +1978,15 @@ inline size_t Properties::Size() const { return property_map_.size(); }
 
 inline bool Properties::Empty() const { return Size() == 0; }
 
-inline Value Properties::operator[](const std::string_view key) const { return property_map_.at(key); }
+inline Value Properties::operator[](const std::string &key) const { return property_map_.at(key); }
 
-inline std::map<std::string_view, Value>::const_iterator Properties::begin() const { return property_map_.begin(); }
+inline std::map<std::string, Value>::const_iterator Properties::begin() const { return property_map_.begin(); }
 
-inline std::map<std::string_view, Value>::const_iterator Properties::end() const { return property_map_.end(); }
+inline std::map<std::string, Value>::const_iterator Properties::end() const { return property_map_.end(); }
 
-inline std::map<std::string_view, Value>::const_iterator Properties::cbegin() const { return property_map_.cbegin(); }
+inline std::map<std::string, Value>::const_iterator Properties::cbegin() const { return property_map_.cbegin(); }
 
-inline std::map<std::string_view, Value>::const_iterator Properties::cend() const { return property_map_.cend(); }
+inline std::map<std::string, Value>::const_iterator Properties::cend() const { return property_map_.cend(); }
 
 inline bool Properties::operator==(const Properties &other) const { return property_map_ == other.property_map_; }
 
@@ -2306,7 +2306,7 @@ inline void Map::Insert(std::string_view key, Value &&value) {
   value.ptr_ = nullptr;
 }
 
-inline std::map<std::string_view, Value>::const_iterator Properties::find(const std::string_view key) const {
+inline std::map<std::string, Value>::const_iterator Properties::find(const std::string &key) const {
   return property_map_.find(key);
 }
 
@@ -2368,7 +2368,7 @@ inline bool Node::HasLabel(std::string_view label) const {
 
 inline class Properties Node::Properties() const { return mgp::Properties(mgp::vertex_iter_properties(ptr_, memory)); }
 
-inline Value Node::operator[](const std::string_view property_name) const { return Properties()[property_name]; }
+inline Value Node::operator[](const std::string &property_name) const { return Properties()[property_name]; }
 
 inline Relationships Node::InRelationships() const {
   auto relationship_iterator = mgp::vertex_iter_in_edges(ptr_, memory);
@@ -2440,9 +2440,7 @@ inline class Properties Relationship::Properties() const {
   return mgp::Properties(mgp::edge_iter_properties(ptr_, memory));
 }
 
-inline Value Relationship::operator[](const std::string_view property_name) const {
-  return Properties()[property_name];
-}
+inline Value Relationship::operator[](const std::string &property_name) const { return Properties()[property_name]; }
 
 inline Node Relationship::From() const { return Node(mgp::edge_get_from(ptr_)); }
 

--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -295,6 +295,8 @@ class Properties {
   /// @note Each key-value pair needs to be checked, ensuing O(n) time complexity.
   Value operator[](const std::string &key) const;
 
+  Value &operator[](const std::string &key);
+
   std::map<std::string, Value>::const_iterator begin() const;
   std::map<std::string, Value>::const_iterator end() const;
 
@@ -600,6 +602,8 @@ class Node {
 
   /// @brief Returns the value of the node’s `property_name` property.
   Value operator[](const std::string &property_name) const;
+
+  Value &operator[](const std::string &property_name);
 
   /// @brief Returns an iterable structure of the node’s inbound relationships.
   Relationships InRelationships() const;
@@ -1979,6 +1983,7 @@ inline size_t Properties::Size() const { return property_map_.size(); }
 inline bool Properties::Empty() const { return Size() == 0; }
 
 inline Value Properties::operator[](const std::string &key) const { return property_map_.at(key); }
+inline Value &Properties::operator[](const std::string &key) { return property_map_[key]; }
 
 inline std::map<std::string, Value>::const_iterator Properties::begin() const { return property_map_.begin(); }
 
@@ -2369,6 +2374,7 @@ inline bool Node::HasLabel(std::string_view label) const {
 inline class Properties Node::Properties() const { return mgp::Properties(mgp::vertex_iter_properties(ptr_, memory)); }
 
 inline Value Node::operator[](const std::string &property_name) const { return Properties()[property_name]; }
+inline Value &Node::operator[](const std::string &property_name) { return Properties()[property_name]; }
 
 inline Relationships Node::InRelationships() const {
   auto relationship_iterator = mgp::vertex_iter_in_edges(ptr_, memory);

--- a/tests/unit/cpp_api.cpp
+++ b/tests/unit/cpp_api.cpp
@@ -429,9 +429,9 @@ TEST_F(CppApiTestFixture, TestNodeProperties) {
   ASSERT_EQ(node_1.Properties().size(), 0);
 
   std::map<std::string, mgp::Value> node1_prop = node_1.Properties();
-  node_1.SetProperty("b", mgp::Value(2.0));
+  node_1.SetProperty("b", mgp::Value("b"));
 
   ASSERT_EQ(node_1.Properties().size(), 1);
-  ASSERT_EQ(node_1.Properties()["b"].ValueDouble(), 2.0);
-  ASSERT_EQ(node_1.GetProperty("b").ValueDouble(), 2.0);
+  ASSERT_EQ(node_1.Properties()["b"].ValueString(), "b");
+  ASSERT_EQ(node_1.GetProperty("b").ValueString(), "b");
 }

--- a/tests/unit/cpp_api.cpp
+++ b/tests/unit/cpp_api.cpp
@@ -195,7 +195,7 @@ TEST_F(CppApiTestFixture, TestNode) {
   ASSERT_EQ(node_1.HasLabel("L1"), true);
   ASSERT_EQ(node_1.HasLabel("L2"), true);
 
-  ASSERT_EQ(node_1.Properties().Size(), 0);
+  ASSERT_EQ(node_1.Properties().size(), 0);
 
   auto node_2 = graph.GetNodeById(node_1.Id());
 
@@ -264,7 +264,7 @@ TEST_F(CppApiTestFixture, TestRelationship) {
   auto relationship = graph.CreateRelationship(node_1, node_2, "edge_type");
 
   ASSERT_EQ(relationship.Type(), "edge_type");
-  ASSERT_EQ(relationship.Properties().Size(), 0);
+  ASSERT_EQ(relationship.Properties().size(), 0);
   ASSERT_EQ(relationship.From().Id(), node_1.Id());
   ASSERT_EQ(relationship.To().Id(), node_2.Id());
 
@@ -421,24 +421,17 @@ TEST_F(CppApiTestFixture, TestDuration) {
 }
 
 TEST_F(CppApiTestFixture, TestNodeProperties) {
-  mgp_graph raw_graph = CreateGraph();
+  mgp_graph raw_graph = CreateGraph(memgraph::storage::View::NEW);
   auto graph = mgp::Graph(&raw_graph);
 
   auto node_1 = graph.CreateNode();
 
-  ASSERT_EQ(node_1.HasLabel("L1"), false);
+  ASSERT_EQ(node_1.Properties().size(), 0);
 
-  node_1.AddLabel("L1");
-  ASSERT_EQ(node_1.HasLabel("L1"), true);
+  std::map<std::string, mgp::Value> node1_prop = node_1.Properties();
+  node_1.SetProperty("b", mgp::Value(2.0));
 
-  node_1.AddLabel("L2");
-  ASSERT_EQ(node_1.HasLabel("L1"), true);
-  ASSERT_EQ(node_1.HasLabel("L2"), true);
-
-  ASSERT_EQ(node_1.Properties().Size(), 0);
-
-  auto node1_prop = node_1.Properties();
-  node1_prop["b"] = mgp::Value(2.0);
-
-  node_1.AddProperty()
+  ASSERT_EQ(node_1.Properties().size(), 1);
+  ASSERT_EQ(node_1.Properties()["b"].ValueDouble(), 2.0);
+  ASSERT_EQ(node_1.GetProperty("b").ValueDouble(), 2.0);
 }

--- a/tests/unit/cpp_api.cpp
+++ b/tests/unit/cpp_api.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -418,4 +418,27 @@ TEST_F(CppApiTestFixture, TestDuration) {
   auto value_x = mgp::Value(duration_1);
   // Use Value move constructor
   auto value_y = mgp::Value(mgp::Duration("PT2M2.33S"));
+}
+
+TEST_F(CppApiTestFixture, TestNodeProperties) {
+  mgp_graph raw_graph = CreateGraph();
+  auto graph = mgp::Graph(&raw_graph);
+
+  auto node_1 = graph.CreateNode();
+
+  ASSERT_EQ(node_1.HasLabel("L1"), false);
+
+  node_1.AddLabel("L1");
+  ASSERT_EQ(node_1.HasLabel("L1"), true);
+
+  node_1.AddLabel("L2");
+  ASSERT_EQ(node_1.HasLabel("L1"), true);
+  ASSERT_EQ(node_1.HasLabel("L2"), true);
+
+  ASSERT_EQ(node_1.Properties().Size(), 0);
+
+  auto node1_prop = node_1.Properties();
+  node1_prop["b"] = mgp::Value(2.0);
+
+  node_1.AddProperty()
 }


### PR DESCRIPTION
This PR fixes few bugs:

- there was a problem with getting Properties - since `std::string_view` was used as a key to store Properties in `std::map`, due to the nature of how properties are retrieved from `mgp_properties_get_next` in combination with `std::string_view`, the new property would overwrite the old one and the user wouldn't get the correct state of properties (some would miss, std::map would be filled with same property)
- there was a missing set_property function in both `mgp.hpp` and `_mgp.hpp`

[master < Task] PR
- [x] Check, and update documentation if necessary -> [yes](https://github.com/memgraph/docs/pull/655)
- [x] Update [changelog](https://docs.memgraph.com/memgraph/changelog) -> still no
- [x] Provide the full content or a guide for the final git message: Fix bug on (vertex|edge) properties in C++ API
