### PR TITLE
Change nuRAFT response limit to respect leadership expiry

### DIFF
--- a/src/coordination/raft_state.cpp
+++ b/src/coordination/raft_state.cpp
@@ -128,6 +128,7 @@ auto RaftState::InitRaftServer() -> void {
   // https://github.com/eBay/NuRaft/blob/master/docs/custom_commit_policy.md#full-consensus-mode
   // we want to set coordinator to unhealthy as soon as it is down and doesn't respond
   auto limits = raft_server::get_raft_limits();
+  // Limit is set to 2 because 2*params.heart_beat_interval_ == params.leadership_expiry_ which is 2000
   limits.response_limit_.store(2);
   raft_server::set_raft_limits(limits);
 

--- a/src/coordination/raft_state.cpp
+++ b/src/coordination/raft_state.cpp
@@ -121,13 +121,15 @@ auto RaftState::InitRaftServer() -> void {
   params.client_req_timeout_ = 3000;
   params.return_method_ = raft_params::blocking;
 
-  // If the leader doesn't receive any response from quorum nodes
-  // in 1800ms, it will step down.
-  // This allows us to achieve strong consistency even if network partition
-  // happens between the current leader and followers.
-  // The value must be <= election_timeout_lower_bound_ so that cluster can never
-  // have multiple leaders.
-  params.leadership_expiry_ = 1800;
+  // leadership expiry needs to be above 0, otherwise leadership never expires
+  // this is bug in nuraft code
+  params.leadership_expiry_ = 2000;
+
+  // https://github.com/eBay/NuRaft/blob/master/docs/custom_commit_policy.md#full-consensus-mode
+  // we want to set coordinator to unhealthy as soon as it is down and doesn't respond
+  auto limits = raft_server::get_raft_limits();
+  limits.response_limit_.store(2);
+  raft_server::set_raft_limits(limits);
 
   raft_server::init_options init_opts;
 


### PR DESCRIPTION
Coordinators didn't yield leadership although they should according to the leadership_expiry_ flag. This diff fixes the issue nuRaft has with leadership expiry, where leadership_expiry is not respected as a limit, but instead, `heart_beat_interval_*raft_server::raft_limits_.response_limit_` is used as expiry for nodes to deem as unhealthy.