### PR TITLE
[master < I953 ] Improve replication logging. 

### DIFF
--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -118,7 +118,7 @@ void Storage::ReplicationClient::InitializeClient() {
   }
 
   current_commit_timestamp = response.current_commit_timestamp;
-  spdlog::trace("Current timestamp on replica: {}", current_commit_timestamp);
+  spdlog::trace("Current timestamp on replica {}: {}", name_, current_commit_timestamp);
   spdlog::trace("Current timestamp on main: {}", storage_->last_commit_timestamp_.load());
   if (current_commit_timestamp == storage_->last_commit_timestamp_.load()) {
     spdlog::debug("Replica '{}' up to date", name_);

--- a/src/storage/v2/replication/replication_server.cpp
+++ b/src/storage/v2/replication/replication_server.cpp
@@ -148,7 +148,7 @@ void Storage::ReplicationServer::AppendDeltasHandler(slk::Reader *req_reader, sl
 
   replication::AppendDeltasRes res{true, storage_->last_commit_timestamp_.load()};
   slk::Save(res, res_builder);
-  spdlog::info("Replication recovery from append deltas finished!");
+  spdlog::debug("Replication recovery from append deltas finished, replica is now up to date!");
 }
 
 void Storage::ReplicationServer::SnapshotHandler(slk::Reader *req_reader, slk::Builder *res_builder) {

--- a/src/storage/v2/replication/replication_server.cpp
+++ b/src/storage/v2/replication/replication_server.cpp
@@ -103,7 +103,7 @@ void Storage::ReplicationServer::FrequentHeartbeatHandler(slk::Reader *req_reade
 }
 
 void Storage::ReplicationServer::AppendDeltasHandler(slk::Reader *req_reader, slk::Builder *res_builder) {
-  spdlog::debug("Started replication recovery as append deltas!");
+  spdlog::debug("Started replication recovery from appending deltas!");
   replication::AppendDeltasReq req;
   slk::Load(&req, req_reader);
 
@@ -221,6 +221,7 @@ void Storage::ReplicationServer::SnapshotHandler(slk::Reader *req_reader, slk::B
 }
 
 void Storage::ReplicationServer::WalFilesHandler(slk::Reader *req_reader, slk::Builder *res_builder) {
+  spdlog::debug("Started replication recovery from received WAL files!");
   replication::WalFilesReq req;
   slk::Load(&req, req_reader);
 
@@ -237,6 +238,7 @@ void Storage::ReplicationServer::WalFilesHandler(slk::Reader *req_reader, slk::B
 
   replication::WalFilesRes res{true, storage_->last_commit_timestamp_.load()};
   slk::Save(res, res_builder);
+  spdlog::debug("Replication recovery from WAL files ended successfully, replica is now up to date!");
 }
 
 void Storage::ReplicationServer::CurrentWalHandler(slk::Reader *req_reader, slk::Builder *res_builder) {

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -2091,6 +2091,7 @@ bool Storage::SetMainReplicationRole() {
   }
 
   replication_role_.store(ReplicationRole::MAIN);
+  spdlog::info("Instance is now in a MAIN roll.");
   return true;
 }
 
@@ -2156,6 +2157,7 @@ utils::BasicResult<Storage::RegisterReplicaError> Storage::RegisterReplica(
     clients.push_back(std::move(client));
     return {};
   });
+  spdlog::info("Replica {} registered.", name);
 }
 
 bool Storage::UnregisterReplica(const std::string &name) {

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -2189,10 +2189,7 @@ std::optional<replication::ReplicaState> Storage::GetReplicaState(const std::str
   });
 }
 
-ReplicationRole Storage::GetReplicationRole() const {
-  spdlog::trace("Getting replication role...");
-  return replication_role_;
-}
+ReplicationRole Storage::GetReplicationRole() const { return replication_role_; }
 
 std::vector<Storage::ReplicaInfo> Storage::ReplicasInfo() {
   spdlog::trace("Getting replicas info...");

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -2093,7 +2093,7 @@ bool Storage::SetMainReplicationRole() {
   }
 
   replication_role_.store(ReplicationRole::MAIN);
-  spdlog::info("Instance is now in a MAIN roll.");
+  spdlog::info("Instance is now in a MAIN role.");
   return true;
 }
 


### PR DESCRIPTION
This is related to the [issue](https://github.com/memgraph/memgraph/issues/953) with replication, logging is added to provide a bit more context on what is happening, which at the moment is not really visible.  Logs mostly include starting points on the replica recovery process flow, via Snapshot file or WAL. 


Closes https://github.com/memgraph/memgraph/issues/953. 



