### PR TITLE
Add last_succ_resp_ms to SHOW INSTANCES output

### DIFF
--- a/src/coordination/coordinator_communication_config.cpp
+++ b/src/coordination/coordinator_communication_config.cpp
@@ -12,19 +12,26 @@
 #ifdef MG_ENTERPRISE
 
 #include "coordination/coordinator_communication_config.hpp"
+#include "utils/uuid.hpp"
+
+#include <chrono>
+#include <json/json.hpp>
+#include <string>
 
 namespace memgraph::coordination {
 
 void to_json(nlohmann::json &j, CoordinatorToCoordinatorConfig const &config) {
   j = nlohmann::json{{"coordinator_id", config.coordinator_id},
                      {"coordinator_server", config.coordinator_server},
-                     {"bolt_server", config.bolt_server}};
+                     {"bolt_server", config.bolt_server},
+                     {"instance_down_timeout_sec", config.instance_down_timeout_sec.count()}};
 }
 
 void from_json(nlohmann::json const &j, CoordinatorToCoordinatorConfig &config) {
   config.coordinator_id = j.at("coordinator_id").get<uint32_t>();
   config.coordinator_server = j.at("coordinator_server").get<io::network::Endpoint>();
   config.bolt_server = j.at("bolt_server").get<io::network::Endpoint>();
+  config.instance_down_timeout_sec = std::chrono::seconds{j.at("instance_down_timeout_sec").get<int>()};
 }
 
 void to_json(nlohmann::json &j, ReplicationClientInfo const &config) {
@@ -60,13 +67,13 @@ void from_json(nlohmann::json const &j, CoordinatorToReplicaConfig &config) {
   config.replication_client_info = j.at("replication_client_info").get<ReplicationClientInfo>();
 }
 
-void from_json(nlohmann::json const &j, InstanceUUIDUpdate &instance_uuid_change) {
-  instance_uuid_change.uuid = j.at("uuid").get<utils::UUID>();
-  instance_uuid_change.instance_name = j.at("instance_name").get<std::string>();
+void from_json(nlohmann::json const &j, InstanceUUIDUpdate &instance_uuid_update) {
+  instance_uuid_update.uuid = j.at("uuid").get<utils::UUID>();
+  instance_uuid_update.instance_name = j.at("instance_name").get<std::string>();
 }
 
-void to_json(nlohmann::json &j, InstanceUUIDUpdate const &instance_uuid_change) {
-  j = nlohmann::json{{"instance_name", instance_uuid_change.instance_name}, {"uuid", instance_uuid_change.uuid}};
+void to_json(nlohmann::json &j, InstanceUUIDUpdate const &instance_uuid_update) {
+  j = nlohmann::json{{"instance_name", instance_uuid_update.instance_name}, {"uuid", instance_uuid_update.uuid}};
 }
 
 }  // namespace memgraph::coordination

--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -162,12 +162,13 @@ auto CoordinatorInstance::ShowInstances() const -> std::vector<InstanceStatus> {
   };
 
   auto const coord_instance_to_status =
-      [&stringify_coord_health](CoordinatorToCoordinatorConfig const &instance) -> InstanceStatus {
+      [this, &stringify_coord_health](CoordinatorToCoordinatorConfig const &instance) -> InstanceStatus {
     return {.instance_name = fmt::format("coordinator_{}", instance.coordinator_id),
             .coordinator_server = instance.coordinator_server.SocketAddress(),
             .bolt_server = instance.bolt_server.SocketAddress(),
             .cluster_role = "coordinator",
-            .health = stringify_coord_health(instance)};
+            .health = stringify_coord_health(instance),
+            .last_succ_resp_ms = raft_state_->CoordLastSuccRespMs(instance.coordinator_id).count()};
   };
 
   auto instances_status = utils::fmap(raft_state_->GetCoordinatorInstances(), coord_instance_to_status);
@@ -189,7 +190,8 @@ auto CoordinatorInstance::ShowInstances() const -> std::vector<InstanceStatus> {
               .management_server = instance.ManagementSocketAddress(),
               .bolt_server = instance.BoltSocketAddress(),
               .cluster_role = stringify_repl_role(instance),
-              .health = stringify_repl_health(instance)};
+              .health = stringify_repl_health(instance),
+              .last_succ_resp_ms = instance.LastSuccRespMs().count()};
     };
 
     {

--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -152,13 +152,24 @@ auto CoordinatorInstance::GetLeaderCoordinatorData() const -> std::optional<Coor
 }
 
 auto CoordinatorInstance::ShowInstances() const -> std::vector<InstanceStatus> {
-  auto const coord_instance_to_status = [](CoordinatorToCoordinatorConfig const &instance) -> InstanceStatus {
+  auto const stringify_coord_health = [this](CoordinatorToCoordinatorConfig const &instance) -> std::string {
+    if (!raft_state_->IsLeader()) {
+      return "unknown";
+    }
+
+    auto const last_succ_resp_ms = raft_state_->CoordLastSuccRespMs(instance.coordinator_id);
+    return last_succ_resp_ms < instance.instance_down_timeout_sec ? "up" : "down";
+  };
+
+  auto const coord_instance_to_status =
+      [&stringify_coord_health](CoordinatorToCoordinatorConfig const &instance) -> InstanceStatus {
     return {.instance_name = fmt::format("coordinator_{}", instance.coordinator_id),
             .coordinator_server = instance.coordinator_server.SocketAddress(),
             .bolt_server = instance.bolt_server.SocketAddress(),
             .cluster_role = "coordinator",
-            .health = "unknown"};
+            .health = stringify_coord_health(instance)};
   };
+
   auto instances_status = utils::fmap(raft_state_->GetCoordinatorInstances(), coord_instance_to_status);
 
   if (raft_state_->IsLeader()) {

--- a/src/coordination/include/coordination/coordinator_communication_config.hpp
+++ b/src/coordination/include/coordination/coordinator_communication_config.hpp
@@ -15,7 +15,9 @@
 
 #include "io/network/endpoint.hpp"
 #include "replication_coordination_glue/mode.hpp"
+#include "utils/logging.hpp"
 #include "utils/string.hpp"
+#include "utils/uuid.hpp"
 
 #include <chrono>
 #include <cstdint>
@@ -25,8 +27,6 @@
 
 #include <fmt/format.h>
 #include "json/json.hpp"
-#include "utils/logging.hpp"
-#include "utils/uuid.hpp"
 
 namespace memgraph::coordination {
 
@@ -91,6 +91,7 @@ struct CoordinatorToCoordinatorConfig {
   uint32_t coordinator_id{0};
   io::network::Endpoint bolt_server;
   io::network::Endpoint coordinator_server;
+  std::chrono::seconds instance_down_timeout_sec{5};
 
   friend bool operator==(CoordinatorToCoordinatorConfig const &, CoordinatorToCoordinatorConfig const &) = default;
 };
@@ -125,8 +126,8 @@ void from_json(nlohmann::json const &j, CoordinatorToCoordinatorConfig &config);
 void to_json(nlohmann::json &j, ReplicationClientInfo const &config);
 void from_json(nlohmann::json const &j, ReplicationClientInfo &config);
 
-void to_json(nlohmann::json &j, InstanceUUIDUpdate const &config);
-void from_json(nlohmann::json const &j, InstanceUUIDUpdate &config);
+void to_json(nlohmann::json &j, InstanceUUIDUpdate const &instance_uuid_update);
+void from_json(nlohmann::json const &j, InstanceUUIDUpdate &instance_uuid_update);
 
 }  // namespace memgraph::coordination
 #endif

--- a/src/coordination/include/coordination/coordinator_instance.hpp
+++ b/src/coordination/include/coordination/coordinator_instance.hpp
@@ -137,6 +137,7 @@ class CoordinatorInstance {
 
   HealthCheckClientCallback client_succ_cb_, client_fail_cb_;
   std::atomic<bool> is_leader_ready_{false};
+
   // NOTE: Must be std::list because we rely on pointer stability.
   // TODO(antoniofilipovic) do we still rely on pointer stability
   std::list<ReplicationInstanceConnector> repl_instances_;

--- a/src/coordination/include/coordination/instance_status.hpp
+++ b/src/coordination/include/coordination/instance_status.hpp
@@ -26,6 +26,7 @@ struct InstanceStatus {
   std::string bolt_server;
   std::string cluster_role;
   std::string health;
+  int64_t last_succ_resp_ms;
 
   friend bool operator==(InstanceStatus const &lhs, InstanceStatus const &rhs) = default;
 };

--- a/src/coordination/include/coordination/raft_state.hpp
+++ b/src/coordination/include/coordination/raft_state.hpp
@@ -89,6 +89,9 @@ class RaftState {
 
   auto TryGetCurrentMainName() const -> std::optional<std::string>;
 
+  // Returns elapsed time in ms since last successful response from the coordinator with id srv_id
+  auto CoordLastSuccRespMs(uint32_t srv_id) -> std::chrono::milliseconds;
+
  private:
   io::network::Endpoint raft_endpoint_;
   uint32_t coordinator_id_;

--- a/src/coordination/include/coordination/replication_instance_connector.hpp
+++ b/src/coordination/include/coordination/replication_instance_connector.hpp
@@ -87,6 +87,9 @@ class ReplicationInstanceConnector {
 
   void SetCallbacks(HealthCheckInstanceCallback succ_cb, HealthCheckInstanceCallback fail_cb);
 
+  // Time passed from the last successful response in milliseconds.
+  auto LastSuccRespMs() const -> std::chrono::milliseconds;
+
  protected:
   auto UpdateReplicaLastResponseUUID() -> void;
   std::unique_ptr<ReplicationInstanceClient> client_;

--- a/src/coordination/raft_state.cpp
+++ b/src/coordination/raft_state.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <functional>
 #include <optional>
 #include <vector>
@@ -161,6 +162,18 @@ auto RaftState::AddCoordinatorInstance(CoordinatorToCoordinatorConfig const &con
     throw RaftAddServerException("Failed to add server {} to the cluster in {}ms", endpoint,
                                  max_tries * waiting_period);
   }
+}
+
+auto RaftState::CoordLastSuccRespMs(uint32_t srv_id) -> std::chrono::milliseconds {
+  using std::chrono::duration_cast;
+  using std::chrono::microseconds;
+  using std::chrono::milliseconds;
+
+  auto const peer_info = raft_server_->get_peer_info(static_cast<int>(srv_id));
+  auto const elapsed_time_ms = duration_cast<milliseconds>(microseconds(peer_info.last_succ_resp_us_));
+  spdlog::trace("Elapsed time in miliseconds since last successful response from coordinator_{}: {}",
+                static_cast<int>(srv_id), elapsed_time_ms.count());
+  return elapsed_time_ms;
 }
 
 auto RaftState::GetCoordinatorInstances() const -> std::vector<CoordinatorToCoordinatorConfig> {

--- a/src/coordination/replication_instance_connector.cpp
+++ b/src/coordination/replication_instance_connector.cpp
@@ -148,5 +148,13 @@ void ReplicationInstanceConnector::SetCallbacks(HealthCheckInstanceCallback succ
   fail_cb_ = fail_cb;
 }
 
+auto ReplicationInstanceConnector::LastSuccRespMs() const -> std::chrono::milliseconds {
+  using std::chrono::duration_cast;
+  using std::chrono::milliseconds;
+  using std::chrono::system_clock;
+
+  return duration_cast<milliseconds>(system_clock::now() - last_response_time_);
+}
+
 }  // namespace memgraph::coordination
 #endif

--- a/src/coordination/replication_instance_connector.cpp
+++ b/src/coordination/replication_instance_connector.cpp
@@ -16,6 +16,7 @@
 #include "replication_coordination_glue/handler.hpp"
 #include "utils/result.hpp"
 
+#include <chrono>
 #include <string>
 #include <utility>
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -1375,7 +1375,8 @@ Callback HandleCoordinatorQuery(CoordinatorQuery *coordinator_query, const Param
         throw QueryRuntimeException("Only coordinator can run SHOW INSTANCES.");
       }
 
-      callback.header = {"name", "bolt_server", "coordinator_server", "management_server", "health", "role"};
+      callback.header = {"name",   "bolt_server", "coordinator_server", "management_server",
+                         "health", "role",        "last_succ_resp_ms"};
       callback.fn = [handler = CoordQueryHandler{*coordinator_state},
                      replica_nfields = callback.header.size()]() mutable {
         auto const instances = handler.ShowInstances();
@@ -1385,7 +1386,8 @@ Callback HandleCoordinatorQuery(CoordinatorQuery *coordinator_query, const Param
                   TypedValue{status.coordinator_server},
                   TypedValue{status.management_server},
                   TypedValue{status.health},
-                  TypedValue{status.cluster_role}};
+                  TypedValue{status.cluster_role},
+                  TypedValue{status.last_succ_resp_ms}};
         };
 
         return utils::fmap(instances, converter);

--- a/tests/e2e/high_availability/common.py
+++ b/tests/e2e/high_availability/common.py
@@ -14,6 +14,11 @@ import typing
 import mgclient
 
 
+# Elapse time is the last element in results hence such slicing works.
+def ignore_elapsed_time_from_results(results: typing.List[tuple]) -> typing.List[tuple]:
+    return [result[:-1] for result in results]
+
+
 def execute_and_fetch_all(cursor: mgclient.Cursor, query: str, params: dict = {}) -> typing.List[tuple]:
     cursor.execute(query, params)
     return cursor.fetchall()

--- a/tests/e2e/high_availability/coord_cluster_registration.py
+++ b/tests/e2e/high_availability/coord_cluster_registration.py
@@ -15,7 +15,12 @@ import tempfile
 
 import interactive_mg_runner
 import pytest
-from common import connect, execute_and_fetch_all, safe_execute
+from common import (
+    connect,
+    execute_and_fetch_all,
+    ignore_elapsed_time_from_results,
+    safe_execute,
+)
 from mg_utils import mg_sleep_and_assert
 
 interactive_mg_runner.SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -230,7 +235,9 @@ def test_register_repl_instances_then_coordinators():
     )
 
     def check_coordinator3():
-        return sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
+        )
 
     expected_cluster_coord3 = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
@@ -245,7 +252,9 @@ def test_register_repl_instances_then_coordinators():
     coordinator1_cursor = connect(host="localhost", port=7690).cursor()
 
     def check_coordinator1():
-        return sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
+        )
 
     expected_cluster_shared = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
@@ -261,7 +270,9 @@ def test_register_repl_instances_then_coordinators():
     coordinator2_cursor = connect(host="localhost", port=7691).cursor()
 
     def check_coordinator2():
-        return sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
+        )
 
     mg_sleep_and_assert(expected_cluster_shared, check_coordinator2)
 
@@ -296,7 +307,9 @@ def test_register_coordinator_then_repl_instances():
     execute_and_fetch_all(coordinator3_cursor, "SET INSTANCE instance_3 TO MAIN")
 
     def check_coordinator3():
-        return sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
+        )
 
     expected_cluster_coord3 = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
@@ -311,7 +324,9 @@ def test_register_coordinator_then_repl_instances():
     coordinator1_cursor = connect(host="localhost", port=7690).cursor()
 
     def check_coordinator1():
-        return sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
+        )
 
     expected_cluster_shared = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
@@ -327,7 +342,9 @@ def test_register_coordinator_then_repl_instances():
     coordinator2_cursor = connect(host="localhost", port=7691).cursor()
 
     def check_coordinator2():
-        return sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
+        )
 
     mg_sleep_and_assert(expected_cluster_shared, check_coordinator2)
 
@@ -374,14 +391,18 @@ def test_coordinators_communication_with_restarts():
     coordinator1_cursor = connect(host="localhost", port=7690).cursor()
 
     def check_coordinator1():
-        return sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
+        )
 
     mg_sleep_and_assert(expected_cluster_shared, check_coordinator1)
 
     coordinator2_cursor = connect(host="localhost", port=7691).cursor()
 
     def check_coordinator2():
-        return sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
+        )
 
     mg_sleep_and_assert(expected_cluster_shared, check_coordinator2)
 
@@ -439,13 +460,19 @@ def test_unregister_replicas(kill_instance):
     execute_and_fetch_all(coordinator3_cursor, "SET INSTANCE instance_3 TO MAIN")
 
     def check_coordinator1():
-        return sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
+        )
 
     def check_coordinator2():
-        return sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
+        )
 
     def check_coordinator3():
-        return sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
+        )
 
     main_cursor = connect(host="localhost", port=7689).cursor()
 
@@ -584,13 +611,19 @@ def test_unregister_main():
     execute_and_fetch_all(coordinator3_cursor, "SET INSTANCE instance_3 TO MAIN")
 
     def check_coordinator1():
-        return sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
+        )
 
     def check_coordinator2():
-        return sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
+        )
 
     def check_coordinator3():
-        return sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
+        )
 
     expected_cluster = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
@@ -726,13 +759,19 @@ def test_register_one_coord_with_env_vars():
     coordinator3_cursor = connect(host="localhost", port=7692).cursor()
 
     def check_coordinator1():
-        return sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
+        )
 
     def check_coordinator2():
-        return sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
+        )
 
     def check_coordinator3():
-        return sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
+        )
 
     expected_cluster = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
@@ -952,13 +991,19 @@ def test_register_one_data_with_env_vars():
         execute_and_fetch_all(coordinator3_cursor, query)
 
     def check_coordinator1():
-        return sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
+        )
 
     def check_coordinator2():
-        return sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
+        )
 
     def check_coordinator3():
-        return sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
+        )
 
     expected_cluster = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
@@ -1058,7 +1103,9 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start():
     expected_cluster = [("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator")]
 
     def check_coordinator3():
-        return sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
+        )
 
     mg_sleep_and_assert(expected_cluster, check_coordinator3)
 
@@ -1084,13 +1131,19 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start():
     coordinator3_cursor = connect(host="localhost", port=7692).cursor()
 
     def check_coordinator1():
-        return sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
+        )
 
     def check_coordinator2():
-        return sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
+        )
 
     def check_coordinator3():
-        return sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
+        )
 
     expected_cluster = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),

--- a/tests/e2e/high_availability/coord_cluster_registration.py
+++ b/tests/e2e/high_availability/coord_cluster_registration.py
@@ -233,9 +233,9 @@ def test_register_repl_instances_then_coordinators():
         return sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
 
     expected_cluster_coord3 = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
@@ -299,9 +299,9 @@ def test_register_coordinator_then_repl_instances():
         return sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
 
     expected_cluster_coord3 = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
@@ -453,9 +453,9 @@ def test_unregister_replicas(kill_instance):
         return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS")))
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
@@ -497,9 +497,9 @@ def test_unregister_replicas(kill_instance):
     execute_and_fetch_all(coordinator3_cursor, "UNREGISTER INSTANCE instance_1")
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
     ]
@@ -532,9 +532,9 @@ def test_unregister_replicas(kill_instance):
     execute_and_fetch_all(coordinator3_cursor, "UNREGISTER INSTANCE instance_2")
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
     ]
 
@@ -593,9 +593,9 @@ def test_unregister_main():
         return sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
@@ -625,9 +625,9 @@ def test_unregister_main():
     interactive_mg_runner.kill(MEMGRAPH_INSTANCES_DESCRIPTION, "instance_3")
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
@@ -649,9 +649,9 @@ def test_unregister_main():
     execute_and_fetch_all(coordinator3_cursor, "UNREGISTER INSTANCE instance_3")
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
     ]
@@ -735,9 +735,9 @@ def test_register_one_coord_with_env_vars():
         return sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
@@ -767,9 +767,9 @@ def test_register_one_coord_with_env_vars():
     interactive_mg_runner.kill(memgraph_instances_desc, "instance_3")
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
@@ -791,9 +791,9 @@ def test_register_one_coord_with_env_vars():
     execute_and_fetch_all(coordinator3_cursor, "UNREGISTER INSTANCE instance_3")
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
     ]
@@ -961,9 +961,9 @@ def test_register_one_data_with_env_vars():
         return sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
@@ -1055,7 +1055,7 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start():
     )
     coordinator3_cursor = connect(host="localhost", port=7692).cursor()
 
-    expected_cluster = [("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator")]
+    expected_cluster = [("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator")]
 
     def check_coordinator3():
         return sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
@@ -1093,9 +1093,9 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start():
         return sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
@@ -1125,9 +1125,9 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start():
     interactive_mg_runner.kill(memgraph_instances_desc, "instance_3")
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
@@ -1149,9 +1149,9 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start():
     execute_and_fetch_all(coordinator3_cursor, "UNREGISTER INSTANCE instance_3")
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
     ]

--- a/tests/e2e/high_availability/coordinator.py
+++ b/tests/e2e/high_availability/coordinator.py
@@ -12,7 +12,7 @@
 import sys
 
 import pytest
-from common import connect, execute_and_fetch_all
+from common import connect, execute_and_fetch_all, ignore_elapsed_time_from_results
 from mg_utils import mg_sleep_and_assert
 
 
@@ -41,7 +41,7 @@ def test_coordinator_show_instances():
     cursor = connect(host="localhost", port=7690).cursor()
 
     def retrieve_data():
-        return sorted(list(execute_and_fetch_all(cursor, "SHOW INSTANCES;")))
+        return sorted(ignore_elapsed_time_from_results(list(execute_and_fetch_all(cursor, "SHOW INSTANCES;"))))
 
     expected_data = [
         ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),

--- a/tests/e2e/high_availability/coordinator.py
+++ b/tests/e2e/high_availability/coordinator.py
@@ -44,7 +44,7 @@ def test_coordinator_show_instances():
         return sorted(list(execute_and_fetch_all(cursor, "SHOW INSTANCES;")))
 
     expected_data = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),

--- a/tests/e2e/high_availability/disable_writing_on_main_after_restart.py
+++ b/tests/e2e/high_availability/disable_writing_on_main_after_restart.py
@@ -16,7 +16,12 @@ import tempfile
 
 import interactive_mg_runner
 import pytest
-from common import connect, execute_and_fetch_all, safe_execute
+from common import (
+    connect,
+    execute_and_fetch_all,
+    ignore_elapsed_time_from_results,
+    safe_execute,
+)
 from mg_utils import mg_sleep_and_assert
 
 interactive_mg_runner.SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -147,7 +152,9 @@ def test_writing_disabled_on_main_restart():
     )
 
     def check_coordinator3():
-        return sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
+        )
 
     expected_cluster_coord3 = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),

--- a/tests/e2e/high_availability/disable_writing_on_main_after_restart.py
+++ b/tests/e2e/high_availability/disable_writing_on_main_after_restart.py
@@ -150,9 +150,9 @@ def test_writing_disabled_on_main_restart():
         return sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
 
     expected_cluster_coord3 = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
     ]
     mg_sleep_and_assert(expected_cluster_coord3, check_coordinator3)
@@ -160,9 +160,9 @@ def test_writing_disabled_on_main_restart():
     interactive_mg_runner.kill(MEMGRAPH_INSTANCES_DESCRIPTION, "instance_3")
 
     expected_cluster_coord3 = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
     ]
 
@@ -180,9 +180,9 @@ def test_writing_disabled_on_main_restart():
         )
 
     expected_cluster_coord3 = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
     ]
 

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -247,9 +247,9 @@ def test_old_main_comes_back_on_new_leader_as_replica():
         return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
@@ -270,9 +270,9 @@ def test_old_main_comes_back_on_new_leader_as_replica():
     interactive_mg_runner.start(inner_instances_description, "instance_3")
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "replica"),
@@ -356,9 +356,9 @@ def test_distributed_automatic_failover():
         return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
 
     expected_data_on_coord = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
@@ -442,9 +442,9 @@ def test_distributed_automatic_failover_with_leadership_change():
         return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
@@ -574,9 +574,9 @@ def test_old_main_comes_back_on_new_leader_as_main():
     interactive_mg_runner.start(inner_memgraph_instances, "instance_3")
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "down", "unknown"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "down", "unknown"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
@@ -742,10 +742,10 @@ def test_registering_4_coords():
         return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
 
     expected_data_on_coord = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "127.0.0.1:7692", "127.0.0.1:10113", "", "unknown", "coordinator"),
-        ("coordinator_4", "0.0.0.0:7693", "0.0.0.0:10114", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "127.0.0.1:7692", "127.0.0.1:10113", "", "up", "coordinator"),
+        ("coordinator_4", "0.0.0.0:7693", "0.0.0.0:10114", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
@@ -879,10 +879,10 @@ def test_registering_coord_log_store():
         return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
 
     coordinators = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "127.0.0.1:7692", "127.0.0.1:10113", "", "unknown", "coordinator"),
-        ("coordinator_4", "0.0.0.0:7693", "0.0.0.0:10114", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "127.0.0.1:7692", "127.0.0.1:10113", "", "up", "coordinator"),
+        ("coordinator_4", "0.0.0.0:7693", "0.0.0.0:10114", "", "up", "coordinator"),
     ]
 
     basic_instances = [
@@ -1033,31 +1033,23 @@ def test_multiple_failovers_in_row_no_leadership_change():
 
         return show_instances_follower_coord
 
-    coordinator_data = [
+    leader_data = [
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
+        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
+        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
+        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+    ]
+
+    follower_data = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
         ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
         ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
+        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
+        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
     ]
-
-    leader_data = []
-    leader_data.extend(coordinator_data)
-    leader_data.extend(
-        [
-            ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-            ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-            ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
-        ]
-    )
-
-    follower_data = []
-    follower_data.extend(coordinator_data)
-    follower_data.extend(
-        [
-            ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-            ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-            ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
-        ]
-    )
 
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
@@ -1072,32 +1064,23 @@ def test_multiple_failovers_in_row_no_leadership_change():
 
     # 4
 
-    leader_data = []
-    leader_data.extend(coordinator_data)
-    leader_data.extend(
-        [
-            ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-            ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-            ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
-        ]
-    )
+    leader_data = [
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
+        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
+        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
+        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+    ]
 
-    follower_data = []
-    follower_data.extend(coordinator_data)
-    follower_data.extend(
-        [
-            ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
-            ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-            (
-                "instance_3",
-                "127.0.0.1:7689",
-                "",
-                "127.0.0.1:10013",
-                "unknown",
-                "unknown",
-            ),
-        ]
-    )
+    follower_data = [
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
+        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
+        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
+    ]
 
     mg_sleep_and_assert_collection(follower_data, get_func_show_instances(coord_cursor_1))
     mg_sleep_and_assert_collection(follower_data, get_func_show_instances(coord_cursor_2))
@@ -1107,25 +1090,23 @@ def test_multiple_failovers_in_row_no_leadership_change():
     interactive_mg_runner.kill(inner_memgraph_instances, "instance_1")
 
     # 6
-    leader_data = []
-    leader_data.extend(coordinator_data)
-    leader_data.extend(
-        [
-            ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "down", "unknown"),
-            ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "main"),
-            ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
-        ]
-    )
+    leader_data = [
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
+        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "down", "unknown"),
+        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "main"),
+        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+    ]
 
-    follower_data = []
-    follower_data.extend(coordinator_data)
-    follower_data.extend(
-        [
-            ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "unknown"),
-            ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "main"),
-            ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
-        ]
-    )
+    follower_data = [
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "unknown"),
+        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "main"),
+        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
+    ]
 
     mg_sleep_and_assert_collection(follower_data, get_func_show_instances(coord_cursor_1))
     mg_sleep_and_assert_collection(follower_data, get_func_show_instances(coord_cursor_2))
@@ -1137,25 +1118,23 @@ def test_multiple_failovers_in_row_no_leadership_change():
 
     # 8
 
-    leader_data = []
-    leader_data.extend(coordinator_data)
-    leader_data.extend(
-        [
-            ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "down", "unknown"),
-            ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "main"),
-            ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "replica"),
-        ]
-    )
+    leader_data = [
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
+        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "down", "unknown"),
+        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "main"),
+        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "replica"),
+    ]
 
-    follower_data = []
-    follower_data.extend(coordinator_data)
-    follower_data.extend(
-        [
-            ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "unknown"),
-            ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "main"),
-            ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "replica"),
-        ]
-    )
+    follower_data = [
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "unknown"),
+        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "main"),
+        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "replica"),
+    ]
 
     mg_sleep_and_assert_collection(follower_data, get_func_show_instances(coord_cursor_1))
     mg_sleep_and_assert_collection(follower_data, get_func_show_instances(coord_cursor_2))
@@ -1165,25 +1144,23 @@ def test_multiple_failovers_in_row_no_leadership_change():
     interactive_mg_runner.kill(inner_memgraph_instances, "instance_2")
 
     # 10
-    leader_data = []
-    leader_data.extend(coordinator_data)
-    leader_data.extend(
-        [
-            ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "down", "unknown"),
-            ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "down", "unknown"),
-            ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
-        ]
-    )
+    leader_data = [
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
+        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "down", "unknown"),
+        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "down", "unknown"),
+        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+    ]
 
-    follower_data = []
-    follower_data.extend(coordinator_data)
-    follower_data.extend(
-        [
-            ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "unknown"),
-            ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "unknown"),
-            ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
-        ]
-    )
+    follower_data = [
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "unknown"),
+        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "unknown"),
+        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+    ]
 
     mg_sleep_and_assert_collection(follower_data, get_func_show_instances(coord_cursor_1))
     mg_sleep_and_assert_collection(follower_data, get_func_show_instances(coord_cursor_2))
@@ -1202,25 +1179,23 @@ def test_multiple_failovers_in_row_no_leadership_change():
     interactive_mg_runner.start(inner_memgraph_instances, "instance_2")
 
     # 13
-    leader_data = []
-    leader_data.extend(coordinator_data)
-    leader_data.extend(
-        [
-            ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-            ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-            ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
-        ]
-    )
+    leader_data = [
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
+        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
+        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
+        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+    ]
 
-    follower_data = []
-    follower_data.extend(coordinator_data)
-    follower_data.extend(
-        [
-            ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-            ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-            ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
-        ]
-    )
+    follower_data = [
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
+        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
+        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+    ]
 
     mg_sleep_and_assert_collection(follower_data, get_func_show_instances(coord_cursor_1))
     mg_sleep_and_assert_collection(follower_data, get_func_show_instances(coord_cursor_2))
@@ -1293,9 +1268,9 @@ def test_multiple_old_mains_single_failover():
         return sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;")))
 
     coordinators = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
     ]
 
     basic_instances = [
@@ -1352,9 +1327,9 @@ def test_multiple_old_mains_single_failover():
         return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
@@ -1463,9 +1438,9 @@ def test_force_reset_works_after_failed_registration():
         return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
@@ -1527,9 +1502,9 @@ def test_force_reset_works_after_failed_registration():
 
     # This will trigger force reset and choosing of new instance as MAIN
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "replica"),
@@ -1615,9 +1590,9 @@ def test_force_reset_works_after_failed_registration_and_main_down():
         return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
@@ -1679,9 +1654,9 @@ def test_force_reset_works_after_failed_registration_and_main_down():
 
     # This will trigger force reset and choosing of new instance as MAIN
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "replica"),
@@ -1767,9 +1742,9 @@ def test_force_reset_works_after_failed_registration_and_replica_down():
         return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
@@ -1838,9 +1813,9 @@ def test_force_reset_works_after_failed_registration_and_replica_down():
     # 5
     # This will trigger force reset and choosing of new instance as MAIN
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "down", "unknown"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "replica"),
@@ -1873,9 +1848,9 @@ def test_force_reset_works_after_failed_registration_and_replica_down():
     # 7
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "replica"),
@@ -1981,9 +1956,9 @@ def test_force_reset_works_after_failed_registration_and_2_coordinators_down():
         return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
@@ -2066,9 +2041,9 @@ def test_force_reset_works_after_failed_registration_and_2_coordinators_down():
     # 7
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "replica"),
@@ -2183,9 +2158,9 @@ def test_coordinator_gets_info_on_other_coordinators():
         return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
@@ -2284,10 +2259,10 @@ def test_coordinator_gets_info_on_other_coordinators():
         return sorted(list(execute_and_fetch_all(coord_cursor_4, "SHOW INSTANCES;")))
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
-        ("coordinator_4", "127.0.0.1:7693", "0.0.0.0:10114", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "down", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
+        ("coordinator_4", "127.0.0.1:7693", "0.0.0.0:10114", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
@@ -2356,9 +2331,9 @@ def test_registration_works_after_main_set():
         return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
@@ -2453,9 +2428,9 @@ def test_coordinator_not_leader_registration_does_not_work():
         return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
-        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "unknown", "coordinator"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -17,7 +17,12 @@ import time
 
 import interactive_mg_runner
 import pytest
-from common import connect, execute_and_fetch_all, safe_execute
+from common import (
+    connect,
+    execute_and_fetch_all,
+    ignore_elapsed_time_from_results,
+    safe_execute,
+)
 from mg_utils import (
     mg_sleep_and_assert,
     mg_sleep_and_assert_any_function,
@@ -239,12 +244,12 @@ def test_old_main_comes_back_on_new_leader_as_replica():
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
 
     def show_instances_coord1():
-        return sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
 
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
 
     def show_instances_coord2():
-        return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     leader_data = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
@@ -353,7 +358,7 @@ def test_distributed_automatic_failover():
     coord_cursor = connect(host="localhost", port=7692).cursor()
 
     def retrieve_data_show_repl_cluster():
-        return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_on_coord = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
@@ -434,12 +439,12 @@ def test_distributed_automatic_failover_with_leadership_change():
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
 
     def show_instances_coord1():
-        return sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
 
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
 
     def show_instances_coord2():
-        return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     leader_data = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
@@ -564,12 +569,12 @@ def test_old_main_comes_back_on_new_leader_as_main():
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
 
     def show_instances_coord1():
-        return sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
 
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
 
     def show_instances_coord2():
-        return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     interactive_mg_runner.start(inner_memgraph_instances, "instance_3")
 
@@ -739,7 +744,7 @@ def test_registering_4_coords():
     coord_cursor = connect(host="localhost", port=7693).cursor()
 
     def retrieve_data_show_repl_cluster():
-        return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_on_coord = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
@@ -876,7 +881,7 @@ def test_registering_coord_log_store():
     coord_cursor = connect(host="localhost", port=7693).cursor()
 
     def retrieve_data_show_repl_cluster():
-        return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     coordinators = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
@@ -1029,7 +1034,7 @@ def test_multiple_failovers_in_row_no_leadership_change():
 
     def get_func_show_instances(cursor):
         def show_instances_follower_coord():
-            return sorted(list(execute_and_fetch_all(cursor, "SHOW INSTANCES;")))
+            return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(cursor, "SHOW INSTANCES;"))))
 
         return show_instances_follower_coord
 
@@ -1265,7 +1270,7 @@ def test_multiple_old_mains_single_failover():
         execute_and_fetch_all(coord_cursor_3, query)
 
     def retrieve_data_show_repl_cluster():
-        return sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
 
     coordinators = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
@@ -1319,12 +1324,12 @@ def test_multiple_old_mains_single_failover():
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
 
     def show_instances_coord1():
-        return sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
 
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
 
     def show_instances_coord2():
-        return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     leader_data = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
@@ -1425,17 +1430,17 @@ def test_force_reset_works_after_failed_registration():
     # 2
 
     def show_instances_coord3():
-        return sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
 
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
 
     def show_instances_coord1():
-        return sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
 
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
 
     def show_instances_coord2():
-        return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     leader_data = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
@@ -1577,17 +1582,17 @@ def test_force_reset_works_after_failed_registration_and_main_down():
     # 2
 
     def show_instances_coord3():
-        return sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
 
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
 
     def show_instances_coord1():
-        return sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
 
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
 
     def show_instances_coord2():
-        return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     leader_data = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
@@ -1729,17 +1734,17 @@ def test_force_reset_works_after_failed_registration_and_replica_down():
     # 2
 
     def show_instances_coord3():
-        return sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
 
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
 
     def show_instances_coord1():
-        return sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
 
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
 
     def show_instances_coord2():
-        return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     leader_data = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
@@ -1943,17 +1948,17 @@ def test_force_reset_works_after_failed_registration_and_2_coordinators_down():
     # 2
 
     def show_instances_coord3():
-        return sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
 
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
 
     def show_instances_coord1():
-        return sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
 
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
 
     def show_instances_coord2():
-        return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     leader_data = [
         ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "up", "coordinator"),
@@ -2061,12 +2066,12 @@ def test_force_reset_works_after_failed_registration_and_2_coordinators_down():
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
 
     def show_instances_coord1():
-        return sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
 
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
 
     def show_instances_coord2():
-        return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     mg_sleep_and_assert_any_function(leader_data, [show_instances_coord1, show_instances_coord2])
     mg_sleep_and_assert_any_function(follower_data, [show_instances_coord1, show_instances_coord2])
@@ -2145,17 +2150,17 @@ def test_coordinator_gets_info_on_other_coordinators():
     # 2
 
     def show_instances_coord3():
-        return sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
 
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
 
     def show_instances_coord1():
-        return sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
 
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
 
     def show_instances_coord2():
-        return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     leader_data = [
         ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "up", "coordinator"),
@@ -2256,7 +2261,7 @@ def test_coordinator_gets_info_on_other_coordinators():
     coord_cursor_4 = connect(host="localhost", port=7693).cursor()
 
     def show_instances_coord4():
-        return sorted(list(execute_and_fetch_all(coord_cursor_4, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_4, "SHOW INSTANCES;"))))
 
     leader_data = [
         ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "up", "coordinator"),
@@ -2318,17 +2323,17 @@ def test_registration_works_after_main_set():
     # 2
 
     def show_instances_coord3():
-        return sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
 
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
 
     def show_instances_coord1():
-        return sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
 
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
 
     def show_instances_coord2():
-        return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     leader_data = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
@@ -2415,17 +2420,17 @@ def test_coordinator_not_leader_registration_does_not_work():
     # 2
 
     def show_instances_coord3():
-        return sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
 
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
 
     def show_instances_coord1():
-        return sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
 
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
 
     def show_instances_coord2():
-        return sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     leader_data = [
         ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "up", "coordinator"),

--- a/tests/e2e/high_availability/not_replicate_from_old_main.py
+++ b/tests/e2e/high_availability/not_replicate_from_old_main.py
@@ -10,13 +10,12 @@
 # licenses/APL.txt.
 
 import os
-import shutil
 import sys
 import tempfile
 
 import interactive_mg_runner
 import pytest
-from common import connect, execute_and_fetch_all
+from common import connect, execute_and_fetch_all, ignore_elapsed_time_from_results
 from mg_utils import mg_sleep_and_assert
 
 interactive_mg_runner.SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -200,7 +199,9 @@ def test_not_replicate_old_main_register_new_cluster():
     first_cluster_coord_cursor = connect(host="localhost", port=7690).cursor()
 
     def show_repl_cluster():
-        return sorted(list(execute_and_fetch_all(first_cluster_coord_cursor, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(first_cluster_coord_cursor, "SHOW INSTANCES;")))
+        )
 
     expected_data_up_first_cluster = [
         ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
@@ -256,7 +257,9 @@ def test_not_replicate_old_main_register_new_cluster():
     # 4
 
     def show_repl_cluster():
-        return sorted(list(execute_and_fetch_all(second_cluster_coord_cursor, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(
+            sorted(list(execute_and_fetch_all(second_cluster_coord_cursor, "SHOW INSTANCES;")))
+        )
 
     expected_data_up_second_cluster = [
         ("coordinator_1", "0.0.0.0:7691", "0.0.0.0:10112", "", "up", "coordinator"),

--- a/tests/e2e/high_availability/not_replicate_from_old_main.py
+++ b/tests/e2e/high_availability/not_replicate_from_old_main.py
@@ -203,7 +203,7 @@ def test_not_replicate_old_main_register_new_cluster():
         return sorted(list(execute_and_fetch_all(first_cluster_coord_cursor, "SHOW INSTANCES;")))
 
     expected_data_up_first_cluster = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "main"),
         ("shared_instance", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
     ]
@@ -259,7 +259,7 @@ def test_not_replicate_old_main_register_new_cluster():
         return sorted(list(execute_and_fetch_all(second_cluster_coord_cursor, "SHOW INSTANCES;")))
 
     expected_data_up_second_cluster = [
-        ("coordinator_1", "0.0.0.0:7691", "0.0.0.0:10112", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7691", "0.0.0.0:10112", "", "up", "coordinator"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
         ("shared_instance", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
     ]

--- a/tests/e2e/high_availability/single_coordinator.py
+++ b/tests/e2e/high_availability/single_coordinator.py
@@ -252,7 +252,7 @@ def test_replication_works_on_failover_replica_1_epoch_2_commits_away(data_recov
         return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "down", "unknown"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "main"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
@@ -269,7 +269,7 @@ def test_replication_works_on_failover_replica_1_epoch_2_commits_away(data_recov
     interactive_mg_runner.start(MEMGRAPH_INNER_INSTANCES_DESCRIPTION, "instance_1")
 
     new_expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "main"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
@@ -289,7 +289,7 @@ def test_replication_works_on_failover_replica_1_epoch_2_commits_away(data_recov
     interactive_mg_runner.start(MEMGRAPH_INNER_INSTANCES_DESCRIPTION, "instance_3")
 
     new_expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "main"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "replica"),
@@ -482,7 +482,7 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
         return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "down", "unknown"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
@@ -506,7 +506,7 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
     # 6
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "down", "unknown"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
@@ -531,7 +531,7 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
     # 10
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "down", "unknown"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "down", "unknown"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
@@ -550,7 +550,7 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
     interactive_mg_runner.start(MEMGRAPH_INNER_INSTANCES_DESCRIPTION, "instance_2")
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "down", "unknown"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
@@ -573,7 +573,7 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
     interactive_mg_runner.start(MEMGRAPH_INNER_INSTANCES_DESCRIPTION, "instance_3")
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "replica"),
@@ -755,7 +755,7 @@ def test_replication_forcefully_works_on_failover_replica_misses_epoch(data_reco
         return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
@@ -787,7 +787,7 @@ def test_replication_forcefully_works_on_failover_replica_misses_epoch(data_reco
     # 7
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "down", "unknown"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "main"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
@@ -821,7 +821,7 @@ def test_replication_forcefully_works_on_failover_replica_misses_epoch(data_reco
     interactive_mg_runner.start(MEMGRAPH_INNER_INSTANCES_DESCRIPTION, "instance_1")
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "down", "unknown"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
@@ -836,7 +836,7 @@ def test_replication_forcefully_works_on_failover_replica_misses_epoch(data_reco
     # 13
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
@@ -1043,7 +1043,7 @@ def test_replication_correct_replica_chosen_up_to_date_data(data_recovery):
 
     # TODO(antoniofilipovic) Before fixing durability, if this is removed we also have an issue. Check after fix
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
@@ -1075,7 +1075,7 @@ def test_replication_correct_replica_chosen_up_to_date_data(data_recovery):
     # 7
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "down", "unknown"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "main"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
@@ -1101,7 +1101,7 @@ def test_replication_correct_replica_chosen_up_to_date_data(data_recovery):
     interactive_mg_runner.kill(MEMGRAPH_INNER_INSTANCES_DESCRIPTION, "instance_4")
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "down", "unknown"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "main"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
@@ -1118,7 +1118,7 @@ def test_replication_correct_replica_chosen_up_to_date_data(data_recovery):
     # 11
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "down", "unknown"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
@@ -1190,7 +1190,7 @@ def test_replication_works_on_failover_simple():
         return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
@@ -1310,7 +1310,7 @@ def test_replication_works_on_replica_instance_restart():
         return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "down", "unknown"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
@@ -1376,7 +1376,7 @@ def test_replication_works_on_replica_instance_restart():
         return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
@@ -1424,7 +1424,7 @@ def test_show_instances():
         return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
 
     expected_data = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
@@ -1447,7 +1447,7 @@ def test_show_instances():
     interactive_mg_runner.kill(MEMGRAPH_INSTANCES_DESCRIPTION, "instance_1")
 
     expected_data = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "down", "unknown"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
@@ -1457,7 +1457,7 @@ def test_show_instances():
     interactive_mg_runner.kill(MEMGRAPH_INSTANCES_DESCRIPTION, "instance_2")
 
     expected_data = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "down", "unknown"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "down", "unknown"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
@@ -1500,7 +1500,7 @@ def test_simple_automatic_failover():
         return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
@@ -1590,7 +1590,7 @@ def test_replica_instance_restarts():
         return sorted(list(execute_and_fetch_all(cursor, "SHOW INSTANCES;")))
 
     expected_data_up = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
@@ -1600,7 +1600,7 @@ def test_replica_instance_restarts():
     interactive_mg_runner.kill(MEMGRAPH_INSTANCES_DESCRIPTION, "instance_1")
 
     expected_data_down = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "down", "unknown"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
@@ -1632,7 +1632,7 @@ def test_automatic_failover_main_back_as_replica():
         return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
 
     expected_data_after_failover = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
@@ -1640,7 +1640,7 @@ def test_automatic_failover_main_back_as_replica():
     mg_sleep_and_assert(expected_data_after_failover, retrieve_data_show_repl_cluster)
 
     expected_data_after_main_coming_back = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "main"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "replica"),
@@ -1671,7 +1671,7 @@ def test_automatic_failover_main_back_as_main():
         return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
 
     expected_data_all_down = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "down", "unknown"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "down", "unknown"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
@@ -1681,7 +1681,7 @@ def test_automatic_failover_main_back_as_main():
 
     interactive_mg_runner.start(MEMGRAPH_INSTANCES_DESCRIPTION, "instance_3")
     expected_data_main_back = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "down", "unknown"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "down", "unknown"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
@@ -1699,7 +1699,7 @@ def test_automatic_failover_main_back_as_main():
     interactive_mg_runner.start(MEMGRAPH_INSTANCES_DESCRIPTION, "instance_2")
 
     expected_data_replicas_back = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "unknown", "coordinator"),
+        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
         ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
         ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),

--- a/tests/e2e/high_availability/single_coordinator.py
+++ b/tests/e2e/high_availability/single_coordinator.py
@@ -15,7 +15,12 @@ import tempfile
 
 import interactive_mg_runner
 import pytest
-from common import connect, execute_and_fetch_all, safe_execute
+from common import (
+    connect,
+    execute_and_fetch_all,
+    ignore_elapsed_time_from_results,
+    safe_execute,
+)
 from mg_utils import mg_sleep_and_assert, mg_sleep_and_assert_collection
 
 interactive_mg_runner.SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -249,7 +254,7 @@ def test_replication_works_on_failover_replica_1_epoch_2_commits_away(data_recov
     coord_cursor = connect(host="localhost", port=7690).cursor()
 
     def retrieve_data_show_instances():
-        return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_on_coord = [
         ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
@@ -479,7 +484,7 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
     coord_cursor = connect(host="localhost", port=7690).cursor()
 
     def retrieve_data_show_instances():
-        return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_on_coord = [
         ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
@@ -752,7 +757,7 @@ def test_replication_forcefully_works_on_failover_replica_misses_epoch(data_reco
     coord_cursor = connect(host="localhost", port=7690).cursor()
 
     def retrieve_data_show_instances():
-        return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_on_coord = [
         ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
@@ -1039,7 +1044,7 @@ def test_replication_correct_replica_chosen_up_to_date_data(data_recovery):
     coord_cursor = connect(host="localhost", port=7690).cursor()
 
     def retrieve_data_show_instances():
-        return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     # TODO(antoniofilipovic) Before fixing durability, if this is removed we also have an issue. Check after fix
     expected_data_on_coord = [
@@ -1187,7 +1192,7 @@ def test_replication_works_on_failover_simple():
     coord_cursor = connect(host="localhost", port=7690).cursor()
 
     def retrieve_data_show_repl_cluster():
-        return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_on_coord = [
         ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
@@ -1307,7 +1312,7 @@ def test_replication_works_on_replica_instance_restart():
     interactive_mg_runner.kill(MEMGRAPH_INSTANCES_DESCRIPTION, "instance_2")
 
     def retrieve_data_show_repl_cluster():
-        return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_on_coord = [
         ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
@@ -1373,7 +1378,7 @@ def test_replication_works_on_replica_instance_restart():
     interactive_mg_runner.start(MEMGRAPH_INSTANCES_DESCRIPTION, "instance_2")
 
     def retrieve_data_show_repl_cluster():
-        return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_on_coord = [
         ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
@@ -1421,7 +1426,7 @@ def test_show_instances():
     coord_cursor = connect(host="localhost", port=7690).cursor()
 
     def show_repl_cluster():
-        return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data = [
         ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
@@ -1497,7 +1502,7 @@ def test_simple_automatic_failover():
     coord_cursor = connect(host="localhost", port=7690).cursor()
 
     def retrieve_data_show_repl_cluster():
-        return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_on_coord = [
         ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
@@ -1587,7 +1592,7 @@ def test_replica_instance_restarts():
     cursor = connect(host="localhost", port=7690).cursor()
 
     def show_repl_cluster():
-        return sorted(list(execute_and_fetch_all(cursor, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(cursor, "SHOW INSTANCES;"))))
 
     expected_data_up = [
         ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
@@ -1629,7 +1634,7 @@ def test_automatic_failover_main_back_as_replica():
     coord_cursor = connect(host="localhost", port=7690).cursor()
 
     def retrieve_data_show_repl_cluster():
-        return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_after_failover = [
         ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),
@@ -1668,7 +1673,7 @@ def test_automatic_failover_main_back_as_main():
     coord_cursor = connect(host="localhost", port=7690).cursor()
 
     def retrieve_data_show_repl_cluster():
-        return sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_all_down = [
         ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "coordinator"),


### PR DESCRIPTION
### Description

`SHOW INSTANCES` now also returns the time passed in ms since the last successful response from coordinators and replication instances. When ran by followers, return value will be 0.

[master < Task] PR
- [x] Provide the full content or a guide for the final git message
    - **Add last_succ_resp_ms to SHOW INSTANCES output**

### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [x] Write a release note, including added/changed clauses
    - **Users can now see elapsed time in milliseconds since the last successful response from instances to the leader's health ping.**
- [x] Link the documentation PR here
    - **https://github.com/memgraph/documentation/pull/729**
- [x] Tag someone from docs team in the comments
