### PR TITLE
Update Jepsen ports

### DIFF
--- a/tests/jepsen/resources/cluster.edn
+++ b/tests/jepsen/resources/cluster.edn
@@ -1,7 +1,7 @@
-{"n1" {:management-port 10011 :replication-port 10001}
-  "n2" {:management-port 10012 :replication-port 10002}
-  "n3" {:management-port 10013 :replication-port 10003}
-  "n4" {:coordinator-port 10111 :coordinator-id 1}
-  "n5" {:coordinator-port 10112 :coordinator-id 2}
-  "n6" {:coordinator-port 10113 :coordinator-id 3}
+{"n1" {:management-port 10000 :replication-port 20000}
+  "n2" {:management-port 10000 :replication-port 20000}
+  "n3" {:management-port 10000 :replication-port 20000}
+  "n4" {:coordinator-port 12000 :coordinator-id 1}
+  "n5" {:coordinator-port 12000 :coordinator-id 2}
+  "n6" {:coordinator-port 12000 :coordinator-id 3}
 }


### PR DESCRIPTION
### Description

Jepsen HA test is now using one port as management port, one port as coordinator port, one port as replication port on all instances. Seems logical as this is what users will usually do/can do in their deployments.


[master < Task] PR
- [ ] Provide the full content or a guide for the final git message
    - **Update Jepsen ports**


### CI Testing Labels
Please select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - **[Release note text]**
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [x] Tag someone from docs team in the comments
