### PR TITLE
Correct label+property index entry insertion

### DIFF
--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -117,7 +117,8 @@ void InMemoryLabelPropertyIndex::UpdateOnSetProperty(PropertyId property, const 
     return;
   }
 
-  for (const auto &[_, storage] : index->second) {
+  for (const auto &[label, storage] : index->second) {
+    if (!utils::Contains(vertex->labels, label)) continue;
     auto acc = storage->access();
     acc.insert(Entry{value, vertex, tx.start_timestamp});
   }


### PR DESCRIPTION
Only add entry to label+property indexes when label matches.
