### PR TITLE
Upgrade deprecated github actions

### DIFF
--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)
@@ -162,7 +162,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)
@@ -223,7 +223,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)
@@ -347,7 +347,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)
@@ -393,7 +393,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)
@@ -458,7 +458,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)
@@ -502,7 +502,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -139,7 +139,7 @@ jobs:
       - name: Save code coverage
         uses: actions/upload-artifact@v4
         with:
-          name: "Code coverage"
+          name: "Code coverage(Code analysis)"
           path: tools/github/generated/code_coverage.tar.gz
 
       - name: Run clang-tidy
@@ -210,7 +210,7 @@ jobs:
       - name: Save cppcheck and clang-format errors
         uses: actions/upload-artifact@v4
         with:
-          name: "Code coverage"
+          name: "Code coverage(Debug build)"
           path: tools/github/cppcheck_and_clang_format.txt
 
   release_build:
@@ -332,7 +332,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: "Test data"
+          name: "Test data(Release build)"
           path: |
             # multiple paths could be defined
             build/logs
@@ -378,7 +378,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: "Test data"
+          name: "Test data(High availability build)"
           path: |
             # multiple paths could be defined
             build/logs
@@ -442,7 +442,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: "Test data"
+          name: "Test data(MultiTenancy replication build)"
           path: |
             # multiple paths could be defined
             build/logs

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -137,7 +137,7 @@ jobs:
           tar -czf code_coverage.tar.gz coverage.json html report.json summary.rmu
 
       - name: Save code coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "Code coverage"
           path: tools/github/generated/code_coverage.tar.gz
@@ -208,7 +208,7 @@ jobs:
           ./cppcheck_and_clang_format diff
 
       - name: Save cppcheck and clang-format errors
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "Code coverage"
           path: tools/github/cppcheck_and_clang_format.txt
@@ -251,7 +251,7 @@ jobs:
           ./continuous_integration
 
       - name: Save quality assurance status
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "GQL Behave Status"
           path: |
@@ -323,13 +323,13 @@ jobs:
           cpack -G DEB --config ../CPackConfig.cmake
 
       - name: Save enterprise DEB package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "Enterprise DEB package"
           path: build/output/memgraph*.deb
 
       - name: Save test data
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: "Test data"
@@ -375,7 +375,7 @@ jobs:
           ./run.sh "Client initiated failover"
           ./run.sh "Uninitialized cluster"
       - name: Save test data
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: "Test data"
@@ -439,7 +439,7 @@ jobs:
           ./run.sh "Constraints"
 
       - name: Save test data
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: "Test data"
@@ -486,7 +486,7 @@ jobs:
           ./run.sh test-all-individually --binary ../../build/memgraph --ignore-run-stdout-logs --ignore-run-stderr-logs
 
       - name: Save Jepsen report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: "Jepsen Report"

--- a/.github/workflows/full_clang_tidy.yaml
+++ b/.github/workflows/full_clang_tidy.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)

--- a/.github/workflows/package_memgraph.yaml
+++ b/.github/workflows/package_memgraph.yaml
@@ -49,7 +49,7 @@ jobs:
         run: |
           ./release/package/run.sh package amzn-2 ${{ github.event.inputs.build_type }}
       - name: "Upload package"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: amzn-2
           path: build/output/amzn-2/memgraph*.rpm
@@ -67,7 +67,7 @@ jobs:
         run: |
           ./release/package/run.sh package centos-7 ${{ github.event.inputs.build_type }}
       - name: "Upload package"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: centos-7
           path: build/output/centos-7/memgraph*.rpm
@@ -85,7 +85,7 @@ jobs:
         run: |
           ./release/package/run.sh package centos-9 ${{ github.event.inputs.build_type }}
       - name: "Upload package"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: centos-9
           path: build/output/centos-9/memgraph*.rpm
@@ -103,7 +103,7 @@ jobs:
         run: |
           ./release/package/run.sh package debian-10 ${{ github.event.inputs.build_type }}
       - name: "Upload package"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: debian-10
           path: build/output/debian-10/memgraph*.deb
@@ -121,7 +121,7 @@ jobs:
         run: |
           ./release/package/run.sh package debian-11 ${{ github.event.inputs.build_type }}
       - name: "Upload package"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: debian-11
           path: build/output/debian-11/memgraph*.deb
@@ -139,7 +139,7 @@ jobs:
         run: |
           ./release/package/run.sh package debian-11-arm ${{ github.event.inputs.build_type }}
       - name: "Upload package"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: debian-11-aarch64
           path: build/output/debian-11-arm/memgraph*.deb
@@ -157,7 +157,7 @@ jobs:
         run: |
           ./release/package/run.sh package debian-11 ${{ github.event.inputs.build_type }} --for-platform
       - name: "Upload package"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: debian-11-platform
           path: build/output/debian-11/memgraph*.deb
@@ -177,7 +177,7 @@ jobs:
           ./run.sh package debian-11 ${{ github.event.inputs.build_type }} --for-docker
           ./run.sh docker
       - name: "Upload package"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docker
           path: build/output/docker/memgraph*.tar.gz
@@ -195,7 +195,7 @@ jobs:
         run: |
           ./release/package/run.sh package fedora-36 ${{ github.event.inputs.build_type }}
       - name: "Upload package"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: fedora-36
           path: build/output/fedora-36/memgraph*.rpm
@@ -213,7 +213,7 @@ jobs:
         run: |
           ./release/package/run.sh package ubuntu-18.04 ${{ github.event.inputs.build_type }}
       - name: "Upload package"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ubuntu-18.04
           path: build/output/ubuntu-18.04/memgraph*.deb
@@ -231,7 +231,7 @@ jobs:
         run: |
           ./release/package/run.sh package ubuntu-20.04 ${{ github.event.inputs.build_type }}
       - name: "Upload package"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ubuntu-20.04
           path: build/output/ubuntu-20.04/memgraph*.deb
@@ -249,7 +249,7 @@ jobs:
         run: |
           ./release/package/run.sh package ubuntu-22.04 ${{ github.event.inputs.build_type }}
       - name: "Upload package"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ubuntu-22.04
           path: build/output/ubuntu-22.04/memgraph*.deb
@@ -267,7 +267,7 @@ jobs:
         run: |
           ./release/package/run.sh package ubuntu-22.04-arm ${{ github.event.inputs.build_type }}
       - name: "Upload package"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ubuntu-22.04-aarch64
           path: build/output/ubuntu-22.04-arm/memgraph*.deb

--- a/.github/workflows/package_memgraph.yaml
+++ b/.github/workflows/package_memgraph.yaml
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: "Set up repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required because of release/get_version.py
       - name: "Build package"
@@ -60,7 +60,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: "Set up repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required because of release/get_version.py
       - name: "Build package"
@@ -78,7 +78,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: "Set up repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required because of release/get_version.py
       - name: "Build package"
@@ -96,7 +96,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: "Set up repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required because of release/get_version.py
       - name: "Build package"
@@ -114,7 +114,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: "Set up repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required because of release/get_version.py
       - name: "Build package"
@@ -132,7 +132,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: "Set up repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required because of release/get_version.py
       - name: "Build package"
@@ -150,7 +150,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: "Set up repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required because of release/get_version.py
       - name: "Build package"
@@ -168,7 +168,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: "Set up repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required because of release/get_version.py
       - name: "Build package"
@@ -188,7 +188,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: "Set up repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required because of release/get_version.py
       - name: "Build package"
@@ -206,7 +206,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: "Set up repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required because of release/get_version.py
       - name: "Build package"
@@ -224,7 +224,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: "Set up repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required because of release/get_version.py
       - name: "Build package"
@@ -242,7 +242,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: "Set up repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required because of release/get_version.py
       - name: "Build package"
@@ -260,7 +260,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: "Set up repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required because of release/get_version.py
       - name: "Build package"

--- a/.github/workflows/package_memgraph.yaml
+++ b/.github/workflows/package_memgraph.yaml
@@ -279,7 +279,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           # name: # if name input parameter is not provided, all artifacts are downloaded
                   # and put in directories named after each one.

--- a/.github/workflows/performance_benchmarks.yaml
+++ b/.github/workflows/performance_benchmarks.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)

--- a/.github/workflows/release_debian10.yaml
+++ b/.github/workflows/release_debian10.yaml
@@ -109,7 +109,7 @@ jobs:
           tar -czf code_coverage.tar.gz coverage.json html report.json summary.rmu
 
       - name: Save code coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "Code coverage"
           path: tools/github/generated/code_coverage.tar.gz
@@ -163,7 +163,7 @@ jobs:
           ./cppcheck_and_clang_format diff
 
       - name: Save cppcheck and clang-format errors
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "Code coverage"
           path: tools/github/cppcheck_and_clang_format.txt
@@ -240,7 +240,7 @@ jobs:
           cpack -G DEB --config ../CPackConfig.cmake
 
       - name: Save enterprise DEB package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "Enterprise DEB package"
           path: build/output/memgraph*.deb
@@ -253,7 +253,7 @@ jobs:
           ./continuous_integration
 
       - name: Save quality assurance status
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "GQL Behave Status"
           path: |
@@ -452,7 +452,7 @@ jobs:
           ./run.sh test-all-individually --binary ../../build/memgraph --ignore-run-stdout-logs --ignore-run-stderr-logs
 
       - name: Save Jepsen report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: "Jepsen Report"

--- a/.github/workflows/release_debian10.yaml
+++ b/.github/workflows/release_debian10.yaml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)
@@ -121,7 +121,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)
@@ -175,7 +175,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)
@@ -205,7 +205,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)
@@ -276,7 +276,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)
@@ -327,7 +327,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)
@@ -375,7 +375,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)
@@ -423,7 +423,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)

--- a/.github/workflows/release_debian10.yaml
+++ b/.github/workflows/release_debian10.yaml
@@ -111,7 +111,7 @@ jobs:
       - name: Save code coverage
         uses: actions/upload-artifact@v4
         with:
-          name: "Code coverage"
+          name: "Code coverage(Coverage build)"
           path: tools/github/generated/code_coverage.tar.gz
 
   debug_build:
@@ -165,7 +165,7 @@ jobs:
       - name: Save cppcheck and clang-format errors
         uses: actions/upload-artifact@v4
         with:
-          name: "Code coverage"
+          name: "Code coverage(Debug build)"
           path: tools/github/cppcheck_and_clang_format.txt
 
   debug_integration_test:

--- a/.github/workflows/release_docker.yaml
+++ b/.github/workflows/release_docker.yaml
@@ -19,7 +19,7 @@ jobs:
       DOCKER_REPOSITORY_NAME: memgraph
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/release_mgbench_client.yaml
+++ b/.github/workflows/release_mgbench_client.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/release_ubuntu2004.yaml
+++ b/.github/workflows/release_ubuntu2004.yaml
@@ -105,7 +105,7 @@ jobs:
           tar -czf code_coverage.tar.gz coverage.json html report.json summary.rmu
 
       - name: Save code coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "Code coverage"
           path: tools/github/generated/code_coverage.tar.gz
@@ -159,7 +159,7 @@ jobs:
           ./cppcheck_and_clang_format diff
 
       - name: Save cppcheck and clang-format errors
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "Code coverage"
           path: tools/github/cppcheck_and_clang_format.txt
@@ -236,7 +236,7 @@ jobs:
           cpack -G DEB --config ../CPackConfig.cmake
 
       - name: Save enterprise DEB package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "Enterprise DEB package"
           path: build/output/memgraph*.deb
@@ -249,7 +249,7 @@ jobs:
           ./continuous_integration
 
       - name: Save quality assurance status
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "GQL Behave Status"
           path: |

--- a/.github/workflows/release_ubuntu2004.yaml
+++ b/.github/workflows/release_ubuntu2004.yaml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)
@@ -117,7 +117,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)
@@ -171,7 +171,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)
@@ -201,7 +201,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)
@@ -272,7 +272,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)
@@ -323,7 +323,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)
@@ -371,7 +371,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)

--- a/.github/workflows/release_ubuntu2004.yaml
+++ b/.github/workflows/release_ubuntu2004.yaml
@@ -107,7 +107,7 @@ jobs:
       - name: Save code coverage
         uses: actions/upload-artifact@v4
         with:
-          name: "Code coverage"
+          name: "Code coverage(Coverage build)"
           path: tools/github/generated/code_coverage.tar.gz
 
   debug_build:
@@ -161,7 +161,7 @@ jobs:
       - name: Save cppcheck and clang-format errors
         uses: actions/upload-artifact@v4
         with:
-          name: "Code coverage"
+          name: "Code coverage(Debug build)"
           path: tools/github/cppcheck_and_clang_format.txt
 
   debug_integration_test:

--- a/.github/workflows/stress_test_large.yaml
+++ b/.github/workflows/stress_test_large.yaml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Number of commits to fetch. `0` indicates all history for all
           # branches and tags. (default: 1)

--- a/.github/workflows/upload_to_s3.yaml
+++ b/.github/workflows/upload_to_s3.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v4
         with:
           workflow: package_all.yaml
           workflow_conclusion: success


### PR DESCRIPTION
### This PR will upgrade the following github actions which have become deprecated:
- [x] actions/checkout@v3 —> actions/checkout@v4
- [x] actions/upload-artifact@v3 —> actions/upload-artifact@v4
- [x] actions/download-artifact@v3 —> actions/download-artifact@v4

---
[master < Epic] PR
- [ ] Check, and update documentation if necessary
- [ ] Write E2E tests
- [ ] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch and the Epic branch
- [ ] Provide the full content or a guide for the final git message

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments
