### PR TITLE
Ci modify build types

### DIFF
--- a/.github/workflows/release_build_test.yaml
+++ b/.github/workflows/release_build_test.yaml
@@ -71,7 +71,7 @@ jobs:
       matrix:
         os: [amzn-2, centos-7, centos-9, debian-11, debian-12, fedora-38, fedora-39, rocky-9.3, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
         arch: [amd, arm]
-        build_type: [Release, RelWithDebInfo]
+        build_type: [Release]
         exclude: # Exclude unsupported combinations
           - os: amzn-2
             arch: arm

--- a/.github/workflows/release_build_test.yaml
+++ b/.github/workflows/release_build_test.yaml
@@ -109,6 +109,9 @@ jobs:
         os: [debian-12]
         arch: [amd, arm]
         build_type: [Release, RelWithDebInfo]
+        exclude:
+          - arch: arm
+            build_type: RelWithDebInfo
     uses: ./.github/workflows/reusable_package.yaml
     with:
       os: ${{ matrix.os }}


### PR DESCRIPTION
### Description

This PR removes `RelWithDebInfo` builds from CI.
- packages
- docker arm image


### CI Testing Labels
Please select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
