### PR TITLE
Package and upload RC builds for ARM

### DIFF
--- a/.github/workflows/release_build_test.yaml
+++ b/.github/workflows/release_build_test.yaml
@@ -70,15 +70,18 @@ jobs:
       build_type: ${{ github.event.inputs.build_type || 'Release' }}
     secrets: inherit
 
-  Package:
+  PackageAndUpload:
     if: github.ref_type == 'tag'
     needs: [TestIndividual]
+    strategy:
+      matrix:
+        arch: [amd, arm]
     uses: ./.github/workflows/reusable_package.yaml
     with:
-      os: ${{ github.event.inputs.os || 'debian-11' }}
-      toolchain: ${{ github.event.inputs.toolchain || 'v5' }}
-      arch: "amd"
-      build_type: ${{ github.event.inputs.build_type || 'Release' }}
+      os: 'debian-11'
+      toolchain: 'v5'
+      arch: "${{ matrix.arch }}"
+      build_type: 'Release'
       push_to_s3: 'true'
       s3_bucket: "deps.memgraph.io"
       s3_region: "eu-west-1"

--- a/.github/workflows/release_build_test.yaml
+++ b/.github/workflows/release_build_test.yaml
@@ -71,8 +71,8 @@ jobs:
     secrets: inherit
 
   PackageAndUpload:
-    # if: github.ref_type == 'tag'
-    # needs: [TestIndividual]
+    if: github.ref_type == 'tag'
+    needs: [TestIndividual]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release_build_test.yaml
+++ b/.github/workflows/release_build_test.yaml
@@ -71,7 +71,7 @@ jobs:
     secrets: inherit
 
   PackageAndUpload:
-    if: github.ref_type == 'tag'
+    # if: github.ref_type == 'tag'
     needs: [TestIndividual]
     strategy:
       matrix:

--- a/.github/workflows/release_build_test.yaml
+++ b/.github/workflows/release_build_test.yaml
@@ -72,7 +72,7 @@ jobs:
 
   PackageAndUpload:
     # if: github.ref_type == 'tag'
-    needs: [TestIndividual]
+    # needs: [TestIndividual]
     strategy:
       matrix:
         arch: [amd, arm]

--- a/.github/workflows/release_build_test.yaml
+++ b/.github/workflows/release_build_test.yaml
@@ -74,11 +74,12 @@ jobs:
     # if: github.ref_type == 'tag'
     # needs: [TestIndividual]
     strategy:
+      fail-fast: false
       matrix:
         arch: [amd, arm]
     uses: ./.github/workflows/reusable_package.yaml
     with:
-      os: 'debian-11'
+      os: 'debian-12'
       toolchain: 'v5'
       arch: "${{ matrix.arch }}"
       build_type: 'Release'


### PR DESCRIPTION
### Description

This PR will add the ability to build and push RC ARM builds to S3.

[master < Task] PR
- [x] Provide the full content or a guide for the final git message
    - add job to package and upload successful RC ARM builds to S3


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
