### PR TITLE
Unique memory access for replicating auto-created indices

### DIFF
--- a/src/rpc/version.hpp
+++ b/src/rpc/version.hpp
@@ -31,6 +31,11 @@ constexpr auto v2 = Version{2023'12'07'0'2'14};
 // To each RPC main uuid was added
 constexpr auto v3 = Version{2024'02'02'0'2'14};
 
-constexpr auto current_version = v3;
+// The order of metadata and data deltas has been changed
+// It is now possible that both can be sent in one commit
+// this is due to auto index creation
+constexpr auto v4 = Version{2024'07'02'0'2'18};
+
+constexpr auto current_version = v4;
 
 }  // namespace memgraph::rpc

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2159,6 +2159,111 @@ bool InMemoryStorage::AppendToWal(const Transaction &transaction, uint64_t durab
 
   auto streams = repl_storage_state_.InitializeTransaction(wal_file_->SequenceNumber(), this, db_acc);
 
+  auto const apply_encode = [&](durability::StorageMetadataOperation op, auto &&encode_operation) {
+    auto full_encode_operation = [&](durability::BaseEncoder &encoder) {
+      EncodeOperationPreamble(encoder, op, durability_commit_timestamp);
+      encode_operation(encoder);
+    };
+
+    // durability
+    full_encode_operation(wal_file_->encoder());
+    wal_file_->UpdateStats(durability_commit_timestamp);
+    // replication
+    repl_storage_state_.EncodeToReplicas(streams, full_encode_operation);
+  };
+
+  // Handle metadata deltas
+  for (const auto &md_delta : transaction.md_deltas) {
+    auto const op = ActionToStorageOperation(md_delta.action);
+    switch (md_delta.action) {
+      case MetadataDelta::Action::LABEL_INDEX_CREATE:
+      case MetadataDelta::Action::LABEL_INDEX_DROP: {
+        apply_encode(op,
+                     [&](durability::BaseEncoder &encoder) { EncodeLabel(encoder, *name_id_mapper_, md_delta.label); });
+        break;
+      }
+      case MetadataDelta::Action::LABEL_INDEX_STATS_CLEAR:
+      case MetadataDelta::Action::LABEL_PROPERTY_INDEX_STATS_CLEAR: {
+        apply_encode(op, [&](durability::BaseEncoder &encoder) {
+          EncodeLabel(encoder, *name_id_mapper_, md_delta.label_stats.label);
+        });
+        break;
+      }
+      case MetadataDelta::Action::LABEL_PROPERTY_INDEX_STATS_SET: {
+        apply_encode(op, [&](durability::BaseEncoder &encoder) {
+          EncodeLabelPropertyStats(encoder, *name_id_mapper_, md_delta.label_property_stats.label,
+                                   md_delta.label_property_stats.property, md_delta.label_property_stats.stats);
+        });
+        break;
+      }
+      case MetadataDelta::Action::EDGE_INDEX_CREATE:
+      case MetadataDelta::Action::EDGE_INDEX_DROP: {
+        apply_encode(op, [&](durability::BaseEncoder &encoder) {
+          EncodeEdgeTypeIndex(encoder, *name_id_mapper_, md_delta.edge_type);
+        });
+        break;
+      }
+      case MetadataDelta::Action::EDGE_PROPERTY_INDEX_CREATE:
+      case MetadataDelta::Action::EDGE_PROPERTY_INDEX_DROP: {
+        apply_encode(op, [&](durability::BaseEncoder &encoder) {
+          EncodeEdgeTypePropertyIndex(encoder, *name_id_mapper_, md_delta.edge_type_property.edge_type,
+                                      md_delta.edge_type_property.property);
+        });
+        break;
+      }
+      case MetadataDelta::Action::LABEL_PROPERTY_INDEX_CREATE:
+      case MetadataDelta::Action::LABEL_PROPERTY_INDEX_DROP:
+      case MetadataDelta::Action::EXISTENCE_CONSTRAINT_CREATE:
+      case MetadataDelta::Action::EXISTENCE_CONSTRAINT_DROP: {
+        apply_encode(op, [&](durability::BaseEncoder &encoder) {
+          EncodeLabelProperty(encoder, *name_id_mapper_, md_delta.label_property.label,
+                              md_delta.label_property.property);
+        });
+        break;
+      }
+      case MetadataDelta::Action::LABEL_INDEX_STATS_SET: {
+        apply_encode(op, [&](durability::BaseEncoder &encoder) {
+          EncodeLabelStats(encoder, *name_id_mapper_, md_delta.label_stats.label, md_delta.label_stats.stats);
+        });
+        break;
+      }
+      case MetadataDelta::Action::TEXT_INDEX_CREATE:
+      case MetadataDelta::Action::TEXT_INDEX_DROP: {
+        apply_encode(op, [&](durability::BaseEncoder &encoder) {
+          EncodeTextIndex(encoder, *name_id_mapper_, md_delta.text_index.index_name, md_delta.text_index.label);
+        });
+        break;
+      }
+      case MetadataDelta::Action::UNIQUE_CONSTRAINT_CREATE:
+      case MetadataDelta::Action::UNIQUE_CONSTRAINT_DROP: {
+        apply_encode(op, [&](durability::BaseEncoder &encoder) {
+          EncodeLabelProperties(encoder, *name_id_mapper_, md_delta.label_properties.label,
+                                md_delta.label_properties.properties);
+        });
+        break;
+      }
+      case MetadataDelta::Action::ENUM_CREATE: {
+        apply_encode(op, [&](durability::BaseEncoder &encoder) {
+          EncodeEnumCreate(encoder, enum_store_, md_delta.enum_create_info.etype);
+        });
+        break;
+      }
+      case MetadataDelta::Action::ENUM_ALTER_ADD: {
+        apply_encode(op, [&](durability::BaseEncoder &encoder) {
+          EncodeEnumAlterAdd(encoder, enum_store_, md_delta.enum_alter_add_info.value);
+        });
+        break;
+      }
+      case MetadataDelta::Action::ENUM_ALTER_UPDATE: {
+        apply_encode(op, [&](durability::BaseEncoder &encoder) {
+          EncodeEnumAlterUpdate(encoder, enum_store_, md_delta.enum_alter_update_info.value,
+                                md_delta.enum_alter_update_info.old_value);
+        });
+        break;
+      }
+    }
+  }
+
   auto append_deltas = [&](auto callback) {
     // Helper lambda that traverses the delta chain on order to find the first
     // delta that should be processed and then appends all discovered deltas.
@@ -2312,111 +2417,6 @@ bool InMemoryStorage::AppendToWal(const Transaction &transaction, uint64_t durab
       wal_file_->AppendDelta(delta, parent, timestamp);
       repl_storage_state_.AppendDelta(streams, delta, parent, timestamp);
     });
-  }
-
-  auto const apply_encode = [&](durability::StorageMetadataOperation op, auto &&encode_operation) {
-    auto full_encode_operation = [&](durability::BaseEncoder &encoder) {
-      EncodeOperationPreamble(encoder, op, durability_commit_timestamp);
-      encode_operation(encoder);
-    };
-
-    // durability
-    full_encode_operation(wal_file_->encoder());
-    wal_file_->UpdateStats(durability_commit_timestamp);
-    // replication
-    repl_storage_state_.EncodeToReplicas(streams, full_encode_operation);
-  };
-
-  // Handle metadata deltas
-  for (const auto &md_delta : transaction.md_deltas) {
-    auto const op = ActionToStorageOperation(md_delta.action);
-    switch (md_delta.action) {
-      case MetadataDelta::Action::LABEL_INDEX_CREATE:
-      case MetadataDelta::Action::LABEL_INDEX_DROP: {
-        apply_encode(op,
-                     [&](durability::BaseEncoder &encoder) { EncodeLabel(encoder, *name_id_mapper_, md_delta.label); });
-        break;
-      }
-      case MetadataDelta::Action::LABEL_INDEX_STATS_CLEAR:
-      case MetadataDelta::Action::LABEL_PROPERTY_INDEX_STATS_CLEAR: {
-        apply_encode(op, [&](durability::BaseEncoder &encoder) {
-          EncodeLabel(encoder, *name_id_mapper_, md_delta.label_stats.label);
-        });
-        break;
-      }
-      case MetadataDelta::Action::LABEL_PROPERTY_INDEX_STATS_SET: {
-        apply_encode(op, [&](durability::BaseEncoder &encoder) {
-          EncodeLabelPropertyStats(encoder, *name_id_mapper_, md_delta.label_property_stats.label,
-                                   md_delta.label_property_stats.property, md_delta.label_property_stats.stats);
-        });
-        break;
-      }
-      case MetadataDelta::Action::EDGE_INDEX_CREATE:
-      case MetadataDelta::Action::EDGE_INDEX_DROP: {
-        apply_encode(op, [&](durability::BaseEncoder &encoder) {
-          EncodeEdgeTypeIndex(encoder, *name_id_mapper_, md_delta.edge_type);
-        });
-        break;
-      }
-      case MetadataDelta::Action::EDGE_PROPERTY_INDEX_CREATE:
-      case MetadataDelta::Action::EDGE_PROPERTY_INDEX_DROP: {
-        apply_encode(op, [&](durability::BaseEncoder &encoder) {
-          EncodeEdgeTypePropertyIndex(encoder, *name_id_mapper_, md_delta.edge_type_property.edge_type,
-                                      md_delta.edge_type_property.property);
-        });
-        break;
-      }
-      case MetadataDelta::Action::LABEL_PROPERTY_INDEX_CREATE:
-      case MetadataDelta::Action::LABEL_PROPERTY_INDEX_DROP:
-      case MetadataDelta::Action::EXISTENCE_CONSTRAINT_CREATE:
-      case MetadataDelta::Action::EXISTENCE_CONSTRAINT_DROP: {
-        apply_encode(op, [&](durability::BaseEncoder &encoder) {
-          EncodeLabelProperty(encoder, *name_id_mapper_, md_delta.label_property.label,
-                              md_delta.label_property.property);
-        });
-        break;
-      }
-      case MetadataDelta::Action::LABEL_INDEX_STATS_SET: {
-        apply_encode(op, [&](durability::BaseEncoder &encoder) {
-          EncodeLabelStats(encoder, *name_id_mapper_, md_delta.label_stats.label, md_delta.label_stats.stats);
-        });
-        break;
-      }
-      case MetadataDelta::Action::TEXT_INDEX_CREATE:
-      case MetadataDelta::Action::TEXT_INDEX_DROP: {
-        apply_encode(op, [&](durability::BaseEncoder &encoder) {
-          EncodeTextIndex(encoder, *name_id_mapper_, md_delta.text_index.index_name, md_delta.text_index.label);
-        });
-        break;
-      }
-      case MetadataDelta::Action::UNIQUE_CONSTRAINT_CREATE:
-      case MetadataDelta::Action::UNIQUE_CONSTRAINT_DROP: {
-        apply_encode(op, [&](durability::BaseEncoder &encoder) {
-          EncodeLabelProperties(encoder, *name_id_mapper_, md_delta.label_properties.label,
-                                md_delta.label_properties.properties);
-        });
-        break;
-      }
-      case MetadataDelta::Action::ENUM_CREATE: {
-        apply_encode(op, [&](durability::BaseEncoder &encoder) {
-          EncodeEnumCreate(encoder, enum_store_, md_delta.enum_create_info.etype);
-        });
-        break;
-      }
-      case MetadataDelta::Action::ENUM_ALTER_ADD: {
-        apply_encode(op, [&](durability::BaseEncoder &encoder) {
-          EncodeEnumAlterAdd(encoder, enum_store_, md_delta.enum_alter_add_info.value);
-        });
-        break;
-      }
-      case MetadataDelta::Action::ENUM_ALTER_UPDATE: {
-        apply_encode(op, [&](durability::BaseEncoder &encoder) {
-          EncodeEnumAlterUpdate(encoder, enum_store_, md_delta.enum_alter_update_info.value,
-                                md_delta.enum_alter_update_info.old_value);
-        });
-        break;
-      }
-    }
   }
 
   // Add a delta that indicates that the transaction is fully written to the WAL

--- a/tests/e2e/replication/workloads.yaml
+++ b/tests/e2e/replication/workloads.yaml
@@ -11,9 +11,9 @@ template_validation_queries: &template_validation_queries
 template_simple_cluster: &template_simple_cluster
   cluster:
     replica_1:
-      args: [ "--bolt-port", "7688", "--log-level=TRACE"]
+      args: ["--bolt-port", "7688", "--log-level=TRACE"]
       log_file: "replication-e2e-replica1.log"
-      setup_queries: [ "SET REPLICATION ROLE TO REPLICA WITH PORT 10001;" ]
+      setup_queries: ["SET REPLICATION ROLE TO REPLICA WITH PORT 10001;"]
     replica_2:
       args: ["--bolt-port", "7689", "--log-level=TRACE"]
       log_file: "replication-e2e-replica2.log"
@@ -21,10 +21,11 @@ template_simple_cluster: &template_simple_cluster
     main:
       args: ["--bolt-port", "7687", "--log-level=TRACE"]
       log_file: "replication-e2e-main.log"
-      setup_queries: [
-        "REGISTER REPLICA replica_1 SYNC TO '127.0.0.1:10001'",
-        "REGISTER REPLICA replica_2 ASYNC TO '127.0.0.1:10002'",
-      ]
+      setup_queries:
+        [
+          "REGISTER REPLICA replica_1 SYNC TO '127.0.0.1:10001'",
+          "REGISTER REPLICA replica_2 ASYNC TO '127.0.0.1:10002'",
+        ]
 
 template_cluster: &template_cluster
   cluster:
@@ -46,11 +47,46 @@ template_cluster: &template_cluster
     main:
       args: ["--bolt-port", "7687", "--log-level=TRACE"]
       log_file: "replication-e2e-main.log"
-      setup_queries: [
-        "REGISTER REPLICA replica_1 SYNC TO '127.0.0.1:10001'",
-        "REGISTER REPLICA replica_2 SYNC TO '127.0.0.1:10002'",
-        "REGISTER REPLICA replica_3 ASYNC TO '127.0.0.1:10003'"
-      ]
+      setup_queries:
+        [
+          "REGISTER REPLICA replica_1 SYNC TO '127.0.0.1:10001'",
+          "REGISTER REPLICA replica_2 SYNC TO '127.0.0.1:10002'",
+          "REGISTER REPLICA replica_3 ASYNC TO '127.0.0.1:10003'",
+        ]
+
+template_cluster_indexing: &template_cluster_indexing
+  cluster:
+    replica_1:
+      args: ["--bolt-port", "7688", "--log-level=TRACE"]
+      log_file: "replication-e2e-replica1.log"
+      setup_queries: ["SET REPLICATION ROLE TO REPLICA WITH PORT 10001;"]
+      <<: *template_validation_queries
+    replica_2:
+      args: ["--bolt-port", "7689", "--log-level=TRACE"]
+      log_file: "replication-e2e-replica2.log"
+      setup_queries: ["SET REPLICATION ROLE TO REPLICA WITH PORT 10002;"]
+      <<: *template_validation_queries
+    replica_3:
+      args: ["--bolt-port", "7690", "--log-level=TRACE"]
+      log_file: "replication-e2e-replica3.log"
+      setup_queries: ["SET REPLICATION ROLE TO REPLICA WITH PORT 10003;"]
+      <<: *template_validation_queries
+    main:
+      args:
+        [
+          "--bolt-port",
+          "7687",
+          "--log-level=TRACE",
+          "--storage-automatic-label-index-creation-enabled=TRUE",
+          "--storage-automatic-edge-type-index-creation-enabled=TRUE",
+        ]
+      log_file: "replication-e2e-main.log"
+      setup_queries:
+        [
+          "REGISTER REPLICA replica_1 SYNC TO '127.0.0.1:10001'",
+          "REGISTER REPLICA replica_2 SYNC TO '127.0.0.1:10002'",
+          "REGISTER REPLICA replica_3 ASYNC TO '127.0.0.1:10003'",
+        ]
 
 workloads:
   - name: "Constraints"
@@ -61,7 +97,7 @@ workloads:
   - name: "Index replication"
     binary: "tests/e2e/replication/memgraph__e2e__replication__indices"
     args: []
-    <<: *template_cluster
+    <<: *template_cluster_indexing
 
   - name: "Read-write benchmark"
     binary: "tests/e2e/replication/memgraph__e2e__replication__read_write_benchmark"
@@ -90,11 +126,12 @@ workloads:
       main:
         args: ["--bolt-port", "7687", "--log-level=TRACE"]
         log_file: "replication-e2e-main.log"
-        setup_queries: [
-          "REGISTER REPLICA replica_1 SYNC TO '127.0.0.1:10001'",
-          "REGISTER REPLICA replica_2 SYNC TO '127.0.0.1:10002'",
-          "REGISTER REPLICA replica_3 ASYNC TO '127.0.0.1:10003'"
-        ]
+        setup_queries:
+          [
+            "REGISTER REPLICA replica_1 SYNC TO '127.0.0.1:10001'",
+            "REGISTER REPLICA replica_2 SYNC TO '127.0.0.1:10002'",
+            "REGISTER REPLICA replica_3 ASYNC TO '127.0.0.1:10003'",
+          ]
         validation_queries: []
 
   - name: "Show while creating invalid state"
@@ -103,7 +140,7 @@ workloads:
 
   - name: "Replicate Enum"
     binary: "tests/e2e/pytest_runner.sh"
-    args: [ "replication/replicate_enum.py" ]
+    args: ["replication/replicate_enum.py"]
 
   - name: "Delete edge replication"
     binary: "tests/e2e/pytest_runner.sh"


### PR DESCRIPTION
Fix replication bug around auto index creation. Before it was not possible to have data and metadata deltas in same transaction. Now because of auto index creation it is, hence we need to ensure metadata deltas are sent first to make sure REPLICA uses unique access.