### PR TITLE
changed-link

### DIFF
--- a/src/mg_import_csv.cpp
+++ b/src/mg_import_csv.cpp
@@ -436,7 +436,7 @@ void ProcessNodeRow(memgraph::storage::Storage *store, const std::vector<std::st
       if (it != node_id_map->end()) {
         if (FLAGS_skip_duplicate_nodes) {
           spdlog::warn(memgraph::utils::MessageWithLink("Skipping duplicate node with ID '{}'.", node_id,
-                                                        "https://memgr.ph/csv"));
+                                                        "https://memgr.ph/csv-import-tool"));
           return;
         } else {
           throw LoadException("Node with ID '{}' already exists", node_id);
@@ -529,7 +529,7 @@ void ProcessRelationshipsRow(memgraph::storage::Storage *store, const std::vecto
       if (it == node_id_map.end()) {
         if (FLAGS_skip_bad_relationships) {
           spdlog::warn(memgraph::utils::MessageWithLink("Skipping bad relationship with START_ID '{}'.", node_id,
-                                                        "https://memgr.ph/csv"));
+                                                        "https://memgr.ph/csv-import-tool"));
           return;
         } else {
           throw LoadException("Node with ID '{}' does not exist", node_id);
@@ -547,7 +547,7 @@ void ProcessRelationshipsRow(memgraph::storage::Storage *store, const std::vecto
       if (it == node_id_map.end()) {
         if (FLAGS_skip_bad_relationships) {
           spdlog::warn(memgraph::utils::MessageWithLink("Skipping bad relationship with END_ID '{}'.", node_id,
-                                                        "https://memgr.ph/csv"));
+                                                        "https://memgr.ph/csv-import-tool"));
           return;
         } else {
           throw LoadException("Node with ID '{}' does not exist", node_id);


### PR DESCRIPTION
I've changed the link in the error message of the CSV import tool from https://memgr.ph/csv to https://memgr.ph/csv-import-tool

The link for now is dead as the readme file needs to be merged first and a short link updated to that readme
