### PR TITLE
Extend telemetry v5

### DIFF
--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -403,6 +403,7 @@ int main(int argc, char **argv) {
   std::optional<memgraph::telemetry::Telemetry> telemetry;
   if (FLAGS_telemetry_enabled) {
     telemetry.emplace(telemetry_server, data_directory / "telemetry", run_id, machine_id, std::chrono::minutes(10));
+    // TODO(gitbuda): Add the current storage mode info (figure out the best place).
 #ifdef MG_ENTERPRISE
     telemetry->AddCollector("storage", [&sc_handler]() -> nlohmann::json {
       const auto &info = sc_handler.Info();


### PR DESCRIPTION
TODOs:
- [ ] Add memgraph version to the JSON data memgraph is sending
- [ ] Memory is still per process -> one number per whole memgraph instance
- [ ] Add the current `STORAGE MODE` -> `{ database: { storage_mode: XYZ, vertices: N, edges: M } }`
    - [ ] Isolation level
- [ ] Add the number of databases (from multi-tenancy)
- [ ] Add connected client name / driver language if known
- [ ] Check, and update documentation if necessary -> IMPORTANT: In the telemetry service, Terms of Use
- [ ] Provide the full content or a guide for the final git message
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments