### PR TITLE
Fix flaky gc test

### DIFF
--- a/tests/e2e/garbage_collection/gc_periodic.py
+++ b/tests/e2e/garbage_collection/gc_periodic.py
@@ -49,7 +49,7 @@ def test_gc_periodic(connection):
     memory_pre_creation = get_memory(cursor)
     execute_and_fetch_all(cursor, "UNWIND range(1, 1000) AS index CREATE (:Node);")
     memory_after_creation = get_memory(cursor)
-    time.sleep(2)
+    time.sleep(5)
     memory_after_gc = get_memory(cursor)
 
     assert memory_after_gc < memory_pre_creation + (memory_after_creation - memory_pre_creation) / 4 * 3


### PR DESCRIPTION
Make gc test go through 2 cycles instead of 1 to make it not flaky.

[master < Epic] PR
- [ ] Check, and update documentation if necessary
- [ ] Write E2E tests
- [ ] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch and the Epic branch
- [ ] Provide the full content or a guide for the final git message

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments
