### PR TITLE
Fix: MVCC design on replica and replica stream isolation

### DIFF
--- a/.github/workflows/diff_jepsen.yaml
+++ b/.github/workflows/diff_jepsen.yaml
@@ -72,12 +72,11 @@ jobs:
       - name: Run Jepsen tests
         run: |
           cd tests/jepsen
-          ./run.sh test-all-individually \
+          ./run.sh test \
           --binary ../../build/memgraph \
-          --run-args "--time-limit 120 --concurrency 6" \
+          --run-args "--workload bank --nodes-config resources/replication-config.edn --time-limit 120" \
           --ignore-run-stdout-logs \
           --ignore-run-stderr-logs \
-          --nodes-no 6 \
           --enterprise-license $MEMGRAPH_ENTERPRISE_LICENSE \
           --organization-name $MEMGRAPH_ORGANIZATION_NAME
 

--- a/.github/workflows/diff_jepsen.yaml
+++ b/.github/workflows/diff_jepsen.yaml
@@ -72,11 +72,12 @@ jobs:
       - name: Run Jepsen tests
         run: |
           cd tests/jepsen
-          ./run.sh test \
+          ./run.sh test-all-individually \
           --binary ../../build/memgraph \
-          --run-args "--workload bank --nodes-config resources/replication-config.edn --time-limit 120" \
+          --run-args "--time-limit 120 --concurrency 6" \
           --ignore-run-stdout-logs \
           --ignore-run-stderr-logs \
+          --nodes-no 6 \
           --enterprise-license $MEMGRAPH_ENTERPRISE_LICENSE \
           --organization-name $MEMGRAPH_ORGANIZATION_NAME
 

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -514,7 +514,7 @@ void InMemoryReplicationHandlers::LoadWal(storage::InMemoryStorage *storage, sto
     wal.SetPosition(wal_info.offset_deltas);
 
     for (size_t i = 0; i < wal_info.num_deltas;) {
-      i += ReadAndApplyDelta(storage, &wal, *version);
+      i += ReadAndApplyDeltas(storage, &wal, *version);
     }
 
     spdlog::debug("Replication from current WAL successful!");

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -581,7 +581,7 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
   uint64_t current_delta_idx = 0;  // tracks over how many deltas we iterated, includes also skipped deltas.
   uint64_t applied_deltas = 0;     // Non-skipped deltas
   auto max_delta_timestamp = storage->repl_storage_state_.last_commit_timestamp_.load();
-  auto current_durable_commit_timestamp = storage->repl_storage_state_.last_commit_timestamp_.load();
+  auto current_durable_commit_timestamp = max_delta_timestamp;
   for (bool transaction_complete = false; !transaction_complete; ++current_delta_idx) {
     const auto [delta_timestamp, delta] = ReadDelta(decoder);
     if (delta_timestamp > max_delta_timestamp) {

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -559,9 +559,9 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
   constexpr bool kSharedAccess = false;
 
   std::optional<std::pair<uint64_t, storage::InMemoryStorage::ReplicationAccessor>> commit_timestamp_and_accessor;
-  auto const get_transaction = [storage, &commit_timestamp_and_accessor](
-                                   uint64_t commit_timestamp,
-                                   bool unique = kSharedAccess) -> storage::InMemoryStorage::ReplicationAccessor * {
+  auto const get_transaction_accessor =
+      [storage, &commit_timestamp_and_accessor](
+          uint64_t commit_timestamp, bool unique = kSharedAccess) -> storage::InMemoryStorage::ReplicationAccessor * {
     if (!commit_timestamp_and_accessor) {
       std::unique_ptr<storage::Storage::Accessor> acc = nullptr;
       if (unique) {
@@ -580,31 +580,32 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
 
   uint64_t current_delta_idx = 0;  // tracks over how many deltas we iterated, includes also skipped deltas.
   uint64_t applied_deltas = 0;     // Non-skipped deltas
-  auto max_commit_timestamp = storage->repl_storage_state_.last_commit_timestamp_.load();
-
+  auto max_delta_timestamp = storage->repl_storage_state_.last_commit_timestamp_.load();
+  auto current_durable_commit_timestamp = storage->repl_storage_state_.last_commit_timestamp_.load();
   for (bool transaction_complete = false; !transaction_complete; ++current_delta_idx) {
-    const auto [timestamp, delta] = ReadDelta(decoder);
-    if (timestamp > max_commit_timestamp) {
-      max_commit_timestamp = timestamp;
+    const auto [delta_timestamp, delta] = ReadDelta(decoder);
+    if (delta_timestamp > max_delta_timestamp) {
+      max_delta_timestamp = delta_timestamp;
     }
 
     transaction_complete = storage::durability::IsWalDeltaDataTypeTransactionEnd(delta.type, version);
 
-    if (timestamp < storage->timestamp_) {
-      spdlog::trace("Skipping delta {} {}", timestamp, storage->timestamp_);
+    if (delta_timestamp <= current_durable_commit_timestamp) {
+      spdlog::trace("Skipping delta with timestamp:{}, current durable commit timestamp: {}", delta_timestamp,
+                    current_durable_commit_timestamp);
       continue;
     }
     spdlog::trace("  Delta {}", current_delta_idx);
     switch (delta.type) {
       case WalDeltaData::Type::VERTEX_CREATE: {
         spdlog::trace("       Create vertex {}", delta.vertex_create_delete.gid.AsUint());
-        auto *transaction = get_transaction(timestamp);
+        auto *transaction = get_transaction_accessor(delta_timestamp);
         transaction->CreateVertexEx(delta.vertex_create_delete.gid);
         break;
       }
       case WalDeltaData::Type::VERTEX_DELETE: {
         spdlog::trace("       Delete vertex {}", delta.vertex_create_delete.gid.AsUint());
-        auto *transaction = get_transaction(timestamp);
+        auto *transaction = get_transaction_accessor(delta_timestamp);
         auto vertex = transaction->FindVertex(delta.vertex_create_delete.gid, View::NEW);
         if (!vertex)
           throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
@@ -616,7 +617,7 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
       case WalDeltaData::Type::VERTEX_ADD_LABEL: {
         spdlog::trace("       Vertex {} add label {}", delta.vertex_add_remove_label.gid.AsUint(),
                       delta.vertex_add_remove_label.label);
-        auto *transaction = get_transaction(timestamp);
+        auto *transaction = get_transaction_accessor(delta_timestamp);
         auto vertex = transaction->FindVertex(delta.vertex_add_remove_label.gid, View::NEW);
         if (!vertex)
           throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
@@ -629,7 +630,7 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
       case WalDeltaData::Type::VERTEX_REMOVE_LABEL: {
         spdlog::trace("       Vertex {} remove label {}", delta.vertex_add_remove_label.gid.AsUint(),
                       delta.vertex_add_remove_label.label);
-        auto *transaction = get_transaction(timestamp);
+        auto *transaction = get_transaction_accessor(delta_timestamp);
         auto vertex = transaction->FindVertex(delta.vertex_add_remove_label.gid, View::NEW);
         if (!vertex)
           throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
@@ -642,7 +643,7 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
       case WalDeltaData::Type::VERTEX_SET_PROPERTY: {
         spdlog::trace("       Vertex {} set property", delta.vertex_edge_set_property.gid.AsUint());
         // NOLINTNEXTLINE
-        auto *transaction = get_transaction(timestamp);
+        auto *transaction = get_transaction_accessor(delta_timestamp);
         // NOLINTNEXTLINE
         auto vertex = transaction->FindVertex(delta.vertex_edge_set_property.gid, View::NEW);
         if (!vertex)
@@ -658,7 +659,7 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
         spdlog::trace("       Create edge {} of type {} from vertex {} to vertex {}",
                       delta.edge_create_delete.gid.AsUint(), delta.edge_create_delete.edge_type,
                       delta.edge_create_delete.from_vertex.AsUint(), delta.edge_create_delete.to_vertex.AsUint());
-        auto *transaction = get_transaction(timestamp);
+        auto *transaction = get_transaction_accessor(delta_timestamp);
         auto from_vertex = transaction->FindVertex(delta.edge_create_delete.from_vertex, View::NEW);
         if (!from_vertex)
           throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
@@ -676,7 +677,7 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
         spdlog::trace("       Delete edge {} of type {} from vertex {} to vertex {}",
                       delta.edge_create_delete.gid.AsUint(), delta.edge_create_delete.edge_type,
                       delta.edge_create_delete.from_vertex.AsUint(), delta.edge_create_delete.to_vertex.AsUint());
-        auto *transaction = get_transaction(timestamp);
+        auto *transaction = get_transaction_accessor(delta_timestamp);
         auto from_vertex = transaction->FindVertex(delta.edge_create_delete.from_vertex, View::NEW);
         if (!from_vertex)
           throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
@@ -698,7 +699,7 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
               "Can't set properties on edges because properties on edges "
               "are disabled!");
 
-        auto *transaction = get_transaction(timestamp);
+        auto *transaction = get_transaction_accessor(delta_timestamp);
 
         // The following block of code effectively implements `FindEdge` and
         // yields an accessor that is only valid for managing the edge's
@@ -758,7 +759,7 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
 
       case WalDeltaData::Type::TRANSACTION_END: {
         spdlog::trace("       Transaction end");
-        if (!commit_timestamp_and_accessor || commit_timestamp_and_accessor->first != timestamp)
+        if (!commit_timestamp_and_accessor || commit_timestamp_and_accessor->first != delta_timestamp)
           throw utils::BasicException("Invalid commit data!");
         auto ret = commit_timestamp_and_accessor->second.Commit(
             {.desired_commit_timestamp = commit_timestamp_and_accessor->first, .is_main = false});
@@ -771,14 +772,14 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
       case WalDeltaData::Type::LABEL_INDEX_CREATE: {
         spdlog::trace("       Create label index on :{}", delta.operation_label.label);
         // Need to send the timestamp
-        auto *transaction = get_transaction(timestamp, kUniqueAccess);
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
         if (transaction->CreateIndex(storage->NameToLabel(delta.operation_label.label)).HasError())
           throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
         break;
       }
       case WalDeltaData::Type::LABEL_INDEX_DROP: {
         spdlog::trace("       Drop label index on :{}", delta.operation_label.label);
-        auto *transaction = get_transaction(timestamp, kUniqueAccess);
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
         if (transaction->DropIndex(storage->NameToLabel(delta.operation_label.label)).HasError())
           throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
         break;
@@ -786,7 +787,7 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
       case WalDeltaData::Type::LABEL_INDEX_STATS_SET: {
         spdlog::trace("       Set label index statistics on :{}", delta.operation_label_stats.label);
         // Need to send the timestamp
-        auto *transaction = get_transaction(timestamp);
+        auto *transaction = get_transaction_accessor(delta_timestamp);
         const auto label = storage->NameToLabel(delta.operation_label_stats.label);
         LabelIndexStats stats{};
         if (!FromJson(delta.operation_label_stats.stats, stats)) {
@@ -799,14 +800,14 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
         const auto &info = delta.operation_label;
         spdlog::trace("       Clear label index statistics on :{}", info.label);
         // Need to send the timestamp
-        auto *transaction = get_transaction(timestamp);
+        auto *transaction = get_transaction_accessor(delta_timestamp);
         transaction->DeleteLabelIndexStats(storage->NameToLabel(info.label));
         break;
       }
       case WalDeltaData::Type::LABEL_PROPERTY_INDEX_CREATE: {
         spdlog::trace("       Create label+property index on :{} ({})", delta.operation_label_property.label,
                       delta.operation_label_property.property);
-        auto *transaction = get_transaction(timestamp, kUniqueAccess);
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
         if (transaction
                 ->CreateIndex(storage->NameToLabel(delta.operation_label_property.label),
                               storage->NameToProperty(delta.operation_label_property.property))
@@ -817,7 +818,7 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
       case WalDeltaData::Type::LABEL_PROPERTY_INDEX_DROP: {
         spdlog::trace("       Drop label+property index on :{} ({})", delta.operation_label_property.label,
                       delta.operation_label_property.property);
-        auto *transaction = get_transaction(timestamp, kUniqueAccess);
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
         if (transaction
                 ->DropIndex(storage->NameToLabel(delta.operation_label_property.label),
                             storage->NameToProperty(delta.operation_label_property.property))
@@ -829,7 +830,7 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
         const auto &info = delta.operation_label_property_stats;
         spdlog::trace("       Set label-property index statistics on :{}", info.label);
         // Need to send the timestamp
-        auto *transaction = get_transaction(timestamp);
+        auto *transaction = get_transaction_accessor(delta_timestamp);
         const auto label = storage->NameToLabel(info.label);
         const auto property = storage->NameToProperty(info.property);
         LabelPropertyIndexStats stats{};
@@ -843,20 +844,20 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
         const auto &info = delta.operation_label;
         spdlog::trace("       Clear label-property index statistics on :{}", info.label);
         // Need to send the timestamp
-        auto *transaction = get_transaction(timestamp);
+        auto *transaction = get_transaction_accessor(delta_timestamp);
         transaction->DeleteLabelPropertyIndexStats(storage->NameToLabel(info.label));
         break;
       }
       case WalDeltaData::Type::EDGE_INDEX_CREATE: {
         spdlog::trace("       Create edge index on :{}", delta.operation_edge_type.edge_type);
-        auto *transaction = get_transaction(timestamp, kUniqueAccess);
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
         if (transaction->CreateIndex(storage->NameToEdgeType(delta.operation_label.label)).HasError())
           throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
         break;
       }
       case WalDeltaData::Type::EDGE_INDEX_DROP: {
         spdlog::trace("       Drop edge index on :{}", delta.operation_edge_type.edge_type);
-        auto *transaction = get_transaction(timestamp, kUniqueAccess);
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
         if (transaction->DropIndex(storage->NameToEdgeType(delta.operation_label.label)).HasError())
           throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
         break;
@@ -872,7 +873,7 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
       case WalDeltaData::Type::EXISTENCE_CONSTRAINT_CREATE: {
         spdlog::trace("       Create existence constraint on :{} ({})", delta.operation_label_property.label,
                       delta.operation_label_property.property);
-        auto *transaction = get_transaction(timestamp, kUniqueAccess);
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
         auto ret =
             transaction->CreateExistenceConstraint(storage->NameToLabel(delta.operation_label_property.label),
                                                    storage->NameToProperty(delta.operation_label_property.property));
@@ -883,7 +884,7 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
       case WalDeltaData::Type::EXISTENCE_CONSTRAINT_DROP: {
         spdlog::trace("       Drop existence constraint on :{} ({})", delta.operation_label_property.label,
                       delta.operation_label_property.property);
-        auto *transaction = get_transaction(timestamp, kUniqueAccess);
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
         if (transaction
                 ->DropExistenceConstraint(storage->NameToLabel(delta.operation_label_property.label),
                                           storage->NameToProperty(delta.operation_label_property.property))
@@ -899,7 +900,7 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
         for (const auto &prop : delta.operation_label_properties.properties) {
           properties.emplace(storage->NameToProperty(prop));
         }
-        auto *transaction = get_transaction(timestamp, kUniqueAccess);
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
         auto ret = transaction->CreateUniqueConstraint(storage->NameToLabel(delta.operation_label_properties.label),
                                                        properties);
         if (!ret.HasValue() || ret.GetValue() != UniqueConstraints::CreationStatus::SUCCESS)
@@ -914,7 +915,7 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
         for (const auto &prop : delta.operation_label_properties.properties) {
           properties.emplace(storage->NameToProperty(prop));
         }
-        auto *transaction = get_transaction(timestamp, kUniqueAccess);
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
         auto ret =
             transaction->DropUniqueConstraint(storage->NameToLabel(delta.operation_label_properties.label), properties);
         if (ret != UniqueConstraints::DeletionStatus::SUCCESS) {
@@ -928,7 +929,7 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
 
   if (commit_timestamp_and_accessor) throw utils::BasicException("Did not finish the transaction!");
 
-  storage->repl_storage_state_.last_commit_timestamp_ = max_commit_timestamp;
+  storage->repl_storage_state_.last_commit_timestamp_ = max_delta_timestamp;
 
   spdlog::debug("Applied {} deltas", applied_deltas);
   return current_delta_idx;

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -237,7 +237,7 @@ void InMemoryReplicationHandlers::AppendDeltasHandler(dbms::DbmsHandler *dbms_ha
     return;
   }
 
-  ReadAndApplyDelta(
+  ReadAndApplyDeltas(
       storage, &decoder,
       storage::durability::kVersion);  // TODO: Check if we are always using the latest version when replicating
 
@@ -549,9 +549,9 @@ void InMemoryReplicationHandlers::TimestampHandler(dbms::DbmsHandler *dbms_handl
 }
 
 // The number of applied deltas also includes skipped deltas.
-uint64_t InMemoryReplicationHandlers::ReadAndApplyDelta(storage::InMemoryStorage *storage,
-                                                        storage::durability::BaseDecoder *decoder,
-                                                        const uint64_t version) {
+uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorage *storage,
+                                                         storage::durability::BaseDecoder *decoder,
+                                                         const uint64_t version) {
   auto edge_acc = storage->edges_.access();
   auto vertex_acc = storage->vertices_.access();
 

--- a/src/dbms/inmemory/replication_handlers.hpp
+++ b/src/dbms/inmemory/replication_handlers.hpp
@@ -54,8 +54,8 @@ class InMemoryReplicationHandlers {
 
   static void LoadWal(storage::InMemoryStorage *storage, storage::replication::Decoder *decoder);
 
-  static uint64_t ReadAndApplyDelta(storage::InMemoryStorage *storage, storage::durability::BaseDecoder *decoder,
-                                    uint64_t version);
+  static uint64_t ReadAndApplyDeltas(storage::InMemoryStorage *storage, storage::durability::BaseDecoder *decoder,
+                                     uint64_t version);
 };
 
 }  // namespace memgraph::dbms

--- a/src/storage/v2/CMakeLists.txt
+++ b/src/storage/v2/CMakeLists.txt
@@ -55,4 +55,4 @@ target_sources(mg-storage-v2
 )
 
 target_include_directories(mg-storage-v2 PUBLIC ${CMAKE_SOURCE_DIR}/include)
-target_link_libraries(mg-storage-v2 mg::replication Threads::Threads mg-utils mg-flags gflags absl::flat_hash_map mg-rpc mg-slk mg-events mg-memory mgcxx_text_search tantivy_text_search)
+target_link_libraries(mg-storage-v2 mg::replication Threads::Threads mg-utils mg-flags gflags absl::flat_hash_map mg-rpc mg-slk mg-events mg-memory lib::rangev3 mgcxx_text_search tantivy_text_search)

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -1631,7 +1631,7 @@ utils::BasicResult<StorageManipulationError, void> DiskStorage::DiskAccessor::Co
     // This is usually done by the MVCC, but it does not handle the metadata deltas
     transaction_.EnsureCommitTimestampExists();
     auto engine_guard = std::unique_lock{storage_->engine_lock_};
-    commit_timestamp_.emplace(disk_storage->CommitTimestamp(reparg.desired_commit_timestamp));
+    commit_timestamp_.emplace(disk_storage->GetCommitTimestamp());
     transaction_.commit_timestamp->store(*commit_timestamp_, std::memory_order_release);
 
     for (const auto &md_delta : transaction_.md_deltas) {
@@ -1725,7 +1725,7 @@ utils::BasicResult<StorageManipulationError, void> DiskStorage::DiskAccessor::Co
               }))) {
   } else {
     auto engine_guard = std::unique_lock{storage_->engine_lock_};
-    commit_timestamp_.emplace(disk_storage->CommitTimestamp(reparg.desired_commit_timestamp));
+    commit_timestamp_.emplace(disk_storage->GetCommitTimestamp());
     transaction_.commit_timestamp->store(*commit_timestamp_, std::memory_order_release);
 
     if (edge_import_mode_active) {
@@ -2089,13 +2089,7 @@ Transaction DiskStorage::CreateTransaction(IsolationLevel isolation_level, Stora
           storage_mode,   edge_import_mode_active, !constraints_.empty()};
 }
 
-uint64_t DiskStorage::CommitTimestamp(const std::optional<uint64_t> desired_commit_timestamp) {
-  if (!desired_commit_timestamp) {
-    return timestamp_++;
-  }
-  timestamp_ = std::max(timestamp_, *desired_commit_timestamp + 1);
-  return *desired_commit_timestamp;
-}
+uint64_t DiskStorage::GetCommitTimestamp() { return timestamp_++; }
 
 std::unique_ptr<Storage::Accessor> DiskStorage::Access(
     memgraph::replication_coordination_glue::ReplicationRole /*replication_role*/,

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -333,7 +333,7 @@ class DiskStorage final : public Storage {
 
   void PrepareForNewEpoch() override { throw utils::BasicException("Disk storage mode does not support replication."); }
 
-  uint64_t CommitTimestamp(std::optional<uint64_t> desired_commit_timestamp = {});
+  uint64_t GetCommitTimestamp();
 
   std::unique_ptr<RocksDBStorage> kvstore_;
   DurableMetadata durable_metadata_;

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2407,6 +2407,7 @@ uint64_t InMemoryStorage::CommitTimestamp(const std::optional<uint64_t> desired_
   if (!desired_commit_timestamp) {
     return timestamp_++;
   }
+
   // Special case logic, when txn is on REPLICA
   auto normal_next_timestamp = timestamp_;
   // any timestamps which are to be skipped need to be marked as finished
@@ -2414,6 +2415,10 @@ uint64_t InMemoryStorage::CommitTimestamp(const std::optional<uint64_t> desired_
   for (auto const used_timestamp : std::ranges::views::iota(normal_next_timestamp, *desired_commit_timestamp)) {
     commit_log_->MarkFinished(used_timestamp);
   }
+
+  MG_ASSERT(*desired_commit_timestamp >= normal_next_timestamp,
+            "Invalid timestamp! Desired commit ts: {} normal next ts {}", *desired_commit_timestamp,
+            normal_next_timestamp);
   timestamp_ = std::max(normal_next_timestamp, *desired_commit_timestamp + 1);
   return *desired_commit_timestamp;
 }

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -924,7 +924,7 @@ utils::BasicResult<StorageManipulationError, void> InMemoryStorage::InMemoryAcce
           // Replica can only update the last commit timestamp with
           // the commits received from main.
           // Update the last commit timestamp
-          mem_storage->repl_storage_state_.last_commit_timestamp_.store(*commit_timestamp_);
+          mem_storage->repl_storage_state_.last_commit_timestamp_.store(durability_commit_timestamp);
         }
 
         // TODO: can and should this be moved earlier?
@@ -2396,28 +2396,7 @@ void InMemoryStorage::FreeMemory(std::unique_lock<utils::ResourceLock> main_guar
 }
 
 uint64_t InMemoryStorage::CommitTimestamp(const std::optional<uint64_t> desired_commit_timestamp) {
-  // Normal logic, when txn is on MAIN
-  if (!desired_commit_timestamp) {
-    return timestamp_++;
-  } else {
-    return timestamp_++;
-  }
-
-  /*
-  // Special case logic, when txn is on REPLICA
-  auto normal_next_timestamp = timestamp_;
-  // any timestamps which are to be skipped need to be marked as finished
-  // otherwise GC would stop working correctly
-  for (auto const used_timestamp : std::ranges::views::iota(normal_next_timestamp, *desired_commit_timestamp)) {
-    commit_log_->MarkFinished(used_timestamp);
-  }
-
-  MG_ASSERT(*desired_commit_timestamp >= normal_next_timestamp,
-            "Invalid timestamp! Desired commit ts: {} normal next ts {}", *desired_commit_timestamp,
-            normal_next_timestamp);
-  timestamp_ = std::max(normal_next_timestamp, *desired_commit_timestamp + 1);
-  return *desired_commit_timestamp;
-   */
+  return timestamp_++;
 }
 
 void InMemoryStorage::PrepareForNewEpoch() {

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1595,17 +1595,7 @@ Transaction InMemoryStorage::CreateTransaction(
   {
     auto guard = std::lock_guard{engine_lock_};
     transaction_id = transaction_id_++;
-    // Replica should have only read queries and the write queries
-    // can come from main instance with any past timestamp.
-    // To preserve snapshot isolation we set the start timestamp
-    // of any query on replica to the last commited transaction
-    // which is timestamp_ as only commit of transaction with writes
-    // can change the value of it.
-    if (replication_role == memgraph::replication_coordination_glue::ReplicationRole::MAIN) {
-      start_timestamp = timestamp_++;
-    } else {
-      start_timestamp = timestamp_;
-    }
+    start_timestamp = timestamp_++;
   }
   return {transaction_id, start_timestamp, isolation_level, storage_mode, false, !constraints_.empty()};
 }

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -868,7 +868,7 @@ utils::BasicResult<StorageManipulationError, void> InMemoryStorage::InMemoryAcce
 
       auto *mem_unique_constraints =
           static_cast<InMemoryUniqueConstraints *>(storage_->constraints_.unique_constraints_.get());
-      commit_timestamp_.emplace(mem_storage->CommitTimestamp(reparg.desired_commit_timestamp));
+      commit_timestamp_.emplace(mem_storage->GetCommitTimestamp());
 
       if (transaction_.constraint_verification_info &&
           transaction_.constraint_verification_info->NeedsUniqueConstraintVerification()) {
@@ -2395,9 +2395,7 @@ void InMemoryStorage::FreeMemory(std::unique_lock<utils::ResourceLock> main_guar
   edges_.run_gc();
 }
 
-uint64_t InMemoryStorage::CommitTimestamp(const std::optional<uint64_t> desired_commit_timestamp) {
-  return timestamp_++;
-}
+uint64_t InMemoryStorage::GetCommitTimestamp() { return timestamp_++; }
 
 void InMemoryStorage::PrepareForNewEpoch() {
   std::unique_lock engine_guard{engine_lock_};

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -409,23 +409,25 @@ class InMemoryStorage final : public Storage {
   [[nodiscard]] bool AppendToWal(const Transaction &transaction, uint64_t final_commit_timestamp,
                                  DatabaseAccessProtector db_acc);
   void AppendToWalDataDefinition(durability::StorageMetadataOperation operation, LabelId label,
-                                 uint64_t final_commit_timestamp);
+                                 uint64_t final_commit_timestamp, std::span<std::optional<ReplicaStream>> streams);
   void AppendToWalDataDefinition(durability::StorageMetadataOperation operation, EdgeTypeId edge_type,
-                                 uint64_t final_commit_timestamp);
+                                 uint64_t final_commit_timestamp, std::span<std::optional<ReplicaStream>> streams);
   void AppendToWalDataDefinition(durability::StorageMetadataOperation operation, LabelId label,
-                                 const std::set<PropertyId> &properties, uint64_t final_commit_timestamp);
+                                 const std::set<PropertyId> &properties, uint64_t final_commit_timestamp,
+                                 std::span<std::optional<ReplicaStream>> streams);
   void AppendToWalDataDefinition(durability::StorageMetadataOperation operation, LabelId label, LabelIndexStats stats,
-                                 uint64_t final_commit_timestamp);
+                                 uint64_t final_commit_timestamp, std::span<std::optional<ReplicaStream>> streams);
   void AppendToWalDataDefinition(durability::StorageMetadataOperation operation, LabelId label,
                                  const std::set<PropertyId> &properties, LabelPropertyIndexStats property_stats,
-                                 uint64_t final_commit_timestamp);
+                                 uint64_t final_commit_timestamp, std::span<std::optional<ReplicaStream>> streams);
   void AppendToWalDataDefinition(durability::StorageMetadataOperation operation,
                                  const std::optional<std::string> text_index_name, LabelId label,
                                  const std::set<PropertyId> &properties, LabelIndexStats stats,
-                                 LabelPropertyIndexStats property_stats, uint64_t final_commit_timestamp);
+                                 LabelPropertyIndexStats property_stats, uint64_t final_commit_timestamp,
+                                 std::span<std::optional<ReplicaStream>> streams);
   void AppendToWalDataDefinition(durability::StorageMetadataOperation operation,
                                  const std::optional<std::string> text_index_name, LabelId label,
-                                 uint64_t final_commit_timestamp);
+                                 uint64_t final_commit_timestamp, std::span<std::optional<ReplicaStream>> streams);
 
   uint64_t CommitTimestamp(std::optional<uint64_t> desired_commit_timestamp = {});
 

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -406,7 +406,7 @@ class InMemoryStorage final : public Storage {
   StorageInfo GetInfo(memgraph::replication_coordination_glue::ReplicationRole replication_role) override;
 
   /// Return true in all cases except if any sync replicas have not sent confirmation.
-  [[nodiscard]] bool AppendToWal(const Transaction &transaction, uint64_t final_commit_timestamp,
+  [[nodiscard]] bool AppendToWal(const Transaction &transaction, uint64_t durability_commit_timestamp,
                                  DatabaseAccessProtector db_acc);
   void AppendToWalDataDefinition(durability::StorageMetadataOperation operation, LabelId label,
                                  uint64_t final_commit_timestamp, std::span<std::optional<ReplicaStream>> streams);

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -429,7 +429,7 @@ class InMemoryStorage final : public Storage {
                                  const std::optional<std::string> text_index_name, LabelId label,
                                  uint64_t final_commit_timestamp, std::span<std::optional<ReplicaStream>> streams);
 
-  uint64_t CommitTimestamp(std::optional<uint64_t> desired_commit_timestamp = {});
+  uint64_t GetCommitTimestamp();
 
   void PrepareForNewEpoch() override;
 

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -193,7 +193,8 @@ auto ReplicationStorageClient::StartTransactionReplication(const uint64_t curren
                                                            DatabaseAccessProtector db_acc)
     -> std::optional<ReplicaStream> {
   auto locked_state = replica_state_.Lock();
-  spdlog::trace("Starting transaction replication for replica {} in state {}", client_.name_, StateToString());
+  spdlog::trace("Starting transaction replication for replica {} in state {}", client_.name_,
+                StateToString(*locked_state));
   std::optional<ReplicaStream> replica_stream;
   switch (*locked_state) {
     using enum replication::ReplicaState;
@@ -241,7 +242,8 @@ bool ReplicationStorageClient::FinalizeTransactionReplication(Storage *storage, 
   // valid during a single transaction replication (if the assumption
   // that this and other transaction replication functions can only be
   // called from a one thread stands)
-  spdlog::trace("Finalizing transaction on replica {} in state {}", client_.name_, StateToString());
+  spdlog::trace("Finalizing transaction on replica {} in state {}", client_.name_,
+                StateToString(*replica_state_.Lock()));
   if (State() != replication::ReplicaState::REPLICATING) {
     spdlog::trace("Skipping finalizing transaction on replica {} because it's not replicating", client_.name_);
     return false;

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -341,6 +341,7 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_commit, memgraph:
                     transaction_guard.unlock();
                     spdlog::debug("Sending current wal file to {}", client_.name_);
                     replica_commit = ReplicateCurrentWal(main_uuid, mem_storage, rpcClient, *mem_storage->wal_file_);
+                    spdlog::debug("Replica commit after replicating current wal: {}", replica_commit);
                   } else {
                     spdlog::debug("Cannot recover using current wal file {}", client_.name_);
                   }

--- a/src/storage/v2/replication/replication_client.hpp
+++ b/src/storage/v2/replication/replication_client.hpp
@@ -114,10 +114,8 @@ class ReplicationStorageClient {
 
   auto State() const -> replication::ReplicaState { return replica_state_.WithLock(std::identity()); }
 
-  auto StateToString() const -> std::string {
-    auto state = replica_state_.WithLock(std::identity());
-
-    switch (state) {
+  auto StateToString(replication::ReplicaState &replica_state) const -> std::string {
+    switch (replica_state) {
       case replication::ReplicaState::MAYBE_BEHIND:
         return "MAYBE_BEHIND";
       case replication::ReplicaState::READY:

--- a/src/storage/v2/replication/replication_client.hpp
+++ b/src/storage/v2/replication/replication_client.hpp
@@ -177,10 +177,8 @@ class ReplicationStorageClient {
     try {
       callback(*replica_stream);  // failure state what if not streaming (std::nullopt)
     } catch (const rpc::RpcFailedException &) {
-      replica_state_.WithLock([this, &replica_stream](auto &state) {
-        replica_stream.reset();
-        state = replication::ReplicaState::MAYBE_BEHIND;
-      });
+      replica_state_.WithLock(
+          [this, &replica_stream](auto &state) { state = replication::ReplicaState::MAYBE_BEHIND; });
       LogRpcFailure();
       return;
     }

--- a/src/storage/v2/replication/replication_client.hpp
+++ b/src/storage/v2/replication/replication_client.hpp
@@ -148,7 +148,10 @@ class ReplicationStorageClient {
     try {
       callback(*replica_stream_);  // failure state what if not streaming (std::nullopt)
     } catch (const rpc::RpcFailedException &) {
-      replica_state_.WithLock([](auto &state) { state = replication::ReplicaState::MAYBE_BEHIND; });
+      replica_state_.WithLock([this](auto &state) {
+        replica_stream_.reset();
+        state = replication::ReplicaState::MAYBE_BEHIND;
+      });
       LogRpcFailure();
       return;
     }

--- a/src/storage/v2/replication/replication_client.hpp
+++ b/src/storage/v2/replication/replication_client.hpp
@@ -104,6 +104,25 @@ class ReplicationStorageClient {
   auto Endpoint() const -> io::network::Endpoint const & { return client_.rpc_client_.Endpoint(); }
 
   auto State() const -> replication::ReplicaState { return replica_state_.WithLock(std::identity()); }
+
+  auto StateToString() const -> std::string {
+    auto state = replica_state_.WithLock(std::identity());
+
+    switch (state) {
+      case replication::ReplicaState::MAYBE_BEHIND:
+        return "MAYBE_BEHIND";
+      case replication::ReplicaState::READY:
+        return "READY";
+      case replication::ReplicaState::REPLICATING:
+        return "REPLICATING";
+      case replication::ReplicaState::RECOVERY:
+        return "RECOVERY";
+      case replication::ReplicaState::DIVERGED_FROM_MAIN:
+        return "DIVERGED_FROM_MAIN";
+      default:
+        return "Unknown ReplicaState";
+    }
+  }
   auto GetTimestampInfo(Storage const *storage) -> TimestampInfo;
 
   /**

--- a/src/storage/v2/replication/replication_client.hpp
+++ b/src/storage/v2/replication/replication_client.hpp
@@ -165,7 +165,7 @@ class ReplicationStorageClient {
       return;
     }
     if (!replica_stream || replica_stream->IsDefunct()) {
-      replica_state_.WithLock([this, &replica_stream](auto &state) {
+      replica_state_.WithLock([&replica_stream](auto &state) {
         replica_stream.reset();
         state = replication::ReplicaState::MAYBE_BEHIND;
       });
@@ -175,8 +175,7 @@ class ReplicationStorageClient {
     try {
       callback(*replica_stream);  // failure state what if not streaming (std::nullopt)
     } catch (const rpc::RpcFailedException &) {
-      replica_state_.WithLock(
-          [this, &replica_stream](auto &state) { state = replication::ReplicaState::MAYBE_BEHIND; });
+      replica_state_.WithLock([](auto &state) { state = replication::ReplicaState::MAYBE_BEHIND; });
       LogRpcFailure();
       return;
     }

--- a/src/storage/v2/replication/replication_storage_state.cpp
+++ b/src/storage/v2/replication/replication_storage_state.cpp
@@ -14,72 +14,95 @@
 #include "replication/replication_server.hpp"
 #include "storage/v2/replication/replication_client.hpp"
 
+#include <span>
+
 namespace memgraph::storage {
 
-void ReplicationStorageState::InitializeTransaction(uint64_t seq_num, Storage *storage,
-                                                    DatabaseAccessProtector db_acc) {
-  replication_clients_.WithLock([=, db_acc = std::move(db_acc)](auto &clients) mutable {
+auto ReplicationStorageState::InitializeTransaction(uint64_t seq_num, Storage *storage, DatabaseAccessProtector db_acc)
+    -> std::vector<std::optional<ReplicaStream>> {
+  std::vector<std::optional<ReplicaStream>> replica_streams;
+  replication_clients_.WithLock([&, db_acc = std::move(db_acc)](auto &clients) mutable {
     for (auto &client : clients) {
-      client->StartTransactionReplication(seq_num, storage, std::move(db_acc));
+      replica_streams.emplace_back(client->StartTransactionReplication(seq_num, storage, std::move(db_acc)));
+    }
+  });
+  return replica_streams;
+}
+
+void ReplicationStorageState::AppendDelta(const Delta &delta, const Vertex &vertex, uint64_t timestamp,
+                                          std::span<std::optional<ReplicaStream>> replica_streams) {
+  replication_clients_.WithLock([&](auto &clients) {
+    for (int i = 0; i < clients.size(); i++) {
+      auto &client = clients[i];
+      auto &replica_stream = replica_streams[i];
+      client->IfStreamingTransaction([&](auto &stream) { stream.AppendDelta(delta, vertex, timestamp); },
+                                     replica_stream);
     }
   });
 }
 
-void ReplicationStorageState::AppendDelta(const Delta &delta, const Vertex &vertex, uint64_t timestamp) {
+void ReplicationStorageState::AppendDelta(const Delta &delta, const Edge &edge, uint64_t timestamp,
+                                          std::span<std::optional<ReplicaStream>> replica_streams) {
   replication_clients_.WithLock([&](auto &clients) {
-    for (auto &client : clients) {
-      client->IfStreamingTransaction([&](auto &stream) { stream.AppendDelta(delta, vertex, timestamp); });
-    }
-  });
-}
-
-void ReplicationStorageState::AppendDelta(const Delta &delta, const Edge &edge, uint64_t timestamp) {
-  replication_clients_.WithLock([&](auto &clients) {
-    for (auto &client : clients) {
-      client->IfStreamingTransaction([&](auto &stream) { stream.AppendDelta(delta, edge, timestamp); });
+    for (int i = 0; i < clients.size(); i++) {
+      auto &client = clients[i];
+      auto &replica_stream = replica_streams[i];
+      client->IfStreamingTransaction([&](auto &stream) { stream.AppendDelta(delta, edge, timestamp); }, replica_stream);
     }
   });
 }
 void ReplicationStorageState::AppendOperation(durability::StorageMetadataOperation operation, LabelId label,
                                               const std::set<PropertyId> &properties, const LabelIndexStats &stats,
                                               const LabelPropertyIndexStats &property_stats,
-                                              uint64_t final_commit_timestamp) {
+                                              uint64_t final_commit_timestamp,
+                                              std::span<std::optional<ReplicaStream>> replica_streams) {
   replication_clients_.WithLock([&](auto &clients) {
-    for (auto &client : clients) {
-      client->IfStreamingTransaction([&](auto &stream) {
-        stream.AppendOperation(operation, label, properties, stats, property_stats, final_commit_timestamp);
-      });
+    for (int i = 0; i < clients.size(); i++) {
+      auto &client = clients[i];
+      auto &replica_stream = replica_streams[i];
+      client->IfStreamingTransaction(
+          [&](auto &stream) {
+            stream.AppendOperation(operation, label, properties, stats, property_stats, final_commit_timestamp);
+          },
+          replica_stream);
     }
   });
 }
 
 void ReplicationStorageState::AppendOperation(durability::StorageMetadataOperation operation, EdgeTypeId edge_type,
-                                              uint64_t final_commit_timestamp) {
+                                              uint64_t final_commit_timestamp,
+                                              std::span<std::optional<ReplicaStream>> replica_streams) {
   replication_clients_.WithLock([&](auto &clients) {
-    for (auto &client : clients) {
+    for (int i = 0; i < clients.size(); i++) {
+      auto &client = clients[i];
+      auto &replica_stream = replica_streams[i];
       client->IfStreamingTransaction(
-          [&](auto &stream) { stream.AppendOperation(operation, edge_type, final_commit_timestamp); });
+          [&](auto &stream) { stream.AppendOperation(operation, edge_type, final_commit_timestamp); }, replica_stream);
     }
   });
 }
 
-bool ReplicationStorageState::FinalizeTransaction(uint64_t timestamp, Storage *storage,
-                                                  DatabaseAccessProtector db_acc) {
-  return replication_clients_.WithLock([=, db_acc = std::move(db_acc)](auto &clients) mutable {
-    bool finalized_on_all_replicas = true;
-    MG_ASSERT(clients.empty() || db_acc.has_value(),
-              "Any clients assumes we are MAIN, we should have gatekeeper_access_wrapper so we can correctly "
-              "handle ASYNC tasks");
-    for (ReplicationClientPtr &client : clients) {
-      client->IfStreamingTransaction([&](auto &stream) { stream.AppendTransactionEnd(timestamp); });
-      const auto finalized = client->FinalizeTransactionReplication(storage, std::move(db_acc));
+bool ReplicationStorageState::FinalizeTransaction(uint64_t timestamp, Storage *storage, DatabaseAccessProtector db_acc,
+                                                  std::vector<std::optional<ReplicaStream>> replica_streams) {
+  return replication_clients_.WithLock(
+      [=, db_acc = std::move(db_acc), replica_streams = std::move(replica_streams)](auto &clients) mutable {
+        bool finalized_on_all_replicas = true;
+        MG_ASSERT(clients.empty() || db_acc.has_value(),
+                  "Any clients assumes we are MAIN, we should have gatekeeper_access_wrapper so we can correctly "
+                  "handle ASYNC tasks");
+        for (int i = 0; i < clients.size(); i++) {
+          auto &client = clients[i];
+          auto &replica_stream = replica_streams[i];
+          client->IfStreamingTransaction([&](auto &stream) { stream.AppendTransactionEnd(timestamp); }, replica_stream);
+          const auto finalized =
+              client->FinalizeTransactionReplication(storage, std::move(db_acc), std::move(replica_stream));
 
-      if (client->Mode() == replication_coordination_glue::ReplicationMode::SYNC) {
-        finalized_on_all_replicas = finalized && finalized_on_all_replicas;
-      }
-    }
-    return finalized_on_all_replicas;
-  });
+          if (client->Mode() == replication_coordination_glue::ReplicationMode::SYNC) {
+            finalized_on_all_replicas = finalized && finalized_on_all_replicas;
+          }
+        }
+        return finalized_on_all_replicas;
+      });
 }
 
 std::optional<replication::ReplicaState> ReplicationStorageState::GetReplicaState(std::string_view name) const {

--- a/src/storage/v2/replication/replication_storage_state.cpp
+++ b/src/storage/v2/replication/replication_storage_state.cpp
@@ -25,7 +25,7 @@ auto ReplicationStorageState::InitializeTransaction(uint64_t seq_num, Storage *s
   std::vector<std::optional<ReplicaStream>> replica_streams;
   replication_clients_.WithLock([&, db_accessor = std::move(db_acc)](auto &clients) mutable {
     for (auto &client : clients) {
-      replica_streams.emplace_back(client->StartTransactionReplication(seq_num, storage, std::move(db_accessor)));
+      replica_streams.emplace_back(client->StartTransactionReplication(seq_num, storage, db_accessor));
     }
   });
   return replica_streams;

--- a/src/storage/v2/replication/replication_storage_state.cpp
+++ b/src/storage/v2/replication/replication_storage_state.cpp
@@ -87,8 +87,7 @@ bool ReplicationStorageState::FinalizeTransaction(uint64_t timestamp, Storage *s
               "handle ASYNC tasks");
     for (auto &&[i, replica_stream] : ranges::views::enumerate(replica_streams)) {
       clients[i]->IfStreamingTransaction([&](auto &stream) { stream.AppendTransactionEnd(timestamp); }, replica_stream);
-      const auto finalized =
-          clients[i]->FinalizeTransactionReplication(storage, std::move(db_acc), std::move(replica_stream));
+      const auto finalized = clients[i]->FinalizeTransactionReplication(storage, db_acc, std::move(replica_stream));
 
       if (clients[i]->Mode() == replication_coordination_glue::ReplicationMode::SYNC) {
         finalized_on_all_replicas = finalized && finalized_on_all_replicas;

--- a/src/storage/v2/replication/replication_storage_state.hpp
+++ b/src/storage/v2/replication/replication_storage_state.hpp
@@ -32,23 +32,31 @@
 #include "storage/v2/replication/serialization.hpp"
 #include "utils/synchronized.hpp"
 
+#include <span>
+
 namespace memgraph::storage {
 
 class Storage;
 
 class ReplicationStorageClient;
+class ReplicaStream;
 
 struct ReplicationStorageState {
   // Only MAIN can send
-  void InitializeTransaction(uint64_t seq_num, Storage *storage, DatabaseAccessProtector db_acc);
-  void AppendDelta(const Delta &delta, const Vertex &vertex, uint64_t timestamp);
-  void AppendDelta(const Delta &delta, const Edge &edge, uint64_t timestamp);
+  auto InitializeTransaction(uint64_t seq_num, Storage *storage, DatabaseAccessProtector db_acc)
+      -> std::vector<std::optional<ReplicaStream>>;
+  void AppendDelta(const Delta &delta, const Vertex &vertex, uint64_t timestamp,
+                   std::span<std::optional<ReplicaStream>> replica_streams);
+  void AppendDelta(const Delta &delta, const Edge &edge, uint64_t timestamp,
+                   std::span<std::optional<ReplicaStream>> replica_streams);
   void AppendOperation(durability::StorageMetadataOperation operation, LabelId label,
                        const std::set<PropertyId> &properties, const LabelIndexStats &stats,
-                       const LabelPropertyIndexStats &property_stats, uint64_t final_commit_timestamp);
+                       const LabelPropertyIndexStats &property_stats, uint64_t final_commit_timestamp,
+                       std::span<std::optional<ReplicaStream>> replica_streams);
   void AppendOperation(durability::StorageMetadataOperation operation, EdgeTypeId edge_type,
-                       uint64_t final_commit_timestamp);
-  bool FinalizeTransaction(uint64_t timestamp, Storage *storage, DatabaseAccessProtector db_acc);
+                       uint64_t final_commit_timestamp, std::span<std::optional<ReplicaStream>> replica_streams);
+  bool FinalizeTransaction(uint64_t timestamp, Storage *storage, DatabaseAccessProtector db_acc,
+                           std::vector<std::optional<ReplicaStream>> replica_stream);
 
   // Getters
   auto GetReplicaState(std::string_view name) const -> std::optional<replication::ReplicaState>;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,20 +1,28 @@
-# benchmark test binaries
+add_subdirectory(benchmark)
 
 # macro_benchmark test binaries
+add_subdirectory(macro_benchmark)
 
 # stress test binaries
+add_subdirectory(stress)
 
 # concurrent test binaries
+add_subdirectory(concurrent)
 
 # manual test binaries
+add_subdirectory(manual)
 
 # unit test binaries
+add_subdirectory(unit)
 
 # property based test binaries
+add_subdirectory(property_based)
 
 # integration test binaries
+add_subdirectory(integration)
 
 # e2e test binaries
 add_subdirectory(e2e)
 
 # mgbench benchmark test binaries
+add_subdirectory(mgbench)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,29 +1,20 @@
 # benchmark test binaries
-add_subdirectory(benchmark)
 
 # macro_benchmark test binaries
-add_subdirectory(macro_benchmark)
 
 # stress test binaries
-add_subdirectory(stress)
 
 # concurrent test binaries
-add_subdirectory(concurrent)
 
 # manual test binaries
-add_subdirectory(manual)
 
 # unit test binaries
-add_subdirectory(unit)
 
 # property based test binaries
-add_subdirectory(property_based)
 
 # integration test binaries
-add_subdirectory(integration)
 
 # e2e test binaries
 add_subdirectory(e2e)
 
 # mgbench benchmark test binaries
-add_subdirectory(mgbench)


### PR DESCRIPTION
### Description

Jepsen found a few bugs in replication, this PR fixes two of them.

When the replica recovered completely, on the next txn replication, it expected `replica_stream_` to be already destroyed. There MG_ASSERT failed. Now, the replica stream is created as a local variable for transactions.

Another bug is related to the MVCC of the replica. Because REPLICA’s transaction timestamps are contingent on MAIN’s timestamps, resulting in the transaction timestamp counter (used for obtaining the start transaction ID, and commit timestamp ID) staying the same when the READ transaction started, MVCC guarantees were broken. Any time the WRITE transaction would commit before the READ transaction would finish, GC could incorrectly unlink deltas as the WRITE transaction would mark its start timestamp as finished, not knowing that the READ transaction is still in the system. This would result in the replica’s READ query reading two different data snapshots during a single transaction.

[master < Task] PR
- [ ] Provide the full content or a guide for the final git message
    - **Fix: MVCC design on replica and replica stream isolation**


### CI Testing Labels
Please select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - **[Release note text]**
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [ ] Tag someone from docs team in the comments
