### PR TITLE
Bring benchmarks back on in CI

### DIFF
--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -110,8 +110,7 @@ jobs:
       os: 'debian-11'
       toolchain: 'v5'
       run_core: ${{ needs.DiffSetup.outputs.run_release_core }}
-      run_benchmark: 'false'
-      # run_benchmark: ${{ needs.DiffSetup.outputs.run_release_benchmark }}
+      run_benchmark: ${{ needs.DiffSetup.outputs.run_release_benchmark }}
       run_e2e: ${{ needs.DiffSetup.outputs.run_release_e2e }}
       run_stress: ${{ needs.DiffSetup.outputs.run_release_stress }}
     secrets: inherit


### PR DESCRIPTION
The bench-graph deployment has been fixed, so now benchmarks are back in action in CI.