### PR TITLE
Add killing of random number of coordinator nodes

### DIFF
--- a/tests/jepsen/src/jepsen/memgraph/core.clj
+++ b/tests/jepsen/src/jepsen/memgraph/core.clj
@@ -5,6 +5,7 @@
     [checker :as checker]
     [generator :as gen]
     [tests :as tests]]
+   [clojure.tools.logging :refer [info]]
    [jepsen.memgraph
     [bank :as bank]
     [large :as large]
@@ -45,7 +46,7 @@
             :checker         (checker/compose
                               {:stats      (checker/stats)
                                :exceptions (utils/unhandled-exceptions)
-                               :log-checker (checker/log-file-pattern #"assert|[eE]xception" "memgraph.log")
+                               :log-checker (checker/log-file-pattern #"assert|NullPointerException|json.exception.parse_error" "memgraph.log")
                                :workload   (:checker workload)})
             :nodes           (keys (:nodes-config opts))
             :nemesis        (:nemesis nemesis)
@@ -76,7 +77,7 @@
             :checker         (checker/compose
                               {:stats      (checker/stats)
                                :exceptions (utils/unhandled-exceptions)
-                               :log-checker (checker/log-file-pattern #"assert|[eE]xception" "memgraph.log")
+                               :log-checker (checker/log-file-pattern #"assert|NullPointerException|json.exception.parse_error" "memgraph.log")
                                :workload   (:checker workload)})
             :nemesis         (:nemesis nemesis)
             :generator       gen})))
@@ -117,6 +118,9 @@
 (defn single-test
   "Takes base CLI options and constructs a single test."
   [opts]
+
+  (info "Results")
+
   (let [workload (if (:workload opts)
                    (:workload opts)
                    (throw (Exception. "Workload undefined!")))
@@ -141,7 +145,8 @@
                           :organization organization})]
     (if (or (= workload :high_availability) (= workload :habank))
       (memgraph-ha-test test-opts)
-      (memgraph-test test-opts))))
+      (memgraph-test test-opts)))
+  )
 
 (def cli-opts
   "CLI options for tests."

--- a/tests/jepsen/src/jepsen/memgraph/core.clj
+++ b/tests/jepsen/src/jepsen/memgraph/core.clj
@@ -45,7 +45,7 @@
             :checker         (checker/compose
                               {:stats      (checker/stats)
                                :exceptions (utils/unhandled-exceptions)
-                               :log-checker (checker/log-file-pattern #"assert|NullPointerException" "memgraph.log")
+                               :log-checker (checker/log-file-pattern #"assert|exception" "memgraph.log")
                                :workload   (:checker workload)})
             :nodes           (keys (:nodes-config opts))
             :nemesis        (:nemesis nemesis)
@@ -76,7 +76,7 @@
             :checker         (checker/compose
                               {:stats      (checker/stats)
                                :exceptions (utils/unhandled-exceptions)
-                               :log-checker (checker/log-file-pattern #"assert|NullPointerException" "memgraph.log")
+                               :log-checker (checker/log-file-pattern #"assert|exception" "memgraph.log")
                                :workload   (:checker workload)})
             :nemesis         (:nemesis nemesis)
             :generator       gen})))

--- a/tests/jepsen/src/jepsen/memgraph/core.clj
+++ b/tests/jepsen/src/jepsen/memgraph/core.clj
@@ -45,7 +45,7 @@
             :checker         (checker/compose
                               {:stats      (checker/stats)
                                :exceptions (utils/unhandled-exceptions)
-                               :log-checker (checker/log-file-pattern #"assert|exception" "memgraph.log")
+                               :log-checker (checker/log-file-pattern #"assert|[eE]xception" "memgraph.log")
                                :workload   (:checker workload)})
             :nodes           (keys (:nodes-config opts))
             :nemesis        (:nemesis nemesis)
@@ -76,7 +76,7 @@
             :checker         (checker/compose
                               {:stats      (checker/stats)
                                :exceptions (utils/unhandled-exceptions)
-                               :log-checker (checker/log-file-pattern #"assert|exception" "memgraph.log")
+                               :log-checker (checker/log-file-pattern #"assert|[eE]xception" "memgraph.log")
                                :workload   (:checker workload)})
             :nemesis         (:nemesis nemesis)
             :generator       gen})))

--- a/tests/jepsen/src/jepsen/memgraph/utils.clj
+++ b/tests/jepsen/src/jepsen/memgraph/utils.clj
@@ -27,16 +27,11 @@
         coords (take-last 3 coll)
         data-instances-to-kill (rand-int (+ 1 (count data-instances)))
         chosen-data-instances (take data-instances-to-kill (shuffle data-instances))
-        kill-coord? (< (rand) 0.5)]
-
-    (if kill-coord?
-      (let [chosen-coord (first (shuffle coords))
-            chosen-instances (conj chosen-data-instances chosen-coord)]
-        (info "Chosen instances" chosen-instances)
-        chosen-instances)
-      (do
-        (info "Chosen instances" chosen-data-instances)
-        chosen-data-instances))))
+        coords-to-kill (rand-int (+ 1 (count coords)))
+        chosen-coords (take coords-to-kill (shuffle coords))
+        chosen-instances (concat chosen-data-instances chosen-coords)]
+    (info "Chosen instances" chosen-instances)
+    chosen-instances))
 
 ; neo4j-clj related utils.
 (defmacro with-session

--- a/tests/jepsen/test/jepsen/memgraph/memgraph_test.clj
+++ b/tests/jepsen/test/jepsen/memgraph/memgraph_test.clj
@@ -11,22 +11,14 @@
 
 (deftest random-non-empty-subset
   (testing "Random, non-empty subset func from utils."
-    (let [in ["n1" "n2" "n3" "n4" "n5" "n5"]
-          out (utils/random-nonempty-subset in)
-          n4-occurences (count (filter #(= % "n4") out))
-          n5-occurences (count (filter #(= % "n5") out))
-          n6-occurences (count (filter #(= % "n6") out))
-          coord-total-occurences (+ n4-occurences n5-occurences n6-occurences)]
+    (let [in ["n1" "n2" "n3" "n4" "n5" "n6"]
+          out (utils/random-nonempty-subset in)]
 
       (is (=
            (count out)
            (count (distinct out))))
 
-      (is (< n4-occurences 2))
-      (is (< n5-occurences 2))
-      (is (< n6-occurences 2))
-      (is (< coord-total-occurences 2))
-      (is (< (count out) 5)))))
+      (is (<= (count out) 6)))))
 
 (deftest op
   (testing "Test utils/op"


### PR DESCRIPTION
Exception was thrown on coordinator state construction is now added to log checkers. Random number of coordinators are killed when nemesis turns on, before at most one coordinator was killed. Durability in HA made this possible.
