### PR TITLE
[master < T1205] Change failing object insertion with gid to throw exception

### DIFF
--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -483,7 +483,6 @@ Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdgeEx(VertexAcces
     if (!inserted) {
       throw utils::BasicException("The edge must be inserted here");
     }
-
     MG_ASSERT(it != acc.end(), "Invalid Edge accessor!");
     edge = EdgeRef(&*it);
     if (delta) {

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -18,6 +18,7 @@
 #include "storage/v2/edge_direction.hpp"
 #include "storage/v2/storage_mode.hpp"
 #include "storage/v2/vertex_accessor.hpp"
+#include "utils/exceptions.hpp"
 #include "utils/stat.hpp"
 
 /// REPLICATION ///
@@ -234,7 +235,9 @@ VertexAccessor InMemoryStorage::InMemoryAccessor::CreateVertexEx(storage::Gid gi
 
   auto *delta = CreateDeleteObjectDelta(&transaction_);
   auto [it, inserted] = acc.insert(Vertex{gid, delta});
-  MG_ASSERT(inserted, "The vertex must be inserted here!");
+  if (!inserted) {
+    throw utils::BasicException("The edge must be inserted here");
+  }
   MG_ASSERT(it != acc.end(), "Invalid Vertex accessor!");
   if (delta) {
     delta->prev.Set(&*it);
@@ -477,7 +480,10 @@ Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdgeEx(VertexAcces
 
     auto *delta = CreateDeleteObjectDelta(&transaction_);
     auto [it, inserted] = acc.insert(Edge(gid, delta));
-    MG_ASSERT(inserted, "The edge must be inserted here!");
+    if (!inserted) {
+      throw utils::BasicException("The edge must be inserted here");
+    }
+
     MG_ASSERT(it != acc.end(), "Invalid Edge accessor!");
     edge = EdgeRef(&*it);
     if (delta) {

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -76,6 +76,10 @@ class InMemoryStorage final : public Storage {
     /// @throw std::bad_alloc
     VertexAccessor CreateVertex() override;
 
+    // TODO Better naming
+    /// @throw std::bad_alloc
+    VertexAccessor CreateVertexEx(storage::Gid gid);
+
     std::optional<VertexAccessor> FindVertex(Gid gid, View view) override;
 
     VerticesIterable Vertices(View view) override {
@@ -218,6 +222,10 @@ class InMemoryStorage final : public Storage {
     /// @throw std::bad_alloc
     Result<EdgeAccessor> CreateEdge(VertexAccessor *from, VertexAccessor *to, EdgeTypeId edge_type) override;
 
+    // TODO Better naming
+    /// @throw std::bad_alloc
+    Result<EdgeAccessor> CreateEdgeEx(VertexAccessor *from, VertexAccessor *to, EdgeTypeId edge_type, storage::Gid gid);
+
     /// Accessor to the deleted edge if a deletion took place, std::nullopt otherwise
     /// @throw std::bad_alloc
     Result<std::optional<EdgeAccessor>> DeleteEdge(EdgeAccessor *edge) override;
@@ -256,12 +264,6 @@ class InMemoryStorage final : public Storage {
     void FinalizeTransaction() override;
 
    protected:
-    // TODO Better naming
-    /// @throw std::bad_alloc
-    VertexAccessor CreateVertexEx(storage::Gid gid);
-    /// @throw std::bad_alloc
-    Result<EdgeAccessor> CreateEdgeEx(VertexAccessor *from, VertexAccessor *to, EdgeTypeId edge_type, storage::Gid gid);
-
     Config::Items config_;
   };
 


### PR DESCRIPTION
There is an idea to create MAGE modules that could import vertices and edges with their respective IDs. With the current implementation attempting to create a vertex/edge with an ID that already existed/exists would crash the Memgraph instance which is not ideal. Would modifying this to throw an exception instead be a problem (in replication)?

[master < Epic] PR
- [ ] Check, and update documentation if necessary
- [ ] Write E2E tests
- [ ] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch and the Epic branch
- [ ] Provide the full content or a guide for the final git message

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments
