### PR TITLE
Update package_memgraph workflow

### DIFF
--- a/.github/workflows/package_memgraph.yaml
+++ b/.github/workflows/package_memgraph.yaml
@@ -64,7 +64,7 @@ on:
           - eu-west-1
       s3_dest_dir:
         type: string
-        description: "Target dir path in S3 bucket. For official packages use format 'memgraph/vX.Y.Z'. For unofficial packages use format 'memgraph-unofficial/<SOMETHING>'"
+        description: "Target dir path in chosen S3 bucket, don't end the path with '/'. For bucket 'download.memgraph.io' use format 'memgraph/vX.Y.Z'."
         default: ''
 
 jobs:

--- a/.github/workflows/reusable_package.yaml
+++ b/.github/workflows/reusable_package.yaml
@@ -51,6 +51,19 @@ jobs:
     env:
       mgdeps_cache_host: "${{ inputs.arch == 'arm' && 'false' || 'mgdeps-cache' }}" # Required because strange is not connected to memgraph openVPN
     steps:
+      - name: "Validate S3 dest dir for official package"
+        if: ${{ inputs.push_to_s3 == 'true' && inputs.s3_bucket == 'download.memgraph.com' }}
+        run: |
+          if [[ "${{ inputs.build_type }}" == 'RelWithDebInfo' ]]; then
+            echo -e "Error: You are pushing a RelWithDebInfo build to 'download.memgraph.com'."
+            exit 1
+          fi
+          if ! [[ "${{ inputs.s3_dest_dir }}" =~ memgraph/v[0-9]\.[0-9]+\.[0-9]+$ ]]; then
+            echo -e "Error: ${{ inputs.s3_dest_dir }} is not a valid official format. When pushing to 'download.memgraph.com' the dest dir has to match format 'memgraph/vX.Y.Z'!"
+            exit 1
+          fi
+          echo -e "Passed: Dest dir ${{ inputs.s3_dest_dir }} has a valid official format."
+
       - name: "Set up repository"
         uses: actions/checkout@v4
         with:
@@ -153,20 +166,7 @@ jobs:
           name: ${{ env.ARTIFACT_NAME }}
           path: "${{ env.FOR_DOCKER == 'true' && env.DOCKER_ARTIFACT_DIR || env.PACKAGE_ARTIFACT_DIR }}/memgraph*"
 
-      - name: Validate S3 dest dir
-        if: ${{ inputs.push_to_s3 == 'true' && inputs.s3_bucket == 'download.memgraph.com' }}
-        run: |
-          if [[ "${{ inputs.build_type }}" == 'RelWithDebInfo' ]]; then
-            echo -e "Error: You are pushing a RelWithDebInfo build to 'download.memgraph.com'."
-            exit 1
-          fi
-          if ! [[ "${{ inputs.s3_dest_dir }}" =~ memgraph/v[0-9]\.[0-9]+\.[0-9]+$ ]]; then
-            echo -e "Error: ${{ inputs.s3_dest_dir }} is not a valid official format. When pushing to 'download.memgraph.com' the dest dir has to match format 'memgraph/vX.Y.Z'!"
-            exit 1
-          fi
-          echo -e "Passed: Dest dir ${{ inputs.s3_dest_dir }} has a valid official format."
-
-      - name: Upload to S3
+      - name: "Upload to S3"
         if: ${{ inputs.push_to_s3 == 'true' }}
         run:
           aws s3 sync $SOURCE_DIR s3://${{ inputs.s3_bucket }}/$DEST_DIR


### PR DESCRIPTION
This PR updates the package_memgraph.yaml workflow in the following ways:
- updates the description for s3_dest_dir input because it was deprecated
- moves step to validate S3 dest dir path to start of a job to fail fast