### PR TITLE
FilterMatch comopile-time error fix

### DIFF
--- a/src/query/plan/preprocess.cpp
+++ b/src/query/plan/preprocess.cpp
@@ -539,6 +539,14 @@ void AddMatching(const Match &match, SymbolTable &symbol_table, AstStorage &stor
   }
 }
 
+PatternFilterVisitor::PatternFilterVisitor(SymbolTable &symbol_table, AstStorage &storage)
+    : symbol_table_(symbol_table), storage_(storage) {}
+
+PatternFilterVisitor::~PatternFilterVisitor() = default;
+
+PatternFilterVisitor::PatternFilterVisitor(const PatternFilterVisitor &) = default;
+PatternFilterVisitor::PatternFilterVisitor(PatternFilterVisitor &&) noexcept = default;
+
 void PatternFilterVisitor::Visit(Exists &op) {
   std::vector<Pattern *> patterns;
   patterns.push_back(op.pattern_);
@@ -551,6 +559,8 @@ void PatternFilterVisitor::Visit(Exists &op) {
 
   matchings_.push_back(std::move(filter_matching));
 }
+
+std::vector<FilterMatching> PatternFilterVisitor::getMatchings() { return matchings_; }
 
 static void ParseForeach(query::Foreach &foreach, SingleQueryPart &query_part, AstStorage &storage,
                          SymbolTable &symbol_table) {
@@ -622,5 +632,16 @@ QueryParts CollectQueryParts(SymbolTable &symbol_table, AstStorage &storage, Cyp
   }
   return QueryParts{query_parts, distinct};
 }
+
+FilterInfo::FilterInfo() = default;
+FilterInfo::~FilterInfo() = default;
+
+FilterInfo::FilterInfo(const FilterInfo &) = default;
+FilterInfo &FilterInfo::operator=(const FilterInfo &) = default;
+FilterInfo::FilterInfo(FilterInfo &&) noexcept = default;
+FilterInfo &FilterInfo::operator=(FilterInfo &&) noexcept = default;
+
+FilterInfo::FilterInfo(Type type, Expression *expression, std::unordered_set<Symbol> used_symbols)
+    : type(type), expression(expression), used_symbols(used_symbols) {}
 
 }  // namespace memgraph::query::plan

--- a/src/query/plan/preprocess.hpp
+++ b/src/query/plan/preprocess.hpp
@@ -128,8 +128,13 @@ enum class PatternFilterType { EXISTS };
 /// Collects matchings from filters that include patterns
 class PatternFilterVisitor : public ExpressionVisitor<void> {
  public:
-  explicit PatternFilterVisitor(SymbolTable &symbol_table, AstStorage &storage)
-      : symbol_table_(symbol_table), storage_(storage) {}
+  explicit PatternFilterVisitor(SymbolTable &symbol_table, AstStorage &storage);
+  ~PatternFilterVisitor() override;
+
+  PatternFilterVisitor(const PatternFilterVisitor &);
+  PatternFilterVisitor &operator=(const PatternFilterVisitor &) = delete;
+  PatternFilterVisitor(PatternFilterVisitor &&) noexcept;
+  PatternFilterVisitor &operator=(PatternFilterVisitor &&) noexcept = delete;
 
   using ExpressionVisitor<void>::Visit;
 
@@ -200,7 +205,7 @@ class PatternFilterVisitor : public ExpressionVisitor<void> {
   void Visit(NamedExpression &op) override{};
   void Visit(RegexMatch &op) override{};
 
-  std::vector<FilterMatching> getMatchings() { return matchings_; }
+  std::vector<FilterMatching> getMatchings();
 
   SymbolTable &symbol_table_;
   AstStorage &storage_;
@@ -265,6 +270,17 @@ struct FilterInfo {
   /// information which can be used to produce indexed scans of graph
   /// elements.
   enum class Type { Generic, Label, Property, Id, Pattern };
+
+  FilterInfo();
+  ~FilterInfo();
+
+  FilterInfo(const FilterInfo &);
+  FilterInfo &operator=(const FilterInfo &);
+  FilterInfo(FilterInfo &&) noexcept;
+  FilterInfo &operator=(FilterInfo &&) noexcept;
+
+  // Back-compatibility in tests
+  FilterInfo(Type type, Expression *expression, std::unordered_set<Symbol> used_symbols);
 
   Type type;
   /// The original filter expression which must be satisfied.


### PR DESCRIPTION
The error was due to using the forwardly declared struct FilterMatch in inlined functions before the struct was defined.
Most of the time it was in auto-generated constructors and destructors. Not sure why clang 15 does this differently than 13.