### PR TITLE
Fix: ipv6 resolution in dns test

### DIFF
--- a/tests/unit/network_endpoint.cpp
+++ b/tests/unit/network_endpoint.cpp
@@ -48,16 +48,26 @@ TEST(Endpoint, DNSResolution) {
 
   // test constructor
   endpoint = endpoint_t("localhost", 12347);
-  EXPECT_EQ(endpoint.GetAddress(), "127.0.0.1");
-  EXPECT_EQ(endpoint.GetPort(), 12347);
-  EXPECT_EQ(endpoint.GetIpFamily(), endpoint_t::IpFamily::IP4);
+  if (endpoint.GetIpFamily() == endpoint_t::IpFamily::IP4) {
+    EXPECT_EQ(endpoint.GetAddress(), "127.0.0.1");
+    EXPECT_EQ(endpoint.GetPort(), 12347);
+    EXPECT_EQ(endpoint.GetIpFamily(), endpoint_t::IpFamily::IP4);
+  } else {
+    EXPECT_EQ(endpoint.GetAddress(), "::1");
+    EXPECT_EQ(endpoint.GetPort(), 12347);
+    EXPECT_EQ(endpoint.GetIpFamily(), endpoint_t::IpFamily::IP6);
+  }
 }
 
 TEST(Endpoint, DNSResolutiononParsing) {
   auto const maybe_endpoint = memgraph::io::network::Endpoint::ParseAndCreateSocketOrAddress("localhost:7687");
 
   ASSERT_EQ(maybe_endpoint.has_value(), true);
-  EXPECT_EQ(maybe_endpoint->GetAddress(), "127.0.0.1");
-  EXPECT_EQ(maybe_endpoint->GetPort(), 7687);
-  EXPECT_EQ(maybe_endpoint->GetIpFamily(), endpoint_t::IpFamily::IP4);
+  if (maybe_endpoint->GetIpFamily() == endpoint_t::IpFamily::IP4) {
+    EXPECT_EQ(maybe_endpoint->GetAddress(), "127.0.0.1");
+    EXPECT_EQ(maybe_endpoint->GetPort(), 7687);
+  } else {
+    EXPECT_EQ(maybe_endpoint->GetAddress(), "::1");
+    EXPECT_EQ(maybe_endpoint->GetPort(), 7687);
+  }
 }


### PR DESCRIPTION
### Description

Fixes DNS resolution to ipv6 in case of test. DNS can be resolved to ipv6 in case of localhost also

[master < Task] PR
- [ ] Provide the full content or a guide for the final git message
    - Fix DNS resolution to ipv6 in case of test


### CI Testing Labels
Please select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_


### Documentation checklist
- [ ] Add the documentation label tag
- [ ] Add the bug / feature label tag
- [ ] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - Not needed
- [ ] Link the documentation PR here
    - Not needed
- [ ] Tag someone from docs team in the comments
