### PR TITLE
Refresh Jepsen cluster -> Memgraph build

### DIFF
--- a/.github/workflows/diff_jepsen.yaml
+++ b/.github/workflows/diff_jepsen.yaml
@@ -34,6 +34,11 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Refresh Jepsen Cluster
+        run: |
+          cd tests/jepsen
+          ./run.sh cluster-refresh --nodes-no 6
+
       - name: Spin up mgbuild container
         run: |
           ./release/package/mgbuild.sh \
@@ -58,11 +63,6 @@ jobs:
           --os $OS \
           --arch $ARCH \
           copy --binary --dest-dir build
-
-      - name: Refresh Jepsen Cluster
-        run: |
-          cd tests/jepsen
-          ./run.sh cluster-refresh --nodes-no 6
 
       - name: Run unit tests for Jepsen code
         run: |


### PR DESCRIPTION
### Description

Refreshing Jepsen cluster can fail because of GitHub issues, move it earlier so we don't have to build Memgraph before.

[master < Task] PR
- [x] Provide the full content or a guide for the final git message
    - **Refresh Jepsen cluster before building Memgraph**


### CI Testing Labels
Please select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - **[Release note text]**
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [x] Tag someone from docs team in the comments
