### PR TITLE
Improve testing output of `SHOW INSTANCES` 

### DIFF
--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -28,6 +28,7 @@ from mg_utils import (
     mg_sleep_and_assert,
     mg_sleep_and_assert_any_function,
     mg_sleep_and_assert_collection,
+    mg_sleep_and_assert_multiple,
 )
 
 interactive_mg_runner.SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -252,7 +253,8 @@ def test_old_main_comes_back_on_new_leader_as_replica():
     def show_instances_coord2():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
-    leader_data = [
+    # Both instance_1 and instance_2 could become main depending on the order of pings in the system.
+    leader_data_inst1_main = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
         ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
         ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "coordinator"),
@@ -260,9 +262,17 @@ def test_old_main_comes_back_on_new_leader_as_replica():
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
     ]
-    mg_sleep_and_assert_any_function(leader_data, [show_instances_coord1, show_instances_coord2])
 
-    follower_data = [
+    leader_data_inst2_main = [
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "coordinator"),
+        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
+        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "main"),
+        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+    ]
+
+    follower_data_inst1_main = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
         ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
         ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
@@ -270,8 +280,21 @@ def test_old_main_comes_back_on_new_leader_as_replica():
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
     ]
-    mg_sleep_and_assert_any_function(leader_data, [show_instances_coord1, show_instances_coord2])
-    mg_sleep_and_assert_any_function(follower_data, [show_instances_coord1, show_instances_coord2])
+    follower_data_inst2_main = [
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
+        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "main"),
+        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
+    ]
+
+    mg_sleep_and_assert_multiple(
+        [leader_data_inst1_main, leader_data_inst2_main], [show_instances_coord1, show_instances_coord2]
+    )
+    mg_sleep_and_assert_multiple(
+        [follower_data_inst1_main, follower_data_inst2_main], [show_instances_coord1, show_instances_coord2]
+    )
 
     interactive_mg_runner.start(inner_instances_description, "instance_3")
 
@@ -447,7 +470,8 @@ def test_distributed_automatic_failover_with_leadership_change():
     def show_instances_coord2():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
-    leader_data = [
+    # Both instance_1 and instance_2 could become main depending on the order of pings in the system.
+    leader_data_inst1_main = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
         ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
         ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "coordinator"),
@@ -455,9 +479,16 @@ def test_distributed_automatic_failover_with_leadership_change():
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
     ]
-    mg_sleep_and_assert_any_function(leader_data, [show_instances_coord1, show_instances_coord2])
+    leader_data_inst2_main = [
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "coordinator"),
+        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
+        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "main"),
+        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+    ]
 
-    follower_data = [
+    follower_data_inst1_main = [
         ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
         ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
         ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
@@ -465,8 +496,22 @@ def test_distributed_automatic_failover_with_leadership_change():
         ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
         ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
     ]
-    mg_sleep_and_assert_any_function(leader_data, [show_instances_coord1, show_instances_coord2])
-    mg_sleep_and_assert_any_function(follower_data, [show_instances_coord1, show_instances_coord2])
+    follower_data_inst2_main = [
+        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "coordinator"),
+        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "coordinator"),
+        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "coordinator"),
+        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
+        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "main"),
+        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
+    ]
+
+    mg_sleep_and_assert_multiple(
+        [leader_data_inst1_main, leader_data_inst2_main], [show_instances_coord1, show_instances_coord2]
+    )
+
+    mg_sleep_and_assert_multiple(
+        [follower_data_inst1_main, follower_data_inst2_main], [show_instances_coord1, show_instances_coord2]
+    )
 
     new_main_cursor = connect(host="localhost", port=7687).cursor()
 

--- a/tests/e2e/mg_utils.py
+++ b/tests/e2e/mg_utils.py
@@ -2,6 +2,9 @@ import time
 
 
 def mg_sleep_and_assert(expected_value, function_to_retrieve_data, max_duration=20, time_between_attempt=0.2):
+    """
+    This function will keep calling the function_to_retrieve_data until the result is equal to the expected_value.
+    """
     result = function_to_retrieve_data()
     start_time = time.time()
     while result != expected_value:
@@ -18,6 +21,9 @@ def mg_sleep_and_assert(expected_value, function_to_retrieve_data, max_duration=
 
 
 def mg_assert_until(expected_value, function_to_retrieve_data, max_duration=20, time_between_attempt=0.2) -> None:
+    """
+    Assert for max_duration that the function_to_retrieve_data returns the expected_value
+    """
     start_time = time.time()
     duration = time.time() - start_time
     while duration < max_duration:
@@ -27,9 +33,35 @@ def mg_assert_until(expected_value, function_to_retrieve_data, max_duration=20, 
         duration = time.time() - start_time
 
 
+def mg_sleep_and_assert_multiple(
+    expected_values, functions_to_retrieve_data, max_duration=20, time_between_attempt=0.2
+):
+    """
+    This function will keep calling the functions in functions_to_retrieve_data until one of them returns a value that is in expected_values.
+    """
+    result = [f() for f in functions_to_retrieve_data]
+    if any((x in expected_values for x in result)):
+        return True
+    start_time = time.time()
+    while True:
+        duration = time.time() - start_time
+        if duration > max_duration:
+            assert (
+                False
+            ), f" mg_sleep_and_assert has tried for too long and did not get the expected result! Last result was: {result}"
+
+        time.sleep(time_between_attempt)
+        result = [f() for f in functions_to_retrieve_data]
+        if any((x in expected_values for x in result)):
+            return True
+
+
 def mg_sleep_and_assert_any_function(
     expected_value, functions_to_retrieve_data, max_duration=20, time_between_attempt=0.2
 ):
+    """
+    This function will keep calling the functions in functions_to_retrieve_data until one of them returns the expected value.
+    """
     result = [f() for f in functions_to_retrieve_data]
     if any((x == expected_value for x in result)):
         return result
@@ -52,6 +84,9 @@ def mg_sleep_and_assert_any_function(
 def mg_sleep_and_assert_collection(
     expected_value, function_to_retrieve_data, max_duration=20, time_between_attempt=0.2
 ):
+    """
+    This function will keep calling the function_to_retrieve_data until the result is equal to the expected_value.
+    """
     result = function_to_retrieve_data()
     start_time = time.time()
     while len(result) != len(expected_value) or any((x not in result for x in expected_value)):


### PR DESCRIPTION
### Description

In some tests we were incorrectly assuming which instance will become new in situations when both current main and current leader of the cluster died.

[master < Task] PR
- [x] Provide the full content or a guide for the final git message
    - **Improve testing output of `SHOW INSTANCES`**


### CI Testing Labels
Please select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - **[Release note text]**
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [x] Tag someone from docs team in the comments
