### PR TITLE
Per-db auth

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ add_subdirectory(slk)
 add_subdirectory(rpc)
 add_subdirectory(license)
 add_subdirectory(auth)
+add_subdirectory(dbms)
 
 if(MG_ENTERPRISE)
         add_subdirectory(audit)

--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -35,18 +35,18 @@ namespace memgraph::auth {
 namespace {
 
 // Constant list of all available permissions.
-const std::vector<Permission> kPermissionsAll = {Permission::MATCH,       Permission::CREATE,
-                                                 Permission::MERGE,       Permission::DELETE,
-                                                 Permission::SET,         Permission::REMOVE,
-                                                 Permission::INDEX,       Permission::STATS,
-                                                 Permission::CONSTRAINT,  Permission::DUMP,
-                                                 Permission::AUTH,        Permission::REPLICATION,
-                                                 Permission::DURABILITY,  Permission::READ_FILE,
-                                                 Permission::FREE_MEMORY, Permission::TRIGGER,
-                                                 Permission::CONFIG,      Permission::STREAM,
-                                                 Permission::MODULE_READ, Permission::MODULE_WRITE,
-                                                 Permission::WEBSOCKET,   Permission::TRANSACTION_MANAGEMENT,
-                                                 Permission::STORAGE_MODE};
+const std::vector<Permission> kPermissionsAll = {Permission::MATCH,        Permission::CREATE,
+                                                 Permission::MERGE,        Permission::DELETE,
+                                                 Permission::SET,          Permission::REMOVE,
+                                                 Permission::INDEX,        Permission::STATS,
+                                                 Permission::CONSTRAINT,   Permission::DUMP,
+                                                 Permission::AUTH,         Permission::REPLICATION,
+                                                 Permission::DURABILITY,   Permission::READ_FILE,
+                                                 Permission::FREE_MEMORY,  Permission::TRIGGER,
+                                                 Permission::CONFIG,       Permission::STREAM,
+                                                 Permission::MODULE_READ,  Permission::MODULE_WRITE,
+                                                 Permission::WEBSOCKET,    Permission::TRANSACTION_MANAGEMENT,
+                                                 Permission::STORAGE_MODE, Permission::MULTI_TENANT};
 
 }  // namespace
 
@@ -98,6 +98,8 @@ std::string PermissionToString(Permission permission) {
       return "TRANSACTION_MANAGEMENT";
     case Permission::STORAGE_MODE:
       return "STORAGE_MODE";
+    case Permission::MULTI_TENANT:
+      return "MULTI_TENANT";
   }
 }
 

--- a/src/auth/models.hpp
+++ b/src/auth/models.hpp
@@ -41,7 +41,8 @@ enum class Permission : uint64_t {
   MODULE_WRITE = 1U << 19U,
   WEBSOCKET    = 1U << 20U,
   TRANSACTION_MANAGEMENT = 1U << 21U,
-  STORAGE_MODE    = 1U << 22U
+  STORAGE_MODE    = 1U << 22U,
+  MULTI_TENANT    = 1U << 23U,
 };
 // clang-format on
 

--- a/src/dbms/CMakeLists.txt
+++ b/src/dbms/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(mg-dbms INTERFACE)
+target_include_directories(mg-dbms INTERFACE .)
+target_link_libraries(mg-dbms INTERFACE mg-glue)

--- a/src/dbms/auth_handler.hpp
+++ b/src/dbms/auth_handler.hpp
@@ -1,0 +1,96 @@
+// Copyright 2023 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+
+#include "auth/auth.hpp"
+#include "global.hpp"
+#include "glue/auth_checker.hpp"
+#include "glue/auth_handler.hpp"
+#include "utils/result.hpp"
+#include "utils/rw_lock.hpp"
+
+namespace memgraph::dbms {
+
+/**
+ * @brief Multi-tenancy handler of authentication context.
+ */
+class AuthHandler {
+ public:
+  using ContextT = auth::Auth;
+  using LockT = utils::WritePrioritizedRWLock;
+
+  struct AuthContext {
+    explicit AuthContext(const std::filesystem::path &data_directory, const std::string &ah_flags = "")
+        : auth(data_directory / "auth"), auth_handler(&auth, ah_flags), auth_checker(&auth) {}
+
+    utils::Synchronized<ContextT, LockT> auth;
+    glue::AuthQueryHandler auth_handler;
+    glue::AuthChecker auth_checker;
+  };
+
+  using NewResult = utils::BasicResult<NewError, std::shared_ptr<AuthContext>>;
+
+  AuthHandler() = default;
+
+  /**
+   * @brief Create a new authentication context associated to the "name" database.
+   *
+   * @param name name of the database
+   * @param data_directory underlying RocksDB directory
+   * @param config glue::AuthHandler setup flags
+   * @return NewResult pointer to context on success, error on failure
+   */
+  NewResult New(std::string_view name, const std::filesystem::path &data_directory, const std::string &ah_flags) {
+    auto [itr, success] = auth_.emplace(name, std::make_shared<AuthContext>(data_directory, ah_flags));
+    if (success) {
+      return itr->second;
+    }
+    return NewError::EXISTS;
+  }
+
+  /**
+   * @brief Get pointer to the authentication context associated with "name" database.
+   *
+   * @param name name of the database
+   * @return std::optional<std::shared_ptr<AuthContext>> empty on error
+   */
+  std::optional<std::shared_ptr<AuthContext>> Get(const std::string &name) {
+    if (auto search = auth_.find(name); search != auth_.end()) {
+      return search->second;
+    }
+    return {};
+  }
+
+  /**
+   * @brief Delete the authentication context associated with the "name" database
+   *
+   * @param name name of the database
+   * @return true on success
+   */
+  bool Delete(const std::string &name) {
+    if (auto itr = auth_.find(name); itr != auth_.end()) {
+      auth_.erase(itr);
+      return true;
+    }
+    return false;
+  }
+
+ private:
+  std::unordered_map<std::string, std::shared_ptr<AuthContext>> auth_;  //!< map to all active interpreters
+};
+
+}  // namespace memgraph::dbms

--- a/src/dbms/session_context.hpp
+++ b/src/dbms/session_context.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "auth/auth.hpp"
+#include "auth_handler.hpp"
 #include "query/interpreter.hpp"
 #include "storage/v2/storage.hpp"
 #include "utils/synchronized.hpp"
@@ -33,7 +34,7 @@ struct SessionContext {
 
   SessionContext(std::shared_ptr<memgraph::storage::Storage> db,
                  std::shared_ptr<memgraph::query::InterpreterContext> interpreter_context, std::string run,
-                 memgraph::utils::Synchronized<memgraph::auth::Auth, memgraph::utils::WritePrioritizedRWLock> *auth
+                 std::shared_ptr<AuthHandler::AuthContext> auth_context
 #if MG_ENTERPRISE
                  ,
                  memgraph::audit::Log *audit_log
@@ -42,7 +43,8 @@ struct SessionContext {
       : db(db),
         interpreter_context(interpreter_context),
         run_id(run),
-        auth(auth)
+        auth_context(auth_context),
+        auth(&auth_context->auth)
 #if MG_ENTERPRISE
         ,
         audit_log(audit_log)
@@ -54,10 +56,11 @@ struct SessionContext {
   std::shared_ptr<memgraph::query::InterpreterContext> interpreter_context;
   const std::string run_id;
 
-  memgraph::utils::Synchronized<memgraph::auth::Auth, memgraph::utils::WritePrioritizedRWLock> *auth;
+  std::shared_ptr<AuthHandler::AuthContext> auth_context;
+  memgraph::utils::Synchronized<memgraph::auth::Auth, memgraph::utils::WritePrioritizedRWLock> *const auth;
 
 #if MG_ENTERPRISE
-  memgraph::audit::Log *audit_log;
+  memgraph::audit::Log *const audit_log;
 #endif
 };
 

--- a/src/dbms/session_context.hpp
+++ b/src/dbms/session_context.hpp
@@ -33,7 +33,6 @@ struct SessionContext {
 
   SessionContext(std::shared_ptr<memgraph::storage::Storage> db,
                  std::shared_ptr<memgraph::query::InterpreterContext> interpreter_context, std::string run,
-                 std::string db_name,
                  memgraph::utils::Synchronized<memgraph::auth::Auth, memgraph::utils::WritePrioritizedRWLock> *auth
 #if MG_ENTERPRISE
                  ,
@@ -43,7 +42,6 @@ struct SessionContext {
       : db(db),
         interpreter_context(interpreter_context),
         run_id(run),
-        db_name(db_name),
         auth(auth)
 #if MG_ENTERPRISE
         ,
@@ -55,7 +53,6 @@ struct SessionContext {
   std::shared_ptr<memgraph::storage::Storage> db;
   std::shared_ptr<memgraph::query::InterpreterContext> interpreter_context;
   const std::string run_id;
-  const std::string db_name;
 
   memgraph::utils::Synchronized<memgraph::auth::Auth, memgraph::utils::WritePrioritizedRWLock> *auth;
 

--- a/src/dbms/session_context_handler.hpp
+++ b/src/dbms/session_context_handler.hpp
@@ -304,7 +304,7 @@ class SessionContextHandler {
                                             storage_config.durability.storage_directory);
       if (new_interp.HasValue()) {
         return SessionContext {
-          new_storage.GetValue(), new_interp.GetValue(), run_id_, name, auth_
+          new_storage.GetValue(), new_interp.GetValue(), run_id_, auth_
 #if MG_ENTERPRISE
               ,
               audit_log_
@@ -370,7 +370,7 @@ class SessionContextHandler {
       auto interp = interp_handler_.Get(name);
       if (interp) {
         return SessionContext {
-          *storage, *interp, run_id_, name, auth_
+          *storage, *interp, run_id_, auth_
 #if MG_ENTERPRISE
               ,
               audit_log_

--- a/src/dbms/session_context_handler.hpp
+++ b/src/dbms/session_context_handler.hpp
@@ -19,6 +19,8 @@
 
 #include "constants.hpp"
 #include "global.hpp"
+#include "glue/auth_checker.hpp"
+#include "glue/auth_handler.hpp"
 #include "interp_handler.hpp"
 #include "query/config.hpp"
 #include "query/interpreter.hpp"
@@ -54,9 +56,14 @@ class SessionContextHandler {
   using StorageConfigT = storage::Config;
   using InterpT = query::InterpreterContext;
   using InterpConfigT = query::InterpreterConfig;
-  using ConfigT = std::pair<StorageConfigT, InterpConfigT>;
   using LockT = utils::RWLock;
   using NewResultT = utils::BasicResult<NewError, SessionContext>;
+
+  struct Config {
+    StorageConfigT storage_config;  //!< Storage configuration
+    InterpConfigT interp_config;    //!< Interpreter context configuration
+    std::string ah_flags;           //!< glue::AuthHandler setup flags
+  };
 
   SessionContextHandler(const SessionContextHandler &) = delete;
   SessionContextHandler &operator=(const SessionContextHandler &) = delete;
@@ -76,38 +83,22 @@ class SessionContextHandler {
   /**
    * @brief Initialize the handler.
    *
-   * @param auth pointer to the authenticator
-   * @param audit_log pointer to the audit logger
+   * @param audit_log pointer to the audit logger (ENTERPRISE only)
    * @param configs storage and interpreter configurations
    */
 #if MG_ENTERPRISE
-  void Init(memgraph::utils::Synchronized<memgraph::auth::Auth, memgraph::utils::WritePrioritizedRWLock> *auth,
-            memgraph::audit::Log *audit_log, ConfigT configs) {
+  void Init(memgraph::audit::Log *audit_log, Config configs) {
 #else
-  void Init(memgraph::utils::Synchronized<memgraph::auth::Auth, memgraph::utils::WritePrioritizedRWLock> *auth,
-            ConfigT configs) {
+  void Init(Config configs) {
 #endif
     std::lock_guard<LockT> wr(lock_);
     MG_ASSERT(!initialized_, "Tried to reinitialize SessionContextHandler.");
     default_configs_ = configs;
-    auth_ = auth;
 #if MG_ENTERPRISE
     audit_log_ = audit_log;
 #endif
     MG_ASSERT(!NewDefault_().HasError(), "Failed while creating the default DB.");
     initialized_ = true;
-  }
-
-  /**
-   * @brief
-   *
-   * TODO Check how this should be handled.
-   *
-   * @param auth_checker
-   * @param auth_handler
-   */
-  void LinkQueryAuth(query::AuthChecker *auth_checker, query::AuthQueryHandler *auth_handler) {
-    interp_handler_.LinkQueryAuth(auth_checker, auth_handler);
   }
 
   /**
@@ -201,7 +192,7 @@ class SessionContextHandler {
       }
     }
     // Low level handlers
-    if (!interp_handler_.Delete(db_name) || !storage_handler_.Delete(db_name)) {
+    if (!interp_handler_.Delete(db_name) || !auth_handler_.Delete(db_name) || !storage_handler_.Delete(db_name)) {
       return DeleteError::FAIL;
     }
     return {};  // Success
@@ -210,9 +201,9 @@ class SessionContextHandler {
   /**
    * @brief Set the default configurations.
    *
-   * @param configs std::pair of storage and interpreter configurations
+   * @param configs storage, interpreter and authorization configurations
    */
-  void SetDefaultConfigs(ConfigT configs) {
+  void SetDefaultConfigs(Config configs) {
     std::lock_guard<LockT> wr(lock_);
     default_configs_ = configs;
   }
@@ -220,9 +211,9 @@ class SessionContextHandler {
   /**
    * @brief Get the default configurations.
    *
-   * @return std::optional<ConfigT>
+   * @return std::optional<Config>
    */
-  std::optional<ConfigT> GetDefaultConfigs() const {
+  std::optional<Config> GetDefaultConfigs() const {
     std::shared_lock<LockT> rd(lock_);
     return default_configs_;
   }
@@ -253,7 +244,7 @@ class SessionContextHandler {
   SessionContextHandler() : lock_{utils::RWLock::Priority::READ}, initialized_{false}, run_id_{utils::GenerateUUID()} {}
   ~SessionContextHandler() {}
 
-  std::optional<std::filesystem::path> StorageDir(const std::string &name) const {
+  std::optional<std::filesystem::path> StorageDir_(const std::string &name) const {
     try {
       const auto conf = storage_handler_.GetConfig(name);
       if (conf) {
@@ -281,9 +272,9 @@ class SessionContextHandler {
    */
   NewResultT New_(const std::string &name, std::filesystem::path storage_subdir) {
     if (default_configs_) {
-      auto storage = default_configs_->first;
+      auto storage = default_configs_->storage_config;
       storage.durability.storage_directory /= storage_subdir;
-      return New_(name, storage, default_configs_->second);
+      return New_(name, storage, default_configs_->interp_config, default_configs_->ah_flags);
     }
     return NewError::NO_CONFIGS;
   }
@@ -296,23 +287,29 @@ class SessionContextHandler {
    * @param inter_config interpreter configuration
    * @return NewResultT context on success, error on failure
    */
-  NewResultT New_(const std::string &name, StorageConfigT &storage_config, InterpConfigT &inter_config) {
+  NewResultT New_(const std::string &name, StorageConfigT &storage_config, InterpConfigT &inter_config,
+                  const std::string &ah_flags) {
     auto new_storage = storage_handler_.New(name, storage_config);
     if (new_storage.HasValue()) {
-      // storage config can be something else if storage already exists, or return false or reread config
-      auto new_interp = interp_handler_.New(name, new_storage.GetValue().get(), inter_config,
-                                            storage_config.durability.storage_directory);
-      if (new_interp.HasValue()) {
-        return SessionContext {
-          new_storage.GetValue(), new_interp.GetValue(), run_id_, auth_
+      auto new_auth = auth_handler_.New(name, storage_config.durability.storage_directory, ah_flags);
+      if (new_auth.HasValue()) {
+        auto &auth_context = new_auth.GetValue();
+        auto new_interp = interp_handler_.New(name, new_storage.GetValue().get(), inter_config,
+                                              storage_config.durability.storage_directory, auth_context->auth_handler,
+                                              auth_context->auth_checker);
+        if (new_interp.HasValue()) {
+          return SessionContext {
+            new_storage.GetValue(), new_interp.GetValue(), run_id_, auth_context
 #if MG_ENTERPRISE
-              ,
-              audit_log_
+                ,
+                audit_log_
 #endif
-        };
+          };
+        }
+        // TODO: Handler partial success
+        return new_interp.GetError();
       }
-      // TODO: Storage succeeded, but interpreter failed... How to handle?
-      return new_interp.GetError();
+      return new_auth.GetError();
     }
     return new_storage.GetError();
   }
@@ -327,13 +324,14 @@ class SessionContextHandler {
     auto res = New_(kDefaultDB, ".");
     if (res.HasValue()) {
       // Symlink to support back-compatibility
-      const auto dir = StorageDir(kDefaultDB);
+      const auto dir = StorageDir_(kDefaultDB);
       MG_ASSERT(dir, "Failed to find storage path.");
       const auto main_dir = *dir / kDefaultDB;
       if (!std::filesystem::exists(main_dir)) {
         std::filesystem::create_directory(main_dir);
       }
-      const std::vector<std::string> skip{"auth", "audit_log", "internal_modules", "settings", kDefaultDB};
+      // Some directories are redundant (skip those)
+      const std::vector<std::string> skip{"audit_log", "internal_modules", "settings", kDefaultDB};
       for (auto const &item : std::filesystem::directory_iterator{*dir}) {
         const auto dir_name = std::filesystem::relative(item.path(), item.path().parent_path());
         if (std::find(skip.begin(), skip.end(), dir_name) != skip.end()) continue;
@@ -345,11 +343,10 @@ class SessionContextHandler {
           std::error_code ec;
           const auto test_link = std::filesystem::read_symlink(link, ec);
           if (ec || test_link != to) {
-            MG_ASSERT(
-                false,
-                "Memgraph storage directory incompatible with new version.\n"
-                "Please use a clean directory or move directory \"{}\" under a new directory called \"memgraph\".",
-                dir_name.string());
+            MG_ASSERT(false,
+                      "Memgraph storage directory incompatible with new version.\n"
+                      "Please use a clean directory or remove \"{}\" and try again.",
+                      link.string());
           }
         }
       }
@@ -367,15 +364,18 @@ class SessionContextHandler {
   SessionContext Get_(const std::string &name) {
     auto storage = storage_handler_.Get(name);
     if (storage) {
-      auto interp = interp_handler_.Get(name);
-      if (interp) {
-        return SessionContext {
-          *storage, *interp, run_id_, auth_
+      auto auth = auth_handler_.Get(name);
+      if (auth) {
+        auto interp = interp_handler_.Get(name);
+        if (interp) {
+          return SessionContext {
+            *storage, *interp, run_id_, *auth
 #if MG_ENTERPRISE
-              ,
-              audit_log_
+                ,
+                audit_log_
 #endif
-        };
+          };
+        }
       }
     }
     throw SessionContextException("Tried to retrieve an unknown database.");
@@ -386,10 +386,9 @@ class SessionContextHandler {
   std::atomic_bool initialized_;  //!< initialized flag (safeguard against multiple init calls)
   StorageHandler<StorageT, StorageConfigT> storage_handler_;     //!< multi-tenancy storage handler
   InterpContextHandler<InterpT, InterpConfigT> interp_handler_;  //!< multi-tenancy interpreter handler
-  std::optional<ConfigT> default_configs_;                       //!< default storage and interpreter configurations
+  AuthHandler auth_handler_;                                     //!< multi-tenancy authorization handler
+  std::optional<Config> default_configs_;                        //!< default storage and interpreter configurations
   const std::string run_id_;                                     //!< run's unique identifier (auto generated)
-  memgraph::utils::Synchronized<memgraph::auth::Auth, memgraph::utils::WritePrioritizedRWLock>
-      *auth_;  //!< pointer to the authorizer
 #if MG_ENTERPRISE
   memgraph::audit::Log *audit_log_;  //!< pointer to the audit logger
 #endif

--- a/src/dbms/storage_handler.hpp
+++ b/src/dbms/storage_handler.hpp
@@ -43,7 +43,7 @@ class StorageHandler {
    * @param config storage configuration
    * @return NewResult pointer to storage on success, error on failure
    */
-  NewResult New(std::string_view name, const TConfig &config) {
+  NewResult New(const std::string &name, const TConfig &config) {
     // Control that no one is using the same data directory
     if (storage_.find(std::string(name)) != storage_.end()) {
       return NewError::EXISTS;
@@ -56,7 +56,7 @@ class StorageHandler {
       return NewError::EXISTS;
     }
     // Create storage
-    auto [itr, success] = storage_.emplace(name, std::make_pair(std::make_shared<TStorage>(config), config));
+    auto [itr, success] = storage_.emplace(name, std::make_pair(std::make_shared<TStorage>(config, name), config));
     if (success) return itr->second.first;
     return NewError::EXISTS;
   }
@@ -68,7 +68,7 @@ class StorageHandler {
    * @param storage_subdir undelying RocksDB directory
    * @return NewResult pointer to storage on success, error on failure
    */
-  NewResult New(std::string_view name, std::filesystem::path storage_subdir) {
+  NewResult New(const std::string &name, std::filesystem::path storage_subdir) {
     if (default_config_) {
       auto config = default_config_;
       config->durability.storage_directory /= storage_subdir;
@@ -83,7 +83,7 @@ class StorageHandler {
    * @param name name of the database
    * @return NewResult pointer to storage on success, error on failure
    */
-  NewResult New(std::string_view name) { return New(name, name); }
+  NewResult New(const std::string &name) { return New(name, name); }
 
   /**
    * @brief Get storage associated with "name" database

--- a/src/glue/auth.cpp
+++ b/src/glue/auth.cpp
@@ -62,6 +62,8 @@ auth::Permission PrivilegeToPermission(query::AuthQuery::Privilege privilege) {
       return auth::Permission::STORAGE_MODE;
     case query::AuthQuery::Privilege::TRANSACTION_MANAGEMENT:
       return auth::Permission::TRANSACTION_MANAGEMENT;
+    case query::AuthQuery::Privilege::MULTI_TENANT:
+      return auth::Permission::MULTI_TENANT;
   }
 }
 

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -537,7 +537,7 @@ class SessionHL final {
 #ifdef MG_ENTERPRISE
     if (memgraph::license::global_license_checker.IsEnterpriseValidFast()) {
       audit_log_->Record(endpoint_.address().to_string(), user_ ? *username : "", query,
-                         memgraph::storage::PropertyValue(params_pv), session_context_.db_name);
+                         memgraph::storage::PropertyValue(params_pv), db_->id());
     }
 #endif
     try {
@@ -572,6 +572,8 @@ class SessionHL final {
 
   void Abort() { interpreter_.Abort(); }
 
+  // Called during Init
+  // TODO: Handle multi-db once the user cen set which DB to use at login (also a todo)
   bool Authenticate(const std::string &username, const std::string &password) {
     auto locked_auth = auth_->Lock();
     if (!locked_auth->HasUsers()) {

--- a/src/query/CMakeLists.txt
+++ b/src/query/CMakeLists.txt
@@ -52,6 +52,7 @@ else()
     find_package(Python3 "${MG_PYTHON_VERSION}" EXACT REQUIRED COMPONENTS Development)
 endif()
 target_link_libraries(mg-query Python3::Python)
+target_link_libraries(mg-query mg-dbms)
 
 # Generate Antlr openCypher parser
 

--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -471,6 +471,8 @@ class DbAccessor final {
   storage::IndicesInfo ListAllIndices() const { return accessor_->ListAllIndices(); }
 
   storage::ConstraintsInfo ListAllConstraints() const { return accessor_->ListAllConstraints(); }
+
+  const std::string &id() const { return accessor_->id(); }
 };
 
 class SubgraphDbAccessor final {

--- a/src/query/frontend/ast/ast.hpp
+++ b/src/query/frontend/ast/ast.hpp
@@ -2802,7 +2802,8 @@ class AuthQuery : public memgraph::query::Query {
     MODULE_WRITE,
     WEBSOCKET,
     STORAGE_MODE,
-    TRANSACTION_MANAGEMENT
+    TRANSACTION_MANAGEMENT,
+    MULTI_TENANT,
   };
 
   enum class FineGrainedPrivilege { NOTHING, READ, UPDATE, CREATE_DELETE };
@@ -2855,18 +2856,18 @@ class AuthQuery : public memgraph::query::Query {
 
 /// Constant that holds all available privileges.
 const std::vector<AuthQuery::Privilege> kPrivilegesAll = {
-    AuthQuery::Privilege::CREATE,      AuthQuery::Privilege::DELETE,
-    AuthQuery::Privilege::MATCH,       AuthQuery::Privilege::MERGE,
-    AuthQuery::Privilege::SET,         AuthQuery::Privilege::REMOVE,
-    AuthQuery::Privilege::INDEX,       AuthQuery::Privilege::STATS,
-    AuthQuery::Privilege::AUTH,        AuthQuery::Privilege::CONSTRAINT,
-    AuthQuery::Privilege::DUMP,        AuthQuery::Privilege::REPLICATION,
-    AuthQuery::Privilege::READ_FILE,   AuthQuery::Privilege::DURABILITY,
-    AuthQuery::Privilege::FREE_MEMORY, AuthQuery::Privilege::TRIGGER,
-    AuthQuery::Privilege::CONFIG,      AuthQuery::Privilege::STREAM,
-    AuthQuery::Privilege::MODULE_READ, AuthQuery::Privilege::MODULE_WRITE,
-    AuthQuery::Privilege::WEBSOCKET,   AuthQuery::Privilege::TRANSACTION_MANAGEMENT,
-    AuthQuery::Privilege::STORAGE_MODE};
+    AuthQuery::Privilege::CREATE,       AuthQuery::Privilege::DELETE,
+    AuthQuery::Privilege::MATCH,        AuthQuery::Privilege::MERGE,
+    AuthQuery::Privilege::SET,          AuthQuery::Privilege::REMOVE,
+    AuthQuery::Privilege::INDEX,        AuthQuery::Privilege::STATS,
+    AuthQuery::Privilege::AUTH,         AuthQuery::Privilege::CONSTRAINT,
+    AuthQuery::Privilege::DUMP,         AuthQuery::Privilege::REPLICATION,
+    AuthQuery::Privilege::READ_FILE,    AuthQuery::Privilege::DURABILITY,
+    AuthQuery::Privilege::FREE_MEMORY,  AuthQuery::Privilege::TRIGGER,
+    AuthQuery::Privilege::CONFIG,       AuthQuery::Privilege::STREAM,
+    AuthQuery::Privilege::MODULE_READ,  AuthQuery::Privilege::MODULE_WRITE,
+    AuthQuery::Privilege::WEBSOCKET,    AuthQuery::Privilege::TRANSACTION_MANAGEMENT,
+    AuthQuery::Privilege::STORAGE_MODE, AuthQuery::Privilege::MULTI_TENANT};
 
 class InfoQuery : public memgraph::query::Query {
  public:

--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -1531,6 +1531,7 @@ antlrcpp::Any CypherMainVisitor::visitPrivilege(MemgraphCypher::PrivilegeContext
   if (ctx->WEBSOCKET()) return AuthQuery::Privilege::WEBSOCKET;
   if (ctx->TRANSACTION_MANAGEMENT()) return AuthQuery::Privilege::TRANSACTION_MANAGEMENT;
   if (ctx->STORAGE_MODE()) return AuthQuery::Privilege::STORAGE_MODE;
+  if (ctx->MULTI_TENANT()) return AuthQuery::Privilege::MULTI_TENANT;
   LOG_FATAL("Should not get here - unknown privilege!");
 }
 

--- a/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
+++ b/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
@@ -287,6 +287,7 @@ privilege : CREATE
           | WEBSOCKET
           | TRANSACTION_MANAGEMENT
           | STORAGE_MODE
+          | MULTI_TENANT
           ;
 
 granularPrivilege : NOTHING | READ | UPDATE | CREATE_DELETE ;

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -1188,8 +1188,14 @@ using RWType = plan::ReadWriteTypeChecker::RWType;
 }  // namespace
 
 InterpreterContext::InterpreterContext(storage::Storage *db, const InterpreterConfig config,
-                                       const std::filesystem::path &data_directory)
-    : db(db), trigger_store(data_directory / "triggers"), config(config), streams{this, data_directory / "streams"} {}
+                                       const std::filesystem::path &data_directory, query::AuthQueryHandler *ah,
+                                       query::AuthChecker *ac)
+    : db(db),
+      auth(ah),
+      auth_checker(ac),
+      trigger_store(data_directory / "triggers"),
+      config(config),
+      streams{this, data_directory / "streams"} {}
 
 Interpreter::Interpreter(InterpreterContext *interpreter_context) : interpreter_context_(interpreter_context) {
   MG_ASSERT(interpreter_context_, "Interpreter context must not be NULL");

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -210,7 +210,8 @@ class Interpreter;
  */
 struct InterpreterContext {
   explicit InterpreterContext(storage::Storage *db, InterpreterConfig config,
-                              const std::filesystem::path &data_directory);
+                              const std::filesystem::path &data_directory, query::AuthQueryHandler *ah = nullptr,
+                              query::AuthChecker *ac = nullptr);
 
   storage::Storage *db;
 
@@ -224,8 +225,8 @@ struct InterpreterContext {
   std::optional<double> tsc_frequency{utils::GetTSCFrequency()};
   std::atomic<bool> is_shutting_down{false};
 
-  AuthQueryHandler *auth{nullptr};
-  AuthChecker *auth_checker{nullptr};
+  AuthQueryHandler *auth;
+  AuthChecker *auth_checker;
 
   utils::SkipList<QueryCacheEntry> ast_cache;
   utils::SkipList<PlanCacheEntry> plan_cache;

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -324,7 +324,7 @@ bool VerticesIterable::Iterator::operator==(const Iterator &other) const {
   }
 }
 
-Storage::Storage(Config config)
+Storage::Storage(Config config, const std::string &id)
     : indices_(&constraints_, config.items),
       isolation_level_(config.transaction.isolation_level),
       storage_mode_(StorageMode::IN_MEMORY_TRANSACTIONAL),
@@ -334,7 +334,8 @@ Storage::Storage(Config config)
       lock_file_path_(config_.durability.storage_directory / durability::kLockFile),
       uuid_(utils::GenerateUUID()),
       epoch_id_(utils::GenerateUUID()),
-      global_locker_(file_retainer_.AddLocker()) {
+      global_locker_(file_retainer_.AddLocker()),
+      id_(id) {
   if (config_.durability.snapshot_wal_mode == Config::Durability::SnapshotWalMode::DISABLED &&
       replication_role_ == ReplicationRole::MAIN) {
     spdlog::warn(

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -194,7 +194,7 @@ class Storage final {
  public:
   /// @throw std::system_error
   /// @throw std::bad_alloc
-  explicit Storage(Config config = Config());
+  explicit Storage(Config config = Config(), const std::string &id = "");
 
   ~Storage();
 
@@ -354,6 +354,8 @@ class Storage final {
 
     std::optional<uint64_t> GetTransactionId() const;
 
+    const std::string &id() const { return storage_->id(); }
+
    private:
     /// @throw std::bad_alloc
     VertexAccessor CreateVertex(storage::Gid gid);
@@ -372,6 +374,8 @@ class Storage final {
   Accessor Access(std::optional<IsolationLevel> override_isolation_level = {}) {
     return Accessor{this, override_isolation_level.value_or(isolation_level_), storage_mode_};
   }
+
+  const std::string &id() const { return id_; }
 
   const std::string &LabelToName(LabelId label) const;
   const std::string &PropertyToName(PropertyId property) const;
@@ -681,6 +685,7 @@ class Storage final {
   ReplicationClientList replication_clients_;
 
   std::atomic<ReplicationRole> replication_role_{ReplicationRole::MAIN};
+  const std::string id_;  //!< High-level assigned ID
 };
 
 }  // namespace memgraph::storage


### PR DESCRIPTION
Moved auth under the session context handler. Each db has an independent auth instance (stopped using a global auth).
This is in line with the overall design for v1, where an issued command affects only the current db.