### PR TITLE
Add macOS support under environment/util.sh:operating_system

### DIFF
--- a/environment/util.sh
+++ b/environment/util.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
 function operating_system() {
-    grep -E '^(VERSION_)?ID=' /etc/os-release | \
-    sort | cut -d '=' -f 2- | sed 's/"//g' | paste -s -d '-'
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        grep -E '^(VERSION_)?ID=' /etc/os-release | \
+        sort | cut -d '=' -f 2- | sed 's/"//g' | paste -s -d '-'
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "$(sw_vers -productName)-$(sw_vers -productVersion | cut -d '.' -f 1)"
+    else
+        echo "operating_system called on an unknown OS"
+        exit 1
+    fi
 }
 
 function check_operating_system() {

--- a/release/package/ubuntu-22.04/Dockerfile
+++ b/release/package/ubuntu-22.04/Dockerfile
@@ -13,6 +13,6 @@ RUN apt update && apt install -y \
 RUN wget -q https://s3-eu-west-1.amazonaws.com/deps.memgraph.io/${TOOLCHAIN_VERSION}/${TOOLCHAIN_VERSION}-binaries-ubuntu-22.04-amd64.tar.gz \
     -O ${TOOLCHAIN_VERSION}-binaries-ubuntu-22.04-amd64.tar.gz \
     && tar xzvf ${TOOLCHAIN_VERSION}-binaries-ubuntu-22.04-amd64.tar.gz -C /opt \
-    && rm xzvf ${TOOLCHAIN_VERSION}-binaries-ubuntu-22.04-amd64.tar.gz
+    && rm ${TOOLCHAIN_VERSION}-binaries-ubuntu-22.04-amd64.tar.gz
 
 ENTRYPOINT ["sleep", "infinity"]


### PR DESCRIPTION
Needed to be able to build memgraph on macOS hosts via builder Docker images.