### PR TITLE
Add stress test without verification

### DIFF
--- a/tests/stress/test_config.py
+++ b/tests/stress/test_config.py
@@ -90,6 +90,12 @@ SMALL_DATASET = [
         DatasetConstants.MODE: [get_default_database_mode()],
     },
     {
+        DatasetConstants.TEST: "match_create_delete.py",
+        DatasetConstants.OPTIONS: [],
+        DatasetConstants.TIMEOUT: 5,
+        DatasetConstants.MODE: [get_default_database_mode()],
+    },
+    {
         DatasetConstants.TEST: "parser.cpp",
         DatasetConstants.OPTIONS: ["--per-worker-query-count", "1000"],
         DatasetConstants.TIMEOUT: 5,
@@ -150,6 +156,12 @@ LARGE_DATASET = (
         {
             DatasetConstants.TEST: "create_match.py",
             DatasetConstants.OPTIONS: ["--vertex-count", "500000", "--create-pack-size", "500"],
+            DatasetConstants.TIMEOUT: 30,
+            DatasetConstants.MODE: [get_default_database_mode()],
+        },
+        {
+            DatasetConstants.TEST: "match_create_delete.py",
+            DatasetConstants.OPTIONS: ["--repetition-count", "3000000"],
             DatasetConstants.TIMEOUT: 30,
             DatasetConstants.MODE: [get_default_database_mode()],
         },


### PR DESCRIPTION
The stress test creates a supernode subgraph, matches the edge count and deletes a certain subgraph in the database repeatedly to see how Memgraph performs in a high load environment.

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments
