### PR TITLE
Improve HA networking

### DIFF
--- a/src/communication/http/server.hpp
+++ b/src/communication/http/server.hpp
@@ -67,7 +67,7 @@ Server<TRequestHandler, TSessionContext>::Server(io::network::Endpoint endpoint,
                                                  ServerContext *context)
     : listener_{Listener<TRequestHandler, TSessionContext>::Create(
           ioc_, session_context, context,
-          tcp::endpoint{boost::asio::ip::make_address(endpoint.GetAddress()), endpoint.GetPort()})} {}
+          tcp::endpoint{boost::asio::ip::make_address(endpoint.GetResolvedIPAddress()), endpoint.GetPort()})} {}
 
 template <class TRequestHandler, typename TSessionContext>
 void Server<TRequestHandler, TSessionContext>::Start() {

--- a/src/communication/websocket/server.hpp
+++ b/src/communication/websocket/server.hpp
@@ -29,8 +29,8 @@ class Server final {
  public:
   explicit Server(io::network::Endpoint endpoint, ServerContext *context, AuthenticationInterface &auth)
       : listener_{Listener::Create(
-            ioc_, context, tcp::endpoint{boost::asio::ip::make_address(endpoint.GetAddress()), endpoint.GetPort()},
-            auth)} {}
+            ioc_, context,
+            tcp::endpoint{boost::asio::ip::make_address(endpoint.GetResolvedIPAddress()), endpoint.GetPort()}, auth)} {}
 
   Server(const Server &) = delete;
   Server(Server &&) = delete;

--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -201,8 +201,8 @@ auto CoordinatorInstance::ShowInstances() const -> std::vector<InstanceStatus> {
   auto const coord_instance_to_status =
       [this, &stringify_coord_health](CoordinatorToCoordinatorConfig const &instance) -> InstanceStatus {
     return {.instance_name = fmt::format("coordinator_{}", instance.coordinator_id),
-            .coordinator_server = instance.coordinator_server.SocketAddress(),
-            .bolt_server = instance.bolt_server.SocketAddress(),
+            .coordinator_server = instance.coordinator_server.SocketAddress(),  // show non-resolved IP
+            .bolt_server = instance.bolt_server.SocketAddress(),                // show non-resolved IP
             .cluster_role = "coordinator",
             .health = stringify_coord_health(instance),
             .last_succ_resp_ms = raft_state_->CoordLastSuccRespMs(instance.coordinator_id).count()};
@@ -224,8 +224,8 @@ auto CoordinatorInstance::ShowInstances() const -> std::vector<InstanceStatus> {
     auto process_repl_instance_as_leader =
         [&stringify_repl_role, &stringify_repl_health](ReplicationInstanceConnector const &instance) -> InstanceStatus {
       return {.instance_name = instance.InstanceName(),
-              .management_server = instance.ManagementSocketAddress(),
-              .bolt_server = instance.BoltSocketAddress(),
+              .management_server = instance.ManagementSocketAddress(),  // show non-resolved IP
+              .bolt_server = instance.BoltSocketAddress(),              // show non-resolved IP
               .cluster_role = stringify_repl_role(instance),
               .health = stringify_repl_health(instance),
               .last_succ_resp_ms = instance.LastSuccRespMs().count()};
@@ -251,8 +251,8 @@ auto CoordinatorInstance::ShowInstances() const -> std::vector<InstanceStatus> {
     auto process_repl_instance_as_follower =
         [&stringify_inst_status](ReplicationInstanceState const &instance) -> InstanceStatus {
       return {.instance_name = instance.config.instance_name,
-              .management_server = instance.config.ManagementSocketAddress(),
-              .bolt_server = instance.config.BoltSocketAddress(),
+              .management_server = instance.config.ManagementSocketAddress(),  // show non-resolved IP
+              .bolt_server = instance.config.BoltSocketAddress(),              // show non-resolved IP
               .cluster_role = stringify_inst_status(instance),
               .health = "unknown"};
     };

--- a/src/coordination/coordinator_server.cpp
+++ b/src/coordination/coordinator_server.cpp
@@ -46,7 +46,7 @@ CoordinatorServer::CoordinatorServer(const ManagementServerConfig &config)
 CoordinatorServer::~CoordinatorServer() {
   if (rpc_server_.IsRunning()) {
     auto const &endpoint = rpc_server_.endpoint();
-    spdlog::trace("Closing coordinator server on {}:{}", endpoint.GetAddress(), endpoint.GetPort());
+    spdlog::trace("Closing coordinator server on {}:{}", endpoint.GetHostname(), endpoint.GetPort());
     rpc_server_.Shutdown();
   }
   rpc_server_.AwaitShutdown();

--- a/src/coordination/coordinator_server.cpp
+++ b/src/coordination/coordinator_server.cpp
@@ -46,7 +46,7 @@ CoordinatorServer::CoordinatorServer(const ManagementServerConfig &config)
 CoordinatorServer::~CoordinatorServer() {
   if (rpc_server_.IsRunning()) {
     auto const &endpoint = rpc_server_.endpoint();
-    spdlog::trace("Closing coordinator server on {}:{}", endpoint.GetHostname(), endpoint.GetPort());
+    spdlog::trace("Closing coordinator server on {}", endpoint.SocketAddress());
     rpc_server_.Shutdown();
   }
   rpc_server_.AwaitShutdown();

--- a/src/coordination/coordinator_state_manager.cpp
+++ b/src/coordination/coordinator_state_manager.cpp
@@ -40,7 +40,7 @@ CoordinatorStateManager::CoordinatorStateManager(CoordinatorInstanceInitConfig c
       CoordinatorToCoordinatorConfig{config.coordinator_id, io::network::Endpoint("0.0.0.0", config.bolt_port),
                                      io::network::Endpoint{"0.0.0.0", static_cast<uint16_t>(config.coordinator_port)}};
   my_srv_config_ = cs_new<srv_config>(config.coordinator_id, 0, c2c.coordinator_server.SocketAddress(),
-                                      nlohmann::json(c2c).dump(), false);
+                                      nlohmann::json(c2c).dump(), false);  // non-resolved IP in SocketAddress
 
   cluster_config_ = cs_new<cluster_config>();
   cluster_config_->get_servers().push_back(my_srv_config_);

--- a/src/coordination/include/coordination/coordinator_handlers.hpp
+++ b/src/coordination/include/coordination/coordinator_handlers.hpp
@@ -57,7 +57,8 @@ class CoordinatorHandlers {
           .name = repl_info_config.instance_name,
           .mode = repl_info_config.replication_mode,
           .ip_address = repl_info_config.replication_server
-                            .GetResolvedIPAddress(),  // when registering replica, we need to resolve IP
+                            .GetHostname(),  // when using ReplicationClientConfig in coordination, ip_address isn't
+                                             // necessarily an IP address, could be hostname = DNS entry.
           .port = repl_info_config.replication_server.GetPort(),
       };
     };

--- a/src/coordination/include/coordination/coordinator_handlers.hpp
+++ b/src/coordination/include/coordination/coordinator_handlers.hpp
@@ -57,8 +57,8 @@ class CoordinatorHandlers {
           .name = repl_info_config.instance_name,
           .mode = repl_info_config.replication_mode,
           .ip_address = repl_info_config.replication_server
-                            .GetHostname(),  // when using ReplicationClientConfig in coordination, ip_address isn't
-                                             // necessarily an IP address, could be hostname = DNS entry.
+                            .GetAddress(),  // when using ReplicationClientConfig in HA cluster, ip_address isn't
+                                            // necessarily an IP address, could be hostname = DNS entry.
           .port = repl_info_config.replication_server.GetPort(),
       };
     };

--- a/src/coordination/include/coordination/coordinator_handlers.hpp
+++ b/src/coordination/include/coordination/coordinator_handlers.hpp
@@ -56,7 +56,8 @@ class CoordinatorHandlers {
       return replication::ReplicationClientConfig{
           .name = repl_info_config.instance_name,
           .mode = repl_info_config.replication_mode,
-          .ip_address = repl_info_config.replication_server.GetAddress(),
+          .ip_address = repl_info_config.replication_server
+                            .GetResolvedIPAddress(),  // when registering replica, we need to resolve IP
           .port = repl_info_config.replication_server.GetPort(),
       };
     };

--- a/src/coordination/include/coordination/coordinator_slk.hpp
+++ b/src/coordination/include/coordination/coordinator_slk.hpp
@@ -23,15 +23,13 @@ namespace memgraph::slk {
 using ReplicationClientInfo = coordination::ReplicationClientInfo;
 
 inline void Save(io::network::Endpoint const &obj, Builder *builder) {
-  Save(obj.GetAddress(), builder);
+  Save(obj.GetHostname(), builder);
   Save(obj.GetPort(), builder);
-  Save(obj.GetIpFamily(), builder);
 }
 
 inline void Load(io::network::Endpoint *obj, Reader *reader) {
-  Load(&obj->GetAddress(), reader);
+  Load(&obj->GetHostname(), reader);
   Load(&obj->GetPort(), reader);
-  Load(&obj->GetIpFamily(), reader);
 }
 
 inline void Save(ReplicationClientInfo const &obj, Builder *builder) {

--- a/src/coordination/include/coordination/coordinator_slk.hpp
+++ b/src/coordination/include/coordination/coordinator_slk.hpp
@@ -23,12 +23,12 @@ namespace memgraph::slk {
 using ReplicationClientInfo = coordination::ReplicationClientInfo;
 
 inline void Save(io::network::Endpoint const &obj, Builder *builder) {
-  Save(obj.GetHostname(), builder);
+  Save(obj.GetAddress(), builder);
   Save(obj.GetPort(), builder);
 }
 
 inline void Load(io::network::Endpoint *obj, Reader *reader) {
-  Load(&obj->GetHostname(), reader);
+  Load(&obj->GetAddress(), reader);
   Load(&obj->GetPort(), reader);
 }
 

--- a/src/coordination/include/coordination/raft_state.hpp
+++ b/src/coordination/include/coordination/raft_state.hpp
@@ -98,7 +98,7 @@ class RaftState {
   auto CoordLastSuccRespMs(uint32_t srv_id) -> std::chrono::milliseconds;
 
  private:
-  io::network::Endpoint raft_endpoint_;
+  int coordinator_port_;
   uint32_t coordinator_id_;
 
   ptr<CoordinatorStateMachine> state_machine_;

--- a/src/coordination/raft_state.cpp
+++ b/src/coordination/raft_state.cpp
@@ -186,7 +186,7 @@ auto RaftState::RaftSocketAddress() const -> std::string {
 auto RaftState::AddCoordinatorInstance(CoordinatorToCoordinatorConfig const &config) -> void {
   spdlog::trace("Adding coordinator instance {} start in RaftState for coordinator_{}", config.coordinator_id,
                 coordinator_id_);
-  auto const endpoint = config.coordinator_server.SocketAddress();
+  auto const endpoint = config.coordinator_server.SocketAddress();  // non-resolved IP
   auto const aux = nlohmann::json(config).dump();
   srv_config const srv_config_to_add(static_cast<int>(config.coordinator_id), 0, endpoint, aux, false);
 
@@ -472,7 +472,7 @@ auto RaftState::GetRoutingTable() const -> RoutingTable {
   auto res = RoutingTable{};
 
   auto const repl_instance_to_bolt = [](ReplicationInstanceState const &instance) {
-    return instance.config.BoltSocketAddress();
+    return instance.config.BoltSocketAddress();  // non-resolved IP
   };
 
   // TODO: (andi) This is wrong check, Fico will correct in #1819.
@@ -501,7 +501,7 @@ auto RaftState::GetRoutingTable() const -> RoutingTable {
   }
 
   auto const coord_instance_to_bolt = [](CoordinatorToCoordinatorConfig const &instance) {
-    return instance.bolt_server.SocketAddress();
+    return instance.bolt_server.SocketAddress();  // non-resolved IP
   };
 
   auto const &raft_log_coord_instances = GetCoordinatorInstances();

--- a/src/io/network/addrinfo.cpp
+++ b/src/io/network/addrinfo.cpp
@@ -20,7 +20,7 @@ namespace memgraph::io::network {
 
 static_assert(std::forward_iterator<AddrInfo::Iterator> && std::equality_comparable<AddrInfo::Iterator>);
 
-AddrInfo::AddrInfo(const Endpoint &endpoint) : AddrInfo(endpoint.GetAddress(), endpoint.GetPort()) {}
+AddrInfo::AddrInfo(const Endpoint &endpoint) : AddrInfo(endpoint.GetResolvedIPAddress(), endpoint.GetPort()) {}
 
 AddrInfo::AddrInfo(const std::string &addr, uint16_t port) : info_{nullptr, nullptr} {
   addrinfo hints{

--- a/src/io/network/endpoint.cpp
+++ b/src/io/network/endpoint.cpp
@@ -174,7 +174,7 @@ void Endpoint::SetHostname(std::string const &hostname) { hostname_ = hostname; 
 void Endpoint::SetPort(uint16_t port) { port_ = port; }
 
 void to_json(nlohmann::json &j, Endpoint const &config) {
-  j = nlohmann::json{{"hostname", config.GetHostname()}, {"port", config.GetPort()}, {"family", config.GetIpFamily()}};
+  j = nlohmann::json{{"hostname", config.GetHostname()}, {"port", config.GetPort()}};
 }
 
 void from_json(nlohmann::json const &j, Endpoint &config) {

--- a/src/io/network/endpoint.hpp
+++ b/src/io/network/endpoint.hpp
@@ -24,7 +24,7 @@ namespace memgraph::io::network {
 class Endpoint {
  public:
   Endpoint() = default;
-  Endpoint(std::string hostname, uint16_t port);
+  Endpoint(std::string address, uint16_t port);
 
   Endpoint(Endpoint const &) = default;
   Endpoint(Endpoint &&) noexcept = default;
@@ -40,15 +40,15 @@ class Endpoint {
                                                                std::optional<uint16_t> default_port = {});
 
   // Returns hostname as specified by user. Could be FQDN (IP address) or DNS name.
-  [[nodiscard]] auto GetHostname() const -> std::string const &;
-  [[nodiscard]] auto GetHostname() -> std::string &;
+  [[nodiscard]] auto GetAddress() const -> std::string const &;
+  [[nodiscard]] auto GetAddress() -> std::string &;
   [[nodiscard]] auto GetPort() const -> uint16_t const &;
   [[nodiscard]] auto GetPort() -> uint16_t &;
 
   // Does resolution
   [[nodiscard]] auto GetIpFamily() const -> IpFamily;
 
-  void SetHostname(std::string const &hostname);
+  void SetAddress(std::string address);
   void SetPort(uint16_t port);
 
   // Returns hostname:port as specified by user. Could be FQDN (IP address) or DNS name.
@@ -69,7 +69,7 @@ class Endpoint {
 
   static auto ValidatePort(std::optional<uint16_t> port) -> bool;
 
-  std::string hostname_{};
+  std::string address_{};
   uint16_t port_{0};
 };
 

--- a/src/io/network/endpoint.hpp
+++ b/src/io/network/endpoint.hpp
@@ -24,7 +24,7 @@ namespace memgraph::io::network {
 class Endpoint {
  public:
   Endpoint() = default;
-  Endpoint(std::string const &ip_address, uint16_t port);
+  Endpoint(std::string hostname, uint16_t port);
 
   Endpoint(Endpoint const &) = default;
   Endpoint(Endpoint &&) noexcept = default;
@@ -39,14 +39,26 @@ class Endpoint {
   static std::optional<Endpoint> ParseAndCreateSocketOrAddress(std::string_view address,
                                                                std::optional<uint16_t> default_port = {});
 
-  [[nodiscard]] auto GetAddress() const -> std::string const &;
+  // Returns hostname as specified by user. Could be FQDN (IP address) or DNS name.
+  [[nodiscard]] auto GetHostname() const -> std::string const &;
+  [[nodiscard]] auto GetHostname() -> std::string &;
   [[nodiscard]] auto GetPort() const -> uint16_t const &;
-  [[nodiscard]] auto GetIpFamily() const -> IpFamily const &;
-  [[nodiscard]] auto GetAddress() -> std::string &;
   [[nodiscard]] auto GetPort() -> uint16_t &;
-  [[nodiscard]] auto GetIpFamily() -> IpFamily &;
 
+  // Does resolution
+  [[nodiscard]] auto GetIpFamily() const -> IpFamily;
+
+  void SetHostname(std::string const &hostname);
+  void SetPort(uint16_t port);
+
+  // Returns hostname:port as specified by user. Could be FQDN (IP address) or DNS name.
   [[nodiscard]] std::string SocketAddress() const;
+
+  // Returns IP address:port, after resolving the hostname.
+  [[nodiscard]] std::string GetResolvedSocketAddress() const;
+
+  // Returns IP address, after resolving the hostname.
+  [[nodiscard]] std::string GetResolvedIPAddress() const;
 
   bool operator==(const Endpoint &other) const = default;
   friend std::ostream &operator<<(std::ostream &os, const Endpoint &endpoint);
@@ -57,9 +69,8 @@ class Endpoint {
 
   static auto ValidatePort(std::optional<uint16_t> port) -> bool;
 
-  std::string address_;
+  std::string hostname_{};
   uint16_t port_{0};
-  IpFamily ip_family_{IpFamily::NONE};
 };
 
 void to_json(nlohmann::json &j, Endpoint const &config);

--- a/src/io/network/socket.cpp
+++ b/src/io/network/socket.cpp
@@ -115,7 +115,7 @@ bool Socket::Bind(const Endpoint &endpoint) {
     return false;
   }
 
-  endpoint_ = Endpoint(endpoint.GetAddress(), ntohs(portdata.sin6_port));
+  endpoint_ = Endpoint(endpoint.GetResolvedIPAddress(), ntohs(portdata.sin6_port));
 
   return true;
 }

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -339,13 +339,13 @@ class ReplQueryHandler {
     auto maybe_endpoint = io::network::Endpoint::ParseAndCreateSocketOrAddress(
         socket_address, memgraph::replication::kDefaultReplicationPort);
     if (maybe_endpoint) {
-      const auto replication_config =
-          replication::ReplicationClientConfig{.name = name,
-                                               .mode = repl_mode,
-                                               .ip_address = maybe_endpoint->GetResolvedIPAddress(),
-                                               .port = maybe_endpoint->GetPort(),
-                                               .replica_check_frequency = replica_check_frequency,
-                                               .ssl = std::nullopt};
+      const auto replication_config = replication::ReplicationClientConfig{
+          .name = name,
+          .mode = repl_mode,
+          .ip_address = maybe_endpoint->GetResolvedIPAddress(),  // TODO: (andi) Solve for replication
+          .port = maybe_endpoint->GetPort(),
+          .replica_check_frequency = replica_check_frequency,
+          .ssl = std::nullopt};
 
       const auto error = handler_->TryRegisterReplica(replication_config).HasError();
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -342,7 +342,7 @@ class ReplQueryHandler {
       const auto replication_config =
           replication::ReplicationClientConfig{.name = name,
                                                .mode = repl_mode,
-                                               .ip_address = std::move(maybe_endpoint->GetAddress()),
+                                               .ip_address = maybe_endpoint->GetResolvedIPAddress(),
                                                .port = maybe_endpoint->GetPort(),
                                                .replica_check_frequency = replica_check_frequency,
                                                .ssl = std::nullopt};

--- a/src/query/replication_query_handler.hpp
+++ b/src/query/replication_query_handler.hpp
@@ -66,7 +66,7 @@ struct ReplicasInfo {
       : name_(std::move(name)),
         socket_address_(std::move(socket_address)),
         sync_mode_(sync_mode),
-        system_info_(std::move(system_info)),
+        system_info_(system_info),
         data_info_(std::move(data_info)) {}
 
   std::string name_;

--- a/src/replication/replication_server.cpp
+++ b/src/replication/replication_server.cpp
@@ -43,7 +43,7 @@ ReplicationServer::ReplicationServer(const memgraph::replication::ReplicationSer
 ReplicationServer::~ReplicationServer() {
   if (rpc_server_.IsRunning()) {
     auto const &endpoint = rpc_server_.endpoint();
-    spdlog::trace("Closing replication server on {}:{}", endpoint.GetHostname(), endpoint.GetPort());
+    spdlog::trace("Closing replication server on {}", endpoint.SocketAddress());
     rpc_server_.Shutdown();
   }
   rpc_server_.AwaitShutdown();

--- a/src/replication/replication_server.cpp
+++ b/src/replication/replication_server.cpp
@@ -43,7 +43,7 @@ ReplicationServer::ReplicationServer(const memgraph::replication::ReplicationSer
 ReplicationServer::~ReplicationServer() {
   if (rpc_server_.IsRunning()) {
     auto const &endpoint = rpc_server_.endpoint();
-    spdlog::trace("Closing replication server on {}:{}", endpoint.GetAddress(), endpoint.GetPort());
+    spdlog::trace("Closing replication server on {}:{}", endpoint.GetHostname(), endpoint.GetPort());
     rpc_server_.Shutdown();
   }
   rpc_server_.AwaitShutdown();

--- a/src/replication/state.cpp
+++ b/src/replication/state.cpp
@@ -295,7 +295,7 @@ utils::BasicResult<RegisterReplicaError, ReplicationClient *> ReplicationState::
     auto endpoint_check = [&](auto const &replicas) {
       auto endpoint_matches = [&config](auto const &replica) {
         const auto &ep = replica.rpc_client_.Endpoint();
-        return ep.GetAddress() == config.ip_address && ep.GetPort() == config.port;
+        return ep.GetResolvedIPAddress() == config.ip_address && ep.GetPort() == config.port;
       };
       return std::any_of(replicas.begin(), replicas.end(), endpoint_matches);
     };

--- a/src/replication_handler/replication_handler.cpp
+++ b/src/replication_handler/replication_handler.cpp
@@ -134,7 +134,7 @@ void StartReplicaClient(replication::ReplicationClient &client, dbms::DbmsHandle
 #endif
   // No client error, start instance level client
   auto const &endpoint = client.rpc_client_.Endpoint();
-  spdlog::trace("Replication client started at: {}", endpoint.SocketAddress());
+  spdlog::trace("Replication client started at: {}", endpoint.SocketAddress());  // non-resolved IP
   client.StartFrequentCheck([&, license = license::global_license_checker.IsEnterpriseValidFast(), main_uuid](
                                 bool reconnect, replication::ReplicationClient &client) mutable {
     if (client.try_set_uuid && replication_coordination_glue::SendSwapMainUUIDRpc(client.rpc_client_, main_uuid)) {

--- a/tests/e2e/replication/common.hpp
+++ b/tests/e2e/replication/common.hpp
@@ -46,7 +46,7 @@ auto ParseDatabaseEndpoints(const std::string &database_endpoints_str) {
 
 auto Connect(const memgraph::io::network::Endpoint &database_endpoint) {
   mg::Client::Params params;
-  params.host = database_endpoint.GetAddress();
+  params.host = database_endpoint.GetResolvedIPAddress();
   params.port = database_endpoint.GetPort();
   params.use_ssl = FLAGS_use_ssl;
   auto client = mg::Client::Connect(params);

--- a/tests/e2e/replication/indices.cpp
+++ b/tests/e2e/replication/indices.cpp
@@ -106,8 +106,8 @@ int main(int argc, char **argv) {
         client->Execute("ANALYZE GRAPH DELETE STATISTICS;");
         const auto data = client->FetchAll();
         if (data->size() != 4) {
-          LOG_FATAL("Not all statistics were replicated! Failed endpoint {}:{}", database_endpoint.GetAddress(),
-                    database_endpoint.GetPort());
+          LOG_FATAL("Not all statistics were replicated! Failed endpoint {}:{}",
+                    database_endpoint.GetResolvedIPAddress(), database_endpoint.GetPort());
         }
         check_delete_stats(data, 0, "Node");
         check_delete_stats(data, 1, "Node2");
@@ -135,8 +135,8 @@ int main(int argc, char **argv) {
       if (const auto data = client->FetchAll()) {
         // Hacky way to determine if the statistics were replicated
         if (data->size() != 0) {
-          LOG_FATAL("Not all statistics were replicated! Failed endpoint {}:{}", database_endpoint.GetAddress(),
-                    database_endpoint.GetPort());
+          LOG_FATAL("Not all statistics were replicated! Failed endpoint {}:{}",
+                    database_endpoint.GetResolvedIPAddress(), database_endpoint.GetPort());
         }
       } else {
         LOG_FATAL("Unable to delete statistics from {}", database_endpoints[i]);

--- a/tests/unit/network_endpoint.cpp
+++ b/tests/unit/network_endpoint.cpp
@@ -22,7 +22,7 @@ TEST(Endpoint, IPv4) {
 
   // test constructor
   endpoint = endpoint_t("127.0.0.1", 12347);
-  EXPECT_EQ(endpoint.GetHostname(), "127.0.0.1");
+  EXPECT_EQ(endpoint.GetAddress(), "127.0.0.1");
   EXPECT_EQ(endpoint.GetPort(), 12347);
   EXPECT_EQ(endpoint.GetIpFamily(), endpoint_t::IpFamily::IP4);
 }
@@ -32,7 +32,7 @@ TEST(Endpoint, IPv6) {
 
   // test constructor
   endpoint = endpoint_t("ab:cd:ef::3", 12347);
-  EXPECT_EQ(endpoint.GetHostname(), "ab:cd:ef::3");
+  EXPECT_EQ(endpoint.GetAddress(), "ab:cd:ef::3");
   EXPECT_EQ(endpoint.GetPort(), 12347);
   EXPECT_EQ(endpoint.GetIpFamily(), endpoint_t::IpFamily::IP6);
 }

--- a/tests/unit/network_endpoint.cpp
+++ b/tests/unit/network_endpoint.cpp
@@ -22,12 +22,9 @@ TEST(Endpoint, IPv4) {
 
   // test constructor
   endpoint = endpoint_t("127.0.0.1", 12347);
-  EXPECT_EQ(endpoint.GetAddress(), "127.0.0.1");
+  EXPECT_EQ(endpoint.GetHostname(), "127.0.0.1");
   EXPECT_EQ(endpoint.GetPort(), 12347);
   EXPECT_EQ(endpoint.GetIpFamily(), endpoint_t::IpFamily::IP4);
-
-  // test address invalid
-  EXPECT_THROW(endpoint_t("invalid", 12345), memgraph::io::network::NetworkError);
 }
 
 TEST(Endpoint, IPv6) {
@@ -35,12 +32,9 @@ TEST(Endpoint, IPv6) {
 
   // test constructor
   endpoint = endpoint_t("ab:cd:ef::3", 12347);
-  EXPECT_EQ(endpoint.GetAddress(), "ab:cd:ef::3");
+  EXPECT_EQ(endpoint.GetHostname(), "ab:cd:ef::3");
   EXPECT_EQ(endpoint.GetPort(), 12347);
   EXPECT_EQ(endpoint.GetIpFamily(), endpoint_t::IpFamily::IP6);
-
-  // test address invalid
-  EXPECT_THROW(endpoint_t("::g", 12345), memgraph::io::network::NetworkError);
 }
 
 TEST(Endpoint, DNSResolution) {
@@ -49,11 +43,11 @@ TEST(Endpoint, DNSResolution) {
   // test constructor
   endpoint = endpoint_t("localhost", 12347);
   if (endpoint.GetIpFamily() == endpoint_t::IpFamily::IP4) {
-    EXPECT_EQ(endpoint.GetAddress(), "127.0.0.1");
+    EXPECT_EQ(endpoint.GetResolvedIPAddress(), "127.0.0.1");
     EXPECT_EQ(endpoint.GetPort(), 12347);
     EXPECT_EQ(endpoint.GetIpFamily(), endpoint_t::IpFamily::IP4);
   } else {
-    EXPECT_EQ(endpoint.GetAddress(), "::1");
+    EXPECT_EQ(endpoint.GetResolvedIPAddress(), "::1");
     EXPECT_EQ(endpoint.GetPort(), 12347);
     EXPECT_EQ(endpoint.GetIpFamily(), endpoint_t::IpFamily::IP6);
   }
@@ -64,10 +58,10 @@ TEST(Endpoint, DNSResolutiononParsing) {
 
   ASSERT_EQ(maybe_endpoint.has_value(), true);
   if (maybe_endpoint->GetIpFamily() == endpoint_t::IpFamily::IP4) {
-    EXPECT_EQ(maybe_endpoint->GetAddress(), "127.0.0.1");
+    EXPECT_EQ(maybe_endpoint->GetResolvedIPAddress(), "127.0.0.1");
     EXPECT_EQ(maybe_endpoint->GetPort(), 7687);
   } else {
-    EXPECT_EQ(maybe_endpoint->GetAddress(), "::1");
+    EXPECT_EQ(maybe_endpoint->GetResolvedIPAddress(), "::1");
     EXPECT_EQ(maybe_endpoint->GetPort(), 7687);
   }
 }

--- a/tests/unit/storage_v2_replication.cpp
+++ b/tests/unit/storage_v2_replication.cpp
@@ -1020,10 +1020,10 @@ TEST_F(ReplicationTest, RestoringReplicationAtStartupAfterDroppingReplica) {
 
   ASSERT_EQ(replica_infos.size(), 2);
   ASSERT_EQ(replica_infos[0].name, replicas[0]);
-  ASSERT_EQ(replica_infos[0].endpoint.GetAddress(), local_host);
+  ASSERT_EQ(replica_infos[0].endpoint.GetResolvedIPAddress(), local_host);
   ASSERT_EQ(replica_infos[0].endpoint.GetPort(), ports[0]);
   ASSERT_EQ(replica_infos[1].name, replicas[1]);
-  ASSERT_EQ(replica_infos[1].endpoint.GetAddress(), local_host);
+  ASSERT_EQ(replica_infos[1].endpoint.GetResolvedIPAddress(), local_host);
   ASSERT_EQ(replica_infos[1].endpoint.GetPort(), ports[1]);
 
   main.reset();
@@ -1033,10 +1033,10 @@ TEST_F(ReplicationTest, RestoringReplicationAtStartupAfterDroppingReplica) {
   replica_infos = other_main.db.storage()->ReplicasInfo();
   ASSERT_EQ(replica_infos.size(), 2);
   ASSERT_EQ(replica_infos[0].name, replicas[0]);
-  ASSERT_EQ(replica_infos[0].endpoint.GetAddress(), local_host);
+  ASSERT_EQ(replica_infos[0].endpoint.GetResolvedIPAddress(), local_host);
   ASSERT_EQ(replica_infos[0].endpoint.GetPort(), ports[0]);
   ASSERT_EQ(replica_infos[1].name, replicas[1]);
-  ASSERT_EQ(replica_infos[1].endpoint.GetAddress(), local_host);
+  ASSERT_EQ(replica_infos[1].endpoint.GetResolvedIPAddress(), local_host);
   ASSERT_EQ(replica_infos[1].endpoint.GetPort(), ports[1]);
 }
 
@@ -1081,10 +1081,10 @@ TEST_F(ReplicationTest, RestoringReplicationAtStartup) {
 
   ASSERT_EQ(replica_infos.size(), 2);
   ASSERT_EQ(replica_infos[0].name, replicas[0]);
-  ASSERT_EQ(replica_infos[0].endpoint.GetAddress(), local_host);
+  ASSERT_EQ(replica_infos[0].endpoint.GetResolvedIPAddress(), local_host);
   ASSERT_EQ(replica_infos[0].endpoint.GetPort(), ports[0]);
   ASSERT_EQ(replica_infos[1].name, replicas[1]);
-  ASSERT_EQ(replica_infos[1].endpoint.GetAddress(), local_host);
+  ASSERT_EQ(replica_infos[1].endpoint.GetResolvedIPAddress(), local_host);
   ASSERT_EQ(replica_infos[1].endpoint.GetPort(), ports[1]);
 
   auto handler = main->repl_handler;
@@ -1094,7 +1094,7 @@ TEST_F(ReplicationTest, RestoringReplicationAtStartup) {
   replica_infos = main->db.storage()->ReplicasInfo();
   ASSERT_EQ(replica_infos.size(), 1);
   ASSERT_EQ(replica_infos[0].name, replicas[1]);
-  ASSERT_EQ(replica_infos[0].endpoint.GetAddress(), local_host);
+  ASSERT_EQ(replica_infos[0].endpoint.GetResolvedIPAddress(), local_host);
   ASSERT_EQ(replica_infos[0].endpoint.GetPort(), ports[1]);
 
   main.reset();
@@ -1104,7 +1104,7 @@ TEST_F(ReplicationTest, RestoringReplicationAtStartup) {
   replica_infos = other_main.db.storage()->ReplicasInfo();
   ASSERT_EQ(replica_infos.size(), 1);
   ASSERT_EQ(replica_infos[0].name, replicas[1]);
-  ASSERT_EQ(replica_infos[0].endpoint.GetAddress(), local_host);
+  ASSERT_EQ(replica_infos[0].endpoint.GetResolvedIPAddress(), local_host);
   ASSERT_EQ(replica_infos[0].endpoint.GetPort(), ports[1]);
 }
 


### PR DESCRIPTION
### Description

`SHOW INSTANCES` now returns non-resolved IP address = DNS entry.
DNS can be used when adding coordinator instance.
You can use DNS for registering instances, DNS is resolved to IP every time when connecting sockets. Socket is connected when streaming data using RPC communication.
Replication is untouched and will be handled separately.

Output in Kubernetes cluster:
![image](https://github.com/memgraph/memgraph/assets/53269502/3b0da3c8-fd5d-436b-8bab-ca8b14ac623f)

[master < Task] PR
- [x] Provide the full content or a guide for the final git message
    - **Improve HA networking**

### CI Testing Labels
Please select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [x] Write a release note, including added/changed clauses
    - **`SHOW INSTANCES` now returns non-resolved IP addresses when using DNS in HA cluster.**
    - **In HA cluster, `DNS` is being resolved every time when streaming data using RPC connections. This means that Kubernetes Pod can get restarted without any consequences on Memgraph connections.**
    - **IPFamily isn't persisted anymore as part of the `Endpoint` class**. -> @kgolubic this could be breaking not sure
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [x] Tag someone from docs team in the comments
