### PR TITLE
[TCO] small_vector for LabelIds in Vertex

### DIFF
--- a/src/glue/auth_checker.cpp
+++ b/src/glue/auth_checker.cpp
@@ -27,7 +27,7 @@
 #ifdef MG_ENTERPRISE
 namespace {
 bool IsAuthorizedLabels(const memgraph::auth::UserOrRole &user_or_role, const memgraph::query::DbAccessor *dba,
-                        const std::vector<memgraph::storage::LabelId> &labels,
+                        std::span<memgraph::storage::LabelId const> labels,
                         const memgraph::query::AuthQuery::FineGrainedPrivilege fine_grained_privilege) {
   if (!memgraph::license::global_license_checker.IsEnterpriseValidFast()) {
     return true;

--- a/src/storage/v2/CMakeLists.txt
+++ b/src/storage/v2/CMakeLists.txt
@@ -44,6 +44,8 @@ add_library(mg-storage-v2 STATIC
         replication/rpc.cpp
         replication/replication_storage_state.cpp
         inmemory/replication/recovery.cpp
+        label_set.hpp
+        label_set.cpp
 )
 
 target_include_directories(mg-storage-v2 PUBLIC ${CMAKE_SOURCE_DIR}/include)

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -45,6 +45,7 @@
 #include "storage/v2/edge_ref.hpp"
 #include "storage/v2/edges_iterable.hpp"
 #include "storage/v2/id_types.hpp"
+#include "storage/v2/label_set.hpp"
 #include "storage/v2/modified_edge.hpp"
 #include "storage/v2/mvcc.hpp"
 #include "storage/v2/property_store.hpp"
@@ -1359,12 +1360,12 @@ std::optional<storage::VertexAccessor> DiskStorage::LoadVertexToMainMemoryCache(
 }
 
 VertexAccessor DiskStorage::CreateVertexFromDisk(Transaction *transaction, utils::SkipList<Vertex>::Accessor &accessor,
-                                                 storage::Gid gid, std::vector<LabelId> label_ids,
+                                                 storage::Gid gid, std::span<storage::LabelId const> label_ids,
                                                  PropertyStore properties, Delta *delta) {
   auto [it, inserted] = accessor.insert(Vertex{gid, delta});
   MG_ASSERT(inserted, "The vertex must be inserted here!");
   MG_ASSERT(it != accessor.end(), "Invalid Vertex accessor!");
-  it->labels = std::move(label_ids);
+  it->labels = memgraph::storage::label_set(label_ids.begin(), label_ids.end());
   it->properties = std::move(properties);
   delta->prev.Set(&*it);
   return {&*it, this, transaction};

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -1365,7 +1365,7 @@ VertexAccessor DiskStorage::CreateVertexFromDisk(Transaction *transaction, utils
   auto [it, inserted] = accessor.insert(Vertex{gid, delta});
   MG_ASSERT(inserted, "The vertex must be inserted here!");
   MG_ASSERT(it != accessor.end(), "Invalid Vertex accessor!");
-  it->labels = memgraph::storage::label_set(label_ids.begin(), label_ids.end());
+  it->labels = memgraph::storage::label_set(label_ids);
   it->properties = std::move(properties);
   delta->prev.Set(&*it);
   return {&*it, this, transaction};

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -277,8 +277,8 @@ class DiskStorage final : public Storage {
       utils::SkipList<Vertex> *indexed_vertices);
 
   VertexAccessor CreateVertexFromDisk(Transaction *transaction, utils::SkipList<Vertex>::Accessor &accessor,
-                                      storage::Gid gid, std::vector<LabelId> label_ids, PropertyStore properties,
-                                      Delta *delta);
+                                      storage::Gid gid, std::span<storage::LabelId const> label_ids,
+                                      PropertyStore properties, Delta *delta);
 
   std::optional<storage::VertexAccessor> LoadVertexToMainMemoryCache(Transaction *transaction, const std::string &key,
                                                                      const std::string &value, std::string &&ts);

--- a/src/storage/v2/indices/text_index.cpp
+++ b/src/storage/v2/indices/text_index.cpp
@@ -112,7 +112,7 @@ std::string TextIndex::StringifyProperties(const std::map<PropertyId, PropertyVa
   return utils::Join(indexable_properties_as_string, " ");
 }
 
-std::vector<mgcxx::text_search::Context *> TextIndex::GetApplicableTextIndices(const std::vector<LabelId> &labels) {
+std::vector<mgcxx::text_search::Context *> TextIndex::GetApplicableTextIndices(std::span<LabelId const> labels) {
   if (!flags::AreExperimentsEnabled(flags::Experiments::TEXT_SEARCH)) {
     throw query::TextSearchDisabledException();
   }

--- a/src/storage/v2/indices/text_index.hpp
+++ b/src/storage/v2/indices/text_index.hpp
@@ -42,7 +42,7 @@ class TextIndex {
 
   std::string StringifyProperties(const std::map<PropertyId, PropertyValue> &properties);
 
-  std::vector<mgcxx::text_search::Context *> GetApplicableTextIndices(const std::vector<LabelId> &labels);
+  std::vector<mgcxx::text_search::Context *> GetApplicableTextIndices(std::span<LabelId const> labels);
 
   void LoadNodeToTextIndices(const std::int64_t gid, const nlohmann::json &properties,
                              const std::string &property_values_as_str,

--- a/src/storage/v2/label_set.cpp
+++ b/src/storage/v2/label_set.cpp
@@ -1,0 +1,12 @@
+// Copyright 2024 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "storage/v2/label_set.hpp"

--- a/src/storage/v2/label_set.hpp
+++ b/src/storage/v2/label_set.hpp
@@ -1,0 +1,47 @@
+// Copyright 2024 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include "storage/v2/id_types.hpp"
+
+namespace memgraph::storage {
+
+// custom datastructure to hold LabelIds
+// design goals:
+// - 16B, so we are smaller than std::vector<LabelId> (24B)
+// - small representation to avoid allocation
+// layout:
+//  Heap allocation
+//  ┌─────────┬─────────┐
+//  │SIZE     │CAPACITY │
+//  ├─────────┴─────────┤    ┌────┬────┬────┬─
+//  │PTR                ├───►│    │    │    │ ...
+//  └───────────────────┘    └────┴────┴────┴─
+//  Small representation
+//  ┌─────────┬─────────┐
+//  │<=2      │2        │
+//  ├─────────┼─────────┤
+//  │Label1   │Label2   │
+//  └─────────┴─────────┘
+
+using old_label_set = std::vector<LabelId>;
+
+namespace in_progress {
+struct label_set {};
+
+static_assert(sizeof(label_set) < sizeof(old_label_set));
+
+}  // namespace in_progress
+
+using label_set = old_label_set;
+
+}  // namespace memgraph::storage

--- a/src/storage/v2/label_set.hpp
+++ b/src/storage/v2/label_set.hpp
@@ -14,6 +14,7 @@
 #include "storage/v2/id_types.hpp"
 
 #include <cstdint>
+#include <span>
 
 namespace memgraph::storage {
 
@@ -34,10 +35,6 @@ namespace memgraph::storage {
 //  ├─────────┼─────────┤
 //  │Label1   │Label2   │
 //  └─────────┴─────────┘
-
-using old_label_set = std::vector<LabelId>;
-
-namespace in_progress {
 struct label_set {
   using value_type = LabelId;
   using reference = value_type &;
@@ -47,43 +44,115 @@ struct label_set {
   using iterator = LabelId *;
   using const_iterator = LabelId const *;
 
-  using reverse_iterator = LabelId *;
-  using const_reverse_iterator = LabelId const *;
-
-  auto begin() -> iterator;
-  auto end() -> iterator;
-  auto begin() const -> const_iterator;
-  auto end() const -> const_iterator;
-
-  auto rbegin() -> reverse_iterator;
-  auto rend() -> reverse_iterator;
-  auto rbegin() const -> const_reverse_iterator;
-  auto rend() const -> const_reverse_iterator;
-
-  auto cbegin() const -> const_iterator;
-  auto cend() const -> const_iterator;
-
-  void push_back(LabelId);
-  void emplace_back(LabelId);
-  reference back();
-  const_reference back() const;
-  void pop_back();
-  void reserve(size_type new_cap);
-
-  auto size() const noexcept -> std::size_t;
-
-  template <typename It>
-  label_set(It begin, It end);
-
-  auto operator[](size_t idx) -> reference;
-  auto operator[](size_t idx) const -> const_reference;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
   label_set() = default;
-  label_set(label_set const &);
-  label_set(label_set &&) noexcept;
-  label_set &operator=(label_set const &);
-  label_set &operator=(label_set &&) noexcept;
-  ~label_set();
+  label_set(label_set const &other) : size_{other.size_}, capacity_{std::max(other.size_, kSmallCapacity)} {
+    if (capacity_ != kSmallCapacity) [[unlikely]] {
+      buffer_ = new LabelId[capacity_];
+    }
+    std::ranges::copy(other, begin());
+  }
+  label_set(label_set &&other) noexcept
+      : size_{std::exchange(other.size_, 0)}, capacity_{std::exchange(other.capacity_, kSmallCapacity)} {
+    if (capacity_ == kSmallCapacity) {
+      small_buffer_ = other.small_buffer_;
+    } else {
+      buffer_ = std::exchange(other.buffer_, nullptr);
+    }
+  }
+  label_set &operator=(label_set const &other) {
+    if (this == std::addressof(other)) return *this;
+    if (other.size_ <= capacity_) {
+      std::ranges::copy(other, begin());
+    } else {
+      auto new_buffer = new LabelId[other.size_];
+      std::ranges::copy(other, new_buffer);
+      if (capacity_ != kSmallCapacity) [[unlikely]] {
+        delete[] buffer_;
+      }
+      buffer_ = new_buffer;
+      capacity_ = other.size_;
+    }
+    size_ = other.size_;
+    return *this;
+  }
+  label_set &operator=(label_set &&other) noexcept {
+    if (this == std::addressof(other)) return *this;
+    if (capacity_ != kSmallCapacity) [[unlikely]] {
+      delete[] buffer_;
+    }
+    size_ = std::exchange(other.size_, 0);
+    capacity_ = std::exchange(other.capacity_, kSmallCapacity);
+    if (capacity_ == kSmallCapacity) {
+      small_buffer_ = other.small_buffer_;
+    } else {
+      buffer_ = std::exchange(other.buffer_, nullptr);
+    }
+    return *this;
+  }
+  ~label_set() {
+    if (capacity_ != kSmallCapacity) [[unlikely]] {
+      delete[] buffer_;
+    }
+  }
+
+  explicit label_set(std::span<LabelId const> other)
+      : size_(other.size()), capacity_{std::max<size_type>(other.size(), kSmallCapacity)} {
+    if (capacity_ != kSmallCapacity) [[unlikely]] {
+      buffer_ = new LabelId[capacity_];
+    }
+    std::ranges::copy(other, begin());
+  }
+
+  auto begin() -> iterator { return (capacity_ == kSmallCapacity) ? small_buffer_.begin() : buffer_; }
+  auto end() -> iterator { return begin() + size_; }
+  auto begin() const -> const_iterator { return (capacity_ == kSmallCapacity) ? small_buffer_.begin() : buffer_; }
+  auto end() const -> const_iterator { return begin() + size_; }
+  auto cbegin() const -> const_iterator { return begin(); }
+  auto cend() const -> const_iterator { return end(); }
+
+  auto rbegin() -> reverse_iterator { return reverse_iterator{end()}; }
+  auto rend() -> reverse_iterator { return reverse_iterator{begin()}; }
+  auto rbegin() const -> const_reverse_iterator { return const_reverse_iterator{end()}; }
+  auto rend() const -> const_reverse_iterator { return const_reverse_iterator{begin()}; }
+  auto crbegin() const -> const_reverse_iterator { return const_reverse_iterator{end()}; }
+  auto crend() const -> const_reverse_iterator { return const_reverse_iterator{begin()}; }
+
+  void push_back(LabelId id) {
+    if (size_ == capacity_) {
+      auto new_cap = capacity_ * 2;
+      auto new_buffer = new LabelId[new_cap];
+      std::ranges::copy(*this, new_buffer);
+      if (capacity_ != kSmallCapacity) delete[] buffer_;
+      buffer_ = new_buffer;
+      capacity_ = new_cap;
+    }
+    begin()[size_] = id;
+    ++size_;
+  };
+  void emplace_back(LabelId id) { push_back(id); };
+  auto back() -> reference { return *rbegin(); };
+  auto back() const -> const_reference { return *crbegin(); }
+  void pop_back() {
+    if (size_) --size_;
+  }
+  void reserve(size_type new_cap) {
+    if (capacity_ < new_cap) {
+      auto new_buffer = new LabelId[new_cap];
+      std::ranges::copy(*this, new_buffer);
+      if (capacity_ != kSmallCapacity) delete[] buffer_;
+      buffer_ = new_buffer;
+      capacity_ = new_cap;
+    }
+  }
+
+  auto size() const noexcept -> std::size_t { return size_; };
+  auto capacity() const noexcept -> std::size_t { return capacity_; };
+
+  auto operator[](size_t idx) -> reference { return *(begin() + idx); }
+  auto operator[](size_t idx) const -> const_reference { return *(begin() + idx); }
 
  private:
   static constexpr size_type kSmallCapacity = sizeof(LabelId *) / sizeof(LabelId);
@@ -97,10 +166,6 @@ struct label_set {
 };
 
 static_assert(sizeof(label_set) == 16);
-static_assert(sizeof(label_set) < sizeof(old_label_set));
-
-}  // namespace in_progress
-
-using label_set = old_label_set;  // in_progress::label_set;
+static_assert(sizeof(label_set) < sizeof(std::vector<LabelId>));
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/vertex.hpp
+++ b/src/storage/v2/vertex.hpp
@@ -33,7 +33,7 @@ struct Vertex {
 
   const Gid gid;
 
-  std::vector<LabelId> labels;
+  label_set labels;
   PropertyStore properties;
 
   std::vector<std::tuple<EdgeTypeId, Vertex *, EdgeRef>> in_edges;

--- a/src/storage/v2/vertex.hpp
+++ b/src/storage/v2/vertex.hpp
@@ -18,6 +18,7 @@
 #include "storage/v2/delta.hpp"
 #include "storage/v2/edge_ref.hpp"
 #include "storage/v2/id_types.hpp"
+#include "storage/v2/label_set.hpp"
 #include "storage/v2/property_store.hpp"
 #include "utils/rw_spin_lock.hpp"
 

--- a/src/storage/v2/vertex_accessor.cpp
+++ b/src/storage/v2/vertex_accessor.cpp
@@ -215,10 +215,10 @@ Result<bool> VertexAccessor::HasLabel(LabelId label, View view) const {
   return has_label;
 }
 
-Result<std::vector<LabelId>> VertexAccessor::Labels(View view) const {
+Result<label_set> VertexAccessor::Labels(View view) const {
   bool exists = true;
   bool deleted = false;
-  std::vector<LabelId> labels;
+  label_set labels;
   Delta *delta = nullptr;
   {
     auto guard = std::shared_lock{vertex_->lock};

--- a/src/storage/v2/vertex_accessor.hpp
+++ b/src/storage/v2/vertex_accessor.hpp
@@ -59,7 +59,7 @@ class VertexAccessor final {
   /// @throw std::bad_alloc
   /// @throw std::length_error if the resulting vector exceeds
   ///        std::vector::max_size().
-  Result<std::vector<LabelId>> Labels(View view) const;
+  Result<label_set> Labels(View view) const;
 
   /// Set a property value and return the old value.
   /// @throw std::bad_alloc

--- a/src/storage/v2/vertex_info_cache.cpp
+++ b/src/storage/v2/vertex_info_cache.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2024 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -12,7 +12,6 @@
 #include "storage/v2/vertex_info_cache.hpp"
 
 #include "storage/v2/property_value.hpp"
-
 #include "utils/flag_validation.hpp"
 
 // NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
@@ -83,10 +82,10 @@ void VertexInfoCache::Invalidate(Vertex const *vertex) {
 }
 
 auto VertexInfoCache::GetLabels(View view, Vertex const *vertex) const
-    -> std::optional<std::reference_wrapper<std::vector<LabelId> const>> {
-  return FetchHelper<std::vector<LabelId>>(*this, std::mem_fn(&VertexInfoCache::Caches::labelCache_), view, vertex);
+    -> std::optional<std::reference_wrapper<label_set const>> {
+  return FetchHelper<label_set>(*this, std::mem_fn(&VertexInfoCache::Caches::labelCache_), view, vertex);
 }
-void VertexInfoCache::StoreLabels(View view, Vertex const *vertex, const std::vector<LabelId> &res) {
+void VertexInfoCache::StoreLabels(View view, Vertex const *vertex, const label_set &res) {
   Store(res, *this, std::mem_fn(&Caches::labelCache_), view, vertex);
 }
 auto VertexInfoCache::GetHasLabel(View view, Vertex const *vertex, LabelId label) const -> std::optional<bool> {

--- a/src/storage/v2/vertex_info_cache.hpp
+++ b/src/storage/v2/vertex_info_cache.hpp
@@ -13,6 +13,7 @@
 #include "storage/v2/edge_direction.hpp"
 #include "storage/v2/edge_ref.hpp"
 #include "storage/v2/id_types.hpp"
+#include "storage/v2/label_set.hpp"
 #include "storage/v2/view.hpp"
 
 #include "absl/container/flat_hash_map.h"
@@ -65,9 +66,9 @@ struct VertexInfoCache final {
 
   void Invalidate(Vertex const *vertex);
 
-  auto GetLabels(View view, Vertex const *vertex) const -> detail::optref<std::vector<LabelId> const>;
+  auto GetLabels(View view, Vertex const *vertex) const -> detail::optref<label_set const>;
 
-  void StoreLabels(View view, Vertex const *vertex, std::vector<LabelId> const &res);
+  void StoreLabels(View view, Vertex const *vertex, label_set const &res);
 
   auto GetHasLabel(View view, Vertex const *vertex, LabelId label) const -> std::optional<bool>;
 
@@ -146,7 +147,7 @@ struct VertexInfoCache final {
     map<Vertex const *, bool> deletedCache_;
     map<std::tuple<Vertex const *, LabelId>, bool> hasLabelCache_;
     map<std::tuple<Vertex const *, PropertyId>, PropertyValue> propertyValueCache_;
-    map<Vertex const *, std::vector<LabelId>> labelCache_;
+    map<Vertex const *, label_set> labelCache_;
     map<Vertex const *, std::map<PropertyId, PropertyValue>> propertiesCache_;
     // TODO: nest keys (edge_types) -> (src+dst) -> EdgeStore
     map<EdgeKey, EdgeStore> inEdgesCache_;

--- a/src/storage/v2/vertex_info_helpers.hpp
+++ b/src/storage/v2/vertex_info_helpers.hpp
@@ -91,7 +91,7 @@ inline auto HasLabel_ActionMethod(bool &has_label, LabelId label) {
   // clang-format on
 }
 
-inline auto Labels_ActionMethod(std::vector<LabelId> &labels) {
+inline auto Labels_ActionMethod(storage::label_set &labels) {
   using enum Delta::Action;
   // clang-format off
   return utils::Overloaded{

--- a/src/utils/rocksdb_serialization.hpp
+++ b/src/utils/rocksdb_serialization.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2024 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -21,6 +21,7 @@
 
 #include "storage/v2/edge_accessor.hpp"
 #include "storage/v2/id_types.hpp"
+#include "storage/v2/label_set.hpp"
 #include "storage/v2/property_store.hpp"
 #include "storage/v2/vertex.hpp"
 #include "storage/v2/vertex_accessor.hpp"
@@ -149,7 +150,7 @@ inline std::string SerializeEdgeAsValue(const std::string &src_vertex_gid, const
 }
 
 inline std::string SerializeVertexAsValueForAuxiliaryStorages(storage::LabelId label_to_remove,
-                                                              const std::vector<storage::LabelId> &vertex_labels,
+                                                              std::span<storage::LabelId const> vertex_labels,
                                                               const storage::PropertyStore &property_store) {
   std::vector<storage::LabelId> labels_without_target;
   labels_without_target.reserve(vertex_labels.size());
@@ -215,7 +216,7 @@ inline std::string SerializeVertexAsKeyForUniqueConstraint(const storage::LabelI
 }
 
 inline std::string SerializeVertexAsValueForUniqueConstraint(const storage::LabelId &constraint_label,
-                                                             const std::vector<storage::LabelId> &vertex_labels,
+                                                             std::span<storage::LabelId const> vertex_labels,
                                                              const storage::PropertyStore &property_store) {
   return SerializeVertexAsValueForAuxiliaryStorages(constraint_label, vertex_labels, property_store);
 }
@@ -246,7 +247,7 @@ inline std::string SerializeVertexAsKeyForLabelIndex(storage::LabelId label, sto
 inline std::string_view ExtractGidFromLabelIndexStorage(const std::string &key) { return ExtractGidFromKey(key); }
 
 inline std::string SerializeVertexAsValueForLabelIndex(storage::LabelId indexing_label,
-                                                       const std::vector<storage::LabelId> &vertex_labels,
+                                                       std::span<storage::LabelId const> vertex_labels,
                                                        const storage::PropertyStore &property_store) {
   return SerializeVertexAsValueForAuxiliaryStorages(indexing_label, vertex_labels, property_store);
 }
@@ -288,7 +289,7 @@ inline std::string SerializeVertexAsKeyForLabelPropertyIndex(storage::LabelId la
 }
 
 inline std::string SerializeVertexAsValueForLabelPropertyIndex(storage::LabelId indexing_label,
-                                                               const std::vector<storage::LabelId> &vertex_labels,
+                                                               std::span<storage::LabelId const> vertex_labels,
                                                                const storage::PropertyStore &property_store) {
   return SerializeVertexAsValueForAuxiliaryStorages(indexing_label, vertex_labels, property_store);
 }

--- a/tests/unit/query_procedures_mgp_graph.cpp
+++ b/tests/unit/query_procedures_mgp_graph.cpp
@@ -409,7 +409,8 @@ TYPED_TEST(MgpGraphTest, VertexAddLabel) {
     ASSERT_TRUE(maybe_vertex);
     const auto label_ids = maybe_vertex->Labels(memgraph::storage::View::NEW);
     ASSERT_TRUE(label_ids.HasValue());
-    EXPECT_THAT(*label_ids, ::testing::ContainerEq(std::vector{read_uncommited_accessor->NameToLabel(label)}));
+    EXPECT_EQ(label_ids->size(), 1);
+    EXPECT_EQ((*label_ids)[0], read_uncommited_accessor->NameToLabel(label));
   };
   ASSERT_NO_FATAL_FAILURE(check_label());
   EXPECT_SUCCESS(mgp_vertex_add_label(vertex.get(), mgp_label{label.data()}));


### PR DESCRIPTION
### Description

8B reduction in Vertex.
Avoid heap allocation for 1 or 2 LabelIds, by using small buffer.

_Analysis to follow_

[master < Task] PR
- [ ] Provide the full content or a guide for the final git message
    - **[FINAL GIT MESSAGE]**


### CI Testing Labels
Please select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_


### Documentation checklist
- [ ] Add the documentation label tag
- [ ] Add the bug / feature label tag
- [ ] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - **[Release note text]**
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [ ] Tag someone from docs team in the comments
