### PR TITLE
Storage GC changes

### DIFF
--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -10,6 +10,6 @@ add_library(mg-memory STATIC ${memory_src_files})
 target_link_libraries(mg-memory mg-utils fmt)
 
 if (ENABLE_JEMALLOC)
-  target_link_libraries(mg-memory Jemalloc::Jemalloc)
+  target_link_libraries(mg-memory Jemalloc::Jemalloc ${CMAKE_DL_LIBS})
   target_compile_definitions(mg-memory PRIVATE USE_JEMALLOC=1)
 endif()

--- a/src/storage/v2/delta.hpp
+++ b/src/storage/v2/delta.hpp
@@ -122,7 +122,7 @@ inline bool operator==(const PreviousPtr::Pointer &a, const PreviousPtr::Pointer
 inline bool operator!=(const PreviousPtr::Pointer &a, const PreviousPtr::Pointer &b) { return !(a == b); }
 
 struct Delta {
-  enum class Action {
+  enum class Action : std::uint8_t {
     /// Use for Vertex and Edge
     /// Used for disk storage for modifying MVCC logic and storing old key. Storing old key is necessary for
     /// deleting old-data (compaction).

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -411,23 +411,28 @@ class InMemoryStorage final : public Storage {
   // whatever.
   std::optional<CommitLog> commit_log_;
 
-  utils::Synchronized<std::list<Transaction>, utils::SpinLock> committed_transactions_{};
   utils::Scheduler gc_runner_;
   std::mutex gc_lock_;
 
   using BondPmrLd = Bond<utils::pmr::list<Delta>>;
-  // Ownership of unlinked deltas is transfered to garabage_undo_buffers once transaction is commited
-  utils::Synchronized<std::list<std::tuple<uint64_t, BondPmrLd, std::unique_ptr<std::atomic<uint64_t>>>>,
-                      utils::SpinLock>
-      garbage_undo_buffers_{};
+  struct GCDeltas {
+    GCDeltas(uint64_t mark_timestamp, BondPmrLd deltas, std::unique_ptr<std::atomic<uint64_t>> commit_timestamp)
+        : mark_timestamp_{mark_timestamp}, deltas_{std::move(deltas)}, commit_timestamp_{std::move(commit_timestamp)} {}
+
+    uint64_t mark_timestamp_;                                  //!< a timestamp no active transaction currently has
+    BondPmrLd deltas_;                                         //!< the deltas that need cleaning
+    std::unique_ptr<std::atomic<uint64_t>> commit_timestamp_;  //!< the timestamp the deltas are pointing at
+  };
+
+  // Ownership of linked deltas is transferred to committed_transactions_ once transaction is commited
+  utils::Synchronized<std::list<GCDeltas>, utils::SpinLock> committed_transactions_{};
+
+  // Ownership of unlinked deltas is transferred to garabage_undo_buffers once transaction is commited/aborted
+  utils::Synchronized<std::list<GCDeltas>, utils::SpinLock> garbage_undo_buffers_{};
 
   // Vertices that are logically deleted but still have to be removed from
   // indices before removing them from the main storage.
   utils::Synchronized<std::list<Gid>, utils::SpinLock> deleted_vertices_;
-
-  // Vertices that are logically deleted and removed from indices and now wait
-  // to be removed from the main storage.
-  std::list<std::pair<uint64_t, Gid>> garbage_vertices_;
 
   // Edges that are logically deleted and wait to be removed from the main
   // storage.

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -419,9 +419,12 @@ class InMemoryStorage final : public Storage {
     GCDeltas(uint64_t mark_timestamp, BondPmrLd deltas, std::unique_ptr<std::atomic<uint64_t>> commit_timestamp)
         : mark_timestamp_{mark_timestamp}, deltas_{std::move(deltas)}, commit_timestamp_{std::move(commit_timestamp)} {}
 
-    uint64_t mark_timestamp_;                                  //!< a timestamp no active transaction currently has
-    BondPmrLd deltas_;                                         //!< the deltas that need cleaning
-    std::unique_ptr<std::atomic<uint64_t>> commit_timestamp_;  //!< the timestamp the deltas are pointing at
+    GCDeltas(GCDeltas &&) = default;
+    GCDeltas &operator=(GCDeltas &&) = default;
+
+    uint64_t mark_timestamp_{};                                  //!< a timestamp no active transaction currently has
+    BondPmrLd deltas_;                                           //!< the deltas that need cleaning
+    std::unique_ptr<std::atomic<uint64_t>> commit_timestamp_{};  //!< the timestamp the deltas are pointing at
   };
 
   // Ownership of linked deltas is transferred to committed_transactions_ once transaction is commited

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -411,13 +411,15 @@ class InMemoryStorage final : public Storage {
   // whatever.
   std::optional<CommitLog> commit_log_;
 
-  utils::Synchronized<std::list<Transaction>, utils::SpinLock> committed_transactions_;
+  utils::Synchronized<std::list<Transaction>, utils::SpinLock> committed_transactions_{};
   utils::Scheduler gc_runner_;
   std::mutex gc_lock_;
 
   using BondPmrLd = Bond<utils::pmr::list<Delta>>;
   // Ownership of unlinked deltas is transfered to garabage_undo_buffers once transaction is commited
-  utils::Synchronized<std::list<std::pair<uint64_t, BondPmrLd>>, utils::SpinLock> garbage_undo_buffers_;
+  utils::Synchronized<std::list<std::tuple<uint64_t, BondPmrLd, std::unique_ptr<std::atomic<uint64_t>>>>,
+                      utils::SpinLock>
+      garbage_undo_buffers_{};
 
   // Vertices that are logically deleted but still have to be removed from
   // indices before removing them from the main storage.

--- a/src/storage/v2/transaction.hpp
+++ b/src/storage/v2/transaction.hpp
@@ -46,31 +46,26 @@ struct Transaction {
       : transaction_id(transaction_id),
         start_timestamp(start_timestamp),
         command_id(0),
-        deltas(1024UL),
+        deltas(0),
         md_deltas(utils::NewDeleteResource()),
         must_abort(false),
         isolation_level(isolation_level),
         storage_mode(storage_mode),
-        edge_import_mode_active(edge_import_mode_active) {}
+        edge_import_mode_active(edge_import_mode_active),
+        vertices_{(storage_mode == StorageMode::ON_DISK_TRANSACTIONAL)
+                      ? std::optional<utils::SkipList<Vertex>>{std::in_place}
+                      : std::nullopt},
+        edges_{(storage_mode == StorageMode::ON_DISK_TRANSACTIONAL)
+                   ? std::optional<utils::SkipList<Edge>>{std::in_place}
+                   : std::nullopt} {}
 
-  Transaction(Transaction &&other) noexcept
-      : transaction_id(other.transaction_id),
-        start_timestamp(other.start_timestamp),
-        commit_timestamp(std::move(other.commit_timestamp)),
-        command_id(other.command_id),
-        deltas(std::move(other.deltas)),
-        md_deltas(std::move(other.md_deltas)),
-        must_abort(other.must_abort),
-        isolation_level(other.isolation_level),
-        storage_mode(other.storage_mode),
-        edge_import_mode_active(other.edge_import_mode_active),
-        manyDeltasCache{std::move(other.manyDeltasCache)} {}
+  Transaction(Transaction &&other) noexcept = default;
 
   Transaction(const Transaction &) = delete;
   Transaction &operator=(const Transaction &) = delete;
-  Transaction &operator=(Transaction &&other) = delete;
+  Transaction &operator=(Transaction &&other) = default;
 
-  ~Transaction() {}
+  ~Transaction() = default;
 
   bool IsDiskStorage() const { return storage_mode == StorageMode::ON_DISK_TRANSACTIONAL; }
 
@@ -86,41 +81,41 @@ struct Transaction {
 
   bool RemoveModifiedEdge(const Gid &gid) { return modified_edges_.erase(gid) > 0U; }
 
-  uint64_t transaction_id;
-  uint64_t start_timestamp;
+  uint64_t transaction_id{};
+  uint64_t start_timestamp{};
   // The `Transaction` object is stack allocated, but the `commit_timestamp`
   // must be heap allocated because `Delta`s have a pointer to it, and that
   // pointer must stay valid after the `Transaction` is moved into
   // `commited_transactions_` list for GC.
-  std::unique_ptr<std::atomic<uint64_t>> commit_timestamp;
-  uint64_t command_id;
+  std::unique_ptr<std::atomic<uint64_t>> commit_timestamp{};
+  uint64_t command_id{};
 
   Bond<PmrListDelta> deltas;
   utils::pmr::list<MetadataDelta> md_deltas;
-  bool must_abort;
-  IsolationLevel isolation_level;
-  StorageMode storage_mode;
+  bool must_abort{};
+  IsolationLevel isolation_level{};
+  StorageMode storage_mode{};
   bool edge_import_mode_active{false};
 
   // A cache which is consistent to the current transaction_id + command_id.
   // Used to speedup getting info about a vertex when there is a long delta
   // chain involved in rebuilding that info.
-  mutable VertexInfoCache manyDeltasCache;
+  mutable VertexInfoCache manyDeltasCache{};
 
   // Store modified edges GID mapped to changed Delta and serialized edge key
   // Only for disk storage
-  ModifiedEdgesMap modified_edges_;
-  rocksdb::Transaction *disk_transaction_;
+  ModifiedEdgesMap modified_edges_{};
+  rocksdb::Transaction *disk_transaction_{};
   /// Main storage
-  utils::SkipList<Vertex> vertices_;
-  std::vector<std::unique_ptr<utils::SkipList<Vertex>>> index_storage_;
+  std::optional<utils::SkipList<Vertex>> vertices_{};
+  std::vector<std::unique_ptr<utils::SkipList<Vertex>>> index_storage_{};
 
   /// We need them because query context for indexed reading is cleared after the query is done not after the
   /// transaction is done
-  std::vector<std::list<Delta>> index_deltas_storage_;
-  utils::SkipList<Edge> edges_;
-  std::map<std::string, std::pair<std::string, std::string>> edges_to_delete_;
-  std::map<std::string, std::string> vertices_to_delete_;
+  std::vector<std::list<Delta>> index_deltas_storage_{};
+  std::optional<utils::SkipList<Edge>> edges_{};
+  std::map<std::string, std::pair<std::string, std::string>> edges_to_delete_{};
+  std::map<std::string, std::string> vertices_to_delete_{};
   bool scanned_all_vertices_ = false;
 };
 

--- a/src/storage/v2/vertex_info_cache.cpp
+++ b/src/storage/v2/vertex_info_cache.cpp
@@ -51,8 +51,6 @@ void Store(Value &&value, VertexInfoCache &caches, Func &&getCache, View view, K
   cache.emplace(key_type{std::forward<Keys>(keys)...}, std::forward<Value>(value));
 }
 
-VertexInfoCache::VertexInfoCache() = default;
-VertexInfoCache::~VertexInfoCache() = default;
 VertexInfoCache::VertexInfoCache(VertexInfoCache &&) noexcept = default;
 VertexInfoCache &VertexInfoCache::operator=(VertexInfoCache &&) noexcept = default;
 

--- a/src/storage/v2/vertex_info_cache.hpp
+++ b/src/storage/v2/vertex_info_cache.hpp
@@ -45,8 +45,8 @@ class PropertyValue;
  * - only for View::OLD
  */
 struct VertexInfoCache final {
-  VertexInfoCache();
-  ~VertexInfoCache();
+  VertexInfoCache() = default;
+  ~VertexInfoCache() = default;
 
   // By design would be a mistake to copy the cache
   VertexInfoCache(VertexInfoCache const &) = delete;

--- a/src/utils/bond.hpp
+++ b/src/utils/bond.hpp
@@ -26,15 +26,20 @@ struct Bond {
       : res_(std::make_unique<resource>(initial_size)),
         container_(memgraph::utils::Allocator<Container>(res_.get()).template new_object<Container>()){};
 
-  Bond(Bond &&other) noexcept : res_(std::exchange(other.res_, nullptr)), container_(other.container_) {
-    other.container_ = nullptr;
-  }
+  Bond(Bond &&other) noexcept
+      : res_(std::exchange(other.res_, nullptr)), container_(std::exchange(other.container_, nullptr)) {}
 
   Bond(const Bond &other) = delete;
 
   Bond &operator=(const Bond &other) = delete;
 
-  Bond &operator=(Bond &&other) = delete;
+  Bond &operator=(Bond &&other) {
+    if (this != &other) {
+      res_ = std::exchange(other.res_, nullptr);
+      container_ = std::exchange(other.container_, nullptr);
+    }
+    return *this;
+  };
 
   auto use() -> Container & { return *container_; }
 

--- a/src/utils/scheduler.hpp
+++ b/src/utils/scheduler.hpp
@@ -58,17 +58,19 @@ class Scheduler {
         // the start of the program. Since Server will log some messages on
         // the program start we let him log first and we make sure by first
         // waiting that funcion f will not log before it.
-        std::unique_lock<std::mutex> lk(mutex_);
-        auto now = std::chrono::system_clock::now();
         start_time += pause;
-        if (start_time > now) {
-          condition_variable_.wait_until(lk, start_time, [&] { return is_working_.load() == false; });
-        } else {
+        {
+          std::unique_lock<std::mutex> lk(mutex_);
+          auto const stopped =
+              condition_variable_.wait_until(lk, start_time, [&] { return is_working_.load() == false; });
+          if (stopped) break;
+        }
+        f();
+        auto now = std::chrono::system_clock::now();
+        if (start_time < now) {
+          // `f` took longer than `pause` to complete
           start_time = now;
         }
-
-        if (!is_working_) break;
-        f();
       }
     });
   }
@@ -80,10 +82,7 @@ class Scheduler {
    */
   void Stop() {
     is_working_.store(false);
-    {
-      std::unique_lock<std::mutex> lk(mutex_);
-      condition_variable_.notify_one();
-    }
+    condition_variable_.notify_one();
     if (thread_.joinable()) thread_.join();
   }
 

--- a/src/utils/scheduler.hpp
+++ b/src/utils/scheduler.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -62,7 +62,7 @@ class Scheduler {
         auto now = std::chrono::system_clock::now();
         start_time += pause;
         if (start_time > now) {
-          condition_variable_.wait_for(lk, start_time - now, [&] { return is_working_.load() == false; });
+          condition_variable_.wait_until(lk, start_time, [&] { return is_working_.load() == false; });
         } else {
           start_time = now;
         }

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -13,7 +13,7 @@ function(add_benchmark test_cpp)
   # used to help create two targets of the same name even though CMake
   # requires unique logical target names
   set_target_properties(${target_name} PROPERTIES OUTPUT_NAME ${exec_name})
-  target_link_libraries(${target_name} benchmark gflags)
+  target_link_libraries(${target_name} benchmark gflags mg-memory)
   # register test
   add_test(${target_name} ${exec_name})
   add_dependencies(memgraph__benchmark ${target_name})

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -60,5 +60,8 @@ target_link_libraries(${test_prefix}expansion mg-query mg-communication mg-licen
 add_benchmark(storage_v2_gc.cpp)
 target_link_libraries(${test_prefix}storage_v2_gc mg-storage-v2)
 
+add_benchmark(storage_v2_gc2.cpp)
+target_link_libraries(${test_prefix}storage_v2_gc2 mg-storage-v2)
+
 add_benchmark(storage_v2_property_store.cpp)
 target_link_libraries(${test_prefix}storage_v2_property_store mg-storage-v2)

--- a/tests/benchmark/storage_v2_gc2.cpp
+++ b/tests/benchmark/storage_v2_gc2.cpp
@@ -1,0 +1,65 @@
+// Copyright 2023 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <iostream>
+
+#include <gflags/gflags.h>
+
+#include "storage/v2/inmemory/storage.hpp"
+#include "storage/v2/storage.hpp"
+#include "utils/timer.hpp"
+
+// This benchmark should be run for a fixed amount of time that is
+// large compared to GC interval to make the output relevant.
+
+DEFINE_int32(num_poperties, 10'000, "number of set property per transaction");
+DEFINE_int32(num_iterations, 5'000, "number of iterations");
+
+std::pair<std::string, memgraph::storage::Config> TestConfigurations[] = {
+    //{"NoGc", memgraph::storage::Config{.gc = {.type = memgraph::storage::Config::Gc::Type::NONE}}},
+    {"100msPeriodicGc", memgraph::storage::Config{.gc = {.type = memgraph::storage::Config::Gc::Type::PERIODIC,
+                                                         .interval = std::chrono::milliseconds(100)}}},
+    {"1000msPeriodicGc", memgraph::storage::Config{.gc = {.type = memgraph::storage::Config::Gc::Type::PERIODIC,
+                                                          .interval = std::chrono::milliseconds(1000)}}}};
+
+int main(int argc, char *argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  for (const auto &config : TestConfigurations) {
+    memgraph::utils::Timer timer;
+    std::chrono::duration<double> end_bench;
+    {
+      std::unique_ptr<memgraph::storage::Storage> storage(new memgraph::storage::InMemoryStorage(config.second));
+      std::array<memgraph::storage::Gid, 1> vertices;
+      memgraph::storage::PropertyId pid;
+      {
+        auto acc = storage->Access();
+        vertices[0] = acc->CreateVertex().Gid();
+        pid = acc->NameToProperty("NEW_PROP");
+        MG_ASSERT(!acc->Commit().HasError());
+      }
+
+      for (int iter = 0; iter != FLAGS_num_iterations; ++iter) {
+        auto acc = storage->Access();
+        auto vertex1 = acc->FindVertex(vertices[0], memgraph::storage::View::OLD);
+        for (auto i = 0; i != FLAGS_num_poperties; ++i) {
+          MG_ASSERT(!vertex1.value().SetProperty(pid, memgraph::storage::PropertyValue{i}).HasError());
+        }
+        MG_ASSERT(!acc->Commit().HasError());
+      }
+
+      end_bench = timer.Elapsed();
+      std::cout << "Config: " << config.first << ", Time: " << end_bench.count() << std::endl;
+    }
+    auto end_shutdown = timer.Elapsed();
+    std::cout << "Shutdown: " << (end_shutdown - end_bench).count() << std::endl;
+  }
+}


### PR DESCRIPTION
- Make Bond move assignable
- Make benchmark use jemalloc to be a better indicator of production use
- Make parts of Transaction optional, so not to impact IN_MEMORY's GC
- Reduce contention on committed_transactions_
  * No need to do empty check + clear, just do clear
  * For some time now, the order of the committed_transactions_ has been random, hence no need to lock to attempt an insert order
  * Move all committed_transactions_ to local variable, rather than locking once per transaction being processed.
- Fix subtle GC bug, the commited_transaction unique_ptr that a delta was pointing to was deleted while delta was still potentially accessed
- garbage_undo_buffers_ processing can happen earlier
- As committed_transactions order is random, check all of them to see which can be processed
- Don't preallocate anything for the deltas monotonic pool
