### PR TITLE
Extend ToBoolean function so it casts "t" to true and "f" to false.

### DIFF
--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2024 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -504,8 +504,8 @@ TypedValue ToBoolean(const TypedValue *args, int64_t nargs, const FunctionContex
     return TypedValue(value.ValueInt() != 0L, ctx.memory);
   } else {
     auto s = utils::ToUpperCase(utils::Trim(value.ValueString()));
-    if (s == "TRUE") return TypedValue(true, ctx.memory);
-    if (s == "FALSE") return TypedValue(false, ctx.memory);
+    if (s == "TRUE" || s == "T") return TypedValue(true, ctx.memory);
+    if (s == "FALSE" || s == "F") return TypedValue(false, ctx.memory);
     // I think this is just stupid and that exception should be thrown, but
     // neo4j does it this way...
     return TypedValue(ctx.memory);

--- a/tests/gql_behave/tests/memgraph_V1/features/functions.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/functions.feature
@@ -60,6 +60,34 @@ Feature: Functions
             | false |
             | true  |
 
+    Scenario: ToBoolean test 03:
+        Given an empty graph
+        And having executed
+            """
+            CREATE (:Node {prop: ToBoolean("t")});
+            """
+        When executing query:
+            """
+            MATCH (n:Node) RETURN n.prop;
+            """
+        Then the result should be:
+            | n.prop |
+            | true   |
+
+    Scenario: ToBoolean test 03:
+        Given an empty graph
+        And having executed
+            """
+            CREATE (:Node {prop: ToBoolean("f")});
+            """
+        When executing query:
+            """
+            MATCH (n:Node) RETURN n.prop;
+            """
+        Then the result should be:
+            | n.prop |
+            | false  |
+
     Scenario: ToInteger test 01:
         Given an empty graph
         And having executed


### PR DESCRIPTION
User from community requested this extension for ToBoolean function. Since, e.g., postgresql COPY to CSV will record true values as "t" and false values as "f". 
We also might need to update documentation so it's clear what values ToBoolean casts to true or false.

[master < Task] PR
- [x] Check, and update documentation if necessary
- [x] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [x] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments

Release note: Strings "t" and "f" are now resolved into true and false.

closes #1538 
