### PR TITLE
[master < ] Update mgbench c++ client

### DIFF
--- a/tests/mgbench/client.cpp
+++ b/tests/mgbench/client.cpp
@@ -54,7 +54,10 @@ DEFINE_bool(queries_json, false,
 
 DEFINE_string(input, "", "Input file. By default stdin is used.");
 DEFINE_string(output, "", "Output file. By default stdout is used.");
-DEFINE_bool(validation, false, "Set to true to run client in validation mode");
+DEFINE_bool(validation, false,
+            "Set to true to run client in validation mode."
+            "Validation mode works for singe query and returns results for validation"
+            "with metadata");
 
 std::pair<std::map<std::string, memgraph::communication::bolt::Value>, uint64_t> ExecuteNTimesTillSuccess(
     memgraph::communication::bolt::Client *client, const std::string &query,
@@ -351,8 +354,8 @@ int main(int argc, char **argv) {
   spdlog::info("Running a bolt client with following settings:");
   spdlog::info("Adress: {} ", FLAGS_address);
   spdlog::info("Port: {} ", FLAGS_port);
-  spdlog::info("Username: {} ", FLAGS_port);
-  spdlog::info("Password: {} ", FLAGS_port);
+  spdlog::info("Username: {} ", FLAGS_username);
+  spdlog::info("Password: {} ", FLAGS_password);
   spdlog::info("Usessl: {} ", FLAGS_use_ssl);
   spdlog::info("Num of worker: {}", FLAGS_num_workers);
   spdlog::info("Max retries: {}", FLAGS_max_retries);

--- a/tests/mgbench/client.cpp
+++ b/tests/mgbench/client.cpp
@@ -336,6 +336,7 @@ int main(int argc, char **argv) {
   spdlog::info("Usessl: {} ", FLAGS_use_ssl);
   spdlog::info("Num of worker: {}", FLAGS_num_workers);
   spdlog::info("Max retries: {}", FLAGS_max_retries);
+  spdlog::info("Query JSON: {}", FLAGS_queries_json);
   spdlog::info("Input: {}", FLAGS_input);
   spdlog::info("Output: {}", FLAGS_output);
   spdlog::info("Validation: {}", FLAGS_validation);

--- a/tests/mgbench/client.cpp
+++ b/tests/mgbench/client.cpp
@@ -16,6 +16,7 @@
 #include <fstream>
 #include <limits>
 #include <map>
+#include <ostream>
 #include <string>
 #include <thread>
 #include <vector>
@@ -256,6 +257,16 @@ void Execute(
   (*stream) << summary.dump() << std::endl;
 }
 
+nlohmann::json BoltRecordsToJSONStrings(std::vector<std::vector<memgraph::communication::bolt::Value>> &results) {
+  nlohmann::json res = nlohmann::json::object();
+  std::ostringstream oss;
+  for (int i = 0; i < results.size(); i++) {
+    oss << results[i];
+    res[std::to_string(i)] = oss.str();
+  }
+  return res;
+}
+
 // Validation mode works on single thread with 1 query.
 void Execute_validation(
     const std::vector<std::pair<std::string, std::map<std::string, memgraph::communication::bolt::Value>>> &queries,
@@ -308,7 +319,7 @@ void Execute_validation(
   summary["count"] = 1;
   summary["duration"] = final_duration;
   summary["metadata"] = final_metadata.Export();
-  summary["results"] = final_results;
+  summary["results"] = BoltRecordsToJSONStrings(final_results);
   summary["num_workers"] = FLAGS_num_workers;
 
   (*stream) << summary.dump() << std::endl;

--- a/tests/mgbench/runners.py
+++ b/tests/mgbench/runners.py
@@ -398,7 +398,13 @@ class Client:
             password=self._password,
             port=self._bolt_port,
         )
+
         ret = subprocess.run(args, capture_output=True, check=True)
+        error = ret.stderr.decode("utf-8").strip().split("\n")
+        if error and error[0] != "":
+            print("Reported errros from client")
+            print(error)
+
         data = ret.stdout.decode("utf-8").strip().split("\n")
-        # data = [x for x in data if not x.startswith("[")]
+        data = [x for x in data if not x.startswith("[")]
         return list(map(json.loads, data))


### PR DESCRIPTION
- We have moved latency measurment to the client side. Each executed workload/query will come with its standard latency measurements (min, max, mean, p99, p95, p90, p75, p50) 
- Logging has been fixed, client is now reporting everything to stderr and stdout properly. 
- Validation mode accepts single query, execute it, and returns results alongside metadata. For workload validation between different vendors. 

Tasks: 
- [x] Add latency measurement on the client
- [x] Fix logging on the client  
- [x] Add validation mode 

Optional task: 
- [ ] Add per thread execution mode 