### PR TITLE
Patch NuRaft for clang-17 compilation

### DIFF
--- a/libs/.gitignore
+++ b/libs/.gitignore
@@ -7,3 +7,4 @@
 !pulsar.patch
 !antlr4.10.1.patch
 !rocksdb8.1.1.patch
+!nuraft2.1.0.patch

--- a/libs/nuraft2.1.0.patch
+++ b/libs/nuraft2.1.0.patch
@@ -3,9 +3,9 @@ index 8fe1ec9..9497355 100644
 --- a/include/libnuraft/asio_service_options.hxx
 +++ b/include/libnuraft/asio_service_options.hxx
 @@ -17,6 +17,7 @@ limitations under the License.
-
+ 
  #pragma once
-
+ 
 +#include <cstdint>
  #include <functional>
  #include <string>
@@ -17,7 +17,8 @@ index 7b71624..d48c1e2 100644
 @@ -18,6 +18,7 @@ limitations under the License.
  #ifndef _CALLBACK_H_
  #define _CALLBACK_H_
-
+ 
 +#include <cstdint>
  #include <functional>
  #include <string>
+ 

--- a/libs/nuraft2.1.0.patch
+++ b/libs/nuraft2.1.0.patch
@@ -1,0 +1,23 @@
+diff --git a/include/libnuraft/asio_service_options.hxx b/include/libnuraft/asio_service_options.hxx
+index 8fe1ec9..9497355 100644
+--- a/include/libnuraft/asio_service_options.hxx
++++ b/include/libnuraft/asio_service_options.hxx
+@@ -17,6 +17,7 @@ limitations under the License.
+
+ #pragma once
+
++#include <cstdint>
+ #include <functional>
+ #include <string>
+ #include <system_error>
+diff --git a/include/libnuraft/callback.hxx b/include/libnuraft/callback.hxx
+index 7b71624..d48c1e2 100644
+--- a/include/libnuraft/callback.hxx
++++ b/include/libnuraft/callback.hxx
+@@ -18,6 +18,7 @@ limitations under the License.
+ #ifndef _CALLBACK_H_
+ #define _CALLBACK_H_
+
++#include <cstdint>
+ #include <functional>
+ #include <string>

--- a/libs/setup.sh
+++ b/libs/setup.sh
@@ -286,5 +286,6 @@ repo_clone_try_double "${primary_urls[range-v3]}" "${secondary_urls[range-v3]}" 
 nuraft_tag="v2.1.0"
 repo_clone_try_double "${primary_urls[nuraft]}" "${secondary_urls[nuraft]}" "nuraft" "$nuraft_tag" true
 pushd nuraft
+git apply ../nuraft2.1.0.patch
 ./prepare.sh
 popd


### PR DESCRIPTION
NOTE: Required to be able to use toolchain-v5

It seems better compared to using the latest commit from https://github.com/eBay/NuRaft/tree/master (because versioning is not clear -> who knows what will break memgraph's code).