### PR TITLE
Add option to test e2e directory

### DIFF
--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -5,7 +5,7 @@ cd "$SCRIPT_DIR"
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../../libs/mgclient/lib
 
 print_help() {
-  echo -e "$0 ["workload name string"]"
+  echo -e "$0 ["workload name string"]" or "$0 ["workload dir string"]" "*" or "$0 ["workload dir string"]" "[workload name string]"
   echo -e ""
   echo -e "  NOTE: some tests require enterprise licence key,"
   echo -e "        to run those define the folowing env vars:"
@@ -27,7 +27,7 @@ if [ "$#" -eq 0 ]; then
   # NOTE: If you want to run all tests under specific folder/section just
   # replace the dot (root directory below) with the folder name, e.g.
   # `--workloads-root-directory replication`.
-  python3 runner.py --workloads-root-directory .
+  python3 runner.py --workloads-root-directory . --workload-name "import_mode"
 elif [ "$#" -eq 1 ]; then
   if [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
     print_help
@@ -37,6 +37,14 @@ elif [ "$#" -eq 1 ]; then
   # workloads.yaml file. E.g. `streams/workloads.yaml` has a list of
   # `workloads:` and each workload has it's `-name`.
   python3 runner.py --workloads-root-directory . --workload-name "$1"
+elif [ "$#" -eq 2 ]; then
+  check_license
+  # NOTE: --workload-dir is whole directory. If you want to test whole dir
+  # run ./run.sh triggers "*"
+  # --workload-name comes from each individual folder/section
+  # workloads.yaml file. E.g. `streams/workloads.yaml` has a list of
+  # `workloads:` and each workload has it's `-name`.
+  python3 runner.py --workloads-root-directory . --workload-dir "$1" --workload-name "$2"
 else
   print_help
 fi


### PR DESCRIPTION
The idea of this PR is to make it easier to test the whole directory. Instead of testing one by one tests from the e2e folder, now it should be possible to test the whole folder, i.e "triggers"

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments
