### PR TITLE
[E952 < T] Support tenant recovery at startup

### DIFF
--- a/src/dbms/global.hpp
+++ b/src/dbms/global.hpp
@@ -22,6 +22,7 @@ enum class DeleteError : uint8_t {
   USING,
   NON_EXISTENT,
   FAIL,
+  DISK_FAIL,
 };
 
 enum class NewError : uint8_t {

--- a/src/dbms/storage_handler.hpp
+++ b/src/dbms/storage_handler.hpp
@@ -47,11 +47,11 @@ class StorageHandler {
    * @return NewResult pointer to storage on success, error on failure
    */
   NewResult New(const std::string &name, const TConfig &config) {
-    // Control that no one is using the same data directory
+    // TODO better checks
     if (storage_.find(std::string(name)) != storage_.end()) {
       return NewError::EXISTS;
     }
-    // TODO better check
+    // Control that no one is using the same data directory
     if (std::any_of(storage_.begin(), storage_.end(), [&](const auto &elem) {
           return elem.second.config_.durability.storage_directory == config.durability.storage_directory;
         })) {

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -223,6 +223,15 @@ DEFINE_bool(telemetry_enabled, false,
             "the database runtime (vertex and edge counts and resource usage) "
             "to allow for easier improvement of the product.");
 
+// Multi-tenant flags
+#ifdef MG_ENTERPRISE
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_bool(tenant_recover_on_startup, false,
+            "Controls whether the previous tenants get created on startup."
+            "Note: storage configuration dictates whether individual tenants recover their data (see "
+            "--storage-recover-on-startup).");
+#endif
+
 // Streams flags
 // NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_uint32(
@@ -911,7 +920,8 @@ int main(int argc, char **argv) {
 #ifdef MG_ENTERPRISE
   // SessionContext handler (multi-tenancy)
   auto &sc_handler = memgraph::dbms::SessionContextHandler::get();
-  sc_handler.Init(&audit_log, {db_config, interp_config, FLAGS_auth_user_or_role_name_regex});
+  sc_handler.Init(&audit_log, {db_config, interp_config, FLAGS_auth_user_or_role_name_regex},
+                  FLAGS_tenant_recover_on_startup);
   // Just for current support... TODO remove
   auto session_context = sc_handler.Get(memgraph::dbms::kDefaultDB);
 #else

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -226,10 +226,10 @@ DEFINE_bool(telemetry_enabled, false,
 // Multi-tenant flags
 #ifdef MG_ENTERPRISE
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_bool(tenant_recover_on_startup, false,
-            "Controls whether the previous tenants get created on startup."
-            "Note: storage configuration dictates whether individual tenants recover their data (see "
-            "--storage-recover-on-startup).");
+DEFINE_HIDDEN_bool(tenant_recover_on_startup, false,
+                   "Controls whether the previous tenants get created on startup."
+                   "Note: storage configuration dictates whether individual tenants recover their data (see "
+                   "--storage-recover-on-startup).");
 #endif
 
 // Streams flags

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -2881,6 +2881,9 @@ PreparedQuery PrepareMultiDatabaseQuery(ParsedQuery parsed_query, bool in_explic
                 case dbms::DeleteError::FAIL:
                   res = "Failed while deleting " + db_name;
                   break;
+                case dbms::DeleteError::DISK_FAIL:
+                  res = "Failed to clean storage of " + db_name;
+                  break;
               }
             } else {
               res = "Successfully deleted " + db_name;


### PR DESCRIPTION
User can recover previous tenants by passing an argument to memgraph.
In addition drop database will delete the storage directory, so successive creates won't recover old data.
Note: needed to merge on sync so we'll be sure no one is using the storage when the dir gets deleted.