### PR TITLE
[T1238 < T1247] Add exceptions for unimplemented EXISTS query parts

### DIFF
--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -448,11 +448,11 @@ bool SymbolGenerator::PreVisit(Exists &exists) {
   auto &scope = scopes_.back();
 
   if (scope.in_set_property) {
-    throw SemanticException("Set property can not be used with exists, but only during matching!");
+    throw utils::NotYetImplemented("Set property can not be used with exists, but only during matching!");
   }
 
   if (scope.in_with) {
-    throw SemanticException("WITH can not be used with exists, but only during matching!");
+    throw utils::NotYetImplemented("WITH can not be used with exists, but only during matching!");
   }
 
   scope.in_exists = true;

--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -473,6 +473,8 @@ bool SymbolGenerator::PostVisit(Exists & /*exists*/) {
 bool SymbolGenerator::PreVisit(SetProperty & /*set_property*/) {
   auto &scope = scopes_.back();
   scope.in_set_property = true;
+
+  return true;
 }
 
 bool SymbolGenerator::PostVisit(SetProperty & /*set_property*/) {

--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -447,6 +447,14 @@ bool SymbolGenerator::PreVisit(Extract &extract) {
 bool SymbolGenerator::PreVisit(Exists &exists) {
   auto &scope = scopes_.back();
 
+  if (scope.in_set_property) {
+    throw SemanticException("Set property can not be used with exists, but only during matching!");
+  }
+
+  if (scope.in_with) {
+    throw SemanticException("WITH can not be used with exists, but only during matching!");
+  }
+
   scope.in_exists = true;
 
   const auto &symbol = CreateAnonymousSymbol();
@@ -458,6 +466,18 @@ bool SymbolGenerator::PreVisit(Exists &exists) {
 bool SymbolGenerator::PostVisit(Exists & /*exists*/) {
   auto &scope = scopes_.back();
   scope.in_exists = false;
+
+  return true;
+}
+
+bool SymbolGenerator::PreVisit(SetProperty & /*set_property*/) {
+  auto &scope = scopes_.back();
+  scope.in_set_property = true;
+}
+
+bool SymbolGenerator::PostVisit(SetProperty & /*set_property*/) {
+  auto &scope = scopes_.back();
+  scope.in_set_property = false;
 
   return true;
 }

--- a/src/query/frontend/semantic/symbol_generator.hpp
+++ b/src/query/frontend/semantic/symbol_generator.hpp
@@ -64,6 +64,8 @@ class SymbolGenerator : public HierarchicalTreeVisitor {
   bool PostVisit(Match &) override;
   bool PreVisit(Foreach &) override;
   bool PostVisit(Foreach &) override;
+  bool PreVisit(SetProperty &) override;
+  bool PostVisit(SetProperty &) override;
 
   // Expressions
   ReturnType Visit(Identifier &) override;
@@ -116,6 +118,7 @@ class SymbolGenerator : public HierarchicalTreeVisitor {
     bool in_match{false};
     bool in_foreach{false};
     bool in_exists{false};
+    bool in_set_property{false};
     // True when visiting a pattern atom (node or edge) identifier, which can be
     // reused or created in the pattern itself.
     bool in_pattern_atom_identifier{false};

--- a/src/query/frontend/semantic/symbol_generator.hpp
+++ b/src/query/frontend/semantic/symbol_generator.hpp
@@ -64,8 +64,8 @@ class SymbolGenerator : public HierarchicalTreeVisitor {
   bool PostVisit(Match &) override;
   bool PreVisit(Foreach &) override;
   bool PostVisit(Foreach &) override;
-  bool PreVisit(SetProperty &) override;
-  bool PostVisit(SetProperty &) override;
+  bool PreVisit(SetProperty & /*set_property*/) override;
+  bool PostVisit(SetProperty & /*set_property*/) override;
 
   // Expressions
   ReturnType Visit(Identifier &) override;

--- a/src/query/plan/rule_based_planner.cpp
+++ b/src/query/plan/rule_based_planner.cpp
@@ -235,10 +235,6 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
     return true;
   }
 
-  bool PreVisit(Exists & /*exists*/) override {
-    throw SemanticException("Exists functionality works only with matching clauses!");
-  }
-
   bool Visit(Identifier &ident) override {
     const auto &symbol = symbol_table_.at(ident);
     if (!utils::Contains(output_symbols_, symbol)) {

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -28,9 +28,7 @@ Feature: WHERE exists
           | n.prop |
           | 1      |
           | 3      |
-
-  Scenario: Test exists with edge specifier
-      Given an empty graph
+MATCH (n:One) WHERE exists((n)-[]-()) RETURN n.prop ORDER BY n.prop;
       And having executed:
           """
           CREATE (:One {prop:1})-[:TYPE]->(:Two)
@@ -351,16 +349,7 @@ Feature: WHERE exists
           """
           CREATE (:One {prop:1})-[:TYPE {prop: 1}]->(:Two {prop: 2})-[:TYPE {prop:2}]->(:Three {prop: 3})
           """
-      When executing query:
-          """
-          MATCH (n) WHERE exists(({prop: 1})-[:TYPE]->(n)-[:TYPE2]->(:Three)) RETURN n.prop;
-          """
-      Then the result should be empty
-
-
-  Scenario: Test node-only hop
-      Given an empty graph
-      And having executed:
+      When executing query:SemanticException
           """
           CREATE (:One {prop:1})-[:TYPE {prop: 1}]->(:Two {prop: 2})-[:TYPE {prop:2}]->(:Three {prop: 3})
           """
@@ -504,3 +493,15 @@ Feature: WHERE exists
           MATCH (n:One) WHERE exists((n)-[]-()) in [false] RETURN n.prop;
           """
       Then the result should be empty
+
+  Scenario: Test exists does not work in SetProperty clauses
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:One {prop:1})-[:TYPE]->(:Two);
+          """
+      When executing query:
+          """
+          MATCH (n:Two) SET n.prop = exists((n)<-[:TYPE]-()) RETURN n.prop;
+          """
+      Then an error should be raised

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -28,7 +28,9 @@ Feature: WHERE exists
           | n.prop |
           | 1      |
           | 3      |
-MATCH (n:One) WHERE exists((n)-[]-()) RETURN n.prop ORDER BY n.prop;
+
+  Scenario: Test exists with edge specifier
+      Given an empty graph
       And having executed:
           """
           CREATE (:One {prop:1})-[:TYPE]->(:Two)
@@ -349,7 +351,15 @@ MATCH (n:One) WHERE exists((n)-[]-()) RETURN n.prop ORDER BY n.prop;
           """
           CREATE (:One {prop:1})-[:TYPE {prop: 1}]->(:Two {prop: 2})-[:TYPE {prop:2}]->(:Three {prop: 3})
           """
-      When executing query:SemanticException
+      When executing query:
+          """
+          MATCH (n) WHERE exists(({prop: 1})-[:TYPE]->(n)-[:TYPE2]->(:Three)) RETURN n.prop;
+          """
+      Then the result should be empty
+
+  Scenario: Test node-only hop
+      Given an empty graph
+      And having executed:
           """
           CREATE (:One {prop:1})-[:TYPE {prop: 1}]->(:Two {prop: 2})-[:TYPE {prop:2}]->(:Three {prop: 3})
           """


### PR DESCRIPTION
The PR namely concerns SET and WITH clauses where exists() functionality does not work yet. A not implemented exception is thrown.
