### PR TITLE
[master < ] Fix a crash caused when declaring a path with only one node in OPTIONAL MATCH clause 

### DIFF
--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -518,6 +518,10 @@ bool SymbolGenerator::PreVisit(Exists &exists) {
     throw utils::NotYetImplemented("WITH can not be used with exists, but only during matching!");
   }
 
+  if (scope.in_return) {
+    throw utils::NotYetImplemented("RETURN can not be used with exists, but only during matching!");
+  }
+
   scope.in_exists = true;
 
   const auto &symbol = CreateAnonymousSymbol();

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -491,6 +491,10 @@ class RuleBasedPlanner {
         last_op = GenFilters(std::move(last_op), bound_symbols, filters, storage, symbol_table);
         last_op = impl::GenNamedPaths(std::move(last_op), bound_symbols, named_paths);
         last_op = GenFilters(std::move(last_op), bound_symbols, filters, storage, symbol_table);
+      } else if (named_paths.size() == 1U) {
+        last_op = GenFilters(std::move(last_op), bound_symbols, filters, storage, symbol_table);
+        last_op = impl::GenNamedPaths(std::move(last_op), bound_symbols, named_paths);
+        last_op = GenFilters(std::move(last_op), bound_symbols, filters, storage, symbol_table);
       }
 
       if (expansion.edge) {

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -527,3 +527,15 @@ Feature: WHERE exists
           MATCH (n:Two) SET n.prop = exists((n)<-[:TYPE]-()) RETURN n.prop;
           """
       Then an error should be raised
+
+  Scenario: Test exists does not work in RETURN clauses
+      Given an empty graph
+      And having executed:
+          """
+          CREATE (:One {prop:1})-[:TYPE]->(:Two);
+          """
+      When executing query:
+          """
+          MATCH (n) RETURN exists((n)-[]-());
+          """
+      Then an error should be raised


### PR DESCRIPTION
A query that defines path as just a single node that is already declared in the previous MATCH or OPTIONAL MATCH clause, for example, MATCH (n1) OPTIONAL MATCH p=(n1) RETURN 1; will fail and will crash memgraph. 

When the user defines a path, memgraph will generate a ConstructNamedPath operator. Memgraph uses bound_symbols to save symbols for which it needs to generate a ScanAll operator. If the path has a relationship, memgraph will generate an Expand logical operator. 
A case in which the path consists of only a single node and that node is already in bound_symbols isn't covered, so memgraph will fail in the planning phase.

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments
