### PR TITLE
Move paths-ignore logic from diff.yaml to tools/diff_setup.py

### DIFF
--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -6,12 +6,6 @@ concurrency:
 on:
   merge_group:
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - ".clang-format"
-      - "CODEOWNERS"
-      - "licenses/*"
   workflow_dispatch:
     inputs:
       community_core:

--- a/tools/diff_setup.py
+++ b/tools/diff_setup.py
@@ -51,8 +51,19 @@ class DiffSetup:
 
     def _check_diff_workflow(self) -> bool:
         for file in os.popen(f"git diff --name-only {self._base_branch}").read().splitlines():
-            if not file.startswith(".github/workflows/") or file.startswith(".github/workflows/diff"):
-                return True
+            if file.startswith("docs/"):
+                continue
+            elif file.startswith("licenses/"):
+                continue
+            elif file.endswith(".md"):
+                continue
+            elif file.startswith(".clang-format"):
+                continue
+            elif file.startswith("CODEOWNERS"):
+                continue
+            elif file.startswith(".github/workflows/") and not file.startswith(".github/workflows/diff"):
+                continue
+            return True
         return False
 
     def _check_pr_label(self, build: str, test: str, pr_labels: list) -> bool:


### PR DESCRIPTION
This PR fixes CI being stalled when updating files previously defined under paths-ignore in diff.yaml