### PR TITLE
Fix crash caused by deleting non-existing relationship

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,7 +297,7 @@ if (MG_ENTERPRISE)
   add_definitions(-DMG_ENTERPRISE)
 endif()
 
-set(ENABLE_JEMALLOC ON)
+set(ENABLE_JEMALLOC OFF)
 
 if (ASAN)
   message(WARNING "Disabling jemalloc as it doesn't work well with ASAN")

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -1292,7 +1292,7 @@ std::optional<plan::ProfilingStatsWithTotalTime> PullPlan::Pull(AnyStream *strea
   std::optional<utils::PoolResource> pool_memory;
   static constexpr auto kMaxBlockPerChunks = 128;
 
-  if (!use_monotonic_memory_) {
+  if (use_monotonic_memory_) {
     pool_memory.emplace(kMaxBlockPerChunks, kExecutionPoolMaxBlockSize, &resource_with_exception,
                         &resource_with_exception);
   } else {
@@ -3669,7 +3669,7 @@ Interpreter::PrepareResult Interpreter::Prepare(const std::string &query_string,
       bool hasAllShortestPaths = IsAllShortestPathsQuery(clauses);
       // Using PoolResource without MonotonicMemoryResouce for LOAD CSV reduces memory usage.
       bool usePool = hasAllShortestPaths || IsCallBatchedProcedureQuery(clauses) || IsLoadCsvQuery(clauses);
-      return {usePool, hasAllShortestPaths};
+      return {true, hasAllShortestPaths};
     }();  // IILE
 
     // Setup QueryExecution

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -321,6 +321,10 @@ EdgeInfoForDeletion Storage::Accessor::PrepareDeletableEdges(const std::unordere
 
   // also add edges which we want to delete from the query
   for (const auto &edge_accessor : edges) {
+    if (edge_accessor->from_vertex_->deleted || edge_accessor->to_vertex_->deleted) {
+      continue;
+    }
+
     partial_src_vertices.insert(edge_accessor->from_vertex_);
     partial_dest_vertices.insert(edge_accessor->to_vertex_);
 


### PR DESCRIPTION
This PR is about preventing a crash caused by deleting a non-existing relationship. 

ATM query: 
`CREATE (n0)<-[r0:T3]-(n1) DETACH DELETE n0 DETACH DELETE r0 RETURN n1;`
will crash the database.

The problem is in the second DETACH DELETE clause in which we are trying to detach relationship r0 from its edges, since edge n0 is deleted by the previous DETACH DELETE clause, that will crash a database.

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments
