### PR TITLE
Add NuRaft logs

### DIFF
--- a/src/coordination/CMakeLists.txt
+++ b/src/coordination/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(mg-coordination
         include/nuraft/coordinator_log_store.hpp
         include/nuraft/coordinator_state_machine.hpp
         include/nuraft/coordinator_state_manager.hpp
+        include/nuraft/logger.hpp
 
         PRIVATE
         coordinator_communication_config.cpp
@@ -37,6 +38,7 @@ target_sources(mg-coordination
         coordinator_state_machine.cpp
         coordinator_state_manager.cpp
         coordinator_cluster_state.cpp
+        logger.cpp
 )
 target_include_directories(mg-coordination PUBLIC include)
 

--- a/src/coordination/CMakeLists.txt
+++ b/src/coordination/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(mg-coordination
         include/nuraft/coordinator_state_machine.hpp
         include/nuraft/coordinator_state_manager.hpp
         include/nuraft/logger.hpp
+        include/nuraft/logger_wrapper.hpp
 
         PRIVATE
         coordinator_communication_config.cpp
@@ -39,6 +40,7 @@ target_sources(mg-coordination
         coordinator_state_manager.cpp
         coordinator_cluster_state.cpp
         logger.cpp
+        logger_wrapper.cpp
 )
 target_include_directories(mg-coordination PUBLIC include)
 

--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -247,7 +247,6 @@ auto CoordinatorInstance::ShowInstances() const -> std::vector<InstanceStatus> {
       return "replica";
     };
 
-    // TODO: (andi) Add capability that followers can also return socket addresses
     auto process_repl_instance_as_follower =
         [&stringify_inst_status](ReplicationInstanceState const &instance) -> InstanceStatus {
       return {.instance_name = instance.config.instance_name,

--- a/src/coordination/coordinator_log_store.cpp
+++ b/src/coordination/coordinator_log_store.cpp
@@ -54,8 +54,8 @@ uint64_t CoordinatorLogStore::start_index() const { return start_idx_; }
 ptr<log_entry> CoordinatorLogStore::last_entry() const {
   auto lock = std::lock_guard{logs_lock_};
 
-  uint64_t const last_idx = start_idx_ + logs_.size() - 1;
-  auto const last_src = FindOrDefault_(last_idx - 1);
+  uint64_t const next_slot = start_idx_ + logs_.size() - 1;
+  auto const last_src = FindOrDefault_(next_slot - 1);
 
   return MakeClone(last_src);
 }

--- a/src/coordination/coordinator_state_machine.cpp
+++ b/src/coordination/coordinator_state_machine.cpp
@@ -12,13 +12,14 @@
 #ifdef MG_ENTERPRISE
 
 #include "nuraft/coordinator_state_machine.hpp"
-#include "utils/logging.hpp"
 
 namespace {
 constexpr int MAX_SNAPSHOTS = 3;
 }  // namespace
 
 namespace memgraph::coordination {
+
+CoordinatorStateMachine::CoordinatorStateMachine(ptr<logger> logger) : logger_(std::move(logger)) {}
 
 auto CoordinatorStateMachine::MainExists() const -> bool { return cluster_state_.MainExists(); }
 
@@ -107,7 +108,8 @@ auto CoordinatorStateMachine::DecodeLog(buffer &data) -> std::pair<TRaftLog, Raf
 auto CoordinatorStateMachine::pre_commit(ulong const /*log_idx*/, buffer & /*data*/) -> ptr<buffer> { return nullptr; }
 
 auto CoordinatorStateMachine::commit(ulong const log_idx, buffer &data) -> ptr<buffer> {
-  spdlog::debug("Commit: log_idx={}, data.size()={}", log_idx, data.size());
+  logger_->put_details(6, __FILE__, __FUNCTION__, __LINE__,
+                       fmt::format("Commit: log_idx={}, data.size()={}", log_idx, data.size()));
   auto const [parsed_data, log_action] = DecodeLog(data);
   cluster_state_.DoAction(parsed_data, log_action);
   last_committed_idx_ = log_idx;
@@ -120,18 +122,20 @@ auto CoordinatorStateMachine::commit(ulong const log_idx, buffer &data) -> ptr<b
 }
 
 auto CoordinatorStateMachine::commit_config(ulong const log_idx, ptr<cluster_config> & /*new_conf*/) -> void {
+  logger_->put_details(6, __FILE__, __FUNCTION__, __LINE__, fmt::format("Commit config: log_idx={}", log_idx));
   last_committed_idx_ = log_idx;
-  spdlog::debug("Commit config: log_idx={}", log_idx);
 }
 
 auto CoordinatorStateMachine::rollback(ulong const log_idx, buffer &data) -> void {
   // NOTE: Nothing since we don't do anything in pre_commit
-  spdlog::debug("Rollback: log_idx={}, data.size()={}", log_idx, data.size());
+  logger_->put_details(6, __FILE__, __FUNCTION__, __LINE__,
+                       fmt::format("Rollback: log_idx={}, data.size()={}", log_idx, data.size()));
 }
 
 auto CoordinatorStateMachine::read_logical_snp_obj(snapshot &snapshot, void *& /*user_snp_ctx*/, ulong obj_id,
                                                    ptr<buffer> &data_out, bool &is_last_obj) -> int {
-  spdlog::debug("read logical snapshot object, obj_id: {}", obj_id);
+  logger_->put_details(6, __FILE__, __FUNCTION__, __LINE__,
+                       fmt::format("Read logical snapshot object, obj_id: {}", obj_id));
 
   ptr<SnapshotCtx> ctx = nullptr;
   {
@@ -162,8 +166,9 @@ auto CoordinatorStateMachine::read_logical_snp_obj(snapshot &snapshot, void *& /
 
 auto CoordinatorStateMachine::save_logical_snp_obj(snapshot &snapshot, ulong &obj_id, buffer &data, bool is_first_obj,
                                                    bool is_last_obj) -> void {
-  spdlog::debug("save logical snapshot object, obj_id: {}, is_first_obj: {}, is_last_obj: {}", obj_id, is_first_obj,
-                is_last_obj);
+  logger_->put_details(6, __FILE__, __FUNCTION__, __LINE__,
+                       fmt::format("Save logical snapshot object, obj_id: {}, is_first_obj: {}, is_last_obj: {}",
+                                   obj_id, is_first_obj, is_last_obj));
 
   if (obj_id == 0) {
     ptr<buffer> snp_buf = snapshot.serialize();
@@ -182,7 +187,8 @@ auto CoordinatorStateMachine::save_logical_snp_obj(snapshot &snapshot, ulong &ob
 
 auto CoordinatorStateMachine::apply_snapshot(snapshot &s) -> bool {
   auto ll = std::lock_guard{snapshots_lock_};
-  spdlog::debug("apply snapshot, last_log_idx: {}", s.get_last_log_idx());
+  logger_->put_details(6, __FILE__, __FUNCTION__, __LINE__,
+                       fmt::format("Apply snapshot, last_log_idx: {}", s.get_last_log_idx()));
 
   auto entry = snapshots_.find(s.get_last_log_idx());
   if (entry == snapshots_.end()) return false;
@@ -195,10 +201,10 @@ auto CoordinatorStateMachine::free_user_snp_ctx(void *&user_snp_ctx) -> void {}
 
 auto CoordinatorStateMachine::last_snapshot() -> ptr<snapshot> {
   auto ll = std::lock_guard{snapshots_lock_};
-  spdlog::debug("Getting last snapshot from state machine.");
+  logger_->put_details(6, __FILE__, __FUNCTION__, __LINE__, "Getting last snapshot from state machine.");
   auto entry = snapshots_.rbegin();
   if (entry == snapshots_.rend()) {
-    spdlog::debug("There is no snapshot.");
+    logger_->put_details(6, __FILE__, __FUNCTION__, __LINE__, "There is no snapshot.");
     return nullptr;
   }
 
@@ -207,12 +213,13 @@ auto CoordinatorStateMachine::last_snapshot() -> ptr<snapshot> {
 }
 
 auto CoordinatorStateMachine::last_commit_index() -> ulong {
-  spdlog::trace("Last committed index from state machine {}", last_committed_idx_);
+  logger_->put_details(6, __FILE__, __FUNCTION__, __LINE__, "Getting last committed index from state machine.");
   return last_committed_idx_;
 }
 
 auto CoordinatorStateMachine::create_snapshot(snapshot &s, async_result<bool>::handler_type &when_done) -> void {
-  spdlog::debug("create_snapshot, last_log_idx: {}", s.get_last_log_idx());
+  logger_->put_details(6, __FILE__, __FUNCTION__, __LINE__,
+                       fmt::format("Create snapshot, last_log_idx: {}", s.get_last_log_idx()));
   ptr<buffer> snp_buf = s.serialize();
   ptr<snapshot> ss = snapshot::deserialize(*snp_buf);
   create_snapshot_internal(ss);
@@ -224,7 +231,8 @@ auto CoordinatorStateMachine::create_snapshot(snapshot &s, async_result<bool>::h
 
 auto CoordinatorStateMachine::create_snapshot_internal(ptr<snapshot> snapshot) -> void {
   auto ll = std::lock_guard{snapshots_lock_};
-  spdlog::debug("create_snapshot_internal, last_log_idx: {}", snapshot->get_last_log_idx());
+  logger_->put_details(6, __FILE__, __FUNCTION__, __LINE__,
+                       fmt::format("Create snapshot internal, last_log_idx: {}", snapshot->get_last_log_idx()));
 
   auto ctx = cs_new<SnapshotCtx>(snapshot, cluster_state_);
   snapshots_[snapshot->get_last_log_idx()] = ctx;

--- a/src/coordination/include/coordination/coordinator_communication_config.hpp
+++ b/src/coordination/include/coordination/coordinator_communication_config.hpp
@@ -41,13 +41,17 @@ struct CoordinatorInstanceInitConfig {
   int coordinator_port{0};
   int bolt_port{0};
   std::filesystem::path durability_dir;
+  std::string nuraft_log_file;
 
+  // If nuraft_log_file isn't provided, spdlog::logger for NuRaft will still get created but withot sinks effectively
+  // then being a no-op logger.
   explicit CoordinatorInstanceInitConfig(uint32_t coordinator_id, int coordinator_port, int bolt_port,
-                                         std::filesystem::path durability_dir)
+                                         std::filesystem::path durability_dir, std::string nuraft_log_file = "")
       : coordinator_id(coordinator_id),
         coordinator_port(coordinator_port),
         bolt_port(bolt_port),
-        durability_dir(std::move(durability_dir)) {
+        durability_dir(std::move(durability_dir)),
+        nuraft_log_file(std::move(nuraft_log_file)) {
     MG_ASSERT(!this->durability_dir.empty(), "Path empty");
   }
 };

--- a/src/coordination/include/coordination/raft_state.hpp
+++ b/src/coordination/include/coordination/raft_state.hpp
@@ -19,7 +19,9 @@
 #include "io/network/endpoint.hpp"
 #include "nuraft/coordinator_state_machine.hpp"
 #include "nuraft/coordinator_state_manager.hpp"
+#include "nuraft/logger.hpp"
 
+#include <libnuraft/logger.hxx>
 #include <libnuraft/nuraft.hxx>
 
 namespace memgraph::coordination {
@@ -101,12 +103,12 @@ class RaftState {
   int coordinator_port_;
   uint32_t coordinator_id_;
 
-  ptr<CoordinatorStateMachine> state_machine_;
-  ptr<CoordinatorStateManager> state_manager_;
   ptr<logger> logger_;
   ptr<raft_server> raft_server_;
   ptr<asio_service> asio_service_;
   ptr<rpc_listener> asio_listener_;
+  ptr<CoordinatorStateMachine> state_machine_;
+  ptr<CoordinatorStateManager> state_manager_;
 
   BecomeLeaderCb become_leader_cb_;
   BecomeFollowerCb become_follower_cb_;

--- a/src/coordination/include/coordination/raft_state.hpp
+++ b/src/coordination/include/coordination/raft_state.hpp
@@ -19,7 +19,6 @@
 #include "io/network/endpoint.hpp"
 #include "nuraft/coordinator_state_machine.hpp"
 #include "nuraft/coordinator_state_manager.hpp"
-#include "nuraft/logger.hpp"
 
 #include <libnuraft/logger.hxx>
 #include <libnuraft/nuraft.hxx>

--- a/src/coordination/include/nuraft/coordinator_state_machine.hpp
+++ b/src/coordination/include/nuraft/coordinator_state_machine.hpp
@@ -18,7 +18,11 @@
 #include "nuraft/raft_log_action.hpp"
 
 #include <spdlog/spdlog.h>
+// clang-format off
+// First import nuraft.hxx then logger.hxx to avoid problem with __interface_body__
 #include <libnuraft/nuraft.hxx>
+#include <libnuraft/logger.hxx>
+// clang-format on
 
 #include <variant>
 
@@ -29,13 +33,14 @@ using nuraft::buffer;
 using nuraft::buffer_serializer;
 using nuraft::cluster_config;
 using nuraft::int32;
+using nuraft::logger;
 using nuraft::ptr;
 using nuraft::snapshot;
 using nuraft::state_machine;
 
 class CoordinatorStateMachine : public state_machine {
  public:
-  CoordinatorStateMachine() = default;
+  explicit CoordinatorStateMachine(ptr<logger> logger);
   CoordinatorStateMachine(CoordinatorStateMachine const &) = delete;
   CoordinatorStateMachine &operator=(CoordinatorStateMachine const &) = delete;
   CoordinatorStateMachine(CoordinatorStateMachine &&) = delete;
@@ -111,6 +116,7 @@ class CoordinatorStateMachine : public state_machine {
   std::map<uint64_t, ptr<SnapshotCtx>> snapshots_;
   std::mutex snapshots_lock_;
 
+  ptr<logger> logger_;
   ptr<snapshot> last_snapshot_;
   std::mutex last_snapshot_lock_;
 };

--- a/src/coordination/include/nuraft/coordinator_state_machine.hpp
+++ b/src/coordination/include/nuraft/coordinator_state_machine.hpp
@@ -15,14 +15,10 @@
 
 #include "coordination/coordinator_communication_config.hpp"
 #include "nuraft/coordinator_cluster_state.hpp"
+#include "nuraft/logger_wrapper.hpp"
 #include "nuraft/raft_log_action.hpp"
 
 #include <spdlog/spdlog.h>
-// clang-format off
-// First import nuraft.hxx then logger.hxx to avoid problem with __interface_body__
-#include <libnuraft/nuraft.hxx>
-#include <libnuraft/logger.hxx>
-// clang-format on
 
 #include <variant>
 
@@ -40,7 +36,7 @@ using nuraft::state_machine;
 
 class CoordinatorStateMachine : public state_machine {
  public:
-  explicit CoordinatorStateMachine(ptr<logger> logger);
+  explicit CoordinatorStateMachine(LoggerWrapper logger);
   CoordinatorStateMachine(CoordinatorStateMachine const &) = delete;
   CoordinatorStateMachine &operator=(CoordinatorStateMachine const &) = delete;
   CoordinatorStateMachine(CoordinatorStateMachine &&) = delete;
@@ -116,7 +112,7 @@ class CoordinatorStateMachine : public state_machine {
   std::map<uint64_t, ptr<SnapshotCtx>> snapshots_;
   std::mutex snapshots_lock_;
 
-  ptr<logger> logger_;
+  LoggerWrapper logger_;
   ptr<snapshot> last_snapshot_;
   std::mutex last_snapshot_lock_;
 };

--- a/src/coordination/include/nuraft/coordinator_state_manager.hpp
+++ b/src/coordination/include/nuraft/coordinator_state_manager.hpp
@@ -18,19 +18,24 @@
 #include "nuraft/coordinator_log_store.hpp"
 
 #include <spdlog/spdlog.h>
+// clang-format off
+// First import nuraft.hxx then logger.hxx to avoid problem with __interface_body__
 #include <libnuraft/nuraft.hxx>
+#include <libnuraft/logger.hxx>
+// clang-format on
 
 namespace memgraph::coordination {
 
 using nuraft::cluster_config;
 using nuraft::cs_new;
+using nuraft::logger;
 using nuraft::srv_config;
 using nuraft::srv_state;
 using nuraft::state_mgr;
 
 class CoordinatorStateManager : public state_mgr {
  public:
-  explicit CoordinatorStateManager(CoordinatorInstanceInitConfig const &config);
+  explicit CoordinatorStateManager(CoordinatorInstanceInitConfig const &config, ptr<logger> logger);
 
   CoordinatorStateManager(CoordinatorStateManager const &) = delete;
   CoordinatorStateManager &operator=(CoordinatorStateManager const &) = delete;
@@ -58,6 +63,7 @@ class CoordinatorStateManager : public state_mgr {
  private:
   int my_id_;
   ptr<CoordinatorLogStore> cur_log_store_;
+  ptr<logger> logger_;
   ptr<srv_config> my_srv_config_;
   ptr<cluster_config> cluster_config_;
   ptr<srv_state> saved_state_;

--- a/src/coordination/include/nuraft/coordinator_state_manager.hpp
+++ b/src/coordination/include/nuraft/coordinator_state_manager.hpp
@@ -16,13 +16,9 @@
 #include "coordination/coordinator_communication_config.hpp"
 #include "kvstore/kvstore.hpp"
 #include "nuraft/coordinator_log_store.hpp"
+#include "nuraft/logger_wrapper.hpp"
 
 #include <spdlog/spdlog.h>
-// clang-format off
-// First import nuraft.hxx then logger.hxx to avoid problem with __interface_body__
-#include <libnuraft/nuraft.hxx>
-#include <libnuraft/logger.hxx>
-// clang-format on
 
 namespace memgraph::coordination {
 
@@ -35,7 +31,7 @@ using nuraft::state_mgr;
 
 class CoordinatorStateManager : public state_mgr {
  public:
-  explicit CoordinatorStateManager(CoordinatorInstanceInitConfig const &config, ptr<logger> logger);
+  explicit CoordinatorStateManager(CoordinatorInstanceInitConfig const &config, LoggerWrapper logger);
 
   CoordinatorStateManager(CoordinatorStateManager const &) = delete;
   CoordinatorStateManager &operator=(CoordinatorStateManager const &) = delete;
@@ -63,7 +59,7 @@ class CoordinatorStateManager : public state_mgr {
  private:
   int my_id_;
   ptr<CoordinatorLogStore> cur_log_store_;
-  ptr<logger> logger_;
+  LoggerWrapper logger_;
   ptr<srv_config> my_srv_config_;
   ptr<cluster_config> cluster_config_;
   ptr<srv_state> saved_state_;

--- a/src/coordination/include/nuraft/log_level.hpp
+++ b/src/coordination/include/nuraft/log_level.hpp
@@ -1,0 +1,34 @@
+// Copyright 2024 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#ifdef MG_ENTERPRISE
+
+#include <cstdint>
+
+namespace memgraph::coordination {
+
+/**
+ NuRaft log level:
+ *    Trace:    6
+ *    Debug:    5
+ *    Info:     4
+ *    Warning:  3
+ *    Error:    2
+ *    Fatal:    1
+ */
+
+enum class nuraft_log_level : uint8_t { FATAL = 1, ERROR = 2, WARNING = 3, INFO = 4, DEBUG = 5, TRACE = 6 };
+
+}  // namespace memgraph::coordination
+
+#endif

--- a/src/coordination/include/nuraft/logger.hpp
+++ b/src/coordination/include/nuraft/logger.hpp
@@ -1,0 +1,80 @@
+// Copyright 2024 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#ifdef MG_ENTERPRISE
+
+#include <string>
+
+#include <spdlog/common.h>
+#include <spdlog/sinks/daily_file_sink.h>
+#include <spdlog/spdlog.h>
+// clang-format off
+// First import nuraft.hxx then logger.hxx to avoid problem with __interface_body__
+#include <libnuraft/nuraft.hxx>
+#include <libnuraft/logger.hxx>
+// clang-format on
+
+namespace memgraph::coordination {
+
+using nuraft::logger;
+
+class Logger final : public logger {
+ public:
+  explicit Logger(std::string log_file);
+
+  Logger(const Logger &) = delete;
+  Logger &operator=(const Logger &) = delete;
+  Logger(Logger &&) = delete;
+  Logger &operator=(Logger &&) = delete;
+
+  ~Logger() override;
+
+  // Deprecated
+  void debug(const std::string &log_line) override;
+
+  // Deprecated
+  void info(const std::string &log_line) override;
+
+  // Deprecated
+  void warn(const std::string &log_line) override;
+
+  // Deprecated
+  void err(const std::string &log_line) override;
+
+  void put_details(int level, const char *source_file, const char *func_name, size_t line_number,
+                   const std::string &log_line) override;
+
+  // Map from NuRaft log level to Spdlog log level.
+  void set_level(int l) override;
+
+  // Map from spdlog log level to NuRaft log level.
+  int get_level() override;
+
+ private:
+  /**
+   NuRaft log level:
+   *    Trace:    6
+   *    Debug:    5
+   *    Info:     4
+   *    Warning:  3
+   *    Error:    2
+   *    Fatal:    1
+   */
+  static spdlog::level::level_enum GetSpdlogLevel(int nuraft_log_level);
+
+  std::shared_ptr<spdlog::logger> logger_;
+};
+
+}  // namespace memgraph::coordination
+
+#endif

--- a/src/coordination/include/nuraft/logger.hpp
+++ b/src/coordination/include/nuraft/logger.hpp
@@ -13,11 +13,12 @@
 
 #ifdef MG_ENTERPRISE
 
-#include <string>
+#include "nuraft/log_level.hpp"
 
 #include <spdlog/common.h>
 #include <spdlog/sinks/daily_file_sink.h>
 #include <spdlog/spdlog.h>
+#include <string>
 // clang-format off
 // First import nuraft.hxx then logger.hxx to avoid problem with __interface_body__
 #include <libnuraft/nuraft.hxx>
@@ -28,6 +29,10 @@ namespace memgraph::coordination {
 
 using nuraft::logger;
 
+/**
+ * Logger class that wraps the spdlog logger. NuRaft uses directly this object. However, devs should use @LoggerWrapper
+ * to log messages.
+ */
 class Logger final : public logger {
  public:
   explicit Logger(std::string log_file);
@@ -55,22 +60,16 @@ class Logger final : public logger {
                    const std::string &log_line) override;
 
   // Map from NuRaft log level to Spdlog log level.
+  // Not intended to be used, implementation provided if necessary
   void set_level(int l) override;
 
   // Map from spdlog log level to NuRaft log level.
+  // Not intended to be used, implementation provided if necessary
   int get_level() override;
 
  private:
-  /**
-   NuRaft log level:
-   *    Trace:    6
-   *    Debug:    5
-   *    Info:     4
-   *    Warning:  3
-   *    Error:    2
-   *    Fatal:    1
-   */
   static spdlog::level::level_enum GetSpdlogLevel(int nuraft_log_level);
+  static nuraft_log_level GetNuRaftLevel(spdlog::level::level_enum spdlog_level);
 
   std::shared_ptr<spdlog::logger> logger_;
 };

--- a/src/coordination/include/nuraft/logger_wrapper.hpp
+++ b/src/coordination/include/nuraft/logger_wrapper.hpp
@@ -1,0 +1,39 @@
+// Copyright 2024 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#ifdef MG_ENTERPRISE
+
+#include "nuraft/log_level.hpp"
+#include "nuraft/logger.hpp"
+
+#include <source_location>
+#include <string>
+
+namespace memgraph::coordination {
+
+class LoggerWrapper {
+ public:
+  explicit LoggerWrapper(Logger *logger);
+
+  void Log(nuraft_log_level level, std::string const &log_line,
+           std::source_location location = std::source_location::current());
+
+ private:
+  Logger *logger_;
+};
+
+static_assert(std::is_trivially_copyable_v<LoggerWrapper>, "LoggerWrapper must be trivially copyable");
+
+}  // namespace memgraph::coordination
+
+#endif

--- a/src/coordination/logger.cpp
+++ b/src/coordination/logger.cpp
@@ -1,0 +1,104 @@
+// Copyright 2024 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#ifdef MG_ENTERPRISE
+
+#include "nuraft/logger.hpp"
+
+namespace {
+constexpr int log_retention_count = 35;
+
+}  // namespace
+
+namespace memgraph::coordination {
+
+Logger::Logger(std::string log_file) {
+  time_t current_time{0};
+  struct tm *local_time{nullptr};
+
+  // TODO: (andi) I think not needed
+  time(&current_time);  // NOLINT
+  local_time = localtime(&current_time);
+
+  auto const sinks = {std::make_shared<spdlog::sinks::daily_file_sink_mt>(
+      std::move(log_file), local_time->tm_hour, local_time->tm_min, false, log_retention_count)};
+  logger_ = std::make_shared<spdlog::logger>("NuRaft", sinks.begin(), sinks.end());
+  logger_->set_level(spdlog::level::trace);
+  logger_->flush_on(spdlog::level::trace);
+}
+
+Logger::~Logger() {
+  logger_->flush();
+  logger_.reset();
+  logger_ = nullptr;
+}
+
+void Logger::debug(const std::string &log_line) { logger_->log(spdlog::level::debug, log_line); }
+void Logger::info(const std::string &log_line) { logger_->log(spdlog::level::info, log_line); }
+void Logger::warn(const std::string &log_line) { logger_->log(spdlog::level::warn, log_line); }
+void Logger::err(const std::string &log_line) { logger_->log(spdlog::level::err, log_line); }
+
+void Logger::put_details(int level, const char *source_file, const char *func_name, size_t line_number,
+                         const std::string &log_line) {
+  logger_->log(spdlog::source_loc{source_file, static_cast<int>(line_number), func_name}, GetSpdlogLevel(level),
+               log_line);
+}
+
+void Logger::set_level(int l) { logger_->set_level(GetSpdlogLevel(l)); }
+
+int Logger::get_level() {
+  auto const level = logger_->level();
+  if (level == spdlog::level::trace) {
+    return 6;
+  }
+  if (level == spdlog::level::debug) {
+    return 5;
+  }
+  if (level == spdlog::level::info) {
+    return 4;
+  }
+  if (level == spdlog::level::warn) {
+    return 3;
+  }
+  if (level == spdlog::level::err) {
+    return 2;
+  }
+  if (level == spdlog::level::critical) {  // critical=fatal
+    return 1;
+  }
+
+  return 0;
+}
+
+spdlog::level::level_enum Logger::GetSpdlogLevel(int nuraft_log_level) {
+  switch (nuraft_log_level) {
+    case 6:
+      return spdlog::level::trace;
+    case 5:
+      return spdlog::level::debug;
+    case 4:
+      return spdlog::level::info;
+    case 3:
+      return spdlog::level::warn;
+    case 2:
+      return spdlog::level::err;
+    case 1:
+      return spdlog::level::critical;  // critical=fatal
+    default:
+      return spdlog::level::trace;
+  }
+}
+
+}  // namespace memgraph::coordination
+
+#endif

--- a/src/coordination/logger.cpp
+++ b/src/coordination/logger.cpp
@@ -36,6 +36,7 @@ Logger::Logger(std::string log_file) {
   logger_ = std::make_shared<spdlog::logger>("NuRaft", sinks.begin(), sinks.end());
   logger_->set_level(spdlog::level::trace);
   logger_->flush_on(spdlog::level::trace);
+  set_level(static_cast<int>(nuraft_log_level::TRACE));
 }
 
 Logger::~Logger() {
@@ -58,45 +59,47 @@ void Logger::put_details(int level, const char *source_file, const char *func_na
 void Logger::set_level(int l) { logger_->set_level(GetSpdlogLevel(l)); }
 
 int Logger::get_level() {
-  auto const level = logger_->level();
-  if (level == spdlog::level::trace) {
-    return 6;
-  }
-  if (level == spdlog::level::debug) {
-    return 5;
-  }
-  if (level == spdlog::level::info) {
-    return 4;
-  }
-  if (level == spdlog::level::warn) {
-    return 3;
-  }
-  if (level == spdlog::level::err) {
-    return 2;
-  }
-  if (level == spdlog::level::critical) {  // critical=fatal
-    return 1;
-  }
-
-  return 0;
+  auto const nuraft_log_level = GetNuRaftLevel(logger_->level());
+  return static_cast<int>(nuraft_log_level);
 }
 
 spdlog::level::level_enum Logger::GetSpdlogLevel(int nuraft_log_level) {
-  switch (nuraft_log_level) {
-    case 6:
+  auto const nuraft_level = static_cast<enum nuraft_log_level>(nuraft_log_level);
+
+  switch (nuraft_level) {
+    case nuraft_log_level::TRACE:
       return spdlog::level::trace;
-    case 5:
+    case nuraft_log_level::DEBUG:
       return spdlog::level::debug;
-    case 4:
+    case nuraft_log_level::INFO:
       return spdlog::level::info;
-    case 3:
+    case nuraft_log_level::WARNING:
       return spdlog::level::warn;
-    case 2:
+    case nuraft_log_level::ERROR:
       return spdlog::level::err;
-    case 1:
+    case nuraft_log_level::FATAL:
       return spdlog::level::critical;  // critical=fatal
     default:
       return spdlog::level::trace;
+  }
+}
+
+nuraft_log_level Logger::GetNuRaftLevel(spdlog::level::level_enum spdlog_level) {
+  switch (spdlog_level) {
+    case spdlog::level::trace:
+      return nuraft_log_level::TRACE;
+    case spdlog::level::debug:
+      return nuraft_log_level::DEBUG;
+    case spdlog::level::info:
+      return nuraft_log_level::INFO;
+    case spdlog::level::warn:
+      return nuraft_log_level::WARNING;
+    case spdlog::level::err:
+      return nuraft_log_level::ERROR;
+    case spdlog::level::critical:  // critical=fatal
+      return nuraft_log_level::FATAL;
+    default:
+      return nuraft_log_level::TRACE;
   }
 }
 

--- a/src/coordination/logger_wrapper.cpp
+++ b/src/coordination/logger_wrapper.cpp
@@ -1,0 +1,27 @@
+// Copyright 2024 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#ifdef MG_ENTERPRISE
+
+#include "nuraft/logger_wrapper.hpp"
+
+namespace memgraph::coordination {
+
+LoggerWrapper::LoggerWrapper(Logger *logger) : logger_(logger) {}
+
+void LoggerWrapper::Log(nuraft_log_level level, std::string const &log_line, std::source_location location) {
+  logger_->put_details(static_cast<int>(level), location.file_name(), location.function_name(), location.line(),
+                       log_line);
+}
+
+}  // namespace memgraph::coordination
+
+#endif

--- a/src/coordination/raft_state.cpp
+++ b/src/coordination/raft_state.cpp
@@ -44,9 +44,9 @@ RaftState::RaftState(CoordinatorInstanceInitConfig const &config, BecomeLeaderCb
                      BecomeFollowerCb become_follower_cb)
     : coordinator_port_(config.coordinator_port),
       coordinator_id_(config.coordinator_id),
-      state_machine_(cs_new<CoordinatorStateMachine>()),
-      state_manager_(cs_new<CoordinatorStateManager>(config)),
-      logger_(nullptr),
+      logger_(cs_new<Logger>(fmt::format("/home/andi/Memgraph/logs/nuraft/coordinator_{}.log", coordinator_id_))),
+      state_machine_(cs_new<CoordinatorStateMachine>(logger_)),
+      state_manager_(cs_new<CoordinatorStateManager>(config, logger_)),
       become_leader_cb_(std::move(become_leader_cb)),
       become_follower_cb_(std::move(become_follower_cb)) {}
 

--- a/src/coordination/raft_state.cpp
+++ b/src/coordination/raft_state.cpp
@@ -44,7 +44,7 @@ RaftState::RaftState(CoordinatorInstanceInitConfig const &config, BecomeLeaderCb
                      BecomeFollowerCb become_follower_cb)
     : coordinator_port_(config.coordinator_port),
       coordinator_id_(config.coordinator_id),
-      logger_(cs_new<Logger>(fmt::format("/home/andi/Memgraph/logs/nuraft/coordinator_{}.log", coordinator_id_))),
+      logger_(cs_new<Logger>(config.nuraft_log_file)),
       state_machine_(cs_new<CoordinatorStateMachine>(logger_)),
       state_manager_(cs_new<CoordinatorStateManager>(config, logger_)),
       become_leader_cb_(std::move(become_leader_cb)),

--- a/src/coordination/raft_state.cpp
+++ b/src/coordination/raft_state.cpp
@@ -23,6 +23,7 @@
 #include "coordination/coordinator_communication_config.hpp"
 #include "coordination/coordinator_exceptions.hpp"
 #include "coordination/raft_state.hpp"
+#include "nuraft/logger_wrapper.hpp"
 #include "utils/counter.hpp"
 #include "utils/logging.hpp"
 
@@ -45,8 +46,8 @@ RaftState::RaftState(CoordinatorInstanceInitConfig const &config, BecomeLeaderCb
     : coordinator_port_(config.coordinator_port),
       coordinator_id_(config.coordinator_id),
       logger_(cs_new<Logger>(config.nuraft_log_file)),
-      state_machine_(cs_new<CoordinatorStateMachine>(logger_)),
-      state_manager_(cs_new<CoordinatorStateManager>(config, logger_)),
+      state_machine_(cs_new<CoordinatorStateMachine>(LoggerWrapper(static_cast<Logger *>(logger_.get())))),
+      state_manager_(cs_new<CoordinatorStateManager>(config, LoggerWrapper(static_cast<Logger *>(logger_.get())))),
       become_leader_cb_(std::move(become_leader_cb)),
       become_follower_cb_(std::move(become_follower_cb)) {}
 

--- a/src/flags/coordination.cpp
+++ b/src/flags/coordination.cpp
@@ -30,4 +30,6 @@ DEFINE_uint32(instance_down_timeout_sec, 5, "Time duration after which an instan
 DEFINE_uint32(instance_health_check_frequency_sec, 1, "The time duration between two health checks/pings.");
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_uint32(instance_get_uuid_frequency_sec, 10, "The time duration between two instance uuid checks.");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_string(nuraft_log_file, "", "Path to the file where NuRaft logs are saved.");
 #endif

--- a/src/flags/coordination.hpp
+++ b/src/flags/coordination.hpp
@@ -26,4 +26,6 @@ DECLARE_uint32(instance_down_timeout_sec);
 DECLARE_uint32(instance_health_check_frequency_sec);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_uint32(instance_get_uuid_frequency_sec);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DECLARE_string(nuraft_log_file);
 #endif

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -511,7 +511,7 @@ int main(int argc, char **argv) {
       memgraph::utils::EnsureDirOrDie(high_availability_data_dir);
       coordinator_state.emplace(CoordinatorInstanceInitConfig{coordination_setup.coordinator_id,
                                                               coordination_setup.coordinator_port, extracted_bolt_port,
-                                                              high_availability_data_dir});
+                                                              high_availability_data_dir, FLAGS_nuraft_log_file});
     } else {
       coordinator_state.emplace(ReplicationInstanceInitConfig{.management_port = coordination_setup.management_port});
     }

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -82,6 +82,7 @@ startup_config_dict = {
         "List of default Kafka brokers as a comma separated list of broker host or host:port.",
     ),
     "log_file": ("", "", "Path to where the log should be stored."),
+    "nuraft_log_file": ("", "", "Path to the file where NuRaft logs are saved."),
     "log_level": (
         "WARNING",
         "TRACE",

--- a/tests/unit/coordinator_state_manager.cpp
+++ b/tests/unit/coordinator_state_manager.cpp
@@ -53,9 +53,10 @@ class CoordinatorStateManagerTest : public ::testing::Test {
 TEST_F(CoordinatorStateManagerTest, SingleCoord) {
   CoordinatorInstanceInitConfig config{1, 12345, 9090, test_folder_ / "high_availability" / "coordination"};
   using memgraph::coordination::Logger;
-  using nuraft::logger;
+  using memgraph::coordination::LoggerWrapper;
 
-  ptr<logger> my_logger = cs_new<Logger>("");
+  Logger logger("");
+  LoggerWrapper my_logger(&logger);
 
   ptr<cluster_config> old_config;
   {
@@ -81,8 +82,10 @@ TEST_F(CoordinatorStateManagerTest, MultipleCoords) {
   CoordinatorInstanceInitConfig config{0, 12345, 9090, test_folder_ / "high_availability" / "coordination"};
 
   using memgraph::coordination::Logger;
-  using nuraft::logger;
-  ptr<logger> my_logger = cs_new<Logger>("");
+  using memgraph::coordination::LoggerWrapper;
+
+  Logger logger("");
+  LoggerWrapper my_logger(&logger);
 
   {
     ptr<CoordinatorStateManager> state_manager_ = cs_new<CoordinatorStateManager>(config, my_logger);


### PR DESCRIPTION
### Description

- Added logger object for NuRaft logs which serves as adapter between spdlog and NuRaft logger :heavy_check_mark: 
- Logger object is shared between state machine, state manager and raft server :heavy_check_mark: 
- Existing logs from state machine and state manager are moved under this new logger :heavy_check_mark: 
- `CoordinatorInstanceInitConfig` extended with `nuraft_log_file` :heavy_check_mark: 
   - if arg not provided, logger will still be created but without any sinks, effectively creating no-op logger :heavy_check_mark: 
- Added `nuraft_log_file` flag :heavy_check_mark: 

### Logs examples
```
[2024-05-31 13:43:06.386] [NuRaft] [info] [asio_service.cxx:771] Raft ASIO listener initiated, UNSECURED
[2024-05-31 13:43:06.386] [NuRaft] [trace] [coordinator_state_machine.cpp:216] Getting last committed index from state machine.
[2024-05-31 13:43:06.386] [NuRaft] [trace] [coordinator_state_machine.cpp:216] Getting last committed index from state machine.
[2024-05-31 13:43:06.386] [NuRaft] [trace] [coordinator_state_machine.cpp:216] Getting last committed index from state machine.
[2024-05-31 13:43:06.386] [NuRaft] [trace] [coordinator_state_manager.cpp:100] Reading server state in coordinator state manager.
[2024-05-31 13:43:06.386] [NuRaft] [trace] [coordinator_state_manager.cpp:49] Loading cluster config from RocksDb
[2024-05-31 13:43:06.386] [NuRaft] [trace] [coordinator_state_manager.cpp:52] Didn't find anything stored on disk for cluster config.
[2024-05-31 13:43:06.386] [NuRaft] [trace] [coordinator_state_machine.cpp:204] Getting last snapshot from state machine.
[2024-05-31 13:43:06.386] [NuRaft] [trace] [coordinator_state_machine.cpp:207] There is no snapshot.
[2024-05-31 13:43:06.386] [NuRaft] [info] [raft_server.cxx:427] parameters: timeout 200 - 400, heartbeat 100, leadership expiry 200, max batch 100, backoff 50, snapshot distance 5, enable randomized snapshot creation NO, log sync stop gap 99999, reserved logs 5, client timeout 3000, auto forwarding OFF, API call type BLOCKING, custom commit quorum size 0, custom election quorum size 0, snapshot receiver INCLUDED, leadership transfer wait time 0, grace period of lagging state machine 0, snapshot IO: BLOCKING, parallel log appending: OFF
[2024-05-31 13:43:06.386] [NuRaft] [info] [raft_server.cxx:352] new timeout range: 200 -- 400
[2024-05-31 13:43:06.387] [NuRaft] [info] [raft_server.cxx:172]    === INIT RAFT SERVER ===
commit index 0
term 0
election timer allowed
log store start 1, end 0
config log idx 0, prev log idx 0
[2024-05-31 13:43:06.387] [NuRaft] [info] [raft_server.cxx:265] peer 1: DC ID 0, 0.0.0.0:10111, voting member, 1
my id: 1, voting_member
num peers: 0
[2024-05-31 13:43:06.387] [NuRaft] [info] [raft_server.cxx:284] global manager does not exist. will use local thread for commit and append
[2024-05-31 13:43:06.387] [NuRaft] [info] [raft_server.cxx:311] wait for HB, for 50 + [200, 400] ms
[2024-05-31 13:43:06.387] [NuRaft] [trace] [handle_commit.cxx:123] commit_cv_ sleep
[2024-05-31 13:43:06.387] [NuRaft] [info] [handle_append_entries.cxx:49] bg append_entries thread initiated
[2024-05-31 13:43:06.437] [NuRaft] [trace] [handle_timeout.cxx:184] re-schedule election timer
[2024-05-31 13:43:06.437] [NuRaft] [debug] [raft_server.cxx:319] server 1 started
[2024-05-31 13:43:06.437] [NuRaft] [trace] [asio_service.cxx:241] asio rpc session created: 0x728201401c10
[2024-05-31 13:43:06.800] [NuRaft] [trace] [handle_timeout.cxx:201] election timeout
[2024-05-31 13:43:06.800] [NuRaft] [warning] [handle_timeout.cxx:286] Election timeout, initiate leader election
[2024-05-31 13:43:06.800] [NuRaft] [info] [handle_priority.cxx:214] [PRIORITY] decay, target 1 -> 1, mine 1
[2024-05-31 13:43:06.800] [NuRaft] [info] [handle_timeout.cxx:304] [ELECTION TIMEOUT] current role: follower, log last term 0, state term 0, target p 1, my p 1, hb dead, pre-vote NOT done
[2024-05-31 13:43:06.800] [NuRaft] [trace] [coordinator_state_manager.cpp:94] Saving server state in coordinator state manager.
[2024-05-31 13:43:06.800] [NuRaft] [info] [handle_vote.cxx:230] [VOTE INIT] my id 1, my role candidate, term 1, log idx 0, log term 0, priority (target 1 / mine 1)
[2024-05-31 13:43:06.800] [NuRaft] [info] [raft_server.cxx:984] number of pending commit elements: 0
[2024-05-31 13:43:06.800] [NuRaft] [info] [raft_server.cxx:1000] state machine commit index 0, precommit index 0, last log index 0
[2024-05-31 13:43:06.800] [NuRaft] [info] [raft_server.cxx:1039] [BECOME LEADER] appended new config at 1
[2024-05-31 13:43:06.800] [NuRaft] [debug] [handle_commit.cxx:45] trigger commit upto 1
[2024-05-31 13:43:06.801] [NuRaft] [trace] [handle_commit.cxx:63] local log idx 1, target_commit_idx 1, quick_commit_index_ 1, state_->get_commit_idx() 0
[2024-05-31 13:43:06.801] [NuRaft] [trace] [handle_commit.cxx:74] commit_cv_ notify (local thread)
[2024-05-31 13:43:06.801] [NuRaft] [trace] [handle_commit.cxx:126] commit_cv_ wake up
[
```
- [x] Provide the full content or a guide for the final git message
    - **Add NuRaft logs**


### CI Testing Labels
Please select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [x] Write a release note, including added/changed clauses
    - **Added flag `--nuraft-log-file` for explicitly managing logs coming from NuRaft.**
- [x] Link the documentation PR here
    - **https://github.com/memgraph/documentation/pull/816**
- [x] Tag someone from docs team in the comments
