### PR TITLE
Allow user to connect without database

### DIFF
--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -161,9 +161,18 @@ bool SessionHL::Authenticate(const std::string &username, const std::string &pas
   }
 #ifdef MG_ENTERPRISE
   // Start off with the default database
-  interpreter_.SetCurrentDB(GetDefaultDB(), false);
+  try {
+    interpreter_.SetCurrentDB(GetDefaultDB(), false);
+  } catch (auth::AuthException &) {
+    // Failed to get default db, connect without db
+    interpreter_.ResetDB();
+  }
 #endif
-  implicit_db_.emplace(GetCurrentDB());
+  const auto db = GetCurrentDB();
+  if (db.empty())
+    implicit_db_.reset();
+  else
+    implicit_db_.emplace(std::move(db));
   return res;
 }
 
@@ -254,7 +263,8 @@ using memgraph::communication::bolt::Value;
 #ifdef MG_ENTERPRISE
 auto SessionHL::Route(std::map<std::string, Value> const &routing,
                       std::vector<memgraph::communication::bolt::Value> const & /*bookmarks*/,
-                      std::map<std::string, Value> const & /*extra*/) -> std::map<std::string, Value> {
+                      std::map<std::string, Value> const &
+                      /*extra*/) -> std::map<std::string, Value> {
   auto routing_map = ranges::views::transform(
                          routing, [](auto const &pair) { return std::pair(pair.first, pair.second.ValueString()); }) |
                      ranges::to<std::map<std::string, std::string>>();
@@ -347,7 +357,7 @@ void SessionHL::Configure(const std::map<std::string, memgraph::communication::b
     if (!in_explicit_db_) implicit_db_.emplace(current);  // Still not in an explicit database, save for recovery
     in_explicit_db_ = true;
     // NOTE: Once in a transaction, the drivers stop explicitly sending the db and count on using it until commit
-  } else if (in_explicit_db_ && !interpreter_.in_explicit_transaction_) {  // Just on a switch
+  } else if (!implicit_db_ || (in_explicit_db_ && !interpreter_.in_explicit_transaction_)) {  // Just on a switch
     if (implicit_db_) {
       db = *implicit_db_;
     } else {
@@ -382,7 +392,7 @@ SessionHL::SessionHL(memgraph::query::InterpreterContext *interpreter_context,
 #endif
       auth_(auth),
       endpoint_(std::move(endpoint)),
-      implicit_db_(dbms::kDefaultDB) {
+      implicit_db_(std::nullopt) {
   // Metrics update
   memgraph::metrics::IncrementCounter(memgraph::metrics::ActiveBoltSessions);
 #ifdef MG_ENTERPRISE

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -1907,11 +1907,6 @@ bool IsQueryWrite(const query::plan::ReadWriteTypeChecker::RWType query_type) {
 
 Interpreter::Interpreter(InterpreterContext *interpreter_context) : interpreter_context_(interpreter_context) {
   MG_ASSERT(interpreter_context_, "Interpreter context must not be NULL");
-#ifndef MG_ENTERPRISE
-  auto db_acc = interpreter_context_->dbms_handler->Get();
-  MG_ASSERT(db_acc, "Database accessor needs to be valid");
-  current_db_.db_acc_ = std::move(db_acc);
-#endif
 }
 
 Interpreter::Interpreter(InterpreterContext *interpreter_context, memgraph::dbms::DatabaseAccess db)

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -221,6 +221,13 @@ struct CurrentDB {
     in_explicit_db_ = in_explicit_db;
   }
 
+  void ResetDB() {
+    db_acc_.reset();
+    db_transactional_accessor_.reset();
+    execution_db_accessor_.reset();
+    trigger_context_collector_.reset();
+  }
+
   // TODO: don't provide explicitly via constructor, instead have a lazy way of getting the current/default
   // DatabaseAccess
   //       hence, explict bolt "use DB" in metadata wouldn't necessarily get access unless query required it.
@@ -266,6 +273,7 @@ class Interpreter final {
 
 #ifdef MG_ENTERPRISE
   void SetCurrentDB(std::string_view db_name, bool explicit_db);
+  void ResetDB() { current_db_.ResetDB(); }
   void OnChangeCB(auto cb) { on_change_.emplace(cb); }
 #endif
 


### PR DESCRIPTION
### Description

Allow users to connect without a database defined.
If a user has a default db, the user will connect to that database.
If a user does not have a default db, we will connect without a database defined. Only db-less queries should be allowed.
If a user defines the database via the client, we will use the same logic as above, but each query will be executed against the user-defined db. Multi-tenant auth will be executed at first query execution.

Q: Should we allow multi-tenant queries (ex: `USE DATABASE x`) even without db?

[master < Task] PR
- [ ] Provide the full content or a guide for the final git message
    - **[FINAL GIT MESSAGE]**


### Documentation checklist
- [ ] Add the documentation label tag
- [ ] Add the bug / feature label tag
- [ ] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - **[Release note text]**
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [ ] Tag someone from docs team in the comments
