### PR TITLE
Add simulator support for adding a message delay to every sent message

### DIFF
--- a/src/io/message_conversion.hpp
+++ b/src/io/message_conversion.hpp
@@ -13,6 +13,7 @@
 
 #include <boost/core/demangle.hpp>
 
+#include "io/time.hpp"
 #include "io/transport.hpp"
 #include "utils/type_info_ref.hpp"
 
@@ -38,6 +39,7 @@ struct OpaqueMessage {
   uint64_t request_id;
   std::any message;
   utils::TypeInfoRef type_info;
+  Time deliverable_at;
 
   /// Recursively tries to match a specific type from the outer
   /// variant's parameter pack against the type of the std::any,

--- a/src/io/simulator/simulator_config.hpp
+++ b/src/io/simulator/simulator_config.hpp
@@ -26,5 +26,6 @@ struct SimulatorConfig {
   uint64_t rng_seed = 0;
   Time start_time = Time::min();
   Time abort_time = Time::max();
+  Duration message_delay = std::chrono::microseconds(100);
 };
 };  // namespace memgraph::io::simulator

--- a/src/io/simulator/simulator_handle.cpp
+++ b/src/io/simulator/simulator_handle.cpp
@@ -175,8 +175,8 @@ bool SimulatorHandle::MaybeTickSimulator() {
     spdlog::trace("simulator adding message to can_receive_ from {} to {}", opaque_message.from_address.last_known_port,
                   opaque_message.to_address.last_known_port);
     const auto &[om_vec, inserted] =
-        can_receive_.try_emplace(to_address.ToPartialAddress(), std::vector<OpaqueMessage>());
-    om_vec->second.emplace_back(std::move(opaque_message));
+        can_receive_.try_emplace(to_address.ToPartialAddress(), std::deque<OpaqueMessage>());
+    om_vec->second.emplace_front(std::move(opaque_message));
   }
 
   return true;


### PR DESCRIPTION
Over time this will be a distribution rather than a static latency, but this will let us start to feel out the distributed design space while changing the query engine and looking at the PROFILE response for simulated cypher queries, as well as latency histograms on general activity.