### PR TITLE
[master < 1137-remove-link-to-discourse] Remove link to Discourse forum

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,6 @@ license](./licenses/BSL.txt).</br> Memgraph Enterprise is available under the
 
 - :purple_heart: [**Discord**](https://discord.gg/memgraph)
 - :ocean: [**Stack Overflow**](https://stackoverflow.com/questions/tagged/memgraphdb)
-- :busts_in_silhouette: [**Discourse forum**](https://discourse.memgraph.com/)
 - :bird: [**Twitter**](https://twitter.com/memgraphdb)
 - :movie_camera:
   [**YouTube**](https://www.youtube.com/channel/UCZ3HOJvHGxtQ_JHxOselBYg)


### PR DESCRIPTION
 I've removed the link to the Discourse forum for the README.md file.
