### PR TITLE
Execute state check on becoming leader

### DIFF
--- a/src/coordination/coordinator_state.cpp
+++ b/src/coordination/coordinator_state.cpp
@@ -84,13 +84,16 @@ auto CoordinatorState::DemoteInstanceToReplica(std::string_view instance_name) -
       data_);
 }
 
-auto CoordinatorState::VerifyOrCorrectClusterState() -> VerifyOrCorrectClusterStateStatus {
+auto CoordinatorState::ReconcileClusterState() -> ReconcileClusterStateStatus {
   MG_ASSERT(std::holds_alternative<CoordinatorInstance>(data_),
             "Coordinator cannot force reset cluster state since variant holds wrong alternative.");
 
   return std::visit(
       memgraph::utils::Overloaded{[](const CoordinatorMainReplicaData & /*coordinator_main_replica_data*/) {
-                                    return VerifyOrCorrectClusterStateStatus::FAIL;
+                                    spdlog::error(
+                                        "Coordinator cannot force reset cluster state since it is not a "
+                                        "coordinator instance.");
+                                    return ReconcileClusterStateStatus::FAIL;
                                   },
                                   [](CoordinatorInstance &coordinator_instance) {
                                     return coordinator_instance.TryVerifyOrCorrectClusterState();

--- a/src/coordination/coordinator_state.cpp
+++ b/src/coordination/coordinator_state.cpp
@@ -84,16 +84,17 @@ auto CoordinatorState::DemoteInstanceToReplica(std::string_view instance_name) -
       data_);
 }
 
-auto CoordinatorState::ForceResetClusterState() -> ForceResetClusterStateStatus {
+auto CoordinatorState::VerifyOrCorrectClusterState() -> VerifyOrCorrectClusterStateStatus {
   MG_ASSERT(std::holds_alternative<CoordinatorInstance>(data_),
             "Coordinator cannot force reset cluster state since variant holds wrong alternative.");
 
   return std::visit(
-      memgraph::utils::Overloaded{
-          [](const CoordinatorMainReplicaData & /*coordinator_main_replica_data*/) {
-            return ForceResetClusterStateStatus::NOT_COORDINATOR;
-          },
-          [](CoordinatorInstance &coordinator_instance) { return coordinator_instance.TryForceResetClusterState(); }},
+      memgraph::utils::Overloaded{[](const CoordinatorMainReplicaData & /*coordinator_main_replica_data*/) {
+                                    return VerifyOrCorrectClusterStateStatus::FAIL;
+                                  },
+                                  [](CoordinatorInstance &coordinator_instance) {
+                                    return coordinator_instance.TryVerifyOrCorrectClusterState();
+                                  }},
       data_);
 }
 

--- a/src/coordination/include/coordination/coordinator_instance.hpp
+++ b/src/coordination/include/coordination/coordinator_instance.hpp
@@ -83,9 +83,9 @@ class CoordinatorInstance {
 
   auto DemoteInstanceToReplica(std::string_view instance_name) -> DemoteInstanceCoordinatorStatus;
 
-  auto TryVerifyOrCorrectClusterState() -> VerifyOrCorrectClusterStateStatus;
+  auto TryVerifyOrCorrectClusterState() -> ReconcileClusterStateStatus;
 
-  auto VerifyOrCorrectClusterState() -> VerifyOrCorrectClusterStateStatus;
+  auto ReconcileClusterState() -> ReconcileClusterStateStatus;
 
   auto IsLeader() const -> bool;
 
@@ -156,7 +156,7 @@ class CoordinatorInstance {
 
   void DemoteFailCallback(std::string_view repl_instance_name);
 
-  auto VerifyOrCorrectClusterState_() -> VerifyOrCorrectClusterStateStatus;
+  auto ReconcileClusterState_() -> ReconcileClusterStateStatus;
 
   auto GetBecomeLeaderCallback() -> std::function<void()>;
   auto GetBecomeFollowerCallback() -> std::function<void()>;
@@ -165,7 +165,7 @@ class CoordinatorInstance {
 
   HealthCheckClientCallback client_succ_cb_, client_fail_cb_;
   // Raft updates leadership before callback is executed. IsLeader() can return true, but
-  // leader callback or force reset haven't yet be executed. This flag tracks if coordinator is set up to
+  // leader callback or reconcile cluster state haven't yet be executed. This flag tracks if coordinator is set up to
   // accept queries.
   std::atomic<bool> is_leader_ready_{false};
   std::atomic<bool> is_shutting_down_{false};
@@ -175,7 +175,7 @@ class CoordinatorInstance {
 
   std::unique_ptr<RaftState> raft_state_;
 
-  // Thread pool must be destructed first, because there is a possibility we are doing force reset in thread
+  // Thread pool must be destructed first, because there is a possibility we are doing reconcile cluster state in thread
   // while coordinator is destructed
   utils::ThreadPool thread_pool_{1};
 

--- a/src/coordination/include/coordination/coordinator_instance.hpp
+++ b/src/coordination/include/coordination/coordinator_instance.hpp
@@ -83,11 +83,9 @@ class CoordinatorInstance {
 
   auto DemoteInstanceToReplica(std::string_view instance_name) -> DemoteInstanceCoordinatorStatus;
 
-  auto TryForceResetClusterState() -> ForceResetClusterStateStatus;
+  auto TryVerifyOrCorrectClusterState() -> VerifyOrCorrectClusterStateStatus;
 
-  auto ForceResetClusterState() -> ForceResetClusterStateStatus;
-
-  auto EnsureHealthyClusterState() -> EnsureHealthyClusterStateStatus;
+  auto VerifyOrCorrectClusterState() -> VerifyOrCorrectClusterStateStatus;
 
   auto IsLeader() const -> bool;
 
@@ -97,6 +95,10 @@ class CoordinatorInstance {
 
   auto GetRaftState() -> RaftState &;
   auto GetRaftState() const -> RaftState const &;
+
+  static auto GetSuccessCallbackTypeName(ReplicationInstanceConnector const &instance) -> std::string_view;
+
+  static auto GetFailCallbackTypeName(ReplicationInstanceConnector const &instance) -> std::string_view;
 
  private:
   template <ranges::forward_range R>
@@ -154,10 +156,7 @@ class CoordinatorInstance {
 
   void DemoteFailCallback(std::string_view repl_instance_name);
 
-  // TODO(fico): remove
-  auto ForceResetCluster_() -> ForceResetClusterStateStatus;
-
-  auto EnsureHealthyClusterState_() -> EnsureHealthyClusterStateStatus;
+  auto VerifyOrCorrectClusterState_() -> VerifyOrCorrectClusterStateStatus;
 
   auto GetBecomeLeaderCallback() -> std::function<void()>;
   auto GetBecomeFollowerCallback() -> std::function<void()>;

--- a/src/coordination/include/coordination/coordinator_instance.hpp
+++ b/src/coordination/include/coordination/coordinator_instance.hpp
@@ -87,6 +87,8 @@ class CoordinatorInstance {
 
   auto ForceResetClusterState() -> ForceResetClusterStateStatus;
 
+  auto EnsureHealthyClusterState() -> EnsureHealthyClusterStateStatus;
+
   auto IsLeader() const -> bool;
 
   void ShuttingDown();
@@ -152,7 +154,10 @@ class CoordinatorInstance {
 
   void DemoteFailCallback(std::string_view repl_instance_name);
 
+  // TODO(fico): remove
   auto ForceResetCluster_() -> ForceResetClusterStateStatus;
+
+  auto EnsureHealthyClusterState_() -> EnsureHealthyClusterStateStatus;
 
   auto GetBecomeLeaderCallback() -> std::function<void()>;
   auto GetBecomeFollowerCallback() -> std::function<void()>;

--- a/src/coordination/include/coordination/coordinator_state.hpp
+++ b/src/coordination/include/coordination/coordinator_state.hpp
@@ -45,7 +45,7 @@ class CoordinatorState {
 
   [[nodiscard]] auto DemoteInstanceToReplica(std::string_view instance_name) -> DemoteInstanceCoordinatorStatus;
 
-  [[nodiscard]] auto VerifyOrCorrectClusterState() -> VerifyOrCorrectClusterStateStatus;
+  [[nodiscard]] auto ReconcileClusterState() -> ReconcileClusterStateStatus;
 
   [[nodiscard]] auto SetReplicationInstanceToMain(std::string_view instance_name) -> SetInstanceToMainCoordinatorStatus;
 

--- a/src/coordination/include/coordination/coordinator_state.hpp
+++ b/src/coordination/include/coordination/coordinator_state.hpp
@@ -45,7 +45,7 @@ class CoordinatorState {
 
   [[nodiscard]] auto DemoteInstanceToReplica(std::string_view instance_name) -> DemoteInstanceCoordinatorStatus;
 
-  [[nodiscard]] auto ForceResetClusterState() -> ForceResetClusterStateStatus;
+  [[nodiscard]] auto VerifyOrCorrectClusterState() -> VerifyOrCorrectClusterStateStatus;
 
   [[nodiscard]] auto SetReplicationInstanceToMain(std::string_view instance_name) -> SetInstanceToMainCoordinatorStatus;
 

--- a/src/coordination/include/coordination/register_main_replica_coordinator_status.hpp
+++ b/src/coordination/include/coordination/register_main_replica_coordinator_status.hpp
@@ -91,5 +91,7 @@ enum class ForceResetClusterStateStatus : uint8_t {
   SHUTTING_DOWN
 };
 
+enum class EnsureHealthyClusterStateStatus : uint8_t { SUCCESS, FAIL, SHUTTING_DOWN };
+
 }  // namespace memgraph::coordination
 #endif

--- a/src/coordination/include/coordination/register_main_replica_coordinator_status.hpp
+++ b/src/coordination/include/coordination/register_main_replica_coordinator_status.hpp
@@ -78,7 +78,7 @@ enum class DemoteInstanceCoordinatorStatus : uint8_t {
   NOT_COORDINATOR
 };
 
-enum class VerifyOrCorrectClusterStateStatus : uint8_t { SUCCESS, FAIL, SHUTTING_DOWN };
+enum class ReconcileClusterStateStatus : uint8_t { SUCCESS, FAIL, SHUTTING_DOWN };
 
 }  // namespace memgraph::coordination
 #endif

--- a/src/coordination/include/coordination/register_main_replica_coordinator_status.hpp
+++ b/src/coordination/include/coordination/register_main_replica_coordinator_status.hpp
@@ -78,20 +78,7 @@ enum class DemoteInstanceCoordinatorStatus : uint8_t {
   NOT_COORDINATOR
 };
 
-enum class ForceResetClusterStateStatus : uint8_t {
-  NOT_LEADER,
-  RPC_FAILED,
-  ACTION_FAILED,
-  RAFT_LOG_ERROR,
-  NO_NEW_MAIN,
-  SUCCESS,
-  FAILED_TO_OPEN_LOCK,
-  FAILED_TO_CLOSE_LOCK,
-  NOT_COORDINATOR,
-  SHUTTING_DOWN
-};
-
-enum class EnsureHealthyClusterStateStatus : uint8_t { SUCCESS, FAIL, SHUTTING_DOWN };
+enum class VerifyOrCorrectClusterStateStatus : uint8_t { SUCCESS, FAIL, SHUTTING_DOWN };
 
 }  // namespace memgraph::coordination
 #endif

--- a/src/coordination/include/coordination/replication_instance_connector.hpp
+++ b/src/coordination/include/coordination/replication_instance_connector.hpp
@@ -82,8 +82,8 @@ class ReplicationInstanceConnector {
 
   auto EnableWritingOnMain() -> bool;
 
-  auto GetSuccessCallback() -> HealthCheckInstanceCallback;
-  auto GetFailCallback() -> HealthCheckInstanceCallback;
+  auto GetSuccessCallback() const -> HealthCheckInstanceCallback;
+  auto GetFailCallback() const -> HealthCheckInstanceCallback;
 
   void SetCallbacks(HealthCheckInstanceCallback succ_cb, HealthCheckInstanceCallback fail_cb);
 

--- a/src/coordination/raft_state.cpp
+++ b/src/coordination/raft_state.cpp
@@ -125,13 +125,14 @@ auto RaftState::InitRaftServer() -> void {
   // this is bug in nuraft code
   params.leadership_expiry_ = 2000;
 
+  /*
   // https://github.com/eBay/NuRaft/blob/master/docs/custom_commit_policy.md#full-consensus-mode
   // we want to set coordinator to unhealthy as soon as it is down and doesn't respond
   auto limits = raft_server::get_raft_limits();
   // Limit is set to 2 because 2*params.heart_beat_interval_ == params.leadership_expiry_ which is 2000
   limits.response_limit_.store(2);
   raft_server::set_raft_limits(limits);
-
+ */
   raft_server::init_options init_opts;
 
   init_opts.start_server_in_constructor_ = false;

--- a/src/coordination/raft_state.cpp
+++ b/src/coordination/raft_state.cpp
@@ -125,14 +125,13 @@ auto RaftState::InitRaftServer() -> void {
   // this is bug in nuraft code
   params.leadership_expiry_ = 2000;
 
-  /*
   // https://github.com/eBay/NuRaft/blob/master/docs/custom_commit_policy.md#full-consensus-mode
   // we want to set coordinator to unhealthy as soon as it is down and doesn't respond
   auto limits = raft_server::get_raft_limits();
   // Limit is set to 2 because 2*params.heart_beat_interval_ == params.leadership_expiry_ which is 2000
   limits.response_limit_.store(2);
   raft_server::set_raft_limits(limits);
- */
+
   raft_server::init_options init_opts;
 
   init_opts.start_server_in_constructor_ = false;

--- a/src/coordination/replication_instance_connector.cpp
+++ b/src/coordination/replication_instance_connector.cpp
@@ -100,8 +100,8 @@ auto ReplicationInstanceConnector::GetReplicationClientInfo() const -> coordinat
   return client_->GetReplicationClientInfo();
 }
 
-auto ReplicationInstanceConnector::GetSuccessCallback() -> HealthCheckInstanceCallback { return succ_cb_; }
-auto ReplicationInstanceConnector::GetFailCallback() -> HealthCheckInstanceCallback { return fail_cb_; }
+auto ReplicationInstanceConnector::GetSuccessCallback() const -> HealthCheckInstanceCallback { return succ_cb_; }
+auto ReplicationInstanceConnector::GetFailCallback() const -> HealthCheckInstanceCallback { return fail_cb_; }
 
 auto ReplicationInstanceConnector::GetClient() -> ReplicationInstanceClient & { return *client_; }
 

--- a/src/dbms/coordinator_handler.cpp
+++ b/src/dbms/coordinator_handler.cpp
@@ -43,8 +43,10 @@ auto CoordinatorHandler::SetReplicationInstanceToMain(std::string_view instance_
   return coordinator_state_.SetReplicationInstanceToMain(instance_name);
 }
 
-auto CoordinatorHandler::ForceResetClusterState() -> coordination::ForceResetClusterStateStatus {
-  return coordinator_state_.ForceResetClusterState();
+auto CoordinatorHandler::ForceResetClusterState() -> coordination::VerifyOrCorrectClusterStateStatus {
+  // Query is called ForceResetClusterState but internally we have function which verifies and corrects
+  // cluster state
+  return coordinator_state_.VerifyOrCorrectClusterState();
 }
 
 auto CoordinatorHandler::ShowInstances() const -> std::vector<coordination::InstanceStatus> {

--- a/src/dbms/coordinator_handler.cpp
+++ b/src/dbms/coordinator_handler.cpp
@@ -43,10 +43,10 @@ auto CoordinatorHandler::SetReplicationInstanceToMain(std::string_view instance_
   return coordinator_state_.SetReplicationInstanceToMain(instance_name);
 }
 
-auto CoordinatorHandler::ForceResetClusterState() -> coordination::VerifyOrCorrectClusterStateStatus {
+auto CoordinatorHandler::ForceResetClusterState() -> coordination::ReconcileClusterStateStatus {
   // Query is called ForceResetClusterState but internally we have function which verifies and corrects
   // cluster state
-  return coordinator_state_.VerifyOrCorrectClusterState();
+  return coordinator_state_.ReconcileClusterState();
 }
 
 auto CoordinatorHandler::ShowInstances() const -> std::vector<coordination::InstanceStatus> {

--- a/src/dbms/coordinator_handler.hpp
+++ b/src/dbms/coordinator_handler.hpp
@@ -43,7 +43,7 @@ class CoordinatorHandler {
 
   auto DemoteInstanceToReplica(std::string_view instance_name) -> coordination::DemoteInstanceCoordinatorStatus;
 
-  auto ForceResetClusterState() -> coordination::ForceResetClusterStateStatus;
+  auto ForceResetClusterState() -> coordination::VerifyOrCorrectClusterStateStatus;
 
   auto ShowInstances() const -> std::vector<coordination::InstanceStatus>;
 

--- a/src/dbms/coordinator_handler.hpp
+++ b/src/dbms/coordinator_handler.hpp
@@ -43,7 +43,7 @@ class CoordinatorHandler {
 
   auto DemoteInstanceToReplica(std::string_view instance_name) -> coordination::DemoteInstanceCoordinatorStatus;
 
-  auto ForceResetClusterState() -> coordination::VerifyOrCorrectClusterStateStatus;
+  auto ForceResetClusterState() -> coordination::ReconcileClusterStateStatus;
 
   auto ShowInstances() const -> std::vector<coordination::InstanceStatus>;
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -484,7 +484,7 @@ class CoordQueryHandler final : public query::CoordinatorQueryHandler {
 
   void ForceResetClusterState() override {
     auto status = coordinator_handler_.ForceResetClusterState();
-    using enum memgraph::coordination::VerifyOrCorrectClusterStateStatus;
+    using enum memgraph::coordination::ReconcileClusterStateStatus;
     switch (status) {
       case SHUTTING_DOWN:
         throw QueryRuntimeException("Couldn't finish force reset as cluster is shutting down!");

--- a/src/query/metadata.cpp
+++ b/src/query/metadata.cpp
@@ -76,7 +76,7 @@ constexpr std::string_view GetCodeString(const NotificationCode code) {
     case NotificationCode::DEMOTE_INSTANCE_TO_REPLICA:
       return "DemoteInstanceToReplica"sv;
     case NotificationCode::FORCE_RESET_CLUSTER_STATE:
-      return "VerifyOrCorrectClusterState"sv;
+      return "ReconcileClusterState"sv;
 #endif
     case NotificationCode::REPLICA_PORT_WARNING:
       return "ReplicaPortWarning"sv;

--- a/src/query/metadata.cpp
+++ b/src/query/metadata.cpp
@@ -76,7 +76,7 @@ constexpr std::string_view GetCodeString(const NotificationCode code) {
     case NotificationCode::DEMOTE_INSTANCE_TO_REPLICA:
       return "DemoteInstanceToReplica"sv;
     case NotificationCode::FORCE_RESET_CLUSTER_STATE:
-      return "ForceResetClusterState"sv;
+      return "VerifyOrCorrectClusterState"sv;
 #endif
     case NotificationCode::REPLICA_PORT_WARNING:
       return "ReplicaPortWarning"sv;

--- a/tests/e2e/high_availability/coord_cluster_registration.py
+++ b/tests/e2e/high_availability/coord_cluster_registration.py
@@ -1144,7 +1144,7 @@ def test_add_coord_instance_fails():
     interactive_mg_runner.stop_all()
     safe_execute(shutil.rmtree, TEMP_DIR)
     memgraph_instances_description_all = get_instances_description(test_name="test_add_coord_instance_fails")
-    interactive_mg_runner.start_all(memgraph_instances_description_all)
+    interactive_mg_runner.start_all(memgraph_instances_description_all, keep_directories=False)
 
     coordinator3_cursor = connect(host="localhost", port=7692).cursor()
 

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -453,7 +453,12 @@ def test_even_number_coords(use_durability):
     interactive_mg_runner.kill(inner_instances_description, "coordinator_2")
 
     # 5
-    # no leader, we get default output
+
+    with pytest.raises(Exception) as e:
+        execute_and_fetch_all(coord_cursor_3, "SET INSTANCE instance_3 TO MAIN;")
+
+    assert "Couldn't register instance as cluster didn't accept start of action!" in str(e.value)
+
     follower_data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "unknown", "follower"),
         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "unknown", "follower"),
@@ -465,11 +470,6 @@ def test_even_number_coords(use_durability):
     ]
 
     mg_sleep_and_assert(follower_data, show_instances_coord3)
-
-    with pytest.raises(Exception) as e:
-        execute_and_fetch_all(coord_cursor_3, "SET INSTANCE instance_3 TO MAIN;")
-
-    assert "Couldn't set instance to main since coordinator is not a leader!" in str(e.value)
 
     # 6
     interactive_mg_runner.start(inner_instances_description, "coordinator_1")

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -335,7 +335,7 @@ def update_tuple_value(
     return list_tuples
 
 
-@pytest.mark.parametrize("use_durability", [True])
+@pytest.mark.parametrize("use_durability", [True, False])
 def test_even_number_coords(use_durability):
     # Goal is to check that nothing gets broken on even number of coords when 2 coords are down
     # 1. Start all instances.
@@ -476,7 +476,6 @@ def test_even_number_coords(use_durability):
     interactive_mg_runner.start(inner_instances_description, "coordinator_2")
 
     # 7
-    leader_coord_instance_3_demoted = find_instance_and_assert_instances(instance_role="leader", num_coordinators=3)
 
     leader_data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
@@ -488,9 +487,16 @@ def test_even_number_coords(use_durability):
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
     ]
 
+    leader_coord_instance_3_demoted = find_instance_and_assert_instances(instance_role="leader", num_coordinators=3)
+
+    main_instance_3_demoted = find_instance_and_assert_instances(instance_role="main", num_coordinators=3)
+
     assert leader_coord_instance_3_demoted is not None, "Leader not found"
 
+    assert main_instance_3_demoted is not None, "Main not found"
+
     leader_data = update_tuple_value(leader_data, leader_coord_instance_3_demoted, 0, -1, "leader")
+    leader_data = update_tuple_value(leader_data, main_instance_3_demoted, 0, -1, "main")
 
     port_mappings = {
         "coordinator_1": 7690,
@@ -498,22 +504,6 @@ def test_even_number_coords(use_durability):
         "coordinator_3": 7692,
         "coordinator_4": 7693,
     }
-
-    for coord, port in port_mappings.items():
-        coord_cursor = connect(host="localhost", port=port).cursor()
-
-        def show_instances():
-            return ignore_elapsed_time_from_results(
-                sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
-            )
-
-        mg_sleep_and_assert(leader_data, show_instances)
-
-    coord_cursor_leader = connect(host="localhost", port=port_mappings[leader_coord_instance_3_demoted]).cursor()
-
-    execute_and_fetch_all(coord_cursor_leader, "SET INSTANCE instance_3 TO MAIN;")
-
-    leader_data = update_tuple_value(leader_data, "instance_3", 0, -1, "main")
 
     for coord, port in port_mappings.items():
         coord_cursor = connect(host="localhost", port=port).cursor()
@@ -1913,149 +1903,38 @@ def test_force_reset_works_after_failed_registration():
     data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
-    ]
-
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
-
-    vertex_count = 10
-    for _ in range(vertex_count):
-        execute_and_fetch_all(instance_1_cursor, "CREATE ();")
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
-
-    instance_1_cursor = connect(port=7687, host="localhost").cursor()
-    instance_2_cursor = connect(port=7688, host="localhost").cursor()
-
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_3_cursor))
-
-    interactive_mg_runner.stop_all(keep_directories=False)
-
-
-def test_force_reset_works_after_failed_registration_and_main_down():
-    # Goal of this test is to check when action fails, that force reset happens
-    # and everything works correctly when MAIN is down (needs to be demoted)
-    # 1. Start all instances.
-    # 2. Check everything works correctly
-    # 3. Kill main
-    # 4. Try to register instance which doesn't exist
-    # 4. Enter force reset
-    # 5. Check that everything works correctly with two instances
-    # 6. Start main instance
-    # 7. Check that main is correctly demoted to replica
-
-    # 1
-    temp_dir = tempfile.TemporaryDirectory()
-    temp_dir_name = temp_dir.name
-
-    inner_instances_description = get_instances_description_no_setup(
-        temp_dir_name, test_name="test_force_reset_works_after_failed_registration_and_main_down"
-    )
-
-    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-
-    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-    for query in get_default_setup_queries():
-        execute_and_fetch_all(coord_cursor_3, query)
-
-    # 2
-
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
-    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
-    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
-
-    instance_3_cursor = connect(host="localhost", port=7689).cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
-
-    replicas = [
-        (
-            "instance_1",
-            "localhost:10001",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-        (
-            "instance_2",
-            "localhost:10002",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-    ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
-
-    vertex_count = 0
-    instance_1_cursor = connect(port=7687, host="localhost").cursor()
-    instance_2_cursor = connect(port=7688, host="localhost").cursor()
-
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
-
-    with pytest.raises(Exception) as e:
-        execute_and_fetch_all(
-            coord_cursor_3,
-            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': 'localhost:10050', 'replication_server': 'localhost:10051'};",
-        )
-
-    # This will trigger force reset and choosing of new instance as MAIN
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
     ]
 
+    leader_name = find_instance_and_assert_instances(instance_role="leader", num_coordinators=3)
+
+    main_name = find_instance_and_assert_instances(instance_role="main", num_coordinators=3)
+
+    assert leader_name is not None, "leader is None"
+    assert main_name is not None, "Main is None"
+
+    data = update_tuple_value(data, leader_name, 0, -1, "leader")
+    data = update_tuple_value(data, main_name, 0, -1, "main")
+
     mg_sleep_and_assert(data, show_instances_coord3)
     mg_sleep_and_assert(data, show_instances_coord1)
     mg_sleep_and_assert(data, show_instances_coord2)
 
+    def get_port(instance_name):
+        mappings = {
+            "instance_1": 7687,
+            "instance_2": 7688,
+            "instance_3": 7689,
+        }
+        return mappings[instance_name]
+
+    instance_main_cursor = connect(port=get_port(main_name), host="localhost").cursor()
     vertex_count = 10
     for _ in range(vertex_count):
-        execute_and_fetch_all(instance_1_cursor, "CREATE ();")
+        execute_and_fetch_all(instance_main_cursor, "CREATE ();")
 
     def get_vertex_count_func(cursor):
         def get_vertex_count():
@@ -2063,12 +1942,9 @@ def test_force_reset_works_after_failed_registration_and_main_down():
 
         return get_vertex_count
 
-    instance_1_cursor = connect(port=7687, host="localhost").cursor()
-    instance_2_cursor = connect(port=7688, host="localhost").cursor()
-
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_3_cursor))
+    for instance in ["instance_1", "instance_2", "instance_3"]:
+        cursor = connect(port=get_port(instance), host="localhost").cursor()
+        mg_sleep_and_assert(vertex_count, get_vertex_count_func(cursor))
 
     interactive_mg_runner.stop_all(keep_directories=False)
 
@@ -2176,15 +2052,25 @@ def test_force_reset_works_after_failed_registration_and_replica_down():
         )
 
     # 5
-    # This will trigger force reset and choosing of new instance as MAIN
+    # This will trigger verify and correct cluster state, where we shouldn't choose new MAIN
     data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
         ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
+
+    leader_name = "coordinator_3"
+
+    main_name = "instance_3"
+
+    assert leader_name is not None, "leader is None"
+    assert main_name is not None, "Main is None"
+
+    data = update_tuple_value(data, leader_name, 0, -1, "leader")
+    data = update_tuple_value(data, main_name, 0, -1, "main")
 
     mg_sleep_and_assert(data, show_instances_coord3)
     mg_sleep_and_assert(data, show_instances_coord1)
@@ -2199,20 +2085,40 @@ def test_force_reset_works_after_failed_registration_and_replica_down():
     data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
     ]
+
+    data = update_tuple_value(data, leader_name, 0, -1, "leader")
+    data = update_tuple_value(data, main_name, 0, -1, "main")
 
     mg_sleep_and_assert(data, show_instances_coord3)
     mg_sleep_and_assert(data, show_instances_coord1)
     mg_sleep_and_assert(data, show_instances_coord2)
 
+    def get_port(instance_name):
+        mappings = {
+            "instance_1": 7687,
+            "instance_2": 7688,
+            "instance_3": 7689,
+        }
+        return mappings[instance_name]
+
+    main_cursor = connect(port=get_port(main_name), host="localhost").cursor()
+
     def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_1_cursor, "SHOW REPLICAS;")))
+        return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")))
 
     replicas = [
+        (
+            "instance_1",
+            "localhost:10001",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
         (
             "instance_2",
             "localhost:10002",
@@ -2228,13 +2134,14 @@ def test_force_reset_works_after_failed_registration_and_replica_down():
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
     ]
+    replicas = [replica for replica in replicas if replica[0] != main_name]
     mg_sleep_and_assert_collection(replicas, show_replicas)
 
     # 8
 
     vertex_count = 10
     for _ in range(vertex_count):
-        execute_and_fetch_all(instance_1_cursor, "CREATE ();")
+        execute_and_fetch_all(main_cursor, "CREATE ();")
 
     def get_vertex_count_func(cursor):
         def get_vertex_count():
@@ -2242,12 +2149,9 @@ def test_force_reset_works_after_failed_registration_and_replica_down():
 
         return get_vertex_count
 
-    instance_1_cursor = connect(port=7687, host="localhost").cursor()
-    instance_2_cursor = connect(port=7688, host="localhost").cursor()
-
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_3_cursor))
+    for instance in ["instance_1", "instance_2", "instance_3"]:
+        cursor = connect(port=get_port(instance), host="localhost").cursor()
+        mg_sleep_and_assert(vertex_count, get_vertex_count_func(cursor))
 
     interactive_mg_runner.stop_all(keep_directories=False)
 
@@ -2369,14 +2273,14 @@ def test_force_reset_works_after_failed_registration_and_2_coordinators_down():
     interactive_mg_runner.start(inner_instances_description, "coordinator_2")
 
     # 7
-
+    # main must be the same after leader election as before, we can't demote old main
     leader_data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     leader_name = find_instance_and_assert_instances(
@@ -2400,19 +2304,19 @@ def test_force_reset_works_after_failed_registration_and_2_coordinators_down():
     mg_sleep_and_assert(leader_data, show_instances_coord2)
 
     def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_1_cursor, "SHOW REPLICAS;")))
+        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
 
     replicas = [
         (
-            "instance_2",
-            "localhost:10002",
+            "instance_1",
+            "localhost:10001",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
         (
-            "instance_3",
-            "localhost:10003",
+            "instance_2",
+            "localhost:10002",
             "sync",
             {"behind": None, "status": "ready", "ts": 0},
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
@@ -2424,7 +2328,7 @@ def test_force_reset_works_after_failed_registration_and_2_coordinators_down():
 
     vertex_count = 10
     for _ in range(vertex_count):
-        execute_and_fetch_all(instance_1_cursor, "CREATE ();")
+        execute_and_fetch_all(instance_3_cursor, "CREATE ();")
 
     def get_vertex_count_func(cursor):
         def get_vertex_count():
@@ -2432,12 +2336,17 @@ def test_force_reset_works_after_failed_registration_and_2_coordinators_down():
 
         return get_vertex_count
 
-    instance_1_cursor = connect(port=7687, host="localhost").cursor()
-    instance_2_cursor = connect(port=7688, host="localhost").cursor()
+    def get_port(instance_name):
+        mappings = {
+            "instance_1": 7687,
+            "instance_2": 7688,
+            "instance_3": 7689,
+        }
+        return mappings[instance_name]
 
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_3_cursor))
+    for instance in ["instance_1", "instance_2", "instance_3"]:
+        cursor = connect(port=get_port(instance), host="localhost").cursor()
+        mg_sleep_and_assert(vertex_count, get_vertex_count_func(cursor))
 
     interactive_mg_runner.stop_all(keep_directories=False)
 
@@ -3434,4 +3343,4 @@ def test_first_coord_restarts():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__, "-k", "test_even_number_coords"]))
+    sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -335,7 +335,7 @@ def update_tuple_value(
     return list_tuples
 
 
-@pytest.mark.parametrize("use_durability", [True, False])
+@pytest.mark.parametrize("use_durability", [True])
 def test_even_number_coords(use_durability):
     # Goal is to check that nothing gets broken on even number of coords when 2 coords are down
     # 1. Start all instances.
@@ -457,7 +457,7 @@ def test_even_number_coords(use_durability):
     with pytest.raises(Exception) as e:
         execute_and_fetch_all(coord_cursor_3, "SET INSTANCE instance_3 TO MAIN;")
 
-    assert "Couldn't register instance as cluster didn't accept start of action!" in str(e.value)
+    assert "Couldn't set instance to main as cluster didn't accept start of action!" in str(e.value)
 
     follower_data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "unknown", "follower"),
@@ -3434,11 +3434,4 @@ def test_first_coord_restarts():
 
 
 if __name__ == "__main__":
-    sys.exit(
-        pytest.main(
-            [
-                __file__,
-                "-rA",
-            ]
-        )
-    )
+    sys.exit(pytest.main([__file__, "-k", "test_even_number_coords"]))

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -2927,9 +2927,9 @@ def test_coordinator_user_action_force_reset_works():
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
     mg_sleep_and_assert(data, show_instances_coord3)


### PR DESCRIPTION
When becoming the leader in case everything seems okay we don't do any checks. But the coordinator can become leader and only do commits of older logs afterwards (when we exit become leader callback), meaning we could miss logs which put us in unhealthy state.

To fix that problem, we will alter become leader callback to always do check of whole cluster and set it in healthy state in the beginning. 