### PR TITLE
[T1250 < T1251] Expose metrics data in critical parts of the system

### DIFF
--- a/src/communication/bolt/v1/states/executing.hpp
+++ b/src/communication/bolt/v1/states/executing.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -22,9 +22,14 @@
 #include "communication/bolt/v1/state.hpp"
 #include "communication/bolt/v1/states/handlers.hpp"
 #include "communication/bolt/v1/value.hpp"
+#include "utils/event_counter.hpp"
 #include "utils/likely.hpp"
 #include "utils/logging.hpp"
 #include "utils/message.hpp"
+
+namespace Statistics {
+extern const Event BoltMessages;
+}  // namespace Statistics
 
 namespace memgraph::communication::bolt {
 
@@ -94,6 +99,7 @@ State RunHandlerV4(Signature signature, TSession &session, State state, Marker m
  */
 template <typename TSession>
 State StateExecutingRun(TSession &session, State state) {
+  Statistics::IncrementCounter(Statistics::BoltMessages);
   Marker marker;
   Signature signature;
   if (!session.decoder_.ReadMessageHeader(&signature, &marker)) {

--- a/src/communication/v2/listener.hpp
+++ b/src/communication/v2/listener.hpp
@@ -35,7 +35,7 @@
 #include "utils/synchronized.hpp"
 
 namespace Statistics {
-extern const Event ActiveConnections;
+extern const Event ActiveSessions;
 }  // namespace Statistics
 
 namespace memgraph::communication::v2 {
@@ -115,10 +115,9 @@ class Listener final : public std::enable_shared_from_this<Listener<TSession, TS
       return OnError(ec, "accept");
     }
 
-    Statistics::IncrementCounter(Statistics::ActiveConnections);
-
     auto session = SessionHandler::Create(std::move(socket), data_, *server_context_, endpoint_, inactivity_timeout_,
                                           service_name_);
+
     session->Start();
     DoAccept();
   }

--- a/src/communication/v2/listener.hpp
+++ b/src/communication/v2/listener.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -30,8 +30,13 @@
 #include "communication/context.hpp"
 #include "communication/v2/pool.hpp"
 #include "communication/v2/session.hpp"
+#include "utils/event_counter.hpp"
 #include "utils/spin_lock.hpp"
 #include "utils/synchronized.hpp"
+
+namespace Statistics {
+extern const Event ActiveConnections;
+}  // namespace Statistics
 
 namespace memgraph::communication::v2 {
 
@@ -109,6 +114,8 @@ class Listener final : public std::enable_shared_from_this<Listener<TSession, TS
     if (ec) {
       return OnError(ec, "accept");
     }
+
+    Statistics::IncrementCounter(Statistics::ActiveConnections);
 
     auto session = SessionHandler::Create(std::move(socket), data_, *server_context_, endpoint_, inactivity_timeout_,
                                           service_name_);

--- a/src/communication/v2/session.hpp
+++ b/src/communication/v2/session.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -43,8 +43,13 @@
 
 #include "communication/context.hpp"
 #include "communication/exceptions.hpp"
+#include "utils/event_counter.hpp"
 #include "utils/logging.hpp"
 #include "utils/variant_helpers.hpp"
+
+namespace Statistics {
+extern const Event ActiveConnections;
+}  // namespace Statistics
 
 namespace memgraph::communication::v2 {
 
@@ -429,6 +434,8 @@ class Session final : public std::enable_shared_from_this<Session<TSession, TSes
       }
       lowest_layer.close();
     });
+
+    Statistics::DecrementCounter(Statistics::ActiveConnections);
   }
 
   void DoHandshake() {

--- a/src/http_handlers/metrics.hpp
+++ b/src/http_handlers/metrics.hpp
@@ -35,11 +35,13 @@ struct MetricsResponse {
  public:
   nlohmann::json AsJson() {
     auto metrics_response = nlohmann::json();
-    metrics_response["vertex_count"] = vertex_count;
-    metrics_response["edge_count"] = edge_count;
-    metrics_response["average_degree"] = average_degree;
-    metrics_response["memory_usage"] = memory_usage;
-    metrics_response["disk_usage"] = disk_usage;
+    const auto *general_type = "General";
+
+    metrics_response[general_type]["vertex_count"] = vertex_count;
+    metrics_response[general_type]["edge_count"] = edge_count;
+    metrics_response[general_type]["average_degree"] = average_degree;
+    metrics_response[general_type]["memory_usage"] = memory_usage;
+    metrics_response[general_type]["disk_usage"] = disk_usage;
 
     for (const auto &event_counter : event_counters) {
       auto type = std::get<1>(event_counter);

--- a/src/http_handlers/metrics.hpp
+++ b/src/http_handlers/metrics.hpp
@@ -74,11 +74,11 @@ class MetricsService {
 
   std::vector<std::pair<std::string, uint64_t>> GetEventCounters() {
     std::vector<std::pair<std::string, uint64_t>> event_counters;
-    event_counters.reserve(EventCounter::End());
+    event_counters.reserve(Statistics::End());
 
-    for (auto i = 0; i < EventCounter::End(); i++) {
-      event_counters.emplace_back(EventCounter::GetName(i),
-                                  EventCounter::global_counters[i].load(std::memory_order_relaxed));
+    for (auto i = 0; i < Statistics::End(); i++) {
+      event_counters.emplace_back(Statistics::GetName(i),
+                                  Statistics::global_counters[i].load(std::memory_order_relaxed));
     }
 
     return event_counters;

--- a/src/http_handlers/metrics.hpp
+++ b/src/http_handlers/metrics.hpp
@@ -117,7 +117,7 @@ class MetricsService {
     event_histograms.reserve(Statistics::HistogramEnd());
 
     for (auto i = 0; i < Statistics::HistogramEnd(); i++) {
-      auto name = Statistics::GetHistogramName(i);
+      const auto *name = Statistics::GetHistogramName(i);
       auto &histogram = Statistics::global_histograms[i];
 
       for (auto &[percentile, value] : histogram.YieldPercentiles()) {

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -1009,8 +1009,8 @@ int main(int argc, char **argv) {
     });
     telemetry->AddCollector("event_counters", []() -> nlohmann::json {
       nlohmann::json ret;
-      for (size_t i = 0; i < EventCounter::End(); ++i) {
-        ret[EventCounter::GetName(i)] = EventCounter::global_counters[i].load(std::memory_order_relaxed);
+      for (size_t i = 0; i < Statistics::End(); ++i) {
+        ret[Statistics::GetName(i)] = Statistics::global_counters[i].load(std::memory_order_relaxed);
       }
       return ret;
     });

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -1009,8 +1009,8 @@ int main(int argc, char **argv) {
     });
     telemetry->AddCollector("event_counters", []() -> nlohmann::json {
       nlohmann::json ret;
-      for (size_t i = 0; i < Statistics::End(); ++i) {
-        ret[Statistics::GetName(i)] = Statistics::global_counters[i].load(std::memory_order_relaxed);
+      for (size_t i = 0; i < Statistics::CounterEnd(); ++i) {
+        ret[Statistics::GetCounterName(i)] = Statistics::global_counters[i].load(std::memory_order_relaxed);
       }
       return ret;
     });

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -44,9 +44,9 @@
 #include "utils/timer.hpp"
 #include "utils/tsc.hpp"
 
-namespace EventCounter {
+namespace Statistics {
 extern const Event FailedQuery;
-}  // namespace EventCounter
+}  // namespace Statistics
 
 namespace memgraph::query {
 
@@ -496,7 +496,7 @@ std::map<std::string, TypedValue> Interpreter::Pull(TStream *result_stream, std:
     query_execution.reset(nullptr);
     throw;
   } catch (const utils::BasicException &) {
-    EventCounter::IncrementCounter(EventCounter::FailedQuery);
+    Statistics::IncrementCounter(Statistics::FailedQuery);
     AbortCommand(&query_execution);
     throw;
   }

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -80,7 +80,7 @@
     LOG_FATAL("Operator " #class_name " has no single input!");  \
   }
 
-namespace EventCounter {
+namespace Statistics {
 extern const Event OnceOperator;
 extern const Event CreateNodeOperator;
 extern const Event CreateExpandOperator;
@@ -118,7 +118,7 @@ extern const Event ForeachOperator;
 extern const Event EmptyResultOperator;
 extern const Event EvaluatePatternFilterOperator;
 extern const Event ApplyOperator;
-}  // namespace EventCounter
+}  // namespace Statistics
 
 namespace memgraph::query::plan {
 
@@ -169,7 +169,7 @@ bool Once::OnceCursor::Pull(Frame &, ExecutionContext &context) {
 }
 
 UniqueCursorPtr Once::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::OnceOperator);
+  Statistics::IncrementCounter(Statistics::OnceOperator);
 
   return MakeUniqueCursorPtr<OnceCursor>(mem);
 }
@@ -231,7 +231,7 @@ VertexAccessor &CreateLocalVertex(const NodeCreationInfo &node_info, Frame *fram
 ACCEPT_WITH_INPUT(CreateNode)
 
 UniqueCursorPtr CreateNode::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::CreateNodeOperator);
+  Statistics::IncrementCounter(Statistics::CreateNodeOperator);
 
   return MakeUniqueCursorPtr<CreateNodeCursor>(mem, *this, mem);
 }
@@ -281,7 +281,7 @@ CreateExpand::CreateExpand(const NodeCreationInfo &node_info, const EdgeCreation
 ACCEPT_WITH_INPUT(CreateExpand)
 
 UniqueCursorPtr CreateExpand::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::CreateNodeOperator);
+  Statistics::IncrementCounter(Statistics::CreateNodeOperator);
 
   return MakeUniqueCursorPtr<CreateExpandCursor>(mem, *this, mem);
 }
@@ -488,7 +488,7 @@ ScanAll::ScanAll(const std::shared_ptr<LogicalOperator> &input, Symbol output_sy
 ACCEPT_WITH_INPUT(ScanAll)
 
 UniqueCursorPtr ScanAll::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::ScanAllOperator);
+  Statistics::IncrementCounter(Statistics::ScanAllOperator);
 
   auto vertices = [this](Frame &, ExecutionContext &context) {
     auto *db = context.db_accessor;
@@ -511,7 +511,7 @@ ScanAllByLabel::ScanAllByLabel(const std::shared_ptr<LogicalOperator> &input, Sy
 ACCEPT_WITH_INPUT(ScanAllByLabel)
 
 UniqueCursorPtr ScanAllByLabel::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::ScanAllByLabelOperator);
+  Statistics::IncrementCounter(Statistics::ScanAllByLabelOperator);
 
   auto vertices = [this](Frame &, ExecutionContext &context) {
     auto *db = context.db_accessor;
@@ -541,7 +541,7 @@ ScanAllByLabelPropertyRange::ScanAllByLabelPropertyRange(const std::shared_ptr<L
 ACCEPT_WITH_INPUT(ScanAllByLabelPropertyRange)
 
 UniqueCursorPtr ScanAllByLabelPropertyRange::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::ScanAllByLabelPropertyRangeOperator);
+  Statistics::IncrementCounter(Statistics::ScanAllByLabelPropertyRangeOperator);
 
   auto vertices = [this](Frame &frame, ExecutionContext &context)
       -> std::optional<decltype(context.db_accessor->Vertices(view_, label_, property_, std::nullopt, std::nullopt))> {
@@ -601,7 +601,7 @@ ScanAllByLabelPropertyValue::ScanAllByLabelPropertyValue(const std::shared_ptr<L
 ACCEPT_WITH_INPUT(ScanAllByLabelPropertyValue)
 
 UniqueCursorPtr ScanAllByLabelPropertyValue::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::ScanAllByLabelPropertyValueOperator);
+  Statistics::IncrementCounter(Statistics::ScanAllByLabelPropertyValueOperator);
 
   auto vertices = [this](Frame &frame, ExecutionContext &context)
       -> std::optional<decltype(context.db_accessor->Vertices(view_, label_, property_, storage::PropertyValue()))> {
@@ -626,7 +626,7 @@ ScanAllByLabelProperty::ScanAllByLabelProperty(const std::shared_ptr<LogicalOper
 ACCEPT_WITH_INPUT(ScanAllByLabelProperty)
 
 UniqueCursorPtr ScanAllByLabelProperty::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::ScanAllByLabelPropertyOperator);
+  Statistics::IncrementCounter(Statistics::ScanAllByLabelPropertyOperator);
 
   auto vertices = [this](Frame &frame, ExecutionContext &context) {
     auto *db = context.db_accessor;
@@ -645,7 +645,7 @@ ScanAllById::ScanAllById(const std::shared_ptr<LogicalOperator> &input, Symbol o
 ACCEPT_WITH_INPUT(ScanAllById)
 
 UniqueCursorPtr ScanAllById::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::ScanAllByIdOperator);
+  Statistics::IncrementCounter(Statistics::ScanAllByIdOperator);
 
   auto vertices = [this](Frame &frame, ExecutionContext &context) -> std::optional<std::vector<VertexAccessor>> {
     auto *db = context.db_accessor;
@@ -700,7 +700,7 @@ Expand::Expand(const std::shared_ptr<LogicalOperator> &input, Symbol input_symbo
 ACCEPT_WITH_INPUT(Expand)
 
 UniqueCursorPtr Expand::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::ExpandOperator);
+  Statistics::IncrementCounter(Statistics::ExpandOperator);
 
   return MakeUniqueCursorPtr<ExpandCursor>(mem, *this, mem);
 }
@@ -2170,7 +2170,7 @@ class ExpandAllShortestPathsCursor : public query::plan::Cursor {
 };
 
 UniqueCursorPtr ExpandVariable::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::ExpandVariableOperator);
+  Statistics::IncrementCounter(Statistics::ExpandVariableOperator);
 
   switch (type_) {
     case EdgeAtom::Type::BREADTH_FIRST:
@@ -2273,7 +2273,7 @@ class ConstructNamedPathCursor : public Cursor {
 ACCEPT_WITH_INPUT(ConstructNamedPath)
 
 UniqueCursorPtr ConstructNamedPath::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::ConstructNamedPathOperator);
+  Statistics::IncrementCounter(Statistics::ConstructNamedPathOperator);
 
   return MakeUniqueCursorPtr<ConstructNamedPathCursor>(mem, *this, mem);
 }
@@ -2299,7 +2299,7 @@ bool Filter::Accept(HierarchicalLogicalOperatorVisitor &visitor) {
 }
 
 UniqueCursorPtr Filter::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::FilterOperator);
+  Statistics::IncrementCounter(Statistics::FilterOperator);
 
   return MakeUniqueCursorPtr<FilterCursor>(mem, *this, mem);
 }
@@ -2352,7 +2352,7 @@ EvaluatePatternFilter::EvaluatePatternFilter(const std::shared_ptr<LogicalOperat
 ACCEPT_WITH_INPUT(EvaluatePatternFilter);
 
 UniqueCursorPtr EvaluatePatternFilter::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::EvaluatePatternFilterOperator);
+  Statistics::IncrementCounter(Statistics::EvaluatePatternFilterOperator);
 
   return MakeUniqueCursorPtr<EvaluatePatternFilterCursor>(mem, *this, mem);
 }
@@ -2385,7 +2385,7 @@ Produce::Produce(const std::shared_ptr<LogicalOperator> &input, const std::vecto
 ACCEPT_WITH_INPUT(Produce)
 
 UniqueCursorPtr Produce::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::ProduceOperator);
+  Statistics::IncrementCounter(Statistics::ProduceOperator);
 
   return MakeUniqueCursorPtr<ProduceCursor>(mem, *this, mem);
 }
@@ -2428,7 +2428,7 @@ Delete::Delete(const std::shared_ptr<LogicalOperator> &input_, const std::vector
 ACCEPT_WITH_INPUT(Delete)
 
 UniqueCursorPtr Delete::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::DeleteOperator);
+  Statistics::IncrementCounter(Statistics::DeleteOperator);
 
   return MakeUniqueCursorPtr<DeleteCursor>(mem, *this, mem);
 }
@@ -2580,7 +2580,7 @@ SetProperty::SetProperty(const std::shared_ptr<LogicalOperator> &input, storage:
 ACCEPT_WITH_INPUT(SetProperty)
 
 UniqueCursorPtr SetProperty::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::SetPropertyOperator);
+  Statistics::IncrementCounter(Statistics::SetPropertyOperator);
 
   return MakeUniqueCursorPtr<SetPropertyCursor>(mem, *this, mem);
 }
@@ -2663,7 +2663,7 @@ SetProperties::SetProperties(const std::shared_ptr<LogicalOperator> &input, Symb
 ACCEPT_WITH_INPUT(SetProperties)
 
 UniqueCursorPtr SetProperties::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::SetPropertiesOperator);
+  Statistics::IncrementCounter(Statistics::SetPropertiesOperator);
 
   return MakeUniqueCursorPtr<SetPropertiesCursor>(mem, *this, mem);
 }
@@ -2860,7 +2860,7 @@ SetLabels::SetLabels(const std::shared_ptr<LogicalOperator> &input, Symbol input
 ACCEPT_WITH_INPUT(SetLabels)
 
 UniqueCursorPtr SetLabels::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::SetLabelsOperator);
+  Statistics::IncrementCounter(Statistics::SetLabelsOperator);
 
   return MakeUniqueCursorPtr<SetLabelsCursor>(mem, *this, mem);
 }
@@ -2932,7 +2932,7 @@ RemoveProperty::RemoveProperty(const std::shared_ptr<LogicalOperator> &input, st
 ACCEPT_WITH_INPUT(RemoveProperty)
 
 UniqueCursorPtr RemoveProperty::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::RemovePropertyOperator);
+  Statistics::IncrementCounter(Statistics::RemovePropertyOperator);
 
   return MakeUniqueCursorPtr<RemovePropertyCursor>(mem, *this, mem);
 }
@@ -3018,7 +3018,7 @@ RemoveLabels::RemoveLabels(const std::shared_ptr<LogicalOperator> &input, Symbol
 ACCEPT_WITH_INPUT(RemoveLabels)
 
 UniqueCursorPtr RemoveLabels::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::RemoveLabelsOperator);
+  Statistics::IncrementCounter(Statistics::RemoveLabelsOperator);
 
   return MakeUniqueCursorPtr<RemoveLabelsCursor>(mem, *this, mem);
 }
@@ -3091,7 +3091,7 @@ EdgeUniquenessFilter::EdgeUniquenessFilter(const std::shared_ptr<LogicalOperator
 ACCEPT_WITH_INPUT(EdgeUniquenessFilter)
 
 UniqueCursorPtr EdgeUniquenessFilter::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::EdgeUniquenessFilterOperator);
+  Statistics::IncrementCounter(Statistics::EdgeUniquenessFilterOperator);
 
   return MakeUniqueCursorPtr<EdgeUniquenessFilterCursor>(mem, *this, mem);
 }
@@ -3193,7 +3193,7 @@ class EmptyResultCursor : public Cursor {
 };
 
 UniqueCursorPtr EmptyResult::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::EmptyResultOperator);
+  Statistics::IncrementCounter(Statistics::EmptyResultOperator);
 
   return MakeUniqueCursorPtr<EmptyResultCursor>(mem, *this, mem);
 }
@@ -3254,7 +3254,7 @@ class AccumulateCursor : public Cursor {
 };
 
 UniqueCursorPtr Accumulate::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::AccumulateOperator);
+  Statistics::IncrementCounter(Statistics::AccumulateOperator);
 
   return MakeUniqueCursorPtr<AccumulateCursor>(mem, *this, mem);
 }
@@ -3616,7 +3616,7 @@ class AggregateCursor : public Cursor {
 };
 
 UniqueCursorPtr Aggregate::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::AggregateOperator);
+  Statistics::IncrementCounter(Statistics::AggregateOperator);
 
   return MakeUniqueCursorPtr<AggregateCursor>(mem, *this, mem);
 }
@@ -3627,7 +3627,7 @@ Skip::Skip(const std::shared_ptr<LogicalOperator> &input, Expression *expression
 ACCEPT_WITH_INPUT(Skip)
 
 UniqueCursorPtr Skip::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::SkipOperator);
+  Statistics::IncrementCounter(Statistics::SkipOperator);
 
   return MakeUniqueCursorPtr<SkipCursor>(mem, *this, mem);
 }
@@ -3680,7 +3680,7 @@ Limit::Limit(const std::shared_ptr<LogicalOperator> &input, Expression *expressi
 ACCEPT_WITH_INPUT(Limit)
 
 UniqueCursorPtr Limit::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::LimitOperator);
+  Statistics::IncrementCounter(Statistics::LimitOperator);
 
   return MakeUniqueCursorPtr<LimitCursor>(mem, *this, mem);
 }
@@ -3828,7 +3828,7 @@ class OrderByCursor : public Cursor {
 };
 
 UniqueCursorPtr OrderBy::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::OrderByOperator);
+  Statistics::IncrementCounter(Statistics::OrderByOperator);
 
   return MakeUniqueCursorPtr<OrderByCursor>(mem, *this, mem);
 }
@@ -3845,7 +3845,7 @@ bool Merge::Accept(HierarchicalLogicalOperatorVisitor &visitor) {
 }
 
 UniqueCursorPtr Merge::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::MergeOperator);
+  Statistics::IncrementCounter(Statistics::MergeOperator);
 
   return MakeUniqueCursorPtr<MergeCursor>(mem, *this, mem);
 }
@@ -3925,7 +3925,7 @@ bool Optional::Accept(HierarchicalLogicalOperatorVisitor &visitor) {
 }
 
 UniqueCursorPtr Optional::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::OptionalOperator);
+  Statistics::IncrementCounter(Statistics::OptionalOperator);
 
   return MakeUniqueCursorPtr<OptionalCursor>(mem, *this, mem);
 }
@@ -4053,7 +4053,7 @@ class UnwindCursor : public Cursor {
 };
 
 UniqueCursorPtr Unwind::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::UnwindOperator);
+  Statistics::IncrementCounter(Statistics::UnwindOperator);
 
   return MakeUniqueCursorPtr<UnwindCursor>(mem, *this, mem);
 }
@@ -4107,7 +4107,7 @@ Distinct::Distinct(const std::shared_ptr<LogicalOperator> &input, const std::vec
 ACCEPT_WITH_INPUT(Distinct)
 
 UniqueCursorPtr Distinct::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::DistinctOperator);
+  Statistics::IncrementCounter(Statistics::DistinctOperator);
 
   return MakeUniqueCursorPtr<DistinctCursor>(mem, *this, mem);
 }
@@ -4129,7 +4129,7 @@ Union::Union(const std::shared_ptr<LogicalOperator> &left_op, const std::shared_
       right_symbols_(right_symbols) {}
 
 UniqueCursorPtr Union::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::UnionOperator);
+  Statistics::IncrementCounter(Statistics::UnionOperator);
 
   return MakeUniqueCursorPtr<Union::UnionCursor>(mem, *this, mem);
 }
@@ -4288,7 +4288,7 @@ class CartesianCursor : public Cursor {
 }  // namespace
 
 UniqueCursorPtr Cartesian::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::CartesianOperator);
+  Statistics::IncrementCounter(Statistics::CartesianOperator);
 
   return MakeUniqueCursorPtr<CartesianCursor>(mem, *this, mem);
 }
@@ -4579,7 +4579,7 @@ class CallProcedureCursor : public Cursor {
 };
 
 UniqueCursorPtr CallProcedure::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::CallProcedureOperator);
+  Statistics::IncrementCounter(Statistics::CallProcedureOperator);
   CallProcedure::IncrementCounter(procedure_name_);
 
   return MakeUniqueCursorPtr<CallProcedureCursor>(mem, this, mem);
@@ -4785,7 +4785,7 @@ Foreach::Foreach(std::shared_ptr<LogicalOperator> input, std::shared_ptr<Logical
       loop_variable_symbol_(loop_variable_symbol) {}
 
 UniqueCursorPtr Foreach::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::ForeachOperator);
+  Statistics::IncrementCounter(Statistics::ForeachOperator);
   return MakeUniqueCursorPtr<ForeachCursor>(mem, *this, mem);
 }
 
@@ -4817,7 +4817,7 @@ bool Apply::Accept(HierarchicalLogicalOperatorVisitor &visitor) {
 }
 
 UniqueCursorPtr Apply::MakeCursor(utils::MemoryResource *mem) const {
-  EventCounter::IncrementCounter(EventCounter::ApplyOperator);
+  Statistics::IncrementCounter(Statistics::ApplyOperator);
 
   return MakeUniqueCursorPtr<ApplyCursor>(mem, *this, mem);
 }

--- a/src/query/stream/streams.cpp
+++ b/src/query/stream/streams.cpp
@@ -36,9 +36,9 @@
 #include "utils/pmr/string.hpp"
 #include "utils/variant_helpers.hpp"
 
-namespace EventCounter {
+namespace Statistics {
 extern const Event MessagesConsumed;
-}  // namespace EventCounter
+}  // namespace Statistics
 
 namespace memgraph::query::stream {
 namespace {
@@ -495,7 +495,7 @@ Streams::StreamsMap::iterator Streams::CreateConsumer(StreamsMap &map, const std
     utils::OnScopeExit interpreter_cleanup{
         [interpreter_context, interpreter]() { interpreter_context->interpreters->erase(interpreter.get()); }};
 
-    EventCounter::IncrementCounter(EventCounter::MessagesConsumed, messages.size());
+    Statistics::IncrementCounter(Statistics::MessagesConsumed, messages.size());
     CallCustomTransformation(transformation_name, messages, result, accessor, *memory_resource, stream_name);
 
     DiscardValueResultStream stream;

--- a/src/query/trigger.cpp
+++ b/src/query/trigger.cpp
@@ -25,9 +25,9 @@
 #include "utils/event_counter.hpp"
 #include "utils/memory.hpp"
 
-namespace EventCounter {
+namespace Statistics {
 extern const Event TriggersExecuted;
-}  // namespace EventCounter
+}  // namespace Statistics
 
 namespace memgraph::query {
 namespace {
@@ -248,7 +248,7 @@ void Trigger::Execute(DbAccessor *dba, utils::MonotonicBufferResource *execution
     ;
 
   cursor->Shutdown();
-  EventCounter::IncrementCounter(EventCounter::TriggersExecuted);
+  Statistics::IncrementCounter(Statistics::TriggersExecuted);
 }
 
 namespace {

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -2,6 +2,7 @@ set(utils_src_files
     async_timer.cpp
     base64.cpp
     event_counter.cpp
+    event_gauge.cpp
     csv_parsing.cpp
     file.cpp
     file_locker.cpp

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -3,6 +3,7 @@ set(utils_src_files
     base64.cpp
     event_counter.cpp
     event_gauge.cpp
+    event_histogram.cpp
     csv_parsing.cpp
     file.cpp
     file_locker.cpp

--- a/src/utils/event_counter.cpp
+++ b/src/utils/event_counter.cpp
@@ -123,7 +123,7 @@ const char *GetCounterDocumentation(const Event event) {
 
 const char *GetCounterType(const Event event) {
   static const char *strings[] = {
-#define M(NAME, TYPE, DOCUMENTATION) #NAME,
+#define M(NAME, TYPE, DOCUMENTATION) #TYPE,
       APPLY_FOR_COUNTERS(M)
 #undef M
   };

--- a/src/utils/event_counter.cpp
+++ b/src/utils/event_counter.cpp
@@ -62,7 +62,17 @@
   M(TriggersCreated, "Number of Triggers created.")                                                        \
   M(TriggersExecuted, "Number of Triggers executed.")                                                      \
                                                                                                            \
-  M(ActiveConnections, "Number of active connections.")
+  M(ActiveSessions, "Number of active connections.")                                                       \
+  M(ActiveBoltSessions, "Number of active Bolt connections.")                                              \
+  M(ActiveTCPSessions, "Number of active TCP connections.")                                                \
+  M(ActiveSSLSessions, "Number of active SSL connections.")                                                \
+  M(ActiveWebsocketSessions, "Number of active websocket connections.")                                    \
+                                                                                                           \
+  M(ActiveTransactions, "Number of active transactions.")                                                  \
+  M(CommitedTransactions, "Number of committed transactions.")                                             \
+  M(RollbackedTransactions, "Number of rollbacked transactions.")                                          \
+                                                                                                           \
+  M(BoltMessages, "Number of Bolt messages sent.")
 
 namespace Statistics {
 

--- a/src/utils/event_counter.cpp
+++ b/src/utils/event_counter.cpp
@@ -66,7 +66,7 @@
   M(ActiveBoltSessions, "Number of active Bolt connections.")                                              \
   M(ActiveTCPSessions, "Number of active TCP connections.")                                                \
   M(ActiveSSLSessions, "Number of active SSL connections.")                                                \
-  M(ActiveWebsocketSessions, "Number of active websocket connections.")                                    \
+  M(ActiveWebSocketSessions, "Number of active websocket connections.")                                    \
                                                                                                            \
   M(ActiveTransactions, "Number of active transactions.")                                                  \
   M(CommitedTransactions, "Number of committed transactions.")                                             \

--- a/src/utils/event_counter.cpp
+++ b/src/utils/event_counter.cpp
@@ -60,7 +60,9 @@
   M(StreamsCreated, "Number of Streams created.")                                                          \
   M(MessagesConsumed, "Number of consumed streamed messages.")                                             \
   M(TriggersCreated, "Number of Triggers created.")                                                        \
-  M(TriggersExecuted, "Number of Triggers executed.")
+  M(TriggersExecuted, "Number of Triggers executed.")                                                      \
+                                                                                                           \
+  M(ActiveConnections, "Number of active connections.")
 
 namespace Statistics {
 
@@ -82,7 +84,12 @@ void EventCounters::Increment(const Event event, Count amount) {
   counters_[event].fetch_add(amount, std::memory_order_relaxed);
 }
 
+void EventCounters::Decrement(const Event event, Count amount) {
+  counters_[event].fetch_sub(amount, std::memory_order_relaxed);
+}
+
 void IncrementCounter(const Event event, Count amount) { global_counters.Increment(event, amount); }
+void DecrementCounter(const Event event, Count amount) { global_counters.Decrement(event, amount); }
 
 const char *GetName(const Event event) {
   static const char *strings[] = {

--- a/src/utils/event_counter.cpp
+++ b/src/utils/event_counter.cpp
@@ -11,7 +11,7 @@
 
 #include "utils/event_counter.hpp"
 
-#define APPLY_FOR_EVENTS(M)                                                                                \
+#define APPLY_FOR_COUNTERS(M)                                                                              \
   M(ReadQuery, "Number of read-only queries executed.")                                                    \
   M(WriteQuery, "Number of write-only queries executed.")                                                  \
   M(ReadWriteQuery, "Number of read-write queries executed.")                                              \
@@ -68,7 +68,7 @@ namespace Statistics {
 
 // define every Event as an index in the array of counters
 #define M(NAME, DOCUMENTATION) extern const Event NAME = __COUNTER__;
-APPLY_FOR_EVENTS(M)
+APPLY_FOR_COUNTERS(M)
 #undef M
 
 inline constexpr Event END = __COUNTER__;
@@ -91,26 +91,25 @@ void EventCounters::Decrement(const Event event, Count amount) {
 void IncrementCounter(const Event event, Count amount) { global_counters.Increment(event, amount); }
 void DecrementCounter(const Event event, Count amount) { global_counters.Decrement(event, amount); }
 
-const char *GetName(const Event event) {
+const char *GetCounterName(const Event event) {
   static const char *strings[] = {
 #define M(NAME, DOCUMENTATION) #NAME,
-      APPLY_FOR_EVENTS(M)
+      APPLY_FOR_COUNTERS(M)
 #undef M
   };
 
   return strings[event];
 }
 
-const char *GetDocumentation(const Event event) {
+const char *GetCounterDocumentation(const Event event) {
   static const char *strings[] = {
 #define M(NAME, DOCUMENTATION) DOCUMENTATION,
-      APPLY_FOR_EVENTS(M)
+      APPLY_FOR_COUNTERS(M)
 #undef M
   };
 
   return strings[event];
 }
 
-Event End() { return END; }
-
+Event CounterEnd() { return END; }
 }  // namespace Statistics

--- a/src/utils/event_counter.cpp
+++ b/src/utils/event_counter.cpp
@@ -62,7 +62,7 @@
   M(TriggersCreated, "Number of Triggers created.")                                                        \
   M(TriggersExecuted, "Number of Triggers executed.")
 
-namespace EventCounter {
+namespace Statistics {
 
 // define every Event as an index in the array of counters
 #define M(NAME, DOCUMENTATION) extern const Event NAME = __COUNTER__;
@@ -106,4 +106,4 @@ const char *GetDocumentation(const Event event) {
 
 Event End() { return END; }
 
-}  // namespace EventCounter
+}  // namespace Statistics

--- a/src/utils/event_counter.cpp
+++ b/src/utils/event_counter.cpp
@@ -11,73 +11,73 @@
 
 #include "utils/event_counter.hpp"
 
-#define APPLY_FOR_COUNTERS(M)                                                                              \
-  M(ReadQuery, "Number of read-only queries executed.")                                                    \
-  M(WriteQuery, "Number of write-only queries executed.")                                                  \
-  M(ReadWriteQuery, "Number of read-write queries executed.")                                              \
-                                                                                                           \
-  M(OnceOperator, "Number of times Once operator was used.")                                               \
-  M(CreateNodeOperator, "Number of times CreateNode operator was used.")                                   \
-  M(CreateExpandOperator, "Number of times CreateExpand operator was used.")                               \
-  M(ScanAllOperator, "Number of times ScanAll operator was used.")                                         \
-  M(ScanAllByLabelOperator, "Number of times ScanAllByLabel operator was used.")                           \
-  M(ScanAllByLabelPropertyRangeOperator, "Number of times ScanAllByLabelPropertyRange operator was used.") \
-  M(ScanAllByLabelPropertyValueOperator, "Number of times ScanAllByLabelPropertyValue operator was used.") \
-  M(ScanAllByLabelPropertyOperator, "Number of times ScanAllByLabelProperty operator was used.")           \
-  M(ScanAllByIdOperator, "Number of times ScanAllById operator was used.")                                 \
-  M(ExpandOperator, "Number of times Expand operator was used.")                                           \
-  M(ExpandVariableOperator, "Number of times ExpandVariable operator was used.")                           \
-  M(ConstructNamedPathOperator, "Number of times ConstructNamedPath operator was used.")                   \
-  M(FilterOperator, "Number of times Filter operator was used.")                                           \
-  M(ProduceOperator, "Number of times Produce operator was used.")                                         \
-  M(DeleteOperator, "Number of times Delete operator was used.")                                           \
-  M(SetPropertyOperator, "Number of times SetProperty operator was used.")                                 \
-  M(SetPropertiesOperator, "Number of times SetProperties operator was used.")                             \
-  M(SetLabelsOperator, "Number of times SetLabels operator was used.")                                     \
-  M(RemovePropertyOperator, "Number of times RemoveProperty operator was used.")                           \
-  M(RemoveLabelsOperator, "Number of times RemoveLabels operator was used.")                               \
-  M(EdgeUniquenessFilterOperator, "Number of times EdgeUniquenessFilter operator was used.")               \
-  M(EmptyResultOperator, "Number of times EmptyResult operator was used.")                                 \
-  M(AccumulateOperator, "Number of times Accumulate operator was used.")                                   \
-  M(AggregateOperator, "Number of times Aggregate operator was used.")                                     \
-  M(SkipOperator, "Number of times Skip operator was used.")                                               \
-  M(LimitOperator, "Number of times Limit operator was used.")                                             \
-  M(OrderByOperator, "Number of times OrderBy operator was used.")                                         \
-  M(MergeOperator, "Number of times Merge operator was used.")                                             \
-  M(OptionalOperator, "Number of times Optional operator was used.")                                       \
-  M(UnwindOperator, "Number of times Unwind operator was used.")                                           \
-  M(DistinctOperator, "Number of times Distinct operator was used.")                                       \
-  M(UnionOperator, "Number of times Union operator was used.")                                             \
-  M(CartesianOperator, "Number of times Cartesian operator was used.")                                     \
-  M(CallProcedureOperator, "Number of times CallProcedure operator was used.")                             \
-  M(ForeachOperator, "Number of times Foreach operator was used.")                                         \
-  M(EvaluatePatternFilterOperator, "Number of times EvaluatePatternFilter operator was used.")             \
-  M(ApplyOperator, "Number of times ApplyOperator operator was used.")                                     \
-                                                                                                           \
-  M(FailedQuery, "Number of times executing a query failed.")                                              \
-  M(LabelIndexCreated, "Number of times a label index was created.")                                       \
-  M(LabelPropertyIndexCreated, "Number of times a label property index was created.")                      \
-  M(StreamsCreated, "Number of Streams created.")                                                          \
-  M(MessagesConsumed, "Number of consumed streamed messages.")                                             \
-  M(TriggersCreated, "Number of Triggers created.")                                                        \
-  M(TriggersExecuted, "Number of Triggers executed.")                                                      \
-                                                                                                           \
-  M(ActiveSessions, "Number of active connections.")                                                       \
-  M(ActiveBoltSessions, "Number of active Bolt connections.")                                              \
-  M(ActiveTCPSessions, "Number of active TCP connections.")                                                \
-  M(ActiveSSLSessions, "Number of active SSL connections.")                                                \
-  M(ActiveWebSocketSessions, "Number of active websocket connections.")                                    \
-                                                                                                           \
-  M(ActiveTransactions, "Number of active transactions.")                                                  \
-  M(CommitedTransactions, "Number of committed transactions.")                                             \
-  M(RollbackedTransactions, "Number of rollbacked transactions.")                                          \
-                                                                                                           \
-  M(BoltMessages, "Number of Bolt messages sent.")
+#define APPLY_FOR_COUNTERS(M)                                                                                        \
+  M(ReadQuery, QueryType, "Number of read-only queries executed.")                                                   \
+  M(WriteQuery, QueryType, "Number of write-only queries executed.")                                                 \
+  M(ReadWriteQuery, QueryType, "Number of read-write queries executed.")                                             \
+                                                                                                                     \
+  M(OnceOperator, Operator, "Number of times Once operator was used.")                                               \
+  M(CreateNodeOperator, Operator, "Number of times CreateNode operator was used.")                                   \
+  M(CreateExpandOperator, Operator, "Number of times CreateExpand operator was used.")                               \
+  M(ScanAllOperator, Operator, "Number of times ScanAll operator was used.")                                         \
+  M(ScanAllByLabelOperator, Operator, "Number of times ScanAllByLabel operator was used.")                           \
+  M(ScanAllByLabelPropertyRangeOperator, Operator, "Number of times ScanAllByLabelPropertyRange operator was used.") \
+  M(ScanAllByLabelPropertyValueOperator, Operator, "Number of times ScanAllByLabelPropertyValue operator was used.") \
+  M(ScanAllByLabelPropertyOperator, Operator, "Number of times ScanAllByLabelProperty operator was used.")           \
+  M(ScanAllByIdOperator, Operator, "Number of times ScanAllById operator was used.")                                 \
+  M(ExpandOperator, Operator, "Number of times Expand operator was used.")                                           \
+  M(ExpandVariableOperator, Operator, "Number of times ExpandVariable operator was used.")                           \
+  M(ConstructNamedPathOperator, Operator, "Number of times ConstructNamedPath operator was used.")                   \
+  M(FilterOperator, Operator, "Number of times Filter operator was used.")                                           \
+  M(ProduceOperator, Operator, "Number of times Produce operator was used.")                                         \
+  M(DeleteOperator, Operator, "Number of times Delete operator was used.")                                           \
+  M(SetPropertyOperator, Operator, "Number of times SetProperty operator was used.")                                 \
+  M(SetPropertiesOperator, Operator, "Number of times SetProperties operator was used.")                             \
+  M(SetLabelsOperator, Operator, "Number of times SetLabels operator was used.")                                     \
+  M(RemovePropertyOperator, Operator, "Number of times RemoveProperty operator was used.")                           \
+  M(RemoveLabelsOperator, Operator, "Number of times RemoveLabels operator was used.")                               \
+  M(EdgeUniquenessFilterOperator, Operator, "Number of times EdgeUniquenessFilter operator was used.")               \
+  M(EmptyResultOperator, Operator, "Number of times EmptyResult operator was used.")                                 \
+  M(AccumulateOperator, Operator, "Number of times Accumulate operator was used.")                                   \
+  M(AggregateOperator, Operator, "Number of times Aggregate operator was used.")                                     \
+  M(SkipOperator, Operator, "Number of times Skip operator was used.")                                               \
+  M(LimitOperator, Operator, "Number of times Limit operator was used.")                                             \
+  M(OrderByOperator, Operator, "Number of times OrderBy operator was used.")                                         \
+  M(MergeOperator, Operator, "Number of times Merge operator was used.")                                             \
+  M(OptionalOperator, Operator, "Number of times Optional operator was used.")                                       \
+  M(UnwindOperator, Operator, "Number of times Unwind operator was used.")                                           \
+  M(DistinctOperator, Operator, "Number of times Distinct operator was used.")                                       \
+  M(UnionOperator, Operator, "Number of times Union operator was used.")                                             \
+  M(CartesianOperator, Operator, "Number of times Cartesian operator was used.")                                     \
+  M(CallProcedureOperator, Operator, "Number of times CallProcedure operator was used.")                             \
+  M(ForeachOperator, Operator, "Number of times Foreach operator was used.")                                         \
+  M(EvaluatePatternFilterOperator, Operator, "Number of times EvaluatePatternFilter operator was used.")             \
+  M(ApplyOperator, Operator, "Number of times ApplyOperator operator was used.")                                     \
+                                                                                                                     \
+  M(LabelIndexCreated, Index, "Number of times a label index was created.")                                          \
+  M(LabelPropertyIndexCreated, Index, "Number of times a label property index was created.")                         \
+                                                                                                                     \
+  M(StreamsCreated, Stream, "Number of Streams created.")                                                            \
+  M(MessagesConsumed, Stream, "Number of consumed streamed messages.")                                               \
+                                                                                                                     \
+  M(TriggersCreated, Trigger, "Number of Triggers created.")                                                         \
+  M(TriggersExecuted, Trigger, "Number of Triggers executed.")                                                       \
+                                                                                                                     \
+  M(ActiveSessions, Session, "Number of active connections.")                                                        \
+  M(ActiveBoltSessions, Session, "Number of active Bolt connections.")                                               \
+  M(ActiveTCPSessions, Session, "Number of active TCP connections.")                                                 \
+  M(ActiveSSLSessions, Session, "Number of active SSL connections.")                                                 \
+  M(ActiveWebSocketSessions, Session, "Number of active websocket connections.")                                     \
+  M(BoltMessages, Session, "Number of Bolt messages sent.")                                                          \
+                                                                                                                     \
+  M(ActiveTransactions, Transaction, "Number of active transactions.")                                               \
+  M(CommitedTransactions, Transaction, "Number of committed transactions.")                                          \
+  M(RollbackedTransactions, Transaction, "Number of rollbacked transactions.")                                       \
+  M(FailedQuery, Transaction, "Number of times executing a query failed.")
 
 namespace Statistics {
-
 // define every Event as an index in the array of counters
-#define M(NAME, DOCUMENTATION) extern const Event NAME = __COUNTER__;
+#define M(NAME, TYPE, DOCUMENTATION) extern const Event NAME = __COUNTER__;
 APPLY_FOR_COUNTERS(M)
 #undef M
 
@@ -103,7 +103,7 @@ void DecrementCounter(const Event event, Count amount) { global_counters.Decreme
 
 const char *GetCounterName(const Event event) {
   static const char *strings[] = {
-#define M(NAME, DOCUMENTATION) #NAME,
+#define M(NAME, TYPE, DOCUMENTATION) #NAME,
       APPLY_FOR_COUNTERS(M)
 #undef M
   };
@@ -113,7 +113,17 @@ const char *GetCounterName(const Event event) {
 
 const char *GetCounterDocumentation(const Event event) {
   static const char *strings[] = {
-#define M(NAME, DOCUMENTATION) DOCUMENTATION,
+#define M(NAME, TYPE, DOCUMENTATION) DOCUMENTATION,
+      APPLY_FOR_COUNTERS(M)
+#undef M
+  };
+
+  return strings[event];
+}
+
+const char *GetCounterType(const Event event) {
+  static const char *strings[] = {
+#define M(NAME, TYPE, DOCUMENTATION) #NAME,
       APPLY_FOR_COUNTERS(M)
 #undef M
   };

--- a/src/utils/event_counter.hpp
+++ b/src/utils/event_counter.hpp
@@ -42,9 +42,8 @@ extern EventCounters global_counters;
 void IncrementCounter(Event event, Count amount = 1);
 void DecrementCounter(Event event, Count amount = 1);
 
-const char *GetName(Event event);
-const char *GetDocumentation(Event event);
+const char *GetCounterName(Event event);
+const char *GetCounterDocumentation(Event event);
 
-Event End();
-
+Event CounterEnd();
 }  // namespace Statistics

--- a/src/utils/event_counter.hpp
+++ b/src/utils/event_counter.hpp
@@ -29,6 +29,8 @@ class EventCounters {
 
   void Increment(Event event, Count amount = 1);
 
+  void Decrement(Event event, Count amount = 1);
+
   static const Event num_counters;
 
  private:
@@ -38,6 +40,7 @@ class EventCounters {
 extern EventCounters global_counters;
 
 void IncrementCounter(Event event, Count amount = 1);
+void DecrementCounter(Event event, Count amount = 1);
 
 const char *GetName(Event event);
 const char *GetDocumentation(Event event);

--- a/src/utils/event_counter.hpp
+++ b/src/utils/event_counter.hpp
@@ -10,6 +10,7 @@
 // licenses/APL.txt.
 
 #pragma once
+
 #include <atomic>
 #include <cstdlib>
 #include <memory>

--- a/src/utils/event_counter.hpp
+++ b/src/utils/event_counter.hpp
@@ -1,4 +1,4 @@
-// Copyright 2021 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -14,7 +14,7 @@
 #include <cstdlib>
 #include <memory>
 
-namespace EventCounter {
+namespace Statistics {
 using Event = uint64_t;
 using Count = uint64_t;
 using Counter = std::atomic<Count>;
@@ -44,4 +44,4 @@ const char *GetDocumentation(Event event);
 
 Event End();
 
-}  // namespace EventCounter
+}  // namespace Statistics

--- a/src/utils/event_counter.hpp
+++ b/src/utils/event_counter.hpp
@@ -45,6 +45,7 @@ void DecrementCounter(Event event, Count amount = 1);
 
 const char *GetCounterName(Event event);
 const char *GetCounterDocumentation(Event event);
+const char *GetCounterType(const Event event);
 
 Event CounterEnd();
 }  // namespace Statistics

--- a/src/utils/event_gauge.cpp
+++ b/src/utils/event_gauge.cpp
@@ -11,17 +11,13 @@
 
 #include "utils/event_gauge.hpp"
 
-#define APPLY_FOR_GAUGES(M)           \
-  M(SomeGauge, "Gauge description.")  \
-  M(SomeGauge2, "Gauge description.") \
-  M(SomeGauge3, "Gauge description.") \
-  M(SomeGauge4, "Gauge description.") \
-  M(SomeGauge5, "Gauge description.")
+// We don't have any gauges for now
+#define APPLY_FOR_GAUGES(M)
 
 namespace Statistics {
 
 // define every Event as an index in the array of gauges
-#define M(NAME, DOCUMENTATION) extern const Event NAME = __COUNTER__;
+#define M(NAME, TYPE, DOCUMENTATION) extern const Event NAME = __COUNTER__;
 APPLY_FOR_GAUGES(M)
 #undef M
 
@@ -40,7 +36,7 @@ void SetGaugeValue(const Event event, Value value) { global_gauges.SetValue(even
 
 const char *GetGaugeName(const Event event) {
   static const char *strings[] = {
-#define M(NAME, DOCUMENTATION) #NAME,
+#define M(NAME, TYPE, DOCUMENTATION) #NAME,
       APPLY_FOR_GAUGES(M)
 #undef M
   };
@@ -50,7 +46,17 @@ const char *GetGaugeName(const Event event) {
 
 const char *GetGaugeDocumentation(const Event event) {
   static const char *strings[] = {
-#define M(NAME, DOCUMENTATION) DOCUMENTATION,
+#define M(NAME, TYPE, DOCUMENTATION) DOCUMENTATION,
+      APPLY_FOR_GAUGES(M)
+#undef M
+  };
+
+  return strings[event];
+}
+
+const char *GetGaugeType(const Event event) {
+  static const char *strings[] = {
+#define M(NAME, TYPE, DOCUMENTATION) #TYPE,
       APPLY_FOR_GAUGES(M)
 #undef M
   };

--- a/src/utils/event_gauge.cpp
+++ b/src/utils/event_gauge.cpp
@@ -1,0 +1,63 @@
+// Copyright 2023 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "utils/event_gauge.hpp"
+
+#define APPLY_FOR_GAUGES(M)           \
+  M(SomeGauge, "Gauge description.")  \
+  M(SomeGauge2, "Gauge description.") \
+  M(SomeGauge3, "Gauge description.") \
+  M(SomeGauge4, "Gauge description.") \
+  M(SomeGauge5, "Gauge description.")
+
+namespace Statistics {
+
+// define every Event as an index in the array of gauges
+#define M(NAME, DOCUMENTATION) extern const Event NAME = __COUNTER__;
+APPLY_FOR_GAUGES(M)
+#undef M
+
+inline constexpr Event END = __COUNTER__;
+
+// Initialize array for the global gauges with all values set to 0
+Gauge global_gauges_array[END]{};
+// Initialize global counters
+EventGauges global_gauges(global_gauges_array);
+
+const Event EventGauges::num_gauges = END;
+
+void EventGauges::SetValue(const Event event, Value value) { gauges_[event].store(value, std::memory_order_seq_cst); }
+
+void SetGaugeValue(const Event event, Value value) { global_gauges.SetValue(event, value); }
+
+const char *GetGaugeName(const Event event) {
+  static const char *strings[] = {
+#define M(NAME, DOCUMENTATION) #NAME,
+      APPLY_FOR_GAUGES(M)
+#undef M
+  };
+
+  return strings[event];
+}
+
+const char *GetGaugeDocumentation(const Event event) {
+  static const char *strings[] = {
+#define M(NAME, DOCUMENTATION) DOCUMENTATION,
+      APPLY_FOR_GAUGES(M)
+#undef M
+  };
+
+  return strings[event];
+}
+
+Event GaugeEnd() { return END; }
+
+}  // namespace Statistics

--- a/src/utils/event_gauge.hpp
+++ b/src/utils/event_gauge.hpp
@@ -10,6 +10,7 @@
 // licenses/APL.txt.
 
 #pragma once
+
 #include <atomic>
 #include <cstdlib>
 #include <memory>

--- a/src/utils/event_gauge.hpp
+++ b/src/utils/event_gauge.hpp
@@ -42,6 +42,7 @@ void SetGaugeValue(Event event, Value value);
 
 const char *GetGaugeName(Event event);
 const char *GetGaugeDocumentation(Event event);
+const char *GetGaugeType(const Event event);
 
 Event GaugeEnd();
 }  // namespace Statistics

--- a/src/utils/event_gauge.hpp
+++ b/src/utils/event_gauge.hpp
@@ -1,0 +1,46 @@
+// Copyright 2023 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+#include <atomic>
+#include <cstdlib>
+#include <memory>
+
+namespace Statistics {
+using Event = uint64_t;
+using Value = uint64_t;
+using Gauge = std::atomic<Value>;
+
+class EventGauges {
+ public:
+  explicit EventGauges(Gauge *allocated_gauges) noexcept : gauges_(allocated_gauges) {}
+
+  auto &operator[](const Event event) { return gauges_[event]; }
+
+  const auto &operator[](const Event event) const { return gauges_[event]; }
+
+  void SetValue(Event event, Value value);
+
+  static const Event num_gauges;
+
+ private:
+  Gauge *gauges_;
+};
+
+extern EventGauges global_gauges;
+
+void SetGaugeValue(Event event, Value value);
+
+const char *GetGaugeName(Event event);
+const char *GetGaugeDocumentation(Event event);
+
+Event GaugeEnd();
+}  // namespace Statistics

--- a/src/utils/event_histogram.cpp
+++ b/src/utils/event_histogram.cpp
@@ -11,14 +11,14 @@
 
 #include "utils/event_histogram.hpp"
 
-#define APPLY_FOR_HISTOGRAMS(M)                                                                  \
-  M(QueryExecutionLatency_us, "Query execution latency in microseconds", 0, 25, 50, 75, 99, 100) \
-  M(SnapshotCreationLatency_us, "Snapshot creation latency in microseconds", 50, 90, 100)
+#define APPLY_FOR_HISTOGRAMS(M)                                                                         \
+  M(QueryExecutionLatency_us, Query, "Query execution latency in microseconds", 0, 25, 50, 75, 99, 100) \
+  M(SnapshotCreationLatency_us, Snapshot, "Snapshot creation latency in microseconds", 50, 90, 100)
 
 namespace Statistics {
 
 // define every Event as an index in the array of counters
-#define M(NAME, DOCUMENTATION, ...) extern const Event NAME = __COUNTER__;
+#define M(NAME, TYPE, DOCUMENTATION, ...) extern const Event NAME = __COUNTER__;
 APPLY_FOR_HISTOGRAMS(M)
 #undef M
 
@@ -26,7 +26,7 @@ inline constexpr Event END = __COUNTER__;
 
 // Initialize array for the global histogram with all named histograms and their percentiles
 Histogram global_histograms_array[END]{
-#define M(NAME, DOCUMENTATION, ...) Histogram({__VA_ARGS__}),
+#define M(NAME, TYPE, DOCUMENTATION, ...) Histogram({__VA_ARGS__}),
     APPLY_FOR_HISTOGRAMS(M)
 #undef M
 };
@@ -41,7 +41,7 @@ void EventHistograms::Measure(const Event event, Value value) { histograms_[even
 
 const char *GetHistogramName(const Event event) {
   static const char *strings[] = {
-#define M(NAME, DOCUMENTATION, ...) #NAME,
+#define M(NAME, TYPE, DOCUMENTATION, ...) #NAME,
       APPLY_FOR_HISTOGRAMS(M)
 #undef M
   };
@@ -51,7 +51,17 @@ const char *GetHistogramName(const Event event) {
 
 const char *GetHistogramDocumentation(const Event event) {
   static const char *strings[] = {
-#define M(NAME, DOCUMENTATION, ...) DOCUMENTATION,
+#define M(NAME, TYPE, DOCUMENTATION, ...) DOCUMENTATION,
+      APPLY_FOR_HISTOGRAMS(M)
+#undef M
+  };
+
+  return strings[event];
+}
+
+const char *GetHistogramType(const Event event) {
+  static const char *strings[] = {
+#define M(NAME, TYPE, DOCUMENTATION, ...) #TYPE,
       APPLY_FOR_HISTOGRAMS(M)
 #undef M
   };

--- a/src/utils/event_histogram.cpp
+++ b/src/utils/event_histogram.cpp
@@ -1,0 +1,56 @@
+// Copyright 2023 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "utils/event_histogram.hpp"
+
+#define APPLY_FOR_HISTOGRAMS(M)   \
+  M(Histogram1, "Some histogram") \
+  M(Histogram2, "Some histogram") \
+  M(Histogram3, "Some histogram")
+
+namespace Statistics {
+
+// define every Event as an index in the array of counters
+#define M(NAME, DOCUMENTATION) extern const Event NAME = __COUNTER__;
+APPLY_FOR_HISTOGRAMS(M)
+#undef M
+
+inline constexpr Event END = __COUNTER__;
+
+// Initialize array for the global counter with all values set to 0
+Histogram global_histograms_array[END]{};
+// Initialize global counters
+EventHistograms global_histograms(global_histograms_array);
+
+const Event EventHistograms::num_histograms = END;
+
+const char *GetHistogramName(const Event event) {
+  static const char *strings[] = {
+#define M(NAME, DOCUMENTATION) #NAME,
+      APPLY_FOR_HISTOGRAMS(M)
+#undef M
+  };
+
+  return strings[event];
+}
+
+const char *GetHistogramDocumentation(const Event event) {
+  static const char *strings[] = {
+#define M(NAME, DOCUMENTATION) DOCUMENTATION,
+      APPLY_FOR_HISTOGRAMS(M)
+#undef M
+  };
+
+  return strings[event];
+}
+
+Event HistogramEnd() { return END; }
+}  // namespace Statistics

--- a/src/utils/event_histogram.cpp
+++ b/src/utils/event_histogram.cpp
@@ -11,7 +11,9 @@
 
 #include "utils/event_histogram.hpp"
 
-#define APPLY_FOR_HISTOGRAMS(M) M(QueryLatency_us, "Query latency in microseconds", 0, 25, 50, 75, 99, 100)
+#define APPLY_FOR_HISTOGRAMS(M)                                                                  \
+  M(QueryExecutionLatency_us, "Query execution latency in microseconds", 0, 25, 50, 75, 99, 100) \
+  M(SnapshotCreationLatency_us, "Snapshot creation latency in microseconds", 50, 90, 100)
 
 namespace Statistics {
 

--- a/src/utils/event_histogram.cpp
+++ b/src/utils/event_histogram.cpp
@@ -11,10 +11,7 @@
 
 #include "utils/event_histogram.hpp"
 
-#define APPLY_FOR_HISTOGRAMS(M)                       \
-  M(Histogram1, "Some histogram", 0, 25, 50, 75, 100) \
-  M(Histogram2, "Some histogram", 0, 50, 99)          \
-  M(Histogram3, "Some histogram", 0, 90, 100)
+#define APPLY_FOR_HISTOGRAMS(M) M(QueryLatency_us, "Query latency in microseconds", 0, 25, 50, 75, 99, 100)
 
 namespace Statistics {
 
@@ -35,6 +32,10 @@ Histogram global_histograms_array[END]{
 EventHistograms global_histograms(global_histograms_array);
 
 const Event EventHistograms::num_histograms = END;
+
+void Measure(const Event event, Value value) { global_histograms.Measure(event, value); }
+
+void EventHistograms::Measure(const Event event, Value value) { histograms_[event].Measure(value); }
 
 const char *GetHistogramName(const Event event) {
   static const char *strings[] = {

--- a/src/utils/event_histogram.hpp
+++ b/src/utils/event_histogram.hpp
@@ -150,6 +150,8 @@ class EventHistograms {
 
   const auto &operator[](const Event event) const { return histograms_[event]; }
 
+  void Measure(const Event event, Value value);
+
   static const Event num_histograms;
 
  private:
@@ -157,6 +159,8 @@ class EventHistograms {
 };
 
 extern EventHistograms global_histograms;
+
+void Measure(const Event event, Value value);
 
 const char *GetHistogramName(Event event);
 const char *GetHistogramDocumentation(Event event);

--- a/src/utils/event_histogram.hpp
+++ b/src/utils/event_histogram.hpp
@@ -1,0 +1,156 @@
+// Copyright 2023 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <cmath>
+
+#include "utils/logging.hpp"
+
+namespace Statistics {
+using Event = uint64_t;
+using Value = uint64_t;
+using Measurement = std::atomic<uint64_t>;
+
+// This is a logarithmically bucketing histogram optimized
+// for collecting network response latency distributions.
+// It "compresses" values by mapping them to a point on a
+// logarithmic curve, which serves as the bucket index. This
+// compression technique allows for very accurate histograms
+// (unlike what is the case for sampling or lossy probabilistic
+// approaches) with the trade-off that we sacrifice around 1%
+// precision.
+//
+// properties:
+// * roughly 1% precision loss - can be higher for values
+//   less than 100, so if measuring latency, generally do
+//   so in microseconds.
+// * ~32kb constant space, single allocation per Histogram.
+// * Histogram::Percentile() will return 0 if there were no
+//   samples measured yet.
+class Histogram {
+  // This is the number of buckets that observed values
+  // will be logarithmically compressed into.
+  constexpr static auto kSampleLimit = 4096;
+
+  // This is roughly 1/error rate, where 100.0 is roughly
+  // a 1% error bound for measurements. This is less true
+  // for tiny measurements, but because we tend to measure
+  // microseconds, it is usually over 100, which is where
+  // the error bound starts to stabilize a bit. This has
+  // been tuned to allow the maximum uint64_t to compress
+  // within 4096 samples while still achieving a high accuracy.
+  constexpr static auto kPrecision = 92.0;
+
+  // samples_ stores per-bucket counts for measurements
+  // that have been mapped to a specific uint64_t in
+  // the "compression" logic below.
+  std::vector<uint64_t> samples_ = {};
+
+  std::vector<uint8_t> percentiles_ = {0, 25, 50, 75, 90, 100};
+
+  // count_ is the number of measurements that have been
+  // included in this Histogram.
+  Measurement count_ = 0;
+
+  // sum_ is the summed value of all measurements that
+  // have been included in this Histogram.
+  Measurement sum_ = 0;
+
+  std::mutex samples_mutex_;
+
+ public:
+  Histogram() { samples_.resize(kSampleLimit, 0); }
+
+  uint64_t Count() const { return count_.load(std::memory_order_relaxed); }
+
+  uint64_t Sum() const { return sum_.load(std::memory_order_relaxed); }
+
+  void Measure(uint64_t value) {
+    // "compression" logic
+    double boosted = 1.0 + static_cast<double>(value);
+    double ln = std::log(boosted);
+    double compressed = (kPrecision * ln) + 0.5;
+
+    MG_ASSERT(compressed < kSampleLimit, "compressing value {} to {} is invalid", value, compressed);
+    auto sample_index = static_cast<uint16_t>(compressed);
+
+    count_.fetch_add(1, std::memory_order_relaxed);
+    sum_.fetch_add(value, std::memory_order_relaxed);
+
+    {
+      std::lock_guard<std::mutex> lock(samples_mutex_);
+      samples_[sample_index]++;
+    }
+  }
+
+  auto YieldPercentiles() const {
+    std::vector<std::pair<uint64_t, uint64_t>> percentile_yield;
+    percentile_yield.reserve(percentiles_.size());
+
+    for (const auto percentile : percentiles_) {
+      percentile_yield.emplace_back(std::make_pair(percentile, Percentile(percentile)));
+    }
+
+    return percentile_yield;
+  }
+
+  uint64_t Percentile(double percentile) const {
+    MG_ASSERT(percentile <= 100.0, "percentiles must not exceed 100.0");
+    MG_ASSERT(percentile >= 0.0, "percentiles must be greater than or equal to 0.0");
+
+    if (count_ == 0) {
+      return 0;
+    }
+
+    const auto floated_count = static_cast<double>(count_);
+    const auto target = std::max(floated_count * percentile / 100.0, 1.0);
+
+    auto scanned = 0.0;
+
+    for (int i = 0; i < kSampleLimit; i++) {
+      const auto samples_at_index = samples_[i];
+      scanned += static_cast<double>(samples_at_index);
+      if (scanned >= target) {
+        // "decompression" logic
+        auto floated = static_cast<double>(i);
+        auto unboosted = floated / kPrecision;
+        auto decompressed = std::exp(unboosted) - 1.0;
+        return static_cast<uint64_t>(decompressed);
+      }
+    }
+
+    LOG_FATAL("bug in Histogram::Percentile where it failed to return the {} percentile", percentile);
+    return 0;
+  }
+};
+
+class EventHistograms {
+ public:
+  explicit EventHistograms(Histogram *allocated_histograms) noexcept : histograms_(allocated_histograms) {}
+
+  auto &operator[](const Event event) { return histograms_[event]; }
+
+  const auto &operator[](const Event event) const { return histograms_[event]; }
+
+  static const Event num_histograms;
+
+ private:
+  Histogram *histograms_;
+};
+
+extern EventHistograms global_histograms;
+
+const char *GetHistogramName(Event event);
+const char *GetHistogramDocumentation(Event event);
+
+Event HistogramEnd();
+}  // namespace Statistics

--- a/src/utils/event_histogram.hpp
+++ b/src/utils/event_histogram.hpp
@@ -164,6 +164,7 @@ void Measure(const Event event, Value value);
 
 const char *GetHistogramName(Event event);
 const char *GetHistogramDocumentation(Event event);
+const char *GetHistogramType(const Event event);
 
 Event HistogramEnd();
 }  // namespace Statistics

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -224,6 +224,9 @@ target_link_libraries(${test_prefix}utils_algorithm mg-utils)
 add_unit_test(utils_exceptions.cpp)
 target_link_libraries(${test_prefix}utils_exceptions mg-utils)
 
+add_unit_test(utils_histogram.cpp)
+target_link_libraries(${test_prefix}utils_histogram mg-utils)
+
 add_unit_test(utils_file.cpp)
 target_link_libraries(${test_prefix}utils_file mg-utils)
 

--- a/tests/unit/utils_histogram.cpp
+++ b/tests/unit/utils_histogram.cpp
@@ -1,0 +1,46 @@
+// Copyright 2023 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "utils/event_histogram.hpp"
+#include "utils/logging.hpp"
+
+TEST(Histogram, BasicFunctionality) {
+  Statistics::Histogram histo{};
+
+  for (int i = 0; i < 9000; i++) {
+    histo.Measure(10);
+  }
+  for (int i = 0; i < 900; i++) {
+    histo.Measure(25);
+  }
+  for (int i = 0; i < 90; i++) {
+    histo.Measure(33);
+  }
+  for (int i = 0; i < 9; i++) {
+    histo.Measure(47);
+  }
+  histo.Measure(500);
+
+  ASSERT_EQ(histo.Percentile(0.0), 10);
+  ASSERT_EQ(histo.Percentile(99.0), 25);
+  ASSERT_EQ(histo.Percentile(99.89), 32);
+  ASSERT_EQ(histo.Percentile(99.99), 46);
+  ASSERT_EQ(histo.Percentile(100.0), 500);
+
+  uint64_t max = std::numeric_limits<uint64_t>::max();
+  histo.Measure(max);
+  auto observed_max = static_cast<double>(histo.Percentile(100.0));
+  auto diff = (max - observed_max) / max;
+  ASSERT_THAT(diff, testing::Lt(0.01));
+}


### PR DESCRIPTION
The goal of this PR is to add counters, gauges, and histograms, to all the necessary parts of the system.
That includes:
- queries
- sessions
- streams
- transactions
- triggers
- snapshots
- operators
- general metrics

All the metrics could be exposed with the http server addition in the branch that this code will be merged to.