### PR TITLE
[master < ] Extend memgraph::slk

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,20 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.4.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 23.1.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v13.0.0
+    rev: v15.0.7
     hooks:
       - id: clang-format

--- a/init
+++ b/init
@@ -149,9 +149,9 @@ python3 -m pre_commit install
 
 # Install py format tools
 echo "Install black formatter"
-python3 -m pip install black==22.8.*
+python3 -m pip install black==23.1.*
 echo "Install isort"
-python3 -m pip install isort==5.10.*
+python3 -m pip install isort==5.12.*
 
 # Link `include/mgp.py` with `release/mgp/mgp.py`
 ln -v -f include/mgp.py release/mgp/mgp.py

--- a/src/slk/loopback.hpp
+++ b/src/slk/loopback.hpp
@@ -1,0 +1,72 @@
+// Copyright 2023 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include "slk/streams.hpp"
+#include "utils/logging.hpp"
+
+namespace memgraph::slk {
+
+/// Class used for basic SLK use-cases.
+/// It creates a `memgraph::slk::Builder` that can be written to. After you
+/// have written the data to the builder, you can get a `memgraph::slk::Reader`
+/// and try to decode the encoded data.
+class Loopback {
+ public:
+  ~Loopback() {
+    MG_ASSERT(builder_, "You haven't created a builder!");
+    MG_ASSERT(reader_, "You haven't created a reader!");
+    reader_->Finalize();
+  }
+
+  memgraph::slk::Builder *GetBuilder() {
+    MG_ASSERT(!builder_, "You have already allocated a builder!");
+    builder_ = std::make_unique<memgraph::slk::Builder>(
+        [this](const uint8_t *data, size_t size, bool have_more) { Write(data, size, have_more); });
+    return builder_.get();
+  }
+
+  memgraph::slk::Reader *GetReader() {
+    MG_ASSERT(builder_, "You must first get a builder before getting a reader!");
+    MG_ASSERT(!reader_, "You have already allocated a reader!");
+    builder_->Finalize();
+    auto ret = memgraph::slk::CheckStreamComplete(data_.data(), data_.size());
+    MG_ASSERT(ret.status == memgraph::slk::StreamStatus::COMPLETE);
+    MG_ASSERT(ret.stream_size == data_.size());
+    size_ = ret.encoded_data_size;
+    reader_ = std::make_unique<memgraph::slk::Reader>(data_.data(), data_.size());
+    return reader_.get();
+  }
+
+  size_t size() { return size_; }
+
+ private:
+  void Write(const uint8_t *data, size_t size, bool have_more) {
+    for (size_t i = 0; i < size; ++i) {
+      data_.push_back(data[i]);
+    }
+  }
+
+  std::vector<uint8_t> data_;
+  std::unique_ptr<memgraph::slk::Builder> builder_;
+  std::unique_ptr<memgraph::slk::Reader> reader_;
+  size_t size_{0};
+};
+
+}  // namespace memgraph::slk

--- a/src/slk/loopback.hpp
+++ b/src/slk/loopback.hpp
@@ -29,6 +29,12 @@ namespace memgraph::slk {
 /// and try to decode the encoded data.
 class Loopback {
  public:
+  Loopback() = default;
+  Loopback(const Loopback &) = delete;
+  Loopback &operator=(const Loopback &) = delete;
+  Loopback(Loopback &&) = delete;
+  Loopback &operator=(Loopback &&) = delete;
+
   ~Loopback() {
     MG_ASSERT(builder_, "You haven't created a builder!");
     MG_ASSERT(reader_, "You haven't created a reader!");
@@ -54,7 +60,7 @@ class Loopback {
     return reader_.get();
   }
 
-  size_t size() { return size_; }
+  size_t size() const { return size_; }
 
  private:
   void Write(const uint8_t *data, size_t size, bool have_more) {

--- a/src/slk/streams.hpp
+++ b/src/slk/streams.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -46,7 +46,7 @@ static_assert(kSegmentMaxDataSize <= std::numeric_limits<SegmentSize>::max(),
 /// Builder used to create a SLK segment stream.
 class Builder {
  public:
-  Builder(std::function<void(const uint8_t *, size_t, bool)> write_func);
+  explicit Builder(std::function<void(const uint8_t *, size_t, bool)> write_func);
 
   /// Function used internally by SLK to serialize the data.
   void Save(const uint8_t *data, uint64_t size);


### PR DESCRIPTION
because SLK is simple, convenient and efficient

- [ ] Add loopback for simple serialization
- [ ] Revise `Builder` and `Reader` types
- [ ] Add compression as an option on the serialization side