### PR TITLE
[master < T1094] Extend insert on record to accept mgp::Value

### DIFF
--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -3281,44 +3281,31 @@ inline void Record::Insert(const char *field_name, const Duration &duration) {
 inline void Record::Insert(const char *field_name, const Value &value) {
   switch (value.Type()) {
     case Type::Bool:
-      Insert(field_name, value.ValueBool());
-      break;
+      return Insert(field_name, value.ValueBool());
     case Type::Int:
-      Insert(field_name, value.ValueInt());
-      break;
+      return Insert(field_name, value.ValueInt());
     case Type::Double:
-      Insert(field_name, value.ValueDouble());
-      break;
+      return Insert(field_name, value.ValueDouble());
     case Type::String:
-      Insert(field_name, value.ValueString());
-      break;
+      return Insert(field_name, value.ValueString());
     case Type::List:
-      Insert(field_name, value.ValueList());
-      break;
+      return Insert(field_name, value.ValueList());
     case Type::Map:
-      Insert(field_name, value.ValueMap());
-      break;
+      return Insert(field_name, value.ValueMap());
     case Type::Node:
-      Insert(field_name, value.ValueNode());
-      break;
+      return Insert(field_name, value.ValueNode());
     case Type::Relationship:
-      Insert(field_name, value.ValueRelationship());
-      break;
+      return Insert(field_name, value.ValueRelationship());
     case Type::Path:
-      Insert(field_name, value.ValuePath());
-      break;
+      return Insert(field_name, value.ValuePath());
     case Type::Date:
-      Insert(field_name, value.ValueDate());
-      break;
+      return Insert(field_name, value.ValueDate());
     case Type::LocalTime:
-      Insert(field_name, value.ValueLocalTime());
-      break;
+      return Insert(field_name, value.ValueLocalTime());
     case Type::LocalDateTime:
-      Insert(field_name, value.ValueLocalDateTime());
-      break;
+      return Insert(field_name, value.ValueLocalDateTime());
     case Type::Duration:
-      Insert(field_name, value.ValueDuration());
-      break;
+      return Insert(field_name, value.ValueDuration());
 
     default:
       throw ValueException("No Record.Insert for this datatype");

--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -1180,6 +1180,8 @@ class Record {
   void Insert(const char *field_name, const LocalDateTime &local_date_time);
   /// @brief Inserts a @ref Duration value under field `field_name`.
   void Insert(const char *field_name, const Duration &duration);
+  /// @brief Inserts a @ref Value value under field `field_name`, and then call appropriate insert.
+  void Insert(const char *field_name, const Value &value);
 
  private:
   mgp_result_record *record_;
@@ -3274,6 +3276,53 @@ inline void Record::Insert(const char *field_name, const Duration &duration) {
   auto mgp_val = mgp::value_make_duration(mgp::duration_copy(duration.ptr_, memory));
   { mgp::result_record_insert(record_, field_name, mgp_val); }
   mgp::value_destroy(mgp_val);
+}
+
+inline void Record::Insert(const char *field_name, const Value &value) {
+  switch (value.Type()) {
+    case Type::Bool:
+      Insert(field_name, value.ValueBool());
+      break;
+    case Type::Int:
+      Insert(field_name, value.ValueInt());
+      break;
+    case Type::Double:
+      Insert(field_name, value.ValueDouble());
+      break;
+    case Type::String:
+      Insert(field_name, value.ValueString());
+      break;
+    case Type::List:
+      Insert(field_name, value.ValueList());
+      break;
+    case Type::Map:
+      Insert(field_name, value.ValueMap());
+      break;
+    case Type::Node:
+      Insert(field_name, value.ValueNode());
+      break;
+    case Type::Relationship:
+      Insert(field_name, value.ValueRelationship());
+      break;
+    case Type::Path:
+      Insert(field_name, value.ValuePath());
+      break;
+    case Type::Date:
+      Insert(field_name, value.ValueDate());
+      break;
+    case Type::LocalTime:
+      Insert(field_name, value.ValueLocalTime());
+      break;
+    case Type::LocalDateTime:
+      Insert(field_name, value.ValueLocalDateTime());
+      break;
+    case Type::Duration:
+      Insert(field_name, value.ValueDuration());
+      break;
+
+    default:
+      throw ValueException("No Record.Insert for this datatype");
+  }
 }
 
 // RecordFactory:


### PR DESCRIPTION
This is an additional overload of Record::Insert function. While writing collections query module in  C++ API, the need for returning mgp::Any datatype in AddProcedure was discovered. The changes in this PR adress this problem, and by overloading Record::Insert to accept mgp::Value, mgp::Any datatype can be inserted into Record.

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [x] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [X] Write a release note here 
You are now able to return mgp::Type::Any inside Record when writing query modules in C++ API.

- [X] Tag someone from docs team in the comments
