### PR TITLE
Temporarily disable benchmarks on diff workflow runs

### DIFF
--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -110,7 +110,8 @@ jobs:
       os: 'debian-11'
       toolchain: 'v5'
       run_core: ${{ needs.DiffSetup.outputs.run_release_core }}
-      run_benchmark: ${{ needs.DiffSetup.outputs.run_release_benchmark }}
+      run_benchmark: 'false'
+      # run_benchmark: ${{ needs.DiffSetup.outputs.run_release_benchmark }}
       run_e2e: ${{ needs.DiffSetup.outputs.run_release_e2e }}
       run_stress: ${{ needs.DiffSetup.outputs.run_release_stress }}
     secrets: inherit


### PR DESCRIPTION
This PR temporarily disables benchmarks on diff workflow runs because we are experiencing issues with the mgbench depoyment. After the issue is fixed, benchmarks will be reenabled.