### PR TITLE
Fix unbound variable causing crash inside subquery

### DIFF
--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2024 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -394,9 +394,16 @@ SymbolGenerator::ReturnType SymbolGenerator::Visit(Identifier &ident) {
     // can reference symbols bound later in the same MATCH. We collect them
     // here, so that they can be checked after visiting Match.
     scope.identifiers_in_match.emplace_back(&ident);
+  } else if (scope.in_call_subquery && !scope.in_with) {
+    if (!scope.symbols.contains(ident.name_) && !ConsumePredefinedIdentifier(ident.name_)) {
+      throw UnboundVariableError(ident.name_);
+    }
+    symbol = GetOrCreateSymbol(ident.name_, ident.user_declared_, Symbol::Type::ANY);
   } else {
     // Everything else references a bound symbol.
-    if (!HasSymbol(ident.name_) && !ConsumePredefinedIdentifier(ident.name_)) throw UnboundVariableError(ident.name_);
+    if (!HasSymbol(ident.name_) && !ConsumePredefinedIdentifier(ident.name_)) {
+      throw UnboundVariableError(ident.name_);
+    }
     symbol = GetOrCreateSymbol(ident.name_, ident.user_declared_, Symbol::Type::ANY);
   }
   ident.MapTo(symbol);

--- a/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
@@ -185,6 +185,20 @@ Feature: Subqueries
             """
         Then an error should be raised
 
+    Scenario: Subquery with an unbound variable
+        Given an empty graph
+        When executing query:
+        """
+        MATCH (label1)
+        CALL {
+            MATCH (label2)
+            WHERE label1.property > 0
+            return 1
+        }
+        return 1
+        """
+        Then an error should be raised
+
     Scenario: Subquery returning primitive but not aliased
         Given an empty graph
         And having executed

--- a/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
@@ -189,11 +189,11 @@ Feature: Subqueries
         Given an empty graph
         When executing query:
         """
-        MATCH (label1)
+        MATCH (node1)
         CALL {
-            MATCH (label2)
-            WHERE label1.property > 0
-            return 1
+            MATCH (node2)
+            WHERE node1.property > 0
+            return 1 as state
         }
         return 1
         """


### PR DESCRIPTION
Having an unbound variable inside a subquery causes a crash due to checking all scopes instead of only the local (last) one in case of a call subquery.

[master < Epic] PR
- [ ] Check, and update documentation if necessary
- [ ] Write E2E tests
- [ ] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch and the Epic branch
- [ ] Provide the full content or a guide for the final git message

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message

closes #1636 

To keep docs changelog up to date, one more thing to do:
- [X] Write a release note here, including added/changed clauses
Unbound variable inside a subquery no longer causes a crash.
- [ ] Tag someone from docs team in the comments
