### PR TITLE
Splitting the logic for authentication and password change

### DIFF
--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -604,10 +604,11 @@ User::User(const std::string &username, std::optional<HashedPassword> password_h
 #endif
 
 bool User::CheckPassword(const std::string &password) {
-  if (!password_hash_) {
-    return password.empty();
-  }
   return password_hash_ ? password_hash_->VerifyPassword(password) : true;
+}
+
+bool User::CheckPasswordExplicit(const std::string &password) {
+  return password_hash_ ? password_hash_->VerifyPassword(password) : password.empty();
 }
 
 void User::UpdatePassword(const std::optional<std::string> &password,

--- a/src/auth/models.hpp
+++ b/src/auth/models.hpp
@@ -367,6 +367,7 @@ class User final {
 
   /// @throw AuthException if unable to verify the password.
   bool CheckPassword(const std::string &password);
+  bool CheckPasswordExplicit(const std::string &password);
 
   bool UpgradeHash(const std::string password) {
     if (!password_hash_) return false;

--- a/src/glue/auth_handler.cpp
+++ b/src/glue/auth_handler.cpp
@@ -362,7 +362,7 @@ void AuthQueryHandler::ChangePassword(const std::string &username, const std::op
     if (!user) {
       throw memgraph::query::QueryRuntimeException("User '{}' doesn't exist.", username);
     }
-    if (user->CheckPassword(*oldPassword)) {
+    if (user->CheckPasswordExplicit(*oldPassword)) {
       locked_auth->UpdatePassword(*user, newPassword);
       locked_auth->SaveUser(*user, system_tx);
     } else {

--- a/tests/unit/auth.cpp
+++ b/tests/unit/auth.cpp
@@ -66,7 +66,7 @@ TEST_F(AuthWithStorage, Authenticate) {
   ASSERT_NE(user, std::nullopt);
   ASSERT_TRUE(auth->HasUsers());
 
-  ASSERT_FALSE(auth->Authenticate("test", "123"));
+  ASSERT_TRUE(auth->Authenticate("test", "123"));
   ASSERT_TRUE(auth->Authenticate("test", ""));
 
   user->UpdatePassword("123");
@@ -80,8 +80,8 @@ TEST_F(AuthWithStorage, Authenticate) {
   user->UpdatePassword();
   auth->SaveUser(*user);
 
-  ASSERT_EQ(auth->Authenticate("test", "123"), std::nullopt);
-  ASSERT_EQ(auth->Authenticate("test", "456"), std::nullopt);
+  ASSERT_NE(auth->Authenticate("test", "123"), std::nullopt);
+  ASSERT_NE(auth->Authenticate("test", "456"), std::nullopt);
 
   ASSERT_EQ(auth->Authenticate("nonexistant", "123"), std::nullopt);
 }
@@ -341,7 +341,7 @@ TEST_F(AuthWithStorage, UserPasswordCreation) {
   {
     auto user = auth->AddUser("test");
     ASSERT_TRUE(user);
-    ASSERT_FALSE(auth->Authenticate("test", "123"));
+    ASSERT_TRUE(auth->Authenticate("test", "123"));
     ASSERT_TRUE(auth->Authenticate("test", ""));
     ASSERT_TRUE(auth->RemoveUser(user->username()));
   }


### PR DESCRIPTION
This change will revert the breaking change from PR #2166
Now a password-less user can login using any string, but must define empty string when trying to change it.