### PR TITLE
[master <] Fix replica exception message

### DIFF
--- a/src/query/exceptions.hpp
+++ b/src/query/exceptions.hpp
@@ -254,7 +254,7 @@ class ReplicationException : public utils::BasicException {
  public:
   using utils::BasicException::BasicException;
   explicit ReplicationException(const std::string &message)
-      : utils::BasicException("Replication Exception: {} Check the status of the replicas using 'SHOW REPLICA' query.",
+      : utils::BasicException("Replication Exception: {} Check the status of the replicas using 'SHOW REPLICAS' query.",
                               message) {}
 };
 


### PR DESCRIPTION
I was testing replication in Memgraph and noticed that the exception message for when you try to write to MAIN with SYNC replica down consists of a non-existent query. `SHOW REPLICA` query does not exist, and `SHOW REPLICAS` query is the correct one. 