### PR TITLE
[master < T580-FL] Improve LOAD CSV speed

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,7 +52,7 @@ target_link_libraries(memgraph ${mg_single_node_v2_libs})
 # NOTE: `include/mg_procedure.syms` describes a pattern match for symbols which
 # should be dynamically exported, so that `dlopen` can correctly link the
 # symbols in custom procedure module libraries.
-target_link_libraries(memgraph "-Wl,--dynamic-list=${CMAKE_SOURCE_DIR}/include/mg_procedure.syms")
+target_link_libraries(memgraph "-Wl,--dynamic-list=${CMAKE_SOURCE_DIR}/include/mg_procedure.syms" "-lprofiler")
 set_target_properties(memgraph PROPERTIES
 
         # Set the executable output name to include version information.

--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -123,6 +123,11 @@ class VertexAccessor final {
 
   storage::Result<storage::PropertyValue> SetProperty(storage::PropertyId key, const storage::PropertyValue &value) {
     return impl_.SetProperty(key, value);
+  }
+
+  storage::Result<std::vector<storage::PropertyValue>> SetProperties(
+      std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+    return impl_.SetBatchProperties(properties);
   }
 
   storage::Result<storage::PropertyValue> RemoveProperty(storage::PropertyId key) {

--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -126,8 +126,8 @@ class VertexAccessor final {
   }
 
   storage::Result<std::vector<storage::PropertyValue>> SetProperties(
-      std::map<storage::PropertyId, storage::PropertyValue> &properties) {
-    return impl_.SetBatchProperties(properties);
+      std::vector<std::pair<storage::PropertyId, storage::PropertyValue>> &properties) {
+    return impl_.SetProperties(properties);
   }
 
   storage::Result<storage::PropertyValue> RemoveProperty(storage::PropertyId key) {

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -231,8 +231,6 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
   }
 
   TypedValue Visit(SubscriptOperator &list_indexing) override {
-    // auto start = std::chrono::steady_clock::now();
-
     ReferenceExpressionEvaluator referenceExpressionEvaluator(frame_, symbol_table_, ctx_, dba_, view_);
 
     auto *lhs = list_indexing.expression1_->Accept(referenceExpressionEvaluator);
@@ -255,14 +253,6 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
       if (index_int >= static_cast<int64_t>(list.size()) || index_int < 0) return TypedValue(ctx_->memory);
       // NOTE: Explicit move is needed, so that we return the move constructed
       // value and preserve the correct MemoryResource.
-      // auto end = std::chrono::steady_clock::now();
-      // std::chrono::duration<double> dif = end - start;
-      // total2 += dif;
-
-      // if (total2 > new_print2) {
-      //   std::cout << "Time difference visit = " << total2.count() << "[s]" << std::endl;
-      //   new_print2 += static_cast<std::chrono::duration<double>>(1.0);
-      // }
       return TypedValue(list[index_int]);
     }
 

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -231,7 +231,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
   }
 
   TypedValue Visit(SubscriptOperator &list_indexing) override {
-    auto start = std::chrono::steady_clock::now();
+    // auto start = std::chrono::steady_clock::now();
 
     ReferenceExpressionEvaluator referenceExpressionEvaluator(frame_, symbol_table_, ctx_, dba_, view_);
 
@@ -255,14 +255,14 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
       if (index_int >= static_cast<int64_t>(list.size()) || index_int < 0) return TypedValue(ctx_->memory);
       // NOTE: Explicit move is needed, so that we return the move constructed
       // value and preserve the correct MemoryResource.
-      auto end = std::chrono::steady_clock::now();
-      std::chrono::duration<double> dif = end - start;
-      total2 += dif;
+      // auto end = std::chrono::steady_clock::now();
+      // std::chrono::duration<double> dif = end - start;
+      // total2 += dif;
 
-      if (total2 > new_print2) {
-        std::cout << "Time difference visit = " << total2.count() << "[s]" << std::endl;
-        new_print2 += static_cast<std::chrono::duration<double>>(1.0);
-      }
+      // if (total2 > new_print2) {
+      //   std::cout << "Time difference visit = " << total2.count() << "[s]" << std::endl;
+      //   new_print2 += static_cast<std::chrono::duration<double>>(1.0);
+      // }
       return TypedValue(list[index_int]);
     }
 

--- a/src/query/parameters.hpp
+++ b/src/query/parameters.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -32,7 +32,7 @@ struct Parameters {
    * @param position Token position in query of value.
    * @param value
    */
-  void Add(int position, const storage::PropertyValue &value) { storage_.emplace_back(position, value); }
+  void Add(int position, const storage::PropertyValue &value) { storage_.emplace(position, value); }
 
   /**
    *  Returns the value found for the given token position.
@@ -41,9 +41,8 @@ struct Parameters {
    *  @return Value for the given token position.
    */
   const storage::PropertyValue &AtTokenPosition(int position) const {
-    auto found = std::find_if(storage_.begin(), storage_.end(), [&](const auto &a) { return a.first == position; });
-    MG_ASSERT(found != storage_.end(), "Token position must be present in container");
-    return found->second;
+    MG_ASSERT(storage_.contains(position), "Token position must be present in container");
+    return storage_.at(position);
   }
 
   /**
@@ -53,9 +52,9 @@ struct Parameters {
    * @param position Which stripped param is sought.
    * @return Token position and value for sought param.
    */
-  const std::pair<int, storage::PropertyValue> &At(int position) const {
+  const storage::PropertyValue &At(int position) const {
     MG_ASSERT(position < static_cast<int>(storage_.size()), "Invalid position");
-    return storage_[position];
+    return storage_.at(position);
   }
 
   /** Returns the number of arguments in this container */
@@ -65,7 +64,7 @@ struct Parameters {
   auto end() const { return storage_.end(); }
 
  private:
-  std::vector<std::pair<int, storage::PropertyValue>> storage_;
+  std::unordered_map<int, storage::PropertyValue> storage_;
 };
 
 }  // namespace memgraph::query

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -213,10 +213,14 @@ VertexAccessor &CreateLocalVertex(const NodeCreationInfo &node_info, Frame *fram
   // when we update PropertyValue with custom allocator.
 
   // auto start = std::chrono::steady_clock::now();
+
+  std::map<storage::PropertyId, storage::PropertyValue> properties;
   if (const auto *node_info_properties = std::get_if<PropertiesMapList>(&node_info.properties)) {
     for (const auto &[key, value_expression] : *node_info_properties) {
-      PropsSetChecked(&new_node, key, value_expression->Accept(evaluator));
+      properties.emplace(key, value_expression->Accept(evaluator));
+      // PropsSetChecked(&new_node, key, );
     }
+    new_node.SetProperties(properties);
   } else {
     auto property_map = evaluator.Visit(*std::get<ParameterLookup *>(node_info.properties));
     for (const auto &[key, value] : property_map.ValueMap()) {

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -212,12 +212,10 @@ VertexAccessor &CreateLocalVertex(const NodeCreationInfo &node_info, Frame *fram
   // TODO: PropsSetChecked allocates a PropertyValue, make it use context.memory
   // when we update PropertyValue with custom allocator.
 
-  // auto start = std::chrono::steady_clock::now();
-
-  std::map<storage::PropertyId, storage::PropertyValue> properties;
+  std::vector<std::pair<storage::PropertyId, storage::PropertyValue>> properties;
   if (const auto *node_info_properties = std::get_if<PropertiesMapList>(&node_info.properties)) {
     for (const auto &[key, value_expression] : *node_info_properties) {
-      properties.emplace(key, value_expression->Accept(evaluator));
+      properties.emplace_back(key, value_expression->Accept(evaluator));
       // PropsSetChecked(&new_node, key, );
     }
     new_node.SetProperties(properties);
@@ -228,14 +226,6 @@ VertexAccessor &CreateLocalVertex(const NodeCreationInfo &node_info, Frame *fram
       PropsSetChecked(&new_node, property_id, value);
     }
   }
-  // auto end = std::chrono::steady_clock::now();
-  // std::chrono::duration<double> dif = end - start;
-  // total += dif;
-
-  // if (total > new_print) {
-  //   std::cout << "Time difference props set checked = " << total.count() << "[s]" << std::endl;
-  //   new_print += static_cast<std::chrono::duration<double>>(10.0);
-  // }
 
   (*frame)[node_info.symbol] = new_node;
   return (*frame)[node_info.symbol].ValueVertex();

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -212,7 +212,7 @@ VertexAccessor &CreateLocalVertex(const NodeCreationInfo &node_info, Frame *fram
   // TODO: PropsSetChecked allocates a PropertyValue, make it use context.memory
   // when we update PropertyValue with custom allocator.
 
-  auto start = std::chrono::steady_clock::now();
+  // auto start = std::chrono::steady_clock::now();
   if (const auto *node_info_properties = std::get_if<PropertiesMapList>(&node_info.properties)) {
     for (const auto &[key, value_expression] : *node_info_properties) {
       PropsSetChecked(&new_node, key, value_expression->Accept(evaluator));
@@ -224,14 +224,14 @@ VertexAccessor &CreateLocalVertex(const NodeCreationInfo &node_info, Frame *fram
       PropsSetChecked(&new_node, property_id, value);
     }
   }
-  auto end = std::chrono::steady_clock::now();
-  std::chrono::duration<double> dif = end - start;
-  total += dif;
+  // auto end = std::chrono::steady_clock::now();
+  // std::chrono::duration<double> dif = end - start;
+  // total += dif;
 
-  if (total > new_print) {
-    std::cout << "Time difference props set checked = " << total.count() << "[s]" << std::endl;
-    new_print += static_cast<std::chrono::duration<double>>(10.0);
-  }
+  // if (total > new_print) {
+  //   std::cout << "Time difference props set checked = " << total.count() << "[s]" << std::endl;
+  //   new_print += static_cast<std::chrono::duration<double>>(10.0);
+  // }
 
   (*frame)[node_info.symbol] = new_node;
   return (*frame)[node_info.symbol].ValueVertex();

--- a/src/storage/v2/property_store.cpp
+++ b/src/storage/v2/property_store.cpp
@@ -1167,7 +1167,7 @@ bool PropertyStore::SetProperty(PropertyId property, const PropertyValue &value)
 }
 
 // use this function only when inserting new properties
-bool PropertyStore::SetProperties(std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+bool PropertyStore::SetProperties(std::vector<std::pair<storage::PropertyId, storage::PropertyValue>> &properties) {
   uint64_t size;
   uint8_t *data;
   std::tie(size, data) = GetSizeData(buffer_);

--- a/src/storage/v2/property_store.cpp
+++ b/src/storage/v2/property_store.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -970,6 +970,8 @@ PropertyValue PropertyStore::GetProperty(PropertyId property) const {
   if (FindSpecificProperty(&reader, property, &value) != DecodeExpectedPropertyStatus::EQUAL) return PropertyValue();
   return value;
 }
+
+PropertyValue PropertyStore::GetEmptyProperty() const { return PropertyValue(); }
 
 bool PropertyStore::HasProperty(PropertyId property) const {
   uint64_t size;

--- a/src/storage/v2/property_store.hpp
+++ b/src/storage/v2/property_store.hpp
@@ -61,7 +61,7 @@ class PropertyStore {
   /// @throw std::bad_alloc
   bool SetProperty(PropertyId property, const PropertyValue &value);
 
-  bool SetProperties(std::map<storage::PropertyId, storage::PropertyValue> &properties);
+  bool SetProperties(std::vector<std::pair<storage::PropertyId, storage::PropertyValue>> &properties);
 
   /// Remove all properties and return `true` if any removal took place.
   /// `false` is returned if there were no properties to remove. The time

--- a/src/storage/v2/property_store.hpp
+++ b/src/storage/v2/property_store.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -41,6 +41,8 @@ class PropertyStore {
   /// Checks whether the property `property` exists in the store. The time
   /// complexity of this function is O(n).
   bool HasProperty(PropertyId property) const;
+
+  PropertyValue GetEmptyProperty() const;
 
   /// Checks whether the property `property` is equal to the specified value
   /// `value`. This function doesn't perform any memory allocations while

--- a/src/storage/v2/property_store.hpp
+++ b/src/storage/v2/property_store.hpp
@@ -61,6 +61,8 @@ class PropertyStore {
   /// @throw std::bad_alloc
   bool SetProperty(PropertyId property, const PropertyValue &value);
 
+  bool SetProperties(std::map<storage::PropertyId, storage::PropertyValue> &properties);
+
   /// Remove all properties and return `true` if any removal took place.
   /// `false` is returned if there were no properties to remove. The time
   /// complexity of this function is O(1).

--- a/src/storage/v2/vertex_accessor.cpp
+++ b/src/storage/v2/vertex_accessor.cpp
@@ -245,8 +245,8 @@ Result<PropertyValue> VertexAccessor::SetProperty(PropertyId property, const Pro
   return std::move(current_value);
 }
 
-Result<std::vector<storage::PropertyValue>> VertexAccessor::SetBatchProperties(
-    std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+Result<std::vector<storage::PropertyValue>> VertexAccessor::SetProperties(
+    std::vector<std::pair<storage::PropertyId, storage::PropertyValue>> &properties) {
   // Be careful when calling this function
   // It will set properties in batch, without checking if property already exists
 

--- a/src/storage/v2/vertex_accessor.cpp
+++ b/src/storage/v2/vertex_accessor.cpp
@@ -212,7 +212,7 @@ Result<std::vector<LabelId>> VertexAccessor::Labels(View view) const {
 }
 
 Result<PropertyValue> VertexAccessor::SetProperty(PropertyId property, const PropertyValue &value) {
-  auto start = std::chrono::steady_clock::now();
+  // auto start = std::chrono::steady_clock::now();
 
   utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
   std::lock_guard<utils::SpinLock> guard(vertex_->lock);
@@ -233,14 +233,14 @@ Result<PropertyValue> VertexAccessor::SetProperty(PropertyId property, const Pro
 
   UpdateOnSetProperty(indices_, property, value, vertex_, *transaction_);
 
-  auto end = std::chrono::steady_clock::now();
-  std::chrono::duration<double> dif = end - start;
-  total += dif;
+  // auto end = std::chrono::steady_clock::now();
+  // std::chrono::duration<double> dif = end - start;
+  // total += dif;
 
-  if (total > new_print) {
-    std::cout << "Time difference = " << total.count() << "[s]" << std::endl;
-    new_print += static_cast<std::chrono::duration<double>>(2.0);
-  }
+  // if (total > new_print) {
+  //   std::cout << "Time difference = " << total.count() << "[s]" << std::endl;
+  //   new_print += static_cast<std::chrono::duration<double>>(2.0);
+  // }
 
   return std::move(current_value);
 }

--- a/src/storage/v2/vertex_accessor.cpp
+++ b/src/storage/v2/vertex_accessor.cpp
@@ -258,10 +258,12 @@ Result<std::vector<storage::PropertyValue>> VertexAccessor::SetBatchProperties(
   if (vertex_->deleted) return Error::DELETED_OBJECT;
 
   std::vector<storage::PropertyValue> new_values;
+
+  vertex_->properties.SetProperties(properties);
+
   for (const auto &[property, value] : properties) {
     auto current_value = vertex_->properties.GetEmptyProperty();
     CreateAndLinkDelta(transaction_, vertex_, Delta::SetPropertyTag(), property, current_value);
-    vertex_->properties.SetProperty(property, value);
     UpdateOnSetProperty(indices_, property, value, vertex_, *transaction_);
     new_values.emplace_back(current_value);
   }

--- a/src/storage/v2/vertex_accessor.hpp
+++ b/src/storage/v2/vertex_accessor.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source

--- a/src/storage/v2/vertex_accessor.hpp
+++ b/src/storage/v2/vertex_accessor.hpp
@@ -68,6 +68,9 @@ class VertexAccessor final {
   /// @throw std::bad_alloc
   Result<PropertyValue> SetProperty(PropertyId property, const PropertyValue &value);
 
+  Result<std::vector<storage::PropertyValue>> SetBatchProperties(
+      std::map<storage::PropertyId, storage::PropertyValue> &properties);
+
   /// Remove all properties and return the values of the removed properties.
   /// @throw std::bad_alloc
   Result<std::map<PropertyId, PropertyValue>> ClearProperties();

--- a/src/storage/v2/vertex_accessor.hpp
+++ b/src/storage/v2/vertex_accessor.hpp
@@ -68,8 +68,8 @@ class VertexAccessor final {
   /// @throw std::bad_alloc
   Result<PropertyValue> SetProperty(PropertyId property, const PropertyValue &value);
 
-  Result<std::vector<storage::PropertyValue>> SetBatchProperties(
-      std::map<storage::PropertyId, storage::PropertyValue> &properties);
+  Result<std::vector<storage::PropertyValue>> SetProperties(
+      std::vector<std::pair<storage::PropertyId, storage::PropertyValue>> &properties);
 
   /// Remove all properties and return the values of the removed properties.
   /// @throw std::bad_alloc


### PR DESCRIPTION
The idea of this top comment is the following:
- give a quick overview of what was improved (`1. What's improved`)
- give a more detailed overview of benchmarking (`2. Benchmarking`)
- explain steps towards speed improvements found during profiling (`3. Profiling summary`)


## 1. What's improved

After profiling analysis available in section `3. Profiling summary` there were 2 Pull requests to branch `master` of Memgraph:
 - #788 
 - #774

These two PRs proved to **increase** the performance of LOAD CSV import on rich graphs with lots of properties which was shown to be a critical point for improvement.

Another **important** thing to notice is that when doing the import, the **user** can **drastically enhance the performance** of import by using the `READ UNCOMMITED` isolation level on the transaction, due to the fact that it is probably the only transaction doing changes, and such transaction in most cases should be able to see its changes (changes that transaction made).


Description of test: Import X nodes with Y properties each from 1 file (`nodes.csv`) and then `Z` edges with `W` properties from another file( `edges.csv`).

| X | Y | Z| W |Throughput time (OLD)  [node/seconds] | Thorughput time (NEW) nodes [seconds] | Throughput (OLD) [edges/s] | Throughput (NEW) [edges/s] |
| -- | -- | -- |  -- | -- |  -- | -- | -- |
|100000 |10 | 200000| 10 |  120 K/s ( 0.83 s)  | **165 K/s (0.6 s)**  |  70 K/s (2.85 s) | **85 K/s (2.36 s)**  |
|100000 |20 | 200000| 20 |  48 K/s ( 2.06 s)  | **102 K/s (0.96 s)**  |  38 K/s (5.25 s) | **62.5 K/s (3.24 s)**  |
|100000 |30 | 200000| 30 |  28 K/s ( 3.5 s)  | **74 K/s (1.37 s)**  |  15 K/s (7.8 s) | **50 K/s (4.05s)**  |

## 2. Benchmarking

The idea of benchmarking was to check how much we improved with new changes introduced from **Profiling summary** down below, and how different ISOLATION levels on transaction impact throughput

 1. Import nodes and edges from the same file (in the same file there are 2 nodes and 1 edge per line)
- Description: Import 1 000 000 lines, and from each line create 2 nodes and 1 new edge. Each line will have X properties, of 10 string length. Each node has X/2 features, where X is even. No header.

| Number of properties per line | Import time (OLD) [seconds] | Import time (NEW) [seconds] | Throughput (OLD) [lines/s] | Throughput (NEW) [lines/s] |
| -- | -- | -- |  -- | -- |
|2 | 3.6s | 3.917 s| **277K** | 256K |
|10 | 9.6s | 8.4 s|  104 K | **119 K** |
|20 | 22s | 12.9 s| 45.5 K | **77.5 K**  |


2. Import nodes from one file, and then edges from another file
- Description: Import X nodes with Y properties nodes from 1 file and then Z edges with W properties from another file.

| X | Y | Z| W |Throughput time (OLD)  [node/seconds] | Thorughput time (NEW) nodes [seconds] | Throughput (OLD) [edges/s] | Throughput (NEW) [edges/s] |
| -- | -- | -- |  -- | -- |  -- | -- | -- |
|1M |10 | 5M| 5 |  117K/s (total 8.8seconds)  |  | 51K/s (total: 98 seconds)  |   |

3. Import nodes from one file, and edges from another file using `SNAPSHOT` or `READ UNCOMMITTED` isolation level
- Description: Import X nodes with few properties [1,3] and Z edges with few properties [1,3]

| X | Z |Throughput time (`SNAPSHOT`)  [node/seconds] | Throughput time (`READ UNCOMMITTED`) nodes [seconds] | Throughput (`SNAPSHOT`) [edges/s] | Throughput (`READ UNCOMMITTED`) [edges/s] | ratio (edges/nodes)|
| -- | -- | -- |  -- | -- | -- | -- |
|3500 | 50K|  50K/s (0.07 seconds)  |  50K/s (0.07 seconds)  | 100K/s (0.5 seconds) | 100K/s (0.5 seconds) | 14 |
| 3500 | 500K|  50K/s (0.07 seconds)  |  50K/s (0.07 seconds)  | 16K/s (31 seconds) | 106 K/s (4.7 seconds) :heavy_check_mark:  |  **142** |
|3.5M | 5M|  397 K/s (8.8 seconds)  |  397 K/s (8.8 seconds) | 90 K/s (55.1 seconds) |  92 K/s (54 seconds) | 1.5|




## 3. Profiling Summary

**The Problem and Goal**
LOAD CSV speed: 5000 lines/second at graphs with a lot of properties -> get at least 10 000 lines/second :heavy_check_mark: 

**Context**
 Dataset + Queries = Workload -> Read **Profiling Summary** below

| Experiment Name | Description | Throughput (lines/s) |  Throughput (edges/s) |
| -- | -- | -- | -- |
| Check baseline import speed on 100 000 lines, with 100 string properties per line, 10 char each string | Read more description [here](https://github.com/memgraph/memgraph/pull/753#issuecomment-1411921127).  **The test was done on [1]** | 4350 | 4350 |
| Implement `ReferenceExpressionEvaluator` to avoid copying every `row` when evaluating the expression | Visitor was the real bottleneck and I confirmed this with `gperftools` and by [measuring time spent in that function](https://github.com/memgraph/memgraph/pull/753#issuecomment-1411921127), it made sense to avoid copying the whole list just to get one object from it. **The test was done on [1]** | 8550 | 8550 |
|  Lookup of parameters [takes time](https://github.com/memgraph/memgraph/pull/753#issuecomment-1413677072) as it needs to iterate through `std::vector` each time to find a specific index | After profiling, it seemed it is better with `ReferenceExpressionEvaluator`, but `AtTokenPostion` was still taking a lot of time. I changed std::vector with std::map for faster lookup, in this case. **The test was done on [1]** | 9520 | 9520 |
| Test batch insertion of properties when creating vertices | Test batch insert of properties due to the fact that [flamegraph](https://user-images.githubusercontent.com/61245998/216326788-a423acc3-f4b4-473f-ba44-4378e0756529.svg) showed (read more [here](https://github.com/memgraph/memgraph/pull/753#issuecomment-1415948417)) it took a lot of time to insert property 1 by one. Due to guarantees on creating vertex that no two of the same properties can exist inside `{}`, we can batch insert properties without checking if it exists or not. **The test was done on [1]** | 10.9K | 10.9K |
| Implement `SetProperties` in `PropertyStore`| From profiling in flamegraph, it seems a lot of time is wasted on the DecodeExpectedProperty function which shows that probably problem is that for each new property when there is the setting of a new property, we need to check whether this property exists already, and copy memory block of properties. To avoid that, we can set all properties all at once. **The test was done on [1]** | 18.1K | 18.1K |
| Test using std::vector instead of `std::map` to process properties in batch| From flamegraph it seems like we can squeeze out a little bit more time out of execution since std::map takes a bit of time. **The test was done on [1]** |**>20K/s** | **>20K/s** |

**Test Summary**
| Test ID | Test query | Test description| Test file|
|--| --| --|--|
| 1 | `LOAD CSV FROM ".../generated_text.csv" NO HEADER AS row CREATE (a: Label {arg0:row[0],...,arg49:row[49]}), (b: Label {arg50:row[50],...,arg99:row[99]}), (a)-[:CONNECTED_TO]->(b);`  | 100 000 lines file with 100 properties per line, 10 char string each property. Create 2 nodes and 1 edge between them for each line (200 000 nodes created and 100 000 edges)| |
|TODO | TODO | TODO | TODO |


