### PR TITLE
Fix diff_setup.py behavior on merge_group event

### DIFF
--- a/tools/diff_setup.py
+++ b/tools/diff_setup.py
@@ -83,7 +83,7 @@ class DiffSetup:
         event_name = self._get_event_name()
         print(f"Event name: {event_name}")
         if event_name == "merge_group":
-            self._get_default_test_suite(True)
+            self._get_default_test_suite(self._check_diff_workflow())
         elif event_name == "pull_request":
             if self._check_diff_workflow():
                 self._setup_pull_request()


### PR DESCRIPTION
### Description

`tools/diff_setup.py` script runs all tests on `merge_group` event. Even when changes which don't modify the relevant codebase happen. This PR fixes that.


### CI Testing Labels
Please select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
