### PR TITLE
Fix NuRaft launcher race condition when creating raft server

### DIFF
--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -1174,5 +1174,7 @@ auto CoordinatorInstance::HasReplicaState(std::string_view instance_name) const 
 
 auto CoordinatorInstance::GetRoutingTable() const -> RoutingTable { return raft_state_->GetRoutingTable(); }
 
+auto CoordinatorInstance::IsLeader() const -> bool { return raft_state_->IsLeader(); }
+
 }  // namespace memgraph::coordination
 #endif

--- a/src/coordination/include/coordination/coordinator_instance.hpp
+++ b/src/coordination/include/coordination/coordinator_instance.hpp
@@ -80,6 +80,8 @@ class CoordinatorInstance {
 
   auto ForceResetClusterState() -> ForceResetClusterStateStatus;
 
+  auto IsLeader() const -> bool;
+
   void ShuttingDown();
 
  private:

--- a/src/coordination/include/coordination/raft_state.hpp
+++ b/src/coordination/include/coordination/raft_state.hpp
@@ -110,6 +110,7 @@ class RaftState {
 
   BecomeLeaderCb become_leader_cb_;
   BecomeFollowerCb become_follower_cb_;
+  std::atomic<bool> first_cb_executed_{false};
 };
 
 }  // namespace memgraph::coordination

--- a/src/coordination/include/coordination/raft_state.hpp
+++ b/src/coordination/include/coordination/raft_state.hpp
@@ -110,7 +110,6 @@ class RaftState {
 
   BecomeLeaderCb become_leader_cb_;
   BecomeFollowerCb become_follower_cb_;
-  std::atomic<bool> first_cb_executed_{false};
 };
 
 }  // namespace memgraph::coordination

--- a/src/coordination/include/coordination/raft_state.hpp
+++ b/src/coordination/include/coordination/raft_state.hpp
@@ -31,11 +31,16 @@ using BecomeLeaderCb = std::function<void()>;
 using BecomeFollowerCb = std::function<void()>;
 using RoutingTable = std::vector<std::pair<std::vector<std::string>, std::string>>;
 
+using nuraft::asio_service;
 using nuraft::buffer;
+using nuraft::context;
+using nuraft::delayed_task_scheduler;
 using nuraft::logger;
 using nuraft::ptr;
 using nuraft::raft_launcher;
 using nuraft::raft_server;
+using nuraft::rpc_client_factory;
+using nuraft::rpc_listener;
 using nuraft::srv_config;
 using nuraft::state_machine;
 using nuraft::state_mgr;
@@ -99,8 +104,9 @@ class RaftState {
   ptr<CoordinatorStateMachine> state_machine_;
   ptr<CoordinatorStateManager> state_manager_;
   ptr<logger> logger_;
-  raft_launcher launcher_;
   ptr<raft_server> raft_server_;
+  ptr<asio_service> asio_service_;
+  ptr<rpc_listener> asio_listener_;
 
   BecomeLeaderCb become_leader_cb_;
   BecomeFollowerCb become_follower_cb_;

--- a/src/coordination/raft_state.cpp
+++ b/src/coordination/raft_state.cpp
@@ -90,6 +90,7 @@ auto RaftState::InitRaftServer() -> void {
       become_follower_cb_();
       spdlog::trace("Node {} became follower", param->myId);
     }
+    first_cb_executed_ = true;
     return CbReturnCode::Ok;
   };
 
@@ -128,7 +129,7 @@ auto RaftState::InitRaftServer() -> void {
   // Don't return until role is set
   auto maybe_stop = utils::ResettableCounter<500>();
   while (!maybe_stop()) {
-    if (raft_server_->is_leader()) {
+    if (first_cb_executed_) {
       break;
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(10));

--- a/tests/unit/coordinator_instance.cpp
+++ b/tests/unit/coordinator_instance.cpp
@@ -73,8 +73,6 @@ TEST_F(CoordinatorInstanceTest, ConnectCoordinators) {
                                                           main_data_directory / "high_availability1" / "coordinator"};
 
   auto instance1 = CoordinatorInstance{init_config1};
-  while (!instance1.IsLeader()) {
-  }
 
   auto const init_config2 = CoordinatorInstanceInitConfig{coordinator_ids[1], coordinator_ports[1], bolt_ports[1],
                                                           main_data_directory / "high_availability2" / "coordinator"};

--- a/tests/unit/coordinator_instance.cpp
+++ b/tests/unit/coordinator_instance.cpp
@@ -73,6 +73,8 @@ TEST_F(CoordinatorInstanceTest, ConnectCoordinators) {
                                                           main_data_directory / "high_availability1" / "coordinator"};
 
   auto instance1 = CoordinatorInstance{init_config1};
+  while (!instance1.IsLeader()) {
+  }
 
   auto const init_config2 = CoordinatorInstanceInitConfig{coordinator_ids[1], coordinator_ports[1], bolt_ports[1],
                                                           main_data_directory / "high_availability2" / "coordinator"};


### PR DESCRIPTION
### Description

Fixes bug in NuRaft by removing raft_launcher and instead manually setting up raft_server, rpc_listener...
We consider raft server successfully created once it is behaving as a leader.

[master < Task] PR
- [x] Provide the full content or a guide for the final git message
    - **Fix NuRaft launcher race condition when creating raft server**


### CI Testing Labels
Please select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [x] Write a release note, including added/changed clauses
    - **Fix NuRaft launcher race condition when creating raft server**
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [x] Tag someone from docs team in the comments
