### PR TITLE
Improve replication code

### DIFF
--- a/src/dbms/database.hpp
+++ b/src/dbms/database.hpp
@@ -68,12 +68,12 @@ class Database {
    */
   std::unique_ptr<storage::Storage::Accessor> Access(
       std::optional<storage::IsolationLevel> override_isolation_level = {}) {
-    return storage_->Access(repl_state_->GetRole(), override_isolation_level);
+    return storage_->Access(override_isolation_level);
   }
 
   std::unique_ptr<storage::Storage::Accessor> UniqueAccess(
       std::optional<storage::IsolationLevel> override_isolation_level = {}) {
-    return storage_->UniqueAccess(repl_state_->GetRole(), override_isolation_level);
+    return storage_->UniqueAccess(override_isolation_level);
   }
 
   /**
@@ -110,9 +110,9 @@ class Database {
    * @param force_directory Use the configured directory, do not try to decipher the multi-db version
    * @return DatabaseInfo
    */
-  DatabaseInfo GetInfo(replication_coordination_glue::ReplicationRole replication_role) const {
+  DatabaseInfo GetInfo() const {
     DatabaseInfo info;
-    info.storage_info = storage_->GetInfo(replication_role);
+    info.storage_info = storage_->GetInfo();
     info.triggers = trigger_store_.GetTriggerInfo().size();
     info.streams = streams_.GetStreamInfo().size();
     return info;

--- a/src/dbms/dbms_handler.hpp
+++ b/src/dbms/dbms_handler.hpp
@@ -291,7 +291,7 @@ class DbmsHandler {
    *
    * @return Statistics
    */
-  Statistics Stats(memgraph::replication_coordination_glue::ReplicationRole replication_role) {
+  Statistics Stats() {
     Statistics stats{};
     // TODO: Handle overflow?
 #ifdef MG_ENTERPRISE
@@ -304,7 +304,7 @@ class DbmsHandler {
       auto db_acc_opt = db_gk.access();
       if (db_acc_opt) {
         auto &db_acc = *db_acc_opt;
-        const auto &info = db_acc->GetInfo(replication_role);
+        const auto &info = db_acc->GetInfo();
         const auto &storage_info = info.storage_info;
         stats.num_vertex += storage_info.vertex_count;
         stats.num_edges += storage_info.edge_count;
@@ -327,7 +327,7 @@ class DbmsHandler {
    *
    * @return std::vector<DatabaseInfo>
    */
-  std::vector<DatabaseInfo> Info(memgraph::replication_coordination_glue::ReplicationRole replication_role) {
+  std::vector<DatabaseInfo> Info() {
     std::vector<DatabaseInfo> res;
 #ifdef MG_ENTERPRISE
     auto rd = std::shared_lock{lock_};
@@ -340,7 +340,7 @@ class DbmsHandler {
       auto db_acc_opt = db_gk.access();
       if (db_acc_opt) {
         auto &db_acc = *db_acc_opt;
-        res.push_back(db_acc->GetInfo(replication_role));
+        res.push_back(db_acc->GetInfo());
       }
     }
     return res;

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -566,9 +566,9 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
     if (!commit_timestamp_and_accessor) {
       std::unique_ptr<storage::Storage::Accessor> acc = nullptr;
       if (unique) {
-        acc = storage->UniqueAccess(ReplicationRole::REPLICA);
+        acc = storage->UniqueAccess();
       } else {
-        acc = storage->Access(ReplicationRole::REPLICA);
+        acc = storage->Access();
       }
       auto inmem_acc = std::unique_ptr<storage::InMemoryStorage::InMemoryAccessor>(
           static_cast<storage::InMemoryStorage::InMemoryAccessor *>(acc.release()));

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -657,9 +657,9 @@ int main(int argc, char **argv) {
   if (FLAGS_telemetry_enabled) {
     telemetry.emplace(telemetry_server, data_directory / "telemetry", memgraph::glue::run_id_, machine_id,
                       service_name == "BoltS", FLAGS_data_directory, std::chrono::minutes(10));
-    telemetry->AddStorageCollector(dbms_handler, *auth_, repl_state);
+    telemetry->AddStorageCollector(dbms_handler, *auth_);
 #ifdef MG_ENTERPRISE
-    telemetry->AddDatabaseCollector(dbms_handler, repl_state);
+    telemetry->AddDatabaseCollector(dbms_handler);
 #else
     telemetry->AddDatabaseCollector();
 #endif

--- a/src/mg_import_csv.cpp
+++ b/src/mg_import_csv.cpp
@@ -432,7 +432,7 @@ void ProcessNodeRow(memgraph::storage::Storage *store, const std::vector<std::st
                     const std::vector<Field> &fields, const std::vector<std::string> &additional_labels,
                     std::unordered_map<NodeId, memgraph::storage::Gid> *node_id_map) {
   std::optional<NodeId> id;
-  auto acc = store->Access(ReplicationRole::MAIN);
+  auto acc = store->Access();
   auto node = acc->CreateVertex();
   for (size_t i = 0; i < row.size(); ++i) {
     const auto &field = fields[i];
@@ -578,7 +578,7 @@ void ProcessRelationshipsRow(memgraph::storage::Storage *store, const std::vecto
   if (!end_id) throw LoadException("END_ID must be set");
   if (!relationship_type) throw LoadException("Relationship TYPE must be set");
 
-  auto acc = store->Access(ReplicationRole::MAIN);
+  auto acc = store->Access();
   auto from_node = acc->FindVertex(*start_id, memgraph::storage::View::NEW);
   if (!from_node) throw LoadException("From node must be in the storage");
   auto to_node = acc->FindVertex(*end_id, memgraph::storage::View::NEW);

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -204,12 +204,10 @@ class DiskStorage final : public Storage {
   };
 
   using Storage::Access;
-  std::unique_ptr<Accessor> Access(memgraph::replication_coordination_glue::ReplicationRole replication_role,
-                                   std::optional<IsolationLevel> override_isolation_level) override;
+  std::unique_ptr<Accessor> Access(std::optional<IsolationLevel> override_isolation_level) override;
 
   using Storage::UniqueAccess;
-  std::unique_ptr<Accessor> UniqueAccess(memgraph::replication_coordination_glue::ReplicationRole replication_role,
-                                         std::optional<IsolationLevel> override_isolation_level) override;
+  std::unique_ptr<Accessor> UniqueAccess(std::optional<IsolationLevel> override_isolation_level) override;
 
   /// Flushing methods
   [[nodiscard]] utils::BasicResult<StorageManipulationError, void> FlushIndexCache(Transaction *transaction);
@@ -313,8 +311,7 @@ class DiskStorage final : public Storage {
 
   RocksDBStorage *GetRocksDBStorage() const { return kvstore_.get(); }
 
-  Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode,
-                                memgraph::replication_coordination_glue::ReplicationRole replication_role) override;
+  Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode) override;
 
   void SetEdgeImportMode(EdgeImportMode edge_import_status);
 
@@ -339,7 +336,7 @@ class DiskStorage final : public Storage {
                                                                                           PropertyId property);
 
   StorageInfo GetBaseInfo() override;
-  StorageInfo GetInfo(memgraph::replication_coordination_glue::ReplicationRole replication_role) override;
+  StorageInfo GetInfo() override;
 
   void FreeMemory(std::unique_lock<utils::ResourceLock> /*lock*/, bool /*periodic*/) override {}
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -867,6 +867,7 @@ utils::BasicResult<StorageManipulationError, void> InMemoryStorage::InMemoryAcce
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
 
   // TODO: duplicated transaction finalisation in md_deltas and deltas processing cases
+  // TODO: (andi) If empty, then we just need to set is_transaction_active_ to false and return
   if (transaction_.deltas.empty() && transaction_.md_deltas.empty()) {
     // We don't have to update the commit timestamp here because no one reads
     // it.
@@ -875,6 +876,7 @@ utils::BasicResult<StorageManipulationError, void> InMemoryStorage::InMemoryAcce
     // This is usually done by the MVCC, but it does not handle the metadata deltas
     transaction_.EnsureCommitTimestampExists();
 
+    // TODO:(andi) ExistenceConstraints validation block
     if (transaction_.constraint_verification_info &&
         transaction_.constraint_verification_info->NeedsExistenceConstraintVerification()) {
       const auto vertices_to_update =
@@ -902,6 +904,7 @@ utils::BasicResult<StorageManipulationError, void> InMemoryStorage::InMemoryAcce
     {
       auto engine_guard = std::unique_lock{storage_->engine_lock_};
 
+      // TODO: (andi) LabelIndex auto-creation block.
       if (storage_->config_.salient.items.enable_label_index_auto_creation) {
         storage_->labels_to_auto_index_.WithLock([&](auto &label_indices) {
           for (auto &label : label_indices) {
@@ -917,6 +920,7 @@ utils::BasicResult<StorageManipulationError, void> InMemoryStorage::InMemoryAcce
         });
       }
 
+      // TODO: (andi) EdgeIndex auto-creation block.
       if (storage_->config_.salient.items.enable_edge_type_index_auto_creation) {
         storage_->edge_types_to_auto_index_.WithLock([&](auto &edge_type_indices) {
           for (auto &edge_type : edge_type_indices) {
@@ -2424,6 +2428,7 @@ bool InMemoryStorage::AppendToWal(const Transaction &transaction, uint64_t durab
   }
 
   // Add a delta that indicates that the transaction is fully written to the WAL
+  // TODO: (andi) I think this should happen in reverse order
   wal_file_->AppendTransactionEnd(durability_commit_timestamp);
   FinalizeWalFile();
 

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -76,8 +76,7 @@ class InMemoryStorage final : public Storage {
     friend class InMemoryStorage;
 
     explicit InMemoryAccessor(auto tag, InMemoryStorage *storage, IsolationLevel isolation_level,
-                              StorageMode storage_mode,
-                              memgraph::replication_coordination_glue::ReplicationRole replication_role);
+                              StorageMode storage_mode);
 
    public:
     InMemoryAccessor(const InMemoryAccessor &) = delete;
@@ -389,11 +388,9 @@ class InMemoryStorage final : public Storage {
   };
 
   using Storage::Access;
-  std::unique_ptr<Accessor> Access(memgraph::replication_coordination_glue::ReplicationRole replication_role,
-                                   std::optional<IsolationLevel> override_isolation_level) override;
+  std::unique_ptr<Accessor> Access(std::optional<IsolationLevel> override_isolation_level) override;
   using Storage::UniqueAccess;
-  std::unique_ptr<Accessor> UniqueAccess(memgraph::replication_coordination_glue::ReplicationRole replication_role,
-                                         std::optional<IsolationLevel> override_isolation_level) override;
+  std::unique_ptr<Accessor> UniqueAccess(std::optional<IsolationLevel> override_isolation_level) override;
 
   void FreeMemory(std::unique_lock<utils::ResourceLock> main_guard, bool periodic) override;
 
@@ -406,8 +403,7 @@ class InMemoryStorage final : public Storage {
 
   void CreateSnapshotHandler(std::function<utils::BasicResult<InMemoryStorage::CreateSnapshotError>()> cb);
 
-  Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode,
-                                memgraph::replication_coordination_glue::ReplicationRole replication_role) override;
+  Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode) override;
 
   void SetStorageMode(StorageMode storage_mode);
 
@@ -432,7 +428,7 @@ class InMemoryStorage final : public Storage {
   void FinalizeWalFile();
 
   StorageInfo GetBaseInfo() override;
-  StorageInfo GetInfo(memgraph::replication_coordination_glue::ReplicationRole replication_role) override;
+  StorageInfo GetInfo() override;
 
   /// Return true in all cases except if any sync replicas have not sent confirmation.
   [[nodiscard]] bool AppendToWal(const Transaction &transaction, uint64_t durability_commit_timestamp,

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -268,6 +268,7 @@ bool ReplicationStorageClient::FinalizeTransactionReplication(Storage *storage, 
             // When async replica executes this part of the code, the state could've changes since the check
             // at the beginning of the function happened.
             if (!response.success || state == replication::ReplicaState::RECOVERY) {
+              state = replication::ReplicaState::RECOVERY;
               // NOLINTNEXTLINE
               client_.thread_pool_.AddTask([storage, response, db_acc = std::move(db_acc), this] {
                 this->RecoverReplica(response.current_commit_timestamp, storage);

--- a/src/storage/v2/replication/replication_storage_state.cpp
+++ b/src/storage/v2/replication/replication_storage_state.cpp
@@ -24,6 +24,7 @@ auto ReplicationStorageState::InitializeTransaction(uint64_t seq_num, Storage *s
     -> std::vector<std::optional<ReplicaStream>> {
   std::vector<std::optional<ReplicaStream>> replica_streams;
   replication_clients_.WithLock([&, db_accessor = std::move(db_acc)](auto &clients) mutable {
+    replica_streams.reserve(clients.size());
     for (auto &client : clients) {
       replica_streams.emplace_back(client->StartTransactionReplication(seq_num, storage, db_accessor));
     }

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -48,28 +48,26 @@ Storage::Storage(Config config, StorageMode storage_mode)
 }
 
 Storage::Accessor::Accessor(SharedAccess /* tag */, Storage *storage, IsolationLevel isolation_level,
-                            StorageMode storage_mode,
-                            memgraph::replication_coordination_glue::ReplicationRole replication_role)
+                            StorageMode storage_mode)
     : storage_(storage),
       // The lock must be acquired before creating the transaction object to
       // prevent freshly created transactions from dangling in an active state
       // during exclusive operations.
       storage_guard_(storage_->main_lock_),
       unique_guard_(storage_->main_lock_, std::defer_lock),
-      transaction_(storage->CreateTransaction(isolation_level, storage_mode, replication_role)),
+      transaction_(storage->CreateTransaction(isolation_level, storage_mode)),
       is_transaction_active_(true),
       creation_storage_mode_(storage_mode) {}
 
 Storage::Accessor::Accessor(UniqueAccess /* tag */, Storage *storage, IsolationLevel isolation_level,
-                            StorageMode storage_mode,
-                            memgraph::replication_coordination_glue::ReplicationRole replication_role)
+                            StorageMode storage_mode)
     : storage_(storage),
       // The lock must be acquired before creating the transaction object to
       // prevent freshly created transactions from dangling in an active state
       // during exclusive operations.
       storage_guard_(storage_->main_lock_, std::defer_lock),
       unique_guard_(storage_->main_lock_),
-      transaction_(storage->CreateTransaction(isolation_level, storage_mode, replication_role)),
+      transaction_(storage->CreateTransaction(isolation_level, storage_mode)),
       is_transaction_active_(true),
       creation_storage_mode_(storage_mode) {}
 

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -154,10 +154,8 @@ class Storage {
     static constexpr struct UniqueAccess {
     } unique_access;
 
-    Accessor(SharedAccess /* tag */, Storage *storage, IsolationLevel isolation_level, StorageMode storage_mode,
-             memgraph::replication_coordination_glue::ReplicationRole replication_role);
-    Accessor(UniqueAccess /* tag */, Storage *storage, IsolationLevel isolation_level, StorageMode storage_mode,
-             memgraph::replication_coordination_glue::ReplicationRole replication_role);
+    Accessor(SharedAccess /* tag */, Storage *storage, IsolationLevel isolation_level, StorageMode storage_mode);
+    Accessor(UniqueAccess /* tag */, Storage *storage, IsolationLevel isolation_level, StorageMode storage_mode);
     Accessor(const Accessor &) = delete;
     Accessor &operator=(const Accessor &) = delete;
     Accessor &operator=(Accessor &&other) = delete;
@@ -455,19 +453,12 @@ class Storage {
     }
   }
 
-  virtual std::unique_ptr<Accessor> Access(memgraph::replication_coordination_glue::ReplicationRole replication_role,
-                                           std::optional<IsolationLevel> override_isolation_level) = 0;
+  virtual std::unique_ptr<Accessor> Access(std::optional<IsolationLevel> override_isolation_level) = 0;
 
-  std::unique_ptr<Accessor> Access(memgraph::replication_coordination_glue::ReplicationRole replication_role) {
-    return Access(replication_role, {});
-  }
+  std::unique_ptr<Accessor> Access() { return Access({}); }
 
-  virtual std::unique_ptr<Accessor> UniqueAccess(
-      memgraph::replication_coordination_glue::ReplicationRole replication_role,
-      std::optional<IsolationLevel> override_isolation_level) = 0;
-  std::unique_ptr<Accessor> UniqueAccess(memgraph::replication_coordination_glue::ReplicationRole replication_role) {
-    return UniqueAccess(replication_role, {});
-  }
+  virtual std::unique_ptr<Accessor> UniqueAccess(std::optional<IsolationLevel> override_isolation_level) = 0;
+  std::unique_ptr<Accessor> UniqueAccess() { return UniqueAccess({}); }
 
   enum class SetIsolationLevelError : uint8_t { DisabledForAnalyticalMode };
 
@@ -476,10 +467,9 @@ class Storage {
 
   virtual StorageInfo GetBaseInfo() = 0;
 
-  virtual StorageInfo GetInfo(memgraph::replication_coordination_glue::ReplicationRole replication_role) = 0;
+  virtual StorageInfo GetInfo() = 0;
 
-  virtual Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode,
-                                        memgraph::replication_coordination_glue::ReplicationRole replication_role) = 0;
+  virtual Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode) = 0;
 
   virtual void PrepareForNewEpoch() = 0;
 

--- a/src/telemetry/telemetry.cpp
+++ b/src/telemetry/telemetry.cpp
@@ -151,9 +151,9 @@ void Telemetry::AddClientCollector() {
 }
 
 #ifdef MG_ENTERPRISE
-void Telemetry::AddDatabaseCollector(dbms::DbmsHandler &dbms_handler, replication::ReplicationState &repl_state) {
-  AddCollector("database", [&dbms_handler, &repl_state]() -> nlohmann::json {
-    const auto &infos = dbms_handler.Info(repl_state.GetRole());
+void Telemetry::AddDatabaseCollector(dbms::DbmsHandler &dbms_handler) {
+  AddCollector("database", [&dbms_handler]() -> nlohmann::json {
+    const auto &infos = dbms_handler.Info();
     auto dbs = nlohmann::json::array();
     for (const auto &db_info : infos) {
       dbs.push_back(memgraph::dbms::ToJson(db_info));
@@ -164,10 +164,9 @@ void Telemetry::AddDatabaseCollector(dbms::DbmsHandler &dbms_handler, replicatio
 #else
 #endif
 
-void Telemetry::AddStorageCollector(dbms::DbmsHandler &dbms_handler, memgraph::auth::SynchedAuth &auth,
-                                    memgraph::replication::ReplicationState &repl_state) {
-  AddCollector("storage", [&dbms_handler, &auth, &repl_state]() -> nlohmann::json {
-    auto stats = dbms_handler.Stats(repl_state.GetRole());
+void Telemetry::AddStorageCollector(dbms::DbmsHandler &dbms_handler, memgraph::auth::SynchedAuth &auth) {
+  AddCollector("storage", [&dbms_handler, &auth]() -> nlohmann::json {
+    auto stats = dbms_handler.Stats();
     stats.users = auth->AllUsers().size();
     return ToJson(stats);
   });

--- a/src/telemetry/telemetry.hpp
+++ b/src/telemetry/telemetry.hpp
@@ -43,11 +43,10 @@ class Telemetry final {
   void AddCollector(const std::string &name, const std::function<const nlohmann::json(void)> &func);
 
   // Specialized collectors
-  void AddStorageCollector(dbms::DbmsHandler &dbms_handler, memgraph::auth::SynchedAuth &auth,
-                           memgraph::replication::ReplicationState &repl_state);
+  void AddStorageCollector(dbms::DbmsHandler &dbms_handler, memgraph::auth::SynchedAuth &auth);
 
 #ifdef MG_ENTERPRISE
-  void AddDatabaseCollector(dbms::DbmsHandler &dbms_handler, replication::ReplicationState &repl_state);
+  void AddDatabaseCollector(dbms::DbmsHandler &dbms_handler);
 #else
   void AddDatabaseCollector() {
     AddCollector("database", []() -> nlohmann::json { return nlohmann::json::array(); });

--- a/tests/benchmark/query/eval.cpp
+++ b/tests/benchmark/query/eval.cpp
@@ -41,7 +41,7 @@ static void MapLiteral(benchmark::State &state) {
   TMemory memory;
   memgraph::query::Frame frame(symbol_table.max_position(), memory.get());
   std::unique_ptr<memgraph::storage::Storage> db(new memgraph::storage::InMemoryStorage());
-  auto storage_dba = db->Access(ReplicationRole::MAIN);
+  auto storage_dba = db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   std::unordered_map<memgraph::query::PropertyIx, memgraph::query::Expression *> elements;
   for (int64_t i = 0; i < state.range(0); ++i) {
@@ -72,7 +72,7 @@ static void AdditionOperator(benchmark::State &state) {
   TMemory memory;
   memgraph::query::Frame frame(symbol_table.max_position(), memory.get());
   std::unique_ptr<memgraph::storage::Storage> db(new memgraph::storage::InMemoryStorage());
-  auto storage_dba = db->Access(ReplicationRole::MAIN);
+  auto storage_dba = db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   memgraph::query::Expression *expr = ast.Create<memgraph::query::PrimitiveLiteral>(0);
   for (int64_t i = 0; i < state.range(0); ++i) {

--- a/tests/benchmark/query/planner.cpp
+++ b/tests/benchmark/query/planner.cpp
@@ -47,7 +47,7 @@ static memgraph::query::CypherQuery *AddChainedMatches(int num_matches, memgraph
 
 static void BM_PlanChainedMatches(benchmark::State &state) {
   std::unique_ptr<memgraph::storage::Storage> db(new memgraph::storage::InMemoryStorage());
-  auto storage_dba = db->Access(ReplicationRole::MAIN);
+  auto storage_dba = db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   while (state.KeepRunning()) {
     state.PauseTiming();
@@ -98,10 +98,10 @@ static auto CreateIndexedVertices(int index_count, int vertex_count, memgraph::s
   auto label = db->NameToLabel("label");
   auto prop = db->NameToProperty("prop");
   {
-    auto unique_acc = db->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = db->UniqueAccess();
     [[maybe_unused]] auto _ = unique_acc->CreateIndex(label, prop);
   }
-  auto dba = db->Access(ReplicationRole::MAIN);
+  auto dba = db->Access();
   for (int vi = 0; vi < vertex_count; ++vi) {
     for (int index = 0; index < index_count; ++index) {
       auto vertex = dba->CreateVertex();
@@ -120,7 +120,7 @@ static void BM_PlanAndEstimateIndexedMatching(benchmark::State &state) {
   int index_count = state.range(0);
   int vertex_count = state.range(1);
   std::tie(label, prop) = CreateIndexedVertices(index_count, vertex_count, db.get());
-  auto storage_dba = db->Access(ReplicationRole::MAIN);
+  auto storage_dba = db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   memgraph::query::Parameters parameters;
   while (state.KeepRunning()) {
@@ -150,7 +150,7 @@ static void BM_PlanAndEstimateIndexedMatchingWithCachedCounts(benchmark::State &
   int index_count = state.range(0);
   int vertex_count = state.range(1);
   std::tie(label, prop) = CreateIndexedVertices(index_count, vertex_count, db.get());
-  auto storage_dba = db->Access(ReplicationRole::MAIN);
+  auto storage_dba = db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   auto vertex_counts = memgraph::query::plan::MakeVertexCountCache(&dba);
   memgraph::query::Parameters parameters;

--- a/tests/benchmark/storage_v2_gc.cpp
+++ b/tests/benchmark/storage_v2_gc.cpp
@@ -44,7 +44,7 @@ void UpdateLabelFunc(int thread_id, memgraph::storage::Storage *storage,
 
   memgraph::utils::Timer timer;
   for (int iter = 0; iter < num_iterations; ++iter) {
-    auto acc = storage->Access(ReplicationRole::MAIN);
+    auto acc = storage->Access();
     memgraph::storage::Gid gid = vertices.at(vertex_dist(gen));
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     MG_ASSERT(vertex.has_value(), "Vertex with GID {} doesn't exist", gid.AsUint());
@@ -63,7 +63,7 @@ int main(int argc, char *argv[]) {
     std::unique_ptr<memgraph::storage::Storage> storage(new memgraph::storage::InMemoryStorage(config.second));
     std::vector<memgraph::storage::Gid> vertices;
     {
-      auto acc = storage->Access(ReplicationRole::MAIN);
+      auto acc = storage->Access();
       for (int i = 0; i < FLAGS_num_vertices; ++i) {
         vertices.push_back(acc->CreateVertex().Gid());
       }

--- a/tests/benchmark/storage_v2_gc2.cpp
+++ b/tests/benchmark/storage_v2_gc2.cpp
@@ -43,14 +43,14 @@ int main(int argc, char *argv[]) {
       std::array<memgraph::storage::Gid, 1> vertices;
       memgraph::storage::PropertyId pid;
       {
-        auto acc = storage->Access(ReplicationRole::MAIN);
+        auto acc = storage->Access();
         vertices[0] = acc->CreateVertex().Gid();
         pid = acc->NameToProperty("NEW_PROP");
         MG_ASSERT(!acc->Commit().HasError());
       }
 
       for (int iter = 0; iter != FLAGS_num_iterations; ++iter) {
-        auto acc = storage->Access(ReplicationRole::MAIN);
+        auto acc = storage->Access();
         auto vertex1 = acc->FindVertex(vertices[0], memgraph::storage::View::OLD);
         for (auto i = 0; i != FLAGS_num_poperties; ++i) {
           MG_ASSERT(!vertex1.value().SetProperty(pid, memgraph::storage::PropertyValue{i}).HasError());

--- a/tests/concurrent/storage_indices.cpp
+++ b/tests/concurrent/storage_indices.cpp
@@ -33,7 +33,7 @@ TEST(Storage, LabelIndex) {
 
   auto label = store->NameToLabel("label");
   {
-    auto unique_acc = store->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = store->UniqueAccess();
     ASSERT_FALSE(unique_acc->CreateIndex(label).HasError());
   }
 
@@ -46,7 +46,7 @@ TEST(Storage, LabelIndex) {
       gids.reserve(kNumIterations * kVerifierBatchSize);
       for (uint64_t i = 0; i < kNumIterations; ++i) {
         for (uint64_t j = 0; j < kVerifierBatchSize; ++j) {
-          auto acc = store->Access(ReplicationRole::MAIN);
+          auto acc = store->Access();
           auto vertex = acc->CreateVertex();
           gids.emplace(vertex.Gid(), false);
           auto ret = vertex.AddLabel(label);
@@ -55,7 +55,7 @@ TEST(Storage, LabelIndex) {
           ASSERT_FALSE(acc->Commit().HasError());
         }
         {
-          auto acc = store->Access(ReplicationRole::MAIN);
+          auto acc = store->Access();
           auto vertices = acc->Vertices(label, memgraph::storage::View::OLD);
           for (auto vertex : vertices) {
             auto it = gids.find(vertex.Gid());
@@ -83,7 +83,7 @@ TEST(Storage, LabelIndex) {
       gids.resize(kMutatorBatchSize);
       while (mutators_run.load(std::memory_order_acquire)) {
         for (uint64_t i = 0; i < kMutatorBatchSize; ++i) {
-          auto acc = store->Access(ReplicationRole::MAIN);
+          auto acc = store->Access();
           auto vertex = acc->CreateVertex();
           gids[i] = vertex.Gid();
           auto ret = vertex.AddLabel(label);
@@ -92,7 +92,7 @@ TEST(Storage, LabelIndex) {
           ASSERT_FALSE(acc->Commit().HasError());
         }
         for (uint64_t i = 0; i < kMutatorBatchSize; ++i) {
-          auto acc = store->Access(ReplicationRole::MAIN);
+          auto acc = store->Access();
           auto vertex = acc->FindVertex(gids[i], memgraph::storage::View::OLD);
           ASSERT_TRUE(vertex);
           ASSERT_TRUE(acc->DeleteVertex(&*vertex).HasValue());
@@ -118,7 +118,7 @@ TEST(Storage, LabelPropertyIndex) {
   auto label = store->NameToLabel("label");
   auto prop = store->NameToProperty("prop");
   {
-    auto unique_acc = store->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = store->UniqueAccess();
     ASSERT_FALSE(unique_acc->CreateIndex(label, prop).HasError());
   }
 
@@ -131,7 +131,7 @@ TEST(Storage, LabelPropertyIndex) {
       gids.reserve(kNumIterations * kVerifierBatchSize);
       for (uint64_t i = 0; i < kNumIterations; ++i) {
         for (uint64_t j = 0; j < kVerifierBatchSize; ++j) {
-          auto acc = store->Access(ReplicationRole::MAIN);
+          auto acc = store->Access();
           auto vertex = acc->CreateVertex();
           gids.emplace(vertex.Gid(), false);
           {
@@ -147,7 +147,7 @@ TEST(Storage, LabelPropertyIndex) {
           ASSERT_FALSE(acc->Commit().HasError());
         }
         {
-          auto acc = store->Access(ReplicationRole::MAIN);
+          auto acc = store->Access();
           auto vertices = acc->Vertices(label, prop, memgraph::storage::View::OLD);
           for (auto vertex : vertices) {
             auto it = gids.find(vertex.Gid());
@@ -175,7 +175,7 @@ TEST(Storage, LabelPropertyIndex) {
       gids.resize(kMutatorBatchSize);
       while (mutators_run.load(std::memory_order_acquire)) {
         for (uint64_t i = 0; i < kMutatorBatchSize; ++i) {
-          auto acc = store->Access(ReplicationRole::MAIN);
+          auto acc = store->Access();
           auto vertex = acc->CreateVertex();
           gids[i] = vertex.Gid();
           {
@@ -191,7 +191,7 @@ TEST(Storage, LabelPropertyIndex) {
           ASSERT_FALSE(acc->Commit().HasError());
         }
         for (uint64_t i = 0; i < kMutatorBatchSize; ++i) {
-          auto acc = store->Access(ReplicationRole::MAIN);
+          auto acc = store->Access();
           auto vertex = acc->FindVertex(gids[i], memgraph::storage::View::OLD);
           ASSERT_TRUE(vertex);
           ASSERT_TRUE(acc->DeleteVertex(&*vertex).HasValue());

--- a/tests/concurrent/storage_unique_constraints.cpp
+++ b/tests/concurrent/storage_unique_constraints.cpp
@@ -36,7 +36,7 @@ class StorageUniqueConstraints : public ::testing::Test {
 
   void SetUp() override {
     // Create initial vertices.
-    auto acc = storage->Access(ReplicationRole::MAIN);
+    auto acc = storage->Access();
     // NOLINTNEXTLINE(modernize-loop-convert)
     for (int i = 0; i < kNumThreads; ++i) {
       auto vertex = acc->CreateVertex();
@@ -57,7 +57,7 @@ void SetProperties(memgraph::storage::Storage *storage, memgraph::storage::Gid g
                    const std::vector<PropertyId> &properties, const std::vector<PropertyValue> &values,
                    bool *commit_status) {
   ASSERT_EQ(properties.size(), values.size());
-  auto acc = storage->Access(ReplicationRole::MAIN);
+  auto acc = storage->Access();
   auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
   ASSERT_TRUE(vertex);
   int value = 0;
@@ -73,7 +73,7 @@ void SetProperties(memgraph::storage::Storage *storage, memgraph::storage::Gid g
 }
 
 void AddLabel(memgraph::storage::Storage *storage, memgraph::storage::Gid gid, LabelId label, bool *commit_status) {
-  auto acc = storage->Access(ReplicationRole::MAIN);
+  auto acc = storage->Access();
   auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
   ASSERT_TRUE(vertex);
   for (int iter = 0; iter < 40000; ++iter) {
@@ -86,7 +86,7 @@ void AddLabel(memgraph::storage::Storage *storage, memgraph::storage::Gid gid, L
 
 TEST_F(StorageUniqueConstraints, ChangeProperties) {
   {
-    auto unique_acc = storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = storage->UniqueAccess();
     auto res = unique_acc->CreateUniqueConstraint(label, {prop1, prop2, prop3});
     ASSERT_TRUE(res.HasValue());
     ASSERT_EQ(res.GetValue(), memgraph::storage::UniqueConstraints::CreationStatus::SUCCESS);
@@ -94,7 +94,7 @@ TEST_F(StorageUniqueConstraints, ChangeProperties) {
   }
 
   {
-    auto acc = storage->Access(ReplicationRole::MAIN);
+    auto acc = storage->Access();
     // NOLINTNEXTLINE(modernize-loop-convert)
     for (int i = 0; i < kNumThreads; ++i) {
       auto vertex = acc->FindVertex(gids[i], memgraph::storage::View::OLD);
@@ -170,7 +170,7 @@ TEST_F(StorageUniqueConstraints, ChangeProperties) {
 
 TEST_F(StorageUniqueConstraints, ChangeLabels) {
   {
-    auto unique_acc = storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = storage->UniqueAccess();
     auto res = unique_acc->CreateUniqueConstraint(label, {prop1, prop2, prop3});
     ASSERT_TRUE(res.HasValue());
     ASSERT_EQ(res.GetValue(), memgraph::storage::UniqueConstraints::CreationStatus::SUCCESS);
@@ -183,7 +183,7 @@ TEST_F(StorageUniqueConstraints, ChangeLabels) {
   // succeed, as the others should result with constraint violation.
 
   {
-    auto acc = storage->Access(ReplicationRole::MAIN);
+    auto acc = storage->Access();
     // NOLINTNEXTLINE(modernize-loop-convert)
     for (int i = 0; i < kNumThreads; ++i) {
       auto vertex = acc->FindVertex(gids[i], memgraph::storage::View::OLD);
@@ -198,7 +198,7 @@ TEST_F(StorageUniqueConstraints, ChangeLabels) {
   for (int iter = 0; iter < 20; ++iter) {
     // Clear labels.
     {
-      auto acc = storage->Access(ReplicationRole::MAIN);
+      auto acc = storage->Access();
       // NOLINTNEXTLINE(modernize-loop-convert)
       for (int i = 0; i < kNumThreads; ++i) {
         auto vertex = acc->FindVertex(gids[i], memgraph::storage::View::OLD);
@@ -229,7 +229,7 @@ TEST_F(StorageUniqueConstraints, ChangeLabels) {
   // should succeed.
 
   {
-    auto acc = storage->Access(ReplicationRole::MAIN);
+    auto acc = storage->Access();
     // NOLINTNEXTLINE(modernize-loop-convert)
     for (int i = 0; i < kNumThreads; ++i) {
       auto vertex = acc->FindVertex(gids[i], memgraph::storage::View::OLD);
@@ -244,7 +244,7 @@ TEST_F(StorageUniqueConstraints, ChangeLabels) {
   for (int iter = 0; iter < 20; ++iter) {
     // Clear labels.
     {
-      auto acc = storage->Access(ReplicationRole::MAIN);
+      auto acc = storage->Access();
       // NOLINTNEXTLINE(modernize-loop-convert)
       for (int i = 0; i < kNumThreads; ++i) {
         auto vertex = acc->FindVertex(gids[i], memgraph::storage::View::OLD);

--- a/tests/integration/telemetry/client.cpp
+++ b/tests/integration/telemetry/client.cpp
@@ -71,9 +71,9 @@ int main(int argc, char **argv) {
   });
 
   // Memgraph specific collectors
-  telemetry.AddStorageCollector(dbms_handler, auth_, repl_state);
+  telemetry.AddStorageCollector(dbms_handler, auth_);
 #ifdef MG_ENTERPRISE
-  telemetry.AddDatabaseCollector(dbms_handler, repl_state);
+  telemetry.AddDatabaseCollector(dbms_handler);
 #else
   telemetry.AddDatabaseCollector();
 #endif

--- a/tests/manual/expression_pretty_printer.cpp
+++ b/tests/manual/expression_pretty_printer.cpp
@@ -46,7 +46,7 @@ memgraph::query::Expression *GetExpression(memgraph::query::Query *query) {
 int main() {
   std::unique_ptr<memgraph::storage::Storage> store(
       new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = true}}}));
-  auto storage_acc = store->Access(memgraph::replication_coordination_glue::ReplicationRole::MAIN);
+  auto storage_acc = store->Access();
   memgraph::query::DbAccessor db_acc(storage_acc.get());
 
   memgraph::query::AstStorage ast_storage;

--- a/tests/manual/query_planner.cpp
+++ b/tests/manual/query_planner.cpp
@@ -21,7 +21,7 @@ int main(int argc, char *argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   spdlog::set_level(spdlog::level::err);
   std::unique_ptr<memgraph::storage::Storage> db(new memgraph::storage::InMemoryStorage());
-  auto storage_dba = db->Access(ReplicationRole::MAIN);
+  auto storage_dba = db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   RunInteractivePlanning(&dba);
   return 0;

--- a/tests/property_based/random_graph.cpp
+++ b/tests/property_based/random_graph.cpp
@@ -40,7 +40,7 @@ RC_GTEST_PROP(RandomGraph, RandomGraph, (std::vector<std::string> vertex_labels,
   std::unordered_map<memgraph::storage::VertexAccessor, std::string> vertex_label_map;
   std::unordered_map<memgraph::storage::EdgeAccessor, std::string> edge_type_map;
 
-  auto dba = db->Access(ReplicationRole::MAIN);
+  auto dba = db->Access();
 
   for (auto label : vertex_labels) {
     auto vertex_accessor = dba->CreateVertex();

--- a/tests/unit/auth_checker.cpp
+++ b/tests/unit/auth_checker.cpp
@@ -34,7 +34,7 @@ class FineGrainedAuthCheckerFixture : public testing::Test {
 
   memgraph::storage::Config config = disk_test_utils::GenerateOnDiskConfig(testSuite);
   std::unique_ptr<memgraph::storage::Storage> db{new StorageType(config)};
-  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{db->Access(ReplicationRole::MAIN)};
+  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{db->Access()};
   memgraph::query::DbAccessor dba{storage_dba.get()};
 
   // make a V-graph (v3)<-[r2]-(v1)-[r1]->(v2)

--- a/tests/unit/bfs_fine_grained.cpp
+++ b/tests/unit/bfs_fine_grained.cpp
@@ -42,9 +42,7 @@ class VertexDb : public Database {
     }
   }
 
-  std::unique_ptr<memgraph::storage::Storage::Accessor> Access() override {
-    return db_->Access(memgraph::replication_coordination_glue::ReplicationRole::MAIN);
-  }
+  std::unique_ptr<memgraph::storage::Storage::Accessor> Access() override { return db_->Access(); }
 
   std::unique_ptr<LogicalOperator> MakeBfsOperator(Symbol source_sym, Symbol sink_sym, Symbol edge_sym,
                                                    EdgeAtom::Direction direction,

--- a/tests/unit/bfs_single_node.cpp
+++ b/tests/unit/bfs_single_node.cpp
@@ -31,9 +31,7 @@ class SingleNodeDb : public Database {
     }
   }
 
-  std::unique_ptr<memgraph::storage::Storage::Accessor> Access() override {
-    return db_->Access(memgraph::replication_coordination_glue::ReplicationRole::MAIN);
-  }
+  std::unique_ptr<memgraph::storage::Storage::Accessor> Access() override { return db_->Access(); }
 
   std::unique_ptr<LogicalOperator> MakeBfsOperator(Symbol source_sym, Symbol sink_sym, Symbol edge_sym,
                                                    EdgeAtom::Direction direction,

--- a/tests/unit/bolt_encoder.cpp
+++ b/tests/unit/bolt_encoder.cpp
@@ -183,7 +183,7 @@ void TestVertexAndEdgeWithDifferentStorages(std::unique_ptr<memgraph::storage::S
   output.clear();
 
   // create vertex
-  auto dba = db->Access(memgraph::replication_coordination_glue::ReplicationRole::MAIN);
+  auto dba = db->Access();
   auto va1 = dba->CreateVertex();
   auto va2 = dba->CreateVertex();
   auto l1 = dba->NameToLabel("label1");

--- a/tests/unit/clearing_old_disk_data.cpp
+++ b/tests/unit/clearing_old_disk_data.cpp
@@ -35,7 +35,7 @@ TEST_F(ClearingOldDiskDataTest, TestNumOfEntriesWithVertexTimestampUpdate) {
   auto *tx_db = disk_storage->GetRocksDBStorage()->db_;
   ASSERT_EQ(disk_test_utils::GetRealNumberOfEntriesInRocksDB(tx_db), 0);
 
-  auto acc1 = disk_storage->Access(ReplicationRole::MAIN);
+  auto acc1 = disk_storage->Access();
   auto vertex1 = acc1->CreateVertex();
   auto label1 = acc1->NameToLabel("DiskLabel");
   auto property1 = acc1->NameToProperty("DiskProperty");
@@ -45,7 +45,7 @@ TEST_F(ClearingOldDiskDataTest, TestNumOfEntriesWithVertexTimestampUpdate) {
 
   ASSERT_EQ(disk_test_utils::GetRealNumberOfEntriesInRocksDB(tx_db), 1);
 
-  auto acc2 = disk_storage->Access(ReplicationRole::MAIN);
+  auto acc2 = disk_storage->Access();
   auto vertex2 = acc2->FindVertex(vertex1.Gid(), memgraph::storage::View::NEW).value();
   /// This is the same property as in the first transaction, we just want to test
   /// the number of entries inside RocksDB when the timestamp changes
@@ -60,7 +60,7 @@ TEST_F(ClearingOldDiskDataTest, TestNumOfEntriesWithVertexValueUpdate) {
   auto *tx_db = disk_storage->GetRocksDBStorage()->db_;
   ASSERT_EQ(disk_test_utils::GetRealNumberOfEntriesInRocksDB(tx_db), 0);
 
-  auto acc1 = disk_storage->Access(ReplicationRole::MAIN);
+  auto acc1 = disk_storage->Access();
   auto vertex1 = acc1->CreateVertex();
   auto label1 = acc1->NameToLabel("DiskLabel");
   auto property1 = acc1->NameToProperty("DiskProperty");
@@ -70,7 +70,7 @@ TEST_F(ClearingOldDiskDataTest, TestNumOfEntriesWithVertexValueUpdate) {
 
   ASSERT_EQ(disk_test_utils::GetRealNumberOfEntriesInRocksDB(tx_db), 1);
 
-  auto acc2 = disk_storage->Access(ReplicationRole::MAIN);
+  auto acc2 = disk_storage->Access();
   auto vertex2 = acc2->FindVertex(vertex1.Gid(), memgraph::storage::View::NEW).value();
   /// This is the same property as in the first transaction, we just want to test
   /// the number of entries inside RocksDB when the timestamp changes
@@ -85,7 +85,7 @@ TEST_F(ClearingOldDiskDataTest, TestNumOfEntriesWithVertexKeyUpdate) {
   auto *tx_db = disk_storage->GetRocksDBStorage()->db_;
   ASSERT_EQ(disk_test_utils::GetRealNumberOfEntriesInRocksDB(tx_db), 0);
 
-  auto acc1 = disk_storage->Access(ReplicationRole::MAIN);
+  auto acc1 = disk_storage->Access();
   auto vertex1 = acc1->CreateVertex();
   auto label1 = acc1->NameToLabel("DiskLabel");
   auto property1 = acc1->NameToProperty("DiskProperty");
@@ -95,7 +95,7 @@ TEST_F(ClearingOldDiskDataTest, TestNumOfEntriesWithVertexKeyUpdate) {
 
   ASSERT_EQ(disk_test_utils::GetRealNumberOfEntriesInRocksDB(tx_db), 1);
 
-  auto acc2 = disk_storage->Access(ReplicationRole::MAIN);
+  auto acc2 = disk_storage->Access();
   auto vertex2 = acc2->FindVertex(vertex1.Gid(), memgraph::storage::View::NEW).value();
   auto label2 = acc2->NameToLabel("DiskLabel2");
   ASSERT_TRUE(vertex2.AddLabel(label2).HasValue());
@@ -108,7 +108,7 @@ TEST_F(ClearingOldDiskDataTest, TestNumOfEntriesWithEdgeTimestampUpdate) {
   auto *tx_db = disk_storage->GetRocksDBStorage()->db_;
   ASSERT_EQ(disk_test_utils::GetRealNumberOfEntriesInRocksDB(tx_db), 0);
 
-  auto acc1 = disk_storage->Access(ReplicationRole::MAIN);
+  auto acc1 = disk_storage->Access();
 
   auto label1 = acc1->NameToLabel("DiskLabel");
   auto property1 = acc1->NameToProperty("DiskProperty");
@@ -128,7 +128,7 @@ TEST_F(ClearingOldDiskDataTest, TestNumOfEntriesWithEdgeTimestampUpdate) {
 
   ASSERT_EQ(disk_test_utils::GetRealNumberOfEntriesInRocksDB(tx_db), 5);
 
-  auto acc2 = disk_storage->Access(ReplicationRole::MAIN);
+  auto acc2 = disk_storage->Access();
   auto from_vertex = acc2->FindVertex(from.Gid(), memgraph::storage::View::NEW).value();
 
   auto ret = from_vertex.OutEdges(memgraph::storage::View::NEW);
@@ -147,7 +147,7 @@ TEST_F(ClearingOldDiskDataTest, TestNumOfEntriesWithEdgeValueUpdate) {
   auto *tx_db = disk_storage->GetRocksDBStorage()->db_;
   ASSERT_EQ(disk_test_utils::GetRealNumberOfEntriesInRocksDB(tx_db), 0);
 
-  auto acc1 = disk_storage->Access(ReplicationRole::MAIN);
+  auto acc1 = disk_storage->Access();
 
   auto label1 = acc1->NameToLabel("DiskLabel");
   auto property1 = acc1->NameToProperty("DiskProperty");
@@ -167,7 +167,7 @@ TEST_F(ClearingOldDiskDataTest, TestNumOfEntriesWithEdgeValueUpdate) {
 
   ASSERT_EQ(disk_test_utils::GetRealNumberOfEntriesInRocksDB(tx_db), 5);
 
-  auto acc2 = disk_storage->Access(ReplicationRole::MAIN);
+  auto acc2 = disk_storage->Access();
   auto from_vertex = acc2->FindVertex(from.Gid(), memgraph::storage::View::NEW).value();
 
   auto ret = from_vertex.OutEdges(memgraph::storage::View::NEW);
@@ -184,7 +184,7 @@ TEST_F(ClearingOldDiskDataTest, TestTimestampAfterCommit) {
   auto *tx_db = disk_storage->GetRocksDBStorage()->db_;
   ASSERT_EQ(disk_test_utils::GetRealNumberOfEntriesInRocksDB(tx_db), 0);
 
-  auto acc1 = disk_storage->Access(ReplicationRole::MAIN);
+  auto acc1 = disk_storage->Access();
   auto vertex1 = acc1->CreateVertex();
   auto label1 = acc1->NameToLabel("DiskLabel");
   auto property1 = acc1->NameToProperty("DiskProperty");
@@ -197,7 +197,7 @@ TEST_F(ClearingOldDiskDataTest, TestTimestampAfterCommit) {
   ASSERT_EQ(saved_timestamp.has_value(), true);
   ASSERT_EQ(disk_storage->timestamp_, saved_timestamp);
 
-  auto acc2 = disk_storage->Access(ReplicationRole::MAIN);
+  auto acc2 = disk_storage->Access();
   auto vertex2 = acc2->CreateVertex();
   auto label2 = acc2->NameToLabel("DiskLabel2");
   auto property2 = acc2->NameToProperty("DiskProperty2");

--- a/tests/unit/coordinator_state_machine.cpp
+++ b/tests/unit/coordinator_state_machine.cpp
@@ -176,7 +176,7 @@ TEST_F(CoordinatorStateMachineTest, SerializeDeserializeSnapshot) {
     old_config = state_manager_->load_config();
     auto const c2c =
         CoordinatorToCoordinatorConfig{config.coordinator_id_, memgraph::io::network::Endpoint("0.0.0.0", 9091),
-                                       memgraph::io::network::Endpoint{"0.0.0.0", 12346}};
+                                       memgraph::io::network::Endpoint{"0.0.0.0", 12346}, "localhost"};
     auto temp_srv_config =
         cs_new<srv_config>(1, 0, c2c.coordinator_server.SocketAddress(), nlohmann::json(c2c).dump(), false);
     // second coord stored here

--- a/tests/unit/coordinator_state_manager.cpp
+++ b/tests/unit/coordinator_state_manager.cpp
@@ -91,7 +91,7 @@ TEST_F(CoordinatorStateManagerTest, MultipleCoords) {
     old_config = state_manager_->load_config();
     auto const c2c =
         CoordinatorToCoordinatorConfig{config.coordinator_id_, memgraph::io::network::Endpoint("0.0.0.0", 9091),
-                                       memgraph::io::network::Endpoint{"0.0.0.0", 12346}};
+                                       memgraph::io::network::Endpoint{"0.0.0.0", 12346}, "localhost"};
     auto temp_srv_config =
         cs_new<srv_config>(1, 0, c2c.coordinator_server.SocketAddress(), nlohmann::json(c2c).dump(), false);
     // second coord stored here

--- a/tests/unit/cpp_api.cpp
+++ b/tests/unit/cpp_api.cpp
@@ -43,8 +43,7 @@ struct CppApiTestFixture : public ::testing::Test {
   }
 
   memgraph::query::DbAccessor &CreateDbAccessor(const memgraph::storage::IsolationLevel isolationLevel) {
-    accessors_.push_back(
-        storage->Access(memgraph::replication_coordination_glue::ReplicationRole::MAIN, isolationLevel));
+    accessors_.push_back(storage->Access(isolationLevel));
     db_accessors_.emplace_back(accessors_.back().get());
     return db_accessors_.back();
   }

--- a/tests/unit/database_get_info.cpp
+++ b/tests/unit/database_get_info.cpp
@@ -191,8 +191,7 @@ TYPED_TEST(InfoTest, InfoCheck) {
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
 
-  const auto &info = db_acc->GetInfo(
-      memgraph::replication_coordination_glue::ReplicationRole::MAIN);  // force to use configured directory
+  const auto &info = db_acc->GetInfo();  // force to use configured directory
 
   ASSERT_EQ(info.storage_info.vertex_count, 5);
   ASSERT_EQ(info.storage_info.edge_count, 2);

--- a/tests/unit/plan_pretty_print.cpp
+++ b/tests/unit/plan_pretty_print.cpp
@@ -44,7 +44,7 @@ class PrintToJsonTest : public ::testing::Test {
   PrintToJsonTest()
       : config(disk_test_utils::GenerateOnDiskConfig(testSuite)),
         db(new StorageType(config)),
-        dba_storage(db->Access(memgraph::replication_coordination_glue::ReplicationRole::MAIN)),
+        dba_storage(db->Access()),
         dba(dba_storage.get()) {}
 
   void TearDown() override {

--- a/tests/unit/query_common.hpp
+++ b/tests/unit/query_common.hpp
@@ -72,7 +72,7 @@ auto ToIntMap(const TypedValue &t) {
 std::string ToString(Expression *expr) {
   std::unique_ptr<memgraph::storage::Storage> store(
       new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = true}}}));
-  auto storage_acc = store->Access(memgraph::replication_coordination_glue::ReplicationRole::MAIN);
+  auto storage_acc = store->Access();
   memgraph::query::DbAccessor dba(storage_acc.get());
 
   std::ostringstream ss;
@@ -83,7 +83,7 @@ std::string ToString(Expression *expr) {
 std::string ToString(NamedExpression *expr) {
   std::unique_ptr<memgraph::storage::Storage> store(
       new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = true}}}));
-  auto storage_acc = store->Access(memgraph::replication_coordination_glue::ReplicationRole::MAIN);
+  auto storage_acc = store->Access();
   memgraph::query::DbAccessor dba(storage_acc.get());
 
   std::ostringstream ss;

--- a/tests/unit/query_cost_estimator.cpp
+++ b/tests/unit/query_cost_estimator.cpp
@@ -52,16 +52,16 @@ class QueryCostEstimator : public ::testing::Test {
 
   void SetUp() override {
     {
-      auto unique_acc = db->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = db->UniqueAccess();
       ASSERT_FALSE(unique_acc->CreateIndex(label).HasError());
       ASSERT_FALSE(unique_acc->Commit().HasError());
     }
     {
-      auto unique_acc = db->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = db->UniqueAccess();
       ASSERT_FALSE(unique_acc->CreateIndex(label, property).HasError());
       ASSERT_FALSE(unique_acc->Commit().HasError());
     }
-    storage_dba.emplace(db->Access(ReplicationRole::MAIN));
+    storage_dba.emplace(db->Access());
     dba.emplace(storage_dba->get());
   }
 

--- a/tests/unit/query_dump.cpp
+++ b/tests/unit/query_dump.cpp
@@ -157,7 +157,7 @@ DatabaseState GetState(memgraph::storage::Storage *db) {
   // Capture all vertices
   std::map<memgraph::storage::Gid, int64_t> gid_mapping;
   std::set<DatabaseState::Vertex> vertices;
-  auto dba = db->Access(memgraph::replication_coordination_glue::ReplicationRole::MAIN);
+  auto dba = db->Access();
   for (const auto &vertex : dba->Vertices(memgraph::storage::View::NEW)) {
     std::set<std::string, std::less<>> labels;
     auto maybe_labels = vertex.Labels(memgraph::storage::View::NEW);
@@ -1161,7 +1161,7 @@ TYPED_TEST(DumpTest, MultiplePartialPulls) {
 }
 
 TYPED_TEST(DumpTest, DumpDatabaseWithTriggers) {
-  auto acc = this->db->storage()->Access(memgraph::replication_coordination_glue::ReplicationRole::MAIN);
+  auto acc = this->db->storage()->Access();
   memgraph::query::DbAccessor dba(acc.get());
   {
     auto trigger_store = this->db.get()->trigger_store();

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -68,7 +68,7 @@ class ExpressionEvaluatorTest : public ::testing::Test {
   ExpressionEvaluatorTest()
       : config(disk_test_utils::GenerateOnDiskConfig(testSuite)),
         db(new StorageType(config)),
-        storage_dba(db->Access(memgraph::replication_coordination_glue::ReplicationRole::MAIN)),
+        storage_dba(db->Access()),
         dba(storage_dba.get()) {}
 
   ~ExpressionEvaluatorTest() override {

--- a/tests/unit/query_hint_provider.cpp
+++ b/tests/unit/query_hint_provider.cpp
@@ -39,7 +39,7 @@ class HintProviderSuite : public ::testing::Test {
   int symbol_count = 0;
 
   void SetUp() {
-    storage_dba.emplace(db->Access(memgraph::replication_coordination_glue::ReplicationRole::MAIN));
+    storage_dba.emplace(db->Access());
     dba.emplace(storage_dba->get());
   }
 

--- a/tests/unit/query_plan_accumulate_aggregate.cpp
+++ b/tests/unit/query_plan_accumulate_aggregate.cpp
@@ -97,7 +97,7 @@ TYPED_TEST(QueryPlanTest, Accumulate) {
     this->db.reset(nullptr);
     this->CleanStorageDirs();
     this->db = std::make_unique<TypeParam>(this->config);
-    auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+    auto storage_dba = this->db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
     auto prop = dba.NameToProperty("x");
 
@@ -150,7 +150,7 @@ TYPED_TEST(QueryPlanTest, AccumulateAdvance) {
     this->db.reset();
     this->CleanStorageDirs();
     this->db = std::make_unique<TypeParam>(this->config);
-    auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+    auto storage_dba = this->db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
     SymbolTable symbol_table;
     NodeCreationInfo node;
@@ -169,7 +169,7 @@ TYPED_TEST(QueryPlanTest, AccumulateAdvance) {
 template <typename StorageType>
 class QueryPlanAggregateOps : public QueryPlanTest<StorageType> {
  protected:
-  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{this->db->Access(ReplicationRole::MAIN)};
+  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{this->db->Access()};
   memgraph::query::DbAccessor dba{storage_dba.get()};
   memgraph::storage::PropertyId prop = this->db->NameToProperty("prop");
 
@@ -310,7 +310,7 @@ TYPED_TEST(QueryPlanTest, AggregateGroupByValues) {
   // Tests that distinct groups are aggregated properly for values of all types.
   // Also test the "remember" part of the Aggregation API as final results are
   // obtained via a property lookup of a remembered node.
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   // a vector of memgraph::storage::PropertyValue to be set as property values on vertices
@@ -372,7 +372,7 @@ TYPED_TEST(QueryPlanTest, AggregateMultipleGroupBy) {
   // in this test we have 3 different properties that have different values
   // for different records and assert that we get the correct combination
   // of values in our groups
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   auto prop1 = dba.NameToProperty("prop1");
@@ -403,7 +403,7 @@ TYPED_TEST(QueryPlanTest, AggregateMultipleGroupBy) {
 }
 
 TYPED_TEST(QueryPlanTest, AggregateNoInput) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   SymbolTable symbol_table;
 
@@ -426,7 +426,7 @@ TYPED_TEST(QueryPlanTest, AggregateCountEdgeCases) {
   //  - 2 vertices in database, property set on one
   //  - 2 vertices in database, property set on both
 
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   auto prop = dba.NameToProperty("prop");
 
@@ -478,7 +478,7 @@ TYPED_TEST(QueryPlanTest, AggregateFirstValueTypes) {
   // testing exceptions that get emitted by the first-value
   // type check
 
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   auto v1 = dba.InsertVertex();
@@ -530,7 +530,7 @@ TYPED_TEST(QueryPlanTest, AggregateTypes) {
   // does not check all combinations that can result in an exception
   // (that logic is defined and tested by TypedValue)
 
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   auto p1 = dba.NameToProperty("p1");  // has only string props
@@ -583,7 +583,7 @@ TYPED_TEST(QueryPlanTest, AggregateTypes) {
 }
 
 TYPED_TEST(QueryPlanTest, Unwind) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   SymbolTable symbol_table;
 
@@ -719,7 +719,7 @@ TYPED_TEST(QueryPlanTest, AggregateGroupByValuesWithDistinct) {
   // Tests that distinct groups are aggregated properly for values of all types.
   // Also test the "remember" part of the Aggregation API as final results are
   // obtained via a property lookup of a remembered node.
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   // a vector of memgraph::storage::PropertyValue to be set as property values on vertices
@@ -784,7 +784,7 @@ TYPED_TEST(QueryPlanTest, AggregateMultipleGroupByWithDistinct) {
   // in this test we have 3 different properties that have different values
   // for different records and assert that we get the correct combination
   // of values in our groups
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   auto prop1 = dba.NameToProperty("prop1");
@@ -816,7 +816,7 @@ TYPED_TEST(QueryPlanTest, AggregateMultipleGroupByWithDistinct) {
 }
 
 TYPED_TEST(QueryPlanTest, AggregateNoInputWithDistinct) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   SymbolTable symbol_table;
 
@@ -839,7 +839,7 @@ TYPED_TEST(QueryPlanTest, AggregateCountEdgeCasesWithDistinct) {
   //  - 2 vertices in database, property set on one
   //  - 2 vertices in database, property set on both
 
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   auto prop = dba.NameToProperty("prop");
 
@@ -891,7 +891,7 @@ TYPED_TEST(QueryPlanTest, AggregateFirstValueTypesWithDistinct) {
   // testing exceptions that get emitted by the first-value
   // type check
 
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   auto v1 = dba.InsertVertex();
@@ -943,7 +943,7 @@ TYPED_TEST(QueryPlanTest, AggregateTypesWithDistinct) {
   // does not check all combinations that can result in an exception
   // (that logic is defined and tested by TypedValue)
 
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   auto p1 = dba.NameToProperty("p1");  // has only string props

--- a/tests/unit/query_plan_bag_semantics.cpp
+++ b/tests/unit/query_plan_bag_semantics.cpp
@@ -54,7 +54,7 @@ using StorageTypes = ::testing::Types<memgraph::storage::InMemoryStorage, memgra
 TYPED_TEST_SUITE(QueryPlanTest, StorageTypes);
 
 TYPED_TEST(QueryPlanTest, Skip) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   SymbolTable symbol_table;
 
@@ -82,7 +82,7 @@ TYPED_TEST(QueryPlanTest, Skip) {
 }
 
 TYPED_TEST(QueryPlanTest, Limit) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   SymbolTable symbol_table;
 
@@ -113,7 +113,7 @@ TYPED_TEST(QueryPlanTest, CreateLimit) {
   // CREATE (n), (m)
   // MATCH (n) CREATE (m) LIMIT 1
   // in the end we need to have 3 vertices in the db
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   dba.InsertVertex();
   dba.InsertVertex();
@@ -134,7 +134,7 @@ TYPED_TEST(QueryPlanTest, CreateLimit) {
 }
 
 TYPED_TEST(QueryPlanTest, OrderBy) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   SymbolTable symbol_table;
   auto prop = dba.NameToProperty("prop");
@@ -180,8 +180,11 @@ TYPED_TEST(QueryPlanTest, OrderBy) {
     auto order_equal = [&values, &shuffled]() {
       return std::equal(values.begin(), values.end(), shuffled.begin(), TypedValue::BoolEqual{});
     };
+
+    std::random_device rd;
+    std::mt19937 g(rd());
     for (int i = 0; i < 50 && order_equal(); ++i) {
-      std::random_shuffle(shuffled.begin(), shuffled.end());
+      std::shuffle(shuffled.begin(), shuffled.end(), g);
     }
     ASSERT_FALSE(order_equal());
 
@@ -205,7 +208,7 @@ TYPED_TEST(QueryPlanTest, OrderBy) {
 }
 
 TYPED_TEST(QueryPlanTest, OrderByMultiple) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   SymbolTable symbol_table;
 
@@ -218,8 +221,12 @@ TYPED_TEST(QueryPlanTest, OrderByMultiple) {
   // "right" sequence, but randomized
   const int N = 20;
   std::vector<std::pair<int, int>> prop_values;
+
   for (int i = 0; i < N * N; ++i) prop_values.emplace_back(i % N, i / N);
-  std::random_shuffle(prop_values.begin(), prop_values.end());
+
+  std::random_device rd;
+  std::mt19937 g(rd());
+  std::shuffle(prop_values.begin(), prop_values.end(), g);
   for (const auto &pair : prop_values) {
     auto v = dba.InsertVertex();
     ASSERT_TRUE(v.SetProperty(p1, memgraph::storage::PropertyValue(pair.first)).HasValue());
@@ -257,7 +264,7 @@ TYPED_TEST(QueryPlanTest, OrderByMultiple) {
 }
 
 TYPED_TEST(QueryPlanTest, OrderByExceptions) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   SymbolTable symbol_table;
   auto prop = dba.NameToProperty("prop");

--- a/tests/unit/query_plan_create_set_remove_delete.cpp
+++ b/tests/unit/query_plan_create_set_remove_delete.cpp
@@ -59,7 +59,7 @@ using StorageTypes = ::testing::Types<memgraph::storage::InMemoryStorage, memgra
 TYPED_TEST_SUITE(QueryPlanTest, StorageTypes);
 
 TYPED_TEST(QueryPlanTest, CreateNodeWithAttributes) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   memgraph::storage::LabelId label = dba.NameToLabel("Person");
@@ -103,7 +103,7 @@ TYPED_TEST(QueryPlanTest, CreateNodeWithAttributes) {
 TYPED_TEST(QueryPlanTest, FineGrainedCreateNodeWithAttributes) {
   memgraph::license::global_license_checker.EnableTesting();
   memgraph::query::SymbolTable symbol_table;
-  auto dba = this->db->Access(ReplicationRole::MAIN);
+  auto dba = this->db->Access();
   DbAccessor execution_dba(dba.get());
   const auto label = dba->NameToLabel("label1");
   const auto property = memgraph::storage::PropertyId::FromInt(1);
@@ -143,7 +143,7 @@ TYPED_TEST(QueryPlanTest, FineGrainedCreateNodeWithAttributes) {
 
 TYPED_TEST(QueryPlanTest, CreateReturn) {
   // test CREATE (n:Person {age: 42}) RETURN n, n.age
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   memgraph::storage::LabelId label = dba.NameToLabel("Person");
@@ -183,7 +183,7 @@ TYPED_TEST(QueryPlanTest, FineGrainedCreateReturn) {
   memgraph::license::global_license_checker.EnableTesting();
 
   // test CREATE (n:Person {age: 42}) RETURN n, n.age
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   const auto label = dba.NameToLabel("label");
@@ -238,7 +238,7 @@ TYPED_TEST(QueryPlanTest, FineGrainedCreateReturn) {
 #endif
 
 TYPED_TEST(QueryPlanTest, CreateExpand) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   memgraph::storage::LabelId label_node_1 = dba.NameToLabel("Node1");
@@ -316,7 +316,7 @@ TYPED_TEST(QueryPlanTest, CreateExpand) {
 template <typename StorageType>
 class CreateExpandWithAuthFixture : public QueryPlanTest<StorageType> {
  protected:
-  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{this->db->Access(ReplicationRole::MAIN)};
+  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{this->db->Access()};
   memgraph::query::DbAccessor dba{storage_dba.get()};
   SymbolTable symbol_table;
 
@@ -446,7 +446,7 @@ TYPED_TEST(CreateExpandWithAuthFixture, CreateExpandWithCycleWithEverythingGrant
 }
 
 TYPED_TEST(QueryPlanTest, MatchCreateNode) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   // add three nodes we'll match and expand-create from
@@ -474,7 +474,7 @@ TYPED_TEST(QueryPlanTest, MatchCreateNode) {
 template <typename StorageType>
 class MatchCreateNodeWithAuthFixture : public QueryPlanTest<StorageType> {
  protected:
-  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{this->db->Access(ReplicationRole::MAIN)};
+  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{this->db->Access()};
   memgraph::query::DbAccessor dba{storage_dba.get()};
   SymbolTable symbol_table;
 
@@ -554,7 +554,7 @@ TYPED_TEST(MatchCreateNodeWithAuthFixture, MatchCreateWithOneLabelDeniedThrows) 
 #endif
 
 TYPED_TEST(QueryPlanTest, MatchCreateExpand) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   // add three nodes we'll match and expand-create from
@@ -602,7 +602,7 @@ TYPED_TEST(QueryPlanTest, MatchCreateExpand) {
 template <typename StorageType>
 class MatchCreateExpandWithAuthFixture : public QueryPlanTest<StorageType> {
  protected:
-  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{this->db->Access(ReplicationRole::MAIN)};
+  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{this->db->Access()};
   memgraph::query::DbAccessor dba{storage_dba.get()};
   SymbolTable symbol_table;
 
@@ -747,7 +747,7 @@ TYPED_TEST(MatchCreateExpandWithAuthFixture, MatchCreateExpandWithCycleExecutesW
 #endif
 
 TYPED_TEST(QueryPlanTest, Delete) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   // make a fully-connected (one-direction, no cycles) with 4 nodes
@@ -819,7 +819,7 @@ TYPED_TEST(QueryPlanTest, Delete) {
 template <typename StorageType>
 class DeleteOperatorWithAuthFixture : public QueryPlanTest<StorageType> {
  protected:
-  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{this->db->Access(ReplicationRole::MAIN)};
+  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{this->db->Access()};
   memgraph::query::DbAccessor dba{storage_dba.get()};
   SymbolTable symbol_table;
 
@@ -979,7 +979,7 @@ TYPED_TEST(QueryPlanTest, DeleteTwiceDeleteBlockingEdge) {
   // MATCH (n)-[r]-(m) [DETACH] DELETE n, r, m
 
   auto test_delete = [this](bool detach) {
-    auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+    auto storage_dba = this->db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
 
     auto v1 = dba.InsertVertex();
@@ -1014,7 +1014,7 @@ TYPED_TEST(QueryPlanTest, DeleteTwiceDeleteBlockingEdge) {
 
 TYPED_TEST(QueryPlanTest, DeleteReturn) {
   // MATCH (n) DETACH DELETE n RETURN n
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   // graph with 4 vertices
@@ -1048,7 +1048,7 @@ TYPED_TEST(QueryPlanTest, DeleteReturn) {
 
 TYPED_TEST(QueryPlanTest, DeleteNull) {
   // test (simplified) WITH Null as x delete x
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   SymbolTable symbol_table;
 
@@ -1072,7 +1072,7 @@ TYPED_TEST(QueryPlanTest, DeleteAdvance) {
   auto advance = std::make_shared<Accumulate>(delete_op, std::vector<Symbol>{n.sym_}, true);
   auto res_sym = symbol_table.CreateSymbol("res", true);
   {
-    auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+    auto storage_dba = this->db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
     dba.InsertVertex();
     dba.AdvanceCommand();
@@ -1081,7 +1081,7 @@ TYPED_TEST(QueryPlanTest, DeleteAdvance) {
     EXPECT_EQ(1, PullAll(*produce, &context));
   }
   {
-    auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+    auto storage_dba = this->db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
     dba.InsertVertex();
     dba.AdvanceCommand();
@@ -1093,7 +1093,7 @@ TYPED_TEST(QueryPlanTest, DeleteAdvance) {
 }
 
 TYPED_TEST(QueryPlanTest, SetProperty) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   // graph with 4 vertices in connected pairs
@@ -1149,7 +1149,7 @@ TYPED_TEST(QueryPlanTest, SetProperty) {
 
 TYPED_TEST(QueryPlanTest, SetProperties) {
   auto test_set_properties = [this](bool update) {
-    auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+    auto storage_dba = this->db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
 
     // graph: ({a: 0})-[:R {b:1}]->({c:2})
@@ -1222,7 +1222,7 @@ TYPED_TEST(QueryPlanTest, SetProperties) {
 }
 
 TYPED_TEST(QueryPlanTest, SetLabels) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   auto label1 = dba.NameToLabel("label1");
@@ -1276,7 +1276,7 @@ TYPED_TEST(QueryPlanTest, SetLabelsWithFineGrained) {
     memgraph::auth::User user{"test"};
     user.fine_grained_access_handler().label_permissions().Grant("*",
                                                                  memgraph::auth::FineGrainedPermission::CREATE_DELETE);
-    auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+    auto storage_dba = this->db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
     auto label1 = dba.NameToLabel("label1");
     auto label2 = dba.NameToLabel("label2");
@@ -1293,7 +1293,7 @@ TYPED_TEST(QueryPlanTest, SetLabelsWithFineGrained) {
   {
     memgraph::auth::User user{"test"};
     user.fine_grained_access_handler().label_permissions().Grant("*", memgraph::auth::FineGrainedPermission::UPDATE);
-    auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+    auto storage_dba = this->db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
     auto label1 = dba.NameToLabel("label1");
     auto label2 = dba.NameToLabel("label2");
@@ -1312,7 +1312,7 @@ TYPED_TEST(QueryPlanTest, SetLabelsWithFineGrained) {
     user.fine_grained_access_handler().label_permissions().Grant("label3",
                                                                  memgraph::auth::FineGrainedPermission::CREATE_DELETE);
 
-    auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+    auto storage_dba = this->db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
     auto label1 = dba.NameToLabel("label1");
     auto label2 = dba.NameToLabel("label2");
@@ -1324,7 +1324,7 @@ TYPED_TEST(QueryPlanTest, SetLabelsWithFineGrained) {
 #endif
 
 TYPED_TEST(QueryPlanTest, RemoveProperty) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   // graph with 4 vertices in connected pairs
@@ -1386,7 +1386,7 @@ TYPED_TEST(QueryPlanTest, RemoveProperty) {
 }
 
 TYPED_TEST(QueryPlanTest, RemoveLabels) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   auto label1 = dba.NameToLabel("label1");
@@ -1451,7 +1451,7 @@ TYPED_TEST(QueryPlanTest, RemoveLabelsFineGrainedFiltering) {
     memgraph::auth::User user{"test"};
     user.fine_grained_access_handler().label_permissions().Grant("*",
                                                                  memgraph::auth::FineGrainedPermission::CREATE_DELETE);
-    auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+    auto storage_dba = this->db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
     auto label1 = dba.NameToLabel("label1");
     auto label2 = dba.NameToLabel("label2");
@@ -1468,7 +1468,7 @@ TYPED_TEST(QueryPlanTest, RemoveLabelsFineGrainedFiltering) {
   {
     memgraph::auth::User user{"test"};
     user.fine_grained_access_handler().label_permissions().Grant("*", memgraph::auth::FineGrainedPermission::UPDATE);
-    auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+    auto storage_dba = this->db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
     auto label1 = dba.NameToLabel("label1");
     auto label2 = dba.NameToLabel("label2");
@@ -1487,7 +1487,7 @@ TYPED_TEST(QueryPlanTest, RemoveLabelsFineGrainedFiltering) {
     user.fine_grained_access_handler().label_permissions().Grant("label3",
                                                                  memgraph::auth::FineGrainedPermission::CREATE_DELETE);
 
-    auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+    auto storage_dba = this->db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
     auto label1 = dba.NameToLabel("label1");
     auto label2 = dba.NameToLabel("label2");
@@ -1499,7 +1499,7 @@ TYPED_TEST(QueryPlanTest, RemoveLabelsFineGrainedFiltering) {
 #endif
 
 TYPED_TEST(QueryPlanTest, NodeFilterSet) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   // Create a graph such that (v1 {prop: 42}) is connected to v2 and v3.
   auto v1 = dba.InsertVertex();
@@ -1537,7 +1537,7 @@ TYPED_TEST(QueryPlanTest, NodeFilterSet) {
 }
 
 TYPED_TEST(QueryPlanTest, FilterRemove) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   // Create a graph such that (v1 {prop: 42}) is connected to v2 and v3.
   auto v1 = dba.InsertVertex();
@@ -1571,7 +1571,7 @@ TYPED_TEST(QueryPlanTest, FilterRemove) {
 }
 
 TYPED_TEST(QueryPlanTest, SetRemove) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   auto v = dba.InsertVertex();
   auto label1 = dba.NameToLabel("label1");
@@ -1601,7 +1601,7 @@ TYPED_TEST(QueryPlanTest, Merge) {
   //  - merge_match branch looks for an expansion (any direction)
   //    and sets some property (for result validation)
   //  - merge_create branch just sets some other property
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   auto v1 = dba.InsertVertex();
   auto v2 = dba.InsertVertex();
@@ -1643,7 +1643,7 @@ TYPED_TEST(QueryPlanTest, Merge) {
 TYPED_TEST(QueryPlanTest, MergeNoInput) {
   // merge with no input, creates a single node
 
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   SymbolTable symbol_table;
 
@@ -1661,7 +1661,7 @@ TYPED_TEST(QueryPlanTest, MergeNoInput) {
 
 TYPED_TEST(QueryPlanTest, SetPropertyWithCaching) {
   // SET (Null).prop = 42
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   SymbolTable symbol_table;
   auto prop = PROPERTY_PAIR(dba, "property");
@@ -1676,7 +1676,7 @@ TYPED_TEST(QueryPlanTest, SetPropertyWithCaching) {
 
 TYPED_TEST(QueryPlanTest, SetPropertyOnNull) {
   // SET (Null).prop = 42
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   SymbolTable symbol_table;
   auto prop = PROPERTY_PAIR(dba, "property");
@@ -1691,7 +1691,7 @@ TYPED_TEST(QueryPlanTest, SetPropertyOnNull) {
 
 TYPED_TEST(QueryPlanTest, SetPropertiesOnNull) {
   // OPTIONAL MATCH (n) SET n = n
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   SymbolTable symbol_table;
   auto n = MakeScanAll(this->storage, symbol_table, "n");
@@ -1704,7 +1704,7 @@ TYPED_TEST(QueryPlanTest, SetPropertiesOnNull) {
 }
 
 TYPED_TEST(QueryPlanTest, UpdateSetPropertiesFromMap) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   // Add a single vertex. ( {property: 43})
   auto vertex_accessor = dba.InsertVertex();
@@ -1739,7 +1739,7 @@ TYPED_TEST(QueryPlanTest, UpdateSetPropertiesFromMap) {
 }
 
 TYPED_TEST(QueryPlanTest, SetPropertiesFromMapWithCaching) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   // Add a single vertex. ({prop1: 43, prop2: 44})
@@ -1779,7 +1779,7 @@ TYPED_TEST(QueryPlanTest, SetPropertiesFromMapWithCaching) {
 
 TYPED_TEST(QueryPlanTest, SetLabelsOnNull) {
   // OPTIONAL MATCH (n) SET n :label
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   auto label = dba.NameToLabel("label");
   std::vector<StorageLabelType> labels;
@@ -1795,7 +1795,7 @@ TYPED_TEST(QueryPlanTest, SetLabelsOnNull) {
 
 TYPED_TEST(QueryPlanTest, RemovePropertyOnNull) {
   // REMOVE (Null).prop
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   SymbolTable symbol_table;
   auto prop = PROPERTY_PAIR(dba, "property");
@@ -1809,7 +1809,7 @@ TYPED_TEST(QueryPlanTest, RemovePropertyOnNull) {
 
 TYPED_TEST(QueryPlanTest, RemoveLabelsOnNull) {
   // OPTIONAL MATCH (n) REMOVE n :label
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   auto label = dba.NameToLabel("label");
   std::vector<StorageLabelType> labels;
@@ -1825,7 +1825,7 @@ TYPED_TEST(QueryPlanTest, RemoveLabelsOnNull) {
 
 TYPED_TEST(QueryPlanTest, DeleteSetProperty) {
   // MATCH (n) DELETE n SET n.property = 42 RETURN n
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   // Add a single vertex.
   dba.InsertVertex();
@@ -1851,7 +1851,7 @@ TYPED_TEST(QueryPlanTest, DeleteSetProperty) {
 TYPED_TEST(QueryPlanTest, DeleteSetPropertiesFromMap) {
   // MATCH (n) DELETE n SET n = {property: 42} return n
   // MATCH (n) DELETE n SET n += {property: 42} return n
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   // Add a single vertex.
   dba.InsertVertex();
@@ -1879,7 +1879,7 @@ TYPED_TEST(QueryPlanTest, DeleteSetPropertiesFromMap) {
 
 TYPED_TEST(QueryPlanTest, DeleteSetPropertiesFrom) {
   // MATCH (n) DELETE n SET n = n RETURN n
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   // Add a single vertex.
   {
@@ -1908,7 +1908,7 @@ TYPED_TEST(QueryPlanTest, DeleteSetPropertiesFrom) {
 
 TYPED_TEST(QueryPlanTest, DeleteRemoveLabels) {
   // MATCH (n) DELETE n REMOVE n :label return n
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   // Add a single vertex.
   dba.InsertVertex();
@@ -1933,7 +1933,7 @@ TYPED_TEST(QueryPlanTest, DeleteRemoveLabels) {
 
 TYPED_TEST(QueryPlanTest, DeleteRemoveProperty) {
   // MATCH (n) DELETE n REMOVE n.property RETURN n
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   // Add a single vertex.
   dba.InsertVertex();
@@ -1963,7 +1963,7 @@ TYPED_TEST(QueryPlanTest, DeleteRemoveProperty) {
 template <typename StorageType>
 class UpdatePropertiesWithAuthFixture : public QueryPlanTest<StorageType> {
  protected:
-  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{this->db->Access(ReplicationRole::MAIN)};
+  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{this->db->Access()};
   memgraph::query::DbAccessor dba{storage_dba.get()};
   SymbolTable symbol_table;
 
@@ -2600,7 +2600,7 @@ class DynamicExpandFixture : public testing::Test {
   const std::string testSuite = "query_plan_create_set_remove_delete_dynamic_expand";
   memgraph::storage::Config config = disk_test_utils::GenerateOnDiskConfig(testSuite);
   std::unique_ptr<memgraph::storage::Storage> db{new StorageType(config)};
-  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{db->Access(ReplicationRole::MAIN)};
+  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{db->Access()};
   memgraph::query::DbAccessor dba{storage_dba.get()};
   SymbolTable symbol_table;
   AstStorage storage;

--- a/tests/unit/query_plan_match_filter_return.cpp
+++ b/tests/unit/query_plan_match_filter_return.cpp
@@ -51,7 +51,7 @@ class MatchReturnFixture : public testing::Test {
  protected:
   memgraph::storage::Config config = disk_test_utils::GenerateOnDiskConfig(testSuite);
   std::unique_ptr<memgraph::storage::Storage> db{new StorageType(config)};
-  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{db->Access(ReplicationRole::MAIN)};
+  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{db->Access()};
   memgraph::query::DbAccessor dba{storage_dba.get()};
   AstStorage storage;
   SymbolTable symbol_table;
@@ -240,7 +240,7 @@ class QueryPlan : public testing::Test {
 TYPED_TEST_SUITE(QueryPlan, StorageTypes);
 
 TYPED_TEST(QueryPlan, MatchReturnCartesian) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   ASSERT_TRUE(dba.InsertVertex().AddLabel(dba.NameToLabel("l1")).HasValue());
@@ -264,7 +264,7 @@ TYPED_TEST(QueryPlan, MatchReturnCartesian) {
 }
 
 TYPED_TEST(QueryPlan, StandaloneReturn) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   // add a few nodes to the database
@@ -286,7 +286,7 @@ TYPED_TEST(QueryPlan, StandaloneReturn) {
 }
 
 TYPED_TEST(QueryPlan, NodeFilterLabelsAndProperties) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   // add a few nodes to the database
@@ -339,7 +339,7 @@ TYPED_TEST(QueryPlan, NodeFilterLabelsAndProperties) {
 }
 
 TYPED_TEST(QueryPlan, NodeFilterMultipleLabels) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   // add a few nodes to the database
@@ -385,7 +385,7 @@ TYPED_TEST(QueryPlan, NodeFilterMultipleLabels) {
 }
 
 TYPED_TEST(QueryPlan, Cartesian) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   auto add_vertex = [&dba](std::string label) {
@@ -422,7 +422,7 @@ TYPED_TEST(QueryPlan, Cartesian) {
 }
 
 TYPED_TEST(QueryPlan, CartesianEmptySet) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   SymbolTable symbol_table;
 
@@ -442,7 +442,7 @@ TYPED_TEST(QueryPlan, CartesianEmptySet) {
 }
 
 TYPED_TEST(QueryPlan, CartesianThreeWay) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   auto add_vertex = [&dba](std::string label) {
     auto vertex = dba.InsertVertex();
@@ -492,7 +492,7 @@ class ExpandFixture : public testing::Test {
  protected:
   memgraph::storage::Config config = disk_test_utils::GenerateOnDiskConfig(testSuite);
   std::unique_ptr<memgraph::storage::Storage> db{new StorageType(config)};
-  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{db->Access(ReplicationRole::MAIN)};
+  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{db->Access()};
   memgraph::query::DbAccessor dba{storage_dba.get()};
   SymbolTable symbol_table;
   AstStorage storage;
@@ -652,7 +652,7 @@ class QueryPlanExpandVariable : public testing::Test {
 
   memgraph::storage::Config config = disk_test_utils::GenerateOnDiskConfig(testSuite);
   std::unique_ptr<memgraph::storage::Storage> db{new StorageType(config)};
-  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{db->Access(ReplicationRole::MAIN)};
+  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{db->Access()};
   memgraph::query::DbAccessor dba{storage_dba.get()};
   // labels for layers in the double chain
   std::vector<memgraph::storage::LabelId> labels;
@@ -1807,7 +1807,7 @@ class QueryPlanExpandWeightedShortestPath : public testing::Test {
  protected:
   memgraph::storage::Config config = disk_test_utils::GenerateOnDiskConfig(testSuite);
   std::unique_ptr<memgraph::storage::Storage> db{new StorageType(config)};
-  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{db->Access(ReplicationRole::MAIN)};
+  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{db->Access()};
   memgraph::query::DbAccessor dba{storage_dba.get()};
   std::pair<std::string, memgraph::storage::PropertyId> prop = PROPERTY_PAIR(dba, "property");
   memgraph::storage::EdgeTypeId edge_type = dba.NameToEdgeType("edge_type");
@@ -2251,7 +2251,7 @@ class QueryPlanExpandAllShortestPaths : public testing::Test {
  protected:
   memgraph::storage::Config config = disk_test_utils::GenerateOnDiskConfig(testSuite);
   std::unique_ptr<memgraph::storage::Storage> db{new StorageType(config)};
-  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{db->Access(ReplicationRole::MAIN)};
+  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{db->Access()};
   memgraph::query::DbAccessor dba{storage_dba.get()};
   std::pair<std::string, memgraph::storage::PropertyId> prop = PROPERTY_PAIR(dba, "property");
   memgraph::storage::EdgeTypeId edge_type = dba.NameToEdgeType("edge_type");
@@ -2702,7 +2702,7 @@ TYPED_TEST(QueryPlanExpandAllShortestPaths, BasicWithFineGrainedFiltering) {
 #endif
 
 TYPED_TEST(QueryPlan, ExpandOptional) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   SymbolTable symbol_table;
@@ -2753,7 +2753,7 @@ TYPED_TEST(QueryPlan, ExpandOptional) {
 }
 
 TYPED_TEST(QueryPlan, OptionalMatchEmptyDB) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   SymbolTable symbol_table;
 
@@ -2770,7 +2770,7 @@ TYPED_TEST(QueryPlan, OptionalMatchEmptyDB) {
 }
 
 TYPED_TEST(QueryPlan, OptionalMatchEmptyDBExpandFromNode) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   SymbolTable symbol_table;
   // OPTIONAL MATCH (n)
@@ -2793,7 +2793,7 @@ TYPED_TEST(QueryPlan, OptionalMatchEmptyDBExpandFromNode) {
 }
 
 TYPED_TEST(QueryPlan, OptionalMatchThenExpandToMissingNode) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   // Make a graph with 2 connected, unlabeled nodes.
   auto v1 = dba.InsertVertex();
@@ -2838,7 +2838,7 @@ TYPED_TEST(QueryPlan, OptionalMatchThenExpandToMissingNode) {
 }
 
 TYPED_TEST(QueryPlan, ExpandExistingNode) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   // make a graph (v1)->(v2) that
@@ -2876,7 +2876,7 @@ TYPED_TEST(QueryPlan, ExpandExistingNode) {
 TYPED_TEST(QueryPlan, ExpandBothCycleEdgeCase) {
   // we're testing that expanding on BOTH
   // does only one expansion for a cycle
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   auto v = dba.InsertVertex();
@@ -2893,7 +2893,7 @@ TYPED_TEST(QueryPlan, ExpandBothCycleEdgeCase) {
 }
 
 TYPED_TEST(QueryPlan, EdgeFilter) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   // make an N-star expanding from (v1)
@@ -2953,7 +2953,7 @@ TYPED_TEST(QueryPlan, EdgeFilter) {
 }
 
 TYPED_TEST(QueryPlan, EdgeFilterMultipleTypes) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   auto v1 = dba.InsertVertex();
@@ -2983,7 +2983,7 @@ TYPED_TEST(QueryPlan, EdgeFilterMultipleTypes) {
 }
 
 TYPED_TEST(QueryPlan, Filter) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   // add a 6 nodes with property 'prop', 2 have true as value
@@ -3007,7 +3007,7 @@ TYPED_TEST(QueryPlan, Filter) {
 }
 
 TYPED_TEST(QueryPlan, EdgeUniquenessFilter) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   // make a graph that has (v1)->(v2) and a recursive edge (v1)->(v1)
@@ -3042,7 +3042,7 @@ TYPED_TEST(QueryPlan, Distinct) {
   // test queries like
   // UNWIND [1, 2, 3, 3] AS x RETURN DISTINCT x
 
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   SymbolTable symbol_table;
 
@@ -3086,11 +3086,11 @@ TYPED_TEST(QueryPlan, Distinct) {
 TYPED_TEST(QueryPlan, ScanAllByLabel) {
   auto label = this->db->NameToLabel("label");
   {
-    auto unique_acc = this->db->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->db->UniqueAccess();
     [[maybe_unused]] auto _ = unique_acc->CreateIndex(label);
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   // Add a vertex with a label and one without.
   auto labeled_vertex = dba.InsertVertex();
@@ -3137,7 +3137,7 @@ TYPED_TEST(QueryPlan, ScanAllByLabelProperty) {
       memgraph::storage::PropertyValue(
           std::vector<memgraph::storage::PropertyValue>{memgraph::storage::PropertyValue(2)})};
   {
-    auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+    auto storage_dba = this->db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
     for (const auto &value : values) {
       auto vertex = dba.InsertVertex();
@@ -3148,12 +3148,12 @@ TYPED_TEST(QueryPlan, ScanAllByLabelProperty) {
   }
 
   {
-    auto unique_acc = this->db->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->db->UniqueAccess();
     [[maybe_unused]] auto _ = unique_acc->CreateIndex(label, prop);
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
 
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   ASSERT_EQ(14, CountIterable(dba.Vertices(memgraph::storage::View::OLD)));
 
@@ -3247,7 +3247,7 @@ TYPED_TEST(QueryPlan, ScanAllByLabelPropertyEqualityNoError) {
   auto label = this->db->NameToLabel("label");
   auto prop = this->db->NameToProperty("prop");
   {
-    auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+    auto storage_dba = this->db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
     auto number_vertex = dba.InsertVertex();
     ASSERT_TRUE(number_vertex.AddLabel(label).HasValue());
@@ -3258,12 +3258,12 @@ TYPED_TEST(QueryPlan, ScanAllByLabelPropertyEqualityNoError) {
     ASSERT_FALSE(dba.Commit().HasError());
   }
   {
-    auto unique_acc = this->db->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->db->UniqueAccess();
     [[maybe_unused]] auto _ = unique_acc->CreateIndex(label, prop);
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
 
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   EXPECT_EQ(2, CountIterable(dba.Vertices(memgraph::storage::View::OLD)));
   // MATCH (n :label {prop: 42})
@@ -3287,7 +3287,7 @@ TYPED_TEST(QueryPlan, ScanAllByLabelPropertyValueError) {
   auto label = this->db->NameToLabel("label");
   auto prop = this->db->NameToProperty("prop");
   {
-    auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+    auto storage_dba = this->db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
     for (int i = 0; i < 2; ++i) {
       auto vertex = dba.InsertVertex();
@@ -3297,12 +3297,12 @@ TYPED_TEST(QueryPlan, ScanAllByLabelPropertyValueError) {
     ASSERT_FALSE(dba.Commit().HasError());
   }
   {
-    auto unique_acc = this->db->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->db->UniqueAccess();
     [[maybe_unused]] auto _ = unique_acc->CreateIndex(label, prop);
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
 
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   EXPECT_EQ(2, CountIterable(dba.Vertices(memgraph::storage::View::OLD)));
   // MATCH (m), (n :label {prop: m})
@@ -3320,7 +3320,7 @@ TYPED_TEST(QueryPlan, ScanAllByLabelPropertyRangeError) {
   auto label = this->db->NameToLabel("label");
   auto prop = this->db->NameToProperty("prop");
   {
-    auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+    auto storage_dba = this->db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
     for (int i = 0; i < 2; ++i) {
       auto vertex = dba.InsertVertex();
@@ -3330,12 +3330,12 @@ TYPED_TEST(QueryPlan, ScanAllByLabelPropertyRangeError) {
     ASSERT_FALSE(dba.Commit().HasError());
   }
   {
-    auto unique_acc = this->db->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->db->UniqueAccess();
     [[maybe_unused]] auto _ = unique_acc->CreateIndex(label, prop);
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
 
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   EXPECT_EQ(2, CountIterable(dba.Vertices(memgraph::storage::View::OLD)));
   // MATCH (m), (n :label {prop: m})
@@ -3376,7 +3376,7 @@ TYPED_TEST(QueryPlan, ScanAllByLabelPropertyEqualNull) {
   auto label = this->db->NameToLabel("label");
   auto prop = this->db->NameToProperty("prop");
   {
-    auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+    auto storage_dba = this->db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
     auto vertex = dba.InsertVertex();
     ASSERT_TRUE(vertex.AddLabel(label).HasValue());
@@ -3386,12 +3386,12 @@ TYPED_TEST(QueryPlan, ScanAllByLabelPropertyEqualNull) {
     ASSERT_FALSE(dba.Commit().HasError());
   }
   {
-    auto unique_acc = this->db->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->db->UniqueAccess();
     [[maybe_unused]] auto _ = unique_acc->CreateIndex(label, prop);
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
 
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   EXPECT_EQ(2, CountIterable(dba.Vertices(memgraph::storage::View::OLD)));
   // MATCH (n :label {prop: 42})
@@ -3413,7 +3413,7 @@ TYPED_TEST(QueryPlan, ScanAllByLabelPropertyRangeNull) {
   auto label = this->db->NameToLabel("label");
   auto prop = this->db->NameToProperty("prop");
   {
-    auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+    auto storage_dba = this->db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
     auto vertex = dba.InsertVertex();
     ASSERT_TRUE(vertex.AddLabel(label).HasValue());
@@ -3423,12 +3423,12 @@ TYPED_TEST(QueryPlan, ScanAllByLabelPropertyRangeNull) {
     ASSERT_FALSE(dba.Commit().HasError());
   }
   {
-    auto unique_acc = this->db->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->db->UniqueAccess();
     [[maybe_unused]] auto _ = unique_acc->CreateIndex(label, prop);
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
 
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   EXPECT_EQ(2, CountIterable(dba.Vertices(memgraph::storage::View::OLD)));
   // MATCH (n :label) WHERE null <= n.prop < null
@@ -3448,7 +3448,7 @@ TYPED_TEST(QueryPlan, ScanAllByLabelPropertyNoValueInIndexContinuation) {
   auto label = this->db->NameToLabel("label");
   auto prop = this->db->NameToProperty("prop");
   {
-    auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+    auto storage_dba = this->db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
     auto v = dba.InsertVertex();
     ASSERT_TRUE(v.AddLabel(label).HasValue());
@@ -3456,12 +3456,12 @@ TYPED_TEST(QueryPlan, ScanAllByLabelPropertyNoValueInIndexContinuation) {
     ASSERT_FALSE(dba.Commit().HasError());
   }
   {
-    auto unique_acc = this->db->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->db->UniqueAccess();
     [[maybe_unused]] auto _ = unique_acc->CreateIndex(label, prop);
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
 
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   EXPECT_EQ(1, CountIterable(dba.Vertices(memgraph::storage::View::OLD)));
 
@@ -3491,7 +3491,7 @@ TYPED_TEST(QueryPlan, ScanAllEqualsScanAllByLabelProperty) {
   const int prop_value1 = 42, prop_value2 = 69;
 
   for (int i = 0; i < vertex_count; ++i) {
-    auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+    auto storage_dba = this->db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
     auto v = dba.InsertVertex();
     ASSERT_TRUE(v.AddLabel(label).HasValue());
@@ -3501,14 +3501,14 @@ TYPED_TEST(QueryPlan, ScanAllEqualsScanAllByLabelProperty) {
   }
 
   {
-    auto unique_acc = this->db->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->db->UniqueAccess();
     [[maybe_unused]] auto _ = unique_acc->CreateIndex(label, prop);
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
 
   // Make sure there are `vertex_count` vertices
   {
-    auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+    auto storage_dba = this->db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
     EXPECT_EQ(vertex_count, CountIterable(dba.Vertices(memgraph::storage::View::OLD)));
   }
@@ -3516,7 +3516,7 @@ TYPED_TEST(QueryPlan, ScanAllEqualsScanAllByLabelProperty) {
   // Make sure there are `vertex_prop_count` results when using index
   auto count_with_index = [this, &label, &prop](int prop_value, int prop_count) {
     SymbolTable symbol_table;
-    auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+    auto storage_dba = this->db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
     auto scan_all_by_label_property_value =
         MakeScanAllByLabelPropertyValue(this->storage, symbol_table, "n", label, prop, "prop", LITERAL(prop_value));
@@ -3530,7 +3530,7 @@ TYPED_TEST(QueryPlan, ScanAllEqualsScanAllByLabelProperty) {
   // Make sure there are `vertex_count` results when using scan all
   auto count_with_scan_all = [this, &prop](int prop_value, int prop_count) {
     SymbolTable symbol_table;
-    auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+    auto storage_dba = this->db->Access();
     memgraph::query::DbAccessor dba(storage_dba.get());
     auto scan_all = MakeScanAll(this->storage, symbol_table, "n");
     auto e = PROPERTY_LOOKUP(dba, IDENT("n")->MapTo(scan_all.sym_), std::make_pair("prop", prop));
@@ -3555,7 +3555,7 @@ class ExistsFixture : public testing::Test {
  protected:
   memgraph::storage::Config config = disk_test_utils::GenerateOnDiskConfig(testSuite);
   std::unique_ptr<memgraph::storage::Storage> db{new StorageType(config)};
-  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{db->Access(ReplicationRole::MAIN)};
+  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{db->Access()};
   memgraph::query::DbAccessor dba{storage_dba.get()};
   AstStorage storage;
   SymbolTable symbol_table;
@@ -3784,7 +3784,7 @@ class SubqueriesFeature : public testing::Test {
  protected:
   memgraph::storage::Config config = disk_test_utils::GenerateOnDiskConfig(testSuite);
   std::unique_ptr<memgraph::storage::Storage> db{new StorageType(config)};
-  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{db->Access(ReplicationRole::MAIN)};
+  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{db->Access()};
   memgraph::query::DbAccessor dba{storage_dba.get()};
   AstStorage storage;
   SymbolTable symbol_table;

--- a/tests/unit/query_plan_operator_to_string.cpp
+++ b/tests/unit/query_plan_operator_to_string.cpp
@@ -37,7 +37,7 @@ class OperatorToStringTest : public ::testing::Test {
   OperatorToStringTest()
       : config(disk_test_utils::GenerateOnDiskConfig(testSuite)),
         db(new StorageType(config)),
-        dba_storage(db->Access(memgraph::replication_coordination_glue::ReplicationRole::MAIN)),
+        dba_storage(db->Access()),
         dba(dba_storage.get()) {}
 
   ~OperatorToStringTest() override {

--- a/tests/unit/query_plan_read_write_typecheck.cpp
+++ b/tests/unit/query_plan_read_write_typecheck.cpp
@@ -36,8 +36,7 @@ class ReadWriteTypeCheckTest : public ::testing::Test {
 
   memgraph::storage::Config config = disk_test_utils::GenerateOnDiskConfig(testSuite);
   std::unique_ptr<memgraph::storage::Storage> db{new StorageType(config)};
-  std::unique_ptr<memgraph::storage::Storage::Accessor> dba_storage{
-      db->Access(memgraph::replication_coordination_glue::ReplicationRole::MAIN)};
+  std::unique_ptr<memgraph::storage::Storage::Accessor> dba_storage{db->Access()};
   memgraph::query::DbAccessor dba{dba_storage.get()};
 
   void TearDown() override {

--- a/tests/unit/query_plan_v2_create_set_remove_delete.cpp
+++ b/tests/unit/query_plan_v2_create_set_remove_delete.cpp
@@ -38,7 +38,7 @@ using StorageTypes = ::testing::Types<memgraph::storage::InMemoryStorage, memgra
 TYPED_TEST_SUITE(QueryPlan, StorageTypes);
 
 TYPED_TEST(QueryPlan, CreateNodeWithAttributes) {
-  auto dba = this->db->Access(ReplicationRole::MAIN);
+  auto dba = this->db->Access();
 
   auto label = memgraph::storage::LabelId::FromInt(42);
   auto property = memgraph::storage::PropertyId::FromInt(1);
@@ -76,7 +76,7 @@ TYPED_TEST(QueryPlan, CreateNodeWithAttributes) {
 TYPED_TEST(QueryPlan, ScanAllEmpty) {
   memgraph::query::AstStorage ast;
   memgraph::query::SymbolTable symbol_table;
-  auto dba = this->db->Access(ReplicationRole::MAIN);
+  auto dba = this->db->Access();
   DbAccessor execution_dba(dba.get());
   auto node_symbol = symbol_table.CreateSymbol("n", true);
   {
@@ -101,13 +101,13 @@ TYPED_TEST(QueryPlan, ScanAllEmpty) {
 
 TYPED_TEST(QueryPlan, ScanAll) {
   {
-    auto dba = this->db->Access(ReplicationRole::MAIN);
+    auto dba = this->db->Access();
     for (int i = 0; i < 42; ++i) dba->CreateVertex();
     EXPECT_FALSE(dba->Commit().HasError());
   }
   memgraph::query::AstStorage ast;
   memgraph::query::SymbolTable symbol_table;
-  auto dba = this->db->Access(ReplicationRole::MAIN);
+  auto dba = this->db->Access();
   DbAccessor execution_dba(dba.get());
   auto node_symbol = symbol_table.CreateSymbol("n", true);
   memgraph::query::plan::ScanAll scan_all(nullptr, node_symbol);
@@ -122,12 +122,12 @@ TYPED_TEST(QueryPlan, ScanAll) {
 TYPED_TEST(QueryPlan, ScanAllByLabel) {
   auto label = this->db->NameToLabel("label");
   {
-    auto unique_acc = this->db->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->db->UniqueAccess();
     ASSERT_FALSE(unique_acc->CreateIndex(label).HasError());
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
   {
-    auto dba = this->db->Access(ReplicationRole::MAIN);
+    auto dba = this->db->Access();
     // Add some unlabeled vertices
     for (int i = 0; i < 12; ++i) dba->CreateVertex();
     // Add labeled vertices
@@ -137,7 +137,7 @@ TYPED_TEST(QueryPlan, ScanAllByLabel) {
     }
     EXPECT_FALSE(dba->Commit().HasError());
   }
-  auto dba = this->db->Access(ReplicationRole::MAIN);
+  auto dba = this->db->Access();
   memgraph::query::AstStorage ast;
   memgraph::query::SymbolTable symbol_table;
   auto node_symbol = symbol_table.CreateSymbol("n", true);

--- a/tests/unit/query_pretty_print.cpp
+++ b/tests/unit/query_pretty_print.cpp
@@ -36,8 +36,7 @@ class ExpressionPrettyPrinterTest : public ::testing::Test {
   const std::string testSuite = "query_pretty_print";
   memgraph::storage::Config config = disk_test_utils::GenerateOnDiskConfig(testSuite);
   std::unique_ptr<memgraph::storage::Storage> db{new StorageType(config)};
-  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{
-      db->Access(memgraph::replication_coordination_glue::ReplicationRole::MAIN)};
+  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{db->Access()};
   memgraph::query::DbAccessor dba{storage_dba.get()};
   AstStorage storage;
 

--- a/tests/unit/query_procedure_mgp_type.cpp
+++ b/tests/unit/query_procedure_mgp_type.cpp
@@ -246,7 +246,7 @@ TYPED_TEST(CypherType, MapSatisfiesType) {
 }
 
 TYPED_TEST(CypherType, VertexSatisfiesType) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   auto vertex = dba.InsertVertex();
   mgp_memory memory{memgraph::utils::NewDeleteResource()};
@@ -269,7 +269,7 @@ TYPED_TEST(CypherType, VertexSatisfiesType) {
 }
 
 TYPED_TEST(CypherType, EdgeSatisfiesType) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   auto v1 = dba.InsertVertex();
   auto v2 = dba.InsertVertex();
@@ -293,7 +293,7 @@ TYPED_TEST(CypherType, EdgeSatisfiesType) {
 }
 
 TYPED_TEST(CypherType, PathSatisfiesType) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   auto v1 = dba.InsertVertex();
   auto v2 = dba.InsertVertex();

--- a/tests/unit/query_procedure_py_module.cpp
+++ b/tests/unit/query_procedure_py_module.cpp
@@ -118,7 +118,7 @@ static void AssertPickleAndCopyAreNotSupported(PyObject *py_obj) {
 TYPED_TEST(PyModule, PyVertex) {
   // Initialize the database with 2 vertices and 1 edge.
   {
-    auto dba = this->db->Access(ReplicationRole::MAIN);
+    auto dba = this->db->Access();
     auto v1 = dba->CreateVertex();
     auto v2 = dba->CreateVertex();
 
@@ -131,7 +131,7 @@ TYPED_TEST(PyModule, PyVertex) {
     ASSERT_FALSE(dba->Commit().HasError());
   }
   // Get the first vertex as an mgp_value.
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   mgp_memory memory{memgraph::utils::NewDeleteResource()};
   mgp_graph graph{&dba, memgraph::storage::View::OLD, nullptr, dba.GetStorageMode()};
@@ -167,7 +167,7 @@ TYPED_TEST(PyModule, PyVertex) {
 TYPED_TEST(PyModule, PyEdge) {
   // Initialize the database with 2 vertices and 1 edge.
   {
-    auto dba = this->db->Access(ReplicationRole::MAIN);
+    auto dba = this->db->Access();
     auto v1 = dba->CreateVertex();
     auto v2 = dba->CreateVertex();
 
@@ -181,7 +181,7 @@ TYPED_TEST(PyModule, PyEdge) {
     ASSERT_FALSE(dba->Commit().HasError());
   }
   // Get the edge as an mgp_value.
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   mgp_memory memory{memgraph::utils::NewDeleteResource()};
   mgp_graph graph{&dba, memgraph::storage::View::OLD, nullptr, dba.GetStorageMode()};
@@ -221,13 +221,13 @@ TYPED_TEST(PyModule, PyEdge) {
 
 TYPED_TEST(PyModule, PyPath) {
   {
-    auto dba = this->db->Access(ReplicationRole::MAIN);
+    auto dba = this->db->Access();
     auto v1 = dba->CreateVertex();
     auto v2 = dba->CreateVertex();
     ASSERT_TRUE(dba->CreateEdge(&v1, &v2, dba->NameToEdgeType("type")).HasValue());
     ASSERT_FALSE(dba->Commit().HasError());
   }
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   mgp_memory memory{memgraph::utils::NewDeleteResource()};
   mgp_graph graph{&dba, memgraph::storage::View::OLD, nullptr, dba.GetStorageMode()};

--- a/tests/unit/query_procedures_mgp_graph.cpp
+++ b/tests/unit/query_procedures_mgp_graph.cpp
@@ -157,7 +157,7 @@ class MgpGraphTest : public ::testing::Test {
   }
 
   memgraph::query::DbAccessor &CreateDbAccessor(const memgraph::storage::IsolationLevel isolationLevel) {
-    accessors_.push_back(storage->Access(ReplicationRole::MAIN, isolationLevel));
+    accessors_.push_back(storage->Access(isolationLevel));
     db_accessors_.emplace_back(accessors_.back().get());
     return db_accessors_.back();
   }
@@ -196,8 +196,7 @@ TYPED_TEST(MgpGraphTest, CreateVertex) {
     return;
   }
   mgp_graph graph = this->CreateGraph();
-  auto read_uncommited_accessor =
-      this->storage->Access(ReplicationRole::MAIN, memgraph::storage::IsolationLevel::READ_UNCOMMITTED);
+  auto read_uncommited_accessor = this->storage->Access(memgraph::storage::IsolationLevel::READ_UNCOMMITTED);
   EXPECT_EQ(CountVertices(*read_uncommited_accessor, memgraph::storage::View::NEW), 0);
   MgpVertexPtr vertex{EXPECT_MGP_NO_ERROR(mgp_vertex *, mgp_graph_create_vertex, &graph, &this->memory)};
   EXPECT_NE(vertex, nullptr);
@@ -220,8 +219,7 @@ TYPED_TEST(MgpGraphTest, DeleteVertex) {
     ASSERT_FALSE(accessor.Commit().HasError());
   }
   mgp_graph graph = this->CreateGraph();
-  auto read_uncommited_accessor =
-      this->storage->Access(ReplicationRole::MAIN, memgraph::storage::IsolationLevel::READ_UNCOMMITTED);
+  auto read_uncommited_accessor = this->storage->Access(memgraph::storage::IsolationLevel::READ_UNCOMMITTED);
   EXPECT_EQ(CountVertices(*read_uncommited_accessor, memgraph::storage::View::NEW), 1);
   MgpVertexPtr vertex{EXPECT_MGP_NO_ERROR(mgp_vertex *, mgp_graph_get_vertex_by_id, &graph,
                                           mgp_vertex_id{vertex_id.AsInt()}, &this->memory)};
@@ -237,8 +235,7 @@ TYPED_TEST(MgpGraphTest, DetachDeleteVertex) {
   }
   const auto vertex_ids = this->CreateEdge();
   auto graph = this->CreateGraph();
-  auto read_uncommited_accessor =
-      this->storage->Access(ReplicationRole::MAIN, memgraph::storage::IsolationLevel::READ_UNCOMMITTED);
+  auto read_uncommited_accessor = this->storage->Access(memgraph::storage::IsolationLevel::READ_UNCOMMITTED);
   EXPECT_EQ(CountVertices(*read_uncommited_accessor, memgraph::storage::View::NEW), 2);
   MgpVertexPtr vertex{EXPECT_MGP_NO_ERROR(mgp_vertex *, mgp_graph_get_vertex_by_id, &graph,
                                           mgp_vertex_id{vertex_ids.front().AsInt()}, &this->memory)};
@@ -260,8 +257,7 @@ TYPED_TEST(MgpGraphTest, CreateDeleteWithImmutableGraph) {
     vertex_id = vertex.Gid();
     ASSERT_FALSE(accessor.Commit().HasError());
   }
-  auto read_uncommited_accessor =
-      this->storage->Access(ReplicationRole::MAIN, memgraph::storage::IsolationLevel::READ_UNCOMMITTED);
+  auto read_uncommited_accessor = this->storage->Access(memgraph::storage::IsolationLevel::READ_UNCOMMITTED);
   EXPECT_EQ(CountVertices(*read_uncommited_accessor, memgraph::storage::View::NEW), 1);
 
   mgp_graph immutable_graph = this->CreateGraph(memgraph::storage::View::OLD);
@@ -332,8 +328,7 @@ TYPED_TEST(MgpGraphTest, VertexSetProperty) {
     ASSERT_TRUE(result.HasValue());
     ASSERT_FALSE(accessor.Commit().HasError());
   }
-  auto read_uncommited_accessor =
-      this->storage->Access(ReplicationRole::MAIN, memgraph::storage::IsolationLevel::READ_UNCOMMITTED);
+  auto read_uncommited_accessor = this->storage->Access(memgraph::storage::IsolationLevel::READ_UNCOMMITTED);
   EXPECT_EQ(CountVertices(*read_uncommited_accessor, memgraph::storage::View::NEW), 1);
 
   mgp_graph graph = this->CreateGraph(memgraph::storage::View::NEW);
@@ -403,8 +398,7 @@ TYPED_TEST(MgpGraphTest, VertexAddLabel) {
   auto check_label = [&]() {
     EXPECT_NE(EXPECT_MGP_NO_ERROR(int, mgp_vertex_has_label_named, vertex.get(), label.data()), 0);
 
-    auto read_uncommited_accessor =
-        this->storage->Access(ReplicationRole::MAIN, memgraph::storage::IsolationLevel::READ_UNCOMMITTED);
+    auto read_uncommited_accessor = this->storage->Access(memgraph::storage::IsolationLevel::READ_UNCOMMITTED);
     const auto maybe_vertex = read_uncommited_accessor->FindVertex(vertex_id, memgraph::storage::View::NEW);
     ASSERT_TRUE(maybe_vertex);
     const auto label_ids = maybe_vertex->Labels(memgraph::storage::View::NEW);
@@ -442,8 +436,7 @@ TYPED_TEST(MgpGraphTest, VertexRemoveLabel) {
   auto check_label = [&]() {
     EXPECT_EQ(EXPECT_MGP_NO_ERROR(int, mgp_vertex_has_label_named, vertex.get(), label.data()), 0);
 
-    auto read_uncommited_accessor =
-        this->storage->Access(ReplicationRole::MAIN, memgraph::storage::IsolationLevel::READ_UNCOMMITTED);
+    auto read_uncommited_accessor = this->storage->Access(memgraph::storage::IsolationLevel::READ_UNCOMMITTED);
     const auto maybe_vertex = read_uncommited_accessor->FindVertex(vertex_id, memgraph::storage::View::NEW);
     ASSERT_TRUE(maybe_vertex);
     const auto label_ids = maybe_vertex->Labels(memgraph::storage::View::NEW);
@@ -632,15 +625,14 @@ TYPED_TEST(MgpGraphTest, EdgeSetProperty) {
   {
     const auto vertex_ids = this->CreateEdge();
     from_vertex_id = vertex_ids[0];
-    auto accessor = this->storage->Access(ReplicationRole::MAIN, memgraph::storage::IsolationLevel::SNAPSHOT_ISOLATION);
+    auto accessor = this->storage->Access(memgraph::storage::IsolationLevel::SNAPSHOT_ISOLATION);
     auto edge = get_edge(accessor.get());
     const auto result =
         edge.SetProperty(accessor->NameToProperty(property_to_update), memgraph::storage::PropertyValue(42));
     ASSERT_TRUE(result.HasValue());
     ASSERT_FALSE(accessor->Commit().HasError());
   }
-  auto read_uncommited_accessor =
-      this->storage->Access(ReplicationRole::MAIN, memgraph::storage::IsolationLevel::READ_UNCOMMITTED);
+  auto read_uncommited_accessor = this->storage->Access(memgraph::storage::IsolationLevel::READ_UNCOMMITTED);
 
   mgp_graph graph = this->CreateGraph(memgraph::storage::View::NEW);
   MgpEdgePtr edge;

--- a/tests/unit/query_semantic.cpp
+++ b/tests/unit/query_semantic.cpp
@@ -34,8 +34,7 @@ class TestSymbolGenerator : public ::testing::Test {
   const std::string testSuite = "query_semantic";
   memgraph::storage::Config config = disk_test_utils::GenerateOnDiskConfig(testSuite);
   std::unique_ptr<memgraph::storage::Storage> db{new StorageType(config)};
-  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{
-      db->Access(memgraph::replication_coordination_glue::ReplicationRole::MAIN)};
+  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{db->Access()};
   memgraph::query::DbAccessor dba{storage_dba.get()};
   AstStorage storage;
 

--- a/tests/unit/query_trigger.cpp
+++ b/tests/unit/query_trigger.cpp
@@ -83,7 +83,7 @@ class TriggerContextTest : public ::testing::Test {
   }
 
   memgraph::storage::Storage::Accessor *StartTransaction() {
-    accessors.emplace_back(db->Access(ReplicationRole::MAIN));
+    accessors.emplace_back(db->Access());
     return accessors.back().get();
   }
 
@@ -916,7 +916,7 @@ class TriggerStoreTest : public ::testing::Test {
 
     config = disk_test_utils::GenerateOnDiskConfig(testSuite);
     storage = std::make_unique<StorageType>(config);
-    storage_accessor = storage->Access(ReplicationRole::MAIN);
+    storage_accessor = storage->Access();
     dba.emplace(storage_accessor.get());
   }
 

--- a/tests/unit/query_variable_start_planner.cpp
+++ b/tests/unit/query_variable_start_planner.cpp
@@ -111,7 +111,7 @@ using StorageTypes = ::testing::Types<memgraph::storage::InMemoryStorage, memgra
 TYPED_TEST_SUITE(TestVariableStartPlanner, StorageTypes);
 
 TYPED_TEST(TestVariableStartPlanner, MatchReturn) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   // Make a graph (v1) -[:r]-> (v2)
   auto v1 = dba.InsertVertex();
@@ -128,7 +128,7 @@ TYPED_TEST(TestVariableStartPlanner, MatchReturn) {
 }
 
 TYPED_TEST(TestVariableStartPlanner, MatchTripletPatternReturn) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   // Make a graph (v1) -[:r]-> (v2) -[:r]-> (v3)
   auto v1 = dba.InsertVertex();
@@ -160,7 +160,7 @@ TYPED_TEST(TestVariableStartPlanner, MatchTripletPatternReturn) {
 }
 
 TYPED_TEST(TestVariableStartPlanner, MatchOptionalMatchReturn) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   // Make a graph (v1) -[:r]-> (v2) -[:r]-> (v3)
   auto v1 = dba.InsertVertex();
@@ -187,7 +187,7 @@ TYPED_TEST(TestVariableStartPlanner, MatchOptionalMatchReturn) {
 }
 
 TYPED_TEST(TestVariableStartPlanner, MatchOptionalMatchMergeReturn) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   // Graph (v1) -[:r]-> (v2)
   memgraph::query::VertexAccessor v1(dba.InsertVertex());
@@ -211,7 +211,7 @@ TYPED_TEST(TestVariableStartPlanner, MatchOptionalMatchMergeReturn) {
 }
 
 TYPED_TEST(TestVariableStartPlanner, MatchWithMatchReturn) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   // Graph (v1) -[:r]-> (v2)
   memgraph::query::VertexAccessor v1(dba.InsertVertex());
@@ -231,7 +231,7 @@ TYPED_TEST(TestVariableStartPlanner, MatchWithMatchReturn) {
 }
 
 TYPED_TEST(TestVariableStartPlanner, MatchVariableExpand) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   // Graph (v1) -[:r1]-> (v2) -[:r2]-> (v3)
   auto v1 = dba.InsertVertex();
@@ -254,7 +254,7 @@ TYPED_TEST(TestVariableStartPlanner, MatchVariableExpand) {
 }
 
 TYPED_TEST(TestVariableStartPlanner, MatchVariableExpandReferenceNode) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   auto id = dba.NameToProperty("id");
   // Graph (v1 {id:1}) -[:r1]-> (v2 {id: 2}) -[:r2]-> (v3 {id: 3})
@@ -282,7 +282,7 @@ TYPED_TEST(TestVariableStartPlanner, MatchVariableExpandReferenceNode) {
 }
 
 TYPED_TEST(TestVariableStartPlanner, MatchVariableExpandBoth) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   auto id = dba.NameToProperty("id");
   // Graph (v1 {id:1}) -[:r1]-> (v2) -[:r2]-> (v3)
@@ -308,7 +308,7 @@ TYPED_TEST(TestVariableStartPlanner, MatchVariableExpandBoth) {
 }
 
 TYPED_TEST(TestVariableStartPlanner, MatchBfs) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   auto id = dba.NameToProperty("id");
   // Graph (v1 {id:1}) -[:r1]-> (v2 {id: 2}) -[:r2]-> (v3 {id: 3})
@@ -335,7 +335,7 @@ TYPED_TEST(TestVariableStartPlanner, MatchBfs) {
 }
 
 TYPED_TEST(TestVariableStartPlanner, TestBasicSubquery) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   auto v1 = dba.InsertVertex();
@@ -357,7 +357,7 @@ TYPED_TEST(TestVariableStartPlanner, TestBasicSubquery) {
 }
 
 TYPED_TEST(TestVariableStartPlanner, TestBasicSubqueryWithMatching) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
 
   auto v1 = dba.InsertVertex();
@@ -378,7 +378,7 @@ TYPED_TEST(TestVariableStartPlanner, TestBasicSubqueryWithMatching) {
 }
 
 TYPED_TEST(TestVariableStartPlanner, TestSubqueryWithUnion) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   auto id = dba.NameToProperty("id");
 
@@ -406,7 +406,7 @@ TYPED_TEST(TestVariableStartPlanner, TestSubqueryWithUnion) {
 }
 
 TYPED_TEST(TestVariableStartPlanner, TestSubqueryWithTripleUnion) {
-  auto storage_dba = this->db->Access(ReplicationRole::MAIN);
+  auto storage_dba = this->db->Access();
   memgraph::query::DbAccessor dba(storage_dba.get());
   auto id = dba.NameToProperty("id");
 

--- a/tests/unit/storage_rocks.cpp
+++ b/tests/unit/storage_rocks.cpp
@@ -57,14 +57,14 @@ class RocksDBStorageTest : public ::testing::TestWithParam<bool> {
 };
 
 TEST_F(RocksDBStorageTest, SerializeVertexGID) {
-  auto acc = storage->Access(ReplicationRole::MAIN);
+  auto acc = storage->Access();
   auto vertex = acc->CreateVertex();
   auto gid = vertex.Gid();
   ASSERT_EQ(memgraph::utils::SerializeVertex(*vertex.vertex_), "|" + gid.ToString());
 }
 
 TEST_F(RocksDBStorageTest, SerializeVertexGIDLabels) {
-  auto acc = storage->Access(ReplicationRole::MAIN);
+  auto acc = storage->Access();
   auto vertex = acc->CreateVertex();
   auto ser_player_label = acc->NameToLabel("Player");
   auto ser_user_label = acc->NameToLabel("User");

--- a/tests/unit/storage_v2.cpp
+++ b/tests/unit/storage_v2.cpp
@@ -55,7 +55,7 @@ TYPED_TEST_SUITE(StorageV2Test, StorageTypes);
 TYPED_TEST(StorageV2Test, Commit) {
   memgraph::storage::Gid gid = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     ASSERT_FALSE(acc->FindVertex(gid, memgraph::storage::View::OLD).has_value());
@@ -65,7 +65,7 @@ TYPED_TEST(StorageV2Test, Commit) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     ASSERT_TRUE(acc->FindVertex(gid, memgraph::storage::View::OLD).has_value());
     EXPECT_EQ(CountVertices(*acc, memgraph::storage::View::OLD), 1U);
     ASSERT_TRUE(acc->FindVertex(gid, memgraph::storage::View::NEW).has_value());
@@ -73,7 +73,7 @@ TYPED_TEST(StorageV2Test, Commit) {
     acc->Abort();
   }
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -89,7 +89,7 @@ TYPED_TEST(StorageV2Test, Commit) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     ASSERT_FALSE(acc->FindVertex(gid, memgraph::storage::View::OLD).has_value());
     EXPECT_EQ(CountVertices(*acc, memgraph::storage::View::OLD), 0U);
     ASSERT_FALSE(acc->FindVertex(gid, memgraph::storage::View::NEW).has_value());
@@ -102,7 +102,7 @@ TYPED_TEST(StorageV2Test, Commit) {
 TYPED_TEST(StorageV2Test, Abort) {
   memgraph::storage::Gid gid = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     ASSERT_FALSE(acc->FindVertex(gid, memgraph::storage::View::OLD).has_value());
@@ -112,7 +112,7 @@ TYPED_TEST(StorageV2Test, Abort) {
     acc->Abort();
   }
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     ASSERT_FALSE(acc->FindVertex(gid, memgraph::storage::View::OLD).has_value());
     EXPECT_EQ(CountVertices(*acc, memgraph::storage::View::OLD), 0U);
     ASSERT_FALSE(acc->FindVertex(gid, memgraph::storage::View::NEW).has_value());
@@ -126,7 +126,7 @@ TYPED_TEST(StorageV2Test, AdvanceCommandCommit) {
   memgraph::storage::Gid gid1 = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid2 = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
 
     auto vertex1 = acc->CreateVertex();
     gid1 = vertex1.Gid();
@@ -150,7 +150,7 @@ TYPED_TEST(StorageV2Test, AdvanceCommandCommit) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     ASSERT_TRUE(acc->FindVertex(gid1, memgraph::storage::View::OLD).has_value());
     ASSERT_TRUE(acc->FindVertex(gid1, memgraph::storage::View::NEW).has_value());
     ASSERT_TRUE(acc->FindVertex(gid2, memgraph::storage::View::OLD).has_value());
@@ -166,7 +166,7 @@ TYPED_TEST(StorageV2Test, AdvanceCommandAbort) {
   memgraph::storage::Gid gid1 = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid2 = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
 
     auto vertex1 = acc->CreateVertex();
     gid1 = vertex1.Gid();
@@ -190,7 +190,7 @@ TYPED_TEST(StorageV2Test, AdvanceCommandAbort) {
     acc->Abort();
   }
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     ASSERT_FALSE(acc->FindVertex(gid1, memgraph::storage::View::OLD).has_value());
     ASSERT_FALSE(acc->FindVertex(gid1, memgraph::storage::View::NEW).has_value());
     ASSERT_FALSE(acc->FindVertex(gid2, memgraph::storage::View::OLD).has_value());
@@ -203,8 +203,8 @@ TYPED_TEST(StorageV2Test, AdvanceCommandAbort) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TYPED_TEST(StorageV2Test, SnapshotIsolation) {
-  auto acc1 = this->store->Access(ReplicationRole::MAIN);
-  auto acc2 = this->store->Access(ReplicationRole::MAIN);
+  auto acc1 = this->store->Access();
+  auto acc2 = this->store->Access();
 
   auto vertex = acc1->CreateVertex();
   auto gid = vertex.Gid();
@@ -225,7 +225,7 @@ TYPED_TEST(StorageV2Test, SnapshotIsolation) {
 
   acc2->Abort();
 
-  auto acc3 = this->store->Access(ReplicationRole::MAIN);
+  auto acc3 = this->store->Access();
   ASSERT_TRUE(acc3->FindVertex(gid, memgraph::storage::View::OLD).has_value());
   EXPECT_EQ(CountVertices(*acc3, memgraph::storage::View::OLD), 1U);
   ASSERT_TRUE(acc3->FindVertex(gid, memgraph::storage::View::NEW).has_value());
@@ -237,7 +237,7 @@ TYPED_TEST(StorageV2Test, SnapshotIsolation) {
 TYPED_TEST(StorageV2Test, AccessorMove) {
   memgraph::storage::Gid gid = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
 
@@ -256,7 +256,7 @@ TYPED_TEST(StorageV2Test, AccessorMove) {
     ASSERT_FALSE(moved->Commit().HasError());
   }
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     ASSERT_TRUE(acc->FindVertex(gid, memgraph::storage::View::OLD).has_value());
     EXPECT_EQ(CountVertices(*acc, memgraph::storage::View::OLD), 1U);
     ASSERT_TRUE(acc->FindVertex(gid, memgraph::storage::View::NEW).has_value());
@@ -268,8 +268,8 @@ TYPED_TEST(StorageV2Test, AccessorMove) {
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TYPED_TEST(StorageV2Test, VertexDeleteCommit) {
   memgraph::storage::Gid gid = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
-  auto acc1 = this->store->Access(ReplicationRole::MAIN);  // read transaction
-  auto acc2 = this->store->Access(ReplicationRole::MAIN);  // write transaction
+  auto acc1 = this->store->Access();  // read transaction
+  auto acc2 = this->store->Access();  // write transaction
 
   // Create the vertex in transaction 2
   {
@@ -282,8 +282,8 @@ TYPED_TEST(StorageV2Test, VertexDeleteCommit) {
     ASSERT_FALSE(acc2->Commit().HasError());
   }
 
-  auto acc3 = this->store->Access(ReplicationRole::MAIN);  // read transaction
-  auto acc4 = this->store->Access(ReplicationRole::MAIN);  // write transaction
+  auto acc3 = this->store->Access();  // read transaction
+  auto acc4 = this->store->Access();  // write transaction
 
   // Check whether the vertex exists in transaction 1
   ASSERT_FALSE(acc1->FindVertex(gid, memgraph::storage::View::OLD).has_value());
@@ -316,7 +316,7 @@ TYPED_TEST(StorageV2Test, VertexDeleteCommit) {
     ASSERT_FALSE(acc4->Commit().HasError());
   }
 
-  auto acc5 = this->store->Access(ReplicationRole::MAIN);  // read transaction
+  auto acc5 = this->store->Access();  // read transaction
 
   // Check whether the vertex exists in transaction 1
   ASSERT_FALSE(acc1->FindVertex(gid, memgraph::storage::View::OLD).has_value());
@@ -341,8 +341,8 @@ TYPED_TEST(StorageV2Test, VertexDeleteCommit) {
 TYPED_TEST(StorageV2Test, VertexDeleteAbort) {
   memgraph::storage::Gid gid = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
-  auto acc1 = this->store->Access(ReplicationRole::MAIN);  // read transaction
-  auto acc2 = this->store->Access(ReplicationRole::MAIN);  // write transaction
+  auto acc1 = this->store->Access();  // read transaction
+  auto acc2 = this->store->Access();  // write transaction
 
   // Create the vertex in transaction 2
   {
@@ -355,8 +355,8 @@ TYPED_TEST(StorageV2Test, VertexDeleteAbort) {
     ASSERT_FALSE(acc2->Commit().HasError());
   }
 
-  auto acc3 = this->store->Access(ReplicationRole::MAIN);  // read transaction
-  auto acc4 = this->store->Access(ReplicationRole::MAIN);  // write transaction (aborted)
+  auto acc3 = this->store->Access();  // read transaction
+  auto acc4 = this->store->Access();  // write transaction (aborted)
 
   // Check whether the vertex exists in transaction 1
   ASSERT_FALSE(acc1->FindVertex(gid, memgraph::storage::View::OLD).has_value());
@@ -389,8 +389,8 @@ TYPED_TEST(StorageV2Test, VertexDeleteAbort) {
     acc4->Abort();
   }
 
-  auto acc5 = this->store->Access(ReplicationRole::MAIN);  // read transaction
-  auto acc6 = this->store->Access(ReplicationRole::MAIN);  // write transaction
+  auto acc5 = this->store->Access();  // read transaction
+  auto acc6 = this->store->Access();  // write transaction
 
   // Check whether the vertex exists in transaction 1
   ASSERT_FALSE(acc1->FindVertex(gid, memgraph::storage::View::OLD).has_value());
@@ -429,7 +429,7 @@ TYPED_TEST(StorageV2Test, VertexDeleteAbort) {
     ASSERT_FALSE(acc6->Commit().HasError());
   }
 
-  auto acc7 = this->store->Access(ReplicationRole::MAIN);  // read transaction
+  auto acc7 = this->store->Access();  // read transaction
 
   // Check whether the vertex exists in transaction 1
   ASSERT_FALSE(acc1->FindVertex(gid, memgraph::storage::View::OLD).has_value());
@@ -468,14 +468,14 @@ TYPED_TEST(StorageV2Test, VertexDeleteSerializationError) {
 
   // Create vertex
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     ASSERT_FALSE(acc->Commit().HasError());
   }
 
-  auto acc1 = this->store->Access(ReplicationRole::MAIN);
-  auto acc2 = this->store->Access(ReplicationRole::MAIN);
+  auto acc1 = this->store->Access();
+  auto acc2 = this->store->Access();
 
   // Delete vertex in accessor 1
   {
@@ -548,7 +548,7 @@ TYPED_TEST(StorageV2Test, VertexDeleteSerializationError) {
 
   // Check whether the vertex exists
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_FALSE(vertex);
     EXPECT_EQ(CountVertices(*acc, memgraph::storage::View::OLD), 0U);
@@ -565,7 +565,7 @@ TYPED_TEST(StorageV2Test, VertexDeleteSpecialCases) {
   // Create vertex and delete it in the same transaction, but abort the
   // transaction
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->CreateVertex();
     gid1 = vertex.Gid();
     ASSERT_FALSE(acc->FindVertex(gid1, memgraph::storage::View::OLD).has_value());
@@ -585,7 +585,7 @@ TYPED_TEST(StorageV2Test, VertexDeleteSpecialCases) {
 
   // Create vertex and delete it in the same transaction
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->CreateVertex();
     gid2 = vertex.Gid();
     ASSERT_FALSE(acc->FindVertex(gid2, memgraph::storage::View::OLD).has_value());
@@ -605,7 +605,7 @@ TYPED_TEST(StorageV2Test, VertexDeleteSpecialCases) {
 
   // Check whether the vertices exist
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     ASSERT_FALSE(acc->FindVertex(gid1, memgraph::storage::View::OLD).has_value());
     ASSERT_FALSE(acc->FindVertex(gid1, memgraph::storage::View::NEW).has_value());
     ASSERT_FALSE(acc->FindVertex(gid2, memgraph::storage::View::OLD).has_value());
@@ -622,7 +622,7 @@ TYPED_TEST(StorageV2Test, VertexDeleteLabel) {
 
   // Create the vertex
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     ASSERT_FALSE(acc->FindVertex(gid, memgraph::storage::View::OLD).has_value());
@@ -632,7 +632,7 @@ TYPED_TEST(StorageV2Test, VertexDeleteLabel) {
 
   // Add label, delete the vertex and check the label API (same command)
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -686,7 +686,7 @@ TYPED_TEST(StorageV2Test, VertexDeleteLabel) {
 
   // Add label, delete the vertex and check the label API (different command)
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -777,7 +777,7 @@ TYPED_TEST(StorageV2Test, VertexDeleteProperty) {
 
   // Create the vertex
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     ASSERT_FALSE(acc->FindVertex(gid, memgraph::storage::View::OLD).has_value());
@@ -787,7 +787,7 @@ TYPED_TEST(StorageV2Test, VertexDeleteProperty) {
 
   // Set property, delete the vertex and check the property API (same command)
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -835,7 +835,7 @@ TYPED_TEST(StorageV2Test, VertexDeleteProperty) {
   // Set property, delete the vertex and check the property API (different
   // command)
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -918,7 +918,7 @@ TYPED_TEST(StorageV2Test, VertexLabelCommit) {
   memgraph::storage::Gid gid = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
 
@@ -950,7 +950,7 @@ TYPED_TEST(StorageV2Test, VertexLabelCommit) {
     spdlog::debug("Commit done");
   }
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -979,7 +979,7 @@ TYPED_TEST(StorageV2Test, VertexLabelCommit) {
     spdlog::debug("Abort done");
   }
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -1011,7 +1011,7 @@ TYPED_TEST(StorageV2Test, VertexLabelCommit) {
     spdlog::debug("Commit done");
   }
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -1038,7 +1038,7 @@ TYPED_TEST(StorageV2Test, VertexLabelAbort) {
 
   // Create the vertex.
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     ASSERT_FALSE(acc->Commit().HasError());
@@ -1046,7 +1046,7 @@ TYPED_TEST(StorageV2Test, VertexLabelAbort) {
 
   // Add label 5, but abort the transaction.
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -1079,7 +1079,7 @@ TYPED_TEST(StorageV2Test, VertexLabelAbort) {
 
   // Check that label 5 doesn't exist.
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -1100,7 +1100,7 @@ TYPED_TEST(StorageV2Test, VertexLabelAbort) {
 
   // Add label 5.
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -1133,7 +1133,7 @@ TYPED_TEST(StorageV2Test, VertexLabelAbort) {
 
   // Check that label 5 exists.
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -1163,7 +1163,7 @@ TYPED_TEST(StorageV2Test, VertexLabelAbort) {
 
   // Remove label 5, but abort the transaction.
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -1196,7 +1196,7 @@ TYPED_TEST(StorageV2Test, VertexLabelAbort) {
 
   // Check that label 5 exists.
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -1226,7 +1226,7 @@ TYPED_TEST(StorageV2Test, VertexLabelAbort) {
 
   // Remove label 5.
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -1259,7 +1259,7 @@ TYPED_TEST(StorageV2Test, VertexLabelAbort) {
 
   // Check that label 5 doesn't exist.
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -1283,14 +1283,14 @@ TYPED_TEST(StorageV2Test, VertexLabelAbort) {
 TYPED_TEST(StorageV2Test, VertexLabelSerializationError) {
   memgraph::storage::Gid gid = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     ASSERT_FALSE(acc->Commit().HasError());
   }
 
-  auto acc1 = this->store->Access(ReplicationRole::MAIN);
-  auto acc2 = this->store->Access(ReplicationRole::MAIN);
+  auto acc1 = this->store->Access();
+  auto acc2 = this->store->Access();
 
   // Add label 1 in accessor 1.
   {
@@ -1373,7 +1373,7 @@ TYPED_TEST(StorageV2Test, VertexLabelSerializationError) {
 
   // Check which labels exist.
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -1404,7 +1404,7 @@ TYPED_TEST(StorageV2Test, VertexLabelSerializationError) {
 TYPED_TEST(StorageV2Test, VertexPropertyCommit) {
   memgraph::storage::Gid gid = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
 
@@ -1442,7 +1442,7 @@ TYPED_TEST(StorageV2Test, VertexPropertyCommit) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -1470,7 +1470,7 @@ TYPED_TEST(StorageV2Test, VertexPropertyCommit) {
     acc->Abort();
   }
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -1501,7 +1501,7 @@ TYPED_TEST(StorageV2Test, VertexPropertyCommit) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -1527,7 +1527,7 @@ TYPED_TEST(StorageV2Test, VertexPropertyAbort) {
 
   // Create the vertex.
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     ASSERT_FALSE(acc->Commit().HasError());
@@ -1535,7 +1535,7 @@ TYPED_TEST(StorageV2Test, VertexPropertyAbort) {
 
   // Set property 5 to "nandare", but abort the transaction.
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -1575,7 +1575,7 @@ TYPED_TEST(StorageV2Test, VertexPropertyAbort) {
 
   // Check that property 5 is null.
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -1596,7 +1596,7 @@ TYPED_TEST(StorageV2Test, VertexPropertyAbort) {
 
   // Set property 5 to "nandare".
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -1636,7 +1636,7 @@ TYPED_TEST(StorageV2Test, VertexPropertyAbort) {
 
   // Check that property 5 is "nandare".
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -1666,7 +1666,7 @@ TYPED_TEST(StorageV2Test, VertexPropertyAbort) {
 
   // Set property 5 to null, but abort the transaction.
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -1707,7 +1707,7 @@ TYPED_TEST(StorageV2Test, VertexPropertyAbort) {
 
   // Check that property 5 is "nandare".
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -1737,7 +1737,7 @@ TYPED_TEST(StorageV2Test, VertexPropertyAbort) {
 
   // Set property 5 to null.
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -1778,7 +1778,7 @@ TYPED_TEST(StorageV2Test, VertexPropertyAbort) {
 
   // Check that property 5 is null.
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -1802,14 +1802,14 @@ TYPED_TEST(StorageV2Test, VertexPropertyAbort) {
 TYPED_TEST(StorageV2Test, VertexPropertySerializationError) {
   memgraph::storage::Gid gid = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     ASSERT_FALSE(acc->Commit().HasError());
   }
 
-  auto acc1 = this->store->Access(ReplicationRole::MAIN);
-  auto acc2 = this->store->Access(ReplicationRole::MAIN);
+  auto acc1 = this->store->Access();
+  auto acc2 = this->store->Access();
 
   // Set property 1 to 123 in accessor 1.
   {
@@ -1886,7 +1886,7 @@ TYPED_TEST(StorageV2Test, VertexPropertySerializationError) {
 
   // Check which properties exist.
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -1915,7 +1915,7 @@ TYPED_TEST(StorageV2Test, VertexPropertySerializationError) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TYPED_TEST(StorageV2Test, VertexLabelPropertyMixed) {
-  auto acc = this->store->Access(ReplicationRole::MAIN);
+  auto acc = this->store->Access();
   auto vertex = acc->CreateVertex();
 
   auto label = acc->NameToLabel("label5");
@@ -2157,7 +2157,7 @@ TYPED_TEST(StorageV2Test, VertexPropertyClear) {
   auto property1 = this->store->NameToProperty("property1");
   auto property2 = this->store->NameToProperty("property2");
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
 
@@ -2168,7 +2168,7 @@ TYPED_TEST(StorageV2Test, VertexPropertyClear) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -2200,7 +2200,7 @@ TYPED_TEST(StorageV2Test, VertexPropertyClear) {
     acc->Abort();
   }
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -2211,7 +2211,7 @@ TYPED_TEST(StorageV2Test, VertexPropertyClear) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -2244,7 +2244,7 @@ TYPED_TEST(StorageV2Test, VertexPropertyClear) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -2260,7 +2260,7 @@ TYPED_TEST(StorageV2Test, VertexNonexistentLabelPropertyEdgeAPI) {
   auto label = this->store->NameToLabel("label");
   auto property = this->store->NameToProperty("property");
 
-  auto acc = this->store->Access(ReplicationRole::MAIN);
+  auto acc = this->store->Access();
   auto vertex = acc->CreateVertex();
 
   // Check state before (OLD view).
@@ -2316,8 +2316,8 @@ TYPED_TEST(StorageV2Test, VertexNonexistentLabelPropertyEdgeAPI) {
 }
 
 TYPED_TEST(StorageV2Test, VertexVisibilitySingleTransaction) {
-  auto acc1 = this->store->Access(ReplicationRole::MAIN);
-  auto acc2 = this->store->Access(ReplicationRole::MAIN);
+  auto acc1 = this->store->Access();
+  auto acc2 = this->store->Access();
 
   auto vertex = acc1->CreateVertex();
   auto gid = vertex.Gid();
@@ -2336,7 +2336,7 @@ TYPED_TEST(StorageV2Test, VertexVisibilitySingleTransaction) {
 
   ASSERT_TRUE(vertex.SetProperty(acc1->NameToProperty("meaning"), memgraph::storage::PropertyValue(42)).HasValue());
 
-  auto acc3 = this->store->Access(ReplicationRole::MAIN);
+  auto acc3 = this->store->Access();
 
   EXPECT_FALSE(acc1->FindVertex(gid, memgraph::storage::View::OLD));
   EXPECT_TRUE(acc1->FindVertex(gid, memgraph::storage::View::NEW));
@@ -2373,8 +2373,8 @@ TYPED_TEST(StorageV2Test, VertexVisibilityMultipleTransactions) {
   memgraph::storage::Gid gid;
 
   {
-    auto acc1 = this->store->Access(ReplicationRole::MAIN);
-    auto acc2 = this->store->Access(ReplicationRole::MAIN);
+    auto acc1 = this->store->Access();
+    auto acc2 = this->store->Access();
 
     auto vertex = acc1->CreateVertex();
     gid = vertex.Gid();
@@ -2403,8 +2403,8 @@ TYPED_TEST(StorageV2Test, VertexVisibilityMultipleTransactions) {
   }
 
   {
-    auto acc1 = this->store->Access(ReplicationRole::MAIN);
-    auto acc2 = this->store->Access(ReplicationRole::MAIN);
+    auto acc1 = this->store->Access();
+    auto acc2 = this->store->Access();
 
     auto vertex = acc1->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
@@ -2437,7 +2437,7 @@ TYPED_TEST(StorageV2Test, VertexVisibilityMultipleTransactions) {
 
     ASSERT_TRUE(vertex->SetProperty(acc1->NameToProperty("meaning"), memgraph::storage::PropertyValue(42)).HasValue());
 
-    auto acc3 = this->store->Access(ReplicationRole::MAIN);
+    auto acc3 = this->store->Access();
 
     EXPECT_TRUE(acc1->FindVertex(gid, memgraph::storage::View::OLD));
     EXPECT_TRUE(acc1->FindVertex(gid, memgraph::storage::View::NEW));
@@ -2479,15 +2479,15 @@ TYPED_TEST(StorageV2Test, VertexVisibilityMultipleTransactions) {
   }
 
   {
-    auto acc1 = this->store->Access(ReplicationRole::MAIN);
-    auto acc2 = this->store->Access(ReplicationRole::MAIN);
+    auto acc1 = this->store->Access();
+    auto acc2 = this->store->Access();
 
     auto vertex = acc1->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
     ASSERT_TRUE(acc1->DeleteVertex(&*vertex).HasValue());
 
-    auto acc3 = this->store->Access(ReplicationRole::MAIN);
+    auto acc3 = this->store->Access();
 
     EXPECT_TRUE(acc1->FindVertex(gid, memgraph::storage::View::OLD));
     EXPECT_FALSE(acc1->FindVertex(gid, memgraph::storage::View::NEW));
@@ -2529,7 +2529,7 @@ TYPED_TEST(StorageV2Test, VertexVisibilityMultipleTransactions) {
   }
 
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
 
     EXPECT_TRUE(acc->FindVertex(gid, memgraph::storage::View::OLD));
     EXPECT_TRUE(acc->FindVertex(gid, memgraph::storage::View::NEW));
@@ -2543,15 +2543,15 @@ TYPED_TEST(StorageV2Test, VertexVisibilityMultipleTransactions) {
   }
 
   {
-    auto acc1 = this->store->Access(ReplicationRole::MAIN);
-    auto acc2 = this->store->Access(ReplicationRole::MAIN);
+    auto acc1 = this->store->Access();
+    auto acc2 = this->store->Access();
 
     auto vertex = acc1->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
     ASSERT_TRUE(acc1->DeleteVertex(&*vertex).HasValue());
 
-    auto acc3 = this->store->Access(ReplicationRole::MAIN);
+    auto acc3 = this->store->Access();
 
     EXPECT_TRUE(acc1->FindVertex(gid, memgraph::storage::View::OLD));
     EXPECT_FALSE(acc1->FindVertex(gid, memgraph::storage::View::NEW));
@@ -2593,7 +2593,7 @@ TYPED_TEST(StorageV2Test, VertexVisibilityMultipleTransactions) {
   }
 
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
 
     EXPECT_FALSE(acc->FindVertex(gid, memgraph::storage::View::OLD));
     EXPECT_FALSE(acc->FindVertex(gid, memgraph::storage::View::NEW));
@@ -2615,14 +2615,14 @@ TYPED_TEST(StorageV2Test, DeletedVertexAccessor) {
   std::optional<memgraph::storage::Gid> gid;
   // Create the vertex
   {
-    auto acc = this->store->Access(ReplicationRole::MAIN);
+    auto acc = this->store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     ASSERT_FALSE(vertex.SetProperty(property, property_value).HasError());
     ASSERT_FALSE(acc->Commit().HasError());
   }
 
-  auto acc = this->store->Access(ReplicationRole::MAIN);
+  auto acc = this->store->Access();
   auto vertex = acc->FindVertex(*gid, memgraph::storage::View::OLD);
   ASSERT_TRUE(vertex);
   auto maybe_deleted_vertex = acc->DeleteVertex(&*vertex);

--- a/tests/unit/storage_v2_constraints.cpp
+++ b/tests/unit/storage_v2_constraints.cpp
@@ -83,7 +83,7 @@ TYPED_TEST_SUITE(ConstraintsTest, StorageTypes);
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TYPED_TEST(ConstraintsTest, ExistenceConstraintsCreateAndDrop) {
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_EQ(acc->ListAllConstraints().existence.size(), 0);
     ASSERT_NO_ERROR(acc->Commit());
   }
@@ -94,7 +94,7 @@ TYPED_TEST(ConstraintsTest, ExistenceConstraintsCreateAndDrop) {
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(acc->ListAllConstraints().existence, UnorderedElementsAre(std::make_pair(this->label1, this->prop1)));
     ASSERT_NO_ERROR(acc->Commit());
   }
@@ -105,7 +105,7 @@ TYPED_TEST(ConstraintsTest, ExistenceConstraintsCreateAndDrop) {
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(acc->ListAllConstraints().existence, UnorderedElementsAre(std::make_pair(this->label1, this->prop1)));
     ASSERT_NO_ERROR(acc->Commit());
   }
@@ -116,7 +116,7 @@ TYPED_TEST(ConstraintsTest, ExistenceConstraintsCreateAndDrop) {
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(acc->ListAllConstraints().existence, UnorderedElementsAre(std::make_pair(this->label1, this->prop1),
                                                                           std::make_pair(this->label2, this->prop1)));
     ASSERT_NO_ERROR(acc->Commit());
@@ -132,7 +132,7 @@ TYPED_TEST(ConstraintsTest, ExistenceConstraintsCreateAndDrop) {
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(acc->ListAllConstraints().existence, UnorderedElementsAre(std::make_pair(this->label2, this->prop1)));
     ASSERT_NO_ERROR(acc->Commit());
   }
@@ -147,7 +147,7 @@ TYPED_TEST(ConstraintsTest, ExistenceConstraintsCreateAndDrop) {
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_EQ(acc->ListAllConstraints().existence.size(), 0);
     ASSERT_NO_ERROR(acc->Commit());
   }
@@ -158,7 +158,7 @@ TYPED_TEST(ConstraintsTest, ExistenceConstraintsCreateAndDrop) {
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(acc->ListAllConstraints().existence, UnorderedElementsAre(std::make_pair(this->label2, this->prop1)));
     ASSERT_NO_ERROR(acc->Commit());
   }
@@ -167,7 +167,7 @@ TYPED_TEST(ConstraintsTest, ExistenceConstraintsCreateAndDrop) {
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TYPED_TEST(ConstraintsTest, ExistenceConstraintsCreateFailure1) {
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex = acc->CreateVertex();
     ASSERT_NO_ERROR(vertex.AddLabel(this->label1));
     ASSERT_NO_ERROR(acc->Commit());
@@ -182,7 +182,7 @@ TYPED_TEST(ConstraintsTest, ExistenceConstraintsCreateFailure1) {
     ASSERT_FALSE(unique_acc->Commit().HasError());  // TODO: Check if we are committing here?
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (auto vertex : acc->Vertices(View::OLD)) {
       ASSERT_NO_ERROR(acc->DeleteVertex(&vertex));
     }
@@ -199,7 +199,7 @@ TYPED_TEST(ConstraintsTest, ExistenceConstraintsCreateFailure1) {
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TYPED_TEST(ConstraintsTest, ExistenceConstraintsCreateFailure2) {
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex = acc->CreateVertex();
     ASSERT_NO_ERROR(vertex.AddLabel(this->label1));
     ASSERT_NO_ERROR(acc->Commit());
@@ -214,7 +214,7 @@ TYPED_TEST(ConstraintsTest, ExistenceConstraintsCreateFailure2) {
     ASSERT_FALSE(unique_acc->Commit().HasError());  // TODO: Check if we are committing here?
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (auto vertex : acc->Vertices(View::OLD)) {
       ASSERT_NO_ERROR(vertex.SetProperty(this->prop1, PropertyValue(1)));
     }
@@ -238,7 +238,7 @@ TYPED_TEST(ConstraintsTest, ExistenceConstraintsViolationOnCommit) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex = acc->CreateVertex();
     ASSERT_NO_ERROR(vertex.AddLabel(this->label1));
 
@@ -250,7 +250,7 @@ TYPED_TEST(ConstraintsTest, ExistenceConstraintsViolationOnCommit) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex = acc->CreateVertex();
     ASSERT_NO_ERROR(vertex.AddLabel(this->label1));
     ASSERT_NO_ERROR(vertex.SetProperty(this->prop1, PropertyValue(1)));
@@ -258,7 +258,7 @@ TYPED_TEST(ConstraintsTest, ExistenceConstraintsViolationOnCommit) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (auto vertex : acc->Vertices(View::OLD)) {
       ASSERT_NO_ERROR(vertex.SetProperty(this->prop1, PropertyValue()));
     }
@@ -271,7 +271,7 @@ TYPED_TEST(ConstraintsTest, ExistenceConstraintsViolationOnCommit) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (auto vertex : acc->Vertices(View::OLD)) {
       ASSERT_NO_ERROR(vertex.SetProperty(this->prop1, PropertyValue()));
     }
@@ -287,7 +287,7 @@ TYPED_TEST(ConstraintsTest, ExistenceConstraintsViolationOnCommit) {
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex = acc->CreateVertex();
     ASSERT_NO_ERROR(vertex.AddLabel(this->label1));
     ASSERT_NO_ERROR(acc->Commit());
@@ -297,7 +297,7 @@ TYPED_TEST(ConstraintsTest, ExistenceConstraintsViolationOnCommit) {
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TYPED_TEST(ConstraintsTest, UniqueConstraintsCreateAndDropAndList) {
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_EQ(acc->ListAllConstraints().unique.size(), 0);
     ASSERT_NO_ERROR(acc->Commit());
   }
@@ -309,7 +309,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsCreateAndDropAndList) {
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(acc->ListAllConstraints().unique,
                 UnorderedElementsAre(std::make_pair(this->label1, std::set<PropertyId>{this->prop1})));
     ASSERT_NO_ERROR(acc->Commit());
@@ -322,7 +322,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsCreateAndDropAndList) {
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(acc->ListAllConstraints().unique,
                 UnorderedElementsAre(std::make_pair(this->label1, std::set<PropertyId>{this->prop1})));
     ASSERT_NO_ERROR(acc->Commit());
@@ -335,7 +335,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsCreateAndDropAndList) {
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(acc->ListAllConstraints().unique,
                 UnorderedElementsAre(std::make_pair(this->label1, std::set<PropertyId>{this->prop1}),
                                      std::make_pair(this->label2, std::set<PropertyId>{this->prop1})));
@@ -354,7 +354,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsCreateAndDropAndList) {
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(acc->ListAllConstraints().unique,
                 UnorderedElementsAre(std::make_pair(this->label2, std::set<PropertyId>{this->prop1})));
     ASSERT_NO_ERROR(acc->Commit());
@@ -372,7 +372,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsCreateAndDropAndList) {
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_EQ(acc->ListAllConstraints().unique.size(), 0);
     ASSERT_NO_ERROR(acc->Commit());
   }
@@ -383,7 +383,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsCreateAndDropAndList) {
     EXPECT_EQ(res.GetValue(), UniqueConstraints::CreationStatus::SUCCESS);
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(acc->ListAllConstraints().unique,
                 UnorderedElementsAre(std::make_pair(this->label2, std::set<PropertyId>{this->prop1})));
     ASSERT_NO_ERROR(acc->Commit());
@@ -393,7 +393,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsCreateAndDropAndList) {
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TYPED_TEST(ConstraintsTest, UniqueConstraintsCreateFailure1) {
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (int i = 0; i < 2; ++i) {
       auto vertex1 = acc->CreateVertex();
       ASSERT_NO_ERROR(vertex1.AddLabel(this->label1));
@@ -413,7 +413,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsCreateFailure1) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (auto vertex : acc->Vertices(View::OLD)) {
       ASSERT_NO_ERROR(acc->DeleteVertex(&vertex));
     }
@@ -432,7 +432,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsCreateFailure1) {
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TYPED_TEST(ConstraintsTest, UniqueConstraintsCreateFailure2) {
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (int i = 0; i < 2; ++i) {
       auto vertex = acc->CreateVertex();
       ASSERT_NO_ERROR(vertex.AddLabel(this->label1));
@@ -452,7 +452,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsCreateFailure2) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     int value = 0;
     for (auto vertex : acc->Vertices(View::OLD)) {
       ASSERT_NO_ERROR(vertex.SetProperty(this->prop1, PropertyValue(value)));
@@ -475,7 +475,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsNoViolation1) {
   Gid gid1;
   Gid gid2;
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex1 = acc->CreateVertex();
     auto vertex2 = acc->CreateVertex();
     gid1 = vertex1.Gid();
@@ -495,7 +495,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsNoViolation1) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex1 = acc->FindVertex(gid1, View::OLD);
     auto vertex2 = acc->FindVertex(gid2, View::OLD);
 
@@ -507,7 +507,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsNoViolation1) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex1 = acc->FindVertex(gid1, View::OLD);
     auto vertex2 = acc->FindVertex(gid2, View::OLD);
     ASSERT_NO_ERROR(vertex1->SetProperty(this->prop1, PropertyValue(2)));
@@ -530,8 +530,8 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsNoViolation2) {
     // tx1: B---SP(v1, 1)---SP(v1, 2)---OK--
     // tx2: -B---SP(v2, 2)---SP(v2, 1)---OK-
 
-    auto acc1 = this->storage->Access(ReplicationRole::MAIN);
-    auto acc2 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc1 = this->storage->Access();
+    auto acc2 = this->storage->Access();
     auto vertex1 = acc1->CreateVertex();
     auto vertex2 = acc2->CreateVertex();
 
@@ -563,7 +563,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsNoViolation3) {
     // tx2: --------------------B---SP(v1, 2)---OK--
     // tx3: ---------------------B---SP(v2, 1)---OK-
 
-    auto acc1 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc1 = this->storage->Access();
     auto vertex1 = acc1->CreateVertex();
     auto gid = vertex1.Gid();
 
@@ -572,8 +572,8 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsNoViolation3) {
 
     ASSERT_NO_ERROR(acc1->Commit());
 
-    auto acc2 = this->storage->Access(ReplicationRole::MAIN);
-    auto acc3 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc2 = this->storage->Access();
+    auto acc3 = this->storage->Access();
     auto vertex2 = acc2->FindVertex(gid, View::NEW);  // vertex1 == vertex2
     auto vertex3 = acc3->CreateVertex();
 
@@ -601,7 +601,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsNoViolation4) {
     // tx2: --------------------B---SP(v2, 1)-----OK-
     // tx3: ---------------------B---SP(v1, 2)---OK--
 
-    auto acc1 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc1 = this->storage->Access();
     auto vertex1 = acc1->CreateVertex();
     auto gid = vertex1.Gid();
 
@@ -609,8 +609,8 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsNoViolation4) {
 
     ASSERT_NO_ERROR(acc1->Commit());
 
-    auto acc2 = this->storage->Access(ReplicationRole::MAIN);
-    auto acc3 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc2 = this->storage->Access();
+    auto acc3 = this->storage->Access();
     auto vertex2 = acc2->CreateVertex();
     auto vertex3 = acc3->FindVertex(gid, View::NEW);
 
@@ -634,7 +634,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsViolationOnCommit1) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex1 = acc->CreateVertex();
     auto vertex2 = acc->CreateVertex();
     ASSERT_NO_ERROR(vertex1.AddLabel(this->label1));
@@ -665,7 +665,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsViolationOnCommit2) {
     // tx2: -------------------------------B---SP(v1, 3)---OK----
     // tx3: --------------------------------B---SP(v2, 3)---FAIL-
 
-    auto acc1 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc1 = this->storage->Access();
     auto vertex1 = acc1->CreateVertex();
     auto vertex2 = acc1->CreateVertex();
     auto gid1 = vertex1.Gid();
@@ -678,8 +678,8 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsViolationOnCommit2) {
 
     ASSERT_NO_ERROR(acc1->Commit());
 
-    auto acc2 = this->storage->Access(ReplicationRole::MAIN);
-    auto acc3 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc2 = this->storage->Access();
+    auto acc3 = this->storage->Access();
     auto vertex3 = acc2->FindVertex(gid1, View::NEW);  // vertex3 == vertex1
     auto vertex4 = acc3->FindVertex(gid2, View::NEW);  // vertex4 == vertex2
 
@@ -711,7 +711,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsViolationOnCommit3) {
     // tx2: -------------------------------B---SP(v1, 2)---FAIL--
     // tx3: --------------------------------B---SP(v2, 1)---FAIL-
 
-    auto acc1 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc1 = this->storage->Access();
     auto vertex1 = acc1->CreateVertex();
     auto vertex2 = acc1->CreateVertex();
     auto gid1 = vertex1.Gid();
@@ -724,8 +724,8 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsViolationOnCommit3) {
 
     ASSERT_NO_ERROR(acc1->Commit());
 
-    auto acc2 = this->storage->Access(ReplicationRole::MAIN);
-    auto acc3 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc2 = this->storage->Access();
+    auto acc3 = this->storage->Access();
     auto vertex3 = acc2->FindVertex(gid1, View::OLD);  // vertex3 == vertex1
     auto vertex4 = acc3->FindVertex(gid2, View::OLD);  // vertex4 == vertex2
 
@@ -764,7 +764,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsLabelAlteration) {
   {
     // B---AL(v2)---SP(v1, 1)---SP(v2, 1)---OK
 
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex1 = acc->CreateVertex();
     auto vertex2 = acc->CreateVertex();
     gid1 = vertex1.Gid();
@@ -784,8 +784,8 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsLabelAlteration) {
     // tx1: B---AL(v1)-----OK-
     // tx2: -B---RL(v2)---OK--
 
-    auto acc1 = this->storage->Access(ReplicationRole::MAIN);
-    auto acc2 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc1 = this->storage->Access();
+    auto acc2 = this->storage->Access();
     auto vertex1 = acc1->FindVertex(gid1, View::OLD);
     auto vertex2 = acc2->FindVertex(gid2, View::OLD);
 
@@ -813,7 +813,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsLabelAlteration) {
   {
     // B---AL(v2)---FAIL
 
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex2 = acc->FindVertex(gid2, View::OLD);
     ASSERT_NO_ERROR(vertex2->AddLabel(this->label1));
 
@@ -826,7 +826,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsLabelAlteration) {
   {
     // B---RL(v1)---OK
 
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex1 = acc->FindVertex(gid1, View::OLD);
     ASSERT_NO_ERROR(vertex1->RemoveLabel(this->label1));
     ASSERT_NO_ERROR(acc->Commit());
@@ -836,8 +836,8 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsLabelAlteration) {
     // tx1: B---AL(v1)-----FAIL
     // tx2: -B---AL(v2)---OK---
 
-    auto acc1 = this->storage->Access(ReplicationRole::MAIN);
-    auto acc2 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc1 = this->storage->Access();
+    auto acc2 = this->storage->Access();
     auto vertex1 = acc1->FindVertex(gid1, View::OLD);
     auto vertex2 = acc2->FindVertex(gid2, View::OLD);
 
@@ -913,7 +913,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsPropertySetSize) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(acc->ListAllConstraints().unique, UnorderedElementsAre(std::make_pair(this->label1, properties)));
     ASSERT_NO_ERROR(acc->Commit());
   }
@@ -924,7 +924,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsPropertySetSize) {
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     ASSERT_TRUE(acc->ListAllConstraints().unique.empty());
     ASSERT_NO_ERROR(acc->Commit());
   }
@@ -953,7 +953,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsMultipleProperties) {
   Gid gid1;
   Gid gid2;
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex1 = acc->CreateVertex();
     auto vertex2 = acc->CreateVertex();
     gid1 = vertex1.Gid();
@@ -973,7 +973,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsMultipleProperties) {
   // Try to change property of the second vertex so it becomes the same as the
   // first vertex-> It should fail.
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex2 = acc->FindVertex(gid2, View::OLD);
     ASSERT_NO_ERROR(vertex2->SetProperty(this->prop2, PropertyValue(2)));
     auto res = acc->Commit();
@@ -987,7 +987,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsMultipleProperties) {
   // both vertices should now be equal. However, this operation should succeed
   // since null value is treated as non-existing property.
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex1 = acc->FindVertex(gid1, View::OLD);
     auto vertex2 = acc->FindVertex(gid2, View::OLD);
     ASSERT_NO_ERROR(vertex1->SetProperty(this->prop2, PropertyValue()));
@@ -1007,7 +1007,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsInsertAbortInsert) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex = acc->CreateVertex();
     ASSERT_NO_ERROR(vertex.AddLabel(this->label1));
     ASSERT_NO_ERROR(vertex.SetProperty(this->prop1, PropertyValue(1)));
@@ -1016,7 +1016,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsInsertAbortInsert) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex = acc->CreateVertex();
     ASSERT_NO_ERROR(vertex.AddLabel(this->label1));
     ASSERT_NO_ERROR(vertex.SetProperty(this->prop2, PropertyValue(2)));
@@ -1036,7 +1036,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsInsertRemoveInsert) {
 
   Gid gid;
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     ASSERT_NO_ERROR(vertex.AddLabel(this->label1));
@@ -1046,14 +1046,14 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsInsertRemoveInsert) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex = acc->FindVertex(gid, View::OLD);
     ASSERT_NO_ERROR(acc->DeleteVertex(&*vertex));
     ASSERT_NO_ERROR(acc->Commit());
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex = acc->CreateVertex();
     ASSERT_NO_ERROR(vertex.AddLabel(this->label1));
     ASSERT_NO_ERROR(vertex.SetProperty(this->prop1, PropertyValue(1)));
@@ -1073,7 +1073,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsInsertRemoveAbortInsert) {
 
   Gid gid;
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     ASSERT_NO_ERROR(vertex.AddLabel(this->label1));
@@ -1083,14 +1083,14 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsInsertRemoveAbortInsert) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex = acc->FindVertex(gid, View::OLD);
     ASSERT_NO_ERROR(acc->DeleteVertex(&*vertex));
     acc->Abort();
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex = acc->CreateVertex();
     ASSERT_NO_ERROR(vertex.AddLabel(this->label1));
     ASSERT_NO_ERROR(vertex.SetProperty(this->prop2, PropertyValue(1)));
@@ -1116,7 +1116,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsDeleteVertexSetProperty) {
   Gid gid1;
   Gid gid2;
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex1 = acc->CreateVertex();
     auto vertex2 = acc->CreateVertex();
     gid1 = vertex1.Gid();
@@ -1131,8 +1131,8 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsDeleteVertexSetProperty) {
   }
 
   {
-    auto acc1 = this->storage->Access(ReplicationRole::MAIN);
-    auto acc2 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc1 = this->storage->Access();
+    auto acc2 = this->storage->Access();
     auto vertex1 = acc1->FindVertex(gid1, View::OLD);
     auto vertex2 = acc2->FindVertex(gid2, View::OLD);
 
@@ -1158,7 +1158,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsInsertDropInsert) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex = acc->CreateVertex();
     ASSERT_NO_ERROR(vertex.AddLabel(this->label1));
     ASSERT_NO_ERROR(vertex.SetProperty(this->prop1, PropertyValue(1)));
@@ -1174,7 +1174,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsInsertDropInsert) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex = acc->CreateVertex();
     ASSERT_NO_ERROR(vertex.AddLabel(this->label1));
     ASSERT_NO_ERROR(vertex.SetProperty(this->prop2, PropertyValue(2)));
@@ -1196,7 +1196,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsComparePropertyValues) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex = acc->CreateVertex();
     ASSERT_NO_ERROR(vertex.AddLabel(this->label1));
     ASSERT_NO_ERROR(vertex.SetProperty(this->prop1, PropertyValue(2)));
@@ -1205,7 +1205,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsComparePropertyValues) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex = acc->CreateVertex();
     ASSERT_NO_ERROR(vertex.AddLabel(this->label1));
     ASSERT_NO_ERROR(vertex.SetProperty(this->prop1, PropertyValue(1)));
@@ -1214,7 +1214,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsComparePropertyValues) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex = acc->CreateVertex();
     ASSERT_NO_ERROR(vertex.AddLabel(this->label1));
     ASSERT_NO_ERROR(vertex.SetProperty(this->prop2, PropertyValue(0)));
@@ -1240,7 +1240,7 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsClearOldData) {
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
 
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex = acc->CreateVertex();
     ASSERT_NO_ERROR(vertex.AddLabel(this->label1));
     ASSERT_NO_ERROR(vertex.SetProperty(this->prop1, PropertyValue(2)));
@@ -1248,14 +1248,14 @@ TYPED_TEST(ConstraintsTest, UniqueConstraintsClearOldData) {
 
     ASSERT_EQ(disk_test_utils::GetRealNumberOfEntriesInRocksDB(tx_db), 1);
 
-    auto acc2 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc2 = this->storage->Access();
     auto vertex2 = acc2->FindVertex(vertex.Gid(), memgraph::storage::View::NEW).value();
     ASSERT_TRUE(vertex2.SetProperty(this->prop1, memgraph::storage::PropertyValue(2)).HasValue());
     ASSERT_FALSE(acc2->Commit().HasError());
 
     ASSERT_EQ(disk_test_utils::GetRealNumberOfEntriesInRocksDB(tx_db), 1);
 
-    auto acc3 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc3 = this->storage->Access();
     auto vertex3 = acc3->FindVertex(vertex.Gid(), memgraph::storage::View::NEW).value();
     ASSERT_TRUE(vertex3.SetProperty(this->prop1, memgraph::storage::PropertyValue(10)).HasValue());
     ASSERT_FALSE(acc3->Commit().HasError());

--- a/tests/unit/storage_v2_durability_inmemory.cpp
+++ b/tests/unit/storage_v2_durability_inmemory.cpp
@@ -98,38 +98,38 @@ class DurabilityTest : public ::testing::TestWithParam<bool> {
 
     {
       // Create enum.
-      auto unique_acc = store->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = store->UniqueAccess();
       ASSERT_FALSE(unique_acc->CreateEnum("enum1"s, std::vector{"v1"s, "v2"s}).HasError());
       ASSERT_FALSE(unique_acc->Commit().HasError());
     }
     {
       // alter enum.
-      auto unique_acc = store->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = store->UniqueAccess();
       ASSERT_FALSE(unique_acc->EnumAlterAdd("enum1", "v3").HasError());
       ASSERT_FALSE(unique_acc->Commit().HasError());
     }
     {
       // Create label index.
-      auto unique_acc = store->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = store->UniqueAccess();
       ASSERT_FALSE(unique_acc->CreateIndex(label_unindexed).HasError());
       ASSERT_FALSE(unique_acc->Commit().HasError());
     }
     {
       // Create label index statistics.
-      auto acc = store->Access(ReplicationRole::MAIN);
+      auto acc = store->Access();
       acc->SetIndexStats(label_unindexed, memgraph::storage::LabelIndexStats{1, 2});
       ASSERT_TRUE(acc->GetIndexStats(label_unindexed));
       ASSERT_FALSE(acc->Commit().HasError());
     }
     {
       // Create label+property index.
-      auto unique_acc = store->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = store->UniqueAccess();
       ASSERT_FALSE(unique_acc->CreateIndex(label_indexed, property_id).HasError());
       ASSERT_FALSE(unique_acc->Commit().HasError());
     }
     {
       // Create label+property index statistics.
-      auto acc = store->Access(ReplicationRole::MAIN);
+      auto acc = store->Access();
       acc->SetIndexStats(label_indexed, property_id, memgraph::storage::LabelPropertyIndexStats{1, 2, 3.4, 5.6, 0.0});
       ASSERT_TRUE(acc->GetIndexStats(label_indexed, property_id));
       ASSERT_FALSE(acc->Commit().HasError());
@@ -137,13 +137,13 @@ class DurabilityTest : public ::testing::TestWithParam<bool> {
 
     {
       // Create existence constraint.
-      auto unique_acc = store->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = store->UniqueAccess();
       ASSERT_FALSE(unique_acc->CreateExistenceConstraint(label_unindexed, property_id).HasError());
       ASSERT_FALSE(unique_acc->Commit().HasError());
     }
     {
       // Create unique constraint.
-      auto unique_acc = store->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = store->UniqueAccess();
       ASSERT_FALSE(unique_acc->CreateUniqueConstraint(label_unindexed, {property_id, property_extra}).HasError());
       ASSERT_FALSE(unique_acc->Commit().HasError());
     }
@@ -151,7 +151,7 @@ class DurabilityTest : public ::testing::TestWithParam<bool> {
     // Create vertices.
     auto enum_val = *store->enum_store_.ToEnum("enum1", "v2");
     for (uint64_t i = 0; i < kNumBaseVertices; ++i) {
-      auto acc = store->Access(ReplicationRole::MAIN);
+      auto acc = store->Access();
       auto vertex = acc->CreateVertex();
       base_vertex_gids_[i] = vertex.Gid();
       if (i < kNumBaseVertices / 2) {
@@ -172,7 +172,7 @@ class DurabilityTest : public ::testing::TestWithParam<bool> {
 
     // Create edges.
     for (uint64_t i = 0; i < kNumBaseEdges; ++i) {
-      auto acc = store->Access(ReplicationRole::MAIN);
+      auto acc = store->Access();
       auto vertex1 = acc->FindVertex(base_vertex_gids_[(i / 2) % kNumBaseVertices], memgraph::storage::View::OLD);
       ASSERT_TRUE(vertex1);
       auto vertex2 = acc->FindVertex(base_vertex_gids_[(i / 3) % kNumBaseVertices], memgraph::storage::View::OLD);
@@ -208,26 +208,26 @@ class DurabilityTest : public ::testing::TestWithParam<bool> {
 
     {
       // Create label index.
-      auto unique_acc = store->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = store->UniqueAccess();
       ASSERT_FALSE(unique_acc->CreateIndex(label_unused).HasError());
       ASSERT_FALSE(unique_acc->Commit().HasError());
     }
     {
       // Create label index statistics.
-      auto acc = store->Access(ReplicationRole::MAIN);
+      auto acc = store->Access();
       acc->SetIndexStats(label_unused, memgraph::storage::LabelIndexStats{123, 9.87});
       ASSERT_TRUE(acc->GetIndexStats(label_unused));
       ASSERT_FALSE(acc->Commit().HasError());
     }
     {
       // Create label+property index.
-      auto unique_acc = store->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = store->UniqueAccess();
       ASSERT_FALSE(unique_acc->CreateIndex(label_indexed, property_count).HasError());
       ASSERT_FALSE(unique_acc->Commit().HasError());
     }
     {
       // Create label+property index statistics.
-      auto acc = store->Access(ReplicationRole::MAIN);
+      auto acc = store->Access();
       acc->SetIndexStats(label_indexed, property_count,
                          memgraph::storage::LabelPropertyIndexStats{456798, 312345, 12312312.2, 123123.2, 67876.9});
       ASSERT_TRUE(acc->GetIndexStats(label_indexed, property_count));
@@ -236,25 +236,25 @@ class DurabilityTest : public ::testing::TestWithParam<bool> {
 
     {
       // Create existence constraint.
-      auto unique_acc = store->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = store->UniqueAccess();
       ASSERT_FALSE(unique_acc->CreateExistenceConstraint(label_unused, property_count).HasError());
       ASSERT_FALSE(unique_acc->Commit().HasError());
     }
 
     {
       // Create unique constraint.
-      auto unique_acc = store->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = store->UniqueAccess();
       ASSERT_FALSE(unique_acc->CreateUniqueConstraint(label_unused, {property_count}).HasError());
       ASSERT_FALSE(unique_acc->Commit().HasError());
     }
 
     // Storage accessor.
     std::unique_ptr<memgraph::storage::Storage::Accessor> acc;
-    if (single_transaction) acc = store->Access(ReplicationRole::MAIN);
+    if (single_transaction) acc = store->Access();
 
     // Create vertices.
     for (uint64_t i = 0; i < kNumExtendedVertices; ++i) {
-      if (!single_transaction) acc = store->Access(ReplicationRole::MAIN);
+      if (!single_transaction) acc = store->Access();
       auto vertex = acc->CreateVertex();
       extended_vertex_gids_[i] = vertex.Gid();
       if (i < kNumExtendedVertices / 2) {
@@ -268,7 +268,7 @@ class DurabilityTest : public ::testing::TestWithParam<bool> {
 
     // Create edges.
     for (uint64_t i = 0; i < kNumExtendedEdges; ++i) {
-      if (!single_transaction) acc = store->Access(ReplicationRole::MAIN);
+      if (!single_transaction) acc = store->Access();
       auto vertex1 =
           acc->FindVertex(extended_vertex_gids_[(i / 5) % kNumExtendedVertices], memgraph::storage::View::NEW);
       ASSERT_TRUE(vertex1);
@@ -294,7 +294,7 @@ class DurabilityTest : public ::testing::TestWithParam<bool> {
   void CreateEdgeIndex(memgraph::storage::Storage *store, memgraph::storage::EdgeTypeId edge_type) {
     {
       // Create edge-type index.
-      auto unique_acc = store->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = store->UniqueAccess();
       ASSERT_FALSE(unique_acc->CreateIndex(edge_type).HasError());
       ASSERT_FALSE(unique_acc->Commit().HasError());
     }
@@ -304,7 +304,7 @@ class DurabilityTest : public ::testing::TestWithParam<bool> {
                                memgraph::storage::PropertyId prop) {
     {
       // Create edge-type index.
-      auto unique_acc = store->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = store->UniqueAccess();
       ASSERT_FALSE(unique_acc->CreateIndex(edge_type, prop).HasError());
       ASSERT_FALSE(unique_acc->Commit().HasError());
     }
@@ -332,7 +332,7 @@ class DurabilityTest : public ::testing::TestWithParam<bool> {
     ASSERT_FALSE(store->enum_store_.ToEnum("enum2", "v1").HasValue());
 
     // Create storage accessor.
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
 
     // Verify indices info.
     {

--- a/tests/unit/storage_v2_edge_inmemory.cpp
+++ b/tests/unit/storage_v2_edge_inmemory.cpp
@@ -34,7 +34,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSmallerCommit) {
 
   // Create vertices
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->CreateVertex();
     auto vertex_to = acc->CreateVertex();
     gid_from = vertex_from.Gid();
@@ -44,7 +44,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSmallerCommit) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -118,7 +118,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSmallerCommit) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -225,7 +225,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromLargerCommit) {
 
   // Create vertices
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_to = acc->CreateVertex();
     auto vertex_from = acc->CreateVertex();
     gid_to = vertex_to.Gid();
@@ -235,7 +235,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromLargerCommit) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -303,7 +303,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromLargerCommit) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -397,7 +397,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSameCommit) {
 
   // Create vertex
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->CreateVertex();
     gid_vertex = vertex.Gid();
     ASSERT_FALSE(acc->Commit().HasError());
@@ -405,7 +405,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSameCommit) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -463,7 +463,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSameCommit) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -544,7 +544,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSmallerAbort) {
 
   // Create vertices
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->CreateVertex();
     auto vertex_to = acc->CreateVertex();
     gid_from = vertex_from.Gid();
@@ -554,7 +554,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSmallerAbort) {
 
   // Create edge, but abort the transaction
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -622,7 +622,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSmallerAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -651,7 +651,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSmallerAbort) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -719,7 +719,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSmallerAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -814,7 +814,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromLargerAbort) {
 
   // Create vertices
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_to = acc->CreateVertex();
     auto vertex_from = acc->CreateVertex();
     gid_to = vertex_to.Gid();
@@ -824,7 +824,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromLargerAbort) {
 
   // Create edge, but abort the transaction
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -892,7 +892,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromLargerAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -921,7 +921,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromLargerAbort) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -989,7 +989,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromLargerAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -1083,7 +1083,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSameAbort) {
 
   // Create vertex
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->CreateVertex();
     gid_vertex = vertex.Gid();
     ASSERT_FALSE(acc->Commit().HasError());
@@ -1091,7 +1091,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSameAbort) {
 
   // Create edge, but abort the transaction
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -1149,7 +1149,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSameAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -1168,7 +1168,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSameAbort) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -1226,7 +1226,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSameAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -1311,7 +1311,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerCommit) {
 
   // Create vertices
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->CreateVertex();
     auto vertex_to = acc->CreateVertex();
     gid_from = vertex_from.Gid();
@@ -1321,7 +1321,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerCommit) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -1389,7 +1389,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerCommit) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -1476,7 +1476,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerCommit) {
 
   // Delete edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -1543,7 +1543,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerCommit) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -1580,7 +1580,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerCommit) {
 
   // Create vertices
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_to = acc->CreateVertex();
     auto vertex_from = acc->CreateVertex();
     gid_from = vertex_from.Gid();
@@ -1590,7 +1590,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerCommit) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -1658,7 +1658,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerCommit) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -1745,7 +1745,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerCommit) {
 
   // Delete edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -1812,7 +1812,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerCommit) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -1848,7 +1848,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameCommit) {
 
   // Create vertex
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->CreateVertex();
     gid_vertex = vertex.Gid();
     ASSERT_FALSE(acc->Commit().HasError());
@@ -1856,7 +1856,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameCommit) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -1914,7 +1914,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameCommit) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -1991,7 +1991,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameCommit) {
 
   // Delete edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -2048,7 +2048,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameCommit) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -2075,7 +2075,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerAbort) {
 
   // Create vertices
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->CreateVertex();
     auto vertex_to = acc->CreateVertex();
     gid_from = vertex_from.Gid();
@@ -2085,7 +2085,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerAbort) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2153,7 +2153,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2240,7 +2240,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerAbort) {
 
   // Delete the edge, but abort the transaction
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2307,7 +2307,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2394,7 +2394,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerAbort) {
 
   // Delete the edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2461,7 +2461,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2498,7 +2498,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerAbort) {
 
   // Create vertices
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->CreateVertex();
     auto vertex_to = acc->CreateVertex();
     gid_from = vertex_from.Gid();
@@ -2508,7 +2508,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerAbort) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2576,7 +2576,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2663,7 +2663,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerAbort) {
 
   // Delete the edge, but abort the transaction
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2730,7 +2730,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2818,7 +2818,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerAbort) {
 
   // Delete the edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2885,7 +2885,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2921,7 +2921,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameAbort) {
 
   // Create vertex
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->CreateVertex();
     gid_vertex = vertex.Gid();
     ASSERT_FALSE(acc->Commit().HasError());
@@ -2929,7 +2929,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameAbort) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -2987,7 +2987,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -3064,7 +3064,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameAbort) {
 
   // Delete the edge, but abort the transaction
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -3121,7 +3121,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -3198,7 +3198,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameAbort) {
 
   // Delete the edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -3255,7 +3255,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -3282,7 +3282,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteSingleCommit) {
 
   // Create dataset
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->CreateVertex();
     auto vertex_to = acc->CreateVertex();
 
@@ -3331,7 +3331,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteSingleCommit) {
 
   // Detach delete vertex
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -3395,7 +3395,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteSingleCommit) {
 
   // Check dataset
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_FALSE(vertex_from);
@@ -3422,7 +3422,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteMultipleCommit) {
 
   // Create dataset
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex1 = acc->CreateVertex();
     auto vertex2 = acc->CreateVertex();
 
@@ -3549,7 +3549,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteMultipleCommit) {
 
   // Detach delete vertex
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex1 = acc->FindVertex(gid_vertex1, memgraph::storage::View::NEW);
     auto vertex2 = acc->FindVertex(gid_vertex2, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex1);
@@ -3687,7 +3687,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteMultipleCommit) {
 
   // Check dataset
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex1 = acc->FindVertex(gid_vertex1, memgraph::storage::View::NEW);
     auto vertex2 = acc->FindVertex(gid_vertex2, memgraph::storage::View::NEW);
     ASSERT_FALSE(vertex1);
@@ -3752,7 +3752,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteSingleAbort) {
 
   // Create dataset
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->CreateVertex();
     auto vertex_to = acc->CreateVertex();
 
@@ -3801,7 +3801,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteSingleAbort) {
 
   // Detach delete vertex, but abort the transaction
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -3865,7 +3865,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteSingleAbort) {
 
   // Check dataset
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -3906,7 +3906,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteSingleAbort) {
 
   // Detach delete vertex
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -3970,7 +3970,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteSingleAbort) {
 
   // Check dataset
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_FALSE(vertex_from);
@@ -3997,7 +3997,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteMultipleAbort) {
 
   // Create dataset
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex1 = acc->CreateVertex();
     auto vertex2 = acc->CreateVertex();
 
@@ -4124,7 +4124,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteMultipleAbort) {
 
   // Detach delete vertex, but abort the transaction
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex1 = acc->FindVertex(gid_vertex1, memgraph::storage::View::NEW);
     auto vertex2 = acc->FindVertex(gid_vertex2, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex1);
@@ -4262,7 +4262,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteMultipleAbort) {
 
   // Check dataset
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex1 = acc->FindVertex(gid_vertex1, memgraph::storage::View::NEW);
     auto vertex2 = acc->FindVertex(gid_vertex2, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex1);
@@ -4440,7 +4440,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteMultipleAbort) {
 
   // Detach delete vertex
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex1 = acc->FindVertex(gid_vertex1, memgraph::storage::View::NEW);
     auto vertex2 = acc->FindVertex(gid_vertex2, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex1);
@@ -4578,7 +4578,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteMultipleAbort) {
 
   // Check dataset
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex1 = acc->FindVertex(gid_vertex1, memgraph::storage::View::NEW);
     auto vertex2 = acc->FindVertex(gid_vertex2, memgraph::storage::View::NEW);
     ASSERT_FALSE(vertex1);
@@ -4640,7 +4640,7 @@ TEST(StorageWithProperties, EdgePropertyCommit) {
       new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = true}}}));
   memgraph::storage::Gid gid = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     auto et = acc->NameToEdgeType("et5");
@@ -4683,7 +4683,7 @@ TEST(StorageWithProperties, EdgePropertyCommit) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
     auto edge = vertex->OutEdges(memgraph::storage::View::NEW).GetValue().edges[0];
@@ -4712,7 +4712,7 @@ TEST(StorageWithProperties, EdgePropertyCommit) {
     acc->Abort();
   }
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
     auto edge = vertex->OutEdges(memgraph::storage::View::NEW).GetValue().edges[0];
@@ -4744,7 +4744,7 @@ TEST(StorageWithProperties, EdgePropertyCommit) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
     auto edge = vertex->OutEdges(memgraph::storage::View::NEW).GetValue().edges[0];
@@ -4773,7 +4773,7 @@ TEST(StorageWithProperties, EdgePropertyAbort) {
 
   // Create the vertex.
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     auto et = acc->NameToEdgeType("et5");
@@ -4786,7 +4786,7 @@ TEST(StorageWithProperties, EdgePropertyAbort) {
 
   // Set property 5 to "nandare", but abort the transaction.
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
     auto edge = vertex->OutEdges(memgraph::storage::View::NEW).GetValue().edges[0];
@@ -4827,7 +4827,7 @@ TEST(StorageWithProperties, EdgePropertyAbort) {
 
   // Check that property 5 is null.
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
     auto edge = vertex->OutEdges(memgraph::storage::View::NEW).GetValue().edges[0];
@@ -4849,7 +4849,7 @@ TEST(StorageWithProperties, EdgePropertyAbort) {
 
   // Set property 5 to "nandare".
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
     auto edge = vertex->OutEdges(memgraph::storage::View::NEW).GetValue().edges[0];
@@ -4890,7 +4890,7 @@ TEST(StorageWithProperties, EdgePropertyAbort) {
 
   // Check that property 5 is "nandare".
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
     auto edge = vertex->OutEdges(memgraph::storage::View::NEW).GetValue().edges[0];
@@ -4921,7 +4921,7 @@ TEST(StorageWithProperties, EdgePropertyAbort) {
 
   // Set property 5 to null, but abort the transaction.
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
     auto edge = vertex->OutEdges(memgraph::storage::View::NEW).GetValue().edges[0];
@@ -4963,7 +4963,7 @@ TEST(StorageWithProperties, EdgePropertyAbort) {
 
   // Check that property 5 is "nandare".
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
     auto edge = vertex->OutEdges(memgraph::storage::View::NEW).GetValue().edges[0];
@@ -4994,7 +4994,7 @@ TEST(StorageWithProperties, EdgePropertyAbort) {
 
   // Set property 5 to null.
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
     auto edge = vertex->OutEdges(memgraph::storage::View::NEW).GetValue().edges[0];
@@ -5036,7 +5036,7 @@ TEST(StorageWithProperties, EdgePropertyAbort) {
 
   // Check that property 5 is null.
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
     auto edge = vertex->OutEdges(memgraph::storage::View::NEW).GetValue().edges[0];
@@ -5063,7 +5063,7 @@ TEST(StorageWithProperties, EdgePropertySerializationError) {
       new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = true}}}));
   memgraph::storage::Gid gid = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     auto et = acc->NameToEdgeType("et5");
@@ -5074,8 +5074,8 @@ TEST(StorageWithProperties, EdgePropertySerializationError) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
 
-  auto acc1 = store->Access(ReplicationRole::MAIN);
-  auto acc2 = store->Access(ReplicationRole::MAIN);
+  auto acc1 = store->Access();
+  auto acc2 = store->Access();
 
   // Set property 1 to 123 in accessor 1.
   {
@@ -5140,7 +5140,7 @@ TEST(StorageWithProperties, EdgePropertySerializationError) {
 
   // Check which properties exist.
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
     auto edge = vertex->OutEdges(memgraph::storage::View::NEW).GetValue().edges[0];
@@ -5175,7 +5175,7 @@ TEST(StorageWithProperties, EdgePropertyClear) {
   auto property1 = store->NameToProperty("property1");
   auto property2 = store->NameToProperty("property2");
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     auto et = acc->NameToEdgeType("et5");
@@ -5191,7 +5191,7 @@ TEST(StorageWithProperties, EdgePropertyClear) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
     auto edge = vertex->OutEdges(memgraph::storage::View::NEW).GetValue().edges[0];
@@ -5224,7 +5224,7 @@ TEST(StorageWithProperties, EdgePropertyClear) {
     acc->Abort();
   }
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
     auto edge = vertex->OutEdges(memgraph::storage::View::NEW).GetValue().edges[0];
@@ -5236,7 +5236,7 @@ TEST(StorageWithProperties, EdgePropertyClear) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
     auto edge = vertex->OutEdges(memgraph::storage::View::NEW).GetValue().edges[0];
@@ -5270,7 +5270,7 @@ TEST(StorageWithProperties, EdgePropertyClear) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
     auto edge = vertex->OutEdges(memgraph::storage::View::NEW).GetValue().edges[0];
@@ -5289,7 +5289,7 @@ TEST(StorageWithoutProperties, EdgePropertyAbort) {
       new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = false}}}));
   memgraph::storage::Gid gid = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     auto et = acc->NameToEdgeType("et5");
@@ -5300,7 +5300,7 @@ TEST(StorageWithoutProperties, EdgePropertyAbort) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
     auto edge = vertex->OutEdges(memgraph::storage::View::NEW).GetValue().edges[0];
@@ -5331,7 +5331,7 @@ TEST(StorageWithoutProperties, EdgePropertyAbort) {
     acc->Abort();
   }
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
     auto edge = vertex->OutEdges(memgraph::storage::View::NEW).GetValue().edges[0];
@@ -5358,7 +5358,7 @@ TEST(StorageWithoutProperties, EdgePropertyClear) {
       new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = false}}}));
   memgraph::storage::Gid gid;
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     auto et = acc->NameToEdgeType("et5");
@@ -5369,7 +5369,7 @@ TEST(StorageWithoutProperties, EdgePropertyClear) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
     auto edge = vertex->OutEdges(memgraph::storage::View::NEW).GetValue().edges[0];
@@ -5386,7 +5386,7 @@ TEST(StorageWithProperties, EdgeNonexistentPropertyAPI) {
 
   auto property = store->NameToProperty("property");
 
-  auto acc = store->Access(ReplicationRole::MAIN);
+  auto acc = store->Access();
   auto vertex = acc->CreateVertex();
   auto edge = acc->CreateEdge(&vertex, &vertex, acc->NameToEdgeType("edge"));
   ASSERT_TRUE(edge.HasValue());

--- a/tests/unit/storage_v2_edge_ondisk.cpp
+++ b/tests/unit/storage_v2_edge_ondisk.cpp
@@ -38,7 +38,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSmallerCommit) {
 
   // Create vertices
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->CreateVertex();
     auto vertex_to = acc->CreateVertex();
     gid_from = vertex_from.Gid();
@@ -48,7 +48,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSmallerCommit) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -122,7 +122,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSmallerCommit) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -231,7 +231,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromLargerCommit) {
 
   // Create vertices
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_to = acc->CreateVertex();
     auto vertex_from = acc->CreateVertex();
     gid_to = vertex_to.Gid();
@@ -241,7 +241,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromLargerCommit) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -309,7 +309,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromLargerCommit) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -405,7 +405,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSameCommit) {
 
   // Create vertex
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->CreateVertex();
     gid_vertex = vertex.Gid();
     ASSERT_FALSE(acc->Commit().HasError());
@@ -413,7 +413,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSameCommit) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -471,7 +471,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSameCommit) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -554,7 +554,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSmallerAbort) {
 
   // Create vertices
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->CreateVertex();
     auto vertex_to = acc->CreateVertex();
     gid_from = vertex_from.Gid();
@@ -564,7 +564,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSmallerAbort) {
 
   // Create edge, but abort the transaction
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -632,7 +632,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSmallerAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -661,7 +661,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSmallerAbort) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -729,7 +729,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSmallerAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -826,7 +826,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromLargerAbort) {
 
   // Create vertices
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_to = acc->CreateVertex();
     auto vertex_from = acc->CreateVertex();
     gid_to = vertex_to.Gid();
@@ -836,7 +836,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromLargerAbort) {
 
   // Create edge, but abort the transaction
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -904,7 +904,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromLargerAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -933,7 +933,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromLargerAbort) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -1001,7 +1001,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromLargerAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -1097,7 +1097,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSameAbort) {
 
   // Create vertex
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->CreateVertex();
     gid_vertex = vertex.Gid();
     ASSERT_FALSE(acc->Commit().HasError());
@@ -1105,7 +1105,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSameAbort) {
 
   // Create edge, but abort the transaction
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -1163,7 +1163,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSameAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -1182,7 +1182,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSameAbort) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -1240,7 +1240,7 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSameAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -1327,7 +1327,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerCommit) {
 
   // Create vertices
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->CreateVertex();
     auto vertex_to = acc->CreateVertex();
     gid_from = vertex_from.Gid();
@@ -1337,7 +1337,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerCommit) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -1405,7 +1405,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerCommit) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -1492,7 +1492,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerCommit) {
 
   // Delete edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -1559,7 +1559,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerCommit) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -1598,7 +1598,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerCommit) {
 
   // Create vertices
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_to = acc->CreateVertex();
     auto vertex_from = acc->CreateVertex();
     gid_from = vertex_from.Gid();
@@ -1608,7 +1608,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerCommit) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -1676,7 +1676,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerCommit) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -1763,7 +1763,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerCommit) {
 
   // Delete edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -1830,7 +1830,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerCommit) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -1868,7 +1868,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameCommit) {
 
   // Create vertex
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->CreateVertex();
     gid_vertex = vertex.Gid();
     ASSERT_FALSE(acc->Commit().HasError());
@@ -1876,7 +1876,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameCommit) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -1934,7 +1934,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameCommit) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -2011,7 +2011,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameCommit) {
 
   // Delete edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -2068,7 +2068,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameCommit) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -2097,7 +2097,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerAbort) {
 
   // Create vertices
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->CreateVertex();
     auto vertex_to = acc->CreateVertex();
     gid_from = vertex_from.Gid();
@@ -2107,7 +2107,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerAbort) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2175,7 +2175,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2262,7 +2262,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerAbort) {
 
   // Delete the edge, but abort the transaction
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2329,7 +2329,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2416,7 +2416,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerAbort) {
 
   // Delete the edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2483,7 +2483,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2522,7 +2522,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerAbort) {
 
   // Create vertices
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->CreateVertex();
     auto vertex_to = acc->CreateVertex();
     gid_from = vertex_from.Gid();
@@ -2532,7 +2532,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerAbort) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2600,7 +2600,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2687,7 +2687,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerAbort) {
 
   // Delete the edge, but abort the transaction
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2754,7 +2754,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2842,7 +2842,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerAbort) {
 
   // Delete the edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2909,7 +2909,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -2947,7 +2947,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameAbort) {
 
   // Create vertex
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->CreateVertex();
     gid_vertex = vertex.Gid();
     ASSERT_FALSE(acc->Commit().HasError());
@@ -2955,7 +2955,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameAbort) {
 
   // Create edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -3013,7 +3013,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -3090,7 +3090,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameAbort) {
 
   // Delete the edge, but abort the transaction
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -3147,7 +3147,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -3224,7 +3224,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameAbort) {
 
   // Delete the edge
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -3281,7 +3281,7 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameAbort) {
 
   // Check whether the edge exists
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid_vertex, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex);
 
@@ -3310,7 +3310,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteSingleCommit) {
 
   // Create dataset
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->CreateVertex();
     auto vertex_to = acc->CreateVertex();
 
@@ -3359,7 +3359,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteSingleCommit) {
 
   // Detach delete vertex
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -3423,7 +3423,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteSingleCommit) {
 
   // Check dataset
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_FALSE(vertex_from);
@@ -3452,7 +3452,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteMultipleCommit) {
 
   // Create dataset
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex1 = acc->CreateVertex();
     auto vertex2 = acc->CreateVertex();
 
@@ -3579,7 +3579,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteMultipleCommit) {
 
   // Detach delete vertex
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex1 = acc->FindVertex(gid_vertex1, memgraph::storage::View::NEW);
     auto vertex2 = acc->FindVertex(gid_vertex2, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex1);
@@ -3717,7 +3717,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteMultipleCommit) {
 
   // Check dataset
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex1 = acc->FindVertex(gid_vertex1, memgraph::storage::View::NEW);
     auto vertex2 = acc->FindVertex(gid_vertex2, memgraph::storage::View::NEW);
     ASSERT_FALSE(vertex1);
@@ -3784,7 +3784,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteSingleAbort) {
 
   // Create dataset
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->CreateVertex();
     auto vertex_to = acc->CreateVertex();
 
@@ -3833,7 +3833,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteSingleAbort) {
 
   // Detach delete vertex, but abort the transaction
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -3897,7 +3897,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteSingleAbort) {
 
   // Check dataset
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -3938,7 +3938,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteSingleAbort) {
 
   // Detach delete vertex
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex_from);
@@ -4002,7 +4002,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteSingleAbort) {
 
   // Check dataset
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex_from = acc->FindVertex(gid_from, memgraph::storage::View::NEW);
     auto vertex_to = acc->FindVertex(gid_to, memgraph::storage::View::NEW);
     ASSERT_FALSE(vertex_from);
@@ -4031,7 +4031,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteMultipleAbort) {
 
   // Create dataset
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex1 = acc->CreateVertex();
     auto vertex2 = acc->CreateVertex();
 
@@ -4158,7 +4158,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteMultipleAbort) {
 
   // Detach delete vertex, but abort the transaction
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex1 = acc->FindVertex(gid_vertex1, memgraph::storage::View::NEW);
     auto vertex2 = acc->FindVertex(gid_vertex2, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex1);
@@ -4296,7 +4296,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteMultipleAbort) {
 
   // Check dataset
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex1 = acc->FindVertex(gid_vertex1, memgraph::storage::View::NEW);
     auto vertex2 = acc->FindVertex(gid_vertex2, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex1);
@@ -4474,7 +4474,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteMultipleAbort) {
 
   // Detach delete vertex
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex1 = acc->FindVertex(gid_vertex1, memgraph::storage::View::NEW);
     auto vertex2 = acc->FindVertex(gid_vertex2, memgraph::storage::View::NEW);
     ASSERT_TRUE(vertex1);
@@ -4612,7 +4612,7 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteMultipleAbort) {
 
   // Check dataset
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex1 = acc->FindVertex(gid_vertex1, memgraph::storage::View::NEW);
     auto vertex2 = acc->FindVertex(gid_vertex2, memgraph::storage::View::NEW);
     ASSERT_FALSE(vertex1);
@@ -4676,7 +4676,7 @@ TEST(StorageWithProperties, EdgePropertyCommit) {
   std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::DiskStorage(config));
   memgraph::storage::Gid gid = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     auto et = acc->NameToEdgeType("et5");
@@ -4719,7 +4719,7 @@ TEST(StorageWithProperties, EdgePropertyCommit) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -4749,7 +4749,7 @@ TEST(StorageWithProperties, EdgePropertyCommit) {
     acc->Abort();
   }
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -4782,7 +4782,7 @@ TEST(StorageWithProperties, EdgePropertyCommit) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -4814,7 +4814,7 @@ TEST(StorageWithProperties, EdgePropertyAbort) {
 
   // Create the vertex.
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     auto et = acc->NameToEdgeType("et5");
@@ -4827,7 +4827,7 @@ TEST(StorageWithProperties, EdgePropertyAbort) {
 
   // Set property 5 to "nandare", but abort the transaction.
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -4869,7 +4869,7 @@ TEST(StorageWithProperties, EdgePropertyAbort) {
 
   // Check that property 5 is null.
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
     auto edge = vertex->OutEdges(memgraph::storage::View::NEW).GetValue().edges[0];
@@ -4891,7 +4891,7 @@ TEST(StorageWithProperties, EdgePropertyAbort) {
 
   // Set property 5 to "nandare".
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -4933,7 +4933,7 @@ TEST(StorageWithProperties, EdgePropertyAbort) {
 
   // Check that property 5 is "nandare".
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -4965,7 +4965,7 @@ TEST(StorageWithProperties, EdgePropertyAbort) {
 
   // Set property 5 to null, but abort the transaction.
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -5008,7 +5008,7 @@ TEST(StorageWithProperties, EdgePropertyAbort) {
 
   // Check that property 5 is "nandare".
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -5040,7 +5040,7 @@ TEST(StorageWithProperties, EdgePropertyAbort) {
 
   // Set property 5 to null.
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -5083,7 +5083,7 @@ TEST(StorageWithProperties, EdgePropertyAbort) {
 
   // Check that property 5 is null.
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -5113,7 +5113,7 @@ TEST(StorageWithProperties, EdgePropertySerializationError) {
   std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::DiskStorage(config));
   memgraph::storage::Gid gid = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     auto et = acc->NameToEdgeType("et5");
@@ -5124,8 +5124,8 @@ TEST(StorageWithProperties, EdgePropertySerializationError) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
 
-  auto acc1 = store->Access(ReplicationRole::MAIN);
-  auto acc2 = store->Access(ReplicationRole::MAIN);
+  auto acc1 = store->Access();
+  auto acc2 = store->Access();
 
   // Set property 1 to 123 in accessor 1.
   {
@@ -5196,7 +5196,7 @@ TEST(StorageWithProperties, EdgePropertySerializationError) {
 
   // Check which properties exist.
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -5234,7 +5234,7 @@ TEST(StorageWithProperties, EdgePropertyClear) {
   auto property1 = store->NameToProperty("property1");
   auto property2 = store->NameToProperty("property2");
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     auto et = acc->NameToEdgeType("et5");
@@ -5250,7 +5250,7 @@ TEST(StorageWithProperties, EdgePropertyClear) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -5284,7 +5284,7 @@ TEST(StorageWithProperties, EdgePropertyClear) {
     acc->Abort();
   }
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -5297,7 +5297,7 @@ TEST(StorageWithProperties, EdgePropertyClear) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -5332,7 +5332,7 @@ TEST(StorageWithProperties, EdgePropertyClear) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -5354,7 +5354,7 @@ TEST(StorageWithoutProperties, EdgePropertyAbort) {
   std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::DiskStorage(config));
   memgraph::storage::Gid gid = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     spdlog::trace("Created vertex with gid: {}", gid.AsInt());
@@ -5366,7 +5366,7 @@ TEST(StorageWithoutProperties, EdgePropertyAbort) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -5398,7 +5398,7 @@ TEST(StorageWithoutProperties, EdgePropertyAbort) {
     acc->Abort();
   }
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -5428,7 +5428,7 @@ TEST(StorageWithoutProperties, EdgePropertyClear) {
   std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::DiskStorage(config));
   memgraph::storage::Gid gid;
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->CreateVertex();
     gid = vertex.Gid();
     auto et = acc->NameToEdgeType("et5");
@@ -5439,7 +5439,7 @@ TEST(StorageWithoutProperties, EdgePropertyClear) {
     ASSERT_FALSE(acc->Commit().HasError());
   }
   {
-    auto acc = store->Access(ReplicationRole::MAIN);
+    auto acc = store->Access();
     auto vertex = acc->FindVertex(gid, memgraph::storage::View::OLD);
     ASSERT_TRUE(vertex);
 
@@ -5459,7 +5459,7 @@ TEST(StorageWithProperties, EdgeNonexistentPropertyAPI) {
 
   auto property = store->NameToProperty("property");
 
-  auto acc = store->Access(ReplicationRole::MAIN);
+  auto acc = store->Access();
   auto vertex = acc->CreateVertex();
   auto edge = acc->CreateEdge(&vertex, &vertex, acc->NameToEdgeType("edge"));
   ASSERT_TRUE(edge.HasValue());

--- a/tests/unit/storage_v2_gc.cpp
+++ b/tests/unit/storage_v2_gc.cpp
@@ -32,7 +32,7 @@ TEST(StorageV2Gc, Sanity) {
   std::vector<memgraph::storage::Gid> vertices;
 
   {
-    auto acc = storage->Access(ReplicationRole::MAIN);
+    auto acc = storage->Access();
     // Create some vertices, but delete some of them immediately.
     for (uint64_t i = 0; i < 1000; ++i) {
       auto vertex = acc->CreateVertex();
@@ -64,7 +64,7 @@ TEST(StorageV2Gc, Sanity) {
 
   // Verify existing vertices and add labels to some of them.
   {
-    auto acc = storage->Access(ReplicationRole::MAIN);
+    auto acc = storage->Access();
     for (uint64_t i = 0; i < 1000; ++i) {
       auto vertex = acc->FindVertex(vertices[i], memgraph::storage::View::OLD);
       EXPECT_EQ(vertex.has_value(), i % 5 != 0);
@@ -102,7 +102,7 @@ TEST(StorageV2Gc, Sanity) {
 
   // Add and remove some edges.
   {
-    auto acc = storage->Access(ReplicationRole::MAIN);
+    auto acc = storage->Access();
     for (uint64_t i = 0; i < 1000; ++i) {
       auto from_vertex = acc->FindVertex(vertices[i], memgraph::storage::View::OLD);
       auto to_vertex = acc->FindVertex(vertices[(i + 1) % 1000], memgraph::storage::View::OLD);
@@ -172,13 +172,13 @@ TEST(StorageV2Gc, Indices) {
       std::make_unique<memgraph::storage::InMemoryStorage>(memgraph::storage::Config{
           .gc = {.type = memgraph::storage::Config::Gc::Type::PERIODIC, .interval = std::chrono::milliseconds(100)}}));
   {
-    auto unique_acc = storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = storage->UniqueAccess();
     ASSERT_FALSE(unique_acc->CreateIndex(storage->NameToLabel("label")).HasError());
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
 
   {
-    auto acc0 = storage->Access(ReplicationRole::MAIN);
+    auto acc0 = storage->Access();
     for (uint64_t i = 0; i < 1000; ++i) {
       auto vertex = acc0->CreateVertex();
       ASSERT_TRUE(*vertex.AddLabel(acc0->NameToLabel("label")));
@@ -186,9 +186,9 @@ TEST(StorageV2Gc, Indices) {
     ASSERT_FALSE(acc0->Commit().HasError());
   }
   {
-    auto acc1 = storage->Access(ReplicationRole::MAIN);
+    auto acc1 = storage->Access();
 
-    auto acc2 = storage->Access(ReplicationRole::MAIN);
+    auto acc2 = storage->Access();
     for (auto vertex : acc2->Vertices(memgraph::storage::View::OLD)) {
       ASSERT_TRUE(*vertex.RemoveLabel(acc2->NameToLabel("label")));
     }

--- a/tests/unit/storage_v2_get_info.cpp
+++ b/tests/unit/storage_v2_get_info.cpp
@@ -63,17 +63,17 @@ TYPED_TEST(InfoTest, InfoCheck) {
 
   {
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       ASSERT_FALSE(unique_acc->CreateExistenceConstraint(lbl, prop).HasError());
       ASSERT_FALSE(unique_acc->Commit().HasError());
     }
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       ASSERT_FALSE(unique_acc->DropExistenceConstraint(lbl, prop).HasError());
       ASSERT_FALSE(unique_acc->Commit().HasError());
     }
 
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto v1 = acc->CreateVertex();
     auto v2 = acc->CreateVertex();
     auto v3 = acc->CreateVertex();
@@ -93,49 +93,49 @@ TYPED_TEST(InfoTest, InfoCheck) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     ASSERT_FALSE(unique_acc->CreateIndex(lbl).HasError());
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     ASSERT_FALSE(unique_acc->CreateIndex(lbl, prop).HasError());
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     ASSERT_FALSE(unique_acc->CreateIndex(lbl, prop2).HasError());
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     ASSERT_FALSE(unique_acc->DropIndex(lbl, prop).HasError());
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     ASSERT_FALSE(unique_acc->CreateUniqueConstraint(lbl, {prop2}).HasError());
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     ASSERT_FALSE(unique_acc->CreateUniqueConstraint(lbl2, {prop}).HasError());
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     ASSERT_FALSE(unique_acc->CreateUniqueConstraint(lbl3, {prop}).HasError());
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     ASSERT_EQ(unique_acc->DropUniqueConstraint(lbl, {prop2}),
               memgraph::storage::UniqueConstraints::DeletionStatus::SUCCESS);
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
 
-  StorageInfo info = this->storage->GetInfo(ReplicationRole::MAIN);
+  StorageInfo info = this->storage->GetInfo();
 
   ASSERT_EQ(info.vertex_count, 5);
   ASSERT_EQ(info.edge_count, 2);

--- a/tests/unit/storage_v2_indices.cpp
+++ b/tests/unit/storage_v2_indices.cpp
@@ -25,7 +25,6 @@
 
 // NOLINTNEXTLINE(google-build-using-namespace)
 using namespace memgraph::storage;
-using memgraph::replication_coordination_glue::ReplicationRole;
 using testing::IsEmpty;
 using testing::Types;
 using testing::UnorderedElementsAre;
@@ -39,7 +38,7 @@ class IndexTest : public testing::Test {
   void SetUp() override {
     config_ = disk_test_utils::GenerateOnDiskConfig(testSuite);
     this->storage = std::make_unique<StorageType>(config_);
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     this->prop_id = acc->NameToProperty("id");
     this->prop_val = acc->NameToProperty("val");
     this->label1 = acc->NameToLabel("label1");
@@ -109,13 +108,13 @@ TYPED_TEST_SUITE(IndexTest, StorageTypes);
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TYPED_TEST(IndexTest, LabelIndexCreate) {
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_FALSE(acc->LabelIndexExists(this->label1));
     EXPECT_EQ(acc->ListAllIndices().label.size(), 0);
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (int i = 0; i < 10; ++i) {
       auto vertex = this->CreateVertex(acc.get());
       ASSERT_NO_ERROR(vertex.AddLabel(i % 2 ? this->label1 : this->label2));
@@ -124,19 +123,19 @@ TYPED_TEST(IndexTest, LabelIndexCreate) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->label1).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(this->GetIds(acc->Vertices(this->label1, View::OLD), View::OLD), UnorderedElementsAre(1, 3, 5, 7, 9));
     EXPECT_THAT(this->GetIds(acc->Vertices(this->label1, View::NEW), View::NEW), UnorderedElementsAre(1, 3, 5, 7, 9));
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (int i = 10; i < 20; ++i) {
       auto vertex = this->CreateVertex(acc.get());
       ASSERT_NO_ERROR(vertex.AddLabel(i % 2 ? this->label1 : this->label2));
@@ -158,7 +157,7 @@ TYPED_TEST(IndexTest, LabelIndexCreate) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (int i = 10; i < 20; ++i) {
       auto vertex = this->CreateVertex(acc.get());
       ASSERT_NO_ERROR(vertex.AddLabel(i % 2 ? this->label1 : this->label2));
@@ -179,7 +178,7 @@ TYPED_TEST(IndexTest, LabelIndexCreate) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(this->GetIds(acc->Vertices(this->label1, View::OLD), View::OLD),
                 UnorderedElementsAre(1, 3, 5, 7, 9, 21, 23, 25, 27, 29));
     EXPECT_THAT(this->GetIds(acc->Vertices(this->label1, View::NEW), View::NEW),
@@ -199,13 +198,13 @@ TYPED_TEST(IndexTest, LabelIndexCreate) {
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TYPED_TEST(IndexTest, LabelIndexDrop) {
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_FALSE(acc->LabelIndexExists(this->label1));
     EXPECT_EQ(acc->ListAllIndices().label.size(), 0);
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (int i = 0; i < 10; ++i) {
       auto vertex = this->CreateVertex(acc.get());
       ASSERT_NO_ERROR(vertex.AddLabel(i % 2 ? this->label1 : this->label2));
@@ -214,41 +213,41 @@ TYPED_TEST(IndexTest, LabelIndexDrop) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->label1).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(this->GetIds(acc->Vertices(this->label1, View::OLD), View::OLD), UnorderedElementsAre(1, 3, 5, 7, 9));
     EXPECT_THAT(this->GetIds(acc->Vertices(this->label1, View::NEW), View::NEW), UnorderedElementsAre(1, 3, 5, 7, 9));
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->DropIndex(this->label1).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_FALSE(acc->LabelIndexExists(this->label1));
     EXPECT_EQ(acc->ListAllIndices().label.size(), 0);
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_TRUE(unique_acc->DropIndex(this->label1).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_FALSE(acc->LabelIndexExists(this->label1));
     EXPECT_EQ(acc->ListAllIndices().label.size(), 0);
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (int i = 10; i < 20; ++i) {
       auto vertex = this->CreateVertex(acc.get());
       ASSERT_NO_ERROR(vertex.AddLabel(i % 2 ? this->label1 : this->label2));
@@ -257,18 +256,18 @@ TYPED_TEST(IndexTest, LabelIndexDrop) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->label1).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_TRUE(acc->LabelIndexExists(this->label1));
     EXPECT_THAT(acc->ListAllIndices().label, UnorderedElementsAre(this->label1));
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
 
     EXPECT_THAT(this->GetIds(acc->Vertices(this->label1, View::OLD), View::OLD),
                 UnorderedElementsAre(1, 3, 5, 7, 9, 11, 13, 15, 17, 19));
@@ -294,17 +293,17 @@ TYPED_TEST(IndexTest, LabelIndexBasic) {
   //    vertices.
   // 4. Delete even numbered vertices.
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->label1).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->label2).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
 
-  auto acc = this->storage->Access(ReplicationRole::MAIN);
+  auto acc = this->storage->Access();
   EXPECT_THAT(acc->ListAllIndices().label, UnorderedElementsAre(this->label1, this->label2));
   EXPECT_THAT(this->GetIds(acc->Vertices(this->label1, View::OLD), View::OLD), IsEmpty());
   EXPECT_THAT(this->GetIds(acc->Vertices(this->label2, View::OLD), View::OLD), IsEmpty());
@@ -367,18 +366,18 @@ TYPED_TEST(IndexTest, LabelIndexDuplicateVersions) {
   // the same vertex in the index (they only differ by the timestamp). This test
   // checks that duplicates are properly filtered out.
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->label1).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->label2).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (int i = 0; i < 5; ++i) {
       auto vertex = this->CreateVertex(acc.get());
       ASSERT_NO_ERROR(vertex.AddLabel(this->label1));
@@ -390,7 +389,7 @@ TYPED_TEST(IndexTest, LabelIndexDuplicateVersions) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(this->GetIds(acc->Vertices(this->label1, View::OLD), View::OLD), UnorderedElementsAre(0, 1, 2, 3, 4));
 
     for (auto vertex : acc->Vertices(View::OLD)) {
@@ -415,19 +414,19 @@ TYPED_TEST(IndexTest, LabelIndexDuplicateVersions) {
 TYPED_TEST(IndexTest, LabelIndexTransactionalIsolation) {
   // Check that transactions only see entries they are supposed to see.
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->label1).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->label2).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
 
-  auto acc_before = this->storage->Access(ReplicationRole::MAIN);
-  auto acc = this->storage->Access(ReplicationRole::MAIN);
-  auto acc_after = this->storage->Access(ReplicationRole::MAIN);
+  auto acc_before = this->storage->Access();
+  auto acc = this->storage->Access();
+  auto acc_after = this->storage->Access();
 
   for (int i = 0; i < 5; ++i) {
     auto vertex = this->CreateVertex(acc.get());
@@ -442,7 +441,7 @@ TYPED_TEST(IndexTest, LabelIndexTransactionalIsolation) {
 
   ASSERT_NO_ERROR(acc->Commit());
 
-  auto acc_after_commit = this->storage->Access(ReplicationRole::MAIN);
+  auto acc_after_commit = this->storage->Access();
 
   EXPECT_THAT(this->GetIds(acc_before->Vertices(this->label1, View::NEW), View::NEW), IsEmpty());
 
@@ -456,17 +455,17 @@ TYPED_TEST(IndexTest, LabelIndexTransactionalIsolation) {
 TYPED_TEST(IndexTest, LabelIndexCountEstimate) {
   if constexpr ((std::is_same_v<TypeParam, memgraph::storage::InMemoryStorage>)) {
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->CreateIndex(this->label1).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->CreateIndex(this->label2).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
 
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (int i = 0; i < 20; ++i) {
       auto vertex = this->CreateVertex(acc.get());
       ASSERT_NO_ERROR(vertex.AddLabel(i % 3 ? this->label1 : this->label2));
@@ -480,23 +479,23 @@ TYPED_TEST(IndexTest, LabelIndexCountEstimate) {
 TYPED_TEST(IndexTest, LabelIndexDeletedVertex) {
   if constexpr ((std::is_same_v<TypeParam, memgraph::storage::DiskStorage>)) {
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->CreateIndex(this->label1).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
-    auto acc1 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc1 = this->storage->Access();
     auto vertex1 = this->CreateVertex(acc1.get());
     ASSERT_NO_ERROR(vertex1.AddLabel(this->label1));
     auto vertex2 = this->CreateVertex(acc1.get());
     ASSERT_NO_ERROR(vertex2.AddLabel(this->label1));
     EXPECT_THAT(this->GetIds(acc1->Vertices(this->label1, View::NEW), View::NEW), UnorderedElementsAre(0, 1));
     ASSERT_NO_ERROR(acc1->Commit());
-    auto acc2 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc2 = this->storage->Access();
     auto vertex_to_delete = acc2->FindVertex(vertex1.Gid(), memgraph::storage::View::NEW);
     auto res = acc2->DeleteVertex(&*vertex_to_delete);
     ASSERT_FALSE(res.HasError());
     ASSERT_NO_ERROR(acc2->Commit());
-    auto acc3 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc3 = this->storage->Access();
     EXPECT_THAT(this->GetIds(acc3->Vertices(this->label1, View::NEW), View::NEW), UnorderedElementsAre(1));
   }
 }
@@ -504,23 +503,23 @@ TYPED_TEST(IndexTest, LabelIndexDeletedVertex) {
 TYPED_TEST(IndexTest, LabelIndexRemoveIndexedLabel) {
   if constexpr ((std::is_same_v<TypeParam, memgraph::storage::DiskStorage>)) {
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->CreateIndex(this->label1).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
-    auto acc1 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc1 = this->storage->Access();
     auto vertex1 = this->CreateVertex(acc1.get());
     ASSERT_NO_ERROR(vertex1.AddLabel(this->label1));
     auto vertex2 = this->CreateVertex(acc1.get());
     ASSERT_NO_ERROR(vertex2.AddLabel(this->label1));
     ASSERT_NO_ERROR(acc1->Commit());
-    auto acc2 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc2 = this->storage->Access();
     EXPECT_THAT(this->GetIds(acc2->Vertices(this->label1, View::NEW), View::NEW), UnorderedElementsAre(0, 1));
     auto vertex_to_delete = acc2->FindVertex(vertex1.Gid(), memgraph::storage::View::NEW);
     auto res = vertex_to_delete->RemoveLabel(this->label1);
     ASSERT_FALSE(res.HasError());
     ASSERT_NO_ERROR(acc2->Commit());
-    auto acc3 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc3 = this->storage->Access();
     EXPECT_THAT(this->GetIds(acc3->Vertices(this->label1, View::NEW), View::NEW), UnorderedElementsAre(1));
   }
 }
@@ -528,17 +527,17 @@ TYPED_TEST(IndexTest, LabelIndexRemoveIndexedLabel) {
 TYPED_TEST(IndexTest, LabelIndexRemoveAndAddIndexedLabel) {
   if constexpr ((std::is_same_v<TypeParam, memgraph::storage::DiskStorage>)) {
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->CreateIndex(this->label1).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
-    auto acc1 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc1 = this->storage->Access();
     auto vertex1 = this->CreateVertex(acc1.get());
     ASSERT_NO_ERROR(vertex1.AddLabel(this->label1));
     auto vertex2 = this->CreateVertex(acc1.get());
     ASSERT_NO_ERROR(vertex2.AddLabel(this->label1));
     ASSERT_NO_ERROR(acc1->Commit());
-    auto acc2 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc2 = this->storage->Access();
     EXPECT_THAT(this->GetIds(acc2->Vertices(this->label1, View::NEW), View::NEW), UnorderedElementsAre(0, 1));
     auto vertex_to_delete = acc2->FindVertex(vertex1.Gid(), memgraph::storage::View::NEW);
     auto res_remove = vertex_to_delete->RemoveLabel(this->label1);
@@ -546,7 +545,7 @@ TYPED_TEST(IndexTest, LabelIndexRemoveAndAddIndexedLabel) {
     auto res_add = vertex_to_delete->AddLabel(this->label1);
     ASSERT_FALSE(res_add.HasError());
     ASSERT_NO_ERROR(acc2->Commit());
-    auto acc3 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc3 = this->storage->Access();
     EXPECT_THAT(this->GetIds(acc3->Vertices(this->label1, View::NEW), View::NEW), UnorderedElementsAre(0, 1));
   }
 }
@@ -557,11 +556,11 @@ TYPED_TEST(IndexTest, LabelIndexClearOldDataFromDisk) {
         static_cast<memgraph::storage::DiskLabelIndex *>(this->storage->indices_.label_index_.get());
 
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->CreateIndex(this->label1).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
-    auto acc1 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc1 = this->storage->Access();
     auto vertex = this->CreateVertex(acc1.get());
     ASSERT_NO_ERROR(vertex.AddLabel(this->label1));
     ASSERT_NO_ERROR(vertex.SetProperty(this->prop_val, PropertyValue(10)));
@@ -570,14 +569,14 @@ TYPED_TEST(IndexTest, LabelIndexClearOldDataFromDisk) {
     auto *tx_db = disk_label_index->GetRocksDBStorage()->db_;
     ASSERT_EQ(disk_test_utils::GetRealNumberOfEntriesInRocksDB(tx_db), 1);
 
-    auto acc2 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc2 = this->storage->Access();
     auto vertex2 = acc2->FindVertex(vertex.Gid(), memgraph::storage::View::NEW).value();
     ASSERT_TRUE(vertex2.SetProperty(this->prop_val, memgraph::storage::PropertyValue(10)).HasValue());
     ASSERT_FALSE(acc2->Commit().HasError());
 
     ASSERT_EQ(disk_test_utils::GetRealNumberOfEntriesInRocksDB(tx_db), 1);
 
-    auto acc3 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc3 = this->storage->Access();
     auto vertex3 = acc3->FindVertex(vertex.Gid(), memgraph::storage::View::NEW).value();
     ASSERT_TRUE(vertex3.SetProperty(this->prop_val, memgraph::storage::PropertyValue(15)).HasValue());
     ASSERT_FALSE(acc3->Commit().HasError());
@@ -589,92 +588,92 @@ TYPED_TEST(IndexTest, LabelIndexClearOldDataFromDisk) {
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TYPED_TEST(IndexTest, LabelPropertyIndexCreateAndDrop) {
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_EQ(acc->ListAllIndices().label_property.size(), 0);
   }
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->label1, this->prop_id).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_TRUE(acc->LabelPropertyIndexExists(this->label1, this->prop_id));
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(acc->ListAllIndices().label_property,
                 UnorderedElementsAre(std::make_pair(this->label1, this->prop_id)));
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_FALSE(acc->LabelPropertyIndexExists(this->label2, this->prop_id));
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_TRUE(unique_acc->CreateIndex(this->label1, this->prop_id).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(acc->ListAllIndices().label_property,
                 UnorderedElementsAre(std::make_pair(this->label1, this->prop_id)));
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->label2, this->prop_id).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_TRUE(acc->LabelPropertyIndexExists(this->label2, this->prop_id));
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(
         acc->ListAllIndices().label_property,
         UnorderedElementsAre(std::make_pair(this->label1, this->prop_id), std::make_pair(this->label2, this->prop_id)));
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->DropIndex(this->label1, this->prop_id).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_FALSE(acc->LabelPropertyIndexExists(this->label1, this->prop_id));
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(acc->ListAllIndices().label_property,
                 UnorderedElementsAre(std::make_pair(this->label2, this->prop_id)));
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_TRUE(unique_acc->DropIndex(this->label1, this->prop_id).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->DropIndex(this->label2, this->prop_id).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_FALSE(acc->LabelPropertyIndexExists(this->label2, this->prop_id));
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_EQ(acc->ListAllIndices().label_property.size(), 0);
   }
 }
@@ -687,17 +686,17 @@ TYPED_TEST(IndexTest, LabelPropertyIndexCreateAndDrop) {
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TYPED_TEST(IndexTest, LabelPropertyIndexBasic) {
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->label1, this->prop_val).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->label2, this->prop_val).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
 
-  auto acc = this->storage->Access(ReplicationRole::MAIN);
+  auto acc = this->storage->Access();
   EXPECT_THAT(this->GetIds(acc->Vertices(this->label1, this->prop_val, View::OLD), View::OLD), IsEmpty());
 
   for (int i = 0; i < 10; ++i) {
@@ -782,13 +781,13 @@ TYPED_TEST(IndexTest, LabelPropertyIndexBasic) {
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TYPED_TEST(IndexTest, LabelPropertyIndexDuplicateVersions) {
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->label1, this->prop_val).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (int i = 0; i < 5; ++i) {
       auto vertex = this->CreateVertex(acc.get());
       ASSERT_NO_ERROR(vertex.AddLabel(this->label1));
@@ -802,7 +801,7 @@ TYPED_TEST(IndexTest, LabelPropertyIndexDuplicateVersions) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(this->GetIds(acc->Vertices(this->label1, this->prop_val, View::OLD), View::OLD),
                 UnorderedElementsAre(0, 1, 2, 3, 4));
 
@@ -829,14 +828,14 @@ TYPED_TEST(IndexTest, LabelPropertyIndexDuplicateVersions) {
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TYPED_TEST(IndexTest, LabelPropertyIndexTransactionalIsolation) {
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->label1, this->prop_val).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
 
-  auto acc_before = this->storage->Access(ReplicationRole::MAIN);
-  auto acc = this->storage->Access(ReplicationRole::MAIN);
-  auto acc_after = this->storage->Access(ReplicationRole::MAIN);
+  auto acc_before = this->storage->Access();
+  auto acc = this->storage->Access();
+  auto acc_after = this->storage->Access();
 
   for (int i = 0; i < 5; ++i) {
     auto vertex = this->CreateVertex(acc.get());
@@ -853,7 +852,7 @@ TYPED_TEST(IndexTest, LabelPropertyIndexTransactionalIsolation) {
 
   ASSERT_NO_ERROR(acc->Commit());
 
-  auto acc_after_commit = this->storage->Access(ReplicationRole::MAIN);
+  auto acc_after_commit = this->storage->Access();
 
   EXPECT_THAT(this->GetIds(acc_before->Vertices(this->label1, this->prop_val, View::NEW), View::NEW), IsEmpty());
 
@@ -872,13 +871,13 @@ TYPED_TEST(IndexTest, LabelPropertyIndexFiltering) {
   // properly.
 
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->label1, this->prop_val).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
 
     for (int i = 0; i < 10; ++i) {
       auto vertex = this->CreateVertex(acc.get());
@@ -888,7 +887,7 @@ TYPED_TEST(IndexTest, LabelPropertyIndexFiltering) {
     ASSERT_NO_ERROR(acc->Commit());
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (int i = 0; i < 5; ++i) {
       EXPECT_THAT(this->GetIds(acc->Vertices(this->label1, this->prop_val, PropertyValue(i), View::OLD)),
                   UnorderedElementsAre(2 * i, 2 * i + 1));
@@ -946,12 +945,12 @@ TYPED_TEST(IndexTest, LabelPropertyIndexFiltering) {
 TYPED_TEST(IndexTest, LabelPropertyIndexCountEstimate) {
   if constexpr ((std::is_same_v<TypeParam, memgraph::storage::InMemoryStorage>)) {
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->CreateIndex(this->label1, this->prop_val).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
 
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (int i = 1; i <= 10; ++i) {
       for (int j = 0; j < i; ++j) {
         auto vertex = this->CreateVertex(acc.get());
@@ -974,7 +973,7 @@ TYPED_TEST(IndexTest, LabelPropertyIndexCountEstimate) {
 
 TYPED_TEST(IndexTest, LabelPropertyIndexMixedIteration) {
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->label1, this->prop_val).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
@@ -1023,7 +1022,7 @@ TYPED_TEST(IndexTest, LabelPropertyIndexMixedIteration) {
 
   // Create vertices, each with one of the values above.
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (const auto &value : values) {
       auto v = acc->CreateVertex();
       ASSERT_TRUE(v.AddLabel(this->label1).HasValue());
@@ -1034,7 +1033,7 @@ TYPED_TEST(IndexTest, LabelPropertyIndexMixedIteration) {
 
   // Verify that all nodes are in the index.
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto iterable = acc->Vertices(this->label1, this->prop_val, View::OLD);
     auto it = iterable.begin();
     for (const auto &value : values) {
@@ -1051,7 +1050,7 @@ TYPED_TEST(IndexTest, LabelPropertyIndexMixedIteration) {
   auto verify = [&](const std::optional<memgraph::utils::Bound<PropertyValue>> &from,
                     const std::optional<memgraph::utils::Bound<PropertyValue>> &to,
                     const std::vector<PropertyValue> &expected) {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto iterable = acc->Vertices(this->label1, this->prop_val, from, to, View::OLD);
     size_t i = 0;
     for (auto it = iterable.begin(); it != iterable.end(); ++it, ++i) {
@@ -1204,11 +1203,11 @@ TYPED_TEST(IndexTest, LabelPropertyIndexMixedIteration) {
 TYPED_TEST(IndexTest, LabelPropertyIndexDeletedVertex) {
   if constexpr ((std::is_same_v<TypeParam, memgraph::storage::DiskStorage>)) {
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->CreateIndex(this->label1, this->prop_val).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
-    auto acc1 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc1 = this->storage->Access();
 
     auto vertex1 = this->CreateVertex(acc1.get());
     ASSERT_NO_ERROR(vertex1.AddLabel(this->label1));
@@ -1221,13 +1220,13 @@ TYPED_TEST(IndexTest, LabelPropertyIndexDeletedVertex) {
     EXPECT_THAT(this->GetIds(acc1->Vertices(this->label1, View::NEW), View::NEW), UnorderedElementsAre(0, 1));
     ASSERT_NO_ERROR(acc1->Commit());
 
-    auto acc2 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc2 = this->storage->Access();
     auto vertex_to_delete = acc2->FindVertex(vertex1.Gid(), memgraph::storage::View::NEW);
     auto res = acc2->DeleteVertex(&*vertex_to_delete);
     ASSERT_FALSE(res.HasError());
     ASSERT_NO_ERROR(acc2->Commit());
 
-    auto acc3 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc3 = this->storage->Access();
     EXPECT_THAT(this->GetIds(acc3->Vertices(this->label1, this->prop_val, View::NEW), View::NEW),
                 UnorderedElementsAre(1));
   }
@@ -1237,11 +1236,11 @@ TYPED_TEST(IndexTest, LabelPropertyIndexDeletedVertex) {
 TYPED_TEST(IndexTest, LabelPropertyIndexRemoveIndexedLabel) {
   if constexpr ((std::is_same_v<TypeParam, memgraph::storage::DiskStorage>)) {
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->CreateIndex(this->label1, this->prop_val).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
-    auto acc1 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc1 = this->storage->Access();
 
     auto vertex1 = this->CreateVertex(acc1.get());
     ASSERT_NO_ERROR(vertex1.AddLabel(this->label1));
@@ -1254,13 +1253,13 @@ TYPED_TEST(IndexTest, LabelPropertyIndexRemoveIndexedLabel) {
     EXPECT_THAT(this->GetIds(acc1->Vertices(this->label1, View::NEW), View::NEW), UnorderedElementsAre(0, 1));
     ASSERT_NO_ERROR(acc1->Commit());
 
-    auto acc2 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc2 = this->storage->Access();
     auto vertex_to_delete = acc2->FindVertex(vertex1.Gid(), memgraph::storage::View::NEW);
     auto res = vertex_to_delete->RemoveLabel(this->label1);
     ASSERT_FALSE(res.HasError());
     ASSERT_NO_ERROR(acc2->Commit());
 
-    auto acc3 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc3 = this->storage->Access();
     EXPECT_THAT(this->GetIds(acc3->Vertices(this->label1, this->prop_val, View::NEW), View::NEW),
                 UnorderedElementsAre(1));
   }
@@ -1269,11 +1268,11 @@ TYPED_TEST(IndexTest, LabelPropertyIndexRemoveIndexedLabel) {
 TYPED_TEST(IndexTest, LabelPropertyIndexRemoveAndAddIndexedLabel) {
   if constexpr ((std::is_same_v<TypeParam, memgraph::storage::DiskStorage>)) {
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->CreateIndex(this->label1, this->prop_val).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
-    auto acc1 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc1 = this->storage->Access();
 
     auto vertex1 = this->CreateVertex(acc1.get());
     ASSERT_NO_ERROR(vertex1.AddLabel(this->label1));
@@ -1286,7 +1285,7 @@ TYPED_TEST(IndexTest, LabelPropertyIndexRemoveAndAddIndexedLabel) {
     EXPECT_THAT(this->GetIds(acc1->Vertices(this->label1, View::NEW), View::NEW), UnorderedElementsAre(0, 1));
     ASSERT_NO_ERROR(acc1->Commit());
 
-    auto acc2 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc2 = this->storage->Access();
     auto target_vertex = acc2->FindVertex(vertex1.Gid(), memgraph::storage::View::NEW);
     auto remove_res = target_vertex->RemoveLabel(this->label1);
     ASSERT_FALSE(remove_res.HasError());
@@ -1302,11 +1301,11 @@ TYPED_TEST(IndexTest, LabelPropertyIndexClearOldDataFromDisk) {
         static_cast<memgraph::storage::DiskLabelPropertyIndex *>(this->storage->indices_.label_property_index_.get());
 
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->CreateIndex(this->label1, this->prop_val).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
-    auto acc1 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc1 = this->storage->Access();
     auto vertex = this->CreateVertex(acc1.get());
     ASSERT_NO_ERROR(vertex.AddLabel(this->label1));
     ASSERT_NO_ERROR(vertex.SetProperty(this->prop_val, PropertyValue(10)));
@@ -1315,14 +1314,14 @@ TYPED_TEST(IndexTest, LabelPropertyIndexClearOldDataFromDisk) {
     auto *tx_db = disk_label_property_index->GetRocksDBStorage()->db_;
     ASSERT_EQ(disk_test_utils::GetRealNumberOfEntriesInRocksDB(tx_db), 1);
 
-    auto acc2 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc2 = this->storage->Access();
     auto vertex2 = acc2->FindVertex(vertex.Gid(), memgraph::storage::View::NEW).value();
     ASSERT_TRUE(vertex2.SetProperty(this->prop_val, memgraph::storage::PropertyValue(10)).HasValue());
     ASSERT_FALSE(acc2->Commit().HasError());
 
     ASSERT_EQ(disk_test_utils::GetRealNumberOfEntriesInRocksDB(tx_db), 1);
 
-    auto acc3 = this->storage->Access(ReplicationRole::MAIN);
+    auto acc3 = this->storage->Access();
     auto vertex3 = acc3->FindVertex(vertex.Gid(), memgraph::storage::View::NEW).value();
     ASSERT_TRUE(vertex3.SetProperty(this->prop_val, memgraph::storage::PropertyValue(15)).HasValue());
     ASSERT_FALSE(acc3->Commit().HasError());
@@ -1335,13 +1334,13 @@ TYPED_TEST(IndexTest, LabelPropertyIndexClearOldDataFromDisk) {
 TYPED_TEST(IndexTest, EdgeTypeIndexCreate) {
   if constexpr ((std::is_same_v<TypeParam, memgraph::storage::InMemoryStorage>)) {
     {
-      auto acc = this->storage->Access(ReplicationRole::MAIN);
+      auto acc = this->storage->Access();
       EXPECT_FALSE(acc->EdgeTypeIndexExists(this->edge_type_id1));
       EXPECT_EQ(acc->ListAllIndices().edge_type.size(), 0);
     }
 
     {
-      auto acc = this->storage->Access(ReplicationRole::MAIN);
+      auto acc = this->storage->Access();
       for (int i = 0; i < 10; ++i) {
         auto vertex_from = this->CreateVertexWithoutProperties(acc.get());
         auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
@@ -1351,13 +1350,13 @@ TYPED_TEST(IndexTest, EdgeTypeIndexCreate) {
     }
 
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
 
     {
-      auto acc = this->storage->Access(ReplicationRole::MAIN);
+      auto acc = this->storage->Access();
       EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, View::OLD), View::OLD),
                   UnorderedElementsAre(1, 3, 5, 7, 9));
       EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, View::NEW), View::NEW),
@@ -1365,7 +1364,7 @@ TYPED_TEST(IndexTest, EdgeTypeIndexCreate) {
     }
 
     {
-      auto acc = this->storage->Access(ReplicationRole::MAIN);
+      auto acc = this->storage->Access();
       for (int i = 10; i < 20; ++i) {
         auto vertex_from = this->CreateVertexWithoutProperties(acc.get());
         auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
@@ -1388,7 +1387,7 @@ TYPED_TEST(IndexTest, EdgeTypeIndexCreate) {
     }
 
     {
-      auto acc = this->storage->Access(ReplicationRole::MAIN);
+      auto acc = this->storage->Access();
       for (int i = 10; i < 20; ++i) {
         auto vertex_from = this->CreateVertexWithoutProperties(acc.get());
         auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
@@ -1411,7 +1410,7 @@ TYPED_TEST(IndexTest, EdgeTypeIndexCreate) {
     }
 
     {
-      auto acc = this->storage->Access(ReplicationRole::MAIN);
+      auto acc = this->storage->Access();
       EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, View::OLD), View::OLD),
                   UnorderedElementsAre(1, 3, 5, 7, 9, 21, 23, 25, 27, 29));
       EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, View::NEW), View::NEW),
@@ -1433,13 +1432,13 @@ TYPED_TEST(IndexTest, EdgeTypeIndexCreate) {
 TYPED_TEST(IndexTest, EdgeTypeIndexDrop) {
   if constexpr ((std::is_same_v<TypeParam, memgraph::storage::InMemoryStorage>)) {
     {
-      auto acc = this->storage->Access(ReplicationRole::MAIN);
+      auto acc = this->storage->Access();
       EXPECT_FALSE(acc->EdgeTypeIndexExists(this->edge_type_id1));
       EXPECT_EQ(acc->ListAllIndices().edge_type.size(), 0);
     }
 
     {
-      auto acc = this->storage->Access(ReplicationRole::MAIN);
+      auto acc = this->storage->Access();
       for (int i = 0; i < 10; ++i) {
         auto vertex_from = this->CreateVertexWithoutProperties(acc.get());
         auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
@@ -1449,13 +1448,13 @@ TYPED_TEST(IndexTest, EdgeTypeIndexDrop) {
     }
 
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
 
     {
-      auto acc = this->storage->Access(ReplicationRole::MAIN);
+      auto acc = this->storage->Access();
       EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, View::OLD), View::OLD),
                   UnorderedElementsAre(1, 3, 5, 7, 9));
       EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, View::NEW), View::NEW),
@@ -1463,29 +1462,29 @@ TYPED_TEST(IndexTest, EdgeTypeIndexDrop) {
     }
 
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->DropIndex(this->edge_type_id1).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
     {
-      auto acc = this->storage->Access(ReplicationRole::MAIN);
+      auto acc = this->storage->Access();
       EXPECT_FALSE(acc->EdgeTypeIndexExists(this->edge_type_id1));
       EXPECT_EQ(acc->ListAllIndices().label.size(), 0);
     }
 
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       EXPECT_TRUE(unique_acc->DropIndex(this->edge_type_id1).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
     {
-      auto acc = this->storage->Access(ReplicationRole::MAIN);
+      auto acc = this->storage->Access();
       EXPECT_FALSE(acc->EdgeTypeIndexExists(this->edge_type_id1));
       EXPECT_EQ(acc->ListAllIndices().label.size(), 0);
     }
 
     {
-      auto acc = this->storage->Access(ReplicationRole::MAIN);
+      auto acc = this->storage->Access();
       for (int i = 10; i < 20; ++i) {
         auto vertex_from = this->CreateVertexWithoutProperties(acc.get());
         auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
@@ -1495,18 +1494,18 @@ TYPED_TEST(IndexTest, EdgeTypeIndexDrop) {
     }
 
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
     {
-      auto acc = this->storage->Access(ReplicationRole::MAIN);
+      auto acc = this->storage->Access();
       EXPECT_TRUE(acc->EdgeTypeIndexExists(this->edge_type_id1));
       EXPECT_THAT(acc->ListAllIndices().edge_type, UnorderedElementsAre(this->edge_type_id1));
     }
 
     {
-      auto acc = this->storage->Access(ReplicationRole::MAIN);
+      auto acc = this->storage->Access();
 
       EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, View::OLD), View::OLD),
                   UnorderedElementsAre(1, 3, 5, 7, 9, 11, 13, 15, 17, 19));
@@ -1532,17 +1531,17 @@ TYPED_TEST(IndexTest, EdgeTypeIndexBasic) {
   // 3. Delete even numbered edges.
   if constexpr ((std::is_same_v<TypeParam, memgraph::storage::InMemoryStorage>)) {
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id2).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
 
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(acc->ListAllIndices().edge_type, UnorderedElementsAre(this->edge_type_id1, this->edge_type_id2));
     EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, View::OLD), View::OLD), IsEmpty());
     EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id2, View::OLD), View::OLD), IsEmpty());
@@ -1606,19 +1605,19 @@ TYPED_TEST(IndexTest, EdgeTypeIndexTransactionalIsolation) {
   if constexpr ((std::is_same_v<TypeParam, memgraph::storage::InMemoryStorage>)) {
     // Check that transactions only see entries they are supposed to see.
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id2).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
 
-    auto acc_before = this->storage->Access(ReplicationRole::MAIN);
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
-    auto acc_after = this->storage->Access(ReplicationRole::MAIN);
+    auto acc_before = this->storage->Access();
+    auto acc = this->storage->Access();
+    auto acc_after = this->storage->Access();
 
     for (int i = 0; i < 5; ++i) {
       auto vertex_from = this->CreateVertexWithoutProperties(acc.get());
@@ -1635,7 +1634,7 @@ TYPED_TEST(IndexTest, EdgeTypeIndexTransactionalIsolation) {
 
     ASSERT_NO_ERROR(acc->Commit());
 
-    auto acc_after_commit = this->storage->Access(ReplicationRole::MAIN);
+    auto acc_after_commit = this->storage->Access();
 
     EXPECT_THAT(this->GetIds(acc_before->Edges(this->edge_type_id1, View::NEW), View::NEW), IsEmpty());
 
@@ -1650,17 +1649,17 @@ TYPED_TEST(IndexTest, EdgeTypeIndexTransactionalIsolation) {
 TYPED_TEST(IndexTest, EdgeTypeIndexCountEstimate) {
   if constexpr ((std::is_same_v<TypeParam, memgraph::storage::InMemoryStorage>)) {
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id2).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
 
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (int i = 0; i < 20; ++i) {
       auto vertex_from = this->CreateVertexWithoutProperties(acc.get());
       auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
@@ -1676,12 +1675,12 @@ TYPED_TEST(IndexTest, EdgeTypeIndexCountEstimate) {
 TYPED_TEST(IndexTest, EdgeTypeIndexRepeatingEdgeTypesBetweenSameVertices) {
   if constexpr ((std::is_same_v<TypeParam, memgraph::storage::InMemoryStorage>)) {
     {
-      auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+      auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
     }
 
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     auto vertex_from = this->CreateVertexWithoutProperties(acc.get());
     auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
 
@@ -1702,13 +1701,13 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexCreate) {
     return;
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_FALSE(acc->EdgeTypePropertyIndexExists(this->edge_type_id1, this->edge_prop_id1));
     EXPECT_EQ(acc->ListAllIndices().edge_type_property.size(), 0);
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (int i = 0; i < 10; ++i) {
       auto vertex_from = this->CreateVertexWithoutProperties(acc.get());
       auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
@@ -1720,13 +1719,13 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexCreate) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, this->edge_prop_id1, View::OLD), View::OLD),
                 UnorderedElementsAre(1, 3, 5, 7, 9));
     EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, this->edge_prop_id1, View::NEW), View::NEW),
@@ -1734,7 +1733,7 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexCreate) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (int i = 10; i < 20; ++i) {
       auto vertex_from = this->CreateVertexWithoutProperties(acc.get());
       auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
@@ -1759,7 +1758,7 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexCreate) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (int i = 10; i < 20; ++i) {
       auto vertex_from = this->CreateVertexWithoutProperties(acc.get());
       auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
@@ -1784,7 +1783,7 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexCreate) {
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, this->edge_prop_id1, View::OLD), View::OLD),
                 UnorderedElementsAre(1, 3, 5, 7, 9, 21, 23, 25, 27, 29));
     EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, this->edge_prop_id1, View::NEW), View::NEW),
@@ -1807,13 +1806,13 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexDrop) {
     return;
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_FALSE(acc->EdgeTypePropertyIndexExists(this->edge_type_id1, this->edge_prop_id1));
     EXPECT_EQ(acc->ListAllIndices().edge_type_property.size(), 0);
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (int i = 0; i < 10; ++i) {
       auto vertex_from = this->CreateVertexWithoutProperties(acc.get());
       auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
@@ -1825,13 +1824,13 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexDrop) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, this->edge_prop_id1, View::OLD), View::OLD),
                 UnorderedElementsAre(1, 3, 5, 7, 9));
     EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, this->edge_prop_id1, View::NEW), View::NEW),
@@ -1839,29 +1838,29 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexDrop) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->DropIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_FALSE(acc->EdgeTypePropertyIndexExists(this->edge_type_id1, this->edge_prop_id1));
     EXPECT_EQ(acc->ListAllIndices().edge_type_property.size(), 0);
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_TRUE(unique_acc->DropIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_FALSE(acc->EdgeTypePropertyIndexExists(this->edge_type_id1, this->edge_prop_id1));
     EXPECT_EQ(acc->ListAllIndices().edge_type_property.size(), 0);
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     for (int i = 10; i < 20; ++i) {
       auto vertex_from = this->CreateVertexWithoutProperties(acc.get());
       auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
@@ -1873,19 +1872,19 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexDrop) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
     EXPECT_TRUE(acc->EdgeTypePropertyIndexExists(this->edge_type_id1, this->edge_prop_id1));
     EXPECT_THAT(acc->ListAllIndices().edge_type_property,
                 UnorderedElementsAre(std::make_pair(this->edge_type_id1, this->edge_prop_id1)));
   }
 
   {
-    auto acc = this->storage->Access(ReplicationRole::MAIN);
+    auto acc = this->storage->Access();
 
     EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, this->edge_prop_id1, View::OLD), View::OLD),
                 UnorderedElementsAre(1, 3, 5, 7, 9, 11, 13, 15, 17, 19));
@@ -1912,17 +1911,17 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexBasic) {
     return;
   }
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id2, this->edge_prop_id2).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
 
-  auto acc = this->storage->Access(ReplicationRole::MAIN);
+  auto acc = this->storage->Access();
   EXPECT_THAT(acc->ListAllIndices().edge_type_property,
               UnorderedElementsAre(std::make_pair(this->edge_type_id1, this->edge_prop_id1),
                                    std::make_pair(this->edge_type_id2, this->edge_prop_id2)));
@@ -1995,19 +1994,19 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexTransactionalIsolation) {
   }
   // Check that transactions only see entries they are supposed to see.
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id2, this->edge_prop_id2).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
 
-  auto acc_before = this->storage->Access(ReplicationRole::MAIN);
-  auto acc = this->storage->Access(ReplicationRole::MAIN);
-  auto acc_after = this->storage->Access(ReplicationRole::MAIN);
+  auto acc_before = this->storage->Access();
+  auto acc = this->storage->Access();
+  auto acc_after = this->storage->Access();
 
   for (int i = 0; i < 5; ++i) {
     auto vertex_from = this->CreateVertexWithoutProperties(acc.get());
@@ -2027,7 +2026,7 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexTransactionalIsolation) {
 
   ASSERT_NO_ERROR(acc->Commit());
 
-  auto acc_after_commit = this->storage->Access(ReplicationRole::MAIN);
+  auto acc_after_commit = this->storage->Access();
 
   EXPECT_THAT(this->GetIds(acc_before->Edges(this->edge_type_id1, this->edge_prop_id1, View::NEW), View::NEW),
               IsEmpty());
@@ -2045,17 +2044,17 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexCountEstimate) {
     return;
   }
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id2, this->edge_prop_id2).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
 
-  auto acc = this->storage->Access(ReplicationRole::MAIN);
+  auto acc = this->storage->Access();
   for (int i = 0; i < 20; ++i) {
     auto vertex_from = this->CreateVertexWithoutProperties(acc.get());
     auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
@@ -2078,12 +2077,12 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexRepeatingEdgeTypesBetweenSameVertices
     return;
   }
   {
-    auto unique_acc = this->storage->UniqueAccess(ReplicationRole::MAIN);
+    auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }
 
-  auto acc = this->storage->Access(ReplicationRole::MAIN);
+  auto acc = this->storage->Access();
   auto vertex_from = this->CreateVertexWithoutProperties(acc.get());
   auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
 

--- a/tests/unit/storage_v2_isolation_level.cpp
+++ b/tests/unit/storage_v2_isolation_level.cpp
@@ -45,9 +45,9 @@ class StorageIsolationLevelTest : public ::testing::TestWithParam<memgraph::stor
   void TestVisibility(std::unique_ptr<memgraph::storage::Storage> &storage,
                       const memgraph::storage::IsolationLevel &default_isolation_level,
                       const memgraph::storage::IsolationLevel &override_isolation_level) {
-    auto creator = storage->Access(ReplicationRole::MAIN);
-    auto default_isolation_level_reader = storage->Access(ReplicationRole::MAIN);
-    auto override_isolation_level_reader = storage->Access(ReplicationRole::MAIN, override_isolation_level);
+    auto creator = storage->Access();
+    auto default_isolation_level_reader = storage->Access();
+    auto override_isolation_level_reader = storage->Access(override_isolation_level);
 
     ASSERT_EQ(VerticesCount(default_isolation_level_reader.get()), 0);
     ASSERT_EQ(VerticesCount(override_isolation_level_reader.get()), 0);
@@ -90,7 +90,7 @@ class StorageIsolationLevelTest : public ::testing::TestWithParam<memgraph::stor
     ASSERT_FALSE(override_isolation_level_reader->Commit().HasError());
 
     SCOPED_TRACE("Visibility after a new transaction is started");
-    auto verifier = storage->Access(ReplicationRole::MAIN);
+    auto verifier = storage->Access();
     ASSERT_EQ(VerticesCount(verifier.get()), iteration_count);
     ASSERT_FALSE(verifier->Commit().HasError());
   }

--- a/tests/unit/storage_v2_show_storage_info.cpp
+++ b/tests/unit/storage_v2_show_storage_info.cpp
@@ -44,7 +44,7 @@ class ShowStorageInfoTest : public testing::Test {
 };
 
 TEST_F(ShowStorageInfoTest, CountOnAbort) {
-  auto acc = this->storage->Access(memgraph::replication_coordination_glue::ReplicationRole::MAIN);
+  auto acc = this->storage->Access();
   auto src_vertex = acc->CreateVertex();
   auto dest_vertex = acc->CreateVertex();
   auto et = acc->NameToEdgeType("et5");

--- a/tests/unit/storage_v2_storage_mode.cpp
+++ b/tests/unit/storage_v2_storage_mode.cpp
@@ -44,8 +44,8 @@ TEST_P(StorageModeTest, Mode) {
           .transaction{.isolation_level = memgraph::storage::IsolationLevel::SNAPSHOT_ISOLATION}});
 
   static_cast<memgraph::storage::InMemoryStorage *>(storage.get())->SetStorageMode(storage_mode);
-  auto creator = storage->Access(memgraph::replication_coordination_glue::ReplicationRole::MAIN);
-  auto other_analytics_mode_reader = storage->Access(memgraph::replication_coordination_glue::ReplicationRole::MAIN);
+  auto creator = storage->Access();
+  auto other_analytics_mode_reader = storage->Access();
 
   ASSERT_EQ(CountVertices(*creator, memgraph::storage::View::OLD), 0);
   ASSERT_EQ(CountVertices(*other_analytics_mode_reader, memgraph::storage::View::OLD), 0);

--- a/tests/unit/typed_value.cpp
+++ b/tests/unit/typed_value.cpp
@@ -41,8 +41,7 @@ class AllTypesFixture : public testing::Test {
   std::vector<TypedValue> values_;
   memgraph::storage::Config config_{disk_test_utils::GenerateOnDiskConfig(testSuite)};
   std::unique_ptr<memgraph::storage::Storage> db{new StorageType(config_)};
-  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{
-      db->Access(memgraph::replication_coordination_glue::ReplicationRole::MAIN)};
+  std::unique_ptr<memgraph::storage::Storage::Accessor> storage_dba{db->Access()};
   memgraph::query::DbAccessor dba{storage_dba.get()};
 
   void SetUp() override {


### PR DESCRIPTION
Decoupled storage accessor from replication role.
Decoupled `storage->GetInfo` from replication role.
Decouped `dbms::Stats` from replication role.
Decoupled telemetry code from replication role.
Decoupled `CreateTransaction` from replication role.