### PR TITLE
Remove benchmark job from flakiness checker

### DIFF
--- a/.github/workflows/check_flakiness.yaml
+++ b/.github/workflows/check_flakiness.yaml
@@ -26,9 +26,6 @@ on:
       release_core:
         type: boolean
         default: true
-      release_benchmark:
-        type: boolean
-        default: true
       release_e2e:
         type: boolean
         default: true
@@ -158,7 +155,7 @@ jobs:
       os: 'debian-11'
       toolchain: 'v5'
       run_core: ${{ needs.DiffSetup.outputs.run_release_core }}
-      run_benchmark: ${{ needs.DiffSetup.outputs.run_release_benchmark }}
+      run_benchmark: 'false'
       run_e2e: ${{ needs.DiffSetup.outputs.run_release_e2e }}
       run_stress: ${{ needs.DiffSetup.outputs.run_release_stress }}
       run_id: "${{ matrix.run_no }}"


### PR DESCRIPTION
This PR removes the benchmark job from the check_flakiness.yaml workflow.