### PR TITLE
Use YAML configuration on server startup

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -339,3 +339,5 @@ import_library(mgcxx_text_search STATIC ${MGCXX_TEXT_SEARCH_LIBRARY} ${MGCXX_INC
 
 # setup strong_type (cmake sub_directory tolerant)
 add_subdirectory(strong_type EXCLUDE_FROM_ALL)
+
+add_subdirectory(yaml_cpp EXCLUDE_FROM_ALL)

--- a/libs/setup.sh
+++ b/libs/setup.sh
@@ -158,6 +158,7 @@ declare -A primary_urls=(
   ["asio"]="http://$local_cache_host/git/asio.git"
   ["mgcxx"]="http://$local_cache_host/git/mgcxx.git"
   ["strong_type"]="http://$local_cache_host/git/strong_type.git"
+  ["yaml_cpp"]="https://github.com/jbeder/yaml-cpp.git"
 )
 
 # The goal of secondary urls is to have links to the "source of truth" of
@@ -191,6 +192,7 @@ declare -A secondary_urls=(
   ["asio"]="https://github.com/chriskohlhoff/asio.git"
   ["mgcxx"]="https://github.com/memgraph/mgcxx.git"
   ["strong_type"]="https://github.com/rollbear/strong_type.git"
+  ["yaml_cpp"]="https://github.com/jbeder/yaml-cpp.git"
 )
 
 # antlr
@@ -337,3 +339,8 @@ repo_clone_try_double "${primary_urls[mgcxx]}" "${secondary_urls[mgcxx]}" "mgcxx
 # strong_type v14
 strong_type_ref="v14"
 repo_clone_try_double "${primary_urls[strong_type]}" "${secondary_urls[strong_type]}" "strong_type" "$strong_type_ref"
+
+
+# yaml_cpp
+yaml_cpp_ref="0.8.0"
+repo_clone_try_double "${primary_urls[yaml_cpp]}" "${secondary_urls[yaml_cpp]}" "yaml_cpp" "$yaml_cpp_ref"

--- a/src/coordination/CMakeLists.txt
+++ b/src/coordination/CMakeLists.txt
@@ -59,5 +59,5 @@ target_sources(mg-coordination
 target_include_directories(mg-coordination PUBLIC include)
 
 target_link_libraries(mg-coordination
-    PUBLIC mg::utils mg::rpc mg::slk mg::io mg::repl_coord_glue lib::rangev3 nuraft mg-replication_handler
+    PUBLIC mg::utils mg::rpc mg::slk mg::io mg::repl_coord_glue lib::rangev3 nuraft yaml-cpp::yaml-cpp mg-replication_handler
 )

--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -91,9 +91,6 @@ CoordinatorInstance::CoordinatorInstance(CoordinatorInstanceInitConfig const &co
                                             CoordinationClusterChangeObserver{this});
   AddOrUpdateClientConnectors(raft_state_->GetCoordinatorToCoordinatorConfigs());
   raft_state_->InitRaftServer();
-
-  YAML::Emitter out;
-  out << "Hello, World!";
 }
 
 CoordinatorInstance::~CoordinatorInstance() {

--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -51,6 +51,8 @@
 #include <range/v3/view/filter.hpp>
 #include <range/v3/view/transform.hpp>
 
+#include "yaml-cpp/yaml.h"
+
 namespace memgraph::coordination {
 
 using nuraft::ptr;
@@ -89,6 +91,9 @@ CoordinatorInstance::CoordinatorInstance(CoordinatorInstanceInitConfig const &co
                                             CoordinationClusterChangeObserver{this});
   AddOrUpdateClientConnectors(raft_state_->GetCoordinatorToCoordinatorConfigs());
   raft_state_->InitRaftServer();
+
+  YAML::Emitter out;
+  out << "Hello, World!";
 }
 
 CoordinatorInstance::~CoordinatorInstance() {


### PR DESCRIPTION
The problem when starting cluster from query is it is not possible to modify configuration anymore as there is no input from which you can modify. Therefore, this change should fix the issue with the modification of the cluster when migrating to the newer version