### PR TITLE
Fix communication restarts

### DIFF
--- a/tests/e2e/high_availability/common.py
+++ b/tests/e2e/high_availability/common.py
@@ -9,6 +9,7 @@
 # by the Apache License, Version 2.0, included in the file
 # licenses/APL.txt.
 
+import time
 import typing
 
 import mgclient
@@ -36,3 +37,72 @@ def safe_execute(function, *args):
     except Exception as e:
         print("Exception occurred: ", str(e))
         pass
+
+
+def find_instance_and_assert_instances(
+    instance_role: str, num_coordinators: int = 3, coord_ids_to_skip_validation=None, wait_period=10
+):
+    if coord_ids_to_skip_validation is None:
+        coord_ids_to_skip_validation = set()
+
+    start_time = time.time()
+
+    def find_instances():
+        all_instances = []
+        for i in range(0, num_coordinators):
+            if (i + 1) in coord_ids_to_skip_validation:
+                continue
+            coord_cursor = connect(host="localhost", port=7690 + i).cursor()
+
+            def show_instances():
+                return ignore_elapsed_time_from_results(
+                    sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
+                )
+
+            instances = show_instances()
+            for instance in instances:
+                if instance[-1] == instance_role:
+                    all_instances.append(instance[0])  # coordinator name
+
+        return all_instances
+
+    all_instances = []
+    expected_num_instances = num_coordinators - len(coord_ids_to_skip_validation)
+    while True:
+        if len(all_instances) == expected_num_instances or time.time() - start_time > wait_period:
+            break
+        all_instances = find_instances()
+        time.sleep(0.5)
+
+    assert (
+        len(all_instances) == expected_num_instances
+    ), f"{instance_role}s not found, got {all_instances}, expected {expected_num_instances}, as num_coordinators: {num_coordinators}, coord_ids_to_skip_validation: {coord_ids_to_skip_validation}"
+
+    instance = all_instances[0]
+
+    for l in all_instances:
+        assert l == instance, "Leaders are not the same"
+
+    assert instance is not None and instance != "" and len(all_instances) > 0, f"{instance_role} not found"
+    return instance
+
+
+def update_tuple_value(
+    list_tuples: typing.List, searching_key: str, searching_index: int, index_in_tuple_value: int, new_value: str
+):
+    def find_tuple():
+        for i, tuple_obj in enumerate(list_tuples):
+            if tuple_obj[searching_index] != searching_key:
+                continue
+            return i
+        return None
+
+    index_tuple = find_tuple()
+    assert index_tuple is not None, "Tuple not found"
+
+    tuple_obj = list_tuples[index_tuple]
+    tuple_obj_list = list(tuple_obj)
+    tuple_obj_list[index_in_tuple_value] = new_value
+    list_tuples[index_tuple] = tuple(tuple_obj_list)
+
+    return list_tuples

--- a/tests/e2e/high_availability/coord_cluster_registration.py
+++ b/tests/e2e/high_availability/coord_cluster_registration.py
@@ -348,7 +348,7 @@ def test_coordinators_communication_with_restarts():
     # 1 Start all instances
     safe_execute(shutil.rmtree, TEMP_DIR)
     MEMGRAPH_INSTANCES_DESCRIPTION = get_instances_description(test_name="coordinators_communication_with_restarts")
-    interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION, keep_directories=True)
+    interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION, keep_directories=False)
 
     coordinator3_cursor = connect(host="localhost", port=7692).cursor()
 

--- a/tests/e2e/high_availability/coord_cluster_registration.py
+++ b/tests/e2e/high_availability/coord_cluster_registration.py
@@ -343,7 +343,7 @@ def test_coordinators_communication_with_restarts():
     # 1 Start all instances
     safe_execute(shutil.rmtree, TEMP_DIR)
     MEMGRAPH_INSTANCES_DESCRIPTION = get_instances_description(test_name="coordinators_communication_with_restarts")
-    interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION, keep_directories=False)
+    interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION, keep_directories=True)
 
     coordinator3_cursor = connect(host="localhost", port=7692).cursor()
 

--- a/tests/e2e/high_availability/coord_cluster_registration.py
+++ b/tests/e2e/high_availability/coord_cluster_registration.py
@@ -89,6 +89,7 @@ def get_instances_description(test_name: str):
                 "--management-port=10121",
             ],
             "log_file": f"high_availability/coord_cluster_registration/{test_name}/coordinator1.log",
+            "data_directory": f"{TEMP_DIR}/coordinator_1",
             "setup_queries": [],
         },
         "coordinator_2": {
@@ -103,6 +104,7 @@ def get_instances_description(test_name: str):
                 "--management-port=10122",
             ],
             "log_file": f"high_availability/coord_cluster_registration/{test_name}/coordinator2.log",
+            "data_directory": f"{TEMP_DIR}/coordinator_2",
             "setup_queries": [],
         },
         "coordinator_3": {
@@ -117,6 +119,7 @@ def get_instances_description(test_name: str):
                 "--management-port=10123",
             ],
             "log_file": f"high_availability/coord_cluster_registration/{test_name}/coordinator3.log",
+            "data_directory": f"{TEMP_DIR}/coordinator_3",
             "setup_queries": [],
         },
     }
@@ -184,6 +187,7 @@ def get_instances_description_no_coord(test_name: str):
                 "--management-port=10121",
             ],
             "log_file": f"high_availability/coord_cluster_registration/{test_name}/coordinator1.log",
+            "data_directory": f"{TEMP_DIR}/coordinator_1",
             "setup_queries": [],
         },
         "coordinator_2": {
@@ -198,6 +202,7 @@ def get_instances_description_no_coord(test_name: str):
                 "--management-port=10122",
             ],
             "log_file": f"high_availability/coord_cluster_registration/{test_name}/coordinator2.log",
+            "data_directory": f"{TEMP_DIR}/coordinator_2",
             "setup_queries": [],
         },
     }

--- a/tests/e2e/high_availability/coord_cluster_registration.py
+++ b/tests/e2e/high_availability/coord_cluster_registration.py
@@ -12,17 +12,18 @@ import os
 import shutil
 import sys
 import tempfile
-from typing import List
 
 import interactive_mg_runner
 import pytest
 from common import (
     connect,
     execute_and_fetch_all,
+    find_instance_and_assert_instances,
     ignore_elapsed_time_from_results,
     safe_execute,
+    update_tuple_value,
 )
-from mg_utils import find_instance_and_assert_instances, mg_sleep_and_assert
+from mg_utils import mg_sleep_and_assert
 
 interactive_mg_runner.SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 interactive_mg_runner.PROJECT_DIR = os.path.normpath(
@@ -32,27 +33,6 @@ interactive_mg_runner.BUILD_DIR = os.path.normpath(os.path.join(interactive_mg_r
 interactive_mg_runner.MEMGRAPH_BINARY = os.path.normpath(os.path.join(interactive_mg_runner.BUILD_DIR, "memgraph"))
 
 TEMP_DIR = tempfile.TemporaryDirectory().name
-
-
-def update_tuple_value(
-    list_tuples: List, searching_key: str, searching_index: int, index_in_tuple_value: int, new_value: str
-):
-    def find_tuple():
-        for i, tuple_obj in enumerate(list_tuples):
-            if tuple_obj[searching_index] != searching_key:
-                continue
-            return i
-        return None
-
-    index_tuple = find_tuple()
-    assert index_tuple is not None, "Tuple not found"
-
-    tuple_obj = list_tuples[index_tuple]
-    tuple_obj_list = list(tuple_obj)
-    tuple_obj_list[index_in_tuple_value] = new_value
-    list_tuples[index_tuple] = tuple(tuple_obj_list)
-
-    return list_tuples
 
 
 def get_instances_description(test_name: str):

--- a/tests/e2e/high_availability/coordinator.py
+++ b/tests/e2e/high_availability/coordinator.py
@@ -98,6 +98,7 @@ def get_memgraph_instances_description(test_name: str):
                 "10121",
             ],
             "log_file": f"high_availability/coordinator/{test_name}/coordinator1.log",
+            "data_directory": f"{TEMP_DIR}/coordinator_1",
             "setup_queries": [
                 "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
                 "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",

--- a/tests/e2e/high_availability/disable_writing_on_main_after_restart.py
+++ b/tests/e2e/high_availability/disable_writing_on_main_after_restart.py
@@ -103,6 +103,7 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
             "--management-port=10121",
         ],
         "log_file": "high_availability/disable_writing_on_main_after_restart/test_writing_disabled_on_main_restart/coordinator1.log",
+        "data_directory": f"{TEMP_DIR}/coordinator_1",
         "setup_queries": [],
     },
     "coordinator_2": {
@@ -117,6 +118,7 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
             "--management-port=10122",
         ],
         "log_file": "high_availability/disable_writing_on_main_after_restart/test_writing_disabled_on_main_restart/coordinator2.log",
+        "data_directory": f"{TEMP_DIR}/coordinator_2",
         "setup_queries": [],
     },
     "coordinator_3": {
@@ -132,6 +134,7 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
             "--management-port=10123",
         ],
         "log_file": "high_availability/disable_writing_on_main_after_restart/test_writing_disabled_on_main_restart/coordinator3.log",
+        "data_directory": f"{TEMP_DIR}/coordinator_3",
         "setup_queries": [],
     },
 }

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -11,19 +11,18 @@
 
 import concurrent.futures
 import os
-import shutil
 import sys
 import tempfile
 import time
-from typing import List
 
 import interactive_mg_runner
 import pytest
 from common import (
     connect,
     execute_and_fetch_all,
+    find_instance_and_assert_instances,
     ignore_elapsed_time_from_results,
-    safe_execute,
+    update_tuple_value,
 )
 from mg_utils import (
     mg_assert_until,
@@ -264,75 +263,6 @@ def get_instances_description_no_setup_4_coords(temp_dir, test_name: str, use_du
             "setup_queries": [],
         },
     }
-
-
-def find_instance_and_assert_instances(
-    instance_role: str, num_coordinators: int = 3, coord_ids_to_skip_validation=None, wait_period=10
-):
-    if coord_ids_to_skip_validation is None:
-        coord_ids_to_skip_validation = set()
-
-    start_time = time.time()
-
-    def find_instances():
-        all_instances = []
-        for i in range(0, num_coordinators):
-            if (i + 1) in coord_ids_to_skip_validation:
-                continue
-            coord_cursor = connect(host="localhost", port=7690 + i).cursor()
-
-            def show_instances():
-                return ignore_elapsed_time_from_results(
-                    sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
-                )
-
-            instances = show_instances()
-            for instance in instances:
-                if instance[-1] == instance_role:
-                    all_instances.append(instance[0])  # coordinator name
-
-        return all_instances
-
-    all_instances = []
-    expected_num_instances = num_coordinators - len(coord_ids_to_skip_validation)
-    while True:
-        if len(all_instances) == expected_num_instances or time.time() - start_time > wait_period:
-            break
-        all_instances = find_instances()
-        time.sleep(0.5)
-
-    assert (
-        len(all_instances) == expected_num_instances
-    ), f"{instance_role}s not found, got {all_instances}, expected {expected_num_instances}, as num_coordinators: {num_coordinators}, coord_ids_to_skip_validation: {coord_ids_to_skip_validation}"
-
-    instance = all_instances[0]
-
-    for l in all_instances:
-        assert l == instance, "Leaders are not the same"
-
-    assert instance is not None and instance != "" and len(all_instances) > 0, f"{instance_role} not found"
-    return instance
-
-
-def update_tuple_value(
-    list_tuples: List, searching_key: str, searching_index: int, index_in_tuple_value: int, new_value: str
-):
-    def find_tuple():
-        for i, tuple_obj in enumerate(list_tuples):
-            if tuple_obj[searching_index] != searching_key:
-                continue
-            return i
-        return None
-
-    index_tuple = find_tuple()
-    assert index_tuple is not None, "Tuple not found"
-
-    tuple_obj = list_tuples[index_tuple]
-    tuple_obj_list = list(tuple_obj)
-    tuple_obj_list[index_in_tuple_value] = new_value
-    list_tuples[index_tuple] = tuple(tuple_obj_list)
-
-    return list_tuples
 
 
 @pytest.mark.parametrize("use_durability", [True, False])

--- a/tests/e2e/high_availability/manual_setting_replicas.py
+++ b/tests/e2e/high_availability/manual_setting_replicas.py
@@ -11,6 +11,7 @@
 
 import os
 import sys
+import tempfile
 
 import interactive_mg_runner
 import pytest
@@ -22,6 +23,8 @@ interactive_mg_runner.PROJECT_DIR = os.path.normpath(
 )
 interactive_mg_runner.BUILD_DIR = os.path.normpath(os.path.join(interactive_mg_runner.PROJECT_DIR, "build"))
 interactive_mg_runner.MEMGRAPH_BINARY = os.path.normpath(os.path.join(interactive_mg_runner.BUILD_DIR, "memgraph"))
+
+TEMP_DIR = tempfile.TemporaryDirectory().name
 
 MEMGRAPH_INSTANCES_DESCRIPTION = {
     "instance_3": {

--- a/tests/e2e/high_availability/manual_setting_replicas.py
+++ b/tests/e2e/high_availability/manual_setting_replicas.py
@@ -35,6 +35,7 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
             "10013",
         ],
         "log_file": "high_availability/manual_setting_replicas/main.log",
+        "data_directory": f"{TEMP_DIR}/instance_3",
         "setup_queries": [],
     },
 }

--- a/tests/e2e/high_availability/not_replicate_from_old_main.py
+++ b/tests/e2e/high_availability/not_replicate_from_old_main.py
@@ -185,6 +185,7 @@ def test_not_replicate_old_main_register_new_cluster():
                 "--management-port=10121",
             ],
             "log_file": "coordinator.log",
+            "data_directory": f"{TEMP_DIR}/coordinator_1",
             "setup_queries": [
                 "REGISTER INSTANCE shared_instance WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
                 "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
@@ -242,6 +243,7 @@ def test_not_replicate_old_main_register_new_cluster():
                 "--management-port=10122",
             ],
             "log_file": "coordinator.log",
+            "data_directory": f"{TEMP_DIR}/coordinator_2",
             "setup_queries": [],
         },
     }

--- a/tests/e2e/high_availability/single_coordinator.py
+++ b/tests/e2e/high_availability/single_coordinator.py
@@ -95,6 +95,7 @@ def get_memgraph_instances_description(test_name: str, data_recovery_on_startup:
                 "--management-port=10121",
             ],
             "log_file": f"high_availability/single_coordinator/{test_name}/coordinator.log",
+            "data_directory": f"{TEMP_DIR}/coordinator",
             "setup_queries": [
                 "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
                 "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
@@ -189,6 +190,7 @@ def get_memgraph_instances_description_4_instances(test_name: str, data_recovery
                 "--management-port=10121",
             ],
             "log_file": f"high_availability/single_coordinator/{test_name}/coordinator.log",
+            "data_directory": f"{TEMP_DIR}/coordinator",
             "setup_queries": [
                 "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
                 "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",


### PR DESCRIPTION
Coordinators instances in some tests were started without data directory flag causing problems on restarts.