### PR TITLE
Disable jepsen tests

### DIFF
--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -99,7 +99,8 @@ jobs:
     needs: DiffSetup
     uses: ./.github/workflows/diff_jepsen.yaml
     with:
-      run_core: ${{ needs.DiffSetup.outputs.run_jepsen_core }}
+      run_core: 'false'
+      # run_core: ${{ needs.DiffSetup.outputs.run_jepsen_core }}
     secrets: inherit
 
   Release:


### PR DESCRIPTION
Jepsen tests are experiencing an issue due to `opendjk-22`, until the issue is fixed jepsen tests are disabled in CI.