### PR TITLE
Fix unresolved host errors

### DIFF
--- a/libs/setup.sh
+++ b/libs/setup.sh
@@ -259,7 +259,7 @@ repo_clone_try_double "${primary_urls[absl]}" "${secondary_urls[absl]}" "absl" "
 
 # jemalloc ea6b3e973b477b8061e0076bb257dbd7f3faa756
 JEMALLOC_COMMIT_VERSION="5.2.1"
-repo_clone_try_double "${secondary_urls[jemalloc]}" "${secondary_urls[jemalloc]}" "jemalloc" "$JEMALLOC_COMMIT_VERSION"
+repo_clone_try_double "${primary_urls[jemalloc]}" "${secondary_urls[jemalloc]}" "jemalloc" "$JEMALLOC_COMMIT_VERSION"
 
 # this is hack for cmake in libs to set path, and for FindJemalloc to use Jemalloc_INCLUDE_DIR
 pushd jemalloc


### PR DESCRIPTION
Example:
* https://github.com/memgraph/memgraph/actions/runs/7113635425/job/19366009223

```
Cloning primary from https://github.com/jemalloc/jemalloc.git secondary from https://github.com/jemalloc/jemalloc.git
Cloning from https://github.com/jemalloc/jemalloc.git
Cloning into 'jemalloc'...
fatal: unable to access 'https://github.com/jemalloc/jemalloc.git/': Could not resolve host: github.com
```

As visible above, the primary URL (which should link to the local dependency cache) was by mistake identical to the secondary (“live”) one.

[master < Task] PR
- [x] Check, and update documentation if necessary
- [x] Provide the full content or a guide for the final git message
> Fix unresolved host errors

To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments
