### PR TITLE
Implement constant time label and edge type retrieval

### DIFF
--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -597,6 +597,13 @@ class DbAccessor final {
     return accessor_->ApproximateVertexCount(label, property, lower, upper);
   }
 
+  std::vector<std::string> ListAllPossiblyPresentVertexLabels() const {
+    return accessor_->ListAllPossiblyPresentVertexLabels();
+  }
+  std::vector<std::string> ListAllPossiblyPresentEdgeTypes() const {
+    return accessor_->ListAllPossiblyPresentEdgeTypes();
+  }
+
   storage::IndicesInfo ListAllIndices() const { return accessor_->ListAllIndices(); }
 
   storage::ConstraintsInfo ListAllConstraints() const { return accessor_->ListAllConstraints(); }

--- a/src/query/frontend/ast/ast.hpp
+++ b/src/query/frontend/ast/ast.hpp
@@ -2932,7 +2932,7 @@ class DatabaseInfoQuery : public memgraph::query::Query {
   static const utils::TypeInfo kType;
   const utils::TypeInfo &GetTypeInfo() const override { return kType; }
 
-  enum class InfoType { INDEX, CONSTRAINT };
+  enum class InfoType { INDEX, CONSTRAINT, EDGE_TYPES, NODE_LABELS };
 
   DEFVISITABLE(QueryVisitor<void>);
 

--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -124,6 +124,14 @@ antlrcpp::Any CypherMainVisitor::visitDatabaseInfoQuery(MemgraphCypher::Database
     info_query->info_type_ = DatabaseInfoQuery::InfoType::CONSTRAINT;
     return info_query;
   }
+  if (ctx->edgetypeInfo()) {
+    info_query->info_type_ = DatabaseInfoQuery::InfoType::EDGE_TYPES;
+    return info_query;
+  }
+  if (ctx->nodelabelInfo()) {
+    info_query->info_type_ = DatabaseInfoQuery::InfoType::NODE_LABELS;
+    return info_query;
+  }
   // Should never get here
   throw utils::NotYetImplemented("Database info query: '{}'", ctx->getText());
 }

--- a/src/query/frontend/opencypher/grammar/Cypher.g4
+++ b/src/query/frontend/opencypher/grammar/Cypher.g4
@@ -47,9 +47,13 @@ indexInfo : INDEX INFO ;
 
 constraintInfo : CONSTRAINT INFO ;
 
+edgetypeInfo : EDGE_TYPES INFO ;
+
+nodelabelInfo : NODE_LABELS INFO ;
+
 buildInfo : BUILD INFO ;
 
-databaseInfoQuery : SHOW ( indexInfo | constraintInfo ) ;
+databaseInfoQuery : SHOW ( indexInfo | constraintInfo | edgetypeInfo | nodelabelInfo ) ;
 
 systemInfoQuery : SHOW ( storageInfo | buildInfo ) ;
 

--- a/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
+++ b/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
@@ -61,6 +61,7 @@ memgraphCypherKeyword : cypherKeyword
                       | GRANT
                       | HEADER
                       | IDENTIFIED
+                      | NODE_LABELS
                       | NULLIF
                       | IMPORT
                       | INACTIVE

--- a/src/query/frontend/opencypher/grammar/MemgraphCypherLexer.g4
+++ b/src/query/frontend/opencypher/grammar/MemgraphCypherLexer.g4
@@ -89,6 +89,7 @@ MULTI_DATABASE_EDIT     : M U L T I UNDERSCORE D A T A B A S E UNDERSCORE E D I 
 MULTI_DATABASE_USE      : M U L T I UNDERSCORE D A T A B A S E UNDERSCORE U S E ;
 NEXT                    : N E X T ;
 NO                      : N O ;
+NODE_LABELS             : N O D E UNDERSCORE L A B E L S ;
 NOTHING                 : N O T H I N G ;
 ON_DISK_TRANSACTIONAL   : O N UNDERSCORE D I S K UNDERSCORE T R A N S A C T I O N A L ;
 NULLIF                  : N U L L I F ;

--- a/src/query/frontend/semantic/required_privileges.cpp
+++ b/src/query/frontend/semantic/required_privileges.cpp
@@ -38,6 +38,9 @@ class PrivilegeExtractor : public QueryVisitor<void>, public HierarchicalTreeVis
   void Visit(DatabaseInfoQuery &info_query) override {
     switch (info_query.info_type_) {
       case DatabaseInfoQuery::InfoType::INDEX:
+      // TODO: Reconsider priviliges, this 4 should have the same.
+      case DatabaseInfoQuery::InfoType::EDGE_TYPES:
+      case DatabaseInfoQuery::InfoType::NODE_LABELS:
         // TODO: This should be INDEX | STATS, but we don't have support for
         // *or* with privileges.
         AddPrivilege(AuthQuery::Privilege::INDEX);

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3076,6 +3076,38 @@ PreparedQuery PrepareDatabaseInfoQuery(ParsedQuery parsed_query, bool in_explici
       };
       break;
     }
+    case DatabaseInfoQuery::InfoType::EDGE_TYPES: {
+      header = {"edge types"};
+      handler = [storage = current_db.db_acc_->get()->storage(), dba] {
+        auto edge_types = dba->ListAllPossiblyPresentEdgeTypes();
+        std::vector<std::vector<TypedValue>> results;
+        results.reserve(edge_types.size());
+        for (auto &edge_type : edge_types) {
+          results.push_back({TypedValue(edge_type)});
+        }
+
+        return std::pair{results, QueryHandlerResult::COMMIT};
+      };
+
+      break;
+    }
+    case DatabaseInfoQuery::InfoType::NODE_LABELS: {
+      header = {"node labels"};
+      handler = [storage = current_db.db_acc_->get()->storage(), dba] {
+        auto node_labels = dba->ListAllPossiblyPresentVertexLabels();
+        std::vector<std::vector<TypedValue>> results;
+        results.reserve(node_labels.size());
+        for (auto &node_label : node_labels) {
+          results.push_back({TypedValue(node_label)});
+        }
+
+        return std::pair{results, QueryHandlerResult::COMMIT};
+      };
+
+      break;
+    }
+
+      // NODE_LABELS
   }
 
   return PreparedQuery{std::move(header), std::move(parsed_query.required_privileges),

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -944,6 +944,7 @@ Result<EdgeAccessor> DiskStorage::DiskAccessor::CreateEdge(VertexAccessor *from,
   transaction_.manyDeltasCache.Invalidate(from_vertex, edge_type, EdgeDirection::OUT);
   transaction_.manyDeltasCache.Invalidate(to_vertex, edge_type, EdgeDirection::IN);
 
+  storage_->stored_edge_types_.insert(edge_type);
   storage_->edge_count_.fetch_add(1, std::memory_order_acq_rel);
 
   return EdgeAccessor(edge, edge_type, from_vertex, to_vertex, storage_, &transaction_);

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -331,6 +331,7 @@ Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdge(VertexAccesso
     if (to_vertex->deleted) return Error::DELETED_OBJECT;
   }
 
+  storage_->stored_edge_types_.insert(edge_type);
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
   auto gid = storage::Gid::FromUint(mem_storage->edge_id_.fetch_add(1, std::memory_order_acq_rel));
   EdgeRef edge(gid);
@@ -394,6 +395,8 @@ Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdgeEx(VertexAcces
     if (!PrepareForWrite(&transaction_, to_vertex)) return Error::SERIALIZATION_ERROR;
     if (to_vertex->deleted) return Error::DELETED_OBJECT;
   }
+
+  storage_->stored_edge_types_.insert(edge_type);
 
   // NOTE: When we update the next `edge_id_` here we perform a RMW
   // (read-modify-write) operation that ISN'T atomic! But, that isn't an issue

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -122,6 +122,24 @@ std::optional<uint64_t> Storage::Accessor::GetTransactionId() const {
   return {};
 }
 
+std::vector<std::string> Storage::Accessor::ListAllPossiblyPresentVertexLabels() const {
+  std::vector<std::string> vertex_labels;
+  vertex_labels.reserve(storage_->stored_node_labels_.size());
+  for (const auto label : storage_->stored_node_labels_) {
+    vertex_labels.emplace_back(LabelToName(label));
+  }
+  return vertex_labels;
+}
+
+std::vector<std::string> Storage::Accessor::ListAllPossiblyPresentEdgeTypes() const {
+  std::vector<std::string> edge_types;
+  edge_types.reserve(storage_->stored_edge_types_.size());
+  for (const auto edge_type : storage_->stored_edge_types_) {
+    edge_types.emplace_back(EdgeTypeToName(edge_type));
+  }
+  return edge_types;
+}
+
 void Storage::Accessor::AdvanceCommand() {
   transaction_.manyDeltasCache.Clear();  // TODO: Just invalidate the View::OLD cache, NEW should still be fine
   ++transaction_.command_id;

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -237,6 +237,10 @@ class Storage {
 
     const std::string &id() const { return storage_->id(); }
 
+    std::vector<std::string> ListAllPossiblyPresentVertexLabels() const;
+
+    std::vector<std::string> ListAllPossiblyPresentEdgeTypes() const;
+
     virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(LabelId label) = 0;
 
     virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(LabelId label, PropertyId property) = 0;
@@ -383,6 +387,18 @@ class Storage {
 
   Indices indices_;
   Constraints constraints_;
+
+  // Datastructures to provide fast retrieval of node-label and
+  // edge-type related metadata.
+  // Currently we should not remove any node-labels or edge-types even
+  // if the set of given types are currently not present in the
+  // database. This metadata is usually used by client side
+  // applications that want to be aware of the kind of data that *may*
+  // be present in the database.
+
+  // TODO(gvolfing): check if this would be faster with flat_maps.
+  std::unordered_set<LabelId> stored_node_labels_;
+  std::unordered_set<EdgeTypeId> stored_edge_types_;
 
   std::atomic<uint64_t> vertex_id_{0};
   std::atomic<uint64_t> edge_id_{0};

--- a/src/storage/v2/vertex_accessor.cpp
+++ b/src/storage/v2/vertex_accessor.cpp
@@ -109,6 +109,7 @@ Result<bool> VertexAccessor::AddLabel(LabelId label) {
 
   CreateAndLinkDelta(transaction_, vertex_, Delta::RemoveLabelTag(), label);
   vertex_->labels.push_back(label);
+  storage_->stored_node_labels_.insert(label);
 
   /// TODO: some by pointers, some by reference => not good, make it better
   storage_->constraints_.unique_constraints_->UpdateOnAddLabel(label, *vertex_, transaction_->start_timestamp);


### PR DESCRIPTION
Users have requested a way to be able to retrieve the node-labels and edge-types inside Memgraph in constant time. This PR provides a way of doing that.

Two queries has been added
 - SHOW NODE_LABELS INFO
 - SHOW EDGE_TYPES INFO

to retrieve the list of labels on nodes and types of edges respectively.
