### PR TITLE
Split now supports empty delimiter

### DIFF
--- a/src/utils/string.hpp
+++ b/src/utils/string.hpp
@@ -209,8 +209,13 @@ std::vector<TString, TAllocator> *Split(std::vector<TString, TAllocator> *out, c
   if (src.empty()) return out;
   size_t index = 0;
   while (splits < 0 || splits-- != 0) {
-    auto n = src.find(delimiter, index);
-    if (n == std::string::npos) break;
+    size_t n = 0;
+    if (delimiter.empty()) {  // Special case where we just return characters
+      n = index + 1;
+    } else {
+      n = src.find(delimiter, index);
+    }
+    if (n >= src.size()) break;
     out->emplace_back(src.substr(index, n - index));
     index = n + delimiter.size();
   }


### PR DESCRIPTION
Split was not checking the delimiter's size and would run forever when delimiter was empty.
Now, in case of an empty delimiter, we just split all characters.

closes https://github.com/memgraph/memgraph/issues/1625 
closes https://github.com/memgraph/memgraph/issues/609

[master < Task] PR
- [ ] Check, and update documentation if necessary
- [ ] Provide the full content or a guide for the final git message


To keep docs changelog up to date, one more thing to do:
- [ ] Write a release note here, including added/changed clauses
- [ ] Tag someone from docs team in the comments
