### PR TITLE
Replicate only durable commits to replicas during recovery

### DIFF
--- a/src/storage/v2/durability/serialization.hpp
+++ b/src/storage/v2/durability/serialization.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2024 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source

--- a/src/storage/v2/inmemory/replication/recovery.cpp
+++ b/src/storage/v2/inmemory/replication/recovery.cpp
@@ -98,10 +98,8 @@ uint64_t ReplicateCurrentWal(const utils::UUID &main_uuid, const InMemoryStorage
   stream.AppendFilename(wal_file.Path().filename());
   utils::InputFile file;
   MG_ASSERT(file.Open(wal_file.Path()), "Failed to open current WAL file at {}!", wal_file.Path());
-  const auto [buffer, buffer_size] = wal_file.CurrentFileBuffer();
-  stream.AppendSize(file.GetSize() + buffer_size);
+  stream.AppendSize(file.GetSize());
   stream.AppendFileData(&file);
-  stream.AppendBufferData(buffer, buffer_size);
   auto response = stream.Finalize();
   return response.current_commit_timestamp;
 }

--- a/src/utils/file.hpp
+++ b/src/utils/file.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2024 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source

--- a/tests/jepsen/src/jepsen/memgraph/bank.clj
+++ b/tests/jepsen/src/jepsen/memgraph/bank.clj
@@ -166,10 +166,10 @@
                            (filter #(= :ok (:type %)))
                            (filter #(= :read (:f %))))
             bad-reads (->> ok-reads
-                           (map #(->> % :value :accounts))
-                           (filter #(= (count %) 5))
-                           (map (fn [op]
-                                  (let [balances       (map :balance op)
+                           (map #(->> % :value))
+                           (filter #(= (count (:accounts %)) 5))
+                           (map (fn [value]
+                                  (let [balances  (map :balance (:accounts value))
                                         expected-total (* account-num starting-balance)]
                                     (cond (and
                                            (not-empty balances)
@@ -179,12 +179,12 @@
                                           {:type :wrong-total
                                            :expected expected-total
                                            :found (reduce + balances)
-                                           :op op}
+                                           :value value}
 
                                           (some neg? balances)
                                           {:type :negative-value
                                            :found balances
-                                           :op op}))))
+                                           :op value}))))
                            (filter identity)
                            (into []))
             empty-nodes (let [all-nodes (->> ok-reads


### PR DESCRIPTION
### Description

Send only durable part of the buffer to replicas during recovery
Better checker for jepsen test for easier debugging.
Improved logs to more easily reason about applying deltas during recovery.

Before this PR, even with `fsync` set to 1, replicas could get non-durable data from main. If main would die and get back, replica could be in more advanced state than main = issue.

[master < Task] PR
- [x] Provide the full content or a guide for the final git message
    - **Replica only durable commits to replicas during recovery**

### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [x] Write a release note, including added/changed clauses
    - **During recovery process, when replicas are behind main, they will receive only commits which are already fsynced on main.**
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [ ] Tag someone from docs team in the comments
