### PR TITLE
Fail starting coordinator with invalid config options for health pings

### DIFF
--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -419,6 +419,16 @@ int main(int argc, char **argv) {
     db_config.durability.snapshot_interval = 0s;
   }
 
+#ifdef MG_ENTERPRISE
+  if (std::chrono::seconds(FLAGS_instance_down_timeout_sec) <
+      std::chrono::seconds(FLAGS_instance_health_check_frequency_sec)) {
+    LOG_FATAL(
+        "Instance down timeout config option must be greater than or equal to instance health check frequency config "
+        "option!");
+  }
+
+#endif
+
   // Default interpreter configuration
   memgraph::query::InterpreterConfig interp_config{
       .query = {.allow_load_csv = FLAGS_allow_load_csv},


### PR DESCRIPTION
### Description

- Instance down timeout config option must be greater than or equal to instance health check frequency config option. If not, abort starting Memgraph coordinator instance.

[master < Task] PR
- [x] Provide the full content or a guide for the final git message
    - **Fail starting coordinator with invalid config options for health pings**


### CI Testing Labels
Please select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [x] Write a release note, including added/changed clauses
    - **Coordinator won't be started if `--instance-down-timeout-sec` option is smaller than `--instance-health-check-frequency-sec`.**
- [ ] Link the documentation PR here
    - **https://github.com/memgraph/documentation/pull/833**
- [x] Tag someone from docs team in the comments
