### PR TITLE
Speedup socket unit test

### DIFF
--- a/src/io/network/socket.cpp
+++ b/src/io/network/socket.cpp
@@ -216,7 +216,7 @@ bool Socket::Write(const uint8_t *data, size_t len, bool have_more) {
   return true;
 }
 
-bool Socket::Write(const std::string &s, bool have_more) {
+bool Socket::Write(std::string_view s, bool have_more) {
   return Write(reinterpret_cast<const uint8_t *>(s.data()), s.size(), have_more);
 }
 

--- a/src/io/network/socket.hpp
+++ b/src/io/network/socket.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -149,7 +149,7 @@ class Socket {
    *             false if write failed
    */
   bool Write(const uint8_t *data, size_t len, bool have_more = false);
-  bool Write(const std::string &s, bool have_more = false);
+  bool Write(std::string_view s, bool have_more = false);
 
   /**
    * Read data from the socket.


### PR DESCRIPTION
Was testing a setup that wasn't used in production. It would start off transferring `10000` then for some reason it would unnecessarily thrash small buffers. 

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments
