### PR TITLE
Improve txn isolation level tests

### DIFF
--- a/tests/manual/test_isolation_level.py
+++ b/tests/manual/test_isolation_level.py
@@ -17,6 +17,9 @@ All of these tests begin with a dataset of:
     Kv { key: 2, value: 20 }
 
 and then assert various transactional correctness properties.
+
+Update: 06/2024
+Tests are written in a form: Does isolation level with which Memgraph DB is started exhibit certain phenomenon?
 """
 
 import argparse
@@ -86,35 +89,42 @@ def assert_eq(a, b):
         assert a == b
 
 
-def assert_commit_fails(conn, failure="conflicting transactions"):
+def check_commit_fails(conn, failure="conflicting transactions"):
     try:
         conn.commit()
         # should always abort
-        print("expected transaction to fail with", failure, "but it incorrectly committed successfully")
-        assert False
+        return False
     except mgclient.DatabaseError as e:
-        assert failure in str(e), "expected exception containing text {failure} but instead it was {e}"
+        if failure not in str(e):
+            return False
+    return True
 
 
-def conflicting_update(cursor, key, value):
+def conflicting_update(cursor, key, value) -> bool:
     try:
         update(cursor, key, value)
-        assert False
+        return False
     except mgclient.DatabaseError as e:
-        assert str(e).startswith("Cannot resolve conflicting transactions")
+        if not str(e).startswith("Cannot resolve conflicting transactions"):
+            return False
+    return True
 
 
 def select(cursor, key, expected):
     actual = get(cursor, key)
     if actual != expected:
         print("expected key", key, "to have value", expected, "but instead it had value", actual)
-        assert False
+        return False
+    return True
 
 
 def select_all(cursor, expected):
     cursor.execute("MATCH (kv: Kv {}) RETURN kv")
     actual = [r[0].properties["value"] for r in cursor.fetchall()]
-    assert actual == expected, "expected values {expected}, but instead it had values {actual}"
+    if actual != expected:
+        print(f"expected values {expected}, but instead it had values {actual}")
+        return False
+    return True
 
 
 """
@@ -122,12 +132,14 @@ def select_all(cursor, expected):
 """
 
 
-def g0(c1, c2):
+def g0(c1, c2, *_):
     cursor_1 = c1.cursor()
     cursor_2 = c2.cursor()
 
     update(cursor_1, 1, 11)
-    conflicting_update(cursor_2, 1, 12)
+    # We use pessimistic transactional approach in in-memory storage mode so we fail early
+    if not conflicting_update(cursor_2, 1, 12):
+        return False, "X g0 test failed"
     update(cursor_1, 2, 21)
     c1.commit()
 
@@ -142,19 +154,22 @@ def g0(c1, c2):
     # this point, so there's nothing we
     # need to do here.
     # update(cursor_2, 2, 22)
-    # assert_commit_fails(c2)
+    # check_commit_fails(c2)
 
-    select(cursor_1, 1, [11])
-    select(cursor_1, 2, [21])
+    if not select(cursor_1, 1, [11]):
+        return False, "X g0 test failed"
+    if not select(cursor_1, 2, [21]):
+        return False, "X g0 test failed"
 
-    select(cursor_2, 1, [11])
-    select(cursor_2, 2, [21])
+    if not select(cursor_2, 1, [11]):
+        return False, "X g0 test failed"
+    if not select(cursor_2, 2, [21]):
+        return False, "X g0 test failed"
 
     c1.commit()
     c2.commit()
 
-    print("✓ g0 test passed")
-    return True
+    return True, "✓ g0 test passed"
 
 
 """
@@ -162,19 +177,20 @@ def g0(c1, c2):
 """
 
 
-def g1a(c1, c2):
+def g1a(c1, c2, *_):
     cursor_1 = c1.cursor()
     cursor_2 = c2.cursor()
 
     update(cursor_1, 1, 101)
-    select(cursor_2, 1, [10])
+    if not select(cursor_2, 1, [10]):
+        return False, "X g1a test failed"
     c1.rollback()
 
-    select(cursor_2, 1, [10])
+    if not select(cursor_2, 1, [10]):
+        return False, "X g1a test failed"
     c2.commit()
 
-    print("✓ g1a test passed")
-    return True
+    return True, "✓ g1a test passed"
 
 
 """
@@ -182,24 +198,26 @@ def g1a(c1, c2):
 """
 
 
-def g1b(c1, c2, global_isolation_level):
+def g1b(c1, c2, global_isolation_level: str):
     cursor_1 = c1.cursor()
     cursor_2 = c2.cursor()
 
     update(cursor_1, 1, 101)
-    select(cursor_2, 1, [10])
+    if not select(cursor_2, 1, [10]):
+        return False, "X g1b test failed"
     update(cursor_1, 1, 11)
     c1.commit()
 
     if global_isolation_level == "READ_COMMITTED":
-        select(cursor_2, 1, [11])
+        if not select(cursor_2, 1, [11]):
+            return False, "X g1b test failed"
     else:
-        select(cursor_2, 1, [10])  # For SI should pass, for READ_UNCOMMITTED, it should fail
+        if not select(cursor_2, 1, [10]):  # For SI should pass, for READ_UNCOMMITTED, it should fail
+            return False, "X g1b test failed"
 
     c2.commit()
 
-    print("✓ g1b test passed")
-    return True
+    return True, "✓ g1b test passed"
 
 
 """
@@ -207,21 +225,22 @@ def g1b(c1, c2, global_isolation_level):
 """
 
 
-def g1c(c1, c2):
+def g1c(c1, c2, *_):
     cursor_1 = c1.cursor()
     cursor_2 = c2.cursor()
 
     update(cursor_1, 1, 11)
     update(cursor_2, 2, 22)
 
-    select(cursor_1, 2, [20])
-    select(cursor_2, 1, [10])
+    if not select(cursor_1, 2, [20]):
+        return False, "X g1c test failed"
+    if not select(cursor_2, 1, [10]):
+        return False, "X g1c test failed"
 
     c1.commit()
     c2.commit()
 
-    print("✓ g1c test passed")
-    return True
+    return True, "✓ g1c test passed"
 
 
 """
@@ -230,25 +249,27 @@ def g1c(c1, c2):
 """
 
 
-def g1_predA(c1, c2, global_isolation_level):
+def g1_predA(c1, c2, global_isolation_level: str):
     cursor_1 = c1.cursor()
     cursor_2 = c2.cursor()
 
-    select_all(cursor_1, [10, 20])
+    if not select_all(cursor_1, [10, 20]):
+        return False, "X g1_predA test failed"
 
     update(cursor_2, 1, 100)
     update(cursor_2, 2, 200)
     c2.commit()
 
     if global_isolation_level == "READ_COMMITTED":
-        select_all(cursor_1, [100, 200])
+        if not select_all(cursor_1, [100, 200]):
+            return False, "X g1_predA test failed"
     else:
-        select_all(cursor_1, [10, 20])
+        if not select_all(cursor_1, [10, 20]):
+            return False, "X g1_predA test failed"
 
     c1.commit()
 
-    print("✓ g1_predA test passed")
-    return True
+    return True, "✓ g1_predA test passed"
 
 
 """
@@ -257,15 +278,17 @@ def g1_predA(c1, c2, global_isolation_level):
 """
 
 
-def g1_predB(c1, c2, global_isolation_level):
+def g1_predB(c1, c2, global_isolation_level: str):
     cursor_1 = c1.cursor()
     cursor_2 = c2.cursor()
 
     execute_and_fetch_all(cursor_1, "CREATE (n:Node {value: 30})")
     c1.commit()
-    select_all(cursor_1, [10, 20])
+    if not select_all(cursor_1, [10, 20]):
+        return False, "X g1_predB test failed"
 
-    assert_eq(execute_and_fetch_all(cursor_1, "MATCH (n:Node) RETURN n")[0][0].properties["value"], 30)
+    if not execute_and_fetch_all(cursor_1, "MATCH (n:Node) RETURN n")[0][0].properties["value"] == 30:
+        return False, "X g1_predB test failed"
 
     update(cursor_2, 1, 100)
     update(cursor_2, 2, 200)
@@ -273,16 +296,19 @@ def g1_predB(c1, c2, global_isolation_level):
     c2.commit()
 
     if global_isolation_level == "READ_COMMITTED":
-        select_all(cursor_1, [100, 200])
-        assert_eq(execute_and_fetch_all(cursor_1, "MATCH (n:Node) RETURN n")[0][0].properties["value"], 300)
+        if not select_all(cursor_1, [100, 200]):
+            return False, "X g1_predB test failed"
+        if not execute_and_fetch_all(cursor_1, "MATCH (n:Node) RETURN n")[0][0].properties["value"] == 300:
+            return False, "X g1_predB test failed"
     else:
-        select_all(cursor_1, [10, 20])
-        assert_eq(execute_and_fetch_all(cursor_1, "MATCH (n:Node) RETURN n")[0][0].properties["value"], 30)
+        if not select_all(cursor_1, [10, 20]):
+            return False, "X g1_predB test failed"
+        if not execute_and_fetch_all(cursor_1, "MATCH (n:Node) RETURN n")[0][0].properties["value"] == 30:
+            return False, "X g1_predB test failed"
 
     c1.commit()
 
-    print("✓ g1_predB test passed")
-    return True
+    return True, "✓ g1_predB test passed"
 
 
 """
@@ -297,22 +323,26 @@ def otv(c1, c2, c3):
 
     update(cursor_1, 1, 11)
     update(cursor_1, 2, 19)
-    conflicting_update(cursor_2, 1, 12)
+    if not conflicting_update(cursor_2, 1, 12):
+        return False, "X otv test failed"
 
     c1.commit()
 
-    select(cursor_3, 1, [11])
-    select(cursor_3, 2, [19])
+    if not select(cursor_3, 1, [11]):
+        return False, "X otv test failed"
+    if not select(cursor_3, 2, [19]):
+        return False, "X otv test failed"
 
     # cursor_2 update not required due to its early-abort above
 
-    select(cursor_3, 1, [11])
-    select(cursor_3, 2, [19])
+    if not select(cursor_3, 1, [11]):
+        return False, "X otv test failed"
+    if not select(cursor_3, 2, [19]):
+        return False, "X otv test failed"
 
     c3.commit()
 
-    print("✓ otv test passed")
-    return True
+    return True, "✓ otv test passed"
 
 
 """
@@ -320,19 +350,20 @@ def otv(c1, c2, c3):
 """
 
 
-def pmp(c1, c2):
+def pmp(c1, c2, *_):
     cursor_1 = c1.cursor()
     cursor_2 = c2.cursor()
 
-    select(cursor_1, 3, [])
+    if not select(cursor_1, 3, []):
+        return False, "X pmp test failed"
     update(cursor_2, 3, 30)
     c2.commit()
 
-    select(cursor_1, 3, [])
+    if not select(cursor_1, 3, []):
+        return False, "X pmp test failed"
     c1.commit()
 
-    print("✓ pmp test passed")
-    return True
+    return True, "✓ pmp test passed"
 
 
 """
@@ -340,30 +371,34 @@ def pmp(c1, c2):
 """
 
 
-def pmp_write(c1, c2):
+def pmp_write(c1, c2, *_):
     cursor_1 = c1.cursor()
     cursor_2 = c2.cursor()
 
     cursor_1.execute("MATCH (kv: Kv {}) SET kv.value = kv.value + 10 RETURN kv")
 
-    select(cursor_2, 1, [10])
-    select(cursor_2, 2, [20])
+    if not select(cursor_2, 1, [10]):
+        return False, "X pmp_write test failed"
+    if not select(cursor_2, 2, [20]):
+        return False, "X pmp_write test failed"
 
     try:
         cursor_2.execute("MATCH (kv:Kv { value: 20 }) DETACH DELETE kv;")
-        assert False
+        return False, "X pmp_write test failed"
     except mgclient.DatabaseError as e:
-        assert "conflicting transactions" in str(e)
+        if "conflicting transactions" not in str(e):
+            return False, "X pmp_write test failed"
 
     c1.commit()
 
-    select(cursor_1, 1, [20])
-    select(cursor_1, 2, [30])
+    if not select(cursor_1, 1, [20]):
+        return False, "X pmp_write test failed"
+    if not select(cursor_1, 2, [30]):
+        return False, "X pmp_write test failed"
 
     c1.commit()
 
-    print("✓ pmp_write test passed")
-    return True
+    return True, "✓ pmp_write test passed"
 
 
 """
@@ -371,20 +406,22 @@ def pmp_write(c1, c2):
 """
 
 
-def p4(c1, c2):
+def p4(c1, c2, *_):
     cursor_1 = c1.cursor()
     cursor_2 = c2.cursor()
 
-    select(cursor_1, 1, [10])
-    select(cursor_2, 1, [10])
+    if not select(cursor_1, 1, [10]):
+        return False, "X p4 test failed"
+    if not select(cursor_2, 1, [10]):
+        return False, "X p4 test failed"
 
     update(cursor_1, 1, 11)
-    conflicting_update(cursor_2, 1, 11)
+    if not conflicting_update(cursor_2, 1, 11):
+        return False, "X p4 test failed"
 
     c1.commit()
 
-    print("✓ p4 test passed")
-    return True
+    return True, "✓ p4 test passed"
 
 
 """
@@ -392,23 +429,28 @@ def p4(c1, c2):
 """
 
 
-def g_single(c1, c2):
+def g_single(c1, c2, *_):
     cursor_1 = c1.cursor()
     cursor_2 = c2.cursor()
 
-    select(cursor_1, 1, [10])
-    select(cursor_2, 1, [10])
-    select(cursor_2, 2, [20])
+    if not select(cursor_1, 1, [10]):
+        return False, "X g_single test failed"
+    if not select(cursor_2, 1, [10]):
+        return False, "X g_single test failed"
+    if not select(cursor_2, 2, [20]):
+        return False, "X g_single test failed"
 
     update(cursor_2, 1, 12)
     update(cursor_2, 2, 18)
     c2.commit()
 
-    select(cursor_1, 2, [20])
+    if not select(
+        cursor_1, 2, [20]
+    ):  # If this wouldn't be 20, we would have a cycle between T1 and T2.  T1-rw->T2-wr->T1
+        return False, "X g_single test failed"
     c1.commit()
 
-    print("✓ g_single test passed")
-    return True
+    return True, "✓ g_single test passed"
 
 
 """
@@ -416,25 +458,28 @@ def g_single(c1, c2):
 """
 
 
-def g_single_dependencies(c1, c2):
+def g_single_dependencies(c1, c2, *_):
     cursor_1 = c1.cursor()
     cursor_2 = c2.cursor()
 
     cursor_1.execute("MATCH (kv: Kv {}) WHERE kv.value % 5 = 0 RETURN kv")
     found = [r[0].properties["value"] for r in cursor_1.fetchall()]
-    assert found == [10, 20]
+    if found != [10, 20]:
+        return False, "X g_single_dependencies test failed"
 
     cursor_2.execute("MATCH (kv: Kv { value: 10 }) SET kv.value = 12 RETURN kv")
     c2.commit()
 
-    cursor_1.execute("MATCH (kv: Kv {}) WHERE kv.value % 3 = 0 RETURN kv")
+    cursor_1.execute(
+        "MATCH (kv: Kv {}) WHERE kv.value % 3 = 0 RETURN kv"
+    )  # If we would see here 12, we would have a cycle between T1 and T2.  T1-rw->T2-wr->T1
     found = [r[0].properties["value"] for r in cursor_1.fetchall()]
-    assert found == []
+    if found != []:
+        return False, "X g_single_dependencies test failed"
 
     c1.commit()
 
-    print("✓ g_single_dependencies test passed")
-    return True
+    return True, "✓ g_single_dependencies test passed"
 
 
 """
@@ -442,13 +487,15 @@ def g_single_dependencies(c1, c2):
 """
 
 
-def g_single_write_1(c1, c2):
+def g_single_write_1(c1, c2, *_):
     cursor_1 = c1.cursor()
     cursor_2 = c2.cursor()
 
-    select(cursor_1, 1, [10])
+    if not select(cursor_1, 1, [10]):
+        return False, "X g_single_write_1 test failed"
 
-    select_all(cursor_2, [10, 20])
+    if not select_all(cursor_2, [10, 20]):
+        return False, "X g_single_write_1 test failed"
 
     update(cursor_2, 1, 12)
     update(cursor_2, 2, 18)
@@ -456,16 +503,17 @@ def g_single_write_1(c1, c2):
 
     try:
         cursor_1.execute("MATCH (kv:Kv { value: 20 }) DETACH DELETE kv;")
-        assert False
+        return False, "X g_single_write_1 test failed"
     except mgclient.DatabaseError as e:
-        assert "conflicting transactions" in str(e)
+        if "conflicting transactions" not in str(e):
+            return False, "X g_single_write_1 test failed"
 
-    select_all(cursor_2, [12, 18])
+    if not select_all(cursor_2, [12, 18]):
+        return False, "X g_single_write_1 test failed"
 
     c2.commit()
 
-    print("✓ g_single_write_1 test passed")
-    return True
+    return True, "✓ g_single_write_1 test passed"
 
 
 """
@@ -473,24 +521,26 @@ def g_single_write_1(c1, c2):
 """
 
 
-def g_single_write_2(c1, c2):
+def g_single_write_2(c1, c2, *_):
     cursor_1 = c1.cursor()
     cursor_2 = c2.cursor()
 
-    select(cursor_1, 1, [10])
-    select_all(cursor_2, [10, 20])
+    if not select(cursor_1, 1, [10]):
+        return False, "X g_single_write_2 test failed"
+    if not select_all(cursor_2, [10, 20]):
+        return False, "X g_single_write_2 test failed"
 
     update(cursor_2, 1, 12)
 
     cursor_1.execute("MATCH (kv:Kv { value: 20 }) DETACH DELETE kv;")
 
-    conflicting_update(cursor_2, 2, 18)
+    if not conflicting_update(cursor_2, 2, 18):
+        return False, "X g_single_write_2 test failed"
 
     c1.rollback()
     # c2.commit()
 
-    print("✓ g_single_write_2 test passed (although the abort rate is pessimistically high)")
-    return True
+    return True, "✓ g_single_write_2 test passed"
 
 
 """
@@ -498,35 +548,36 @@ def g_single_write_2(c1, c2):
 """
 
 
-def g2_item(c1, c2):
+def g2_item(c1, c2, *_):
     cursor_1 = c1.cursor()
     cursor_2 = c2.cursor()
 
     cursor_1.execute("MATCH (kv: Kv {}) WHERE kv.key = 1 OR kv.key = 2 RETURN kv")
     found = [r[0].properties["value"] for r in cursor_1.fetchall()]
-    assert found == [10, 20]
+    if found != [10, 20]:
+        return False, "X g2_item test failed"
 
     cursor_2.execute("MATCH (kv: Kv {}) WHERE kv.key = 1 OR kv.key = 2 RETURN kv")
     found = [r[0].properties["value"] for r in cursor_2.fetchall()]
-    assert found == [10, 20]
+    if found != [10, 20]:
+        return False, "X g2_item test failed"
 
     update(cursor_1, 1, 11)
     update(cursor_2, 2, 21)
 
     c1.commit()
 
-    try:
-        assert_commit_fails(c2)
-        print("✓ g2_item test passed")
-        return True
-    except:
-        print(
-            "X g2_item test failed - database exhibits write skew -",
-            "writes based on invalidated reads should have failed,",
-            "causing repeatable read (PL-2.99) and serializability (PL-3)",
-            "to fail to be achieved",
+    if not check_commit_fails(c2):
+        return (
+            False,
+            """
+X g2_item test failed - database exhibits write skew -
+writes based on invalidated reads should have failed,
+causing repeatable read (PL-2.99) and serializability (PL-3)
+to fail to be achieved""",
         )
-        return False
+
+    return True, "✓ g2_item test passed"
 
 
 """
@@ -534,36 +585,37 @@ def g2_item(c1, c2):
 """
 
 
-def g2(c1, c2):
+def g2(c1, c2, *_):
     cursor_1 = c1.cursor()
     cursor_2 = c2.cursor()
 
     cursor_1.execute("MATCH (kv: Kv {}) WHERE kv.value % 3 = 0 RETURN kv")
     found = [r[0].properties["value"] for r in cursor_1.fetchall()]
-    assert found == []
+    if found != []:
+        return False, "X g2 test failed"
 
     cursor_2.execute("MATCH (kv: Kv {}) WHERE kv.value % 3 = 0 RETURN kv")
     found = [r[0].properties["value"] for r in cursor_2.fetchall()]
-    assert found == []
+    if found != []:
+        return False, "X g2 test failed"
 
     update(cursor_1, 3, 30)
     update(cursor_2, 4, 42)
 
     c1.commit()
 
-    try:
-        assert_commit_fails(c2)
-        print("✓ g2 test passed")
-        return True
-    except:
-        print(
-            "X g2 test failed - database exhibits write skew on predicate read -",
-            "concurrent transactions that should have caused a predicate read to",
-            "return data in one transaction actually returned nothing in both.",
-            "Both transactions committed, but one of them should have failed due",
-            "to having a predicate invalidated",
+    if not check_commit_fails(c2):
+        return (
+            False,
+            """
+X g2 test failed - database exhibits write skew on predicate read -,
+concurrent transactions that should have caused a predicate read to,
+return data in one transaction actually returned nothing in both.,
+Both transactions committed, but one of them should have failed due,
+to having a predicate invalidated""",
         )
-        return False
+
+    return True, "✓ g2 test passed"
 
 
 """
@@ -573,30 +625,68 @@ def g2(c1, c2):
 
 def g2_two_edges(c1, c2, c3):
     cursor_1 = c1.cursor()
-    select_all(cursor_1, [10, 20])
+    if not select_all(cursor_1, [10, 20]):
+        return False, "X g2_two_edges test failed"
 
     cursor_2 = c2.cursor()
     cursor_2.execute("MATCH (kv: Kv { key: 2 }) SET kv.value = kv.value + 5 RETURN kv;")
     found = [r[0].properties["value"] for r in cursor_2.fetchall()]
-    assert found == [25]
+    if found != [25]:
+        return False, "X g2_two_edges test failed"
+
     c2.commit()
 
     cursor_3 = c3.cursor()
-    select_all(cursor_3, [10, 25])
+    if not select_all(cursor_3, [10, 25]):
+        return False, "X g2_two_edges test failed"
     c3.commit()
 
-    try:
-        conflicting_update(cursor_1, 1, 0)
-        print("✓ g2_two_edges test passed")
-        return True
-    except:
+    if not conflicting_update(cursor_1, 1, 0):
         c3.rollback()
-        print(
-            "X g2_two_edges test failed: database exhibits write skew on predicate read -",
-            "a transaction's read set was invalidated in two concurrent transactions,"
-            "and it should have failed to commit if we want to be serializable",
+        return (
+            False,
+            """
+X g2_two_edges test failed: database exhibits write skew on predicate read -
+a transaction's read set was invalidated in two concurrent transactions,
+and it should have failed to commit if we want to be serializable""",
         )
-        return False
+
+    return True, "✓ g2_two_edges test passed"
+
+
+def two_conn_phenomenon(phen_func, global_isolation_level):
+    c1 = mgclient.connect(host=args.host, port=args.port)
+    c1.autocommit = False
+    c2 = mgclient.connect(host=args.host, port=args.port)
+    c2.autocommit = False
+
+    setup(c1)
+    res, info = phen_func(c1, c2, global_isolation_level)
+    print(info)
+
+    c1.close()
+    c2.close()
+
+    return res
+
+
+def three_conn_phenomenon(phen_func):
+    c1 = mgclient.connect(host=args.host, port=args.port)
+    c1.autocommit = False
+    c2 = mgclient.connect(host=args.host, port=args.port)
+    c2.autocommit = False
+    c3 = mgclient.connect(host=args.host, port=args.port)
+    c3.autocommit = False
+
+    setup(c1)
+    res, info = phen_func(c1, c2, c3)
+    print(info)
+
+    c1.close()
+    c2.close()
+    c3.close()
+
+    return res
 
 
 if __name__ == "__main__":
@@ -608,70 +698,31 @@ if __name__ == "__main__":
     info_conn = mgclient.connect(host=args.host, port=args.port)
     info_conn.autocommit = True
     info_cursor = info_conn.cursor()
-    # execute_and_fetch_all(info_cursor, "MATCH (n) DETACH DELETE n")
     res = execute_and_fetch_all(info_cursor, "show storage info")
     res = {r[0]: r[1] for r in res}
     global_isolation_level = res["global_isolation_level"]
-    print(f"global isolation level: {global_isolation_level}")
+    print(f"Database started with global isolation level set to: {global_isolation_level}")
+    info_conn.close()
 
-    c1 = mgclient.connect(host=args.host, port=args.port)
-    c1.autocommit = False
-    c2 = mgclient.connect(host=args.host, port=args.port)
-    c2.autocommit = False
-    c3 = mgclient.connect(host=args.host, port=args.port)
-    c3.autocommit = False
+    g0 = two_conn_phenomenon(g0, global_isolation_level)
+    g1a = two_conn_phenomenon(g1a, global_isolation_level)
+    g1b = two_conn_phenomenon(g1b, global_isolation_level)
+    g1c = two_conn_phenomenon(g1c, global_isolation_level)
+    g1_predA = two_conn_phenomenon(g1_predA, global_isolation_level)
+    g1_predB = two_conn_phenomenon(g1_predB, global_isolation_level)
+    otv = three_conn_phenomenon(otv)
+    pmp = two_conn_phenomenon(pmp, global_isolation_level)
+    pmp_write = two_conn_phenomenon(pmp_write, global_isolation_level)
+    p4 = two_conn_phenomenon(p4, global_isolation_level)
+    g_single = two_conn_phenomenon(g_single, global_isolation_level)
+    g_single_dependencies = two_conn_phenomenon(g_single_dependencies, global_isolation_level)
+    g_single_write_1 = two_conn_phenomenon(g_single_write_1, global_isolation_level)
+    g_single_write_2 = two_conn_phenomenon(g_single_write_2, global_isolation_level)
+    g2_item = two_conn_phenomenon(g2_item, global_isolation_level)
+    g2 = two_conn_phenomenon(g2, global_isolation_level)
+    g2_two_edges = three_conn_phenomenon(g2_two_edges)
 
-    setup(c1)
-    g0 = g0(c1, c2)
-
-    setup(c1)
-    g1a = g1a(c1, c2)
-
-    setup(c1)
-    g1b = g1b(c1, c2, global_isolation_level)
-
-    setup(c1)
-    g1c = g1c(c1, c2)
-
-    setup(c1)
-    g1_predA = g1_predA(c1, c2, global_isolation_level)
-
-    setup(c1)
-    g1_predB = g1_predB(c1, c2, global_isolation_level)
-
-    setup(c1)
-    otv = otv(c1, c2, c3)
-
-    setup(c1)
-    pmp = pmp(c1, c2)
-
-    setup(c1)
-    pmp_write = pmp_write(c1, c2)
-
-    setup(c1)
-    p4 = p4(c1, c2)
-
-    setup(c1)
-    g_single = g_single(c1, c2)
-
-    setup(c1)
-    g_single_dependencies = g_single_dependencies(c1, c2)
-
-    setup(c1)
-    g_single_write_1 = g_single_write_1(c1, c2)
-
-    setup(c1)
-    g_single_write_2 = g_single_write_2(c1, c2)
-
-    setup(c1)
-    g2_item = g2_item(c1, c2)
-
-    setup(c1)
-    g2 = g2(c1, c2)
-
-    setup(c1)
-    g2_two_edges = g2_two_edges(c1, c2, c3)
-
+    # Check Isolation Levels
     g1 = all([g1a, g1b, g1c])
     repeatable_read = all([g1, g2_item])
     snapshot_isolation = all(
@@ -681,7 +732,7 @@ if __name__ == "__main__":
 
     print("")
 
-    print("results:")
+    print("Isolation levels that Memgraph supports: ")
     print(f"PL-2: {g1}")
     print(f"PL-2': {g1 and g1_predA}")
     print(f"PL-2'': {g1 and g1_predB}")

--- a/tests/manual/test_isolation_level.py
+++ b/tests/manual/test_isolation_level.py
@@ -654,7 +654,7 @@ and it should have failed to commit if we want to be serializable""",
     return True, "✓ g2_two_edges test passed"
 
 
-def two_conn_phenomenon(phen_func, global_isolation_level):
+def two_txns_phenomenon(phen_func, global_isolation_level):
     c1 = mgclient.connect(host=args.host, port=args.port)
     c1.autocommit = False
     c2 = mgclient.connect(host=args.host, port=args.port)
@@ -670,7 +670,7 @@ def two_conn_phenomenon(phen_func, global_isolation_level):
     return res
 
 
-def three_conn_phenomenon(phen_func):
+def three_txns_phenomenon(phen_func):
     c1 = mgclient.connect(host=args.host, port=args.port)
     c1.autocommit = False
     c2 = mgclient.connect(host=args.host, port=args.port)
@@ -704,23 +704,23 @@ if __name__ == "__main__":
     print(f"Database started with global isolation level set to: {global_isolation_level}")
     info_conn.close()
 
-    g0 = two_conn_phenomenon(g0, global_isolation_level)
-    g1a = two_conn_phenomenon(g1a, global_isolation_level)
-    g1b = two_conn_phenomenon(g1b, global_isolation_level)
-    g1c = two_conn_phenomenon(g1c, global_isolation_level)
-    g1_predA = two_conn_phenomenon(g1_predA, global_isolation_level)
-    g1_predB = two_conn_phenomenon(g1_predB, global_isolation_level)
-    otv = three_conn_phenomenon(otv)
-    pmp = two_conn_phenomenon(pmp, global_isolation_level)
-    pmp_write = two_conn_phenomenon(pmp_write, global_isolation_level)
-    p4 = two_conn_phenomenon(p4, global_isolation_level)
-    g_single = two_conn_phenomenon(g_single, global_isolation_level)
-    g_single_dependencies = two_conn_phenomenon(g_single_dependencies, global_isolation_level)
-    g_single_write_1 = two_conn_phenomenon(g_single_write_1, global_isolation_level)
-    g_single_write_2 = two_conn_phenomenon(g_single_write_2, global_isolation_level)
-    g2_item = two_conn_phenomenon(g2_item, global_isolation_level)
-    g2 = two_conn_phenomenon(g2, global_isolation_level)
-    g2_two_edges = three_conn_phenomenon(g2_two_edges)
+    g0 = two_txns_phenomenon(g0, global_isolation_level)
+    g1a = two_txns_phenomenon(g1a, global_isolation_level)
+    g1b = two_txns_phenomenon(g1b, global_isolation_level)
+    g1c = two_txns_phenomenon(g1c, global_isolation_level)
+    g1_predA = two_txns_phenomenon(g1_predA, global_isolation_level)
+    g1_predB = two_txns_phenomenon(g1_predB, global_isolation_level)
+    otv = three_txns_phenomenon(otv)
+    pmp = two_txns_phenomenon(pmp, global_isolation_level)
+    pmp_write = two_txns_phenomenon(pmp_write, global_isolation_level)
+    p4 = two_txns_phenomenon(p4, global_isolation_level)
+    g_single = two_txns_phenomenon(g_single, global_isolation_level)
+    g_single_dependencies = two_txns_phenomenon(g_single_dependencies, global_isolation_level)
+    g_single_write_1 = two_txns_phenomenon(g_single_write_1, global_isolation_level)
+    g_single_write_2 = two_txns_phenomenon(g_single_write_2, global_isolation_level)
+    g2_item = two_txns_phenomenon(g2_item, global_isolation_level)
+    g2 = two_txns_phenomenon(g2, global_isolation_level)
+    g2_two_edges = three_txns_phenomenon(g2_two_edges)
 
     # Check Isolation Levels
     g1 = all([g1a, g1b, g1c])


### PR DESCRIPTION
### Description

- asserts are changed to return statements in order to allow executing tests on lower isolation levels
- logic of g1b test has changed a bit in a way to allow `READ_COMMITTED` test to pass -> With `READ_COMMITTED` g1b = intermediate reads should pass
- Added test for testing gpred_a -> see definition in Adya's PhD
- Added test for gpred_b -> see definition in Adya's PhD

[master < Task] PR
- [x] Provide the full content or a guide for the final git message
    - **Improve txn isolation level tests**


### CI Testing Labels
Please select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - **[Release note text]**
- [x] Link the documentation PR here
    - **https://github.com/memgraph/documentation/pull/807**
- [x] Tag someone from docs team in the comments
