### PR TITLE
[master < T945] Handle user-defined metadata and expose it with SHOW TRANSACTIONS

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,7 @@
 ---
-Language:     Cpp
 BasedOnStyle: Google
+---
+Language:     Cpp
 Standard:     "c++20"
 UseTab:       Never
 DerivePointerAlignment: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: v4.4.0
     hooks:
       - id: check-yaml
+        args: [--allow-multiple-documents]
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black

--- a/src/communication/bolt/v1/session.hpp
+++ b/src/communication/bolt/v1/session.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -63,7 +63,8 @@ class Session {
    * if an explicit transaction was started.
    */
   virtual std::pair<std::vector<std::string>, std::optional<int>> Interpret(
-      const std::string &query, const std::map<std::string, Value> &params) = 0;
+      const std::string &query, const std::map<std::string, Value> &params,
+      const std::map<std::string, memgraph::communication::bolt::Value> &extra) = 0;
 
   /**
    * Put results of the processed query in the `encoder`.
@@ -85,7 +86,7 @@ class Session {
    */
   virtual std::map<std::string, Value> Discard(std::optional<int> n, std::optional<int> qid) = 0;
 
-  virtual void BeginTransaction() = 0;
+  virtual void BeginTransaction(const std::map<std::string, memgraph::communication::bolt::Value> &) = 0;
   virtual void CommitTransaction() = 0;
   virtual void RollbackTransaction() = 0;
 

--- a/src/communication/bolt/v1/session.hpp
+++ b/src/communication/bolt/v1/session.hpp
@@ -64,7 +64,7 @@ class Session {
    */
   virtual std::pair<std::vector<std::string>, std::optional<int>> Interpret(
       const std::string &query, const std::map<std::string, Value> &params,
-      const std::map<std::string, memgraph::communication::bolt::Value> &extra) = 0;
+      const std::map<std::string, memgraph::communication::bolt::Value> &metadata) = 0;
 
   /**
    * Put results of the processed query in the `encoder`.

--- a/src/communication/bolt/v1/states/handlers.hpp
+++ b/src/communication/bolt/v1/states/handlers.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <map>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -209,7 +210,7 @@ State HandleRunV1(TSession &session, const State state, const Marker marker) {
 
   try {
     // Interpret can throw.
-    const auto [header, qid] = session.Interpret(query.ValueString(), params.ValueMap());
+    const auto [header, qid] = session.Interpret(query.ValueString(), params.ValueMap(), {});
     // Convert std::string to Value
     std::vector<Value> vec;
     std::map<std::string, Value> data;
@@ -266,7 +267,7 @@ State HandleRunV4(TSession &session, const State state, const Marker marker) {
 
   try {
     // Interpret can throw.
-    const auto [header, qid] = session.Interpret(query.ValueString(), params.ValueMap());
+    const auto [header, qid] = session.Interpret(query.ValueString(), params.ValueMap(), extra.ValueMap());
     // Convert std::string to Value
     std::vector<Value> vec;
     std::map<std::string, Value> data;
@@ -360,7 +361,7 @@ State HandleBegin(TSession &session, const State state, const Marker marker) {
   }
 
   try {
-    session.BeginTransaction();
+    session.BeginTransaction(extra.ValueMap());
   } catch (const std::exception &e) {
     return HandleFailure(session, e);
   }

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -535,7 +535,9 @@ class BoltSession final : public memgraph::communication::bolt::Session<memgraph
 
   void BeginTransaction(const std::map<std::string, memgraph::communication::bolt::Value> &metadata) override {
     std::map<std::string, memgraph::storage::PropertyValue> metadata_pv;
-    for (const auto &kv : metadata) metadata_pv.emplace(kv.first, memgraph::glue::ToPropertyValue(kv.second));
+    for (const auto &[key, bolt_value] : metadata) {
+      metadata_pv.emplace(key, memgraph::glue::ToPropertyValue(bolt_value));
+    }
     interpreter_.BeginTransaction(metadata_pv);
   }
 
@@ -548,8 +550,12 @@ class BoltSession final : public memgraph::communication::bolt::Session<memgraph
       const std::map<std::string, memgraph::communication::bolt::Value> &metadata) override {
     std::map<std::string, memgraph::storage::PropertyValue> params_pv;
     std::map<std::string, memgraph::storage::PropertyValue> metadata_pv;
-    for (const auto &kv : params) params_pv.emplace(kv.first, memgraph::glue::ToPropertyValue(kv.second));
-    for (const auto &kv : metadata) metadata_pv.emplace(kv.first, memgraph::glue::ToPropertyValue(kv.second));
+    for (const auto &[key, bolt_param] : params) {
+      params_pv.emplace(key, memgraph::glue::ToPropertyValue(bolt_param));
+    }
+    for (const auto &[key, bolt_md] : metadata) {
+      metadata_pv.emplace(key, memgraph::glue::ToPropertyValue(bolt_md));
+    }
     const std::string *username{nullptr};
     if (user_) {
       username = &user_->username();

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -1193,6 +1193,8 @@ PreparedQuery Interpreter::PrepareTransactionQuery(std::string_view query_upper,
   std::function<void()> handler;
 
   if (query_upper == "BEGIN") {
+    // TODO: Evaluate doing move(metadata). Currently the metadata is very small, but this will be important if it ever
+    // becomes large.
     handler = [this, metadata] {
       if (in_explicit_transaction_) {
         throw ExplicitTransactionUsageException("Nested transactions are not supported.");

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -117,9 +118,9 @@ concept HasEmpty = requires(T t) {
   { t.empty() } -> std::convertible_to<bool>;
 };
 
-template <HasEmpty T>
+template <typename T>
 inline std::optional<T> GenOptional(const T &in) {
-  return in.empty() ? std::nullopt : std::optional<T>{in};
+  return in.empty() ? std::nullopt : std::make_optional<T>(in);
 }
 
 struct Callback {
@@ -2794,7 +2795,7 @@ Interpreter::PrepareResult Interpreter::Prepare(const std::string &query_string,
   transaction_queries_->push_back(query_string);
 
   // All queries other than transaction control queries advance the command in
-  // an explicit transaction block.in_explicit_transaction_
+  // an explicit transaction block.
   if (in_explicit_transaction_) {
     AdvanceCommand();
   } else if (db_accessor_) {

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -261,6 +261,7 @@ class Interpreter final {
   std::optional<std::string> username_;
   bool in_explicit_transaction_{false};
   bool expect_rollback_{false};
+  std::optional<std::map<std::string, storage::PropertyValue>> metadata_{};  //!< User defined transaction metadata
 
   /**
    * Prepare a query for execution.
@@ -271,7 +272,8 @@ class Interpreter final {
    * @throw query::QueryException
    */
   PrepareResult Prepare(const std::string &query, const std::map<std::string, storage::PropertyValue> &params,
-                        const std::string *username);
+                        const std::string *username,
+                        const std::map<std::string, storage::PropertyValue> &metadata = {});
 
   /**
    * Execute the last prepared query and stream *all* of the results into the
@@ -315,7 +317,7 @@ class Interpreter final {
   std::map<std::string, TypedValue> Pull(TStream *result_stream, std::optional<int> n = {},
                                          std::optional<int> qid = {});
 
-  void BeginTransaction();
+  void BeginTransaction(const std::map<std::string, storage::PropertyValue> &metadata = {});
 
   /*
   Returns transaction id or empty if the db_accessor is not initialized.
@@ -405,7 +407,8 @@ class Interpreter final {
   std::optional<storage::IsolationLevel> interpreter_isolation_level;
   std::optional<storage::IsolationLevel> next_transaction_isolation_level;
 
-  PreparedQuery PrepareTransactionQuery(std::string_view query_upper);
+  PreparedQuery PrepareTransactionQuery(std::string_view query_upper,
+                                        const std::map<std::string, storage::PropertyValue> &metadata = {});
   void Commit();
   void AdvanceCommand();
   void AbortCommand(std::unique_ptr<QueryExecution> *query_execution);

--- a/tests/drivers/csharp/v4_1/Metadata/Metadata.csproj
+++ b/tests/drivers/csharp/v4_1/Metadata/Metadata.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Neo4j.Driver.Simple" Version="4.1.1" />
+  </ItemGroup>
+
+</Project>

--- a/tests/drivers/csharp/v4_1/Metadata/Program.cs
+++ b/tests/drivers/csharp/v4_1/Metadata/Program.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using Neo4j.Driver;
+
+public class Transactions {
+  public static void Main(string[] args) {
+    var driver =
+        GraphDatabase.Driver("bolt://localhost:7687", AuthTokens.None,
+                             (builder) => builder.WithEncryptionLevel(EncryptionLevel.None));
+    ClearDatabase(driver);
+        // Explicit transaction query.
+        using (var session = driver.Session()) {
+          Console.WriteLine("Checking explicit transaction metadata...");
+          var txMetadata = new Dictionary<string, object> {
+            { "ver", "transaction" }, { "str", "oho" }, { "num", 456 }
+          };
+          using (var tx = session.BeginTransaction(txConfig => txConfig.WithMetadata(txMetadata))) {
+            tx.Run("MATCH (n) RETURN n LIMIT 1").Consume();
+            // Check transaction info from another thread
+            Thread show_tx = new Thread(() => ShowTx(ref driver));
+            show_tx.Start();
+            show_tx.Join();
+            // End current transaction
+            tx.Commit();
+          }
+        }
+        // Implicit transaction query
+        using (var session = driver.Session()) {
+          Console.WriteLine("Checking implicit transaction metadata...");
+          var txMetadata = new Dictionary<string, object> {
+            { "ver", "session" }, { "str", "aha" }, { "num", 123 }
+          };
+          CheckMD(session.Run("SHOW TRANSACTIONS", txConfig => txConfig.WithMetadata(txMetadata)));
+        }
+
+        Console.WriteLine("All ok!");
+  }
+
+  private static void ClearDatabase(IDriver driver) {
+    using (var session = driver.Session()) session.Run("MATCH (n) DETACH DELETE n").Consume();
+  }
+
+  public static void ShowTx(ref IDriver driver) {
+    using (var session = driver.Session()) {
+      CheckMD(session.Run("SHOW TRANSACTIONS"));
+    }
+  }
+
+  public static void CheckMD(IResult tx_md) {
+    int n = 0;
+    try {
+      foreach (var res in tx_md) {
+        var md = res["metadata"].As<Dictionary<string, object>>();
+        if (md.Count != 0) {
+          if (md["ver"].As<string>() == "transaction" && md["str"].As<string>() == "oho" &&
+              md["num"].As<int>() == 456) {
+            n = n + 1;
+          } else if (md["ver"].As<string>() == "session" && md["str"].As<string>() == "aha" &&
+                     md["num"].As<int>() == 123) {
+            n = n + 1;
+          }
+        }
+      }
+    } catch {
+      n = 0;
+    }
+    if (n == 0) {
+      Console.WriteLine("Metadata error!");
+      Environment.Exit(1);
+    }
+  }
+}

--- a/tests/drivers/go/v4/metadata.go
+++ b/tests/drivers/go/v4/metadata.go
@@ -19,11 +19,16 @@ func check_md(result neo4j.Result, err error) {
       log.Fatal("Failed to read metadata!")
     }
     md_map, ok := md.(map[string]interface{})
-    if ok && md_map["ver"].(string) == "session" && md_map["str"].(string) == "aha" && md_map["num"].(int64) == 123{
-      n++
-    }
-    else if ok && md_map["ver"].(string) == "transaction" && md_map["str"].(string) == "oho" && md_map["num"].(int64) == 456{
-      n++
+    if ok {
+      ver_val, ver_ok := md_map["ver"]
+      str_val, str_ok := md_map["str"]
+      num_val, num_ok := md_map["num"]
+      if (ver_ok && str_ok && num_ok) {
+        if ((ver_val.(string) == "session" && str_val.(string) == "aha" && num_val.(int64) == 123) ||
+            (ver_val.(string) == "transaction" && str_val.(string) == "oho" && num_val.(int64) == 456)) {
+          n++
+        }
+      }
     }
   }
   if n == 0 {
@@ -39,7 +44,7 @@ func check_tx(driver neo4j.Driver) {
   sessionConfig := neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite}
   session, err := driver.NewSession(sessionConfig)
   if err != nil {
-    log.Fatal("An error occured while creating a session: %s", err)
+    log.Fatal("An error occurred while creating a session: %s", err)
   }
 
   defer session.Close()
@@ -61,16 +66,18 @@ func main() {
   sessionConfig := neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite}
   session, err := driver.NewSession(sessionConfig)
   if err != nil {
-    log.Fatal("An error occured while creating a session: %s", err)
+    log.Fatal("An error occurred while creating a session: %s", err)
   }
 
   defer session.Close()
 
   // Implicit transaction
+  fmt.Println("Checking implicit transaction metadata...")
   result, err := session.Run("SHOW TRANSACTIONS", nil, neo4j.WithTxMetadata(map[string]interface{}{"ver":"session", "str":"aha", "num":123}))
   check_md(result, err)
 
   // Explicit transaction
+  fmt.Println("Checking explicit transaction metadata...")
   tx, err := session.BeginTransaction(neo4j.WithTxMetadata(map[string]interface{}{"ver":"transaction", "str":"oho", "num":456}))
   if err != nil {
     handle_error(err)

--- a/tests/drivers/go/v4/metadata.go
+++ b/tests/drivers/go/v4/metadata.go
@@ -1,0 +1,83 @@
+package main
+
+import "github.com/neo4j/neo4j-go-driver/neo4j"
+import "log"
+import "fmt"
+
+func handle_error(err error) {
+  log.Fatal("Error occured: %s", err)
+}
+
+func check_md(result neo4j.Result, err error) {
+  if err != nil {
+    handle_error(err)
+  }
+  n := 0
+  for result.Next() {
+    md, ok := result.Record().Get("metadata")
+    if !ok {
+      log.Fatal("Failed to read metadata!")
+    }
+    md_map, ok := md.(map[string]interface{})
+    if ok && md_map["ver"].(string) == "session" && md_map["str"].(string) == "aha" && md_map["num"].(int64) == 123{
+      n++
+    }
+    else if ok && md_map["ver"].(string) == "transaction" && md_map["str"].(string) == "oho" && md_map["num"].(int64) == 456{
+      n++
+    }
+  }
+  if n == 0 {
+    log.Fatal("Wrong metadata values!")
+  }
+  _, err = result.Consume()
+  if err != nil {
+    handle_error(err)
+  }
+}
+
+func check_tx(driver neo4j.Driver) {
+  sessionConfig := neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite}
+  session, err := driver.NewSession(sessionConfig)
+  if err != nil {
+    log.Fatal("An error occured while creating a session: %s", err)
+  }
+
+  defer session.Close()
+
+  result, err := session.Run("SHOW TRANSACTIONS", nil)
+  check_md(result, err)
+}
+
+func main() {
+  configForNeo4j40 := func(conf *neo4j.Config) { conf.Encrypted = false }
+
+  driver, err := neo4j.NewDriver("bolt://localhost:7687", neo4j.BasicAuth("", "", ""), configForNeo4j40)
+  if err != nil {
+    log.Fatal("An error occurred opening conn: %s", err)
+  }
+
+  defer driver.Close()
+
+  sessionConfig := neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite}
+  session, err := driver.NewSession(sessionConfig)
+  if err != nil {
+    log.Fatal("An error occured while creating a session: %s", err)
+  }
+
+  defer session.Close()
+
+  // Implicit transaction
+  result, err := session.Run("SHOW TRANSACTIONS", nil, neo4j.WithTxMetadata(map[string]interface{}{"ver":"session", "str":"aha", "num":123}))
+  check_md(result, err)
+
+  // Explicit transaction
+  tx, err := session.BeginTransaction(neo4j.WithTxMetadata(map[string]interface{}{"ver":"transaction", "str":"oho", "num":456}))
+  if err != nil {
+    handle_error(err)
+  }
+  tx.Run("MATCH (n) RETURN n LIMIT 1", map[string]interface{}{})
+  go check_tx(driver)
+  tx.Commit()
+
+  fmt.Println("All ok!")
+}

--- a/tests/drivers/go/v4/run.sh
+++ b/tests/drivers/go/v4/run.sh
@@ -12,3 +12,4 @@ go get github.com/neo4j/neo4j-go-driver/neo4j
 
 go run docs_how_to_query.go
 go run transactions.go
+go run metadata.go

--- a/tests/drivers/java/v1/Basic.java
+++ b/tests/drivers/java/v1/Basic.java
@@ -1,38 +1,39 @@
+import static org.neo4j.driver.v1.Values.parameters;
+
+import java.util.*;
 import org.neo4j.driver.v1.*;
 import org.neo4j.driver.v1.types.*;
-import static org.neo4j.driver.v1.Values.parameters;
-import java.util.*;
 
 public class Basic {
-    public static void main(String[] args) {
-        Config config = Config.build().withoutEncryption().toConfig();
-        Driver driver = GraphDatabase.driver( "bolt://localhost:7687", AuthTokens.basic( "neo4j", "1234" ), config );
+  public static void main(String[] args) {
+    Config config = Config.build().withoutEncryption().toConfig();
+    Driver driver =
+        GraphDatabase.driver("bolt://localhost:7687", AuthTokens.basic("neo4j", "1234"), config);
 
-        try ( Session session = driver.session() ) {
-            StatementResult rs1 = session.run( "MATCH (n) DETACH DELETE n" );
-            System.out.println( "Database cleared." );
+    try (Session session = driver.session()) {
+      StatementResult rs1 = session.run("MATCH (n) DETACH DELETE n");
+      System.out.println("Database cleared.");
 
-            StatementResult rs2 = session.run( "CREATE (alice: Person {name: 'Alice', age: 22})" );
-            System.out.println( "Record created." );
+      StatementResult rs2 = session.run("CREATE (alice: Person {name: 'Alice', age: 22})");
+      System.out.println("Record created.");
 
-            StatementResult rs3 = session.run( "MATCH (n) RETURN n" );
-            System.out.println( "Record matched." );
+      StatementResult rs3 = session.run("MATCH (n) RETURN n");
+      System.out.println("Record matched.");
 
-            List<Record> records = rs3.list();
-            Record record = records.get( 0 );
-            Node node = record.get( "n" ).asNode();
-            if ( !node.get("name").asString().equals( "Alice" ) || node.get("age").asInt() != 22 ) {
-              System.out.println( "Data doesn't match!" );
-              System.exit( 1 );
-            }
+      List<org.neo4j.driver.v1.Record> records = rs3.list();
+      org.neo4j.driver.v1.Record record = records.get(0);
+      Node node = record.get("n").asNode();
+      if (!node.get("name").asString().equals("Alice") || node.get("age").asInt() != 22) {
+        System.out.println("Data doesn't match!");
+        System.exit(1);
+      }
 
-            System.out.println( "All ok!" );
-        }
-        catch ( Exception e ) {
-            System.out.println( e );
-            System.exit( 1 );
-        }
-
-        driver.close();
+      System.out.println("All ok!");
+    } catch (Exception e) {
+      System.out.println(e);
+      System.exit(1);
     }
+
+    driver.close();
+  }
 }

--- a/tests/drivers/java/v4_1/Metadata.java
+++ b/tests/drivers/java/v4_1/Metadata.java
@@ -1,0 +1,111 @@
+import static org.neo4j.driver.Values.parameters;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.Transaction;
+import org.neo4j.driver.TransactionConfig;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.exceptions.ClientException;
+import org.neo4j.driver.exceptions.TransientException;
+
+public class Metadata {
+  public static String createPerson(Transaction tx, String name) {
+    Result result =
+        tx.run("CREATE (a:Person {name: $name}) RETURN a.name", parameters("name", name));
+    return result.single().get(0).asString();
+  }
+
+  public static void checkMd(Result result) {
+    int n = 0;
+    while (result.hasNext()) {
+      Record r = result.next();
+      Value md = r.get("metadata");
+      if (md != null && Objects.equals(md.get("ver").asString(), "transaction")
+          && Objects.equals(md.get("str").asString(), "oho")
+          && Objects.equals(md.get("num").asInt(), 456)) {
+        n = n + 1;
+      } else if (md != null && Objects.equals(md.get("ver").asString(), "session")
+          && Objects.equals(md.get("str").asString(), "aha")
+          && Objects.equals(md.get("num").asInt(), 123)) {
+        n = n + 1;
+      }
+    }
+    if (n == 0) {
+      System.out.println("Error while reading metadata!");
+      System.exit(1);
+    }
+  }
+
+  public static void main(String[] args) {
+    Config config = Config.builder()
+                        .withoutEncryption()
+                        .withMaxTransactionRetryTime(0, TimeUnit.SECONDS)
+                        .build();
+    Driver driver =
+        GraphDatabase.driver("bolt://localhost:7687", AuthTokens.basic("neo4j", "1234"), config);
+
+    try (Session session = driver.session()) {
+      // Explicit transaction
+      System.out.println("Checking explicit transaction metadata...");
+      try {
+        TransactionConfig tx_config =
+            TransactionConfig.builder()
+                .withTimeout(Duration.ofSeconds(2))
+                .withMetadata(Map.ofEntries(Map.entry("ver", "transaction"),
+                    Map.entry("str", "oho"), Map.entry("num", 456)))
+                .build();
+        Transaction tx = session.beginTransaction(tx_config);
+        tx.run("MATCH (n) RETURN n LIMIT 1");
+        // Check the metadata from another thread
+        try {
+          Runnable checkTx = new Runnable() {
+            public void run() {
+              try (Session s = driver.session()) {
+                checkMd(s.run("SHOW TRANSACTIONS"));
+              } catch (ClientException e) {
+                System.out.println(e);
+              }
+            }
+          };
+          Thread thread = new Thread(checkTx);
+          thread.start();
+          thread.join();
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
+        tx.commit();
+      } catch (ClientException e) {
+        System.out.println(e);
+      }
+
+      // Implicit transaction
+      System.out.println("Checking implicit transaction metadata...");
+      try {
+        TransactionConfig tx_config = TransactionConfig.builder()
+                                          .withTimeout(Duration.ofSeconds(2))
+                                          .withMetadata(Map.ofEntries(Map.entry("ver", "session"),
+                                              Map.entry("str", "aha"), Map.entry("num", 123)))
+                                          .build();
+        checkMd(session.run("SHOW TRANSACTIONS", tx_config));
+      } catch (ClientException e) {
+        System.out.println(e);
+      }
+
+      System.out.println("All ok!");
+
+    } catch (Exception e) {
+      System.out.println(e);
+      System.exit(1);
+    }
+
+    driver.close();
+  }
+}

--- a/tests/drivers/java/v4_1/run.sh
+++ b/tests/drivers/java/v4_1/run.sh
@@ -35,3 +35,6 @@ java -classpath .:$DRIVER:$REACTIVE_STREAM_DEP MaxQueryLength
 
 javac -classpath .:$DRIVER:$REACTIVE_STREAM_DEP Transactions.java
 java -classpath .:$DRIVER:$REACTIVE_STREAM_DEP Transactions
+
+javac -classpath .:$DRIVER:$REACTIVE_STREAM_DEP Metadata.java
+java -classpath .:$DRIVER:$REACTIVE_STREAM_DEP Metadata

--- a/tests/drivers/node/v4_1/metadata.js
+++ b/tests/drivers/node/v4_1/metadata.js
@@ -1,0 +1,31 @@
+var neo4j = require('neo4j-driver');
+var driver = neo4j.driver("bolt://localhost:7687",
+                          neo4j.auth.basic("", ""),
+                          { encrypted: 'ENCRYPTION_OFF' });
+var session = driver.session();
+
+function die() {
+  session.close();
+  driver.close();
+  process.exit(1);
+}
+
+function run_query(query, callback) {
+  var run = session.run(query, {}, {metadata:{"ver":"session", "str":"aha", "num":123}});
+  run.then(callback).catch(function (error) {
+    console.log(error);
+    die();
+  });
+}
+
+console.log("Checking implicit transaction metadata...");
+run_query("SHOW TRANSACTIONS;", function (result) {
+  const md = result.records[0].get("metadata");
+  if (md["ver"] != "session" || md["str"] != "aha" || md["num"] != 123){
+    console.log("Error while reading metadata!");
+    die();
+  }
+  console.log("All ok!");
+  session.close();
+  driver.close();
+});

--- a/tests/drivers/node/v4_1/run.sh
+++ b/tests/drivers/node/v4_1/run.sh
@@ -15,3 +15,4 @@ fi
 
 node docs_how_to_query.js
 node max_query_length.js
+node metadata.js

--- a/tests/drivers/python/v4_1/metadata.py
+++ b/tests/drivers/python/v4_1/metadata.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2021 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+import threading
+
+import neo4j
+
+
+def check_md(tx_md):
+    n = 0
+    for record in tx_md:
+        md = record[3]
+        if md["ver"] == "session" and md["str"] == "aha" and md["num"] == 123:
+            n = n + 1
+        elif md["ver"] == "transaction" and md["str"] == "oho" and md["num"] == 456:
+            n = n + 1
+    return n
+
+
+def session_run(driver):
+    print("Checking implicit transaction metadata...")
+    with driver.session() as session:
+        query = neo4j.Query("SHOW TRANSACTIONS", timeout=2, metadata={"ver": "session", "str": "aha", "num": 123})
+        result = session.run(query).values()
+        assert check_md(result) == 1, "metadata info error!"
+
+
+def show_tx(driver, tx_md):
+    with driver.session() as session:
+        query = neo4j.Query("SHOW TRANSACTIONS", timeout=2, metadata={"ver": "session", "str": "aha", "num": 123})
+        for t in session.run(query).values():
+            tx_md.append(t)
+
+
+def transaction_run(driver):
+    print("Checking explicit transaction metadata...")
+    with driver.session() as session:
+        tx = session.begin_transaction(timeout=2, metadata={"ver": "transaction", "str": "oho", "num": 456})
+        tx.run("MATCH (n) RETURN n LIMIT 1").consume()
+        tx_md = []
+        th = threading.Thread(target=show_tx, args=(driver, tx_md))
+        th.start()
+        if th.is_alive():
+            th.join()
+        tx.commit()
+        assert check_md(tx_md) == 2, "metadata info error!"
+
+
+if __name__ == "__main__":
+    driver = neo4j.GraphDatabase.driver("bolt://localhost:7687", auth=("user", "pass"), encrypted=False)
+    session_run(driver)
+    transaction_run(driver)
+    driver.close()
+    print("All ok!")

--- a/tests/drivers/python/v4_1/run.sh
+++ b/tests/drivers/python/v4_1/run.sh
@@ -31,3 +31,4 @@ source ve3/bin/activate
 python3 docs_how_to_query.py || exit 1
 python3 max_query_length.py || exit 1
 python3 transactions.py || exit 1
+python3 metadata.py || exit 1

--- a/tests/unit/bolt_session.cpp
+++ b/tests/unit/bolt_session.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -39,7 +39,8 @@ class TestSession : public Session<TestInputStream, TestOutputStream> {
       : Session<TestInputStream, TestOutputStream>(input_stream, output_stream) {}
 
   std::pair<std::vector<std::string>, std::optional<int>> Interpret(
-      const std::string &query, const std::map<std::string, Value> &params) override {
+      const std::string &query, const std::map<std::string, Value> &params,
+      const std::map<std::string, Value> &metadata = {}) override {
     if (query == kQueryReturn42 || query == kQueryEmpty || query == kQueryReturnMultiple) {
       query_ = query;
       return {{"result_name"}, {}};
@@ -78,7 +79,7 @@ class TestSession : public Session<TestInputStream, TestOutputStream> {
 
   std::map<std::string, Value> Discard(std::optional<int>, std::optional<int>) override { return {}; }
 
-  void BeginTransaction() override {}
+  void BeginTransaction(const std::map<std::string, Value> &metadata) override {}
   void CommitTransaction() override {}
   void RollbackTransaction() override {}
 

--- a/tests/unit/bolt_session.cpp
+++ b/tests/unit/bolt_session.cpp
@@ -12,6 +12,7 @@
 #include <string>
 
 #include <gflags/gflags.h>
+#include <gtest/gtest.h>
 
 #include "bolt_common.hpp"
 #include "communication/bolt/v1/session.hpp"
@@ -27,6 +28,7 @@ using memgraph::communication::bolt::Value;
 static const char *kInvalidQuery = "invalid query";
 static const char *kQueryReturn42 = "RETURN 42";
 static const char *kQueryReturnMultiple = "UNWIND [1,2,3] as n RETURN n";
+static const char *kQueryShowTx = "SHOW TRANSACTIONS";
 static const char *kQueryEmpty = "no results";
 
 class TestSessionData {};
@@ -40,10 +42,17 @@ class TestSession : public Session<TestInputStream, TestOutputStream> {
 
   std::pair<std::vector<std::string>, std::optional<int>> Interpret(
       const std::string &query, const std::map<std::string, Value> &params,
-      const std::map<std::string, Value> &metadata = {}) override {
+      const std::map<std::string, Value> &metadata) override {
+    if (!metadata.empty()) md_ = metadata;
     if (query == kQueryReturn42 || query == kQueryEmpty || query == kQueryReturnMultiple) {
       query_ = query;
       return {{"result_name"}, {}};
+    } else if (query == kQueryShowTx) {
+      if (md_.at("str").ValueString() != "aha" || md_.at("num").ValueInt() != 123) {
+        throw ClientError("Wrong metadata!");
+      }
+      query_ = query;
+      return {{"username", "transaction_id", "query", "metadata"}, {}};
     } else {
       query_ = "";
       throw ClientError("client sent invalid query");
@@ -72,6 +81,9 @@ class TestSession : public Session<TestInputStream, TestOutputStream> {
       }
 
       return {std::pair("has_more", true)};
+    } else if (query_ == kQueryShowTx) {
+      encoder->MessageRecord({"", 1234567890, query_, md_});
+      return {};
     } else {
       throw ClientError("client sent invalid query");
     }
@@ -79,11 +91,11 @@ class TestSession : public Session<TestInputStream, TestOutputStream> {
 
   std::map<std::string, Value> Discard(std::optional<int>, std::optional<int>) override { return {}; }
 
-  void BeginTransaction(const std::map<std::string, Value> &metadata) override {}
-  void CommitTransaction() override {}
-  void RollbackTransaction() override {}
+  void BeginTransaction(const std::map<std::string, Value> &metadata) override { md_ = metadata; }
+  void CommitTransaction() override { md_.clear(); }
+  void RollbackTransaction() override { md_.clear(); }
 
-  void Abort() override {}
+  void Abort() override { md_.clear(); }
 
   bool Authenticate(const std::string &username, const std::string &password) override { return true; }
 
@@ -91,6 +103,7 @@ class TestSession : public Session<TestInputStream, TestOutputStream> {
 
  private:
   std::string query_;
+  std::map<std::string, Value> md_;
 };
 
 // TODO: This could be done in fixture.
@@ -158,6 +171,10 @@ inline constexpr uint8_t handshake_req[] = {0x60, 0x60, 0xb0, 0x17, 0x00, 0x00, 
                                             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 inline constexpr uint8_t handshake_resp[] = {0x00, 0x00, 0x03, 0x04};
 inline constexpr uint8_t route[]{0xb3, 0x66, 0xa0, 0x90, 0xc0};
+const std::string extra_w_metadata =
+    "\xa2\x8b\x74\x78\x5f\x6d\x65\x74\x61\x64\x61\x74\x61\xa2\x83\x73\x74\x72\x83\x61\x68\x61\x83\x6e\x75\x6d\x7b\x8a"
+    "\x74\x78\x5f\x74\x69\x6d\x65\x6f\x75\x74\xc9\x07\xd0";
+inline constexpr uint8_t commit[] = {0xb0, 0x12};
 }  // namespace v4_3
 
 // Write bolt chunk header (length)
@@ -230,10 +247,11 @@ void ExecuteInit(TestInputStream &input_stream, TestSession &session, std::vecto
 }
 
 // Write bolt encoded run request
-void WriteRunRequest(TestInputStream &input_stream, const char *str, const bool is_v4 = false) {
+void WriteRunRequest(TestInputStream &input_stream, const char *str, const bool is_v4 = false,
+                     const std::string &extra = "\xA0") {
   // write chunk header
   auto len = strlen(str);
-  WriteChunkHeader(input_stream, (3 + is_v4) + 2 + len + 1);
+  WriteChunkHeader(input_stream, (3 + is_v4 * extra.size()) + 2 + len + 1);
 
   const auto *run_header = is_v4 ? v4::run_req_header : run_req_header;
   const auto run_header_size = is_v4 ? sizeof(v4::run_req_header) : sizeof(run_req_header);
@@ -251,7 +269,7 @@ void WriteRunRequest(TestInputStream &input_stream, const char *str, const bool 
 
   if (is_v4) {
     // write empty map for extra field
-    input_stream.Write("\xA0", 1);  // TinyMap
+    input_stream.Write(extra.data(), extra.size());  // TinyMap
   }
 
   // write chunk tail
@@ -1121,5 +1139,29 @@ TEST(BoltSession, ResetInIdle) {
     ExecuteInit(input_stream, session, output, true);
     ASSERT_NO_THROW(ExecuteCommand(input_stream, session, v4::reset_req, sizeof(v4::reset_req)));
     EXPECT_EQ(session.state_, State::Idle);
+  }
+}
+
+TEST(BoltSession, PassMetadata) {
+  // v4+
+  {
+    INIT_VARS;
+
+    ExecuteHandshake(input_stream, session, output, v4_3::handshake_req, v4_3::handshake_resp);
+    ExecuteInit(input_stream, session, output, true);
+
+    WriteRunRequest(input_stream, kQueryShowTx, true, v4_3::extra_w_metadata);
+    session.Execute();
+    ASSERT_EQ(session.state_, State::Result);
+
+    ExecuteCommand(input_stream, session, v4::pullall_req, sizeof(v4::pullall_req));
+    ASSERT_EQ(session.state_, State::Idle);
+    PrintOutput(output);
+    constexpr std::array<uint8_t, 5> md_num_123{0x83, 0x6E, 0x75, 0x6D, 0x7B};
+    constexpr std::array<uint8_t, 8> md_str_aha{0x83, 0x73, 0x74, 0x72, 0x83, 0x61, 0x68, 0x61};
+    auto find_num = std::search(begin(output), end(output), begin(md_num_123), end(md_num_123));
+    EXPECT_NE(find_num, end(output));
+    auto find_str = std::search(begin(output), end(output), begin(md_str_aha), end(md_str_aha));
+    EXPECT_NE(find_str, end(output));
   }
 }


### PR DESCRIPTION
[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here
- [ ] Tag someone from docs team in the comments

This feature should allow users to pass user-defined metadata via their clients. This is useful when a user has many transactions and they would want to better differentiate between them. 
Once the metadata is passed to Memgraph, the user can query it by executing SHOW TRANSACTIONS, whose output has a new field "metadata".