### PR TITLE
[master < ] Bugfix: Path generation ignores edge's element_id

### DIFF
--- a/src/communication/bolt/v1/value.hpp
+++ b/src/communication/bolt/v1/value.hpp
@@ -112,7 +112,7 @@ struct Path {
     for (uint i = 0; i < edges.size(); i++) {
       const auto &e = edges[i];
       const auto &v = vertices[i + 1];
-      UnboundedEdge unbounded_edge{e.id, e.type, e.properties};
+      UnboundedEdge unbounded_edge{e.id, e.type, e.properties, e.element_id};
       add_element(this->edges, unbounded_edge, e.to == v.id ? 1 : -1, 1);
       add_element(this->vertices, v, 1, 0);
     }

--- a/tests/drivers/python/v5_8/path.py
+++ b/tests/drivers/python/v5_8/path.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2021 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+from neo4j import GraphDatabase, basic_auth
+from neo4j.exceptions import ClientError, TransientError
+
+with GraphDatabase.driver("bolt://localhost:7687", auth=None, encrypted=False) as driver:
+    # Setup the graph.
+    with driver.session() as session:
+        session.run("MATCH (n) DETACH DELETE n").consume()
+        session.run(
+            "CREATE (:Node{id:1})-[:IS_CONNECTED]->(:Node{id:2})-[:IS_CONNECTED]->(:Node{id:3})-[:IS_CONNECTED]->(:Node{id:4})"
+        ).consume()
+
+    # Return a path of length 2
+    with driver.session() as session:
+        res = session.run("MATCH p = (:Node)-[:IS_CONNECTED*..2]->(:Node) RETURN p").values()
+        assert len(res) == 5, "Didn't find all the paths"
+
+    # Return a path of length 3
+    with driver.session() as session:
+        res = session.run("MATCH p = (:Node)-[:IS_CONNECTED*3]->(:Node) RETURN p").values()
+        assert len(res) == 1, "Didn't find the path"
+
+    print("All ok!")

--- a/tests/drivers/python/v5_8/run.sh
+++ b/tests/drivers/python/v5_8/run.sh
@@ -24,3 +24,4 @@ source ve3/bin/activate
 python3 docs_how_to_query.py || exit 1
 python3 max_query_length.py || exit 1
 python3 transactions.py || exit 1
+python3 path.py || exit 1


### PR DESCRIPTION
Bolt v5 introduced element_id to Vertex and Edges.
When generating a Path, the edge's element_id got ignored and defaulted to "".

closes #1100 