### PR TITLE
Ensure headers exist for clang-tidy analysis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,6 +416,9 @@ if(QUERY_MODULES)
   add_subdirectory(query_modules)
 endif()
 
+# All targets which generate code, useful as a single target to build for clang-tidy analysis to work
+add_custom_target(generated_code DEPENDS generate_opencypher_parser mgcxx-proj)
+
 install(FILES ${CMAKE_BINARY_DIR}/bin/mgconsole
   PERMISSIONS OWNER_EXECUTE OWNER_READ OWNER_WRITE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
   TYPE BIN)

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -363,6 +363,12 @@ build_memgraph () {
   local cmake_cmd="cmake $build_type_flag $skip_rpath_flags $arm_flag $community_flag $telemetry_id_override_flag $coverage_flag $asan_flag $ubsan_flag .."
   docker exec -u mg "$build_container" bash -c "cd $container_build_dir && $ACTIVATE_TOOLCHAIN && $ACTIVATE_CARGO && $cmake_cmd"
   if [[ "$cmake_only" == "true" ]]; then
+    build_target(){
+      target=$1
+      docker exec -u mg "$build_container" bash -c "$ACTIVATE_TOOLCHAIN && $ACTIVATE_CARGO && cmake --build $container_build_dir --target $target -- -j"'$(nproc)'
+    }
+    # Force build that generate the header files needed by analysis (ie. clang-tidy)
+    build_target generated_code
     return
   fi
   # ' is used instead of " because we need to run make within the allowed


### PR DESCRIPTION
`generate_opencypher_parser` and `mgcxx-proj` produce headers that clang-tidy will need to use for its analysis. Made a custom target for them and ensured `mgbuild.sh` will build them when needed.