### PR TITLE
Turn e2e tests back on for release build workflows

### DIFF
--- a/.github/workflows/release_debian10.yaml
+++ b/.github/workflows/release_debian10.yaml
@@ -329,7 +329,6 @@ jobs:
             --no-strict
 
   release_e2e_test:
-    if: false
     name: "Release End-to-end Test"
     runs-on: [self-hosted, Linux, X64, Debian10]
     timeout-minutes: 60

--- a/.github/workflows/release_ubuntu2004.yaml
+++ b/.github/workflows/release_ubuntu2004.yaml
@@ -325,7 +325,6 @@ jobs:
             --no-strict
 
   release_e2e_test:
-    if: false
     name: "Release End-to-end Test"
     runs-on: [self-hosted, Linux, X64, Ubuntu20.04]
     timeout-minutes: 60


### PR DESCRIPTION
[master < Epic] PR
- [ ] Check, and update documentation if necessary
- [ ] Write E2E tests
- [ ] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch and the Epic branch
- [ ] Provide the full content or a guide for the final git message

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments
