### PR TITLE
Fix --memory-limit flag 

### DIFF
--- a/src/utils/memory_tracker.cpp
+++ b/src/utils/memory_tracker.cpp
@@ -12,6 +12,7 @@
 #include "utils/memory_tracker.hpp"
 
 #include <atomic>
+#include <cstdint>
 #include <exception>
 #include <stdexcept>
 
@@ -102,7 +103,7 @@ void MemoryTracker::Alloc(const int64_t size) {
   MG_ASSERT(size >= 0, "Negative size passed to the MemoryTracker.");
 
   const int64_t os_without_allocation =
-      OS_process_reported_memory_.load(std::memory_order_relaxed) - amount_.load(std::memory_order_relaxed);
+      abs(OS_process_reported_memory_.load(std::memory_order_relaxed) - amount_.load(std::memory_order_relaxed));
 
   const int64_t will_be = size + amount_.fetch_add(size, std::memory_order_relaxed) + os_without_allocation;
 
@@ -118,7 +119,6 @@ void MemoryTracker::Alloc(const int64_t size) {
                     "use to {}, while the maximum allowed size for allocation is set to {}.",
                     GetReadableSize(size), GetReadableSize(will_be), GetReadableSize(current_hard_limit)));
   }
-  SetOsProcessReportedMemory(GetMemoryUsage());
   UpdatePeak(will_be);
 }
 

--- a/src/utils/memory_tracker.cpp
+++ b/src/utils/memory_tracker.cpp
@@ -124,7 +124,7 @@ void MemoryTracker::Alloc(const int64_t size) {
 
 void MemoryTracker::Free(const int64_t size) { amount_.fetch_sub(size, std::memory_order_relaxed); }
 
-void MemoryTracker::SetOsProcessReportedMemory(int64_t memory) {
+void MemoryTracker::SetOsProcessReportedMemory(uint64_t memory) {
   OS_process_reported_memory_.store(memory, std::memory_order_relaxed);
 }
 

--- a/src/utils/memory_tracker.hpp
+++ b/src/utils/memory_tracker.hpp
@@ -62,7 +62,7 @@ class MemoryTracker final {
   void SetHardLimit(int64_t limit);
   void TryRaiseHardLimit(int64_t limit);
   void SetMaximumHardLimit(int64_t limit);
-  void SetOsProcessReportedMemory(int64_t memory);
+  void SetOsProcessReportedMemory(uint64_t memory);
 
   // By creating an object of this class, every allocation in its scope that goes over
   // the set hard limit produces an OutOfMemoryException.

--- a/src/utils/memory_tracker.hpp
+++ b/src/utils/memory_tracker.hpp
@@ -28,8 +28,8 @@ class MemoryTracker final {
   std::atomic<int64_t> amount_{0};
   std::atomic<int64_t> peak_{0};
   std::atomic<int64_t> hard_limit_{0};
-  std::atomic<int64_t> OS_process_reported_memory_{0};  // Amount of memory reported by the OS. Includes the overhead of
-                                                        // the binary, dynamic libraries, fragmentation, etc.
+  std::atomic<uint64_t> OS_process_reported_memory_{0};  // Amount of memory reported by the OS. Includes the overhead
+                                                         // of the binary, dynamic libraries, fragmentation, etc.
   // Maximum possible value of a hard limit. If it's set to 0, no upper bound on the hard limit is set.
   int64_t maximum_hard_limit_{0};
 
@@ -63,6 +63,8 @@ class MemoryTracker final {
   void TryRaiseHardLimit(int64_t limit);
   void SetMaximumHardLimit(int64_t limit);
   void SetOsProcessReportedMemory(uint64_t memory);
+
+  void StartOsMemoryTracking();
 
   // By creating an object of this class, every allocation in its scope that goes over
   // the set hard limit produces an OutOfMemoryException.

--- a/src/utils/memory_tracker.hpp
+++ b/src/utils/memory_tracker.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -13,6 +13,7 @@
 
 #include <atomic>
 
+#include "stat.hpp"
 #include "utils/exceptions.hpp"
 
 namespace memgraph::utils {
@@ -27,6 +28,8 @@ class MemoryTracker final {
   std::atomic<int64_t> amount_{0};
   std::atomic<int64_t> peak_{0};
   std::atomic<int64_t> hard_limit_{0};
+  std::atomic<int64_t> OS_process_reported_memory_{0};  // Amount of memory reported by the OS. Includes the overhead of
+                                                        // the binary, dynamic libraries, fragmentation, etc.
   // Maximum possible value of a hard limit. If it's set to 0, no upper bound on the hard limit is set.
   int64_t maximum_hard_limit_{0};
 
@@ -54,9 +57,12 @@ class MemoryTracker final {
 
   auto HardLimit() const { return hard_limit_.load(std::memory_order_relaxed); }
 
+  auto OsProcessReportedMemory() const { return OS_process_reported_memory_.load(std::memory_order_relaxed); }
+
   void SetHardLimit(int64_t limit);
   void TryRaiseHardLimit(int64_t limit);
   void SetMaximumHardLimit(int64_t limit);
+  void SetOsProcessReportedMemory(int64_t memory);
 
   // By creating an object of this class, every allocation in its scope that goes over
   // the set hard limit produces an OutOfMemoryException.

--- a/tests/e2e/memory/CMakeLists.txt
+++ b/tests/e2e/memory/CMakeLists.txt
@@ -17,4 +17,6 @@ function(copy_memory_e2e_python_files FILE_NAME)
 endfunction()
 
 copy_memory_e2e_python_files(common.py)
-copy_memory_e2e_python_files(memory_limit_pid.py)
+copy_memory_e2e_python_files(memory_limit_write.py)
+copy_memory_e2e_python_files(memory_limit_read.py)
+copy_memory_e2e_python_files(memory_limit_delete.py)

--- a/tests/e2e/memory/CMakeLists.txt
+++ b/tests/e2e/memory/CMakeLists.txt
@@ -11,3 +11,10 @@ target_link_libraries(memgraph__e2e__memory__limit_global_alloc gflags mgclient 
 add_executable(memgraph__e2e__memory__limit_global_alloc_proc memory_limit_global_alloc_proc.cpp)
 target_link_libraries(memgraph__e2e__memory__limit_global_alloc_proc gflags mgclient mg-utils mg-io Threads::Threads)
 
+
+function(copy_memory_e2e_python_files FILE_NAME)
+    copy_e2e_python_files(memory ${FILE_NAME})
+endfunction()
+
+copy_memory_e2e_python_files(common.py)
+copy_memory_e2e_python_files(memory_limit_pid.py)

--- a/tests/e2e/memory/common.py
+++ b/tests/e2e/memory/common.py
@@ -1,0 +1,27 @@
+# Copyright 2023 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+import typing
+
+import mgclient
+import pytest
+
+
+def execute_and_fetch_all(cursor: mgclient.Cursor, query: str, params: dict = {}) -> typing.List[tuple]:
+    cursor.execute(query, params)
+    return cursor.fetchall()
+
+
+@pytest.fixture
+def connect(**kwargs) -> mgclient.Connection:
+    connection = mgclient.connect(host="localhost", port=7687, **kwargs)
+    connection.autocommit = True
+    return connection

--- a/tests/e2e/memory/common.py
+++ b/tests/e2e/memory/common.py
@@ -11,6 +11,7 @@
 
 import subprocess
 import sys
+import time
 import typing
 
 import mgclient
@@ -32,15 +33,6 @@ def get_memgraph_pid() -> str:
         print(f"Exception: {e}", file=sys.stderr)
         exit(1)
     return output[0]
-
-
-def connect_heap_track_to_memgraph(pid) -> None:
-    command = f"heaptrack -p {pid} -o ./memgraph.heaptrack"
-    try:
-        subprocess.Popen(command, shell=True)
-    except subprocess.CalledProcessError as e:
-        print(f"Exception: {e}", file=sys.stderr)
-        exit(1)
 
 
 def read_pid_peak_memory_in_MB(pid: str) -> int:

--- a/tests/e2e/memory/common.py
+++ b/tests/e2e/memory/common.py
@@ -34,6 +34,15 @@ def get_memgraph_pid() -> str:
     return output[0]
 
 
+def connect_heap_track_to_memgraph(pid) -> None:
+    command = f"heaptrack -p {pid} -o ./memgraph.heaptrack"
+    try:
+        subprocess.Popen(command, shell=True)
+    except subprocess.CalledProcessError as e:
+        print(f"Exception: {e}", file=sys.stderr)
+        exit(1)
+
+
 def read_pid_peak_memory_in_MB(pid: str) -> int:
     command = f"grep ^VmHWM /proc/{pid}/status"
     output = subprocess.check_output(command, shell=True).decode("utf-8").strip()

--- a/tests/e2e/memory/common.py
+++ b/tests/e2e/memory/common.py
@@ -16,6 +16,9 @@ import typing
 import mgclient
 import pytest
 
+MEMORY_LIMIT = 1024  # MB check if workloads.yaml --memory-limit is properly configured.
+THRESHOLD = 0.01  # 1% of memory limit, defines the acceptable overdrive threshold for memory usage.
+
 
 def get_memgraph_pid() -> str:
     command = f"pgrep memgraph"
@@ -32,7 +35,7 @@ def get_memgraph_pid() -> str:
 
 
 def read_pid_peak_memory_in_MB(pid: str) -> int:
-    command = f"grep ^VmPeak /proc/{pid}/status"
+    command = f"grep ^VmHWM /proc/{pid}/status"
     output = subprocess.check_output(command, shell=True).decode("utf-8").strip()
     process_peak_memory = output.split(":")[1].strip().split(" ")[0]
     return int(process_peak_memory) / 1024

--- a/tests/e2e/memory/common.py
+++ b/tests/e2e/memory/common.py
@@ -17,7 +17,7 @@ import typing
 import mgclient
 import pytest
 
-MEMORY_LIMIT = 1024  # MB check if workloads.yaml --memory-limit is properly configured.
+MEMORY_LIMIT = 1000  # MB check if workloads.yaml --memory-limit is properly configured.
 THRESHOLD = 0.01  # 1% of memory limit, defines the acceptable overdrive threshold for memory usage.
 
 

--- a/tests/e2e/memory/memory_limit_delete.py
+++ b/tests/e2e/memory/memory_limit_delete.py
@@ -7,7 +7,7 @@ import pytest
 from common import MEMORY_LIMIT, THRESHOLD, connect
 
 
-def test_memgraph_memory_limit_read(connect):
+def test_memgraph_memory_limit_delete(connect):
     memgraph_pid = common.get_memgraph_pid()
     start_time = time.time()
     end_time = start_time + 30
@@ -43,8 +43,8 @@ def test_memgraph_memory_limit_read(connect):
 
     # Run memory intensive query
     try:
-        print("Running memory intensive query...")
-        common.execute_and_fetch_all(cursor, "MATCH path=(n)-[e]-(m) RETURN path;")
+        print("Running delete query")
+        common.execute_and_fetch_all(cursor, "MATCH n DETACH DELETE n;")
     except Exception as e:
         print(f"Exception: {e}", file=sys.stderr)
         if "Memory limit exceeded" not in str(e):

--- a/tests/e2e/memory/memory_limit_pid.py
+++ b/tests/e2e/memory/memory_limit_pid.py
@@ -1,0 +1,50 @@
+import subprocess
+import sys
+import time
+
+import pytest
+from common import connect, execute_and_fetch_all
+
+MEMORY_LIMIT = 1024  # MB
+THRESHOLD = 0.01  # 1% of memory limit
+
+
+def test_memgraph_memory_control_via_pid(connect):
+    memgraph_pid = subprocess.check_output(["pgrep", "memgraph"]).decode("utf-8").strip()
+    start_time = time.time()
+    end_time = start_time + 30
+
+    cursor = connect.cursor()
+    counter = 0
+    try:
+        while True:
+            command = f"ps -p {memgraph_pid} -o rss="
+            output = subprocess.check_output(command, shell=True)
+            current_memory_usage = int(output.decode("utf-8").strip()) / 1024
+            print(
+                f"Nodes created {counter * 10000} Current memory usage of process {memgraph_pid} (memgraph): {current_memory_usage} MB"
+            )
+            execute_and_fetch_all(cursor, "FOREACH (i IN range(0,10000) | CREATE (:Node {id: i}));")
+            counter += 1
+            if time.time() > end_time:
+                print("Time limit exceeded, breaking loop.", file=sys.stderr)
+                break
+    except Exception as e:
+        print(f"Exception: {e}", file=sys.stderr)
+        pass
+
+    command = f"grep ^VmPeak /proc/{memgraph_pid}/status"
+    output = subprocess.check_output(command, shell=True).decode("utf-8").strip()
+    process_peak_memory = output.split(":")[1].strip().split(" ")[0]
+    memgraph_peak_memory_usage_mb = int(process_peak_memory) / 1024
+    MEMORY_LIMIT_WITH_THRESHOLD = MEMORY_LIMIT + (MEMORY_LIMIT * THRESHOLD)
+    if memgraph_peak_memory_usage_mb > MEMORY_LIMIT_WITH_THRESHOLD:
+        assert False, f"""Memgraph peak memory usage is greater than memory limit {MEMORY_LIMIT} MB + 1%
+                            of memory limit threshold, total {MEMORY_LIMIT_WITH_THRESHOLD}. Peak Memgraph
+                            memory usage: {memgraph_peak_memory_usage_mb} MB."""
+    else:
+        assert True
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/memory/memory_limit_read.py
+++ b/tests/e2e/memory/memory_limit_read.py
@@ -1,0 +1,67 @@
+import subprocess
+import sys
+import time
+
+import common
+import pytest
+from common import MEMORY_LIMIT, THRESHOLD, connect
+
+
+def test_memgraph_memory_limit_read(connect):
+    memgraph_pid = common.get_memgraph_pid()
+    start_time = time.time()
+    end_time = start_time + 30
+
+    cursor = connect.cursor()
+    # Take a memory sample before the test
+    current_memory_usage = common.read_pid_current_memory_in_MB(memgraph_pid)
+    memgraph_peak_memory_usage_mb = common.read_pid_peak_memory_in_MB(memgraph_pid)
+
+    # Create nodes until the 95% of the memory limit is reached
+    counter = 0
+    while current_memory_usage < (MEMORY_LIMIT * 0.95):
+        common.execute_and_fetch_all(
+            cursor, "FOREACH (i IN range(0, 10000) | CREATE (:Node {id: i})-[:REl]->(:Node {id: i}));"
+        )
+        current_memory_usage = common.read_pid_current_memory_in_MB(memgraph_pid)
+        print(f"Current memory usage of Memgraph: {current_memory_usage} MB new nodes/relationships created!")
+        memgraph_peak_memory_usage_mb = common.read_pid_peak_memory_in_MB(memgraph_pid)
+        counter += 1
+
+    # Take a memory sample after the 90% of the memory limit is reached
+    print(f"Current memory usage of Memgraph: {current_memory_usage} MB after 90% of memory limit reached")
+    print(
+        f"Current peak memory usage of Memgraph: {memgraph_peak_memory_usage_mb} MB after 90% of memory limit reached"
+    )
+    common.execute_and_fetch_all(cursor, "FREE MEMORY;")
+    print("Memory freed")
+    current_memory_usage = common.read_pid_current_memory_in_MB(memgraph_pid)
+    memgraph_peak_memory_usage_mb = common.read_pid_peak_memory_in_MB(memgraph_pid)
+
+    # Take a memory sample after the memory is freed
+    print(f"Current memory usage of Memgraph after FREE MEMORY: {current_memory_usage} MB")
+
+    # Run memory intensive query
+    try:
+        print("Running memory intensive query...")
+        common.execute_and_fetch_all(cursor, "MATCH path=(n)-[e]-(m) RETURN path;")
+    except Exception as e:
+        print(f"Exception: {e}", file=sys.stderr)
+        if "Memory limit exceeded" not in str(e):
+            assert False, f"Unexpected exception: {e}, test not valid!"
+        pass
+
+    current_memory_usage = common.read_pid_current_memory_in_MB(memgraph_pid)
+    memgraph_peak_memory_usage_mb = common.read_pid_peak_memory_in_MB(memgraph_pid)
+    MEMORY_LIMIT_WITH_THRESHOLD = MEMORY_LIMIT + (MEMORY_LIMIT * THRESHOLD)
+    if memgraph_peak_memory_usage_mb > MEMORY_LIMIT_WITH_THRESHOLD:
+        assert False, f"""Memgraph peak memory usage is greater than memory limit {MEMORY_LIMIT} MB + 1%
+                            of memory limit threshold, total {MEMORY_LIMIT_WITH_THRESHOLD}. Peak Memgraph
+                            memory usage: {memgraph_peak_memory_usage_mb} MB."""
+    else:
+        print(f"Memory limit not exceeded, peak memory usage: {memgraph_peak_memory_usage_mb} MB")
+        assert True
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/memory/memory_limit_write.py
+++ b/tests/e2e/memory/memory_limit_write.py
@@ -9,7 +9,6 @@ from common import MEMORY_LIMIT, THRESHOLD, connect
 
 def test_memgraph_memory_limit_write(connect):
     memgraph_pid = common.get_memgraph_pid()
-    common.connect_heap_track_to_memgraph(memgraph_pid)
     start_time = time.time()
     end_time = start_time + 30
 

--- a/tests/e2e/memory/memory_limit_write.py
+++ b/tests/e2e/memory/memory_limit_write.py
@@ -9,11 +9,13 @@ from common import MEMORY_LIMIT, THRESHOLD, connect
 
 def test_memgraph_memory_limit_write(connect):
     memgraph_pid = common.get_memgraph_pid()
+    common.connect_heap_track_to_memgraph(memgraph_pid)
     start_time = time.time()
     end_time = start_time + 30
 
     cursor = connect.cursor()
     counter = 0
+
     # Take a memory sample before the test
     current_memory_usage = common.read_pid_current_memory_in_MB(memgraph_pid)
     memgraph_peak_memory_usage_mb = common.read_pid_peak_memory_in_MB(memgraph_pid)

--- a/tests/e2e/memory/memory_limit_write.py
+++ b/tests/e2e/memory/memory_limit_write.py
@@ -4,13 +4,10 @@ import time
 
 import common
 import pytest
-from common import connect
-
-MEMORY_LIMIT = 1024  # MB
-THRESHOLD = 0.01  # 1% of memory limit
+from common import MEMORY_LIMIT, THRESHOLD, connect
 
 
-def test_memgraph_memory_limit_via_pid(connect):
+def test_memgraph_memory_limit_write(connect):
     memgraph_pid = common.get_memgraph_pid()
     start_time = time.time()
     end_time = start_time + 30
@@ -47,6 +44,7 @@ def test_memgraph_memory_limit_via_pid(connect):
                             of memory limit threshold, total {MEMORY_LIMIT_WITH_THRESHOLD}. Peak Memgraph
                             memory usage: {memgraph_peak_memory_usage_mb} MB."""
     else:
+        print(f"Memory limit not exceeded, peak memory usage: {memgraph_peak_memory_usage_mb} MB")
         assert True
 
 

--- a/tests/e2e/memory/workloads.yaml
+++ b/tests/e2e/memory/workloads.yaml
@@ -2,14 +2,14 @@ bolt_port: &bolt_port "7687"
 template_cluster: &template_cluster
   cluster:
     main:
-      args: ["--bolt-port", *bolt_port, "--memory-limit=1024", "--storage-gc-cycle-sec=180", "--log-level=TRACE"]
+      args: ["--bolt-port", *bolt_port, "--memory-limit=1000", "--storage-gc-cycle-sec=180", "--log-level=TRACE"]
       log_file: "memory-e2e.log"
       setup_queries: []
       validation_queries: []
 disk_cluster: &disk_cluster
   cluster:
     main:
-      args: ["--bolt-port", *bolt_port, "--memory-limit=1024", "--storage-gc-cycle-sec=180", "--log-level=TRACE"]
+      args: ["--bolt-port", *bolt_port, "--memory-limit=1000", "--storage-gc-cycle-sec=180", "--log-level=TRACE"]
       log_file: "memory-e2e.log"
       setup_queries: ["STORAGE MODE ON_DISK_TRANSACTIONAL"]
       validation_queries: []

--- a/tests/e2e/memory/workloads.yaml
+++ b/tests/e2e/memory/workloads.yaml
@@ -2,14 +2,14 @@ bolt_port: &bolt_port "7687"
 template_cluster: &template_cluster
   cluster:
     main:
-      args: ["--bolt-port", *bolt_port, "--memory-limit=1000", "--storage-gc-cycle-sec=180", "--log-level=TRACE"]
+      args: ["--bolt-port", *bolt_port, "--memory-limit=1024", "--storage-gc-cycle-sec=180", "--log-level=TRACE"]
       log_file: "memory-e2e.log"
       setup_queries: []
       validation_queries: []
 disk_cluster: &disk_cluster
   cluster:
     main:
-      args: ["--bolt-port", *bolt_port, "--memory-limit=1000", "--storage-gc-cycle-sec=180", "--log-level=TRACE"]
+      args: ["--bolt-port", *bolt_port, "--memory-limit=1024", "--storage-gc-cycle-sec=180", "--log-level=TRACE"]
       log_file: "memory-e2e.log"
       setup_queries: ["STORAGE MODE ON_DISK_TRANSACTIONAL"]
       validation_queries: []
@@ -31,4 +31,9 @@ workloads:
     binary: "tests/e2e/memory/memgraph__e2e__memory__limit_global_alloc_proc"
     args: ["--bolt-port", *bolt_port, "--timeout", "180"]
     proc: "tests/e2e/memory/procedures/"
+    <<: *template_cluster
+
+  - name: "Memory limit pid"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["memory/memory_limit_pid.py"]
     <<: *template_cluster

--- a/tests/e2e/memory/workloads.yaml
+++ b/tests/e2e/memory/workloads.yaml
@@ -33,7 +33,17 @@ workloads:
     proc: "tests/e2e/memory/procedures/"
     <<: *template_cluster
 
-  - name: "Memory limit pid"
+  - name: "Memory limit write"
     binary: "tests/e2e/pytest_runner.sh"
-    args: ["memory/memory_limit_pid.py"]
+    args: ["memory/memory_limit_write.py"]
+    <<: *template_cluster
+
+  - name: "Memory limit read"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["memory/memory_limit_read.py"]
+    <<: *template_cluster
+
+  - name: "Memory limit delete"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["memory/memory_limit_read.py"]
     <<: *template_cluster


### PR DESCRIPTION
### e2e: 
  - [x] Write basic e2e basic limit test with write query
  - [x] Wtite basics e2e basic limit test with big read query 
  - [x] Write basic e2e delete limit test
 
###  Fixes: 
  - [ ] Fix the global allocator counter (as much as possible) 
  - [ ] ...
 

### Observations: 

**e2e tests:** 
Memgraph uses approximately 10% more memory the specified by the limit. These are values from OS perspective, both RSS and Peak RSS value of the process. 
Limit = 1024 MB - This should be a hard limit.

```
...
Nodes created 1,700,000 current memory usage of Memgraph: 1078.328125 MB
Current peak memory usage of Memgraph: 1085.83984375 MB
// RSS value after the last insert.  (ps -p {pid} -o rss=) 
Nodes created 1,800,000 current memory usage of Memgraph: 1131.05078125 MB-
// Peak value - grep ^VmHWM /proc/{pid}/status
Current peak memory usage of Memgraph: 1138.5390625 MB - 

```

**Debugging Memgraph Memory** 
Memgraph clean start ( --limit=512) 
```
total_memory_tracker.hard_limit = 512MB 
total_memory_tracker.allocated = 3 MB

```


IMO, when setting the global memory limit via (--memory-limit)  we should consider only the limit that is visible from the OS perspective. 


[master < Epic] PR
- [ ] Check, and update documentation if necessary
- [ ] Write E2E tests
- [ ] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch and the Epic branch
- [ ] Provide the full content or a guide for the final git message

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments

Closes: [#745](https://github.com/memgraph/memgraph/issues/745)