### PR TITLE
[master < T1080] overload << operator for mgp::Type

### DIFF
--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -395,8 +395,9 @@ class List {
 
   /// @brief Returns the value at the given `index`.
   const Value operator[](size_t index) const;
+
   /// @brief Returns type as string.
-  const std::string TypeString();
+  const std::string TypeString() const;
 
   class Iterator {
    private:
@@ -492,9 +493,6 @@ class Map {
   /// @brief Returns the value at the given `key`.
   Value const At(std::string_view key) const;
 
-  /// @brief Returns type as string.
-  const std::string TypeString();
-
   class Iterator {
    public:
     friend class Map;
@@ -544,6 +542,8 @@ class Map {
   bool operator==(const Map &other) const;
   /// @exception std::runtime_error Map contains value of unknown type.
   bool operator!=(const Map &other) const;
+  /// @brief Returns type as string.
+  const std::string TypeString() const;
 
  private:
   mgp_map *ptr_;
@@ -605,9 +605,8 @@ class Node {
   bool operator==(const Node &other) const;
   /// @exception std::runtime_error Node properties contain value(s) of unknown type.
   bool operator!=(const Node &other) const;
-
   /// @brief Returns type as string.
-  const std::string TypeString();
+  const std::string TypeString() const;
 
  private:
   mgp_vertex *ptr_;
@@ -663,9 +662,8 @@ class Relationship {
   bool operator==(const Relationship &other) const;
   /// @exception std::runtime_error Relationship properties contain value(s) of unknown type.
   bool operator!=(const Relationship &other) const;
-
   /// @brief Returns type as string.
-  const std::string TypeString();
+  const std::string TypeString() const;
 
  private:
   mgp_edge *ptr_;
@@ -714,9 +712,8 @@ class Path {
   bool operator==(const Path &other) const;
   /// @exception std::runtime_error Path contains element(s) with unknown value.
   bool operator!=(const Path &other) const;
-
   /// @brief Returns type as string.
-  const std::string TypeString();
+  const std::string TypeString() const;
 
  private:
   mgp_path *ptr_;
@@ -776,7 +773,7 @@ class Date {
   bool operator<(const Date &other) const;
 
   /// @brief Returns type as string.
-  const std::string TypeString();
+  const std::string TypeString() const;
 
  private:
   mgp_date *ptr_;
@@ -838,7 +835,7 @@ class LocalTime {
   bool operator<(const LocalTime &other) const;
 
   /// @brief Returns type as string.
-  const std::string TypeString();
+  const std::string TypeString() const;
 
  private:
   mgp_local_time *ptr_;
@@ -906,7 +903,7 @@ class LocalDateTime {
   bool operator<(const LocalDateTime &other) const;
 
   /// @brief Returns type as string.
-  const std::string TypeString();
+  const std::string TypeString() const;
 
  private:
   mgp_local_date_time *ptr_;
@@ -960,7 +957,7 @@ class Duration {
   bool operator<(const Duration &other) const;
 
   /// @brief Returns type as string.
-  const std::string TypeString();
+  const std::string TypeString() const;
 
  private:
   mgp_duration *ptr_;
@@ -1154,7 +1151,8 @@ class Value {
   /// @exception std::runtime_error Unknown value type.
   bool operator!=(const Value &other) const;
 
-  std::string TypeString() const;
+  /// @brief Returns type as string.
+  const std::string TypeString() const;
 
  private:
   mgp_value *ptr_;
@@ -1346,6 +1344,20 @@ enum class ProcedureType : uint8_t {
 inline void AddProcedure(mgp_proc_cb callback, std::string_view name, ProcedureType proc_type,
                          std::vector<Parameter> parameters, std::vector<Return> returns, mgp_module *module,
                          mgp_memory *memory);
+
+/// @brief Adds a batch procedure to the query module.
+/// @param callback - procedure callback
+/// @param initializer - procedure initializer
+/// @param cleanup - procedure cleanup
+/// @param name - procedure name
+/// @param proc_type - procedure type (read/write)
+/// @param parameters - procedure parameters
+/// @param returns - procedure return values
+/// @param module - the query module that the procedure is added to
+/// @param memory - access to memory
+inline void AddBatchProcedure(mgp_proc_cb callback, mgp_proc_initializer initializer, mgp_proc_cleanup cleanup,
+                              std::string_view name, ProcedureType proc_type, std::vector<Parameter> parameters,
+                              std::vector<Return> returns, mgp_module *module, mgp_memory *memory);
 
 /// @brief Adds a function to the query module.
 /// @param callback - function callback
@@ -2162,7 +2174,7 @@ inline bool List::operator==(const List &other) const { return util::ListsEqual(
 
 inline bool List::operator!=(const List &other) const { return !(*this == other); }
 
-inline const std::string List::TypeString() { return "Type: List"; }
+inline const std::string List::TypeString() const { return "Type: List"; }
 
 // MapItem:
 
@@ -2322,7 +2334,7 @@ inline bool Map::operator==(const Map &other) const { return util::MapsEqual(ptr
 
 inline bool Map::operator!=(const Map &other) const { return !(*this == other); }
 
-inline const std::string Map::TypeString() { return "Type: Map"; }
+inline const std::string Map::TypeString() const { return "Type: Map"; }
 
 /* #endregion */
 
@@ -2422,7 +2434,7 @@ inline bool Node::operator==(const Node &other) const { return util::NodesEqual(
 
 inline bool Node::operator!=(const Node &other) const { return !(*this == other); }
 
-inline const std::string Node::TypeString() { return "Type: Node"; }
+inline const std::string Node::TypeString() const { return "Type: Node"; }
 
 // Relationship:
 
@@ -2496,7 +2508,7 @@ inline bool Relationship::operator==(const Relationship &other) const {
 
 inline bool Relationship::operator!=(const Relationship &other) const { return !(*this == other); }
 
-inline const std::string Relationship::TypeString() { return "Type: Relationship"; }
+inline const std::string Relationship::TypeString() const { return "Type: Relationship"; }
 
 // Path:
 
@@ -2559,7 +2571,7 @@ inline bool Path::operator==(const Path &other) const { return util::PathsEqual(
 
 inline bool Path::operator!=(const Path &other) const { return !(*this == other); }
 
-inline const std::string Path::TypeString() { return "Type: Path"; }
+inline const std::string Path::TypeString() const { return "Type: Path"; }
 /* #endregion */
 
 /* #region Temporal types (Date, LocalTime, LocalDateTime, Duration) */
@@ -2655,8 +2667,7 @@ inline bool Date::operator<(const Date &other) const {
 
   return is_less;
 }
-
-inline const std::string Date::TypeString() { return "Type: Date"; }
+inline const std::string Date::TypeString() const { return "Type: Date"; }
 
 // LocalTime:
 
@@ -2755,8 +2766,7 @@ inline bool LocalTime::operator<(const LocalTime &other) const {
 
   return is_less;
 }
-
-inline const std::string LocalTime::TypeString() { return "Type: LocalTime"; }
+inline const std::string LocalTime::TypeString() const { return "Type: LocalTime"; }
 
 // LocalDateTime:
 
@@ -2870,8 +2880,7 @@ inline bool LocalDateTime::operator<(const LocalDateTime &other) const {
 
   return is_less;
 }
-
-inline const std::string LocalDateTime::TypeString() { return "Type: LocalDateTime"; }
+inline const std::string LocalDateTime::TypeString() const { return "Type: LocalDateTime"; }
 
 // Duration:
 
@@ -2960,7 +2969,7 @@ inline bool Duration::operator<(const Duration &other) const {
   return is_less;
 }
 
-inline const std::string Duration::TypeString() { return "Type: Duration"; }
+inline const std::string Duration::TypeString() const { return "Type: Duration"; }
 
 /* #endregion */
 
@@ -3218,7 +3227,7 @@ inline bool Value::operator==(const Value &other) const { return util::ValuesEqu
 
 inline bool Value::operator!=(const Value &other) const { return !(*this == other); }
 
-inline std::string Value::TypeString() const {
+inline const std::string Value::TypeString() const {
   if (Value::IsNull())
     return "Type: Null";
   else if (Value::IsBool())
@@ -3250,7 +3259,6 @@ inline std::string Value::TypeString() const {
   else
     return "Type: Unknown";
 }
-
 /* #endregion */
 
 /* #region Record */
@@ -3517,14 +3525,12 @@ inline mgp_type *Return::GetMGPType() const {
   return util::ToMGPType(type_);
 }
 
-void AddProcedure(mgp_proc_cb callback, std::string_view name, ProcedureType proc_type,
-                  std::vector<Parameter> parameters, std::vector<Return> returns, mgp_module *module,
-                  mgp_memory *memory) {
-  auto proc = (proc_type == ProcedureType::Read) ? mgp::module_add_read_procedure(module, name.data(), callback)
-                                                 : mgp::module_add_write_procedure(module, name.data(), callback);
-
+// do not enter
+namespace detail {
+inline void AddParamsReturnsToProc(mgp_proc *proc, std::vector<Parameter> &parameters,
+                                   const std::vector<Return> &returns) {
   for (const auto &parameter : parameters) {
-    auto parameter_name = parameter.name.data();
+    const auto *parameter_name = parameter.name.data();
     if (!parameter.optional) {
       mgp::proc_add_arg(proc, parameter_name, parameter.GetMGPType());
     } else {
@@ -3533,18 +3539,35 @@ void AddProcedure(mgp_proc_cb callback, std::string_view name, ProcedureType pro
   }
 
   for (const auto return_ : returns) {
-    auto return_name = return_.name.data();
-
+    const auto *return_name = return_.name.data();
     mgp::proc_add_result(proc, return_name, return_.GetMGPType());
   }
+}
+}  // namespace detail
+
+void AddProcedure(mgp_proc_cb callback, std::string_view name, ProcedureType proc_type,
+                  std::vector<Parameter> parameters, std::vector<Return> returns, mgp_module *module,
+                  mgp_memory *memory) {
+  auto *proc = (proc_type == ProcedureType::Read) ? mgp::module_add_read_procedure(module, name.data(), callback)
+                                                  : mgp::module_add_write_procedure(module, name.data(), callback);
+  detail::AddParamsReturnsToProc(proc, parameters, returns);
+}
+
+void AddBatchProcedure(mgp_proc_cb callback, mgp_proc_initializer initializer, mgp_proc_cleanup cleanup,
+                       std::string_view name, ProcedureType proc_type, std::vector<Parameter> parameters,
+                       std::vector<Return> returns, mgp_module *module, mgp_memory *memory) {
+  auto *proc = (proc_type == ProcedureType::Read)
+                   ? mgp::module_add_batch_read_procedure(module, name.data(), callback, initializer, cleanup)
+                   : mgp::module_add_batch_write_procedure(module, name.data(), callback, initializer, cleanup);
+  detail::AddParamsReturnsToProc(proc, parameters, returns);
 }
 
 void AddFunction(mgp_func_cb callback, std::string_view name, std::vector<Parameter> parameters, mgp_module *module,
                  mgp_memory *memory) {
-  auto func = mgp::module_add_function(module, name.data(), callback);
+  auto *func = mgp::module_add_function(module, name.data(), callback);
 
   for (const auto &parameter : parameters) {
-    auto parameter_name = parameter.name.data();
+    const auto *parameter_name = parameter.name.data();
 
     if (!parameter.optional) {
       mgp::func_add_arg(func, parameter_name, parameter.GetMGPType());

--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -395,6 +395,8 @@ class List {
 
   /// @brief Returns the value at the given `index`.
   const Value operator[](size_t index) const;
+  /// @brief Returns type as string.
+  const std::string TypeString();
 
   class Iterator {
    private:
@@ -489,6 +491,9 @@ class Map {
   Value const operator[](std::string_view key) const;
   /// @brief Returns the value at the given `key`.
   Value const At(std::string_view key) const;
+
+  /// @brief Returns type as string.
+  const std::string TypeString();
 
   class Iterator {
    public:
@@ -601,6 +606,9 @@ class Node {
   /// @exception std::runtime_error Node properties contain value(s) of unknown type.
   bool operator!=(const Node &other) const;
 
+  /// @brief Returns type as string.
+  const std::string TypeString();
+
  private:
   mgp_vertex *ptr_;
 };
@@ -656,6 +664,9 @@ class Relationship {
   /// @exception std::runtime_error Relationship properties contain value(s) of unknown type.
   bool operator!=(const Relationship &other) const;
 
+  /// @brief Returns type as string.
+  const std::string TypeString();
+
  private:
   mgp_edge *ptr_;
 };
@@ -703,6 +714,9 @@ class Path {
   bool operator==(const Path &other) const;
   /// @exception std::runtime_error Path contains element(s) with unknown value.
   bool operator!=(const Path &other) const;
+
+  /// @brief Returns type as string.
+  const std::string TypeString();
 
  private:
   mgp_path *ptr_;
@@ -760,6 +774,9 @@ class Date {
   Duration operator-(const Date &other) const;
 
   bool operator<(const Date &other) const;
+
+  /// @brief Returns type as string.
+  const std::string TypeString();
 
  private:
   mgp_date *ptr_;
@@ -819,6 +836,9 @@ class LocalTime {
   Duration operator-(const LocalTime &other) const;
 
   bool operator<(const LocalTime &other) const;
+
+  /// @brief Returns type as string.
+  const std::string TypeString();
 
  private:
   mgp_local_time *ptr_;
@@ -885,6 +905,9 @@ class LocalDateTime {
 
   bool operator<(const LocalDateTime &other) const;
 
+  /// @brief Returns type as string.
+  const std::string TypeString();
+
  private:
   mgp_local_date_time *ptr_;
 };
@@ -935,6 +958,9 @@ class Duration {
   Duration operator-() const;
 
   bool operator<(const Duration &other) const;
+
+  /// @brief Returns type as string.
+  const std::string TypeString();
 
  private:
   mgp_duration *ptr_;
@@ -1128,6 +1154,8 @@ class Value {
   /// @exception std::runtime_error Unknown value type.
   bool operator!=(const Value &other) const;
 
+  std::string TypeString() const;
+
  private:
   mgp_value *ptr_;
 };
@@ -1318,20 +1346,6 @@ enum class ProcedureType : uint8_t {
 inline void AddProcedure(mgp_proc_cb callback, std::string_view name, ProcedureType proc_type,
                          std::vector<Parameter> parameters, std::vector<Return> returns, mgp_module *module,
                          mgp_memory *memory);
-
-/// @brief Adds a batch procedure to the query module.
-/// @param callback - procedure callback
-/// @param initializer - procedure initializer
-/// @param cleanup - procedure cleanup
-/// @param name - procedure name
-/// @param proc_type - procedure type (read/write)
-/// @param parameters - procedure parameters
-/// @param returns - procedure return values
-/// @param module - the query module that the procedure is added to
-/// @param memory - access to memory
-inline void AddBatchProcedure(mgp_proc_cb callback, mgp_proc_initializer initializer, mgp_proc_cleanup cleanup,
-                              std::string_view name, ProcedureType proc_type, std::vector<Parameter> parameters,
-                              std::vector<Return> returns, mgp_module *module, mgp_memory *memory);
 
 /// @brief Adds a function to the query module.
 /// @param callback - function callback
@@ -2148,6 +2162,8 @@ inline bool List::operator==(const List &other) const { return util::ListsEqual(
 
 inline bool List::operator!=(const List &other) const { return !(*this == other); }
 
+inline const std::string List::TypeString() { return "Type: List"; }
+
 // MapItem:
 
 inline bool MapItem::operator==(MapItem &other) const { return key == other.key && value == other.value; }
@@ -2306,6 +2322,8 @@ inline bool Map::operator==(const Map &other) const { return util::MapsEqual(ptr
 
 inline bool Map::operator!=(const Map &other) const { return !(*this == other); }
 
+inline const std::string Map::TypeString() { return "Type: Map"; }
+
 /* #endregion */
 
 /* #region Graph elements (Node, Relationship & Path) */
@@ -2404,6 +2422,8 @@ inline bool Node::operator==(const Node &other) const { return util::NodesEqual(
 
 inline bool Node::operator!=(const Node &other) const { return !(*this == other); }
 
+inline const std::string Node::TypeString() { return "Type: Node"; }
+
 // Relationship:
 
 inline Relationship::Relationship(mgp_edge *ptr) : ptr_(mgp::edge_copy(ptr, memory)) {}
@@ -2476,6 +2496,8 @@ inline bool Relationship::operator==(const Relationship &other) const {
 
 inline bool Relationship::operator!=(const Relationship &other) const { return !(*this == other); }
 
+inline const std::string Relationship::TypeString() { return "Type: Relationship"; }
+
 // Path:
 
 inline Path::Path(mgp_path *ptr) : ptr_(mgp::path_copy(ptr, memory)) {}
@@ -2536,6 +2558,8 @@ inline void Path::Expand(const Relationship &relationship) { mgp::path_expand(pt
 inline bool Path::operator==(const Path &other) const { return util::PathsEqual(ptr_, other.ptr_); }
 
 inline bool Path::operator!=(const Path &other) const { return !(*this == other); }
+
+inline const std::string Path::TypeString() { return "Type: Path"; }
 /* #endregion */
 
 /* #region Temporal types (Date, LocalTime, LocalDateTime, Duration) */
@@ -2631,6 +2655,8 @@ inline bool Date::operator<(const Date &other) const {
 
   return is_less;
 }
+
+inline const std::string Date::TypeString() { return "Type: Date"; }
 
 // LocalTime:
 
@@ -2729,6 +2755,8 @@ inline bool LocalTime::operator<(const LocalTime &other) const {
 
   return is_less;
 }
+
+inline const std::string LocalTime::TypeString() { return "Type: LocalTime"; }
 
 // LocalDateTime:
 
@@ -2843,6 +2871,8 @@ inline bool LocalDateTime::operator<(const LocalDateTime &other) const {
   return is_less;
 }
 
+inline const std::string LocalDateTime::TypeString() { return "Type: LocalDateTime"; }
+
 // Duration:
 
 inline Duration::Duration(mgp_duration *ptr) : ptr_(mgp::duration_copy(ptr, memory)) {}
@@ -2929,6 +2959,8 @@ inline bool Duration::operator<(const Duration &other) const {
 
   return is_less;
 }
+
+inline const std::string Duration::TypeString() { return "Type: Duration"; }
 
 /* #endregion */
 
@@ -3185,6 +3217,40 @@ inline bool Value::IsDuration() const { return mgp::value_is_duration(ptr_); }
 inline bool Value::operator==(const Value &other) const { return util::ValuesEqual(ptr_, other.ptr_); }
 
 inline bool Value::operator!=(const Value &other) const { return !(*this == other); }
+
+inline std::string Value::TypeString() const {
+  if (Value::IsNull())
+    return "Type: Null";
+  else if (Value::IsBool())
+    return "Type: Bool";
+  else if (Value::IsInt())
+    return "Type: Int";
+  else if (Value::IsDouble())
+    return "Type: Double";
+  else if (Value::IsString())
+    return "Type: String";
+  else if (Value::IsList())
+    return "Type: List";
+  else if (Value::IsMap())
+    return "Type: Map";
+  else if (Value::IsNode())
+    return "Type: Node";
+  else if (Value::IsRelationship())
+    return "Type: Relationship";
+  else if (Value::IsPath())
+    return "Type: Path";
+  else if (Value::IsDate())
+    return "Type: Date";
+  else if (Value::IsLocalTime())
+    return "Type: LocalTime";
+  else if (Value::IsLocalDateTime())
+    return "Type: LocalDateTime";
+  else if (Value::IsDuration())
+    return "Type: Duration";
+  else
+    return "Type: Unknown";
+}
+
 /* #endregion */
 
 /* #region Record */
@@ -3451,12 +3517,14 @@ inline mgp_type *Return::GetMGPType() const {
   return util::ToMGPType(type_);
 }
 
-// do not enter
-namespace detail {
-inline void AddParamsReturnsToProc(mgp_proc *proc, std::vector<Parameter> &parameters,
-                                   const std::vector<Return> &returns) {
+void AddProcedure(mgp_proc_cb callback, std::string_view name, ProcedureType proc_type,
+                  std::vector<Parameter> parameters, std::vector<Return> returns, mgp_module *module,
+                  mgp_memory *memory) {
+  auto proc = (proc_type == ProcedureType::Read) ? mgp::module_add_read_procedure(module, name.data(), callback)
+                                                 : mgp::module_add_write_procedure(module, name.data(), callback);
+
   for (const auto &parameter : parameters) {
-    const auto *parameter_name = parameter.name.data();
+    auto parameter_name = parameter.name.data();
     if (!parameter.optional) {
       mgp::proc_add_arg(proc, parameter_name, parameter.GetMGPType());
     } else {
@@ -3465,35 +3533,18 @@ inline void AddParamsReturnsToProc(mgp_proc *proc, std::vector<Parameter> &param
   }
 
   for (const auto return_ : returns) {
-    const auto *return_name = return_.name.data();
+    auto return_name = return_.name.data();
+
     mgp::proc_add_result(proc, return_name, return_.GetMGPType());
   }
-}
-}  // namespace detail
-
-void AddProcedure(mgp_proc_cb callback, std::string_view name, ProcedureType proc_type,
-                  std::vector<Parameter> parameters, std::vector<Return> returns, mgp_module *module,
-                  mgp_memory *memory) {
-  auto *proc = (proc_type == ProcedureType::Read) ? mgp::module_add_read_procedure(module, name.data(), callback)
-                                                  : mgp::module_add_write_procedure(module, name.data(), callback);
-  detail::AddParamsReturnsToProc(proc, parameters, returns);
-}
-
-void AddBatchProcedure(mgp_proc_cb callback, mgp_proc_initializer initializer, mgp_proc_cleanup cleanup,
-                       std::string_view name, ProcedureType proc_type, std::vector<Parameter> parameters,
-                       std::vector<Return> returns, mgp_module *module, mgp_memory *memory) {
-  auto *proc = (proc_type == ProcedureType::Read)
-                   ? mgp::module_add_batch_read_procedure(module, name.data(), callback, initializer, cleanup)
-                   : mgp::module_add_batch_write_procedure(module, name.data(), callback, initializer, cleanup);
-  detail::AddParamsReturnsToProc(proc, parameters, returns);
 }
 
 void AddFunction(mgp_func_cb callback, std::string_view name, std::vector<Parameter> parameters, mgp_module *module,
                  mgp_memory *memory) {
-  auto *func = mgp::module_add_function(module, name.data(), callback);
+  auto func = mgp::module_add_function(module, name.data(), callback);
 
   for (const auto &parameter : parameters) {
-    const auto *parameter_name = parameter.name.data();
+    auto parameter_name = parameter.name.data();
 
     if (!parameter.optional) {
       mgp::func_add_arg(func, parameter_name, parameter.GetMGPType());

--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -396,9 +396,6 @@ class List {
   /// @brief Returns the value at the given `index`.
   const Value operator[](size_t index) const;
 
-  /// @brief Returns type as string.
-  const std::string TypeString() const;
-
   class Iterator {
    private:
     friend class List;
@@ -542,8 +539,6 @@ class Map {
   bool operator==(const Map &other) const;
   /// @exception std::runtime_error Map contains value of unknown type.
   bool operator!=(const Map &other) const;
-  /// @brief Returns type as string.
-  const std::string TypeString() const;
 
  private:
   mgp_map *ptr_;
@@ -605,8 +600,6 @@ class Node {
   bool operator==(const Node &other) const;
   /// @exception std::runtime_error Node properties contain value(s) of unknown type.
   bool operator!=(const Node &other) const;
-  /// @brief Returns type as string.
-  const std::string TypeString() const;
 
  private:
   mgp_vertex *ptr_;
@@ -662,8 +655,6 @@ class Relationship {
   bool operator==(const Relationship &other) const;
   /// @exception std::runtime_error Relationship properties contain value(s) of unknown type.
   bool operator!=(const Relationship &other) const;
-  /// @brief Returns type as string.
-  const std::string TypeString() const;
 
  private:
   mgp_edge *ptr_;
@@ -712,8 +703,6 @@ class Path {
   bool operator==(const Path &other) const;
   /// @exception std::runtime_error Path contains element(s) with unknown value.
   bool operator!=(const Path &other) const;
-  /// @brief Returns type as string.
-  const std::string TypeString() const;
 
  private:
   mgp_path *ptr_;
@@ -771,9 +760,6 @@ class Date {
   Duration operator-(const Date &other) const;
 
   bool operator<(const Date &other) const;
-
-  /// @brief Returns type as string.
-  const std::string TypeString() const;
 
  private:
   mgp_date *ptr_;
@@ -833,9 +819,6 @@ class LocalTime {
   Duration operator-(const LocalTime &other) const;
 
   bool operator<(const LocalTime &other) const;
-
-  /// @brief Returns type as string.
-  const std::string TypeString() const;
 
  private:
   mgp_local_time *ptr_;
@@ -902,9 +885,6 @@ class LocalDateTime {
 
   bool operator<(const LocalDateTime &other) const;
 
-  /// @brief Returns type as string.
-  const std::string TypeString() const;
-
  private:
   mgp_local_date_time *ptr_;
 };
@@ -955,9 +935,6 @@ class Duration {
   Duration operator-() const;
 
   bool operator<(const Duration &other) const;
-
-  /// @brief Returns type as string.
-  const std::string TypeString() const;
 
  private:
   mgp_duration *ptr_;
@@ -1150,9 +1127,6 @@ class Value {
   bool operator==(const Value &other) const;
   /// @exception std::runtime_error Unknown value type.
   bool operator!=(const Value &other) const;
-
-  /// @brief Returns type as string.
-  const std::string TypeString() const;
 
  private:
   mgp_value *ptr_;
@@ -2174,8 +2148,6 @@ inline bool List::operator==(const List &other) const { return util::ListsEqual(
 
 inline bool List::operator!=(const List &other) const { return !(*this == other); }
 
-inline const std::string List::TypeString() const { return "Type: List"; }
-
 // MapItem:
 
 inline bool MapItem::operator==(MapItem &other) const { return key == other.key && value == other.value; }
@@ -2334,8 +2306,6 @@ inline bool Map::operator==(const Map &other) const { return util::MapsEqual(ptr
 
 inline bool Map::operator!=(const Map &other) const { return !(*this == other); }
 
-inline const std::string Map::TypeString() const { return "Type: Map"; }
-
 /* #endregion */
 
 /* #region Graph elements (Node, Relationship & Path) */
@@ -2434,8 +2404,6 @@ inline bool Node::operator==(const Node &other) const { return util::NodesEqual(
 
 inline bool Node::operator!=(const Node &other) const { return !(*this == other); }
 
-inline const std::string Node::TypeString() const { return "Type: Node"; }
-
 // Relationship:
 
 inline Relationship::Relationship(mgp_edge *ptr) : ptr_(mgp::edge_copy(ptr, memory)) {}
@@ -2508,8 +2476,6 @@ inline bool Relationship::operator==(const Relationship &other) const {
 
 inline bool Relationship::operator!=(const Relationship &other) const { return !(*this == other); }
 
-inline const std::string Relationship::TypeString() const { return "Type: Relationship"; }
-
 // Path:
 
 inline Path::Path(mgp_path *ptr) : ptr_(mgp::path_copy(ptr, memory)) {}
@@ -2571,7 +2537,6 @@ inline bool Path::operator==(const Path &other) const { return util::PathsEqual(
 
 inline bool Path::operator!=(const Path &other) const { return !(*this == other); }
 
-inline const std::string Path::TypeString() const { return "Type: Path"; }
 /* #endregion */
 
 /* #region Temporal types (Date, LocalTime, LocalDateTime, Duration) */
@@ -2667,7 +2632,6 @@ inline bool Date::operator<(const Date &other) const {
 
   return is_less;
 }
-inline const std::string Date::TypeString() const { return "Type: Date"; }
 
 // LocalTime:
 
@@ -2766,7 +2730,6 @@ inline bool LocalTime::operator<(const LocalTime &other) const {
 
   return is_less;
 }
-inline const std::string LocalTime::TypeString() const { return "Type: LocalTime"; }
 
 // LocalDateTime:
 
@@ -2880,7 +2843,6 @@ inline bool LocalDateTime::operator<(const LocalDateTime &other) const {
 
   return is_less;
 }
-inline const std::string LocalDateTime::TypeString() const { return "Type: LocalDateTime"; }
 
 // Duration:
 
@@ -2968,8 +2930,6 @@ inline bool Duration::operator<(const Duration &other) const {
 
   return is_less;
 }
-
-inline const std::string Duration::TypeString() const { return "Type: Duration"; }
 
 /* #endregion */
 
@@ -3227,40 +3187,38 @@ inline bool Value::operator==(const Value &other) const { return util::ValuesEqu
 
 inline bool Value::operator!=(const Value &other) const { return !(*this == other); }
 
-inline const std::string Value::TypeString() const {
-  const mgp::Type &valueType = Type();
-
-  switch (valueType) {
-    case Type::Null:
-      return "Type: Null";
-    case Type::Bool:
-      return "Type: Bool";
-    case Type::Int:
-      return "Type: Int";
-    case Type::Double:
-      return "Type: Double";
-    case Type::String:
-      return "String";
-    case Type::List:
-      return "List";
-    case Type::Map:
-      return "Map";
-    case Type::Node:
-      return "Node";
-    case Type::Relationship:
-      return "Relationship";
-    case Type::Path:
-      return "Path";
-    case Type::Date:
-      return "Date";
-    case Type::LocalTime:
-      return "LocalTime";
-    case Type::LocalDateTime:
-      return "LocalDateTime";
-    case Type::Duration:
-      return "Duration";
+inline std::ostream &operator<<(std::ostream &os, const mgp::Type &type) {
+  switch (type) {
+    case mgp::Type::Null:
+      return os << "null";
+    case mgp::Type::Bool:
+      return os << "bool";
+    case mgp::Type::Int:
+      return os << "int";
+    case mgp::Type::Double:
+      return os << "double";
+    case mgp::Type::String:
+      return os << "string";
+    case mgp::Type::List:
+      return os << "list";
+    case mgp::Type::Map:
+      return os << "map";
+    case mgp::Type::Node:
+      return os << "vertex";
+    case mgp::Type::Relationship:
+      return os << "edge";
+    case mgp::Type::Path:
+      return os << "path";
+    case mgp::Type::Date:
+      return os << "date";
+    case mgp::Type::LocalTime:
+      return os << "local_time";
+    case mgp::Type::LocalDateTime:
+      return os << "local_date_time";
+    case mgp::Type::Duration:
+      return os << "duration";
     default:
-      throw ValueException(" No known type");
+      throw ValueException("Unknown type");
   }
 }
 

--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -3228,37 +3228,42 @@ inline bool Value::operator==(const Value &other) const { return util::ValuesEqu
 inline bool Value::operator!=(const Value &other) const { return !(*this == other); }
 
 inline const std::string Value::TypeString() const {
-  if (Value::IsNull())
-    return "Type: Null";
-  else if (Value::IsBool())
-    return "Type: Bool";
-  else if (Value::IsInt())
-    return "Type: Int";
-  else if (Value::IsDouble())
-    return "Type: Double";
-  else if (Value::IsString())
-    return "Type: String";
-  else if (Value::IsList())
-    return "Type: List";
-  else if (Value::IsMap())
-    return "Type: Map";
-  else if (Value::IsNode())
-    return "Type: Node";
-  else if (Value::IsRelationship())
-    return "Type: Relationship";
-  else if (Value::IsPath())
-    return "Type: Path";
-  else if (Value::IsDate())
-    return "Type: Date";
-  else if (Value::IsLocalTime())
-    return "Type: LocalTime";
-  else if (Value::IsLocalDateTime())
-    return "Type: LocalDateTime";
-  else if (Value::IsDuration())
-    return "Type: Duration";
-  else
-    return "Type: Unknown";
+  const mgp::Type &valueType = Type();
+
+  switch (valueType) {
+    case Type::Null:
+      return "Type: Null";
+    case Type::Bool:
+      return "Type: Bool";
+    case Type::Int:
+      return "Type: Int";
+    case Type::Double:
+      return "Type: Double";
+    case Type::String:
+      return "Type: String";
+    case Type::List:
+      return "Type: List";
+    case Type::Map:
+      return "Type: Map";
+    case Type::Node:
+      return "Type: Node";
+    case Type::Relationship:
+      return "Type: Relationship";
+    case Type::Path:
+      return "Type: Path";
+    case Type::Date:
+      return "Type: Date";
+    case Type::LocalTime:
+      return "Type: LocalTime";
+    case Type::LocalDateTime:
+      return "Type: LocalDateTime";
+    case Type::Duration:
+      return "Type: Duration";
+    default:
+      return "Type: Unknown";
+  }
 }
+
 /* #endregion */
 
 /* #region Record */

--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -3240,27 +3240,27 @@ inline const std::string Value::TypeString() const {
     case Type::Double:
       return "Type: Double";
     case Type::String:
-      return "Type: String";
+      return "String";
     case Type::List:
-      return "Type: List";
+      return "List";
     case Type::Map:
-      return "Type: Map";
+      return "Map";
     case Type::Node:
-      return "Type: Node";
+      return "Node";
     case Type::Relationship:
-      return "Type: Relationship";
+      return "Relationship";
     case Type::Path:
-      return "Type: Path";
+      return "Path";
     case Type::Date:
-      return "Type: Date";
+      return "Date";
     case Type::LocalTime:
-      return "Type: LocalTime";
+      return "LocalTime";
     case Type::LocalDateTime:
-      return "Type: LocalDateTime";
+      return "LocalDateTime";
     case Type::Duration:
-      return "Type: Duration";
+      return "Duration";
     default:
-      return "Type: Unknown";
+      throw ValueException(" No known type");
   }
 }
 

--- a/tests/unit/cpp_api.cpp
+++ b/tests/unit/cpp_api.cpp
@@ -471,3 +471,17 @@ TYPED_TEST(CppApiTestFixture, TestNodeProperties) {
   ASSERT_EQ(node_1.Properties()["b"].ValueString(), "b");
   ASSERT_EQ(node_1.GetProperty("b").ValueString(), "b");
 }
+
+TYPED_TEST(CppApiTestFixture, TestValueTypeString) {
+  const int64_t &int1 = 8;
+  const std::string_view &string1 = "string";
+  const mgp::List &list = mgp::List();
+
+  const mgp::Value int_test1 = mgp::Value(int1);
+  const mgp::Value string_test1 = mgp::Value(string1);
+  const mgp::Value list_test1 = mgp::Value(list);
+
+  ASSERT_EQ(int_test1.TypeString(), "Type: Int");
+  ASSERT_EQ(string_test1.TypeString(), "Type: String");
+  ASSERT_EQ(list_test1.TypeString(), "Type: List");
+}

--- a/tests/unit/cpp_api.cpp
+++ b/tests/unit/cpp_api.cpp
@@ -10,6 +10,7 @@
 // licenses/APL.txt.
 
 #include <queue>
+#include <sstream>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -472,16 +473,28 @@ TYPED_TEST(CppApiTestFixture, TestNodeProperties) {
   ASSERT_EQ(node_1.GetProperty("b").ValueString(), "b");
 }
 
-TYPED_TEST(CppApiTestFixture, TestValueTypeString) {
-  const int64_t &int1 = 8;
-  const std::string_view &string1 = "string";
-  const mgp::List &list = mgp::List();
+TYPED_TEST(CppApiTestFixture, TestTypeOperatorStream) {
+  std::string string1 = "string";
+  int64_t int1 = 4;
+  mgp::List list = mgp::List();
 
-  const mgp::Value int_test1 = mgp::Value(int1);
-  const mgp::Value string_test1 = mgp::Value(string1);
-  const mgp::Value list_test1 = mgp::Value(list);
+  mgp::Value string_value = mgp::Value(string1);
+  mgp::Value int_value = mgp::Value(int1);
+  mgp::Value list_value = mgp::Value(list);
 
-  ASSERT_EQ(int_test1.TypeString(), "Type: Int");
-  ASSERT_EQ(string_test1.TypeString(), "Type: String");
-  ASSERT_EQ(list_test1.TypeString(), "Type: List");
+  std::ostringstream oss_str;
+  oss_str << string_value.Type();
+  std::string str_test = oss_str.str();
+
+  std::ostringstream oss_int;
+  oss_int << int_value.Type();
+  std::string int_test = oss_int.str();
+
+  std::ostringstream oss_list;
+  oss_list << list_value.Type();
+  std::string list_test = oss_list.str();
+
+  ASSERT_EQ(str_test, "string");
+  ASSERT_EQ(int_test, "int");
+  ASSERT_EQ(list_test, "list");
 }


### PR DESCRIPTION
During writing collections query module, the need to be able to print the mgp::Type was found, so it was solved with this PR.

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [x] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [X] Write a release note here 
You are now able to print the type of mgp::Type() using operator << . For example, if you have a mgp::List() list, cout<< list <<endl will output "list".

- [X] Tag someone from docs team in the comments
