### PR TITLE
[master < T1211] Optimize expansion from source vertex for disk storage

### DIFF
--- a/src/storage/v2/disk/rocksdb_storage.cpp
+++ b/src/storage/v2/disk/rocksdb_storage.cpp
@@ -10,7 +10,11 @@
 // licenses/APL.txt.
 
 #include "rocksdb_storage.hpp"
+#include <rocksdb/slice.h>
 #include <string_view>
+#include "utils/algorithm.hpp"
+#include "utils/disk_utils.hpp"
+#include "utils/exceptions.hpp"
 #include "utils/rocksdb_serialization.hpp"
 
 namespace memgraph::storage {
@@ -18,6 +22,7 @@ namespace memgraph::storage {
 namespace {
 
 inline rocksdb::Slice StripTimestampFromUserKey(const rocksdb::Slice &user_key, size_t ts_sz) {
+  // spdlog::debug("StripTimestampFromUserKey: {}", user_key.ToString());
   rocksdb::Slice ret = user_key;
   ret.remove_suffix(ts_sz);
   return ret;
@@ -30,11 +35,14 @@ inline rocksdb::Slice ExtractTimestampFromUserKey(const rocksdb::Slice &user_key
 }
 
 // Extracts global id from user key. User key must be without timestamp.
-std::string_view ExtractGidFromUserKey(const rocksdb::Slice &key) {
-  spdlog::debug("Extracted gid from key: {}", key.ToString());
-  assert(key.size() >= 2);
-  auto keyStrView = key.ToStringView();
-  return keyStrView.substr(keyStrView.find_last_of('|') + 1);
+inline std::string_view ExtractGidFromUserKey(const rocksdb::Slice &key) {
+  std::string_view keyStrView = key.ToStringView();
+  // spdlog::debug("ExtractGidFromKey: {}", keyStrView);
+  if (utils::Contains(keyStrView, '|')) {
+    assert(key.size() >= 2);
+    return keyStrView.substr(keyStrView.find_last_of('|') + 1);
+  }
+  return keyStrView;
 }
 
 }  // namespace
@@ -44,30 +52,66 @@ ComparatorWithU64TsImpl::ComparatorWithU64TsImpl()
   assert(cmp_without_ts_->timestamp_size() == 0);
 }
 
+/// TODO: try to write somehow unit test for this
 int ComparatorWithU64TsImpl::Compare(const rocksdb::Slice &a, const rocksdb::Slice &b) const {
-  int ret = CompareWithoutTimestamp(a, b);
-  if (ret != 0) {
-    return ret;
+  std::string a_str = a.ToString();
+  std::string b_str = b.ToString();
+  // spdlog::debug("Received a: {} b: {} in compare method", a_str, b_str);
+  uint32_t num_separators_a = std::count(a_str.begin(), a_str.end(), '|');
+  uint32_t num_separators_b = std::count(b_str.begin(), b_str.end(), '|');
+  utils::RocksDBType a_key_type = utils::GetRocksDBKeyType(num_separators_a);
+  utils::RocksDBType b_key_type = utils::GetRocksDBKeyType(num_separators_b);
+  if (utils::ComparingVertexWithVertex(a_key_type, b_key_type) ||
+      utils::ComparingEdgeWithEdge(a_key_type, b_key_type)) {
+    int ret = CompareWithoutTimestamp(a, b);
+    if (ret != 0) {
+      return ret;
+    }
+    // Compare timestamp.
+    // For the same user key with different timestamps, larger (newer) timestamp
+    // comes first.
+    return CompareTimestamp(ExtractTimestampFromUserKey(b), ExtractTimestampFromUserKey(a));
   }
-  // Compare timestamp.
-  // For the same user key with different timestamps, larger (newer) timestamp
-  // comes first.
-  return CompareTimestamp(ExtractTimestampFromUserKey(b), ExtractTimestampFromUserKey(a));
+  if (utils::ComparingEdgeWithGID(a_key_type, b_key_type)) {
+    return CompareEdgeWithGidForPrefixSearch(a_str, b_str);
+  }
+  throw utils::BasicException(
+      "Cannot handle specific compare use-case when one of the keys are neither vertex nor edge.");
 }
 
+int ComparatorWithU64TsImpl::CompareEdgeWithGidForPrefixSearch(const std::string_view edge,
+                                                               const std::string_view source_vertex_gid) const {
+  // spdlog::debug("Compare edge with gid for prefix search START");
+  rocksdb::Slice stripped_src_vertex_gid = StripTimestampFromUserKey(source_vertex_gid, timestamp_size());
+  // rocksdb::Slice stripped_src_vertex_gid = source_vertex_gid;
+  std::string_view edge_source_vertex_gid = edge.substr(0, edge.find('|'));
+  // spdlog::debug("Edge: {} Edge source vertex gid: {} Size: {} Source vertex gid: {} Size: {}", edge,
+  //               edge_source_vertex_gid, edge_source_vertex_gid.size(), stripped_src_vertex_gid.ToString(),
+  //               stripped_src_vertex_gid.ToString().size());
+  int cmp_res = cmp_without_ts_->Compare(edge_source_vertex_gid, stripped_src_vertex_gid);
+  // spdlog::debug("Compare result: {}", cmp_res);
+  return cmp_res;
+}
+
+/// TODO: entered CompareWithoutTimestamp with GID. Handle something like in a compare function.
 int ComparatorWithU64TsImpl::CompareWithoutTimestamp(const rocksdb::Slice &a, bool a_has_ts, const rocksdb::Slice &b,
                                                      bool b_has_ts) const {
   const size_t ts_sz = timestamp_size();
+  // spdlog::debug("Timestamp size: {}", ts_sz);
+  // spdlog::debug("a_has_ts: {} b_has_ts: {}", a_has_ts, b_has_ts);
+  // spdlog::debug("a size: {} b size: {}", a.size(), b.size());
   assert(!a_has_ts || a.size() >= ts_sz);
   assert(!b_has_ts || b.size() >= ts_sz);
-  spdlog::debug("a key: {}", a.ToString());
-  spdlog::debug("b key: {}", b.ToString());
+  // spdlog::debug("a key: {}", a.ToString());
+  // spdlog::debug("b key: {}", b.ToString());
   rocksdb::Slice lhsUserKey = a_has_ts ? StripTimestampFromUserKey(a, ts_sz) : a;
   rocksdb::Slice rhsUserKey = b_has_ts ? StripTimestampFromUserKey(b, ts_sz) : b;
-  spdlog::debug("lhsUserKey: {}", lhsUserKey.ToString());
-  spdlog::debug("rhsUserKey: {}", rhsUserKey.ToString());
+  // spdlog::debug("lhsUserKey: {}", lhsUserKey.ToString());
+  // spdlog::debug("rhsUserKey: {}", rhsUserKey.ToString());
   rocksdb::Slice lhsGid = ExtractGidFromUserKey(lhsUserKey);
   rocksdb::Slice rhsGid = ExtractGidFromUserKey(rhsUserKey);
+  // spdlog::debug("lhsGid: {}", lhsGid.ToString());
+  // spdlog::debug("rhsGid: {}", rhsGid.ToString());
   return cmp_without_ts_->Compare(lhsGid, rhsGid);
 }
 

--- a/src/storage/v2/disk/rocksdb_storage.cpp
+++ b/src/storage/v2/disk/rocksdb_storage.cpp
@@ -31,6 +31,7 @@ inline rocksdb::Slice ExtractTimestampFromUserKey(const rocksdb::Slice &user_key
 
 // Extracts global id from user key. User key must be without timestamp.
 std::string_view ExtractGidFromUserKey(const rocksdb::Slice &key) {
+  spdlog::debug("Extracted gid from key: {}", key.ToString());
   assert(key.size() >= 2);
   auto keyStrView = key.ToStringView();
   return keyStrView.substr(keyStrView.find_last_of('|') + 1);
@@ -59,8 +60,12 @@ int ComparatorWithU64TsImpl::CompareWithoutTimestamp(const rocksdb::Slice &a, bo
   const size_t ts_sz = timestamp_size();
   assert(!a_has_ts || a.size() >= ts_sz);
   assert(!b_has_ts || b.size() >= ts_sz);
+  spdlog::debug("a key: {}", a.ToString());
+  spdlog::debug("b key: {}", b.ToString());
   rocksdb::Slice lhsUserKey = a_has_ts ? StripTimestampFromUserKey(a, ts_sz) : a;
   rocksdb::Slice rhsUserKey = b_has_ts ? StripTimestampFromUserKey(b, ts_sz) : b;
+  spdlog::debug("lhsUserKey: {}", lhsUserKey.ToString());
+  spdlog::debug("rhsUserKey: {}", rhsUserKey.ToString());
   rocksdb::Slice lhsGid = ExtractGidFromUserKey(lhsUserKey);
   rocksdb::Slice rhsGid = ExtractGidFromUserKey(rhsUserKey);
   return cmp_without_ts_->Compare(lhsGid, rhsGid);

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -382,6 +382,7 @@ std::optional<EdgeAccessor> DiskStorage::DiskAccessor::DeserializeEdge(const roc
 }
 
 VerticesIterable DiskStorage::DiskAccessor::Vertices(View view) {
+  spdlog::debug("Scanning all vertices");
   auto *disk_storage = static_cast<DiskStorage *>(storage_);
   rocksdb::ReadOptions ro;
   std::string strTs = utils::StringTimestamp(transaction_.start_timestamp);

--- a/src/utils/disk_utils.hpp
+++ b/src/utils/disk_utils.hpp
@@ -15,6 +15,8 @@
 
 namespace memgraph::utils {
 
+enum RocksDBType { VERTEX, EDGE, GID };
+
 inline std::optional<std::string> GetOldDiskKeyOrNull(storage::Delta *head) {
   while (head->next != nullptr) {
     head = head->next;
@@ -23,6 +25,28 @@ inline std::optional<std::string> GetOldDiskKeyOrNull(storage::Delta *head) {
     return head->old_disk_key;
   }
   return std::nullopt;
+}
+
+inline RocksDBType GetRocksDBKeyType(uint32_t num_separators) {
+  if (num_separators == 0) {
+    return RocksDBType::GID;
+  }
+  if (num_separators == 4) {
+    return RocksDBType::EDGE;
+  }
+  return RocksDBType::VERTEX;
+}
+
+inline bool ComparingVertexWithVertex(RocksDBType type_a, RocksDBType type_b) {
+  return type_a == RocksDBType::VERTEX && type_b == RocksDBType::VERTEX;
+}
+
+inline bool ComparingEdgeWithEdge(RocksDBType type_a, RocksDBType type_b) {
+  return type_a == RocksDBType::EDGE && type_b == RocksDBType::EDGE;
+}
+
+inline bool ComparingEdgeWithGID(RocksDBType type_a, RocksDBType type_b) {
+  return type_a == RocksDBType::EDGE && type_b == RocksDBType::GID;
 }
 
 }  // namespace memgraph::utils

--- a/tests/unit/storage_v2_edge_ondisk.cpp
+++ b/tests/unit/storage_v2_edge_ondisk.cpp
@@ -4247,9 +4247,6 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteSingleAbort) {
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_FALSE(vertex_from);
     ASSERT_TRUE(vertex_to);
-    // We prefetch edges implicitly when go thorough query Accessor
-    acc->PrefetchOutEdges(*vertex_from);
-    acc->PrefetchInEdges(*vertex_from);
     acc->PrefetchOutEdges(*vertex_to);
     acc->PrefetchInEdges(*vertex_to);
 


### PR DESCRIPTION
### Update 28.08.2023
Experiments with Ribbon filter - conclusion is that the same custom BloomFilterPolicy is needed. The policy has been created in separate PR.

Baseline: Reading 9900 edges for Memgraph debug version takes 10.5 on a local machine for query:
`MATCH (n)<-[r]-(m) RETURN *;`

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments
