### PR TITLE
Exclude tests/**/* directory and files from the static analysis by SonarCloud

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -6,6 +6,7 @@ sonar.sources = src/**/*
 # Path to tests
 sonar.tests = tests/**/*
 # sonar.test.exclusions=
+sonar.exclusions=tests/**/*
 # sonar.test.inclusions=
 
 # Source encoding


### PR DESCRIPTION
### Description
As suggested by phind.com AI

Change the SonarCloud configuration to exclude the tests directory. This should reduce the noise and distraction.
