### PR TITLE
Fix nuRaft init script issue

### DIFF
--- a/libs/setup.sh
+++ b/libs/setup.sh
@@ -288,7 +288,7 @@ repo_clone_try_double "${primary_urls[range-v3]}" "${secondary_urls[range-v3]}" 
 # NuRaft
 NURAFT_COMMIT_HASH="4b148a7e76291898c838a7457eeda2b16f7317ea"
 NURAFT_TAG="master"
-repo_clone_try_double "${primary_urls[nuraft]}" "${secondary_urls[nuraft]}" "nuraft" "$NURAFT_TAG" true
+repo_clone_try_double "${primary_urls[nuraft]}" "${secondary_urls[nuraft]}" "nuraft" "$NURAFT_TAG" false
 pushd nuraft
 git checkout $NURAFT_COMMIT_HASH
 git apply ../nuraft.patch


### PR DESCRIPTION
### Description

nuRaft needs also `git fetch` to checkout to specific older commits. This fixes the issue @gvolfing experienced with the `./init` script. Link to slack thread here: https://memgraph.slack.com/archives/CS5827FK3/p1713266466780389

[master < Task] PR
- [x] Provide the full content or a guide for the final git message
    - Fix nuRaft init script issue


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug/feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [x] Write a release note, including added/changed clauses
    - No docs, internal
- [x] Link the documentation PR here
    - *No docs, internal
- [x] Tag someone from docs team in the comments
