### PR TITLE
Fix Jepsen setup failing because of openjdk-21-jdk-headless

### DIFF
--- a/tests/jepsen/0-3-5.patch
+++ b/tests/jepsen/0-3-5.patch
@@ -1,0 +1,13 @@
+diff --git a/docker/control/Dockerfile b/docker/control/Dockerfile
+index 4b95de3b..306c9759 100644
+--- a/docker/control/Dockerfile
++++ b/docker/control/Dockerfile
+@@ -14,7 +14,7 @@ ADD ./apt-preferences /etc/apt/preferences
+ #
+ RUN apt-get -qy update && \
+     apt-get -qy install \
+-        curl dos2unix emacs git gnuplot graphviz htop iputils-ping libjna-java openjdk-21-jdk-headless pssh screen vim wget
++        curl dos2unix emacs git gnuplot graphviz htop iputils-ping libjna-java openjdk-22-jdk-headless pssh screen vim wget
+
+ RUN wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && \
+     mv lein /usr/bin && \

--- a/tests/jepsen/run.sh
+++ b/tests/jepsen/run.sh
@@ -57,11 +57,16 @@ if ! command -v docker > /dev/null 2>&1 || ! command -v docker compose > /dev/nu
 fi
 
 if [ ! -d "$script_dir/jepsen" ]; then
-    # TODO(deda): install apt get docker-compose-plugin on all build machines.
-   echo "Cloning Jepsen ..."
-    git clone http://mgdeps-cache:8000/git/jepsen.git -b "$JEPSEN_VERSION" "$script_dir/jepsen" &> /dev/null \
-    || git clone https://github.com/jepsen-io/jepsen.git -b "$JEPSEN_VERSION" "$script_dir/jepsen"
-
+  echo "Cloning Jepsen $JEPSEN_VERSION ..."
+  git clone http://mgdeps-cache:8000/git/jepsen.git -b "$JEPSEN_VERSION" "$script_dir/jepsen" &> /dev/null \
+  || git clone https://github.com/jepsen-io/jepsen.git -b "$JEPSEN_VERSION" "$script_dir/jepsen"
+  # Apply patch for Jepsen 0.3.5 which replaces openjdk-21-jdk-headless with openjdk-22-jdk-headless
+  if [[ "$JEPSEN_VERSION" == "v0.3.5" ]]; then
+    echo "Applying patch for Jepsen 0.3.5 ..."
+    cd "$script_dir/jepsen"
+    git apply "$script_dir/0-3-5.patch"
+    cd "$script_dir"
+  fi
 fi
 
 PROCESS_ARGS() {


### PR DESCRIPTION
Replace openjdk-21-jdk-headless with openjdk-22-jdk-headless in Dockerfile for control node

Jepsen startup is failing because it tries to apt-get openjdk-21-jdk-headless which is classified as unstable and so it cannot be found.