### PR TITLE
Fix jepsen cluster build

### DIFF
--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -99,8 +99,7 @@ jobs:
     needs: DiffSetup
     uses: ./.github/workflows/diff_jepsen.yaml
     with:
-      run_core: 'false'
-      # run_core: ${{ needs.DiffSetup.outputs.run_jepsen_core }}
+      run_core: ${{ needs.DiffSetup.outputs.run_jepsen_core }}
     secrets: inherit
 
   Release:

--- a/tests/jepsen/0-3-5.patch
+++ b/tests/jepsen/0-3-5.patch
@@ -1,22 +1,13 @@
 diff --git a/docker/control/Dockerfile b/docker/control/Dockerfile
-index 4b95de3b..d6355497 100644
+index 4b95de3b..306c9759 100644
 --- a/docker/control/Dockerfile
 +++ b/docker/control/Dockerfile
-@@ -5,16 +5,13 @@ STOPSIGNAL SIGRTMIN+3
-
- ENV LEIN_ROOT true
-
--# JDK21 only in Debian testing
--RUN echo "deb http://deb.debian.org/debian testing main" >> /etc/apt/sources.list
--ADD ./apt-preferences /etc/apt/preferences
-
- #
- # Jepsen dependencies
+@@ -14,7 +14,7 @@ ADD ./apt-preferences /etc/apt/preferences
  #
  RUN apt-get -qy update && \
      apt-get -qy install \
 -        curl dos2unix emacs git gnuplot graphviz htop iputils-ping libjna-java openjdk-21-jdk-headless pssh screen vim wget
-+        curl dos2unix emacs git gnuplot graphviz htop iputils-ping libjna-java openjdk-17-jdk-headless pssh screen vim wget
++        curl dos2unix emacs git gnuplot graphviz htop iputils-ping libjna-java openjdk-22-jdk-headless pssh screen vim wget
 
  RUN wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && \
      mv lein /usr/bin && \

--- a/tests/jepsen/0-3-5.patch
+++ b/tests/jepsen/0-3-5.patch
@@ -1,13 +1,20 @@
 diff --git a/docker/control/Dockerfile b/docker/control/Dockerfile
-index 4b95de3b..306c9759 100644
+index 4b95de3b..0e7788aa 100644
 --- a/docker/control/Dockerfile
 +++ b/docker/control/Dockerfile
-@@ -14,7 +14,7 @@ ADD ./apt-preferences /etc/apt/preferences
+@@ -7,13 +7,13 @@ ENV LEIN_ROOT true
+
+ # JDK21 only in Debian testing
+ RUN echo "deb http://deb.debian.org/debian testing main" >> /etc/apt/sources.list
+-ADD ./apt-preferences /etc/apt/preferences
++RUN echo "deb http://deb.debian.org/debian trixie main" >> /etc/apt/sources.list
+
+ #
+ # Jepsen dependencies
  #
  RUN apt-get -qy update && \
-     apt-get -qy install \
--        curl dos2unix emacs git gnuplot graphviz htop iputils-ping libjna-java openjdk-21-jdk-headless pssh screen vim wget
-+        curl dos2unix emacs git gnuplot graphviz htop iputils-ping libjna-java openjdk-22-jdk-headless pssh screen vim wget
+-    apt-get -qy install \
++    apt-get -qy -o Dpkg::Options::="--force-confnew" install \
+         curl dos2unix emacs git gnuplot graphviz htop iputils-ping libjna-java openjdk-21-jdk-headless pssh screen vim wget
 
  RUN wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && \
-     mv lein /usr/bin && \

--- a/tests/jepsen/0-3-5.patch
+++ b/tests/jepsen/0-3-5.patch
@@ -1,13 +1,22 @@
 diff --git a/docker/control/Dockerfile b/docker/control/Dockerfile
-index 4b95de3b..306c9759 100644
+index 4b95de3b..d6355497 100644
 --- a/docker/control/Dockerfile
 +++ b/docker/control/Dockerfile
-@@ -14,7 +14,7 @@ ADD ./apt-preferences /etc/apt/preferences
+@@ -5,16 +5,13 @@ STOPSIGNAL SIGRTMIN+3
+
+ ENV LEIN_ROOT true
+
+-# JDK21 only in Debian testing
+-RUN echo "deb http://deb.debian.org/debian testing main" >> /etc/apt/sources.list
+-ADD ./apt-preferences /etc/apt/preferences
+
+ #
+ # Jepsen dependencies
  #
  RUN apt-get -qy update && \
      apt-get -qy install \
 -        curl dos2unix emacs git gnuplot graphviz htop iputils-ping libjna-java openjdk-21-jdk-headless pssh screen vim wget
-+        curl dos2unix emacs git gnuplot graphviz htop iputils-ping libjna-java openjdk-22-jdk-headless pssh screen vim wget
++        curl dos2unix emacs git gnuplot graphviz htop iputils-ping libjna-java openjdk-17-jdk-headless pssh screen vim wget
 
  RUN wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && \
      mv lein /usr/bin && \


### PR DESCRIPTION
Building jepsen images has been experiencing issues due to dependency to latest libc6. This PR fixes that and brings back jepsen tests.