### PR TITLE
[SchemaInfo] Storage side implementation for statistics merge and updating statistics on vertex creation

### DIFF
--- a/src/storage/v2/CMakeLists.txt
+++ b/src/storage/v2/CMakeLists.txt
@@ -44,6 +44,7 @@ target_sources(mg-storage-v2
         replication/rpc.cpp
         replication/replication_storage_state.cpp
         inmemory/replication/recovery.cpp
+        schema_info.cpp
 
         PUBLIC
         FILE_SET HEADERS
@@ -54,6 +55,7 @@ target_sources(mg-storage-v2
         vertex_info_cache_fwd.hpp
         vertex_info_cache.hpp
         delta_container.hpp
+        schema_info.hpp
 )
 
 find_package(gflags REQUIRED)

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -369,6 +369,11 @@ class InMemoryStorage final : public Storage {
     void FastDiscardOfDeltas(uint64_t oldest_active_timestamp, std::unique_lock<std::mutex> gc_guard);
     void GCRapidDeltaCleanup(std::list<Gid> &current_deleted_vertices, std::list<Gid> &current_deleted_edges);
     SalientConfig::Items config_;
+
+   private:
+    // Used by CreateVertex and CreateVertexEx
+    // @throw std::bad_alloc
+    VertexAccessor CreateVertexInternal(storage::Gid gid);
   };
 
   class ReplicationAccessor final : public InMemoryAccessor {

--- a/src/storage/v2/schema_info.cpp
+++ b/src/storage/v2/schema_info.cpp
@@ -1,0 +1,48 @@
+// Copyright 2024 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "storage/v2/schema_info.hpp"
+
+namespace memgraph::storage {
+
+void PropertyInfo::MergeStats(PropertyInfo &&info) {
+  for (auto &[type, number_of_occurrences] : info.property_types) {
+    auto &existing_value = property_types[type];
+    existing_value += number_of_occurrences;
+  }
+  property_types.insert(info.property_types.begin(), info.property_types.end());
+  number_of_property_occurrences += info.number_of_property_occurrences;
+}
+
+void LabelsInfo::MergeStats(LabelsInfo &&info) {
+  number_of_label_occurrences += info.number_of_label_occurrences;
+  for (auto &[key, value] : info.properties) {
+    auto &existing_value = properties[key];
+    existing_value.MergeStats(std::move(value));
+  }
+}
+
+void NodesInfo::MergeStats(NodesInfo &&info) {
+  for (auto &[key, value] : info.node_types_properties) {
+    auto &existing_value = node_types_properties[key];
+    existing_value.MergeStats(std::move(value));
+  }
+}
+
+void NodesInfo::AddVertex() {
+  node_types_properties[LabelsSet{}].MergeStats(LabelsInfo{.number_of_label_occurrences = 1});
+}
+
+void SchemaInfo::MergeStats(SchemaInfo &&info) { nodes.MergeStats(std::move(info.nodes)); }
+
+void SchemaInfo::AddVertex() { nodes.AddVertex(); }
+
+}  // namespace memgraph::storage

--- a/src/storage/v2/schema_info.hpp
+++ b/src/storage/v2/schema_info.hpp
@@ -1,0 +1,79 @@
+// Copyright 2024 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <cstdint>
+#include <set>
+#include <string>
+#include <unordered_map>
+
+#include <boost/functional/hash.hpp>
+
+namespace memgraph::storage {
+
+enum struct SchemaPropertyType : uint8_t {
+  Null,
+  String,
+  Boolean,
+  Integer,
+  Float,
+  List,
+  Map,
+  Duration,
+  Date,
+  LocalTime,
+  LocalDateTime,
+  ZonedDateTime
+};
+
+struct PropertyInfo {
+  std::unordered_map<SchemaPropertyType, int64_t> property_types;
+  int64_t number_of_property_occurrences = 0;
+
+  PropertyInfo() = default;
+
+  void MergeStats(PropertyInfo &&info);
+};
+
+struct LabelsInfo {
+  std::unordered_map<std::string, PropertyInfo> properties;  // key is a property name
+  int64_t number_of_label_occurrences = 0;
+
+  void MergeStats(LabelsInfo &&info);
+};
+
+struct LabelsHash {
+  std::size_t operator()(const std::set<std::string> &s) const { return boost::hash_range(s.begin(), s.end()); }
+};
+
+struct LabelsComparator {
+  bool operator()(const std::set<std::string> &lhs, const std::set<std::string> &rhs) const { return lhs == rhs; }
+};
+
+struct NodesInfo {
+  using LabelsSet = std::set<std::string>;
+  std::unordered_map<LabelsSet, LabelsInfo, LabelsHash, LabelsComparator> node_types_properties;
+
+  void MergeStats(NodesInfo &&info);
+
+  void AddVertex();
+};
+
+struct SchemaInfo {
+  NodesInfo nodes;
+
+  void MergeStats(SchemaInfo &&info);
+
+  void AddVertex();
+};
+
+}  // namespace memgraph::storage

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -38,6 +38,7 @@
 #include "storage/v2/replication/enums.hpp"
 #include "storage/v2/replication/replication_client.hpp"
 #include "storage/v2/replication/replication_storage_state.hpp"
+#include "storage/v2/schema_info.hpp"
 #include "storage/v2/storage_error.hpp"
 #include "storage/v2/storage_mode.hpp"
 #include "storage/v2/transaction.hpp"
@@ -400,6 +401,8 @@ class Storage {
       return storage_->enum_store_.ToEnum(enum_str);
     }
 
+    auto GetSchemaInfo() { return storage_->schema_info_; }
+
    protected:
     Storage *storage_;
     std::shared_lock<utils::ResourceLock> storage_guard_;
@@ -547,6 +550,9 @@ class Storage {
 
   // Mutable methods only safe if we have UniqueAccess to this storage
   EnumStore enum_store_;
+
+  // Database schema info about nodes, edges, indices and constraints
+  SchemaInfo schema_info_;
 };
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/transaction.hpp
+++ b/src/storage/v2/transaction.hpp
@@ -16,6 +16,7 @@
 #include <memory>
 
 #include "storage/v2/id_types.hpp"
+#include "storage/v2/schema_info.hpp"
 #include "utils/memory.hpp"
 #include "utils/skip_list.hpp"
 
@@ -122,6 +123,9 @@ struct Transaction {
   bool scanned_all_vertices_ = false;
   std::set<LabelId> introduced_new_label_index_;
   std::set<EdgeTypeId> introduced_new_edge_type_index_;
+
+  // Transaction-local schema info object which is merged with the database schema info on commit.
+  SchemaInfo schema_info_;
 };
 
 inline bool operator==(const Transaction &first, const Transaction &second) {

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -379,6 +379,12 @@ target_link_libraries(${test_prefix}database_get_info mg-storage-v2 mg-glue mg-d
 add_unit_test(storage_v2_storage_mode.cpp)
 target_link_libraries(${test_prefix}storage_v2_storage_mode mg-storage-v2 storage_test_utils mg-query mg-glue)
 
+add_unit_test(storage_v2_schema_info.cpp)
+target_link_libraries(${test_prefix}storage_v2_schema_info mg-storage-v2)
+
+add_unit_test(storage_v2_get_schema_info_from_storage.cpp)
+target_link_libraries(${test_prefix}storage_v2_get_schema_info_from_storage mg-storage-v2)
+
 add_unit_test(replication_persistence_helper.cpp)
 target_link_libraries(${test_prefix}replication_persistence_helper mg-storage-v2 mg-repl_coord_glue)
 

--- a/tests/unit/storage_v2_get_schema_info_from_storage.cpp
+++ b/tests/unit/storage_v2_get_schema_info_from_storage.cpp
@@ -1,0 +1,70 @@
+// Copyright 2024 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "storage/v2/inmemory/storage.hpp"
+#include <gtest/gtest.h>
+#include "storage/v2/id_types.hpp"
+#include "storage/v2/storage.hpp"
+
+// NOLINTNEXTLINE(google-build-using-namespace)
+using namespace memgraph::storage;
+
+class GetSchemaInfoTest : public testing::Test {
+ public:
+  const std::string testSuite = "storage_v2__show_schema_info";
+
+  GetSchemaInfoTest() { storage = std::make_unique<memgraph::storage::InMemoryStorage>(); }
+
+  void TearDown() override { storage.reset(nullptr); }
+
+  std::unique_ptr<Storage> storage;
+};
+
+TEST_F(GetSchemaInfoTest, CountOnOneCreateVertex) {
+  auto acc = this->storage->Access();
+  // CREATE (n)
+  acc->CreateVertex();
+
+  auto schemaInfo = acc->GetSchemaInfo();
+  EXPECT_EQ(schemaInfo.nodes.node_types_properties.size(), 1);
+  EXPECT_TRUE(schemaInfo.nodes.node_types_properties.begin()->first.empty());  // no labels
+  EXPECT_EQ(schemaInfo.nodes.node_types_properties.begin()->second.number_of_label_occurrences, 1);
+  EXPECT_TRUE(schemaInfo.nodes.node_types_properties.begin()->second.properties.empty());  // no properties
+}
+
+TEST_F(GetSchemaInfoTest, CountOnTwoCreateVertex) {
+  auto acc = this->storage->Access();
+  // CREATE (n)
+  acc->CreateVertex();
+  acc->CreateVertex();
+
+  auto schemaInfo = acc->GetSchemaInfo();
+  EXPECT_EQ(schemaInfo.nodes.node_types_properties.size(), 1);
+  EXPECT_TRUE(schemaInfo.nodes.node_types_properties.begin()->first.empty());  // no labels
+  EXPECT_EQ(schemaInfo.nodes.node_types_properties.begin()->second.number_of_label_occurrences, 2);
+  EXPECT_TRUE(schemaInfo.nodes.node_types_properties.begin()->second.properties.empty());  // no properties
+}
+
+TEST_F(GetSchemaInfoTest, CountOnReplicationAccessorCreateVertexEx) {
+  auto inmem_acc = std::unique_ptr<InMemoryStorage::InMemoryAccessor>(
+      static_cast<InMemoryStorage::InMemoryAccessor *>(this->storage->Access().release()));
+  auto acc = InMemoryStorage::ReplicationAccessor(std::move(*inmem_acc));
+  // CREATE (n) in replication handler
+  acc.CreateVertexEx(Gid::FromUint(0));
+  acc.CreateVertexEx(Gid::FromUint(1));
+
+  auto check_acc = this->storage->Access();
+  auto schemaInfo = check_acc->GetSchemaInfo();
+  EXPECT_EQ(schemaInfo.nodes.node_types_properties.size(), 1);
+  EXPECT_TRUE(schemaInfo.nodes.node_types_properties.begin()->first.empty());  // no labels
+  EXPECT_EQ(schemaInfo.nodes.node_types_properties.begin()->second.number_of_label_occurrences, 2);
+  EXPECT_TRUE(schemaInfo.nodes.node_types_properties.begin()->second.properties.empty());  // no properties
+}

--- a/tests/unit/storage_v2_schema_info.cpp
+++ b/tests/unit/storage_v2_schema_info.cpp
@@ -1,0 +1,229 @@
+// Copyright 2024 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <gtest/gtest.h>
+#include <boost/asio/execution/prefer_only.hpp>
+
+#include "storage/v2/schema_info.hpp"
+
+// NOLINTNEXTLINE(google-build-using-namespace)
+using namespace memgraph::storage;
+
+TEST(PropertyInfo, DefaultConstruction) {
+  PropertyInfo propInfo;
+  EXPECT_TRUE(propInfo.property_types.empty());
+  EXPECT_EQ(propInfo.number_of_property_occurrences, 0);
+}
+
+TEST(PropertyInfo, MergeWithEmptyStats) {
+  PropertyInfo propInfo;
+  propInfo.number_of_property_occurrences = 1;
+  propInfo.property_types[SchemaPropertyType::Integer] = 1;
+
+  PropertyInfo propInfo2;
+  propInfo.MergeStats(std::move(propInfo2));
+
+  EXPECT_EQ(propInfo.property_types.size(), 1);
+  EXPECT_EQ(propInfo.property_types[SchemaPropertyType::Integer], 1);
+  EXPECT_EQ(propInfo.number_of_property_occurrences, 1);
+}
+
+TEST(PropertyInfo, MergeWithDifferentTypeStats) {
+  PropertyInfo propInfo;
+  propInfo.number_of_property_occurrences = 1;
+  propInfo.property_types[SchemaPropertyType::Integer] = 1;
+
+  PropertyInfo propInfo2;
+  propInfo2.number_of_property_occurrences = 1;
+  propInfo2.property_types[SchemaPropertyType::String] = 1;
+
+  propInfo.MergeStats(std::move(propInfo2));
+
+  EXPECT_EQ(propInfo.number_of_property_occurrences, 2);
+  EXPECT_EQ(propInfo.property_types.size(), 2);
+  EXPECT_EQ(propInfo.property_types[SchemaPropertyType::Integer], 1);
+  EXPECT_EQ(propInfo.property_types[SchemaPropertyType::String], 1);
+}
+
+TEST(PropertyInfo, MergeWithSameTypeStats) {
+  PropertyInfo propInfo;
+  propInfo.number_of_property_occurrences = 1;
+  propInfo.property_types[SchemaPropertyType::Integer] = 1;
+
+  PropertyInfo propInfo2;
+  propInfo2.number_of_property_occurrences = 2;
+  propInfo2.property_types[SchemaPropertyType::Integer] = 2;
+
+  propInfo.MergeStats(std::move(propInfo2));
+
+  EXPECT_EQ(propInfo.number_of_property_occurrences, 3);
+  EXPECT_EQ(propInfo.property_types.size(), 1);
+  EXPECT_EQ(propInfo.property_types[SchemaPropertyType::Integer], 3);
+}
+
+TEST(LabelsInfo, DefaultConstruction) {
+  LabelsInfo labelsInfo;
+  EXPECT_EQ(labelsInfo.number_of_label_occurrences, 0);
+  EXPECT_TRUE(labelsInfo.properties.empty());
+}
+
+TEST(LabelsInfo, MergeWithEmptyStats) {
+  LabelsInfo labelsInfo;
+  labelsInfo.number_of_label_occurrences = 1;
+  PropertyInfo propInfo;
+
+  propInfo.number_of_property_occurrences = 1;
+  labelsInfo.properties["prop1"].number_of_property_occurrences = 1;
+
+  LabelsInfo labelsInfo2;
+
+  labelsInfo.MergeStats(std::move(labelsInfo2));
+
+  EXPECT_EQ(labelsInfo.number_of_label_occurrences, 1);
+  EXPECT_EQ(labelsInfo.properties.size(), 1);
+  EXPECT_EQ(labelsInfo.properties["prop1"].number_of_property_occurrences, 1);
+}
+
+TEST(LabelsInfo, MergeWithDifferentPropertyStats) {
+  LabelsInfo labelsInfo;
+  labelsInfo.number_of_label_occurrences = 1;
+  PropertyInfo propInfo;
+
+  propInfo.number_of_property_occurrences = 1;
+  labelsInfo.properties["prop1"].number_of_property_occurrences = 1;
+
+  LabelsInfo labelsInfo2;
+  labelsInfo2.number_of_label_occurrences = 3;
+  labelsInfo2.properties["prop2"].number_of_property_occurrences = 2;
+  labelsInfo2.properties["prop3"].number_of_property_occurrences = 1;
+
+  labelsInfo.MergeStats(std::move(labelsInfo2));
+
+  EXPECT_EQ(labelsInfo.number_of_label_occurrences, 4);
+  EXPECT_EQ(labelsInfo.properties.size(), 3);
+  EXPECT_EQ(labelsInfo.properties["prop1"].number_of_property_occurrences, 1);
+  EXPECT_EQ(labelsInfo.properties["prop2"].number_of_property_occurrences, 2);
+  EXPECT_EQ(labelsInfo.properties["prop3"].number_of_property_occurrences, 1);
+}
+
+TEST(LabelsInfo, MergeWithSamePropertyStats) {
+  LabelsInfo labelsInfo;
+  labelsInfo.number_of_label_occurrences = 1;
+  PropertyInfo propInfo;
+
+  propInfo.number_of_property_occurrences = 1;
+  labelsInfo.properties["prop1"].number_of_property_occurrences = 1;
+
+  LabelsInfo labelsInfo2;
+  labelsInfo2.number_of_label_occurrences = 2;
+  labelsInfo2.properties["prop1"].number_of_property_occurrences = 2;
+
+  labelsInfo.MergeStats(std::move(labelsInfo2));
+
+  EXPECT_EQ(labelsInfo.number_of_label_occurrences, 3);
+  EXPECT_EQ(labelsInfo.properties.size(), 1);
+  EXPECT_EQ(labelsInfo.properties["prop1"].number_of_property_occurrences, 3);
+}
+
+TEST(LabelsInfo, MergeLabelsWithEmptyPropertyStats) {
+  LabelsInfo labelsInfo;
+  labelsInfo.number_of_label_occurrences = 1;
+
+  LabelsInfo labelsInfo2;
+  labelsInfo2.number_of_label_occurrences = 2;
+
+  labelsInfo.MergeStats(std::move(labelsInfo2));
+
+  EXPECT_EQ(labelsInfo.number_of_label_occurrences, 3);
+  EXPECT_TRUE(labelsInfo.properties.empty());
+}
+
+TEST(NodesInfo, DefaultConstruction) {
+  NodesInfo nodesInfo;
+  EXPECT_TRUE(nodesInfo.node_types_properties.empty());
+}
+
+TEST(NodesInfo, MergeWithEmptyStats) {
+  NodesInfo nodesInfo;
+  NodesInfo::LabelsSet labelsSet;
+  labelsSet.insert("lbl1");
+  nodesInfo.node_types_properties.emplace(labelsSet, LabelsInfo());
+
+  NodesInfo nodesInfo2;
+
+  nodesInfo.MergeStats(std::move(nodesInfo2));
+
+  EXPECT_EQ(nodesInfo.node_types_properties.size(), 1);
+}
+
+TEST(NodesInfo, MergeWithDifferentLabelsStats) {
+  NodesInfo nodesInfo;
+  NodesInfo::LabelsSet labelsSet1;
+  labelsSet1.insert("lbl1");
+  nodesInfo.node_types_properties.emplace(labelsSet1, LabelsInfo());
+
+  NodesInfo nodesInfo2;
+  NodesInfo::LabelsSet labelsSet2;
+  labelsSet2.insert("lbl2");
+  nodesInfo2.node_types_properties.emplace(labelsSet2, LabelsInfo());
+
+  nodesInfo.MergeStats(std::move(nodesInfo2));
+
+  EXPECT_EQ(nodesInfo.node_types_properties.size(), 2);
+}
+
+TEST(NodesInfo, MergeWithSameLabelsStats) {
+  NodesInfo nodesInfo;
+  NodesInfo::LabelsSet labelsSet1;
+  labelsSet1.insert("lbl1");
+  nodesInfo.node_types_properties.emplace(labelsSet1, LabelsInfo());
+
+  NodesInfo nodesInfo2;
+  nodesInfo2.node_types_properties.emplace(labelsSet1, LabelsInfo());
+
+  nodesInfo.MergeStats(std::move(nodesInfo2));
+
+  EXPECT_EQ(nodesInfo.node_types_properties.size(), 1);
+}
+
+TEST(SchemaInfo, DefaultConstruction) {
+  SchemaInfo schemaInfo;
+  EXPECT_TRUE(schemaInfo.nodes.node_types_properties.empty());
+}
+
+TEST(SchemaInfo, MergeWithEmptyStats) {
+  SchemaInfo schemaInfo;
+  NodesInfo::LabelsSet labelsSet1;
+  labelsSet1.insert("lbl1");
+  schemaInfo.nodes.node_types_properties.emplace(labelsSet1, LabelsInfo());
+
+  SchemaInfo schemaInfo2;
+
+  schemaInfo.MergeStats(std::move(schemaInfo2));
+
+  EXPECT_EQ(schemaInfo.nodes.node_types_properties.size(), 1);
+}
+
+TEST(SchemaInfo, MergeWithNodeStats) {
+  SchemaInfo schemaInfo;
+  NodesInfo::LabelsSet labelsSet1;
+  labelsSet1.insert("lbl1");
+  schemaInfo.nodes.node_types_properties.emplace(labelsSet1, LabelsInfo());
+
+  SchemaInfo schemaInfo2;
+  NodesInfo::LabelsSet labelsSet2;
+  labelsSet2.insert("lbl2");
+  schemaInfo2.nodes.node_types_properties.emplace(labelsSet2, LabelsInfo());
+
+  schemaInfo.MergeStats(std::move(schemaInfo2));
+
+  EXPECT_EQ(schemaInfo.nodes.node_types_properties.size(), 2);
+}


### PR DESCRIPTION
Storage side implementation for statistics merge and updating statistics on vertex creation.
Add unit tests.
Add stats update for CreateVertex and CreateVertexEx.

Why: we want to have `SHOW SCHEMA INFO` query which will return schema info statistics in constant time.
So this is preparation for doing this from storage side.