### PR TITLE
Run arm builds on github large runner

### DIFF
--- a/.github/workflows/reusable_package.yaml
+++ b/.github/workflows/reusable_package.yaml
@@ -46,7 +46,7 @@ on:
 
 jobs:
   PackageAndUpload:
-    runs-on: ["${{ inputs.arch == 'arm' && 'ubuntu-large-arm' || 'self-hosted, DockerMgBuild, X64' }}"]
+    runs-on: ${{ matrix.arch == 'arm' && 'ubuntu-large-arm' || fromJSON('[ "self-hosted", "DockerMgBuild", "X64" ]') }}
     timeout-minutes: ${{ inputs.arch == 'arm' && 120 || 60 }}
     env:
       mgdeps_cache_host: "${{ inputs.arch == 'arm' && '100.116.34.131' || 'mgdeps-cache' }}" # Required because strange is not connected to memgraph openVPN

--- a/.github/workflows/reusable_package.yaml
+++ b/.github/workflows/reusable_package.yaml
@@ -46,7 +46,7 @@ on:
 
 jobs:
   PackageAndUpload:
-    runs-on: ${{ inputs.arch == 'arm' && 'ubuntu-large-arm' || '[self-hosted, DockerMgBuild, X64]' }}
+    runs-on: ["${{ inputs.arch == 'arm' && 'ubuntu-large-arm' || 'self-hosted, DockerMgBuild, X64' }}"]
     timeout-minutes: ${{ inputs.arch == 'arm' && 120 || 60 }}
     env:
       mgdeps_cache_host: "${{ inputs.arch == 'arm' && '100.116.34.131' || 'mgdeps-cache' }}" # Required because strange is not connected to memgraph openVPN

--- a/.github/workflows/reusable_package.yaml
+++ b/.github/workflows/reusable_package.yaml
@@ -46,7 +46,7 @@ on:
 
 jobs:
   PackageAndUpload:
-    runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
+    runs-on: ${{ inputs.arch == 'arm' && 'ubuntu-large-arm' || '[self-hosted, DockerMgBuild, X64]' }}
     timeout-minutes: ${{ inputs.arch == 'arm' && 120 || 60 }}
     env:
       mgdeps_cache_host: "${{ inputs.arch == 'arm' && '100.116.34.131' || 'mgdeps-cache' }}" # Required because strange is not connected to memgraph openVPN
@@ -57,7 +57,8 @@ jobs:
           fetch-depth: 0 # Required because of release/get_version.py
 
       - name: "Unlock keychain for current session" # Required beacuse ARM builds run on macos
-        if: ${{ inputs.arch == 'arm' }}
+        # if: ${{ inputs.arch == 'arm' }}
+        if: false
         run: security -v unlock-keychain -p ${{ secrets.SELF_HOSTED_RUNNER_PASSWORD }} ~/Library/Keychains/login.keychain-db
 
       - name: "Log in to Docker Hub"

--- a/.github/workflows/reusable_package.yaml
+++ b/.github/workflows/reusable_package.yaml
@@ -46,7 +46,7 @@ on:
 
 jobs:
   PackageAndUpload:
-    runs-on: ${{ matrix.arch == 'arm' && 'ubuntu-large-arm' || fromJSON('[ "self-hosted", "DockerMgBuild", "X64" ]') }}
+    runs-on: ${{ inputs.arch == 'arm' && 'ubuntu-large-arm' || fromJSON('[ "self-hosted", "DockerMgBuild", "X64" ]') }}
     timeout-minutes: ${{ inputs.arch == 'arm' && 120 || 60 }}
     env:
       mgdeps_cache_host: "${{ inputs.arch == 'arm' && '100.116.34.131' || 'mgdeps-cache' }}" # Required because strange is not connected to memgraph openVPN

--- a/.github/workflows/reusable_package.yaml
+++ b/.github/workflows/reusable_package.yaml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ${{ inputs.arch == 'arm' && 'ubuntu-large-arm' || fromJSON('[ "self-hosted", "DockerMgBuild", "X64" ]') }}
     timeout-minutes: ${{ inputs.arch == 'arm' && 120 || 60 }}
     env:
-      mgdeps_cache_host: "${{ inputs.arch == 'arm' && '100.116.34.131' || 'mgdeps-cache' }}" # Required because strange is not connected to memgraph openVPN
+      mgdeps_cache_host: "${{ inputs.arch == 'arm' && 'false' || 'mgdeps-cache' }}" # Required because strange is not connected to memgraph openVPN
     steps:
       - name: "Set up repository"
         uses: actions/checkout@v4

--- a/libs/setup.sh
+++ b/libs/setup.sh
@@ -72,7 +72,7 @@ file_get_try_double () {
     if [ -z "$secondary_url" ]; then echo "Secondary should not be empty." && exit 1; fi
     filename="$(basename "$secondary_url")"
     # Redirect primary/cache to /dev/null to make it less confusing for a new contributor because only CI has access to the cache.
-    wget -nv "$primary_url" -O "$filename" >/dev/null 2>&1 || wget -nv "$secondary_url" -O "$filename" || exit 1
+    wget --timeout=10 -nv "$primary_url" -O "$filename" >/dev/null 2>&1 || wget -nv "$secondary_url" -O "$filename" || exit 1
 }
 
 repo_clone_try_double () {

--- a/libs/setup.sh
+++ b/libs/setup.sh
@@ -67,12 +67,13 @@ clone () {
 file_get_try_double () {
     primary_url="$1"
     secondary_url="$2"
+    timeout_s="${3:-5}"
     echo "Download primary from $primary_url secondary from $secondary_url"
     if [ -z "$primary_url" ]; then echo "Primary should not be empty." && exit 1; fi
     if [ -z "$secondary_url" ]; then echo "Secondary should not be empty." && exit 1; fi
     filename="$(basename "$secondary_url")"
     # Redirect primary/cache to /dev/null to make it less confusing for a new contributor because only CI has access to the cache.
-    wget --timeout=5 --tries=1 -nv "$primary_url" -O "$filename" >/dev/null 2>&1 || wget -nv "$secondary_url" -O "$filename" || exit 1
+    timeout $timeout_s wget-nv "$primary_url" -O "$filename" >/dev/null 2>&1 || wget -nv "$secondary_url" -O "$filename" || exit 1
 }
 
 repo_clone_try_double () {
@@ -81,13 +82,14 @@ repo_clone_try_double () {
     folder_name="$3"
     ref="$4"
     shallow="${5:-false}"
+    timeout_s="${6:-5}"
     echo "Cloning primary from $primary_url secondary from $secondary_url"
     if [ -z "$primary_url" ]; then echo "Primary should not be empty." && exit 1; fi
     if [ -z "$secondary_url" ]; then echo "Secondary should not be empty." && exit 1; fi
     if [ -z "$folder_name" ]; then echo "Clone folder should not be empty." && exit 1; fi
     if [ -z "$ref" ]; then echo "Git clone ref should not be empty." && exit 1; fi
     # Redirect primary/cache to /dev/null to make it less confusing for a new contributor because only CI has access to the cache.
-    clone "$primary_url" "$folder_name" "$ref" "$shallow" >/dev/null 2>&1 || clone "$secondary_url" "$folder_name" "$ref" "$shallow" || exit 1
+    timeout $timeout_s clone "$primary_url" "$folder_name" "$ref" "$shallow" >/dev/null 2>&1 || clone "$secondary_url" "$folder_name" "$ref" "$shallow" || exit 1
 }
 
 # List all dependencies.

--- a/libs/setup.sh
+++ b/libs/setup.sh
@@ -17,6 +17,7 @@ function print_help () {
 use_cache=true
 if [[ "$local_cache_host" == "false" ]]; then
   use_cache=false
+  echo -e "\n--- Not using cache ---\n"
 fi
 
 if [[ $# -eq 1 && "$1" == "-h" ]]; then

--- a/libs/setup.sh
+++ b/libs/setup.sh
@@ -11,11 +11,11 @@ function print_help () {
     echo "Usage: $0 [OPTION]"
     echo -e "Setup libs for the project.\n"
     echo "Optonal environment variables:"
-    echo -e "  MGDEPS_CACHE_HOST_PORT\thost and port for mgdeps cache service, set to 'false' to not use mgdeps-cache (default: mgdeps-cache:8000) "
+    echo -e "  MGDEPS_CACHE_HOST_PORT\thost and port for mgdeps cache service, set host to 'false' to not use mgdeps-cache (default: mgdeps-cache:8000) "
 }
 
 use_cache=true
-if [[ "$local_cache_host" == "false" ]]; then
+if [[ "${local_cache_host%:*}" == "false" ]]; then
   use_cache=false
   echo -e "\n--- Not using cache ---\n"
 fi

--- a/libs/setup.sh
+++ b/libs/setup.sh
@@ -67,13 +67,12 @@ clone () {
 file_get_try_double () {
     primary_url="$1"
     secondary_url="$2"
-    timeout_s="${3:-5}"
     echo "Download primary from $primary_url secondary from $secondary_url"
     if [ -z "$primary_url" ]; then echo "Primary should not be empty." && exit 1; fi
     if [ -z "$secondary_url" ]; then echo "Secondary should not be empty." && exit 1; fi
     filename="$(basename "$secondary_url")"
     # Redirect primary/cache to /dev/null to make it less confusing for a new contributor because only CI has access to the cache.
-    timeout $timeout_s wget-nv "$primary_url" -O "$filename" >/dev/null 2>&1 || wget -nv "$secondary_url" -O "$filename" || exit 1
+    timeout 5 wget-nv "$primary_url" -O "$filename" >/dev/null 2>&1 || wget -nv "$secondary_url" -O "$filename" || exit 1
 }
 
 repo_clone_try_double () {
@@ -82,14 +81,13 @@ repo_clone_try_double () {
     folder_name="$3"
     ref="$4"
     shallow="${5:-false}"
-    timeout_s="${6:-5}"
     echo "Cloning primary from $primary_url secondary from $secondary_url"
     if [ -z "$primary_url" ]; then echo "Primary should not be empty." && exit 1; fi
     if [ -z "$secondary_url" ]; then echo "Secondary should not be empty." && exit 1; fi
     if [ -z "$folder_name" ]; then echo "Clone folder should not be empty." && exit 1; fi
     if [ -z "$ref" ]; then echo "Git clone ref should not be empty." && exit 1; fi
     # Redirect primary/cache to /dev/null to make it less confusing for a new contributor because only CI has access to the cache.
-    timeout $timeout_s clone "$primary_url" "$folder_name" "$ref" "$shallow" >/dev/null 2>&1 || clone "$secondary_url" "$folder_name" "$ref" "$shallow" || exit 1
+    timeout 5 clone "$primary_url" "$folder_name" "$ref" "$shallow" >/dev/null 2>&1 || clone "$secondary_url" "$folder_name" "$ref" "$shallow" || exit 1
 }
 
 # List all dependencies.

--- a/libs/setup.sh
+++ b/libs/setup.sh
@@ -72,7 +72,7 @@ file_get_try_double () {
     if [ -z "$secondary_url" ]; then echo "Secondary should not be empty." && exit 1; fi
     filename="$(basename "$secondary_url")"
     # Redirect primary/cache to /dev/null to make it less confusing for a new contributor because only CI has access to the cache.
-    wget --timeout=10 -nv "$primary_url" -O "$filename" >/dev/null 2>&1 || wget -nv "$secondary_url" -O "$filename" || exit 1
+    wget --timeout=5 --tries=1 -nv "$primary_url" -O "$filename" >/dev/null 2>&1 || wget -nv "$secondary_url" -O "$filename" || exit 1
 }
 
 repo_clone_try_double () {

--- a/libs/setup.sh
+++ b/libs/setup.sh
@@ -7,6 +7,27 @@ local_cache_host=${MGDEPS_CACHE_HOST_PORT:-mgdeps-cache:8000}
 working_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "${working_dir}"
 
+function print_help () {
+    echo "Usage: $0 [OPTION]"
+    echo -e "Setup libs for the project.\n"
+    echo "Optonal environment variables:"
+    echo -e "  MGDEPS_CACHE_HOST_PORT\thost and port for mgdeps cache service, set to 'false' to not use mgdeps-cache (default: mgdeps-cache:8000) "
+}
+
+use_cache=true
+if [[ "$local_cache_host" == "false" ]]; then
+  use_cache=false
+fi
+
+if [[ $# -eq 1 && "$1" == "-h" ]]; then
+    print_help
+    exit 0
+else
+    echo "Invalid argument provided: $1"
+    print_help
+    exit 1
+fi
+
 # Clones a git repository and optionally cherry picks additional commits. The
 # function will try to preserve any local changes in the repo.
 # clone GIT_REPO DIR_NAME CHECKOUT_ID [CHERRY_PICK_ID]...
@@ -67,12 +88,17 @@ clone () {
 file_get_try_double () {
     primary_url="$1"
     secondary_url="$2"
-    echo "Download primary from $primary_url secondary from $secondary_url"
     if [ -z "$primary_url" ]; then echo "Primary should not be empty." && exit 1; fi
     if [ -z "$secondary_url" ]; then echo "Secondary should not be empty." && exit 1; fi
     filename="$(basename "$secondary_url")"
-    # Redirect primary/cache to /dev/null to make it less confusing for a new contributor because only CI has access to the cache.
-    timeout 5 wget -nv "$primary_url" -O "$filename" >/dev/null 2>&1 || wget -nv "$secondary_url" -O "$filename" || exit 1
+    if [[ "$use_cache" == true ]]; then
+      echo "Download primary from $primary_url secondary from $secondary_url"
+      # Redirect primary/cache to /dev/null to make it less confusing for a new contributor because only CI has access to the cache.
+      timeout 15 wget -nv "$primary_url" -O "$filename" >/dev/null 2>&1 || wget -nv "$secondary_url" -O "$filename" || exit 1
+    else
+      echo "Download from $secondary_url"
+      wget -nv "$secondary_url" -O "$filename" || exit 1
+    fi
 }
 
 repo_clone_try_double () {
@@ -81,13 +107,18 @@ repo_clone_try_double () {
     folder_name="$3"
     ref="$4"
     shallow="${5:-false}"
-    echo "Cloning primary from $primary_url secondary from $secondary_url"
     if [ -z "$primary_url" ]; then echo "Primary should not be empty." && exit 1; fi
     if [ -z "$secondary_url" ]; then echo "Secondary should not be empty." && exit 1; fi
     if [ -z "$folder_name" ]; then echo "Clone folder should not be empty." && exit 1; fi
     if [ -z "$ref" ]; then echo "Git clone ref should not be empty." && exit 1; fi
-    # Redirect primary/cache to /dev/null to make it less confusing for a new contributor because only CI has access to the cache.
-    timeout 5 clone "$primary_url" "$folder_name" "$ref" "$shallow" >/dev/null 2>&1 || clone "$secondary_url" "$folder_name" "$ref" "$shallow" || exit 1
+    if [[ "$use_cache" == true ]]; then
+      echo "Cloning primary from $primary_url secondary from $secondary_url"
+      # Redirect primary/cache to /dev/null to make it less confusing for a new contributor because only CI has access to the cache.
+      clone "$primary_url" "$folder_name" "$ref" "$shallow" >/dev/null 2>&1 || clone "$secondary_url" "$folder_name" "$ref" "$shallow" || exit 1
+    else
+      echo "Cloning from $secondary_url"
+      clone "$secondary_url" "$folder_name" "$ref" "$shallow" || exit 1
+    fi
 }
 
 # List all dependencies.

--- a/libs/setup.sh
+++ b/libs/setup.sh
@@ -72,7 +72,7 @@ file_get_try_double () {
     if [ -z "$secondary_url" ]; then echo "Secondary should not be empty." && exit 1; fi
     filename="$(basename "$secondary_url")"
     # Redirect primary/cache to /dev/null to make it less confusing for a new contributor because only CI has access to the cache.
-    timeout 5 wget-nv "$primary_url" -O "$filename" >/dev/null 2>&1 || wget -nv "$secondary_url" -O "$filename" || exit 1
+    timeout 5 wget -nv "$primary_url" -O "$filename" >/dev/null 2>&1 || wget -nv "$secondary_url" -O "$filename" || exit 1
 }
 
 repo_clone_try_double () {

--- a/libs/setup.sh
+++ b/libs/setup.sh
@@ -22,10 +22,6 @@ fi
 if [[ $# -eq 1 && "$1" == "-h" ]]; then
     print_help
     exit 0
-else
-    echo "Invalid argument provided: $1"
-    print_help
-    exit 1
 fi
 
 # Clones a git repository and optionally cherry picks additional commits. The


### PR DESCRIPTION
This PR fixes our arm machine bottleneck when building artifacts. When building for arm the builds will now be run on github hosted large ubuntu arm runner. Additionally this PR also adds the option to bypass the cache when setting up libs.