### PR TITLE
Change auth durability to store hash algorithm

### DIFF
--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -13,6 +13,7 @@
 
 #include <fmt/format.h>
 
+#include "auth/crypto.hpp"
 #include "auth/exceptions.hpp"
 #include "license/license.hpp"
 #include "utils/flag_validation.hpp"
@@ -43,6 +44,7 @@ namespace memgraph::auth {
 const std::string kUserPrefix = "user:";
 const std::string kRolePrefix = "role:";
 const std::string kLinkPrefix = "link:";
+const std::string kVersion = "version";
 
 /**
  * All data stored in the `Auth` storage is stored in an underlying
@@ -61,8 +63,57 @@ const std::string kLinkPrefix = "link:";
  * key="link:<username>", value="<rolename>"
  */
 
+namespace {
+void MigrateVersions(kvstore::KVStore &store) {
+  auto version_str = store.Get(kVersion);
+
+  if (!version_str) {
+    using namespace std::string_literals;
+
+    // pre versioning, add version to the store
+    auto puts = std::map<std::string, std::string>{{kVersion, "V1"}};
+
+    // also add hash kind into durability
+
+    auto it = store.begin(kUserPrefix);
+    auto const e = store.end(kUserPrefix);
+
+    if (it != e) {
+      const auto hash_algo = CurrentEncryptionAlgorithm();
+      spdlog::info("Updating auth durability, assuming previously stored as {}", AsString(hash_algo));
+
+      for (; it != e; ++it) {
+        auto const &[key, value] = *it;
+        try {
+          auto user_data = nlohmann::json::parse(value);
+          auto password_hash = user_data["password_hash"];
+          if (!password_hash.is_string()) {
+            throw AuthException("Couldn't load user data!");
+          }
+          // upgrade the password_hash to include the hash algortihm
+          if (password_hash.empty()) {
+            user_data["password_hash"] = nullptr;
+          } else {
+            user_data["password_hash"] = HashedPassword{hash_algo, password_hash};
+          }
+          puts.emplace(key, user_data.dump());
+        } catch (const nlohmann::json::parse_error &e) {
+          throw AuthException("Couldn't load user data!");
+        }
+      }
+    }
+
+    // Perform migration to V1
+    store.PutMultiple(puts);
+    version_str = "V1";
+  }
+}
+};  // namespace
+
 Auth::Auth(std::string storage_directory, Config config)
-    : storage_(std::move(storage_directory)), module_(FLAGS_auth_module_executable), config_{std::move(config)} {}
+    : storage_(std::move(storage_directory)), module_(FLAGS_auth_module_executable), config_{std::move(config)} {
+  MigrateVersions(storage_);
+}
 
 std::optional<User> Auth::Authenticate(const std::string &username, const std::string &password) {
   if (module_.IsUsed()) {

--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -82,7 +82,7 @@ void MigrateVersions(kvstore::KVStore &store) {
     auto const e = store.end(kUserPrefix);
 
     if (it != e) {
-      const auto hash_algo = CurrentEncryptionAlgorithm();
+      const auto hash_algo = CurrentHashAlgorithm();
       spdlog::info("Updating auth durability, assuming previously stored as {}", AsString(hash_algo));
 
       for (; it != e; ++it) {
@@ -208,6 +208,10 @@ std::optional<User> Auth::Authenticate(const std::string &username, const std::s
                                           username, "https://memgr.ph/auth"));
       return std::nullopt;
     }
+    if (user->UpgradeHash(password)) {
+      SaveUser(*user);
+    }
+
     return user;
   }
 }

--- a/src/auth/crypto.cpp
+++ b/src/auth/crypto.cpp
@@ -147,8 +147,8 @@ bool VerifyPassword(const std::string &password, const std::string &hash, const 
 }
 }  // namespace SHA
 
-HashedPassword EncryptPassword(const std::string &password) {
-  auto const hash_algo = CurrentEncryptionAlgorithm();
+HashedPassword EncryptPassword(const std::string &password, std::optional<PasswordHashAlgorithm> override_algo) {
+  auto const hash_algo = override_algo.value_or(CurrentEncryptionAlgorithm());
   auto password_hash = std::invoke([&] {
     switch (hash_algo) {
       case PasswordHashAlgorithm::BCRYPT:

--- a/src/auth/crypto.hpp
+++ b/src/auth/crypto.hpp
@@ -16,11 +16,11 @@ namespace memgraph::auth {
 /// Need to be stable, auth durability depends on this
 enum class PasswordHashAlgorithm : uint8_t { BCRYPT = 0, SHA256 = 1, SHA256_MULTIPLE = 2 };
 
-void SetEncryptionAlgorithm(std::string const &algo);
+void SetHashAlgorithm(std::string_view algo);
 
-auto CurrentEncryptionAlgorithm() -> PasswordHashAlgorithm;
+auto CurrentHashAlgorithm() -> PasswordHashAlgorithm;
 
-auto AsString(PasswordHashAlgorithm enc_algo) -> std::string_view;
+auto AsString(PasswordHashAlgorithm hash_algo) -> std::string_view;
 
 struct HashedPassword {
   HashedPassword() = default;
@@ -35,6 +35,10 @@ struct HashedPassword {
 
   bool VerifyPassword(const std::string &password);
 
+  bool IsSalted() const;
+
+  auto HashAlgo() const -> PasswordHashAlgorithm { return hash_algo; }
+
   friend void to_json(nlohmann::json &j, const HashedPassword &p);
   friend void from_json(const nlohmann::json &j, HashedPassword &p);
 
@@ -43,9 +47,6 @@ struct HashedPassword {
   std::string password_hash{};
 };
 
-/// @throw AuthException if unable to encrypt the password.
-HashedPassword EncryptPassword(const std::string &password, std::optional<PasswordHashAlgorithm> override_algo = {});
-
-/// @throw AuthException if unable to verify the password.
-bool VerifyPassword(const std::string &password, const HashedPassword &hash);
+/// @throw AuthException if unable to hash the password.
+HashedPassword HashPassword(const std::string &password, std::optional<PasswordHashAlgorithm> override_algo = {});
 }  // namespace memgraph::auth

--- a/src/auth/crypto.hpp
+++ b/src/auth/crypto.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <json/json.hpp>
+#include <optional>
 #include <string>
 
 namespace memgraph::auth {
@@ -34,16 +35,16 @@ struct HashedPassword {
 
   bool VerifyPassword(const std::string &password);
 
+  friend void to_json(nlohmann::json &j, const HashedPassword &p);
+  friend void from_json(const nlohmann::json &j, HashedPassword &p);
+
  private:
   PasswordHashAlgorithm hash_algo{PasswordHashAlgorithm::BCRYPT};
   std::string password_hash{};
-
-  friend void to_json(nlohmann::json &j, const HashedPassword &p);
-  friend void from_json(const nlohmann::json &j, HashedPassword &p);
 };
 
 /// @throw AuthException if unable to encrypt the password.
-HashedPassword EncryptPassword(const std::string &password);
+HashedPassword EncryptPassword(const std::string &password, std::optional<PasswordHashAlgorithm> override_algo = {});
 
 /// @throw AuthException if unable to verify the password.
 bool VerifyPassword(const std::string &password, const HashedPassword &hash);

--- a/src/auth/crypto.hpp
+++ b/src/auth/crypto.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2024 Memgraph Ltd.
 //
 // Licensed as a Memgraph Enterprise file under the Memgraph Enterprise
 // License (the "License"); by using this file, you agree to be bound by the terms of the License, and you may not use
@@ -8,14 +8,43 @@
 
 #pragma once
 
+#include <json/json.hpp>
 #include <string>
 
 namespace memgraph::auth {
-enum class PasswordEncryptionAlgorithm : uint8_t { BCRYPT, SHA256, SHA256_MULTIPLE };
+/// Need to be stable, auth durability depends on this
+enum class PasswordHashAlgorithm : uint8_t { BCRYPT = 0, SHA256 = 1, SHA256_MULTIPLE = 2 };
+
+void SetEncryptionAlgorithm(std::string const &algo);
+
+auto CurrentEncryptionAlgorithm() -> PasswordHashAlgorithm;
+
+auto AsString(PasswordHashAlgorithm enc_algo) -> std::string_view;
+
+struct HashedPassword {
+  HashedPassword() = default;
+  HashedPassword(PasswordHashAlgorithm hash_algo, std::string password_hash)
+      : hash_algo{hash_algo}, password_hash{std::move(password_hash)} {}
+  HashedPassword(HashedPassword const &) = default;
+  HashedPassword(HashedPassword &&) = default;
+  HashedPassword &operator=(HashedPassword const &) = default;
+  HashedPassword &operator=(HashedPassword &&) = default;
+
+  friend bool operator==(HashedPassword const &, HashedPassword const &) = default;
+
+  bool VerifyPassword(const std::string &password);
+
+ private:
+  PasswordHashAlgorithm hash_algo{PasswordHashAlgorithm::BCRYPT};
+  std::string password_hash{};
+
+  friend void to_json(nlohmann::json &j, const HashedPassword &p);
+  friend void from_json(const nlohmann::json &j, HashedPassword &p);
+};
 
 /// @throw AuthException if unable to encrypt the password.
-std::string EncryptPassword(const std::string &password);
+HashedPassword EncryptPassword(const std::string &password);
 
 /// @throw AuthException if unable to verify the password.
-bool VerifyPassword(const std::string &password, const std::string &hash);
+bool VerifyPassword(const std::string &password, const HashedPassword &hash);
 }  // namespace memgraph::auth

--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -588,12 +588,13 @@ bool User::CheckPassword(const std::string &password) {
   return password_hash_ ? password_hash_->VerifyPassword(password) : true;
 }
 
-void User::UpdatePassword(const std::optional<std::string> &password) {
+void User::UpdatePassword(const std::optional<std::string> &password,
+                          std::optional<PasswordHashAlgorithm> algo_override) {
   if (!password) {
     password_hash_.reset();
     return;
   }
-  password_hash_ = EncryptPassword(*password);
+  password_hash_ = HashPassword(*password, algo_override);
 }
 
 void User::SetRole(const Role &role) { role_.emplace(role); }

--- a/src/auth/models.hpp
+++ b/src/auth/models.hpp
@@ -15,6 +15,7 @@
 
 #include <json/json.hpp>
 #include <utility>
+#include "crypto.hpp"
 #include "dbms/constants.hpp"
 #include "utils/logging.hpp"
 
@@ -332,9 +333,9 @@ class User final {
   User();
 
   explicit User(const std::string &username);
-  User(const std::string &username, std::string password_hash, const Permissions &permissions);
+  User(const std::string &username, std::optional<HashedPassword> password_hash, const Permissions &permissions);
 #ifdef MG_ENTERPRISE
-  User(const std::string &username, std::string password_hash, const Permissions &permissions,
+  User(const std::string &username, std::optional<HashedPassword> password_hash, const Permissions &permissions,
        FineGrainedAccessHandler fine_grained_access_handler, Databases db_access = {});
 #endif
   User(const User &) = default;
@@ -382,7 +383,7 @@ class User final {
 
  private:
   std::string username_;
-  std::string password_hash_;
+  std::optional<HashedPassword> password_hash_;
   Permissions permissions_;
 #ifdef MG_ENTERPRISE
   FineGrainedAccessHandler fine_grained_access_handler_;

--- a/src/auth/models.hpp
+++ b/src/auth/models.hpp
@@ -347,8 +347,18 @@ class User final {
   /// @throw AuthException if unable to verify the password.
   bool CheckPassword(const std::string &password);
 
+  bool UpgradeHash(const std::string password) {
+    if (!password_hash_) return false;
+    if (password_hash_->IsSalted()) return false;
+
+    auto const algo = password_hash_->HashAlgo();
+    UpdatePassword(password, algo);
+    return true;
+  }
+
   /// @throw AuthException if unable to set the password.
-  void UpdatePassword(const std::optional<std::string> &password = std::nullopt);
+  void UpdatePassword(const std::optional<std::string> &password = {},
+                      std::optional<PasswordHashAlgorithm> algo_override = std::nullopt);
 
   void SetRole(const Role &role);
 

--- a/src/utils/enum.hpp
+++ b/src/utils/enum.hpp
@@ -55,6 +55,18 @@ std::optional<Enum> StringToEnum(const auto &value, const auto &mappings) {
   return mapping_iter->second;
 }
 
+// Tries to convert a enum into string, which would then contain a value if the conversion
+// has been successful.
+template <typename Enum>
+auto EnumToString(const auto &value, const auto &mappings) -> std::optional<std::string_view> {
+  const auto mapping_iter =
+      std::find_if(mappings.begin(), mappings.end(), [&](const auto &mapping) { return mapping.second == value; });
+  if (mapping_iter == mappings.cend()) {
+    return std::nullopt;
+  }
+  return mapping_iter->first;
+}
+
 template <typename T, typename Enum>
 requires std::integral<T>
 inline T EnumToNum(Enum res) {

--- a/tests/unit/auth.cpp
+++ b/tests/unit/auth.cpp
@@ -994,3 +994,14 @@ TEST_F(AuthWithStorageWithVariousEncryptionAlgorithms, AddUserSha256_1024) {
   ASSERT_TRUE(user);
   ASSERT_EQ(user->username(), "alice");
 }
+
+TEST(Serialize, HashedPassword) {
+  for (auto algo :
+       {PasswordHashAlgorithm::BCRYPT, PasswordHashAlgorithm::SHA256, PasswordHashAlgorithm::SHA256_MULTIPLE}) {
+    auto sut = EncryptPassword("password", algo);
+    nlohmann::json j = sut;
+    auto ret = j.get<HashedPassword>();
+    ASSERT_EQ(sut, ret);
+    ASSERT_TRUE(ret.VerifyPassword("password"));
+  }
+}

--- a/tests/unit/auth.cpp
+++ b/tests/unit/auth.cpp
@@ -666,6 +666,17 @@ TEST(AuthWithoutStorage, UserSerializeDeserialize) {
   ASSERT_EQ(user, output);
 }
 
+TEST(AuthWithoutStorage, UserSerializeDeserializeWithOutPassword) {
+  auto user = User("test");
+  user.permissions().Grant(Permission::MATCH);
+  user.permissions().Deny(Permission::MERGE);
+
+  auto data = user.Serialize();
+
+  auto output = User::Deserialize(data);
+  ASSERT_EQ(user, output);
+}
+
 TEST(AuthWithoutStorage, RoleSerializeDeserialize) {
   auto role = Role("test");
   role.permissions().Grant(Permission::MATCH);

--- a/tests/unit/auth.cpp
+++ b/tests/unit/auth.cpp
@@ -727,7 +727,7 @@ TEST(AuthWithoutStorage, CaseInsensitivity) {
   {
     auto perms = Permissions();
     auto fine_grained_access_handler = FineGrainedAccessHandler();
-    auto passwordHash = EncryptPassword("pw");
+    auto passwordHash = HashPassword("pw");
     auto user1 = User("test", passwordHash, perms, fine_grained_access_handler);
     auto user2 = User("Test", passwordHash, perms, fine_grained_access_handler);
     ASSERT_EQ(user1, user2);
@@ -932,49 +932,49 @@ TEST_F(AuthWithStorage, CaseInsensitivity) {
 }
 
 TEST(AuthWithoutStorage, Crypto) {
-  auto hash = EncryptPassword("hello");
+  auto hash = HashPassword("hello");
   ASSERT_TRUE(hash.VerifyPassword("hello"));
   ASSERT_FALSE(hash.VerifyPassword("hello1"));
 }
 
 class AuthWithVariousEncryptionAlgorithms : public ::testing::Test {
  protected:
-  void SetUp() override { SetEncryptionAlgorithm("bcrypt"); }
+  void SetUp() override { SetHashAlgorithm("bcrypt"); }
 };
 
 TEST_F(AuthWithVariousEncryptionAlgorithms, VerifyPasswordDefault) {
-  auto hash = EncryptPassword("hello");
+  auto hash = HashPassword("hello");
   ASSERT_TRUE(hash.VerifyPassword("hello"));
   ASSERT_FALSE(hash.VerifyPassword("hello1"));
 }
 
 TEST_F(AuthWithVariousEncryptionAlgorithms, VerifyPasswordSHA256) {
-  SetEncryptionAlgorithm("sha256");
-  auto hash = EncryptPassword("hello");
+  SetHashAlgorithm("sha256");
+  auto hash = HashPassword("hello");
   ASSERT_TRUE(hash.VerifyPassword("hello"));
   ASSERT_FALSE(hash.VerifyPassword("hello1"));
 }
 
 TEST_F(AuthWithVariousEncryptionAlgorithms, VerifyPasswordSHA256_1024) {
-  SetEncryptionAlgorithm("sha256-multiple");
-  auto hash = EncryptPassword("hello");
+  SetHashAlgorithm("sha256-multiple");
+  auto hash = HashPassword("hello");
   ASSERT_TRUE(hash.VerifyPassword("hello"));
   ASSERT_FALSE(hash.VerifyPassword("hello1"));
 }
 
 TEST_F(AuthWithVariousEncryptionAlgorithms, SetEncryptionAlgorithmNonsenseThrow) {
-  ASSERT_THROW(SetEncryptionAlgorithm("abcd"), AuthException);
+  ASSERT_THROW(SetHashAlgorithm("abcd"), AuthException);
 }
 
 TEST_F(AuthWithVariousEncryptionAlgorithms, SetEncryptionAlgorithmEmptyThrow) {
-  ASSERT_THROW(SetEncryptionAlgorithm(""), AuthException);
+  ASSERT_THROW(SetHashAlgorithm(""), AuthException);
 }
 
 class AuthWithStorageWithVariousEncryptionAlgorithms : public ::testing::Test {
  protected:
   void SetUp() override {
     memgraph::utils::EnsureDir(test_folder_);
-    SetEncryptionAlgorithm("bcrypt");
+    SetHashAlgorithm("bcrypt");
 
     memgraph::license::global_license_checker.EnableTesting();
   }
@@ -993,14 +993,14 @@ TEST_F(AuthWithStorageWithVariousEncryptionAlgorithms, AddUserDefault) {
 }
 
 TEST_F(AuthWithStorageWithVariousEncryptionAlgorithms, AddUserSha256) {
-  SetEncryptionAlgorithm("sha256");
+  SetHashAlgorithm("sha256");
   auto user = auth.AddUser("Alice", "alice");
   ASSERT_TRUE(user);
   ASSERT_EQ(user->username(), "alice");
 }
 
 TEST_F(AuthWithStorageWithVariousEncryptionAlgorithms, AddUserSha256_1024) {
-  SetEncryptionAlgorithm("sha256-multiple");
+  SetHashAlgorithm("sha256-multiple");
   auto user = auth.AddUser("Alice", "alice");
   ASSERT_TRUE(user);
   ASSERT_EQ(user->username(), "alice");
@@ -1009,7 +1009,7 @@ TEST_F(AuthWithStorageWithVariousEncryptionAlgorithms, AddUserSha256_1024) {
 TEST(Serialize, HashedPassword) {
   for (auto algo :
        {PasswordHashAlgorithm::BCRYPT, PasswordHashAlgorithm::SHA256, PasswordHashAlgorithm::SHA256_MULTIPLE}) {
-    auto sut = EncryptPassword("password", algo);
+    auto sut = HashPassword("password", algo);
     nlohmann::json j = sut;
     auto ret = j.get<HashedPassword>();
     ASSERT_EQ(sut, ret);

--- a/tests/unit/auth.cpp
+++ b/tests/unit/auth.cpp
@@ -716,8 +716,9 @@ TEST(AuthWithoutStorage, CaseInsensitivity) {
   {
     auto perms = Permissions();
     auto fine_grained_access_handler = FineGrainedAccessHandler();
-    auto user1 = User("test", "pw", perms, fine_grained_access_handler);
-    auto user2 = User("Test", "pw", perms, fine_grained_access_handler);
+    auto passwordHash = EncryptPassword("pw");
+    auto user1 = User("test", passwordHash, perms, fine_grained_access_handler);
+    auto user2 = User("Test", passwordHash, perms, fine_grained_access_handler);
     ASSERT_EQ(user1, user2);
     ASSERT_EQ(user1.username(), user2.username());
     ASSERT_EQ(user1.username(), "test");
@@ -921,50 +922,49 @@ TEST_F(AuthWithStorage, CaseInsensitivity) {
 
 TEST(AuthWithoutStorage, Crypto) {
   auto hash = EncryptPassword("hello");
-  ASSERT_TRUE(VerifyPassword("hello", hash));
-  ASSERT_FALSE(VerifyPassword("hello1", hash));
+  ASSERT_TRUE(hash.VerifyPassword("hello"));
+  ASSERT_FALSE(hash.VerifyPassword("hello1"));
 }
 
 class AuthWithVariousEncryptionAlgorithms : public ::testing::Test {
  protected:
-  void SetUp() override { FLAGS_password_encryption_algorithm = "bcrypt"; }
+  void SetUp() override { SetEncryptionAlgorithm("bcrypt"); }
 };
 
 TEST_F(AuthWithVariousEncryptionAlgorithms, VerifyPasswordDefault) {
   auto hash = EncryptPassword("hello");
-  ASSERT_TRUE(VerifyPassword("hello", hash));
-  ASSERT_FALSE(VerifyPassword("hello1", hash));
+  ASSERT_TRUE(hash.VerifyPassword("hello"));
+  ASSERT_FALSE(hash.VerifyPassword("hello1"));
 }
 
 TEST_F(AuthWithVariousEncryptionAlgorithms, VerifyPasswordSHA256) {
-  FLAGS_password_encryption_algorithm = "sha256";
+  SetEncryptionAlgorithm("sha256");
   auto hash = EncryptPassword("hello");
-  ASSERT_TRUE(VerifyPassword("hello", hash));
-  ASSERT_FALSE(VerifyPassword("hello1", hash));
+  ASSERT_TRUE(hash.VerifyPassword("hello"));
+  ASSERT_FALSE(hash.VerifyPassword("hello1"));
 }
 
 TEST_F(AuthWithVariousEncryptionAlgorithms, VerifyPasswordSHA256_1024) {
-  FLAGS_password_encryption_algorithm = "sha256-multiple";
+  SetEncryptionAlgorithm("sha256-multiple");
   auto hash = EncryptPassword("hello");
-  ASSERT_TRUE(VerifyPassword("hello", hash));
-  ASSERT_FALSE(VerifyPassword("hello1", hash));
+  ASSERT_TRUE(hash.VerifyPassword("hello"));
+  ASSERT_FALSE(hash.VerifyPassword("hello1"));
 }
 
-TEST_F(AuthWithVariousEncryptionAlgorithms, VerifyPasswordThrow) {
-  FLAGS_password_encryption_algorithm = "abcd";
-  ASSERT_THROW(EncryptPassword("hello"), AuthException);
+TEST_F(AuthWithVariousEncryptionAlgorithms, SetEncryptionAlgorithmNonsenseThrow) {
+  ASSERT_THROW(SetEncryptionAlgorithm("abcd"), AuthException);
 }
 
-TEST_F(AuthWithVariousEncryptionAlgorithms, VerifyPasswordEmptyEncryptionThrow) {
-  FLAGS_password_encryption_algorithm = "";
-  ASSERT_THROW(EncryptPassword("hello"), AuthException);
+TEST_F(AuthWithVariousEncryptionAlgorithms, SetEncryptionAlgorithmEmptyThrow) {
+  ASSERT_THROW(SetEncryptionAlgorithm(""), AuthException);
 }
 
 class AuthWithStorageWithVariousEncryptionAlgorithms : public ::testing::Test {
  protected:
   void SetUp() override {
     memgraph::utils::EnsureDir(test_folder_);
-    FLAGS_password_encryption_algorithm = "bcrypt";
+    SetEncryptionAlgorithm("bcrypt");
+
     memgraph::license::global_license_checker.EnableTesting();
   }
 
@@ -982,25 +982,15 @@ TEST_F(AuthWithStorageWithVariousEncryptionAlgorithms, AddUserDefault) {
 }
 
 TEST_F(AuthWithStorageWithVariousEncryptionAlgorithms, AddUserSha256) {
-  FLAGS_password_encryption_algorithm = "sha256";
+  SetEncryptionAlgorithm("sha256");
   auto user = auth.AddUser("Alice", "alice");
   ASSERT_TRUE(user);
   ASSERT_EQ(user->username(), "alice");
 }
 
 TEST_F(AuthWithStorageWithVariousEncryptionAlgorithms, AddUserSha256_1024) {
-  FLAGS_password_encryption_algorithm = "sha256-multiple";
+  SetEncryptionAlgorithm("sha256-multiple");
   auto user = auth.AddUser("Alice", "alice");
   ASSERT_TRUE(user);
   ASSERT_EQ(user->username(), "alice");
-}
-
-TEST_F(AuthWithStorageWithVariousEncryptionAlgorithms, AddUserThrow) {
-  FLAGS_password_encryption_algorithm = "abcd";
-  ASSERT_THROW(auth.AddUser("Alice", "alice"), AuthException);
-}
-
-TEST_F(AuthWithStorageWithVariousEncryptionAlgorithms, AddUserEmptyPasswordEncryptionThrow) {
-  FLAGS_password_encryption_algorithm = "";
-  ASSERT_THROW(auth.AddUser("Alice", "alice"), AuthException);
 }

--- a/tests/unit/auth_handler.cpp
+++ b/tests/unit/auth_handler.cpp
@@ -57,7 +57,7 @@ TEST_F(AuthQueryHandlerFixture, GivenAuthQueryHandlerWhenInitializedHaveNoUserna
 }
 
 TEST_F(AuthQueryHandlerFixture, GivenUserWhenNoDeniesOrGrantsThenNothingIsReturned) {
-  memgraph::auth::User user = memgraph::auth::User{user_name, "", perms};
+  memgraph::auth::User user = memgraph::auth::User{user_name, std::nullopt, perms};
   auth->SaveUser(user);
 
   { ASSERT_EQ(auth_handler.GetUsernames().size(), 1); }
@@ -71,7 +71,7 @@ TEST_F(AuthQueryHandlerFixture, GivenUserWhenNoDeniesOrGrantsThenNothingIsReturn
 
 TEST_F(AuthQueryHandlerFixture, GivenUserWhenAddedGrantPermissionThenItIsReturned) {
   perms.Grant(memgraph::auth::Permission::MATCH);
-  memgraph::auth::User user = memgraph::auth::User{user_name, "", perms};
+  memgraph::auth::User user = memgraph::auth::User{user_name, std::nullopt, perms};
   auth->SaveUser(user);
 
   auto privileges = auth_handler.GetPrivileges(user_name);
@@ -92,7 +92,7 @@ TEST_F(AuthQueryHandlerFixture, GivenUserWhenAddedGrantPermissionThenItIsReturne
 
 TEST_F(AuthQueryHandlerFixture, GivenUserWhenAddedDenyPermissionThenItIsReturned) {
   perms.Deny(memgraph::auth::Permission::MATCH);
-  memgraph::auth::User user = memgraph::auth::User{user_name, "", perms};
+  memgraph::auth::User user = memgraph::auth::User{user_name, std::nullopt, perms};
   auth->SaveUser(user);
 
   auto privileges = auth_handler.GetPrivileges(user_name);
@@ -114,7 +114,7 @@ TEST_F(AuthQueryHandlerFixture, GivenUserWhenAddedDenyPermissionThenItIsReturned
 TEST_F(AuthQueryHandlerFixture, GivenUserWhenPrivilegeRevokedThenNothingIsReturned) {
   perms.Deny(memgraph::auth::Permission::MATCH);
   perms.Revoke(memgraph::auth::Permission::MATCH);
-  memgraph::auth::User user = memgraph::auth::User{user_name, "", perms};
+  memgraph::auth::User user = memgraph::auth::User{user_name, std::nullopt, perms};
   auth->SaveUser(user);
 
   auto privileges = auth_handler.GetPrivileges(user_name);
@@ -180,7 +180,7 @@ TEST_F(AuthQueryHandlerFixture, GivenRoleWhenPrivilegeRevokedThenNothingIsReturn
 TEST_F(AuthQueryHandlerFixture, GivenUserWhenGrantedTwoPrivilegesThenBothAreReturned) {
   perms.Grant(memgraph::auth::Permission::MATCH);
   perms.Grant(memgraph::auth::Permission::CREATE);
-  memgraph::auth::User user = memgraph::auth::User{user_name, "", perms};
+  memgraph::auth::User user = memgraph::auth::User{user_name, std::nullopt, perms};
   auth->SaveUser(user);
 
   auto privileges = auth_handler.GetPrivileges(user_name);
@@ -191,7 +191,7 @@ TEST_F(AuthQueryHandlerFixture, GivenUserAndRoleWhenOneGrantedAndOtherGrantedThe
   perms.Grant(memgraph::auth::Permission::MATCH);
   memgraph::auth::Role role = memgraph::auth::Role{"Mates_role", perms};
   auth->SaveRole(role);
-  memgraph::auth::User user = memgraph::auth::User{user_name, "", perms};
+  memgraph::auth::User user = memgraph::auth::User{user_name, std::nullopt, perms};
   user.SetRole(role);
   auth->SaveUser(user);
 
@@ -215,7 +215,7 @@ TEST_F(AuthQueryHandlerFixture, GivenUserAndRoleWhenOneDeniedAndOtherDeniedThenB
   perms.Deny(memgraph::auth::Permission::MATCH);
   memgraph::auth::Role role = memgraph::auth::Role{"Mates_role", perms};
   auth->SaveRole(role);
-  memgraph::auth::User user = memgraph::auth::User{user_name, "", perms};
+  memgraph::auth::User user = memgraph::auth::User{user_name, std::nullopt, perms};
   user.SetRole(role);
   auth->SaveUser(user);
 
@@ -245,7 +245,7 @@ TEST_F(AuthQueryHandlerFixture, GivenUserAndRoleWhenOneGrantedAndOtherDeniedThen
   user_perms.Grant(memgraph::auth::Permission::MATCH);
   memgraph::auth::User user = memgraph::auth::User{
       user_name,
-      "",
+      std::nullopt,
       user_perms,
   };
   user.SetRole(role);
@@ -275,7 +275,7 @@ TEST_F(AuthQueryHandlerFixture, GivenUserAndRoleWhenOneDeniedAndOtherGrantedThen
 
   memgraph::auth::Permissions user_perms{};
   user_perms.Deny(memgraph::auth::Permission::MATCH);
-  memgraph::auth::User user = memgraph::auth::User{user_name, "", user_perms};
+  memgraph::auth::User user = memgraph::auth::User{user_name, std::nullopt, user_perms};
   user.SetRole(role);
   auth->SaveUser(user);
 
@@ -305,7 +305,7 @@ TEST_F(AuthQueryHandlerFixture, GivenUserWhenGrantedPrivilegeOnLabelThenIsDispla
       memgraph::auth::FineGrainedAccessPermissions{},
   };
 
-  memgraph::auth::User user = memgraph::auth::User{user_name, "", perms, handler};
+  memgraph::auth::User user = memgraph::auth::User{user_name, std::nullopt, perms, handler};
   auth->SaveUser(user);
 
   auto privileges = auth_handler.GetPrivileges(user_name);
@@ -334,7 +334,7 @@ TEST_F(AuthQueryHandlerFixture, GivenUserWhenGrantedMultiplePrivilegesOnLabelThe
       memgraph::auth::FineGrainedAccessPermissions{},
   };
 
-  memgraph::auth::User user = memgraph::auth::User{user_name, "", perms, handler};
+  memgraph::auth::User user = memgraph::auth::User{user_name, std::nullopt, perms, handler};
   auth->SaveUser(user);
 
   auto privileges = auth_handler.GetPrivileges(user_name);
@@ -364,7 +364,7 @@ TEST_F(AuthQueryHandlerFixture, GivenUserWhenGrantedAllPrivilegesOnLabelThenTopO
       memgraph::auth::FineGrainedAccessPermissions{},
   };
 
-  memgraph::auth::User user = memgraph::auth::User{user_name, "", perms, handler};
+  memgraph::auth::User user = memgraph::auth::User{user_name, std::nullopt, perms, handler};
   auth->SaveUser(user);
 
   auto privileges = auth_handler.GetPrivileges(user_name);
@@ -392,7 +392,7 @@ TEST_F(AuthQueryHandlerFixture, GivenUserWhenGrantedGlobalPrivilegeOnLabelThenIs
       memgraph::auth::FineGrainedAccessPermissions{},
   };
 
-  memgraph::auth::User user = memgraph::auth::User{user_name, "", perms, handler};
+  memgraph::auth::User user = memgraph::auth::User{user_name, std::nullopt, perms, handler};
   auth->SaveUser(user);
 
   auto privileges = auth_handler.GetPrivileges(user_name);
@@ -421,7 +421,7 @@ TEST_F(AuthQueryHandlerFixture, GivenUserWhenGrantedGlobalMultiplePrivilegesOnLa
       memgraph::auth::FineGrainedAccessPermissions{},
   };
 
-  memgraph::auth::User user = memgraph::auth::User{user_name, "", perms, handler};
+  memgraph::auth::User user = memgraph::auth::User{user_name, std::nullopt, perms, handler};
   auth->SaveUser(user);
 
   auto privileges = auth_handler.GetPrivileges(user_name);
@@ -451,7 +451,7 @@ TEST_F(AuthQueryHandlerFixture, GivenUserWhenGrantedGlobalAllPrivilegesOnLabelTh
       memgraph::auth::FineGrainedAccessPermissions{},
   };
 
-  memgraph::auth::User user = memgraph::auth::User{user_name, "", perms, handler};
+  memgraph::auth::User user = memgraph::auth::User{user_name, std::nullopt, perms, handler};
   auth->SaveUser(user);
 
   auto privileges = auth_handler.GetPrivileges(user_name);
@@ -480,7 +480,7 @@ TEST_F(AuthQueryHandlerFixture, GivenUserWhenGrantedPrivilegeOnEdgeTypeThenIsDis
       memgraph::auth::FineGrainedAccessPermissions{read_permission},
   };
 
-  memgraph::auth::User user = memgraph::auth::User{user_name, "", perms, handler};
+  memgraph::auth::User user = memgraph::auth::User{user_name, std::nullopt, perms, handler};
   auth->SaveUser(user);
 
   auto privileges = auth_handler.GetPrivileges(user_name);
@@ -509,7 +509,7 @@ TEST_F(AuthQueryHandlerFixture, GivenUserWhenGrantedMultiplePrivilegesOnEdgeType
       memgraph::auth::FineGrainedAccessPermissions{read_permission},
   };
 
-  memgraph::auth::User user = memgraph::auth::User{user_name, "", perms, handler};
+  memgraph::auth::User user = memgraph::auth::User{user_name, std::nullopt, perms, handler};
   auth->SaveUser(user);
 
   auto privileges = auth_handler.GetPrivileges(user_name);
@@ -539,7 +539,7 @@ TEST_F(AuthQueryHandlerFixture, GivenUserWhenGrantedAllPrivilegesOnEdgeTypeThenT
       memgraph::auth::FineGrainedAccessPermissions{read_permission},
   };
 
-  memgraph::auth::User user = memgraph::auth::User{user_name, "", perms, handler};
+  memgraph::auth::User user = memgraph::auth::User{user_name, std::nullopt, perms, handler};
   auth->SaveUser(user);
 
   auto privileges = auth_handler.GetPrivileges(user_name);
@@ -567,7 +567,7 @@ TEST_F(AuthQueryHandlerFixture, GivenUserWhenGrantedGlobalPrivilegeOnEdgeTypeThe
       memgraph::auth::FineGrainedAccessPermissions{read_permission},
   };
 
-  memgraph::auth::User user = memgraph::auth::User{user_name, "", perms, handler};
+  memgraph::auth::User user = memgraph::auth::User{user_name, std::nullopt, perms, handler};
   auth->SaveUser(user);
 
   auto privileges = auth_handler.GetPrivileges(user_name);
@@ -597,7 +597,7 @@ TEST_F(AuthQueryHandlerFixture, GivenUserWhenGrantedGlobalMultiplePrivilegesOnEd
 
   };
 
-  memgraph::auth::User user = memgraph::auth::User{user_name, "", perms, handler};
+  memgraph::auth::User user = memgraph::auth::User{user_name, std::nullopt, perms, handler};
   auth->SaveUser(user);
 
   auto privileges = auth_handler.GetPrivileges(user_name);
@@ -627,7 +627,7 @@ TEST_F(AuthQueryHandlerFixture, GivenUserWhenGrantedGlobalAllPrivilegesOnEdgeTyp
       memgraph::auth::FineGrainedAccessPermissions{read_permission},
   };
 
-  memgraph::auth::User user = memgraph::auth::User{user_name, "", perms, handler};
+  memgraph::auth::User user = memgraph::auth::User{user_name, std::nullopt, perms, handler};
   auth->SaveUser(user);
 
   auto privileges = auth_handler.GetPrivileges(user_name);
@@ -656,7 +656,7 @@ TEST_F(AuthQueryHandlerFixture, GivenUserWhenGrantedAndDeniedOnLabelThenNoPermis
       memgraph::auth::FineGrainedAccessPermissions{},
   };
 
-  memgraph::auth::User user = memgraph::auth::User{user_name, "", perms, handler};
+  memgraph::auth::User user = memgraph::auth::User{user_name, std::nullopt, perms, handler};
   auth->SaveUser(user);
 
   auto privileges = auth_handler.GetPrivileges(user_name);
@@ -685,7 +685,7 @@ TEST_F(AuthQueryHandlerFixture, GivenUserWhenGrantedAndDeniedOnEdgeTypeThenNoPer
       memgraph::auth::FineGrainedAccessPermissions{read_permission},
   };
 
-  memgraph::auth::User user = memgraph::auth::User{user_name, "", perms, handler};
+  memgraph::auth::User user = memgraph::auth::User{user_name, std::nullopt, perms, handler};
   auth->SaveUser(user);
 
   auto privileges = auth_handler.GetPrivileges(user_name);
@@ -714,7 +714,7 @@ TEST_F(AuthQueryHandlerFixture, GivenUserWhenGrantedReadAndDeniedUpdateThenOneIs
       memgraph::auth::FineGrainedAccessPermissions{read_permission},
   };
 
-  memgraph::auth::User user = memgraph::auth::User{user_name, "", perms, handler};
+  memgraph::auth::User user = memgraph::auth::User{user_name, std::nullopt, perms, handler};
   auth->SaveUser(user);
 
   auto privileges = auth_handler.GetPrivileges(user_name);


### PR DESCRIPTION
To facilitate replication of auth information the hash algorithm used for the hash can not be just flag controlled --password-encryption-algorithm. 

Auth durability migration will introduce a new `version` key.
New "V1" will take the password_hash strings and make them a object which includes both algorithm and hashed password.

Also allow SHA256 hash algorithm to upgrade itself to include a hash once user has validated there password.

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments

Changelog message: Added the password hashing algorithm into auth durability along side the password hash. Also sha256 based passwords hash will upon validation be upgraded to be rehashed with salt.
