### PR TITLE
Freeze mgcxx deps properly

### DIFF
--- a/libs/setup.sh
+++ b/libs/setup.sh
@@ -296,5 +296,5 @@ repo_clone_try_double "${primary_urls[asio]}" "${secondary_urls[asio]}" "asio" "
 popd
 
 # mgcxx (text search)
-mgcxx_tag="v0.0.5"
+mgcxx_tag="v0.0.6"
 repo_clone_try_double "${primary_urls[mgcxx]}" "${secondary_urls[mgcxx]}" "mgcxx" "$mgcxx_tag" true


### PR DESCRIPTION
This should be a fix for the problem where mgcxx deps suddenly change (memgraph's build randomly fails).
`Cargo.lock` added (freeze of dependencies) under https://github.com/memgraph/mgcxx/pull/9 (v0.0.6)