### PR TITLE
Add debian-11-arm build with toolchain v5

### DIFF
--- a/.github/workflows/package_memgraph.yaml
+++ b/.github/workflows/package_memgraph.yaml
@@ -151,7 +151,7 @@ jobs:
     secrets: inherit
 
   Debian11-arm:
-    if: ${{ (github.event.inputs.os == 'debian-11-arm' || github.event.inputs.os == 'all') && github.event.inputs.toolchain == 'v4' }}
+    if: ${{ github.event.inputs.os == 'debian-11-arm' || github.event.inputs.os == 'all' }}
     uses: ./.github/workflows/reusable_package.yaml
     with:
       os: "debian-11"

--- a/release/package/arm-builders-v5.yml
+++ b/release/package/arm-builders-v5.yml
@@ -1,6 +1,17 @@
 version: "3"
 
 services:
+  mgbuild_v5_debian-11-arm:
+    image: "memgraph/mgbuild:v5_debian-11-arm"
+    build:
+      context: debian-11-arm
+      args:
+        TOOLCHAIN_VERSION: "v5"
+    extra_hosts:
+      - "mgdeps-cache:10.42.16.10"
+      - "bench-graph-api:10.42.16.10"
+    container_name: "mgbuild_v5_debian-11-arm"
+
   mgbuild_v5_debian-12-arm:
     image: "memgraph/mgbuild:v5_debian-12-arm"
     build:

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -30,7 +30,7 @@ SUPPORTED_OS_V4=(
 SUPPORTED_OS_V5=(
     amzn-2
     centos-7 centos-9
-    debian-11 debian-12 debian-12-arm
+    debian-11 debian-11-arm debian-12 debian-12-arm
     fedora-38 fedora-39
     rocky-9.3
     ubuntu-20.04 ubuntu-22.04 ubuntu-22.04-arm


### PR DESCRIPTION
### Description

This PR adds `debian-11-arm` as a supported OS for building and packaging memgraph with `toolchain v5`.
This is needed in order to push the `1.15.1` release on `mage`

[master < Task] PR

### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
