### PR TITLE
[master < T582-FL] Fix label-based auth using OLD view instead of NEW when merging nodes

### DIFF
--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -448,7 +448,7 @@ class ScanAllCursor : public Cursor {
 #ifdef MG_ENTERPRISE
   bool FindNextVertex(const ExecutionContext &context) {
     while (vertices_it_.value() != vertices_.value().end()) {
-      if (context.auth_checker->Has(*vertices_it_.value(), memgraph::storage::View::OLD,
+      if (context.auth_checker->Has(*vertices_it_.value(), memgraph::storage::View::NEW,
                                     memgraph::query::AuthQuery::FineGrainedPrivilege::READ)) {
         return true;
       }


### PR DESCRIPTION
```
UNWIND 
[{id: '1', lat: 10, lng: 10}, {id: '2', lat: 10, lng: 10}, {id: '3', lat: 10, lng: 10}] AS row
MERGE (o:Location {id: row.id}) RETURN o;
```
did not work and threw an exception because newly created nodes were not seen and therefore prohibited.

**Changelog message**: Label based auth improved to see information about newly created nodes when merging nodes inside a query.

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Update [changelog](https://docs.memgraph.com/memgraph/changelog)
- [ ] Provide the full content or a guide for the final git message
