### PR TITLE
HA: Add force reset of cluster

### DIFF
--- a/src/coordination/coordinator_client.cpp
+++ b/src/coordination/coordinator_client.cpp
@@ -70,10 +70,6 @@ void CoordinatorClient::StartFrequentCheck() {
             auto stream{rpc_client_.Stream<memgraph::replication_coordination_glue::FrequentHeartbeatRpc>()};
             stream.AwaitResponse();
           }
-          // Subtle race condition:
-          // acquiring of lock needs to happen before function call, as function callback can be changed
-          // for instance after lock is already acquired
-          // (failover case when instance is promoted to MAIN)
           succ_cb_(coord_instance_, instance_name);
         } catch (rpc::RpcFailedException const &) {
           fail_cb_(coord_instance_, instance_name);

--- a/src/coordination/coordinator_client.cpp
+++ b/src/coordination/coordinator_client.cpp
@@ -60,21 +60,16 @@ void CoordinatorClient::StartFrequentCheck() {
   MG_ASSERT(config_.instance_health_check_frequency_sec > std::chrono::seconds(0),
             "Health check frequency must be greater than 0");
 
-  instance_checker_.Run(
-      config_.instance_name, config_.instance_health_check_frequency_sec,
-      [this, instance_name = config_.instance_name] {
-        try {
-          spdlog::trace("Sending frequent heartbeat to machine {} on {}", instance_name,
-                        config_.CoordinatorSocketAddress());
-          {  // NOTE: This is intentionally scoped so that stream lock could get released.
-            auto stream{rpc_client_.Stream<memgraph::replication_coordination_glue::FrequentHeartbeatRpc>()};
-            stream.AwaitResponse();
-          }
-          succ_cb_(coord_instance_, instance_name);
-        } catch (rpc::RpcFailedException const &) {
-          fail_cb_(coord_instance_, instance_name);
-        }
-      });
+  instance_checker_.Run(config_.instance_name, config_.instance_health_check_frequency_sec,
+                        [this, instance_name = config_.instance_name] {
+                          spdlog::trace("Sending frequent heartbeat to machine {} on {}", instance_name,
+                                        config_.CoordinatorSocketAddress());
+                          if (SendFrequentHeartbeat()) {
+                            succ_cb_(coord_instance_, instance_name);
+                            return;
+                          }
+                          fail_cb_(coord_instance_, instance_name);
+                        });
 }
 
 void CoordinatorClient::StopFrequentCheck() { instance_checker_.Stop(); }
@@ -114,6 +109,16 @@ auto CoordinatorClient::DemoteToReplica() const -> bool {
     spdlog::error("Failed to set instance {} to replica!", instance_name);
   }
   return false;
+}
+
+auto CoordinatorClient::SendFrequentHeartbeat() const -> bool {
+  try {
+    auto stream{rpc_client_.Stream<memgraph::replication_coordination_glue::FrequentHeartbeatRpc>()};
+    stream.AwaitResponse();
+    return true;
+  } catch (rpc::RpcFailedException const &) {
+    return false;
+  }
 }
 
 auto CoordinatorClient::SendSwapMainUUIDRpc(utils::UUID const &uuid) const -> bool {

--- a/src/coordination/coordinator_cluster_state.cpp
+++ b/src/coordination/coordinator_cluster_state.cpp
@@ -136,10 +136,6 @@ auto CoordinatorClusterState::DoAction(TRaftLog log_entry, RaftLogAction log_act
       spdlog::trace("DoAction: update uuid of new main {}", std::string{current_main_uuid_});
       break;
     }
-    case RaftLogAction::OPEN_LOCK_FORCE_RESET: {
-      is_healthy_ = false;
-      break;
-    }
     case RaftLogAction::UPDATE_UUID_FOR_INSTANCE: {
       auto const instance_uuid_change = std::get<InstanceUUIDUpdate>(log_entry);
       auto it = repl_instances_.find(instance_uuid_change.instance_name);
@@ -155,35 +151,10 @@ auto CoordinatorClusterState::DoAction(TRaftLog log_entry, RaftLogAction log_act
       spdlog::trace("DoAction: add coordinator instance {}", config.coordinator_server_id);
       break;
     }
-    case RaftLogAction::OPEN_LOCK_REGISTER_REPLICATION_INSTANCE: {
+    case RaftLogAction::OPEN_LOCK: {
       is_lock_opened_ = true;
-      spdlog::trace("DoAction: open lock register");
+      spdlog::trace("DoAction: Opened lock");
       break;
-      // TODO(antoniofilipovic) save what we are doing to be able to undo....
-    }
-    case RaftLogAction::OPEN_LOCK_UNREGISTER_REPLICATION_INSTANCE: {
-      is_lock_opened_ = true;
-      spdlog::trace("DoAction: open lock unregister");
-      break;
-      // TODO(antoniofilipovic) save what we are doing
-    }
-    case RaftLogAction::OPEN_LOCK_SET_INSTANCE_AS_MAIN: {
-      is_lock_opened_ = true;
-      spdlog::trace("DoAction: open lock set instance as main");
-      break;
-      // TODO(antoniofilipovic) save what we are doing
-    }
-    case RaftLogAction::OPEN_LOCK_FAILOVER: {
-      is_lock_opened_ = true;
-      spdlog::trace("DoAction: open lock failover");
-      break;
-      // TODO(antoniofilipovic) save what we are doing
-    }
-    case RaftLogAction::OPEN_LOCK_SET_INSTANCE_AS_REPLICA: {
-      is_lock_opened_ = true;
-      spdlog::trace("DoAction: open lock set instance as replica");
-      break;
-      // TODO(antoniofilipovic) save what we need to undo
     }
   }
 }

--- a/src/coordination/coordinator_cluster_state.cpp
+++ b/src/coordination/coordinator_cluster_state.cpp
@@ -99,7 +99,7 @@ auto CoordinatorClusterState::DoAction(TRaftLog log_entry, RaftLogAction log_act
       spdlog::trace("DoAction: register replication instance {}", config.instance_name);
       // Setting instance uuid to random, if registration fails, we are still in random state
       repl_instances_.emplace(config.instance_name,
-                              ReplicationInstanceState{config, ReplicationRole::REPLICA, utils::UUID{}});
+                              ReplicationInstanceState{config, ReplicationRole::REPLICA, utils::UUID{}, false});
       break;
     }
     case RaftLogAction::UNREGISTER_REPLICATION_INSTANCE: {
@@ -123,6 +123,7 @@ auto CoordinatorClusterState::DoAction(TRaftLog log_entry, RaftLogAction log_act
       auto it = repl_instances_.find(instance_name);
       MG_ASSERT(it != repl_instances_.end(), "Instance does not exist as part of raft state!");
       it->second.status = ReplicationRole::REPLICA;
+      it->second.needs_demote = false;
       spdlog::trace("DoAction: set replication instance {} as replica", instance_name);
       break;
     }
@@ -151,7 +152,7 @@ auto CoordinatorClusterState::DoAction(TRaftLog log_entry, RaftLogAction log_act
       auto it = repl_instances_.find(instance_name);
       MG_ASSERT(it != repl_instances_.end(), "Instance does not exist as part of raft state!");
       it->second.needs_demote = true;
-      spdlog::trace("Added action that instance {} needs demote", instance_name);
+      spdlog::trace("Added action that instance {} needs demote to replica", instance_name);
       break;
     }
     case RaftLogAction::OPEN_LOCK: {

--- a/src/coordination/coordinator_cluster_state.cpp
+++ b/src/coordination/coordinator_cluster_state.cpp
@@ -136,6 +136,10 @@ auto CoordinatorClusterState::DoAction(TRaftLog log_entry, RaftLogAction log_act
       spdlog::trace("DoAction: update uuid of new main {}", std::string{current_main_uuid_});
       break;
     }
+    case RaftLogAction::OPEN_LOCK_FORCE_RESET: {
+      is_healthy_ = false;
+      break;
+    }
     case RaftLogAction::UPDATE_UUID_FOR_INSTANCE: {
       auto const instance_uuid_change = std::get<InstanceUUIDUpdate>(log_entry);
       auto it = repl_instances_.find(instance_uuid_change.instance_name);

--- a/src/coordination/coordinator_cluster_state.cpp
+++ b/src/coordination/coordinator_cluster_state.cpp
@@ -160,6 +160,7 @@ auto CoordinatorClusterState::DoAction(TRaftLog log_entry, RaftLogAction log_act
       MG_ASSERT(it != repl_instances_.end(), "Instance does not exist as part of raft state!");
       it->second.needs_demote = true;
       spdlog::trace("Added action that instance {} needs demote", instance_name);
+      break;
     }
     case RaftLogAction::OPEN_LOCK: {
       is_lock_opened_ = true;

--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -80,15 +80,12 @@ CoordinatorInstance::CoordinatorInstance()
               // We need to stop checks before taking a lock because deadlock can happen if instances waits
               // to take a lock in frequent check, and this thread already has a lock and waits for instance to
               // be done with frequent check
-              for (auto &repl_instance : repl_instances_) {
-                repl_instance.StopFrequentCheck();
-              }
-              auto lock = std::unique_lock{coord_instance_lock_};
               std::ranges::for_each(repl_instances_, [](auto &repl_instance) {
                 spdlog::trace("Stopping frequent checks for instance {}", repl_instance.InstanceName());
                 repl_instance.StopFrequentCheck();
                 spdlog::trace("Stopped frequent checks for instance {}", repl_instance.InstanceName());
               });
+              auto lock = std::unique_lock{coord_instance_lock_};
               repl_instances_.clear();
               spdlog::info("Stopped all replication instance frequent checks.");
             });

--- a/src/coordination/coordinator_state_machine.cpp
+++ b/src/coordination/coordinator_state_machine.cpp
@@ -90,6 +90,10 @@ auto CoordinatorStateMachine::SerializeOpenLockSetInstanceAsReplica(std::string_
   return CreateLog({{"action", RaftLogAction::OPEN_LOCK_SET_INSTANCE_AS_REPLICA}, {"info", instance_name}});
 }
 
+auto CoordinatorStateMachine::SerializeOpenLockForceReset() -> ptr<buffer> {
+  return CreateLog({{"action", RaftLogAction::OPEN_LOCK_SET_INSTANCE_AS_REPLICA}, {"info", std::string{}}});
+}
+
 auto CoordinatorStateMachine::DecodeLog(buffer &data) -> std::pair<TRaftLog, RaftLogAction> {
   buffer_serializer bs(data);
   auto const json = nlohmann::json::parse(bs.get_str());
@@ -100,6 +104,8 @@ auto CoordinatorStateMachine::DecodeLog(buffer &data) -> std::pair<TRaftLog, Raf
     case RaftLogAction::OPEN_LOCK_REGISTER_REPLICATION_INSTANCE: {
       return {info.get<CoordinatorToReplicaConfig>(), action};
     }
+    case RaftLogAction::OPEN_LOCK_FORCE_RESET:
+      [[fallthrough]];
     case RaftLogAction::OPEN_LOCK_UNREGISTER_REPLICATION_INSTANCE:
       [[fallthrough]];
     case RaftLogAction::OPEN_LOCK_FAILOVER:

--- a/src/coordination/coordinator_state_machine.cpp
+++ b/src/coordination/coordinator_state_machine.cpp
@@ -42,6 +42,10 @@ auto CoordinatorStateMachine::SerializeOpenLock() -> ptr<buffer> {
   return CreateLog({{"action", RaftLogAction::OPEN_LOCK}});
 }
 
+auto CoordinatorStateMachine::SerializeCloseLock() -> ptr<buffer> {
+  return CreateLog({{"action", RaftLogAction::CLOSE_LOCK}});
+}
+
 auto CoordinatorStateMachine::SerializeRegisterInstance(CoordinatorToReplicaConfig const &config) -> ptr<buffer> {
   return CreateLog({{"action", RaftLogAction::REGISTER_REPLICATION_INSTANCE}, {"info", config}});
 }
@@ -84,7 +88,9 @@ auto CoordinatorStateMachine::DecodeLog(buffer &data) -> std::pair<TRaftLog, Raf
   auto const &info = json["info"];
 
   switch (action) {
-    case RaftLogAction::OPEN_LOCK: {
+    case RaftLogAction::OPEN_LOCK:
+      [[fallthrough]];
+    case RaftLogAction::CLOSE_LOCK: {
       return {std::monostate{}, action};
     }
     case RaftLogAction::REGISTER_REPLICATION_INSTANCE:

--- a/src/coordination/coordinator_state_machine.cpp
+++ b/src/coordination/coordinator_state_machine.cpp
@@ -59,6 +59,10 @@ auto CoordinatorStateMachine::SerializeSetInstanceAsReplica(std::string_view ins
   return CreateLog({{"action", RaftLogAction::SET_INSTANCE_AS_REPLICA}, {"info", instance_name}});
 }
 
+auto CoordinatorStateMachine::SerializeInstanceNeedsDemote(std::string_view instance_name) -> ptr<buffer> {
+  return CreateLog({{"action", RaftLogAction::INSTANCE_NEEDS_DEMOTE}, {"info", std::string{instance_name}}});
+}
+
 auto CoordinatorStateMachine::SerializeUpdateUUIDForNewMain(utils::UUID const &uuid) -> ptr<buffer> {
   return CreateLog({{"action", RaftLogAction::UPDATE_UUID_OF_NEW_MAIN}, {"info", uuid}});
 }
@@ -91,6 +95,8 @@ auto CoordinatorStateMachine::DecodeLog(buffer &data) -> std::pair<TRaftLog, Raf
     case RaftLogAction::SET_INSTANCE_AS_MAIN:
       return {info.get<InstanceUUIDUpdate>(), action};
     case RaftLogAction::UNREGISTER_REPLICATION_INSTANCE:
+      [[fallthrough]];
+    case RaftLogAction::INSTANCE_NEEDS_DEMOTE:
       [[fallthrough]];
     case RaftLogAction::SET_INSTANCE_AS_REPLICA:
       return {info.get<std::string>(), action};

--- a/src/coordination/coordinator_state_machine.cpp
+++ b/src/coordination/coordinator_state_machine.cpp
@@ -39,7 +39,7 @@ auto CoordinatorStateMachine::CreateLog(nlohmann::json &&log) -> ptr<buffer> {
 }
 
 auto CoordinatorStateMachine::SerializeOpenLock() -> ptr<buffer> {
-  return CreateLog({{"action", RaftLogAction::OPEN_LOCK}, {"info", nullptr}});
+  return CreateLog({{"action", RaftLogAction::OPEN_LOCK}});
 }
 
 auto CoordinatorStateMachine::SerializeRegisterInstance(CoordinatorToReplicaConfig const &config) -> ptr<buffer> {

--- a/src/coordination/coordinator_state_machine.cpp
+++ b/src/coordination/coordinator_state_machine.cpp
@@ -39,11 +39,11 @@ auto CoordinatorStateMachine::CreateLog(nlohmann::json &&log) -> ptr<buffer> {
 }
 
 auto CoordinatorStateMachine::SerializeOpenLock() -> ptr<buffer> {
-  return CreateLog({{"action", RaftLogAction::OPEN_LOCK}});
+  return CreateLog({{"action", RaftLogAction::OPEN_LOCK}, {"info", nullptr}});
 }
 
 auto CoordinatorStateMachine::SerializeCloseLock() -> ptr<buffer> {
-  return CreateLog({{"action", RaftLogAction::CLOSE_LOCK}});
+  return CreateLog({{"action", RaftLogAction::CLOSE_LOCK}, {"info", nullptr}});
 }
 
 auto CoordinatorStateMachine::SerializeRegisterInstance(CoordinatorToReplicaConfig const &config) -> ptr<buffer> {
@@ -85,7 +85,7 @@ auto CoordinatorStateMachine::DecodeLog(buffer &data) -> std::pair<TRaftLog, Raf
   buffer_serializer bs(data);
   auto const json = nlohmann::json::parse(bs.get_str());
   auto const action = json["action"].get<RaftLogAction>();
-  auto const &info = json["info"];
+  auto const &info = json.at("info");
 
   switch (action) {
     case RaftLogAction::OPEN_LOCK:

--- a/src/coordination/include/coordination/coordinator_client.hpp
+++ b/src/coordination/include/coordination/coordinator_client.hpp
@@ -85,6 +85,9 @@ class CoordinatorClient {
 
   CoordinatorToReplicaConfig config_;
   CoordinatorInstance *coord_instance_;
+  // The reason why we have HealthCheckClientCallback is because we need to acquire lock
+  // before we do correct function call (main or replica), as otherwise we can enter REPLICA callback
+  // but right before instance was promoted to MAIN
   HealthCheckClientCallback succ_cb_;
   HealthCheckClientCallback fail_cb_;
 };

--- a/src/coordination/include/coordination/coordinator_client.hpp
+++ b/src/coordination/include/coordination/coordinator_client.hpp
@@ -15,6 +15,7 @@
 
 #include "coordination/coordinator_communication_config.hpp"
 #include "replication_coordination_glue/common.hpp"
+#include "replication_coordination_glue/role.hpp"
 #include "rpc/client.hpp"
 #include "rpc_errors.hpp"
 #include "utils/result.hpp"
@@ -63,6 +64,8 @@ class CoordinatorClient {
   auto SendGetInstanceUUIDRpc() const -> memgraph::utils::BasicResult<GetInstanceUUIDError, std::optional<utils::UUID>>;
 
   auto ReplicationClientInfo() const -> ReplicationClientInfo;
+
+  auto SendFrequentHeartbeat() const -> bool;
 
   auto SendGetInstanceTimestampsRpc() const
       -> utils::BasicResult<GetInstanceUUIDError, replication_coordination_glue::DatabaseHistories>;

--- a/src/coordination/include/coordination/coordinator_instance.hpp
+++ b/src/coordination/include/coordination/coordinator_instance.hpp
@@ -112,6 +112,10 @@ class CoordinatorInstance {
 
   void ReplicaFailCallback(std::string_view);
 
+  void UniversalSuccessCallback(std::string_view);
+
+  void UniversalFailCallback(std::string_view);
+
   void ForceResetCluster();
 
   HealthCheckClientCallback client_succ_cb_, client_fail_cb_;

--- a/src/coordination/include/coordination/coordinator_instance.hpp
+++ b/src/coordination/include/coordination/coordinator_instance.hpp
@@ -77,6 +77,8 @@ class CoordinatorInstance {
 
   void ReplicaFailCallback(std::string_view);
 
+  void ForceResetCluster();
+
   HealthCheckClientCallback client_succ_cb_, client_fail_cb_;
   // NOTE: Must be std::list because we rely on pointer stability.
   std::list<ReplicationInstance> repl_instances_;

--- a/src/coordination/include/coordination/coordinator_instance.hpp
+++ b/src/coordination/include/coordination/coordinator_instance.hpp
@@ -69,7 +69,10 @@ class CoordinatorInstance {
  private:
   template <ranges::forward_range R>
   auto GetMostUpToDateInstanceFromHistories(R &&alive_instances) -> std::optional<std::string> {
-    auto const get_ts = [](ReplicationInstance &replica) { return replica.GetClient().SendGetInstanceTimestampsRpc(); };
+    auto const get_ts = [](ReplicationInstance &replica) {
+      spdlog::trace("Sending get instance timestamps to {}", replica.InstanceName());
+      return replica.GetClient().SendGetInstanceTimestampsRpc();
+    };
 
     auto maybe_instance_db_histories = alive_instances | ranges::views::transform(get_ts) | ranges::to<std::vector>();
 
@@ -112,9 +115,9 @@ class CoordinatorInstance {
 
   void ReplicaFailCallback(std::string_view);
 
-  void UniversalSuccessCallback(std::string_view);
+  void DemoteSuccessCallback(std::string_view repl_instance_name);
 
-  void UniversalFailCallback(std::string_view);
+  void DemoteFailCallback(std::string_view repl_instance_name);
 
   void ForceResetCluster();
 

--- a/src/coordination/include/coordination/coordinator_instance.hpp
+++ b/src/coordination/include/coordination/coordinator_instance.hpp
@@ -81,6 +81,7 @@ class CoordinatorInstance {
 
   HealthCheckClientCallback client_succ_cb_, client_fail_cb_;
   // NOTE: Must be std::list because we rely on pointer stability.
+  // TODO(antoniofilipovic) do we still rely on pointer stability
   std::list<ReplicationInstance> repl_instances_;
   mutable utils::ResourceLock coord_instance_lock_{};
 

--- a/src/coordination/include/coordination/coordinator_instance.hpp
+++ b/src/coordination/include/coordination/coordinator_instance.hpp
@@ -67,6 +67,41 @@ class CoordinatorInstance {
   auto HasReplicaState(std::string_view instance_name) const -> bool;
 
  private:
+  template <ranges::forward_range R>
+  auto GetMostUpToDateInstanceFromHistories(R &&alive_instances) -> std::optional<std::string> {
+    auto const get_ts = [](ReplicationInstance &replica) { return replica.GetClient().SendGetInstanceTimestampsRpc(); };
+
+    auto maybe_instance_db_histories = alive_instances | ranges::views::transform(get_ts) | ranges::to<std::vector>();
+
+    auto const ts_has_error = [](auto const &res) -> bool { return res.HasError(); };
+
+    if (std::ranges::any_of(maybe_instance_db_histories, ts_has_error)) {
+      spdlog::error("At least one instance which was alive didn't provide per database history.");
+      return std::nullopt;
+    }
+
+    auto const ts_has_value = [](auto const &zipped) -> bool {
+      auto &[replica, res] = zipped;
+      return res.HasValue();
+    };
+
+    auto transform_to_pairs = ranges::views::transform([](auto const &zipped) {
+      auto &[replica, res] = zipped;
+      return std::make_pair(replica.InstanceName(), res.GetValue());
+    });
+
+    auto instance_db_histories = ranges::views::zip(alive_instances, maybe_instance_db_histories) |
+                                 ranges::views::filter(ts_has_value) | transform_to_pairs | ranges::to<std::vector>();
+
+    auto [most_up_to_date_instance, latest_epoch, latest_commit_timestamp] =
+        ChooseMostUpToDateInstance(instance_db_histories);
+
+    spdlog::trace("The most up to date instance is {} with epoch {} and {} latest commit timestamp",
+                  most_up_to_date_instance, latest_epoch, latest_commit_timestamp);  // NOLINT
+
+    return most_up_to_date_instance;
+  }
+
   auto FindReplicationInstance(std::string_view replication_instance_name) -> ReplicationInstance &;
 
   void MainFailCallback(std::string_view);

--- a/src/coordination/include/coordination/coordinator_rpc.hpp
+++ b/src/coordination/include/coordination/coordinator_rpc.hpp
@@ -16,7 +16,6 @@
 
 #include "coordination/coordinator_communication_config.hpp"
 #include "replication_coordination_glue/common.hpp"
-#include "replication_coordination_glue/role.hpp"
 #include "rpc/messages.hpp"
 #include "slk/serialization.hpp"
 

--- a/src/coordination/include/coordination/coordinator_rpc.hpp
+++ b/src/coordination/include/coordination/coordinator_rpc.hpp
@@ -16,6 +16,7 @@
 
 #include "coordination/coordinator_communication_config.hpp"
 #include "replication_coordination_glue/common.hpp"
+#include "replication_coordination_glue/role.hpp"
 #include "rpc/messages.hpp"
 #include "slk/serialization.hpp"
 

--- a/src/coordination/include/coordination/raft_state.hpp
+++ b/src/coordination/include/coordination/raft_state.hpp
@@ -71,6 +71,7 @@ class RaftState {
   auto AppendUpdateUUIDForNewMainLog(utils::UUID const &uuid) -> bool;
   auto AppendUpdateUUIDForInstanceLog(std::string_view instance_name, utils::UUID const &uuid) -> bool;
   auto AppendOpenLock() -> bool;
+  auto AppendCloseLock() -> bool;
   auto AppendAddCoordinatorInstanceLog(CoordinatorToCoordinatorConfig const &config) -> bool;
   auto AppendInstanceNeedsDemote(std::string_view) -> bool;
 

--- a/src/coordination/include/coordination/raft_state.hpp
+++ b/src/coordination/include/coordination/raft_state.hpp
@@ -76,6 +76,7 @@ class RaftState {
   auto AppendOpenLockSetInstanceToMain(std::string_view instance_name) -> bool;
   auto AppendOpenLockSetInstanceToReplica(std::string_view instance_name) -> bool;
   auto AppendAddCoordinatorInstanceLog(CoordinatorToCoordinatorConfig const &config) -> bool;
+  auto AppendOpenLockForceReset() -> bool;
 
   auto GetReplicationInstances() const -> std::vector<ReplicationInstanceState>;
   // TODO: (andi) Do we need then GetAllCoordinators?

--- a/src/coordination/include/coordination/raft_state.hpp
+++ b/src/coordination/include/coordination/raft_state.hpp
@@ -70,13 +70,8 @@ class RaftState {
   auto AppendSetInstanceAsReplicaLog(std::string_view instance_name) -> bool;
   auto AppendUpdateUUIDForNewMainLog(utils::UUID const &uuid) -> bool;
   auto AppendUpdateUUIDForInstanceLog(std::string_view instance_name, utils::UUID const &uuid) -> bool;
-  auto AppendOpenLockRegister(CoordinatorToReplicaConfig const &) -> bool;
-  auto AppendOpenLockUnregister(std::string_view) -> bool;
-  auto AppendOpenLockFailover(std::string_view instance_name) -> bool;
-  auto AppendOpenLockSetInstanceToMain(std::string_view instance_name) -> bool;
-  auto AppendOpenLockSetInstanceToReplica(std::string_view instance_name) -> bool;
+  auto AppendOpenLock() -> bool;
   auto AppendAddCoordinatorInstanceLog(CoordinatorToCoordinatorConfig const &config) -> bool;
-  auto AppendOpenLockForceReset() -> bool;
 
   auto GetReplicationInstances() const -> std::vector<ReplicationInstanceState>;
   // TODO: (andi) Do we need then GetAllCoordinators?

--- a/src/coordination/include/coordination/raft_state.hpp
+++ b/src/coordination/include/coordination/raft_state.hpp
@@ -72,6 +72,7 @@ class RaftState {
   auto AppendUpdateUUIDForInstanceLog(std::string_view instance_name, utils::UUID const &uuid) -> bool;
   auto AppendOpenLock() -> bool;
   auto AppendAddCoordinatorInstanceLog(CoordinatorToCoordinatorConfig const &config) -> bool;
+  auto AppendInstanceNeedsDemote(std::string_view) -> bool;
 
   auto GetReplicationInstances() const -> std::vector<ReplicationInstanceState>;
   // TODO: (andi) Do we need then GetAllCoordinators?

--- a/src/coordination/include/coordination/register_main_replica_coordinator_status.hpp
+++ b/src/coordination/include/coordination/register_main_replica_coordinator_status.hpp
@@ -27,7 +27,7 @@ enum class RegisterInstanceCoordinatorStatus : uint8_t {
   RAFT_LOG_ERROR,
   SUCCESS,
   LOCK_OPENED,
-  OPEN_LOCK
+  FAILED_TO_OPEN_LOCK
 };
 
 enum class UnregisterInstanceCoordinatorStatus : uint8_t {
@@ -39,7 +39,7 @@ enum class UnregisterInstanceCoordinatorStatus : uint8_t {
   RAFT_LOG_ERROR,
   SUCCESS,
   LOCK_OPENED,
-  OPEN_LOCK
+  FAILED_TO_OPEN_LOCK
 };
 
 enum class SetInstanceToMainCoordinatorStatus : uint8_t {
@@ -52,7 +52,7 @@ enum class SetInstanceToMainCoordinatorStatus : uint8_t {
   SWAP_UUID_FAILED,
   SUCCESS,
   LOCK_OPENED,
-  OPEN_LOCK,
+  FAILED_TO_OPEN_LOCK,
   ENABLE_WRITING_FAILED
 };
 

--- a/src/coordination/include/coordination/register_main_replica_coordinator_status.hpp
+++ b/src/coordination/include/coordination/register_main_replica_coordinator_status.hpp
@@ -27,7 +27,8 @@ enum class RegisterInstanceCoordinatorStatus : uint8_t {
   RAFT_LOG_ERROR,
   SUCCESS,
   LOCK_OPENED,
-  FAILED_TO_OPEN_LOCK
+  FAILED_TO_OPEN_LOCK,
+  FAILED_TO_CLOSE_LOCK
 };
 
 enum class UnregisterInstanceCoordinatorStatus : uint8_t {
@@ -39,7 +40,8 @@ enum class UnregisterInstanceCoordinatorStatus : uint8_t {
   RAFT_LOG_ERROR,
   SUCCESS,
   LOCK_OPENED,
-  FAILED_TO_OPEN_LOCK
+  FAILED_TO_OPEN_LOCK,
+  FAILED_TO_CLOSE_LOCK
 };
 
 enum class SetInstanceToMainCoordinatorStatus : uint8_t {
@@ -53,7 +55,8 @@ enum class SetInstanceToMainCoordinatorStatus : uint8_t {
   SUCCESS,
   LOCK_OPENED,
   FAILED_TO_OPEN_LOCK,
-  ENABLE_WRITING_FAILED
+  ENABLE_WRITING_FAILED,
+  FAILED_TO_CLOSE_LOCK
 };
 
 }  // namespace memgraph::coordination

--- a/src/coordination/include/coordination/replication_instance.hpp
+++ b/src/coordination/include/coordination/replication_instance.hpp
@@ -23,7 +23,6 @@
 
 #include <libnuraft/nuraft.hxx>
 
-#include <functional>
 namespace memgraph::coordination {
 
 class CoordinatorInstance;

--- a/src/coordination/include/coordination/replication_instance.hpp
+++ b/src/coordination/include/coordination/replication_instance.hpp
@@ -82,6 +82,8 @@ class ReplicationInstance {
   auto GetSuccessCallback() -> HealthCheckInstanceCallback &;
   auto GetFailCallback() -> HealthCheckInstanceCallback &;
 
+  void SetCallbacks(HealthCheckInstanceCallback succ_cb, HealthCheckInstanceCallback fail_cb);
+
  private:
   CoordinatorClient client_;
   std::chrono::system_clock::time_point last_response_time_{};

--- a/src/coordination/include/coordination/replication_instance.hpp
+++ b/src/coordination/include/coordination/replication_instance.hpp
@@ -23,6 +23,7 @@
 
 #include <libnuraft/nuraft.hxx>
 
+#include <functional>
 namespace memgraph::coordination {
 
 class CoordinatorInstance;
@@ -59,6 +60,8 @@ class ReplicationInstance {
 
   auto SendDemoteToReplicaRpc() -> bool;
 
+  auto SendFrequentHeartbeat() const -> bool;
+
   auto DemoteToReplica(HealthCheckInstanceCallback replica_succ_cb, HealthCheckInstanceCallback replica_fail_cb)
       -> bool;
 
@@ -79,8 +82,8 @@ class ReplicationInstance {
 
   auto EnableWritingOnMain() -> bool;
 
-  auto GetSuccessCallback() -> HealthCheckInstanceCallback &;
-  auto GetFailCallback() -> HealthCheckInstanceCallback &;
+  auto GetSuccessCallback() -> HealthCheckInstanceCallback;
+  auto GetFailCallback() -> HealthCheckInstanceCallback;
 
   void SetCallbacks(HealthCheckInstanceCallback succ_cb, HealthCheckInstanceCallback fail_cb);
 

--- a/src/coordination/include/nuraft/coordinator_cluster_state.hpp
+++ b/src/coordination/include/nuraft/coordinator_cluster_state.hpp
@@ -61,8 +61,8 @@ struct CoordinatorInstanceState {
 void to_json(nlohmann::json &j, ReplicationInstanceState const &instance_state);
 void from_json(nlohmann::json const &j, ReplicationInstanceState &instance_state);
 
-using TRaftLog = std::variant<CoordinatorToReplicaConfig, std::string, utils::UUID, CoordinatorToCoordinatorConfig,
-                              InstanceUUIDUpdate>;
+using TRaftLog = std::variant<std::monostate, CoordinatorToReplicaConfig, std::string, utils::UUID,
+                              CoordinatorToCoordinatorConfig, InstanceUUIDUpdate>;
 
 using nuraft::buffer;
 using nuraft::buffer_serializer;

--- a/src/coordination/include/nuraft/coordinator_cluster_state.hpp
+++ b/src/coordination/include/nuraft/coordinator_cluster_state.hpp
@@ -43,8 +43,11 @@ struct ReplicationInstanceState {
   // For MAIN we don't enable writing until cluster is in healthy state
   utils::UUID instance_uuid;
 
+  bool needs_demote{false};
+
   friend auto operator==(ReplicationInstanceState const &lhs, ReplicationInstanceState const &rhs) -> bool {
-    return lhs.config == rhs.config && lhs.status == rhs.status && lhs.instance_uuid == rhs.instance_uuid;
+    return lhs.config == rhs.config && lhs.status == rhs.status && lhs.instance_uuid == rhs.instance_uuid &&
+           lhs.needs_demote == rhs.needs_demote;
   }
 };
 

--- a/src/coordination/include/nuraft/coordinator_cluster_state.hpp
+++ b/src/coordination/include/nuraft/coordinator_cluster_state.hpp
@@ -64,8 +64,8 @@ struct CoordinatorInstanceState {
 void to_json(nlohmann::json &j, ReplicationInstanceState const &instance_state);
 void from_json(nlohmann::json const &j, ReplicationInstanceState &instance_state);
 
-using TRaftLog = std::variant<std::monostate, CoordinatorToReplicaConfig, std::string, utils::UUID,
-                              CoordinatorToCoordinatorConfig, InstanceUUIDUpdate>;
+using TRaftLog = std::variant<std::string, utils::UUID, CoordinatorToReplicaConfig, CoordinatorToCoordinatorConfig,
+                              InstanceUUIDUpdate, std::monostate>;
 
 using nuraft::buffer;
 using nuraft::buffer_serializer;

--- a/src/coordination/include/nuraft/coordinator_state_machine.hpp
+++ b/src/coordination/include/nuraft/coordinator_state_machine.hpp
@@ -51,6 +51,7 @@ class CoordinatorStateMachine : public state_machine {
   static auto SerializeUpdateUUIDForNewMain(utils::UUID const &uuid) -> ptr<buffer>;
   static auto SerializeUpdateUUIDForInstance(InstanceUUIDUpdate const &instance_uuid_change) -> ptr<buffer>;
   static auto SerializeAddCoordinatorInstance(CoordinatorToCoordinatorConfig const &config) -> ptr<buffer>;
+  static auto SerializeInstanceNeedsDemote(std::string_view instance_name) -> ptr<buffer>;
 
   static auto DecodeLog(buffer &data) -> std::pair<TRaftLog, RaftLogAction>;
 

--- a/src/coordination/include/nuraft/coordinator_state_machine.hpp
+++ b/src/coordination/include/nuraft/coordinator_state_machine.hpp
@@ -44,6 +44,7 @@ class CoordinatorStateMachine : public state_machine {
 
   static auto CreateLog(nlohmann::json &&log) -> ptr<buffer>;
   static auto SerializeOpenLock() -> ptr<buffer>;
+  static auto SerializeCloseLock() -> ptr<buffer>;
   static auto SerializeRegisterInstance(CoordinatorToReplicaConfig const &config) -> ptr<buffer>;
   static auto SerializeUnregisterInstance(std::string_view instance_name) -> ptr<buffer>;
   static auto SerializeSetInstanceAsMain(InstanceUUIDUpdate const &instance_uuid_change) -> ptr<buffer>;

--- a/src/coordination/include/nuraft/coordinator_state_machine.hpp
+++ b/src/coordination/include/nuraft/coordinator_state_machine.hpp
@@ -43,10 +43,7 @@ class CoordinatorStateMachine : public state_machine {
   ~CoordinatorStateMachine() override = default;
 
   static auto CreateLog(nlohmann::json &&log) -> ptr<buffer>;
-  static auto SerializeOpenLockRegister(CoordinatorToReplicaConfig const &config) -> ptr<buffer>;
-  static auto SerializeOpenLockUnregister(std::string_view instance_name) -> ptr<buffer>;
-  static auto SerializeOpenLockSetInstanceAsMain(std::string_view instance_name) -> ptr<buffer>;
-  static auto SerializeOpenLockFailover(std::string_view instance_name) -> ptr<buffer>;
+  static auto SerializeOpenLock() -> ptr<buffer>;
   static auto SerializeRegisterInstance(CoordinatorToReplicaConfig const &config) -> ptr<buffer>;
   static auto SerializeUnregisterInstance(std::string_view instance_name) -> ptr<buffer>;
   static auto SerializeSetInstanceAsMain(InstanceUUIDUpdate const &instance_uuid_change) -> ptr<buffer>;
@@ -54,8 +51,6 @@ class CoordinatorStateMachine : public state_machine {
   static auto SerializeUpdateUUIDForNewMain(utils::UUID const &uuid) -> ptr<buffer>;
   static auto SerializeUpdateUUIDForInstance(InstanceUUIDUpdate const &instance_uuid_change) -> ptr<buffer>;
   static auto SerializeAddCoordinatorInstance(CoordinatorToCoordinatorConfig const &config) -> ptr<buffer>;
-  static auto SerializeOpenLockSetInstanceAsReplica(std::string_view instance_name) -> ptr<buffer>;
-  static auto SerializeOpenLockForceReset() -> ptr<buffer>;
 
   static auto DecodeLog(buffer &data) -> std::pair<TRaftLog, RaftLogAction>;
 

--- a/src/coordination/include/nuraft/coordinator_state_machine.hpp
+++ b/src/coordination/include/nuraft/coordinator_state_machine.hpp
@@ -55,6 +55,7 @@ class CoordinatorStateMachine : public state_machine {
   static auto SerializeUpdateUUIDForInstance(InstanceUUIDUpdate const &instance_uuid_change) -> ptr<buffer>;
   static auto SerializeAddCoordinatorInstance(CoordinatorToCoordinatorConfig const &config) -> ptr<buffer>;
   static auto SerializeOpenLockSetInstanceAsReplica(std::string_view instance_name) -> ptr<buffer>;
+  static auto SerializeOpenLockForceReset() -> ptr<buffer>;
 
   static auto DecodeLog(buffer &data) -> std::pair<TRaftLog, RaftLogAction>;
 

--- a/src/coordination/include/nuraft/raft_log_action.hpp
+++ b/src/coordination/include/nuraft/raft_log_action.hpp
@@ -31,7 +31,8 @@ enum class RaftLogAction : uint8_t {
   UPDATE_UUID_OF_NEW_MAIN,
   ADD_COORDINATOR_INSTANCE,
   UPDATE_UUID_FOR_INSTANCE,
-  INSTANCE_NEEDS_DEMOTE
+  INSTANCE_NEEDS_DEMOTE,
+  CLOSE_LOCK
 };
 
 NLOHMANN_JSON_SERIALIZE_ENUM(RaftLogAction, {{RaftLogAction::REGISTER_REPLICATION_INSTANCE, "register"},
@@ -42,7 +43,8 @@ NLOHMANN_JSON_SERIALIZE_ENUM(RaftLogAction, {{RaftLogAction::REGISTER_REPLICATIO
                                              {RaftLogAction::ADD_COORDINATOR_INSTANCE, "add_coordinator_instance"},
                                              {RaftLogAction::UPDATE_UUID_FOR_INSTANCE, "update_uuid_for_instance"},
                                              {RaftLogAction::INSTANCE_NEEDS_DEMOTE, "instance_needs_demote"},
-                                             {RaftLogAction::OPEN_LOCK, "open_lock"}})
+                                             {RaftLogAction::OPEN_LOCK, "open_lock"},
+                                             {RaftLogAction::CLOSE_LOCK, "close_lock"}})
 
 }  // namespace memgraph::coordination
 #endif

--- a/src/coordination/include/nuraft/raft_log_action.hpp
+++ b/src/coordination/include/nuraft/raft_log_action.hpp
@@ -31,6 +31,7 @@ enum class RaftLogAction : uint8_t {
   UPDATE_UUID_OF_NEW_MAIN,
   ADD_COORDINATOR_INSTANCE,
   UPDATE_UUID_FOR_INSTANCE,
+  INSTANCE_NEEDS_DEMOTE
 };
 
 NLOHMANN_JSON_SERIALIZE_ENUM(RaftLogAction, {{RaftLogAction::REGISTER_REPLICATION_INSTANCE, "register"},
@@ -40,6 +41,7 @@ NLOHMANN_JSON_SERIALIZE_ENUM(RaftLogAction, {{RaftLogAction::REGISTER_REPLICATIO
                                              {RaftLogAction::UPDATE_UUID_OF_NEW_MAIN, "update_uuid_of_new_main"},
                                              {RaftLogAction::ADD_COORDINATOR_INSTANCE, "add_coordinator_instance"},
                                              {RaftLogAction::UPDATE_UUID_FOR_INSTANCE, "update_uuid_for_instance"},
+                                             {RaftLogAction::INSTANCE_NEEDS_DEMOTE, "instance_needs_demote"},
                                              {RaftLogAction::OPEN_LOCK, "open_lock"}})
 
 }  // namespace memgraph::coordination

--- a/src/coordination/include/nuraft/raft_log_action.hpp
+++ b/src/coordination/include/nuraft/raft_log_action.hpp
@@ -35,6 +35,7 @@ enum class RaftLogAction : uint8_t {
   UPDATE_UUID_OF_NEW_MAIN,
   ADD_COORDINATOR_INSTANCE,
   UPDATE_UUID_FOR_INSTANCE,
+  OPEN_LOCK_FORCE_RESET,
 };
 
 NLOHMANN_JSON_SERIALIZE_ENUM(RaftLogAction,
@@ -50,7 +51,8 @@ NLOHMANN_JSON_SERIALIZE_ENUM(RaftLogAction,
                                "open_lock_unregister_instance"},
                               {RaftLogAction::OPEN_LOCK_FAILOVER, "open_lock_failover"},
                               {RaftLogAction::OPEN_LOCK_SET_INSTANCE_AS_MAIN, "open_lock_set_instance_as_main"},
-                              {RaftLogAction::OPEN_LOCK_SET_INSTANCE_AS_REPLICA, "open_lock_set_instance_as_replica"}})
+                              {RaftLogAction::OPEN_LOCK_SET_INSTANCE_AS_REPLICA, "open_lock_set_instance_as_replica"},
+                              {RaftLogAction::OPEN_LOCK_FORCE_RESET, "force_reset"}})
 
 }  // namespace memgraph::coordination
 #endif

--- a/src/coordination/include/nuraft/raft_log_action.hpp
+++ b/src/coordination/include/nuraft/raft_log_action.hpp
@@ -23,11 +23,7 @@
 namespace memgraph::coordination {
 
 enum class RaftLogAction : uint8_t {
-  OPEN_LOCK_REGISTER_REPLICATION_INSTANCE,
-  OPEN_LOCK_UNREGISTER_REPLICATION_INSTANCE,
-  OPEN_LOCK_FAILOVER,
-  OPEN_LOCK_SET_INSTANCE_AS_MAIN,
-  OPEN_LOCK_SET_INSTANCE_AS_REPLICA,
+  OPEN_LOCK,
   REGISTER_REPLICATION_INSTANCE,
   UNREGISTER_REPLICATION_INSTANCE,
   SET_INSTANCE_AS_MAIN,
@@ -35,24 +31,16 @@ enum class RaftLogAction : uint8_t {
   UPDATE_UUID_OF_NEW_MAIN,
   ADD_COORDINATOR_INSTANCE,
   UPDATE_UUID_FOR_INSTANCE,
-  OPEN_LOCK_FORCE_RESET,
 };
 
-NLOHMANN_JSON_SERIALIZE_ENUM(RaftLogAction,
-                             {{RaftLogAction::REGISTER_REPLICATION_INSTANCE, "register"},
-                              {RaftLogAction::UNREGISTER_REPLICATION_INSTANCE, "unregister"},
-                              {RaftLogAction::SET_INSTANCE_AS_MAIN, "promote"},
-                              {RaftLogAction::SET_INSTANCE_AS_REPLICA, "demote"},
-                              {RaftLogAction::UPDATE_UUID_OF_NEW_MAIN, "update_uuid_of_new_main"},
-                              {RaftLogAction::ADD_COORDINATOR_INSTANCE, "add_coordinator_instance"},
-                              {RaftLogAction::UPDATE_UUID_FOR_INSTANCE, "update_uuid_for_instance"},
-                              {RaftLogAction::OPEN_LOCK_REGISTER_REPLICATION_INSTANCE, "open_lock_register_instance"},
-                              {RaftLogAction::OPEN_LOCK_UNREGISTER_REPLICATION_INSTANCE,
-                               "open_lock_unregister_instance"},
-                              {RaftLogAction::OPEN_LOCK_FAILOVER, "open_lock_failover"},
-                              {RaftLogAction::OPEN_LOCK_SET_INSTANCE_AS_MAIN, "open_lock_set_instance_as_main"},
-                              {RaftLogAction::OPEN_LOCK_SET_INSTANCE_AS_REPLICA, "open_lock_set_instance_as_replica"},
-                              {RaftLogAction::OPEN_LOCK_FORCE_RESET, "force_reset"}})
+NLOHMANN_JSON_SERIALIZE_ENUM(RaftLogAction, {{RaftLogAction::REGISTER_REPLICATION_INSTANCE, "register"},
+                                             {RaftLogAction::UNREGISTER_REPLICATION_INSTANCE, "unregister"},
+                                             {RaftLogAction::SET_INSTANCE_AS_MAIN, "promote"},
+                                             {RaftLogAction::SET_INSTANCE_AS_REPLICA, "demote"},
+                                             {RaftLogAction::UPDATE_UUID_OF_NEW_MAIN, "update_uuid_of_new_main"},
+                                             {RaftLogAction::ADD_COORDINATOR_INSTANCE, "add_coordinator_instance"},
+                                             {RaftLogAction::UPDATE_UUID_FOR_INSTANCE, "update_uuid_for_instance"},
+                                             {RaftLogAction::OPEN_LOCK, "open_lock"}})
 
 }  // namespace memgraph::coordination
 #endif

--- a/src/coordination/raft_state.cpp
+++ b/src/coordination/raft_state.cpp
@@ -168,9 +168,29 @@ auto RaftState::AppendOpenLock() -> bool {
     spdlog::error("Failed to accept request to open lock");
     return false;
   }
+  spdlog::trace("Request for opening lock accepted");
 
   if (res->get_result_code() != nuraft::cmd_result_code::OK) {
     spdlog::error("Failed to open lock with error code {}", int(res->get_result_code()));
+    return false;
+  }
+
+  return true;
+}
+
+auto RaftState::AppendCloseLock() -> bool {
+  auto new_log = CoordinatorStateMachine::SerializeCloseLock();
+  auto const res = raft_server_->append_entries({new_log});
+
+  if (!res->get_accepted()) {
+    spdlog::error("Failed to accept request to close lock");
+    return false;
+  }
+
+  spdlog::trace("Request for closing lock accepted");
+
+  if (res->get_result_code() != nuraft::cmd_result_code::OK) {
+    spdlog::error("Failed to close lock with error code {}", int(res->get_result_code()));
     return false;
   }
 
@@ -190,7 +210,7 @@ auto RaftState::AppendRegisterReplicationInstanceLog(CoordinatorToReplicaConfig 
     return false;
   }
 
-  spdlog::info("Request for registering instance {} accepted", config.instance_name);
+  spdlog::trace("Request for registering instance {} accepted", config.instance_name);
 
   if (res->get_result_code() != nuraft::cmd_result_code::OK) {
     spdlog::error("Failed to register instance {} with error code {}", config.instance_name,
@@ -212,7 +232,7 @@ auto RaftState::AppendUnregisterReplicationInstanceLog(std::string_view instance
     return false;
   }
 
-  spdlog::info("Request for unregistering instance {} accepted", instance_name);
+  spdlog::trace("Request for unregistering instance {} accepted", instance_name);
 
   if (res->get_result_code() != nuraft::cmd_result_code::OK) {
     spdlog::error("Failed to unregister instance {} with error code {}", instance_name, int(res->get_result_code()));
@@ -233,7 +253,7 @@ auto RaftState::AppendSetInstanceAsMainLog(std::string_view instance_name, utils
     return false;
   }
 
-  spdlog::info("Request for promoting instance {} accepted", instance_name);
+  spdlog::trace("Request for promoting instance {} accepted", instance_name);
 
   if (res->get_result_code() != nuraft::cmd_result_code::OK) {
     spdlog::error("Failed to promote instance {} with error code {}", instance_name, int(res->get_result_code()));
@@ -252,7 +272,7 @@ auto RaftState::AppendSetInstanceAsReplicaLog(std::string_view instance_name) ->
         instance_name);
     return false;
   }
-  spdlog::info("Request for demoting instance {} accepted", instance_name);
+  spdlog::trace("Request for demoting instance {} accepted", instance_name);
 
   if (res->get_result_code() != nuraft::cmd_result_code::OK) {
     spdlog::error("Failed to promote instance {} with error code {}", instance_name, int(res->get_result_code()));
@@ -292,7 +312,7 @@ auto RaftState::AppendAddCoordinatorInstanceLog(CoordinatorToCoordinatorConfig c
     return false;
   }
 
-  spdlog::info("Request for adding coordinator instance {} accepted", config.coordinator_server_id);
+  spdlog::trace("Request for adding coordinator instance {} accepted", config.coordinator_server_id);
 
   if (res->get_result_code() != nuraft::cmd_result_code::OK) {
     spdlog::error("Failed to add coordinator instance {} with error code {}", config.coordinator_server_id,

--- a/src/coordination/replication_instance.cpp
+++ b/src/coordination/replication_instance.cpp
@@ -64,6 +64,8 @@ auto ReplicationInstance::PromoteToMain(utils::UUID const &new_uuid, Replication
 
 auto ReplicationInstance::SendDemoteToReplicaRpc() -> bool { return client_.DemoteToReplica(); }
 
+auto ReplicationInstance::SendFrequentHeartbeat() const -> bool { return client_.SendFrequentHeartbeat(); }
+
 auto ReplicationInstance::DemoteToReplica(HealthCheckInstanceCallback replica_succ_cb,
                                           HealthCheckInstanceCallback replica_fail_cb) -> bool {
   if (!client_.DemoteToReplica()) {
@@ -85,8 +87,8 @@ auto ReplicationInstance::ReplicationClientInfo() const -> coordination::Replica
   return client_.ReplicationClientInfo();
 }
 
-auto ReplicationInstance::GetSuccessCallback() -> HealthCheckInstanceCallback & { return succ_cb_; }
-auto ReplicationInstance::GetFailCallback() -> HealthCheckInstanceCallback & { return fail_cb_; }
+auto ReplicationInstance::GetSuccessCallback() -> HealthCheckInstanceCallback { return succ_cb_; }
+auto ReplicationInstance::GetFailCallback() -> HealthCheckInstanceCallback { return fail_cb_; }
 
 auto ReplicationInstance::GetClient() -> CoordinatorClient & { return client_; }
 

--- a/src/coordination/replication_instance.cpp
+++ b/src/coordination/replication_instance.cpp
@@ -128,5 +128,10 @@ auto ReplicationInstance::SendGetInstanceUUID()
 
 void ReplicationInstance::UpdateReplicaLastResponseUUID() { last_check_of_uuid_ = std::chrono::system_clock::now(); }
 
+void ReplicationInstance::SetCallbacks(HealthCheckInstanceCallback succ_cb, HealthCheckInstanceCallback fail_cb) {
+  succ_cb_ = succ_cb;
+  fail_cb_ = fail_cb;
+}
+
 }  // namespace memgraph::coordination
 #endif

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -409,9 +409,8 @@ class CoordQueryHandler final : public query::CoordinatorQueryHandler {
             "Couldn't unregister replica instance because current main instance couldn't unregister replica!");
       case LOCK_OPENED:
         throw QueryRuntimeException("Couldn't unregister replica because the last action didn't finish successfully!");
-      case OPEN_LOCK:
-        throw QueryRuntimeException(
-            "Couldn't register instance as cluster didn't accept entering unregistration state!");
+      case FAILED_TO_OPEN_LOCK:
+        throw QueryRuntimeException("Couldn't register instance as cluster didn't accept start of action!");
       case SUCCESS:
         break;
     }
@@ -477,9 +476,8 @@ class CoordQueryHandler final : public query::CoordinatorQueryHandler {
       case LOCK_OPENED:
         throw QueryRuntimeException(
             "Couldn't register replica instance because because the last action didn't finish successfully!");
-      case OPEN_LOCK:
-        throw QueryRuntimeException(
-            "Couldn't register replica instance because cluster didn't accept registration query!");
+      case FAILED_TO_OPEN_LOCK:
+        throw QueryRuntimeException("Couldn't register instance as cluster didn't accept start of action!");
       case SUCCESS:
         break;
     }
@@ -525,9 +523,8 @@ class CoordQueryHandler final : public query::CoordinatorQueryHandler {
             "Couldn't set replica instance to main! Check coordinator and replica for more logs");
       case SWAP_UUID_FAILED:
         throw QueryRuntimeException("Couldn't set replica instance to main. Replicas didn't swap uuid of new main.");
-      case OPEN_LOCK:
-        throw QueryRuntimeException(
-            "Couldn't set replica instance to main as cluster didn't accept setting instance state.");
+      case FAILED_TO_OPEN_LOCK:
+        throw QueryRuntimeException("Couldn't register instance as cluster didn't accept start of action!");
       case LOCK_OPENED:
         throw QueryRuntimeException(
             "Couldn't register replica instance because because the last action didn't finish successfully!");

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -411,6 +411,8 @@ class CoordQueryHandler final : public query::CoordinatorQueryHandler {
         throw QueryRuntimeException("Couldn't unregister replica because the last action didn't finish successfully!");
       case FAILED_TO_OPEN_LOCK:
         throw QueryRuntimeException("Couldn't register instance as cluster didn't accept start of action!");
+      case FAILED_TO_CLOSE_LOCK:
+        throw QueryRuntimeException("Couldn't register instance as cluster didn't accept successful finish of action!");
       case SUCCESS:
         break;
     }
@@ -478,6 +480,8 @@ class CoordQueryHandler final : public query::CoordinatorQueryHandler {
             "Couldn't register replica instance because because the last action didn't finish successfully!");
       case FAILED_TO_OPEN_LOCK:
         throw QueryRuntimeException("Couldn't register instance as cluster didn't accept start of action!");
+      case FAILED_TO_CLOSE_LOCK:
+        throw QueryRuntimeException("Couldn't register instance as cluster didn't accept successful finish of action!");
       case SUCCESS:
         break;
     }
@@ -530,6 +534,8 @@ class CoordQueryHandler final : public query::CoordinatorQueryHandler {
             "Couldn't register replica instance because because the last action didn't finish successfully!");
       case ENABLE_WRITING_FAILED:
         throw QueryRuntimeException("Instance promoted to MAIN, but couldn't enable writing to instance.");
+      case FAILED_TO_CLOSE_LOCK:
+        throw QueryRuntimeException("Couldn't register instance as cluster didn't accept successful finish of action!");
       case SUCCESS:
         break;
     }

--- a/src/replication_coordination_glue/common.hpp
+++ b/src/replication_coordination_glue/common.hpp
@@ -24,7 +24,7 @@ namespace memgraph::replication_coordination_glue {
 struct DatabaseHistory {
   memgraph::utils::UUID db_uuid;
   std::vector<std::pair<std::string, uint64_t>> history;
-  std::string name;
+  std::string name;  // db name
 };
 
 using DatabaseHistories = std::vector<DatabaseHistory>;

--- a/src/replication_coordination_glue/role.hpp
+++ b/src/replication_coordination_glue/role.hpp
@@ -17,7 +17,7 @@
 
 namespace memgraph::replication_coordination_glue {
 
-// TODO: figure out a way of ensuring that usage of this type is never uninitialed/defaulted incorrectly to MAIN
+// TODO: figure out a way of ensuring that usage of this type is never uninitialized/defaulted incorrectly to MAIN
 enum class ReplicationRole : uint8_t { MAIN, REPLICA };
 
 NLOHMANN_JSON_SERIALIZE_ENUM(ReplicationRole, {{ReplicationRole::MAIN, "main"}, {ReplicationRole::REPLICA, "replica"}})

--- a/tests/drivers/run.sh
+++ b/tests/drivers/run.sh
@@ -38,6 +38,7 @@ $binary_dir/memgraph \
     --bolt-cert-file="" \
     --log-file=$tmpdir/logs/memgarph.log \
     --also-log-to-stderr \
+    --telemetry-enabled=false \
     --log-level ERROR &
 pid=$!
 wait_for_server 7687

--- a/tests/drivers/run_cluster.sh
+++ b/tests/drivers/run_cluster.sh
@@ -37,6 +37,7 @@ $binary_dir/memgraph \
     --also-log-to-stderr \
     --management-port=10011 \
     --experimental-enabled=high-availability \
+    --telemetry-enabled=false \
     --log-level ERROR &
 pid_instance_1=$!
 wait_for_server 7687
@@ -53,6 +54,7 @@ $binary_dir/memgraph \
     --also-log-to-stderr \
     --management-port=10012 \
     --experimental-enabled=high-availability \
+    --telemetry-enabled=false \
     --log-level ERROR &
 pid_instance_2=$!
 wait_for_server 7688
@@ -69,6 +71,7 @@ $binary_dir/memgraph \
     --also-log-to-stderr \
     --management-port=10013 \
     --experimental-enabled=high-availability \
+    --telemetry-enabled=false \
     --log-level ERROR &
 pid_instance_3=$!
 wait_for_server 7689
@@ -87,6 +90,7 @@ $binary_dir/memgraph \
     --coordinator-id=1 \
     --coordinator-port=10111 \
     --experimental-enabled=high-availability \
+    --telemetry-enabled=false \
     --log-level ERROR &
 pid_coordinator_1=$!
 wait_for_server 7690
@@ -104,6 +108,7 @@ $binary_dir/memgraph \
     --coordinator-id=2 \
     --coordinator-port=10112 \
     --experimental-enabled=high-availability \
+    --telemetry-enabled=false \
     --log-level ERROR &
 pid_coordinator_2=$!
 wait_for_server 7691
@@ -121,6 +126,7 @@ $binary_dir/memgraph \
     --coordinator-id=3 \
     --coordinator-port=10113 \
     --experimental-enabled=high-availability \
+    --telemetry-enabled=false \
     --log-level ERROR &
 pid_coordinator_3=$!
 wait_for_server 7692

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -219,7 +219,7 @@ def test_old_main_comes_back_on_new_leader_as_replica():
     safe_execute(shutil.rmtree, TEMP_DIR)
     inner_instances_description = get_instances_description_no_setup()
 
-    interactive_mg_runner.start_all(inner_instances_description)
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
 
     setup_queries = [
         "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
@@ -1433,7 +1433,7 @@ def test_force_reset_works_after_failed_registration():
     safe_execute(shutil.rmtree, TEMP_DIR)
     inner_instances_description = get_instances_description_no_setup()
 
-    interactive_mg_runner.start_all(inner_instances_description)
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
 
     setup_queries = [
         "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
@@ -1547,6 +1547,385 @@ def test_force_reset_works_after_failed_registration():
     mg_sleep_and_assert(leader_data, show_instances_coord3)
     mg_sleep_and_assert(follower_data, show_instances_coord1)
     mg_sleep_and_assert(follower_data, show_instances_coord2)
+
+    vertex_count = 10
+    for i in range(vertex_count):
+        execute_and_fetch_all(instance_1_cursor, "CREATE ();")
+
+    def get_vertex_count_func(cursor):
+        def get_vertex_count():
+            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+        return get_vertex_count
+
+    instance_1_cursor = connect(port=7687, host="localhost").cursor()
+    instance_2_cursor = connect(port=7688, host="localhost").cursor()
+
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_3_cursor))
+
+    interactive_mg_runner.stop_all(inner_instances_description)
+    safe_execute(shutil.rmtree, TEMP_DIR)
+
+
+def test_force_reset_works_after_failed_registration_and_main_down():
+    # Goal of this test is to check when leadership changes
+    # and we have old MAIN down, that we don't start failover
+    # 1. Start all instances.
+    # 2. Check everything works correctly
+    # 3. Kill main
+    # 4. Try to register instance which doesn't exist
+    # 4. Enter force reset
+    # 5. Check that everything works correctly with two instances
+    # 6. Start main instance
+    # 7. Check that main is correctly demoted to replica
+
+    # 1
+    safe_execute(shutil.rmtree, TEMP_DIR)
+    inner_instances_description = get_instances_description_no_setup()
+
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+
+    setup_queries = [
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "SET INSTANCE instance_3 TO MAIN",
+    ]
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+    for query in setup_queries:
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    # 2
+
+    def show_instances_coord3():
+        return sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;")))
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        return sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;")))
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    def show_instances_coord2():
+        return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
+
+    leader_data = [
+        ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "127.0.0.1:10113", "", "unknown", "coordinator"),
+        ("instance_1", "", "127.0.0.1:10011", "up", "replica"),
+        ("instance_2", "", "127.0.0.1:10012", "up", "replica"),
+        ("instance_3", "", "127.0.0.1:10013", "up", "main"),
+    ]
+
+    follower_data = [
+        ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "127.0.0.1:10113", "", "unknown", "coordinator"),
+        ("instance_1", "", "", "unknown", "replica"),
+        ("instance_2", "", "", "unknown", "replica"),
+        ("instance_3", "", "", "unknown", "main"),
+    ]
+    mg_sleep_and_assert(leader_data, show_instances_coord3)
+    mg_sleep_and_assert(follower_data, show_instances_coord1)
+    mg_sleep_and_assert(follower_data, show_instances_coord2)
+
+    instance_3_cursor = connect(host="localhost", port=7689).cursor()
+
+    def show_replicas():
+        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+
+    replicas = [
+        (
+            "instance_1",
+            "127.0.0.1:10001",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+        (
+            "instance_2",
+            "127.0.0.1:10002",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+    ]
+    mg_sleep_and_assert_collection(replicas, show_replicas)
+
+    def get_vertex_count_func(cursor):
+        def get_vertex_count():
+            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+        return get_vertex_count
+
+    vertex_count = 0
+    instance_1_cursor = connect(port=7687, host="localhost").cursor()
+    instance_2_cursor = connect(port=7688, host="localhost").cursor()
+
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+
+    with pytest.raises(Exception) as e:
+        execute_and_fetch_all(
+            coord_cursor_3,
+            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': '127.0.0.1:7680', 'management_server': '127.0.0.1:10050', 'replication_server': '127.0.0.1:10051'};",
+        )
+
+    # This will trigger force reset and choosing of new instance as MAIN
+    leader_data = [
+        ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "127.0.0.1:10113", "", "unknown", "coordinator"),
+        ("instance_1", "", "127.0.0.1:10011", "up", "main"),
+        ("instance_2", "", "127.0.0.1:10012", "up", "replica"),
+        ("instance_3", "", "127.0.0.1:10013", "up", "replica"),
+    ]
+
+    follower_data = [
+        ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "127.0.0.1:10113", "", "unknown", "coordinator"),
+        ("instance_1", "", "", "unknown", "main"),
+        ("instance_2", "", "", "unknown", "replica"),
+        ("instance_3", "", "", "unknown", "replica"),
+    ]
+
+    mg_sleep_and_assert(leader_data, show_instances_coord3)
+    mg_sleep_and_assert(follower_data, show_instances_coord1)
+    mg_sleep_and_assert(follower_data, show_instances_coord2)
+
+    vertex_count = 10
+    for i in range(vertex_count):
+        execute_and_fetch_all(instance_1_cursor, "CREATE ();")
+
+    def get_vertex_count_func(cursor):
+        def get_vertex_count():
+            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+        return get_vertex_count
+
+    instance_1_cursor = connect(port=7687, host="localhost").cursor()
+    instance_2_cursor = connect(port=7688, host="localhost").cursor()
+
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_3_cursor))
+
+    interactive_mg_runner.stop_all(inner_instances_description)
+    safe_execute(shutil.rmtree, TEMP_DIR)
+
+
+def test_force_reset_works_after_failed_registration_and_replica_down():
+    # Goal of this test is to check when leadership changes
+    # and we have old MAIN down, that we don't start failover
+    # 1. Start all instances.
+    # 2. Check everything works correctly
+    # 3. Kill replica
+    # 4. Try to register instance which doesn't exist
+    # 4. Enter force reset
+    # 5. Check that everything works correctly with two instances
+    # 6. Start replica instance
+    # 7. Check that replica is correctly demoted to replica
+
+    # 1
+    safe_execute(shutil.rmtree, TEMP_DIR)
+    inner_instances_description = get_instances_description_no_setup()
+
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+
+    setup_queries = [
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "SET INSTANCE instance_3 TO MAIN",
+    ]
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+    for query in setup_queries:
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    # 2
+
+    def show_instances_coord3():
+        return sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;")))
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        return sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;")))
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    def show_instances_coord2():
+        return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
+
+    leader_data = [
+        ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "127.0.0.1:10113", "", "unknown", "coordinator"),
+        ("instance_1", "", "127.0.0.1:10011", "up", "replica"),
+        ("instance_2", "", "127.0.0.1:10012", "up", "replica"),
+        ("instance_3", "", "127.0.0.1:10013", "up", "main"),
+    ]
+
+    follower_data = [
+        ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "127.0.0.1:10113", "", "unknown", "coordinator"),
+        ("instance_1", "", "", "unknown", "replica"),
+        ("instance_2", "", "", "unknown", "replica"),
+        ("instance_3", "", "", "unknown", "main"),
+    ]
+    mg_sleep_and_assert(leader_data, show_instances_coord3)
+    mg_sleep_and_assert(follower_data, show_instances_coord1)
+    mg_sleep_and_assert(follower_data, show_instances_coord2)
+
+    instance_3_cursor = connect(host="localhost", port=7689).cursor()
+
+    def show_replicas():
+        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+
+    replicas = [
+        (
+            "instance_1",
+            "127.0.0.1:10001",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+        (
+            "instance_2",
+            "127.0.0.1:10002",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+    ]
+    mg_sleep_and_assert_collection(replicas, show_replicas)
+
+    def get_vertex_count_func(cursor):
+        def get_vertex_count():
+            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+        return get_vertex_count
+
+    vertex_count = 0
+    instance_1_cursor = connect(port=7687, host="localhost").cursor()
+    instance_2_cursor = connect(port=7688, host="localhost").cursor()
+
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+
+    # 3
+
+    interactive_mg_runner.kill(inner_instances_description, "instance_2")
+
+    # 4
+
+    with pytest.raises(Exception) as e:
+        execute_and_fetch_all(
+            coord_cursor_3,
+            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': '127.0.0.1:7680', 'management_server': '127.0.0.1:10050', 'replication_server': '127.0.0.1:10051'};",
+        )
+
+    # 5
+    # This will trigger force reset and choosing of new instance as MAIN
+    leader_data = [
+        ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "127.0.0.1:10113", "", "unknown", "coordinator"),
+        ("instance_1", "", "127.0.0.1:10011", "up", "main"),
+        ("instance_2", "", "127.0.0.1:10012", "down", "unknown"),
+        ("instance_3", "", "127.0.0.1:10013", "up", "replica"),
+    ]
+
+    follower_data = [
+        ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "127.0.0.1:10113", "", "unknown", "coordinator"),
+        ("instance_1", "", "", "unknown", "main"),
+        ("instance_2", "", "", "unknown", "replica"),  # TODO(antoniofilipovic) What is logic behind unknown state
+        ("instance_3", "", "", "unknown", "replica"),
+    ]
+
+    mg_sleep_and_assert(leader_data, show_instances_coord3)
+    mg_sleep_and_assert(follower_data, show_instances_coord1)
+    mg_sleep_and_assert(follower_data, show_instances_coord2)
+
+    # 6
+
+    interactive_mg_runner.start(inner_instances_description, "instance_2")
+
+    # 7
+
+    leader_data = [
+        ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "127.0.0.1:10113", "", "unknown", "coordinator"),
+        ("instance_1", "", "127.0.0.1:10011", "up", "main"),
+        ("instance_2", "", "127.0.0.1:10012", "up", "replica"),
+        ("instance_3", "", "127.0.0.1:10013", "up", "replica"),
+    ]
+
+    follower_data = [
+        ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "127.0.0.1:10113", "", "unknown", "coordinator"),
+        ("instance_1", "", "", "unknown", "main"),
+        ("instance_2", "", "", "unknown", "replica"),
+        ("instance_3", "", "", "unknown", "replica"),
+    ]
+
+    mg_sleep_and_assert(leader_data, show_instances_coord3)
+    mg_sleep_and_assert(follower_data, show_instances_coord1)
+    mg_sleep_and_assert(follower_data, show_instances_coord2)
+
+    def show_replicas():
+        return sorted(list(execute_and_fetch_all(instance_1_cursor, "SHOW REPLICAS;")))
+
+    replicas = [
+        (
+            "instance_2",
+            "127.0.0.1:10002",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+        (
+            "instance_3",
+            "127.0.0.1:10003",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+    ]
+    mg_sleep_and_assert_collection(replicas, show_replicas)
+
+    # 8
+
+    vertex_count = 10
+    for i in range(vertex_count):
+        execute_and_fetch_all(instance_1_cursor, "CREATE ();")
+
+    def get_vertex_count_func(cursor):
+        def get_vertex_count():
+            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+        return get_vertex_count
+
+    instance_1_cursor = connect(port=7687, host="localhost").cursor()
+    instance_2_cursor = connect(port=7688, host="localhost").cursor()
+
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_3_cursor))
 
 
 if __name__ == "__main__":

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -1420,5 +1420,135 @@ def test_multiple_old_mains_single_failover():
         time_slept += 0.1
 
 
+def test_force_reset_works_after_failed_registration():
+    # Goal of this test is to check when leadership changes
+    # and we have old MAIN down, that we don't start failover
+    # 1. Start all instances.
+    # 2. Check everything works correctly
+    # 3. Try register instance which doesn't exist
+    # 4. Enter force reset
+    # 5. Check that everything works correctly
+
+    # 1
+    safe_execute(shutil.rmtree, TEMP_DIR)
+    inner_instances_description = get_instances_description_no_setup()
+
+    interactive_mg_runner.start_all(inner_instances_description)
+
+    setup_queries = [
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "SET INSTANCE instance_3 TO MAIN",
+    ]
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+    for query in setup_queries:
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    # 2
+
+    def show_instances_coord3():
+        return sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;")))
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        return sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;")))
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    def show_instances_coord2():
+        return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
+
+    leader_data = [
+        ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "127.0.0.1:10113", "", "unknown", "coordinator"),
+        ("instance_1", "", "127.0.0.1:10011", "up", "replica"),
+        ("instance_2", "", "127.0.0.1:10012", "up", "replica"),
+        ("instance_3", "", "127.0.0.1:10013", "up", "main"),
+    ]
+
+    follower_data = [
+        ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "127.0.0.1:10113", "", "unknown", "coordinator"),
+        ("instance_1", "", "", "unknown", "replica"),
+        ("instance_2", "", "", "unknown", "replica"),
+        ("instance_3", "", "", "unknown", "main"),
+    ]
+    mg_sleep_and_assert(leader_data, show_instances_coord3)
+    mg_sleep_and_assert(follower_data, show_instances_coord1)
+    mg_sleep_and_assert(follower_data, show_instances_coord2)
+
+    instance_3_cursor = connect(host="localhost", port=7689).cursor()
+
+    def show_replicas():
+        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+
+    replicas = [
+        (
+            "instance_1",
+            "127.0.0.1:10001",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+        (
+            "instance_2",
+            "127.0.0.1:10002",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+    ]
+    mg_sleep_and_assert_collection(replicas, show_replicas)
+
+    def get_vertex_count_func(cursor):
+        def get_vertex_count():
+            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+        return get_vertex_count
+
+    vertex_count = 0
+    instance_1_cursor = connect(port=7687, host="localhost").cursor()
+    instance_2_cursor = connect(port=7688, host="localhost").cursor()
+
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+
+    with pytest.raises(Exception) as e:
+        execute_and_fetch_all(
+            coord_cursor_3,
+            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': '127.0.0.1:7680', 'management_server': '127.0.0.1:10050', 'replication_server': '127.0.0.1:10051'};",
+        )
+
+    # This will trigger force reset and choosing of new instance as MAIN
+    leader_data = [
+        ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "127.0.0.1:10113", "", "unknown", "coordinator"),
+        ("instance_1", "", "127.0.0.1:10011", "up", "main"),
+        ("instance_2", "", "127.0.0.1:10012", "up", "replica"),
+        ("instance_3", "", "127.0.0.1:10013", "down", "unknown"),
+    ]
+
+    follower_data = [
+        ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "127.0.0.1:10113", "", "unknown", "coordinator"),
+        ("instance_1", "", "", "unknown", "main"),
+        ("instance_2", "", "", "unknown", "replica"),
+        ("instance_3", "", "", "unknown", "unknown"),
+    ]
+
+    mg_sleep_and_assert(leader_data, show_instances_coord3)
+    mg_sleep_and_assert(follower_data, show_instances_coord1)
+    mg_sleep_and_assert(follower_data, show_instances_coord2)
+
+
 if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-k", "test_force_reset_works_after_failed_registration", "-vv"]))
     sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -1532,7 +1532,7 @@ def test_force_reset_works_after_failed_registration():
         ("coordinator_3", "127.0.0.1:10113", "", "unknown", "coordinator"),
         ("instance_1", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "", "127.0.0.1:10013", "down", "unknown"),
+        ("instance_3", "", "127.0.0.1:10013", "up", "replica"),
     ]
 
     follower_data = [
@@ -1541,7 +1541,7 @@ def test_force_reset_works_after_failed_registration():
         ("coordinator_3", "127.0.0.1:10113", "", "unknown", "coordinator"),
         ("instance_1", "", "", "unknown", "main"),
         ("instance_2", "", "", "unknown", "replica"),
-        ("instance_3", "", "", "unknown", "unknown"),
+        ("instance_3", "", "", "unknown", "replica"),
     ]
 
     mg_sleep_and_assert(leader_data, show_instances_coord3)
@@ -1550,5 +1550,4 @@ def test_force_reset_works_after_failed_registration():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__, "-k", "test_force_reset_works_after_failed_registration", "-vv"]))
     sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -1421,8 +1421,7 @@ def test_multiple_old_mains_single_failover():
 
 
 def test_force_reset_works_after_failed_registration():
-    # Goal of this test is to check when leadership changes
-    # and we have old MAIN down, that we don't start failover
+    # Goal of this test is to check that force reset works after failed registration
     # 1. Start all instances.
     # 2. Check everything works correctly
     # 3. Try register instance which doesn't exist
@@ -1570,8 +1569,8 @@ def test_force_reset_works_after_failed_registration():
 
 
 def test_force_reset_works_after_failed_registration_and_main_down():
-    # Goal of this test is to check when leadership changes
-    # and we have old MAIN down, that we don't start failover
+    # Goal of this test is to check when action fails, that force reset happens
+    # and everything works correctly when MAIN is down (needs to be demoted)
     # 1. Start all instances.
     # 2. Check everything works correctly
     # 3. Kill main
@@ -1722,8 +1721,8 @@ def test_force_reset_works_after_failed_registration_and_main_down():
 
 
 def test_force_reset_works_after_failed_registration_and_replica_down():
-    # Goal of this test is to check when leadership changes
-    # and we have old MAIN down, that we don't start failover
+    # Goal of this test is to check when action fails, that force reset happens
+    # and everything works correctly when REPLICA is down (can be demoted but doesn't have to - we demote it)
     # 1. Start all instances.
     # 2. Check everything works correctly
     # 3. Kill replica
@@ -1886,6 +1885,209 @@ def test_force_reset_works_after_failed_registration_and_replica_down():
     mg_sleep_and_assert(leader_data, show_instances_coord3)
     mg_sleep_and_assert(follower_data, show_instances_coord1)
     mg_sleep_and_assert(follower_data, show_instances_coord2)
+
+    def show_replicas():
+        return sorted(list(execute_and_fetch_all(instance_1_cursor, "SHOW REPLICAS;")))
+
+    replicas = [
+        (
+            "instance_2",
+            "127.0.0.1:10002",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+        (
+            "instance_3",
+            "127.0.0.1:10003",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+    ]
+    mg_sleep_and_assert_collection(replicas, show_replicas)
+
+    # 8
+
+    vertex_count = 10
+    for i in range(vertex_count):
+        execute_and_fetch_all(instance_1_cursor, "CREATE ();")
+
+    def get_vertex_count_func(cursor):
+        def get_vertex_count():
+            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+        return get_vertex_count
+
+    instance_1_cursor = connect(port=7687, host="localhost").cursor()
+    instance_2_cursor = connect(port=7688, host="localhost").cursor()
+
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_3_cursor))
+
+
+def test_force_reset_works_after_failed_registration_and_2_coordinators_down():
+    # Goal of this test is to check when action fails, that force reset happens
+    # and everything works correctly after majority of coordinators is back up
+    # 1. Start all instances.
+    # 2. Check everything works correctly
+    # 3. Try to register instance which doesn't exist -> Enter force reset
+    # 4. Kill 2 coordinators
+    # 5. New action shouldn't succeed because of opened lock
+    # 6. Start one coordinator
+    # 7. Check that replica failover happens in force reset
+    # 8. Check that everything works correctly
+
+    # 1
+    safe_execute(shutil.rmtree, TEMP_DIR)
+    inner_instances_description = get_instances_description_no_setup()
+
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+
+    setup_queries = [
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "SET INSTANCE instance_3 TO MAIN",
+    ]
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+    for query in setup_queries:
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    # 2
+
+    def show_instances_coord3():
+        return sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;")))
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        return sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;")))
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    def show_instances_coord2():
+        return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
+
+    leader_data = [
+        ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "127.0.0.1:10113", "", "unknown", "coordinator"),
+        ("instance_1", "", "127.0.0.1:10011", "up", "replica"),
+        ("instance_2", "", "127.0.0.1:10012", "up", "replica"),
+        ("instance_3", "", "127.0.0.1:10013", "up", "main"),
+    ]
+
+    follower_data = [
+        ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "127.0.0.1:10113", "", "unknown", "coordinator"),
+        ("instance_1", "", "", "unknown", "replica"),
+        ("instance_2", "", "", "unknown", "replica"),
+        ("instance_3", "", "", "unknown", "main"),
+    ]
+    mg_sleep_and_assert(leader_data, show_instances_coord3)
+    mg_sleep_and_assert(follower_data, show_instances_coord1)
+    mg_sleep_and_assert(follower_data, show_instances_coord2)
+
+    instance_3_cursor = connect(host="localhost", port=7689).cursor()
+
+    def show_replicas():
+        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+
+    replicas = [
+        (
+            "instance_1",
+            "127.0.0.1:10001",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+        (
+            "instance_2",
+            "127.0.0.1:10002",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+    ]
+    mg_sleep_and_assert_collection(replicas, show_replicas)
+
+    def get_vertex_count_func(cursor):
+        def get_vertex_count():
+            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+        return get_vertex_count
+
+    vertex_count = 0
+    instance_1_cursor = connect(port=7687, host="localhost").cursor()
+    instance_2_cursor = connect(port=7688, host="localhost").cursor()
+
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+
+    # 3
+
+    with pytest.raises(Exception) as e:
+        execute_and_fetch_all(
+            coord_cursor_3,
+            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': '127.0.0.1:7680', 'management_server': '127.0.0.1:10050', 'replication_server': '127.0.0.1:10051'};",
+        )
+
+    # 4
+    interactive_mg_runner.kill(inner_instances_description, "coordinator_2")
+    interactive_mg_runner.kill(inner_instances_description, "coordinator_3")
+
+    # 5
+    with pytest.raises(Exception) as e:
+        execute_and_fetch_all(
+            coord_cursor_1,
+            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': '127.0.0.1:7680', 'management_server': '127.0.0.1:10050', 'replication_server': '127.0.0.1:10051'};",
+        )
+
+    assert "Couldn't register replica instance because because the last action didn't finish successfully!" == str(
+        e.value
+    )
+
+    # 6
+
+    interactive_mg_runner.start(inner_instances_description, "coordinator_2")
+
+    # 7
+
+    leader_data = [
+        ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "127.0.0.1:10113", "", "unknown", "coordinator"),
+        ("instance_1", "", "127.0.0.1:10011", "up", "main"),
+        ("instance_2", "", "127.0.0.1:10012", "up", "replica"),
+        ("instance_3", "", "127.0.0.1:10013", "up", "replica"),
+    ]
+
+    follower_data = [
+        ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "127.0.0.1:10113", "", "unknown", "coordinator"),
+        ("instance_1", "", "", "unknown", "main"),
+        ("instance_2", "", "", "unknown", "replica"),
+        ("instance_3", "", "", "unknown", "replica"),
+    ]
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        return sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;")))
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    def show_instances_coord2():
+        return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
+
+    mg_sleep_and_assert_any_function(leader_data, [show_instances_coord1, show_instances_coord2])
+    mg_sleep_and_assert_any_function(follower_data, [show_instances_coord1, show_instances_coord2])
 
     def show_replicas():
         return sorted(list(execute_and_fetch_all(instance_1_cursor, "SHOW REPLICAS;")))


### PR DESCRIPTION
### Description

This PR introduces a force reset of cluster state to state that was before the operation started.

_Implemented_
_Enable force reset to work on:_
- [x] coordinator becoming a leader in an unhealthy state
- [x] failover fail
- [x] register instance fail
- [x] unregister instance fail
- [x]  promote instance to main fail
- [x] force reset fail

_Additional work:_
- [x] Add test when we enter force reset
- [x] Fix bug on not demoting first all instances to replicas
- [x] Take care of instances which were down and couldn't be demoted to replica, but are in unknown state
- [x] Add test when force reset needs to happen
- [x] Add test when main dies before force reset needs to happen
- [x] Add test when replica dies before force reset needs to happen
- [x] Add test when few coordinators die when force reset is happening

[master < Task] PR
- [ ] Provide the full content or a guide for the final git message
    Add force reset of cluster in HA
    - When the action doesn't succeed atomically cluster enters a force reset state. 
    - For instances that are down introduce demote to replica callback.
    - Use unique lock and unlock raft log to change state
    - Add action for instance which needs to be demoted to replica


### Documentation checklist
- [ ] Add the documentation label tag
- [ ] Add the bug / feature label tag
- [ ] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - **[Release note text]**
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [ ] Tag someone from docs team in the comments
