### PR TITLE
Fix aggregations automatically from match return

### DIFF
--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -187,6 +187,8 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
 
   utils::MemoryResource *GetMemoryResource() const { return ctx_->memory; }
 
+  void ResetPropertyLookupCache() { property_lookup_cache_.clear(); }
+
   TypedValue Visit(NamedExpression &named_expression) override {
     const auto &symbol = symbol_table_->at(named_expression);
     auto value = named_expression.expression_->Accept(*this);

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -3619,6 +3619,7 @@ class AggregateCursor : public Cursor {
   void ProcessOne(const Frame &frame, ExpressionEvaluator *evaluator) {
     // Preallocated group_by, since most of the time the aggregation key won't be unique
     reused_group_by_.clear();
+    evaluator->ResetPropertyLookupCache();
 
     for (Expression *expression : self_.group_by_) {
       reused_group_by_.emplace_back(expression->Accept(*evaluator));

--- a/tests/gql_behave/tests/memgraph_V1/features/aggregations.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/aggregations.feature
@@ -426,5 +426,37 @@ Feature: Aggregations
       MATCH (subnet:Subnet) WHERE FALSE WITH subnet, count(subnet.ip) as ips RETURN id(subnet) as id
       """
       Then the result should be:
-        | id |
-        | null  |
+        | id   |
+        | null |
+
+    Scenario: Count directly without WITH clause 01
+      Given an empty graph
+      And having executed
+          """
+          CREATE (:Node {prop1: 1, prop2: 2, prop3: 3}), (:Node {prop1: 10, prop2: 11, prop3: 12}), (:Node {prop1: 20, prop2: 21, prop3: 22})
+          """
+      When executing query:
+      """
+      MATCH (n) RETURN n.prop1, n.prop2, n.prop3, count(*) AS cnt
+      """
+      Then the result should be:
+        | n.prop1 | n.prop2 | n.prop3 | cnt |
+        | 20      | 21      | 22      | 1   |
+        | 10      | 11      | 12      | 1   |
+        | 1       | 2       | 3       | 1   |
+
+    Scenario: Count directly without WITH clause 02
+      Given an empty graph
+      And having executed
+          """
+          CREATE (:Node {prop1: 1, prop2: 2, prop3: 3}), (:Node {prop1: 10, prop2: 11, prop3: 12}), (:Node {prop1: 20, prop2: 21, prop3: 22})
+          """
+      When executing query:
+      """
+      MATCH (n) WITH n.prop1 AS prop1, n.prop2 AS prop2, n.prop3 AS prop3 RETURN prop1, prop2, prop3, count(*) AS cnt;
+      """
+      Then the result should be:
+        | prop1 | prop2 | prop3 | cnt |
+        | 20    | 21    | 22    | 1   |
+        | 10    | 11    | 12    | 1   |
+        | 1     | 2     | 3     | 1   |

--- a/tests/gql_behave/tests/memgraph_V1_on_disk/features/aggregations.feature
+++ b/tests/gql_behave/tests/memgraph_V1_on_disk/features/aggregations.feature
@@ -426,5 +426,37 @@ Feature: Aggregations
       MATCH (subnet:Subnet) WHERE FALSE WITH subnet, count(subnet.ip) as ips RETURN id(subnet) as id
       """
       Then the result should be:
-        | id |
-        | null  |
+        | id   |
+        | null |
+
+    Scenario: Count directly without WITH clause 01
+      Given an empty graph
+      And having executed
+          """
+          CREATE (:Node {prop1: 1, prop2: 2, prop3: 3}), (:Node {prop1: 10, prop2: 11, prop3: 12}), (:Node {prop1: 20, prop2: 21, prop3: 22})
+          """
+      When executing query:
+      """
+      MATCH (n) RETURN n.prop1, n.prop2, n.prop3, count(*) AS cnt
+      """
+      Then the result should be:
+        | n.prop1 | n.prop2 | n.prop3 | cnt |
+        | 20      | 21      | 22      | 1   |
+        | 10      | 11      | 12      | 1   |
+        | 1       | 2       | 3       | 1   |
+
+    Scenario: Count directly without WITH clause 02
+      Given an empty graph
+      And having executed
+          """
+          CREATE (:Node {prop1: 1, prop2: 2, prop3: 3}), (:Node {prop1: 10, prop2: 11, prop3: 12}), (:Node {prop1: 20, prop2: 21, prop3: 22})
+          """
+      When executing query:
+      """
+      MATCH (n) WITH n.prop1 AS prop1, n.prop2 AS prop2, n.prop3 AS prop3 RETURN prop1, prop2, prop3, count(*) AS cnt;
+      """
+      Then the result should be:
+        | prop1 | prop2 | prop3 | cnt |
+        | 20    | 21    | 22    | 1   |
+        | 10    | 11    | 12    | 1   |
+        | 1     | 2     | 3     | 1   |


### PR DESCRIPTION
The PR fixes issue https://github.com/memgraph/memgraph/issues/1517

[master < Task] PR
- [X] Check, and update documentation if necessary
- [X] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [X] Write a release note here, including added/changed clauses
- [X] Tag someone from docs team in the comments

@vpavicic : Changelog: Fixed bug when matching and immediately returning grouped aggregations.
