### PR TITLE
Add coordinator hostname config

### DIFF
--- a/src/coordination/coordinator_communication_config.cpp
+++ b/src/coordination/coordinator_communication_config.cpp
@@ -24,7 +24,8 @@ void to_json(nlohmann::json &j, CoordinatorToCoordinatorConfig const &config) {
   j = nlohmann::json{{"coordinator_id", config.coordinator_id},
                      {"coordinator_server", config.coordinator_server},
                      {"bolt_server", config.bolt_server},
-                     {"instance_down_timeout_sec", config.instance_down_timeout_sec.count()}};
+                     {"instance_down_timeout_sec", config.instance_down_timeout_sec.count()},
+                     {"coordinator_hostname", config.coordinator_hostname}};
 }
 
 void from_json(nlohmann::json const &j, CoordinatorToCoordinatorConfig &config) {
@@ -32,6 +33,7 @@ void from_json(nlohmann::json const &j, CoordinatorToCoordinatorConfig &config) 
   config.coordinator_server = j.at("coordinator_server").get<io::network::Endpoint>();
   config.bolt_server = j.at("bolt_server").get<io::network::Endpoint>();
   config.instance_down_timeout_sec = std::chrono::seconds{j.at("instance_down_timeout_sec").get<int>()};
+  config.coordinator_hostname = j.at("coordinator_hostname").get<std::string>();
 }
 
 void to_json(nlohmann::json &j, ReplicationClientInfo const &config) {

--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -202,12 +202,33 @@ auto CoordinatorInstance::ShowInstances() const -> std::vector<InstanceStatus> {
     return coordinator_id == curr_leader ? "leader" : "follower";
   };
 
-  auto const coord_instance_to_status = [this, &stringify_coord_health, &get_coord_role](
-                                            CoordinatorToCoordinatorConfig const &instance) -> InstanceStatus {
+  auto const get_coordinator_server = [](CoordinatorToCoordinatorConfig const &instance) -> std::string {
+    // If I am the 1st leader, I need separate processing. Only, the 1st leader will have coordinator_server set to
+    // 0.0.0.0. Coordinators that have been registered after the 1st leader will have coordinator_server set to the
+    // actual IP address so for them we can just retrieve their socket address.
+    if (instance.coordinator_server.GetResolvedIPAddress() == "0.0.0.0") {
+      return fmt::format("{}:{}", instance.coordinator_hostname, instance.coordinator_server.GetPort());
+    }
+    return instance.coordinator_server.SocketAddress();
+  };
+
+  auto const get_bolt_server = [](CoordinatorToCoordinatorConfig const &instance) -> std::string {
+    // If I am the 1st leader, I need separate processing. Only, the 1st leader will have bolt_server set to 0.0.0.0.
+    // Coordinators that have been registered after the 1st leader will have bolt_server set to the actual IP address so
+    // for them we can just retrieve their socket address.
+    if (instance.bolt_server.GetResolvedIPAddress() == "0.0.0.0") {
+      return fmt::format("{}:{}", instance.coordinator_hostname, instance.bolt_server.GetPort());
+    }
+    return instance.bolt_server.SocketAddress();
+  };
+
+  auto const coord_instance_to_status =
+      [this, &stringify_coord_health, &get_coord_role, &get_coordinator_server,
+       &get_bolt_server](CoordinatorToCoordinatorConfig const &instance) -> InstanceStatus {
     auto const curr_leader = raft_state_->GetLeaderId();
     return {.instance_name = fmt::format("coordinator_{}", instance.coordinator_id),
-            .coordinator_server = instance.coordinator_server.SocketAddress(),  // show non-resolved IP
-            .bolt_server = instance.bolt_server.SocketAddress(),                // show non-resolved IP
+            .coordinator_server = get_coordinator_server(instance),  // show non-resolved IP
+            .bolt_server = get_bolt_server(instance),                // show non-resolved IP
             .cluster_role = get_coord_role(instance.coordinator_id, curr_leader),
             .health = stringify_coord_health(instance),
             .last_succ_resp_ms = raft_state_->CoordLastSuccRespMs(instance.coordinator_id).count()};

--- a/src/coordination/coordinator_state_manager.cpp
+++ b/src/coordination/coordinator_state_manager.cpp
@@ -87,7 +87,7 @@ CoordinatorStateManager::CoordinatorStateManager(CoordinatorStateManagerConfig c
       durability_(config.state_manager_durability_dir_) {
   auto const c2c =
       CoordinatorToCoordinatorConfig{config.coordinator_id_, io::network::Endpoint("0.0.0.0", config.bolt_port_),
-                                     io::network::Endpoint{"0.0.0.0", static_cast<uint16_t>(config.coordinator_port_)}};
+                                     io::network::Endpoint{"0.0.0.0", static_cast<uint16_t>(config.coordinator_port_)}, config.coordinator_hostname};
   my_srv_config_ = cs_new<srv_config>(config.coordinator_id_, 0, c2c.coordinator_server.SocketAddress(),
                                       nlohmann::json(c2c).dump(), false);
 

--- a/src/coordination/include/coordination/coordinator_communication_config.hpp
+++ b/src/coordination/include/coordination/coordinator_communication_config.hpp
@@ -43,21 +43,25 @@ struct CoordinatorInstanceInitConfig {
   int coordinator_port{0};
   int bolt_port{0};
   std::filesystem::path durability_dir;
+  std::string coordinator_hostname;
   std::string nuraft_log_file;
   bool use_durability;
 
   // If nuraft_log_file isn't provided, spdlog::logger for NuRaft will still get created but without sinks effectively
   // then being a no-op logger.
   explicit CoordinatorInstanceInitConfig(uint32_t coordinator_id, int coordinator_port, int bolt_port,
-                                         std::filesystem::path durability_dir, std::string nuraft_log_file = "",
-                                         bool use_durability = true)
+                                         std::filesystem::path durability_dir, 
+                                         std::string coordinator_hostname,
+                                         std::string nuraft_log_file = "", bool use_durability=true)
       : coordinator_id(coordinator_id),
         coordinator_port(coordinator_port),
         bolt_port(bolt_port),
         durability_dir(std::move(durability_dir)),
+        coordinator_hostname(std::move(coordinator_hostname)),
         nuraft_log_file(std::move(nuraft_log_file)),
         use_durability(use_durability) {
     MG_ASSERT(!this->durability_dir.empty(), "Path empty");
+    MG_ASSERT(!this->coordinator_hostname.empty(), "Hostname empty");
   }
 };
 
@@ -72,17 +76,21 @@ struct CoordinatorStateManagerConfig {
   int coordinator_port_{0};
   int bolt_port_{0};
   std::filesystem::path state_manager_durability_dir_;
+  std::string coordinator_hostname;
   std::optional<LogStoreDurability> log_store_durability_;
 
   CoordinatorStateManagerConfig(uint32_t coordinator_id, int coordinator_port, int bolt_port,
                                 std::filesystem::path state_manager_durability_dir,
+                                std::string coordinator_hostname,
                                 std::optional<LogStoreDurability> log_store_durability = std::nullopt)
       : coordinator_id_(coordinator_id),
         coordinator_port_(coordinator_port),
         bolt_port_(bolt_port),
         state_manager_durability_dir_(std::move(state_manager_durability_dir)),
+        coordinator_hostname(std::move(coordinator_hostname)),
         log_store_durability_(std::move(log_store_durability)) {
     MG_ASSERT(!this->state_manager_durability_dir_.empty(), "State manager durability dir path is empty");
+    MG_ASSERT(!this->coordinator_hostname.empty(), "Hostname empty");
   }
 };
 
@@ -127,6 +135,9 @@ struct CoordinatorToCoordinatorConfig {
   uint32_t coordinator_id{0};
   io::network::Endpoint bolt_server;
   io::network::Endpoint coordinator_server;
+  // Currently, this is needed additionally to the coordinator_server but maybe we could put hostname into bolt_server
+  // and coordinator_server.
+  std::string coordinator_hostname;
   std::chrono::seconds instance_down_timeout_sec{5};
 
   friend bool operator==(CoordinatorToCoordinatorConfig const &, CoordinatorToCoordinatorConfig const &) = default;

--- a/src/coordination/raft_state.cpp
+++ b/src/coordination/raft_state.cpp
@@ -55,7 +55,8 @@ RaftState::RaftState(CoordinatorInstanceInitConfig const &config, BecomeLeaderCb
   memgraph::utils::EnsureDirOrDie(coordinator_state_manager_durability_dir);
 
   CoordinatorStateManagerConfig state_manager_config{config.coordinator_id, config.coordinator_port, config.bolt_port,
-                                                     coordinator_state_manager_durability_dir};
+                                                     coordinator_state_manager_durability_dir,
+                                                     config.coordinator_hostname};
   auto logger_wrapper = LoggerWrapper(static_cast<Logger *>(logger_.get()));
   LogStoreDurability log_store_durability;
 

--- a/src/flags/coord_flag_env_handler.cpp
+++ b/src/flags/coord_flag_env_handler.cpp
@@ -28,17 +28,19 @@
 namespace memgraph::flags {
 
 CoordinationSetup::CoordinationSetup(int management_port, int coordinator_port, uint32_t coordinator_id,
-                                     std::string nuraft_log_file, bool ha_durability)
+                                     std::string nuraft_log_file, bool ha_durability, std::string coordinator_hostname)
     : management_port(management_port),
       coordinator_port(coordinator_port),
       coordinator_id(coordinator_id),
       nuraft_log_file(std::move(nuraft_log_file)),
-      ha_durability(ha_durability) {}
-
+      ha_durability(ha_durability),
+      coordinator_hostname(std::move(coordinator_hostname)) {}
 
 std::string CoordinationSetup::ToString() {
-  return fmt::format("management port: {}, coordinator port: {}, coordinator id: {}, nuraft_log_file: {}",
-                     management_port, coordinator_port, coordinator_id, nuraft_log_file);
+  return fmt::format(
+      "management port: {}, coordinator port: {}, coordinator id: {}, nuraft_log_file: {} ha_durability: {}, "
+      "coordinator_hostname: {}",
+      management_port, coordinator_port, coordinator_id, nuraft_log_file, ha_durability, coordinator_hostname);
 }
 
 [[nodiscard]] auto CoordinationSetup::IsCoordinatorManaged() const -> bool { return management_port != 0; }
@@ -52,15 +54,16 @@ void SetFinalCoordinationSetup() {
 #ifdef MG_ENTERPRISE
 
   std::vector<char const *> const maybe_coord_envs{std::getenv(kMgManagementPort), std::getenv(kMgCoordinatorPort),
-                                                   std::getenv(kMgCoordinatorId), std::getenv(kMgNuRaftLogFile),
-                                                   std::getenv(kMgHaDurability)};
+                                                   std::getenv(kMgCoordinatorId),  std::getenv(kMgNuRaftLogFile),
+                                                   std::getenv(kMgHaDurability),   std::getenv(kMgCoordinatorHostname)};
 
   bool const any_envs_set = std::ranges::any_of(maybe_coord_envs, [](char const *env) { return env != nullptr; });
 
   auto const is_flag_set = []<typename T>(T const &flag) { return flag != T{}; };
 
   bool const any_flags_set = is_flag_set(FLAGS_management_port) || is_flag_set(FLAGS_coordinator_port) ||
-                             is_flag_set(FLAGS_coordinator_id) || is_flag_set(FLAGS_nuraft_log_file);
+                             is_flag_set(FLAGS_coordinator_id) || is_flag_set(FLAGS_nuraft_log_file) ||
+                             is_flag_set(FLAGS_coordinator_hostname);
 
   if (any_flags_set && any_envs_set) {
     spdlog::warn(
@@ -89,16 +92,18 @@ void SetFinalCoordinationSetup() {
 
     if (any_envs_set) {
       spdlog::trace("Coordinator will be initialized using environment variables.");
-      return CoordinationSetup(coord_envs[0] ? std::stoi(coord_envs[0].value()) : 0,
-                               coord_envs[1] ? std::stoi(coord_envs[1].value()) : 0,
-                               coord_envs[2] ? static_cast<uint32_t>(std::stoul(coord_envs[2].value())) : 0,
-                               coord_envs[3] ? coord_envs[3].value() : "",
-                               coord_envs[4] ? bool(std::stoi(coord_envs[4].value())) : false);
+      return CoordinationSetup(
+          coord_envs[0] ? std::stoi(coord_envs[0].value()) : 0, 
+          coord_envs[1] ? std::stoi(coord_envs[1].value()) : 0,
+          coord_envs[2] ? static_cast<uint32_t>(std::stoul(coord_envs[2].value())) : 0,
+          coord_envs[3] ? coord_envs[3].value() : "", 
+          coord_envs[4] ? static_cast<bool>(std::stoi(coord_envs[4].value())) : false,
+          coord_envs[5] ? coord_envs[5].value() : "");
     }
 
     spdlog::trace("Coordinator will be initilized using flags.");
     return CoordinationSetup{FLAGS_management_port, FLAGS_coordinator_port, FLAGS_coordinator_id,
-                             FLAGS_nuraft_log_file, FLAGS_ha_durability};
+                             FLAGS_nuraft_log_file, FLAGS_ha_durability,    FLAGS_coordinator_hostname};
   }();  // iile
 #endif
 }

--- a/src/flags/coord_flag_env_handler.hpp
+++ b/src/flags/coord_flag_env_handler.hpp
@@ -20,6 +20,7 @@ constexpr const char *kMgCoordinatorPort = "MEMGRAPH_COORDINATOR_PORT";
 constexpr const char *kMgCoordinatorId = "MEMGRAPH_COORDINATOR_ID";
 constexpr const char *kMgHaDurability = "MEMGRAPH_HA_DURABILITY";
 constexpr const char *kMgNuRaftLogFile = "MEMGRAPH_NURAFT_LOG_FILE";
+constexpr const char *kMgCoordinatorHostname = "MEMGRAPH_COORDINATOR_HOSTNAME";
 
 // Contains values that could be set by environment variables or flags.
 // These values could be used both for data instances and coordinator instances
@@ -29,10 +30,10 @@ struct CoordinationSetup {
   uint32_t coordinator_id{0};
   std::string nuraft_log_file;
   bool ha_durability{false};
-
+  std::string coordinator_hostname;
 
   explicit CoordinationSetup(int management_port, int coordinator_port, uint32_t coordinator_id,
-                             std::string nuraft_log_file, bool ha_durability);
+                             std::string nuraft_log_file, bool ha_durability, std::string coordinator_hostname);
   CoordinationSetup() = default;
 
   std::string ToString();

--- a/src/flags/coordination.cpp
+++ b/src/flags/coordination.cpp
@@ -34,4 +34,6 @@ DEFINE_uint32(instance_get_uuid_frequency_sec, 10, "The time duration between tw
 DEFINE_string(nuraft_log_file, "", "Path to the file where NuRaft logs are saved.");
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_bool(ha_durability, true, "Whether to use durability for coordinator logs and snapshots.");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_string(coordinator_hostname, "", "Instance's hostname. Used as output of SHOW INSTANCES query.");
 #endif

--- a/src/flags/coordination.hpp
+++ b/src/flags/coordination.hpp
@@ -30,5 +30,6 @@ DECLARE_uint32(instance_get_uuid_frequency_sec);
 DECLARE_string(nuraft_log_file);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_bool(ha_durability);
-
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DECLARE_string(coordinator_hostname);
 #endif

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -525,7 +525,7 @@ int main(int argc, char **argv) {
       memgraph::utils::EnsureDirOrDie(high_availability_data_dir);
       coordinator_state.emplace(CoordinatorInstanceInitConfig{
           coordination_setup.coordinator_id, coordination_setup.coordinator_port, extracted_bolt_port,
-          high_availability_data_dir, coordination_setup.nuraft_log_file, coordination_setup.ha_durability});
+          high_availability_data_dir, coordination_setup.coordinator_hostname, coordination_setup.nuraft_log_file, coordination_setup.ha_durability});
     } else {
       coordinator_state.emplace(ReplicationInstanceInitConfig{.management_port = coordination_setup.management_port});
     }

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -617,10 +617,12 @@ class CoordQueryHandler final : public query::CoordinatorQueryHandler {
       throw QueryRuntimeException("Invalid bolt socket address!");
     }
 
-    auto const coord_coord_config =
-        coordination::CoordinatorToCoordinatorConfig{.coordinator_id = coordinator_id,
-                                                     .bolt_server = *maybe_bolt_server,
-                                                     .coordinator_server = *maybe_coordinator_server};
+    auto const coord_coord_config = coordination::CoordinatorToCoordinatorConfig{
+        .coordinator_id = coordinator_id,
+        .bolt_server = *maybe_bolt_server,
+        .coordinator_server = *maybe_coordinator_server,
+
+    };
 
     auto const status = coordinator_handler_.AddCoordinatorInstance(coord_coord_config);
     switch (status) {

--- a/tests/drivers/run_cluster.sh
+++ b/tests/drivers/run_cluster.sh
@@ -5,7 +5,7 @@ popd () { command popd "$@" > /dev/null; }
 
 function wait_for_server {
     port=$1
-    while ! nc -z -w 1 127.0.0.1 $port; do
+    while ! nc -z -w 1 localhost $port; do
         sleep 0.1
     done
     sleep 1
@@ -89,6 +89,7 @@ $binary_dir/memgraph \
     --also-log-to-stderr \
     --coordinator-id=1 \
     --coordinator-port=10111 \
+    --coordinator-hostname="localhost" \
     --experimental-enabled=high-availability \
     --telemetry-enabled=false \
     --log-level ERROR &
@@ -107,6 +108,7 @@ $binary_dir/memgraph \
     --also-log-to-stderr \
     --coordinator-id=2 \
     --coordinator-port=10112 \
+    --coordinator-hostname="localhost" \
     --experimental-enabled=high-availability \
     --telemetry-enabled=false \
     --log-level ERROR &
@@ -125,6 +127,7 @@ $binary_dir/memgraph \
     --also-log-to-stderr \
     --coordinator-id=3 \
     --coordinator-port=10113 \
+    --coordinator-hostname="localhost" \
     --experimental-enabled=high-availability \
     --telemetry-enabled=false \
     --log-level ERROR &
@@ -133,12 +136,13 @@ wait_for_server 7692
 
 sleep 5
 
-echo 'ADD COORDINATOR 2 WITH CONFIG {"bolt_server": "127.0.0.1:7691", "coordinator_server":  "127.0.0.1:10112"};' | $binary_dir/bin/mgconsole --port 7690
-echo 'ADD COORDINATOR 3 WITH CONFIG {"bolt_server": "127.0.0.1:7692", "coordinator_server":  "127.0.0.1:10113"};' | $binary_dir/bin/mgconsole --port 7690
-echo 'REGISTER INSTANCE instance_1 WITH CONFIG {"bolt_server": "127.0.0.1:7687", "management_server": "127.0.0.1:10011", "replication_server": "127.0.0.1:10001"};'  | $binary_dir/bin/mgconsole --port 7690
-echo 'REGISTER INSTANCE instance_2 WITH CONFIG {"bolt_server": "127.0.0.1:7688", "management_server": "127.0.0.1:10012", "replication_server": "127.0.0.1:10002"};'  | $binary_dir/bin/mgconsole --port 7690
-echo 'REGISTER INSTANCE instance_3 WITH CONFIG {"bolt_server": "127.0.0.1:7689", "management_server": "127.0.0.1:10013", "replication_server": "127.0.0.1:10003"};'  | $binary_dir/bin/mgconsole --port 7690
+echo 'ADD COORDINATOR 2 WITH CONFIG {"bolt_server": "localhost:7691", "coordinator_server":  "localhost:10112"};' | $binary_dir/bin/mgconsole --port 7690
+echo 'ADD COORDINATOR 3 WITH CONFIG {"bolt_server": "localhost:7692", "coordinator_server":  "localhost:10113"};' | $binary_dir/bin/mgconsole --port 7690
+echo 'REGISTER INSTANCE instance_1 WITH CONFIG {"bolt_server": "localhost:7687", "management_server": "localhost:10011", "replication_server": "localhost:10001"};'  | $binary_dir/bin/mgconsole --port 7690
+echo 'REGISTER INSTANCE instance_2 WITH CONFIG {"bolt_server": "localhost:7688", "management_server": "localhost:10012", "replication_server": "localhost:10002"};'  | $binary_dir/bin/mgconsole --port 7690
+echo 'REGISTER INSTANCE instance_3 WITH CONFIG {"bolt_server": "localhost:7689", "management_server": "localhost:10013", "replication_server": "localhost:10003"};'  | $binary_dir/bin/mgconsole --port 7690
 echo 'SET INSTANCE instance_1 TO MAIN;' | $binary_dir/bin/mgconsole --port 7690
+
 
 
 code_test=0

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -73,6 +73,7 @@ startup_config_dict = {
     "instance_down_timeout_sec": ("5", "5", "Time duration after which an instance is considered down."),
     "instance_health_check_frequency_sec": ("1", "1", "The time duration between two health checks/pings."),
     "instance_get_uuid_frequency_sec": ("10", "10", "The time duration between two instance uuid checks."),
+    "coordinator_hostname": ("", "", "Instance's hostname. Used as output of SHOW INSTANCES query."),
     "data_directory": ("mg_data", "mg_data", "Path to directory in which to save all permanent data."),
     "data_recovery_on_startup": (
         "false",

--- a/tests/e2e/high_availability/coord_cluster_registration.py
+++ b/tests/e2e/high_availability/coord_cluster_registration.py
@@ -85,6 +85,8 @@ def get_instances_description():
                 "--log-level=TRACE",
                 "--coordinator-id=1",
                 "--coordinator-port=10111",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/coord_cluster_registration/coordinator1.log",
             "setup_queries": [],
@@ -97,6 +99,8 @@ def get_instances_description():
                 "--log-level=TRACE",
                 "--coordinator-id=2",
                 "--coordinator-port=10112",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/coord_cluster_registration/coordinator2.log",
             "setup_queries": [],
@@ -109,6 +113,8 @@ def get_instances_description():
                 "--log-level=TRACE",
                 "--coordinator-id=3",
                 "--coordinator-port=10113",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/coord_cluster_registration/coordinator3.log",
             "setup_queries": [],
@@ -177,6 +183,8 @@ def get_instances_description_no_coord():
                 "--log-level=TRACE",
                 "--coordinator-id=1",
                 "--coordinator-port=10111",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/coord_cluster_registration/coordinator1.log",
             "setup_queries": [],
@@ -189,6 +197,8 @@ def get_instances_description_no_coord():
                 "--log-level=TRACE",
                 "--coordinator-id=2",
                 "--coordinator-port=10112",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/coord_cluster_registration/coordinator2.log",
             "setup_queries": [],
@@ -203,6 +213,7 @@ def unset_env_flags():
     os.unsetenv("MEMGRAPH_BOLT_PORT")
     os.unsetenv("MEMGRAPH_COORDINATOR_ID")
     os.unsetenv("MEMGRAPH_HA_CLUSTER_INIT_QUERIES")
+    os.unsetenv("MEMGRAPH_COORDINATOR_HOSTNAME")
 
 
 def test_register_repl_instances_then_coordinators():
@@ -214,24 +225,24 @@ def test_register_repl_instances_then_coordinators():
 
     execute_and_fetch_all(
         coordinator3_cursor,
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
     )
     execute_and_fetch_all(
         coordinator3_cursor,
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
     )
     execute_and_fetch_all(
         coordinator3_cursor,
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
     )
     execute_and_fetch_all(coordinator3_cursor, "SET INSTANCE instance_3 TO MAIN")
     execute_and_fetch_all(
         coordinator3_cursor,
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
     )
     execute_and_fetch_all(
         coordinator3_cursor,
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
     )
 
     def check_coordinator3():
@@ -240,12 +251,12 @@ def test_register_repl_instances_then_coordinators():
         )
 
     expected_cluster_coord3 = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
     mg_sleep_and_assert(expected_cluster_coord3, check_coordinator3)
 
@@ -257,12 +268,12 @@ def test_register_repl_instances_then_coordinators():
         )
 
     expected_cluster_shared = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
 
     mg_sleep_and_assert(expected_cluster_shared, check_coordinator1)
@@ -286,23 +297,23 @@ def test_register_coordinator_then_repl_instances():
 
     execute_and_fetch_all(
         coordinator3_cursor,
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
     )
     execute_and_fetch_all(
         coordinator3_cursor,
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
     )
     execute_and_fetch_all(
         coordinator3_cursor,
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
     )
     execute_and_fetch_all(
         coordinator3_cursor,
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
     )
     execute_and_fetch_all(
         coordinator3_cursor,
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
     )
     execute_and_fetch_all(coordinator3_cursor, "SET INSTANCE instance_3 TO MAIN")
 
@@ -312,12 +323,12 @@ def test_register_coordinator_then_repl_instances():
         )
 
     expected_cluster_coord3 = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
     mg_sleep_and_assert(expected_cluster_coord3, check_coordinator3)
 
@@ -329,12 +340,12 @@ def test_register_coordinator_then_repl_instances():
         )
 
     expected_cluster_shared = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
 
     mg_sleep_and_assert(expected_cluster_shared, check_coordinator1)
@@ -359,33 +370,33 @@ def test_coordinators_communication_with_restarts():
 
     execute_and_fetch_all(
         coordinator3_cursor,
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
     )
     execute_and_fetch_all(
         coordinator3_cursor,
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
     )
     execute_and_fetch_all(
         coordinator3_cursor,
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
     )
     execute_and_fetch_all(
         coordinator3_cursor,
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
     )
     execute_and_fetch_all(
         coordinator3_cursor,
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
     )
     execute_and_fetch_all(coordinator3_cursor, "SET INSTANCE instance_3 TO MAIN")
 
     expected_cluster_shared = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
 
     coordinator1_cursor = connect(host="localhost", port=7690).cursor()
@@ -439,23 +450,23 @@ def test_unregister_replicas(kill_instance):
 
     execute_and_fetch_all(
         coordinator3_cursor,
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
     )
     execute_and_fetch_all(
         coordinator3_cursor,
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
     )
     execute_and_fetch_all(
         coordinator3_cursor,
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
     )
     execute_and_fetch_all(
         coordinator3_cursor,
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
     )
     execute_and_fetch_all(
         coordinator3_cursor,
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
     )
     execute_and_fetch_all(coordinator3_cursor, "SET INSTANCE instance_3 TO MAIN")
 
@@ -480,34 +491,34 @@ def test_unregister_replicas(kill_instance):
         return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS")))
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     expected_cluster_shared = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
 
     expected_replicas = [
         (
             "instance_1",
-            "127.0.0.1:10001",
+            "localhost:10001",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
         ),
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
@@ -524,25 +535,25 @@ def test_unregister_replicas(kill_instance):
     execute_and_fetch_all(coordinator3_cursor, "UNREGISTER INSTANCE instance_1")
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     expected_cluster_shared = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
 
     expected_replicas = [
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
@@ -559,17 +570,17 @@ def test_unregister_replicas(kill_instance):
     execute_and_fetch_all(coordinator3_cursor, "UNREGISTER INSTANCE instance_2")
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     expected_cluster_shared = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
     expected_replicas = []
 
@@ -590,23 +601,23 @@ def test_unregister_main():
 
     execute_and_fetch_all(
         coordinator3_cursor,
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
     )
     execute_and_fetch_all(
         coordinator3_cursor,
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
     )
     execute_and_fetch_all(
         coordinator3_cursor,
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
     )
     execute_and_fetch_all(
         coordinator3_cursor,
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
     )
     execute_and_fetch_all(
         coordinator3_cursor,
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
     )
     execute_and_fetch_all(coordinator3_cursor, "SET INSTANCE instance_3 TO MAIN")
 
@@ -626,21 +637,21 @@ def test_unregister_main():
         )
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     expected_cluster_shared = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
 
     mg_sleep_and_assert(expected_cluster_shared, check_coordinator1)
@@ -658,21 +669,21 @@ def test_unregister_main():
     interactive_mg_runner.kill(MEMGRAPH_INSTANCES_DESCRIPTION, "instance_3")
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
     expected_cluster_shared = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "unknown"),
     ]
 
     mg_sleep_and_assert(expected_cluster_shared, check_coordinator1)
@@ -682,25 +693,25 @@ def test_unregister_main():
     execute_and_fetch_all(coordinator3_cursor, "UNREGISTER INSTANCE instance_3")
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
     ]
 
     expected_cluster_shared = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
     ]
 
     expected_replicas = [
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
@@ -727,16 +738,17 @@ def test_register_one_coord_with_env_vars():
     os.environ["MEMGRAPH_COORDINATOR_PORT"] = "10113"
     os.environ["MEMGRAPH_BOLT_PORT"] = "7692"
     os.environ["MEMGRAPH_COORDINATOR_ID"] = "3"
+    os.environ["MEMGRAPH_COORDINATOR_HOSTNAME"] = "localhost"
 
     file_path = os.path.join(TEMP_DIR, "ha_init.cypherl")
     os.environ["MEMGRAPH_HA_CLUSTER_INIT_QUERIES"] = file_path
 
     setup_queries = [
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'};",
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'};",
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'};",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'};",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
         "SET INSTANCE instance_3 TO MAIN",
     ]
     with open(file_path, "w") as writer:
@@ -774,21 +786,21 @@ def test_register_one_coord_with_env_vars():
         )
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     expected_cluster_shared = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
 
     mg_sleep_and_assert(expected_cluster_shared, check_coordinator1)
@@ -806,21 +818,21 @@ def test_register_one_coord_with_env_vars():
     interactive_mg_runner.kill(memgraph_instances_desc, "instance_3")
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
     expected_cluster_shared = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "unknown"),
     ]
 
     mg_sleep_and_assert(expected_cluster_shared, check_coordinator1)
@@ -830,25 +842,25 @@ def test_register_one_coord_with_env_vars():
     execute_and_fetch_all(coordinator3_cursor, "UNREGISTER INSTANCE instance_3")
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
     ]
 
     expected_cluster_shared = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
     ]
 
     expected_replicas = [
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
@@ -921,6 +933,8 @@ def test_register_one_data_with_env_vars():
                 "--log-level=TRACE",
                 "--coordinator-id=1",
                 "--coordinator-port=10111",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/coord_cluster_registration/coordinator1.log",
             "setup_queries": [],
@@ -933,6 +947,8 @@ def test_register_one_data_with_env_vars():
                 "--log-level=TRACE",
                 "--coordinator-id=2",
                 "--coordinator-port=10112",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/coord_cluster_registration/coordinator2.log",
             "setup_queries": [],
@@ -945,6 +961,8 @@ def test_register_one_data_with_env_vars():
                 "--log-level=TRACE",
                 "--coordinator-id=3",
                 "--coordinator-port=10113",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/coord_cluster_registration/coordinator3.log",
             "setup_queries": [],
@@ -980,11 +998,11 @@ def test_register_one_data_with_env_vars():
     coordinator3_cursor = connect(host="localhost", port=7692).cursor()
 
     setup_queries = [
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'};",
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'};",
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'};",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'};",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
         "SET INSTANCE instance_3 TO MAIN",
     ]
     for query in setup_queries:
@@ -1006,21 +1024,21 @@ def test_register_one_data_with_env_vars():
         )
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     expected_cluster_shared = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
 
     mg_sleep_and_assert(expected_cluster_shared, check_coordinator1)
@@ -1068,16 +1086,17 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start():
     os.environ["MEMGRAPH_COORDINATOR_PORT"] = "10113"
     os.environ["MEMGRAPH_BOLT_PORT"] = "7692"
     os.environ["MEMGRAPH_COORDINATOR_ID"] = "3"
+    os.environ["MEMGRAPH_COORDINATOR_HOSTNAME"] = "localhost"
     safe_execute(os.mkdir, TEMP_DIR)
     file_path = os.path.join(TEMP_DIR, "ha_init.cypherl")
     os.environ["MEMGRAPH_HA_CLUSTER_INIT_QUERIES"] = file_path
 
     setup_queries = [
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'};",
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'};",
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'};",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'};",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
         "SET INSTANCE instance_3 TO MAIN",
     ]
     with open(file_path, "w") as writer:
@@ -1100,7 +1119,7 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start():
     )
     coordinator3_cursor = connect(host="localhost", port=7692).cursor()
 
-    expected_cluster = [("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader")]
+    expected_cluster = [("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader")]
 
     def check_coordinator3():
         return ignore_elapsed_time_from_results(
@@ -1123,6 +1142,7 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start():
     os.environ["MEMGRAPH_BOLT_PORT"] = "7692"
     os.environ["MEMGRAPH_COORDINATOR_ID"] = "3"
     os.environ["MEMGRAPH_HA_CLUSTER_INIT_QUERIES"] = file_path
+    os.environ["MEMGRAPH_COORDINATOR_HOSTNAME"] = "localhost"
 
     interactive_mg_runner.start(
         coordinator_3_description,
@@ -1146,21 +1166,21 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start():
         )
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     expected_cluster_shared = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
 
     mg_sleep_and_assert(expected_cluster_shared, check_coordinator1)
@@ -1178,21 +1198,21 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start():
     interactive_mg_runner.kill(memgraph_instances_desc, "instance_3")
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
     expected_cluster_shared = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "unknown"),
     ]
 
     mg_sleep_and_assert(expected_cluster_shared, check_coordinator1)
@@ -1202,25 +1222,25 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start():
     execute_and_fetch_all(coordinator3_cursor, "UNREGISTER INSTANCE instance_3")
 
     expected_cluster = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
     ]
 
     expected_cluster_shared = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
     ]
 
     expected_replicas = [
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
@@ -1250,13 +1270,13 @@ def test_add_coord_instance_fails():
 
     execute_and_fetch_all(
         coordinator3_cursor,
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
     )
 
     try:
         execute_and_fetch_all(
             coordinator3_cursor,
-            "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
+            "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
         )
     except Exception as e:
         assert "Couldn't add coordinator since instance with such id already exists!" == str(e)
@@ -1264,7 +1284,7 @@ def test_add_coord_instance_fails():
     try:
         execute_and_fetch_all(
             coordinator3_cursor,
-            "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10112'}",
+            "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10112'}",
         )
     except Exception as e:
         assert "Couldn't add coordinator since instance with such bolt endpoint already exists!" == str(e)
@@ -1272,7 +1292,7 @@ def test_add_coord_instance_fails():
     try:
         execute_and_fetch_all(
             coordinator3_cursor,
-            "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10111'}",
+            "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10111'}",
         )
     except Exception as e:
         assert "Couldn't add coordinator since instance with such coordinator server already exists!" == str(e)

--- a/tests/e2e/high_availability/coordinator.py
+++ b/tests/e2e/high_availability/coordinator.py
@@ -44,10 +44,10 @@ def test_coordinator_show_instances():
         return sorted(ignore_elapsed_time_from_results(list(execute_and_fetch_all(cursor, "SHOW INSTANCES;"))))
 
     expected_data = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
     ]
     mg_sleep_and_assert(expected_data, retrieve_data)
 
@@ -79,7 +79,7 @@ def test_main_and_replicas_cannot_register_coord_server(port):
     with pytest.raises(Exception) as e:
         execute_and_fetch_all(
             cursor,
-            "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
+            "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7690', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
         )
     assert str(e.value) == "Only coordinator can register coordinator server!"
 

--- a/tests/e2e/high_availability/disable_writing_on_main_after_restart.py
+++ b/tests/e2e/high_availability/disable_writing_on_main_after_restart.py
@@ -99,6 +99,8 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
             "--log-level=TRACE",
             "--coordinator-id=1",
             "--coordinator-port=10111",
+            "--coordinator-hostname",
+            "localhost",
         ],
         "log_file": "high_availability/disable_writing_on_main_after_restart/coordinator1.log",
         "setup_queries": [],
@@ -111,6 +113,8 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
             "--log-level=TRACE",
             "--coordinator-id=2",
             "--coordinator-port=10112",
+            "--coordinator-hostname",
+            "localhost",
         ],
         "log_file": "high_availability/disable_writing_on_main_after_restart/coordinator2.log",
         "setup_queries": [],
@@ -124,6 +128,8 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
             "--coordinator-id=3",
             "--coordinator-port=10113",
             "--also-log-to-stderr",
+            "--coordinator-hostname",
+            "localhost",
         ],
         "log_file": "high_availability/disable_writing_on_main_after_restart/coordinator3.log",
         "setup_queries": [],
@@ -139,16 +145,16 @@ def test_writing_disabled_on_main_restart():
 
     execute_and_fetch_all(
         coordinator3_cursor,
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
     )
     execute_and_fetch_all(coordinator3_cursor, "SET INSTANCE instance_3 TO MAIN")
     execute_and_fetch_all(
         coordinator3_cursor,
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
     )
     execute_and_fetch_all(
         coordinator3_cursor,
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
     )
 
     def check_coordinator3():
@@ -157,20 +163,20 @@ def test_writing_disabled_on_main_restart():
         )
 
     expected_cluster_coord3 = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
     mg_sleep_and_assert(expected_cluster_coord3, check_coordinator3)
 
     interactive_mg_runner.kill(MEMGRAPH_INSTANCES_DESCRIPTION, "instance_3")
 
     expected_cluster_coord3 = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
     mg_sleep_and_assert(expected_cluster_coord3, check_coordinator3)
@@ -187,10 +193,10 @@ def test_writing_disabled_on_main_restart():
         )
 
     expected_cluster_coord3 = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     mg_sleep_and_assert(expected_cluster_coord3, check_coordinator3)

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -92,6 +92,8 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
             "--log-level=TRACE",
             "--coordinator-id=1",
             "--coordinator-port=10111",
+            "--coordinator-hostname",
+            "localhost",
         ],
         "log_file": "high_availability/distributed_coords/coordinator1.log",
         "setup_queries": [],
@@ -104,6 +106,8 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
             "--log-level=TRACE",
             "--coordinator-id=2",
             "--coordinator-port=10112",
+            "--coordinator-hostname",
+            "localhost",
         ],
         "log_file": "high_availability/distributed_coords/coordinator2.log",
         "setup_queries": [],
@@ -116,14 +120,16 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
             "--log-level=TRACE",
             "--coordinator-id=3",
             "--coordinator-port=10113",
+            "--coordinator-hostname",
+            "localhost",
         ],
         "log_file": "high_availability/distributed_coords/coordinator3.log",
         "setup_queries": [
-            "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
-            "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
-            "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-            "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-            "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+            "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
+            "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
+            "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+            "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+            "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
             "SET INSTANCE instance_3 TO MAIN",
         ],
     },
@@ -183,6 +189,8 @@ def get_instances_description_no_setup(use_durability: bool = True):
                 "--coordinator-id=1",
                 "--coordinator-port=10111",
                 f"--ha_durability={use_durability}",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/distributed_coords/coordinator1.log",
             "data_directory": f"{TEMP_DIR}/coordinator_1",
@@ -197,6 +205,8 @@ def get_instances_description_no_setup(use_durability: bool = True):
                 "--coordinator-id=2",
                 "--coordinator-port=10112",
                 f"--ha_durability={use_durability}",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/distributed_coords/coordinator2.log",
             "data_directory": f"{TEMP_DIR}/coordinator_2",
@@ -211,6 +221,8 @@ def get_instances_description_no_setup(use_durability: bool = True):
                 "--coordinator-id=3",
                 "--coordinator-port=10113",
                 f"--ha_durability={use_durability}",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/distributed_coords/coordinator3.log",
             "data_directory": f"{TEMP_DIR}/coordinator_3",
@@ -233,11 +245,11 @@ def test_old_main_comes_back_on_new_leader_as_replica():
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
 
     setup_queries = [
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
         "SET INSTANCE instance_3 TO MAIN",
     ]
     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
@@ -260,75 +272,75 @@ def test_old_main_comes_back_on_new_leader_as_replica():
     # Both instance_1 and instance_2 could become main depending on the order of pings in the system.
     # Both coordinator_1 and coordinator_2 could become leader depending on the NuRaft election.
     leader_data_inst1_main_coord1_leader = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "leader"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
     leader_data_inst1_main_coord2_leader = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "leader"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "leader"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
     leader_data_inst2_main_coord1_leader = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "leader"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "main"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "main"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
     leader_data_inst2_main_coord2_leader = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "leader"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "main"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "leader"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "main"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
     follower_data_inst1_main_coord1_leader = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "leader"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "leader"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "unknown"),
     ]
 
     follower_data_inst1_main_coord2_leader = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "leader"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "leader"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "unknown"),
     ]
 
     follower_data_inst2_main_coord1_leader = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "leader"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "main"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "leader"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "main"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "unknown"),
     ]
 
     follower_data_inst2_main_coord2_leader = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "leader"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "main"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "leader"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "main"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "unknown"),
     ]
 
     mg_sleep_and_assert_multiple(
@@ -353,21 +365,21 @@ def test_old_main_comes_back_on_new_leader_as_replica():
     interactive_mg_runner.start(inner_instances_description, "instance_3")
 
     coord1_leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "leader"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
     ]
 
     coord2_leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "leader"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "leader"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
     ]
 
     mg_sleep_and_assert_multiple(
@@ -408,14 +420,14 @@ def test_old_main_comes_back_on_new_leader_as_replica():
     replicas = [
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
         ),
         (
             "instance_3",
-            "127.0.0.1:10003",
+            "localhost:10003",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
@@ -450,14 +462,14 @@ def test_distributed_automatic_failover():
     expected_data_on_main = [
         (
             "instance_1",
-            "127.0.0.1:10001",
+            "localhost:10001",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
         ),
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
@@ -477,12 +489,12 @@ def test_distributed_automatic_failover():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_on_coord = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
@@ -495,14 +507,14 @@ def test_distributed_automatic_failover():
     expected_data_on_new_main = [
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
         ),
         (
             "instance_3",
-            "127.0.0.1:10003",
+            "localhost:10003",
             "sync",
             {"ts": 0, "behind": None, "status": "invalid"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "invalid"}},
@@ -514,14 +526,14 @@ def test_distributed_automatic_failover():
     expected_data_on_new_main_old_alive = [
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
         ),
         (
             "instance_3",
-            "127.0.0.1:10003",
+            "localhost:10003",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
@@ -538,11 +550,11 @@ def test_distributed_automatic_failover_with_leadership_change():
     interactive_mg_runner.start_all(inner_instances_description)
 
     setup_queries = [
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
         "SET INSTANCE instance_3 TO MAIN",
     ]
     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
@@ -565,75 +577,75 @@ def test_distributed_automatic_failover_with_leadership_change():
     # Both instance_1 and instance_2 could become main depending on the order of pings in the system.
     # Both coordinator_1 and coordinator_2 could become leader depending on the NuRaft election.
     leader_data_inst1_main_coord1_leader = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "leader"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
     leader_data_inst1_main_coord2_leader = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "leader"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "leader"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
     leader_data_inst2_main_coord1_leader = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "leader"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "main"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "main"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
     leader_data_inst2_main_coord2_leader = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "leader"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "main"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "leader"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "main"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
     follower_data_inst1_main_coord1_leader = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "leader"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "leader"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "unknown"),
     ]
 
     follower_data_inst1_main_coord2_leader = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "leader"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "leader"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "unknown"),
     ]
 
     follower_data_inst2_main_coord1_leader = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "leader"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "main"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "leader"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "main"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "unknown"),
     ]
 
     follower_data_inst2_main_coord2_leader = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "leader"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "main"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "leader"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "main"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "unknown"),
     ]
 
     mg_sleep_and_assert_multiple(
@@ -689,14 +701,14 @@ def test_distributed_automatic_failover_with_leadership_change():
     expected_data_on_new_main = [
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
         ),
         (
             "instance_3",
-            "127.0.0.1:10003",
+            "localhost:10003",
             "sync",
             {"ts": 0, "behind": None, "status": "invalid"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "invalid"}},
@@ -708,14 +720,14 @@ def test_distributed_automatic_failover_with_leadership_change():
     expected_data_on_new_main_old_alive = [
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
         ),
         (
             "instance_3",
-            "127.0.0.1:10003",
+            "localhost:10003",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
@@ -744,7 +756,7 @@ def test_no_leader_after_leader_and_follower_die():
     with pytest.raises(Exception) as e:
         execute_and_fetch_all(
             coord_cursor_1,
-            "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
+            "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
         )
         assert "Couldn't register replica instance since coordinator is not a leader!" in str(e)
 
@@ -764,11 +776,11 @@ def test_old_main_comes_back_on_new_leader_as_main():
     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
 
     setup_queries = [
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
         "SET INSTANCE instance_3 TO MAIN",
     ]
 
@@ -793,39 +805,39 @@ def test_old_main_comes_back_on_new_leader_as_main():
     interactive_mg_runner.start(inner_memgraph_instances, "instance_3")
 
     coord1_leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "leader"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "down", "unknown"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "down", "unknown"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     coord2_leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "leader"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "down", "unknown"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "down", "unknown"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "leader"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     coord1_follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "leader"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "leader"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
 
     coord2_follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "leader"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "leader"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
 
     mg_sleep_and_assert_multiple(
@@ -846,14 +858,14 @@ def test_old_main_comes_back_on_new_leader_as_main():
     replicas = [
         (
             "instance_1",
-            "127.0.0.1:10001",
+            "localhost:10001",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
         ),
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
@@ -926,6 +938,8 @@ def test_registering_4_coords():
                 "--log-level=TRACE",
                 "--coordinator-id=1",
                 "--coordinator-port=10111",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/distributed_coords/coordinator1.log",
             "setup_queries": [],
@@ -938,6 +952,8 @@ def test_registering_4_coords():
                 "--log-level=TRACE",
                 "--coordinator-id=2",
                 "--coordinator-port=10112",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/distributed_coords/coordinator2.log",
             "setup_queries": [],
@@ -950,6 +966,8 @@ def test_registering_4_coords():
                 "--log-level=TRACE",
                 "--coordinator-id=3",
                 "--coordinator-port=10113",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/distributed_coords/coordinator3.log",
             "setup_queries": [],
@@ -962,15 +980,17 @@ def test_registering_4_coords():
                 "--log-level=TRACE",
                 "--coordinator-id=4",
                 "--coordinator-port=10114",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/distributed_coords/coordinator4.log",
             "setup_queries": [
-                "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
-                "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
-                "ADD COORDINATOR 3 WITH CONFIG {'bolt_server': '127.0.0.1:7692', 'coordinator_server': '127.0.0.1:10113'}",
-                "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-                "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-                "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+                "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
+                "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
+                "ADD COORDINATOR 3 WITH CONFIG {'bolt_server': 'localhost:7692', 'coordinator_server': 'localhost:10113'}",
+                "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+                "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+                "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
                 "SET INSTANCE instance_3 TO MAIN",
             ],
         },
@@ -984,13 +1004,13 @@ def test_registering_4_coords():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_on_coord = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "127.0.0.1:7692", "127.0.0.1:10113", "", "up", "follower"),
-        ("coordinator_4", "0.0.0.0:7693", "0.0.0.0:10114", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "follower"),
+        ("coordinator_4", "localhost:7693", "localhost:10114", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
 
@@ -1061,6 +1081,8 @@ def test_registering_coord_log_store():
                 "--log-level=TRACE",
                 "--coordinator-id=1",
                 "--coordinator-port=10111",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/distributed_coords/coordinator1.log",
             "setup_queries": [],
@@ -1073,6 +1095,8 @@ def test_registering_coord_log_store():
                 "--log-level=TRACE",
                 "--coordinator-id=2",
                 "--coordinator-port=10112",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/distributed_coords/coordinator2.log",
             "setup_queries": [],
@@ -1085,6 +1109,8 @@ def test_registering_coord_log_store():
                 "--log-level=TRACE",
                 "--coordinator-id=3",
                 "--coordinator-port=10113",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/distributed_coords/coordinator3.log",
             "setup_queries": [],
@@ -1097,15 +1123,17 @@ def test_registering_coord_log_store():
                 "--log-level=TRACE",
                 "--coordinator-id=4",
                 "--coordinator-port=10114",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/distributed_coords/coordinator4.log",
             "setup_queries": [
-                "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
-                "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
-                "ADD COORDINATOR 3 WITH CONFIG {'bolt_server': '127.0.0.1:7692', 'coordinator_server': '127.0.0.1:10113'}",
-                "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-                "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-                "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+                "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
+                "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
+                "ADD COORDINATOR 3 WITH CONFIG {'bolt_server': 'localhost:7692', 'coordinator_server': 'localhost:10113'}",
+                "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+                "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+                "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
             ],
         },
     }
@@ -1121,16 +1149,16 @@ def test_registering_coord_log_store():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     coordinators = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "127.0.0.1:7692", "127.0.0.1:10113", "", "up", "follower"),
-        ("coordinator_4", "0.0.0.0:7693", "0.0.0.0:10114", "", "up", "leader"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "follower"),
+        ("coordinator_4", "localhost:7693", "localhost:10114", "", "up", "leader"),
     ]
 
     basic_instances = [
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "replica"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
     ]
 
     expected_data_on_coord = []
@@ -1171,9 +1199,9 @@ def test_registering_coord_log_store():
         repl_port_id = manag_port_id - 10
         assert repl_port_id < 10011, "Wrong test setup, repl port must be smaller than smallest coord port id"
 
-        bolt_server = f"127.0.0.1:{bolt_port_id}"
-        management_server = f"127.0.0.1:{manag_port_id}"
-        repl_server = f"127.0.0.1:{repl_port_id}"
+        bolt_server = f"localhost:{bolt_port_id}"
+        management_server = f"localhost:{manag_port_id}"
+        repl_server = f"localhost:{repl_port_id}"
 
         config_str = f"{{'bolt_server': '{bolt_server}', 'management_server': '{management_server}', 'replication_server': '{repl_server}'}}"
 
@@ -1197,7 +1225,7 @@ def test_registering_coord_log_store():
 
     # 6
     basic_instances.pop()
-    basic_instances.append(("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"))
+    basic_instances.append(("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"))
 
     new_expected_data_on_coordinator = []
 
@@ -1256,11 +1284,11 @@ def test_multiple_failovers_in_row_no_leadership_change():
     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
 
     setup_queries = [
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
         "SET INSTANCE instance_3 TO MAIN",
     ]
 
@@ -1276,21 +1304,21 @@ def test_multiple_failovers_in_row_no_leadership_change():
         return show_instances_follower_coord
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
 
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
@@ -1307,21 +1335,21 @@ def test_multiple_failovers_in_row_no_leadership_change():
     # 4
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "unknown"),
     ]
 
     mg_sleep_and_assert_collection(follower_data, get_func_show_instances(coord_cursor_1))
@@ -1333,21 +1361,21 @@ def test_multiple_failovers_in_row_no_leadership_change():
 
     # 6
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "down", "unknown"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "main"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "main"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "unknown"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "main"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "unknown"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "main"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "unknown"),
     ]
 
     mg_sleep_and_assert_collection(follower_data, get_func_show_instances(coord_cursor_1))
@@ -1361,21 +1389,21 @@ def test_multiple_failovers_in_row_no_leadership_change():
     # 8
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "down", "unknown"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "main"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "main"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "unknown"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "main"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "unknown"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "main"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "replica"),
     ]
 
     mg_sleep_and_assert_collection(follower_data, get_func_show_instances(coord_cursor_1))
@@ -1387,21 +1415,21 @@ def test_multiple_failovers_in_row_no_leadership_change():
 
     # 10
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "down", "unknown"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "down", "unknown"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "unknown"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "unknown"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "unknown"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "unknown"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
 
     mg_sleep_and_assert_collection(follower_data, get_func_show_instances(coord_cursor_1))
@@ -1422,21 +1450,21 @@ def test_multiple_failovers_in_row_no_leadership_change():
 
     # 13
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
 
     mg_sleep_and_assert_collection(follower_data, get_func_show_instances(coord_cursor_1))
@@ -1451,14 +1479,14 @@ def test_multiple_failovers_in_row_no_leadership_change():
     replicas = [
         (
             "instance_1",
-            "127.0.0.1:10001",
+            "localhost:10001",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 2, "behind": 0, "status": "ready"}},
         ),
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 2, "behind": 0, "status": "ready"}},
@@ -1495,11 +1523,11 @@ def test_multiple_old_mains_single_failover():
     interactive_mg_runner.start_all(inner_instances_description)
 
     setup_queries = [
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
         "SET INSTANCE instance_3 TO MAIN",
     ]
     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
@@ -1510,15 +1538,15 @@ def test_multiple_old_mains_single_failover():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
 
     coordinators = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
     ]
 
     basic_instances = [
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     expected_data_on_coord = []
@@ -1534,9 +1562,9 @@ def test_multiple_old_mains_single_failover():
     # 3
 
     basic_instances = [
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
     expected_data_on_coord = []
@@ -1569,39 +1597,39 @@ def test_multiple_old_mains_single_failover():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     coord1_leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "leader"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
     coord2_leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "leader"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "leader"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
     coord1_follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "leader"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "leader"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "unknown"),
     ]
 
     coord2_follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "leader"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "leader"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "unknown"),
     ]
 
     mg_sleep_and_assert_multiple(
@@ -1619,14 +1647,14 @@ def test_multiple_old_mains_single_failover():
     replicas = [
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
         (
             "instance_3",
-            "127.0.0.1:10003",
+            "localhost:10003",
             "sync",
             {"behind": None, "status": "invalid", "ts": 0},
             {"memgraph": {"behind": 0, "status": "invalid", "ts": 0}},
@@ -1675,11 +1703,11 @@ def test_force_reset_works_after_failed_registration():
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
 
     setup_queries = [
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
         "SET INSTANCE instance_3 TO MAIN",
     ]
     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
@@ -1702,21 +1730,21 @@ def test_force_reset_works_after_failed_registration():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
     mg_sleep_and_assert(leader_data, show_instances_coord3)
     mg_sleep_and_assert(follower_data, show_instances_coord1)
@@ -1730,14 +1758,14 @@ def test_force_reset_works_after_failed_registration():
     replicas = [
         (
             "instance_1",
-            "127.0.0.1:10001",
+            "localhost:10001",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
@@ -1761,26 +1789,26 @@ def test_force_reset_works_after_failed_registration():
     with pytest.raises(Exception) as e:
         execute_and_fetch_all(
             coord_cursor_3,
-            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': '127.0.0.1:7680', 'management_server': '127.0.0.1:10050', 'replication_server': '127.0.0.1:10051'};",
+            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': 'localhost:10050', 'replication_server': 'localhost:10051'};",
         )
 
     # This will trigger force reset and choosing of new instance as MAIN
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "replica"),
     ]
 
     mg_sleep_and_assert(leader_data, show_instances_coord3)
@@ -1827,11 +1855,11 @@ def test_force_reset_works_after_failed_registration_and_main_down():
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
 
     setup_queries = [
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
         "SET INSTANCE instance_3 TO MAIN",
     ]
     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
@@ -1854,21 +1882,21 @@ def test_force_reset_works_after_failed_registration_and_main_down():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
     mg_sleep_and_assert(leader_data, show_instances_coord3)
     mg_sleep_and_assert(follower_data, show_instances_coord1)
@@ -1882,14 +1910,14 @@ def test_force_reset_works_after_failed_registration_and_main_down():
     replicas = [
         (
             "instance_1",
-            "127.0.0.1:10001",
+            "localhost:10001",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
@@ -1913,26 +1941,26 @@ def test_force_reset_works_after_failed_registration_and_main_down():
     with pytest.raises(Exception) as e:
         execute_and_fetch_all(
             coord_cursor_3,
-            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': '127.0.0.1:7680', 'management_server': '127.0.0.1:10050', 'replication_server': '127.0.0.1:10051'};",
+            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': 'localhost:10050', 'replication_server': 'localhost:10051'};",
         )
 
     # This will trigger force reset and choosing of new instance as MAIN
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "replica"),
     ]
 
     mg_sleep_and_assert(leader_data, show_instances_coord3)
@@ -1979,11 +2007,11 @@ def test_force_reset_works_after_failed_registration_and_replica_down():
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
 
     setup_queries = [
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
         "SET INSTANCE instance_3 TO MAIN",
     ]
     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
@@ -2006,21 +2034,21 @@ def test_force_reset_works_after_failed_registration_and_replica_down():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
     mg_sleep_and_assert(leader_data, show_instances_coord3)
     mg_sleep_and_assert(follower_data, show_instances_coord1)
@@ -2034,14 +2062,14 @@ def test_force_reset_works_after_failed_registration_and_replica_down():
     replicas = [
         (
             "instance_1",
-            "127.0.0.1:10001",
+            "localhost:10001",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
@@ -2071,34 +2099,34 @@ def test_force_reset_works_after_failed_registration_and_replica_down():
     with pytest.raises(Exception) as e:
         execute_and_fetch_all(
             coord_cursor_3,
-            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': '127.0.0.1:7680', 'management_server': '127.0.0.1:10050', 'replication_server': '127.0.0.1:10051'};",
+            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': 'localhost:10050', 'replication_server': 'localhost:10051'};",
         )
 
     # 5
     # This will trigger force reset and choosing of new instance as MAIN
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "down", "unknown"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "main"),
         (
             "instance_2",
-            "127.0.0.1:7688",
+            "localhost:7688",
             "",
-            "127.0.0.1:10012",
+            "localhost:10012",
             "unknown",
             "replica",
         ),  # TODO(antoniofilipovic) What is logic behind unknown state
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "replica"),
     ]
 
     mg_sleep_and_assert(leader_data, show_instances_coord3)
@@ -2112,21 +2140,21 @@ def test_force_reset_works_after_failed_registration_and_replica_down():
     # 7
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "replica"),
     ]
 
     mg_sleep_and_assert(leader_data, show_instances_coord3)
@@ -2139,14 +2167,14 @@ def test_force_reset_works_after_failed_registration_and_replica_down():
     replicas = [
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
         (
             "instance_3",
-            "127.0.0.1:10003",
+            "localhost:10003",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
@@ -2193,11 +2221,11 @@ def test_force_reset_works_after_failed_registration_and_2_coordinators_down():
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
 
     setup_queries = [
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '0.0.0.0:10111'}",
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '0.0.0.0:10112'}",
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
         "SET INSTANCE instance_3 TO MAIN",
     ]
     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
@@ -2220,21 +2248,21 @@ def test_force_reset_works_after_failed_registration_and_2_coordinators_down():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
     mg_sleep_and_assert(leader_data, show_instances_coord3)
     mg_sleep_and_assert(follower_data, show_instances_coord1)
@@ -2248,14 +2276,14 @@ def test_force_reset_works_after_failed_registration_and_2_coordinators_down():
     replicas = [
         (
             "instance_1",
-            "127.0.0.1:10001",
+            "localhost:10001",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
@@ -2281,7 +2309,7 @@ def test_force_reset_works_after_failed_registration_and_2_coordinators_down():
     with pytest.raises(Exception) as _:
         execute_and_fetch_all(
             coord_cursor_3,
-            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': '127.0.0.1:7680', 'management_server': '127.0.0.1:10050', 'replication_server': '127.0.0.1:10051'};",
+            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': 'localhost:10050', 'replication_server': 'localhost:10051'};",
         )
 
     # 4
@@ -2292,8 +2320,8 @@ def test_force_reset_works_after_failed_registration_and_2_coordinators_down():
     with pytest.raises(Exception) as e:
         execute_and_fetch_all(
             coord_cursor_1,
-            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': '127.0.0.1:7680', 'management_server': "
-            "'127.0.0.1:10050', 'replication_server': '127.0.0.1:10051'};",
+            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': "
+            "'localhost:10050', 'replication_server': 'localhost:10051'};",
         )
 
     assert "Couldn't register replica instance since coordinator is not a leader!" in str(e.value)
@@ -2305,39 +2333,39 @@ def test_force_reset_works_after_failed_registration_and_2_coordinators_down():
     # 7
 
     coord1_leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
     ]
 
     coord2_leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "up", "leader"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "leader"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
     ]
 
     coord1_follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "unknown", "leader"),
-        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "leader"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "replica"),
     ]
 
     coord2_follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "unknown", "leader"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "leader"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "replica"),
     ]
 
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
@@ -2363,14 +2391,14 @@ def test_force_reset_works_after_failed_registration_and_2_coordinators_down():
     replicas = [
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
         (
             "instance_3",
-            "127.0.0.1:10003",
+            "localhost:10003",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
@@ -2417,11 +2445,11 @@ def test_coordinator_gets_info_on_other_coordinators():
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
 
     setup_queries = [
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '0.0.0.0:10111'}",
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '0.0.0.0:10112'}",
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
         "SET INSTANCE instance_3 TO MAIN",
     ]
     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
@@ -2444,21 +2472,21 @@ def test_coordinator_gets_info_on_other_coordinators():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
     mg_sleep_and_assert(leader_data, show_instances_coord3)
     mg_sleep_and_assert(follower_data, show_instances_coord1)
@@ -2472,14 +2500,14 @@ def test_coordinator_gets_info_on_other_coordinators():
     replicas = [
         (
             "instance_1",
-            "127.0.0.1:10001",
+            "localhost:10001",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
@@ -2524,6 +2552,8 @@ def test_coordinator_gets_info_on_other_coordinators():
                 "--log-level=TRACE",
                 "--coordinator-id=4",
                 "--coordinator-port=10114",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/distributed_coords/coordinator4.log",
             "data_directory": f"{TEMP_DIR}/coordinator_4",
@@ -2534,7 +2564,7 @@ def test_coordinator_gets_info_on_other_coordinators():
     interactive_mg_runner.start(other_instances, "coordinator_4")
     execute_and_fetch_all(
         coord_cursor_3,
-        "ADD COORDINATOR 4 WITH CONFIG {'bolt_server': '127.0.0.1:7693', 'coordinator_server': '0.0.0.0:10114'}",
+        "ADD COORDINATOR 4 WITH CONFIG {'bolt_server': 'localhost:7693', 'coordinator_server': 'localhost:10114'}",
     )
 
     # 6
@@ -2545,23 +2575,23 @@ def test_coordinator_gets_info_on_other_coordinators():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_4, "SHOW INSTANCES;"))))
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "down", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("coordinator_4", "127.0.0.1:7693", "0.0.0.0:10114", "", "up", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "down", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("coordinator_4", "localhost:7693", "localhost:10114", "", "up", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("coordinator_4", "127.0.0.1:7693", "0.0.0.0:10114", "", "unknown", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("coordinator_4", "localhost:7693", "localhost:10114", "", "unknown", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
     mg_sleep_and_assert(leader_data, show_instances_coord3)
     mg_sleep_and_assert(follower_data, show_instances_coord1)
@@ -2590,12 +2620,12 @@ def test_registration_works_after_main_set():
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
 
     setup_queries = [
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
         "SET INSTANCE instance_3 TO MAIN",
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
     ]
     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
     for query in setup_queries:
@@ -2617,21 +2647,21 @@ def test_registration_works_after_main_set():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
     mg_sleep_and_assert(leader_data, show_instances_coord3)
     mg_sleep_and_assert(follower_data, show_instances_coord1)
@@ -2645,14 +2675,14 @@ def test_registration_works_after_main_set():
     replicas = [
         (
             "instance_1",
-            "127.0.0.1:10001",
+            "localhost:10001",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
@@ -2687,11 +2717,11 @@ def test_coordinator_not_leader_registration_does_not_work():
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
 
     setup_queries = [
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '0.0.0.0:10111'}",
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '0.0.0.0:10112'}",
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
         "SET INSTANCE instance_3 TO MAIN",
     ]
     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
@@ -2714,21 +2744,21 @@ def test_coordinator_not_leader_registration_does_not_work():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
     mg_sleep_and_assert(leader_data, show_instances_coord3)
     mg_sleep_and_assert(follower_data, show_instances_coord1)
@@ -2742,14 +2772,14 @@ def test_coordinator_not_leader_registration_does_not_work():
     replicas = [
         (
             "instance_1",
-            "127.0.0.1:10001",
+            "localhost:10001",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
@@ -2775,8 +2805,8 @@ def test_coordinator_not_leader_registration_does_not_work():
     with pytest.raises(Exception) as e:
         execute_and_fetch_all(
             coord_cursor_1,
-            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': '127.0.0.1:7680', 'management_server': "
-            "'127.0.0.1:10050', 'replication_server': '127.0.0.1:10051'};",
+            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': "
+            "'localhost:10050', 'replication_server': 'localhost:10051'};",
         )
 
     assert (
@@ -2821,21 +2851,21 @@ def test_coordinator_user_action_demote_instance_to_replica():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     leader_data_original = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     follower_data_original = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
 
     mg_sleep_and_assert(leader_data_original, show_instances_coord3)
@@ -2850,14 +2880,14 @@ def test_coordinator_user_action_demote_instance_to_replica():
     replicas = [
         (
             "instance_1",
-            "127.0.0.1:10001",
+            "localhost:10001",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
@@ -2888,21 +2918,21 @@ def test_coordinator_user_action_demote_instance_to_replica():
     # 4.
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "replica"),
     ]
     mg_sleep_and_assert(leader_data, show_instances_coord3)
     mg_sleep_and_assert(follower_data, show_instances_coord1)
@@ -2937,11 +2967,11 @@ def test_coordinator_user_action_force_reset_works():
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
 
     setup_queries = [
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '0.0.0.0:10111'}",
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '0.0.0.0:10112'}",
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
         "SET INSTANCE instance_3 TO MAIN",
     ]
     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
@@ -2964,21 +2994,21 @@ def test_coordinator_user_action_force_reset_works():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
     mg_sleep_and_assert(leader_data, show_instances_coord3)
     mg_sleep_and_assert(follower_data, show_instances_coord1)
@@ -2992,14 +3022,14 @@ def test_coordinator_user_action_force_reset_works():
     replicas = [
         (
             "instance_1",
-            "127.0.0.1:10001",
+            "localhost:10001",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
@@ -3030,21 +3060,21 @@ def test_coordinator_user_action_force_reset_works():
     # 4.
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "0.0.0.0:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "0.0.0.0:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "replica"),
     ]
 
     mg_sleep_and_assert(leader_data, show_instances_coord3)
@@ -3069,11 +3099,11 @@ def test_all_coords_down_resume():
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
 
     setup_queries = [
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
         "SET INSTANCE instance_3 TO MAIN",
     ]
 
@@ -3096,21 +3126,21 @@ def test_all_coords_down_resume():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
 
     mg_sleep_and_assert(leader_data, show_instances_coord3)
@@ -3132,39 +3162,39 @@ def test_all_coords_down_resume():
     # 5
 
     leader_data_1 = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "leader"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     leader_data_2 = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "leader"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "down", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "leader"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     follower_data_1 = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "leader"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "leader"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
 
     follower_data_2 = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "leader"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "leader"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
 
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
@@ -3181,39 +3211,39 @@ def test_all_coords_down_resume():
     # 7
 
     leader_data_1 = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "leader"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
     leader_data_2 = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "leader"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "leader"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
     follower_data_1 = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "leader"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "leader"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "unknown"),
     ]
 
     follower_data_2 = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "leader"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "follower"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "leader"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "unknown"),
     ]
 
     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
@@ -3248,11 +3278,11 @@ def test_one_coord_down_with_durability_resume():
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
 
     setup_queries = [
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': '127.0.0.1:7690', 'coordinator_server': '127.0.0.1:10111'}",
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'coordinator_server': '127.0.0.1:10112'}",
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112'}",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
         "SET INSTANCE instance_3 TO MAIN",
     ]
 
@@ -3275,21 +3305,21 @@ def test_one_coord_down_with_durability_resume():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
 
     mg_sleep_and_assert(leader_data, show_instances_coord3)
@@ -3306,21 +3336,21 @@ def test_one_coord_down_with_durability_resume():
     # 5
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "replica"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
     ]
 
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
@@ -3335,21 +3365,21 @@ def test_one_coord_down_with_durability_resume():
     # 7
 
     leader_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "up", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "up", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
     follower_data = [
-        ("coordinator_1", "127.0.0.1:7690", "127.0.0.1:10111", "", "unknown", "follower"),
-        ("coordinator_2", "127.0.0.1:7691", "127.0.0.1:10112", "", "unknown", "follower"),
-        ("coordinator_3", "0.0.0.0:7692", "0.0.0.0:10113", "", "unknown", "leader"),
-        ("instance_1", "127.0.0.1:7687", "", "127.0.0.1:10011", "unknown", "main"),
-        ("instance_2", "127.0.0.1:7688", "", "127.0.0.1:10012", "unknown", "replica"),
-        ("instance_3", "127.0.0.1:7689", "", "127.0.0.1:10013", "unknown", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "", "unknown", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "unknown"),
     ]
 
     mg_sleep_and_assert(leader_data, show_instances_coord3)

--- a/tests/e2e/high_availability/manual_setting_replicas.py
+++ b/tests/e2e/high_availability/manual_setting_replicas.py
@@ -48,7 +48,7 @@ def test_no_manual_setup_on_main():
 
     any_main = connect(host="localhost", port=7687).cursor()
     with pytest.raises(Exception) as e:
-        execute_and_fetch_all(any_main, "REGISTER REPLICA replica_1 SYNC TO '127.0.0.1:10001';")
+        execute_and_fetch_all(any_main, "REGISTER REPLICA replica_1 SYNC TO 'localhost:10001';")
     assert str(e.value) == "Can't register replica manually on instance with coordinator server port."
 
     with pytest.raises(Exception) as e:

--- a/tests/e2e/high_availability/single_coordinator.py
+++ b/tests/e2e/high_availability/single_coordinator.py
@@ -92,12 +92,14 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
             "--log-level=TRACE",
             "--coordinator-id=1",
             "--coordinator-port=10111",
+            "--coordinator-hostname",
+            "localhost",
         ],
         "log_file": "high_availability/single_coordinator/coordinator.log",
         "setup_queries": [
-            "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-            "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-            "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+            "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+            "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+            "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
             "SET INSTANCE instance_3 TO MAIN",
         ],
     },
@@ -187,12 +189,14 @@ def test_replication_works_on_failover_replica_1_epoch_2_commits_away(data_recov
                 "--log-level=TRACE",
                 "--coordinator-id=1",
                 "--coordinator-port=10111",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/single_coordinator/coordinator.log",
             "setup_queries": [
-                "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-                "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-                "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+                "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+                "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+                "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
                 "SET INSTANCE instance_3 TO MAIN",
             ],
         },
@@ -210,14 +214,14 @@ def test_replication_works_on_failover_replica_1_epoch_2_commits_away(data_recov
     expected_data_on_main = [
         (
             "instance_1",
-            "127.0.0.1:10001",
+            "localhost:10001",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
@@ -257,10 +261,10 @@ def test_replication_works_on_failover_replica_1_epoch_2_commits_away(data_recov
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "down", "unknown"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "main"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "down", "unknown"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "up", "main"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
     ]
     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
 
@@ -274,10 +278,10 @@ def test_replication_works_on_failover_replica_1_epoch_2_commits_away(data_recov
     interactive_mg_runner.start(MEMGRAPH_INNER_INSTANCES_DESCRIPTION, "instance_1")
 
     new_expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "main"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "up", "main"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
     ]
     mg_sleep_and_assert(new_expected_data_on_coord, retrieve_data_show_instances)
 
@@ -294,10 +298,10 @@ def test_replication_works_on_failover_replica_1_epoch_2_commits_away(data_recov
     interactive_mg_runner.start(MEMGRAPH_INNER_INSTANCES_DESCRIPTION, "instance_3")
 
     new_expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "main"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "up", "main"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "up", "replica"),
     ]
     mg_sleep_and_assert(new_expected_data_on_coord, retrieve_data_show_instances)
 
@@ -417,13 +421,15 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
                 "--log-level=TRACE",
                 "--coordinator-id=1",
                 "--coordinator-port=10111",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/single_coordinator/coordinator.log",
             "setup_queries": [
-                "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-                "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-                "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
-                "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'management_server': '127.0.0.1:10014', 'replication_server': '127.0.0.1:10004'};",
+                "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+                "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+                "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
+                "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7691', 'management_server': 'localhost:10014', 'replication_server': 'localhost:10004'};",
                 "SET INSTANCE instance_3 TO MAIN",
             ],
         },
@@ -436,21 +442,21 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
     expected_data_on_main = [
         (
             "instance_1",
-            "127.0.0.1:10001",
+            "localhost:10001",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
         (
             "instance_4",
-            "127.0.0.1:10004",
+            "localhost:10004",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
@@ -487,11 +493,11 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "down", "unknown"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
-        ("instance_4", "127.0.0.1:7691", "", "127.0.0.1:10014", "up", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "down", "unknown"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
+        ("instance_4", "localhost:7691", "", "localhost:10014", "up", "replica"),
     ]
     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
 
@@ -511,11 +517,11 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
     # 6
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "down", "unknown"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
-        ("instance_4", "127.0.0.1:7691", "", "127.0.0.1:10014", "up", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "down", "unknown"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
+        ("instance_4", "localhost:7691", "", "localhost:10014", "up", "replica"),
     ]
     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
 
@@ -536,11 +542,11 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
     # 10
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "down", "unknown"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "down", "unknown"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
-        ("instance_4", "127.0.0.1:7691", "", "127.0.0.1:10014", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "down", "unknown"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "down", "unknown"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
+        ("instance_4", "localhost:7691", "", "localhost:10014", "up", "main"),
     ]
     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
 
@@ -555,11 +561,11 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
     interactive_mg_runner.start(MEMGRAPH_INNER_INSTANCES_DESCRIPTION, "instance_2")
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "down", "unknown"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
-        ("instance_4", "127.0.0.1:7691", "", "127.0.0.1:10014", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "down", "unknown"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
+        ("instance_4", "localhost:7691", "", "localhost:10014", "up", "main"),
     ]
     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
 
@@ -578,11 +584,11 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
     interactive_mg_runner.start(MEMGRAPH_INNER_INSTANCES_DESCRIPTION, "instance_3")
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "replica"),
-        ("instance_4", "127.0.0.1:7691", "", "127.0.0.1:10014", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "up", "replica"),
+        ("instance_4", "localhost:7691", "", "localhost:10014", "up", "main"),
     ]
     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
 
@@ -704,13 +710,15 @@ def test_replication_forcefully_works_on_failover_replica_misses_epoch(data_reco
                 "--log-level=TRACE",
                 "--coordinator-id=1",
                 "--coordinator-port=10111",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/single_coordinator/coordinator.log",
             "setup_queries": [
-                "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-                "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-                "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
-                "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'management_server': '127.0.0.1:10014', 'replication_server': '127.0.0.1:10004'};",
+                "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+                "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+                "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
+                "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7691', 'management_server': 'localhost:10014', 'replication_server': 'localhost:10004'};",
                 "SET INSTANCE instance_3 TO MAIN",
             ],
         },
@@ -726,21 +734,21 @@ def test_replication_forcefully_works_on_failover_replica_misses_epoch(data_reco
     expected_data_on_main = [
         (
             "instance_1",
-            "127.0.0.1:10001",
+            "localhost:10001",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
         (
             "instance_4",
-            "127.0.0.1:10004",
+            "localhost:10004",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
@@ -760,11 +768,11 @@ def test_replication_forcefully_works_on_failover_replica_misses_epoch(data_reco
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
-        ("instance_4", "127.0.0.1:7691", "", "127.0.0.1:10014", "up", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
+        ("instance_4", "localhost:7691", "", "localhost:10014", "up", "replica"),
     ]
     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
 
@@ -792,11 +800,11 @@ def test_replication_forcefully_works_on_failover_replica_misses_epoch(data_reco
     # 7
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "down", "unknown"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "main"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
-        ("instance_4", "127.0.0.1:7691", "", "127.0.0.1:10014", "up", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "down", "unknown"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "up", "main"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
+        ("instance_4", "localhost:7691", "", "localhost:10014", "up", "replica"),
     ]
     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
 
@@ -826,11 +834,11 @@ def test_replication_forcefully_works_on_failover_replica_misses_epoch(data_reco
     interactive_mg_runner.start(MEMGRAPH_INNER_INSTANCES_DESCRIPTION, "instance_1")
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "down", "unknown"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
-        ("instance_4", "127.0.0.1:7691", "", "127.0.0.1:10014", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "down", "unknown"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
+        ("instance_4", "localhost:7691", "", "localhost:10014", "down", "unknown"),
     ]
     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
 
@@ -841,11 +849,11 @@ def test_replication_forcefully_works_on_failover_replica_misses_epoch(data_reco
     # 13
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
-        ("instance_4", "127.0.0.1:7691", "", "127.0.0.1:10014", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
+        ("instance_4", "localhost:7691", "", "localhost:10014", "down", "unknown"),
     ]
     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
 
@@ -991,13 +999,15 @@ def test_replication_correct_replica_chosen_up_to_date_data(data_recovery):
                 "--log-level=TRACE",
                 "--coordinator-id=1",
                 "--coordinator-port=10111",
+                "--coordinator-hostname",
+                "localhost",
             ],
             "log_file": "high_availability/single_coordinator/coordinator.log",
             "setup_queries": [
-                "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-                "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-                "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
-                "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': '127.0.0.1:7691', 'management_server': '127.0.0.1:10014', 'replication_server': '127.0.0.1:10004'};",
+                "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+                "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+                "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
+                "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7691', 'management_server': 'localhost:10014', 'replication_server': 'localhost:10004'};",
                 "SET INSTANCE instance_3 TO MAIN",
             ],
         },
@@ -1013,21 +1023,21 @@ def test_replication_correct_replica_chosen_up_to_date_data(data_recovery):
     expected_data_on_main = [
         (
             "instance_1",
-            "127.0.0.1:10001",
+            "localhost:10001",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
         (
             "instance_4",
-            "127.0.0.1:10004",
+            "localhost:10004",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
@@ -1048,11 +1058,11 @@ def test_replication_correct_replica_chosen_up_to_date_data(data_recovery):
 
     # TODO(antoniofilipovic) Before fixing durability, if this is removed we also have an issue. Check after fix
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
-        ("instance_4", "127.0.0.1:7691", "", "127.0.0.1:10014", "up", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
+        ("instance_4", "localhost:7691", "", "localhost:10014", "up", "replica"),
     ]
     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
 
@@ -1080,11 +1090,11 @@ def test_replication_correct_replica_chosen_up_to_date_data(data_recovery):
     # 7
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "down", "unknown"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "main"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
-        ("instance_4", "127.0.0.1:7691", "", "127.0.0.1:10014", "up", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "down", "unknown"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "up", "main"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
+        ("instance_4", "localhost:7691", "", "localhost:10014", "up", "replica"),
     ]
     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
 
@@ -1106,11 +1116,11 @@ def test_replication_correct_replica_chosen_up_to_date_data(data_recovery):
     interactive_mg_runner.kill(MEMGRAPH_INNER_INSTANCES_DESCRIPTION, "instance_4")
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "down", "unknown"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "main"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
-        ("instance_4", "127.0.0.1:7691", "", "127.0.0.1:10014", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "down", "unknown"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "up", "main"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
+        ("instance_4", "localhost:7691", "", "localhost:10014", "down", "unknown"),
     ]
     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
 
@@ -1123,11 +1133,11 @@ def test_replication_correct_replica_chosen_up_to_date_data(data_recovery):
     # 11
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "down", "unknown"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
-        ("instance_4", "127.0.0.1:7691", "", "127.0.0.1:10014", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "down", "unknown"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
+        ("instance_4", "localhost:7691", "", "localhost:10014", "up", "main"),
     ]
     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
 
@@ -1166,14 +1176,14 @@ def test_replication_works_on_failover_simple():
     expected_data_on_main = [
         (
             "instance_1",
-            "127.0.0.1:10001",
+            "localhost:10001",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
         ),
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
@@ -1195,10 +1205,10 @@ def test_replication_works_on_failover_simple():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
     ]
     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
 
@@ -1210,14 +1220,14 @@ def test_replication_works_on_failover_simple():
     expected_data_on_new_main = [
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
         ),
         (
             "instance_3",
-            "127.0.0.1:10003",
+            "localhost:10003",
             "sync",
             {"ts": 0, "behind": None, "status": "invalid"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "invalid"}},
@@ -1245,14 +1255,14 @@ def test_replication_works_on_failover_simple():
     expected_data_on_new_main = [
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 2, "behind": 0, "status": "ready"}},
         ),
         (
             "instance_3",
-            "127.0.0.1:10003",
+            "localhost:10003",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 2, "behind": 0, "status": "ready"}},
@@ -1287,14 +1297,14 @@ def test_replication_works_on_replica_instance_restart():
     expected_data_on_main = [
         (
             "instance_1",
-            "127.0.0.1:10001",
+            "localhost:10001",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
         ),
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
@@ -1315,10 +1325,10 @@ def test_replication_works_on_replica_instance_restart():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "down", "unknown"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "down", "unknown"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
     ]
     mg_sleep_and_assert_collection(expected_data_on_coord, retrieve_data_show_repl_cluster)
 
@@ -1328,14 +1338,14 @@ def test_replication_works_on_replica_instance_restart():
     expected_data_on_main = [
         (
             "instance_1",
-            "127.0.0.1:10001",
+            "localhost:10001",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
         ),
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "invalid"}},
@@ -1358,14 +1368,14 @@ def test_replication_works_on_replica_instance_restart():
     expected_data_on_main = [
         (
             "instance_1",
-            "127.0.0.1:10001",
+            "localhost:10001",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 2, "behind": 0, "status": "ready"}},
         ),
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "invalid"}},
@@ -1381,10 +1391,10 @@ def test_replication_works_on_replica_instance_restart():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
     ]
     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
 
@@ -1394,14 +1404,14 @@ def test_replication_works_on_replica_instance_restart():
     expected_data_on_main = [
         (
             "instance_1",
-            "127.0.0.1:10001",
+            "localhost:10001",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 2, "behind": 0, "status": "ready"}},
         ),
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 2, "behind": 0, "status": "ready"}},
@@ -1429,10 +1439,10 @@ def test_show_instances():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
     ]
     mg_sleep_and_assert(expected_data, show_repl_cluster)
 
@@ -1452,20 +1462,20 @@ def test_show_instances():
     interactive_mg_runner.kill(MEMGRAPH_INSTANCES_DESCRIPTION, "instance_1")
 
     expected_data = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "down", "unknown"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "down", "unknown"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
     ]
     mg_sleep_and_assert(expected_data, show_repl_cluster)
 
     interactive_mg_runner.kill(MEMGRAPH_INSTANCES_DESCRIPTION, "instance_2")
 
     expected_data = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "down", "unknown"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "down", "unknown"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "down", "unknown"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "down", "unknown"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
     ]
     mg_sleep_and_assert(expected_data, show_repl_cluster)
 
@@ -1478,14 +1488,14 @@ def test_simple_automatic_failover():
     expected_data_on_main = [
         (
             "instance_1",
-            "127.0.0.1:10001",
+            "localhost:10001",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
         ),
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
@@ -1505,10 +1515,10 @@ def test_simple_automatic_failover():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_on_coord = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
     ]
     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
 
@@ -1520,14 +1530,14 @@ def test_simple_automatic_failover():
     expected_data_on_new_main = [
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
         ),
         (
             "instance_3",
-            "127.0.0.1:10003",
+            "localhost:10003",
             "sync",
             {"ts": 0, "behind": None, "status": "invalid"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "invalid"}},
@@ -1539,14 +1549,14 @@ def test_simple_automatic_failover():
     expected_data_on_new_main_old_alive = [
         (
             "instance_2",
-            "127.0.0.1:10002",
+            "localhost:10002",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
         ),
         (
             "instance_3",
-            "127.0.0.1:10003",
+            "localhost:10003",
             "sync",
             {"ts": 0, "behind": None, "status": "ready"},
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
@@ -1564,7 +1574,7 @@ def test_registering_replica_fails_name_exists():
     with pytest.raises(Exception) as e:
         execute_and_fetch_all(
             coord_cursor,
-            "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7693', 'management_server': '127.0.0.1:10051', 'replication_server': '127.0.0.1:10111'};",
+            "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7693', 'management_server': 'localhost:10051', 'replication_server': 'localhost:10111'};",
         )
     assert str(e.value) == "Couldn't register replica instance since instance with such name already exists!"
     shutil.rmtree(TEMP_DIR)
@@ -1578,7 +1588,7 @@ def test_registering_replica_fails_endpoint_exists():
     with pytest.raises(Exception) as e:
         execute_and_fetch_all(
             coord_cursor,
-            "REGISTER INSTANCE instance_5 WITH CONFIG {'bolt_server': '127.0.0.1:7693', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10005'};",
+            "REGISTER INSTANCE instance_5 WITH CONFIG {'bolt_server': 'localhost:7693', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10005'};",
         )
     assert (
         str(e.value) == "Couldn't register replica instance since instance with such management server already exists!"
@@ -1595,20 +1605,20 @@ def test_replica_instance_restarts():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(cursor, "SHOW INSTANCES;"))))
 
     expected_data_up = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
     ]
     mg_sleep_and_assert(expected_data_up, show_repl_cluster)
 
     interactive_mg_runner.kill(MEMGRAPH_INSTANCES_DESCRIPTION, "instance_1")
 
     expected_data_down = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "down", "unknown"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "down", "unknown"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
     ]
     mg_sleep_and_assert(expected_data_down, show_repl_cluster)
 
@@ -1637,18 +1647,18 @@ def test_automatic_failover_main_back_as_replica():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_after_failover = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
     ]
     mg_sleep_and_assert(expected_data_after_failover, retrieve_data_show_repl_cluster)
 
     expected_data_after_main_coming_back = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "main"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "replica"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "up", "replica"),
     ]
 
     interactive_mg_runner.start(MEMGRAPH_INSTANCES_DESCRIPTION, "instance_3")
@@ -1676,20 +1686,20 @@ def test_automatic_failover_main_back_as_main():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_all_down = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "down", "unknown"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "down", "unknown"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "down", "unknown"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "down", "unknown"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "down", "unknown"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
     ]
 
     mg_sleep_and_assert(expected_data_all_down, retrieve_data_show_repl_cluster)
 
     interactive_mg_runner.start(MEMGRAPH_INSTANCES_DESCRIPTION, "instance_3")
     expected_data_main_back = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "down", "unknown"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "down", "unknown"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "down", "unknown"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "down", "unknown"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
     ]
     mg_sleep_and_assert(expected_data_main_back, retrieve_data_show_repl_cluster)
 
@@ -1704,10 +1714,10 @@ def test_automatic_failover_main_back_as_main():
     interactive_mg_runner.start(MEMGRAPH_INSTANCES_DESCRIPTION, "instance_2")
 
     expected_data_replicas_back = [
-        ("coordinator_1", "0.0.0.0:7690", "0.0.0.0:10111", "", "up", "leader"),
-        ("instance_1", "127.0.0.1:7688", "", "127.0.0.1:10011", "up", "replica"),
-        ("instance_2", "127.0.0.1:7689", "", "127.0.0.1:10012", "up", "replica"),
-        ("instance_3", "127.0.0.1:7687", "", "127.0.0.1:10013", "up", "main"),
+        ("coordinator_1", "localhost:7690", "localhost:10111", "", "up", "leader"),
+        ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
     ]
 
     mg_sleep_and_assert(expected_data_replicas_back, retrieve_data_show_repl_cluster)

--- a/tests/e2e/high_availability/workloads.yaml
+++ b/tests/e2e/high_availability/workloads.yaml
@@ -13,12 +13,12 @@ ha_cluster: &ha_cluster
       log_file: "high_availability/coordinator/replication-e2e-main.log"
       setup_queries: []
     coordinator:
-      args: ["--experimental-enabled=high-availability", "--bolt-port", "7690", "--log-level=TRACE", "--coordinator-id=1", "--coordinator-port=10111"]
+      args: ["--experimental-enabled=high-availability", "--bolt-port", "7690", "--log-level=TRACE", "--coordinator-id=1", "--coordinator-port=10111", "--coordinator-hostname=localhost"]
       log_file: "high_availability/coordinator/replication-e2e-coordinator.log"
       setup_queries: [
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': '127.0.0.1:7688', 'management_server': '127.0.0.1:10011', 'replication_server': '127.0.0.1:10001'};",
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': '127.0.0.1:7689', 'management_server': '127.0.0.1:10012', 'replication_server': '127.0.0.1:10002'};",
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': '127.0.0.1:7687', 'management_server': '127.0.0.1:10013', 'replication_server': '127.0.0.1:10003'};",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
         "SET INSTANCE instance_3 TO MAIN;"
       ]
 

--- a/tests/jepsen/src/jepsen/memgraph/support.clj
+++ b/tests/jepsen/src/jepsen/memgraph/support.clj
@@ -34,7 +34,7 @@
    :--storage-properties-on-edges))
 
 (defn start-coordinator-node!
-  [test node-config]
+  [test node node-config]
   (cu/start-daemon!
    {:logfile mglog
     :pidfile mgpid
@@ -51,7 +51,9 @@
    :--storage-properties-on-edges
    :--telemetry-enabled false
    :--coordinator-id (get node-config :coordinator-id)
-   :--coordinator-port (get node-config :coordinator-port)))
+   :--coordinator-port (get node-config :coordinator-port)
+   :--coordinator-hostname node
+   ))
 
 (defn start-data-node!
   [test node-config]
@@ -78,7 +80,7 @@
   (let [node-config (get nodes-config node)]
     (info "Starting Memgraph node" node-config)
     (if (:coordinator-id node-config)
-      (start-coordinator-node! test node-config)
+      (start-coordinator-node! test node node-config)
       (if (:management-port node-config)
         (start-data-node! test node-config)
         (start-node! test node)))))

--- a/tests/unit/coordinator_env_flag_handler.cpp
+++ b/tests/unit/coordinator_env_flag_handler.cpp
@@ -19,20 +19,23 @@ class CoordinationSetupTest : public ::testing::Test {
  protected:
   void SetUp() override {}
 
+  // NOTE: Update this function if new environment variables are added
   void TearDown() override {
     unsetenv(memgraph::flags::kMgManagementPort);
     unsetenv(memgraph::flags::kMgCoordinatorPort);
     unsetenv(memgraph::flags::kMgCoordinatorId);
     unsetenv(memgraph::flags::kMgNuRaftLogFile);
+    unsetenv(memgraph::flags::kMgCoordinatorHostname);
   }
 };
 
 TEST_F(CoordinationSetupTest, CoordinationSetupSimple) {
-  memgraph::flags::CoordinationSetup coord_setup(1, 2, 3, "nuraft_log_file", false);
+  memgraph::flags::CoordinationSetup coord_setup(1, 2, 3, "nuraft_log_file", false, "localhost");
   EXPECT_EQ(coord_setup.management_port, 1);
   EXPECT_EQ(coord_setup.coordinator_port, 2);
   EXPECT_EQ(coord_setup.coordinator_id, 3);
   EXPECT_EQ(coord_setup.nuraft_log_file, "nuraft_log_file");
+  EXPECT_EQ(coord_setup.coordinator_hostname, "localhost");
 }
 
 TEST_F(CoordinationSetupTest, CoordinationSetupAll) {
@@ -55,6 +58,10 @@ TEST_F(CoordinationSetupTest, CoordinationSetupAll) {
     FAIL() << "Failed to set MEMGRAPH_NURAFT_LOG_FILE environment variable";
   }
 
+  if (setenv(kMgCoordinatorHostname, "memgraph-svc-cluster-1.dns", 1) != 0) {
+    FAIL() << "Failed to set MEMGRAPH_COORDINATOR_HOSTNAME environment variable";
+  }
+
   memgraph::flags::SetFinalCoordinationSetup();
   auto const &coordination_setup = memgraph::flags::CoordinationSetupInstance();
 
@@ -62,6 +69,7 @@ TEST_F(CoordinationSetupTest, CoordinationSetupAll) {
   EXPECT_EQ(coordination_setup.coordinator_port, 10111);
   EXPECT_EQ(coordination_setup.coordinator_id, 1);
   EXPECT_EQ(coordination_setup.nuraft_log_file, "nuraft_log_file");
+  EXPECT_EQ(coordination_setup.coordinator_hostname, "memgraph-svc-cluster-1.dns");
 }
 
 TEST_F(CoordinationSetupTest, CoordinatorSetupPartial) {
@@ -80,4 +88,5 @@ TEST_F(CoordinationSetupTest, CoordinatorSetupPartial) {
   EXPECT_EQ(coordination_setup.coordinator_port, 10111);
   EXPECT_EQ(coordination_setup.coordinator_id, 1);
   EXPECT_EQ(coordination_setup.nuraft_log_file, "");
+  EXPECT_EQ(coordination_setup.coordinator_hostname, "");
 }

--- a/tests/unit/coordinator_instance.cpp
+++ b/tests/unit/coordinator_instance.cpp
@@ -49,8 +49,9 @@ class CoordinatorInstanceTest : public ::testing::Test {
 
 // Empty until you run 1st RegisterReplicationInstance or AddCoordinatorInstance
 TEST_F(CoordinatorInstanceTest, ShowInstancesEmptyTest) {
-  auto const init_config = CoordinatorInstanceInitConfig{coordinator_ids[0], coordinator_ports[0], bolt_ports[0],
-                                                         main_data_directory / "high_availability" / "coordinator"};
+  auto const init_config =
+      CoordinatorInstanceInitConfig{coordinator_ids[0], coordinator_ports[0], bolt_ports[0],
+                                    main_data_directory / "high_availability" / "coordinator", "localhost"};
 
   auto const instance1 = CoordinatorInstance{init_config};
   auto const instances = instance1.ShowInstances();
@@ -63,18 +64,21 @@ TEST_F(CoordinatorInstanceTest, ConnectCoordinators) {
     }
   };
 
-  auto const init_config1 = CoordinatorInstanceInitConfig{coordinator_ids[0], coordinator_ports[0], bolt_ports[0],
-                                                          main_data_directory / "high_availability1" / "coordinator"};
+  auto const init_config1 =
+      CoordinatorInstanceInitConfig{coordinator_ids[0], coordinator_ports[0], bolt_ports[0],
+                                    main_data_directory / "high_availability1" / "coordinator", "localhost"};
 
   auto instance1 = CoordinatorInstance{init_config1};
 
-  auto const init_config2 = CoordinatorInstanceInitConfig{coordinator_ids[1], coordinator_ports[1], bolt_ports[1],
-                                                          main_data_directory / "high_availability2" / "coordinator"};
+  auto const init_config2 =
+      CoordinatorInstanceInitConfig{coordinator_ids[1], coordinator_ports[1], bolt_ports[1],
+                                    main_data_directory / "high_availability2" / "coordinator", "localhost"};
 
   auto const instance2 = CoordinatorInstance{init_config2};
 
-  auto const init_config3 = CoordinatorInstanceInitConfig{coordinator_ids[2], coordinator_ports[2], bolt_ports[2],
-                                                          main_data_directory / "high_availability3" / "coordinator"};
+  auto const init_config3 =
+      CoordinatorInstanceInitConfig{coordinator_ids[2], coordinator_ports[2], bolt_ports[2],
+                                    main_data_directory / "high_availability3" / "coordinator", "localhost"};
 
   auto const instance3 = CoordinatorInstance{init_config3};
 
@@ -143,18 +147,21 @@ TEST_F(CoordinatorInstanceTest, GetRoutingTable) {
     }
   };
 
-  auto const init_config1 = CoordinatorInstanceInitConfig{coordinator_ids[0], coordinator_ports[0], bolt_ports[0],
-                                                          main_data_directory / "high_availability1" / "coordinator"};
+  auto const init_config1 =
+      CoordinatorInstanceInitConfig{coordinator_ids[0], coordinator_ports[0], bolt_ports[0],
+                                    main_data_directory / "high_availability1" / "coordinator", "localhost"};
 
   auto instance1 = CoordinatorInstance{init_config1};
 
-  auto const init_config2 = CoordinatorInstanceInitConfig{coordinator_ids[1], coordinator_ports[1], bolt_ports[1],
-                                                          main_data_directory / "high_availability2" / "coordinator"};
+  auto const init_config2 =
+      CoordinatorInstanceInitConfig{coordinator_ids[1], coordinator_ports[1], bolt_ports[1],
+                                    main_data_directory / "high_availability2" / "coordinator", "localhost"};
 
   auto const instance2 = CoordinatorInstance{init_config2};
 
-  auto const init_config3 = CoordinatorInstanceInitConfig{coordinator_ids[2], coordinator_ports[2], bolt_ports[2],
-                                                          main_data_directory / "high_availability3" / "coordinator"};
+  auto const init_config3 =
+      CoordinatorInstanceInitConfig{coordinator_ids[2], coordinator_ports[2], bolt_ports[2],
+                                    main_data_directory / "high_availability3" / "coordinator", "localhost"};
 
   auto const instance3 = CoordinatorInstance{init_config3};
 

--- a/tests/unit/coordinator_raft_state.cpp
+++ b/tests/unit/coordinator_raft_state.cpp
@@ -52,13 +52,11 @@ TEST_F(RaftStateTest, RaftStateEmptyMetadata) {
   auto become_leader_cb = []() {};
   auto become_follower_cb = []() {};
 
-  auto const instance_config =
-      CoordinatorInstanceInitConfig{coordinator_id,
-                                    coordinator_port,
-                                    bolt_port,
-                                    test_folder_ / "high_availability" / "coordinator" / "state_manager",
-                                    "",
-                                    false};
+  auto const instance_config = CoordinatorInstanceInitConfig{
+      coordinator_id, coordinator_port,
+      bolt_port,      test_folder_ / "high_availability" / "coordinator" / "state_manager",
+      "localhost",    "",
+      false};
 
   auto raft_state =
       std::make_unique<RaftState>(instance_config, std::move(become_leader_cb), std::move(become_follower_cb));
@@ -78,7 +76,8 @@ TEST_F(RaftStateTest, GetSingleRouterRoutingTable) {
   auto become_follower_cb = []() {};
 
   auto const config = CoordinatorInstanceInitConfig{
-      coordinator_id, coordinator_port, bolt_port, test_folder_ / "high_availability" / "coordinator", "", false};
+      coordinator_id, coordinator_port, bolt_port, test_folder_ / "high_availability" / "coordinator", "localhost", "",
+      false};
 
   auto raft_state = std::make_unique<RaftState>(config, std::move(become_leader_cb), std::move(become_follower_cb));
   raft_state->InitRaftServer();
@@ -96,7 +95,8 @@ TEST_F(RaftStateTest, GetMixedRoutingTable) {
   auto become_leader_cb = []() {};
   auto become_follower_cb = []() {};
   auto const init_config = CoordinatorInstanceInitConfig{
-      coordinator_id, coordinator_port, bolt_port, test_folder_ / "high_availability" / "coordinator", "", false};
+      coordinator_id, coordinator_port, bolt_port, test_folder_ / "high_availability" / "coordinator", "localhost", "",
+      false};
 
   auto raft_state_leader =
       std::make_unique<RaftState>(init_config, std::move(become_leader_cb), std::move(become_follower_cb));

--- a/tests/unit/coordinator_state_machine.cpp
+++ b/tests/unit/coordinator_state_machine.cpp
@@ -169,7 +169,9 @@ TEST_F(CoordinatorStateMachineTest, SerializeDeserializeSnapshot) {
         kv_store_, memgraph::coordination::LogStoreVersion::kV1, memgraph::coordination::LogStoreVersion::kV1};
     CoordinatorStateMachine state_machine{my_logger, log_store_durability};
     CoordinatorStateManagerConfig config{
-        0, 12345, 9090, test_folder_ / "high_availability" / "coordination" / "state_manager", log_store_durability};
+        0,           12345,
+        9090,        test_folder_ / "high_availability" / "coordination" / "state_manager",
+        "localhost", log_store_durability};
     ptr<CoordinatorStateManager> state_manager_ = cs_new<CoordinatorStateManager>(config, my_logger);
     old_config = state_manager_->load_config();
     auto const c2c =

--- a/tests/unit/coordinator_state_manager.cpp
+++ b/tests/unit/coordinator_state_manager.cpp
@@ -51,7 +51,8 @@ class CoordinatorStateManagerTest : public ::testing::Test {
 };
 
 TEST_F(CoordinatorStateManagerTest, SingleCoord) {
-  CoordinatorStateManagerConfig config{1, 12345, 9090, test_folder_ / "high_availability" / "coordination"};
+  CoordinatorStateManagerConfig config{1, 12345, 9090, test_folder_ / "high_availability" / "coordination",
+                                       "localhost"};
   using memgraph::coordination::Logger;
   using memgraph::coordination::LoggerWrapper;
 
@@ -78,7 +79,8 @@ TEST_F(CoordinatorStateManagerTest, SingleCoord) {
 TEST_F(CoordinatorStateManagerTest, MultipleCoords) {
   // 1st coord stored here
   ptr<cluster_config> old_config;
-  CoordinatorStateManagerConfig config{0, 12345, 9090, test_folder_ / "high_availability" / "coordination"};
+  CoordinatorStateManagerConfig config{0, 12345, 9090, test_folder_ / "high_availability" / "coordination",
+                                       "localhost"};
   using memgraph::coordination::Logger;
   using memgraph::coordination::LoggerWrapper;
 

--- a/tests/unit/coordinator_utils.cpp
+++ b/tests/unit/coordinator_utils.cpp
@@ -76,7 +76,7 @@ TEST_F(CoordinationUtils, MemgraphDbHistorySimple) {
   instance_database_histories.emplace_back("instance_3", instance_3_db_histories_);
 
   CoordinatorInstanceInitConfig const init_config1{coordinator_id, coordinator_port, bolt_port,
-                                                   test_folder_ / "high_availability" / "coordinator"};
+                                                   test_folder_ / "high_availability" / "coordinator", "localhost"};
   memgraph::coordination::CoordinatorInstance instance{init_config1};
 
   auto [instance_name, latest_epoch, latest_commit_timestamp] =
@@ -130,7 +130,7 @@ TEST_F(CoordinationUtils, MemgraphDbHistoryLastEpochDifferent) {
   instance_database_histories.emplace_back("instance_3", instance_3_db_histories_);
 
   CoordinatorInstanceInitConfig const init_config1{coordinator_id, coordinator_port, bolt_port,
-                                                   test_folder_ / "high_availability" / "coordinator"};
+                                                   test_folder_ / "high_availability" / "coordinator", "localhost"};
   memgraph::coordination::CoordinatorInstance instance{init_config1};
   auto [instance_name, latest_epoch, latest_commit_timestamp] =
       instance.ChooseMostUpToDateInstance(instance_database_histories);
@@ -187,7 +187,7 @@ TEST_F(CoordinationUtils, MemgraphDbHistoryOneInstanceAheadFewEpochs) {
   instance_database_histories.emplace_back("instance_3", instance_3_db_histories_);
 
   CoordinatorInstanceInitConfig const init_config1{coordinator_id, coordinator_port, bolt_port,
-                                                   test_folder_ / "high_availability" / "coordinator"};
+                                                   test_folder_ / "high_availability" / "coordinator", "localhost"};
   memgraph::coordination::CoordinatorInstance instance{init_config1};
   auto [instance_name, latest_epoch, latest_commit_timestamp] =
       instance.ChooseMostUpToDateInstance(instance_database_histories);
@@ -248,7 +248,7 @@ TEST_F(CoordinationUtils, MemgraphDbHistoryInstancesHistoryDiverged) {
   instance_database_histories.emplace_back("instance_2", instance_2_db_histories_);
 
   CoordinatorInstanceInitConfig const init_config1{coordinator_id, coordinator_port, bolt_port,
-                                                   test_folder_ / "high_availability" / "coordinator"};
+                                                   test_folder_ / "high_availability" / "coordinator", "localhost"};
   memgraph::coordination::CoordinatorInstance instance{init_config1};
   auto [instance_name, latest_epoch, latest_commit_timestamp] =
       instance.ChooseMostUpToDateInstance(instance_database_histories);


### PR DESCRIPTION
Configuration flag `--coordinator-hostname` is added which is used to fix the issue of having 0.0.0.0 in the output of `show instances` on the 1st leader. The flag has its environment variable equivalent in `MEMGRAPH_COORDINATOR_HOSTNAME`. The flag is used solely for the output of `show instances`, from the functional standpoint all stayed the same. High availability e2e tests are changed to use DNS (localhost instead of explicit 127.0.0.1) for consistency reasons. This change is breaking because now all coordinator instances need to provide a configuration option coordinator hostname.

The following output can be expected when setting `--coordinator-hostname=localhost` (no data instances):
memgraph> show instances;
+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+
| name               | bolt_server        | coordinator_server | management_server  | health             | role               | last_succ_resp_ms  |
+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+
| "coordinator_1"    | "localhost:7690"   | "localhost:10111"  | ""                 | "up"               | "leader"            | 0                  |
| "coordinator_2"    | "localhost:7691"   | "localhost:10112"  | ""                 | "up"               | "follower"         | 45                 |
| "coordinator_3"    | "localhost:7692"   | "localhost:10113"  | ""                 | "up"               | "follower"         | 57                 |
+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+
3 rows in set (0.001 sec)
memgraph>


