### PR TITLE
Separate processing jepsen results from the execution

### DIFF
--- a/.github/workflows/diff_jepsen.yaml
+++ b/.github/workflows/diff_jepsen.yaml
@@ -92,6 +92,8 @@ jobs:
           --organization-name $MEMGRAPH_ORGANIZATION_NAME
 
       - name: Process Jepsen results
+        continue-on-error: true
+        if: always()
         run: |
           cd tests/jepsen
           ./run.sh process-results

--- a/.github/workflows/diff_jepsen.yaml
+++ b/.github/workflows/diff_jepsen.yaml
@@ -87,6 +87,8 @@ jobs:
           ./run.sh test-all-individually \
           --binary ../../build/memgraph \
           --run-args "--time-limit 120 --concurrency 6" \
+          --ignore-run-stdout-logs \
+          --ignore-run-stderr-logs \
           --nodes-no 6 \
           --enterprise-license $MEMGRAPH_ENTERPRISE_LICENSE \
           --organization-name $MEMGRAPH_ORGANIZATION_NAME

--- a/.github/workflows/diff_jepsen.yaml
+++ b/.github/workflows/diff_jepsen.yaml
@@ -87,11 +87,14 @@ jobs:
           ./run.sh test-all-individually \
           --binary ../../build/memgraph \
           --run-args "--time-limit 120 --concurrency 6" \
-          --ignore-run-stdout-logs \
-          --ignore-run-stderr-logs \
           --nodes-no 6 \
           --enterprise-license $MEMGRAPH_ENTERPRISE_LICENSE \
           --organization-name $MEMGRAPH_ORGANIZATION_NAME
+
+      - name: Process Jepsen results
+        run: |
+          cd tests/jepsen
+          ./run.sh process-results
 
       - name: Save Jepsen report
         continue-on-error: true


### PR DESCRIPTION
Processing results is now done in separate github tasks to avoid the situation where test fails and we are left without logs.