### PR TITLE
Make diff run on push to master again

### DIFF
--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -4,6 +4,10 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
   pull_request:
     paths-ignore:
       - "docs/**"


### PR DESCRIPTION
### Description

Running `diff` on push to `master` and being able to run `diff` manually was mistakenly disabled in this [commit](https://github.com/memgraph/memgraph/commit/b0cdcd3483ab7e088d338752fdac64482d40af1a)

This PR will revert those changes.

[master < Task] PR
- [x] Provide the full content or a guide for the final git message
    - Enable running diff manually and on push to master


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
