### PR TITLE
Fix multiple mains assert false

### DIFF
--- a/src/coordination/raft_state.cpp
+++ b/src/coordination/raft_state.cpp
@@ -521,13 +521,12 @@ auto RaftState::GetRoutingTable() const -> RoutingTable {
     return instance.config.BoltSocketAddress();  // non-resolved IP
   };
 
-  // TODO: (andi) This is wrong check, Fico will correct in #1819.
   auto const is_instance_main = [&](ReplicationInstanceState const &instance) {
-    return instance.status == ReplicationRole::MAIN;
+    return IsCurrentMain(instance.config.instance_name);
   };
 
   auto const is_instance_replica = [&](ReplicationInstanceState const &instance) {
-    return instance.status == ReplicationRole::REPLICA;
+    return !IsCurrentMain(instance.config.instance_name);
   };
 
   auto const &raft_log_repl_instances = GetReplicationInstances();

--- a/tests/unit/coordinator_raft_state.cpp
+++ b/tests/unit/coordinator_raft_state.cpp
@@ -127,7 +127,10 @@ TEST_F(RaftStateTest, GetMixedRoutingTable) {
                                                        .replication_mode = ReplicationMode::ASYNC,
                                                        .replication_server = Endpoint{"0.0.0.0", 10003}}});
 
-  raft_state_leader->AppendSetInstanceAsMainLog("instance1", UUID{});
+  auto const curr_uuid = UUID{};
+
+  raft_state_leader->AppendSetInstanceAsMainLog("instance1", curr_uuid);
+  raft_state_leader->AppendUpdateUUIDForNewMainLog(curr_uuid);
 
   auto const routing_table = raft_state_leader->GetRoutingTable();
 


### PR DESCRIPTION
When returning routing table, there was a wrong condition checking which data instance is the current main. New check takes into account currently valid cluster's UUID.

