### PR TITLE
[E952 < ] Database authorization speedup

### DIFF
--- a/src/glue/auth_checker.cpp
+++ b/src/glue/auth_checker.cpp
@@ -73,18 +73,19 @@ AuthChecker::AuthChecker(
 bool AuthChecker::IsUserAuthorized(const std::optional<std::string> &username,
                                    const std::vector<memgraph::query::AuthQuery::Privilege> &privileges,
                                    const std::string &db_name) const {
-  std::optional<memgraph::auth::User> maybe_user;
   {
     auto locked_auth = auth_->ReadLock();
     if (!locked_auth->HasUsers()) {
       return true;
     }
-    if (username.has_value()) {
-      maybe_user = locked_auth->GetUser(*username);
+    if (username.has_value() && username != user_.username()) {
+      const auto maybe_user = locked_auth->GetUser(*username);
+      if (!maybe_user) return false;
+      user_ = *maybe_user;
     }
   }
 
-  return maybe_user.has_value() && IsUserAuthorized(*maybe_user, privileges, db_name);
+  return IsUserAuthorized(user_, privileges, db_name);
 }
 
 #ifdef MG_ENTERPRISE
@@ -95,12 +96,14 @@ std::unique_ptr<memgraph::query::FineGrainedAuthChecker> AuthChecker::GetFineGra
   }
   try {
     auto locked_auth = auth_->Lock();
-    auto user = locked_auth->GetUser(username);
-    if (!user) {
-      throw memgraph::query::QueryRuntimeException("User '{}' doesn't exist .", username);
+    if (username != user_.username()) {
+      auto maybe_user = locked_auth->GetUser(username);
+      if (!maybe_user) {
+        throw memgraph::query::QueryRuntimeException("User '{}' doesn't exist .", username);
+      }
+      user_ = *maybe_user;
     }
-
-    return std::make_unique<memgraph::glue::FineGrainedAuthChecker>(std::move(*user), dba);
+    return std::make_unique<memgraph::glue::FineGrainedAuthChecker>(user_, dba);
 
   } catch (const memgraph::auth::AuthException &e) {
     throw memgraph::query::QueryRuntimeException(e.what());

--- a/src/glue/auth_checker.hpp
+++ b/src/glue/auth_checker.hpp
@@ -39,6 +39,7 @@ class AuthChecker : public query::AuthChecker {
 
  private:
   memgraph::utils::Synchronized<memgraph::auth::Auth, memgraph::utils::WritePrioritizedRWLock> *auth_;
+  mutable auth::User user_;
 };
 #ifdef MG_ENTERPRISE
 class FineGrainedAuthChecker : public query::FineGrainedAuthChecker {

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -659,7 +659,7 @@ class SessionHL final : public memgraph::communication::bolt::Session<memgraph::
 #endif
     try {
       auto result = interpreter_->Prepare(query, params_pv, username, metadata_pv, UUID());
-      const std::string db_name = result.db ? *result.db : "";
+      const std::string &db_name = result.db ? *result.db : "";
       if (user_ && !memgraph::glue::AuthChecker::IsUserAuthorized(*user_, result.privileges, db_name)) {
         interpreter_->Abort();
         if (db_name.empty()) {

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -1154,6 +1154,8 @@ PullPlan::PullPlan(const std::shared_ptr<CachedPlan> plan, const Parameters &par
   ctx_.evaluation_context.labels = NamesToLabels(plan->ast_storage().labels_, dba);
 #ifdef MG_ENTERPRISE
   if (license::global_license_checker.IsEnterpriseValidFast() && username.has_value() && dba) {
+    // TODO How can we avoid creating this every time? If we must create it, it would be faster with an auth::User
+    // instead of the username
     auto auth_checker = interpreter_context->auth_checker->GetFineGrainedAuthChecker(*username, dba);
 
     // if the user has global privileges to read, edit and write anything, we don't need to perform authorization

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -2455,8 +2455,8 @@ Callback SwitchMemoryDevice(storage::StorageMode current_mode, storage::StorageM
     if (SwitchingFromDiskToInMemory(current_mode, requested_mode)) {
       throw utils::BasicException(
           "You cannot switch from the on-disk storage mode to an in-memory storage mode while the database is running. "
-          "To make the switch, delete the data directory and restart the database. Once restarted, Memgraph will automatically "
-          "start in the default in-memory transactional storage mode.");
+          "To make the switch, delete the data directory and restart the database. Once restarted, Memgraph will "
+          "automatically start in the default in-memory transactional storage mode.");
     }
     if (SwitchingFromInMemoryToDisk(current_mode, requested_mode)) {
       std::unique_lock main_guard{interpreter_context->db->main_lock_};
@@ -3578,11 +3578,9 @@ Interpreter::PrepareResult Interpreter::Prepare(const std::string &query_string,
       throw QueryException("Write query forbidden on the replica!");
     }
 
-    // Set the target db to the current db (some queries have different target from the current db)
-    if (!query_execution->prepared_query->db) {
-      query_execution->prepared_query->db = interpreter_context_->db->id();
-    }
-    query_execution->summary["db"] = *query_execution->prepared_query->db;
+    // Update summary db (some queries have different target from the current db)
+    const auto &set_db = query_execution->prepared_query->db;
+    query_execution->summary["db"] = set_db ? *set_db : interpreter_context_->db->id();
 
     return {query_execution->prepared_query->header, query_execution->prepared_query->privileges, qid,
             query_execution->prepared_query->db};


### PR DESCRIPTION
Currently for each query we check if the user has access to it. We should check only on db changes or if the query is ran against a different db.