### PR TITLE
Internal query module testing

### DIFF
--- a/query_modules/CMakeLists.txt
+++ b/query_modules/CMakeLists.txt
@@ -45,6 +45,7 @@ install(PROGRAMS $<TARGET_FILE:example_cpp>
 install(FILES example.cpp DESTINATION lib/memgraph/query_modules/src)
 
 add_library(schema SHARED schema.cpp)
+set_target_properties(schema PROPERTIES PREFIX "")
 target_include_directories(schema PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_compile_options(schema PRIVATE -Wall)
 target_link_libraries(schema PRIVATE -static-libgcc -static-libstdc++)
@@ -60,19 +61,20 @@ install(PROGRAMS $<TARGET_FILE:schema>
 # Also install the source of the example, so user can read it.
 install(FILES schema.cpp DESTINATION lib/memgraph/query_modules/src)
 
-add_library(text SHARED text_search_module.cpp)
-target_include_directories(text PRIVATE ${CMAKE_SOURCE_DIR}/include)
-target_compile_options(text PRIVATE -Wall)
-target_link_libraries(text PRIVATE -static-libgcc -static-libstdc++ fmt::fmt)
+add_library(text_search SHARED text_search_module.cpp)
+target_include_directories(text_search PRIVATE ${CMAKE_SOURCE_DIR}/include)
+target_compile_options(text_search PRIVATE -Wall)
+set_target_properties(text_search PROPERTIES PREFIX "")
+target_link_libraries(text_search PRIVATE -static-libgcc -static-libstdc++ fmt::fmt)
 # Strip C++ example in release build.
 if (lower_build_type STREQUAL "release")
-  add_custom_command(TARGET text POST_BUILD
-                     COMMAND strip -s $<TARGET_FILE:text>
+  add_custom_command(TARGET text_search POST_BUILD
+                     COMMAND strip -s $<TARGET_FILE:text_search>
                      COMMENT "Stripping symbols and sections from the C++ text_search module")
 endif()
-install(PROGRAMS $<TARGET_FILE:text>
+install(PROGRAMS $<TARGET_FILE:text_search>
         DESTINATION lib/memgraph/query_modules
-        RENAME text.so)
+        RENAME text_search.so)
 # Also install the source of the example, so user can read it.
 install(FILES text_search_module.cpp DESTINATION lib/memgraph/query_modules/src)
 

--- a/tests/e2e/query_modules/schema_test.py
+++ b/tests/e2e/query_modules/schema_test.py
@@ -20,7 +20,7 @@ def test_assert_creates_label_index_empty_list():
     results = list(
         execute_and_fetch_all(
             cursor,
-            "CALL libschema.assert({Person: []}, {}) YIELD * RETURN *;",
+            "CALL schema.assert({Person: []}, {}) YIELD * RETURN *;",
         )
     )
     assert results == [("Created", "", [], "Person", False)]
@@ -34,7 +34,7 @@ def test_assert_creates_label_index_empty_string():
     results = list(
         execute_and_fetch_all(
             cursor,
-            "CALL libschema.assert({Person: ['']}, {}) YIELD * RETURN *;",
+            "CALL schema.assert({Person: ['']}, {}) YIELD * RETURN *;",
         )
     )
     assert results == [("Created", "", [], "Person", False)]
@@ -47,7 +47,7 @@ def test_assert_index_wrong_properties_type():
     cursor = connect().cursor()
     execute_and_fetch_all(
         cursor,
-        "CALL libschema.assert({Person: ''}, {}) YIELD * RETURN *;",
+        "CALL schema.assert({Person: ''}, {}) YIELD * RETURN *;",
     )
     assert list(execute_and_fetch_all(cursor, "SHOW INDEX INFO;")) == []
 
@@ -56,7 +56,7 @@ def test_assert_property_is_not_a_string():
     cursor = connect().cursor()
     execute_and_fetch_all(
         cursor,
-        "CALL libschema.assert({Person: ['name', 1]}, {}) YIELD * RETURN *;",
+        "CALL schema.assert({Person: ['name', 1]}, {}) YIELD * RETURN *;",
     )
     show_index_results = list(execute_and_fetch_all(cursor, "SHOW INDEX INFO;"))
     assert show_index_results == [("label+property", "Person", "name", 0)]
@@ -68,7 +68,7 @@ def test_assert_creates_label_index_multiple_empty_strings():
     results = list(
         execute_and_fetch_all(
             cursor,
-            "CALL libschema.assert({Person: ['', '', '', '']}, {}) YIELD * RETURN *;",
+            "CALL schema.assert({Person: ['', '', '', '']}, {}) YIELD * RETURN *;",
         )
     )
     assert results == [("Created", "", [], "Person", False)]
@@ -82,7 +82,7 @@ def test_assert_creates_label_property_index():
     results = list(
         execute_and_fetch_all(
             cursor,
-            "CALL libschema.assert({Person: ['name']}, {}) YIELD * RETURN *;",
+            "CALL schema.assert({Person: ['name']}, {}) YIELD * RETURN *;",
         )
     )
     assert results == [("Created", "name", ["name"], "Person", False)]
@@ -96,7 +96,7 @@ def test_assert_creates_multiple_indices():
     results = list(
         execute_and_fetch_all(
             cursor,
-            "CALL libschema.assert({Person: ['', 'id', 'name'], Ball: ['', 'size', 'size', '']}, {}) YIELD * RETURN *;",
+            "CALL schema.assert({Person: ['', 'id', 'name'], Ball: ['', 'size', 'size', '']}, {}) YIELD * RETURN *;",
         )
     )
     assert len(results) == 5
@@ -124,7 +124,7 @@ def test_assert_creates_existence_constraints():
     results = list(
         execute_and_fetch_all(
             cursor,
-            "CALL libschema.assert({}, {}, {Person: ['name', 'surname']}) YIELD * RETURN *;",
+            "CALL schema.assert({}, {}, {Person: ['name', 'surname']}) YIELD * RETURN *;",
         )
     )
     assert results == [
@@ -144,7 +144,7 @@ def test_assert_dropping_indices():
     execute_and_fetch_all(cursor, "CREATE INDEX ON :Person(id);")
     execute_and_fetch_all(cursor, "CREATE INDEX ON :Ball(size);")
     execute_and_fetch_all(cursor, "CREATE INDEX ON :Ball;")
-    results = list(execute_and_fetch_all(cursor, "CALL libschema.assert({}, {}) YIELD * RETURN *;"))
+    results = list(execute_and_fetch_all(cursor, "CALL schema.assert({}, {}) YIELD * RETURN *;"))
     assert len(results) == 4
     assert results[0] == ("Dropped", "", [], "Ball", False)
     assert results[1] == ("Dropped", "size", ["size"], "Ball", False)
@@ -156,13 +156,13 @@ def test_assert_dropping_indices():
 
 def test_assert_existence_constraint_properties_not_list():
     cursor = connect().cursor()
-    execute_and_fetch_all(cursor, "CALL libschema.assert({}, {}, {Person: 'name'}) YIELD * RETURN *;")
+    execute_and_fetch_all(cursor, "CALL schema.assert({}, {}, {Person: 'name'}) YIELD * RETURN *;")
     assert list(execute_and_fetch_all(cursor, "SHOW CONSTRAINT INFO;")) == []
 
 
 def test_assert_existence_constraint_property_not_string():
     cursor = connect().cursor()
-    execute_and_fetch_all(cursor, "CALL libschema.assert({}, {}, {Person: ['name', 1]}) YIELD * RETURN *;")
+    execute_and_fetch_all(cursor, "CALL schema.assert({}, {}, {Person: ['name', 1]}) YIELD * RETURN *;")
     show_constraint_results = list(execute_and_fetch_all(cursor, "SHOW CONSTRAINT INFO;"))
     assert show_constraint_results == [("exists", "Person", "name")]
     execute_and_fetch_all(cursor, "DROP CONSTRAINT ON (n:Person) ASSERT EXISTS (n.name);")
@@ -170,7 +170,7 @@ def test_assert_existence_constraint_property_not_string():
 
 def test_assert_existence_constraint_property_empty_string():
     cursor = connect().cursor()
-    execute_and_fetch_all(cursor, "CALL libschema.assert({}, {}, {Person: ['']}) YIELD * RETURN *;")
+    execute_and_fetch_all(cursor, "CALL schema.assert({}, {}, {Person: ['']}) YIELD * RETURN *;")
     assert list(execute_and_fetch_all(cursor, "SHOW CONSTRAINT INFO;")) == []
 
 
@@ -179,7 +179,7 @@ def test_assert_creates_indices_and_existence_constraints():
     results = list(
         execute_and_fetch_all(
             cursor,
-            "CALL libschema.assert({Person: ['', 'id']}, {}, {Person: ['name', 'surname']}) YIELD * RETURN *;",
+            "CALL schema.assert({Person: ['', 'id']}, {}, {Person: ['name', 'surname']}) YIELD * RETURN *;",
         )
     )
     assert len(results) == 4
@@ -201,7 +201,7 @@ def test_assert_drops_existence_constraints():
     cursor = connect().cursor()
     execute_and_fetch_all(cursor, "CREATE CONSTRAINT ON (n:Person) ASSERT EXISTS (n.name);")
     execute_and_fetch_all(cursor, "CREATE CONSTRAINT ON (n:Person) ASSERT EXISTS (n.surname);")
-    results = list(execute_and_fetch_all(cursor, "CALL libschema.assert({}, {}, {}) YIELD * RETURN *;"))
+    results = list(execute_and_fetch_all(cursor, "CALL schema.assert({}, {}, {}) YIELD * RETURN *;"))
     assert len(results) == 2
     assert results[0] == ("Dropped", "name", ["name"], "Person", False)
     assert results[1] == ("Dropped", "surname", ["surname"], "Person", False)
@@ -214,7 +214,7 @@ def test_assert_creates_unique_constraints():
     results = list(
         execute_and_fetch_all(
             cursor,
-            "CALL libschema.assert({}, {Person: [['name', 'surname']]}) YIELD * RETURN *;",
+            "CALL schema.assert({}, {Person: [['name', 'surname']]}) YIELD * RETURN *;",
         )
     )
     assert results == [("Created", "[name, surname]", ["name", "surname"], "Person", True)]
@@ -229,7 +229,7 @@ def test_assert_creates_multiple_unique_constraints():
     results = list(
         execute_and_fetch_all(
             cursor,
-            "CALL libschema.assert({}, {Person: [['name', 'surname'], ['id']]}) YIELD * RETURN *;",
+            "CALL schema.assert({}, {Person: [['name', 'surname'], ['id']]}) YIELD * RETURN *;",
         )
     )
     assert results == [
@@ -248,7 +248,7 @@ def test_assert_creates_unique_constraints_skip_invalid():
     results = list(
         execute_and_fetch_all(
             cursor,
-            "CALL libschema.assert({}, {Person: [['name', 'surname'], 'wrong_type']}) YIELD * RETURN *;",
+            "CALL schema.assert({}, {Person: [['name', 'surname'], 'wrong_type']}) YIELD * RETURN *;",
         )
     )
     assert results == [("Created", "[name, surname]", ["name", "surname"], "Person", True)]
@@ -263,7 +263,7 @@ def test_assert_creates_unique_constraints_skip_invalid_map_type():
     results = list(
         execute_and_fetch_all(
             cursor,
-            "CALL libschema.assert({}, {Person: [['name', 'surname']], Ball: 'wrong_type'}) YIELD * RETURN *;",
+            "CALL schema.assert({}, {Person: [['name', 'surname']], Ball: 'wrong_type'}) YIELD * RETURN *;",
         )
     )
     assert results == [("Created", "[name, surname]", ["name", "surname"], "Person", True)]
@@ -278,7 +278,7 @@ def test_assert_creates_constraints_and_indices():
     results = list(
         execute_and_fetch_all(
             cursor,
-            "CALL libschema.assert({Person: ['', 'id']}, {Person: [['name', 'surname'], ['id']]}, {Person: ['name', 'surname']}) YIELD * RETURN *;",
+            "CALL schema.assert({Person: ['', 'id']}, {Person: [['name', 'surname'], ['id']]}, {Person: ['name', 'surname']}) YIELD * RETURN *;",
         )
     )
     assert len(results) == 6
@@ -309,7 +309,7 @@ def test_assert_drops_unique_constraints():
     cursor = connect().cursor()
     execute_and_fetch_all(cursor, "CREATE CONSTRAINT ON (n:Person) ASSERT n.name, n.surname IS UNIQUE;")
     execute_and_fetch_all(cursor, "CREATE CONSTRAINT ON (n:Person) ASSERT n.id IS UNIQUE;")
-    results = list(execute_and_fetch_all(cursor, "CALL libschema.assert({}, {}, {}) YIELD * RETURN *;"))
+    results = list(execute_and_fetch_all(cursor, "CALL schema.assert({}, {}, {}) YIELD * RETURN *;"))
     assert len(results) == 2
     assert results[0] == ("Dropped", "[id]", ["id"], "Person", True)
     assert results[1] == ("Dropped", "[name, surname]", ["name", "surname"], "Person", True)
@@ -325,7 +325,7 @@ def test_assert_drops_indices_and_constraints():
     execute_and_fetch_all(cursor, "CREATE CONSTRAINT ON (n:Person) ASSERT n.id IS UNIQUE;")
     execute_and_fetch_all(cursor, "CREATE CONSTRAINT ON (n:Person) ASSERT EXISTS (n.name);")
     execute_and_fetch_all(cursor, "CREATE CONSTRAINT ON (n:Person) ASSERT EXISTS (n.surname);")
-    results = list(execute_and_fetch_all(cursor, "CALL libschema.assert({}, {}, {}) YIELD * RETURN *;"))
+    results = list(execute_and_fetch_all(cursor, "CALL schema.assert({}, {}, {}) YIELD * RETURN *;"))
     assert len(results) == 6
     assert results[0] == ("Dropped", "", [], "Person", False)
     assert results[1] == ("Dropped", "id", ["id"], "Person", False)
@@ -347,7 +347,7 @@ def test_assert_does_not_drop_indices_and_constraints():
     execute_and_fetch_all(cursor, "CREATE CONSTRAINT ON (n:Person) ASSERT n.id IS UNIQUE;")
     execute_and_fetch_all(cursor, "CREATE CONSTRAINT ON (n:Person) ASSERT EXISTS (n.name);")
     execute_and_fetch_all(cursor, "CREATE CONSTRAINT ON (n:Person) ASSERT EXISTS (n.surname);")
-    results = list(execute_and_fetch_all(cursor, "CALL libschema.assert({}, {}, {}, false) YIELD * RETURN *;"))
+    results = list(execute_and_fetch_all(cursor, "CALL schema.assert({}, {}, {}, false) YIELD * RETURN *;"))
     assert len(results) == 0
     show_index_results = list(execute_and_fetch_all(cursor, "SHOW INDEX INFO;"))
     assert show_index_results == [("label", "Person", None, 0), ("label+property", "Person", "id", 0)]
@@ -379,7 +379,7 @@ def test_assert_keeps_existing_indices_and_constraints():
     results = list(
         execute_and_fetch_all(
             cursor,
-            "CALL libschema.assert({Person: ['id']}, {Person: [['name', 'surname']]}, {Person: ['name']}) YIELD * RETURN *;",
+            "CALL schema.assert({Person: ['id']}, {Person: [['name', 'surname']]}, {Person: ['name']}) YIELD * RETURN *;",
         )
     )
 
@@ -428,7 +428,7 @@ def test_node_type_properties1():
     result = list(
         execute_and_fetch_all(
             cursor,
-            f"CALL libschema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
+            f"CALL schema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
         )[0]
     )
     assert (result) == [":`Activity`", ["Activity"], "location", ["String"], True]
@@ -436,7 +436,7 @@ def test_node_type_properties1():
     result = list(
         execute_and_fetch_all(
             cursor,
-            f"CALL libschema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
+            f"CALL schema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
         )[1]
     )
     assert (result) == [":`Activity`", ["Activity"], "name", ["String"], True]
@@ -444,7 +444,7 @@ def test_node_type_properties1():
     result = list(
         execute_and_fetch_all(
             cursor,
-            f"CALL libschema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
+            f"CALL schema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
         )[2]
     )
     assert (result) == [":`Dog`", ["Dog"], "name", ["String"], True]
@@ -452,7 +452,7 @@ def test_node_type_properties1():
     result = list(
         execute_and_fetch_all(
             cursor,
-            f"CALL libschema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
+            f"CALL schema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
         )[3]
     )
     assert (result) == [":`Dog`", ["Dog"], "owner", ["String"], True]
@@ -469,7 +469,7 @@ def test_node_type_properties2():
     )
     result = execute_and_fetch_all(
         cursor,
-        f"CALL libschema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
+        f"CALL schema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
     )
 
     assert (list(result[0])) == [":`MyNode`", ["MyNode"], "", [], False]
@@ -487,7 +487,7 @@ def test_node_type_properties3():
     )
     result = execute_and_fetch_all(
         cursor,
-        f"CALL libschema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
+        f"CALL schema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
     )
 
     assert (list(result[0])) == [":`Dog`", ["Dog"], "name", ["String"], False]
@@ -507,7 +507,7 @@ def test_node_type_properties4():
     result = list(
         execute_and_fetch_all(
             cursor,
-            f"CALL libschema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
+            f"CALL schema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
         )
     )
     assert (list(result[0])) == [":`Label1`:`Label2`", ["Label1", "Label2"], "property1", ["String"], False]
@@ -526,7 +526,7 @@ def test_node_type_properties5():
     )
     result = execute_and_fetch_all(
         cursor,
-        f"CALL libschema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
+        f"CALL schema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
     )
 
     assert (list(result[0])) == [":`Dog`", ["Dog"], "name", ["String"], True]
@@ -544,7 +544,7 @@ def test_node_type_properties6():
     )
     result = execute_and_fetch_all(
         cursor,
-        f"CALL libschema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
+        f"CALL schema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
     )
 
     assert (list(result[0])) == [":`Dog`", ["Dog"], "name", ["String"], True]
@@ -563,7 +563,7 @@ def test_node_type_properties_multiple_property_types():
     )
     result = execute_and_fetch_all(
         cursor,
-        f"CALL libschema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
+        f"CALL schema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
     )
     assert (list(result[0])) == [":`Node`", ["Node"], "prop1", ["Int", "String"], True] or (list(result[0])) == [
         ":`Node`",
@@ -584,7 +584,7 @@ def test_rel_type_properties1():
     result = list(
         execute_and_fetch_all(
             cursor,
-            f"CALL libschema.rel_type_properties() YIELD relType,propertyName, propertyTypes , mandatory RETURN relType, propertyName, propertyTypes , mandatory;",
+            f"CALL schema.rel_type_properties() YIELD relType,propertyName, propertyTypes , mandatory RETURN relType, propertyName, propertyTypes , mandatory;",
         )[0]
     )
     assert (result) == [":`LOVES`", "", [], False]
@@ -601,7 +601,7 @@ def test_rel_type_properties2():
     )
     result = execute_and_fetch_all(
         cursor,
-        f"CALL libschema.rel_type_properties() YIELD relType,propertyName, propertyTypes , mandatory RETURN relType, propertyName, propertyTypes , mandatory;",
+        f"CALL schema.rel_type_properties() YIELD relType,propertyName, propertyTypes , mandatory RETURN relType, propertyName, propertyTypes , mandatory;",
     )
     assert (list(result[0])) == [":`LOVES`", "duration", ["Int"], False]
     assert (result.__len__()) == 1
@@ -617,7 +617,7 @@ def test_rel_type_properties3():
     )
     result = execute_and_fetch_all(
         cursor,
-        f"CALL libschema.rel_type_properties() YIELD relType,propertyName, propertyTypes , mandatory RETURN relType, propertyName, propertyTypes , mandatory;",
+        f"CALL schema.rel_type_properties() YIELD relType,propertyName, propertyTypes , mandatory RETURN relType, propertyName, propertyTypes , mandatory;",
     )
     assert (list(result[0])) == [":`LOVES`", "duration", ["Int"], True]
     assert (result.__len__()) == 1
@@ -634,7 +634,7 @@ def test_rel_type_properties4():
     )
     result = execute_and_fetch_all(
         cursor,
-        f"CALL libschema.rel_type_properties() YIELD relType,propertyName, propertyTypes , mandatory RETURN relType, propertyName, propertyTypes , mandatory;",
+        f"CALL schema.rel_type_properties() YIELD relType,propertyName, propertyTypes , mandatory RETURN relType, propertyName, propertyTypes , mandatory;",
     )
     assert (list(result[0])) == [":`LOVES`", "weather", ["String"], False]
     assert (list(result[1])) == [":`LOVES`", "duration", ["Int"], True]
@@ -652,7 +652,7 @@ def test_rel_type_properties_multiple_property_types():
     )
     result = execute_and_fetch_all(
         cursor,
-        f"CALL libschema.rel_type_properties() YIELD relType,propertyName, propertyTypes , mandatory RETURN relType, propertyName, propertyTypes , mandatory;",
+        f"CALL schema.rel_type_properties() YIELD relType,propertyName, propertyTypes , mandatory RETURN relType, propertyName, propertyTypes , mandatory;",
     )
     assert (list(result[0])) == [":`LOVES`", "duration", ["Int", "String"], True] or (list(result[0])) == [
         ":`LOVES`",

--- a/tests/e2e/text_search/test_text_search.py
+++ b/tests/e2e/text_search/test_text_search.py
@@ -18,7 +18,7 @@ import mgclient
 import pytest
 from common import memgraph, memgraph_with_mixed_data, memgraph_with_text_indexed_data
 
-GET_RULES_2024_DOCUMENT = """CALL libtext.search("complianceDocuments", "data.title:Rules2024") YIELD node
+GET_RULES_2024_DOCUMENT = """CALL text_search.search("complianceDocuments", "data.title:Rules2024") YIELD node
              RETURN node.title AS title, node.version AS version
              ORDER BY version ASC, title ASC;"""
 
@@ -66,7 +66,7 @@ def test_text_search_given_property(memgraph_with_text_indexed_data):
 def test_text_search_all_properties(memgraph_with_text_indexed_data):
     SEARCH_QUERY = "Rules2024"
 
-    ALL_PROPERTIES_QUERY = f"""CALL libtext.search_all("complianceDocuments", "{SEARCH_QUERY}") YIELD node
+    ALL_PROPERTIES_QUERY = f"""CALL text_search.search_all("complianceDocuments", "{SEARCH_QUERY}") YIELD node
              RETURN node
              ORDER BY node.version ASC, node.title ASC;"""
 
@@ -81,7 +81,7 @@ def test_text_search_all_properties(memgraph_with_text_indexed_data):
 
 
 def test_regex_text_search(memgraph_with_text_indexed_data):
-    REGEX_QUERY = """CALL libtext.regex_search("complianceDocuments", "wor.*s") YIELD node
+    REGEX_QUERY = """CALL text_search.regex_search("complianceDocuments", "wor.*s") YIELD node
              RETURN node
              ORDER BY node.version ASC, node.title ASC;"""
 
@@ -99,7 +99,7 @@ def test_text_search_aggregate(memgraph_with_text_indexed_data):
     input_aggregation = json.dumps({"count": {"value_count": {"field": "metadata.gid"}}}, separators=(",", ":"))
     expected_aggregation = json.dumps({"count": {"value": 2.0}}, separators=(",", ":"))
 
-    AGGREGATION_QUERY = f"""CALL libtext.aggregate("complianceDocuments", "data.title:Rules2024", '{input_aggregation}')
+    AGGREGATION_QUERY = f"""CALL text_search.aggregate("complianceDocuments", "data.title:Rules2024", '{input_aggregation}')
                 YIELD aggregation
                 RETURN aggregation;"""
 
@@ -109,7 +109,7 @@ def test_text_search_aggregate(memgraph_with_text_indexed_data):
 
 
 def test_text_search_query_boolean(memgraph_with_text_indexed_data):
-    BOOLEAN_QUERY = """CALL libtext.search("complianceDocuments", "(data.title:Rules2023 OR data.title:Rules2024) AND data.fulltext:words") YIELD node
+    BOOLEAN_QUERY = """CALL text_search.search("complianceDocuments", "(data.title:Rules2023 OR data.title:Rules2024) AND data.fulltext:words") YIELD node
                 RETURN node.title AS title, node.version AS version
                 ORDER BY version ASC, title ASC;"""
 
@@ -159,7 +159,7 @@ def test_update_text_property_of_indexed_node(memgraph_with_text_indexed_data):
 
     result = list(
         memgraph_with_text_indexed_data.execute_and_fetch(
-            """CALL libtext.search("complianceDocuments", "data.title:Rules2030") YIELD node
+            """CALL text_search.search("complianceDocuments", "data.title:Rules2030") YIELD node
              RETURN node.title AS title, node.version AS version
              ORDER BY version ASC, title ASC;"""
         )
@@ -194,7 +194,7 @@ def test_remove_unindexable_property_from_indexed_node(memgraph_with_text_indexe
 
 
 def test_text_search_nonexistent_index(memgraph_with_text_indexed_data):
-    NONEXISTENT_INDEX_QUERY = """CALL libtext.search("noSuchIndex", "data.fulltext:words") YIELD node
+    NONEXISTENT_INDEX_QUERY = """CALL text_search.search("noSuchIndex", "data.fulltext:words") YIELD node
                 RETURN node.title AS title, node.version AS version
                 ORDER BY version ASC, title ASC;"""
 

--- a/tests/e2e/text_search/test_text_search_disabled.py
+++ b/tests/e2e/text_search/test_text_search_disabled.py
@@ -34,7 +34,7 @@ def test_drop_index(memgraph):
 def test_text_search_given_property(memgraph):
     with pytest.raises(gqlalchemy.exceptions.GQLAlchemyDatabaseError, match=TEXT_SEARCH_DISABLED_ERROR) as _:
         memgraph.execute(
-            """CALL libtext.search("complianceDocuments", "data.title:Rules2024") YIELD node
+            """CALL text_search.search("complianceDocuments", "data.title:Rules2024") YIELD node
              RETURN node;"""
         )
 
@@ -42,7 +42,7 @@ def test_text_search_given_property(memgraph):
 def test_text_search_all_properties(memgraph):
     with pytest.raises(gqlalchemy.exceptions.GQLAlchemyDatabaseError, match=TEXT_SEARCH_DISABLED_ERROR) as _:
         memgraph.execute(
-            """CALL libtext.search_all("complianceDocuments", "Rules2024") YIELD node
+            """CALL text_search.search_all("complianceDocuments", "Rules2024") YIELD node
              RETURN node;"""
         )
 
@@ -50,7 +50,7 @@ def test_text_search_all_properties(memgraph):
 def test_regex_text_search(memgraph):
     with pytest.raises(gqlalchemy.exceptions.GQLAlchemyDatabaseError, match=TEXT_SEARCH_DISABLED_ERROR) as _:
         memgraph.execute(
-            """CALL libtext.regex_search("complianceDocuments", "wor.*s") YIELD node
+            """CALL text_search.regex_search("complianceDocuments", "wor.*s") YIELD node
              RETURN node;"""
         )
 
@@ -60,7 +60,7 @@ def test_text_search_aggregate(memgraph):
         input_aggregation = json.dumps({"count": {"value_count": {"field": "metadata.gid"}}}, separators=(",", ":"))
 
         memgraph.execute(
-            f"""CALL libtext.aggregate("complianceDocuments", "wor.*s", '{input_aggregation}') YIELD aggregation
+            f"""CALL text_search.aggregate("complianceDocuments", "wor.*s", '{input_aggregation}') YIELD aggregation
             RETURN aggregation;"""
         )
 


### PR DESCRIPTION
### Description

This PR aims to fix the current situation where adding query modules internally to Memgraph (vs. to [mage](https://github.com/memgraph/mage)) is error-prone.

The fix consists of removing the default `lib` prefix from the query module libraries’ names. That way, developers can immediately see the query modules’ actual names and use them in tests.

[master < Task] PR
- [x] Provide the full content or a guide for the final git message
    > Make internal query modules’ actual names available in testing


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
- [x] ~Write a release note, including added/changed clauses~ N/A
- [x] ~Link the documentation PR here~ N/A
- [x] ~Tag someone from docs team in the comments~ N/A
