### PR TITLE
[BUGFIX] incorrect size representations properties when using on disk

### DIFF
--- a/src/storage/v2/property_store.cpp
+++ b/src/storage/v2/property_store.cpp
@@ -2093,12 +2093,13 @@ void PropertyStore::SetBuffer(const std::string_view buffer) {
   uint32_t size = 0;
   uint8_t *data = nullptr;
   size = buffer.size();
-  if (buffer.size() == sizeof(buffer_) - 1) {  // use local buffer
+  if (buffer.size() <= sizeof(buffer_) - 1) {  // use local buffer
     buffer_[0] = kUseLocalBuffer;
     data = &buffer_[1];
   } else {
-    data = new uint8_t[size];
-    SetSizeData(buffer_, size, data);
+    auto buffer_size = ToMultipleOf8(size);
+    data = new uint8_t[buffer_size];
+    SetSizeData(buffer_, buffer_size, data);
   }
 
   for (uint i = 0; i < size; ++i) {

--- a/src/storage/v2/property_store.cpp
+++ b/src/storage/v2/property_store.cpp
@@ -2090,20 +2090,17 @@ void PropertyStore::SetBuffer(const std::string_view buffer) {
     return;
   }
 
-  uint32_t size = 0;
-  uint8_t *data = nullptr;
-  size = buffer.size();
-  if (buffer.size() <= sizeof(buffer_) - 1) {  // use local buffer
-    buffer_[0] = kUseLocalBuffer;
-    data = &buffer_[1];
-  } else {
-    auto buffer_size = ToMultipleOf8(size);
-    data = new uint8_t[buffer_size];
-    SetSizeData(buffer_, buffer_size, data);
-  }
+  auto size = buffer.size();
+  auto buffer_info = SetupBuffer(buffer_, size);
+  auto view = buffer_info.view;
 
   for (uint i = 0; i < size; ++i) {
-    data[i] = static_cast<uint8_t>(buffer[i]);
+    view[i] = static_cast<uint8_t>(buffer[i]);
+  }
+
+  // Make buffer perminant
+  if (buffer_info.storage_mode == StorageMode::BUFFER) {
+    SetSizeData(buffer_, view.size_bytes(), view.data());
   }
 }
 

--- a/src/utils/memory.cpp
+++ b/src/utils/memory.cpp
@@ -101,14 +101,17 @@ void *MonotonicBufferResource::DoAllocate(size_t bytes, size_t alignment) {
     static_assert(IsPow2(alignof(Buffer)),
                   "Buffer should not be a packed struct in order to be placed "
                   "at the start of an allocation request");
+    // TODO : use better function than RoundUint64ToMultiple because we know alloc_align is a power of 2
     const auto maybe_bytes_for_buffer = RoundUint64ToMultiple(sizeof(Buffer), alloc_align);
     if (!maybe_bytes_for_buffer) throw BadAlloc("Allocation size overflow");
     const size_t bytes_for_buffer = *maybe_bytes_for_buffer;
-    const size_t alloc_size = bytes_for_buffer + size;
-    if (alloc_size < size) throw BadAlloc("Allocation size overflow");
-    void *ptr = memory_->Allocate(alloc_size, alloc_align);
+    // TODO : use better function than RoundUint64ToMultiple because we know alloc_align is a power of 2
+    const auto alloc_size = RoundUint64ToMultiple(bytes_for_buffer + size, alloc_align);
+    if (!alloc_size) throw BadAlloc("Allocation size overflow");
+    if (*alloc_size < size) throw BadAlloc("Allocation size overflow");
+    void *ptr = memory_->Allocate(*alloc_size, alloc_align);
     // Instantiate the Buffer at the start of the allocated block.
-    current_buffer_ = new (ptr) Buffer{current_buffer_, alloc_size - bytes_for_buffer, alloc_align};
+    current_buffer_ = new (ptr) Buffer{current_buffer_, *alloc_size - bytes_for_buffer, alloc_align};
     allocated_ = 0;
   };
 

--- a/src/utils/memory.cpp
+++ b/src/utils/memory.cpp
@@ -108,7 +108,6 @@ void *MonotonicBufferResource::DoAllocate(size_t bytes, size_t alignment) {
     // TODO : use better function than RoundUint64ToMultiple because we know alloc_align is a power of 2
     const auto alloc_size = RoundUint64ToMultiple(bytes_for_buffer + size, alloc_align);
     if (!alloc_size) throw BadAlloc("Allocation size overflow");
-    if (*alloc_size < size) throw BadAlloc("Allocation size overflow");
     void *ptr = memory_->Allocate(*alloc_size, alloc_align);
     // Instantiate the Buffer at the start of the allocated block.
     current_buffer_ = new (ptr) Buffer{current_buffer_, *alloc_size - bytes_for_buffer, alloc_align};

--- a/tests/e2e/interactive_mg_runner.py
+++ b/tests/e2e/interactive_mg_runner.py
@@ -43,7 +43,7 @@ from typing import Optional
 
 import yaml
 
-from memgraph import MemgraphInstanceRunner, extract_bolt_port
+from memgraph import MemgraphInstanceRunner, extract_bolt_port, extract_management_port
 
 log = logging.getLogger("memgraph.tests.e2e")
 
@@ -129,6 +129,11 @@ def _start_instance(
     assert not is_port_in_use(
         bolt_port
     ), f"If this raises, you are trying to start an instance on a port {bolt_port} used by the running instance."
+    management_port = extract_management_port(args)
+    if management_port:
+        assert not is_port_in_use(
+            management_port
+        ), f"If this raises, you are trying to start with coordinator management port {management_port} which is already in use."
 
     log_file_path = os.path.join(BUILD_DIR, "logs", log_file)
 

--- a/tests/e2e/memgraph.py
+++ b/tests/e2e/memgraph.py
@@ -44,6 +44,21 @@ def extract_bolt_port(args):
     return 7687
 
 
+def extract_management_port(args):
+    for arg_index, arg in enumerate(args):
+        if arg.startswith("--management-port="):
+            maybe_port = arg.split("=")[1]
+            if not maybe_port.isdigit():
+                raise Exception("Unable to read management port after --management-port=.")
+            return int(maybe_port)
+        elif arg == "--management-port":
+            maybe_port = args[arg_index + 1]
+            if not maybe_port.isdigit():
+                raise Exception("Unable to read management port after --management-port.")
+            return int(maybe_port)
+    return None
+
+
 def replace_paths(path):
     return path.replace("$PROJECT_DIR", PROJECT_DIR).replace("$SCRIPT_DIR", SCRIPT_DIR).replace("$BUILD_DIR", BUILD_DIR)
 

--- a/tests/gql_behave/continuous_integration
+++ b/tests/gql_behave/continuous_integration
@@ -177,6 +177,8 @@ def main():
             "--stats-file",
             suite["stats_file"],
             suite["test_suite"],
+            "--storage-mode",
+            suite_storage_mode,
         ]
 
         # The exit code isn't checked here because the `behave` framework

--- a/tests/unit/utils_memory.cpp
+++ b/tests/unit/utils_memory.cpp
@@ -114,7 +114,7 @@ TEST(MonotonicBufferResource, AllocationOverCapacity) {
     memgraph::utils::MonotonicBufferResource mem(1000, &test_mem);
     CheckAllocation(&mem, 24, 1);
     EXPECT_EQ(test_mem.new_count_, 1);
-    CheckAllocation(&mem, 976);
+    CheckAllocation(&mem, 985, 1);
     EXPECT_EQ(test_mem.new_count_, 2);
     EXPECT_EQ(test_mem.delete_count_, 0);
     mem.Release();


### PR DESCRIPTION
Recent property store changes added a different correctness invariant that the existing on disk code was unaware of. 

Also minor changes:
- gql_behave test to pass their storage mode to the run command
- memory alignment fixes to avoid potential UB (+ test fix)
- better diagnostic in e2e/interactive_mg_runner.py