### PR TITLE
[master < T583] Change start time of daily build

### DIFF
--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -3,7 +3,7 @@ name: Daily Benchmark
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "0 22 * * *"
 
 jobs:
   release_benchmarks:

--- a/.github/workflows/release_centos8.yaml
+++ b/.github/workflows/release_centos8.yaml
@@ -3,7 +3,7 @@ name: Release CentOS 8
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "0 22 * * *"
 
 jobs:
   community_build:

--- a/.github/workflows/release_debian10.yaml
+++ b/.github/workflows/release_debian10.yaml
@@ -3,7 +3,7 @@ name: Release Debian 10
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "0 22 * * *"
 
 jobs:
   community_build:

--- a/.github/workflows/release_ubuntu2004.yaml
+++ b/.github/workflows/release_ubuntu2004.yaml
@@ -3,7 +3,7 @@ name: Release Ubuntu 20.04
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "0 22 * * *"
 
 jobs:
   community_build:


### PR DESCRIPTION
Since release builds that are run every day take around 10 h to complete, I want them to start at 22 h so they can finish by the time I get to the office. Mostly to be able to start with a release earlier.

[master < Task] PR
- [x] Check, and update documentation if necessary
- [x] Update [changelog](https://docs.memgraph.com/memgraph/changelog)
- [x] Provide the full content or a guide for the final git message
