### PR TITLE
Support label manipulation via variables

### DIFF
--- a/src/query/frontend/opencypher/grammar/Cypher.g4
+++ b/src/query/frontend/opencypher/grammar/Cypher.g4
@@ -191,7 +191,7 @@ relationshipTypes : ':' relTypeName ( '|' ':'? relTypeName )* ;
 
 nodeLabels : nodeLabel ( nodeLabel )* ;
 
-nodeLabel : ':' labelName ;
+nodeLabel : ':' (labelName | expression);
 
 labelName : symbolicName | parameter;
 

--- a/src/query/plan/operator.hpp
+++ b/src/query/plan/operator.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2024 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -290,18 +290,20 @@ struct NodeCreationInfo {
 
   NodeCreationInfo() = default;
 
-  NodeCreationInfo(Symbol symbol, std::vector<storage::LabelId> labels,
+  NodeCreationInfo(Symbol symbol, std::vector<std::variant<storage::LabelId, Expression *>> labels,
                    std::variant<PropertiesMapList, ParameterLookup *> properties)
       : symbol{std::move(symbol)}, labels{std::move(labels)}, properties{std::move(properties)} {};
 
-  NodeCreationInfo(Symbol symbol, std::vector<storage::LabelId> labels, PropertiesMapList properties)
+  NodeCreationInfo(Symbol symbol, std::vector<std::variant<storage::LabelId, Expression *>> labels,
+                   PropertiesMapList properties)
       : symbol{std::move(symbol)}, labels{std::move(labels)}, properties{std::move(properties)} {};
 
-  NodeCreationInfo(Symbol symbol, std::vector<storage::LabelId> labels, ParameterLookup *properties)
+  NodeCreationInfo(Symbol symbol, std::vector<std::variant<storage::LabelId, Expression *>> labels,
+                   ParameterLookup *properties)
       : symbol{std::move(symbol)}, labels{std::move(labels)}, properties{properties} {};
 
   Symbol symbol;
-  std::vector<storage::LabelId> labels;
+  std::vector<std::variant<storage::LabelId, Expression *>> labels;
   std::variant<PropertiesMapList, ParameterLookup *> properties;
 
   NodeCreationInfo Clone(AstStorage *storage) const {

--- a/src/query/plan/preprocess.cpp
+++ b/src/query/plan/preprocess.cpp
@@ -358,11 +358,17 @@ void Filters::CollectPatternFilters(Pattern &pattern, SymbolTable &symbol_table,
   };
   auto add_node_filter = [&](NodeAtom *node) {
     const auto &node_symbol = symbol_table.at(*node->identifier_);
-    if (!node->labels_.empty()) {
-      // Create a LabelsTest and store it.
-      auto *labels_test = storage.Create<LabelsTest>(node->identifier_, node->labels_);
+    std::vector<LabelIx> labels;
+    for (auto label : node->labels_) {
+      if (const auto *label_node = std::get_if<Expression *>(&label)) {
+        throw SemanticException("Parameter lookup not supported in MATCH/MERGE clause!");
+      }
+      labels.push_back(std::get<LabelIx>(label));
+    }
+    if (!labels.empty()) {
+      auto *labels_test = storage.Create<LabelsTest>(node->identifier_, labels);
       auto label_filter = FilterInfo{FilterInfo::Type::Label, labels_test, std::unordered_set<Symbol>{node_symbol}};
-      label_filter.labels = node->labels_;
+      label_filter.labels = labels;
       all_filters_.emplace_back(label_filter);
     }
     add_properties(node);

--- a/src/query/plan/pretty_print.cpp
+++ b/src/query/plan/pretty_print.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2024 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -337,7 +337,15 @@ json ToJson(const std::vector<std::pair<storage::PropertyId, Expression *>> &pro
 json ToJson(const NodeCreationInfo &node_info, const DbAccessor &dba) {
   json self;
   self["symbol"] = ToJson(node_info.symbol);
-  self["labels"] = ToJson(node_info.labels, dba);
+  std::vector<storage::LabelId> labels;
+  for (auto label : node_info.labels) {
+    if (const auto *label_node = std::get_if<Expression *>(&label)) {
+      labels = {};
+      break;
+    }
+    labels.push_back(std::get<storage::LabelId>(label));
+  }
+  self["labels"] = ToJson(labels, dba);
   const auto *props = std::get_if<PropertiesMapList>(&node_info.properties);
   self["properties"] = ToJson(props ? *props : PropertiesMapList{}, dba);
   return self;

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -311,11 +311,19 @@ class RuleBasedPlanner {
                                                        std::unordered_set<Symbol> &bound_symbols) {
     auto node_to_creation_info = [&](const NodeAtom &node) {
       const auto &node_symbol = symbol_table.at(*node.identifier_);
-      std::vector<storage::LabelId> labels;
-      labels.reserve(node.labels_.size());
-      for (const auto &label : node.labels_) {
-        labels.push_back(GetLabel(label));
-      }
+
+      auto labels = std::invoke([&]() -> std::vector<std::variant<storage::LabelId, Expression *>> {
+        std::vector<std::variant<storage::LabelId, Expression *>> labels;
+        labels.reserve(node.labels_.size());
+        for (const auto &label : node.labels_) {
+          if (const auto *label_atom = std::get_if<LabelIx>(&label)) {
+            labels.emplace_back(GetLabel(*label_atom));
+          } else {
+            labels.emplace_back(std::get<Expression *>(label));
+          }
+        }
+        return labels;
+      });
 
       auto properties = std::invoke([&]() -> std::variant<PropertiesMapList, ParameterLookup *> {
         if (const auto *node_properties =


### PR DESCRIPTION
Idea of this PR is to support queries that do some kind of a manipulation with labels (create, match, set...) via variables.
For example: 
```
LOAD CSV FROM "/usr/lib/memgraph/people.csv" WITH HEADER AS row
CREATE (n:row.label  {id: row.id, name: row.name, age: toInteger(row.age), city: row.city});
```

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments

closes #1509 