### PR TITLE
[master < ] Remove DbAccessor from non-transactional queries

### DIFF
--- a/src/query/auth_checker.hpp
+++ b/src/query/auth_checker.hpp
@@ -30,6 +30,8 @@ class AuthChecker {
 #ifdef MG_ENTERPRISE
   [[nodiscard]] virtual std::unique_ptr<FineGrainedAuthChecker> GetFineGrainedAuthChecker(
       const std::string &username, const memgraph::query::DbAccessor *db_accessor) const = 0;
+
+  virtual void ClearCache() const = 0;
 #endif
 };
 #ifdef MG_ENTERPRISE
@@ -103,6 +105,8 @@ class AllowEverythingAuthChecker final : public query::AuthChecker {
                                                                     const query::DbAccessor * /*dba*/) const override {
     return std::make_unique<AllowEverythingFineGrainedAuthChecker>();
   }
+
+  void ClearCache() const override {}
 #endif
 };  // namespace memgraph::query
 

--- a/src/query/cypher_query_interpreter.cpp
+++ b/src/query/cypher_query_interpreter.cpp
@@ -76,7 +76,7 @@ ParsedQuery ParseQuery(const std::string &query_string, const std::map<std::stri
 
     // Convert the ANTLR4 parse tree into an AST.
     AstStorage ast_storage;
-    frontend::ParsingContext context{true};
+    frontend::ParsingContext context{.is_query_cached = true};
     frontend::CypherMainVisitor visitor(context, &ast_storage);
 
     visitor.visit(parser->tree());

--- a/src/query/interpret/eval.cpp
+++ b/src/query/interpret/eval.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -22,9 +22,10 @@ int64_t EvaluateInt(ExpressionEvaluator *evaluator, Expression *expr, const std:
   }
 }
 
-std::optional<size_t> EvaluateMemoryLimit(ExpressionEvaluator *eval, Expression *memory_limit, size_t memory_scale) {
+std::optional<size_t> EvaluateMemoryLimit(ExpressionVisitor<TypedValue> &eval, Expression *memory_limit,
+                                          size_t memory_scale) {
   if (!memory_limit) return std::nullopt;
-  auto limit_value = memory_limit->Accept(*eval);
+  auto limit_value = memory_limit->Accept(eval);
   if (!limit_value.IsInt() || limit_value.ValueInt() <= 0)
     throw QueryRuntimeException("Memory limit must be a non-negative integer.");
   size_t limit = limit_value.ValueInt();

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -99,12 +99,76 @@ class ReferenceExpressionEvaluator : public ExpressionVisitor<TypedValue *> {
   UNSUCCESSFUL_VISIT(RegexMatch);
   UNSUCCESSFUL_VISIT(Exists);
 
+#undef UNSUCCESSFUL_VISIT
+
  private:
   Frame *frame_;
   const SymbolTable *symbol_table_;
   const EvaluationContext *ctx_;
 };
 
+class PrimitiveLiteralExpressionEvaluator : public ExpressionVisitor<TypedValue> {
+ public:
+  explicit PrimitiveLiteralExpressionEvaluator(EvaluationContext const &ctx) : ctx_(&ctx) {}
+  using ExpressionVisitor<TypedValue>::Visit;
+  TypedValue Visit(PrimitiveLiteral &literal) override {
+    // TODO: no need to evaluate constants, we can write it to frame in one
+    // of the previous phases.
+    return TypedValue(literal.value_, ctx_->memory);
+  }
+  TypedValue Visit(ParameterLookup &param_lookup) override {
+    return TypedValue(ctx_->parameters.AtTokenPosition(param_lookup.token_position_), ctx_->memory);
+  }
+
+#define INVALID_VISIT(expr_name) \
+  TypedValue Visit(expr_name &expr) override { throw 1; }
+
+  INVALID_VISIT(NamedExpression)
+  INVALID_VISIT(OrOperator)
+  INVALID_VISIT(XorOperator)
+  INVALID_VISIT(AndOperator)
+  INVALID_VISIT(NotOperator)
+  INVALID_VISIT(AdditionOperator)
+  INVALID_VISIT(SubtractionOperator)
+  INVALID_VISIT(MultiplicationOperator)
+  INVALID_VISIT(DivisionOperator)
+  INVALID_VISIT(ModOperator)
+  INVALID_VISIT(NotEqualOperator)
+  INVALID_VISIT(EqualOperator)
+  INVALID_VISIT(LessOperator)
+  INVALID_VISIT(GreaterOperator)
+  INVALID_VISIT(LessEqualOperator)
+  INVALID_VISIT(GreaterEqualOperator)
+  INVALID_VISIT(InListOperator)
+  INVALID_VISIT(SubscriptOperator)
+  INVALID_VISIT(ListSlicingOperator)
+  INVALID_VISIT(IfOperator)
+  INVALID_VISIT(UnaryPlusOperator)
+  INVALID_VISIT(UnaryMinusOperator)
+  INVALID_VISIT(IsNullOperator)
+  INVALID_VISIT(ListLiteral)
+  INVALID_VISIT(MapLiteral)
+  INVALID_VISIT(MapProjectionLiteral)
+  INVALID_VISIT(PropertyLookup)
+  INVALID_VISIT(AllPropertiesLookup)
+  INVALID_VISIT(LabelsTest)
+  INVALID_VISIT(Aggregation)
+  INVALID_VISIT(Function)
+  INVALID_VISIT(Reduce)
+  INVALID_VISIT(Coalesce)
+  INVALID_VISIT(Extract)
+  INVALID_VISIT(All)
+  INVALID_VISIT(Single)
+  INVALID_VISIT(Any)
+  INVALID_VISIT(None)
+  INVALID_VISIT(Identifier)
+  INVALID_VISIT(RegexMatch)
+  INVALID_VISIT(Exists)
+
+#undef INVALID_VISIT
+ private:
+  EvaluationContext const *ctx_;
+};
 class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
  public:
   ExpressionEvaluator(Frame *frame, const SymbolTable &symbol_table, const EvaluationContext &ctx, DbAccessor *dba,
@@ -1046,6 +1110,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
 /// @throw QueryRuntimeException if expression doesn't evaluate to an int.
 int64_t EvaluateInt(ExpressionEvaluator *evaluator, Expression *expr, const std::string &what);
 
-std::optional<size_t> EvaluateMemoryLimit(ExpressionEvaluator *eval, Expression *memory_limit, size_t memory_scale);
+std::optional<size_t> EvaluateMemoryLimit(ExpressionVisitor<TypedValue> &eval, Expression *memory_limit,
+                                          size_t memory_scale);
 
 }  // namespace memgraph::query

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -120,8 +120,11 @@ class PrimitiveLiteralExpressionEvaluator : public ExpressionVisitor<TypedValue>
     return TypedValue(ctx_->parameters.AtTokenPosition(param_lookup.token_position_), ctx_->memory);
   }
 
-#define INVALID_VISIT(expr_name) \
-  TypedValue Visit(expr_name &expr) override { throw 1; }
+#define INVALID_VISIT(expr_name)                                                             \
+  TypedValue Visit(expr_name & /*expr*/) override {                                          \
+    DLOG_FATAL("Invalid expression type visited with PrimitiveLiteralExpressionEvaluator."); \
+    return {};                                                                               \
+  }
 
   INVALID_VISIT(NamedExpression)
   INVALID_VISIT(OrOperator)

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -4626,7 +4626,7 @@ class CallProcedureCursor : public Cursor {
       // TODO: This will probably need to be changed when we add support for
       // generator like procedures which yield a new result on new query calls.
       auto *memory = self_->memory_resource;
-      auto memory_limit = EvaluateMemoryLimit(&evaluator, self_->memory_limit_, self_->memory_scale_);
+      auto memory_limit = EvaluateMemoryLimit(evaluator, self_->memory_limit_, self_->memory_scale_);
       auto graph = mgp_graph::WritableGraph(*context.db_accessor, graph_view, context);
       CallCustomProcedure(self_->procedure_name_, *proc, self_->arguments_, graph, &evaluator, memory, memory_limit,
                           result_, call_initializer);

--- a/tests/unit/dbms_interp.cpp
+++ b/tests/unit/dbms_interp.cpp
@@ -76,6 +76,8 @@ class TestAuthChecker : public memgraph::query::AuthChecker {
       const std::string & /*username*/, const memgraph::query::DbAccessor * /*db_accessor*/) const override {
     return {};
   }
+
+  void ClearCache() const override {}
 };
 
 std::filesystem::path storage_directory{std::filesystem::temp_directory_path() / "MG_test_unit_dbms_interp"};

--- a/tests/unit/query_trigger.cpp
+++ b/tests/unit/query_trigger.cpp
@@ -47,6 +47,7 @@ class MockAuthChecker : public memgraph::query::AuthChecker {
   MOCK_CONST_METHOD2(GetFineGrainedAuthChecker,
                      std::unique_ptr<memgraph::query::FineGrainedAuthChecker>(
                          const std::string &username, const memgraph::query::DbAccessor *db_accessor));
+  MOCK_CONST_METHOD0(ClearCache, void());
 #endif
 };
 }  // namespace


### PR DESCRIPTION
Some non-transactional queries used the DbAccessor to retrieve information at run-time (mostly to evaluate literals).
Here we created a new evaluator that doesn't use transactional information and has a very limited scope.

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments
