### PR TITLE
Add pymgclient to GQLBehave requirements

### DIFF
--- a/tests/gql_behave/requirements.txt
+++ b/tests/gql_behave/requirements.txt
@@ -2,5 +2,6 @@ behave==1.2.6
 neo4j-driver==4.1.1
 parse==1.18.0
 parse-type==0.5.2
+pymgclient==1.3.1
 PyYAML==6.0.1
 six==1.15.0


### PR DESCRIPTION
Pymgclient was missing from tests/gqlbehave/requirements.txt even though it is used in the run.py script.