### PR TITLE
Change PullPlan to use specific Memory Resource for LOAD CSV

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -305,13 +305,29 @@ class Interpreter final {
  private:
   struct QueryExecution {
     std::optional<PreparedQuery> prepared_query;
-    utils::MonotonicBufferResource execution_memory{kExecutionMemoryBlockSize};
-    utils::ResourceWithOutOfMemoryException execution_memory_with_exception{&execution_memory};
+    std::variant<utils::MonotonicBufferResource, utils::PoolResource> execution_memory;
+    utils::ResourceWithOutOfMemoryException execution_memory_with_exception;
 
     std::map<std::string, TypedValue> summary;
     std::vector<Notification> notifications;
 
-    explicit QueryExecution() = default;
+    explicit QueryExecution(utils::MonotonicBufferResource monotonic_memory)
+        : execution_memory(std::move(monotonic_memory)) {
+      std::visit(
+          [&](auto &memory_resource) {
+            execution_memory_with_exception = utils::ResourceWithOutOfMemoryException(&memory_resource);
+          },
+          execution_memory);
+    };
+
+    explicit QueryExecution(utils::PoolResource pool_resource) : execution_memory(std::move(pool_resource)) {
+      std::visit(
+          [&](auto &memory_resource) {
+            execution_memory_with_exception = utils::ResourceWithOutOfMemoryException(&memory_resource);
+          },
+          execution_memory);
+    };
+
     QueryExecution(const QueryExecution &) = delete;
     QueryExecution(QueryExecution &&) = default;
     QueryExecution &operator=(const QueryExecution &) = delete;
@@ -322,7 +338,7 @@ class Interpreter final {
       // destroy the prepared query which is using that instance
       // of execution memory.
       prepared_query.reset();
-      execution_memory.Release();
+      std::visit([](auto &memory_resource) { memory_resource.Release(); }, execution_memory);
     }
   };
 
@@ -390,7 +406,9 @@ std::map<std::string, TypedValue> Interpreter::Pull(TStream *result_stream, std:
   try {
     // Wrap the (statically polymorphic) stream type into a common type which
     // the handler knows.
-    AnyStream stream{result_stream, &query_execution->execution_memory};
+    AnyStream stream{result_stream,
+                     std::visit([](auto &execution_memory) -> utils::MemoryResource * { return &execution_memory; },
+                                query_execution->execution_memory)};
     const auto maybe_res = query_execution->prepared_query->query_handler(&stream, n);
     // Stream is using execution memory of the query_execution which
     // can be deleted after its execution so the stream should be cleared

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -4647,7 +4647,7 @@ class LoadCsvCursor : public Cursor {
     // have to read at most cardinality(n) rows (but we can read less and stop
     // pulling MATCH).
     if (!input_is_once_ && !input_pulled) return false;
-    auto row = reader_->GetNextRow(context.evaluation_context.memory);
+    auto row = reader_->GetNextRow();
     if (!row) {
       return false;
     }
@@ -4682,7 +4682,7 @@ class LoadCsvCursor : public Cursor {
     return csv::Reader(
         *maybe_file,
         csv::Reader::Config(self_->with_header_, self_->ignore_bad_, std::move(maybe_delim), std::move(maybe_quote)),
-        utils::NewDeleteResource());
+        eval_context->memory);
   }
 };
 

--- a/src/storage/v2/mvcc.hpp
+++ b/src/storage/v2/mvcc.hpp
@@ -104,31 +104,31 @@ inline Delta *CreateDeleteObjectDelta(Transaction *transaction) {
 /// @throw std::bad_alloc
 template <typename TObj, class... Args>
 inline void CreateAndLinkDelta(Transaction *transaction, TObj *object, Args &&...args) {
-  transaction->EnsureCommitTimestampExists();
-  auto delta = &transaction->deltas.emplace_back(std::forward<Args>(args)..., transaction->commit_timestamp.get(),
-                                                 transaction->command_id);
+  // transaction->EnsureCommitTimestampExists();
+  // auto delta = &transaction->deltas.emplace_back(std::forward<Args>(args)..., transaction->commit_timestamp.get(),
+  //                                                transaction->command_id);
 
-  // The operations are written in such order so that both `next` and `prev`
-  // chains are valid at all times. The chains must be valid at all times
-  // because garbage collection (which traverses the chains) is done
-  // concurrently (as well as other execution threads).
+  // // The operations are written in such order so that both `next` and `prev`
+  // // chains are valid at all times. The chains must be valid at all times
+  // // because garbage collection (which traverses the chains) is done
+  // // concurrently (as well as other execution threads).
 
-  // 1. We need to set the next delta of the new delta to the existing delta.
-  delta->next.store(object->delta, std::memory_order_release);
-  // 2. We need to set the previous delta of the new delta to the object.
-  delta->prev.Set(object);
-  // 3. We need to set the previous delta of the existing delta to the new
-  // delta. After this point the garbage collector will be able to see the new
-  // delta but won't modify it until we are done with all of our modifications.
-  if (object->delta) {
-    object->delta->prev.Set(delta);
-  }
-  // 4. Finally, we need to set the object's delta to the new delta. The garbage
-  // collector and other transactions will acquire the object lock to read the
-  // delta from the object. Because the lock is held during the whole time this
-  // modification is being done, everybody else will wait until we are fully
-  // done with our modification before they read the object's delta value.
-  object->delta = delta;
+  // // 1. We need to set the next delta of the new delta to the existing delta.
+  // delta->next.store(object->delta, std::memory_order_release);
+  // // 2. We need to set the previous delta of the new delta to the object.
+  // delta->prev.Set(object);
+  // // 3. We need to set the previous delta of the existing delta to the new
+  // // delta. After this point the garbage collector will be able to see the new
+  // // delta but won't modify it until we are done with all of our modifications.
+  // if (object->delta) {
+  //   object->delta->prev.Set(delta);
+  // }
+  // // 4. Finally, we need to set the object's delta to the new delta. The garbage
+  // // collector and other transactions will acquire the object lock to read the
+  // // delta from the object. Because the lock is held during the whole time this
+  // // modification is being done, everybody else will wait until we are fully
+  // // done with our modification before they read the object's delta value.
+  // object->delta = delta;
 }
 
 }  // namespace memgraph::storage

--- a/src/utils/csv_parsing.hpp
+++ b/src/utils/csv_parsing.hpp
@@ -83,7 +83,7 @@ class Reader {
   using ParsingResult = utils::BasicResult<ParseError, Row>;
   [[nodiscard]] bool HasHeader() const;
   const Header &GetHeader() const;
-  std::optional<Row> GetNextRow(utils::MemoryResource *mem);
+  std::optional<Row> GetNextRow();
 
  private:
   utils::MemoryResource *memory_;
@@ -98,11 +98,11 @@ class Reader {
 
   void TryInitializeHeader();
 
-  std::optional<utils::pmr::string> GetNextLine(utils::MemoryResource *mem);
+  std::optional<utils::pmr::string> GetNextLine();
 
   ParsingResult ParseHeader();
 
-  ParsingResult ParseRow(utils::MemoryResource *mem);
+  ParsingResult ParseRow();
 };
 
 }  // namespace memgraph::csv


### PR DESCRIPTION
This commit changes following:
- introduces std::variant to struct QueryExecution due to the fact that inside such memory can be long csv lines, so such memory can be reused
- changes PullPlan to use PoolResource with 1 chunk per block and 16384 characters of maximal length
- such change will enable to read long csv lines and reuse such memory as on every read of line you can always reuse old memory

[master < Epic] PR
- [ ] Check, and update documentation if necessary
- [ ] Write E2E tests
- [ ] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch and the Epic branch
- [ ] Provide the full content or a guide for the final git message

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here
- [ ] Tag someone from docs team in the comments
