### PR TITLE
Bugfix: HandleTimezone reusing same path in unit tests

### DIFF
--- a/src/utils/tmp_dir.hpp
+++ b/src/utils/tmp_dir.hpp
@@ -1,0 +1,29 @@
+// Copyright 2024 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <filesystem>
+
+namespace memgraph::utils {
+/**
+ * @brief Creates a temporary directory with a unique name under /tmp/
+ *
+ * @return std::filesystem::path
+ * @throws std::filesystem::filesystem_error as defined by create_directories
+ */
+inline std::filesystem::path TempDir() {
+  const std::filesystem::path tmp_dir_path{std::filesystem::temp_directory_path() /= std::tmpnam(nullptr)};
+  std::filesystem::create_directories(tmp_dir_path);
+  return tmp_dir_path;
+}
+
+}  // namespace memgraph::utils


### PR DESCRIPTION
HandleTimezone was introduced with LocalDateTime update. 
It initialized a RocksDB for a the global settings. Its path was fixed and so would conflict while multiple tests were reading/writing to the same RocksDB.