### PR TITLE
[master < T970] Fix storage GC to handle IN_MEMORY_ANALYTICAL

### DIFF
--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -510,7 +510,7 @@ class Storage final {
 
   std::vector<ReplicaInfo> ReplicasInfo();
 
-  void FreeMemory();
+  void FreeMemory(std::unique_lock<utils::RWLock> main_guard = {});
 
   enum class SetIsolationLevelError : uint8_t { DisabledForAnalyticalMode };
 
@@ -544,7 +544,7 @@ class Storage final {
   /// @throw std::system_error
   /// @throw std::bad_alloc
   template <bool force>
-  void CollectGarbage();
+  void CollectGarbage(std::unique_lock<utils::RWLock> main_guard = {});
 
   bool InitializeWalFile();
   void FinalizeWalFile();
@@ -616,6 +616,10 @@ class Storage final {
   // Edges that are logically deleted and wait to be removed from the main
   // storage.
   utils::Synchronized<std::list<Gid>, utils::SpinLock> deleted_edges_;
+
+  // Flags to inform CollectGarbage that it needs to do the more expensive full scans
+  std::atomic<bool> gc_full_scan_vertices_delete_ = false;
+  std::atomic<bool> gc_full_scan_edges_delete_ = false;
 
   // Durability
   std::filesystem::path snapshot_directory_;

--- a/src/utils/skip_list.hpp
+++ b/src/utils/skip_list.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -391,7 +391,7 @@ class SkipListGc final {
 ///
 /// The implementation is based on the work described in the paper
 /// "A Provably Correct Scalable Concurrent Skip List"
-/// https://www.cs.tau.ac.il/~shanir/nir-pubs-web/Papers/OPODIS2006-BA.pdf
+/// http://people.csail.mit.edu/shanir/publications/OPODIS2006-BA.pdf
 ///
 /// The proposed implementation is in Java so the authors don't worry about
 /// garbage collection. This implementation uses the garbage collector that is
@@ -640,6 +640,7 @@ class SkipList final {
       skiplist_ = other.skiplist_;
       id_ = other.id_;
       other.skiplist_ = nullptr;
+      return *this;
     }
 
     /// Functions that return an Iterator (or ConstIterator) to the beginning of
@@ -775,6 +776,7 @@ class SkipList final {
       skiplist_ = other.skiplist_;
       id_ = other.id_;
       other.skiplist_ = nullptr;
+      return *this;
     }
 
     ConstIterator begin() const { return ConstIterator{skiplist_->head_->nexts[0].load(std::memory_order_acquire)}; }

--- a/tests/e2e/CMakeLists.txt
+++ b/tests/e2e/CMakeLists.txt
@@ -47,6 +47,7 @@ add_subdirectory(python_query_modules_reloading)
 add_subdirectory(analyze_graph)
 add_subdirectory(transaction_queue)
 add_subdirectory(mock_api)
+add_subdirectory(analytical_mode)
 
 copy_e2e_python_files(pytest_runner pytest_runner.sh "")
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/memgraph-selfsigned.crt DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/e2e/analytical_mode/CMakeLists.txt
+++ b/tests/e2e/analytical_mode/CMakeLists.txt
@@ -1,0 +1,6 @@
+function(copy_analytical_mode_e2e_python_files FILE_NAME)
+    copy_e2e_python_files(analytical_mode ${FILE_NAME})
+endfunction()
+
+copy_analytical_mode_e2e_python_files(common.py)
+copy_analytical_mode_e2e_python_files(free_memory.py)

--- a/tests/e2e/analytical_mode/common.py
+++ b/tests/e2e/analytical_mode/common.py
@@ -1,0 +1,30 @@
+# Copyright 2023 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+import typing
+
+import mgclient
+import pytest
+
+
+def execute_and_fetch_all(cursor: mgclient.Cursor, query: str, params: dict = {}) -> typing.List[tuple]:
+    cursor.execute(query, params)
+    return cursor.fetchall()
+
+
+@pytest.fixture
+def connect(**kwargs) -> mgclient.Connection:
+    connection = mgclient.connect(host="localhost", port=7687, **kwargs)
+    connection.autocommit = True
+    yield connection
+    cursor = connection.cursor()
+    execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n")
+    execute_and_fetch_all(cursor, "STORAGE MODE IN_MEMORY_TRANSACTIONAL;")

--- a/tests/e2e/analytical_mode/free_memory.py
+++ b/tests/e2e/analytical_mode/free_memory.py
@@ -1,0 +1,63 @@
+# Copyright 2023 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+import sys
+
+import pytest
+from common import connect, execute_and_fetch_all
+
+
+def check_storage_info(cursor, expected_values):
+    cursor.execute("SHOW STORAGE INFO")
+    config = cursor.fetchall()
+
+    for conf in config:
+        conf_name = conf[0]
+        if conf_name in expected_values:
+            assert expected_values[conf_name] == conf[1]
+
+
+def test_analytical_mode_objects_are_actually_deleted_when_asked(connect):
+    """Tests objects are actually freed when deleted in analytical mode."""
+
+    expected_values = {
+        "vertex_count": 0,
+    }
+
+    cursor = connect.cursor()
+    check_storage_info(cursor, expected_values)
+
+    cursor.execute("STORAGE MODE IN_MEMORY_ANALYTICAL;")
+    cursor.execute("MERGE (n) DELETE n;")
+    cursor.execute("FREE MEMORY;")
+
+    check_storage_info(cursor, expected_values)
+
+
+def test_analytical_mode_objects_are_actually_deleted_when_storage_mode_changes(connect):
+    """Tests objects are actually freed when deleted in analytical mode."""
+
+    expected_values = {
+        "vertex_count": 0,
+    }
+
+    cursor = connect.cursor()
+    check_storage_info(cursor, expected_values)
+
+    cursor.execute("STORAGE MODE IN_MEMORY_ANALYTICAL;")
+    cursor.execute("MERGE (n) DELETE n;")
+    cursor.execute("STORAGE MODE IN_MEMORY_TRANSACTIONAL;")
+
+    check_storage_info(cursor, expected_values)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/analytical_mode/workloads.yaml
+++ b/tests/e2e/analytical_mode/workloads.yaml
@@ -1,0 +1,14 @@
+analytical_mode_cluster: &analytical_mode_cluster
+  cluster:
+    main:
+      args: ["--bolt-port", "7687", "--log-level=TRACE"]
+      log_file: "analytical_mode.log"
+      setup_queries: []
+      validation_queries: []
+
+
+workloads:
+  - name: "Analytical mode checks"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["analytical_mode/free_memory.py"]
+    <<: *analytical_mode_cluster


### PR DESCRIPTION
This fix corrects the garbage collection of our in memory store to handle deletions made while in IN_MEMORY_ANALYTICAL mode. They will now be collected rather than leak.

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [x] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [x] Write a release note here -> "Deletions made in IN_MEMORY_ANALYTICAL now handled correctly"
- [ ] Tag someone from docs team in the comments

Closes #957 