### PR TITLE
Fix managing coordinators in HA

### DIFF
--- a/src/coordination/coordinator_cluster_state.cpp
+++ b/src/coordination/coordinator_cluster_state.cpp
@@ -32,21 +32,9 @@ void from_json(nlohmann::json const &j, ReplicationInstanceState &instance_state
   j.at("needs_demote").get_to(instance_state.needs_demote);
 }
 
-void to_json(nlohmann::json &j, CoordinatorInstanceState const &instance_state) {
-  j = nlohmann::json{{"config", instance_state.config}};
-}
-
-void from_json(nlohmann::json const &j, CoordinatorInstanceState &instance_state) {
-  j.at("config").get_to(instance_state.config);
-}
-
 CoordinatorClusterState::CoordinatorClusterState(std::map<std::string, ReplicationInstanceState, std::less<>> instances,
-                                                 std::vector<CoordinatorInstanceState> coordinators,
                                                  utils::UUID const &current_main_uuid, bool is_lock_opened)
-    : repl_instances_{std::move(instances)},
-      coordinators_{std::move(coordinators)},
-      current_main_uuid_(current_main_uuid),
-      is_lock_opened_(is_lock_opened) {}
+    : repl_instances_{std::move(instances)}, current_main_uuid_(current_main_uuid), is_lock_opened_(is_lock_opened) {}
 
 CoordinatorClusterState::CoordinatorClusterState(CoordinatorClusterState const &other)
     : repl_instances_{other.repl_instances_},
@@ -153,12 +141,6 @@ auto CoordinatorClusterState::DoAction(TRaftLog const &log_entry, RaftLogAction 
                     std::string{instance_uuid_change.uuid});
       break;
     }
-    case RaftLogAction::ADD_COORDINATOR_INSTANCE: {
-      auto const &config = std::get<CoordinatorToCoordinatorConfig>(log_entry);
-      coordinators_.emplace_back(CoordinatorInstanceState{config});
-      spdlog::trace("DoAction: add coordinator instance {}", config.coordinator_id);
-      break;
-    }
     case RaftLogAction::INSTANCE_NEEDS_DEMOTE: {
       auto const instance_name = std::get<std::string>(log_entry);
       auto it = repl_instances_.find(instance_name);
@@ -183,7 +165,6 @@ auto CoordinatorClusterState::DoAction(TRaftLog const &log_entry, RaftLogAction 
 auto CoordinatorClusterState::Serialize(ptr<buffer> &data) -> void {
   auto lock = std::shared_lock{log_lock_};
   nlohmann::json j = {{"repl_instances", repl_instances_},
-                      {"coord_instances", coordinators_},
                       {"is_lock_opened", is_lock_opened_},
                       {"current_main_uuid", current_main_uuid_}};
   auto const log = j.dump();
@@ -200,10 +181,8 @@ auto CoordinatorClusterState::Deserialize(buffer &data) -> CoordinatorClusterSta
   auto repl_instances = j.at("repl_instances").get<std::map<std::string, ReplicationInstanceState, std::less<>>>();
   auto current_main_uuid = j.at("current_main_uuid").get<utils::UUID>();
   bool is_lock_opened = j.at("is_lock_opened").get<int>();
-  auto coord_instances = j.at("coord_instances").get<std::vector<CoordinatorInstanceState>>();
 
-  return CoordinatorClusterState{std::move(repl_instances), std::move(coord_instances), current_main_uuid,
-                                 is_lock_opened};
+  return CoordinatorClusterState{std::move(repl_instances), current_main_uuid, is_lock_opened};
 }
 
 auto CoordinatorClusterState::GetReplicationInstances() const -> std::vector<ReplicationInstanceState> {
@@ -220,20 +199,9 @@ auto CoordinatorClusterState::GetInstanceUUID(std::string_view instance_name) co
   return it->second.instance_uuid;
 }
 
-auto CoordinatorClusterState::GetCoordinatorInstances() const -> std::vector<CoordinatorInstanceState> {
-  auto lock = std::shared_lock{log_lock_};
-  return coordinators_;
-}
-
 auto CoordinatorClusterState::IsLockOpened() const -> bool {
   auto lock = std::shared_lock{log_lock_};
   return is_lock_opened_;
-}
-
-auto CoordinatorClusterState::CoordinatorExists(uint32_t coordinator_id) const -> bool {
-  auto lock = std::shared_lock{log_lock_};
-  return std::ranges::any_of(
-      coordinators_, [coordinator_id](auto const &coord) { return coord.config.coordinator_id == coordinator_id; });
 }
 
 }  // namespace memgraph::coordination

--- a/src/coordination/include/coordination/coordinator_instance.hpp
+++ b/src/coordination/include/coordination/coordinator_instance.hpp
@@ -129,8 +129,6 @@ class CoordinatorInstance {
   // Thread pool needs to be constructed before raft state as raft state can call thread pool
   utils::ThreadPool thread_pool_;
   RaftState raft_state_;
-
-  CoordinatorInstanceInitConfig config_;
 };
 
 }  // namespace memgraph::coordination

--- a/src/coordination/include/coordination/raft_state.hpp
+++ b/src/coordination/include/coordination/raft_state.hpp
@@ -60,7 +60,8 @@ class RaftState {
   auto InstanceName() const -> std::string;
   auto RaftSocketAddress() const -> std::string;
 
-  auto AddCoordinatorInstance(coordination::CoordinatorToCoordinatorConfig const &config) -> void;
+  auto AddCoordinatorInstance(CoordinatorToCoordinatorConfig const &config) -> void;
+  auto GetCoordinatorInstances() const -> std::vector<CoordinatorToCoordinatorConfig>;
 
   auto RequestLeadership() -> bool;
   auto IsLeader() const -> bool;
@@ -74,11 +75,9 @@ class RaftState {
   auto AppendUpdateUUIDForInstanceLog(std::string_view instance_name, utils::UUID const &uuid) -> bool;
   auto AppendOpenLock() -> bool;
   auto AppendCloseLock() -> bool;
-  auto AppendAddCoordinatorInstanceLog(CoordinatorToCoordinatorConfig const &config) -> bool;
   auto AppendInstanceNeedsDemote(std::string_view) -> bool;
 
   auto GetReplicationInstances() const -> std::vector<ReplicationInstanceState>;
-  auto GetCoordinatorInstances() const -> std::vector<CoordinatorInstanceState>;
 
   auto MainExists() const -> bool;
   auto HasMainState(std::string_view instance_name) const -> bool;
@@ -90,8 +89,6 @@ class RaftState {
 
   auto IsLockOpened() const -> bool;
   auto GetRoutingTable() const -> RoutingTable;
-
-  auto CoordinatorExists(uint32_t coordinator_id) const -> bool;
 
  private:
   io::network::Endpoint raft_endpoint_;

--- a/src/coordination/include/nuraft/coordinator_state_machine.hpp
+++ b/src/coordination/include/nuraft/coordinator_state_machine.hpp
@@ -82,8 +82,6 @@ class CoordinatorStateMachine : public state_machine {
 
   auto GetReplicationInstances() const -> std::vector<ReplicationInstanceState>;
 
-  auto GetCoordinatorInstances() const -> std::vector<CoordinatorInstanceState>;
-
   // Getters
   auto MainExists() const -> bool;
   auto HasMainState(std::string_view instance_name) const -> bool;
@@ -93,7 +91,6 @@ class CoordinatorStateMachine : public state_machine {
   auto GetCurrentMainUUID() const -> utils::UUID;
   auto GetInstanceUUID(std::string_view instance_name) const -> utils::UUID;
   auto IsLockOpened() const -> bool;
-  auto CoordinatorExists(uint32_t coordinator_id) const -> bool;
 
  private:
   struct SnapshotCtx {

--- a/src/coordination/include/nuraft/coordinator_state_manager.hpp
+++ b/src/coordination/include/nuraft/coordinator_state_manager.hpp
@@ -13,6 +13,7 @@
 
 #ifdef MG_ENTERPRISE
 
+#include "coordination/coordinator_communication_config.hpp"
 #include "nuraft/coordinator_log_store.hpp"
 
 #include <spdlog/spdlog.h>
@@ -28,7 +29,7 @@ using nuraft::state_mgr;
 
 class CoordinatorStateManager : public state_mgr {
  public:
-  explicit CoordinatorStateManager(int srv_id, std::string const &endpoint);
+  explicit CoordinatorStateManager(CoordinatorInstanceInitConfig const &config);
 
   CoordinatorStateManager(CoordinatorStateManager const &) = delete;
   CoordinatorStateManager &operator=(CoordinatorStateManager const &) = delete;
@@ -55,7 +56,6 @@ class CoordinatorStateManager : public state_mgr {
 
  private:
   int my_id_;
-  std::string my_endpoint_;
   ptr<CoordinatorLogStore> cur_log_store_;
   ptr<srv_config> my_srv_config_;
   ptr<cluster_config> cluster_config_;

--- a/src/coordination/include/nuraft/raft_log_action.hpp
+++ b/src/coordination/include/nuraft/raft_log_action.hpp
@@ -29,7 +29,6 @@ enum class RaftLogAction : uint8_t {
   SET_INSTANCE_AS_MAIN,
   SET_INSTANCE_AS_REPLICA,
   UPDATE_UUID_OF_NEW_MAIN,
-  ADD_COORDINATOR_INSTANCE,
   UPDATE_UUID_FOR_INSTANCE,
   INSTANCE_NEEDS_DEMOTE,
   CLOSE_LOCK
@@ -40,7 +39,6 @@ NLOHMANN_JSON_SERIALIZE_ENUM(RaftLogAction, {{RaftLogAction::REGISTER_REPLICATIO
                                              {RaftLogAction::SET_INSTANCE_AS_MAIN, "promote"},
                                              {RaftLogAction::SET_INSTANCE_AS_REPLICA, "demote"},
                                              {RaftLogAction::UPDATE_UUID_OF_NEW_MAIN, "update_uuid_of_new_main"},
-                                             {RaftLogAction::ADD_COORDINATOR_INSTANCE, "add_coordinator_instance"},
                                              {RaftLogAction::UPDATE_UUID_FOR_INSTANCE, "update_uuid_for_instance"},
                                              {RaftLogAction::INSTANCE_NEEDS_DEMOTE, "instance_needs_demote"},
                                              {RaftLogAction::OPEN_LOCK, "open_lock"},

--- a/src/coordination/raft_state.cpp
+++ b/src/coordination/raft_state.cpp
@@ -39,7 +39,7 @@ RaftState::RaftState(CoordinatorInstanceInitConfig const &config, BecomeLeaderCb
     : raft_endpoint_("0.0.0.0", config.coordinator_port),
       coordinator_id_(config.coordinator_id),
       state_machine_(cs_new<CoordinatorStateMachine>()),
-      state_manager_(cs_new<CoordinatorStateManager>(coordinator_id_, raft_endpoint_.SocketAddress())),
+      state_manager_(cs_new<CoordinatorStateManager>(config)),
       logger_(nullptr),
       become_leader_cb_(std::move(become_leader_cb)),
       become_follower_cb_(std::move(become_follower_cb)) {}
@@ -90,6 +90,7 @@ auto RaftState::InitRaftServer() -> void {
   if (!raft_server_) {
     throw RaftServerStartException("Failed to launch raft server on {}", raft_endpoint_.SocketAddress());
   }
+
   auto maybe_stop = utils::ResettableCounter<20>();
   do {
     if (raft_server_->is_initialized()) {
@@ -126,11 +127,12 @@ auto RaftState::InstanceName() const -> std::string { return fmt::format("coordi
 
 auto RaftState::RaftSocketAddress() const -> std::string { return raft_endpoint_.SocketAddress(); }
 
-auto RaftState::AddCoordinatorInstance(coordination::CoordinatorToCoordinatorConfig const &config) -> void {
+auto RaftState::AddCoordinatorInstance(CoordinatorToCoordinatorConfig const &config) -> void {
   spdlog::trace("Adding coordinator instance {} start in RaftState for coordinator_{}", config.coordinator_id,
                 coordinator_id_);
   auto const endpoint = config.coordinator_server.SocketAddress();
-  srv_config const srv_config_to_add(static_cast<int>(config.coordinator_id), endpoint);
+  auto const aux = nlohmann::json(config).dump();
+  srv_config const srv_config_to_add(static_cast<int>(config.coordinator_id), 0, endpoint, aux, false);
 
   auto cmd_result = raft_server_->add_srv(srv_config_to_add);
 
@@ -160,6 +162,18 @@ auto RaftState::AddCoordinatorInstance(coordination::CoordinatorToCoordinatorCon
     throw RaftAddServerException("Failed to add server {} to the cluster in {}ms", endpoint,
                                  max_tries * waiting_period);
   }
+}
+
+auto RaftState::GetCoordinatorInstances() const -> std::vector<CoordinatorToCoordinatorConfig> {
+  std::vector<ptr<srv_config>> srv_configs;
+  raft_server_->get_srv_config_all(srv_configs);
+
+  return ranges::views::transform(
+             srv_configs,
+             [](auto const &srv_config) {
+               return nlohmann::json::parse(srv_config->get_aux()).template get<CoordinatorToCoordinatorConfig>();
+             }) |
+         ranges::to<std::vector>();
 }
 
 auto RaftState::IsLeader() const -> bool { return raft_server_->is_leader(); }
@@ -307,28 +321,6 @@ auto RaftState::AppendUpdateUUIDForNewMainLog(utils::UUID const &uuid) -> bool {
   return true;
 }
 
-auto RaftState::AppendAddCoordinatorInstanceLog(CoordinatorToCoordinatorConfig const &config) -> bool {
-  auto new_log = CoordinatorStateMachine::SerializeAddCoordinatorInstance(config);
-  auto const res = raft_server_->append_entries({new_log});
-  if (!res->get_accepted()) {
-    spdlog::error(
-        "Failed to accept request for adding coordinator instance {}. Most likely the reason is that the instance is "
-        "not the leader.",
-        config.coordinator_id);
-    return false;
-  }
-
-  spdlog::info("Request for adding coordinator instance {} accepted", config.coordinator_id);
-
-  if (res->get_result_code() != nuraft::cmd_result_code::OK) {
-    spdlog::error("Failed to add coordinator instance {} with error code {}", config.coordinator_id,
-                  static_cast<int>(res->get_result_code()));
-    return false;
-  }
-
-  return true;
-}
-
 auto RaftState::AppendInstanceNeedsDemote(std::string_view instance_name) -> bool {
   auto new_log = CoordinatorStateMachine::SerializeInstanceNeedsDemote(instance_name);
   auto const res = raft_server_->append_entries({new_log});
@@ -392,10 +384,6 @@ auto RaftState::GetInstanceUUID(std::string_view instance_name) const -> utils::
   return state_machine_->GetInstanceUUID(instance_name);
 }
 
-auto RaftState::GetCoordinatorInstances() const -> std::vector<CoordinatorInstanceState> {
-  return state_machine_->GetCoordinatorInstances();
-}
-
 auto RaftState::GetRoutingTable() const -> RoutingTable {
   auto res = RoutingTable{};
 
@@ -428,8 +416,8 @@ auto RaftState::GetRoutingTable() const -> RoutingTable {
     res.emplace_back(std::move(bolt_replicas), "READ");
   }
 
-  auto const coord_instance_to_bolt = [](CoordinatorInstanceState const &instance) {
-    return instance.config.bolt_server.SocketAddress();
+  auto const coord_instance_to_bolt = [](CoordinatorToCoordinatorConfig const &instance) {
+    return instance.bolt_server.SocketAddress();
   };
 
   auto const &raft_log_coord_instances = GetCoordinatorInstances();
@@ -439,10 +427,6 @@ auto RaftState::GetRoutingTable() const -> RoutingTable {
   res.emplace_back(std::move(bolt_coords), "ROUTE");
 
   return res;
-}
-
-auto RaftState::CoordinatorExists(uint32_t coordinator_id) const -> bool {
-  return state_machine_->CoordinatorExists(coordinator_id);
 }
 
 }  // namespace memgraph::coordination

--- a/tests/e2e/high_availability/coord_cluster_registration.py
+++ b/tests/e2e/high_availability/coord_cluster_registration.py
@@ -110,69 +110,69 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
 }
 
 
-# def test_register_repl_instances_then_coordinators():
-#     safe_execute(shutil.rmtree, TEMP_DIR)
-#     interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION)
-#
-#     coordinator3_cursor = connect(host="localhost", port=7692).cursor()
-#
-#     execute_and_fetch_all(
-#         coordinator3_cursor,
-#         "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-#     )
-#     execute_and_fetch_all(
-#         coordinator3_cursor,
-#         "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-#     )
-#     execute_and_fetch_all(
-#         coordinator3_cursor,
-#         "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
-#     )
-#     execute_and_fetch_all(coordinator3_cursor, "SET INSTANCE instance_3 TO MAIN")
-#     execute_and_fetch_all(
-#         coordinator3_cursor,
-#         "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
-#     )
-#     execute_and_fetch_all(
-#         coordinator3_cursor,
-#         "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
-#     )
-#
-#     def check_coordinator3():
-#         return sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
-#
-#     expected_cluster_coord3 = [
-#         ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
-#         ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
-#         ("coordinator_3", "0.0.0.0:10113", "", "unknown", "coordinator"),
-#         ("instance_1", "", "127.0.0.1:10011", "up", "replica"),
-#         ("instance_2", "", "127.0.0.1:10012", "up", "replica"),
-#         ("instance_3", "", "127.0.0.1:10013", "up", "main"),
-#     ]
-#     mg_sleep_and_assert(expected_cluster_coord3, check_coordinator3)
-#
-#     coordinator1_cursor = connect(host="localhost", port=7690).cursor()
-#
-#     def check_coordinator1():
-#         return sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
-#
-#     expected_cluster_shared = [
-#         ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
-#         ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
-#         ("coordinator_3", "0.0.0.0:10113", "", "unknown", "coordinator"),
-#         ("instance_1", "", "", "unknown", "replica"),
-#         ("instance_2", "", "", "unknown", "replica"),
-#         ("instance_3", "", "", "unknown", "main"),
-#     ]
-#
-#     mg_sleep_and_assert(expected_cluster_shared, check_coordinator1)
-#
-#     coordinator2_cursor = connect(host="localhost", port=7691).cursor()
-#
-#     def check_coordinator2():
-#         return sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
-#
-#     mg_sleep_and_assert(expected_cluster_shared, check_coordinator2)
+def test_register_repl_instances_then_coordinators():
+    safe_execute(shutil.rmtree, TEMP_DIR)
+    interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION)
+
+    coordinator3_cursor = connect(host="localhost", port=7692).cursor()
+
+    execute_and_fetch_all(
+        coordinator3_cursor,
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
+    )
+    execute_and_fetch_all(
+        coordinator3_cursor,
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
+    )
+    execute_and_fetch_all(
+        coordinator3_cursor,
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+    )
+    execute_and_fetch_all(coordinator3_cursor, "SET INSTANCE instance_3 TO MAIN")
+    execute_and_fetch_all(
+        coordinator3_cursor,
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
+    )
+    execute_and_fetch_all(
+        coordinator3_cursor,
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
+    )
+
+    def check_coordinator3():
+        return sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
+
+    expected_cluster_coord3 = [
+        ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("instance_1", "", "127.0.0.1:10011", "up", "replica"),
+        ("instance_2", "", "127.0.0.1:10012", "up", "replica"),
+        ("instance_3", "", "127.0.0.1:10013", "up", "main"),
+    ]
+    mg_sleep_and_assert(expected_cluster_coord3, check_coordinator3)
+
+    coordinator1_cursor = connect(host="localhost", port=7690).cursor()
+
+    def check_coordinator1():
+        return sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
+
+    expected_cluster_shared = [
+        ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("instance_1", "", "", "unknown", "replica"),
+        ("instance_2", "", "", "unknown", "replica"),
+        ("instance_3", "", "", "unknown", "main"),
+    ]
+
+    mg_sleep_and_assert(expected_cluster_shared, check_coordinator1)
+
+    coordinator2_cursor = connect(host="localhost", port=7691).cursor()
+
+    def check_coordinator2():
+        return sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
+
+    mg_sleep_and_assert(expected_cluster_shared, check_coordinator2)
 
 
 def test_register_coordinator_then_repl_instances():
@@ -240,76 +240,76 @@ def test_register_coordinator_then_repl_instances():
     mg_sleep_and_assert(expected_cluster_shared, check_coordinator2)
 
 
-# def test_coordinators_communication_with_restarts():
-#     # 1 Start all instances
-#     safe_execute(shutil.rmtree, TEMP_DIR)
-#
-#     # 1
-#     interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION)
-#
-#     coordinator3_cursor = connect(host="localhost", port=7692).cursor()
-#
-#     execute_and_fetch_all(
-#         coordinator3_cursor,
-#         "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
-#     )
-#     execute_and_fetch_all(
-#         coordinator3_cursor,
-#         "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
-#     )
-#     execute_and_fetch_all(
-#         coordinator3_cursor,
-#         "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-#     )
-#     execute_and_fetch_all(
-#         coordinator3_cursor,
-#         "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-#     )
-#     execute_and_fetch_all(
-#         coordinator3_cursor,
-#         "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
-#     )
-#     execute_and_fetch_all(coordinator3_cursor, "SET INSTANCE instance_3 TO MAIN")
-#
-#     expected_cluster_shared = [
-#         ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
-#         ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
-#         ("coordinator_3", "0.0.0.0:10113", "", "unknown", "coordinator"),
-#         ("instance_1", "", "", "unknown", "replica"),
-#         ("instance_2", "", "", "unknown", "replica"),
-#         ("instance_3", "", "", "unknown", "main"),
-#     ]
-#
-#     coordinator1_cursor = connect(host="localhost", port=7690).cursor()
-#
-#     def check_coordinator1():
-#         return sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
-#
-#     mg_sleep_and_assert(expected_cluster_shared, check_coordinator1)
-#
-#     coordinator2_cursor = connect(host="localhost", port=7691).cursor()
-#
-#     def check_coordinator2():
-#         return sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
-#
-#     mg_sleep_and_assert(expected_cluster_shared, check_coordinator2)
-#
-#     interactive_mg_runner.kill(MEMGRAPH_INSTANCES_DESCRIPTION, "coordinator_1")
-#     interactive_mg_runner.start(MEMGRAPH_INSTANCES_DESCRIPTION, "coordinator_1")
-#     coordinator1_cursor = connect(host="localhost", port=7690).cursor()
-#
-#     mg_sleep_and_assert(expected_cluster_shared, check_coordinator1)
-#
-#     interactive_mg_runner.kill(MEMGRAPH_INSTANCES_DESCRIPTION, "coordinator_1")
-#     interactive_mg_runner.kill(MEMGRAPH_INSTANCES_DESCRIPTION, "coordinator_2")
-#
-#     interactive_mg_runner.start(MEMGRAPH_INSTANCES_DESCRIPTION, "coordinator_1")
-#     interactive_mg_runner.start(MEMGRAPH_INSTANCES_DESCRIPTION, "coordinator_2")
-#     coordinator1_cursor = connect(host="localhost", port=7690).cursor()
-#     coordinator2_cursor = connect(host="localhost", port=7691).cursor()
-#
-#     mg_sleep_and_assert(expected_cluster_shared, check_coordinator1)
-#     mg_sleep_and_assert(expected_cluster_shared, check_coordinator2)
+def test_coordinators_communication_with_restarts():
+    # 1 Start all instances
+    safe_execute(shutil.rmtree, TEMP_DIR)
+
+    # 1
+    interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION)
+
+    coordinator3_cursor = connect(host="localhost", port=7692).cursor()
+
+    execute_and_fetch_all(
+        coordinator3_cursor,
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
+    )
+    execute_and_fetch_all(
+        coordinator3_cursor,
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
+    )
+    execute_and_fetch_all(
+        coordinator3_cursor,
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
+    )
+    execute_and_fetch_all(
+        coordinator3_cursor,
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
+    )
+    execute_and_fetch_all(
+        coordinator3_cursor,
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+    )
+    execute_and_fetch_all(coordinator3_cursor, "SET INSTANCE instance_3 TO MAIN")
+
+    expected_cluster_shared = [
+        ("coordinator_1", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("instance_1", "", "", "unknown", "replica"),
+        ("instance_2", "", "", "unknown", "replica"),
+        ("instance_3", "", "", "unknown", "main"),
+    ]
+
+    coordinator1_cursor = connect(host="localhost", port=7690).cursor()
+
+    def check_coordinator1():
+        return sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
+
+    mg_sleep_and_assert(expected_cluster_shared, check_coordinator1)
+
+    coordinator2_cursor = connect(host="localhost", port=7691).cursor()
+
+    def check_coordinator2():
+        return sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
+
+    mg_sleep_and_assert(expected_cluster_shared, check_coordinator2)
+
+    interactive_mg_runner.kill(MEMGRAPH_INSTANCES_DESCRIPTION, "coordinator_1")
+    interactive_mg_runner.start(MEMGRAPH_INSTANCES_DESCRIPTION, "coordinator_1")
+    coordinator1_cursor = connect(host="localhost", port=7690).cursor()
+
+    mg_sleep_and_assert(expected_cluster_shared, check_coordinator1)
+
+    interactive_mg_runner.kill(MEMGRAPH_INSTANCES_DESCRIPTION, "coordinator_1")
+    interactive_mg_runner.kill(MEMGRAPH_INSTANCES_DESCRIPTION, "coordinator_2")
+
+    interactive_mg_runner.start(MEMGRAPH_INSTANCES_DESCRIPTION, "coordinator_1")
+    interactive_mg_runner.start(MEMGRAPH_INSTANCES_DESCRIPTION, "coordinator_2")
+    coordinator1_cursor = connect(host="localhost", port=7690).cursor()
+    coordinator2_cursor = connect(host="localhost", port=7691).cursor()
+
+    mg_sleep_and_assert(expected_cluster_shared, check_coordinator1)
+    mg_sleep_and_assert(expected_cluster_shared, check_coordinator2)
 
 
 # TODO: (andi) Test when dealing with distributed coordinators that you can register on one coordinator and unregister from any other coordinator

--- a/tests/unit/coordinator_instance.cpp
+++ b/tests/unit/coordinator_instance.cpp
@@ -42,27 +42,6 @@ class CoordinatorInstanceTest : public ::testing::Test {
                                             "MG_tests_unit_coordinator_instance"};
 };
 
-// TEST_F(CoordinatorInstanceTest, RegisterReplicationInstance) {
-//   auto const init_config =
-//       CoordinatorInstanceInitConfig{.coordinator_id = 4, .coordinator_port = 10110, .bolt_port = 7686};
-//   auto instance1 = CoordinatorInstance{init_config};
-//
-//   auto const coord_to_replica_config =
-//       CoordinatorToReplicaConfig{.instance_name = "instance3",
-//                                  .mgt_server = Endpoint{"0.0.0.0", 10112},
-//                                  .bolt_server = Endpoint{"0.0.0.0", 7687},
-//                                  .replication_client_info = {.instance_name = "instance_name",
-//                                                              .replication_mode = ReplicationMode::ASYNC,
-//                                                              .replication_server = Endpoint{"0.0.0.0", 10001}},
-//                                  .instance_health_check_frequency_sec = std::chrono::seconds{1},
-//                                  .instance_down_timeout_sec = std::chrono::seconds{5},
-//                                  .instance_get_uuid_frequency_sec = std::chrono::seconds{10},
-//                                  .ssl = std::nullopt};
-//
-//   auto status = instance1.RegisterReplicationInstance(coord_to_replica_config);
-//   EXPECT_EQ(status, RegisterInstanceCoordinatorStatus::RPC_FAILED);
-// }
-
 // Empty until you run 1st RegisterReplicationInstance or AddCoordinatorInstance
 TEST_F(CoordinatorInstanceTest, ShowInstancesEmptyTest) {
   auto const init_config =
@@ -70,7 +49,7 @@ TEST_F(CoordinatorInstanceTest, ShowInstancesEmptyTest) {
 
   auto const instance1 = CoordinatorInstance{init_config};
   auto const instances = instance1.ShowInstances();
-  ASSERT_EQ(instances.size(), 0);
+  ASSERT_EQ(instances.size(), 1);
 }
 
 TEST_F(CoordinatorInstanceTest, ConnectCoordinators) {

--- a/tests/unit/coordinator_state_machine.cpp
+++ b/tests/unit/coordinator_state_machine.cpp
@@ -81,17 +81,6 @@ TEST_F(CoordinatorStateMachineTest, SerializeUnregisterReplicationInstance) {
   ASSERT_EQ(bs.get_str(), expected.dump());
 }
 
-TEST_F(CoordinatorStateMachineTest, SerializeAddCoordinatorInstance) {
-  CoordinatorToCoordinatorConfig config{.coordinator_id = 1,
-                                        .bolt_server = Endpoint{"127.0.0.1", 7687},
-                                        .coordinator_server = Endpoint{"127.0.0.1", 10111}};
-
-  ptr<buffer> data = CoordinatorStateMachine::SerializeAddCoordinatorInstance(config);
-  buffer_serializer bs(*data);
-  auto const expected = nlohmann::json{{"action", RaftLogAction::ADD_COORDINATOR_INSTANCE}, {"info", config}};
-  ASSERT_EQ(bs.get_str(), expected.dump());
-}
-
 TEST_F(CoordinatorStateMachineTest, SerializeSetInstanceToMain) {
   auto config =
       CoordinatorToReplicaConfig{.instance_name = "instance3",

--- a/tests/unit/raft_state.cpp
+++ b/tests/unit/raft_state.cpp
@@ -51,7 +51,7 @@ TEST_F(RaftStateTest, RaftStateEmptyMetadata) {
   ASSERT_TRUE(raft_state.GetReplicationInstances().empty());
 
   auto const coords = raft_state.GetCoordinatorInstances();
-  ASSERT_EQ(coords.size(), 0);
+  ASSERT_EQ(coords.size(), 1);
 }
 
 TEST_F(RaftStateTest, GetSingleRouterRoutingTable) {
@@ -67,7 +67,8 @@ TEST_F(RaftStateTest, GetSingleRouterRoutingTable) {
   ASSERT_EQ(routing_table.size(), 1);
 
   auto const routers = routing_table[0];
-  ASSERT_TRUE(routers.first.empty());
+  auto const expected_routers = std::vector<std::string>{"0.0.0.0:7688"};
+  ASSERT_EQ(routers.first, expected_routers);
   ASSERT_EQ(routers.second, "ROUTE");
 }
 
@@ -102,12 +103,6 @@ TEST_F(RaftStateTest, GetMixedRoutingTable) {
                                                        .replication_mode = ReplicationMode::ASYNC,
                                                        .replication_server = Endpoint{"0.0.0.0", 10003}}});
 
-  leader.AppendAddCoordinatorInstanceLog(CoordinatorToCoordinatorConfig{
-      .coordinator_id = 2, .bolt_server = Endpoint{"0.0.0.0", 7691}, .coordinator_server = Endpoint{"0.0.0.0", 10114}});
-
-  leader.AppendAddCoordinatorInstanceLog(CoordinatorToCoordinatorConfig{
-      .coordinator_id = 3, .bolt_server = Endpoint{"0.0.0.0", 7692}, .coordinator_server = Endpoint{"0.0.0.0", 10115}});
-
   leader.AppendSetInstanceAsMainLog("instance1", UUID{});
 
   auto const routing_table = leader.GetRoutingTable();
@@ -125,6 +120,6 @@ TEST_F(RaftStateTest, GetMixedRoutingTable) {
 
   auto const &routers = routing_table[2];
   ASSERT_EQ(routers.second, "ROUTE");
-  auto const expected_routers = std::vector<std::string>{"0.0.0.0:7691", "0.0.0.0:7692"};
+  auto const expected_routers = std::vector<std::string>{"0.0.0.0:7690"};
   ASSERT_EQ(routers.first, expected_routers);
 }


### PR DESCRIPTION
### Description

Coordinator aren't explicitly saved in raft log. They are auto-managed by using `srv_config` from NuRaft. Aux field is used for saving more info about coordinators.

[master < Task] PR
- [x] Provide the full content or a guide for the final git message
    - **Fix managing coordinators in HA**


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - **[Release note text]**
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [ ] Tag someone from docs team in the comments
