### PR TITLE
[master < ] Fix a crash caused by using exists in a RETURN statement

### DIFF
--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -518,6 +518,10 @@ bool SymbolGenerator::PreVisit(Exists &exists) {
     throw utils::NotYetImplemented("WITH can not be used with exists, but only during matching!");
   }
 
+  if (scope.in_return) {
+    throw utils::NotYetImplemented("RETURN can not be used with exists, but only during matching!");
+  }
+
   scope.in_exists = true;
 
   const auto &symbol = CreateAnonymousSymbol();


### PR DESCRIPTION
This PR is about handling queries in which we use exists in a RETURN statement. Since exists is confirmed to work only for filtering in WHERE clauses, exception will be thrown. 

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments
