### PR TITLE
Fix arm packaging by running as root

### DIFF
--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -393,7 +393,7 @@ package_memgraph() {
       docker exec -u root "$build_container" bash -c "apt update"
       package_command=" cpack -G DEB --config ../CPackConfig.cmake "
   fi
-  docker exec -u mg "$build_container" bash -c "mkdir -p $container_output_dir && cd $container_output_dir && $ACTIVATE_TOOLCHAIN && $package_command"
+  docker exec -u root "$build_container" bash -c "mkdir -p $container_output_dir && cd $container_output_dir && $ACTIVATE_TOOLCHAIN && $package_command"
 }
 
 package_docker() {


### PR DESCRIPTION
### Description

This PR fixes permission issues when packaging memgraph by running the process as `root`.
[Example](https://github.com/memgraph/memgraph/actions/runs/9158067144/job/25212873759#step:8:45)

### CI Testing Labels
Please select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
