### PR TITLE
Revert to Release under Diff Release workflow

### DIFF
--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -244,7 +244,7 @@ jobs:
 
           # Build release binaries.
           cd build
-          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+          cmake -DCMAKE_BUILD_TYPE=Release ..
           make -j$THREADS
 
       - name: Run GQL Behave tests


### PR DESCRIPTION
because graphql e2e gets stuck -> TMP fix just to unblock merging to master
the proper fix should be done when we resolve #1391 