### PR TITLE
Add jobs for pushing ARM packages

### DIFF
--- a/.github/workflows/release_build_test.yaml
+++ b/.github/workflows/release_build_test.yaml
@@ -124,9 +124,9 @@ jobs:
     needs: [PackageUbuntu20_04_ARM]
     runs-on: ubuntu-latest
     steps:
-      - name: Download artifacts
+      - name: Download package
         uses: actions/download-artifact@v4
-        with:image:
+        with:
           name: ubuntu-22.04-aarch64
           path: build/output/release
       - name: Upload to S3
@@ -192,9 +192,9 @@ jobs:
     needs: [PackageDebian11_ARM]
     runs-on: ubuntu-latest
     steps:
-      - name: Download artifacts
+      - name: Download package
         uses: actions/download-artifact@v4
-        with:image:
+        with:
           name: debian-11-aarch64
           path: build/output/release
       - name: Upload to S3

--- a/.github/workflows/release_build_test.yaml
+++ b/.github/workflows/release_build_test.yaml
@@ -113,6 +113,22 @@ jobs:
       - name: "Build package"
         run: |
           ./release/package/run.sh package ubuntu-22.04-arm $BUILD_TYPE
+      - name: "Upload package"
+        uses: actions/upload-artifact@v4
+        with:
+          name: ubuntu-22.04-aarch64
+          path: build/output/ubuntu-22.04-arm/memgraph*.deb
+
+  PushToS3Ubuntu20_04_ARM:
+    if: github.ref_type == 'tag'
+    needs: [PackageUbuntu20_04_ARM]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:image:
+          name: ubuntu-22.04-aarch64
+          path: build/output/release
       - name: Upload to S3
         uses: jakejarvis/s3-sync-action@v0.5.1
         env:
@@ -120,13 +136,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: "eu-west-1"
-          SOURCE_DIR: "build/output"
+          SOURCE_DIR: "build/output/release"
           DEST_DIR: "memgraph-unofficial/${{ github.ref_name }}/"
-      - name: "Upload package"
-        uses: actions/upload-artifact@v4
-        with:
-          name: ubuntu-22.04-aarch64
-          path: build/output/ubuntu-22.04-arm/memgraph*.deb
 
   PackageDebian11:
     if: github.ref_type == 'tag'
@@ -170,6 +181,22 @@ jobs:
       - name: "Build package"
         run: |
           ./release/package/run.sh package debian-11-arm $BUILD_TYPE
+      - name: "Upload package"
+        uses: actions/upload-artifact@v4
+        with:
+          name: debian-11-aarch64
+          path: build/output/debian-11-arm/memgraph*.deb
+
+  PushToS3Debian11_ARM:
+    if: github.ref_type == 'tag'
+    needs: [PackageDebian11_ARM]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:image:
+          name: debian-11-aarch64
+          path: build/output/release
       - name: Upload to S3
         uses: jakejarvis/s3-sync-action@v0.5.1
         env:
@@ -177,10 +204,5 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: "eu-west-1"
-          SOURCE_DIR: "build/output"
+          SOURCE_DIR: "build/output/release"
           DEST_DIR: "memgraph-unofficial/${{ github.ref_name }}/"
-      - name: "Upload package"
-        uses: actions/upload-artifact@v4
-        with:
-          name: debian-11-aarch64
-          path: build/output/debian-11-arm/memgraph*.deb


### PR DESCRIPTION
Minor fix, the push to s3 action doesn't work on macOS

---
[master < Epic] PR
- [ ] Check, and update documentation if necessary
- [ ] Write E2E tests
- [ ] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch and the Epic branch
- [ ] Provide the full content or a guide for the final git message

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments
