### PR TITLE
[master < T585-FL] Improve Visit performance

### DIFF
--- a/src/query/frontend/ast/ast.lcp
+++ b/src/query/frontend/ast/ast.lcp
@@ -301,6 +301,7 @@ cpp<#
 
 (lcp:define-class expression (tree "::utils::Visitable<HierarchicalTreeVisitor>"
                                    "::utils::Visitable<ExpressionVisitor<TypedValue>>"
+                                   "::utils::Visitable<ExpressionVisitor<TypedValue*>>"
                                    "::utils::Visitable<ExpressionVisitor<void>>")
   ()
   (:abstractp t)
@@ -308,6 +309,7 @@ cpp<#
     #>cpp
     using utils::Visitable<HierarchicalTreeVisitor>::Accept;
     using utils::Visitable<ExpressionVisitor<TypedValue>>::Accept;
+    using utils::Visitable<ExpressionVisitor<TypedValue*>>::Accept;
     using utils::Visitable<ExpressionVisitor<void>>::Accept;
 
     Expression() = default;
@@ -407,6 +409,7 @@ cpp<#
                           (:public
                             #>cpp
                             DEFVISITABLE(ExpressionVisitor<TypedValue>);
+                            DEFVISITABLE(ExpressionVisitor<TypedValue*>);
                             DEFVISITABLE(ExpressionVisitor<void>);
                             bool Accept(HierarchicalTreeVisitor &visitor) override {
                               if (visitor.PreVisit(*this)) {
@@ -438,6 +441,7 @@ cpp<#
                           (:public
                             #>cpp
                             DEFVISITABLE(ExpressionVisitor<TypedValue>);
+                            DEFVISITABLE(ExpressionVisitor<TypedValue*>);
                             DEFVISITABLE(ExpressionVisitor<void>);
                             bool Accept(HierarchicalTreeVisitor &visitor) override {
                               if (visitor.PreVisit(*this)) {
@@ -485,6 +489,7 @@ cpp<#
     }
 
     DEFVISITABLE(ExpressionVisitor<TypedValue>);
+    DEFVISITABLE(ExpressionVisitor<TypedValue*>);
     DEFVISITABLE(ExpressionVisitor<void>);
     bool Accept(HierarchicalTreeVisitor &visitor) override {
       if (visitor.PreVisit(*this)) {
@@ -538,6 +543,7 @@ cpp<#
     ListSlicingOperator() = default;
 
     DEFVISITABLE(ExpressionVisitor<TypedValue>);
+    DEFVISITABLE(ExpressionVisitor<TypedValue*>);
     DEFVISITABLE(ExpressionVisitor<void>);
     bool Accept(HierarchicalTreeVisitor &visitor) override {
       if (visitor.PreVisit(*this)) {
@@ -581,6 +587,7 @@ cpp<#
     IfOperator() = default;
 
     DEFVISITABLE(ExpressionVisitor<TypedValue>);
+    DEFVISITABLE(ExpressionVisitor<TypedValue*>);
     DEFVISITABLE(ExpressionVisitor<void>);
     bool Accept(HierarchicalTreeVisitor &visitor) override {
       if (visitor.PreVisit(*this)) {
@@ -628,6 +635,7 @@ cpp<#
     PrimitiveLiteral() = default;
 
     DEFVISITABLE(ExpressionVisitor<TypedValue>);
+    DEFVISITABLE(ExpressionVisitor<TypedValue*>);
     DEFVISITABLE(ExpressionVisitor<void>);
     DEFVISITABLE(HierarchicalTreeVisitor);
     cpp<#)
@@ -656,6 +664,7 @@ cpp<#
     ListLiteral() = default;
 
     DEFVISITABLE(ExpressionVisitor<TypedValue>);
+    DEFVISITABLE(ExpressionVisitor<TypedValue*>);
     DEFVISITABLE(ExpressionVisitor<void>);
     bool Accept(HierarchicalTreeVisitor &visitor) override {
       if (visitor.PreVisit(*this)) {
@@ -688,6 +697,7 @@ cpp<#
     MapLiteral() = default;
 
     DEFVISITABLE(ExpressionVisitor<TypedValue>);
+    DEFVISITABLE(ExpressionVisitor<TypedValue*>);
     DEFVISITABLE(ExpressionVisitor<void>);
     bool Accept(HierarchicalTreeVisitor &visitor) override {
       if (visitor.PreVisit(*this)) {
@@ -720,6 +730,7 @@ cpp<#
     Identifier() = default;
 
     DEFVISITABLE(ExpressionVisitor<TypedValue>);
+    DEFVISITABLE(ExpressionVisitor<TypedValue*>);
     DEFVISITABLE(ExpressionVisitor<void>);
     DEFVISITABLE(HierarchicalTreeVisitor);
 
@@ -757,6 +768,7 @@ cpp<#
     PropertyLookup() = default;
 
     DEFVISITABLE(ExpressionVisitor<TypedValue>);
+    DEFVISITABLE(ExpressionVisitor<TypedValue*>);
     DEFVISITABLE(ExpressionVisitor<void>);
     bool Accept(HierarchicalTreeVisitor &visitor) override {
       if (visitor.PreVisit(*this)) {
@@ -797,6 +809,7 @@ cpp<#
     LabelsTest() = default;
 
     DEFVISITABLE(ExpressionVisitor<TypedValue>);
+    DEFVISITABLE(ExpressionVisitor<TypedValue*>);
     DEFVISITABLE(ExpressionVisitor<void>);
     bool Accept(HierarchicalTreeVisitor &visitor) override {
       if (visitor.PreVisit(*this)) {
@@ -837,6 +850,7 @@ cpp<#
     Function() = default;
 
     DEFVISITABLE(ExpressionVisitor<TypedValue>);
+    DEFVISITABLE(ExpressionVisitor<TypedValue*>);
     DEFVISITABLE(ExpressionVisitor<void>);
     bool Accept(HierarchicalTreeVisitor &visitor) override {
       if (visitor.PreVisit(*this)) {
@@ -892,6 +906,7 @@ cpp<#
     Reduce() = default;
 
     DEFVISITABLE(ExpressionVisitor<TypedValue>);
+    DEFVISITABLE(ExpressionVisitor<TypedValue*>);
     DEFVISITABLE(ExpressionVisitor<void>);
     bool Accept(HierarchicalTreeVisitor &visitor) override {
       if (visitor.PreVisit(*this)) {
@@ -930,6 +945,7 @@ cpp<#
    Coalesce() = default;
 
    DEFVISITABLE(ExpressionVisitor<TypedValue>);
+   DEFVISITABLE(ExpressionVisitor<TypedValue*>);
    DEFVISITABLE(ExpressionVisitor<void>);
    bool Accept(HierarchicalTreeVisitor &visitor) override {
      if (visitor.PreVisit(*this)) {
@@ -969,6 +985,7 @@ cpp<#
     Extract() = default;
 
     DEFVISITABLE(ExpressionVisitor<TypedValue>);
+    DEFVISITABLE(ExpressionVisitor<TypedValue*>);
     DEFVISITABLE(ExpressionVisitor<void>);
     bool Accept(HierarchicalTreeVisitor &visitor) override {
       if (visitor.PreVisit(*this)) {
@@ -1005,6 +1022,7 @@ cpp<#
     All() = default;
 
     DEFVISITABLE(ExpressionVisitor<TypedValue>);
+    DEFVISITABLE(ExpressionVisitor<TypedValue*>);
     DEFVISITABLE(ExpressionVisitor<void>);
     bool Accept(HierarchicalTreeVisitor &visitor) override {
       if (visitor.PreVisit(*this)) {
@@ -1046,6 +1064,7 @@ cpp<#
     Single() = default;
 
     DEFVISITABLE(ExpressionVisitor<TypedValue>);
+    DEFVISITABLE(ExpressionVisitor<TypedValue*>);
     DEFVISITABLE(ExpressionVisitor<void>);
     bool Accept(HierarchicalTreeVisitor &visitor) override {
       if (visitor.PreVisit(*this)) {
@@ -1087,6 +1106,7 @@ cpp<#
     Any() = default;
 
     DEFVISITABLE(ExpressionVisitor<TypedValue>);
+    DEFVISITABLE(ExpressionVisitor<TypedValue*>);
     DEFVISITABLE(ExpressionVisitor<void>);
     bool Accept(HierarchicalTreeVisitor &visitor) override {
       if (visitor.PreVisit(*this)) {
@@ -1128,6 +1148,7 @@ cpp<#
     None() = default;
 
     DEFVISITABLE(ExpressionVisitor<TypedValue>);
+    DEFVISITABLE(ExpressionVisitor<TypedValue*>);
     DEFVISITABLE(ExpressionVisitor<void>);
     bool Accept(HierarchicalTreeVisitor &visitor) override {
       if (visitor.PreVisit(*this)) {
@@ -1159,6 +1180,7 @@ cpp<#
     ParameterLookup() = default;
 
     DEFVISITABLE(ExpressionVisitor<TypedValue>);
+    DEFVISITABLE(ExpressionVisitor<TypedValue*>);
     DEFVISITABLE(ExpressionVisitor<void>);
     DEFVISITABLE(HierarchicalTreeVisitor);
     cpp<#)
@@ -1186,6 +1208,7 @@ cpp<#
     RegexMatch() = default;
 
     DEFVISITABLE(ExpressionVisitor<TypedValue>);
+    DEFVISITABLE(ExpressionVisitor<TypedValue*>);
     DEFVISITABLE(ExpressionVisitor<void>);
     bool Accept(HierarchicalTreeVisitor &visitor) override {
       if (visitor.PreVisit(*this)) {
@@ -1205,6 +1228,7 @@ cpp<#
 
 (lcp:define-class named-expression (tree "::utils::Visitable<HierarchicalTreeVisitor>"
                                          "::utils::Visitable<ExpressionVisitor<TypedValue>>"
+                                         "::utils::Visitable<ExpressionVisitor<TypedValue*>>"
                                          "::utils::Visitable<ExpressionVisitor<void>>")
   ((name "std::string" :scope :public)
    (expression "Expression *" :initval "nullptr" :scope :public
@@ -1223,6 +1247,7 @@ cpp<#
     NamedExpression() = default;
 
     DEFVISITABLE(ExpressionVisitor<TypedValue>);
+    DEFVISITABLE(ExpressionVisitor<TypedValue*>);
     DEFVISITABLE(ExpressionVisitor<void>);
     bool Accept(HierarchicalTreeVisitor &visitor) override {
       if (visitor.PreVisit(*this)) {

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -228,8 +228,8 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
 
     TypedValue *lhs_ptr = list_indexing.expression1_->Accept(referenceExpressionEvaluator);
     TypedValue lhs;
-    bool referenced = nullptr != lhs_ptr;
-    if (nullptr == lhs_ptr) {
+    const auto referenced = nullptr != lhs_ptr;
+    if (!referenced) {
       lhs = list_indexing.expression1_->Accept(*this);
       lhs_ptr = &lhs;
     }

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -40,55 +40,55 @@ class ReferenceExpressionEvaluator : public ExpressionVisitor<TypedValue *> {
 
   utils::MemoryResource *GetMemoryResource() const { return ctx_->memory; }
 
-#define UNSUCCESFUL_VISIT(expr_name) \
+#define UNSUCCESSFUL_VISIT(expr_name) \
   TypedValue *Visit(expr_name &expr) override { return nullptr; }
 
   TypedValue *Visit(Identifier &ident) override { return &frame_->at(symbol_table_->at(ident)); }
 
-  UNSUCCESFUL_VISIT(NamedExpression);
-  UNSUCCESFUL_VISIT(OrOperator);
-  UNSUCCESFUL_VISIT(XorOperator);
-  UNSUCCESFUL_VISIT(AdditionOperator);
-  UNSUCCESFUL_VISIT(SubtractionOperator);
-  UNSUCCESFUL_VISIT(MultiplicationOperator);
-  UNSUCCESFUL_VISIT(DivisionOperator);
-  UNSUCCESFUL_VISIT(ModOperator);
-  UNSUCCESFUL_VISIT(NotEqualOperator);
-  UNSUCCESFUL_VISIT(EqualOperator);
-  UNSUCCESFUL_VISIT(LessOperator);
-  UNSUCCESFUL_VISIT(GreaterOperator);
-  UNSUCCESFUL_VISIT(LessEqualOperator);
-  UNSUCCESFUL_VISIT(GreaterEqualOperator);
+  UNSUCCESSFUL_VISIT(NamedExpression);
+  UNSUCCESSFUL_VISIT(OrOperator);
+  UNSUCCESSFUL_VISIT(XorOperator);
+  UNSUCCESSFUL_VISIT(AdditionOperator);
+  UNSUCCESSFUL_VISIT(SubtractionOperator);
+  UNSUCCESSFUL_VISIT(MultiplicationOperator);
+  UNSUCCESSFUL_VISIT(DivisionOperator);
+  UNSUCCESSFUL_VISIT(ModOperator);
+  UNSUCCESSFUL_VISIT(NotEqualOperator);
+  UNSUCCESSFUL_VISIT(EqualOperator);
+  UNSUCCESSFUL_VISIT(LessOperator);
+  UNSUCCESSFUL_VISIT(GreaterOperator);
+  UNSUCCESSFUL_VISIT(LessEqualOperator);
+  UNSUCCESSFUL_VISIT(GreaterEqualOperator);
 
-  UNSUCCESFUL_VISIT(NotOperator);
-  UNSUCCESFUL_VISIT(UnaryPlusOperator);
-  UNSUCCESFUL_VISIT(UnaryMinusOperator);
+  UNSUCCESSFUL_VISIT(NotOperator);
+  UNSUCCESSFUL_VISIT(UnaryPlusOperator);
+  UNSUCCESSFUL_VISIT(UnaryMinusOperator);
 
-  UNSUCCESFUL_VISIT(AndOperator);
-  UNSUCCESFUL_VISIT(IfOperator);
-  UNSUCCESFUL_VISIT(InListOperator);
+  UNSUCCESSFUL_VISIT(AndOperator);
+  UNSUCCESSFUL_VISIT(IfOperator);
+  UNSUCCESSFUL_VISIT(InListOperator);
 
-  UNSUCCESFUL_VISIT(SubscriptOperator);
+  UNSUCCESSFUL_VISIT(SubscriptOperator);
 
-  UNSUCCESFUL_VISIT(ListSlicingOperator);
-  UNSUCCESFUL_VISIT(IsNullOperator);
-  UNSUCCESFUL_VISIT(PropertyLookup);
-  UNSUCCESFUL_VISIT(LabelsTest);
+  UNSUCCESSFUL_VISIT(ListSlicingOperator);
+  UNSUCCESSFUL_VISIT(IsNullOperator);
+  UNSUCCESSFUL_VISIT(PropertyLookup);
+  UNSUCCESSFUL_VISIT(LabelsTest);
 
-  UNSUCCESFUL_VISIT(PrimitiveLiteral);
-  UNSUCCESFUL_VISIT(ListLiteral);
-  UNSUCCESFUL_VISIT(MapLiteral);
-  UNSUCCESFUL_VISIT(Aggregation);
-  UNSUCCESFUL_VISIT(Coalesce);
-  UNSUCCESFUL_VISIT(Function);
-  UNSUCCESFUL_VISIT(Reduce);
-  UNSUCCESFUL_VISIT(Extract);
-  UNSUCCESFUL_VISIT(All);
-  UNSUCCESFUL_VISIT(Single);
-  UNSUCCESFUL_VISIT(Any);
-  UNSUCCESFUL_VISIT(None);
-  UNSUCCESFUL_VISIT(ParameterLookup);
-  UNSUCCESFUL_VISIT(RegexMatch);
+  UNSUCCESSFUL_VISIT(PrimitiveLiteral);
+  UNSUCCESSFUL_VISIT(ListLiteral);
+  UNSUCCESSFUL_VISIT(MapLiteral);
+  UNSUCCESSFUL_VISIT(Aggregation);
+  UNSUCCESSFUL_VISIT(Coalesce);
+  UNSUCCESSFUL_VISIT(Function);
+  UNSUCCESSFUL_VISIT(Reduce);
+  UNSUCCESSFUL_VISIT(Extract);
+  UNSUCCESSFUL_VISIT(All);
+  UNSUCCESSFUL_VISIT(Single);
+  UNSUCCESSFUL_VISIT(Any);
+  UNSUCCESSFUL_VISIT(None);
+  UNSUCCESSFUL_VISIT(ParameterLookup);
+  UNSUCCESSFUL_VISIT(RegexMatch);
 
  private:
   Frame *frame_;

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -26,6 +26,7 @@
 #include "query/interpret/eval.hpp"
 #include "query/interpret/frame.hpp"
 #include "query/path.hpp"
+#include "query/typed_value.hpp"
 #include "storage/v2/storage.hpp"
 #include "utils/exceptions.hpp"
 #include "utils/string.hpp"
@@ -306,7 +307,9 @@ TEST_F(ExpressionEvaluatorTest, ListIndexing) {
   {
     // Legal indexing.
     auto *op = storage.Create<SubscriptOperator>(list_literal, storage.Create<PrimitiveLiteral>(2));
+    std::cout << "here we go" << std::endl;
     auto value = Eval(op);
+    std::cout << "here we go 2" << std::endl;
     EXPECT_EQ(value.ValueInt(), 3);
   }
   {
@@ -423,6 +426,47 @@ TEST_F(ExpressionEvaluatorTest, VertexAndEdgeIndexing) {
                                                   storage.Create<PrimitiveLiteral>(memgraph::storage::PropertyValue()));
     auto value2 = Eval(op2);
     EXPECT_TRUE(value2.IsNull());
+  }
+}
+
+TEST_F(ExpressionEvaluatorTest, TypedValueListIndexing) {
+  auto list_vector = memgraph::utils::pmr::vector<TypedValue>(ctx.memory);
+  list_vector.emplace_back(TypedValue("string1"));
+  list_vector.emplace_back(TypedValue("string2"));
+
+  auto *identifier = storage.Create<Identifier>("n");
+  auto node_symbol = symbol_table.CreateSymbol("n", true);
+  identifier->MapTo(node_symbol);
+  frame[node_symbol] = TypedValue(list_vector, ctx.memory);
+
+  {
+    // Legal indexing.
+    auto *op = storage.Create<SubscriptOperator>(identifier, storage.Create<PrimitiveLiteral>(0));
+    auto value = Eval(op);
+    EXPECT_EQ(value.ValueString(), "string1");
+  }
+  {
+    // Out of bounds indexing
+    auto *op = storage.Create<SubscriptOperator>(identifier, storage.Create<PrimitiveLiteral>(3));
+    auto value = Eval(op);
+    EXPECT_TRUE(value.IsNull());
+  }
+  {
+    // Out of bounds indexing with negative bound.
+    auto *op = storage.Create<SubscriptOperator>(identifier, storage.Create<PrimitiveLiteral>(-100));
+    auto value = Eval(op);
+    EXPECT_TRUE(value.IsNull());
+  }
+  {
+    // Legal indexing with negative index.
+    auto *op = storage.Create<SubscriptOperator>(identifier, storage.Create<PrimitiveLiteral>(-2));
+    auto value = Eval(op);
+    EXPECT_EQ(value.ValueString(), "string1");
+  }
+  {
+    // Indexing with incompatible type.
+    auto *op = storage.Create<SubscriptOperator>(identifier, storage.Create<PrimitiveLiteral>("bla"));
+    EXPECT_THROW(Eval(op), QueryRuntimeException);
   }
 }
 

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -307,9 +307,7 @@ TEST_F(ExpressionEvaluatorTest, ListIndexing) {
   {
     // Legal indexing.
     auto *op = storage.Create<SubscriptOperator>(list_literal, storage.Create<PrimitiveLiteral>(2));
-    std::cout << "here we go" << std::endl;
     auto value = Eval(op);
-    std::cout << "here we go 2" << std::endl;
     EXPECT_EQ(value.ValueInt(), 3);
   }
   {

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -429,7 +429,7 @@ TEST_F(ExpressionEvaluatorTest, VertexAndEdgeIndexing) {
 
 TEST_F(ExpressionEvaluatorTest, TypedValueListIndexing) {
   auto list_vector = memgraph::utils::pmr::vector<TypedValue>(ctx.memory);
-  list_vector.emplace_back(TypedValue("string1"));
+  list_vector.emplace_back("string1");
   list_vector.emplace_back(TypedValue("string2"));
 
   auto *identifier = storage.Create<Identifier>("n");


### PR DESCRIPTION
This PR is one in a series of PRs created due to benchmarking and improving the `LOAD CSV` clause, which was tested and documented [here](https://github.com/memgraph/memgraph/pull/753).

Here I am implementing `ReferenceBasedEvaluator` as it was shown that copying of array of values slows down performance when there are many properties in a `row` created when reading a CSV file.

[master < Task] PR
- [x] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message

**Release note**: Implemented `ReferenceBasedEvaluator` as it was shown that copying of an array of values slows down performance when there are many properties in a `row` created when reading a CSV file

**Benchmarking**
- [x] Import 1 000 000 lines, from each line create 2 nodes and 1 new edge. Each line will have X properties, of 10 string length. Each node has X/2 features, where X is even.


| Number of properties per line | Import time (OLD) [seconds] | Import time (NEW) [seconds] | Throughput (OLD) [lines/s] | Throughput (NEW) [lines/s] |
| -- | -- | -- |  -- | -- |
|2 | 3.6s | 3.429 s|  |  |
|10 | 9.6s | 7.962 s|   |  |
|20 | 22s | 14.718 s|  |   |
