### PR TITLE
Created a custom e2e test activation to include the toolchain libs

### DIFF
--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -267,8 +267,8 @@ jobs:
       - name: Run e2e tests
         run: |
           cd tests
-          ./setup.sh
-          source ve3/bin/activate
+          ./setup.sh /opt/toolchain-v4/activate
+          source ve3/bin/activate_e2e
           cd e2e
           ./run.sh
 

--- a/.github/workflows/release_centos8.yaml
+++ b/.github/workflows/release_centos8.yaml
@@ -266,8 +266,8 @@ jobs:
       - name: Run e2e tests
         run: |
           cd tests
-          ./setup.sh
-          source ve3/bin/activate
+          ./setup.sh /opt/toolchain-v4/activate
+          source ve3/bin/activate_e2e
           cd e2e
           ./run.sh
 

--- a/.github/workflows/release_debian10.yaml
+++ b/.github/workflows/release_debian10.yaml
@@ -265,8 +265,8 @@ jobs:
       - name: Run e2e tests
         run: |
           cd tests
-          ./setup.sh
-          source ve3/bin/activate
+          ./setup.sh /opt/toolchain-v4/activate
+          source ve3/bin/activate_e2e
           cd e2e
           ./run.sh
 

--- a/.github/workflows/release_ubuntu2004.yaml
+++ b/.github/workflows/release_ubuntu2004.yaml
@@ -265,8 +265,8 @@ jobs:
       - name: Run e2e tests
         run: |
           cd tests
-          ./setup.sh
-          source ve3/bin/activate
+          ./setup.sh /opt/toolchain-v4/activate
+          source ve3/bin/activate_e2e
           cd e2e
           ./run.sh
 

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -49,3 +49,46 @@ popd > /dev/null
 deactivate
 
 "$DIR"/e2e/graphql/setup.sh
+
+# Check if setup needs to setup additional variables
+if [ $# == 1 ]; then
+    toolchain=$1
+    if [ -f "$toolchain" ]; then
+        # Get the LD_LIB from toolchain
+        set +u
+        OLD_LD_LIBRARY_PATH=$LD_LIBRARY_PATH
+        source $toolchain
+        NEW_LD_LIBRARY_PATH=$LD_LIBRARY_PATH
+        deactivate
+        set -u
+
+        # Wrapper used to setup the correct libraries
+        tee -a ve3/bin/activate_e2e <<EOF
+#!/bin/bash
+
+# Function to set the environment variable
+set_env_variable() {
+    export LD_LIBRARY_PATH=$NEW_LD_LIBRARY_PATH
+}
+
+# Function to activate the virtual environment and set the environment variable
+activate_e2e() {
+    source ve3/bin/activate
+    set_env_variable
+}
+
+# Function to deactivate the virtual environment and unset the environment variable
+deactivate_e2e() {
+    deactivate
+    export LD_LIBRARY_PATH=$OLD_LD_LIBRARY_PATH
+}
+
+# Activate the virtual environment and set the environment variable
+activate_e2e
+EOF
+
+        chmod +x ve3/bin/activate_e2e
+    else
+        echo "Error: The toolchain virtual enviroonment activation is not a file."
+    fi
+fi


### PR DESCRIPTION
Some e2e tests fail due to misalignment between system compilers/libraries/etc. and our toolchain.
This change will force the use of the toolchain libraries for all e2e tests.