### PR TITLE
LocalDateTime does not convert user date to UTC properly

### DIFF
--- a/src/audit/log.cpp
+++ b/src/audit/log.cpp
@@ -87,7 +87,7 @@ inline nlohmann::json BoltValueToJson(const communication::bolt::Value &value) {
     }
     case LocalDateTime: {
       std::stringstream ss;
-      ss << utils::LocalDateTime(value.ValueLocalDateTime().MicrosecondsSinceEpoch());
+      ss << value.ValueLocalDateTime();
       ret = ss.str();
       break;
     }

--- a/src/communication/bolt/v1/encoder/base_encoder.hpp
+++ b/src/communication/bolt/v1/encoder/base_encoder.hpp
@@ -225,6 +225,7 @@ class BaseEncoder {
   }
 
   void WriteLocalDateTime(const utils::LocalDateTime &local_date_time) {
+    // Bolt defines local date time without timezone (as if UTC)
     WriteRAW(utils::UnderlyingCast(Marker::TinyStruct2));
     WriteRAW(utils::UnderlyingCast(Signature::LocalDateTime));
     WriteInt(local_date_time.SecondsSinceEpoch());

--- a/src/flags/run_time_configurable.cpp
+++ b/src/flags/run_time_configurable.cpp
@@ -11,21 +11,21 @@
 
 #include "flags/run_time_configurable.hpp"
 
+#include <stdexcept>
 #include <string>
-#include <tuple>
 
 #include "gflags/gflags.h"
 
-#include "flags/bolt.hpp"
-#include "flags/general.hpp"
 #include "flags/log_level.hpp"
-#include "flags/query.hpp"
-#include "spdlog/cfg/helpers-inl.h"
 #include "spdlog/spdlog.h"
 #include "utils/exceptions.hpp"
 #include "utils/flag_validation.hpp"
 #include "utils/settings.hpp"
 #include "utils/string.hpp"
+
+namespace {
+bool ValidTimezone(std::string_view tz);
+}
 
 /*
  * Setup GFlags
@@ -59,6 +59,9 @@ DEFINE_bool(hops_limit_partial_results, true,
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_bool(cartesian_product_enabled, true, "Enable cartesian product expansion.");
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, misc-unused-parameters)
+DEFINE_VALIDATED_string(timezone, "UTC", "Define instance's timezone (IANA format).", { return ValidTimezone(value); });
+
 namespace {
 // Bolt server name
 constexpr auto kServerNameSettingKey = "server.name";
@@ -83,11 +86,15 @@ constexpr auto kLogToStderrGFlagsKey = "also_log_to_stderr";
 constexpr auto kCartesianProductEnabledSettingKey = "cartesian-product-enabled";
 constexpr auto kCartesianProductEnabledGFlagsKey = "cartesian-product-enabled";
 
+constexpr auto kTimezoneSettingKey = "timezone";
+constexpr auto kTimezoneGFlagsKey = kTimezoneSettingKey;
+
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
 // Local cache-like thing
 std::atomic<double> execution_timeout_sec_;
 std::atomic<bool> hops_limit_partial_results{true};
 std::atomic<bool> cartesian_product_enabled_{true};
+std::atomic<const std::chrono::time_zone *> timezone_{nullptr};
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 
 auto ToLLEnum(std::string_view val) {
@@ -111,6 +118,17 @@ auto GenHandler(std::string flag, std::string key) {
     return *val;
   };
 }
+
+auto GetTimezone(std::string_view tz) -> const std::chrono::time_zone * {
+  try {
+    return std::chrono::locate_zone(tz);
+  } catch (const std::runtime_error &e) {
+    spdlog::warn("Unsupported timezone: {}", e.what());
+    return nullptr;
+  }
+}
+
+bool ValidTimezone(std::string_view tz) { return GetTimezone(tz) != nullptr; }
 
 }  // namespace
 
@@ -201,9 +219,22 @@ void Initialize() {
       },
       ValidBoolStr);
 
+  /*
+   * Register cartesian enable flag
+   */
   register_flag(
       kCartesianProductEnabledGFlagsKey, kCartesianProductEnabledSettingKey, !kRestore,
       [](const std::string &val) { cartesian_product_enabled_ = val == "true"; }, ValidBoolStr);
+
+  /*
+   * Register timezone setting
+   */
+  register_flag(
+      kTimezoneGFlagsKey, kTimezoneSettingKey, kRestore,
+      [](const std::string &val) {
+        timezone_ = ::GetTimezone(val);  // Cache for faster access
+      },
+      ValidTimezone);
 }
 
 std::string GetServerName() {
@@ -218,5 +249,7 @@ double GetExecutionTimeout() { return execution_timeout_sec_; }
 bool GetHopsLimitPartialResults() { return hops_limit_partial_results; }
 
 bool GetCartesianProductEnabled() { return cartesian_product_enabled_; }
+
+const std::chrono::time_zone *GetTimezone() { return timezone_; }
 
 }  // namespace memgraph::flags::run_time

--- a/src/flags/run_time_configurable.cpp
+++ b/src/flags/run_time_configurable.cpp
@@ -25,7 +25,7 @@
 
 namespace {
 bool ValidTimezone(std::string_view tz);
-}
+}  // namespace
 
 /*
  * Setup GFlags

--- a/src/flags/run_time_configurable.hpp
+++ b/src/flags/run_time_configurable.hpp
@@ -10,8 +10,8 @@
 // licenses/APL.txt.
 #pragma once
 
-#include "utils/spin_lock.hpp"
-#include "utils/synchronized.hpp"
+#include <chrono>
+#include <string>
 
 namespace memgraph::flags::run_time {
 
@@ -48,5 +48,12 @@ bool GetHopsLimitPartialResults();
  * @return bool
  */
 bool GetCartesianProductEnabled();
+
+/**
+ * @brief Get the current timezone object
+ *
+ * @return const std::chrono::time_zone*
+ */
+const std::chrono::time_zone *GetTimezone();
 
 }  // namespace memgraph::flags::run_time

--- a/src/glue/communication.cpp
+++ b/src/glue/communication.cpp
@@ -328,8 +328,9 @@ storage::PropertyValue ToPropertyValue(communication::bolt::Value const &value, 
       return storage::PropertyValue(
           storage::TemporalData(storage::TemporalType::LocalTime, value.ValueLocalTime().MicrosecondsSinceEpoch()));
     case Value::Type::LocalDateTime:
+      // Bolt uses time since epoch without timezone (as if in UTC)
       return storage::PropertyValue(storage::TemporalData(storage::TemporalType::LocalDateTime,
-                                                          value.ValueLocalDateTime().MicrosecondsSinceEpoch()));
+                                                          value.ValueLocalDateTime().SysMicrosecondsSinceEpoch()));
     case Value::Type::Duration:
       return storage::PropertyValue(
           storage::TemporalData(storage::TemporalType::Duration, value.ValueDuration().microseconds));

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -1232,8 +1232,7 @@ TypedValue Date(const TypedValue *args, int64_t nargs, const FunctionContext &ct
   }
 
   if (args[0].IsLocalDateTime()) {
-    utils::Date date{args[0].ValueLocalDateTime().date()};
-    return TypedValue(date, ctx.memory);
+    return TypedValue(utils::Date{args[0].ValueLocalDateTime().date()}, ctx.memory);
   }
 
   if (args[0].IsString()) {
@@ -1260,8 +1259,7 @@ TypedValue LocalTime(const TypedValue *args, int64_t nargs, const FunctionContex
   }
 
   if (args[0].IsLocalDateTime()) {
-    utils::LocalTime local_time{args[0].ValueLocalDateTime().local_time()};
-    return TypedValue(local_time, ctx.memory);
+    return TypedValue(utils::LocalTime{args[0].ValueLocalDateTime().local_time()}, ctx.memory);
   }
 
   if (args[0].IsString()) {

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -1050,7 +1050,8 @@ TypedValue Timestamp(const TypedValue *args, int64_t nargs, const FunctionContex
     return TypedValue(arg.ValueLocalTime().MicrosecondsSinceEpoch(), ctx.memory);
   }
   if (arg.IsLocalDateTime()) {
-    return TypedValue(arg.ValueLocalDateTime().MicrosecondsSinceEpoch(), ctx.memory);
+    // Timestamps need to be in system time (UTC)
+    return TypedValue(arg.ValueLocalDateTime().SysMicrosecondsSinceEpoch(), ctx.memory);
   }
   if (arg.IsDuration()) {
     return TypedValue(arg.ValueDuration().microseconds, ctx.memory);
@@ -1227,11 +1228,11 @@ void MapNumericParameters(auto &parameter_mappings, const auto &input_parameters
 TypedValue Date(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
   FType<Optional<Or<String, Map, LocalDateTime>>>("date", args, nargs);
   if (nargs == 0) {
-    return TypedValue(utils::LocalDateTime(ctx.timestamp).date, ctx.memory);
+    return TypedValue(utils::LocalDateTime(ctx.timestamp).date(), ctx.memory);
   }
 
   if (args[0].IsLocalDateTime()) {
-    utils::Date date{args[0].ValueLocalDateTime().date};
+    utils::Date date{args[0].ValueLocalDateTime().date()};
     return TypedValue(date, ctx.memory);
   }
 
@@ -1255,11 +1256,11 @@ TypedValue LocalTime(const TypedValue *args, int64_t nargs, const FunctionContex
   FType<Optional<Or<String, Map, LocalDateTime>>>("localtime", args, nargs);
 
   if (nargs == 0) {
-    return TypedValue(utils::LocalDateTime(ctx.timestamp).local_time, ctx.memory);
+    return TypedValue(utils::LocalDateTime(ctx.timestamp).local_time(), ctx.memory);
   }
 
   if (args[0].IsLocalDateTime()) {
-    utils::LocalTime local_time{args[0].ValueLocalDateTime().local_time};
+    utils::LocalTime local_time{args[0].ValueLocalDateTime().local_time()};
     return TypedValue(local_time, ctx.memory);
   }
 

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -661,10 +661,10 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
       case TypedValue::Type::LocalDateTime: {
         const auto &prop_name = property_lookup.property_.name;
         const auto &ldt = expression_result_ptr->ValueLocalDateTime();
-        if (auto date_field = maybe_date(ldt.date, prop_name); date_field) {
+        if (auto date_field = maybe_date(ldt.date(), prop_name); date_field) {
           return std::move(*date_field);
         }
-        if (auto lt_field = maybe_local_time(ldt.local_time, prop_name); lt_field) {
+        if (auto lt_field = maybe_local_time(ldt.local_time(), prop_name); lt_field) {
           return TypedValue(*lt_field, ctx_->memory);
         }
         throw QueryRuntimeException("Invalid property name {} for LocalDateTime", prop_name);
@@ -747,8 +747,8 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
       }
       case TypedValue::Type::LocalDateTime: {
         const auto &ldt = expression_result.ValueLocalDateTime();
-        const auto &date = ldt.date;
-        const auto &lt = ldt.local_time;
+        const auto &date = ldt.date();
+        const auto &lt = ldt.local_time();
         result.emplace("year", TypedValue(date.year, ctx_->memory));
         result.emplace("month", TypedValue(date.month, ctx_->memory));
         result.emplace("day", TypedValue(date.day, ctx_->memory));

--- a/src/query/procedure/mg_procedure_impl.cpp
+++ b/src/query/procedure/mg_procedure_impl.cpp
@@ -1515,41 +1515,42 @@ mgp_error mgp_local_date_time_equal(mgp_local_date_time *first, mgp_local_date_t
 }
 
 mgp_error mgp_local_date_time_get_year(mgp_local_date_time *local_date_time, int *year) {
-  return WrapExceptions([local_date_time] { return local_date_time->local_date_time.date.year; }, year);
+  return WrapExceptions([local_date_time] { return local_date_time->local_date_time.date().year; }, year);
 }
 
 mgp_error mgp_local_date_time_get_month(mgp_local_date_time *local_date_time, int *month) {
-  return WrapExceptions([local_date_time] { return local_date_time->local_date_time.date.month; }, month);
+  return WrapExceptions([local_date_time] { return local_date_time->local_date_time.date().month; }, month);
 }
 
 mgp_error mgp_local_date_time_get_day(mgp_local_date_time *local_date_time, int *day) {
-  return WrapExceptions([local_date_time] { return local_date_time->local_date_time.date.day; }, day);
+  return WrapExceptions([local_date_time] { return local_date_time->local_date_time.date().day; }, day);
 }
 
 mgp_error mgp_local_date_time_get_hour(mgp_local_date_time *local_date_time, int *hour) {
-  return WrapExceptions([local_date_time] { return local_date_time->local_date_time.local_time.hour; }, hour);
+  return WrapExceptions([local_date_time] { return local_date_time->local_date_time.local_time().hour; }, hour);
 }
 
 mgp_error mgp_local_date_time_get_minute(mgp_local_date_time *local_date_time, int *minute) {
-  return WrapExceptions([local_date_time] { return local_date_time->local_date_time.local_time.minute; }, minute);
+  return WrapExceptions([local_date_time] { return local_date_time->local_date_time.local_time().minute; }, minute);
 }
 
 mgp_error mgp_local_date_time_get_second(mgp_local_date_time *local_date_time, int *second) {
-  return WrapExceptions([local_date_time] { return local_date_time->local_date_time.local_time.second; }, second);
+  return WrapExceptions([local_date_time] { return local_date_time->local_date_time.local_time().second; }, second);
 }
 
 mgp_error mgp_local_date_time_get_millisecond(mgp_local_date_time *local_date_time, int *millisecond) {
-  return WrapExceptions([local_date_time] { return local_date_time->local_date_time.local_time.millisecond; },
+  return WrapExceptions([local_date_time] { return local_date_time->local_date_time.local_time().millisecond; },
                         millisecond);
 }
 
 mgp_error mgp_local_date_time_get_microsecond(mgp_local_date_time *local_date_time, int *microsecond) {
-  return WrapExceptions([local_date_time] { return local_date_time->local_date_time.local_time.microsecond; },
+  return WrapExceptions([local_date_time] { return local_date_time->local_date_time.local_time().microsecond; },
                         microsecond);
 }
 
 mgp_error mgp_local_date_time_timestamp(mgp_local_date_time *local_date_time, int64_t *timestamp) {
-  return WrapExceptions([local_date_time] { return local_date_time->local_date_time.MicrosecondsSinceEpoch(); },
+  // Timestamps need to be in system time (UTC)
+  return WrapExceptions([local_date_time] { return local_date_time->local_date_time.SysMicrosecondsSinceEpoch(); },
                         timestamp);
 }
 
@@ -1830,9 +1831,10 @@ memgraph::storage::PropertyValue ToPropertyValue(const mgp_value &value) {
       return memgraph::storage::PropertyValue{memgraph::storage::TemporalData{
           memgraph::storage::TemporalType::LocalTime, value.local_time_v->local_time.MicrosecondsSinceEpoch()}};
     case MGP_VALUE_TYPE_LOCAL_DATE_TIME:
+      // Use generic system time (UTC)
       return memgraph::storage::PropertyValue{
           memgraph::storage::TemporalData{memgraph::storage::TemporalType::LocalDateTime,
-                                          value.local_date_time_v->local_date_time.MicrosecondsSinceEpoch()}};
+                                          value.local_date_time_v->local_date_time.SysMicrosecondsSinceEpoch()}};
     case MGP_VALUE_TYPE_DURATION:
       return memgraph::storage::PropertyValue{memgraph::storage::TemporalData{memgraph::storage::TemporalType::Duration,
                                                                               value.duration_v->duration.microseconds}};

--- a/src/query/procedure/py_module.cpp
+++ b/src/query/procedure/py_module.cpp
@@ -2695,8 +2695,8 @@ py::Object MgpValueToPyObject(const mgp_value &value, PyGraph *py_graph) {
       return py_local_time;
     }
     case MGP_VALUE_TYPE_LOCAL_DATE_TIME: {
-      const auto &local_time = value.local_date_time_v->local_date_time.local_time;
-      const auto &date = value.local_date_time_v->local_date_time.date;
+      const auto &local_time = value.local_date_time_v->local_date_time.local_time();
+      const auto &date = value.local_date_time_v->local_date_time.date();
       py::Object py_local_date_time(PyDateTime_FromDateAndTime(
           date.year, date.month, date.day, local_time.hour, local_time.minute, local_time.second,
           local_time.millisecond * kMicrosecondsInMillisecond + local_time.microsecond));

--- a/src/query/typed_value.cpp
+++ b/src/query/typed_value.cpp
@@ -357,8 +357,9 @@ TypedValue::operator storage::PropertyValue() const {
       return storage::PropertyValue(
           storage::TemporalData{storage::TemporalType::LocalTime, local_time_v.MicrosecondsSinceEpoch()});
     case Type::LocalDateTime:
+      // Use generic system time (UTC)
       return storage::PropertyValue(
-          storage::TemporalData{storage::TemporalType::LocalDateTime, local_date_time_v.MicrosecondsSinceEpoch()});
+          storage::TemporalData{storage::TemporalType::LocalDateTime, local_date_time_v.SysMicrosecondsSinceEpoch()});
     case Type::ZonedDateTime:
       return storage::PropertyValue(storage::ZonedTemporalData{storage::ZonedTemporalType::ZonedDateTime,
                                                                zoned_date_time_v.SysTimeSinceEpoch(),

--- a/src/storage/v2/temporal.hpp
+++ b/src/storage/v2/temporal.hpp
@@ -34,6 +34,7 @@ constexpr std::string_view TemporalTypeToString(const TemporalType type) {
 }
 
 struct TemporalData {
+  // For localdatetime use system time (UTC microseconds since epoch)
   explicit TemporalData(TemporalType type, int64_t microseconds);
 
   auto operator<=>(const TemporalData &) const = default;

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -39,7 +39,7 @@ find_package(fmt REQUIRED)
 find_package(gflags REQUIRED)
 find_package(Threads REQUIRED)
 target_link_libraries(mg-utils PUBLIC Boost::headers fmt::fmt spdlog::spdlog json)
-target_link_libraries(mg-utils PRIVATE librdtsc stdc++fs Threads::Threads gflags uuid rt)
+target_link_libraries(mg-utils PRIVATE librdtsc stdc++fs Threads::Threads gflags uuid rt mg-flags)
 
 add_library(mg-settings STATIC)
 target_sources(mg-settings

--- a/src/utils/temporal.cpp
+++ b/src/utils/temporal.cpp
@@ -25,8 +25,13 @@
 #include <utility>
 #include <variant>
 
+#include "flags/run_time_configurable.hpp"
 #include "utils/exceptions.hpp"
 #include "utils/fnv.hpp"
+
+#include <fmt/chrono.h>
+#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace memgraph::utils {
 namespace {
@@ -87,9 +92,9 @@ Date::Date(const DateParameters &date_parameters) {
   day = date_parameters.day;
 }
 
-Date CurrentDate() { return CurrentLocalDateTime().date; }
+Date CurrentDate() { return CurrentLocalDateTime().date(); }
 
-LocalTime CurrentLocalTime() { return CurrentLocalDateTime().local_time; }
+LocalTime CurrentLocalTime() { return CurrentLocalDateTime().local_time(); }
 
 LocalDateTime CurrentLocalDateTime() {
   namespace chrono = std::chrono;
@@ -486,21 +491,50 @@ std::pair<DateParameters, LocalTimeParameters> ParseLocalDateTimeParameters(std:
   }
 }
 
-LocalDateTime::LocalDateTime(const int64_t microseconds) {
-  auto chrono_microseconds = std::chrono::microseconds(microseconds);
-  static constexpr int64_t one_day_in_microseconds = std::chrono::microseconds{std::chrono::days{1}}.count();
-  if (microseconds < 0 && (microseconds % one_day_in_microseconds != 0)) {
-    date = Date(microseconds - one_day_in_microseconds);
-  } else {
-    date = Date(microseconds);
-  }
-  chrono_microseconds -= std::chrono::microseconds{date.MicrosecondsSinceEpoch()};
-  local_time = LocalTime(chrono_microseconds.count());
+LocalDateTime::LocalDateTime(const int64_t microseconds)
+    : us_since_epoch_(std::chrono::sys_time<std::chrono::microseconds>(std::chrono::microseconds(microseconds))) {
+  // Already UTC
 }
 
-// return microseconds normilized with regard to epoch time point
+LocalDateTime::LocalDateTime(const DateParameters &date_parameters, const LocalTimeParameters &local_time_parameters) {
+  auto us_since_epoch_local = std::chrono::microseconds{Date{date_parameters}.MicrosecondsSinceEpoch() +
+                                                        LocalTime{local_time_parameters}.MicrosecondsSinceEpoch()};
+  const auto *tz = flags::run_time::GetTimezone();
+  if (tz) {
+    // APPLY TIMEZONE (local to UTC)
+    us_since_epoch_ =
+        tz->to_sys(std::chrono::local_time<std::chrono::microseconds>(std::chrono::microseconds(us_since_epoch_local)));
+  } else {
+    // Fallback to UTC
+    us_since_epoch_ = std::chrono::sys_time<std::chrono::microseconds>(std::chrono::microseconds(us_since_epoch_local));
+  }
+}
+
+LocalDateTime::LocalDateTime(const Date &date, const LocalTime &local_time) {
+  auto us_since_epoch_local =
+      std::chrono::microseconds{date.MicrosecondsSinceEpoch() + local_time.MicrosecondsSinceEpoch()};
+  const auto *tz = flags::run_time::GetTimezone();
+  if (tz) {
+    // APPLY TIMEZONE (local to UTC)
+    us_since_epoch_ =
+        tz->to_sys(std::chrono::local_time<std::chrono::microseconds>(std::chrono::microseconds(us_since_epoch_local)));
+  } else {
+    // Fallback to UTC
+    us_since_epoch_ = std::chrono::sys_time<std::chrono::microseconds>(std::chrono::microseconds(us_since_epoch_local));
+  }
+}
+
+// return microseconds normalized with regard to epoch time point
+int64_t LocalDateTime::SysMicrosecondsSinceEpoch() const { return us_since_epoch_.time_since_epoch().count(); }
+
 int64_t LocalDateTime::MicrosecondsSinceEpoch() const {
-  return date.MicrosecondsSinceEpoch() + local_time.MicrosecondsSinceEpoch();
+  const auto *tz = flags::run_time::GetTimezone();
+  if (tz) {
+    // APPLY TIMEZONE (UTC to local)
+    return tz->to_local(us_since_epoch_).time_since_epoch().count();
+  }
+  // Fallback to UTC
+  return us_since_epoch_.time_since_epoch().count();
 }
 
 int64_t LocalDateTime::SecondsSinceEpoch() const {
@@ -510,24 +544,33 @@ int64_t LocalDateTime::SecondsSinceEpoch() const {
 
 int64_t LocalDateTime::SubSecondsAsNanoseconds() const {
   namespace chrono = std::chrono;
-  const auto milli_as_nanos = chrono::duration_cast<chrono::nanoseconds>(chrono::milliseconds(local_time.millisecond));
-  const auto micros_as_nanos = chrono::duration_cast<chrono::nanoseconds>(chrono::microseconds(local_time.microsecond));
-
-  return (milli_as_nanos + micros_as_nanos).count();
+  return chrono::duration_cast<chrono::nanoseconds>(chrono::microseconds(MicrosecondsSinceEpoch()) -
+                                                    chrono::seconds(SecondsSinceEpoch()))
+      .count();
 }
 
-std::string LocalDateTime::ToString() const { return date.ToString() + 'T' + local_time.ToString(); }
+std::string LocalDateTime::ToString() const {
+  auto zt = std::chrono::zoned_time(us_since_epoch_);  // Default to UTC
+  const auto *tz = flags::run_time::GetTimezone();
+  if (tz) {
+    // APPLY TIMEZONE (UTC to local)
+    zt = std::chrono::zoned_time(tz, us_since_epoch_);
+  }
+  return std::format("{:%Y-%m-%dT%H:%M:%S}", zt);
+}
 
-LocalDateTime::LocalDateTime(const DateParameters &date_parameters, const LocalTimeParameters &local_time_parameters)
-    : date(date_parameters), local_time(local_time_parameters) {}
+Date LocalDateTime::date() const { return Date{MicrosecondsSinceEpoch()}; }
 
-LocalDateTime::LocalDateTime(const Date &date, const LocalTime &local_time) : date(date), local_time(local_time) {}
+LocalTime LocalDateTime::local_time() const {
+  auto local_datetime = std::chrono::microseconds(MicrosecondsSinceEpoch());
+  /* remove everything above hours */ GetAndSubtractDuration<std::chrono::days>(local_datetime);
+  if (local_datetime.count() < 0) local_datetime += std::chrono::hours(24);
+  return LocalTime{local_datetime.count()};
+}
 
 size_t LocalDateTimeHash::operator()(const LocalDateTime &local_date_time) const {
   utils::HashCombine<uint64_t, uint64_t> hasher;
-  size_t result = hasher(0, LocalTimeHash{}(local_date_time.local_time));
-  result = hasher(result, DateHash{}(local_date_time.date));
-  return result;
+  return hasher(0, local_date_time.MicrosecondsSinceEpoch());
 }
 
 Timezone::Timezone(const std::chrono::minutes offset) {

--- a/src/utils/temporal.hpp
+++ b/src/utils/temporal.hpp
@@ -253,22 +253,89 @@ struct LocalTimeHash {
 std::pair<DateParameters, LocalTimeParameters> ParseLocalDateTimeParameters(std::string_view string);
 
 struct LocalDateTime {
-  // UTC
-  explicit LocalDateTime(int64_t microseconds);
+  /**
+   * @brief Construct a new LocalDateTime object using system time (UTC).
+   *
+   * @param offset_epoch_us Offset from POSIX epoch in microseconds
+   */
+  explicit LocalDateTime(int64_t offset_epoch_us);
 
-  // NOT UTC
+  /**
+   * @brief Construct a new LocalDateTime object using local/calendar date and time.
+   *
+   * This constructor will take in the calendar date-time and convert it to system time using the instance timezone.
+   *
+   * @param date_parameters
+   * @param local_time_parameters
+   */
   explicit LocalDateTime(const DateParameters &date_parameters, const LocalTimeParameters &local_time_parameters);
+
+  /**
+   * @brief Construct a new LocalDateTime object using local/calendar date and time.
+   *
+   * This constructor will take in the calendar date-time and convert it to system time using the instance timezone.
+   *
+   * @param date
+   * @param local_time
+   */
   explicit LocalDateTime(const Date &date, const LocalTime &local_time);
 
-  // UTC
+  /**
+   * @brief Returns offset in system time (UTC).
+   *
+   * @return int64_t
+   */
   int64_t SysMicrosecondsSinceEpoch() const;
 
-  // NOT UTC
+  /**
+   * @brief Returns offset in calendar time.
+   *
+   * @note Useful for object that do not support timezones, but still might want to display the correct time.
+   * @see Date LocalTime
+   *
+   * @return int64_t
+   */
   int64_t MicrosecondsSinceEpoch() const;
+
+  /**
+   * @brief Returns offset in calendar time.
+   *
+   * @note Useful for object that do not support timezones, but still might want to display the correct time.
+   * @see bolt base_encoder
+   *
+   * @return int64_t
+   */
   int64_t SecondsSinceEpoch() const;
+
+  /**
+   * @brief Returns offset in calendar time.
+   *
+   * @note Useful for object that do not support timezones, but still might want to display the correct time.
+   * @see bolt base_encoder
+   *
+   * @return int64_t
+   */
   int64_t SubSecondsAsNanoseconds() const;
+
+  /**
+   * @brief Return string representing calendar time (local/user timezone)
+   *
+   * @return std::string
+   */
   std::string ToString() const;
+
+  /**
+   * @brief Return calendar date (local/user timezone)
+   *
+   * @return Date
+   */
   Date date() const;
+
+  /**
+   * @brief Return calendar time (local/user timezone)
+   *
+   * @return Date
+   */
   LocalTime local_time() const;
 
   auto operator<=>(const LocalDateTime &) const = default;
@@ -276,6 +343,7 @@ struct LocalDateTime {
   friend std::ostream &operator<<(std::ostream &os, const LocalDateTime &ldt) { return os << ldt.ToString(); }
 
   friend LocalDateTime operator+(const LocalDateTime &dt, const Duration &dur) {
+    // Use calendar time since we want to restrict allowed dates
     const auto local_date_time_as_duration = Duration(dt.MicrosecondsSinceEpoch());
     const auto result = local_date_time_as_duration + dur;
     namespace chrono = std::chrono;
@@ -294,8 +362,8 @@ struct LocalDateTime {
     return Duration(lhs.MicrosecondsSinceEpoch()) - Duration(rhs.MicrosecondsSinceEpoch());
   }
 
-  // UTC
-  std::chrono::sys_time<std::chrono::microseconds> us_since_epoch_;
+  std::chrono::sys_time<std::chrono::microseconds>
+      us_since_epoch_;  //!< system time representing the local date time (no timezone applied)
 };
 static_assert(sizeof(LocalDateTime) == 8);
 

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -218,6 +218,11 @@ startup_config_dict = {
         "false",
         "Set to true to enable telemetry. We collect information about the running system (CPU and memory information) and information about the database runtime (vertex and edge counts and resource usage) to allow for easier improvement of the product.",
     ),
+    "timezone": (
+        "UTC",
+        "UTC",
+        "Define instance's timezone (IANA format).",
+    ),
     "query_cost_planner": ("true", "true", "Use the cost-estimating query planner."),
     "query_plan_cache_max_size": ("1000", "1000", "Maximum number of query plans to cache."),
     "query_vertex_count_to_expand_existing": (

--- a/tests/e2e/temporal_types/roundtrip.cpp
+++ b/tests/e2e/temporal_types/roundtrip.cpp
@@ -302,6 +302,11 @@ int main(int argc, char **argv) {
   TestDate(*client);
   TestLocalTime(*client);
   TestLocalDateTime(*client);
+  MaybeExecuteQuery(*client, R"(SET DATABASE SETTING "timezone" TO "Europe/Rome")", "Timezone");
+  TestLocalDateTime(*client);
+  MaybeExecuteQuery(*client, R"(SET DATABASE SETTING "timezone" TO "America/Los_Angeles")", "Timezone");
+  TestLocalDateTime(*client);
+  MaybeExecuteQuery(*client, R"(SET DATABASE SETTING "timezone" TO "UTC")", "Timezone");
   TestZonedDateTime(*client);
   TestDuration(*client);
   return 0;

--- a/tests/e2e/temporal_types/roundtrip.cpp
+++ b/tests/e2e/temporal_types/roundtrip.cpp
@@ -302,10 +302,13 @@ int main(int argc, char **argv) {
   TestDate(*client);
   TestLocalTime(*client);
   TestLocalDateTime(*client);
+  MaybeExecuteQuery(*client, "MATCH(n) DETACH DELETE n", "Clear");
   MaybeExecuteQuery(*client, R"(SET DATABASE SETTING "timezone" TO "Europe/Rome")", "Timezone");
   TestLocalDateTime(*client);
+  MaybeExecuteQuery(*client, "MATCH(n) DETACH DELETE n", "Clear");
   MaybeExecuteQuery(*client, R"(SET DATABASE SETTING "timezone" TO "America/Los_Angeles")", "Timezone");
   TestLocalDateTime(*client);
+  MaybeExecuteQuery(*client, "MATCH(n) DETACH DELETE n", "Clear");
   MaybeExecuteQuery(*client, R"(SET DATABASE SETTING "timezone" TO "UTC")", "Timezone");
   TestZonedDateTime(*client);
   TestDuration(*client);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -289,7 +289,7 @@ add_unit_test(utils_settings.cpp)
 target_link_libraries(${test_prefix}utils_settings mg-utils mg-settings)
 
 add_unit_test(utils_temporal utils_temporal.cpp)
-target_link_libraries(${test_prefix}utils_temporal mg-utils)
+target_link_libraries(${test_prefix}utils_temporal mg-utils mg-flags)
 
 add_unit_test(utils_java_string_formatter.cpp)
 target_link_libraries(${test_prefix}utils_java_string_formatter mg-utils)

--- a/tests/unit/bolt_decoder.cpp
+++ b/tests/unit/bolt_decoder.cpp
@@ -14,11 +14,16 @@
 #include "bolt_common.hpp"
 #include "bolt_testdata.hpp"
 #include "communication/bolt/v1/decoder/decoder.hpp"
+#include "timezone_handler.hpp"
 
 using memgraph::communication::bolt::Value;
 
+namespace {
+
 inline constexpr const int SIZE = 131072;
 uint8_t data[SIZE];
+
+}  // namespace
 
 /**
  * TestDecoderBuffer
@@ -662,7 +667,7 @@ TEST_F(BoltDecoder, LocalTimeOneThousandMicro) {
   AssertThatLocalTimeIsEqual(dv.ValueLocalTime(), local_time);
 }
 
-TEST_F(BoltDecoder, LocalDateTime) {
+void test_LocalDateTime() {
   TestDecoderBuffer buffer;
   DecoderT decoder(buffer);
 
@@ -695,8 +700,18 @@ TEST_F(BoltDecoder, LocalDateTime) {
   buffer.Clear();
   buffer.Write(data.data(), data.size());
   ASSERT_EQ(decoder.ReadValue(&dv, Value::Type::LocalDateTime), true);
-  AssertThatDatesAreEqual(dv.ValueLocalDateTime().date, local_date_time.date);
-  AssertThatLocalTimeIsEqual(dv.ValueLocalDateTime().local_time, local_date_time.local_time);
+  AssertThatDatesAreEqual(dv.ValueLocalDateTime().date(), local_date_time.date());
+  AssertThatLocalTimeIsEqual(dv.ValueLocalDateTime().local_time(), local_date_time.local_time());
+}
+
+TEST_F(BoltDecoder, LocalDateTime) { test_LocalDateTime(); }
+
+TEST_F(BoltDecoder, LocalDateTimeTZ) {
+  HandleTimezone htz;
+  htz.Set("Europe/Rome");
+  test_LocalDateTime();
+  htz.Set("America/Los_Angeles");
+  test_LocalDateTime();
 }
 
 TEST_F(BoltDecoder, ZonedDateTime) {

--- a/tests/unit/cpp_api.cpp
+++ b/tests/unit/cpp_api.cpp
@@ -23,6 +23,7 @@
 #include "storage/v2/disk/storage.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/view.hpp"
+#include "timezone_handler.hpp"
 
 template <typename StorageType>
 struct CppApiTestFixture : public ::testing::Test {
@@ -407,7 +408,7 @@ TYPED_TEST(CppApiTestFixture, TestLocalTime) {
   auto value_y = mgp::Value(mgp::LocalTime("09:15:00"));
 }
 
-TYPED_TEST(CppApiTestFixture, TestLocalDateTime) {
+void test_TestLocalDateTime() {
   auto ldt_1 = mgp::LocalDateTime("2021-10-05T14:15:00");
   auto ldt_2 = mgp::LocalDateTime(2021, 10, 5, 14, 15, 0, 0, 0);
 
@@ -438,6 +439,16 @@ TYPED_TEST(CppApiTestFixture, TestLocalDateTime) {
   auto value_x = mgp::Value(ldt_1);
   // Use Value move constructor
   auto value_y = mgp::Value(mgp::LocalDateTime("2021-10-05T14:15:00"));
+}
+
+TYPED_TEST(CppApiTestFixture, TestLocalDateTime) { test_TestLocalDateTime(); }
+
+TYPED_TEST(CppApiTestFixture, TestLocalDateTimeTZ) {
+  HandleTimezone htz;
+  htz.Set("Europe/Rome");
+  test_TestLocalDateTime();
+  htz.Set("America/Los_Angeles");
+  test_TestLocalDateTime();
 }
 
 TYPED_TEST(CppApiTestFixture, TestDuration) {

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -34,6 +34,7 @@
 #include "storage/v2/enum.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/storage.hpp"
+#include "tests/unit/timezone_handler.hpp"
 #include "utils/exceptions.hpp"
 #include "utils/string.hpp"
 
@@ -1348,48 +1349,57 @@ TYPED_TEST(ExpressionEvaluatorPropertyLookup, LocalTime) {
 }
 
 TYPED_TEST(ExpressionEvaluatorPropertyLookup, LocalDateTime) {
-  const memgraph::utils::LocalDateTime ldt({1993, 8, 6}, {2, 3, 4, 55, 40});
-  this->frame[this->symbol] = TypedValue(ldt);
+  auto test = [&]() {
+    const memgraph::utils::LocalDateTime ldt({1993, 8, 6}, {2, 3, 4, 55, 40});
+    this->frame[this->symbol] = TypedValue(ldt);
 
-  const std::pair year = std::make_pair("year", this->dba.NameToProperty("year"));
-  const auto y = this->Value(year);
-  EXPECT_TRUE(y.IsInt());
-  EXPECT_EQ(y.ValueInt(), 1993);
+    const std::pair year = std::make_pair("year", this->dba.NameToProperty("year"));
+    const auto y = this->Value(year);
+    EXPECT_TRUE(y.IsInt());
+    EXPECT_EQ(y.ValueInt(), 1993);
 
-  const std::pair month = std::make_pair("month", this->dba.NameToProperty("month"));
-  const auto m = this->Value(month);
-  EXPECT_TRUE(m.IsInt());
-  EXPECT_EQ(m.ValueInt(), 8);
+    const std::pair month = std::make_pair("month", this->dba.NameToProperty("month"));
+    const auto m = this->Value(month);
+    EXPECT_TRUE(m.IsInt());
+    EXPECT_EQ(m.ValueInt(), 8);
 
-  const std::pair day = std::make_pair("day", this->dba.NameToProperty("day"));
-  const auto d = this->Value(day);
-  EXPECT_TRUE(d.IsInt());
-  EXPECT_EQ(d.ValueInt(), 6);
+    const std::pair day = std::make_pair("day", this->dba.NameToProperty("day"));
+    const auto d = this->Value(day);
+    EXPECT_TRUE(d.IsInt());
+    EXPECT_EQ(d.ValueInt(), 6);
 
-  const std::pair hour = std::make_pair("hour", this->dba.NameToProperty("hour"));
-  const auto h = this->Value(hour);
-  EXPECT_TRUE(h.IsInt());
-  EXPECT_EQ(h.ValueInt(), 2);
+    const std::pair hour = std::make_pair("hour", this->dba.NameToProperty("hour"));
+    const auto h = this->Value(hour);
+    EXPECT_TRUE(h.IsInt());
+    EXPECT_EQ(h.ValueInt(), 2);
 
-  const std::pair minute = std::make_pair("minute", this->dba.NameToProperty("minute"));
-  const auto min = this->Value(minute);
-  EXPECT_TRUE(min.IsInt());
-  EXPECT_EQ(min.ValueInt(), 3);
+    const std::pair minute = std::make_pair("minute", this->dba.NameToProperty("minute"));
+    const auto min = this->Value(minute);
+    EXPECT_TRUE(min.IsInt());
+    EXPECT_EQ(min.ValueInt(), 3);
 
-  const std::pair second = std::make_pair("second", this->dba.NameToProperty("second"));
-  const auto sec = this->Value(second);
-  EXPECT_TRUE(sec.IsInt());
-  EXPECT_EQ(sec.ValueInt(), 4);
+    const std::pair second = std::make_pair("second", this->dba.NameToProperty("second"));
+    const auto sec = this->Value(second);
+    EXPECT_TRUE(sec.IsInt());
+    EXPECT_EQ(sec.ValueInt(), 4);
 
-  const std::pair millis = std::make_pair("millisecond", this->dba.NameToProperty("millisecond"));
-  const auto mil = this->Value(millis);
-  EXPECT_TRUE(mil.IsInt());
-  EXPECT_EQ(mil.ValueInt(), 55);
+    const std::pair millis = std::make_pair("millisecond", this->dba.NameToProperty("millisecond"));
+    const auto mil = this->Value(millis);
+    EXPECT_TRUE(mil.IsInt());
+    EXPECT_EQ(mil.ValueInt(), 55);
 
-  const std::pair micros = std::make_pair("microsecond", this->dba.NameToProperty("microsecond"));
-  const auto mic = this->Value(micros);
-  EXPECT_TRUE(mic.IsInt());
-  EXPECT_EQ(mic.ValueInt(), 40);
+    const std::pair micros = std::make_pair("microsecond", this->dba.NameToProperty("microsecond"));
+    const auto mic = this->Value(micros);
+    EXPECT_TRUE(mic.IsInt());
+    EXPECT_EQ(mic.ValueInt(), 40);
+  };
+
+  HandleTimezone htz;
+  test();
+  htz.Set("Europe/Rome");
+  test();
+  htz.Set("America/Los_Angeles");
+  test();
 }
 
 TYPED_TEST(ExpressionEvaluatorPropertyLookup, ZonedDateTime) {
@@ -1524,10 +1534,18 @@ TYPED_TEST(ExpressionEvaluatorAllPropertiesLookup, LocalTime) {
 }
 
 TYPED_TEST(ExpressionEvaluatorAllPropertiesLookup, LocalDateTime) {
-  const memgraph::utils::LocalDateTime ldt({1993, 8, 6}, {2, 3, 4, 55, 40});
-  this->frame[this->symbol] = TypedValue(ldt);
-  auto all_properties = this->Value();
-  EXPECT_TRUE(all_properties.IsMap());
+  auto test = [&]() {
+    const memgraph::utils::LocalDateTime ldt({1993, 8, 6}, {2, 3, 4, 55, 40});
+    this->frame[this->symbol] = TypedValue(ldt);
+    auto all_properties = this->Value();
+    EXPECT_TRUE(all_properties.IsMap());
+  };
+  HandleTimezone htz;
+  test();
+  htz.Set("Europe/Rome");
+  test();
+  htz.Set("America/Los_Angeles");
+  test();
 }
 
 TYPED_TEST(ExpressionEvaluatorAllPropertiesLookup, ZonedDateTime) {
@@ -2155,8 +2173,16 @@ TYPED_TEST(FunctionTest, ToStringLocalTime) {
 }
 
 TYPED_TEST(FunctionTest, ToStringLocalDateTime) {
-  const auto ldt = memgraph::utils::LocalDateTime({1970, 1, 2}, {23, 02, 59});
-  EXPECT_EQ(this->EvaluateFunction("TOSTRING", ldt).ValueString(), "1970-01-02T23:02:59.000000");
+  auto test = [&]() {
+    const auto ldt = memgraph::utils::LocalDateTime({1970, 1, 2}, {23, 02, 59});
+    EXPECT_EQ(this->EvaluateFunction("TOSTRING", ldt).ValueString(), "1970-01-02T23:02:59.000000");
+  };
+  HandleTimezone htz;
+  test();
+  htz.Set("Europe/Rome");
+  test();
+  htz.Set("America/Los_Angeles");
+  test();
 }
 
 TYPED_TEST(FunctionTest, ToStringDuration) {
@@ -2192,9 +2218,17 @@ TYPED_TEST(FunctionTest, TimestampLocalTime) {
 }
 
 TYPED_TEST(FunctionTest, TimestampLocalDateTime) {
-  this->ctx.timestamp = 42;
-  const memgraph::utils::LocalDateTime time(20000);
-  EXPECT_EQ(this->EvaluateFunction("TIMESTAMP", time).ValueInt(), 20000);
+  auto test = [&]() {
+    this->ctx.timestamp = 42;
+    const memgraph::utils::LocalDateTime time(20000);
+    EXPECT_EQ(this->EvaluateFunction("TIMESTAMP", time).ValueInt(), 20000);
+  };
+  HandleTimezone htz;
+  test();
+  htz.Set("Europe/Rome");
+  test();
+  htz.Set("America/Los_Angeles");
+  test();
 }
 
 TYPED_TEST(FunctionTest, TimestampDuration) {
@@ -2399,30 +2433,41 @@ TYPED_TEST(FunctionTest, LocalTime) {
 }
 
 TYPED_TEST(FunctionTest, LocalDateTime) {
-  const auto local_date_time = memgraph::utils::LocalDateTime({1970, 1, 1}, {13, 3, 2, 0, 0});
-  EXPECT_EQ(this->EvaluateFunction("LOCALDATETIME", "1970-01-01T13:03:02").ValueLocalDateTime(), local_date_time);
-  const auto today = memgraph::utils::CurrentLocalDateTime();
-  const auto one_sec_in_microseconds = 1000000;
-  const auto map_param = TypedValue(std::map<std::string, TypedValue>{{"year", TypedValue(1972)},
-                                                                      {"month", TypedValue(2)},
-                                                                      {"day", TypedValue(3)},
-                                                                      {"hour", TypedValue(4)},
-                                                                      {"minute", TypedValue(5)},
-                                                                      {"second", TypedValue(6)},
-                                                                      {"millisecond", TypedValue(7)},
-                                                                      {"microsecond", TypedValue(8)}});
+  auto test = [&]() {
+    const auto local_date_time = memgraph::utils::LocalDateTime({1970, 1, 1}, {13, 3, 2, 0, 0});
+    EXPECT_EQ(this->EvaluateFunction("LOCALDATETIME", "1970-01-01T13:03:02").ValueLocalDateTime(), local_date_time);
+    const auto today = memgraph::utils::CurrentLocalDateTime();
+    const auto one_sec_in_microseconds = 1000000;
+    const auto map_param = TypedValue(std::map<std::string, TypedValue>{{"year", TypedValue(1972)},
+                                                                        {"month", TypedValue(2)},
+                                                                        {"day", TypedValue(3)},
+                                                                        {"hour", TypedValue(4)},
+                                                                        {"minute", TypedValue(5)},
+                                                                        {"second", TypedValue(6)},
+                                                                        {"millisecond", TypedValue(7)},
+                                                                        {"microsecond", TypedValue(8)}});
 
-  EXPECT_EQ(this->EvaluateFunction("LOCALDATETIME", map_param).ValueLocalDateTime(),
-            memgraph::utils::LocalDateTime({1972, 2, 3}, {4, 5, 6, 7, 8}));
-  EXPECT_NEAR(this->EvaluateFunction("LOCALDATETIME").ValueLocalDateTime().MicrosecondsSinceEpoch(),
-              today.MicrosecondsSinceEpoch(), one_sec_in_microseconds);
-  EXPECT_THROW(this->EvaluateFunction("LOCALDATETIME", "{}"), memgraph::utils::BasicException);
-  EXPECT_THROW(this->EvaluateFunction("LOCALDATETIME",
-                                      TypedValue(std::map<std::string, TypedValue>{{"hours", TypedValue(1970)}})),
-               QueryRuntimeException);
-  EXPECT_THROW(this->EvaluateFunction("LOCALDATETIME",
-                                      TypedValue(std::map<std::string, TypedValue>{{"seconds", TypedValue(1970)}})),
-               QueryRuntimeException);
+    EXPECT_EQ(this->EvaluateFunction("LOCALDATETIME", map_param).ValueLocalDateTime(),
+              memgraph::utils::LocalDateTime({1972, 2, 3}, {4, 5, 6, 7, 8}));
+    EXPECT_NEAR(this->EvaluateFunction("LOCALDATETIME").ValueLocalDateTime().MicrosecondsSinceEpoch(),
+                today.MicrosecondsSinceEpoch(), one_sec_in_microseconds);
+    EXPECT_NEAR(this->EvaluateFunction("LOCALDATETIME").ValueLocalDateTime().SysMicrosecondsSinceEpoch(),
+                today.SysMicrosecondsSinceEpoch(), one_sec_in_microseconds);
+    EXPECT_THROW(this->EvaluateFunction("LOCALDATETIME", "{}"), memgraph::utils::BasicException);
+    EXPECT_THROW(this->EvaluateFunction("LOCALDATETIME",
+                                        TypedValue(std::map<std::string, TypedValue>{{"hours", TypedValue(1970)}})),
+                 QueryRuntimeException);
+    EXPECT_THROW(this->EvaluateFunction("LOCALDATETIME",
+                                        TypedValue(std::map<std::string, TypedValue>{{"seconds", TypedValue(1970)}})),
+                 QueryRuntimeException);
+  };
+
+  HandleTimezone htz;
+  test();
+  htz.Set("Europe/Rome");
+  test();
+  htz.Set("America/Los_Angeles");
+  test();
 }
 
 TYPED_TEST(FunctionTest, Duration) {

--- a/tests/unit/timezone_handler.hpp
+++ b/tests/unit/timezone_handler.hpp
@@ -1,0 +1,36 @@
+// Copyright 2024 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include "flags/run_time_configurable.hpp"
+#include "utils/settings.hpp"
+
+struct HandleTimezone {
+  HandleTimezone() {
+    memgraph::utils::global_settings.Initialize("/tmp/utils_temporal");
+    memgraph::flags::run_time::Initialize();
+  }
+  ~HandleTimezone() {
+    memgraph::utils::global_settings.SetValue("timezone", "UTC");
+    memgraph::utils::global_settings.Finalize();
+    std::filesystem::remove_all("/tmp/utils_temporal");
+  }
+
+  void Set(std::string_view tz) { memgraph::utils::global_settings.SetValue("timezone", std::string{tz}); }
+
+  // Make sure tests are not using both daylight-saving and standard time
+  int64_t GetOffset_us() {
+    const auto info = std::chrono::locate_zone(*memgraph::utils::global_settings.GetValue("timezone"))
+                          ->get_info(std::chrono::sys_time<std::chrono::seconds>{});
+    return std::chrono::duration_cast<std::chrono::microseconds>(info.offset - info.save).count();
+  };
+};


### PR DESCRIPTION
LocalDateTime now considers set database timezone

Bugfix: LocalDateTime assumed input date-time was always UTC
New command-line argument and database setting `timezone`, which is used for LocalDateTime conversion