### PR TITLE
Allow clang compilers with different names

### DIFF
--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -32,7 +32,7 @@ jobs:
 
           # Build only memgraph release binaries.
           cd build
-          cmake -DCMAKE_BUILD_TYPE=release ..
+          CC=clang CXX=clang++ cmake -DCMAKE_BUILD_TYPE=release ..
           make -j$THREADS
 
       - name: Run macro benchmarks

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -43,7 +43,7 @@ jobs:
 
           # Build community binaries.
           cd build
-          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMG_ENTERPRISE=OFF ..
+          CC=clang CXX=clang++ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMG_ENTERPRISE=OFF ..
           make -j$THREADS
 
       - name: Run unit tests
@@ -111,7 +111,7 @@ jobs:
           source /opt/toolchain-v4/activate
 
           cd build
-          cmake -DTEST_COVERAGE=ON -DASAN=ON -DUBSAN=ON ..
+          CC=clang CXX=clang++ cmake -DTEST_COVERAGE=ON -DASAN=ON -DUBSAN=ON ..
           make -j$THREADS memgraph__unit
 
       - name: Run unit tests
@@ -178,7 +178,7 @@ jobs:
 
           # Build debug binaries.
           cd build
-          cmake ..
+          CC=clang CXX=clang++ cmake ..
           make -j$THREADS
 
       - name: Run leftover CTest tests
@@ -240,7 +240,7 @@ jobs:
 
           # Build release binaries.
           cd build
-          cmake -DCMAKE_BUILD_TYPE=Release ..
+          CC=clang CXX=clang++ cmake -DCMAKE_BUILD_TYPE=Release ..
           make -j$THREADS
 
       - name: Run GQL Behave tests
@@ -362,7 +362,7 @@ jobs:
           ./init
           # Build only memgraph release binarie.
           cd build
-          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+          CC=clang CXX=clang++ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
           make -j$THREADS memgraph
 
       - name: Run Jepsen tests
@@ -403,7 +403,7 @@ jobs:
 
           # Build only memgraph release binaries.
           cd build
-          cmake -DCMAKE_BUILD_TYPE=release ..
+          CC=clang CXX=clang++ cmake -DCMAKE_BUILD_TYPE=release ..
           make -j$THREADS
 
       - name: Run macro benchmarks

--- a/.github/workflows/full_clang_tidy.yaml
+++ b/.github/workflows/full_clang_tidy.yaml
@@ -31,7 +31,7 @@ jobs:
           # Build debug binaries.
 
           cd build
-          cmake ..
+          CC=clang CXX=clang++ cmake ..
           make -j$THREADS
 
       - name: Run clang-tidy

--- a/.github/workflows/performance_benchmarks.yaml
+++ b/.github/workflows/performance_benchmarks.yaml
@@ -30,7 +30,7 @@ jobs:
 
           # Build only memgraph release binaries.
           cd build
-          cmake -DCMAKE_BUILD_TYPE=release ..
+          CC=clang CXX=clang++ cmake -DCMAKE_BUILD_TYPE=release ..
           make -j$THREADS
 
       - name: Get branch name (merge)

--- a/.github/workflows/release_debian10.yaml
+++ b/.github/workflows/release_debian10.yaml
@@ -46,7 +46,7 @@ jobs:
 
           # Build community binaries.
           cd build
-          cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DMG_ENTERPRISE=OFF ..
+          CC=clang CXX=clang++ cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DMG_ENTERPRISE=OFF ..
           make -j$THREADS
 
       - name: Run unit tests
@@ -84,7 +84,7 @@ jobs:
 
           # Build coverage binaries.
           cd build
-          cmake -DTEST_COVERAGE=ON ..
+          CC=clang CXX=clang++ cmake -DTEST_COVERAGE=ON ..
           make -j$THREADS memgraph__unit
 
       - name: Run unit tests
@@ -141,7 +141,7 @@ jobs:
 
           # Build debug binaries.
           cd build
-          cmake ..
+          CC=clang CXX=clang++ cmake ..
           make -j$THREADS
 
       - name: Run leftover CTest tests
@@ -207,7 +207,7 @@ jobs:
 
           # Build release binaries.
           cd build
-          cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
+          CC=clang CXX=clang++ cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
           make -j$THREADS
 
       - name: Create enterprise DEB package
@@ -346,7 +346,7 @@ jobs:
 
           # Build only memgraph release binary.
           cd build
-          cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
+          CC=clang CXX=clang++ cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
           make -j$THREADS memgraph
 
       - name: Run Jepsen tests

--- a/.github/workflows/release_ubuntu2004.yaml
+++ b/.github/workflows/release_ubuntu2004.yaml
@@ -46,7 +46,7 @@ jobs:
 
           # Build community binaries.
           cd build
-          cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DMG_ENTERPRISE=OFF ..
+          CC=clang CXX=clang++ cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DMG_ENTERPRISE=OFF ..
           make -j$THREADS
 
       - name: Run unit tests
@@ -84,7 +84,7 @@ jobs:
 
           # Build coverage binaries.
           cd build
-          cmake -DTEST_COVERAGE=ON ..
+          CC=clang CXX=clang++ cmake -DTEST_COVERAGE=ON ..
           make -j$THREADS memgraph__unit
 
       - name: Run unit tests
@@ -141,7 +141,7 @@ jobs:
 
           # Build debug binaries.
           cd build
-          cmake ..
+          CC=clang CXX=clang++ cmake ..
           make -j$THREADS
 
       - name: Run leftover CTest tests
@@ -207,7 +207,7 @@ jobs:
 
           # Build release binaries.
           cd build
-          cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
+          CC=clang CXX=clang++ cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
           make -j$THREADS
 
       - name: Create enterprise DEB package

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,20 +27,13 @@ else ()
   message(STATUS "CCache: Not used")
 endif(CCACHE_FOUND AND USE_CCACHE)
 
-# choose a compiler
-# NOTE: must be choosen before use of project() or enable_language()
-find_program(CLANG_FOUND clang)
-find_program(CLANGXX_FOUND clang++)
-if (CLANG_FOUND AND CLANGXX_FOUND)
-  set(CMAKE_C_COMPILER ${CLANG_FOUND})
-  set(CMAKE_CXX_COMPILER ${CLANGXX_FOUND})
-else()
-  message(FATAL_ERROR "Couldn't find clang and/or clang++!")
-endif()
-
 # -----------------------------------------------------------------------------
 
 project(memgraph LANGUAGES C CXX)
+
+if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    message(FATAL_ERROR "Clang compiler is required")
+endif()
 
 #TODO: upgrade to cmake 3.24 + CheckIPOSupported
 #cmake_policy(SET CMP0138 NEW)


### PR DESCRIPTION
Rather than inspect for exactly binary name of "clang", check the compiler ID instead.