### PR TITLE
Fix Jepsen upgrade

### DIFF
--- a/tests/jepsen/src/jepsen/memgraph/support.clj
+++ b/tests/jepsen/src/jepsen/memgraph/support.clj
@@ -51,8 +51,7 @@
    :--coordinator-id (get node-config :coordinator-id)
    :--coordinator-port (get node-config :coordinator-port)
    :--coordinator-hostname node
-   :--management-port (get node-config :management-port)
-   ))
+   :--management-port (get node-config :management-port)))
 
 (defn start-data-node!
   [test node-config]
@@ -98,7 +97,9 @@
             nodes-config (:nodes-config opts)
             flush-after-n-txn (:sync-after-n-txn opts)]
         (reset! sync-after-n-txn flush-after-n-txn)
-        (c/su (debian/install ['python3 'python3-dev]))
+        (c/su
+         (c/exec :apt-get :update)
+         (debian/install ['python3 'python3-dev]))
         (c/su (meh (c/exec :killall :memgraph)))
         (try (c/exec :command :-v local-binary)
              (catch Exception _


### PR DESCRIPTION
Fixes issue with fetching libpython3.11 packages when running Jepsen tests.
```
STDERR:
E: Failed to fetch http://deb.debian.org/debian/pool/main/p/python3.11/libpython3.11_3.11.2-6_amd64.deb  404  Not Found [IP: 146.75.2.132 80]
E: Failed to fetch http://deb.debian.org/debian/pool/main/p/python3.11/libpython3.11-dev_3.11.2-6_amd64.deb  404  Not Found [IP: 146.75.2.132 80]
E: Failed to fetch http://deb.debian.org/debian/pool/main/p/python3.11/python3.11-dev_3.11.2-6_amd64.deb  404  Not Found [IP: 146.75.2.132 80]
```
