### PR TITLE
Fix name of docker image from memgraph to memgraph/memgraph

### DIFF
--- a/release/docker/package_docker
+++ b/release/docker/package_docker
@@ -20,8 +20,8 @@ src_path=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --latest)
-        latest_image="memgraph:latest"
-        tag_latest="-t memgraph:latest"
+        latest_image="memgraph/memgraph:latest"
+        tag_latest="-t memgraph/memgraph:latest"
         shift
     ;;
     --package-path)
@@ -88,7 +88,7 @@ else
 fi
 
 tag="${version}${tag_extension}"
-image_name="memgraph:${tag}"
+image_name="memgraph/memgraph:${tag}"
 image_package_name="memgraph-${tag}-docker.tar.gz"
 
 # Build docker image.


### PR DESCRIPTION
This PR fixes the name of resulting docker image for memgraph (memgraph:tag --> memgraph/memgraph:tag)