### PR TITLE
Upgrade os for diff jobs from debian-11 to debian-12

### DIFF
--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -25,7 +25,7 @@ jobs:
       THREADS: 24
       MEMGRAPH_ENTERPRISE_LICENSE: ${{ secrets.MEMGRAPH_ENTERPRISE_LICENSE }}
       MEMGRAPH_ORGANIZATION_NAME: ${{ secrets.MEMGRAPH_ORGANIZATION_NAME }}
-      OS: debian-11
+      OS: debian-12
       TOOLCHAIN: v5
       ARCH: amd
       BUILD_TYPE: RelWithDebInfo
@@ -84,7 +84,7 @@ jobs:
       THREADS: 24
       MEMGRAPH_ENTERPRISE_LICENSE: ${{ secrets.MEMGRAPH_ENTERPRISE_LICENSE }}
       MEMGRAPH_ORGANIZATION_NAME: ${{ secrets.MEMGRAPH_ORGANIZATION_NAME }}
-      OS: debian-11
+      OS: debian-12
       TOOLCHAIN: v5
       ARCH: amd
       BUILD_TYPE: Debug
@@ -204,7 +204,7 @@ jobs:
       THREADS: 24
       MEMGRAPH_ENTERPRISE_LICENSE: ${{ secrets.MEMGRAPH_ENTERPRISE_LICENSE }}
       MEMGRAPH_ORGANIZATION_NAME: ${{ secrets.MEMGRAPH_ORGANIZATION_NAME }}
-      OS: debian-11
+      OS: debian-12
       TOOLCHAIN: v5
       ARCH: amd
       BUILD_TYPE: Debug
@@ -302,7 +302,7 @@ jobs:
       THREADS: 24
       MEMGRAPH_ENTERPRISE_LICENSE: ${{ secrets.MEMGRAPH_ENTERPRISE_LICENSE }}
       MEMGRAPH_ORGANIZATION_NAME: ${{ secrets.MEMGRAPH_ORGANIZATION_NAME }}
-      OS: debian-11
+      OS: debian-12
       TOOLCHAIN: v5
       ARCH: amd
       BUILD_TYPE: Release
@@ -548,7 +548,7 @@ jobs:
       THREADS: 24
       MEMGRAPH_ENTERPRISE_LICENSE: ${{ secrets.MEMGRAPH_ENTERPRISE_LICENSE }}
       MEMGRAPH_ORGANIZATION_NAME: ${{ secrets.MEMGRAPH_ORGANIZATION_NAME }}
-      OS: debian-11
+      OS: debian-12
       TOOLCHAIN: v5
       ARCH: amd
       BUILD_TYPE: Release


### PR DESCRIPTION
### Description

Diff jobs are currently being run on debian 11 OS, this PR will bump it to debian-12.
Jobs:
- [ ] Community build
- [ ] Code analysis
- [ ] Debug build
- [ ] Release build
- [x] Jepsen Test
- [ ] Release Benchmarks

[master < Task] PR
- [ ] Provide the full content or a guide for the final git message
    - **[FINAL GIT MESSAGE]**


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
