### PR TITLE
Fix using path in property value after CREATE

### DIFF
--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2024 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -380,6 +380,7 @@ class RuleBasedPlanner {
     if (pattern.identifier_->user_declared_) {
       std::vector<Symbol> path_elements;
       for (const PatternAtom *atom : pattern.atoms_) path_elements.emplace_back(symbol_table.at(*atom->identifier_));
+      bound_symbols.insert(symbol_table.at(*pattern.identifier_));
       last_op = std::make_unique<ConstructNamedPath>(std::move(last_op), symbol_table.at(*pattern.identifier_),
                                                      path_elements);
     }

--- a/tests/gql_behave/tests/memgraph_V1/features/match.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/match.feature
@@ -771,3 +771,17 @@ Feature: Match
         Then the result should be:
             | path                                        |
             | <(:label1 {id: 1})-[:type1 {id: 1}]->(:label2 {id: 2})-[:type1 {id: 2}]->(:label3 {id: 3})> |
+
+    Scenario: Using path indentifier from CREATE in MERGE
+        Given an empty graph
+        And having executed:
+            """
+            CREATE p0=()-[:T0]->() MERGE ({k:(size(p0))});
+            """
+        When executing query:
+            """
+            MATCH (n {k: 1}) RETURN n;
+            """
+        Then the result should be:
+            | n        |
+            | ({k: 1}) |


### PR DESCRIPTION
Next query would crash database:
`CREATE p0=()-[:T0]->() MERGE ({k:(size(p0))}) RETURN 1`
Problem is that Memgraph isn't updating bound symbols with path identifiers in CREATE. Mentioned problem will be resolved with this PR. 

[master < Task] PR
- [x] Check, and update documentation if necessary
- [x] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [x] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments

Release note: It's possible to use path identifier from CREATE clause in other parts of the query.

closes #1331 