### PR TITLE
Update pulsar client for e2e tests

### DIFF
--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -286,7 +286,7 @@ jobs:
           ./setup.sh
           source ve3/bin/activate
           cd e2e
-          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../../libs/mgclient/lib python runner.py --workloads-root-directory .
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../../libs/mgclient/lib python -v runner.py --workloads-root-directory .
 
       - name: Run stress test (plain)
         run: |

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -286,7 +286,7 @@ jobs:
           ./setup.sh
           source ve3/bin/activate
           cd e2e
-          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../../libs/mgclient/lib python -v runner.py --workloads-root-directory .
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../../libs/mgclient/lib python runner.py --workloads-root-directory .
 
       - name: Run stress test (plain)
         run: |

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -34,14 +34,7 @@ set -u
 PYTHON_MINOR=$(python3 -c 'import sys; print(sys.version_info[:][1])')
 
 # install pulsar-client
-# NOTE (2021-11-15): PyPi doesn't contain pulsar-client for Python 3.9 so we have to use
-# our manually built wheel file. When they update the repository, pulsar-client can be
-# added as a regular PIP dependancy
-if [ $PYTHON_MINOR -lt 9 ]; then
-  pip --timeout 1000 install "pulsar-client==2.8.1"
-else
-  pip --timeout 1000 install https://s3-eu-west-1.amazonaws.com/deps.memgraph.io/pulsar_client-2.8.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl
-fi
+pip --timeout 1000 install "pulsar-client==3.1.0"
 
 for pkg in "${PIP_DEPS[@]}"; do
     pip --timeout 1000 install "$pkg"


### PR DESCRIPTION
Memgraph used outdated pulsar-client 2.8.1.
I updated it to the fresh 3.1.0.