### PR TITLE
Set --replication-restore-state-at-startup to true by default

### DIFF
--- a/src/flags/replication.cpp
+++ b/src/flags/replication.cpp
@@ -11,9 +11,11 @@
 
 #include "replication.hpp"
 
+#include "gflags/gflags.h"
+
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_uint64(replication_replica_check_frequency_sec, 1,
               "The time duration between two replica checks/pings. If < 1, replicas will NOT be checked at all. NOTE: "
               "The MAIN instance allocates a new thread for each REPLICA.");
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_bool(replication_restore_state_on_startup, false, "Restore replication state on startup, e.g. recover replica");
+DEFINE_bool(replication_restore_state_on_startup, true, "Restore replication state on startup, e.g. recover replica");

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -224,8 +224,8 @@ startup_config_dict = {
     ),
     "init_data_file": ("", "", "Path to cypherl file that is used for creating data after server starts."),
     "replication_restore_state_on_startup": (
-        "false",
-        "false",
+        "true",
+        "true",
         "Restore replication state on startup, e.g. recover replica",
     ),
     "query_callable_mappings_path": (


### PR DESCRIPTION
### Description

Flag --replication_restore_state_on_startup is now by default set to true.

[master < Task] PR
- [x] Provide the full content or a guide for the final git message
    - **Set --replication-restore-state-at-startup to true by default**


### CI Testing Labels
Please select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [x] Write a release note, including added/changed clauses
    - **Flag --replication_restore_state_on_startup is now by default set to true.**
- [x] Link the documentation PR here
    - **https://github.com/memgraph/documentation/pull/762**
- [x] Tag someone from docs team in the comments
