### PR TITLE
Add checks after request leadership

### DIFF
--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -459,7 +459,7 @@ auto CoordinatorInstance::SetReplicationInstanceToMain(std::string_view instance
     -> SetInstanceToMainCoordinatorStatus {
   if (!raft_state_.IsLeader()) {
     if (!HasBecomeLeader()) {
-      return RegisterInstanceCoordinatorStatus::NOT_LEADER;
+      return SetInstanceToMainCoordinatorStatus::NOT_LEADER;
     }
     MG_ASSERT(raft_state_.IsLeader() && !raft_state_.IsLockOpened(),
               "Instance needs to become leader and not have lock opened.");
@@ -560,6 +560,7 @@ auto CoordinatorInstance::HasBecomeLeader() -> bool {
   auto waiting_period = 1s;
   auto maybe_stop = utils::ResettableCounter<5>();
   do {
+    spdlog::trace("Waiting for coordinator to become leader.");
     if (!become_leader_.wait_for(lock, waiting_period, [this]() { return leader_set_up_.load(); })) {
       waiting_period *= expontential_backoff;
     }
@@ -660,7 +661,7 @@ auto CoordinatorInstance::UnregisterReplicationInstance(std::string_view instanc
     -> UnregisterInstanceCoordinatorStatus {
   if (!raft_state_.IsLeader()) {
     if (!HasBecomeLeader()) {
-      return RegisterInstanceCoordinatorStatus::NOT_LEADER;
+      return UnregisterInstanceCoordinatorStatus::NOT_LEADER;
     }
     MG_ASSERT(raft_state_.IsLeader() && !raft_state_.IsLockOpened(),
               "Instance needs to become leader and not have lock opened.");

--- a/src/coordination/include/coordination/coordinator_instance.hpp
+++ b/src/coordination/include/coordination/coordinator_instance.hpp
@@ -129,6 +129,8 @@ class CoordinatorInstance {
   // Thread pool needs to be constructed before raft state as raft state can call thread pool
   utils::ThreadPool thread_pool_;
   RaftState raft_state_;
+
+  std::binary_semaphore semaphore_leader{0};
 };
 
 }  // namespace memgraph::coordination

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -2646,14 +2646,4 @@ def test_request_leadership_and_force_reset_works_after_failed_registration_and_
 
 
 if __name__ == "__main__":
-    sys.exit(
-        pytest.main(
-            [
-                __file__,
-                "-k",
-                "test_request_leadership_and_force_reset_works_after_failed_registration_and_2_coordinators_down",
-                "-vv",
-            ]
-        )
-    )
     sys.exit(pytest.main([__file__, "-rA"]))


### PR DESCRIPTION
### Description

This diff checks if everything is properly updated before the follower coordinator becomes LEADER on user action. It is still possible for user to do action while failover is happening but now we have a way to detect that everything is properly set up.


[master < Task] PR
- [ ] Provide the full content or a guide for the final git message
    - Add setup check on leadership change

### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug/feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [x] Write a release note, including added/changed clauses
    - Add check to confirm correct setup after requesting leadership 
- [x] Link the documentation PR here
    - No docs only changelog
- [x] Tag someone from docs team in the comments
