### PR TITLE
Fix same port bug on HA unit tests

### DIFF
--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -101,7 +101,6 @@ jobs:
           --arch $ARCH \
           --enterprise-license $MEMGRAPH_ENTERPRISE_LICENSE \
           --organization-name $MEMGRAPH_ORGANIZATION_NAME \
-          --threads 1 \
           test-memgraph unit
 
       - name: Create enterprise DEB package

--- a/tests/unit/coordinator_instance.cpp
+++ b/tests/unit/coordinator_instance.cpp
@@ -50,7 +50,7 @@ class CoordinatorInstanceTest : public ::testing::Test {
 
   std::vector<uint32_t> const coordinator_ids = {41, 42, 43};
   std::vector<uint16_t> const bolt_ports = {2687, 2688, 2689};
-  std::vector<uint16_t> const coordinator_ports = {40112, 40113, 40114};
+  std::vector<uint16_t> const coordinator_ports = {40113, 40114, 40115};
 };
 
 // Empty until you run 1st RegisterReplicationInstance or AddCoordinatorInstance


### PR DESCRIPTION
### Description

HA unit tests had the same port defined for the `nuRaft` server for `coordinator_instance`.cpp and `coordinator_raft_state.cpp`, which is `40112`

[master < Task] PR
- [x] Provide the full content or a guide for the final git message
    - Fix same port bug

### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [x] Write a release note, including added/changed clauses
    - Internal, no docs
- [x] Link the documentation PR here
    - Internal, no docs
- [x] Tag someone from docs team in the comments
