### PR TITLE
Fix FastDiscardOfDeltas

### DIFF
--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -42,6 +42,45 @@ class InMemoryReplicationHandlers;
 
 namespace memgraph::storage {
 
+struct IndexPerformanceTracker {
+  void update(Delta::Action action) {
+    switch (action) {
+      using enum Delta::Action;
+      case DELETE_DESERIALIZED_OBJECT:
+      case DELETE_OBJECT:
+      case RECREATE_OBJECT: {
+        // can impact correctness, but does not matter for performance
+        return;
+      }
+      case SET_PROPERTY: {
+        // without following the deltas parents to the object we do not know which vertex/edge this delta is for
+        impacts_vertex_indexes_ = true;
+        impacts_edge_indexes_ = true;
+        return;
+      }
+      case ADD_LABEL:
+      case REMOVE_LABEL: {
+        impacts_vertex_indexes_ = true;
+        return;
+      }
+      case ADD_IN_EDGE:
+      case ADD_OUT_EDGE:
+      case REMOVE_IN_EDGE:
+      case REMOVE_OUT_EDGE: {
+        impacts_edge_indexes_ = true;
+        return;
+      }
+    }
+  }
+
+  bool impacts_vertex_indexes() { return impacts_vertex_indexes_; }
+  bool impacts_edge_indexes() { return impacts_edge_indexes_; }
+
+ private:
+  bool impacts_vertex_indexes_ = false;
+  bool impacts_edge_indexes_ = false;
+};
+
 // The storage is based on this paper:
 // https://db.in.tum.de/~muehlbau/papers/mvcc.pdf
 // The paper implements a fully serializable storage, in our implementation we
@@ -367,7 +406,8 @@ class InMemoryStorage final : public Storage {
     /// Duiring commit, in some cases you do not need to hand over deltas to GC
     /// in those cases this method is a light weight way to unlink and discard our deltas
     void FastDiscardOfDeltas(std::unique_lock<std::mutex> gc_guard);
-    void GCRapidDeltaCleanup(std::list<Gid> &current_deleted_vertices, std::list<Gid> &current_deleted_edges);
+    void GCRapidDeltaCleanup(std::list<Gid> &current_deleted_edges, std::list<Gid> &current_deleted_vertices,
+                             IndexPerformanceTracker &impact_tracker);
     SalientConfig::Items config_;
   };
 
@@ -525,6 +565,9 @@ class InMemoryStorage final : public Storage {
   // Edges that are logically deleted and wait to be removed from the main
   // storage.
   utils::Synchronized<std::list<Gid>, utils::SpinLock> deleted_edges_;
+
+  std::atomic<bool> gc_index_cleanup_vertex_performance_ = false;
+  std::atomic<bool> gc_index_cleanup_edge_performance_ = false;
 
   // Flags to inform CollectGarbage that it needs to do the more expensive full scans
   std::atomic<bool> gc_full_scan_vertices_delete_ = false;

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -366,7 +366,7 @@ class InMemoryStorage final : public Storage {
 
     /// Duiring commit, in some cases you do not need to hand over deltas to GC
     /// in those cases this method is a light weight way to unlink and discard our deltas
-    void FastDiscardOfDeltas(uint64_t oldest_active_timestamp, std::unique_lock<std::mutex> gc_guard);
+    void FastDiscardOfDeltas(std::unique_lock<std::mutex> gc_guard);
     void GCRapidDeltaCleanup(std::list<Gid> &current_deleted_vertices, std::list<Gid> &current_deleted_edges);
     SalientConfig::Items config_;
   };

--- a/tests/e2e/garbage_collection/CMakeLists.txt
+++ b/tests/e2e/garbage_collection/CMakeLists.txt
@@ -1,3 +1,10 @@
+function(copy_garbage_collection_e2e_python_files FILE_NAME)
+    copy_e2e_python_files(garbage_collection ${FILE_NAME})
+endfunction()
+
+copy_garbage_collection_e2e_python_files(common.py)
+copy_garbage_collection_e2e_python_files(gc_on_obsolete_indexes.py)
+
 add_executable(memgraph__e2e__garbage_collection periodic.cpp)
 target_link_libraries(memgraph__e2e__garbage_collection mg-storage-v2)
 

--- a/tests/e2e/garbage_collection/common.py
+++ b/tests/e2e/garbage_collection/common.py
@@ -1,0 +1,37 @@
+# Copyright 2024 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+import typing
+
+import mgclient
+import pytest
+
+
+@pytest.fixture(scope="module")
+def cursor(**kwargs) -> mgclient.Connection:
+    connection = mgclient.connect(host="localhost", port=7687, **kwargs)
+    connection.autocommit = True
+    cursor = connection.cursor()
+
+    cursor.execute("FOREACH (i IN range(1, 1000) | CREATE (n:Node {id: i}));")
+    cursor.execute("CREATE INDEX ON :Node(id);")
+    cursor.execute("CREATE INDEX ON :Node")
+
+    yield cursor
+
+    cursor.execute("DROP INDEX ON :Node(id);")
+    cursor.execute("DROP INDEX ON :Node;")
+    cursor.execute("MATCH (n:Node) DELETE n;")
+
+
+def execute_and_fetch_all(cursor: mgclient.Cursor, query: str, params: dict = dict()) -> typing.List[tuple]:
+    cursor.execute(query, params)
+    return cursor.fetchall()

--- a/tests/e2e/garbage_collection/gc_on_obsolete_indexes.py
+++ b/tests/e2e/garbage_collection/gc_on_obsolete_indexes.py
@@ -1,0 +1,45 @@
+# Copyright 2024 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+import sys
+
+import pytest
+from common import cursor, execute_and_fetch_all
+
+
+def test_removing_obsolete_indexes(cursor):
+    index_info = execute_and_fetch_all(cursor, "SHOW INDEX INFO;")
+    expected_index_info = {
+        ("label", "Node", None, 1000),
+        ("label+property", "Node", "id", 1000),
+    }
+    assert set(index_info) == expected_index_info
+
+    cursor.execute("MATCH (n) SET n.id = n.id + 1000;")
+
+    index_info = execute_and_fetch_all(cursor, "SHOW INDEX INFO;")
+    expected_index_info = {
+        ("label", "Node", None, 1000),
+        ("label+property", "Node", "id", 2000),
+    }
+    assert set(index_info) == expected_index_info
+
+    cursor.execute("FREE MEMORY;")
+    index_info = execute_and_fetch_all(cursor, "SHOW INDEX INFO;")
+    expected_index_info = {
+        ("label", "Node", None, 1000),
+        ("label+property", "Node", "id", 1000),
+    }
+    assert set(index_info) == expected_index_info
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/garbage_collection/workloads.yaml
+++ b/tests/e2e/garbage_collection/workloads.yaml
@@ -1,23 +1,26 @@
-args: &args
-  - "--bolt-port"
-  - "7687"
-  - "--log-level=TRACE"
-
 in_memory_cluster: &in_memory_cluster
   cluster:
     main:
-      args: *args
+      args: ["--bolt-port", "7687", "--log-level=TRACE", "--storage-gc-cycle-sec=2"]
       log_file: "garbage_collection-e2e.log"
+      setup_queries: []
+      validation_queries: []
+
+gc_on_obsolete_indexes_cluster: &gc_on_obsolete_indexes_cluster
+  cluster:
+    main:
+      args: ["--bolt-port", "7687", "--log-level=TRACE", "--storage-gc-cycle-sec=240"]
+      log_file: "gc_on_obsolete_indexes-e2e.log"
       setup_queries: []
       validation_queries: []
 
 workloads:
   - name: "Garbage collection"
     binary: "tests/e2e/garbage_collection/memgraph__e2e__garbage_collection"
-    args: ["--storage-gc-cycle-sec=2"]
+    args: []
     <<: *in_memory_cluster
 
   - name: "Garbage collection on obsolete indexes"
-    binary: "tests/e2e/garbage_collection/memgraph__e2e__gc_on_obsolete_indexes"
-    args: ["--storage-gc-cycle-sec=240"]
-    <<: *in_memory_cluster
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["garbage_collection/gc_on_obsolete_indexes.py"]
+    <<: *gc_on_obsolete_indexes_cluster

--- a/tests/e2e/garbage_collection/workloads.yaml
+++ b/tests/e2e/garbage_collection/workloads.yaml
@@ -19,5 +19,5 @@ workloads:
 
   - name: "Garbage collection on obsolete indexes"
     binary: "tests/e2e/garbage_collection/memgraph__e2e__gc_on_obsolete_indexes"
-    args: ["--storage-gc-cycle-sec=60"]
+    args: ["--storage-gc-cycle-sec=0"]
     <<: *in_memory_cluster

--- a/tests/e2e/garbage_collection/workloads.yaml
+++ b/tests/e2e/garbage_collection/workloads.yaml
@@ -2,7 +2,6 @@ args: &args
   - "--bolt-port"
   - "7687"
   - "--log-level=TRACE"
-  - "--storage-gc-cycle-sec=2"
 
 in_memory_cluster: &in_memory_cluster
   cluster:
@@ -15,5 +14,10 @@ in_memory_cluster: &in_memory_cluster
 workloads:
   - name: "Garbage collection"
     binary: "tests/e2e/garbage_collection/memgraph__e2e__garbage_collection"
-    args: []
+    args: ["--storage-gc-cycle-sec=2"]
+    <<: *in_memory_cluster
+
+  - name: "Garbage collection on obsolete indexes"
+    binary: "tests/e2e/garbage_collection/memgraph__e2e__gc_on_obsolete_indexes"
+    args: ["--storage-gc-cycle-sec=60"]
     <<: *in_memory_cluster

--- a/tests/e2e/garbage_collection/workloads.yaml
+++ b/tests/e2e/garbage_collection/workloads.yaml
@@ -19,5 +19,5 @@ workloads:
 
   - name: "Garbage collection on obsolete indexes"
     binary: "tests/e2e/garbage_collection/memgraph__e2e__gc_on_obsolete_indexes"
-    args: ["--storage-gc-cycle-sec=0"]
+    args: ["--storage-gc-cycle-sec=240"]
     <<: *in_memory_cluster


### PR DESCRIPTION
Instead of deleting vertices or edges and removing obsolete index entries in `FastDiscardOfDeltas`, hand over that work to the GC.

Closes #1955 , closes #2226 