### PR TITLE
Fix missing break statement in type conversion

### DIFF
--- a/src/query/procedure/mg_procedure_impl.cpp
+++ b/src/query/procedure/mg_procedure_impl.cpp
@@ -701,6 +701,7 @@ mgp_value::mgp_value(const memgraph::storage::PropertyValue &pv, memgraph::utils
           break;
         }
       }
+      break;
     }
     case memgraph::storage::PropertyValue::Type::ZonedTemporalData: {
       throw std::logic_error{"mgp_value for PropertyValue::Type::ZonedTemporalData doesn't exist."};


### PR DESCRIPTION
### Description

This PR fixes type conversion by adding a missing break statement.

[master < Task] PR
- [x] Provide the full content or a guide for the final git message
    > Fix missing break statement in type conversion


### CI Testing Labels
Please select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
- [x] Write a release note, including added/changed clauses ← N/A (docs unnecessary)
- [x] Link the documentation PR here ← N/A (docs unnecessary)
- [x] Tag someone from docs team in the comments ← N/A (docs unnecessary)
