### PR TITLE
Remove gqlalchemy from stress tests

### DIFF
--- a/tests/stress/common.py
+++ b/tests/stress/common.py
@@ -24,7 +24,6 @@ import time
 from argparse import ArgumentParser
 from threading import Thread
 
-from gqlalchemy import Memgraph
 from neo4j import TRUST_ALL_CERTIFICATES, GraphDatabase
 
 
@@ -95,19 +94,6 @@ def execute_till_success(session, query, max_retries=1000):
             data = result.data()
             summary = result.consume()
             return data, no_failures, summary
-        except Exception:
-            no_failures += 1
-            if no_failures >= max_retries:
-                raise Exception("Query '%s' failed %d times, aborting" % (query, max_retries))
-
-
-def execute_till_success_gqlalchemy(memgraph: Memgraph, query: str, max_retries=1000):
-    """Same method as execute_till_success, but for gqlalchemy."""
-    no_failures = 0
-    while True:
-        try:
-            result = memgraph.execute(query)
-            return result, no_failures
         except Exception:
             no_failures += 1
             if no_failures >= max_retries:
@@ -214,23 +200,6 @@ def argument_driver(args):
         encrypted=args.use_ssl,
         trust=TRUST_ALL_CERTIFICATES,
     )
-
-
-def get_memgraph(args) -> Memgraph:
-    host_port = args.endpoint.split(":")
-
-    connection_params = {
-        "host": host_port[0],
-        "port": int(host_port[1]),
-        "username": args.username,
-        "password": args.password,
-        "encrypted": False,
-    }
-
-    if args.use_ssl:
-        connection_params["encrypted"] = True
-
-    return Memgraph(**connection_params)
 
 
 # This class is used to create and cache sessions. Session is cached by args

--- a/tests/stress/detach_delete.py
+++ b/tests/stress/detach_delete.py
@@ -157,17 +157,15 @@ def run_writer(total_workers_cnt: int, repetition_count: int, sleep_sec: float, 
 
     def verify() -> Tuple[bool, int]:
         # We always create X nodes and therefore the number of nodes needs to be always a fraction of X
-        count = list(execute_till_success(session, f"MATCH (n) RETURN COUNT(n) AS cnt"))[0]["cnt"]
+        count = execute_till_success(session, f"MATCH (n) RETURN COUNT(n) AS cnt")[0][0]["cnt"]
         log.info(f"Worker {worker_id} verified graph count {count} in repetition {curr_repetition}")
 
         assert count <= total_workers_cnt * NUMBER_NODES_IN_CHAIN and count % NUMBER_NODES_IN_CHAIN == 0
 
-        ids = list(
-            execute_till_success(
-                session,
-                f"MATCH (n:Node{worker_id} {{id: 1}})-->(m)-->(o)-->(p) RETURN n.id AS id1, m.id AS id2, o.id AS id3, p.id AS id4",
-            )
-        )
+        ids = execute_till_success(
+            session,
+            f"MATCH (n:Node{worker_id} {{id: 1}})-->(m)-->(o)-->(p) RETURN n.id AS id1, m.id AS id2, o.id AS id3, p.id AS id4",
+        )[0]
 
         if len(ids):
             result = ids[0]

--- a/tests/stress/requirements.txt
+++ b/tests/stress/requirements.txt
@@ -1,2 +1,1 @@
 neo4j-driver==4.1.1
-gqlalchemy==1.3.3


### PR DESCRIPTION
Because installation of gqlalchemy is failing on centos-7, tests are rewritten to use the existing toolset.

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments
