### PR TITLE
Better EXISTS handling

### DIFF
--- a/src/query/frontend/ast/cypher_main_visitor.hpp
+++ b/src/query/frontend/ast/cypher_main_visitor.hpp
@@ -747,6 +747,11 @@ class CypherMainVisitor : public antlropencypher::MemgraphCypherBaseVisitor {
   /**
    * @return Pattern*
    */
+  antlrcpp::Any visitForcePatternPart(MemgraphCypher::ForcePatternPartContext *ctx) override;
+
+  /**
+   * @return Pattern*
+   */
   antlrcpp::Any visitPatternElement(MemgraphCypher::PatternElementContext *ctx) override;
 
   /**

--- a/src/query/frontend/opencypher/grammar/Cypher.g4
+++ b/src/query/frontend/opencypher/grammar/Cypher.g4
@@ -292,7 +292,11 @@ reduceExpression : accumulator=variable '=' initial=expression ',' idInColl '|' 
 
 extractExpression : idInColl '|' expression ;
 
-existsExpression : patternPart ;
+existsExpression : forcePatternPart | .* ;
+
+forcePatternPart : ( variable '=' relationshipsPattern )
+                 | relationshipsPattern
+                 ;
 
 idInColl : variable IN expression ;
 

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph_exists.feature
@@ -357,22 +357,6 @@ Feature: WHERE exists
           """
       Then the result should be empty
 
-  Scenario: Test node-only hop
-      Given an empty graph
-      And having executed:
-          """
-          CREATE (:One {prop:1})-[:TYPE {prop: 1}]->(:Two {prop: 2})-[:TYPE {prop:2}]->(:Three {prop: 3})
-          """
-      When executing query:
-          """
-          MATCH (n) WHERE exists((n)) RETURN n.prop;
-          """
-      Then the result should be:
-          | n.prop |
-          | 1      |
-          | 2      |
-          | 3      |
-
   Scenario: Test exists with different edge type
       Given an empty graph
       And having executed:

--- a/tests/gql_behave/tests/memgraph_V1_on_disk/features/memgraph_exists.feature
+++ b/tests/gql_behave/tests/memgraph_V1_on_disk/features/memgraph_exists.feature
@@ -357,22 +357,6 @@ Feature: WHERE exists
           """
       Then the result should be empty
 
-  Scenario: Test node-only hop
-      Given an empty graph
-      And having executed:
-          """
-          CREATE (:One {prop:1})-[:TYPE {prop: 1}]->(:Two {prop: 2})-[:TYPE {prop:2}]->(:Three {prop: 3})
-          """
-      When executing query:
-          """
-          MATCH (n) WHERE exists((n)) RETURN n.prop;
-          """
-      Then the result should be:
-          | n.prop |
-          | 1      |
-          | 2      |
-          | 3      |
-
   Scenario: Test exists with different edge type
       Given an empty graph
       And having executed:

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -4567,6 +4567,13 @@ TEST_P(CypherMainVisitorTest, ExistsThrow) {
 
   TestInvalidQueryWithMessage<SyntaxException>("MATCH (n) WHERE exists(p=(n)-[]->()) RETURN n;", ast_generator,
                                                "Identifiers are not supported in exists(...).");
+
+  TestInvalidQueryWithMessage<SyntaxException>("MATCH (n) WHERE exists() RETURN n;", ast_generator,
+                                               "EXISTS supports only a single relation as its input.");
+  TestInvalidQueryWithMessage<SyntaxException>("MATCH (n) WHERE exists((n)) RETURN n;", ast_generator,
+                                               "EXISTS supports only a single relation as its input.");
+  TestInvalidQueryWithMessage<SyntaxException>("MATCH (n) WHERE exists((n)-[]) RETURN n;", ast_generator,
+                                               "EXISTS supports only a single relation as its input.");
 }
 
 TEST_P(CypherMainVisitorTest, Exists) {
@@ -4615,22 +4622,6 @@ TEST_P(CypherMainVisitorTest, Exists) {
     ASSERT_TRUE(node2);
     ASSERT_TRUE(edge2);
     ASSERT_TRUE(node3);
-  }
-
-  {
-    const auto *query = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("MATCH (n) WHERE exists((n)) RETURN n;"));
-    const auto *match = dynamic_cast<Match *>(query->single_query_->clauses_[0]);
-
-    const auto *exists = dynamic_cast<Exists *>(match->where_->expression_);
-
-    ASSERT_TRUE(exists);
-
-    const auto pattern = exists->pattern_;
-    ASSERT_TRUE(pattern->atoms_.size() == 1);
-
-    const auto *node = dynamic_cast<NodeAtom *>(pattern->atoms_[0]);
-
-    ASSERT_TRUE(node);
   }
 }
 


### PR DESCRIPTION
Allowing only a single relation (`()-[]->()`) as input.
This will create better error messages. 

NOTE: This will not allow any function called exists to ever be called.

closes https://github.com/memgraph/memgraph/issues/1564

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments
