### PR TITLE
Remove noexcept from functions that may throw

### DIFF
--- a/src/query/procedure/mg_procedure_impl.hpp
+++ b/src/query/procedure/mg_procedure_impl.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -146,10 +146,10 @@ struct mgp_date {
   mgp_date(const memgraph::utils::Date &date, memgraph::utils::MemoryResource *memory) noexcept
       : memory(memory), date(date) {}
 
-  mgp_date(const std::string_view string, memgraph::utils::MemoryResource *memory) noexcept
+  mgp_date(const std::string_view string, memgraph::utils::MemoryResource *memory)
       : memory(memory), date(memgraph::utils::ParseDateParameters(string).first) {}
 
-  mgp_date(const mgp_date_parameters *parameters, memgraph::utils::MemoryResource *memory) noexcept
+  mgp_date(const mgp_date_parameters *parameters, memgraph::utils::MemoryResource *memory)
       : memory(memory), date(MapDateParameters(parameters)) {}
 
   mgp_date(const int64_t microseconds, memgraph::utils::MemoryResource *memory) noexcept
@@ -194,10 +194,10 @@ struct mgp_local_time {
   // have everything noexcept here.
   static_assert(std::is_nothrow_copy_constructible_v<memgraph::utils::LocalTime>);
 
-  mgp_local_time(const std::string_view string, memgraph::utils::MemoryResource *memory) noexcept
+  mgp_local_time(const std::string_view string, memgraph::utils::MemoryResource *memory)
       : memory(memory), local_time(memgraph::utils::ParseLocalTimeParameters(string).first) {}
 
-  mgp_local_time(const mgp_local_time_parameters *parameters, memgraph::utils::MemoryResource *memory) noexcept
+  mgp_local_time(const mgp_local_time_parameters *parameters, memgraph::utils::MemoryResource *memory)
       : memory(memory), local_time(MapLocalTimeParameters(parameters)) {}
 
   mgp_local_time(const memgraph::utils::LocalTime &local_time, memgraph::utils::MemoryResource *memory) noexcept
@@ -250,8 +250,7 @@ struct mgp_local_date_time {
   mgp_local_date_time(const std::string_view string, memgraph::utils::MemoryResource *memory) noexcept
       : memory(memory), local_date_time(CreateLocalDateTimeFromString(string)) {}
 
-  mgp_local_date_time(const mgp_local_date_time_parameters *parameters,
-                      memgraph::utils::MemoryResource *memory) noexcept
+  mgp_local_date_time(const mgp_local_date_time_parameters *parameters, memgraph::utils::MemoryResource *memory)
       : memory(memory),
         local_date_time(MapDateParameters(parameters->date_parameters),
                         MapLocalTimeParameters(parameters->local_time_parameters)) {}
@@ -301,7 +300,7 @@ struct mgp_duration {
   // have everything noexcept here.
   static_assert(std::is_nothrow_copy_constructible_v<memgraph::utils::Duration>);
 
-  mgp_duration(const std::string_view string, memgraph::utils::MemoryResource *memory) noexcept
+  mgp_duration(const std::string_view string, memgraph::utils::MemoryResource *memory)
       : memory(memory), duration(memgraph::utils::ParseDurationParameters(string)) {}
 
   mgp_duration(const mgp_duration_parameters *parameters, memgraph::utils::MemoryResource *memory) noexcept

--- a/tests/unit/cpp_api.cpp
+++ b/tests/unit/cpp_api.cpp
@@ -389,6 +389,10 @@ TEST_F(CppApiTestFixture, TestLocalDateTime) {
   auto ldt_1 = mgp::LocalDateTime("2021-10-05T14:15:00");
   auto ldt_2 = mgp::LocalDateTime(2021, 10, 5, 14, 15, 0, 0, 0);
 
+  ASSERT_ANY_THROW(mgp::LocalDateTime(
+      2021, 10, 0, 14, 15, 0, 0,
+      0));  // ...10, 0, 14... <- 0 is an illegal value for the `day` parameter; must throw an exception
+
   ASSERT_EQ(ldt_1.Year(), 2021);
   ASSERT_EQ(ldt_1.Month(), 10);
   ASSERT_EQ(ldt_1.Day(), 5);


### PR DESCRIPTION
This PR fixes Memgraph crashing when a user’s query procedure attempts to construct a `LocalDateTime` object with invalid parameters
A C++ API `LocalDateTime` object is built upon a `memgraph::utils::LocalDateTime` object, which has a constructor that’s a) noexcept b) constructs a `memgraph::utils::Date` member, which may throw an exception
This error has been fixed together with other `LocalDateTime` constructors that were marked as noexcept but might throw an exception
[master < Task] PR
- [x] Check, and update documentation if necessary
- [x] Provide the full content or a guide for the final git message
> Fix Memgraph crashing when constructing mgp::LocalDateTime objects with invalid parameters

To keep docs changelog up to date, one more thing to do:
- [x] Write a release note here
> Constructing LocalDateTime objects with invalid parameters doesn’t crash Memgraph anymore, but throws an informative exception.
- [x] Tag someone from docs team in the comments
