### PR TITLE
Update release docker workflow to work with toolchain v5

### DIFF
--- a/.github/workflows/release_docker.yaml
+++ b/.github/workflows/release_docker.yaml
@@ -37,8 +37,8 @@ jobs:
       - name: Download memgraph binary
         run: |
           cd release/docker
-          curl -L https://download.memgraph.com/memgraph/v${{ github.event.inputs.version }}/debian-11/memgraph_${{ github.event.inputs.version }}-1_amd64.deb > memgraph-amd64.deb
-          curl -L https://download.memgraph.com/memgraph/v${{ github.event.inputs.version }}/debian-11-aarch64/memgraph_${{ github.event.inputs.version }}-1_arm64.deb > memgraph-arm64.deb
+          curl -L https://download.memgraph.com/memgraph/v${{ github.event.inputs.version }}/debian-12/memgraph_${{ github.event.inputs.version }}-1_amd64.deb > memgraph-amd64.deb
+          curl -L https://download.memgraph.com/memgraph/v${{ github.event.inputs.version }}/debian-12-aarch64/memgraph_${{ github.event.inputs.version }}-1_arm64.deb > memgraph-arm64.deb
 
       - name: Check if specified version is already pushed
         run: |
@@ -65,5 +65,5 @@ jobs:
           --platform linux/amd64,linux/arm64 \
           --tag $DOCKER_ORGANIZATION_NAME/$DOCKER_REPOSITORY_NAME:${{ github.event.inputs.version }} \
           --tag $DOCKER_ORGANIZATION_NAME/$DOCKER_REPOSITORY_NAME:latest \
-          --file memgraph_deb.dockerfile \
+          --file v5_deb.dockerfile \
           --push .


### PR DESCRIPTION
### Description

Update release docker workflow to work with toolchain v5.
- download memgraph debian-12 binaries instead of debian-11
- use v5_deb.dockerfile
- 
[master < Task] PR
- [x] Provide the full content or a guide for the final git message
    - update release docker workflow to work with toolchain v5


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
