### PR TITLE
Fix clang tidy

### DIFF
--- a/tests/code_analysis/clang_tidy.sh
+++ b/tests/code_analysis/clang_tidy.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -eu
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PROJECT_ROOT="$SCRIPT_DIR/../.."
 BASE_BRANCH="origin/master"
@@ -19,5 +21,8 @@ fi
 cd $PROJECT_ROOT
 git diff -U0 $BASE_BRANCH... -- src | ./tools/github/clang-tidy/clang-tidy-diff.py -p 1 -j $THREADS -path build  -regex ".+\.cpp" | tee ./build/clang_tidy_output.txt
 # Fail if any warning is reported
-! cat ./build/clang_tidy_output.txt | ./tools/github/clang-tidy/grep_error_lines.sh > /dev/null
+if  cat ./build/clang_tidy_output.txt | ./tools/github/clang-tidy/grep_error_lines.sh > /dev/null; then
+    echo "ba"
+fi
+
 cd $SCRIPT_DIR

--- a/tests/code_analysis/clang_tidy.sh
+++ b/tests/code_analysis/clang_tidy.sh
@@ -22,7 +22,7 @@ cd $PROJECT_ROOT
 git diff -U0 $BASE_BRANCH... -- src | ./tools/github/clang-tidy/clang-tidy-diff.py -p 1 -j $THREADS -path build  -regex ".+\.cpp" | tee ./build/clang_tidy_output.txt
 # Fail if any warning is reported
 if  cat ./build/clang_tidy_output.txt | ./tools/github/clang-tidy/grep_error_lines.sh > /dev/null; then
-    echo "ba"
+    exit 1
 fi
 
 cd $SCRIPT_DIR

--- a/tools/github/clang-tidy/grep_error_lines.sh
+++ b/tools/github/clang-tidy/grep_error_lines.sh
@@ -3,7 +3,7 @@
 # Matches timestamp like "2021-03-25T17:06:42.2621697Z"
 TIMESTAMP_PATTERN="\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z"
 
-# Matches absolute file pathes with line and column identifier like
+# Matches absolute file paths with line and column identifier like
 # "/opt/actions-runner/_work/memgraph/memgraph/src/utils/exceptions.hpp:71:11:"
 FILE_ABSOLUTE_PATH_PATTERN="/[^:]+:\d+:\d+:"
 


### PR DESCRIPTION
### Description

This diff fixes clang tidy to report errors again.

[master < Task] PR
- [x] Provide the full content or a guide for the final git message
    - Fixes clang tidy


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [x] Write a release note, including added/changed clauses
    - **[Release note text]**
- [x] Link the documentation PR here
    - **[Documentation PR link]**
- [x] Tag someone from docs team in the comments
