### PR TITLE
Add SASL librdkafka dependency

### DIFF
--- a/environment/os/ubuntu-22.04-arm.sh
+++ b/environment/os/ubuntu-22.04-arm.sh
@@ -57,6 +57,7 @@ MEMGRAPH_BUILD_DEPS=(
     dotnet-sdk-6.0 golang nodejs npm
     autoconf # for jemalloc code generation
     libtool  # for protobuf code generation
+    libsasl2-dev # for librdkafka client
 )
 
 list() {

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -209,8 +209,9 @@ import_external_library(librdkafka STATIC
              -DCMAKE_INSTALL_LIBDIR=lib
              -DWITH_SSL=ON
              # If we want SASL, we need to install it on build machines
-             -DWITH_SASL=OFF)
-target_link_libraries(librdkafka INTERFACE ${OPENSSL_LIBRARIES} ZLIB::ZLIB)
+             -DWITH_SASL=ON)
+find_package(Sasl REQUIRED)
+target_link_libraries(librdkafka INTERFACE ${OPENSSL_LIBRARIES} ZLIB::ZLIB ${SASL_STATIC_LIB})
 
 import_library(librdkafka++ STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/librdkafka/lib/librdkafka++.a


### PR DESCRIPTION
- [ ] Ensure static lib is used so that users who install the Memgraph package don't have to install anything in addition
- [ ] Install SASL development library to all build machines