### PR TITLE
[master < T591-FL] Enhance performance of Property Store on node creation

### DIFF
--- a/src/query/common.hpp
+++ b/src/query/common.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -104,6 +104,39 @@ storage::PropertyValue PropsSetChecked(T *record, const storage::PropertyId &key
     return std::move(*maybe_old_value);
   } catch (const TypedValueException &) {
     throw QueryRuntimeException("'{}' cannot be used as a property value.", value.type());
+  }
+}
+
+template <typename T>
+concept AccessorWithSetProperties = requires(T accessor,
+                                             const std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+  { accessor.SetProperties(properties) } -> std::same_as<storage::Result<std::vector<storage::PropertyValue>>>;
+};
+
+/// Set a property `value` mapped with given `key` on a `record`.
+///
+/// @throw QueryRuntimeException if value cannot be set as a property value
+template <AccessorWithSetProperty T>
+storage::PropertyValue MultiPropsSetChecked(T *record,
+                                            std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+  try {
+    auto maybe_old_value = record->SetProperties(properties);
+    if (maybe_old_value.HasError()) {
+      switch (maybe_old_value.GetError()) {
+        case storage::Error::SERIALIZATION_ERROR:
+          throw TransactionSerializationException();
+        case storage::Error::DELETED_OBJECT:
+          throw QueryRuntimeException("Trying to set properties on a deleted object.");
+        case storage::Error::PROPERTIES_DISABLED:
+          throw QueryRuntimeException("Can't set property because properties on edges are disabled.");
+        case storage::Error::VERTEX_HAS_EDGES:
+        case storage::Error::NONEXISTENT_OBJECT:
+          throw QueryRuntimeException("Unexpected error when setting a property.");
+      }
+    }
+    return std::move(*maybe_old_value);
+  } catch (const TypedValueException &) {
+    throw QueryRuntimeException("Cannot set properties.");
   }
 }
 

--- a/src/query/common.hpp
+++ b/src/query/common.hpp
@@ -117,12 +117,11 @@ concept AccessorWithSetProperties = requires(T accessor,
 ///
 /// @throw QueryRuntimeException if value cannot be set as a property value
 template <AccessorWithSetProperty T>
-storage::PropertyValue MultiPropsSetChecked(T *record,
-                                            std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+bool MultiPropsSetChecked(T *record, std::map<storage::PropertyId, storage::PropertyValue> &properties) {
   try {
-    auto maybe_old_value = record->SetProperties(properties);
-    if (maybe_old_value.HasError()) {
-      switch (maybe_old_value.GetError()) {
+    auto maybe_values = record->SetProperties(properties);
+    if (maybe_values.HasError()) {
+      switch (maybe_values.GetError()) {
         case storage::Error::SERIALIZATION_ERROR:
           throw TransactionSerializationException();
         case storage::Error::DELETED_OBJECT:
@@ -134,7 +133,7 @@ storage::PropertyValue MultiPropsSetChecked(T *record,
           throw QueryRuntimeException("Unexpected error when setting a property.");
       }
     }
-    return std::move(*maybe_old_value);
+    return std::move(*maybe_values);
   } catch (const TypedValueException &) {
     throw QueryRuntimeException("Cannot set properties.");
   }

--- a/src/query/common.hpp
+++ b/src/query/common.hpp
@@ -108,18 +108,18 @@ storage::PropertyValue PropsSetChecked(T *record, const storage::PropertyId &key
 }
 
 template <typename T>
-concept AccessorWithSetProperties = requires(T accessor,
-                                             const std::map<storage::PropertyId, storage::PropertyValue> &properties) {
-  { accessor.SetProperties(properties) } -> std::same_as<storage::Result<bool>>;
+concept AccessorWithInitProperties = requires(T accessor,
+                                              const std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+  { accessor.InitProperties(properties) } -> std::same_as<storage::Result<bool>>;
 };
 
 /// Set property `values` mapped with given `key` on a `record`.
 ///
 /// @throw QueryRuntimeException if value cannot be set as a property value
-template <AccessorWithSetProperties T>
-bool MultiPropsSetChecked(T *record, std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+template <AccessorWithInitProperties T>
+bool MultiPropsInitChecked(T *record, std::map<storage::PropertyId, storage::PropertyValue> &properties) {
   try {
-    auto maybe_values = record->SetProperties(properties);
+    auto maybe_values = record->InitProperties(properties);
     if (maybe_values.HasError()) {
       switch (maybe_values.GetError()) {
         case storage::Error::SERIALIZATION_ERROR:

--- a/src/query/common.hpp
+++ b/src/query/common.hpp
@@ -110,13 +110,13 @@ storage::PropertyValue PropsSetChecked(T *record, const storage::PropertyId &key
 template <typename T>
 concept AccessorWithSetProperties = requires(T accessor,
                                              const std::map<storage::PropertyId, storage::PropertyValue> &properties) {
-  { accessor.SetProperties(properties) } -> std::same_as<storage::Result<std::vector<storage::PropertyValue>>>;
+  { accessor.SetProperties(properties) } -> std::same_as<storage::Result<bool>>;
 };
 
-/// Set a property `value` mapped with given `key` on a `record`.
+/// Set property `values` mapped with given `key` on a `record`.
 ///
 /// @throw QueryRuntimeException if value cannot be set as a property value
-template <AccessorWithSetProperty T>
+template <AccessorWithSetProperties T>
 bool MultiPropsSetChecked(T *record, std::map<storage::PropertyId, storage::PropertyValue> &properties) {
   try {
     auto maybe_values = record->SetProperties(properties);

--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -71,8 +71,8 @@ class EdgeAccessor final {
     return impl_.SetProperty(key, value);
   }
 
-  storage::Result<bool> SetProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties) {
-    return impl_.SetProperties(properties);
+  storage::Result<bool> InitProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+    return impl_.InitProperties(properties);
   }
 
   storage::Result<storage::PropertyValue> RemoveProperty(storage::PropertyId key) {
@@ -129,8 +129,8 @@ class VertexAccessor final {
     return impl_.SetProperty(key, value);
   }
 
-  storage::Result<bool> SetProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties) {
-    return impl_.SetProperties(properties);
+  storage::Result<bool> InitProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+    return impl_.InitProperties(properties);
   }
 
   storage::Result<storage::PropertyValue> RemoveProperty(storage::PropertyId key) {

--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -71,7 +71,7 @@ class EdgeAccessor final {
     return impl_.SetProperty(key, value);
   }
 
-  storage::Result<bool> SetProperties(std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+  storage::Result<bool> SetProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties) {
     return impl_.SetProperties(properties);
   }
 
@@ -129,7 +129,7 @@ class VertexAccessor final {
     return impl_.SetProperty(key, value);
   }
 
-  storage::Result<bool> SetProperties(std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+  storage::Result<bool> SetProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties) {
     return impl_.SetProperties(properties);
   }
 

--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -71,6 +71,10 @@ class EdgeAccessor final {
     return impl_.SetProperty(key, value);
   }
 
+  storage::Result<bool> SetProperties(std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+    return impl_.SetProperties(properties);
+  }
+
   storage::Result<storage::PropertyValue> RemoveProperty(storage::PropertyId key) {
     return SetProperty(key, storage::PropertyValue());
   }

--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -123,6 +123,11 @@ class VertexAccessor final {
 
   storage::Result<storage::PropertyValue> SetProperty(storage::PropertyId key, const storage::PropertyValue &value) {
     return impl_.SetProperty(key, value);
+  }
+
+  storage::Result<std::vector<storage::PropertyValue>> SetProperties(
+      std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+    return impl_.SetProperties(properties);
   }
 
   storage::Result<storage::PropertyValue> RemoveProperty(storage::PropertyId key) {

--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -125,8 +125,7 @@ class VertexAccessor final {
     return impl_.SetProperty(key, value);
   }
 
-  storage::Result<std::vector<storage::PropertyValue>> SetProperties(
-      std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+  storage::Result<bool> SetProperties(std::map<storage::PropertyId, storage::PropertyValue> &properties) {
     return impl_.SetProperties(properties);
   }
 

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -312,7 +312,7 @@ EdgeAccessor CreateEdge(const EdgeCreationInfo &edge_info, DbAccessor *dba, Vert
         properties.emplace(dba->NameToProperty(key), value);
       }
     }
-    MultiPropsSetChecked(&edge, properties);
+    if (!properties.empty()) MultiPropsSetChecked(&edge, properties);
 
     (*frame)[edge_info.symbol] = edge;
   } else {

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -220,7 +220,7 @@ VertexAccessor &CreateLocalVertex(const NodeCreationInfo &node_info, Frame *fram
       properties.emplace(dba.NameToProperty(key), value);
     }
   }
-  MultiPropsSetChecked(&new_node, properties);
+  MultiPropsInitChecked(&new_node, properties);
 
   (*frame)[node_info.symbol] = new_node;
   return (*frame)[node_info.symbol].ValueVertex();
@@ -312,7 +312,7 @@ EdgeAccessor CreateEdge(const EdgeCreationInfo &edge_info, DbAccessor *dba, Vert
         properties.emplace(dba->NameToProperty(key), value);
       }
     }
-    if (!properties.empty()) MultiPropsSetChecked(&edge, properties);
+    if (!properties.empty()) MultiPropsInitChecked(&edge, properties);
 
     (*frame)[edge_info.symbol] = edge;
   } else {

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -208,10 +208,12 @@ VertexAccessor &CreateLocalVertex(const NodeCreationInfo &node_info, Frame *fram
                                 storage::View::NEW);
   // TODO: PropsSetChecked allocates a PropertyValue, make it use context.memory
   // when we update PropertyValue with custom allocator.
+  std::map<storage::PropertyId, storage::PropertyValue> properties;
   if (const auto *node_info_properties = std::get_if<PropertiesMapList>(&node_info.properties)) {
     for (const auto &[key, value_expression] : *node_info_properties) {
-      PropsSetChecked(&new_node, key, value_expression->Accept(evaluator));
+      properties.emplace(key, value_expression->Accept(evaluator));
     }
+    new_node.SetProperties(properties);
   } else {
     auto property_map = evaluator.Visit(*std::get<ParameterLookup *>(node_info.properties));
     for (const auto &[key, value] : property_map.ValueMap()) {

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -25,6 +25,7 @@
 
 #include <cppitertools/chain.hpp>
 #include <cppitertools/imap.hpp>
+#include "query/common.hpp"
 #include "spdlog/spdlog.h"
 
 #include "license/license.hpp"
@@ -213,7 +214,7 @@ VertexAccessor &CreateLocalVertex(const NodeCreationInfo &node_info, Frame *fram
     for (const auto &[key, value_expression] : *node_info_properties) {
       properties.emplace(key, value_expression->Accept(evaluator));
     }
-    new_node.SetProperties(properties);
+    MultiPropsSetChecked(&new_node, properties);
   } else {
     auto property_map = evaluator.Visit(*std::get<ParameterLookup *>(node_info.properties));
     for (const auto &[key, value] : property_map.ValueMap()) {

--- a/src/storage/v2/edge_accessor.cpp
+++ b/src/storage/v2/edge_accessor.cpp
@@ -123,7 +123,7 @@ Result<storage::PropertyValue> EdgeAccessor::SetProperty(PropertyId property, co
   return std::move(current_value);
 }
 
-Result<bool> EdgeAccessor::SetProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+Result<bool> EdgeAccessor::InitProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties) {
   utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
   if (!config_.properties_on_edges) return Error::PROPERTIES_DISABLED;
 
@@ -133,7 +133,7 @@ Result<bool> EdgeAccessor::SetProperties(const std::map<storage::PropertyId, sto
 
   if (edge_.ptr->deleted) return Error::DELETED_OBJECT;
 
-  if (!edge_.ptr->properties.SetProperties(properties)) return false;
+  if (!edge_.ptr->properties.InitProperties(properties)) return false;
   for (const auto &[property, _] : properties) {
     CreateAndLinkDelta(transaction_, edge_.ptr, Delta::SetPropertyTag(), property, PropertyValue());
   }

--- a/src/storage/v2/edge_accessor.cpp
+++ b/src/storage/v2/edge_accessor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -121,6 +121,24 @@ Result<storage::PropertyValue> EdgeAccessor::SetProperty(PropertyId property, co
   edge_.ptr->properties.SetProperty(property, value);
 
   return std::move(current_value);
+}
+
+Result<bool> EdgeAccessor::SetProperties(std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+  utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
+  if (!config_.properties_on_edges) return Error::PROPERTIES_DISABLED;
+
+  std::lock_guard<utils::SpinLock> guard(edge_.ptr->lock);
+
+  if (!PrepareForWrite(transaction_, edge_.ptr)) return Error::SERIALIZATION_ERROR;
+
+  if (edge_.ptr->deleted) return Error::DELETED_OBJECT;
+
+  if (!edge_.ptr->properties.SetProperties(properties)) return false;
+  for (const auto &[property, _] : properties) {
+    CreateAndLinkDelta(transaction_, edge_.ptr, Delta::SetPropertyTag(), property, PropertyValue());
+  }
+
+  return true;
 }
 
 Result<std::map<PropertyId, PropertyValue>> EdgeAccessor::ClearProperties() {

--- a/src/storage/v2/edge_accessor.cpp
+++ b/src/storage/v2/edge_accessor.cpp
@@ -123,7 +123,7 @@ Result<storage::PropertyValue> EdgeAccessor::SetProperty(PropertyId property, co
   return std::move(current_value);
 }
 
-Result<bool> EdgeAccessor::SetProperties(std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+Result<bool> EdgeAccessor::SetProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties) {
   utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
   if (!config_.properties_on_edges) return Error::PROPERTIES_DISABLED;
 

--- a/src/storage/v2/edge_accessor.hpp
+++ b/src/storage/v2/edge_accessor.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -57,6 +57,11 @@ class EdgeAccessor final {
   /// Set a property value and return the old value.
   /// @throw std::bad_alloc
   Result<storage::PropertyValue> SetProperty(PropertyId property, const PropertyValue &value);
+
+  /// Set property values only if property store is empty. Returns `true` if successully set all values,
+  /// `false` otherwise.
+  /// @throw std::bad_alloc
+  Result<bool> SetProperties(std::map<storage::PropertyId, storage::PropertyValue> &properties);
 
   /// Remove all properties and return old values for each removed property.
   /// @throw std::bad_alloc

--- a/src/storage/v2/edge_accessor.hpp
+++ b/src/storage/v2/edge_accessor.hpp
@@ -61,7 +61,7 @@ class EdgeAccessor final {
   /// Set property values only if property store is empty. Returns `true` if successully set all values,
   /// `false` otherwise.
   /// @throw std::bad_alloc
-  Result<bool> SetProperties(std::map<storage::PropertyId, storage::PropertyValue> &properties);
+  Result<bool> SetProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties);
 
   /// Remove all properties and return old values for each removed property.
   /// @throw std::bad_alloc

--- a/src/storage/v2/edge_accessor.hpp
+++ b/src/storage/v2/edge_accessor.hpp
@@ -61,7 +61,7 @@ class EdgeAccessor final {
   /// Set property values only if property store is empty. Returns `true` if successully set all values,
   /// `false` otherwise.
   /// @throw std::bad_alloc
-  Result<bool> SetProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties);
+  Result<bool> InitProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties);
 
   /// Remove all properties and return old values for each removed property.
   /// @throw std::bad_alloc

--- a/src/storage/v2/property_store.cpp
+++ b/src/storage/v2/property_store.cpp
@@ -1053,8 +1053,7 @@ bool PropertyStore::SetProperty(PropertyId property, const PropertyValue &value)
         in_local_buffer = true;
       } else {
         // Allocate a new external buffer.
-        auto alloc_data =
-            new uint8_t[property_size_to_power_of_8];  // todo fix this also, add auto *, why did this work?
+        auto *alloc_data = new uint8_t[property_size_to_power_of_8];
         auto alloc_size = property_size_to_power_of_8;
 
         SetSizeData(buffer_, alloc_size, alloc_data);

--- a/src/storage/v2/property_store.cpp
+++ b/src/storage/v2/property_store.cpp
@@ -1147,8 +1147,8 @@ bool PropertyStore::SetProperty(PropertyId property, const PropertyValue &value)
 }
 
 bool PropertyStore::SetProperties(std::map<storage::PropertyId, storage::PropertyValue> &properties) {
-  uint64_t size;
-  uint8_t *data;
+  uint64_t size = 0;
+  uint8_t *data = nullptr;
   std::tie(size, data) = GetSizeData(buffer_);
   if (size != 0) {
     return false;
@@ -1185,7 +1185,7 @@ bool PropertyStore::SetProperties(std::map<storage::PropertyId, storage::Propert
 
   for (const auto &[property, value] : properties) {
     MG_ASSERT(EncodeProperty(&writer, property, value), "Invalid database state!");
-    property_size = writer.Written();
+    writer.Written();
   }
 
   auto metadata = writer.WriteMetadata();

--- a/src/storage/v2/property_store.cpp
+++ b/src/storage/v2/property_store.cpp
@@ -1144,7 +1144,7 @@ bool PropertyStore::SetProperty(PropertyId property, const PropertyValue &value)
   return !existed;
 }
 
-bool PropertyStore::SetProperties(std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+bool PropertyStore::SetProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties) {
   uint64_t size = 0;
   uint8_t *data = nullptr;
   std::tie(size, data) = GetSizeData(buffer_);
@@ -1156,6 +1156,9 @@ bool PropertyStore::SetProperties(std::map<storage::PropertyId, storage::Propert
   {
     Writer writer;
     for (const auto &[property, value] : properties) {
+      if (value.IsNull()) {
+        continue;
+      }
       EncodeProperty(&writer, property, value);
       property_size = writer.Written();
     }
@@ -1182,6 +1185,9 @@ bool PropertyStore::SetProperties(std::map<storage::PropertyId, storage::Propert
   Writer writer(data, size);
 
   for (const auto &[property, value] : properties) {
+    if (value.IsNull()) {
+      continue;
+    }
     MG_ASSERT(EncodeProperty(&writer, property, value), "Invalid database state!");
     writer.Written();
   }

--- a/src/storage/v2/property_store.cpp
+++ b/src/storage/v2/property_store.cpp
@@ -971,8 +971,6 @@ PropertyValue PropertyStore::GetProperty(PropertyId property) const {
   return value;
 }
 
-PropertyValue PropertyStore::GetEmptyProperty() const { return {}; }
-
 bool PropertyStore::HasProperty(PropertyId property) const {
   uint64_t size;
   const uint8_t *data;

--- a/src/storage/v2/property_store.cpp
+++ b/src/storage/v2/property_store.cpp
@@ -1146,12 +1146,13 @@ bool PropertyStore::SetProperty(PropertyId property, const PropertyValue &value)
   return !existed;
 }
 
-// use this function only when inserting new properties
 bool PropertyStore::SetProperties(std::map<storage::PropertyId, storage::PropertyValue> &properties) {
   uint64_t size;
   uint8_t *data;
   std::tie(size, data) = GetSizeData(buffer_);
-  MG_ASSERT(size == 0, "Invalid database state!");
+  if (size != 0) {
+    return false;
+  }
 
   uint64_t property_size = 0;
   {

--- a/src/storage/v2/property_store.cpp
+++ b/src/storage/v2/property_store.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -971,6 +971,8 @@ PropertyValue PropertyStore::GetProperty(PropertyId property) const {
   return value;
 }
 
+PropertyValue PropertyStore::GetEmptyProperty() const { return {}; }
+
 bool PropertyStore::HasProperty(PropertyId property) const {
   uint64_t size;
   const uint8_t *data;
@@ -1142,6 +1144,57 @@ bool PropertyStore::SetProperty(PropertyId property, const PropertyValue &value)
   }
 
   return !existed;
+}
+
+// use this function only when inserting new properties
+bool PropertyStore::SetProperties(std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+  uint64_t size;
+  uint8_t *data;
+  std::tie(size, data) = GetSizeData(buffer_);
+  MG_ASSERT(size == 0, "Invalid database state!");
+
+  uint64_t property_size = 0;
+  {
+    Writer writer;
+    for (const auto &[property, value] : properties) {
+      EncodeProperty(&writer, property, value);
+      property_size = writer.Written();
+    }
+  }
+
+  auto property_size_to_power_of_8 = ToPowerOf8(property_size);
+  if (property_size <= sizeof(buffer_) - 1) {
+    // Use the local buffer.
+    buffer_[0] = kUseLocalBuffer;
+    size = sizeof(buffer_) - 1;
+    data = &buffer_[1];
+  } else {
+    // Allocate a new external buffer.
+    auto alloc_data = new uint8_t[property_size_to_power_of_8];
+    auto alloc_size = property_size_to_power_of_8;
+
+    SetSizeData(buffer_, alloc_size, alloc_data);
+
+    size = alloc_size;
+    data = alloc_data;
+  }
+
+  // Encode the property into the data buffer.
+  Writer writer(data, size);
+
+  for (const auto &[property, value] : properties) {
+    MG_ASSERT(EncodeProperty(&writer, property, value), "Invalid database state!");
+    property_size = writer.Written();
+  }
+
+  auto metadata = writer.WriteMetadata();
+  if (metadata) {
+    // If there is any space left in the buffer we add a tombstone to
+    // indicate that there are no more properties to be decoded.
+    metadata->Set({Type::EMPTY});
+  }
+
+  return true;
 }
 
 bool PropertyStore::ClearProperties() {

--- a/src/storage/v2/property_store.cpp
+++ b/src/storage/v2/property_store.cpp
@@ -1144,7 +1144,7 @@ bool PropertyStore::SetProperty(PropertyId property, const PropertyValue &value)
   return !existed;
 }
 
-bool PropertyStore::SetProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+bool PropertyStore::InitProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties) {
   uint64_t size = 0;
   uint8_t *data = nullptr;
   std::tie(size, data) = GetSizeData(buffer_);

--- a/src/storage/v2/property_store.cpp
+++ b/src/storage/v2/property_store.cpp
@@ -1053,7 +1053,8 @@ bool PropertyStore::SetProperty(PropertyId property, const PropertyValue &value)
         in_local_buffer = true;
       } else {
         // Allocate a new external buffer.
-        auto alloc_data = new uint8_t[property_size_to_power_of_8];
+        auto alloc_data =
+            new uint8_t[property_size_to_power_of_8];  // todo fix this also, add auto *, why did this work?
         auto alloc_size = property_size_to_power_of_8;
 
         SetSizeData(buffer_, alloc_size, alloc_data);
@@ -1169,7 +1170,7 @@ bool PropertyStore::SetProperties(std::map<storage::PropertyId, storage::Propert
     data = &buffer_[1];
   } else {
     // Allocate a new external buffer.
-    auto alloc_data = new uint8_t[property_size_to_power_of_8];
+    auto *alloc_data = new uint8_t[property_size_to_power_of_8];
     auto alloc_size = property_size_to_power_of_8;
 
     SetSizeData(buffer_, alloc_size, alloc_data);

--- a/src/storage/v2/property_store.hpp
+++ b/src/storage/v2/property_store.hpp
@@ -38,8 +38,6 @@ class PropertyStore {
   /// @throw std::bad_alloc
   PropertyValue GetProperty(PropertyId property) const;
 
-  PropertyValue GetEmptyProperty() const;
-
   /// Checks whether the property `property` exists in the store. The time
   /// complexity of this function is O(n).
   bool HasProperty(PropertyId property) const;

--- a/src/storage/v2/property_store.hpp
+++ b/src/storage/v2/property_store.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -38,6 +38,8 @@ class PropertyStore {
   /// @throw std::bad_alloc
   PropertyValue GetProperty(PropertyId property) const;
 
+  PropertyValue GetEmptyProperty() const;
+
   /// Checks whether the property `property` exists in the store. The time
   /// complexity of this function is O(n).
   bool HasProperty(PropertyId property) const;
@@ -58,6 +60,8 @@ class PropertyStore {
   /// O(n).
   /// @throw std::bad_alloc
   bool SetProperty(PropertyId property, const PropertyValue &value);
+
+  bool SetProperties(std::map<storage::PropertyId, storage::PropertyValue> &properties);
 
   /// Remove all properties and return `true` if any removal took place.
   /// `false` is returned if there were no properties to remove. The time

--- a/src/storage/v2/property_store.hpp
+++ b/src/storage/v2/property_store.hpp
@@ -59,11 +59,11 @@ class PropertyStore {
   /// @throw std::bad_alloc
   bool SetProperty(PropertyId property, const PropertyValue &value);
 
-  /// Set property values and return `true` if insertion took place. `false` is
+  /// Init property values and return `true` if insertion took place. `false` is
   /// returned if there exists property in property store and insertion couldn't take place. The time complexity of this
   /// function is O(n).
   /// @throw std::bad_alloc
-  bool SetProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties);
+  bool InitProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties);
 
   /// Remove all properties and return `true` if any removal took place.
   /// `false` is returned if there were no properties to remove. The time

--- a/src/storage/v2/property_store.hpp
+++ b/src/storage/v2/property_store.hpp
@@ -61,6 +61,10 @@ class PropertyStore {
   /// @throw std::bad_alloc
   bool SetProperty(PropertyId property, const PropertyValue &value);
 
+  /// Set property values and return `true` if insertion took place. `false` is
+  /// returned if there exists property in property store and insertion couldn't take place. The time complexity of this
+  /// function is O(n).
+  /// @throw std::bad_alloc
   bool SetProperties(std::map<storage::PropertyId, storage::PropertyValue> &properties);
 
   /// Remove all properties and return `true` if any removal took place.

--- a/src/storage/v2/property_store.hpp
+++ b/src/storage/v2/property_store.hpp
@@ -63,7 +63,7 @@ class PropertyStore {
   /// returned if there exists property in property store and insertion couldn't take place. The time complexity of this
   /// function is O(n).
   /// @throw std::bad_alloc
-  bool SetProperties(std::map<storage::PropertyId, storage::PropertyValue> &properties);
+  bool SetProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties);
 
   /// Remove all properties and return `true` if any removal took place.
   /// `false` is returned if there were no properties to remove. The time

--- a/src/storage/v2/vertex_accessor.cpp
+++ b/src/storage/v2/vertex_accessor.cpp
@@ -230,7 +230,7 @@ Result<PropertyValue> VertexAccessor::SetProperty(PropertyId property, const Pro
   return std::move(current_value);
 }
 
-Result<bool> VertexAccessor::SetProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+Result<bool> VertexAccessor::InitProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties) {
   utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
   std::lock_guard<utils::SpinLock> guard(vertex_->lock);
 
@@ -238,7 +238,7 @@ Result<bool> VertexAccessor::SetProperties(const std::map<storage::PropertyId, s
 
   if (vertex_->deleted) return Error::DELETED_OBJECT;
 
-  if (!vertex_->properties.SetProperties(properties)) return false;
+  if (!vertex_->properties.InitProperties(properties)) return false;
   for (const auto &[property, value] : properties) {
     CreateAndLinkDelta(transaction_, vertex_, Delta::SetPropertyTag(), property, PropertyValue());
     UpdateOnSetProperty(indices_, property, value, vertex_, *transaction_);

--- a/src/storage/v2/vertex_accessor.cpp
+++ b/src/storage/v2/vertex_accessor.cpp
@@ -230,7 +230,7 @@ Result<PropertyValue> VertexAccessor::SetProperty(PropertyId property, const Pro
   return std::move(current_value);
 }
 
-Result<bool> VertexAccessor::SetProperties(std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+Result<bool> VertexAccessor::SetProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties) {
   utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
   std::lock_guard<utils::SpinLock> guard(vertex_->lock);
 

--- a/src/storage/v2/vertex_accessor.cpp
+++ b/src/storage/v2/vertex_accessor.cpp
@@ -240,8 +240,7 @@ Result<bool> VertexAccessor::SetProperties(std::map<storage::PropertyId, storage
 
   if (!vertex_->properties.SetProperties(properties)) return false;
   for (const auto &[property, value] : properties) {
-    CreateAndLinkDelta(transaction_, vertex_, Delta::SetPropertyTag(), property,
-                       vertex_->properties.GetEmptyProperty());
+    CreateAndLinkDelta(transaction_, vertex_, Delta::SetPropertyTag(), property, PropertyValue());
     UpdateOnSetProperty(indices_, property, value, vertex_, *transaction_);
   }
 

--- a/src/storage/v2/vertex_accessor.cpp
+++ b/src/storage/v2/vertex_accessor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -228,6 +228,32 @@ Result<PropertyValue> VertexAccessor::SetProperty(PropertyId property, const Pro
   UpdateOnSetProperty(indices_, property, value, vertex_, *transaction_);
 
   return std::move(current_value);
+}
+
+Result<std::vector<storage::PropertyValue>> VertexAccessor::SetProperties(
+    std::map<storage::PropertyId, storage::PropertyValue> &properties) {
+  // Be careful when calling this function
+  // It will set properties in batch, without checking if property already exists
+
+  utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
+  std::lock_guard<utils::SpinLock> guard(vertex_->lock);
+
+  if (!PrepareForWrite(transaction_, vertex_)) return Error::SERIALIZATION_ERROR;
+
+  if (vertex_->deleted) return Error::DELETED_OBJECT;
+
+  std::vector<storage::PropertyValue> new_values;
+
+  vertex_->properties.SetProperties(properties);
+
+  for (const auto &[property, value] : properties) {
+    auto current_value = vertex_->properties.GetEmptyProperty();
+    CreateAndLinkDelta(transaction_, vertex_, Delta::SetPropertyTag(), property, current_value);
+    UpdateOnSetProperty(indices_, property, value, vertex_, *transaction_);
+    new_values.emplace_back(current_value);
+  }
+
+  return new_values;
 }
 
 Result<std::map<PropertyId, PropertyValue>> VertexAccessor::ClearProperties() {

--- a/src/storage/v2/vertex_accessor.hpp
+++ b/src/storage/v2/vertex_accessor.hpp
@@ -71,7 +71,7 @@ class VertexAccessor final {
   /// Set property values only if property store is empty. Returns `true` if successully set all values,
   /// `false` otherwise.
   /// @throw std::bad_alloc
-  Result<bool> SetProperties(std::map<storage::PropertyId, storage::PropertyValue> &properties);
+  Result<bool> SetProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties);
 
   /// Remove all properties and return the values of the removed properties.
   /// @throw std::bad_alloc

--- a/src/storage/v2/vertex_accessor.hpp
+++ b/src/storage/v2/vertex_accessor.hpp
@@ -68,8 +68,10 @@ class VertexAccessor final {
   /// @throw std::bad_alloc
   Result<PropertyValue> SetProperty(PropertyId property, const PropertyValue &value);
 
-  Result<std::vector<storage::PropertyValue>> SetProperties(
-      std::map<storage::PropertyId, storage::PropertyValue> &properties);
+  /// Set property values only if property store is empty. Returns `true` if successully set all values,
+  /// `false` otherwise.
+  /// @throw std::bad_alloc
+  Result<bool> SetProperties(std::map<storage::PropertyId, storage::PropertyValue> &properties);
 
   /// Remove all properties and return the values of the removed properties.
   /// @throw std::bad_alloc

--- a/src/storage/v2/vertex_accessor.hpp
+++ b/src/storage/v2/vertex_accessor.hpp
@@ -71,7 +71,7 @@ class VertexAccessor final {
   /// Set property values only if property store is empty. Returns `true` if successully set all values,
   /// `false` otherwise.
   /// @throw std::bad_alloc
-  Result<bool> SetProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties);
+  Result<bool> InitProperties(const std::map<storage::PropertyId, storage::PropertyValue> &properties);
 
   /// Remove all properties and return the values of the removed properties.
   /// @throw std::bad_alloc

--- a/src/storage/v2/vertex_accessor.hpp
+++ b/src/storage/v2/vertex_accessor.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -67,6 +67,9 @@ class VertexAccessor final {
   /// Set a property value and return the old value.
   /// @throw std::bad_alloc
   Result<PropertyValue> SetProperty(PropertyId property, const PropertyValue &value);
+
+  Result<std::vector<storage::PropertyValue>> SetProperties(
+      std::map<storage::PropertyId, storage::PropertyValue> &properties);
 
   /// Remove all properties and return the values of the removed properties.
   /// @throw std::bad_alloc

--- a/tests/gql_behave/tests/memgraph_V1/features/functions.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/functions.feature
@@ -585,12 +585,12 @@ Feature: Functions
             """
         When executing query:
             """
-            MATCH ()-[r]->() RETURN PROPERTIES(r) AS p
+            MATCH ()-[r]->() RETURN PROPERTIES(r) AS p ORDER BY p.prop;
             """
         Then the result should be:
             | p         |
+            | {a: null} |
             | {b: true} |
-            | {}        |
             | {c: 123}  |
 
     Scenario: Properties test2:

--- a/tests/gql_behave/tests/memgraph_V1/features/functions.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/functions.feature
@@ -589,7 +589,7 @@ Feature: Functions
             """
         Then the result should be:
             | p         |
-            | {a: null} |
+            | {}        |
             | {b: true} |
             | {c: 123}  |
 

--- a/tests/unit/storage_v2_property_store.cpp
+++ b/tests/unit/storage_v2_property_store.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -648,4 +648,27 @@ TEST(PropertyStore, IsPropertyEqualTemporalData) {
   // Same type, different value.
   ASSERT_FALSE(props.IsPropertyEqual(prop, memgraph::storage::PropertyValue(memgraph::storage::TemporalData{
                                                memgraph::storage::TemporalType::Date, 30})));
+}
+
+TEST(PropertyStore, SetMultipleProperties) {
+  memgraph::storage::PropertyStore store;
+  std::vector<memgraph::storage::PropertyValue> vec{memgraph::storage::PropertyValue(true),
+                                                    memgraph::storage::PropertyValue(123),
+                                                    memgraph::storage::PropertyValue()};
+  std::map<std::string, memgraph::storage::PropertyValue> map{{"nandare", memgraph::storage::PropertyValue(false)}};
+  const memgraph::storage::TemporalData temporal{memgraph::storage::TemporalType::LocalDateTime, 23};
+  std::map<memgraph::storage::PropertyId, memgraph::storage::PropertyValue> data{
+      {memgraph::storage::PropertyId::FromInt(1), memgraph::storage::PropertyValue(true)},
+      {memgraph::storage::PropertyId::FromInt(2), memgraph::storage::PropertyValue(123)},
+      {memgraph::storage::PropertyId::FromInt(3), memgraph::storage::PropertyValue(123.5)},
+      {memgraph::storage::PropertyId::FromInt(4), memgraph::storage::PropertyValue("nandare")},
+      {memgraph::storage::PropertyId::FromInt(5), memgraph::storage::PropertyValue(vec)},
+      {memgraph::storage::PropertyId::FromInt(6), memgraph::storage::PropertyValue(map)},
+      {memgraph::storage::PropertyId::FromInt(7), memgraph::storage::PropertyValue(temporal)}};
+
+  store.SetProperties(data);
+
+  for (auto &[key, value] : data) {
+    ASSERT_TRUE(store.IsPropertyEqual(key, value));
+  }
 }

--- a/tests/unit/storage_v2_property_store.cpp
+++ b/tests/unit/storage_v2_property_store.cpp
@@ -666,7 +666,7 @@ TEST(PropertyStore, SetMultipleProperties) {
       {memgraph::storage::PropertyId::FromInt(6), memgraph::storage::PropertyValue(map)},
       {memgraph::storage::PropertyId::FromInt(7), memgraph::storage::PropertyValue(temporal)}};
 
-  store.SetProperties(data);
+  store.InitProperties(data);
 
   for (auto &[key, value] : data) {
     ASSERT_TRUE(store.IsPropertyEqual(key, value));


### PR DESCRIPTION
[master < Task] PR
- [x] Check, and update documentation if necessary

**Release note**: Improve performance by storing node or edge properties in a property store all at once on node or edge creation, instead of individually,  when dealing with large numbers of properties.

**Benchmarking**
- [x] Import 1 000 000 lines, from each line create 2 nodes and 1 new edge. Each line will have X properties, of 10 string length. Each node has X/2 features, where X is even.

| Number of properties per line | Import time (OLD) [seconds] | Import time (NEW) [seconds] | Throughput (OLD) [lines/s] | Throughput (NEW) [lines/s] |
| -- | -- | -- |  -- | -- |
|2 | 3.6s | 3.6 s|  |  |
|10 | 9.6s | 8.7 s|   |  |
|20 | 22s | 17.5 s|  |   |