### PR TITLE
Replication refactor (part 6)

### DIFF
--- a/release/get_version.py
+++ b/release/get_version.py
@@ -104,7 +104,9 @@ def retry(retry_limit, timeout=100):
                 except Exception:
                     time.sleep(timeout)
             return func(*args, **kwargs)
+
         return wrapper
+
     return inner_func
 
 
@@ -200,19 +202,19 @@ if args.version:
 try:
     current_branch = get_output("git", "rev-parse", "--abbrev-ref", "HEAD")
     if current_branch != "master":
-        branches = get_output("git", "branch")
-        if "master" in branches:
+        branches = get_output("git", "branch", "-r", "--list", "origin/master")
+        if "origin/master" in branches:
             # If master is present locally, the fetch is allowed to fail
             # because this script will still be able to compare against the
             # master branch.
             try:
-                get_output("git", "fetch", "origin", "master:master")
+                get_output("git", "fetch", "origin", "master")
             except Exception:
                 pass
         else:
             # If master is not present locally, the fetch command has to
             # succeed because something else will fail otherwise.
-            get_output("git", "fetch", "origin", "master:master")
+            get_output("git", "fetch", "origin", "master")
 except Exception:
     print("Fatal error while ensuring local master branch.")
     sys.exit(1)
@@ -232,7 +234,7 @@ for branch in branches:
     match = branch_regex.match(branch)
     if match is not None:
         version = tuple(map(int, match.group(1).split(".")))
-        master_branch_merge = get_output("git", "merge-base", "master", branch)
+        master_branch_merge = get_output("git", "merge-base", "origin/master", branch)
         versions.append((version, branch, master_branch_merge))
 versions.sort(reverse=True)
 
@@ -243,7 +245,7 @@ current_version = None
 for version in versions:
     version_tuple, branch, master_branch_merge = version
     current_branch_merge = get_output("git", "merge-base", current_hash, branch)
-    master_current_merge = get_output("git", "merge-base", current_hash, "master")
+    master_current_merge = get_output("git", "merge-base", current_hash, "origin/master")
     # The first check checks whether this commit is a child of `master` and
     # the version branch was created before us.
     # The second check checks whether this commit is a child of the version

--- a/src/dbms/replication_handler.cpp
+++ b/src/dbms/replication_handler.cpp
@@ -144,8 +144,8 @@ auto ReplicationHandler::RegisterReplica(const memgraph::replication::Replicatio
 
     all_clients_good &=
         storage->repl_storage_state_.replication_clients_.WithLock([storage, &config](auto &clients) -> bool {
-          auto client = storage->CreateReplicationClient(config, &storage->repl_storage_state_.epoch_);
-          client->Start();
+          auto client = storage->CreateReplicationClient(config);
+          client->Start(storage);
 
           if (client->State() == storage::replication::ReplicaState::INVALID) {
             return false;
@@ -199,8 +199,8 @@ void RestoreReplication(const replication::ReplicationState &repl_state, storage
           -> memgraph::utils::BasicResult<RegisterReplicaError> {
         return storage.repl_storage_state_.replication_clients_.WithLock(
             [&storage, &config](auto &clients) -> utils::BasicResult<RegisterReplicaError> {
-              auto client = storage.CreateReplicationClient(config, &storage.repl_storage_state_.epoch_);
-              client->Start();
+              auto client = storage.CreateReplicationClient(config);
+              client->Start(&storage);
 
               if (client->State() == storage::replication::ReplicaState::INVALID) {
                 spdlog::warn("Connection failed when registering replica {}. Replica will still be registered.",

--- a/src/query/frontend/ast/ast.hpp
+++ b/src/query/frontend/ast/ast.hpp
@@ -3029,7 +3029,7 @@ class ReplicationQuery : public memgraph::query::Query {
 
   enum class SyncMode { SYNC, ASYNC };
 
-  enum class ReplicaState { READY, REPLICATING, RECOVERY, INVALID };
+  enum class ReplicaState { READY, REPLICATING, RECOVERY, RECOVERY_REQUIRED, UNRESOLVABLE_CONFLICT };
 
   ReplicationQuery() = default;
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -393,6 +393,9 @@ class ReplQueryHandler final : public query::ReplicationQueryHandler {
           repl_info.timestamp_info.current_number_of_timestamp_behind_master;
 
       switch (repl_info.state) {
+        case storage::replication::ReplicaState::UNRESOLVABLE_CONFLICT:
+          replica.state = ReplicationQuery::ReplicaState::UNRESOLVABLE_CONFLICT;
+          break;
         case storage::replication::ReplicaState::READY:
           replica.state = ReplicationQuery::ReplicaState::READY;
           break;
@@ -402,8 +405,8 @@ class ReplQueryHandler final : public query::ReplicationQueryHandler {
         case storage::replication::ReplicaState::RECOVERY:
           replica.state = ReplicationQuery::ReplicaState::RECOVERY;
           break;
-        case storage::replication::ReplicaState::INVALID:
-          replica.state = ReplicationQuery::ReplicaState::INVALID;
+        case storage::replication::ReplicaState::RECOVERY_REQUIRED:
+          replica.state = ReplicationQuery::ReplicaState::RECOVERY_REQUIRED;
           break;
       }
 
@@ -812,6 +815,9 @@ Callback HandleReplicationQuery(ReplicationQuery *repl_query, const Parameters &
               TypedValue(static_cast<int64_t>(replica.current_number_of_timestamp_behind_master)));
 
           switch (replica.state) {
+            case ReplicationQuery::ReplicaState::UNRESOLVABLE_CONFLICT:
+              typed_replica.emplace_back(TypedValue("unresolvable conflict"));
+              break;
             case ReplicationQuery::ReplicaState::READY:
               typed_replica.emplace_back(TypedValue("ready"));
               break;
@@ -821,8 +827,8 @@ Callback HandleReplicationQuery(ReplicationQuery *repl_query, const Parameters &
             case ReplicationQuery::ReplicaState::RECOVERY:
               typed_replica.emplace_back(TypedValue("recovery"));
               break;
-            case ReplicationQuery::ReplicaState::INVALID:
-              typed_replica.emplace_back(TypedValue("invalid"));
+            case ReplicationQuery::ReplicaState::RECOVERY_REQUIRED:
+              typed_replica.emplace_back(TypedValue("waiting for recovery"));
               break;
           }
 

--- a/src/rpc/client.hpp
+++ b/src/rpc/client.hpp
@@ -14,6 +14,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <utility>
 
 #include "communication/client.hpp"
 #include "io/network/endpoint.hpp"
@@ -41,16 +42,25 @@ class Client {
 
     StreamHandler(Client *self, std::unique_lock<std::mutex> &&guard,
                   std::function<typename TRequestResponse::Response(slk::Reader *)> res_load)
-        : self_(self),
-          guard_(std::move(guard)),
-          req_builder_([self](const uint8_t *data, size_t size, bool have_more) {
-            if (!self->client_->Write(data, size, have_more)) throw GenericRpcFailedException();
-          }),
-          res_load_(res_load) {}
+        : self_(self), guard_(std::move(guard)), req_builder_(GenBuilderCallback(self, this)), res_load_(res_load) {}
 
    public:
-    StreamHandler(StreamHandler &&) noexcept = default;
-    StreamHandler &operator=(StreamHandler &&) noexcept = default;
+    StreamHandler(StreamHandler &&other) noexcept
+        : self_{std::exchange(other.self_, nullptr)},
+          defunct_{std::exchange(other.defunct_, true)},
+          guard_{std::move(other.guard_)},
+          req_builder_{std::move(other.req_builder_), GenBuilderCallback(self_, this)},
+          res_load_{std::move(other.res_load_)} {}
+    StreamHandler &operator=(StreamHandler &&other) noexcept {
+      if (&other != this) {
+        self_ = std::exchange(other.self_, nullptr);
+        defunct_ = std::exchange(other.defunct_, true);
+        guard_ = std::move(other.guard_);
+        req_builder_ = slk::Builder(std::move(other.req_builder_, GenBuilderCallback(self_, this)));
+        res_load_ = std::move(other.res_load_);
+      }
+      return *this;
+    }
 
     StreamHandler(const StreamHandler &) = delete;
     StreamHandler &operator=(const StreamHandler &) = delete;
@@ -112,8 +122,23 @@ class Client {
       return res_load_(&res_reader);
     }
 
+    bool IsDefunct() const { return defunct_; }
+
    private:
+    static auto GenBuilderCallback(Client *client, StreamHandler *self) {
+      return [client, self](const uint8_t *data, size_t size, bool have_more) {
+        if (self->defunct_) throw GenericRpcFailedException();
+        if (!client->client_->Write(data, size, have_more)) {
+          client->Abort();
+          self->guard_.unlock();
+          self->defunct_ = true;
+          throw GenericRpcFailedException();
+        }
+      };
+    }
+
     Client *self_;
+    bool defunct_ = false;
     std::unique_lock<std::mutex> guard_;
     slk::Builder req_builder_;
     std::function<typename TRequestResponse::Response(slk::Reader *)> res_load_;
@@ -179,7 +204,7 @@ class Client {
     TRequestResponse::Request::Save(request, handler.GetBuilder());
 
     // Return the handler to the user.
-    return std::move(handler);
+    return handler;
   }
 
   /// Call a previously defined and registered RPC call. This function can

--- a/src/slk/streams.cpp
+++ b/src/slk/streams.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2023 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -17,7 +17,7 @@
 
 namespace memgraph::slk {
 
-Builder::Builder(std::function<void(const uint8_t *, size_t, bool)> write_func) : write_func_(write_func) {}
+Builder::Builder(std::function<void(const uint8_t *, size_t, bool)> write_func) : write_func_(std::move(write_func)) {}
 
 void Builder::Save(const uint8_t *data, uint64_t size) {
   size_t offset = 0;
@@ -29,7 +29,7 @@ void Builder::Save(const uint8_t *data, uint64_t size) {
       to_write = kSegmentMaxDataSize - pos_;
     }
 
-    memcpy(segment_ + sizeof(SegmentSize) + pos_, data + offset, to_write);
+    memcpy(segment_.data() + sizeof(SegmentSize) + pos_, data + offset, to_write);
 
     size -= to_write;
     pos_ += to_write;
@@ -47,15 +47,15 @@ void Builder::FlushSegment(bool final_segment) {
   size_t total_size = sizeof(SegmentSize) + pos_;
 
   SegmentSize size = pos_;
-  memcpy(segment_, &size, sizeof(SegmentSize));
+  memcpy(segment_.data(), &size, sizeof(SegmentSize));
 
   if (final_segment) {
     SegmentSize footer = 0;
-    memcpy(segment_ + total_size, &footer, sizeof(SegmentSize));
+    memcpy(segment_.data() + total_size, &footer, sizeof(SegmentSize));
     total_size += sizeof(SegmentSize);
   }
 
-  write_func_(segment_, total_size, !final_segment);
+  write_func_(segment_.data(), total_size, !final_segment);
 
   pos_ = 0;
 }

--- a/src/slk/streams.hpp
+++ b/src/slk/streams.hpp
@@ -47,6 +47,10 @@ static_assert(kSegmentMaxDataSize <= std::numeric_limits<SegmentSize>::max(),
 class Builder {
  public:
   Builder(std::function<void(const uint8_t *, size_t, bool)> write_func);
+  Builder(Builder &&other, std::function<void(const uint8_t *, size_t, bool)> write_func)
+      : write_func_{std::move(write_func)}, pos_{std::move(other.pos_)}, segment_{std::move(other.segment_)} {
+    other.write_func_ = [](const uint8_t *, size_t, bool) {};
+  }
 
   /// Function used internally by SLK to serialize the data.
   void Save(const uint8_t *data, uint64_t size);
@@ -59,7 +63,7 @@ class Builder {
 
   std::function<void(const uint8_t *, size_t, bool)> write_func_;
   size_t pos_{0};
-  uint8_t segment_[kSegmentMaxTotalSize];
+  std::array<uint8_t, kSegmentMaxTotalSize> segment_;
 };
 
 /// Exception that will be thrown if segments can't be decoded from the byte

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -313,8 +313,7 @@ class DiskStorage final : public Storage {
 
   uint64_t CommitTimestamp(std::optional<uint64_t> desired_commit_timestamp = {});
 
-  auto CreateReplicationClient(const memgraph::replication::ReplicationClientConfig & /*config*/,
-                               const memgraph::replication::ReplicationEpoch * /*current_epoch*/)
+  auto CreateReplicationClient(const memgraph::replication::ReplicationClientConfig &)
       -> std::unique_ptr<ReplicationClient> override {
     throw utils::BasicException("Disk storage mode does not support replication.");
   }

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -313,7 +313,7 @@ class DiskStorage final : public Storage {
 
   uint64_t CommitTimestamp(std::optional<uint64_t> desired_commit_timestamp = {});
 
-  auto CreateReplicationClient(const memgraph::replication::ReplicationClientConfig &)
+  auto CreateReplicationClient(const memgraph::replication::ReplicationClientConfig &, uint64_t)
       -> std::unique_ptr<ReplicationClient> override {
     throw utils::BasicException("Disk storage mode does not support replication.");
   }

--- a/src/storage/v2/inmemory/replication/replication_client.cpp
+++ b/src/storage/v2/inmemory/replication/replication_client.cpp
@@ -151,7 +151,7 @@ void InMemoryReplicationClient::RecoverReplica(uint64_t replica_commit, memgraph
         {
           std::unique_lock client_guard{client_lock_};
           storage->repl_storage_state_.replication_clients_.WithLock([id = id_](ReplicationStorageState::TMP_THING &X) {
-            X.states_[id] = replication::ReplicaState::INVALID;
+            X.states_[id] = replication::ReplicaState::RECOVERY_REQUIRED;
           });
         }
         HandleRpcFailure(storage);

--- a/src/storage/v2/inmemory/replication/replication_client.cpp
+++ b/src/storage/v2/inmemory/replication/replication_client.cpp
@@ -149,12 +149,13 @@ void InMemoryReplicationClient::RecoverReplica(uint64_t replica_commit, memgraph
             recovery_step);
       } catch (const rpc::RpcFailedException &) {
         {
+          spdlog::error(
+              utils::MessageWithLink("Couldn't replicate data to {}.", name_, "https://memgr.ph/replication"));
           std::unique_lock client_guard{client_lock_};
           storage->repl_storage_state_.replication_clients_.WithLock([id = id_](ReplicationStorageState::TMP_THING &X) {
             X.states_[id] = replication::ReplicaState::RECOVERY_REQUIRED;
           });
         }
-        HandleRpcFailure(storage);
         return;
       }
     }

--- a/src/storage/v2/inmemory/replication/replication_client.hpp
+++ b/src/storage/v2/inmemory/replication/replication_client.hpp
@@ -18,11 +18,10 @@ class InMemoryStorage;
 
 class InMemoryReplicationClient : public ReplicationClient {
  public:
-  InMemoryReplicationClient(InMemoryStorage *storage, const memgraph::replication::ReplicationClientConfig &config,
-                            const memgraph::replication::ReplicationEpoch *epoch);
+  InMemoryReplicationClient(const memgraph::replication::ReplicationClientConfig &config);
 
  protected:
-  void RecoverReplica(uint64_t replica_commit) override;
+  void RecoverReplica(uint64_t replica_commit, memgraph::storage::Storage *storage) override;
 
   // TODO: move the GetRecoverySteps stuff below as an internal detail
   using RecoverySnapshot = std::filesystem::path;
@@ -32,7 +31,8 @@ class InMemoryReplicationClient : public ReplicationClient {
     uint64_t current_wal_seq_num;
   };
   using RecoveryStep = std::variant<RecoverySnapshot, RecoveryWals, RecoveryCurrentWal>;
-  std::vector<RecoveryStep> GetRecoverySteps(uint64_t replica_commit, utils::FileRetainer::FileLocker *file_locker);
+  static auto GetRecoverySteps(const uint64_t replica_commit, utils::FileRetainer::FileLocker *file_locker,
+                               const InMemoryStorage *storage) -> std::vector<InMemoryReplicationClient::RecoveryStep>;
 };
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/inmemory/replication/replication_client.hpp
+++ b/src/storage/v2/inmemory/replication/replication_client.hpp
@@ -18,7 +18,7 @@ class InMemoryStorage;
 
 class InMemoryReplicationClient : public ReplicationClient {
  public:
-  InMemoryReplicationClient(const memgraph::replication::ReplicationClientConfig &config);
+  InMemoryReplicationClient(const memgraph::replication::ReplicationClientConfig &config, uint64_t id);
 
  protected:
   void RecoverReplica(uint64_t replica_commit, memgraph::storage::Storage *storage) override;

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1966,9 +1966,9 @@ utils::FileRetainer::FileLockerAccessor::ret_type InMemoryStorage::UnlockPath() 
   return true;
 }
 
-auto InMemoryStorage::CreateReplicationClient(const memgraph::replication::ReplicationClientConfig &config)
+auto InMemoryStorage::CreateReplicationClient(const memgraph::replication::ReplicationClientConfig &config, uint64_t id)
     -> std::unique_ptr<ReplicationClient> {
-  return std::make_unique<InMemoryReplicationClient>(config);
+  return std::make_unique<InMemoryReplicationClient>(config, id);
 }
 
 std::unique_ptr<Storage::Accessor> InMemoryStorage::Access(std::optional<IsolationLevel> override_isolation_level,

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -332,7 +332,7 @@ class InMemoryStorage final : public Storage {
   using Storage::CreateTransaction;
   Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode, bool is_main) override;
 
-  auto CreateReplicationClient(const memgraph::replication::ReplicationClientConfig &config)
+  auto CreateReplicationClient(const memgraph::replication::ReplicationClientConfig &config, uint64_t id)
       -> std::unique_ptr<ReplicationClient> override;
 
   void SetStorageMode(StorageMode storage_mode);

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -332,8 +332,7 @@ class InMemoryStorage final : public Storage {
   using Storage::CreateTransaction;
   Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode, bool is_main) override;
 
-  auto CreateReplicationClient(const memgraph::replication::ReplicationClientConfig &config,
-                               const memgraph::replication::ReplicationEpoch *current_epoch)
+  auto CreateReplicationClient(const memgraph::replication::ReplicationClientConfig &config)
       -> std::unique_ptr<ReplicationClient> override;
 
   void SetStorageMode(StorageMode storage_mode);

--- a/src/storage/v2/replication/enums.hpp
+++ b/src/storage/v2/replication/enums.hpp
@@ -14,6 +14,6 @@
 
 namespace memgraph::storage::replication {
 
-enum class ReplicaState : std::uint8_t { READY, REPLICATING, RECOVERY, INVALID };
+enum class ReplicaState : std::uint8_t { READY, REPLICATING, RECOVERY, RECOVERY_REQUIRED, UNRESOLVABLE_CONFLICT };
 
 }  // namespace memgraph::storage::replication

--- a/src/storage/v2/replication/replication_client.hpp
+++ b/src/storage/v2/replication/replication_client.hpp
@@ -100,15 +100,17 @@ class ReplicationClient {
   [[nodiscard]] bool FinalizeTransactionReplication(Storage *storage,
                                                     std::atomic<replication::ReplicaState> &replica_state);
 
+  void StartFrequentCheck(Storage *storage, std::atomic<replication::ReplicaState> &replica_state);
+  void StopFrequentCheck();
+
  protected:
   virtual void RecoverReplica(uint64_t replica_commit, memgraph::storage::Storage *storage) = 0;
 
-  void InitializeClient(Storage *storage, std::atomic<replication::ReplicaState> &replica_state);
+  void InitializeReplicaState(Storage *storage, std::atomic<replication::ReplicaState> &replica_state);
   void HandleRpcFailure(Storage *storage);
   void TryInitializeClientAsync(Storage *storage);
   void TryInitializeClientSync(Storage *storage, std::atomic<replication::ReplicaState> &replica_state);
-  void FrequentCheck(Storage *storage);
-  void StartFrequentCheck(Storage *storage);
+  void FrequentCheck(Storage *storage, std::atomic<replication::ReplicaState> &replica_state);
 
   uint64_t id_;
   std::string name_;

--- a/src/storage/v2/replication/replication_client.hpp
+++ b/src/storage/v2/replication/replication_client.hpp
@@ -42,7 +42,7 @@ class ReplicationClient;
 // Handler used for transferring the current transaction.
 class ReplicaStream {
  public:
-  explicit ReplicaStream(ReplicationClient *self, uint64_t previous_commit_timestamp, uint64_t current_seq_num);
+  explicit ReplicaStream(Storage *storage, rpc::Client &rpc_client, const uint64_t current_seq_num);
 
   /// @throw rpc::RpcFailedException
   void AppendDelta(const Delta &delta, const Vertex &vertex, uint64_t final_commit_timestamp);
@@ -62,7 +62,7 @@ class ReplicaStream {
   replication::AppendDeltasRes Finalize();
 
  private:
-  ReplicationClient *self_;
+  Storage *storage_;
   rpc::Client::StreamHandler<replication::AppendDeltasRpc> stream_;
 };
 

--- a/src/storage/v2/replication/replication_client.hpp
+++ b/src/storage/v2/replication/replication_client.hpp
@@ -109,7 +109,6 @@ class ReplicationClient {
   virtual void RecoverReplica(uint64_t replica_commit, memgraph::storage::Storage *storage) = 0;
 
   void InitializeReplicaState(Storage *storage, std::atomic<replication::ReplicaState> &replica_state);
-  void HandleRpcFailure(Storage *storage);
   void TryInitializeClientAsync(Storage *storage);
   void TryInitializeClientSync(Storage *storage, std::atomic<replication::ReplicaState> &replica_state);
   void FrequentCheck(Storage *storage, std::atomic<replication::ReplicaState> &replica_state);

--- a/src/storage/v2/replication/replication_client.hpp
+++ b/src/storage/v2/replication/replication_client.hpp
@@ -61,6 +61,8 @@ class ReplicaStream {
   /// @throw rpc::RpcFailedException
   replication::AppendDeltasRes Finalize();
 
+  bool IsDefunct() const { return stream_.IsDefunct(); }
+
  private:
   Storage *storage_;
   rpc::Client::StreamHandler<replication::AppendDeltasRpc> stream_;

--- a/src/storage/v2/replication/replication_storage_state.cpp
+++ b/src/storage/v2/replication/replication_storage_state.cpp
@@ -16,48 +16,51 @@
 
 namespace memgraph::storage {
 
-void ReplicationStorageState::InitializeTransaction(uint64_t seq_num) {
-  replication_clients_.WithLock([&](auto &clients) {
+void ReplicationStorageState::InitializeTransaction(uint64_t seq_num, Storage *storage) {
+  replication_clients_.WithLock([=](auto &clients) {
     for (auto &client : clients) {
-      client->StartTransactionReplication(seq_num);
+      client->StartTransactionReplication(seq_num, storage);
     }
   });
 }
 
-void ReplicationStorageState::AppendDelta(const Delta &delta, const Vertex &vertex, uint64_t timestamp) {
+void ReplicationStorageState::AppendDelta(const Delta &delta, const Vertex &vertex, uint64_t timestamp,
+                                          Storage *storage) {
   replication_clients_.WithLock([&](auto &clients) {
     for (auto &client : clients) {
-      client->IfStreamingTransaction([&](auto &stream) { stream.AppendDelta(delta, vertex, timestamp); });
+      client->IfStreamingTransaction([&](auto &stream) { stream.AppendDelta(delta, vertex, timestamp); }, storage);
     }
   });
 }
 
-void ReplicationStorageState::AppendDelta(const Delta &delta, const Edge &edge, uint64_t timestamp) {
+void ReplicationStorageState::AppendDelta(const Delta &delta, const Edge &edge, uint64_t timestamp, Storage *storage) {
   replication_clients_.WithLock([&](auto &clients) {
     for (auto &client : clients) {
-      client->IfStreamingTransaction([&](auto &stream) { stream.AppendDelta(delta, edge, timestamp); });
+      client->IfStreamingTransaction([&](auto &stream) { stream.AppendDelta(delta, edge, timestamp); }, storage);
     }
   });
 }
 void ReplicationStorageState::AppendOperation(durability::StorageMetadataOperation operation, LabelId label,
                                               const std::set<PropertyId> &properties, const LabelIndexStats &stats,
                                               const LabelPropertyIndexStats &property_stats,
-                                              uint64_t final_commit_timestamp) {
+                                              uint64_t final_commit_timestamp, Storage *storage) {
   replication_clients_.WithLock([&](auto &clients) {
     for (auto &client : clients) {
-      client->IfStreamingTransaction([&](auto &stream) {
-        stream.AppendOperation(operation, label, properties, stats, property_stats, final_commit_timestamp);
-      });
+      client->IfStreamingTransaction(
+          [&](auto &stream) {
+            stream.AppendOperation(operation, label, properties, stats, property_stats, final_commit_timestamp);
+          },
+          storage);
     }
   });
 }
 
-bool ReplicationStorageState::FinalizeTransaction(uint64_t timestamp) {
+bool ReplicationStorageState::FinalizeTransaction(uint64_t timestamp, Storage *storage) {
   return replication_clients_.WithLock([=](auto &clients) {
     bool finalized_on_all_replicas = true;
     for (ReplicationClientPtr &client : clients) {
-      client->IfStreamingTransaction([&](auto &stream) { stream.AppendTransactionEnd(timestamp); });
-      const auto finalized = client->FinalizeTransactionReplication();
+      client->IfStreamingTransaction([&](auto &stream) { stream.AppendTransactionEnd(timestamp); }, storage);
+      const auto finalized = client->FinalizeTransactionReplication(storage);
 
       if (client->Mode() == memgraph::replication::ReplicationMode::SYNC) {
         finalized_on_all_replicas = finalized && finalized_on_all_replicas;
@@ -78,12 +81,12 @@ std::optional<replication::ReplicaState> ReplicationStorageState::GetReplicaStat
   });
 }
 
-std::vector<ReplicaInfo> ReplicationStorageState::ReplicasInfo() const {
-  return replication_clients_.WithReadLock([](auto const &clients) {
+std::vector<ReplicaInfo> ReplicationStorageState::ReplicasInfo(Storage *storage) const {
+  return replication_clients_.WithReadLock([=](auto const &clients) {
     std::vector<ReplicaInfo> replica_infos;
     replica_infos.reserve(clients.size());
-    auto const asReplicaInfo = [](ReplicationClientPtr const &client) -> ReplicaInfo {
-      return {client->Name(), client->Mode(), client->Endpoint(), client->State(), client->GetTimestampInfo()};
+    auto const asReplicaInfo = [=](ReplicationClientPtr const &client) -> ReplicaInfo {
+      return {client->Name(), client->Mode(), client->Endpoint(), client->State(), client->GetTimestampInfo(storage)};
     };
     std::transform(clients.begin(), clients.end(), std::back_inserter(replica_infos), asReplicaInfo);
     return replica_infos;

--- a/src/storage/v2/replication/replication_storage_state.hpp
+++ b/src/storage/v2/replication/replication_storage_state.hpp
@@ -37,17 +37,18 @@ class ReplicationClient;
 
 struct ReplicationStorageState {
   // Only MAIN can send
-  void InitializeTransaction(uint64_t seq_num);
-  void AppendDelta(const Delta &delta, const Vertex &vertex, uint64_t timestamp);
-  void AppendDelta(const Delta &delta, const Edge &edge, uint64_t timestamp);
+  void InitializeTransaction(uint64_t seq_num, Storage *storage);
+  void AppendDelta(const Delta &delta, const Vertex &vertex, uint64_t timestamp, Storage *storage);
+  void AppendDelta(const Delta &delta, const Edge &edge, uint64_t timestamp, Storage *storage);
   void AppendOperation(durability::StorageMetadataOperation operation, LabelId label,
                        const std::set<PropertyId> &properties, const LabelIndexStats &stats,
-                       const LabelPropertyIndexStats &property_stats, uint64_t final_commit_timestamp);
-  bool FinalizeTransaction(uint64_t timestamp);
+                       const LabelPropertyIndexStats &property_stats, uint64_t final_commit_timestamp,
+                       Storage *storage);
+  bool FinalizeTransaction(uint64_t timestamp, Storage *storage);
 
   // Getters
   auto GetReplicaState(std::string_view name) const -> std::optional<replication::ReplicaState>;
-  auto ReplicasInfo() const -> std::vector<ReplicaInfo>;
+  auto ReplicasInfo(Storage *storage) const -> std::vector<ReplicaInfo>;
 
   // History
   void TrackLatestHistory();

--- a/src/storage/v2/replication/replication_storage_state.hpp
+++ b/src/storage/v2/replication/replication_storage_state.hpp
@@ -48,7 +48,7 @@ struct ReplicationStorageState {
 
   // Getters
   auto GetReplicaState(std::string_view name) const -> std::optional<replication::ReplicaState>;
-  auto ReplicasInfo(Storage *storage) const -> std::vector<ReplicaInfo>;
+  auto ReplicasInfo(Storage *storage) -> std::vector<ReplicaInfo>;
 
   // History
   void TrackLatestHistory();
@@ -76,9 +76,15 @@ struct ReplicationStorageState {
   // that we can immediately notify the user if the initialization
   // failed.
   using ReplicationClientPtr = std::unique_ptr<ReplicationClient>;
-  using ReplicationClientList = utils::Synchronized<std::vector<ReplicationClientPtr>, utils::RWSpinLock>;
+  //  using ReplicationClientList = utils::Synchronized<std::vector<ReplicationClientPtr>, utils::RWSpinLock>;
 
-  ReplicationClientList replication_clients_;
+  struct TMP_THING {
+    uint64_t next_id{};
+    std::vector<ReplicationClientPtr> clients;
+    std::map<uint64_t, std::atomic<replication::ReplicaState>> states_;
+  };
+
+  utils::Synchronized<TMP_THING, utils::RWSpinLock> replication_clients_;
 
   memgraph::replication::ReplicationEpoch epoch_;
 };

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -355,11 +355,10 @@ class Storage {
 
   virtual void PrepareForNewEpoch() = 0;
 
-  virtual auto CreateReplicationClient(const memgraph::replication::ReplicationClientConfig &config,
-                                       const memgraph::replication::ReplicationEpoch *current_epoch)
+  virtual auto CreateReplicationClient(const memgraph::replication::ReplicationClientConfig &config)
       -> std::unique_ptr<ReplicationClient> = 0;
 
-  auto ReplicasInfo() const { return repl_storage_state_.ReplicasInfo(); }
+  auto ReplicasInfo() { return repl_storage_state_.ReplicasInfo(this); }
   auto GetReplicaState(std::string_view name) const -> std::optional<replication::ReplicaState> {
     return repl_storage_state_.GetReplicaState(name);
   }
@@ -384,7 +383,7 @@ class Storage {
   Config config_;
 
   // Transaction engine
-  utils::SpinLock engine_lock_;
+  mutable utils::SpinLock engine_lock_;
   uint64_t timestamp_{kTimestampInitialId};
   uint64_t transaction_id_{kTransactionInitialId};
 

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -355,7 +355,7 @@ class Storage {
 
   virtual void PrepareForNewEpoch() = 0;
 
-  virtual auto CreateReplicationClient(const memgraph::replication::ReplicationClientConfig &config)
+  virtual auto CreateReplicationClient(const memgraph::replication::ReplicationClientConfig &config, uint64_t id)
       -> std::unique_ptr<ReplicationClient> = 0;
 
   auto ReplicasInfo() { return repl_storage_state_.ReplicasInfo(this); }


### PR DESCRIPTION
**Note: depends on #1378 rebase this PR once #1378 is delivered & remove this note**

Refactor aim: to decouple replication rpc client from the storage replication state.

ATM we have one client per replica per storage, we only want one client per replica.

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments
