### PR TITLE
Bugfix: Replica now handles skipped transactions

### DIFF
--- a/src/communication/buffer.hpp
+++ b/src/communication/buffer.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2024 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -34,7 +34,7 @@ namespace memgraph::communication {
 class Buffer final {
  private:
   // Initial capacity of the internal buffer.
-  const size_t kBufferInitialSize = 65536;
+  static constexpr size_t kBufferInitialSize = 65'536;
 
  public:
   Buffer();
@@ -68,6 +68,8 @@ class Buffer final {
     void Resize(size_t len);
 
     void Clear();
+
+    void ShrinkBuffer(size_t size);
 
    private:
     Buffer *buffer_;
@@ -168,6 +170,12 @@ class Buffer final {
    * space.
    */
   void Clear();
+
+  /**
+   * This method resizes the internal data buffer.
+   * It can only shrink the buffer to the larger of size and len
+   */
+  void ShrinkBuffer(size_t new_size);
 
   std::vector<uint8_t> data_;
   size_t have_{0};

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -35,6 +35,7 @@
 #include "utils/stat.hpp"
 
 #include <mutex>
+#include <ranges>
 
 namespace memgraph::storage {
 
@@ -2396,10 +2397,18 @@ void InMemoryStorage::FreeMemory(std::unique_lock<utils::ResourceLock> main_guar
 }
 
 uint64_t InMemoryStorage::CommitTimestamp(const std::optional<uint64_t> desired_commit_timestamp) {
+  // Normal logic, when txn is on MAIN
   if (!desired_commit_timestamp) {
     return timestamp_++;
   }
-  timestamp_ = std::max(timestamp_, *desired_commit_timestamp + 1);
+  // Special case logic, when txn is on REPLICA
+  auto normal_next_timestamp = timestamp_;
+  // any timestamps which are to be skipped need to be marked as finished
+  // otherwise GC would stop working correctly
+  for (auto const used_timestamp : std::ranges::views::iota(normal_next_timestamp, *desired_commit_timestamp)) {
+    commit_log_->MarkFinished(used_timestamp);
+  }
+  timestamp_ = std::max(normal_next_timestamp, *desired_commit_timestamp + 1);
   return *desired_commit_timestamp;
 }
 


### PR DESCRIPTION
### Description

On REPLICA the commit timestamp is calculated in an interesting way. This is for reasons related to durability based on the timestamp. The problem is that some timestamps can be skipped, and hence never used on the replica side and hence never finalised. This would mean the commit log would provide incorrect information to GC about what the oldest active timestamp is. Causing GC not to clear away the Deltas being made.

Fix is to make all skipped timestamps to be marked as finalised.

Another memory related issue was the RPC session buffer retained the size of its high watermark. Post Session::Execute we now limit the buffer back to a max of 4MiB.

fixes: #1995

[master < Task] PR
- [x] Provide the full content or a guide for the final git message
    - **Bugfix: Replica now handles skipped transactions**


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [x] Write a release note, including added/changed clauses
    - **Replica now correctly handles skipped timestamps, resulting in the memory used for Deltas being correctly released**
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [x] Tag someone from docs team in the comments
