### PR TITLE
Fix creation of management server in coordinators

### DIFF
--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -57,9 +57,7 @@ using nuraft::ptr;
 
 CoordinatorInstance::CoordinatorInstance(CoordinatorInstanceInitConfig const &config)
     : coordinator_management_server_{ManagementServerConfig{
-          // management server endpoint for leader coord must have coordinator hostname, otherwise
-          // other coordinators won't know where to ping it
-          io::network::Endpoint{config.coordinator_hostname, static_cast<uint16_t>(config.management_port)}}} {
+          io::network::Endpoint{kDefaultManagementServerIp, static_cast<uint16_t>(config.management_port)}}} {
   client_succ_cb_ = [](CoordinatorInstance *self, std::string_view repl_instance_name) -> void {
     spdlog::trace("Acquiring lock in thread {} for client success callback for instance {}", std::this_thread::get_id(),
                   repl_instance_name);

--- a/src/coordination/coordinator_state_manager.cpp
+++ b/src/coordination/coordinator_state_manager.cpp
@@ -102,7 +102,6 @@ CoordinatorStateManager::CoordinatorStateManager(CoordinatorStateManagerConfig c
       durability_(config.state_manager_durability_dir_),
       observer_(observer) {
   auto const c2c = CoordinatorToCoordinatorConfig{
-      // TODO(antonio) sync with Andi on this one
       config.coordinator_id_, io::network::Endpoint(config.coordinator_hostname, config.bolt_port_),
       io::network::Endpoint{config.coordinator_hostname, static_cast<uint16_t>(config.coordinator_port_)},
       io::network::Endpoint{config.coordinator_hostname, static_cast<uint16_t>(config.management_port_)},

--- a/src/io/network/endpoint.cpp
+++ b/src/io/network/endpoint.cpp
@@ -62,7 +62,7 @@ std::string Endpoint::GetResolvedIPAddress() const {
 }
 
 std::ostream &operator<<(std::ostream &os, const Endpoint &endpoint) {
-  return os << endpoint.address_ << delimiter << endpoint.port_;
+  return os << endpoint.GetResolvedSocketAddress();
 }
 
 std::optional<std::tuple<std::string, uint16_t, Endpoint::IpFamily>> Endpoint::TryResolveAddress(

--- a/tests/jepsen/src/jepsen/memgraph/support.clj
+++ b/tests/jepsen/src/jepsen/memgraph/support.clj
@@ -28,7 +28,6 @@
    :--storage-snapshot-interval-sec 300
    :--data-recovery-on-startup
    :--replication-restore-state-on-startup
-   :--data-recovery-on-startup
    :--storage-wal-file-flush-every-n-tx @sync-after-n-txn
    :--telemetry-enabled false
    :--storage-properties-on-edges))
@@ -47,7 +46,6 @@
    :--storage-wal-enabled
    :--storage-snapshot-interval-sec 300
    :--replication-restore-state-on-startup
-   :--data-recovery-on-startup
    :--storage-properties-on-edges
    :--telemetry-enabled false
    :--coordinator-id (get node-config :coordinator-id)


### PR DESCRIPTION
Management server on coordinator instances will be started at 0.0.0.0. Fix for K8 deployment.