### PR TITLE
[master < T0968] - Fix concurrent query module racecondition

### DIFF
--- a/query_modules/example.cpp
+++ b/query_modules/example.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -18,7 +18,7 @@ void ProcImpl(std::vector<mgp::Value> arguments, mgp::Graph graph, mgp::RecordFa
 
 void SampleReadProc(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory) {
   try {
-    mgp::memory = memory;
+    mgp::MemoryResourceDistributorGuard guard(memory);
 
     std::vector<mgp::Value> arguments;
     for (size_t i = 0; i < mgp::list_size(args); i++) {
@@ -34,7 +34,7 @@ void SampleReadProc(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *resul
 }
 
 void AddXNodes(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory) {
-  mgp::memory = memory;
+  mgp::MemoryResourceDistributorGuard guard(memory);
   auto graph = mgp::Graph(memgraph_graph);
 
   std::vector<mgp::Value> arguments;
@@ -49,7 +49,7 @@ void AddXNodes(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mg
 }
 
 void Multiply(mgp_list *args, mgp_func_context *ctx, mgp_func_result *res, mgp_memory *memory) {
-  mgp::memory = memory;
+  mgp::MemoryResourceDistributorGuard guard(memory);
 
   std::vector<mgp::Value> arguments;
   for (size_t i = 0; i < mgp::list_size(args); i++) {
@@ -67,7 +67,7 @@ void Multiply(mgp_list *args, mgp_func_context *ctx, mgp_func_result *res, mgp_m
 
 extern "C" int mgp_init_module(struct mgp_module *module, struct mgp_memory *memory) {
   try {
-    mgp::memory = memory;
+    mgp::MemoryResourceDistributorGuard guard(memory);
 
     AddProcedure(SampleReadProc, "return_true", mgp::ProcedureType::Read,
                  {mgp::Parameter("param_1", mgp::Type::Int), mgp::Parameter("param_2", mgp::Type::Double, 2.3)},
@@ -77,7 +77,7 @@ extern "C" int mgp_init_module(struct mgp_module *module, struct mgp_memory *mem
   }
 
   try {
-    mgp::memory = memory;
+    mgp::MemoryResourceDistributorGuard guard(memory);
 
     mgp::AddProcedure(AddXNodes, "add_x_nodes", mgp::ProcedureType::Write, {mgp::Parameter("param_1", mgp::Type::Int)},
                       {}, module, memory);
@@ -87,7 +87,7 @@ extern "C" int mgp_init_module(struct mgp_module *module, struct mgp_memory *mem
   }
 
   try {
-    mgp::memory = memory;
+    mgp::MemoryResourceDistributorGuard guard(memory);
 
     mgp::AddFunction(Multiply, "multiply",
                      {mgp::Parameter("int", mgp::Type::Int), mgp::Parameter("int", mgp::Type::Int, (int64_t)3)}, module,

--- a/tests/e2e/batched_procedures/procedures/batch_c_read.cpp
+++ b/tests/e2e/batched_procedures/procedures/batch_c_read.cpp
@@ -30,7 +30,7 @@ static int returned_strings{0};
 const char *kReturnOutput = "output";
 
 void NumsBatchInit(struct mgp_list *args, mgp_graph *graph, struct mgp_memory *memory) {
-  mgp::memory = memory;
+  mgp::MemoryResourceDistributorGuard guard(memory);
   const auto arguments = mgp::List(args);
   if (arguments.Empty()) {
     throw std::runtime_error("Expected to recieve argument");
@@ -43,7 +43,7 @@ void NumsBatchInit(struct mgp_list *args, mgp_graph *graph, struct mgp_memory *m
 }
 
 void NumsBatch(struct mgp_list *args, mgp_graph *graph, mgp_result *result, struct mgp_memory *memory) {
-  mgp::memory = memory;
+  mgp::MemoryResourceDistributorGuard guard(memory);
   const auto arguments = mgp::List(args);
   const auto record_factory = mgp::RecordFactory(result);
   if (returned_ints < num_ints) {
@@ -58,7 +58,7 @@ void NumsBatchCleanup() {
 }
 
 void StringsBatchInit(struct mgp_list *args, mgp_graph *graph, struct mgp_memory *memory) {
-  mgp::memory = memory;
+  mgp::MemoryResourceDistributorGuard guard(memory);
   const auto arguments = mgp::List(args);
   if (arguments.Empty()) {
     throw std::runtime_error("Expected to recieve argument");
@@ -71,7 +71,7 @@ void StringsBatchInit(struct mgp_list *args, mgp_graph *graph, struct mgp_memory
 }
 
 void StringsBatch(struct mgp_list *args, mgp_graph *graph, mgp_result *result, struct mgp_memory *memory) {
-  mgp::memory = memory;
+  mgp::MemoryResourceDistributorGuard guard(memory);
   const auto arguments = mgp::List(args);
   const auto record_factory = mgp::RecordFactory(result);
 
@@ -117,7 +117,7 @@ extern "C" int mgp_init_module(struct mgp_module *module, struct mgp_memory *mem
 
   {
     try {
-      mgp::memory = memory;
+      mgp::MemoryResourceDistributorGuard guard(memory);
       mgp::AddBatchProcedure(StringsBatch, StringsBatchInit, StringsBatchCleanup, "batch_strings",
                              mgp::ProcedureType::Read, {mgp::Parameter("num_strings", mgp::Type::Int)},
                              {mgp::Return("output", mgp::Type::String)}, module, memory);

--- a/tests/unit/cpp_api.cpp
+++ b/tests/unit/cpp_api.cpp
@@ -27,12 +27,13 @@
 template <typename StorageType>
 struct CppApiTestFixture : public ::testing::Test {
  protected:
-  virtual void SetUp() override { mgp::memory = &memory; }
+  virtual void SetUp() override { mgp::mrd.Register(&memory); }
 
   void TearDown() override {
     if (std::is_same<StorageType, memgraph::storage::DiskStorage>::value) {
       disk_test_utils::RemoveRocksDbDirs(testSuite);
     }
+    mgp::mrd.UnRegister();
   }
 
   mgp_graph CreateGraph(const memgraph::storage::View view = memgraph::storage::View::NEW) {


### PR DESCRIPTION
Concurrent access to the same query module had a racecondition on the pointer that was used to handle the costum memory management. With this commit, a mapping has been added that keeps information about what thread used what pointer to handle the memory resources. Which should be fine since the respected query executions are running on a dedicated thread. Access to the mapping itself is threadsafe. A simple spinlock has been implemented here, as we shouldn't include memgraph::utils from this header and a traditional mutex might be overkill. A simple RAII wrapper for the mapping container has been also added for simpler client-side use.
