### PR TITLE
Add step to refresh jepsen cluster before test

### DIFF
--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -475,6 +475,11 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
           make -j$THREADS memgraph
 
+      - name: Refresh Jepsen Cluster
+        run: |
+          cd tests/jepsen
+          ./run.sh cluster-refresh
+
       - name: Run Jepsen tests
         run: |
           cd tests/jepsen

--- a/tests/jepsen/run.sh
+++ b/tests/jepsen/run.sh
@@ -187,7 +187,7 @@ PROCESS_RESULTS() {
 CLUSTER_UP() {
   PRINT_CONTEXT
   "$script_dir/jepsen/docker/bin/up" --daemon
-  sleep 1
+  sleep 10
   # Ensure all SSH connections between Jepsen containers work
   for node in $(docker ps --filter name=jepsen* --filter status=running --format "{{.Names}}"); do
       if [ "$node" == "jepsen-control" ]; then

--- a/tests/jepsen/run.sh
+++ b/tests/jepsen/run.sh
@@ -24,7 +24,7 @@ PRINT_CONTEXT() {
 
 HELP_EXIT() {
     echo ""
-    echo "HELP: $0 help|cluster-up|cluster-cleanup|cluster-dealloc|mgbuild|test|test-all-individually [args]"
+    echo "HELP: $0 help|cluster-up|cluster-refresh|cluster-cleanup|cluster-dealloc|mgbuild|test|test-all-individually [args]"
     echo ""
     echo "    test args --binary                 MEMGRAPH_BINARY_PATH"
     echo "              --ignore-run-stdout-logs Ignore lein run stdout logs."
@@ -184,6 +184,37 @@ PROCESS_RESULTS() {
     INFO "Result processing (printing and packing) DONE."
 }
 
+CLUSTER_UP() {
+  PRINT_CONTEXT
+  "$script_dir/jepsen/docker/bin/up" --daemon
+  sleep 1
+  # Ensure all SSH connections between Jepsen containers work
+  for node in $(docker ps --filter name=jepsen* --filter status=running --format "{{.Names}}"); do
+      if [ "$node" == "jepsen-control" ]; then
+          continue
+      fi
+      node_hostname="${node##jepsen-}"
+      docker exec jepsen-control bash -c "ssh -oStrictHostKeyChecking=no -t $node_hostname exit"
+  done
+}
+
+CLUSTER_DEALLOC() {
+  ps=$(docker ps --filter name=jepsen* --filter status=running -q)
+  if [[ ! -z ${ps} ]]; then
+      echo "Killing ${ps}"
+      docker rm -f ${ps}
+      imgs=$(docker images "jepsen*" -q)
+      if [[ ! -z ${imgs} ]]; then
+          echo "Removing ${imgs}"
+          docker images "jepsen*" -q | xargs docker image rmi -f
+      else
+          echo "No Jepsen images detected!"
+      fi
+  else
+      echo "No Jepsen containers detected!"
+  fi
+}
+
 # Initialize testing context by copying source/binary files. Inside CI,
 # Memgraph is tested on a single machine cluster based on Docker containers.
 # Once these tests will be part of the official Jepsen repo, the majority of
@@ -196,8 +227,16 @@ case $1 in
     # the current cluster is broken because it relies on the folder. That can
     # happen easiliy because the jepsen folder is git ignored.
     cluster-up)
-        PRINT_CONTEXT
-        "$script_dir/jepsen/docker/bin/up" --daemon
+        CLUSTER_UP
+    ;;
+
+    cluster-refresh)
+        CLUSTER_DEALLOC
+        CLUSTER_UP
+    ;;
+
+    cluster-dealloc)
+        CLUSTER_DEALLOC
     ;;
 
     cluster-cleanup)
@@ -210,23 +249,6 @@ case $1 in
             INFO "Deleting /opt/memgraph/* on $jepsen_node_name"
             $jepsen_node_exec "rm -rf /opt/memgraph/*"
         done
-    ;;
-
-    cluster-dealloc)
-        ps=$(docker ps --filter name=jepsen* --filter status=running -q)
-        if [[ ! -z ${ps} ]]; then
-            echo "Killing ${ps}"
-            docker rm -f ${ps}
-            imgs=$(docker images "jepsen*" -q)
-            if [[ ! -z ${imgs} ]]; then
-                echo "Removing ${imgs}"
-                docker images "jepsen*" -q | xargs docker image rmi -f
-            else
-                echo "No Jepsen images detected!"
-            fi
-        else
-            echo "No Jepsen containers detected!"
-        fi
     ;;
 
     mgbuild)


### PR DESCRIPTION
This PR will reduce flakiness of Jepsen tests which is mainly due to issues with the local Jepsen cluster.

Every time a Jepsen test is run, the cluster will be refreshed, ie. brought down and back up again.

[master < Epic] PR
- [ ] Check, and update documentation if necessary
- [ ] Write E2E tests
- [ ] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch and the Epic branch
- [ ] Provide the full content or a guide for the final git message

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments
