### PR TITLE
Fix DecodePropertyValueSize for enums

### DIFF
--- a/src/storage/v2/property_store.cpp
+++ b/src/storage/v2/property_store.cpp
@@ -905,11 +905,12 @@ std::optional<uint64_t> DecodeZonedTemporalDataSize(Reader &reader) {
       return true;
     }
     case Type::ENUM:
-      reader->ReadInt(payload_size);
       // double payload
       // - first for enum type
       // - second for enum value
-      property_size += SizeToByteSize(payload_size) * 2;
+      auto const bytes = SizeToByteSize(payload_size) * 2;
+      if (!reader->SkipBytes(bytes)) return false;
+      property_size += bytes;
       return true;
   }
 }


### PR DESCRIPTION
The internal reader was not reading enough bytes. This caused problems when needing to consume the next item and the reader was in the wrong location.

For example:
`CREATE (n {prop:[X::A, ""]}) RETURN propertySize(n, 'prop');`

Use to give:
```
+-------------------------+
| propertySize(n, 'prop') |
+-------------------------+
| 0                       |
+-------------------------+
```

Now correctly gives:
```
+-------------------------+
| propertySize(n, 'prop') |
+-------------------------+
| 8                       |
+-------------------------+
```