### PR TITLE
[master < T575-FL] Improve overall performance of the C/C++ query modules API

### DIFF
--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -4459,7 +4459,12 @@ class CallProcedureCursor : public Cursor {
     }
     for (size_t i = 0; i < self_->result_fields_.size(); ++i) {
       std::string_view field_name(self_->result_fields_[i]);
-      auto result_it = values.find(field_name);
+      auto result_it =
+          std::find_if(values.begin(), values.end(),
+                       [&field_name](const std::pair<memgraph::utils::pmr::string, memgraph::query::TypedValue> &elem) {
+                         return elem.first == field_name;
+                       });
+      // auto result_it = values.find(field_name);
       if (result_it == values.end()) {
         throw QueryRuntimeException("Procedure '{}' did not yield a record with '{}' field.", self_->procedure_name_,
                                     field_name);

--- a/src/query/procedure/mg_procedure_impl.cpp
+++ b/src/query/procedure/mg_procedure_impl.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -1496,7 +1496,8 @@ mgp_error mgp_result_new_record(mgp_result *res, mgp_result_record **result) {
         MG_ASSERT(res->signature, "Expected to have a valid signature");
         res->rows.push_back(mgp_result_record{
             res->signature,
-            memgraph::utils::pmr::map<memgraph::utils::pmr::string, memgraph::query::TypedValue>(memory)});
+            memgraph::utils::pmr::vector<std::pair<memgraph::utils::pmr::string, memgraph::query::TypedValue>>(
+                memory)});
         return &res->rows.back();
       },
       result);
@@ -1516,7 +1517,7 @@ mgp_error mgp_result_record_insert(mgp_result_record *record, const char *field_
       throw std::logic_error{
           fmt::format("The type of value doesn't satisfies the type '{}'!", type->GetPresentableName())};
     }
-    record->values.emplace(field_name, ToTypedValue(*val, memory));
+    record->values.emplace_back(field_name, ToTypedValue(*val, memory));  // move semantics
   });
 }
 

--- a/src/query/procedure/mg_procedure_impl.hpp
+++ b/src/query/procedure/mg_procedure_impl.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source

--- a/src/query/procedure/mg_procedure_impl.hpp
+++ b/src/query/procedure/mg_procedure_impl.hpp
@@ -594,7 +594,8 @@ struct mgp_result_record {
   /// Result record signature as defined for mgp_proc.
   const memgraph::utils::pmr::map<memgraph::utils::pmr::string,
                                   std::pair<const memgraph::query::procedure::CypherType *, bool>> *signature;
-  memgraph::utils::pmr::map<memgraph::utils::pmr::string, memgraph::query::TypedValue> values;
+  // memgraph::utils::pmr::map<memgraph::utils::pmr::string, memgraph::query::TypedValue> values;
+  memgraph::utils::pmr::vector<std::pair<memgraph::utils::pmr::string, memgraph::query::TypedValue>> values;
 };
 
 struct mgp_result {


### PR DESCRIPTION
## Experiments with `mgp_result_record_insert`:

The assumption that needs to be tested is that there is some problem with our allocators:

| Description | Time spent on `mgp_result_record_insert` (%) :arrow_down:  |
| ----- | ----- |
| Baseline | 29.34 |
| memgraph::utils::pmr::unordered_map with std::string | 28.02 |
| memgraph::utils::pmr::unordered_map with std::string, reserve memory up-front = 4 | 27.41 |
| memgraph::utils::pmr::vector<memgraph::utils::pmr::string, TypedValue> | 36.57 |
| translation table with string to int mapping | 29.54 |
| reorganizing storage map[string to vector] | 22.23 |
