### PR TITLE
Add exit on coordinator state ctor error

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -6,6 +6,7 @@ sonar.sources = src/**/*
 # Path to tests
 sonar.tests = tests/**/*
 # sonar.test.exclusions=
+sonar.exclusions=tests/**/*
 # sonar.test.inclusions=
 
 # Source encoding

--- a/src/flags/all.hpp
+++ b/src/flags/all.hpp
@@ -12,6 +12,7 @@
 
 #include "flags/audit.hpp"
 #include "flags/bolt.hpp"
+#include "flags/coordination.hpp"
 #include "flags/experimental.hpp"
 #include "flags/general.hpp"
 #include "flags/isolation_level.hpp"

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -10,6 +10,8 @@
 // licenses/APL.txt.
 
 #include <cstdint>
+#include <exception>
+
 #include "audit/log.hpp"
 #include "auth/auth.hpp"
 #include "communication/websocket/auth.hpp"
@@ -43,11 +45,14 @@
 #include "storage/v2/storage_mode.hpp"
 #include "system/system.hpp"
 #include "telemetry/telemetry.hpp"
+#include "utils/file.hpp"
 #include "utils/signals.hpp"
 #include "utils/sysinfo/memory.hpp"
 #include "utils/system_info.hpp"
 #include "utils/terminate_handler.hpp"
 #include "version.hpp"
+
+#include <spdlog/spdlog.h>
 
 namespace {
 constexpr const char *kMgUser = "MEMGRAPH_USER";

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -10,6 +10,7 @@
 // licenses/APL.txt.
 
 #include <cstdint>
+#include <cstdlib>
 #include <exception>
 
 #include "audit/log.hpp"
@@ -21,6 +22,9 @@
 #include "dbms/dbms_handler.hpp"
 #include "dbms/inmemory/replication_handlers.hpp"
 #include "flags/all.hpp"
+#include "flags/bolt.hpp"
+#include "flags/coordination.hpp"
+#include "flags/general.hpp"
 #include "glue/MonitoringServerT.hpp"
 #include "glue/ServerT.hpp"
 #include "glue/auth_checker.hpp"

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -444,10 +444,15 @@ int main(int argc, char **argv) {
   }
 
   if (FLAGS_coordinator_id && FLAGS_coordinator_port) {
-    auto const high_availability_data_dir = FLAGS_data_directory + "/high_availability" + "/coordinator";
-    memgraph::utils::EnsureDirOrDie(high_availability_data_dir);
-    coordinator_state.emplace(CoordinatorInstanceInitConfig{FLAGS_coordinator_id, FLAGS_coordinator_port,
-                                                            FLAGS_bolt_port, high_availability_data_dir});
+    try {
+      auto const high_availability_data_dir = FLAGS_data_directory + "/high_availability" + "/coordinator";
+      memgraph::utils::EnsureDirOrDie(high_availability_data_dir);
+      coordinator_state.emplace(CoordinatorInstanceInitConfig{FLAGS_coordinator_id, FLAGS_coordinator_port,
+                                                              FLAGS_bolt_port, high_availability_data_dir});
+    } catch (std::exception const &e) {
+      spdlog::error("Exception was thrown on coordinator state construction, shutting down Memgraph. {}", e.what());
+      exit(1);
+    }
   } else {
     coordinator_state.emplace(ReplicationInstanceInitConfig{.management_port = FLAGS_management_port});
   }


### PR DESCRIPTION
### Description

This diff adds exit on construction error for coordinator state in case raft launcher throws an error

[master < Task] PR
- [x] Provide the full content or a guide for the final git message
    - Add exit on coordinator state ctor error


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [x] Write a release note, including added/changed clauses
    - **[Release note text]**
- [x] Link the documentation PR here
    - **[Documentation PR link]**
- [x] Tag someone from docs team in the comments
