### PR TITLE
Add package/release/run.sh build v4 debian-10

### DIFF
--- a/release/package/amzn-2/Dockerfile
+++ b/release/package/amzn-2/Dockerfile
@@ -9,6 +9,7 @@ RUN yum -y update \
 
 RUN wget -q https://s3-eu-west-1.amazonaws.com/deps.memgraph.io/${TOOLCHAIN_VERSION}/${TOOLCHAIN_VERSION}-binaries-amzn-2-x86_64.tar.gz \
     -O ${TOOLCHAIN_VERSION}-binaries-amzn-2-x86_64.tar.gz \
-    && tar xzvf ${TOOLCHAIN_VERSION}-binaries-amzn-2-x86_64.tar.gz -C /opt
+    && tar xzvf ${TOOLCHAIN_VERSION}-binaries-amzn-2-x86_64.tar.gz -C /opt \
+    && rm ${TOOLCHAIN_VERSION}-binaries-amzn-2-x86_64.tar.gz
 
 ENTRYPOINT ["sleep", "infinity"]

--- a/release/package/centos-7/Dockerfile
+++ b/release/package/centos-7/Dockerfile
@@ -9,6 +9,7 @@ RUN yum -y update \
 
 RUN wget -q https://s3-eu-west-1.amazonaws.com/deps.memgraph.io/${TOOLCHAIN_VERSION}/${TOOLCHAIN_VERSION}-binaries-centos-7-x86_64.tar.gz \
     -O ${TOOLCHAIN_VERSION}-binaries-centos-7-x86_64.tar.gz \
-    && tar xzvf ${TOOLCHAIN_VERSION}-binaries-centos-7-x86_64.tar.gz -C /opt
+    && tar xzvf ${TOOLCHAIN_VERSION}-binaries-centos-7-x86_64.tar.gz -C /opt \
+    && rm ${TOOLCHAIN_VERSION}-binaries-centos-7-x86_64.tar.gz
 
 ENTRYPOINT ["sleep", "infinity"]

--- a/release/package/centos-9/Dockerfile
+++ b/release/package/centos-9/Dockerfile
@@ -9,6 +9,7 @@ RUN yum -y update \
 
 RUN wget -q https://s3-eu-west-1.amazonaws.com/deps.memgraph.io/${TOOLCHAIN_VERSION}/${TOOLCHAIN_VERSION}-binaries-centos-9-x86_64.tar.gz \
     -O ${TOOLCHAIN_VERSION}-binaries-centos-9-x86_64.tar.gz \
-    && tar xzvf ${TOOLCHAIN_VERSION}-binaries-centos-9-x86_64.tar.gz -C /opt
+    && tar xzvf ${TOOLCHAIN_VERSION}-binaries-centos-9-x86_64.tar.gz -C /opt \
+    && rm ${TOOLCHAIN_VERSION}-binaries-centos-9-x86_64.tar.gz
 
 ENTRYPOINT ["sleep", "infinity"]

--- a/release/package/debian-10/Dockerfile
+++ b/release/package/debian-10/Dockerfile
@@ -12,6 +12,7 @@ RUN apt update && apt install -y \
 
 RUN wget -q https://s3-eu-west-1.amazonaws.com/deps.memgraph.io/${TOOLCHAIN_VERSION}/${TOOLCHAIN_VERSION}-binaries-debian-10-amd64.tar.gz \
     -O ${TOOLCHAIN_VERSION}-binaries-debian-10-amd64.tar.gz \
-    && tar xzvf ${TOOLCHAIN_VERSION}-binaries-debian-10-amd64.tar.gz -C /opt
+    && tar xzvf ${TOOLCHAIN_VERSION}-binaries-debian-10-amd64.tar.gz -C /opt \
+    && rm ${TOOLCHAIN_VERSION}-binaries-debian-10-amd64.tar.gz
 
 ENTRYPOINT ["sleep", "infinity"]

--- a/release/package/debian-11-arm/Dockerfile
+++ b/release/package/debian-11-arm/Dockerfile
@@ -12,6 +12,7 @@ RUN apt update && apt install -y \
 
 RUN wget -q https://s3-eu-west-1.amazonaws.com/deps.memgraph.io/${TOOLCHAIN_VERSION}/${TOOLCHAIN_VERSION}-binaries-debian-11-arm64.tar.gz \
     -O ${TOOLCHAIN_VERSION}-binaries-debian-11-arm64.tar.gz \
-    && tar xzvf ${TOOLCHAIN_VERSION}-binaries-debian-11-arm64.tar.gz -C /opt
+    && tar xzvf ${TOOLCHAIN_VERSION}-binaries-debian-11-arm64.tar.gz -C /opt \
+    && rm ${TOOLCHAIN_VERSION}-binaries-debian-11-arm64.tar.gz
 
 ENTRYPOINT ["sleep", "infinity"]

--- a/release/package/debian-11/Dockerfile
+++ b/release/package/debian-11/Dockerfile
@@ -12,6 +12,7 @@ RUN apt update && apt install -y \
 
 RUN wget -q https://s3-eu-west-1.amazonaws.com/deps.memgraph.io/${TOOLCHAIN_VERSION}/${TOOLCHAIN_VERSION}-binaries-debian-11-amd64.tar.gz \
     -O ${TOOLCHAIN_VERSION}-binaries-debian-11-amd64.tar.gz \
-    && tar xzvf ${TOOLCHAIN_VERSION}-binaries-debian-11-amd64.tar.gz -C /opt
+    && tar xzvf ${TOOLCHAIN_VERSION}-binaries-debian-11-amd64.tar.gz -C /opt \
+    && rm ${TOOLCHAIN_VERSION}-binaries-debian-11-amd64.tar.gz
 
 ENTRYPOINT ["sleep", "infinity"]

--- a/release/package/fedora-36/Dockerfile
+++ b/release/package/fedora-36/Dockerfile
@@ -10,6 +10,7 @@ RUN yum -y update \
 
 RUN wget -q https://s3-eu-west-1.amazonaws.com/deps.memgraph.io/${TOOLCHAIN_VERSION}/${TOOLCHAIN_VERSION}-binaries-fedora-36-x86_64.tar.gz \
     -O ${TOOLCHAIN_VERSION}-binaries-fedora-36-x86_64.tar.gz \
-    && tar xzvf ${TOOLCHAIN_VERSION}-binaries-fedora-36-x86_64.tar.gz -C /opt
+    && tar xzvf ${TOOLCHAIN_VERSION}-binaries-fedora-36-x86_64.tar.gz -C /opt \
+    && rm ${TOOLCHAIN_VERSION}-binaries-fedora-36-x86_64.tar.gz
 
 ENTRYPOINT ["sleep", "infinity"]

--- a/release/package/run.sh
+++ b/release/package/run.sh
@@ -159,6 +159,19 @@ case "$1" in
         fi
     ;;
 
+    build)
+      shift 1
+      if [[ "$#" -ne 2 ]]; then
+          print_help
+      fi
+      # in the vX format, e.g. v5
+      toolchain_version="$1"
+      os="$2"
+      cd "$SCRIPT_DIR/$os"
+      # TODO(gitbuda): Just copy or install into the container relevant environment/os script.
+      docker build -f Dockerfile --build-arg TOOLCHAIN_VERSION="toolchain-$toolchain_version" -t "memgraph-builder:v4_$os" .
+    ;;
+
     test)
         echo "TODO(gitbuda): Test all packages on mgtest containers."
     ;;

--- a/release/package/run.sh
+++ b/release/package/run.sh
@@ -166,10 +166,10 @@ case "$1" in
       fi
       # in the vX format, e.g. v5
       toolchain_version="$1"
+      # a name of the os folder, e.g. ubuntu-22.04-arm
       os="$2"
       cd "$SCRIPT_DIR/$os"
-      # TODO(gitbuda): Just copy or install into the container relevant environment/os script.
-      docker build -f Dockerfile --build-arg TOOLCHAIN_VERSION="toolchain-$toolchain_version" -t "memgraph-builder:v4_$os" .
+      docker build -f Dockerfile --build-arg TOOLCHAIN_VERSION="toolchain-$toolchain_version" -t "memgraph/memgraph-builder:${toolchain_version}_$os" .
     ;;
 
     test)

--- a/release/package/ubuntu-18.04/Dockerfile
+++ b/release/package/ubuntu-18.04/Dockerfile
@@ -12,6 +12,7 @@ RUN apt update && apt install -y \
 
 RUN wget -q https://s3-eu-west-1.amazonaws.com/deps.memgraph.io/${TOOLCHAIN_VERSION}/${TOOLCHAIN_VERSION}-binaries-ubuntu-18.04-amd64.tar.gz \
     -O ${TOOLCHAIN_VERSION}-binaries-ubuntu-18.04-amd64.tar.gz \
-    && tar xzvf ${TOOLCHAIN_VERSION}-binaries-ubuntu-18.04-amd64.tar.gz -C /opt
+    && tar xzvf ${TOOLCHAIN_VERSION}-binaries-ubuntu-18.04-amd64.tar.gz -C /opt \
+    && rm ${TOOLCHAIN_VERSION}-binaries-ubuntu-18.04-amd64.tar.gz
 
 ENTRYPOINT ["sleep", "infinity"]

--- a/release/package/ubuntu-20.04/Dockerfile
+++ b/release/package/ubuntu-20.04/Dockerfile
@@ -12,6 +12,7 @@ RUN apt update && apt install -y \
 
 RUN wget -q https://s3-eu-west-1.amazonaws.com/deps.memgraph.io/${TOOLCHAIN_VERSION}/${TOOLCHAIN_VERSION}-binaries-ubuntu-20.04-amd64.tar.gz \
     -O ${TOOLCHAIN_VERSION}-binaries-ubuntu-20.04-amd64.tar.gz \
-    && tar xzvf ${TOOLCHAIN_VERSION}-binaries-ubuntu-20.04-amd64.tar.gz -C /opt
+    && tar xzvf ${TOOLCHAIN_VERSION}-binaries-ubuntu-20.04-amd64.tar.gz -C /opt \
+    && rm ${TOOLCHAIN_VERSION}-binaries-ubuntu-20.04-amd64.tar.gz
 
 ENTRYPOINT ["sleep", "infinity"]

--- a/release/package/ubuntu-22.04-arm/Dockerfile
+++ b/release/package/ubuntu-22.04-arm/Dockerfile
@@ -12,6 +12,7 @@ RUN apt update && apt install -y \
 
 RUN wget -q https://s3-eu-west-1.amazonaws.com/deps.memgraph.io/${TOOLCHAIN_VERSION}/${TOOLCHAIN_VERSION}-binaries-ubuntu-22.04-arm64.tar.gz \
     -O ${TOOLCHAIN_VERSION}-binaries-ubuntu-22.04-arm64.tar.gz \
-    && tar xzvf ${TOOLCHAIN_VERSION}-binaries-ubuntu-22.04-arm64.tar.gz -C /opt
+    && tar xzvf ${TOOLCHAIN_VERSION}-binaries-ubuntu-22.04-arm64.tar.gz -C /opt \
+    && rm ${TOOLCHAIN_VERSION}-binaries-ubuntu-22.04-arm64.tar.gz
 
 ENTRYPOINT ["sleep", "infinity"]

--- a/release/package/ubuntu-22.04/Dockerfile
+++ b/release/package/ubuntu-22.04/Dockerfile
@@ -12,6 +12,7 @@ RUN apt update && apt install -y \
 
 RUN wget -q https://s3-eu-west-1.amazonaws.com/deps.memgraph.io/${TOOLCHAIN_VERSION}/${TOOLCHAIN_VERSION}-binaries-ubuntu-22.04-amd64.tar.gz \
     -O ${TOOLCHAIN_VERSION}-binaries-ubuntu-22.04-amd64.tar.gz \
-    && tar xzvf ${TOOLCHAIN_VERSION}-binaries-ubuntu-22.04-amd64.tar.gz -C /opt
+    && tar xzvf ${TOOLCHAIN_VERSION}-binaries-ubuntu-22.04-amd64.tar.gz -C /opt \
+    && rm xzvf ${TOOLCHAIN_VERSION}-binaries-ubuntu-22.04-amd64.tar.gz
 
 ENTRYPOINT ["sleep", "infinity"]


### PR DESCRIPTION
The motivation here is a need for Debian 10 builder image because Jepsen v0.3.0 still requires Debian 10 image (only node containers, e.g., `jepsen-n1`)