### PR TITLE
Add NuRaft log file env variable

### DIFF
--- a/src/flags/coord_flag_env_handler.cpp
+++ b/src/flags/coord_flag_env_handler.cpp
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+#include <algorithm>
 #include <cstdint>
 #include <cstdlib>
 #include <string>
@@ -22,61 +23,79 @@
 #include <range/v3/range/conversion.hpp>
 #include <range/v3/view/drop_while.hpp>
 #include <range/v3/view/take_while.hpp>
+#include <range/v3/view/transform.hpp>
 
 namespace memgraph::flags {
 
-CoordinationSetup::CoordinationSetup(int management_port, int coordinator_port, uint32_t coordinator_id)
-    : management_port(management_port), coordinator_port(coordinator_port), coordinator_id(coordinator_id) {}
+CoordinationSetup::CoordinationSetup(int management_port, int coordinator_port, uint32_t coordinator_id,
+                                     std::string nuraft_log_file)
+    : management_port(management_port),
+      coordinator_port(coordinator_port),
+      coordinator_id(coordinator_id),
+      nuraft_log_file(std::move(nuraft_log_file)) {}
 
 std::string CoordinationSetup::ToString() {
-  return fmt::format("management port: {}, coordinator port {}, coordinator id", management_port, coordinator_port,
-                     coordinator_id);
+  return fmt::format("management port: {}, coordinator port: {}, coordinator id: {}, nuraft_log_file: {}",
+                     management_port, coordinator_port, coordinator_id, nuraft_log_file);
 }
 
+// TODO: (andi) This will change if we add management server to coordinators.
 [[nodiscard]] auto CoordinationSetup::IsCoordinatorManaged() const -> bool { return management_port != 0; }
 
 auto CoordinationSetupInstance() -> CoordinationSetup & {
-  static auto instance = CoordinationSetup{0, 0, 0};
+  static auto instance = CoordinationSetup{};
   return instance;
 }
 
 void SetFinalCoordinationSetup() {
 #ifdef MG_ENTERPRISE
-  auto const *maybe_management_port = std::getenv(kMgManagementPort);
-  auto const *maybe_coordinator_port = std::getenv(kMgCoordinatorPort);
-  auto const *maybe_coordinator_id = std::getenv(kMgCoordinatorId);
 
-  bool const are_envs_set = maybe_management_port || maybe_coordinator_port || maybe_coordinator_id;
-  bool const are_flags_set = FLAGS_management_port || FLAGS_coordinator_port || FLAGS_coordinator_id;
+  std::vector<char const *> const maybe_coord_envs{std::getenv(kMgManagementPort), std::getenv(kMgCoordinatorPort),
+                                                   std::getenv(kMgCoordinatorId), std::getenv(kMgNuRaftLogFile)};
 
-  if (are_envs_set && are_flags_set) {
-    spdlog::trace(
-        "Ignoring coordinator setup(management_port, coordinator_port and coordinator_id) sent via flags as there is "
-        "input in environment variables");
+  bool const any_envs_set = std::ranges::any_of(maybe_coord_envs, [](char const *env) { return env != nullptr; });
+
+  auto const is_flag_set = []<typename T>(T const &flag) { return flag != T{}; };
+
+  bool const any_flags_set = is_flag_set(FLAGS_management_port) || is_flag_set(FLAGS_coordinator_port) ||
+                             is_flag_set(FLAGS_coordinator_id) || is_flag_set(FLAGS_nuraft_log_file);
+
+  if (any_flags_set && any_envs_set) {
+    spdlog::warn(
+        "Both environment variables and flags are set for coordinator setup. Using environment variables as priority. "
+        "Flags will be ignored.");
   }
 
-  auto const canonicalize_string = [](auto &&rng) {
-    auto const is_space = [](auto c) { return c == ' '; };
-
-    return rng | ranges::views::drop_while(is_space) | ranges::views::take_while(std::not_fn(is_space)) |
-           ranges::to<std::string>;
-  };
-
   CoordinationSetupInstance() = [&]() {
-    if (!are_envs_set && !are_flags_set) {
-      return CoordinationSetup{0, 0, 0};
+    if (!any_flags_set && !any_envs_set) {
+      return CoordinationSetup{};
     }
-    if (are_envs_set) {
-      spdlog::trace("Read coordinator setup from env variables: {}.", CoordinationSetupInstance().ToString());
-      return CoordinationSetup(
-          maybe_management_port ? std::stoi(canonicalize_string(std::string_view{maybe_management_port})) : 0,
-          maybe_coordinator_port ? std::stoi(canonicalize_string(std::string_view{maybe_coordinator_port})) : 0,
-          maybe_coordinator_id
-              ? static_cast<uint32_t>(std::stoul(canonicalize_string(std::string_view{maybe_coordinator_id})))
-              : 0);
+
+    auto const trim = [](char const *flag) -> std::optional<std::string> {
+      if (flag == nullptr) {
+        return std::nullopt;
+      }
+
+      auto const is_space = [](auto c) { return c == ' '; };
+
+      return std::string_view{flag} | ranges::views::drop_while(is_space) |
+             ranges::views::take_while(std::not_fn(is_space)) | ranges::to<std::string>;
+    };
+
+    auto const coord_envs =
+        maybe_coord_envs | ranges::views::transform(trim) | ranges::to<std::vector<std::optional<std::string>>>;
+
+    if (any_envs_set) {
+      spdlog::trace("Coordinator will be initialized using environment variables.");
+      return CoordinationSetup(coord_envs[0] ? std::stoi(coord_envs[0].value()) : 0,
+                               coord_envs[1] ? std::stoi(coord_envs[1].value()) : 0,
+                               coord_envs[2] ? static_cast<uint32_t>(std::stoul(coord_envs[2].value())) : 0,
+                               coord_envs[3] ? coord_envs[3].value() : "");
     }
-    spdlog::trace("Read coordinator setup from runtime flags {}.", CoordinationSetupInstance().ToString());
-    return CoordinationSetup{FLAGS_management_port, FLAGS_coordinator_port, FLAGS_coordinator_id};
+
+    spdlog::trace("Coordinator will be initilized using flags.");
+    return CoordinationSetup{FLAGS_management_port, FLAGS_coordinator_port, FLAGS_coordinator_id,
+                             FLAGS_nuraft_log_file};
   }();  // iile
 #endif
 }

--- a/src/flags/coord_flag_env_handler.hpp
+++ b/src/flags/coord_flag_env_handler.hpp
@@ -18,13 +18,19 @@ namespace memgraph::flags {
 constexpr const char *kMgManagementPort = "MEMGRAPH_MANAGEMENT_PORT";
 constexpr const char *kMgCoordinatorPort = "MEMGRAPH_COORDINATOR_PORT";
 constexpr const char *kMgCoordinatorId = "MEMGRAPH_COORDINATOR_ID";
+constexpr const char *kMgNuRaftLogFile = "MEMGRAPH_NURAFT_LOG_FILE";
 
+// Contains values that could be set by environment variables or flags.
+// These values could be used both for data instances and coordinator instances
 struct CoordinationSetup {
   int management_port{0};
   int coordinator_port{0};
   uint32_t coordinator_id{0};
+  std::string nuraft_log_file;
 
-  explicit CoordinationSetup(int management_port, int coordinator_port, uint32_t coordinator_id);
+  explicit CoordinationSetup(int management_port, int coordinator_port, uint32_t coordinator_id,
+                             std::string nuraft_log_file);
+  CoordinationSetup() = default;
 
   std::string ToString();
 

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -523,9 +523,9 @@ int main(int argc, char **argv) {
     if (coordination_setup.coordinator_id && coordination_setup.coordinator_port) {
       auto const high_availability_data_dir = FLAGS_data_directory + "/high_availability" + "/coordinator";
       memgraph::utils::EnsureDirOrDie(high_availability_data_dir);
-      coordinator_state.emplace(CoordinatorInstanceInitConfig{coordination_setup.coordinator_id,
-                                                              coordination_setup.coordinator_port, extracted_bolt_port,
-                                                              high_availability_data_dir, FLAGS_nuraft_log_file});
+      coordinator_state.emplace(CoordinatorInstanceInitConfig{
+          coordination_setup.coordinator_id, coordination_setup.coordinator_port, extracted_bolt_port,
+          high_availability_data_dir, coordination_setup.nuraft_log_file});
     } else {
       coordinator_state.emplace(ReplicationInstanceInitConfig{.management_port = coordination_setup.management_port});
     }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -483,6 +483,13 @@ target_link_libraries(${test_prefix}coordinator_instance gflags mg-coordination 
 target_include_directories(${test_prefix}coordinator_instance PRIVATE ${CMAKE_SOURCE_DIR}/include)
 endif()
 
+# Test coordinator env flag handler
+if(MG_ENTERPRISE)
+add_unit_test(coordinator_env_flag_handler.cpp)
+target_link_libraries(${test_prefix}coordinator_env_flag_handler gflags mg-flags)
+target_include_directories(${test_prefix}coordinator_env_flag_handler PRIVATE ${CMAKE_SOURCE_DIR}/include)
+endif()
+
 # Test replication instance connector
 if(MG_ENTERPRISE)
 add_unit_test(replication_instance_connector.cpp)

--- a/tests/unit/coordinator_cluster_state.cpp
+++ b/tests/unit/coordinator_cluster_state.cpp
@@ -39,9 +39,6 @@ class CoordinatorClusterStateTest : public ::testing::Test {
   void SetUp() override {}
 
   void TearDown() override {}
-
-  std::filesystem::path test_folder_{std::filesystem::temp_directory_path() /
-                                     "MG_tests_unit_coordinator_cluster_state"};
 };
 
 TEST_F(CoordinatorClusterStateTest, RegisterReplicationInstance) {

--- a/tests/unit/coordinator_env_flag_handler.cpp
+++ b/tests/unit/coordinator_env_flag_handler.cpp
@@ -1,0 +1,83 @@
+// Copyright 2024 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "flags/coord_flag_env_handler.hpp"
+
+#include <gtest/gtest.h>
+
+#include <stdlib.h>
+
+class CoordinationSetupTest : public ::testing::Test {
+ protected:
+  void SetUp() override {}
+
+  void TearDown() override {
+    unsetenv(memgraph::flags::kMgManagementPort);
+    unsetenv(memgraph::flags::kMgCoordinatorPort);
+    unsetenv(memgraph::flags::kMgCoordinatorId);
+    unsetenv(memgraph::flags::kMgNuRaftLogFile);
+  }
+};
+
+TEST_F(CoordinationSetupTest, CoordinationSetupSimple) {
+  memgraph::flags::CoordinationSetup coord_setup(1, 2, 3, "nuraft_log_file");
+  EXPECT_EQ(coord_setup.management_port, 1);
+  EXPECT_EQ(coord_setup.coordinator_port, 2);
+  EXPECT_EQ(coord_setup.coordinator_id, 3);
+  EXPECT_EQ(coord_setup.nuraft_log_file, "nuraft_log_file");
+}
+
+TEST_F(CoordinationSetupTest, CoordinationSetupAll) {
+  using namespace memgraph::flags;
+  // If the environment variable named by envname already exists and the value of overwrite is non-zero, the function
+  // shall return success and the environment shall be updated.
+  if (setenv(kMgManagementPort, "10011", 1) != 0) {
+    FAIL() << "Failed to set MEMGRAPH_MANAGEMENT_PORT environment variable";
+  }
+
+  if (setenv(kMgCoordinatorPort, "10111", 1) != 0) {
+    FAIL() << "Failed to set MEMGRAPH_COORDINATOR_PORT environment variable";
+  }
+
+  if (setenv(kMgCoordinatorId, "1", 1) != 0) {
+    FAIL() << "Failed to set MEMGRAPH_COORDINATOR_ID environment variable";
+  }
+
+  if (setenv(kMgNuRaftLogFile, "nuraft_log_file", 1) != 0) {
+    FAIL() << "Failed to set MEMGRAPH_NURAFT_LOG_FILE environment variable";
+  }
+
+  memgraph::flags::SetFinalCoordinationSetup();
+  auto const &coordination_setup = memgraph::flags::CoordinationSetupInstance();
+
+  EXPECT_EQ(coordination_setup.management_port, 10011);
+  EXPECT_EQ(coordination_setup.coordinator_port, 10111);
+  EXPECT_EQ(coordination_setup.coordinator_id, 1);
+  EXPECT_EQ(coordination_setup.nuraft_log_file, "nuraft_log_file");
+}
+
+TEST_F(CoordinationSetupTest, CoordinatorSetupPartial) {
+  using namespace memgraph::flags;
+  if (setenv(kMgCoordinatorPort, "10111", 1) != 0) {
+    FAIL() << "Failed to set MEMGRAPH_COORDINATOR_PORT environment variable";
+  }
+
+  if (setenv(kMgCoordinatorId, "1", 1) != 0) {
+    FAIL() << "Failed to set MEMGRAPH_COORDINATOR_ID environment variable";
+  }
+
+  memgraph::flags::SetFinalCoordinationSetup();
+  auto const &coordination_setup = memgraph::flags::CoordinationSetupInstance();
+  EXPECT_EQ(coordination_setup.management_port, 0);
+  EXPECT_EQ(coordination_setup.coordinator_port, 10111);
+  EXPECT_EQ(coordination_setup.coordinator_id, 1);
+  EXPECT_EQ(coordination_setup.nuraft_log_file, "");
+}


### PR DESCRIPTION
### Description

Add NuRaft log file env variables
Refactored CoordinationSetup flag vs. env.
Added test

[master < Task] PR
- [x] Provide the full content or a guide for the final git message
    - **Add NuRaft log file env variable**


### CI Testing Labels
Please select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [x] Write a release note, including added/changed clauses
    - @kgolubic NuRaft Logger is added in 2.18 so this is not yet released. This PR contains some improvements to that so I think no need for new release note, I think we should just extend release note from https://github.com/memgraph/memgraph/pull/2084 by adding: You can also use environment variable `MEMGRAPH_NURAFT_LOG_FILE` for setting path to NuRaft logs.
- [x] Link the documentation PR here
    - **https://github.com/memgraph/documentation/pull/848**
- [x] Tag someone from docs team in the comments
