### PR TITLE
Update release CI job timeouts

### DIFF
--- a/.github/workflows/release_debian10.yaml
+++ b/.github/workflows/release_debian10.yaml
@@ -24,7 +24,7 @@ jobs:
   community_build:
     name: "Community build"
     runs-on: [self-hosted, Linux, X64, Debian10]
-    timeout-minutes: 90
+    timeout-minutes: 60
 
     steps:
       - name: Set up repository
@@ -63,7 +63,7 @@ jobs:
       THREADS: 24
       MEMGRAPH_ENTERPRISE_LICENSE: ${{ secrets.MEMGRAPH_ENTERPRISE_LICENSE }}
       MEMGRAPH_ORGANIZATION_NAME: ${{ secrets.MEMGRAPH_ORGANIZATION_NAME }}
-    timeout-minutes: 90
+    timeout-minutes: 60
 
     steps:
       - name: Set up repository
@@ -117,7 +117,7 @@ jobs:
   debug_build:
     name: "Debug build"
     runs-on: [self-hosted, Linux, X64, Debian10]
-    timeout-minutes: 90
+    timeout-minutes: 60
 
     steps:
       - name: Set up repository
@@ -171,7 +171,7 @@ jobs:
   debug_integration_test:
     name: "Debug integration tests"
     runs-on: [self-hosted, Linux, X64, Debian10]
-    timeout-minutes: 90
+    timeout-minutes: 60
 
     steps:
       - name: Set up repository
@@ -201,7 +201,7 @@ jobs:
   release_build:
     name: "Release build"
     runs-on: [self-hosted, Linux, X64, Debian10]
-    timeout-minutes: 90
+    timeout-minutes: 60
 
     steps:
       - name: Set up repository
@@ -272,7 +272,7 @@ jobs:
   release_benchmark_tests:
     name: "Release Benchmark Tests"
     runs-on: [self-hosted, Linux, X64, Debian10]
-    timeout-minutes: 90
+    timeout-minutes: 60
 
     steps:
       - name: Set up repository
@@ -324,7 +324,7 @@ jobs:
     if: false
     name: "Release End-to-end Test"
     runs-on: [self-hosted, Linux, X64, Debian10]
-    timeout-minutes: 90
+    timeout-minutes: 60
 
     steps:
       - name: Set up repository
@@ -372,7 +372,7 @@ jobs:
   release_durability_stress_tests:
     name: "Release durability and stress tests"
     runs-on: [self-hosted, Linux, X64, Debian10]
-    timeout-minutes: 90
+    timeout-minutes: 60
 
     steps:
       - name: Set up repository
@@ -420,7 +420,7 @@ jobs:
   release_jepsen_test:
     name: "Release Jepsen Test"
     runs-on: [self-hosted, Linux, X64, Debian10, JepsenControl]
-    timeout-minutes: 90
+    timeout-minutes: 60
 
     steps:
       - name: Set up repository

--- a/.github/workflows/release_ubuntu2004.yaml
+++ b/.github/workflows/release_ubuntu2004.yaml
@@ -24,7 +24,7 @@ jobs:
   community_build:
     name: "Community build"
     runs-on: [self-hosted, Linux, X64, Ubuntu20.04]
-    timeout-minutes: 90
+    timeout-minutes: 60
 
     steps:
       - name: Set up repository
@@ -59,7 +59,7 @@ jobs:
   coverage_build:
     name: "Coverage build"
     runs-on: [self-hosted, Linux, X64, Ubuntu20.04]
-    timeout-minutes: 90
+    timeout-minutes: 60
 
     steps:
       - name: Set up repository
@@ -113,7 +113,7 @@ jobs:
   debug_build:
     name: "Debug build"
     runs-on: [self-hosted, Linux, X64, Ubuntu20.04]
-    timeout-minutes: 90
+    timeout-minutes: 60
 
     steps:
       - name: Set up repository
@@ -167,7 +167,7 @@ jobs:
   debug_integration_test:
     name: "Debug integration tests"
     runs-on: [self-hosted, Linux, X64, Ubuntu20.04]
-    timeout-minutes: 90
+    timeout-minutes: 60
 
     steps:
       - name: Set up repository
@@ -197,7 +197,7 @@ jobs:
   release_build:
     name: "Release build"
     runs-on: [self-hosted, Linux, X64, Ubuntu20.04]
-    timeout-minutes: 90
+    timeout-minutes: 60
 
     steps:
       - name: Set up repository
@@ -268,7 +268,7 @@ jobs:
   release_benchmark_tests:
     name: "Release Benchmark Tests"
     runs-on: [self-hosted, Linux, X64, Ubuntu20.04]
-    timeout-minutes: 90
+    timeout-minutes: 60
 
     steps:
       - name: Set up repository
@@ -320,7 +320,7 @@ jobs:
     if: false
     name: "Release End-to-end Test"
     runs-on: [self-hosted, Linux, X64, Ubuntu20.04]
-    timeout-minutes: 90
+    timeout-minutes: 60
 
     steps:
       - name: Set up repository
@@ -368,7 +368,7 @@ jobs:
   release_durability_stress_tests:
     name: "Release durability and stress tests"
     runs-on: [self-hosted, Linux, X64, Ubuntu20.04]
-    timeout-minutes: 90
+    timeout-minutes: 60
 
     steps:
       - name: Set up repository

--- a/.github/workflows/stress_test_large.yaml
+++ b/.github/workflows/stress_test_large.yaml
@@ -23,7 +23,7 @@ env:
 jobs:
   stress_test_large:
     name: "Stress test large"
-    timeout-minutes: 600
+    timeout-minutes: 720
     strategy:
       matrix:
         os: [Debian10, Ubuntu20.04]


### PR DESCRIPTION
Update timeouts for release CI
- [x] release_debian10 and release_ubuntu2004: 90 min --> 60 min
- [x] stress_test_large: 10 h --> 12 h
---
[master < Epic] PR
- [ ] Check, and update documentation if necessary
- [ ] Write E2E tests
- [ ] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch and the Epic branch
- [ ] Provide the full content or a guide for the final git message

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments
