### PR TITLE
[master < T1090] Add overload for operator< in mgp::Value

### DIFF
--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -3197,42 +3197,31 @@ inline bool Value::operator<(const Value &other) const {
   switch (type) {
     case Type::Null:
       throw ValueException("Cannot compare Null types");
-      break;
     case Type::Bool:
       return ValueBool() < other.ValueBool();
-      break;
     case Type::Int:
       return ValueNumeric() < other.ValueNumeric();
-      break;
     case Type::Double:
       return ValueNumeric() < other.ValueNumeric();
-      break;
     case Type::String:
       return ValueString() < other.ValueString();
-      break;
     case Type::Node:
       return ValueNode() < other.ValueNode();
-      break;
     case Type::Relationship:
       return ValueRelationship() < other.ValueRelationship();
-      break;
     case Type::Date:
       return ValueDate() < other.ValueDate();
-      break;
     case Type::LocalTime:
       return ValueLocalTime() < other.ValueLocalTime();
-      break;
     case Type::LocalDateTime:
       return ValueLocalDateTime() < other.ValueLocalDateTime();
-      break;
     case Type::Duration:
       return ValueDuration() < other.ValueDuration();
-      break;
     default:
       if (IsPath() || IsList() || IsMap()) {
         throw ValueException("Operator < is not defined for this data type");
       } else {
-        return false;
+        throw ValueException("Undefined behaviour");
       }
   }
 }

--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -3189,32 +3189,51 @@ inline bool Value::operator==(const Value &other) const { return util::ValuesEqu
 inline bool Value::operator!=(const Value &other) const { return !(*this == other); }
 
 inline bool Value::operator<(const Value &other) const {
-  if (Type() != other.Type()) {
+  const mgp::Type &type = Type();
+  if (type != other.Type() && !(IsNumeric() && other.IsNumeric())) {
     throw ValueException("Values have to be of the same type");
-  } else if (IsNull()) {
-    throw ValueException("Cannot compare Null types");
-  } else if (IsPath() || IsList() || IsMap()) {
-    throw ValueException(TypeString() + " doesn't have < operator defined");
-  } else if (IsBool()) {
-    return ValueBool() < other.ValueBool();
-  } else if (IsNumeric()) {
-    return ValueNumeric() < other.ValueNumeric();
-  } else if (IsString()) {
-    return ValueString() < other.ValueString();
-  } else if (IsNode()) {
-    return ValueNode() < other.ValueNode();
-  } else if (IsRelationship()) {
-    return ValueRelationship() < other.ValueRelationship();
-  } else if (IsDate()) {
-    return ValueDate() < other.ValueDate();
-  } else if (IsLocalTime()) {
-    return ValueLocalTime() < other.ValueLocalTime();
-  } else if (IsLocalDateTime()) {
-    return ValueLocalDateTime() < other.ValueLocalDateTime();
-  } else if (IsDuration()) {
-    return ValueDuration() < other.ValueDuration();
-  } else {
-    return false;
+  }
+
+  switch (type) {
+    case Type::Null:
+      throw ValueException("Cannot compare Null types");
+      break;
+    case Type::Bool:
+      return ValueBool() < other.ValueBool();
+      break;
+    case Type::Int:
+      return ValueNumeric() < other.ValueNumeric();
+      break;
+    case Type::Double:
+      return ValueNumeric() < other.ValueNumeric();
+      break;
+    case Type::String:
+      return ValueString() < other.ValueString();
+      break;
+    case Type::Node:
+      return ValueNode() < other.ValueNode();
+      break;
+    case Type::Relationship:
+      return ValueRelationship() < other.ValueRelationship();
+      break;
+    case Type::Date:
+      return ValueDate() < other.ValueDate();
+      break;
+    case Type::LocalTime:
+      return ValueLocalTime() < other.ValueLocalTime();
+      break;
+    case Type::LocalDateTime:
+      return ValueLocalDateTime() < other.ValueLocalDateTime();
+      break;
+    case Type::Duration:
+      return ValueDuration() < other.ValueDuration();
+      break;
+    default:
+      if (IsPath() || IsList() || IsMap()) {
+        throw ValueException("Operator < is not defined for this data type");
+      } else {
+        return false;
+      }
   }
 }
 /* #endregion */

--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -1128,6 +1128,8 @@ class Value {
   /// @exception std::runtime_error Unknown value type.
   bool operator!=(const Value &other) const;
 
+  bool operator<(const Value &other) const;
+
  private:
   mgp_value *ptr_;
 };
@@ -3024,7 +3026,7 @@ inline Value::Value(Value &&other) noexcept : ptr_(other.ptr_) { other.ptr_ = nu
 
 inline Value &Value::operator=(const Value &other) noexcept {
   if (this != &other) {
-    mgp::value_destroy(ptr_);
+    Value::mgp::value_destroy(ptr_);
 
     ptr_ = mgp::value_copy(other.ptr_, memory);
   }
@@ -3058,18 +3060,8 @@ inline bool Value::ValueBool() const {
   return mgp::value_get_bool(ptr_);
 }
 
-inline std::int64_t Value::ValueInt() const {
-  if (Type() != Type::Int) {
-    throw ValueException("Type of value is wrong: expected Int.");
-  }
-  return mgp::value_get_int(ptr_);
-}
-
-inline double Value::ValueDouble() const {
-  if (Type() != Type::Double) {
-    throw ValueException("Type of value is wrong: expected Double.");
-  }
-  return mgp::value_get_double(ptr_);
+inline std::int64_t Value::ValueInt() const { Value::throw ValueException("Type of value is wrong: expected Double."); }
+return mgp::value_get_double(ptr_);
 }
 
 inline double Value::ValueNumeric() const {
@@ -3185,6 +3177,36 @@ inline bool Value::IsDuration() const { return mgp::value_is_duration(ptr_); }
 inline bool Value::operator==(const Value &other) const { return util::ValuesEqual(ptr_, other.ptr_); }
 
 inline bool Value::operator!=(const Value &other) const { return !(*this == other); }
+
+inline bool Value::operator<(const Value &other) const {
+  if (Type() != other.Type()) {
+    throw ValueException("Values have to be of the same type");
+  } else if (IsNull()) {
+    throw ValueException("Cannot compare Null types");
+  } else if (IsPath() || IsList() || IsMap()) {
+    throw ValueException(TypeString() + " doesn't have < operator defined");
+  } else if (IsBool()) {
+    return ValueBool() < other.ValueBool();
+  } else if (IsNumeric()) {
+    return ValueNumeric() < other.ValueNumeric();
+  } else if (IsString()) {
+    return ValueString() < other.ValueString();
+  } else if (IsNode()) {
+    return ValueNode() < other.ValueNode();
+  } else if (IsRelationship()) {
+    return ValueRelationship() < other.ValueRelationship();
+  } else if (IsDate()) {
+    return ValueDate() < other.ValueDate();
+  } else if (IsLocalTime()) {
+    return ValueLocalTime() < other.ValueLocalTime();
+  } else if (IsLocalDateTime()) {
+    return ValueLocalDateTime() < other.ValueLocalDateTime();
+  } else if (IsDuration()) {
+    return ValueDuration() < other.ValueDuration();
+  } else {
+    return false;
+  }
+}
 /* #endregion */
 
 /* #region Record */

--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -3026,7 +3026,7 @@ inline Value::Value(Value &&other) noexcept : ptr_(other.ptr_) { other.ptr_ = nu
 
 inline Value &Value::operator=(const Value &other) noexcept {
   if (this != &other) {
-    Value::mgp::value_destroy(ptr_);
+    mgp::value_destroy(ptr_);
 
     ptr_ = mgp::value_copy(other.ptr_, memory);
   }
@@ -3060,8 +3060,18 @@ inline bool Value::ValueBool() const {
   return mgp::value_get_bool(ptr_);
 }
 
-inline std::int64_t Value::ValueInt() const { Value::throw ValueException("Type of value is wrong: expected Double."); }
-return mgp::value_get_double(ptr_);
+inline std::int64_t Value::ValueInt() const {
+  if (Type() != Type::Int) {
+    throw ValueException("Type of value is wrong: expected Int.");
+  }
+  return mgp::value_get_int(ptr_);
+}
+
+inline double Value::ValueDouble() const {
+  if (Type() != Type::Double) {
+    throw ValueException("Type of value is wrong: expected Double.");
+  }
+  return mgp::value_get_double(ptr_);
 }
 
 inline double Value::ValueNumeric() const {

--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -3217,12 +3217,12 @@ inline bool Value::operator<(const Value &other) const {
       return ValueLocalDateTime() < other.ValueLocalDateTime();
     case Type::Duration:
       return ValueDuration() < other.ValueDuration();
+    case Type::Path:
+    case Type::List:
+    case Type::Map:
+      throw ValueException("Operator < is not defined for this Path, List or Map data type");
     default:
-      if (IsPath() || IsList() || IsMap()) {
-        throw ValueException("Operator < is not defined for this data type");
-      } else {
-        throw ValueException("Undefined behaviour");
-      }
+      throw ValueException("Undefined behaviour");
   }
 }
 /* #endregion */

--- a/tests/unit/cpp_api.cpp
+++ b/tests/unit/cpp_api.cpp
@@ -476,9 +476,13 @@ TYPED_TEST(CppApiTestFixture, TestValueOperatorLessThan) {
   const int64_t int1 = 3;
   const int64_t int2 = 4;
   const double double1 = 3.5;
+  const mgp::List list1 = mgp::List();
+  const mgp::Map map1 = mgp::Map();
   const mgp::Value int_test1 = mgp::Value(int1);
   const mgp::Value int_test2 = mgp::Value(int2);
   const mgp::Value double_test1 = mgp::Value(double1);
+  const mgp::Value list_test = mgp::Value(list1);
+  const mgp::Value map_test = mgp::Value(map1);
 
   ASSERT_TRUE(int_test1 < int_test2);
   ASSERT_TRUE(double_test1 < int_test2);
@@ -487,4 +491,6 @@ TYPED_TEST(CppApiTestFixture, TestValueOperatorLessThan) {
   const mgp::Value string_test1 = mgp::Value(string1);
 
   ASSERT_THROW(int_test1 < string_test1, mgp::ValueException);
+  ASSERT_THROW(list_test < map_test, mgp::ValueException);
+  ASSERT_THROW(list_test < list_test, mgp::ValueException);
 }

--- a/tests/unit/cpp_api.cpp
+++ b/tests/unit/cpp_api.cpp
@@ -473,7 +473,6 @@ TYPED_TEST(CppApiTestFixture, TestNodeProperties) {
   ASSERT_EQ(node_1.GetProperty("b").ValueString(), "b");
 }
 
-
 TYPED_TEST(CppApiTestFixture, TestValueOperatorLessThan) {
   const int64_t int1 = 3;
   const int64_t int2 = 4;
@@ -495,6 +494,7 @@ TYPED_TEST(CppApiTestFixture, TestValueOperatorLessThan) {
   ASSERT_THROW(int_test1 < string_test1, mgp::ValueException);
   ASSERT_THROW(list_test < map_test, mgp::ValueException);
   ASSERT_THROW(list_test < list_test, mgp::ValueException);
+}
 
 TYPED_TEST(CppApiTestFixture, TestTypeOperatorStream) {
   std::string string1 = "string";
@@ -520,5 +520,4 @@ TYPED_TEST(CppApiTestFixture, TestTypeOperatorStream) {
   ASSERT_EQ(str_test, "string");
   ASSERT_EQ(int_test, "int");
   ASSERT_EQ(list_test, "list");
-
 }

--- a/tests/unit/cpp_api.cpp
+++ b/tests/unit/cpp_api.cpp
@@ -476,22 +476,15 @@ TYPED_TEST(CppApiTestFixture, TestValueOperatorLessThan) {
   const int64_t int1 = 3;
   const int64_t int2 = 4;
   const double double1 = 3.5;
-  const mgp::Value &int_test1 = mgp::Value(int1);
-  const mgp::Value &int_test2 = mgp::Value(int2);
-  const mgp::Value &double_test1 = mgp::Value(double1);
+  const mgp::Value int_test1 = mgp::Value(int1);
+  const mgp::Value int_test2 = mgp::Value(int2);
+  const mgp::Value double_test1 = mgp::Value(double1);
 
   ASSERT_TRUE(int_test1 < int_test2);
   ASSERT_TRUE(double_test1 < int_test2);
 
-  const std::string_view string1 = "string";
-  const mgp::Value &string_test1 = mgp::Value(string1);
-  bool exceptionThrown = false;
+  const std::string string1 = "string";
+  const mgp::Value string_test1 = mgp::Value(string1);
 
-  try {
-    bool Result = int_test1 < string_test1;
-  } catch (const std::exception &e) {
-    exceptionThrown = true;
-  }
-
-  ASSERT_TRUE(exceptionThrown);
+  ASSERT_THROW(int_test1 < string_test1, mgp::ValueException);
 }

--- a/tests/unit/cpp_api.cpp
+++ b/tests/unit/cpp_api.cpp
@@ -471,3 +471,27 @@ TYPED_TEST(CppApiTestFixture, TestNodeProperties) {
   ASSERT_EQ(node_1.Properties()["b"].ValueString(), "b");
   ASSERT_EQ(node_1.GetProperty("b").ValueString(), "b");
 }
+
+TYPED_TEST(CppApiTestFixture, TestValueOperatorLessThan) {
+  const int64_t int1 = 3;
+  const int64_t int2 = 4;
+  const double double1 = 3.5;
+  const mgp::Value &int_test1 = mgp::Value(int1);
+  const mgp::Value &int_test2 = mgp::Value(int2);
+  const mgp::Value &double_test1 = mgp::Value(double1);
+
+  ASSERT_TRUE(int_test1 < int_test2);
+  ASSERT_TRUE(double_test1 < int_test2);
+
+  const std::string_view string1 = "string";
+  const mgp::Value &string_test1 = mgp::Value(string1);
+  bool exceptionThrown = false;
+
+  try {
+    bool Result = int_test1 < string_test1;
+  } catch (const std::exception &e) {
+    exceptionThrown = true;
+  }
+
+  ASSERT_TRUE(exceptionThrown);
+}


### PR DESCRIPTION
Before, when writing C++ query moduels, directly comparing two mgp::Value variables was not possible. With this PR, it is.

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [x] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [X] Write a release note here 
You are now able to compare two mgp::Value variables with < operator.

- [X] Tag someone from docs team in the comments
