### PR TITLE
[master < T1092] Run jepsen tests always on nightcrawler

### DIFF
--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -319,7 +319,7 @@ jobs:
 
   release_jepsen_test:
     name: "Release Jepsen Test"
-    runs-on: [self-hosted, Linux, X64, Debian10, JepsenControl]
+    runs-on: [self-hosted, Linux, X64, Debian10, JepsenControl, Nightcrawler]
     #continue-on-error: true
     env:
       THREADS: 24

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -319,7 +319,7 @@ jobs:
 
   release_jepsen_test:
     name: "Release Jepsen Test"
-    runs-on: [self-hosted, Linux, X64, Debian10, JepsenControl, Nightcrawler]
+    runs-on: [self-hosted, Linux, X64, Debian10, JepsenControl, nightcrawler]
     #continue-on-error: true
     env:
       THREADS: 24

--- a/.github/workflows/release_debian10.yaml
+++ b/.github/workflows/release_debian10.yaml
@@ -299,7 +299,7 @@ jobs:
 
   release_jepsen_test:
     name: "Release Jepsen Test"
-    runs-on: [self-hosted, Linux, X64, Debian10, JepsenControl]
+    runs-on: [self-hosted, Linux, X64, Debian10, JepsenControl, Nightcrawler]
     env:
       THREADS: 24
       MEMGRAPH_ENTERPRISE_LICENSE: ${{ secrets.MEMGRAPH_ENTERPRISE_LICENSE }}

--- a/.github/workflows/release_debian10.yaml
+++ b/.github/workflows/release_debian10.yaml
@@ -299,7 +299,7 @@ jobs:
 
   release_jepsen_test:
     name: "Release Jepsen Test"
-    runs-on: [self-hosted, Linux, X64, Debian10, JepsenControl, Nightcrawler]
+    runs-on: [self-hosted, Linux, X64, Debian10, JepsenControl, nightcrawler]
     env:
       THREADS: 24
       MEMGRAPH_ENTERPRISE_LICENSE: ${{ secrets.MEMGRAPH_ENTERPRISE_LICENSE }}


### PR DESCRIPTION
Recovering replicas takes variable amount of time on different machines. In Jepsen tests we rely on a fact that all replicas should be prepared before nemesis starts killing them. Hence, I think it makes sense to run distributed tests on a single machine.

TODO:
- here I need to add config that then all other tasks (except Jepsen) shouldn't run on nightcrawler. Otherwise, Jepsen tests wait until all other tasks are finished.

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments
