### PR TITLE
[master < T1249] Add Path.pop to C++ API

### DIFF
--- a/include/_mgp.hpp
+++ b/include/_mgp.hpp
@@ -477,6 +477,8 @@ inline void path_destroy(mgp_path *path) { mgp_path_destroy(path); }
 
 inline void path_expand(mgp_path *path, mgp_edge *edge) { MgInvokeVoid(mgp_path_expand, path, edge); }
 
+inline void path_pop(mgp_path *path) { MgInvokeVoid(mgp_path_pop, path); }
+
 inline size_t path_size(mgp_path *path) { return MgInvoke<size_t>(mgp_path_size, path); }
 
 inline mgp_vertex *path_vertex_at(mgp_path *path, size_t index) {

--- a/include/_mgp_mock.py
+++ b/include/_mgp_mock.py
@@ -333,6 +333,13 @@ class Path:
         self._vertices.append(edge.end_id)
         self._edges.append((edge.start_id, edge.end_id, edge.id))
 
+    def pop(self):
+        if not self._edges:
+            raise IndexError("Path contains not relationships.")
+
+        self._vertices.pop()
+        self._edges.pop()
+
     def vertex_at(self, index: int) -> Vertex:
         return Vertex(self._vertices[index], self._graph)
 

--- a/include/_mgp_mock.py
+++ b/include/_mgp_mock.py
@@ -335,7 +335,7 @@ class Path:
 
     def pop(self):
         if not self._edges:
-            raise IndexError("Path contains not relationships.")
+            raise IndexError("Path contains no relationships.")
 
         self._vertices.pop()
         self._edges.pop()

--- a/include/mg_procedure.h
+++ b/include/mg_procedure.h
@@ -543,6 +543,10 @@ void mgp_path_destroy(struct mgp_path *path);
 /// Return mgp_error::MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate memory for path extension.
 enum mgp_error mgp_path_expand(struct mgp_path *path, struct mgp_edge *edge);
 
+/// Remove the last node and the last relationship from the path.
+/// mgp_error::MGP_ERROR_OUT_OF_RANGE if the path contains no relationships.
+enum mgp_error mgp_path_pop(struct mgp_path *path);
+
 /// Get the number of edges in a mgp_path.
 /// Current implementation always returns without errors.
 enum mgp_error mgp_path_size(struct mgp_path *path, size_t *result);

--- a/include/mg_procedure.h
+++ b/include/mg_procedure.h
@@ -544,7 +544,7 @@ void mgp_path_destroy(struct mgp_path *path);
 enum mgp_error mgp_path_expand(struct mgp_path *path, struct mgp_edge *edge);
 
 /// Remove the last node and the last relationship from the path.
-/// mgp_error::MGP_ERROR_OUT_OF_RANGE if the path contains no relationships.
+/// Return mgp_error::MGP_ERROR_OUT_OF_RANGE if the path contains no relationships.
 enum mgp_error mgp_path_pop(struct mgp_path *path);
 
 /// Get the number of edges in a mgp_path.

--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -886,6 +886,8 @@ class Path {
 
   /// @brief Adds a relationship continuing from the last node on the path.
   void Expand(const Relationship &relationship);
+  /// @brief Removes the last node and the last relationship from the path.
+  void Pop();
 
   /// @exception std::runtime_error Path contains element(s) with unknown value.
   bool operator==(const Path &other) const;
@@ -2994,6 +2996,8 @@ inline Relationship Path::GetRelationshipAt(size_t index) const {
 }
 
 inline void Path::Expand(const Relationship &relationship) { mgp::path_expand(ptr_, relationship.ptr_); }
+
+inline void Path::Pop() { mgp::path_pop(ptr_); }
 
 inline bool Path::operator==(const Path &other) const { return util::PathsEqual(ptr_, other.ptr_); }
 

--- a/include/mgp.py
+++ b/include/mgp.py
@@ -983,6 +983,21 @@ class Path:
         self._vertices = None
         self._edges = None
 
+    def pop(self):
+        """
+        Remove the last node and the last relationship from the path.
+
+        Raises:
+            InvalidContextError: If using an invalid `Path` instance
+            OutOfRangeError: If the path contains no relationships.
+
+        Examples:
+            ```path.pop()```
+        """
+        if not self.is_valid():
+            raise InvalidContextError()
+        self._path.pop()
+
     @property
     def vertices(self) -> typing.Tuple[Vertex, ...]:
         """
@@ -1022,6 +1037,10 @@ class Path:
             num_edges = self._path.size()
             self._edges = tuple(Edge(self._path.edge_at(i)) for i in range(num_edges))
         return self._edges
+
+    @property
+    def length(self) -> int:
+        return self._path.size()
 
 
 class Record:

--- a/include/mgp.py
+++ b/include/mgp.py
@@ -997,6 +997,9 @@ class Path:
         if not self.is_valid():
             raise InvalidContextError()
         self._path.pop()
+        # Invalidate our cached tuples
+        self._vertices = None
+        self._edges = None
 
     @property
     def vertices(self) -> typing.Tuple[Vertex, ...]:

--- a/include/mgp_mock.py
+++ b/include/mgp_mock.py
@@ -944,6 +944,10 @@ class Path:
             raise InvalidContextError()
         self._path.pop()
 
+        # Invalidate cached tuples
+        self._vertices = None
+        self._edges = None
+
     @property
     def vertices(self) -> typing.Tuple[Vertex, ...]:
         """

--- a/include/mgp_mock.py
+++ b/include/mgp_mock.py
@@ -929,6 +929,21 @@ class Path:
         self._vertices = None
         self._edges = None
 
+    def pop(self):
+        """
+        Remove the last node and the last relationship from the path.
+
+        Raises:
+            InvalidContextError: If using an invalid `Path` instance
+            OutOfRangeError: If the path contains no relationships.
+
+        Examples:
+            ```path.pop()```
+        """
+        if not self.is_valid():
+            raise InvalidContextError()
+        self._path.pop()
+
     @property
     def vertices(self) -> typing.Tuple[Vertex, ...]:
         """

--- a/src/query/procedure/mg_procedure_impl.cpp
+++ b/src/query/procedure/mg_procedure_impl.cpp
@@ -1180,6 +1180,17 @@ mgp_error mgp_path_expand(mgp_path *path, mgp_edge *edge) {
   });
 }
 
+mgp_error mgp_path_pop(struct mgp_path *path) {
+  return WrapExceptions([path] {
+    if (path->edges.empty()) {
+      throw std::out_of_range("Path contains no relationships.");
+    }
+
+    path->vertices.pop_back();
+    path->edges.pop_back();
+  });
+}
+
 namespace {
 size_t MgpPathSize(const mgp_path &path) noexcept { return path.edges.size(); }
 }  // namespace

--- a/src/query/procedure/py_module.cpp
+++ b/src/query/procedure/py_module.cpp
@@ -2204,6 +2204,17 @@ PyObject *PyPathExpand(PyPath *self, PyObject *edge) {
   Py_RETURN_NONE;
 }
 
+PyObject *PyPathPop(PyPath *self) {
+  MG_ASSERT(self->path);
+  MG_ASSERT(self->py_graph);
+  MG_ASSERT(self->py_graph->graph);
+
+  if (RaiseExceptionFromErrorCode(mgp_path_pop(self->path))) {
+    return nullptr;
+  }
+  Py_RETURN_NONE;
+}
+
 PyObject *PyPathSize(PyPath *self, PyObject *Py_UNUSED(ignored)) {
   MG_ASSERT(self->path);
   MG_ASSERT(self->py_graph);
@@ -2251,6 +2262,8 @@ static PyMethodDef PyPathMethods[] = {
      "Create a path with a starting vertex."},
     {"expand", reinterpret_cast<PyCFunction>(PyPathExpand), METH_O,
      "Append an edge continuing from the last vertex on the path."},
+    {"pop", reinterpret_cast<PyCFunction>(PyPathPop), METH_NOARGS,
+     "Remove the last node and the last relationship from the path."},
     {"size", reinterpret_cast<PyCFunction>(PyPathSize), METH_NOARGS, "Return the number of edges in a mgp_path."},
     {"vertex_at", reinterpret_cast<PyCFunction>(PyPathVertexAt), METH_VARARGS,
      "Return the vertex from a path at given index."},

--- a/tests/e2e/mock_api/procedures/path.py
+++ b/tests/e2e/mock_api/procedures/path.py
@@ -33,6 +33,16 @@ def compare_apis(ctx: mgp.ProcCtx) -> mgp.Record(results_dict=mgp.Map):
         (2, 1),
     )
 
+    path.pop()
+    mock_path.pop()
+    results["pop"] = test_utils.all_equal(
+        (len(path.vertices), len(path.edges)),
+        (len(mock_path.vertices), len(mock_path.edges)),
+        (1, 0),
+    )
+    path.expand(edge_to_add)
+    mock_path.expand(mock_edge_to_add)
+
     NEXT_ID = 1
     results["vertices"] = test_utils.all_equal(
         all(isinstance(vertex, mgp.Vertex) for vertex in path.vertices),

--- a/tests/e2e/mock_api/test_compare_mock.py
+++ b/tests/e2e/mock_api/test_compare_mock.py
@@ -125,6 +125,7 @@ def test_path():
         "__copy__": True,
         "is_valid": True,
         "expand": True,
+        "pop": True,
         "vertices": True,
         "edges": True,
     }

--- a/tests/unit/cpp_api.cpp
+++ b/tests/unit/cpp_api.cpp
@@ -346,6 +346,9 @@ TYPED_TEST(CppApiTestFixture, TestPath) {
   auto value_x = mgp::Value(path);
   // Use Value move constructor
   auto value_y = mgp::Value(mgp::Path(node_0));
+
+  path.Pop();
+  ASSERT_EQ(path.Length(), 0);
 }
 
 TYPED_TEST(CppApiTestFixture, TestDate) {


### PR DESCRIPTION
There was a need to be able to remove the last element of a path in the C++, C and Python API.

[master < Task] PR
- [x] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [X] Write a release note here, including added/changed clauses
You are now able to remove the last element of a path in C++ (path.Pop()) , C (mgp_path_pop) and Python (path.pop()) API
- [x] Tag someone from docs team in the comments
