### PR TITLE
Run clang tidy in parallel

### DIFF
--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -87,6 +87,7 @@ jobs:
       os: 'debian-11'
       toolchain: 'v5'
       run_core: ${{ needs.DiffSetup.outputs.run_coverage_core }}
+      run_clang_tidy: ${{ needs.DiffSetup.outputs.run_coverage_core }}
     secrets: inherit
 
   Debug:

--- a/.github/workflows/diff_coverage.yaml
+++ b/.github/workflows/diff_coverage.yaml
@@ -19,10 +19,14 @@ on:
         type: string
         description: "Should the core coverage build tests be run? Default is true."
         default: 'true'
+      run_clang_tidy:
+        type: string
+        description: "Should the clang-tidy tests be run? Default is true."
+        default: 'true'
 
 env:
   ARCH: ${{ inputs.arch }}
-  BUILD_TYPE: 'Debug' 
+  BUILD_TYPE: 'Debug'
   MEMGRAPH_ENTERPRISE_LICENSE: ${{ secrets.MEMGRAPH_ENTERPRISE_LICENSE }}
   MEMGRAPH_ORGANIZATION_NAME: ${{ secrets.MEMGRAPH_ORGANIZATION_NAME }}
   OS: ${{ inputs.os }}
@@ -120,6 +124,118 @@ jobs:
         with:
           name: "Code coverage(Code analysis)"
           path: tools/github/generated/code_coverage.tar.gz
+
+      - name: Stop mgbuild container
+        if: always()
+        run: |
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN \
+          --os $OS \
+          --arch $ARCH \
+          stop --remove
+
+  clang-tidy-community:
+    if: ${{ inputs.run_clang_tidy == 'true' }}
+    name: "Core tests"
+    runs-on: [self-hosted, Linux, X64, DockerMgBuild]
+    timeout-minutes: 60
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Spin up mgbuild container
+        run: |
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN \
+          --os $OS \
+          --arch $ARCH \
+          run
+
+      - name: Set base branch
+        run: |
+          base_branch="master"
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base_branch="${{ github.base_ref }}"
+          fi
+          echo "BASE_BRANCH=origin/$base_branch" >> $GITHUB_ENV
+
+      - name: Configure cmake
+        run: |
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN \
+          --os $OS \
+          --arch $ARCH \
+          --build-type $BUILD_TYPE \
+          build-memgraph --cmake-only --community
+
+      - name: Run clang-tidy
+        run: |
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN \
+          --os $OS \
+          --arch $ARCH \
+          --enterprise-license $MEMGRAPH_ENTERPRISE_LICENSE \
+          --organization-name $MEMGRAPH_ORGANIZATION_NAME \
+          test-memgraph clang-tidy --base-branch "${{ env.BASE_BRANCH }}"
+
+      - name: Stop mgbuild container
+        if: always()
+        run: |
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN \
+          --os $OS \
+          --arch $ARCH \
+          stop --remove
+
+  clang-tidy-enterprise:
+    if: ${{ inputs.run_clang_tidy == 'true' }}
+    name: "Core tests"
+    runs-on: [self-hosted, Linux, X64, DockerMgBuild]
+    timeout-minutes: 60
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Spin up mgbuild container
+        run: |
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN \
+          --os $OS \
+          --arch $ARCH \
+          run
+
+      - name: Set base branch
+        run: |
+          base_branch="master"
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base_branch="${{ github.base_ref }}"
+          fi
+          echo "BASE_BRANCH=origin/$base_branch" >> $GITHUB_ENV
+
+      - name: Configure cmake
+        run: |
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN \
+          --os $OS \
+          --arch $ARCH \
+          --build-type $BUILD_TYPE \
+          build-memgraph --cmake-only
 
       - name: Run clang-tidy
         run: |

--- a/.github/workflows/diff_coverage.yaml
+++ b/.github/workflows/diff_coverage.yaml
@@ -136,7 +136,7 @@ jobs:
 
   clang-tidy-community:
     if: ${{ inputs.run_clang_tidy == 'true' }}
-    name: "Core tests"
+    name: "Clang tidy community"
     runs-on: [self-hosted, Linux, X64, DockerMgBuild]
     timeout-minutes: 60
     steps:
@@ -197,7 +197,7 @@ jobs:
 
   clang-tidy-enterprise:
     if: ${{ inputs.run_clang_tidy == 'true' }}
-    name: "Core tests"
+    name: "Clang tidy enterprise"
     runs-on: [self-hosted, Linux, X64, DockerMgBuild]
     timeout-minutes: 60
     steps:

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -99,6 +99,7 @@ print_help () {
 
   echo -e "\nbuild-memgraph options:"
   echo -e "  --asan                        Build with ASAN"
+  echo -e "  --cmake-only                  Only run cmake configure command"
   echo -e "  --community                   Build community version"
   echo -e "  --coverage                    Build with code coverage"
   echo -e "  --for-docker                  Add flag -DMG_TELEMETRY_ID_OVERRIDE=DOCKER to cmake"
@@ -254,6 +255,7 @@ build_memgraph () {
   local asan_flag=""
   local ubsan_flag=""
   local init_only=false
+  local cmake_only=false
   local for_docker=false
   local for_platform=false
   local copy_from_host=true
@@ -265,6 +267,10 @@ build_memgraph () {
       ;;
       --init-only)
         init_only=true
+        shift 1
+      ;;
+      --cmake-only)
+        cmake_only=true
         shift 1
       ;;
       --for-docker)
@@ -356,6 +362,9 @@ build_memgraph () {
   # Define cmake command
   local cmake_cmd="cmake $build_type_flag $skip_rpath_flags $arm_flag $community_flag $telemetry_id_override_flag $coverage_flag $asan_flag $ubsan_flag .."
   docker exec -u mg "$build_container" bash -c "cd $container_build_dir && $ACTIVATE_TOOLCHAIN && $ACTIVATE_CARGO && $cmake_cmd"
+  if [[ "$cmake_only" == "true" ]]; then
+    return
+  fi
   # ' is used instead of " because we need to run make within the allowed
   # container resources.
   # Default value for $threads is 0 instead of $(nproc) because macos


### PR DESCRIPTION
Clang tidy now runs in parallel with coverage build and tests because it was taking too long.