### PR TITLE
Fix jepsen nodes not starting up healthy

### DIFF
--- a/tests/jepsen/run.sh
+++ b/tests/jepsen/run.sh
@@ -178,8 +178,16 @@ PROCESS_RESULTS() {
 
 CLUSTER_UP() {
   PRINT_CONTEXT
-  "$script_dir/jepsen/docker/bin/up" --daemon
-  sleep 10
+  local cnt=0
+  while [[ "$cnt" < 5 ]]; do
+    if ! "$script_dir/jepsen/docker/bin/up" --daemon; then
+      cnt=$((cnt + 1))
+      continue
+    else
+      sleep 10
+      break
+    fi
+  done
   # Ensure all SSH connections between Jepsen containers work
   for node in $(docker ps --filter name=jepsen* --filter status=running --format "{{.Names}}"); do
       if [ "$node" == "jepsen-control" ]; then


### PR DESCRIPTION
### Description

This is a pretty brutish fix, but it works!
This PR will add a loop to check if all nodes started correctly and restart if any failed. The loop will do 5 iterations.

Please delete either the [master < EPIC] or [master < Task] part, depending on what are your needs.

[master < Task] PR
- [x] Provide the full content or a guide for the final git message
    - add a loop to check if all nodes started correctly and restart if any failed


### Documentation checklist
- [x] Add the documentation label tag
