### PR TITLE
Handle bad_alloc being thrown by 3rd party code

### DIFF
--- a/src/communication/bolt/v1/states/handlers.hpp
+++ b/src/communication/bolt/v1/states/handlers.hpp
@@ -27,6 +27,7 @@
 #include "communication/exceptions.hpp"
 #include "storage/v2/property_value.hpp"
 #include "utils/logging.hpp"
+#include "utils/memory_tracker.hpp"
 #include "utils/message.hpp"
 
 namespace memgraph::communication::bolt {
@@ -61,6 +62,20 @@ inline std::pair<std::string, std::string> ExceptionToErrorMessage(const std::ex
     return {"Memgraph.TransientError.MemgraphError.MemgraphError", e.what()};
   }
   if (dynamic_cast<const std::bad_alloc *>(&e)) {
+    {
+      // It is possible that something used C based memory allocation and hence we didn't pick up the MemoryErrorStatus
+      // that corresponds to memory tracker errors. It is possible that 3rd party code or something following C++
+      // conventions will throw std::bad_alloc. We will check here and handle as an OutOfMemoryException if that is the
+      // case.
+      [[maybe_unused]] auto blocker = memgraph::utils::MemoryTracker::OutOfMemoryExceptionBlocker{};
+      if (auto maybe_msg = memgraph::utils::MemoryErrorStatus().msg(); maybe_msg) {
+        DMG_ASSERT(false,
+                   "Something is using C based allocation and triggering MemoryTracker. This should not happen, go via "
+                   "C++ new/delete where possible");
+        return {"Memgraph.TransientError.MemgraphError.MemgraphError", std::move(*maybe_msg)};
+      }
+    }
+
     // std::bad_alloc was thrown, God knows in which state is database ->
     // terminate.
     LOG_FATAL("Memgraph is out of memory");


### PR DESCRIPTION
Also covers the case of if we accidentally use it. We should be checking MemoryErrorStatus upon nullptr, and then throwing typically OutOfMemoryException not std::bad_alloc.