### PR TITLE
[master < T569-FL] Allshortest bugfix

### DIFF
--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -2029,7 +2029,7 @@ class ExpandAllShortestPathsCursor : public query::plan::Cursor {
       while (!pq_.empty()) {
         if (MustAbort(context)) throw HintedAbortError();
 
-        const auto &[current_weight, current_depth, current_vertex, directed_edge] = pq_.top();
+        const auto [current_weight, current_depth, current_vertex, directed_edge] = pq_.top();
         pq_.pop();
 
         const auto &[current_edge, direction, weight] = directed_edge;

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -2029,11 +2029,11 @@ class ExpandAllShortestPathsCursor : public query::plan::Cursor {
       while (!pq_.empty()) {
         if (MustAbort(context)) throw HintedAbortError();
 
-        auto [current_weight, current_depth, current_vertex, directed_edge] = pq_.top();
+        const auto &[current_weight, current_depth, current_vertex, directed_edge] = pq_.top();
         pq_.pop();
 
-        auto &[current_edge, direction, weight] = directed_edge;
-        if (expanded_.find(current_edge) != expanded_.end()) continue;
+        const auto &[current_edge, direction, weight] = directed_edge;
+        if (expanded_.contains(current_edge)) continue;
         expanded_.emplace(current_edge);
 
         // Expand only if what we've just expanded is less than max depth.

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -2032,13 +2032,14 @@ class ExpandAllShortestPathsCursor : public query::plan::Cursor {
         auto [current_weight, current_depth, current_vertex, maybe_directed_edge] = pq_.top();
         pq_.pop();
 
+        if (maybe_directed_edge) {
+          auto &[current_edge, direction, weight] = *maybe_directed_edge;
+          if (expanded_.find(current_edge) != expanded_.end()) continue;
+          expanded_.emplace(current_edge);
+        }
+
         // Expand only if what we've just expanded is less than max depth.
         if (current_depth < upper_bound_) {
-          if (maybe_directed_edge) {
-            auto &[current_edge, direction, weight] = *maybe_directed_edge;
-            if (expanded_.find(current_edge) != expanded_.end()) continue;
-            expanded_.emplace(current_edge);
-          }
           expand_from_vertex(current_vertex, current_weight, current_depth);
         }
 

--- a/tests/gql_behave/tests/memgraph_V1/features/foreach.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/foreach.feature
@@ -82,29 +82,13 @@ Feature: Foreach
       | 4 |
     And no side effects
 
-  Scenario: Foreach shadowing in create
-    Given an empty graph
-    And having executed
-      """
-      FOREACH (i IN [1] | FOREACH (j IN [3,4] | CREATE (i {prop: j})));
-      """
-    When executing query:
-      """
-      MATCH (n) RETURN n.prop
-      """
-    Then the result should be:
-      | n.prop |
-      | 3 |
-      | 4 |
-    And no side effects
-
   Scenario: Foreach set
     Given an empty graph
     And having executed
     """
     CREATE (n1 { marked: false })-[:RELATES]->(n2 { marked: false })
     """
-    And having executed
+    And having executed 
     """
     MATCH p=(n1)-[*]->(n2)
     FOREACH (n IN nodes(p) | SET n.marked = true)
@@ -126,7 +110,7 @@ Feature: Foreach
     """
     CREATE (n1 { marked: false })-[:RELATES]->(n2 { marked: false })
     """
-    And having executed
+    And having executed 
     """
     MATCH p=(n1)-[*]->(n2)
     FOREACH (n IN nodes(p) | REMOVE n.marked)
@@ -148,7 +132,7 @@ Feature: Foreach
     """
     CREATE (n1 { marked: false })-[:RELATES]->(n2 { marked: false })
     """
-    And having executed
+    And having executed 
     """
     MATCH p=(n1)-[*]->(n2)
     FOREACH (n IN nodes(p) | DETACH delete n)
@@ -164,7 +148,7 @@ Feature: Foreach
 
   Scenario: Foreach merge
     Given an empty graph
-    And having executed
+    And having executed 
     """
     FOREACH (i IN [1, 2, 3] | MERGE (n { age : i }))
     """
@@ -182,7 +166,7 @@ Feature: Foreach
 
  Scenario: Foreach nested
    Given an empty graph
-   And having executed
+   And having executed 
    """
    FOREACH (i IN [1, 2, 3] | FOREACH( j IN [1] | CREATE (k { prop : j })))
    """
@@ -199,11 +183,11 @@ Feature: Foreach
 
  Scenario: Foreach multiple update clauses
    Given an empty graph
-   And having executed
+   And having executed 
    """
    CREATE (n1 { marked1: false, marked2: false })-[:RELATES]->(n2 { marked1: false, marked2: false })
    """
-   And having executed
+   And having executed 
    """
    MATCH p=(n1)-[*]->(n2)
    FOREACH (n IN nodes(p) | SET n.marked1 = true SET n.marked2 = true)
@@ -221,11 +205,11 @@ Feature: Foreach
 
  Scenario: Foreach multiple nested update clauses
    Given an empty graph
-   And having executed
+   And having executed 
    """
    CREATE (n1 { marked1: false, marked2: false })-[:RELATES]->(n2 { marked1: false, marked2: false })
    """
-   And having executed
+   And having executed 
    """
    MATCH p=(n1)-[*]->(n2)
    FOREACH (n IN nodes(p) | FOREACH (j IN [1] | SET n.marked1 = true SET n.marked2 = true))
@@ -243,7 +227,7 @@ Feature: Foreach
 
  Scenario: Foreach match foreach return
    Given an empty graph
-   And having executed
+   And having executed 
    """
    CREATE (n {prop: [[], [1,2]]});
    """
@@ -258,7 +242,7 @@ Feature: Foreach
 
  Scenario: Foreach on null value
    Given an empty graph
-   And having executed
+   And having executed 
    """
    CREATE (n);
    """
@@ -270,9 +254,9 @@ Feature: Foreach
      | |
    And no side effects
 
- Scenario: Foreach nested merge
+ Scenario: Foreach nested merge 
    Given an empty graph
-   And having executed
+   And having executed 
    """
    FOREACH(i in [1, 2, 3] | foreach(j in [1] | MERGE (n { age : i })));
    """

--- a/tests/gql_behave/tests/memgraph_V1/features/foreach.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/foreach.feature
@@ -82,13 +82,29 @@ Feature: Foreach
       | 4 |
     And no side effects
 
+  Scenario: Foreach shadowing in create
+    Given an empty graph
+    And having executed
+      """
+      FOREACH (i IN [1] | FOREACH (j IN [3,4] | CREATE (i {prop: j})));
+      """
+    When executing query:
+      """
+      MATCH (n) RETURN n.prop
+      """
+    Then the result should be:
+      | n.prop |
+      | 3 |
+      | 4 |
+    And no side effects
+
   Scenario: Foreach set
     Given an empty graph
     And having executed
     """
     CREATE (n1 { marked: false })-[:RELATES]->(n2 { marked: false })
     """
-    And having executed 
+    And having executed
     """
     MATCH p=(n1)-[*]->(n2)
     FOREACH (n IN nodes(p) | SET n.marked = true)
@@ -110,7 +126,7 @@ Feature: Foreach
     """
     CREATE (n1 { marked: false })-[:RELATES]->(n2 { marked: false })
     """
-    And having executed 
+    And having executed
     """
     MATCH p=(n1)-[*]->(n2)
     FOREACH (n IN nodes(p) | REMOVE n.marked)
@@ -132,7 +148,7 @@ Feature: Foreach
     """
     CREATE (n1 { marked: false })-[:RELATES]->(n2 { marked: false })
     """
-    And having executed 
+    And having executed
     """
     MATCH p=(n1)-[*]->(n2)
     FOREACH (n IN nodes(p) | DETACH delete n)
@@ -148,7 +164,7 @@ Feature: Foreach
 
   Scenario: Foreach merge
     Given an empty graph
-    And having executed 
+    And having executed
     """
     FOREACH (i IN [1, 2, 3] | MERGE (n { age : i }))
     """
@@ -166,7 +182,7 @@ Feature: Foreach
 
  Scenario: Foreach nested
    Given an empty graph
-   And having executed 
+   And having executed
    """
    FOREACH (i IN [1, 2, 3] | FOREACH( j IN [1] | CREATE (k { prop : j })))
    """
@@ -183,11 +199,11 @@ Feature: Foreach
 
  Scenario: Foreach multiple update clauses
    Given an empty graph
-   And having executed 
+   And having executed
    """
    CREATE (n1 { marked1: false, marked2: false })-[:RELATES]->(n2 { marked1: false, marked2: false })
    """
-   And having executed 
+   And having executed
    """
    MATCH p=(n1)-[*]->(n2)
    FOREACH (n IN nodes(p) | SET n.marked1 = true SET n.marked2 = true)
@@ -205,11 +221,11 @@ Feature: Foreach
 
  Scenario: Foreach multiple nested update clauses
    Given an empty graph
-   And having executed 
+   And having executed
    """
    CREATE (n1 { marked1: false, marked2: false })-[:RELATES]->(n2 { marked1: false, marked2: false })
    """
-   And having executed 
+   And having executed
    """
    MATCH p=(n1)-[*]->(n2)
    FOREACH (n IN nodes(p) | FOREACH (j IN [1] | SET n.marked1 = true SET n.marked2 = true))
@@ -227,7 +243,7 @@ Feature: Foreach
 
  Scenario: Foreach match foreach return
    Given an empty graph
-   And having executed 
+   And having executed
    """
    CREATE (n {prop: [[], [1,2]]});
    """
@@ -242,7 +258,7 @@ Feature: Foreach
 
  Scenario: Foreach on null value
    Given an empty graph
-   And having executed 
+   And having executed
    """
    CREATE (n);
    """
@@ -254,9 +270,9 @@ Feature: Foreach
      | |
    And no side effects
 
- Scenario: Foreach nested merge 
+ Scenario: Foreach nested merge
    Given an empty graph
-   And having executed 
+   And having executed
    """
    FOREACH(i in [1, 2, 3] | foreach(j in [1] | MERGE (n { age : i })));
    """

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_allshortest.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_allshortest.feature
@@ -20,9 +20,8 @@ Feature: All Shortest Path
       And having executed:
           """
           CREATE (a {a:'0'})-[:r {w: 2}]->(b {a:'1'})-[:r {w: 3}]->(c {a:'2'}),
-            (n)-[:re {w: 2}]->(b),
+            (a)-[:re {w: 2}]->(b),
             (b)-[:re {w:3}]->(c),
-            (n)-[:r {w: 5}]->(c),
             ({a: '4'})<-[:r {w: 1}]-(a),
             ({a: '5'})<-[:r {w: 1}]-(a),
             (c)-[:r {w: 1}]->({a: '6'}),
@@ -34,7 +33,7 @@ Feature: All Shortest Path
           """
       Then the result should be:
           | c |
-          | 2 |
+          | 4 |
 
   Scenario: Test match allShortest filtered
       Given an empty graph

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_allshortest.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_allshortest.feature
@@ -15,6 +15,27 @@ Feature: All Shortest Path
           | '1' |
           | '3' |
 
+  Scenario: Test match allShortest upper bound 2
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (a {a:'0'})-[:r {w: 2}]->(b {a:'1'})-[:r {w: 3}]->(c {a:'2'}),
+            (n)-[:re {w: 2}]->(b),
+            (b)-[:re {w:3}]->(c),
+            (n)-[:r {w: 5}]->(c),
+            ({a: '4'})<-[:r {w: 1}]-(a),
+            ({a: '5'})<-[:r {w: 1}]-(a),
+            (c)-[:r {w: 1}]->({a: '6'}),
+            (c)-[:r {w: 1}]->({a: '7'})
+          """
+      When executing query:
+          """
+          MATCH path=(n {a:'0'})-[r *allShortest ..2 (e, n | 1 ) w]->(m {a:'2'}) RETURN COUNT(path) AS c
+          """
+      Then the result should be:
+          | c |
+          | 2 |
+
   Scenario: Test match allShortest filtered
       Given an empty graph
       And having executed:


### PR DESCRIPTION
The algorithm outputted duplicated edges when used with an upper bound set to a limiting value. From changes in the code it can be seen that we should have always continued the iteration if we encountered an already expanded edge

[master < Epic] PR
- [ ] Check, and update documentation if necessary
- [ ] Update [changelog](https://docs.memgraph.com/memgraph/changelog)
- [ ] Write E2E tests
- [ ] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch and the Epic branch
- [ ] Provide the full content or a guide for the final git message

[master < Task] PR
- [x] Check, and update documentation if necessary
- [x] Update [changelog](https://docs.memgraph.com/memgraph/changelog)
- [x] Provide the full content or a guide for the final git message
