### PR TITLE
Allow query with a write subquery to omit RETURN

### DIFF
--- a/src/query/frontend/ast/ast.hpp
+++ b/src/query/frontend/ast/ast.hpp
@@ -2026,6 +2026,7 @@ class SingleQuery : public memgraph::query::Tree, public utils::Visitable<Hierar
   }
 
   std::vector<memgraph::query::Clause *> clauses_;
+  bool has_update{};
 
   SingleQuery *Clone(AstStorage *storage) const override {
     SingleQuery *object = storage->Create<SingleQuery>();
@@ -2033,6 +2034,7 @@ class SingleQuery : public memgraph::query::Tree, public utils::Visitable<Hierar
     for (auto i4 = 0; i4 < clauses_.size(); ++i4) {
       object->clauses_[i4] = clauses_[i4] ? clauses_[i4]->Clone(storage) : nullptr;
     }
+    object->has_update = has_update;
     return object;
   }
 

--- a/tests/gql_behave/tests/memgraph_V1/features/create.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/create.feature
@@ -175,3 +175,15 @@ Feature: Create
             CREATE (a:A) CREATE (a:B)
             """
         Then an error should be raised
+
+    Scenario: CREATE via CALL:
+        When executing query:
+            """
+            UNWIND range(1,10) as id
+            CALL {
+                WITH id
+                CREATE (b:B {prop: 1})
+                CREATE (b)-[:IN]->(z)
+            };
+            """
+        Then the result should be empty


### PR DESCRIPTION
We already allow a write query to omit RETURN.
However, queries like
```
CREATE (a:A {id: 1});
MATCH (a:A {id: 1})
WITH a
UNWIND range(1,1000) as id
CALL {
    WITH id, a
    CREATE (b:B {prop: 1})
    CREATE (b)-[:IN]->(z)
};
```
would be categorized as read, because the subquery's (query under CALL) read/write status would be ignored.
Now a query has updates if any one of the subqueries has updates.

closes https://github.com/memgraph/memgraph/issues/1544

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments
