### PR TITLE
Enable ORDER BY over values of multiple distinct types

### DIFF
--- a/src/query/typed_value.hpp
+++ b/src/query/typed_value.hpp
@@ -68,25 +68,27 @@ class TypedValue {
     size_t operator()(const TypedValue &value) const;
   };
 
-  /** A value type. Each type corresponds to exactly one C++ type */
+  /** A value type. Each type corresponds to exactly one C++ type.
+   *  The ORDER BY clause, when processing values of multiple distinct types, sorts them using the below ordering:
+   */
   enum class Type : unsigned {
-    Null,
-    Bool,
-    Int,
-    Double,
-    String,
-    List,
     Map,
     Vertex,
     Edge,
+    List,
     Path,
+    ZonedDateTime,
+    LocalDateTime,
     Date,
     LocalTime,
-    LocalDateTime,
-    ZonedDateTime,
     Duration,
+    String,
+    Bool,
+    Int,
+    Double,
     Graph,
-    Function
+    Function,
+    Null,
   };
 
   // TypedValue at this exact moment of compilation is an incomplete type, and


### PR DESCRIPTION
### Description

This PR addresses #1776 by extending `ORDER BY` so that it can work on values of multiple distinct types.

[master < Task] PR
- [x] Provide the full content or a guide for the final git message
    > Enable ORDER BY over values of multiple distinct types

### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
- [x] Write a release note, including added/changed clauses
    > The `ORDER BY` clause now can order values of different types. #2096
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [ ] Tag someone from docs team in the comments
