### PR TITLE
[master < T] Fix multiple include error

### DIFF
--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -3446,7 +3446,8 @@ inline mgp_type *Return::GetMGPType() const {
 
 // do not enter
 namespace detail {
-void AddParamsReturnsToProc(mgp_proc *proc, std::vector<Parameter> &parameters, const std::vector<Return> &returns) {
+inline void AddParamsReturnsToProc(mgp_proc *proc, std::vector<Parameter> &parameters,
+                                   const std::vector<Return> &returns) {
   for (const auto &parameter : parameters) {
     const auto *parameter_name = parameter.name.data();
     if (!parameter.optional) {


### PR DESCRIPTION
[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments


Made an error in the last [PR](https://github.com/memgraph/memgraph/pull/964) as I didn't put inline on function in detail namespace. But when building MAGE there is a multiple definition error, inline is thus required.