### PR TITLE
[master < TXXXX] Add merge optimization to expand during runtime

### DIFF
--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -159,6 +159,14 @@ class VertexAccessor final {
     return iter::imap(MakeEdgeAccessor, std::move(*maybe_edges));
   }
 
+  auto InEdges(storage::View view, const std::vector<storage::EdgeTypeId> &edge_types, const VertexAccessor &dest,
+               int64_t *expanded_count) const
+      -> storage::Result<decltype(iter::imap(MakeEdgeAccessor, *impl_.InEdges(view)))> {
+    auto maybe_edges = impl_.InEdges(view, edge_types, &dest.impl_, expanded_count);
+    if (maybe_edges.HasError()) return maybe_edges.GetError();
+    return iter::imap(MakeEdgeAccessor, std::move(*maybe_edges));
+  }
+
   auto OutEdges(storage::View view, const std::vector<storage::EdgeTypeId> &edge_types) const
       -> storage::Result<decltype(iter::imap(MakeEdgeAccessor, *impl_.OutEdges(view)))> {
     auto maybe_edges = impl_.OutEdges(view, edge_types);
@@ -172,6 +180,14 @@ class VertexAccessor final {
                 const VertexAccessor &dest) const
       -> storage::Result<decltype(iter::imap(MakeEdgeAccessor, *impl_.OutEdges(view)))> {
     auto maybe_edges = impl_.OutEdges(view, edge_types, &dest.impl_);
+    if (maybe_edges.HasError()) return maybe_edges.GetError();
+    return iter::imap(MakeEdgeAccessor, std::move(*maybe_edges));
+  }
+
+  auto OutEdges(storage::View view, const std::vector<storage::EdgeTypeId> &edge_types, const VertexAccessor &dest,
+                int64_t *expanded_count) const
+      -> storage::Result<decltype(iter::imap(MakeEdgeAccessor, *impl_.OutEdges(view)))> {
+    auto maybe_edges = impl_.OutEdges(view, edge_types, &dest.impl_, expanded_count);
     if (maybe_edges.HasError()) return maybe_edges.GetError();
     return iter::imap(MakeEdgeAccessor, std::move(*maybe_edges));
   }

--- a/src/query/plan/operator.hpp
+++ b/src/query/plan/operator.hpp
@@ -764,6 +764,13 @@ struct ExpandCommon {
   bool existing_node;
 };
 
+struct ExpansionInfo {
+  std::optional<VertexAccessor> input_node;
+  EdgeAtom::Direction direction;
+  std::optional<VertexAccessor> existing_node;
+  bool reversed{false};
+};
+
 /// Expansion operator. For a node existing in the frame it
 /// expands one edge and one node and places them on the frame.
 ///
@@ -826,8 +833,12 @@ class Expand : public memgraph::query::plan::LogicalOperator {
     std::optional<InEdgeIteratorT> in_edges_it_;
     std::optional<OutEdgeT> out_edges_;
     std::optional<OutEdgeIteratorT> out_edges_it_;
+    ExpansionInfo expansion_info_;
+    int64_t prev_input_degree_{-1};
+    int64_t prev_existing_degree_{-1};
 
     bool InitEdges(Frame &, ExecutionContext &);
+    ExpansionInfo GetExpansionInfo(Frame &, ExecutionContext &);
   };
 
   std::shared_ptr<memgraph::query::plan::LogicalOperator> input_;

--- a/src/storage/v2/vertex_accessor.cpp
+++ b/src/storage/v2/vertex_accessor.cpp
@@ -366,7 +366,8 @@ Result<std::map<PropertyId, PropertyValue>> VertexAccessor::Properties(View view
 }
 
 Result<std::vector<EdgeAccessor>> VertexAccessor::InEdges(View view, const std::vector<EdgeTypeId> &edge_types,
-                                                          const VertexAccessor *destination) const {
+                                                          const VertexAccessor *destination,
+                                                          int64_t *expanded_count) const {
   MG_ASSERT(!destination || destination->transaction_ == transaction_, "Invalid accessor!");
   bool exists = true;
   bool deleted = false;
@@ -375,6 +376,9 @@ Result<std::vector<EdgeAccessor>> VertexAccessor::InEdges(View view, const std::
   {
     std::lock_guard<utils::SpinLock> guard(vertex_->lock);
     deleted = vertex_->deleted;
+    if (expanded_count) {
+      *expanded_count = vertex_->in_edges.size();
+    }
     if (edge_types.empty() && !destination) {
       in_edges = vertex_->in_edges;
     } else {
@@ -447,7 +451,8 @@ Result<std::vector<EdgeAccessor>> VertexAccessor::InEdges(View view, const std::
 }
 
 Result<std::vector<EdgeAccessor>> VertexAccessor::OutEdges(View view, const std::vector<EdgeTypeId> &edge_types,
-                                                           const VertexAccessor *destination) const {
+                                                           const VertexAccessor *destination,
+                                                           int64_t *expanded_count) const {
   MG_ASSERT(!destination || destination->transaction_ == transaction_, "Invalid accessor!");
   bool exists = true;
   bool deleted = false;
@@ -456,6 +461,9 @@ Result<std::vector<EdgeAccessor>> VertexAccessor::OutEdges(View view, const std:
   {
     std::lock_guard<utils::SpinLock> guard(vertex_->lock);
     deleted = vertex_->deleted;
+    if (expanded_count) {
+      *expanded_count = vertex_->out_edges.size();
+    }
     if (edge_types.empty() && !destination) {
       out_edges = vertex_->out_edges;
     } else {

--- a/src/storage/v2/vertex_accessor.hpp
+++ b/src/storage/v2/vertex_accessor.hpp
@@ -87,13 +87,15 @@ class VertexAccessor final {
   /// @throw std::length_error if the resulting vector exceeds
   ///        std::vector::max_size().
   Result<std::vector<EdgeAccessor>> InEdges(View view, const std::vector<EdgeTypeId> &edge_types = {},
-                                            const VertexAccessor *destination = nullptr) const;
+                                            const VertexAccessor *destination = nullptr,
+                                            int64_t *expanded_count = nullptr) const;
 
   /// @throw std::bad_alloc
   /// @throw std::length_error if the resulting vector exceeds
   ///        std::vector::max_size().
   Result<std::vector<EdgeAccessor>> OutEdges(View view, const std::vector<EdgeTypeId> &edge_types = {},
-                                             const VertexAccessor *destination = nullptr) const;
+                                             const VertexAccessor *destination = nullptr,
+                                             int64_t *expanded_count = nullptr) const;
 
   Result<size_t> InDegree(View view) const;
 


### PR DESCRIPTION
Expansion during runtime means that not always will the expansion be done from left to right according to EXPLAIN query, but depending on the previous executions and how many edges did we need to check on merge in order to see what's the fewest vector we need to expand.

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments
