### PR TITLE
[master < T565-FL] Use indexes in optional match and foreach

### DIFF
--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -444,7 +444,7 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
 
   bool PreVisit(Foreach &op) override {
     prev_ops_.push_back(&op);
-    return false;
+    return true;
   }
 
   bool PostVisit(Foreach &) override {

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -444,7 +444,9 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
 
   bool PreVisit(Foreach &op) override {
     prev_ops_.push_back(&op);
-    return true;
+    op.input()->Accept(*this);
+    RewriteBranch(&op.update_clauses_);
+    return false;
   }
 
   bool PostVisit(Foreach &) override {

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -174,7 +174,11 @@ class RuleBasedPlanner {
       input_op = PlanMatching(match_ctx, std::move(input_op));
       for (const auto &matching : query_part.optional_matching) {
         MatchContext opt_ctx{matching, *context.symbol_table, context.bound_symbols};
-        auto match_op = PlanMatching(opt_ctx, nullptr);
+
+        std::vector<Symbol> bound_symbols(context_->bound_symbols.begin(), context_->bound_symbols.end());
+        auto once_with_symbols = std::make_unique<Once>(bound_symbols);
+
+        auto match_op = PlanMatching(opt_ctx, std::move(once_with_symbols));
         if (match_op) {
           input_op = std::make_unique<Optional>(std::move(input_op), std::move(match_op), opt_ctx.new_symbols);
         }

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -1729,6 +1729,9 @@ TYPED_TEST(TestPlanner, Foreach) {
     std::list<BaseOpChecker *> updates{&create};
     std::list<BaseOpChecker *> input;
     CheckPlan(planner.plan(), symbol_table, ExpectForeach(input, updates), ExpectEmptyResult());
+
+    DeleteListContent(&on_match);
+    DeleteListContent(&on_create);
   }
 }
 }  // namespace

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -663,7 +663,7 @@ TYPED_TEST(TestPlanner, MatchOptionalMatchWhereReturn) {
 }
 
 TYPED_TEST(TestPlanner, MatchOptionalMatchNodePropertyWithIndex) {
-  // Test MATCH (n) OPTIONAL MATCH (m) WHERE n.prop = m.prop RETURN n
+  // Test MATCH (n:Label) OPTIONAL MATCH (m:Label) WHERE n.prop = m.prop RETURN n
   AstStorage storage;
   FakeDbAccessor dba;
 
@@ -1712,6 +1712,7 @@ TYPED_TEST(TestPlanner, Foreach) {
 
   {
     // FOREACH with index
+    // FOREACH (n in [...] | MERGE (v:Label));
     const auto label_name = "label";
     const auto label = dba.Label(label_name);
     dba.SetIndexCount(label, 0);

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -659,6 +659,30 @@ TYPED_TEST(TestPlanner, MatchOptionalMatchWhereReturn) {
                                    WHERE(LESS(PROPERTY_LOOKUP("m", prop), LITERAL(42))), RETURN("r")));
   std::list<BaseOpChecker *> optional{new ExpectScanAll(), new ExpectExpand(), new ExpectFilter()};
   CheckPlan<TypeParam>(query, storage, ExpectScanAll(), ExpectOptional(optional), ExpectProduce());
+  DeleteListContent(&optional);
+}
+
+TYPED_TEST(TestPlanner, MatchOptionalMatchNodePropertyWithIndex) {
+  // Test MATCH (n) OPTIONAL MATCH (m) WHERE n.prop = m.prop RETURN n
+  AstStorage storage;
+  FakeDbAccessor dba;
+
+  const auto label_name = "label";
+  const auto label = dba.Label(label_name);
+  const auto property = PROPERTY_PAIR("prop");
+  dba.SetIndexCount(label, property.second, 0);
+
+  auto *query = QUERY(SINGLE_QUERY(
+      MATCH(PATTERN(NODE("n", label_name))), OPTIONAL_MATCH(PATTERN(NODE("m", label_name))),
+      WHERE(EQ(PROPERTY_LOOKUP("n", property.second), PROPERTY_LOOKUP("m", property.second))), RETURN("n")));
+
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, storage, symbol_table, query);
+
+  auto m_prop = PROPERTY_LOOKUP("m", property);
+  std::list<BaseOpChecker *> optional{new ExpectScanAllByLabelPropertyValue(label, property, m_prop)};
+
+  CheckPlan(planner.plan(), symbol_table, ExpectScanAll(), ExpectFilter(), ExpectOptional(optional), ExpectProduce());
   DeleteListContent(&optional);
 }
 


### PR DESCRIPTION
Indexes were not applied when using optional match with label property index.The actual problem was that in the additional branch, optional match would not see the bounded symbol when filtering by that symbol's property. Index could not be fetched accordingly

FOREACH. Index was not applied correctly since the plan was forbidden to alter the inner children of the foreach logical operator. Merge can be one of the children, hence the index lookup rewriter can create the index.

[master < Task] PR
- [x] Check, and update documentation if necessary
- [ ] Update [changelog](https://docs.memgraph.com/memgraph/changelog)
- [ ] Provide the full content or a guide for the final git message
