### PR TITLE
Improvements on e2e testing infrastructure

### DIFF
--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -45,7 +45,7 @@ env:
 
 jobs:
   core:
-    if: ${{ inputs.run_core == 'true' }}
+    if: ${{ inputs.run_core == 'true' }}diff_release
     name: "Core tests"
     runs-on: [self-hosted, Linux, X64, DockerMgBuild]
     timeout-minutes: 60

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -311,7 +311,7 @@ jobs:
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
-          copy --build-logs --dest-dir build/e2e/logs
+          copy --build-logs --dest-dir build/logs
 
       - name: Save test data
         continue-on-error: true
@@ -319,7 +319,7 @@ jobs:
         if: always()
         with:
           name: "Test data(Release build)-${{ inputs.run_id }}"
-          path: build/e2e/logs
+          path: build/logs
 
       - name: Stop mgbuild container
         if: always()

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -311,7 +311,7 @@ jobs:
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
-          copy --build-logs --dest-dir build/logs
+          copy --build-logs --dest-dir build/e2e/logs
 
       - name: Save test data
         continue-on-error: true
@@ -319,7 +319,7 @@ jobs:
         if: always()
         with:
           name: "Test data(Release build)-${{ inputs.run_id }}"
-          path: build/logs
+          path: build/e2e/logs
 
       - name: Stop mgbuild container
         if: always()

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -45,7 +45,7 @@ env:
 
 jobs:
   core:
-    if: ${{ inputs.run_core == 'true' }}diff_release
+    if: ${{ inputs.run_core == 'true' }}
     name: "Core tests"
     runs-on: [self-hosted, Linux, X64, DockerMgBuild]
     timeout-minutes: 60

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -483,7 +483,7 @@ copy_memgraph() {
           exit 1
         fi
         artifact="build logs"
-        artifact_name="logs"
+        artifact_name="e2e/logs"
         container_artifact_path="$MGBUILD_BUILD_DIR/$artifact_name"
         host_dir="$PROJECT_BUILD_DIR"
         shift 1

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -483,7 +483,7 @@ copy_memgraph() {
           exit 1
         fi
         artifact="build logs"
-        artifact_name="e2e/logs"
+        artifact_name="logs"
         container_artifact_path="$MGBUILD_BUILD_DIR/$artifact_name"
         host_dir="$PROJECT_BUILD_DIR"
         shift 1

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -484,7 +484,7 @@ copy_memgraph() {
         fi
         artifact="build logs"
         artifact_name="logs"
-        container_artifact_path="$MGBUILD_BUILD_DIR/$artifact_name"
+        container_artifact_path="$MGBUILD_BUILD_DIR/e2e/logs"
         host_dir="$PROJECT_BUILD_DIR"
         shift 1
       ;;
@@ -534,6 +534,10 @@ copy_memgraph() {
     artifact_name=$artifact_name_override
   fi
   local host_artifact_path="$host_dir/$artifact_name"
+  echo "Host dir: '$host_dir'"
+  echo "Artifact name: '$artifact_name'"
+  echo "Host artifact path: '$host_artifact_path'"
+  echo "Container artifact path: '$container_artifact_path'"
   echo -e "Copying memgraph $artifact from $build_container to host ..."
   mkdir -p "$host_dir"
   if [[ "$artifact" == "package" ]]; then

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,28 +1,28 @@
-#add_subdirectory(benchmark)
-#
-## macro_benchmark test binaries
-#add_subdirectory(macro_benchmark)
-#
-## stress test binaries
-#add_subdirectory(stress)
-#
-## concurrent test binaries
-#add_subdirectory(concurrent)
-#
-## manual test binaries
-#add_subdirectory(manual)
-#
-## unit test binaries
-#add_subdirectory(unit)
-#
-## property based test binaries
-#add_subdirectory(property_based)
-#
-## integration test binaries
-#add_subdirectory(integration)
-#
-## e2e test binaries
+add_subdirectory(benchmark)
+
+# macro_benchmark test binaries
+add_subdirectory(macro_benchmark)
+
+# stress test binaries
+add_subdirectory(stress)
+
+# concurrent test binaries
+add_subdirectory(concurrent)
+
+# manual test binaries
+add_subdirectory(manual)
+
+# unit test binaries
+add_subdirectory(unit)
+
+# property based test binaries
+add_subdirectory(property_based)
+
+# integration test binaries
+add_subdirectory(integration)
+
+# e2e test binaries
 add_subdirectory(e2e)
 
 # mgbench benchmark test binaries
-# add_subdirectory(mgbench)
+add_subdirectory(mgbench)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,28 +1,28 @@
-add_subdirectory(benchmark)
-
-# macro_benchmark test binaries
-add_subdirectory(macro_benchmark)
-
-# stress test binaries
-add_subdirectory(stress)
-
-# concurrent test binaries
-add_subdirectory(concurrent)
-
-# manual test binaries
-add_subdirectory(manual)
-
-# unit test binaries
-add_subdirectory(unit)
-
-# property based test binaries
-add_subdirectory(property_based)
-
-# integration test binaries
-add_subdirectory(integration)
-
-# e2e test binaries
+#add_subdirectory(benchmark)
+#
+## macro_benchmark test binaries
+#add_subdirectory(macro_benchmark)
+#
+## stress test binaries
+#add_subdirectory(stress)
+#
+## concurrent test binaries
+#add_subdirectory(concurrent)
+#
+## manual test binaries
+#add_subdirectory(manual)
+#
+## unit test binaries
+#add_subdirectory(unit)
+#
+## property based test binaries
+#add_subdirectory(property_based)
+#
+## integration test binaries
+#add_subdirectory(integration)
+#
+## e2e test binaries
 add_subdirectory(e2e)
 
 # mgbench benchmark test binaries
-add_subdirectory(mgbench)
+# add_subdirectory(mgbench)

--- a/tests/e2e/high_availability/common.py
+++ b/tests/e2e/high_availability/common.py
@@ -15,6 +15,24 @@ import typing
 import mgclient
 
 
+def get_file_path(file: str):
+    return f"high_availabiity/{file}"
+
+
+def get_data_path(file: str, test: str):
+    """
+    Data is stored in high_availabiity folder.
+    """
+    return f"high_availabiity/{file}/{test}"
+
+
+def get_logs_path(file: str, test: str):
+    """
+    Logs are stored in high_availabiity folder.
+    """
+    return f"high_availabiity/{file}/{test}"
+
+
 # Elapse time is the last element in results hence such slicing works.
 def ignore_elapsed_time_from_results(results: typing.List[tuple]) -> typing.List[tuple]:
     return [result[:-1] for result in results]

--- a/tests/e2e/high_availability/common.py
+++ b/tests/e2e/high_availability/common.py
@@ -15,10 +15,6 @@ import typing
 import mgclient
 
 
-def get_file_path(file: str):
-    return f"high_availabiity/{file}"
-
-
 def get_data_path(file: str, test: str):
     """
     Data is stored in high_availabiity folder.

--- a/tests/e2e/high_availability/common.py
+++ b/tests/e2e/high_availability/common.py
@@ -17,16 +17,16 @@ import mgclient
 
 def get_data_path(file: str, test: str):
     """
-    Data is stored in high_availabiity folder.
+    Data is stored in high_availability folder.
     """
-    return f"high_availabiity/{file}/{test}"
+    return f"high_availability/{file}/{test}"
 
 
 def get_logs_path(file: str, test: str):
     """
-    Logs are stored in high_availabiity folder.
+    Logs are stored in high_availability folder.
     """
-    return f"high_availabiity/{file}/{test}"
+    return f"high_availability/{file}/{test}"
 
 
 # Elapse time is the last element in results hence such slicing works.

--- a/tests/e2e/high_availability/coord_cluster_registration.py
+++ b/tests/e2e/high_availability/coord_cluster_registration.py
@@ -9,9 +9,7 @@
 # by the Apache License, Version 2.0, included in the file
 # licenses/APL.txt.
 import os
-import shutil
 import sys
-import tempfile
 
 import interactive_mg_runner
 import pytest
@@ -19,8 +17,9 @@ from common import (
     connect,
     execute_and_fetch_all,
     find_instance_and_assert_instances,
+    get_data_path,
+    get_logs_path,
     ignore_elapsed_time_from_results,
-    safe_execute,
     update_tuple_value,
 )
 from mg_utils import mg_sleep_and_assert
@@ -32,7 +31,7 @@ interactive_mg_runner.PROJECT_DIR = os.path.normpath(
 interactive_mg_runner.BUILD_DIR = os.path.normpath(os.path.join(interactive_mg_runner.PROJECT_DIR, "build"))
 interactive_mg_runner.MEMGRAPH_BINARY = os.path.normpath(os.path.join(interactive_mg_runner.BUILD_DIR, "memgraph"))
 
-TEMP_DIR = tempfile.TemporaryDirectory().name
+file = "coord_cluster_registration"
 
 
 def get_instances_description(test_name: str):
@@ -47,8 +46,8 @@ def get_instances_description(test_name: str):
                 "--management-port",
                 "10011",
             ],
-            "log_file": f"high_availability/coord_cluster_registration/{test_name}/instance_1.log",
-            "data_directory": f"{TEMP_DIR}/instance_1",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_1",
             "setup_queries": [],
         },
         "instance_2": {
@@ -61,8 +60,8 @@ def get_instances_description(test_name: str):
                 "--management-port",
                 "10012",
             ],
-            "log_file": f"high_availability/coord_cluster_registration/{test_name}/instance_2.log",
-            "data_directory": f"{TEMP_DIR}/instance_2",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_2",
             "setup_queries": [],
         },
         "instance_3": {
@@ -75,8 +74,8 @@ def get_instances_description(test_name: str):
                 "--management-port",
                 "10013",
             ],
-            "log_file": f"high_availability/coord_cluster_registration/{test_name}/instance_3.log",
-            "data_directory": f"{TEMP_DIR}/instance_3",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_3.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_3",
             "setup_queries": [],
         },
         "coordinator_1": {
@@ -90,8 +89,8 @@ def get_instances_description(test_name: str):
                 "--coordinator-hostname=localhost",
                 "--management-port=10121",
             ],
-            "log_file": f"high_availability/coord_cluster_registration/{test_name}/coordinator1.log",
-            "data_directory": f"{TEMP_DIR}/coordinator_1",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_1",
             "setup_queries": [],
         },
         "coordinator_2": {
@@ -105,8 +104,8 @@ def get_instances_description(test_name: str):
                 "--coordinator-hostname=localhost",
                 "--management-port=10122",
             ],
-            "log_file": f"high_availability/coord_cluster_registration/{test_name}/coordinator2.log",
-            "data_directory": f"{TEMP_DIR}/coordinator_2",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_2",
             "setup_queries": [],
         },
         "coordinator_3": {
@@ -120,8 +119,8 @@ def get_instances_description(test_name: str):
                 "--coordinator-hostname=localhost",
                 "--management-port=10123",
             ],
-            "log_file": f"high_availability/coord_cluster_registration/{test_name}/coordinator3.log",
-            "data_directory": f"{TEMP_DIR}/coordinator_3",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_3.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_3",
             "setup_queries": [],
         },
     }
@@ -141,8 +140,8 @@ def get_instances_description_no_coord(test_name: str):
                 "--data-recovery-on-startup=false",
                 "--replication-restore-state-on-startup=true",
             ],
-            "log_file": f"high_availability/coord_cluster_registration/{test_name}/instance_1.log",
-            "data_directory": f"{TEMP_DIR}/instance_1",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_1",
             "setup_queries": [],
         },
         "instance_2": {
@@ -157,8 +156,8 @@ def get_instances_description_no_coord(test_name: str):
                 "--data-recovery-on-startup=false",
                 "--replication-restore-state-on-startup=true",
             ],
-            "log_file": f"high_availability/coord_cluster_registration/{test_name}/instance_2.log",
-            "data_directory": f"{TEMP_DIR}/instance_2",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_2",
             "setup_queries": [],
         },
         "instance_3": {
@@ -173,8 +172,8 @@ def get_instances_description_no_coord(test_name: str):
                 "--data-recovery-on-startup=false",
                 "--replication-restore-state-on-startup=true",
             ],
-            "log_file": f"high_availability/coord_cluster_registration/{test_name}/instance_3.log",
-            "data_directory": f"{TEMP_DIR}/instance_3",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_3.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_3",
             "setup_queries": [],
         },
         "coordinator_1": {
@@ -188,8 +187,8 @@ def get_instances_description_no_coord(test_name: str):
                 "--coordinator-hostname=localhost",
                 "--management-port=10121",
             ],
-            "log_file": f"high_availability/coord_cluster_registration/{test_name}/coordinator1.log",
-            "data_directory": f"{TEMP_DIR}/coordinator_1",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_1",
             "setup_queries": [],
         },
         "coordinator_2": {
@@ -203,8 +202,8 @@ def get_instances_description_no_coord(test_name: str):
                 "--coordinator-hostname=localhost",
                 "--management-port=10122",
             ],
-            "log_file": f"high_availability/coord_cluster_registration/{test_name}/coordinator2.log",
-            "data_directory": f"{TEMP_DIR}/coordinator_2",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_2",
             "setup_queries": [],
         },
     }
@@ -220,8 +219,14 @@ def unset_env_flags():
     os.unsetenv("MEMGRAPH_COORDINATOR_HOSTNAME")
 
 
+@pytest.fixture(autouse=True)
+def cleanup_after_test():
+    yield
+    # Stop + delete directories
+    interactive_mg_runner.stop_all(keep_directories=False)
+
+
 def test_register_repl_instances_then_coordinators():
-    safe_execute(shutil.rmtree, TEMP_DIR)
     MEMGRAPH_INSTANCES_DESCRIPTION = get_instances_description(test_name="register_repl_instances_then_coordinators")
     interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION, keep_directories=False)
 
@@ -284,7 +289,6 @@ def test_register_repl_instances_then_coordinators():
 
 
 def test_register_coordinator_then_repl_instances():
-    safe_execute(shutil.rmtree, TEMP_DIR)
     MEMGRAPH_INSTANCES_DESCRIPTION = get_instances_description(test_name="register_coordinator_then_repl_instances")
     interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION, keep_directories=False)
 
@@ -348,7 +352,6 @@ def test_register_coordinator_then_repl_instances():
 
 def test_coordinators_communication_with_restarts():
     # 1 Start all instances
-    safe_execute(shutil.rmtree, TEMP_DIR)
     MEMGRAPH_INSTANCES_DESCRIPTION = get_instances_description(test_name="coordinators_communication_with_restarts")
     interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION, keep_directories=False)
 
@@ -440,7 +443,6 @@ def test_coordinators_communication_with_restarts():
     [True, False],
 )
 def test_unregister_replicas(kill_instance):
-    safe_execute(shutil.rmtree, TEMP_DIR)
     MEMGRAPH_INSTANCES_DESCRIPTION = get_instances_description(
         test_name="test_unregister_replicas_kill_instance_" + str(kill_instance)
     )
@@ -570,7 +572,6 @@ def test_unregister_replicas(kill_instance):
 
 
 def test_unregister_main():
-    safe_execute(shutil.rmtree, TEMP_DIR)
     MEMGRAPH_INSTANCES_DESCRIPTION = get_instances_description(test_name="test_unregister_main")
     interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION)
 
@@ -683,8 +684,8 @@ def test_unregister_main():
 
 
 def test_register_one_coord_with_env_vars():
-    safe_execute(shutil.rmtree, TEMP_DIR)
-    memgraph_instances_desc = get_instances_description_no_coord(test_name="test_register_one_coord_with_env_vars")
+    test_name = "test_register_one_coord_with_env_vars"
+    memgraph_instances_desc = get_instances_description_no_coord(test_name=test_name)
     interactive_mg_runner.start_all(memgraph_instances_desc)
 
     os.environ["MEMGRAPH_EXPERIMENTAL_ENABLED"] = "high-availability"
@@ -695,8 +696,10 @@ def test_register_one_coord_with_env_vars():
     os.environ["MEMGRAPH_COORDINATOR_HOSTNAME"] = "localhost"
     os.environ["MEMGRAPH_MANAGEMENT_PORT"] = "10123"
 
-    file_path = os.path.join(TEMP_DIR, "ha_init.cypherl")
-    os.environ["MEMGRAPH_HA_CLUSTER_INIT_QUERIES"] = file_path
+    init_queries_file = os.path.join(
+        interactive_mg_runner.BUILD_DIR, "e2e", "data", get_data_path(file, test_name), "ha_init.cypherl"
+    )
+    os.environ["MEMGRAPH_HA_CLUSTER_INIT_QUERIES"] = init_queries_file
 
     setup_queries = [
         "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111', 'management_server': 'localhost:10121'};",
@@ -706,7 +709,7 @@ def test_register_one_coord_with_env_vars():
         "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
         "SET INSTANCE instance_3 TO MAIN",
     ]
-    with open(file_path, "w") as writer:
+    with open(init_queries_file, "w") as writer:
         writer.writelines("\n".join(setup_queries))
     interactive_mg_runner.start(
         {
@@ -714,7 +717,8 @@ def test_register_one_coord_with_env_vars():
                 "args": [
                     "--log-level=TRACE",
                 ],
-                "log_file": "high_availability/coord_cluster_registration/coordinator3.log",
+                "log_file": f"{get_logs_path(file, test_name)}/coordinator_3.log",
+                "data_directory": f"{get_data_path(file, test_name)}/coordinator_3",
                 "setup_queries": [],
                 "default_bolt_port": 7692,
             },
@@ -818,7 +822,6 @@ def test_register_one_data_with_env_vars():
     3. start last coord with setup
     4. check everything works
     """
-    safe_execute(shutil.rmtree, TEMP_DIR)
     unset_env_flags()
     test_name = "test_register_one_data_with_env_vars"
     MEMGRAPH_INSTANCES_DESCRIPTION = {
@@ -834,8 +837,8 @@ def test_register_one_data_with_env_vars():
                 "--data-recovery-on-startup=false",
                 "--replication-restore-state-on-startup=true",
             ],
-            "log_file": f"high_availability/coord_cluster_registration/{test_name}/instance_1.log",
-            "data_directory": f"{TEMP_DIR}/instance_1",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_1",
             "setup_queries": [],
         },
         "instance_2": {
@@ -850,8 +853,8 @@ def test_register_one_data_with_env_vars():
                 "--data-recovery-on-startup=false",
                 "--replication-restore-state-on-startup=true",
             ],
-            "log_file": f"high_availability/coord_cluster_registration/{test_name}/instance_2.log",
-            "data_directory": f"{TEMP_DIR}/instance_2",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_2",
             "setup_queries": [],
         },
         "coordinator_1": {
@@ -866,7 +869,8 @@ def test_register_one_data_with_env_vars():
                 "localhost",
                 "--management-port=10121",
             ],
-            "log_file": f"high_availability/coord_cluster_registration/{test_name}/coordinator1.log",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_1",
             "setup_queries": [],
         },
         "coordinator_2": {
@@ -881,7 +885,8 @@ def test_register_one_data_with_env_vars():
                 "localhost",
                 "--management-port=10122",
             ],
-            "log_file": f"high_availability/coord_cluster_registration/{test_name}/coordinator2.log",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_2",
             "setup_queries": [],
         },
         "coordinator_3": {
@@ -896,7 +901,8 @@ def test_register_one_data_with_env_vars():
                 "localhost",
                 "--management-port=10123",
             ],
-            "log_file": f"high_availability/coord_cluster_registration/{test_name}/coordinator3.log",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_3.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_3",
             "setup_queries": [],
         },
     }
@@ -915,8 +921,8 @@ def test_register_one_data_with_env_vars():
                     "--data-recovery-on-startup=false",
                     "--replication-restore-state-on-startup=true",
                 ],
-                "log_file": f"high_availability/coord_cluster_registration/{test_name}/instance_3.log",
-                "data_directory": f"{TEMP_DIR}/instance_3",
+                "log_file": f"{get_logs_path(file, test_name)}/instance_3.log",
+                "data_directory": f"{get_data_path(file, test_name)}/instance_3",
                 "setup_queries": [],
                 "default_bolt_port": 7689,
             },
@@ -1000,11 +1006,8 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start():
     # 5. Again start coord which should use env setup
     # 6. Check everything works
 
-    safe_execute(shutil.rmtree, TEMP_DIR)
-    interactive_mg_runner.stop_all()
-    memgraph_instances_desc = get_instances_description_no_coord(
-        test_name="test_register_one_coord_with_env_vars_no_instances_alive_on_start"
-    )
+    test_name = "test_register_one_coord_with_env_vars_no_instances_alive_on_start"
+    memgraph_instances_desc = get_instances_description_no_coord(test_name=test_name)
 
     os.environ["MEMGRAPH_EXPERIMENTAL_ENABLED"] = "high-availability"
     os.environ["MEMGRAPH_COORDINATOR_PORT"] = "10113"
@@ -1012,9 +1015,11 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start():
     os.environ["MEMGRAPH_COORDINATOR_ID"] = "3"
     os.environ["MEMGRAPH_COORDINATOR_HOSTNAME"] = "localhost"
     os.environ["MEMGRAPH_MANAGEMENT_PORT"] = "10123"
-    safe_execute(os.mkdir, TEMP_DIR)
-    file_path = os.path.join(TEMP_DIR, "ha_init.cypherl")
-    os.environ["MEMGRAPH_HA_CLUSTER_INIT_QUERIES"] = file_path
+
+    init_queries_file = os.path.join(
+        interactive_mg_runner.BUILD_DIR, "e2e", "data", get_data_path(file, test_name), "ha_init.cypherl"
+    )
+    os.environ["MEMGRAPH_HA_CLUSTER_INIT_QUERIES"] = init_queries_file
 
     setup_queries = [
         "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111', 'management_server': 'localhost:10121'};",
@@ -1024,7 +1029,10 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start():
         "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
         "SET INSTANCE instance_3 TO MAIN",
     ]
-    with open(file_path, "w") as writer:
+
+    # We need to create directories before, since start_all is executed after opening file
+    os.makedirs(os.path.dirname(init_queries_file), exist_ok=True)
+    with open(init_queries_file, "w") as writer:
         writer.writelines("\n".join(setup_queries))
 
     test_name = "test_register_one_coord_with_env_vars_no_instances_alive_on_start"
@@ -1033,7 +1041,8 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start():
             "args": [
                 "--log-level=TRACE",
             ],
-            "log_file": f"high_availability/coord_cluster_registration/{test_name}/coordinator3.log",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_3.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_3",
             "setup_queries": [],
             "default_bolt_port": 7692,
         },
@@ -1067,7 +1076,7 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start():
     os.environ["MEMGRAPH_COORDINATOR_PORT"] = "10113"
     os.environ["MEMGRAPH_BOLT_PORT"] = "7692"
     os.environ["MEMGRAPH_COORDINATOR_ID"] = "3"
-    os.environ["MEMGRAPH_HA_CLUSTER_INIT_QUERIES"] = file_path
+    os.environ["MEMGRAPH_HA_CLUSTER_INIT_QUERIES"] = init_queries_file
     os.environ["MEMGRAPH_COORDINATOR_HOSTNAME"] = "localhost"
     os.environ["MEMGRAPH_MANAGEMENT_PORT"] = "10123"
 
@@ -1162,8 +1171,6 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start():
 
 
 def test_add_coord_instance_fails():
-    interactive_mg_runner.stop_all()
-    safe_execute(shutil.rmtree, TEMP_DIR)
     memgraph_instances_description_all = get_instances_description(test_name="test_add_coord_instance_fails")
     interactive_mg_runner.start_all(memgraph_instances_description_all, keep_directories=False)
 

--- a/tests/e2e/high_availability/coord_cluster_registration.py
+++ b/tests/e2e/high_availability/coord_cluster_registration.py
@@ -714,13 +714,10 @@ def test_register_one_coord_with_env_vars():
     interactive_mg_runner.start(
         {
             "coordinator_3": {
-                "args": [
-                    "--log-level=TRACE",
-                ],
+                "args": ["--log-level=TRACE", "--bolt-port=7692"],
                 "log_file": f"{get_logs_path(file, test_name)}/coordinator_3.log",
                 "data_directory": f"{get_data_path(file, test_name)}/coordinator_3",
                 "setup_queries": [],
-                "default_bolt_port": 7692,
             },
         },
         "coordinator_3",
@@ -920,11 +917,11 @@ def test_register_one_data_with_env_vars():
                     "TRACE",
                     "--data-recovery-on-startup=false",
                     "--replication-restore-state-on-startup=true",
+                    "--bolt-port=7689",
                 ],
                 "log_file": f"{get_logs_path(file, test_name)}/instance_3.log",
                 "data_directory": f"{get_data_path(file, test_name)}/instance_3",
                 "setup_queries": [],
-                "default_bolt_port": 7689,
             },
         },
         "instance_3",
@@ -1038,13 +1035,10 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start():
     test_name = "test_register_one_coord_with_env_vars_no_instances_alive_on_start"
     coordinator_3_description = {
         "coordinator_3": {
-            "args": [
-                "--log-level=TRACE",
-            ],
+            "args": ["--log-level=TRACE", "--bolt-port=7692"],
             "log_file": f"{get_logs_path(file, test_name)}/coordinator_3.log",
             "data_directory": f"{get_data_path(file, test_name)}/coordinator_3",
             "setup_queries": [],
-            "default_bolt_port": 7692,
         },
     }
 

--- a/tests/e2e/high_availability/coord_cluster_registration.py
+++ b/tests/e2e/high_availability/coord_cluster_registration.py
@@ -446,7 +446,7 @@ def test_unregister_replicas(kill_instance):
     MEMGRAPH_INSTANCES_DESCRIPTION = get_instances_description(
         test_name="test_unregister_replicas_kill_instance_" + str(kill_instance)
     )
-    interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION)
+    interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION, keep_directories=False)
 
     coordinator1_cursor = connect(host="localhost", port=7690).cursor()
     coordinator2_cursor = connect(host="localhost", port=7691).cursor()
@@ -573,7 +573,7 @@ def test_unregister_replicas(kill_instance):
 
 def test_unregister_main():
     MEMGRAPH_INSTANCES_DESCRIPTION = get_instances_description(test_name="test_unregister_main")
-    interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION)
+    interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION, keep_directories=False)
 
     coordinator1_cursor = connect(host="localhost", port=7690).cursor()
     coordinator2_cursor = connect(host="localhost", port=7691).cursor()
@@ -686,7 +686,7 @@ def test_unregister_main():
 def test_register_one_coord_with_env_vars():
     test_name = "test_register_one_coord_with_env_vars"
     memgraph_instances_desc = get_instances_description_no_coord(test_name=test_name)
-    interactive_mg_runner.start_all(memgraph_instances_desc)
+    interactive_mg_runner.start_all(memgraph_instances_desc, keep_directories=False)
 
     os.environ["MEMGRAPH_EXPERIMENTAL_ENABLED"] = "high-availability"
     os.environ["MEMGRAPH_COORDINATOR_PORT"] = "10113"
@@ -1068,7 +1068,7 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start():
     # intentionally unset flags here because other instances might read them
     unset_env_flags()
 
-    interactive_mg_runner.start_all(memgraph_instances_desc)
+    interactive_mg_runner.start_all(memgraph_instances_desc, keep_directories=False)
     coordinator1_cursor = connect(host="localhost", port=7690).cursor()
     coordinator2_cursor = connect(host="localhost", port=7691).cursor()
 

--- a/tests/e2e/high_availability/coordinator.py
+++ b/tests/e2e/high_availability/coordinator.py
@@ -12,15 +12,16 @@
 import os
 import shutil
 import sys
-import tempfile
 
 import interactive_mg_runner
 import pytest
 from common import (
     connect,
     execute_and_fetch_all,
+    get_data_path,
+    get_file_path,
+    get_logs_path,
     ignore_elapsed_time_from_results,
-    safe_execute,
 )
 from mg_utils import mg_sleep_and_assert
 
@@ -31,7 +32,7 @@ interactive_mg_runner.PROJECT_DIR = os.path.normpath(
 interactive_mg_runner.BUILD_DIR = os.path.normpath(os.path.join(interactive_mg_runner.PROJECT_DIR, "build"))
 interactive_mg_runner.MEMGRAPH_BINARY = os.path.normpath(os.path.join(interactive_mg_runner.BUILD_DIR, "memgraph"))
 
-TEMP_DIR = tempfile.TemporaryDirectory().name
+file = "coordinator"
 
 
 def get_memgraph_instances_description(test_name: str):
@@ -48,8 +49,8 @@ def get_memgraph_instances_description(test_name: str):
                 "--replication-restore-state-on-startup=true",
                 "--data-recovery-on-startup=false",
             ],
-            "log_file": f"high_availability/coordinator/{test_name}/instance_1.log",
-            "data_directory": f"{TEMP_DIR}/instance_1",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_1",
             "setup_queries": [],
         },
         "instance_2": {
@@ -64,8 +65,8 @@ def get_memgraph_instances_description(test_name: str):
                 "--replication-restore-state-on-startup=true",
                 "--data-recovery-on-startup=false",
             ],
-            "log_file": f"high_availability/coordinator/{test_name}/instance_2.log",
-            "data_directory": f"{TEMP_DIR}/instance_2",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_2",
             "setup_queries": [],
         },
         "instance_3": {
@@ -80,8 +81,8 @@ def get_memgraph_instances_description(test_name: str):
                 "--replication-restore-state-on-startup=true",
                 "--data-recovery-on-startup=false",
             ],
-            "log_file": f"high_availability/coordinator/{test_name}/instance_3.log",
-            "data_directory": f"{TEMP_DIR}/instance_3",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_3.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_3",
             "setup_queries": [],
         },
         "coordinator_1": {
@@ -97,8 +98,8 @@ def get_memgraph_instances_description(test_name: str):
                 "--management-port",
                 "10121",
             ],
-            "log_file": f"high_availability/coordinator/{test_name}/coordinator1.log",
-            "data_directory": f"{TEMP_DIR}/coordinator_1",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_1",
             "setup_queries": [
                 "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
                 "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
@@ -110,12 +111,17 @@ def get_memgraph_instances_description(test_name: str):
 
 
 def setup_test(test_name: str):
-    interactive_mg_runner.stop_all(keep_directories=False)
-    safe_execute(shutil.rmtree, TEMP_DIR)
     memgraph_instances_description = get_memgraph_instances_description(test_name)
     interactive_mg_runner.start_all(memgraph_instances_description, keep_directories=False)
 
     return connect(host="localhost", port=7690).cursor()
+
+
+@pytest.fixture(autouse=True)
+def cleanup_after_test():
+    yield
+    print("Stopping all")
+    interactive_mg_runner.stop_all(keep_directories=False)
 
 
 def test_disable_cypher_queries():

--- a/tests/e2e/high_availability/coordinator.py
+++ b/tests/e2e/high_availability/coordinator.py
@@ -19,7 +19,6 @@ from common import (
     connect,
     execute_and_fetch_all,
     get_data_path,
-    get_file_path,
     get_logs_path,
     ignore_elapsed_time_from_results,
 )
@@ -120,7 +119,6 @@ def setup_test(test_name: str):
 @pytest.fixture(autouse=True)
 def cleanup_after_test():
     yield
-    print("Stopping all")
     interactive_mg_runner.stop_all(keep_directories=False)
 
 

--- a/tests/e2e/high_availability/coordinator.py
+++ b/tests/e2e/high_availability/coordinator.py
@@ -10,7 +10,6 @@
 # licenses/APL.txt.
 
 import os
-import shutil
 import sys
 
 import interactive_mg_runner
@@ -171,7 +170,7 @@ def test_coordinator_cannot_call_show_replicas():
     [7687, 7688, 7689],
 )
 def test_main_and_replicas_cannot_call_show_repl_cluster(port):
-    setup_test(test_name="test_main_and_replicas_cannot_call_show_repl_cluster")
+    setup_test(test_name=f"test_main_and_replicas_cannot_call_show_repl_cluster_{port}")
     cursor = connect(host="localhost", port=port).cursor()
     with pytest.raises(Exception) as e:
         execute_and_fetch_all(cursor, "SHOW INSTANCES;")
@@ -183,7 +182,7 @@ def test_main_and_replicas_cannot_call_show_repl_cluster(port):
     [7687, 7688, 7689],
 )
 def test_main_and_replicas_cannot_register_coord_server(port):
-    setup_test(test_name="test_main_and_replicas_cannot_register_coord_server")
+    setup_test(test_name=f"test_main_and_replicas_cannot_register_coord_server_{port}")
     cursor = connect(host="localhost", port=port).cursor()
     with pytest.raises(Exception) as e:
         execute_and_fetch_all(

--- a/tests/e2e/high_availability/disable_writing_on_main_after_restart.py
+++ b/tests/e2e/high_availability/disable_writing_on_main_after_restart.py
@@ -33,6 +33,7 @@ interactive_mg_runner.MEMGRAPH_BINARY = os.path.normpath(os.path.join(interactiv
 file = "disable_writing_on_main_after_restart"
 test_name = "test_writing_disabled_on_main_restart"
 
+
 MEMGRAPH_INSTANCES_DESCRIPTION = {
     "instance_1": {
         "args": [
@@ -142,8 +143,9 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
 
 @pytest.fixture(autouse=True)
 def cleanup_after_test():
+    # Run the test
     yield
-    # Stop + delete directories
+    # Stop + delete directories after running the test
     interactive_mg_runner.stop_all(keep_directories=False)
 
 

--- a/tests/e2e/high_availability/disable_writing_on_main_after_restart.py
+++ b/tests/e2e/high_availability/disable_writing_on_main_after_restart.py
@@ -140,8 +140,15 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
 }
 
 
+@pytest.fixture(autouse=True)
+def cleanup_after_test():
+    yield
+    # Stop + delete directories
+    interactive_mg_runner.stop_all(keep_directories=False)
+
+
 def test_writing_disabled_on_main_restart():
-    interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION)
+    interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION, keep_directories=False)
 
     coordinator3_cursor = connect(host="localhost", port=7692).cursor()
 

--- a/tests/e2e/high_availability/disable_writing_on_main_after_restart.py
+++ b/tests/e2e/high_availability/disable_writing_on_main_after_restart.py
@@ -10,17 +10,16 @@
 # licenses/APL.txt.
 
 import os
-import shutil
 import sys
-import tempfile
 
 import interactive_mg_runner
 import pytest
 from common import (
     connect,
     execute_and_fetch_all,
+    get_data_path,
+    get_logs_path,
     ignore_elapsed_time_from_results,
-    safe_execute,
 )
 from mg_utils import mg_sleep_and_assert
 
@@ -31,7 +30,8 @@ interactive_mg_runner.PROJECT_DIR = os.path.normpath(
 interactive_mg_runner.BUILD_DIR = os.path.normpath(os.path.join(interactive_mg_runner.PROJECT_DIR, "build"))
 interactive_mg_runner.MEMGRAPH_BINARY = os.path.normpath(os.path.join(interactive_mg_runner.BUILD_DIR, "memgraph"))
 
-TEMP_DIR = tempfile.TemporaryDirectory().name
+file = "disable_writing_on_main_after_restart"
+test_name = "test_writing_disabled_on_main_restart"
 
 MEMGRAPH_INSTANCES_DESCRIPTION = {
     "instance_1": {
@@ -49,8 +49,8 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
             "--instance-down-timeout-sec",
             "5",
         ],
-        "log_file": "high_availability/disable_writing_on_main_after_restart/test_writing_disabled_on_main_restart/instance_1.log",
-        "data_directory": f"{TEMP_DIR}/instance_1",
+        "log_file": f"{get_logs_path(file, test_name)}/instance_1.log",
+        "data_directory": f"{get_data_path(file, test_name)}/instance_1",
         "setup_queries": [],
     },
     "instance_2": {
@@ -68,8 +68,8 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
             "--instance-down-timeout-sec",
             "5",
         ],
-        "log_file": "high_availability/disable_writing_on_main_after_restart/test_writing_disabled_on_main_restart/instance_2.log",
-        "data_directory": f"{TEMP_DIR}/instance_2",
+        "log_file": f"{get_logs_path(file, test_name)}/instance_2.log",
+        "data_directory": f"{get_data_path(file, test_name)}/instance_2",
         "setup_queries": [],
     },
     "instance_3": {
@@ -87,8 +87,8 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
             "--instance-down-timeout-sec",
             "10",
         ],
-        "log_file": "high_availability/disable_writing_on_main_after_restart/test_writing_disabled_on_main_restart/instance_3.log",
-        "data_directory": f"{TEMP_DIR}/instance_3",
+        "log_file": f"{get_logs_path(file, test_name)}/instance_3.log",
+        "data_directory": f"{get_data_path(file, test_name)}/instance_3",
         "setup_queries": [],
     },
     "coordinator_1": {
@@ -102,8 +102,8 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
             "--coordinator-hostname=localhost",
             "--management-port=10121",
         ],
-        "log_file": "high_availability/disable_writing_on_main_after_restart/test_writing_disabled_on_main_restart/coordinator1.log",
-        "data_directory": f"{TEMP_DIR}/coordinator_1",
+        "log_file": f"{get_logs_path(file, test_name)}/coordinator_1.log",
+        "data_directory": f"{get_data_path(file, test_name)}/coordinator_1",
         "setup_queries": [],
     },
     "coordinator_2": {
@@ -117,8 +117,8 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
             "--coordinator-hostname=localhost",
             "--management-port=10122",
         ],
-        "log_file": "high_availability/disable_writing_on_main_after_restart/test_writing_disabled_on_main_restart/coordinator2.log",
-        "data_directory": f"{TEMP_DIR}/coordinator_2",
+        "log_file": f"{get_logs_path(file, test_name)}/coordinator_2.log",
+        "data_directory": f"{get_data_path(file, test_name)}/coordinator_2",
         "setup_queries": [],
     },
     "coordinator_3": {
@@ -133,15 +133,14 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
             "--coordinator-hostname=localhost",
             "--management-port=10123",
         ],
-        "log_file": "high_availability/disable_writing_on_main_after_restart/test_writing_disabled_on_main_restart/coordinator3.log",
-        "data_directory": f"{TEMP_DIR}/coordinator_3",
+        "log_file": f"{get_logs_path(file, test_name)}/coordinator_3.log",
+        "data_directory": f"{get_data_path(file, test_name)}/coordinator_3",
         "setup_queries": [],
     },
 }
 
 
 def test_writing_disabled_on_main_restart():
-    safe_execute(shutil.rmtree, TEMP_DIR)
     interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION)
 
     coordinator3_cursor = connect(host="localhost", port=7692).cursor()

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -281,2852 +281,2851 @@ def cleanup_after_test():
     interactive_mg_runner.stop_all(keep_directories=False)
 
 
-# @pytest.mark.parametrize("use_durability", [True, False])
-# def test_even_number_coords(use_durability, test_name):
-#     # Goal is to check that nothing gets broken on even number of coords when 2 coords are down
-#     # 1. Start all instances.
-#     # 2. Check that all instances are up and that one of the instances is a main.
-#     # 3. Demote the main instance.
-#     # 4. Kill two coordinators.
-#     # 5. Wait for leader to become follower
-#     # 6. Bring back up two coordinators.
-#     # 7. Find leader
-#     # 8.
-#
-#     # 1
-#     inner_instances_description = get_instances_description_no_setup_4_coords(
-#         test_name=test_name, use_durability=use_durability
-#     )
-#
-#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-#
-#     setup_queries = [
-#         "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111', 'management_server': 'localhost:10121'}",
-#         "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112', 'management_server': 'localhost:10122'}",
-#         "ADD COORDINATOR 4 WITH CONFIG {'bolt_server': 'localhost:7693', 'coordinator_server': 'localhost:10114', 'management_server': 'localhost:10124'}",
-#         "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
-#         "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
-#         "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
-#         "SET INSTANCE instance_3 TO MAIN",
-#     ]
-#
-#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-#     for query in setup_queries:
-#         execute_and_fetch_all(coord_cursor_3, query)
-#
-#     # 2
-#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-#
-#     def show_instances_coord1():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-#
-#     def show_instances_coord2():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-#
-#     def show_instances_coord3():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_4 = connect(host="localhost", port=7693).cursor()
-#
-#     def show_instances_coord4():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_4, "SHOW INSTANCES;"))))
-#
-#     leader_data_original = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "follower"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#
-#     mg_sleep_and_assert(leader_data_original, show_instances_coord3)
-#     mg_sleep_and_assert(leader_data_original, show_instances_coord1)
-#     mg_sleep_and_assert(leader_data_original, show_instances_coord2)
-#     mg_sleep_and_assert(leader_data_original, show_instances_coord4)
-#
-#     instance_3_cursor = connect(host="localhost", port=7689).cursor()
-#
-#     def show_replicas():
-#         return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
-#
-#     replicas = [
-#         (
-#             "instance_1",
-#             "localhost:10001",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#         (
-#             "instance_2",
-#             "localhost:10002",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#     ]
-#     mg_sleep_and_assert_collection(replicas, show_replicas)
-#
-#     # 3
-#
-#     execute_and_fetch_all(
-#         coord_cursor_3,
-#         "DEMOTE INSTANCE instance_3",
-#     )
-#
-#     leader_data_demoted = leader_data_original.copy()
-#     leader_data_demoted = update_tuple_value(leader_data_demoted, "instance_3", 0, -1, "replica")
-#
-#     mg_sleep_and_assert(leader_data_demoted, show_instances_coord3)
-#     mg_sleep_and_assert(leader_data_demoted, show_instances_coord1)
-#     mg_sleep_and_assert(leader_data_demoted, show_instances_coord2)
-#     mg_sleep_and_assert(leader_data_demoted, show_instances_coord4)
-#
-#     with pytest.raises(Exception) as e:
-#         execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")
-#     assert str(e.value) == "Replica can't show registered replicas (it shouldn't have any)!"
-#
-#     # 4
-#     interactive_mg_runner.kill(inner_instances_description, "coordinator_1")
-#     interactive_mg_runner.kill(inner_instances_description, "coordinator_2")
-#
-#     # 5
-#
-#     with pytest.raises(Exception) as e:
-#         execute_and_fetch_all(coord_cursor_3, "SET INSTANCE instance_3 TO MAIN;")
-#
-#     assert "Couldn't set instance to main as cluster didn't accept start of action!" in str(e.value)
-#
-#     follower_data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "unknown", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "unknown", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "unknown", "follower"),
-#         ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "unknown", "follower"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "replica"),
-#     ]
-#
-#     mg_sleep_and_assert(follower_data, show_instances_coord3)
-#
-#     # 6
-#     interactive_mg_runner.start(inner_instances_description, "coordinator_1")
-#     interactive_mg_runner.start(inner_instances_description, "coordinator_2")
-#
-#     # 7
-#
-#     leader_data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
-#         ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "follower"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
-#     ]
-#
-#     leader_coord_instance_3_demoted = find_instance_and_assert_instances(instance_role="leader", num_coordinators=3)
-#
-#     main_instance_3_demoted = find_instance_and_assert_instances(instance_role="main", num_coordinators=3)
-#
-#     assert leader_coord_instance_3_demoted is not None, "Leader not found"
-#
-#     assert main_instance_3_demoted is not None, "Main not found"
-#
-#     leader_data = update_tuple_value(leader_data, leader_coord_instance_3_demoted, 0, -1, "leader")
-#     leader_data = update_tuple_value(leader_data, main_instance_3_demoted, 0, -1, "main")
-#
-#     port_mappings = {
-#         "coordinator_1": 7690,
-#         "coordinator_2": 7691,
-#         "coordinator_3": 7692,
-#         "coordinator_4": 7693,
-#     }
-#
-#     for coord, port in port_mappings.items():
-#         coord_cursor = connect(host="localhost", port=port).cursor()
-#
-#         def show_instances():
-#             return ignore_elapsed_time_from_results(
-#                 sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
-#             )
-#
-#         mg_sleep_and_assert(leader_data, show_instances)
-#
-#
-#
-# def test_old_main_comes_back_on_new_leader_as_replica(test_name):
-#     # 1. Start all instances.
-#     # 2. Kill the main instance
-#     # 3. Kill the leader
-#     # 4. Start the old main instance
-#     # 5. Run SHOW INSTANCES on the new leader and check that the old main instance is registered as a replica
-#     # 6. Start again previous leader
-#
-#     inner_instances_description = get_instances_description_no_setup(test_name=test_name)
-#
-#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-#
-#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-#     for query in get_default_setup_queries():
-#         execute_and_fetch_all(coord_cursor_3, query)
-#
-#     interactive_mg_runner.kill(inner_instances_description, "coordinator_3")
-#     interactive_mg_runner.kill(inner_instances_description, "instance_3")
-#
-#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-#
-#     def show_instances_coord1():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-#
-#     def show_instances_coord2():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-#
-#     # Wait until failover happens
-#     wait_for_status_change(show_instances_coord1, {"instance_1", "instance_2"}, "main")
-#     wait_for_status_change(show_instances_coord1, {"instance_3"}, "unknown")
-#
-#     # Both instance_1 and instance_2 could become main depending on the order of pings in the system.
-#     # Both coordinator_1 and coordinator_2 could become leader depending on the NuRaft election.
-#     leader_data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
-#     ]
-#
-#     leader_instance_3_down = find_instance_and_assert_instances(
-#         instance_role="leader", num_coordinators=3, coord_ids_to_skip_validation={3}
-#     )
-#     main_instance_3_down = find_instance_and_assert_instances(
-#         instance_role="main", num_coordinators=3, coord_ids_to_skip_validation={3}
-#     )
-#
-#     leader_data = update_tuple_value(leader_data, leader_instance_3_down, 0, -1, "leader")
-#     leader_data = update_tuple_value(leader_data, main_instance_3_down, 0, -1, "main")
-#
-#     def get_show_instances_to_coord(leader_instance):
-#         show_instances_mapping = {
-#             "coordinator_1": show_instances_coord1,
-#             "coordinator_2": show_instances_coord2,
-#         }
-#
-#         return show_instances_mapping.get(leader_instance)
-#
-#     all_live_coords = ["coordinator_1", "coordinator_2"]
-#
-#     for coord in all_live_coords:
-#         mg_sleep_and_assert(leader_data, get_show_instances_to_coord(coord))
-#
-#     interactive_mg_runner.start(inner_instances_description, "instance_3")
-#
-#     coordinator_leader_instance = find_instance_and_assert_instances(
-#         instance_role="leader", num_coordinators=3, coord_ids_to_skip_validation={3}
-#     )
-#     main_instance_id_instance_3_start = find_instance_and_assert_instances(
-#         instance_role="main", num_coordinators=3, coord_ids_to_skip_validation={3}
-#     )
-#
-#     assert (
-#         main_instance_id_instance_3_start == main_instance_3_down
-#     ), f"Main is not {main_instance_3_down} but {main_instance_id_instance_3_start}"
-#     assert (
-#         coordinator_leader_instance == leader_instance_3_down
-#     ), f"Leader is not same as before {leader_instance_3_down}, but {coordinator_leader_instance}"
-#
-#     coord_leader_data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
-#     ]
-#
-#     coord_leader_data = update_tuple_value(coord_leader_data, coordinator_leader_instance, 0, -1, "leader")
-#     coord_leader_data = update_tuple_value(coord_leader_data, main_instance_id_instance_3_start, 0, -1, "main")
-#
-#     mg_sleep_and_assert(coord_leader_data, get_show_instances_to_coord(coordinator_leader_instance))
-#
-#     def connect_to_main_instance():
-#         assert main_instance_id_instance_3_start is not None
-#
-#         port_mapping = {"instance_1": 7687, "instance_2": 7688, "instance_3": 7689}
-#
-#         assert (
-#             main_instance_id_instance_3_start in port_mapping
-#         ), f"Main is not in mappings, but main is {main_instance_id_instance_3_start}"
-#
-#         main_instance_port = port_mapping.get(main_instance_id_instance_3_start)
-#
-#         if main_instance_port is not None:
-#             return connect(host="localhost", port=main_instance_port).cursor()
-#
-#         return None
-#
-#     new_main_cursor = connect_to_main_instance()
-#     assert new_main_cursor is not None, "Main cursor is not found!"
-#
-#     def show_replicas():
-#         return sorted(list(execute_and_fetch_all(new_main_cursor, "SHOW REPLICAS;")))
-#
-#     replicas = [
-#         (
-#             "instance_1",
-#             "localhost:10001",
-#             "sync",
-#             {"ts": 0, "behind": None, "status": "ready"},
-#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-#         ),
-#         (
-#             "instance_2",
-#             "localhost:10002",
-#             "sync",
-#             {"ts": 0, "behind": None, "status": "ready"},
-#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-#         ),
-#         (
-#             "instance_3",
-#             "localhost:10003",
-#             "sync",
-#             {"ts": 0, "behind": None, "status": "ready"},
-#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-#         ),
-#     ]
-#     replicas = [replica for replica in replicas if replica[0] != main_instance_id_instance_3_start]
-#     mg_sleep_and_assert_collection(replicas, show_replicas)
-#
-#     execute_and_fetch_all(new_main_cursor, "CREATE (n:Node {name: 'node'})")
-#
-#     replica_2_cursor = connect(host="localhost", port=7688).cursor()
-#
-#     def get_vertex_count():
-#         return execute_and_fetch_all(replica_2_cursor, "MATCH (n) RETURN count(n)")[0][0]
-#
-#     mg_sleep_and_assert(1, get_vertex_count)
-#
-#     replica_3_cursor = connect(host="localhost", port=7689).cursor()
-#
-#     def get_vertex_count():
-#         return execute_and_fetch_all(replica_3_cursor, "MATCH (n) RETURN count(n)")[0][0]
-#
-#     mg_sleep_and_assert(1, get_vertex_count)
-#
-#     interactive_mg_runner.start(inner_instances_description, "coordinator_3")
-#
-#
-# def test_distributed_automatic_failover(test_name):
-#     inner_instances_description = get_instances_description_no_setup(test_name=test_name)
-#
-#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-#
-#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-#     for query in get_default_setup_queries():
-#         execute_and_fetch_all(coord_cursor_3, query)
-#
-#     main_cursor = connect(host="localhost", port=7689).cursor()
-#     expected_data_on_main = [
-#         (
-#             "instance_1",
-#             "localhost:10001",
-#             "sync",
-#             {"ts": 0, "behind": None, "status": "ready"},
-#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-#         ),
-#         (
-#             "instance_2",
-#             "localhost:10002",
-#             "sync",
-#             {"ts": 0, "behind": None, "status": "ready"},
-#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-#         ),
-#     ]
-#
-#     def retrieve_data_show_replicas():
-#         return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")))
-#
-#     mg_sleep_and_assert_collection(expected_data_on_main, retrieve_data_show_replicas)
-#
-#     interactive_mg_runner.kill(inner_instances_description, "instance_3")
-#
-#     coord_cursor = connect(host="localhost", port=7692).cursor()
-#
-#     def retrieve_data_show_repl_cluster():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
-#
-#     expected_data_on_coord = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
-#     ]
-#
-#     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
-#
-#     new_main_cursor = connect(host="localhost", port=7687).cursor()
-#
-#     def retrieve_data_show_replicas():
-#         return sorted(list(execute_and_fetch_all(new_main_cursor, "SHOW REPLICAS;")))
-#
-#     expected_data_on_new_main = [
-#         (
-#             "instance_2",
-#             "localhost:10002",
-#             "sync",
-#             {"ts": 0, "behind": None, "status": "ready"},
-#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-#         ),
-#         (
-#             "instance_3",
-#             "localhost:10003",
-#             "sync",
-#             {"ts": 0, "behind": None, "status": "invalid"},
-#             {"memgraph": {"ts": 0, "behind": 0, "status": "invalid"}},
-#         ),
-#     ]
-#     mg_sleep_and_assert_collection(expected_data_on_new_main, retrieve_data_show_replicas)
-#
-#     interactive_mg_runner.start(inner_instances_description, "instance_3")
-#     expected_data_on_new_main_old_alive = [
-#         (
-#             "instance_2",
-#             "localhost:10002",
-#             "sync",
-#             {"ts": 0, "behind": None, "status": "ready"},
-#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-#         ),
-#         (
-#             "instance_3",
-#             "localhost:10003",
-#             "sync",
-#             {"ts": 0, "behind": None, "status": "ready"},
-#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-#         ),
-#     ]
-#
-#     mg_sleep_and_assert_collection(expected_data_on_new_main_old_alive, retrieve_data_show_replicas)
-#
-#
-# def test_distributed_automatic_failover_with_leadership_change(test_name):
-#     inner_instances_description = get_instances_description_no_setup(test_name=test_name)
-#
-#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-#
-#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-#     for query in get_default_setup_queries():
-#         execute_and_fetch_all(coord_cursor_3, query)
-#
-#     interactive_mg_runner.kill(inner_instances_description, "coordinator_3")
-#     interactive_mg_runner.kill(inner_instances_description, "instance_3")
-#
-#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-#
-#     def show_instances_coord1():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-#
-#     def show_instances_coord2():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-#
-#     leader_data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
-#     ]
-#
-#     wait_for_status_change(show_instances_coord1, {"instance_1", "instance_2"}, "main")
-#     wait_for_status_change(show_instances_coord1, {"instance_3"}, "unknown")
-#
-#     leader_name = find_instance_and_assert_instances(
-#         instance_role="leader", num_coordinators=3, coord_ids_to_skip_validation={3}
-#     )
-#     main_name = find_instance_and_assert_instances(
-#         instance_role="main", num_coordinators=3, coord_ids_to_skip_validation={3}
-#     )
-#
-#     leader_data = update_tuple_value(leader_data, main_name, 0, -1, "main")
-#     leader_data = update_tuple_value(leader_data, leader_name, 0, -1, "leader")
-#
-#     mg_sleep_and_assert(leader_data, show_instances_coord1)
-#     mg_sleep_and_assert(leader_data, show_instances_coord2)
-#
-#     def connect_to_main_instance():
-#         main_instance_name = main_name
-#         assert main_instance_name is not None
-#
-#         port_mapping = {"instance_1": 7687, "instance_2": 7688}
-#
-#         assert main_instance_name in port_mapping, f"Main is not in mappings, but main is {main_instance_name}"
-#
-#         main_instance_port = port_mapping.get(main_instance_name)
-#
-#         if main_instance_port is not None:
-#             return connect(host="localhost", port=main_instance_port).cursor()
-#
-#         return None
-#
-#     new_main_cursor = connect_to_main_instance()
-#     assert new_main_cursor is not None, "Main cursor is not found!"
-#
-#     def retrieve_data_show_replicas():
-#         return sorted(list(execute_and_fetch_all(new_main_cursor, "SHOW REPLICAS;")))
-#
-#     all_possible_states = [
-#         (
-#             "instance_1",
-#             "localhost:10001",
-#             "sync",
-#             {"ts": 0, "behind": None, "status": "ready"},
-#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-#         ),
-#         (
-#             "instance_2",
-#             "localhost:10002",
-#             "sync",
-#             {"ts": 0, "behind": None, "status": "ready"},
-#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-#         ),
-#         (
-#             "instance_3",
-#             "localhost:10003",
-#             "sync",
-#             {"ts": 0, "behind": None, "status": "invalid"},
-#             {"memgraph": {"ts": 0, "behind": 0, "status": "invalid"}},
-#         ),
-#     ]
-#
-#     expected_data_on_new_main = [state for state in all_possible_states if state[0] != main_name]
-#     mg_sleep_and_assert_collection(expected_data_on_new_main, retrieve_data_show_replicas)
-#
-#     interactive_mg_runner.start(inner_instances_description, "instance_3")
-#
-#     all_possible_states = [
-#         (
-#             "instance_1",
-#             "localhost:10001",
-#             "sync",
-#             {"ts": 0, "behind": None, "status": "ready"},
-#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-#         ),
-#         (
-#             "instance_2",
-#             "localhost:10002",
-#             "sync",
-#             {"ts": 0, "behind": None, "status": "ready"},
-#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-#         ),
-#         (
-#             "instance_3",
-#             "localhost:10003",
-#             "sync",
-#             {"ts": 0, "behind": None, "status": "ready"},
-#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-#         ),
-#     ]
-#     expected_data_on_new_main_old_alive = [state for state in all_possible_states if state[0] != main_name]
-#     mg_sleep_and_assert_collection(expected_data_on_new_main_old_alive, retrieve_data_show_replicas)
-#
-#     interactive_mg_runner.start(inner_instances_description, "coordinator_3")
-#
-#
-# def test_no_leader_after_leader_and_follower_die(test_name):
-#     # 1. Register all but one replication instance on the first leader.
-#     # 2. Kill the leader and a follower.
-#     # 3. Check that the remaining follower is not promoted to leader by trying to register remaining replication instance.
-#
-#     inner_memgraph_instances = get_instances_description_no_setup(test_name=test_name)
-#     interactive_mg_runner.start_all(inner_memgraph_instances, keep_directories=False)
-#
-#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-#
-#     for query in get_default_setup_queries():
-#         execute_and_fetch_all(coord_cursor_3, query)
-#
-#     interactive_mg_runner.kill(inner_memgraph_instances, "coordinator_3")
-#     interactive_mg_runner.kill(inner_memgraph_instances, "coordinator_2")
-#
-#     coord_1_data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "unknown", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "unknown", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "unknown", "follower"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
-#     ]
-#
-#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-#
-#     def show_instances_coord1():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-#
-#     mg_sleep_and_assert(coord_1_data, show_instances_coord1)
-#
-#     with pytest.raises(Exception) as e:
-#         execute_and_fetch_all(
-#             coord_cursor_1,
-#             "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
-#         )
-#         assert "Couldn't register replica instance since coordinator is not a leader!" in str(e)
-#
-#
-# def test_old_main_comes_back_on_new_leader_as_main(test_name):
-#     # 1. Start all instances.
-#     # 2. Kill all instances
-#     # 3. Kill the leader
-#     # 4. Start the old main instance
-#     # 5. Run SHOW INSTANCES on the new leader and check that the old main instance is main once again
-#
-#     inner_memgraph_instances = get_instances_description_no_setup(test_name=test_name)
-#     interactive_mg_runner.start_all(inner_memgraph_instances, keep_directories=False)
-#
-#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-#
-#     for query in get_default_setup_queries():
-#         execute_and_fetch_all(coord_cursor_3, query)
-#
-#     interactive_mg_runner.kill(inner_memgraph_instances, "instance_1")
-#     interactive_mg_runner.kill(inner_memgraph_instances, "instance_2")
-#     interactive_mg_runner.kill(inner_memgraph_instances, "instance_3")
-#     interactive_mg_runner.kill(inner_memgraph_instances, "coordinator_3")
-#
-#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-#
-#     def show_instances_coord1():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-#
-#     def show_instances_coord2():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-#
-#     interactive_mg_runner.start(inner_memgraph_instances, "instance_3")
-#
-#     coord1_leader_data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#
-#     coord2_leader_data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "leader"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#
-#     mg_sleep_and_assert_multiple(
-#         [coord1_leader_data, coord2_leader_data], [show_instances_coord1, show_instances_coord2]
-#     )
-#     mg_sleep_and_assert_multiple(
-#         [coord1_leader_data, coord2_leader_data], [show_instances_coord1, show_instances_coord2]
-#     )
-#
-#     interactive_mg_runner.start(inner_memgraph_instances, "instance_1")
-#     interactive_mg_runner.start(inner_memgraph_instances, "instance_2")
-#
-#     new_main_cursor = connect(host="localhost", port=7689).cursor()
-#
-#     def show_replicas():
-#         return sorted(list(execute_and_fetch_all(new_main_cursor, "SHOW REPLICAS;")))
-#
-#     replicas = [
-#         (
-#             "instance_1",
-#             "localhost:10001",
-#             "sync",
-#             {"ts": 0, "behind": None, "status": "ready"},
-#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-#         ),
-#         (
-#             "instance_2",
-#             "localhost:10002",
-#             "sync",
-#             {"ts": 0, "behind": None, "status": "ready"},
-#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-#         ),
-#     ]
-#     mg_sleep_and_assert_collection(replicas, show_replicas)
-#
-#     execute_and_fetch_all(new_main_cursor, "CREATE (n:Node {name: 'node'})")
-#
-#     replica_1_cursor = connect(host="localhost", port=7687).cursor()
-#     assert len(execute_and_fetch_all(replica_1_cursor, "MATCH (n) RETURN n;")) == 1
-#
-#     replica_2_cursor = connect(host="localhost", port=7688).cursor()
-#     assert len(execute_and_fetch_all(replica_2_cursor, "MATCH (n) RETURN n;")) == 1
-#
-#     interactive_mg_runner.start(inner_memgraph_instances, "coordinator_3")
-#
-#
-# def test_registering_4_coords(test_name):
-#     # Goal of this test is to assure registering of multiple coordinators in row works
-#     INSTANCES_DESCRIPTION = {
-#         "instance_1": {
-#             "args": [
-#                 "--experimental-enabled=high-availability",
-#                 "--bolt-port",
-#                 "7687",
-#                 "--log-level",
-#                 "TRACE",
-#                 "--management-port",
-#                 "10011",
-#             ],
-#             "log_file": f"{get_logs_path(file, test_name)}/instance_1.log",
-#             "data_directory": f"{get_data_path(file, test_name)}/instance_1",
-#             "setup_queries": [],
-#         },
-#         "instance_2": {
-#             "args": [
-#                 "--experimental-enabled=high-availability",
-#                 "--bolt-port",
-#                 "7688",
-#                 "--log-level",
-#                 "TRACE",
-#                 "--management-port",
-#                 "10012",
-#             ],
-#             "log_file": f"{get_logs_path(file, test_name)}/instance_2.log",
-#             "data_directory": f"{get_data_path(file, test_name)}/instance_2",
-#             "setup_queries": [],
-#         },
-#         "instance_3": {
-#             "args": [
-#                 "--experimental-enabled=high-availability",
-#                 "--bolt-port",
-#                 "7689",
-#                 "--log-level",
-#                 "TRACE",
-#                 "--management-port",
-#                 "10013",
-#             ],
-#             "log_file": f"{get_logs_path(file, test_name)}/instance_3.log",
-#             "data_directory": f"{get_data_path(file, test_name)}/instance_3",
-#             "setup_queries": [],
-#         },
-#         "coordinator_1": {
-#             "args": [
-#                 "--experimental-enabled=high-availability",
-#                 "--bolt-port",
-#                 "7690",
-#                 "--log-level=TRACE",
-#                 "--coordinator-id=1",
-#                 "--coordinator-port=10111",
-#                 "--management-port=10121",
-#                 "--coordinator-hostname=localhost",
-#             ],
-#             "log_file": f"{get_logs_path(file, test_name)}/coordinator_1.log",
-#             "data_directory": f"{get_data_path(file, test_name)}/coordinator_1",
-#             "setup_queries": [],
-#         },
-#         "coordinator_2": {
-#             "args": [
-#                 "--experimental-enabled=high-availability",
-#                 "--bolt-port",
-#                 "7691",
-#                 "--log-level=TRACE",
-#                 "--coordinator-id=2",
-#                 "--coordinator-port=10112",
-#                 "--management-port=10122",
-#                 "--coordinator-hostname=localhost",
-#             ],
-#             "log_file": f"{get_logs_path(file, test_name)}/coordinator_2.log",
-#             "data_directory": f"{get_data_path(file, test_name)}/coordinator_2",
-#             "setup_queries": [],
-#         },
-#         "coordinator_3": {
-#             "args": [
-#                 "--experimental-enabled=high-availability",
-#                 "--bolt-port",
-#                 "7692",
-#                 "--log-level=TRACE",
-#                 "--coordinator-id=3",
-#                 "--coordinator-port=10113",
-#                 "--management-port=10123",
-#                 "--coordinator-hostname=localhost",
-#             ],
-#             "log_file": f"{get_logs_path(file, test_name)}/coordinator_3.log",
-#             "data_directory": f"{get_data_path(file, test_name)}/coordinator_3",
-#             "setup_queries": [],
-#         },
-#         "coordinator_4": {
-#             "args": [
-#                 "--experimental-enabled=high-availability",
-#                 "--bolt-port",
-#                 "7693",
-#                 "--log-level=TRACE",
-#                 "--coordinator-id=4",
-#                 "--coordinator-port=10114",
-#                 "--management-port=10124",
-#                 "--coordinator-hostname=localhost",
-#             ],
-#             "log_file": f"{get_logs_path(file, test_name)}/coordinator_4.log",
-#             "data_directory": f"{get_data_path(file, test_name)}/coordinator_4",
-#             "setup_queries": [
-#                 "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111', 'management_server': 'localhost:10121'}",
-#                 "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112', 'management_server': 'localhost:10122'}",
-#                 "ADD COORDINATOR 3 WITH CONFIG {'bolt_server': 'localhost:7692', 'coordinator_server': 'localhost:10113', 'management_server': 'localhost:10123'}",
-#                 "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
-#                 "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
-#                 "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
-#                 "SET INSTANCE instance_3 TO MAIN",
-#             ],
-#         },
-#     }
-#
-#     interactive_mg_runner.start_all(INSTANCES_DESCRIPTION, keep_directories=False)
-#
-#     coord_cursor = connect(host="localhost", port=7693).cursor()
-#
-#     def retrieve_data_show_repl_cluster():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
-#
-#     expected_data_on_coord = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
-#         ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
-#
-#
-# def test_registering_coord_log_store(test_name):
-#     # Goal of this test is to assure registering a bunch of instances and de-registering works properly
-#     # w.r.t nuRaft log
-#     # 1. Start basic instances # 3 logs
-#     # 2. Check all is there
-#     # 3. Create 3 additional instances and add them to cluster # 3 logs -> 1st snapshot
-#     # 4. Check everything is there
-#     # 5. Set main # 1 log
-#     # 6. Check correct state
-#     # 7. Drop 2 new instances # 2 logs
-#     # 8. Check correct state
-#     # 9. Drop 1 new instance # 1 log -> 2nd snapshot
-#     # 10. Check correct state
-#
-#     INSTANCES_DESCRIPTION = {
-#         "instance_1": {
-#             "args": [
-#                 "--experimental-enabled=high-availability",
-#                 "--bolt-port",
-#                 "7687",
-#                 "--log-level",
-#                 "TRACE",
-#                 "--management-port",
-#                 "10011",
-#             ],
-#             "log_file": f"{get_logs_path(file, test_name)}/instance_1.log",
-#             "data_directory": f"{get_data_path(file, test_name)}/instance_1",
-#             "setup_queries": [],
-#         },
-#         "instance_2": {
-#             "args": [
-#                 "--experimental-enabled=high-availability",
-#                 "--bolt-port",
-#                 "7688",
-#                 "--log-level",
-#                 "TRACE",
-#                 "--management-port",
-#                 "10012",
-#             ],
-#             "log_file": f"{get_logs_path(file, test_name)}/instance_2.log",
-#             "data_directory": f"{get_data_path(file, test_name)}/instance_2",
-#             "setup_queries": [],
-#         },
-#         "instance_3": {
-#             "args": [
-#                 "--experimental-enabled=high-availability",
-#                 "--bolt-port",
-#                 "7689",
-#                 "--log-level",
-#                 "TRACE",
-#                 "--management-port",
-#                 "10013",
-#             ],
-#             "log_file": f"{get_logs_path(file, test_name)}/instance_3.log",
-#             "data_directory": f"{get_data_path(file, test_name)}/instance_3",
-#             "setup_queries": [],
-#         },
-#         "coordinator_1": {
-#             "args": [
-#                 "--experimental-enabled=high-availability",
-#                 "--bolt-port",
-#                 "7690",
-#                 "--log-level=TRACE",
-#                 "--coordinator-id=1",
-#                 "--coordinator-port=10111",
-#                 "--coordinator-hostname",
-#                 "localhost",
-#                 "--management-port=10121",
-#             ],
-#             "log_file": f"{get_logs_path(file, test_name)}/coordinator_1.log",
-#             "data_directory": f"{get_data_path(file, test_name)}/coordinator_1",
-#             "setup_queries": [],
-#         },
-#         "coordinator_2": {
-#             "args": [
-#                 "--experimental-enabled=high-availability",
-#                 "--bolt-port",
-#                 "7691",
-#                 "--log-level=TRACE",
-#                 "--coordinator-id=2",
-#                 "--coordinator-port=10112",
-#                 "--coordinator-hostname",
-#                 "localhost",
-#                 "--management-port=10122",
-#             ],
-#             "log_file": f"{get_logs_path(file, test_name)}/coordinator_2.log",
-#             "data_directory": f"{get_data_path(file, test_name)}/coordinator_2",
-#             "setup_queries": [],
-#         },
-#         "coordinator_3": {
-#             "args": [
-#                 "--experimental-enabled=high-availability",
-#                 "--bolt-port",
-#                 "7692",
-#                 "--log-level=TRACE",
-#                 "--coordinator-id=3",
-#                 "--coordinator-port=10113",
-#                 "--coordinator-hostname",
-#                 "localhost",
-#                 "--management-port=10123",
-#             ],
-#             "log_file": f"{get_logs_path(file, test_name)}/coordinator_3.log",
-#             "data_directory": f"{get_data_path(file, test_name)}/coordinator_3",
-#             "setup_queries": [],
-#         },
-#         "coordinator_4": {
-#             "args": [
-#                 "--experimental-enabled=high-availability",
-#                 "--bolt-port",
-#                 "7693",
-#                 "--log-level=TRACE",
-#                 "--coordinator-id=4",
-#                 "--coordinator-port=10114",
-#                 "--coordinator-hostname",
-#                 "localhost",
-#                 "--management-port=10124",
-#             ],
-#             "log_file": f"{get_logs_path(file, test_name)}/coordinator_4.log",
-#             "data_directory": f"{get_data_path(file, test_name)}/coordinator_4",
-#             "setup_queries": [
-#                 "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111', 'management_server': 'localhost:10121'}",
-#                 "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112', 'management_server': 'localhost:10122'}",
-#                 "ADD COORDINATOR 3 WITH CONFIG {'bolt_server': 'localhost:7692', 'coordinator_server': 'localhost:10113',  'management_server': 'localhost:10123'}",
-#                 "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
-#                 "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
-#                 "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
-#             ],
-#         },
-#     }
-#     assert "SET INSTANCE instance_3 TO MAIN" not in INSTANCES_DESCRIPTION["coordinator_4"]["setup_queries"]
-#
-#     # 1
-#     interactive_mg_runner.start_all(INSTANCES_DESCRIPTION, keep_directories=False)
-#
-#     # 2
-#     coord_cursor = connect(host="localhost", port=7693).cursor()
-#
-#     def retrieve_data_show_repl_cluster():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
-#
-#     coordinators = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
-#         ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "leader"),
-#     ]
-#
-#     basic_instances = [
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
-#     ]
-#
-#     expected_data_on_coord = []
-#     expected_data_on_coord.extend(coordinators)
-#     expected_data_on_coord.extend(basic_instances)
-#
-#     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
-#
-#     # 3
-#     instances_ports_added = [10011, 10012, 10013]
-#     bolt_port_id = 7700
-#     manag_port_id = 10014
-#
-#     additional_instances = []
-#     for i in range(4, 7):
-#         instance_name = f"instance_{i}"
-#         args_desc = [
-#             "--experimental-enabled=high-availability",
-#             "--log-level=TRACE",
-#         ]
-#
-#         bolt_port = f"--bolt-port={bolt_port_id}"
-#
-#         manag_server_port = f"--management-port={manag_port_id}"
-#
-#         args_desc.append(bolt_port)
-#         args_desc.append(manag_server_port)
-#
-#         instance_description = {
-#             "args": args_desc,
-#             "log_file": f"{get_logs_path(file, test_name)}/instance_{i}.log",
-#             "data_directory": f"{get_data_path(file, test_name)}/instance_{i}",
-#             "setup_queries": [],
-#         }
-#
-#         full_instance_desc = {instance_name: instance_description}
-#         interactive_mg_runner.start(full_instance_desc, instance_name)
-#         repl_port_id = manag_port_id - 10
-#         assert repl_port_id < 10011, "Wrong test setup, repl port must be smaller than smallest coord port id"
-#
-#         bolt_server = f"localhost:{bolt_port_id}"
-#         management_server = f"localhost:{manag_port_id}"
-#         repl_server = f"localhost:{repl_port_id}"
-#
-#         config_str = f"{{'bolt_server': '{bolt_server}', 'management_server': '{management_server}', 'replication_server': '{repl_server}'}}"
-#
-#         execute_and_fetch_all(
-#             coord_cursor,
-#             f"REGISTER INSTANCE {instance_name} WITH CONFIG {config_str}",
-#         )
-#
-#         additional_instances.append((f"{instance_name}", bolt_server, "", management_server, "up", "replica"))
-#         instances_ports_added.append(manag_port_id)
-#         manag_port_id += 1
-#         bolt_port_id += 1
-#
-#     # 4
-#     expected_data_on_coord.extend(additional_instances)
-#
-#     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
-#
-#     # 5
-#     execute_and_fetch_all(coord_cursor, "SET INSTANCE instance_3 TO MAIN")
-#
-#     # 6
-#     basic_instances.pop()
-#     basic_instances.append(("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"))
-#
-#     new_expected_data_on_coordinator = []
-#
-#     new_expected_data_on_coordinator.extend(coordinators)
-#     new_expected_data_on_coordinator.extend(basic_instances)
-#     new_expected_data_on_coordinator.extend(additional_instances)
-#
-#     mg_sleep_and_assert(new_expected_data_on_coordinator, retrieve_data_show_repl_cluster)
-#
-#     # 7
-#     for i in range(6, 4, -1):
-#         execute_and_fetch_all(coord_cursor, f"UNREGISTER INSTANCE instance_{i};")
-#         additional_instances.pop()
-#
-#     new_expected_data_on_coordinator = []
-#     new_expected_data_on_coordinator.extend(coordinators)
-#     new_expected_data_on_coordinator.extend(basic_instances)
-#     new_expected_data_on_coordinator.extend(additional_instances)
-#
-#     # 8
-#     mg_sleep_and_assert(new_expected_data_on_coordinator, retrieve_data_show_repl_cluster)
-#
-#     # 9
-#
-#     new_expected_data_on_coordinator = []
-#     new_expected_data_on_coordinator.extend(coordinators)
-#     new_expected_data_on_coordinator.extend(basic_instances)
-#
-#     execute_and_fetch_all(coord_cursor, f"UNREGISTER INSTANCE instance_4;")
-#
-#     # 10
-#     mg_sleep_and_assert(new_expected_data_on_coordinator, retrieve_data_show_repl_cluster)
-#
-#
-# def test_multiple_failovers_in_row_no_leadership_change(test_name):
-#     # Goal of this test is to assure multiple failovers in row work without leadership change
-#     # 1. Start basic instances
-#     # 2. Check all is there
-#     # 3. Kill MAIN (instance_3)
-#     # 4. Expect failover (instance_1)
-#     # 5. Kill instance_1
-#     # 6. Expect failover instance_2
-#     # 7. Start instance_3
-#     # 8. Expect instance_3 and instance_2 (MAIN) up
-#     # 9. Kill instance_2
-#     # 10. Expect instance_3 MAIN
-#     # 11. Write some data on instance_3
-#     # 12. Start instance_2 and instance_1
-#     # 13. Expect instance_1 and instance2 to be up and cluster to have correct state
-#     # 13. Expect data to be replicated
-#
-#     # 1
-#     inner_memgraph_instances = get_instances_description_no_setup(test_name=test_name)
-#     interactive_mg_runner.start_all(inner_memgraph_instances, keep_directories=False)
-#
-#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-#
-#     for query in get_default_setup_queries():
-#         execute_and_fetch_all(coord_cursor_3, query)
-#
-#     # 2
-#
-#     def get_func_show_instances(cursor):
-#         def show_instances_follower_coord():
-#             return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(cursor, "SHOW INSTANCES;"))))
-#
-#         return show_instances_follower_coord
-#
-#     data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#
-#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-#
-#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
-#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
-#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
-#
-#     # 3
-#
-#     interactive_mg_runner.kill(inner_memgraph_instances, "instance_3")
-#
-#     # 4
-#
-#     data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
-#     ]
-#
-#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
-#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
-#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
-#
-#     # 5
-#     interactive_mg_runner.kill(inner_memgraph_instances, "instance_1")
-#
-#     # 6
-#     data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "main"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
-#     ]
-#
-#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
-#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
-#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
-#
-#     # 7
-#
-#     interactive_mg_runner.start(inner_memgraph_instances, "instance_3")
-#
-#     # 8
-#
-#     data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "main"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
-#     ]
-#
-#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
-#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
-#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
-#
-#     # 9
-#     interactive_mg_runner.kill(inner_memgraph_instances, "instance_2")
-#
-#     # 10
-#     data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#
-#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
-#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
-#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
-#
-#     # 11
-#
-#     instance_3_cursor = connect(port=7689, host="localhost").cursor()
-#
-#     with pytest.raises(Exception) as e:
-#         execute_and_fetch_all(instance_3_cursor, "CREATE ();")
-#     assert "At least one SYNC replica has not confirmed committing last transaction." in str(e.value)
-#
-#     # 12
-#     interactive_mg_runner.start(inner_memgraph_instances, "instance_1")
-#     interactive_mg_runner.start(inner_memgraph_instances, "instance_2")
-#
-#     # 13
-#     data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#
-#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
-#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
-#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
-#
-#     # 14.
-#
-#     def show_replicas():
-#         return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
-#
-#     replicas = [
-#         (
-#             "instance_1",
-#             "localhost:10001",
-#             "sync",
-#             {"ts": 0, "behind": None, "status": "ready"},
-#             {"memgraph": {"ts": 2, "behind": 0, "status": "ready"}},
-#         ),
-#         (
-#             "instance_2",
-#             "localhost:10002",
-#             "sync",
-#             {"ts": 0, "behind": None, "status": "ready"},
-#             {"memgraph": {"ts": 2, "behind": 0, "status": "ready"}},
-#         ),
-#     ]
-#     mg_sleep_and_assert_collection(replicas, show_replicas)
-#
-#     def get_vertex_count_func(cursor):
-#         def get_vertex_count():
-#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-#
-#         return get_vertex_count
-#
-#     mg_sleep_and_assert(1, get_vertex_count_func(connect(port=7687, host="localhost").cursor()))
-#
-#     mg_sleep_and_assert(1, get_vertex_count_func(connect(port=7688, host="localhost").cursor()))
-#
-#
-# def test_multiple_old_mains_single_failover(test_name):
-#     # Goal of this test is to check when leadership changes
-#     # and we have old MAIN down, that we don't start failover
-#     # 1. Start all instances.
-#     # 2. Kill the main instance
-#     # 3. Do failover
-#     # 4. Kill other main
-#     # 5. Kill leader
-#     # 6. Leave first main down, and start second main
-#     # 7. Second main should write data to new instance all the time
-#
-#     # 1
-#     inner_instances_description = get_instances_description_no_setup(test_name=test_name)
-#
-#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-#
-#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-#     for query in get_default_setup_queries():
-#         execute_and_fetch_all(coord_cursor_3, query)
-#
-#     def retrieve_data_show_repl_cluster():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-#
-#     coordinators = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#     ]
-#
-#     basic_instances = [
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#
-#     expected_data_on_coord = []
-#     expected_data_on_coord.extend(coordinators)
-#     expected_data_on_coord.extend(basic_instances)
-#
-#     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
-#
-#     # 2
-#
-#     interactive_mg_runner.kill(inner_instances_description, "instance_3")
-#
-#     # 3
-#
-#     basic_instances = [
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
-#     ]
-#
-#     expected_data_on_coord = []
-#     expected_data_on_coord.extend(coordinators)
-#     expected_data_on_coord.extend(basic_instances)
-#
-#     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
-#
-#     # 4
-#
-#     interactive_mg_runner.kill(inner_instances_description, "instance_1")
-#
-#     # 5
-#     interactive_mg_runner.kill(inner_instances_description, "coordinator_3")
-#
-#     # 6
-#
-#     interactive_mg_runner.start(inner_instances_description, "instance_1")
-#
-#     # 7
-#
-#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-#
-#     def show_instances_coord1():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-#
-#     def show_instances_coord2():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-#
-#     coord1_leader_data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
-#     ]
-#
-#     coord2_leader_data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "leader"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
-#     ]
-#
-#     mg_sleep_and_assert_multiple(
-#         [coord1_leader_data, coord2_leader_data], [show_instances_coord1, show_instances_coord2]
-#     )
-#     mg_sleep_and_assert_multiple(
-#         [coord1_leader_data, coord2_leader_data], [show_instances_coord1, show_instances_coord2]
-#     )
-#
-#     instance_1_cursor = connect(host="localhost", port=7687).cursor()
-#
-#     def show_replicas():
-#         return sorted(list(execute_and_fetch_all(instance_1_cursor, "SHOW REPLICAS;")))
-#
-#     replicas = [
-#         (
-#             "instance_2",
-#             "localhost:10002",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#         (
-#             "instance_3",
-#             "localhost:10003",
-#             "sync",
-#             {"behind": None, "status": "invalid", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "invalid", "ts": 0}},
-#         ),
-#     ]
-#     mg_sleep_and_assert_collection(replicas, show_replicas)
-#
-#     def get_vertex_count_func(cursor):
-#         def get_vertex_count():
-#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-#
-#         return get_vertex_count
-#
-#     vertex_count = 0
-#     instance_1_cursor = connect(port=7687, host="localhost").cursor()
-#     instance_2_cursor = connect(port=7688, host="localhost").cursor()
-#
-#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
-#
-#     time_slept = 0
-#     failover_time = 5
-#     while time_slept < failover_time:
-#         with pytest.raises(Exception) as e:
-#             execute_and_fetch_all(instance_1_cursor, "CREATE ();")
-#         vertex_count += 1
-#
-#         assert vertex_count == execute_and_fetch_all(instance_1_cursor, "MATCH (n) RETURN count(n);")[0][0]
-#         assert vertex_count == execute_and_fetch_all(instance_2_cursor, "MATCH (n) RETURN count(n);")[0][0]
-#         time.sleep(0.1)
-#         time_slept += 0.1
-#
-#
-# def test_force_reset_works_after_failed_registration(test_name):
-#     # Goal of this test is to check that force reset works after failed registration
-#     # 1. Start all instances.
-#     # 2. Check everything works correctly
-#     # 3. Try register instance which doesn't exist
-#     # 4. Enter force reset
-#     # 5. Check that everything works correctly
-#
-#     # 1
-#     inner_instances_description = get_instances_description_no_setup(test_name=test_name)
-#
-#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-#
-#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-#     for query in get_default_setup_queries():
-#         execute_and_fetch_all(coord_cursor_3, query)
-#
-#     # 2
-#
-#     def show_instances_coord3():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-#
-#     def show_instances_coord1():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-#
-#     def show_instances_coord2():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-#
-#     data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#
-#     mg_sleep_and_assert(data, show_instances_coord3)
-#     mg_sleep_and_assert(data, show_instances_coord1)
-#     mg_sleep_and_assert(data, show_instances_coord2)
-#
-#     instance_3_cursor = connect(host="localhost", port=7689).cursor()
-#
-#     def show_replicas():
-#         return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
-#
-#     replicas = [
-#         (
-#             "instance_1",
-#             "localhost:10001",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#         (
-#             "instance_2",
-#             "localhost:10002",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#     ]
-#     mg_sleep_and_assert_collection(replicas, show_replicas)
-#
-#     def get_vertex_count_func(cursor):
-#         def get_vertex_count():
-#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-#
-#         return get_vertex_count
-#
-#     vertex_count = 0
-#     instance_1_cursor = connect(port=7687, host="localhost").cursor()
-#     instance_2_cursor = connect(port=7688, host="localhost").cursor()
-#
-#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
-#
-#     with pytest.raises(Exception) as e:
-#         execute_and_fetch_all(
-#             coord_cursor_3,
-#             "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': 'localhost:10050', 'replication_server': 'localhost:10051'};",
-#         )
-#
-#     # This will trigger force reset and choosing of new instance as MAIN
-#     data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
-#     ]
-#
-#     leader_name = find_instance_and_assert_instances(instance_role="leader", num_coordinators=3)
-#
-#     main_name = find_instance_and_assert_instances(instance_role="main", num_coordinators=3)
-#
-#     assert leader_name is not None, "leader is None"
-#     assert main_name is not None, "Main is None"
-#
-#     data = update_tuple_value(data, leader_name, 0, -1, "leader")
-#     data = update_tuple_value(data, main_name, 0, -1, "main")
-#
-#     mg_sleep_and_assert(data, show_instances_coord3)
-#     mg_sleep_and_assert(data, show_instances_coord1)
-#     mg_sleep_and_assert(data, show_instances_coord2)
-#
-#     def get_port(instance_name):
-#         mappings = {
-#             "instance_1": 7687,
-#             "instance_2": 7688,
-#             "instance_3": 7689,
-#         }
-#         return mappings[instance_name]
-#
-#     instance_main_cursor = connect(port=get_port(main_name), host="localhost").cursor()
-#     vertex_count = 10
-#     for _ in range(vertex_count):
-#         execute_and_fetch_all(instance_main_cursor, "CREATE ();")
-#
-#     def get_vertex_count_func(cursor):
-#         def get_vertex_count():
-#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-#
-#         return get_vertex_count
-#
-#     for instance in ["instance_1", "instance_2", "instance_3"]:
-#         cursor = connect(port=get_port(instance), host="localhost").cursor()
-#         mg_sleep_and_assert(vertex_count, get_vertex_count_func(cursor))
-#
-#
-# def test_force_reset_works_after_failed_registration_and_replica_down(test_name):
-#     # Goal of this test is to check when action fails, that force reset happens
-#     # and everything works correctly when REPLICA is down (can be demoted but doesn't have to - we demote it)
-#     # 1. Start all instances.
-#     # 2. Check everything works correctly
-#     # 3. Kill replica
-#     # 4. Try to register instance which doesn't exist
-#     # 4. Enter force reset
-#     # 5. Check that everything works correctly with two instances
-#     # 6. Start replica instance
-#     # 7. Check that replica is correctly demoted to replica
-#
-#     # 1
-#     inner_instances_description = get_instances_description_no_setup(test_name=test_name)
-#
-#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-#
-#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-#     for query in get_default_setup_queries():
-#         execute_and_fetch_all(coord_cursor_3, query)
-#
-#     # 2
-#
-#     def show_instances_coord3():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-#
-#     def show_instances_coord1():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-#
-#     def show_instances_coord2():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-#
-#     data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#
-#     mg_sleep_and_assert(data, show_instances_coord3)
-#     mg_sleep_and_assert(data, show_instances_coord1)
-#     mg_sleep_and_assert(data, show_instances_coord2)
-#
-#     instance_3_cursor = connect(host="localhost", port=7689).cursor()
-#
-#     def show_replicas():
-#         return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
-#
-#     replicas = [
-#         (
-#             "instance_1",
-#             "localhost:10001",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#         (
-#             "instance_2",
-#             "localhost:10002",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#     ]
-#     mg_sleep_and_assert_collection(replicas, show_replicas)
-#
-#     def get_vertex_count_func(cursor):
-#         def get_vertex_count():
-#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-#
-#         return get_vertex_count
-#
-#     vertex_count = 0
-#     instance_1_cursor = connect(port=7687, host="localhost").cursor()
-#     instance_2_cursor = connect(port=7688, host="localhost").cursor()
-#
-#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
-#
-#     # 3
-#
-#     interactive_mg_runner.kill(inner_instances_description, "instance_2")
-#
-#     # 4
-#
-#     with pytest.raises(Exception) as e:
-#         execute_and_fetch_all(
-#             coord_cursor_3,
-#             "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': 'localhost:10050', 'replication_server': 'localhost:10051'};",
-#         )
-#
-#     # 5
-#     # This will trigger verify and correct cluster state, where we shouldn't choose new MAIN
-#     data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#
-#     leader_name = "coordinator_3"
-#
-#     main_name = "instance_3"
-#
-#     assert leader_name is not None, "leader is None"
-#     assert main_name is not None, "Main is None"
-#
-#     data = update_tuple_value(data, leader_name, 0, -1, "leader")
-#     data = update_tuple_value(data, main_name, 0, -1, "main")
-#
-#     mg_sleep_and_assert(data, show_instances_coord3)
-#     mg_sleep_and_assert(data, show_instances_coord1)
-#     mg_sleep_and_assert(data, show_instances_coord2)
-#
-#     # 6
-#
-#     interactive_mg_runner.start(inner_instances_description, "instance_2")
-#
-#     # 7
-#
-#     data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
-#     ]
-#
-#     data = update_tuple_value(data, leader_name, 0, -1, "leader")
-#     data = update_tuple_value(data, main_name, 0, -1, "main")
-#
-#     mg_sleep_and_assert(data, show_instances_coord3)
-#     mg_sleep_and_assert(data, show_instances_coord1)
-#     mg_sleep_and_assert(data, show_instances_coord2)
-#
-#     def get_port(instance_name):
-#         mappings = {
-#             "instance_1": 7687,
-#             "instance_2": 7688,
-#             "instance_3": 7689,
-#         }
-#         return mappings[instance_name]
-#
-#     main_cursor = connect(port=get_port(main_name), host="localhost").cursor()
-#
-#     def show_replicas():
-#         return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")))
-#
-#     replicas = [
-#         (
-#             "instance_1",
-#             "localhost:10001",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#         (
-#             "instance_2",
-#             "localhost:10002",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#         (
-#             "instance_3",
-#             "localhost:10003",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#     ]
-#     replicas = [replica for replica in replicas if replica[0] != main_name]
-#     mg_sleep_and_assert_collection(replicas, show_replicas)
-#
-#     # 8
-#
-#     vertex_count = 10
-#     for _ in range(vertex_count):
-#         execute_and_fetch_all(main_cursor, "CREATE ();")
-#
-#     def get_vertex_count_func(cursor):
-#         def get_vertex_count():
-#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-#
-#         return get_vertex_count
-#
-#     for instance in ["instance_1", "instance_2", "instance_3"]:
-#         cursor = connect(port=get_port(instance), host="localhost").cursor()
-#         mg_sleep_and_assert(vertex_count, get_vertex_count_func(cursor))
-#
-#
-# def test_force_reset_works_after_failed_registration_and_2_coordinators_down(test_name):
-#     # Goal of this test is to check when action fails, that force reset happens
-#     # and everything works correctly after majority of coordinators is back up
-#     # 1. Start all instances.
-#     # 2. Check everything works correctly
-#     # 3. Try to register instance which doesn't exist -> Enter force reset
-#     # 4. Kill 2 coordinators
-#     # 5. New action shouldn't succeed because of opened lock
-#     # 6. Start one coordinator
-#     # 7. Check that replica failover happens in force reset
-#     # 8. Check that everything works correctly
-#
-#     # 1
-#     inner_instances_description = get_instances_description_no_setup(test_name=test_name)
-#
-#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-#
-#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-#     for query in get_default_setup_queries():
-#         execute_and_fetch_all(coord_cursor_3, query)
-#
-#     # 2
-#
-#     def show_instances_coord3():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-#
-#     def show_instances_coord1():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-#
-#     def show_instances_coord2():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-#
-#     data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#
-#     mg_sleep_and_assert(data, show_instances_coord3)
-#     mg_sleep_and_assert(data, show_instances_coord1)
-#     mg_sleep_and_assert(data, show_instances_coord2)
-#
-#     instance_3_cursor = connect(host="localhost", port=7689).cursor()
-#
-#     def show_replicas():
-#         return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
-#
-#     replicas = [
-#         (
-#             "instance_1",
-#             "localhost:10001",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#         (
-#             "instance_2",
-#             "localhost:10002",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#     ]
-#     mg_sleep_and_assert_collection(replicas, show_replicas)
-#
-#     def get_vertex_count_func(cursor):
-#         def get_vertex_count():
-#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-#
-#         return get_vertex_count
-#
-#     vertex_count = 0
-#     instance_1_cursor = connect(port=7687, host="localhost").cursor()
-#     instance_2_cursor = connect(port=7688, host="localhost").cursor()
-#
-#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
-#
-#     # 3
-#
-#     with pytest.raises(Exception) as _:
-#         execute_and_fetch_all(
-#             coord_cursor_3,
-#             "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': 'localhost:10050', 'replication_server': 'localhost:10051'};",
-#         )
-#
-#     # 4
-#     interactive_mg_runner.kill(inner_instances_description, "coordinator_2")
-#     interactive_mg_runner.kill(inner_instances_description, "coordinator_3")
-#
-#     # 5
-#     with pytest.raises(Exception) as e:
-#         execute_and_fetch_all(
-#             coord_cursor_1,
-#             "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': "
-#             "'localhost:10050', 'replication_server': 'localhost:10051'};",
-#         )
-#
-#     assert "Couldn't register replica instance since coordinator is not a leader!" in str(e.value)
-#
-#     # 6
-#
-#     interactive_mg_runner.start(inner_instances_description, "coordinator_2")
-#
-#     # 7
-#     # main must be the same after leader election as before, we can't demote old main
-#     leader_data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#
-#     leader_name = find_instance_and_assert_instances(
-#         instance_role="leader", num_coordinators=3, coord_ids_to_skip_validation={3}
-#     )
-#
-#     leader_data = update_tuple_value(leader_data, leader_name, 0, -1, "leader")
-#
-#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-#
-#     def show_instances_coord1():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-#
-#     def show_instances_coord2():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-#
-#     mg_sleep_and_assert(leader_data, show_instances_coord1)
-#
-#     mg_sleep_and_assert(leader_data, show_instances_coord2)
-#
-#     def show_replicas():
-#         return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
-#
-#     replicas = [
-#         (
-#             "instance_1",
-#             "localhost:10001",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#         (
-#             "instance_2",
-#             "localhost:10002",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#     ]
-#     mg_sleep_and_assert_collection(replicas, show_replicas)
-#
-#     # 8
-#
-#     vertex_count = 10
-#     for _ in range(vertex_count):
-#         execute_and_fetch_all(instance_3_cursor, "CREATE ();")
-#
-#     def get_vertex_count_func(cursor):
-#         def get_vertex_count():
-#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-#
-#         return get_vertex_count
-#
-#     def get_port(instance_name):
-#         mappings = {
-#             "instance_1": 7687,
-#             "instance_2": 7688,
-#             "instance_3": 7689,
-#         }
-#         return mappings[instance_name]
-#
-#     for instance in ["instance_1", "instance_2", "instance_3"]:
-#         cursor = connect(port=get_port(instance), host="localhost").cursor()
-#         mg_sleep_and_assert(vertex_count, get_vertex_count_func(cursor))
-#
-#
-# def test_coordinator_gets_info_on_other_coordinators(test_name):
-#     # Goal of this test is to check that coordinator which has cluster state
-#     # after restart gets info on other cluster also which is added in meantime
-#     # 1. Start all instances.
-#     # 2. Check everything works correctly
-#     # 3. Kill one coordinator
-#     # 4. Wait until it is down
-#     # 5. Register new coordinator
-#     # 6. Check that leaders and followers see each other
-#     # 7. Start coordinator which is down
-#     # 8. Check that such coordinator has correct info
-#
-#     # 1
-#
-#     inner_instances_description = get_instances_description_no_setup(test_name=test_name)
-#
-#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-#
-#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-#     for query in get_default_setup_queries():
-#         execute_and_fetch_all(coord_cursor_3, query)
-#
-#     # 2
-#
-#     def show_instances_coord3():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-#
-#     def show_instances_coord1():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-#
-#     def show_instances_coord2():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-#
-#     data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#
-#     mg_sleep_and_assert(data, show_instances_coord3)
-#     mg_sleep_and_assert(data, show_instances_coord1)
-#     mg_sleep_and_assert(data, show_instances_coord2)
-#
-#     instance_3_cursor = connect(host="localhost", port=7689).cursor()
-#
-#     def show_replicas():
-#         return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
-#
-#     replicas = [
-#         (
-#             "instance_1",
-#             "localhost:10001",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#         (
-#             "instance_2",
-#             "localhost:10002",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#     ]
-#     mg_sleep_and_assert_collection(replicas, show_replicas)
-#
-#     def get_vertex_count_func(cursor):
-#         def get_vertex_count():
-#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-#
-#         return get_vertex_count
-#
-#     vertex_count = 0
-#     instance_1_cursor = connect(port=7687, host="localhost").cursor()
-#     instance_2_cursor = connect(port=7688, host="localhost").cursor()
-#
-#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
-#
-#     # 3
-#
-#     interactive_mg_runner.kill(inner_instances_description, "coordinator_2")
-#
-#     # 4
-#
-#     while True:
-#         try:
-#             execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")
-#             time.sleep(0.1)
-#         except Exception:
-#             break
-#
-#     # 5
-#
-#     other_instances = {
-#         "coordinator_4": {
-#             "args": [
-#                 "--experimental-enabled=high-availability",
-#                 "--bolt-port",
-#                 "7693",
-#                 "--log-level=TRACE",
-#                 "--coordinator-id=4",
-#                 "--coordinator-port=10114",
-#                 "--management-port=10124",
-#                 "--coordinator-hostname",
-#                 "localhost",
-#             ],
-#             "log_file": f"{get_logs_path(file, test_name)}/coordinator_4.log",
-#             "data_directory": f"{get_data_path(file, test_name)}/coordinator_4",
-#             "setup_queries": [],
-#         },
-#     }
-#
-#     interactive_mg_runner.start(other_instances, "coordinator_4")
-#     execute_and_fetch_all(
-#         coord_cursor_3,
-#         "ADD COORDINATOR 4 WITH CONFIG {'bolt_server': 'localhost:7693', 'coordinator_server': 'localhost:10114', 'management_server': 'localhost:10124'};",
-#     )
-#
-#     # 6
-#
-#     coord_cursor_4 = connect(host="localhost", port=7693).cursor()
-#
-#     def show_instances_coord4():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_4, "SHOW INSTANCES;"))))
-#
-#     coord2_down_data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "down", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "follower"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#     mg_sleep_and_assert(coord2_down_data, show_instances_coord3)
-#     mg_sleep_and_assert(coord2_down_data, show_instances_coord1)
-#     mg_sleep_and_assert(coord2_down_data, show_instances_coord4)
-#
-#     # 7
-#
-#     interactive_mg_runner.start(inner_instances_description, "coordinator_2")
-#
-#     # 8
-#
-#     coord2_up_data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "follower"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#
-#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-#
-#     mg_sleep_and_assert(coord2_up_data, show_instances_coord2)
-#
-#
-# def test_registration_works_after_main_set(test_name):
-#     # This test tries to register first main and set it to main and afterwards register other instances
-#     # 1. Start all instances.
-#     # 2. Check everything works correctly
-#
-#     # 1
-#     inner_instances_description = get_instances_description_no_setup(test_name=test_name)
-#
-#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-#
-#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-#     for query in get_default_setup_queries():
-#         execute_and_fetch_all(coord_cursor_3, query)
-#
-#     # 2
-#
-#     def show_instances_coord3():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-#
-#     def show_instances_coord1():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-#
-#     def show_instances_coord2():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-#
-#     data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#
-#     mg_sleep_and_assert(data, show_instances_coord3)
-#     mg_sleep_and_assert(data, show_instances_coord1)
-#     mg_sleep_and_assert(data, show_instances_coord2)
-#
-#     instance_3_cursor = connect(host="localhost", port=7689).cursor()
-#
-#     def show_replicas():
-#         return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
-#
-#     replicas = [
-#         (
-#             "instance_1",
-#             "localhost:10001",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#         (
-#             "instance_2",
-#             "localhost:10002",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#     ]
-#     mg_sleep_and_assert_collection(replicas, show_replicas)
-#
-#     def get_vertex_count_func(cursor):
-#         def get_vertex_count():
-#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-#
-#         return get_vertex_count
-#
-#     vertex_count = 0
-#     instance_1_cursor = connect(port=7687, host="localhost").cursor()
-#     instance_2_cursor = connect(port=7688, host="localhost").cursor()
-#
-#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
-#
-#
-# def test_coordinator_not_leader_registration_does_not_work(test_name):
-#     # Goal of this test is to check that it is not possible to register instance on follower coord
-#     # 1. Start all instances.
-#     # 2. Check everything works correctly
-#     # 3. Try to register instance on follower coord
-#
-#     # 1
-#     inner_instances_description = get_instances_description_no_setup(test_name=test_name)
-#
-#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-#
-#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-#     for query in get_default_setup_queries():
-#         execute_and_fetch_all(coord_cursor_3, query)
-#
-#     # 2
-#
-#     def show_instances_coord3():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-#
-#     def show_instances_coord1():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-#
-#     def show_instances_coord2():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-#
-#     data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#     mg_sleep_and_assert(data, show_instances_coord3)
-#     mg_sleep_and_assert(data, show_instances_coord1)
-#     mg_sleep_and_assert(data, show_instances_coord2)
-#
-#     instance_3_cursor = connect(host="localhost", port=7689).cursor()
-#
-#     def show_replicas():
-#         return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
-#
-#     replicas = [
-#         (
-#             "instance_1",
-#             "localhost:10001",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#         (
-#             "instance_2",
-#             "localhost:10002",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#     ]
-#     mg_sleep_and_assert_collection(replicas, show_replicas)
-#
-#     def get_vertex_count_func(cursor):
-#         def get_vertex_count():
-#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-#
-#         return get_vertex_count
-#
-#     vertex_count = 0
-#     instance_1_cursor = connect(port=7687, host="localhost").cursor()
-#     instance_2_cursor = connect(port=7688, host="localhost").cursor()
-#
-#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
-#
-#     # 3
-#
-#     with pytest.raises(Exception) as e:
-#         execute_and_fetch_all(
-#             coord_cursor_1,
-#             "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': "
-#             "'localhost:10050', 'replication_server': 'localhost:10051'};",
-#         )
-#
-#     assert (
-#         "Couldn't register replica instance since coordinator is not a leader! Current leader is coordinator with id 3 with bolt socket address localhost:7692"
-#         == str(e.value)
-#     )
-#
-#
-# def test_coordinator_user_action_demote_instance_to_replica(test_name):
-#     # Goal of this test is to check that it is not possible to register instance on follower coord
-#     # 1. Start all instances.
-#     # 2. Check everything works correctly
-#     # 3. Try to demote instance to replica
-#     # 4. Check we have correct state
-#
-#     # 1
-#     inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
-#
-#     FAILOVER_PERIOD = 2
-#     inner_instances_description["instance_1"]["args"].append(f"--instance-down-timeout-sec={FAILOVER_PERIOD}")
-#     inner_instances_description["instance_2"]["args"].append(f"--instance-down-timeout-sec={FAILOVER_PERIOD}")
-#     inner_instances_description["instance_3"]["args"].append(f"--instance-down-timeout-sec={FAILOVER_PERIOD}")
-#
-#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-#
-#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-#     for query in get_default_setup_queries():
-#         execute_and_fetch_all(coord_cursor_3, query)
-#
-#     # 2
-#
-#     def show_instances_coord3():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-#
-#     def show_instances_coord1():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-#
-#     def show_instances_coord2():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-#
-#     data_original = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#
-#     mg_sleep_and_assert(data_original, show_instances_coord3)
-#     mg_sleep_and_assert(data_original, show_instances_coord1)
-#     mg_sleep_and_assert(data_original, show_instances_coord2)
-#
-#     instance_3_cursor = connect(host="localhost", port=7689).cursor()
-#
-#     def show_replicas():
-#         return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
-#
-#     replicas = [
-#         (
-#             "instance_1",
-#             "localhost:10001",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#         (
-#             "instance_2",
-#             "localhost:10002",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#     ]
-#     mg_sleep_and_assert_collection(replicas, show_replicas)
-#
-#     def get_vertex_count_func(cursor):
-#         def get_vertex_count():
-#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-#
-#         return get_vertex_count
-#
-#     vertex_count = 0
-#     instance_1_cursor = connect(port=7687, host="localhost").cursor()
-#     instance_2_cursor = connect(port=7688, host="localhost").cursor()
-#
-#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
-#
-#     # 3
-#
-#     execute_and_fetch_all(
-#         coord_cursor_3,
-#         "DEMOTE INSTANCE instance_3",
-#     )
-#
-#     # 4.
-#
-#     data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
-#     ]
-#
-#     mg_sleep_and_assert(data, show_instances_coord3)
-#     mg_sleep_and_assert(data, show_instances_coord1)
-#     mg_sleep_and_assert(data, show_instances_coord2)
-#
-#     with pytest.raises(Exception) as e:
-#         execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")
-#     assert str(e.value) == "Replica can't show registered replicas (it shouldn't have any)!"
-#
-#     mg_assert_until(data, show_instances_coord3, FAILOVER_PERIOD + 1)
-#     mg_sleep_and_assert(data, show_instances_coord1)
-#     mg_sleep_and_assert(data, show_instances_coord2)
-#
-#     execute_and_fetch_all(coord_cursor_3, "SET INSTANCE instance_3 TO MAIN;")
-#
-#     mg_sleep_and_assert(data_original, show_instances_coord3)
-#     mg_sleep_and_assert(data_original, show_instances_coord1)
-#     mg_sleep_and_assert(data_original, show_instances_coord2)
-#
-#
-# def test_coordinator_user_action_force_reset_works(test_name):
-#     # Goal of this test is to check that it is not possible to register instance on follower coord
-#     # 1. Start all instances.
-#     # 2. Check everything works correctly
-#     # 3. Try force reset
-#     # 4. Check we have correct state
-#
-#     # 1
-#     inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
-#
-#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-#
-#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-#     for query in get_default_setup_queries():
-#         execute_and_fetch_all(coord_cursor_3, query)
-#
-#     # 2
-#
-#     def show_instances_coord3():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-#
-#     def show_instances_coord1():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-#
-#     def show_instances_coord2():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-#
-#     data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#
-#     mg_sleep_and_assert(data, show_instances_coord3)
-#     mg_sleep_and_assert(data, show_instances_coord1)
-#     mg_sleep_and_assert(data, show_instances_coord2)
-#
-#     instance_3_cursor = connect(host="localhost", port=7689).cursor()
-#
-#     def show_replicas():
-#         return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
-#
-#     replicas = [
-#         (
-#             "instance_1",
-#             "localhost:10001",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#         (
-#             "instance_2",
-#             "localhost:10002",
-#             "sync",
-#             {"behind": None, "status": "ready", "ts": 0},
-#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-#         ),
-#     ]
-#     mg_sleep_and_assert_collection(replicas, show_replicas)
-#
-#     def get_vertex_count_func(cursor):
-#         def get_vertex_count():
-#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-#
-#         return get_vertex_count
-#
-#     vertex_count = 0
-#     instance_1_cursor = connect(port=7687, host="localhost").cursor()
-#     instance_2_cursor = connect(port=7688, host="localhost").cursor()
-#
-#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
-#
-#     # 3
-#
-#     execute_and_fetch_all(
-#         coord_cursor_3,
-#         "FORCE RESET CLUSTER STATE;",
-#     )
-#
-#     # 4.
-#
-#     data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#
-#     mg_sleep_and_assert(data, show_instances_coord3)
-#     mg_sleep_and_assert(data, show_instances_coord1)
-#     mg_sleep_and_assert(data, show_instances_coord2)
-#
-#
-# def test_all_coords_down_resume(test_name):
-#     # Goal of this test is to check that coordinators are able to resume, if cluster is able to resume where it
-#     # left off if all coordinators go down
-#
-#     # 1. Start cluster
-#     # 2. Check everything works correctly
-#     # 3. Stop all coordinators
-#     # 4. Start 2 coordinators, one should be leader, and one follower
-#     # 5. Check everything works correctly
-#
-#     # 1
-#     inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
-#
-#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-#
-#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-#     for query in get_default_setup_queries():
-#         execute_and_fetch_all(coord_cursor_3, query)
-#
-#     # 2
-#     def show_instances_coord3():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-#
-#     def show_instances_coord1():
-#         coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-#
-#     def show_instances_coord2():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-#
-#     data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#
-#     mg_sleep_and_assert(data, show_instances_coord3)
-#     mg_sleep_and_assert(data, show_instances_coord1)
-#     mg_sleep_and_assert(data, show_instances_coord2)
-#
-#     # 3
-#
-#     interactive_mg_runner.kill(inner_instances_description, "coordinator_1")
-#     interactive_mg_runner.kill(inner_instances_description, "coordinator_2")
-#     interactive_mg_runner.kill(inner_instances_description, "coordinator_3")
-#
-#     # 4
-#
-#     with concurrent.futures.ThreadPoolExecutor(2) as executor:
-#         executor.submit(interactive_mg_runner.start, inner_instances_description, "coordinator_2")
-#         executor.submit(interactive_mg_runner.start, inner_instances_description, "coordinator_1")
-#
-#     # 5
-#
-#     leader_data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
-#     ]
-#
-#     wait_for_status_change(show_instances_coord1, {"coordinator_1", "coordinator_2"}, "leader")
-#
-#     leader = find_instance_and_assert_instances(
-#         instance_role="leader", num_coordinators=3, coord_ids_to_skip_validation={3}
-#     )
-#
-#     main = find_instance_and_assert_instances(
-#         instance_role="main", num_coordinators=3, coord_ids_to_skip_validation={3}
-#     )
-#     leader_data = update_tuple_value(leader_data, leader, 0, -1, "leader")
-#     leader_data = update_tuple_value(leader_data, main, 0, -1, "main")
-#
-#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-#
-#     mg_sleep_and_assert(leader_data, show_instances_coord1)
-#
-#     mg_sleep_and_assert(leader_data, show_instances_coord2)
-#
-#     # 6
-#     interactive_mg_runner.kill(inner_instances_description, "instance_3")
-#     interactive_mg_runner.start(inner_instances_description, "coordinator_3")
-#
-#     # 7
-#
-#     leader_data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
-#     ]
-#
-#     wait_for_status_change(show_instances_coord1, {"instance_3"}, "unknown")
-#
-#     leader = find_instance_and_assert_instances(instance_role="leader", num_coordinators=3)
-#
-#     main = find_instance_and_assert_instances(instance_role="main", num_coordinators=3)
-#
-#     leader_data = update_tuple_value(leader_data, leader, 0, -1, "leader")
-#     leader_data = update_tuple_value(leader_data, main, 0, -1, "main")
-#
-#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-#
-#     mg_sleep_and_assert(leader_data, show_instances_coord1)
-#
-#     mg_sleep_and_assert(leader_data, show_instances_coord2)
-#
-#     mg_sleep_and_assert(leader_data, show_instances_coord3)
-#
-#
-# def test_one_coord_down_with_durability_resume(test_name):
-#     # Goal of this test is to check that coordinators are able to resume, if cluster is able to resume where it
-#     # left off if all coordinators go down
-#
-#     # 1. Start cluster
-#     # 2. Check everything works correctly
-#     # 3. Stop all coordinators
-#     # 4. Start 2 coordinators, one should be leader, and one follower
-#     # 5. Check everything works correctly
-#
-#     # 1
-#     inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
-#
-#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-#
-#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-#
-#     for query in get_default_setup_queries():
-#         execute_and_fetch_all(coord_cursor_3, query)
-#
-#     # 2
-#     def show_instances_coord3():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-#
-#     def show_instances_coord1():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-#
-#     def show_instances_coord2():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-#
-#     data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#
-#     mg_sleep_and_assert(data, show_instances_coord3)
-#     mg_sleep_and_assert(data, show_instances_coord1)
-#     mg_sleep_and_assert(data, show_instances_coord2)
-#
-#     # 3
-#
-#     interactive_mg_runner.kill(inner_instances_description, "coordinator_1")
-#
-#     leader_data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "down", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#     mg_sleep_and_assert(leader_data, show_instances_coord3)
-#
-#     # 4
-#     interactive_mg_runner.start(inner_instances_description, "coordinator_1")
-#
-#     # 5
-#
-#     data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#
-#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-#
-#     mg_sleep_and_assert(data, show_instances_coord3)
-#     mg_sleep_and_assert(data, show_instances_coord1)
-#     mg_sleep_and_assert(data, show_instances_coord2)
-#
-#     # 6
-#     interactive_mg_runner.kill(inner_instances_description, "instance_3")
-#
-#     # 7
-#
-#     leader_data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
-#     ]
-#
-#     mg_sleep_and_assert(leader_data, show_instances_coord3)
-#     mg_sleep_and_assert(leader_data, show_instances_coord1)
-#     mg_sleep_and_assert(leader_data, show_instances_coord2)
-#
-#
-# def test_registration_does_not_deadlock_when_instance_is_down(test_name):
-#     # Goal of this test is to assert that system doesn't deadlock in case of failure on registration
-#
-#     # 1
-#     inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
-#
-#     interactive_mg_runner.start(inner_instances_description, "coordinator_1")
-#     interactive_mg_runner.start(inner_instances_description, "coordinator_2")
-#     interactive_mg_runner.start(inner_instances_description, "coordinator_3")
-#
-#     setup_queries = [
-#         "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111', 'management_server': 'localhost:10121'}",
-#         "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112', 'management_server': 'localhost:10122'}",
-#     ]
-#
-#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-#     for query in setup_queries:
-#         execute_and_fetch_all(coord_cursor_3, query)
-#
-#     query = "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};"
-#
-#     with pytest.raises(Exception) as e:
-#         execute_and_fetch_all(coord_cursor_3, query)
-#
-#     assert "Couldn't register replica instance because setting instance to replica failed!" in str(e.value)
-#
-#     interactive_mg_runner.start(inner_instances_description, "instance_1")
-#     execute_and_fetch_all(coord_cursor_3, query)
-#
-#     interactive_mg_runner.start(inner_instances_description, "instance_2")
-#     interactive_mg_runner.start(inner_instances_description, "instance_3")
-#
-#     setup_queries = [
-#         "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
-#         "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
-#         "SET INSTANCE instance_3 TO MAIN",
-#     ]
-#
-#     for query in setup_queries:
-#         execute_and_fetch_all(coord_cursor_3, query)
-#
-#     def show_instances_coord3():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-#
-#     def show_instances_coord1():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-#
-#     def show_instances_coord2():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-#
-#     data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#
-#     mg_sleep_and_assert(data, show_instances_coord3)
-#     mg_sleep_and_assert(data, show_instances_coord1)
-#     mg_sleep_and_assert(data, show_instances_coord2)
-#
-#
-# def test_follower_have_correct_health(test_name):
-#     # Goal of this test is to check that coordinators are able to resume, if cluster is able to resume where it
-#     # left off if all coordinators go down
-#
-#     # 1. Start cluster
-#     # 2. Check everything works correctly
-#     # 3. Stop all coordinators
-#     # 4. Start 2 coordinators, one should be leader, and one follower
-#     # 5. Check everything works correctly
-#
-#     # 1
-#     inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
-#
-#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-#
-#     setup_queries = get_default_setup_queries()
-#
-#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-#     for query in setup_queries:
-#         execute_and_fetch_all(coord_cursor_3, query)
-#
-#     # 2
-#     def show_instances_coord3():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-#
-#     def show_instances_coord1():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-#
-#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-#
-#     def show_instances_coord2():
-#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-#
-#     data = [
-#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-#     ]
-#
-#     mg_sleep_and_assert(data, show_instances_coord3)
-#     mg_sleep_and_assert(data, show_instances_coord1)
-#     mg_sleep_and_assert(data, show_instances_coord2)
+@pytest.mark.parametrize("use_durability", [True, False])
+def test_even_number_coords(use_durability, test_name):
+    # Goal is to check that nothing gets broken on even number of coords when 2 coords are down
+    # 1. Start all instances.
+    # 2. Check that all instances are up and that one of the instances is a main.
+    # 3. Demote the main instance.
+    # 4. Kill two coordinators.
+    # 5. Wait for leader to become follower
+    # 6. Bring back up two coordinators.
+    # 7. Find leader
+    # 8.
+
+    # 1
+    inner_instances_description = get_instances_description_no_setup_4_coords(
+        test_name=test_name, use_durability=use_durability
+    )
+
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+
+    setup_queries = [
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111', 'management_server': 'localhost:10121'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112', 'management_server': 'localhost:10122'}",
+        "ADD COORDINATOR 4 WITH CONFIG {'bolt_server': 'localhost:7693', 'coordinator_server': 'localhost:10114', 'management_server': 'localhost:10124'}",
+        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
+        "SET INSTANCE instance_3 TO MAIN",
+    ]
+
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+    for query in setup_queries:
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    # 2
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    def show_instances_coord2():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+
+    def show_instances_coord3():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+
+    coord_cursor_4 = connect(host="localhost", port=7693).cursor()
+
+    def show_instances_coord4():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_4, "SHOW INSTANCES;"))))
+
+    leader_data_original = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    mg_sleep_and_assert(leader_data_original, show_instances_coord3)
+    mg_sleep_and_assert(leader_data_original, show_instances_coord1)
+    mg_sleep_and_assert(leader_data_original, show_instances_coord2)
+    mg_sleep_and_assert(leader_data_original, show_instances_coord4)
+
+    instance_3_cursor = connect(host="localhost", port=7689).cursor()
+
+    def show_replicas():
+        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+
+    replicas = [
+        (
+            "instance_1",
+            "localhost:10001",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+        (
+            "instance_2",
+            "localhost:10002",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+    ]
+    mg_sleep_and_assert_collection(replicas, show_replicas)
+
+    # 3
+
+    execute_and_fetch_all(
+        coord_cursor_3,
+        "DEMOTE INSTANCE instance_3",
+    )
+
+    leader_data_demoted = leader_data_original.copy()
+    leader_data_demoted = update_tuple_value(leader_data_demoted, "instance_3", 0, -1, "replica")
+
+    mg_sleep_and_assert(leader_data_demoted, show_instances_coord3)
+    mg_sleep_and_assert(leader_data_demoted, show_instances_coord1)
+    mg_sleep_and_assert(leader_data_demoted, show_instances_coord2)
+    mg_sleep_and_assert(leader_data_demoted, show_instances_coord4)
+
+    with pytest.raises(Exception) as e:
+        execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")
+    assert str(e.value) == "Replica can't show registered replicas (it shouldn't have any)!"
+
+    # 4
+    interactive_mg_runner.kill(inner_instances_description, "coordinator_1")
+    interactive_mg_runner.kill(inner_instances_description, "coordinator_2")
+
+    # 5
+
+    with pytest.raises(Exception) as e:
+        execute_and_fetch_all(coord_cursor_3, "SET INSTANCE instance_3 TO MAIN;")
+
+    assert "Couldn't set instance to main as cluster didn't accept start of action!" in str(e.value)
+
+    follower_data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "unknown", "follower"),
+        ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "unknown", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "replica"),
+    ]
+
+    mg_sleep_and_assert(follower_data, show_instances_coord3)
+
+    # 6
+    interactive_mg_runner.start(inner_instances_description, "coordinator_1")
+    interactive_mg_runner.start(inner_instances_description, "coordinator_2")
+
+    # 7
+
+    leader_data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
+        ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
+    ]
+
+    leader_coord_instance_3_demoted = find_instance_and_assert_instances(instance_role="leader", num_coordinators=3)
+
+    main_instance_3_demoted = find_instance_and_assert_instances(instance_role="main", num_coordinators=3)
+
+    assert leader_coord_instance_3_demoted is not None, "Leader not found"
+
+    assert main_instance_3_demoted is not None, "Main not found"
+
+    leader_data = update_tuple_value(leader_data, leader_coord_instance_3_demoted, 0, -1, "leader")
+    leader_data = update_tuple_value(leader_data, main_instance_3_demoted, 0, -1, "main")
+
+    port_mappings = {
+        "coordinator_1": 7690,
+        "coordinator_2": 7691,
+        "coordinator_3": 7692,
+        "coordinator_4": 7693,
+    }
+
+    for coord, port in port_mappings.items():
+        coord_cursor = connect(host="localhost", port=port).cursor()
+
+        def show_instances():
+            return ignore_elapsed_time_from_results(
+                sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
+            )
+
+        mg_sleep_and_assert(leader_data, show_instances)
+
+
+def test_old_main_comes_back_on_new_leader_as_replica(test_name):
+    # 1. Start all instances.
+    # 2. Kill the main instance
+    # 3. Kill the leader
+    # 4. Start the old main instance
+    # 5. Run SHOW INSTANCES on the new leader and check that the old main instance is registered as a replica
+    # 6. Start again previous leader
+
+    inner_instances_description = get_instances_description_no_setup(test_name=test_name)
+
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+    for query in get_default_setup_queries():
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    interactive_mg_runner.kill(inner_instances_description, "coordinator_3")
+    interactive_mg_runner.kill(inner_instances_description, "instance_3")
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    def show_instances_coord2():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+
+    # Wait until failover happens
+    wait_for_status_change(show_instances_coord1, {"instance_1", "instance_2"}, "main")
+    wait_for_status_change(show_instances_coord1, {"instance_3"}, "unknown")
+
+    # Both instance_1 and instance_2 could become main depending on the order of pings in the system.
+    # Both coordinator_1 and coordinator_2 could become leader depending on the NuRaft election.
+    leader_data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
+    ]
+
+    leader_instance_3_down = find_instance_and_assert_instances(
+        instance_role="leader", num_coordinators=3, coord_ids_to_skip_validation={3}
+    )
+    main_instance_3_down = find_instance_and_assert_instances(
+        instance_role="main", num_coordinators=3, coord_ids_to_skip_validation={3}
+    )
+
+    leader_data = update_tuple_value(leader_data, leader_instance_3_down, 0, -1, "leader")
+    leader_data = update_tuple_value(leader_data, main_instance_3_down, 0, -1, "main")
+
+    def get_show_instances_to_coord(leader_instance):
+        show_instances_mapping = {
+            "coordinator_1": show_instances_coord1,
+            "coordinator_2": show_instances_coord2,
+        }
+
+        return show_instances_mapping.get(leader_instance)
+
+    all_live_coords = ["coordinator_1", "coordinator_2"]
+
+    for coord in all_live_coords:
+        mg_sleep_and_assert(leader_data, get_show_instances_to_coord(coord))
+
+    interactive_mg_runner.start(inner_instances_description, "instance_3")
+
+    coordinator_leader_instance = find_instance_and_assert_instances(
+        instance_role="leader", num_coordinators=3, coord_ids_to_skip_validation={3}
+    )
+    main_instance_id_instance_3_start = find_instance_and_assert_instances(
+        instance_role="main", num_coordinators=3, coord_ids_to_skip_validation={3}
+    )
+
+    assert (
+        main_instance_id_instance_3_start == main_instance_3_down
+    ), f"Main is not {main_instance_3_down} but {main_instance_id_instance_3_start}"
+    assert (
+        coordinator_leader_instance == leader_instance_3_down
+    ), f"Leader is not same as before {leader_instance_3_down}, but {coordinator_leader_instance}"
+
+    coord_leader_data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
+    ]
+
+    coord_leader_data = update_tuple_value(coord_leader_data, coordinator_leader_instance, 0, -1, "leader")
+    coord_leader_data = update_tuple_value(coord_leader_data, main_instance_id_instance_3_start, 0, -1, "main")
+
+    mg_sleep_and_assert(coord_leader_data, get_show_instances_to_coord(coordinator_leader_instance))
+
+    def connect_to_main_instance():
+        assert main_instance_id_instance_3_start is not None
+
+        port_mapping = {"instance_1": 7687, "instance_2": 7688, "instance_3": 7689}
+
+        assert (
+            main_instance_id_instance_3_start in port_mapping
+        ), f"Main is not in mappings, but main is {main_instance_id_instance_3_start}"
+
+        main_instance_port = port_mapping.get(main_instance_id_instance_3_start)
+
+        if main_instance_port is not None:
+            return connect(host="localhost", port=main_instance_port).cursor()
+
+        return None
+
+    new_main_cursor = connect_to_main_instance()
+    assert new_main_cursor is not None, "Main cursor is not found!"
+
+    def show_replicas():
+        return sorted(list(execute_and_fetch_all(new_main_cursor, "SHOW REPLICAS;")))
+
+    replicas = [
+        (
+            "instance_1",
+            "localhost:10001",
+            "sync",
+            {"ts": 0, "behind": None, "status": "ready"},
+            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+        ),
+        (
+            "instance_2",
+            "localhost:10002",
+            "sync",
+            {"ts": 0, "behind": None, "status": "ready"},
+            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+        ),
+        (
+            "instance_3",
+            "localhost:10003",
+            "sync",
+            {"ts": 0, "behind": None, "status": "ready"},
+            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+        ),
+    ]
+    replicas = [replica for replica in replicas if replica[0] != main_instance_id_instance_3_start]
+    mg_sleep_and_assert_collection(replicas, show_replicas)
+
+    execute_and_fetch_all(new_main_cursor, "CREATE (n:Node {name: 'node'})")
+
+    replica_2_cursor = connect(host="localhost", port=7688).cursor()
+
+    def get_vertex_count():
+        return execute_and_fetch_all(replica_2_cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+    mg_sleep_and_assert(1, get_vertex_count)
+
+    replica_3_cursor = connect(host="localhost", port=7689).cursor()
+
+    def get_vertex_count():
+        return execute_and_fetch_all(replica_3_cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+    mg_sleep_and_assert(1, get_vertex_count)
+
+    interactive_mg_runner.start(inner_instances_description, "coordinator_3")
+
+
+def test_distributed_automatic_failover(test_name):
+    inner_instances_description = get_instances_description_no_setup(test_name=test_name)
+
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+    for query in get_default_setup_queries():
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    main_cursor = connect(host="localhost", port=7689).cursor()
+    expected_data_on_main = [
+        (
+            "instance_1",
+            "localhost:10001",
+            "sync",
+            {"ts": 0, "behind": None, "status": "ready"},
+            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+        ),
+        (
+            "instance_2",
+            "localhost:10002",
+            "sync",
+            {"ts": 0, "behind": None, "status": "ready"},
+            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+        ),
+    ]
+
+    def retrieve_data_show_replicas():
+        return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")))
+
+    mg_sleep_and_assert_collection(expected_data_on_main, retrieve_data_show_replicas)
+
+    interactive_mg_runner.kill(inner_instances_description, "instance_3")
+
+    coord_cursor = connect(host="localhost", port=7692).cursor()
+
+    def retrieve_data_show_repl_cluster():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
+
+    expected_data_on_coord = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
+    ]
+
+    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
+
+    new_main_cursor = connect(host="localhost", port=7687).cursor()
+
+    def retrieve_data_show_replicas():
+        return sorted(list(execute_and_fetch_all(new_main_cursor, "SHOW REPLICAS;")))
+
+    expected_data_on_new_main = [
+        (
+            "instance_2",
+            "localhost:10002",
+            "sync",
+            {"ts": 0, "behind": None, "status": "ready"},
+            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+        ),
+        (
+            "instance_3",
+            "localhost:10003",
+            "sync",
+            {"ts": 0, "behind": None, "status": "invalid"},
+            {"memgraph": {"ts": 0, "behind": 0, "status": "invalid"}},
+        ),
+    ]
+    mg_sleep_and_assert_collection(expected_data_on_new_main, retrieve_data_show_replicas)
+
+    interactive_mg_runner.start(inner_instances_description, "instance_3")
+    expected_data_on_new_main_old_alive = [
+        (
+            "instance_2",
+            "localhost:10002",
+            "sync",
+            {"ts": 0, "behind": None, "status": "ready"},
+            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+        ),
+        (
+            "instance_3",
+            "localhost:10003",
+            "sync",
+            {"ts": 0, "behind": None, "status": "ready"},
+            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+        ),
+    ]
+
+    mg_sleep_and_assert_collection(expected_data_on_new_main_old_alive, retrieve_data_show_replicas)
+
+
+def test_distributed_automatic_failover_with_leadership_change(test_name):
+    inner_instances_description = get_instances_description_no_setup(test_name=test_name)
+
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+    for query in get_default_setup_queries():
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    interactive_mg_runner.kill(inner_instances_description, "coordinator_3")
+    interactive_mg_runner.kill(inner_instances_description, "instance_3")
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    def show_instances_coord2():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+
+    leader_data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
+    ]
+
+    wait_for_status_change(show_instances_coord1, {"instance_1", "instance_2"}, "main")
+    wait_for_status_change(show_instances_coord1, {"instance_3"}, "unknown")
+
+    leader_name = find_instance_and_assert_instances(
+        instance_role="leader", num_coordinators=3, coord_ids_to_skip_validation={3}
+    )
+    main_name = find_instance_and_assert_instances(
+        instance_role="main", num_coordinators=3, coord_ids_to_skip_validation={3}
+    )
+
+    leader_data = update_tuple_value(leader_data, main_name, 0, -1, "main")
+    leader_data = update_tuple_value(leader_data, leader_name, 0, -1, "leader")
+
+    mg_sleep_and_assert(leader_data, show_instances_coord1)
+    mg_sleep_and_assert(leader_data, show_instances_coord2)
+
+    def connect_to_main_instance():
+        main_instance_name = main_name
+        assert main_instance_name is not None
+
+        port_mapping = {"instance_1": 7687, "instance_2": 7688}
+
+        assert main_instance_name in port_mapping, f"Main is not in mappings, but main is {main_instance_name}"
+
+        main_instance_port = port_mapping.get(main_instance_name)
+
+        if main_instance_port is not None:
+            return connect(host="localhost", port=main_instance_port).cursor()
+
+        return None
+
+    new_main_cursor = connect_to_main_instance()
+    assert new_main_cursor is not None, "Main cursor is not found!"
+
+    def retrieve_data_show_replicas():
+        return sorted(list(execute_and_fetch_all(new_main_cursor, "SHOW REPLICAS;")))
+
+    all_possible_states = [
+        (
+            "instance_1",
+            "localhost:10001",
+            "sync",
+            {"ts": 0, "behind": None, "status": "ready"},
+            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+        ),
+        (
+            "instance_2",
+            "localhost:10002",
+            "sync",
+            {"ts": 0, "behind": None, "status": "ready"},
+            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+        ),
+        (
+            "instance_3",
+            "localhost:10003",
+            "sync",
+            {"ts": 0, "behind": None, "status": "invalid"},
+            {"memgraph": {"ts": 0, "behind": 0, "status": "invalid"}},
+        ),
+    ]
+
+    expected_data_on_new_main = [state for state in all_possible_states if state[0] != main_name]
+    mg_sleep_and_assert_collection(expected_data_on_new_main, retrieve_data_show_replicas)
+
+    interactive_mg_runner.start(inner_instances_description, "instance_3")
+
+    all_possible_states = [
+        (
+            "instance_1",
+            "localhost:10001",
+            "sync",
+            {"ts": 0, "behind": None, "status": "ready"},
+            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+        ),
+        (
+            "instance_2",
+            "localhost:10002",
+            "sync",
+            {"ts": 0, "behind": None, "status": "ready"},
+            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+        ),
+        (
+            "instance_3",
+            "localhost:10003",
+            "sync",
+            {"ts": 0, "behind": None, "status": "ready"},
+            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+        ),
+    ]
+    expected_data_on_new_main_old_alive = [state for state in all_possible_states if state[0] != main_name]
+    mg_sleep_and_assert_collection(expected_data_on_new_main_old_alive, retrieve_data_show_replicas)
+
+    interactive_mg_runner.start(inner_instances_description, "coordinator_3")
+
+
+def test_no_leader_after_leader_and_follower_die(test_name):
+    # 1. Register all but one replication instance on the first leader.
+    # 2. Kill the leader and a follower.
+    # 3. Check that the remaining follower is not promoted to leader by trying to register remaining replication instance.
+
+    inner_memgraph_instances = get_instances_description_no_setup(test_name=test_name)
+    interactive_mg_runner.start_all(inner_memgraph_instances, keep_directories=False)
+
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+
+    for query in get_default_setup_queries():
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    interactive_mg_runner.kill(inner_memgraph_instances, "coordinator_3")
+    interactive_mg_runner.kill(inner_memgraph_instances, "coordinator_2")
+
+    coord_1_data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "unknown", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "unknown", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "unknown", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
+    ]
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+
+    mg_sleep_and_assert(coord_1_data, show_instances_coord1)
+
+    with pytest.raises(Exception) as e:
+        execute_and_fetch_all(
+            coord_cursor_1,
+            "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+        )
+        assert "Couldn't register replica instance since coordinator is not a leader!" in str(e)
+
+
+def test_old_main_comes_back_on_new_leader_as_main(test_name):
+    # 1. Start all instances.
+    # 2. Kill all instances
+    # 3. Kill the leader
+    # 4. Start the old main instance
+    # 5. Run SHOW INSTANCES on the new leader and check that the old main instance is main once again
+
+    inner_memgraph_instances = get_instances_description_no_setup(test_name=test_name)
+    interactive_mg_runner.start_all(inner_memgraph_instances, keep_directories=False)
+
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+
+    for query in get_default_setup_queries():
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    interactive_mg_runner.kill(inner_memgraph_instances, "instance_1")
+    interactive_mg_runner.kill(inner_memgraph_instances, "instance_2")
+    interactive_mg_runner.kill(inner_memgraph_instances, "instance_3")
+    interactive_mg_runner.kill(inner_memgraph_instances, "coordinator_3")
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    def show_instances_coord2():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+
+    interactive_mg_runner.start(inner_memgraph_instances, "instance_3")
+
+    coord1_leader_data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    coord2_leader_data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "leader"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    mg_sleep_and_assert_multiple(
+        [coord1_leader_data, coord2_leader_data], [show_instances_coord1, show_instances_coord2]
+    )
+    mg_sleep_and_assert_multiple(
+        [coord1_leader_data, coord2_leader_data], [show_instances_coord1, show_instances_coord2]
+    )
+
+    interactive_mg_runner.start(inner_memgraph_instances, "instance_1")
+    interactive_mg_runner.start(inner_memgraph_instances, "instance_2")
+
+    new_main_cursor = connect(host="localhost", port=7689).cursor()
+
+    def show_replicas():
+        return sorted(list(execute_and_fetch_all(new_main_cursor, "SHOW REPLICAS;")))
+
+    replicas = [
+        (
+            "instance_1",
+            "localhost:10001",
+            "sync",
+            {"ts": 0, "behind": None, "status": "ready"},
+            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+        ),
+        (
+            "instance_2",
+            "localhost:10002",
+            "sync",
+            {"ts": 0, "behind": None, "status": "ready"},
+            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+        ),
+    ]
+    mg_sleep_and_assert_collection(replicas, show_replicas)
+
+    execute_and_fetch_all(new_main_cursor, "CREATE (n:Node {name: 'node'})")
+
+    replica_1_cursor = connect(host="localhost", port=7687).cursor()
+    assert len(execute_and_fetch_all(replica_1_cursor, "MATCH (n) RETURN n;")) == 1
+
+    replica_2_cursor = connect(host="localhost", port=7688).cursor()
+    assert len(execute_and_fetch_all(replica_2_cursor, "MATCH (n) RETURN n;")) == 1
+
+    interactive_mg_runner.start(inner_memgraph_instances, "coordinator_3")
+
+
+def test_registering_4_coords(test_name):
+    # Goal of this test is to assure registering of multiple coordinators in row works
+    INSTANCES_DESCRIPTION = {
+        "instance_1": {
+            "args": [
+                "--experimental-enabled=high-availability",
+                "--bolt-port",
+                "7687",
+                "--log-level",
+                "TRACE",
+                "--management-port",
+                "10011",
+            ],
+            "log_file": f"{get_logs_path(file, test_name)}/instance_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_1",
+            "setup_queries": [],
+        },
+        "instance_2": {
+            "args": [
+                "--experimental-enabled=high-availability",
+                "--bolt-port",
+                "7688",
+                "--log-level",
+                "TRACE",
+                "--management-port",
+                "10012",
+            ],
+            "log_file": f"{get_logs_path(file, test_name)}/instance_2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_2",
+            "setup_queries": [],
+        },
+        "instance_3": {
+            "args": [
+                "--experimental-enabled=high-availability",
+                "--bolt-port",
+                "7689",
+                "--log-level",
+                "TRACE",
+                "--management-port",
+                "10013",
+            ],
+            "log_file": f"{get_logs_path(file, test_name)}/instance_3.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_3",
+            "setup_queries": [],
+        },
+        "coordinator_1": {
+            "args": [
+                "--experimental-enabled=high-availability",
+                "--bolt-port",
+                "7690",
+                "--log-level=TRACE",
+                "--coordinator-id=1",
+                "--coordinator-port=10111",
+                "--management-port=10121",
+                "--coordinator-hostname=localhost",
+            ],
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_1",
+            "setup_queries": [],
+        },
+        "coordinator_2": {
+            "args": [
+                "--experimental-enabled=high-availability",
+                "--bolt-port",
+                "7691",
+                "--log-level=TRACE",
+                "--coordinator-id=2",
+                "--coordinator-port=10112",
+                "--management-port=10122",
+                "--coordinator-hostname=localhost",
+            ],
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_2",
+            "setup_queries": [],
+        },
+        "coordinator_3": {
+            "args": [
+                "--experimental-enabled=high-availability",
+                "--bolt-port",
+                "7692",
+                "--log-level=TRACE",
+                "--coordinator-id=3",
+                "--coordinator-port=10113",
+                "--management-port=10123",
+                "--coordinator-hostname=localhost",
+            ],
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_3.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_3",
+            "setup_queries": [],
+        },
+        "coordinator_4": {
+            "args": [
+                "--experimental-enabled=high-availability",
+                "--bolt-port",
+                "7693",
+                "--log-level=TRACE",
+                "--coordinator-id=4",
+                "--coordinator-port=10114",
+                "--management-port=10124",
+                "--coordinator-hostname=localhost",
+            ],
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_4.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_4",
+            "setup_queries": [
+                "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111', 'management_server': 'localhost:10121'}",
+                "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112', 'management_server': 'localhost:10122'}",
+                "ADD COORDINATOR 3 WITH CONFIG {'bolt_server': 'localhost:7692', 'coordinator_server': 'localhost:10113', 'management_server': 'localhost:10123'}",
+                "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+                "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+                "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
+                "SET INSTANCE instance_3 TO MAIN",
+            ],
+        },
+    }
+
+    interactive_mg_runner.start_all(INSTANCES_DESCRIPTION, keep_directories=False)
+
+    coord_cursor = connect(host="localhost", port=7693).cursor()
+
+    def retrieve_data_show_repl_cluster():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
+
+    expected_data_on_coord = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
+        ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
+
+
+def test_registering_coord_log_store(test_name):
+    # Goal of this test is to assure registering a bunch of instances and de-registering works properly
+    # w.r.t nuRaft log
+    # 1. Start basic instances # 3 logs
+    # 2. Check all is there
+    # 3. Create 3 additional instances and add them to cluster # 3 logs -> 1st snapshot
+    # 4. Check everything is there
+    # 5. Set main # 1 log
+    # 6. Check correct state
+    # 7. Drop 2 new instances # 2 logs
+    # 8. Check correct state
+    # 9. Drop 1 new instance # 1 log -> 2nd snapshot
+    # 10. Check correct state
+
+    INSTANCES_DESCRIPTION = {
+        "instance_1": {
+            "args": [
+                "--experimental-enabled=high-availability",
+                "--bolt-port",
+                "7687",
+                "--log-level",
+                "TRACE",
+                "--management-port",
+                "10011",
+            ],
+            "log_file": f"{get_logs_path(file, test_name)}/instance_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_1",
+            "setup_queries": [],
+        },
+        "instance_2": {
+            "args": [
+                "--experimental-enabled=high-availability",
+                "--bolt-port",
+                "7688",
+                "--log-level",
+                "TRACE",
+                "--management-port",
+                "10012",
+            ],
+            "log_file": f"{get_logs_path(file, test_name)}/instance_2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_2",
+            "setup_queries": [],
+        },
+        "instance_3": {
+            "args": [
+                "--experimental-enabled=high-availability",
+                "--bolt-port",
+                "7689",
+                "--log-level",
+                "TRACE",
+                "--management-port",
+                "10013",
+            ],
+            "log_file": f"{get_logs_path(file, test_name)}/instance_3.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_3",
+            "setup_queries": [],
+        },
+        "coordinator_1": {
+            "args": [
+                "--experimental-enabled=high-availability",
+                "--bolt-port",
+                "7690",
+                "--log-level=TRACE",
+                "--coordinator-id=1",
+                "--coordinator-port=10111",
+                "--coordinator-hostname",
+                "localhost",
+                "--management-port=10121",
+            ],
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_1",
+            "setup_queries": [],
+        },
+        "coordinator_2": {
+            "args": [
+                "--experimental-enabled=high-availability",
+                "--bolt-port",
+                "7691",
+                "--log-level=TRACE",
+                "--coordinator-id=2",
+                "--coordinator-port=10112",
+                "--coordinator-hostname",
+                "localhost",
+                "--management-port=10122",
+            ],
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_2",
+            "setup_queries": [],
+        },
+        "coordinator_3": {
+            "args": [
+                "--experimental-enabled=high-availability",
+                "--bolt-port",
+                "7692",
+                "--log-level=TRACE",
+                "--coordinator-id=3",
+                "--coordinator-port=10113",
+                "--coordinator-hostname",
+                "localhost",
+                "--management-port=10123",
+            ],
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_3.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_3",
+            "setup_queries": [],
+        },
+        "coordinator_4": {
+            "args": [
+                "--experimental-enabled=high-availability",
+                "--bolt-port",
+                "7693",
+                "--log-level=TRACE",
+                "--coordinator-id=4",
+                "--coordinator-port=10114",
+                "--coordinator-hostname",
+                "localhost",
+                "--management-port=10124",
+            ],
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_4.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_4",
+            "setup_queries": [
+                "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111', 'management_server': 'localhost:10121'}",
+                "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112', 'management_server': 'localhost:10122'}",
+                "ADD COORDINATOR 3 WITH CONFIG {'bolt_server': 'localhost:7692', 'coordinator_server': 'localhost:10113',  'management_server': 'localhost:10123'}",
+                "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+                "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+                "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
+            ],
+        },
+    }
+    assert "SET INSTANCE instance_3 TO MAIN" not in INSTANCES_DESCRIPTION["coordinator_4"]["setup_queries"]
+
+    # 1
+    interactive_mg_runner.start_all(INSTANCES_DESCRIPTION, keep_directories=False)
+
+    # 2
+    coord_cursor = connect(host="localhost", port=7693).cursor()
+
+    def retrieve_data_show_repl_cluster():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
+
+    coordinators = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
+        ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "leader"),
+    ]
+
+    basic_instances = [
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
+    ]
+
+    expected_data_on_coord = []
+    expected_data_on_coord.extend(coordinators)
+    expected_data_on_coord.extend(basic_instances)
+
+    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
+
+    # 3
+    instances_ports_added = [10011, 10012, 10013]
+    bolt_port_id = 7700
+    manag_port_id = 10014
+
+    additional_instances = []
+    for i in range(4, 7):
+        instance_name = f"instance_{i}"
+        args_desc = [
+            "--experimental-enabled=high-availability",
+            "--log-level=TRACE",
+        ]
+
+        bolt_port = f"--bolt-port={bolt_port_id}"
+
+        manag_server_port = f"--management-port={manag_port_id}"
+
+        args_desc.append(bolt_port)
+        args_desc.append(manag_server_port)
+
+        instance_description = {
+            "args": args_desc,
+            "log_file": f"{get_logs_path(file, test_name)}/instance_{i}.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_{i}",
+            "setup_queries": [],
+        }
+
+        full_instance_desc = {instance_name: instance_description}
+        interactive_mg_runner.start(full_instance_desc, instance_name)
+        repl_port_id = manag_port_id - 10
+        assert repl_port_id < 10011, "Wrong test setup, repl port must be smaller than smallest coord port id"
+
+        bolt_server = f"localhost:{bolt_port_id}"
+        management_server = f"localhost:{manag_port_id}"
+        repl_server = f"localhost:{repl_port_id}"
+
+        config_str = f"{{'bolt_server': '{bolt_server}', 'management_server': '{management_server}', 'replication_server': '{repl_server}'}}"
+
+        execute_and_fetch_all(
+            coord_cursor,
+            f"REGISTER INSTANCE {instance_name} WITH CONFIG {config_str}",
+        )
+
+        additional_instances.append((f"{instance_name}", bolt_server, "", management_server, "up", "replica"))
+        instances_ports_added.append(manag_port_id)
+        manag_port_id += 1
+        bolt_port_id += 1
+
+    # 4
+    expected_data_on_coord.extend(additional_instances)
+
+    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
+
+    # 5
+    execute_and_fetch_all(coord_cursor, "SET INSTANCE instance_3 TO MAIN")
+
+    # 6
+    basic_instances.pop()
+    basic_instances.append(("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"))
+
+    new_expected_data_on_coordinator = []
+
+    new_expected_data_on_coordinator.extend(coordinators)
+    new_expected_data_on_coordinator.extend(basic_instances)
+    new_expected_data_on_coordinator.extend(additional_instances)
+
+    mg_sleep_and_assert(new_expected_data_on_coordinator, retrieve_data_show_repl_cluster)
+
+    # 7
+    for i in range(6, 4, -1):
+        execute_and_fetch_all(coord_cursor, f"UNREGISTER INSTANCE instance_{i};")
+        additional_instances.pop()
+
+    new_expected_data_on_coordinator = []
+    new_expected_data_on_coordinator.extend(coordinators)
+    new_expected_data_on_coordinator.extend(basic_instances)
+    new_expected_data_on_coordinator.extend(additional_instances)
+
+    # 8
+    mg_sleep_and_assert(new_expected_data_on_coordinator, retrieve_data_show_repl_cluster)
+
+    # 9
+
+    new_expected_data_on_coordinator = []
+    new_expected_data_on_coordinator.extend(coordinators)
+    new_expected_data_on_coordinator.extend(basic_instances)
+
+    execute_and_fetch_all(coord_cursor, f"UNREGISTER INSTANCE instance_4;")
+
+    # 10
+    mg_sleep_and_assert(new_expected_data_on_coordinator, retrieve_data_show_repl_cluster)
+
+
+def test_multiple_failovers_in_row_no_leadership_change(test_name):
+    # Goal of this test is to assure multiple failovers in row work without leadership change
+    # 1. Start basic instances
+    # 2. Check all is there
+    # 3. Kill MAIN (instance_3)
+    # 4. Expect failover (instance_1)
+    # 5. Kill instance_1
+    # 6. Expect failover instance_2
+    # 7. Start instance_3
+    # 8. Expect instance_3 and instance_2 (MAIN) up
+    # 9. Kill instance_2
+    # 10. Expect instance_3 MAIN
+    # 11. Write some data on instance_3
+    # 12. Start instance_2 and instance_1
+    # 13. Expect instance_1 and instance2 to be up and cluster to have correct state
+    # 13. Expect data to be replicated
+
+    # 1
+    inner_memgraph_instances = get_instances_description_no_setup(test_name=test_name)
+    interactive_mg_runner.start_all(inner_memgraph_instances, keep_directories=False)
+
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+
+    for query in get_default_setup_queries():
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    # 2
+
+    def get_func_show_instances(cursor):
+        def show_instances_follower_coord():
+            return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(cursor, "SHOW INSTANCES;"))))
+
+        return show_instances_follower_coord
+
+    data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
+    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
+    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
+
+    # 3
+
+    interactive_mg_runner.kill(inner_memgraph_instances, "instance_3")
+
+    # 4
+
+    data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
+    ]
+
+    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
+    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
+    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
+
+    # 5
+    interactive_mg_runner.kill(inner_memgraph_instances, "instance_1")
+
+    # 6
+    data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "main"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
+    ]
+
+    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
+    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
+    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
+
+    # 7
+
+    interactive_mg_runner.start(inner_memgraph_instances, "instance_3")
+
+    # 8
+
+    data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "main"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
+    ]
+
+    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
+    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
+    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
+
+    # 9
+    interactive_mg_runner.kill(inner_memgraph_instances, "instance_2")
+
+    # 10
+    data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
+    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
+    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
+
+    # 11
+
+    instance_3_cursor = connect(port=7689, host="localhost").cursor()
+
+    with pytest.raises(Exception) as e:
+        execute_and_fetch_all(instance_3_cursor, "CREATE ();")
+    assert "At least one SYNC replica has not confirmed committing last transaction." in str(e.value)
+
+    # 12
+    interactive_mg_runner.start(inner_memgraph_instances, "instance_1")
+    interactive_mg_runner.start(inner_memgraph_instances, "instance_2")
+
+    # 13
+    data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
+    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
+    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
+
+    # 14.
+
+    def show_replicas():
+        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+
+    replicas = [
+        (
+            "instance_1",
+            "localhost:10001",
+            "sync",
+            {"ts": 0, "behind": None, "status": "ready"},
+            {"memgraph": {"ts": 2, "behind": 0, "status": "ready"}},
+        ),
+        (
+            "instance_2",
+            "localhost:10002",
+            "sync",
+            {"ts": 0, "behind": None, "status": "ready"},
+            {"memgraph": {"ts": 2, "behind": 0, "status": "ready"}},
+        ),
+    ]
+    mg_sleep_and_assert_collection(replicas, show_replicas)
+
+    def get_vertex_count_func(cursor):
+        def get_vertex_count():
+            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+        return get_vertex_count
+
+    mg_sleep_and_assert(1, get_vertex_count_func(connect(port=7687, host="localhost").cursor()))
+
+    mg_sleep_and_assert(1, get_vertex_count_func(connect(port=7688, host="localhost").cursor()))
+
+
+def test_multiple_old_mains_single_failover(test_name):
+    # Goal of this test is to check when leadership changes
+    # and we have old MAIN down, that we don't start failover
+    # 1. Start all instances.
+    # 2. Kill the main instance
+    # 3. Do failover
+    # 4. Kill other main
+    # 5. Kill leader
+    # 6. Leave first main down, and start second main
+    # 7. Second main should write data to new instance all the time
+
+    # 1
+    inner_instances_description = get_instances_description_no_setup(test_name=test_name)
+
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+    for query in get_default_setup_queries():
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    def retrieve_data_show_repl_cluster():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+
+    coordinators = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+    ]
+
+    basic_instances = [
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    expected_data_on_coord = []
+    expected_data_on_coord.extend(coordinators)
+    expected_data_on_coord.extend(basic_instances)
+
+    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
+
+    # 2
+
+    interactive_mg_runner.kill(inner_instances_description, "instance_3")
+
+    # 3
+
+    basic_instances = [
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
+    ]
+
+    expected_data_on_coord = []
+    expected_data_on_coord.extend(coordinators)
+    expected_data_on_coord.extend(basic_instances)
+
+    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
+
+    # 4
+
+    interactive_mg_runner.kill(inner_instances_description, "instance_1")
+
+    # 5
+    interactive_mg_runner.kill(inner_instances_description, "coordinator_3")
+
+    # 6
+
+    interactive_mg_runner.start(inner_instances_description, "instance_1")
+
+    # 7
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    def show_instances_coord2():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+
+    coord1_leader_data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
+    ]
+
+    coord2_leader_data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "leader"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
+    ]
+
+    mg_sleep_and_assert_multiple(
+        [coord1_leader_data, coord2_leader_data], [show_instances_coord1, show_instances_coord2]
+    )
+    mg_sleep_and_assert_multiple(
+        [coord1_leader_data, coord2_leader_data], [show_instances_coord1, show_instances_coord2]
+    )
+
+    instance_1_cursor = connect(host="localhost", port=7687).cursor()
+
+    def show_replicas():
+        return sorted(list(execute_and_fetch_all(instance_1_cursor, "SHOW REPLICAS;")))
+
+    replicas = [
+        (
+            "instance_2",
+            "localhost:10002",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+        (
+            "instance_3",
+            "localhost:10003",
+            "sync",
+            {"behind": None, "status": "invalid", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "invalid", "ts": 0}},
+        ),
+    ]
+    mg_sleep_and_assert_collection(replicas, show_replicas)
+
+    def get_vertex_count_func(cursor):
+        def get_vertex_count():
+            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+        return get_vertex_count
+
+    vertex_count = 0
+    instance_1_cursor = connect(port=7687, host="localhost").cursor()
+    instance_2_cursor = connect(port=7688, host="localhost").cursor()
+
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+
+    time_slept = 0
+    failover_time = 5
+    while time_slept < failover_time:
+        with pytest.raises(Exception) as e:
+            execute_and_fetch_all(instance_1_cursor, "CREATE ();")
+        vertex_count += 1
+
+        assert vertex_count == execute_and_fetch_all(instance_1_cursor, "MATCH (n) RETURN count(n);")[0][0]
+        assert vertex_count == execute_and_fetch_all(instance_2_cursor, "MATCH (n) RETURN count(n);")[0][0]
+        time.sleep(0.1)
+        time_slept += 0.1
+
+
+def test_force_reset_works_after_failed_registration(test_name):
+    # Goal of this test is to check that force reset works after failed registration
+    # 1. Start all instances.
+    # 2. Check everything works correctly
+    # 3. Try register instance which doesn't exist
+    # 4. Enter force reset
+    # 5. Check that everything works correctly
+
+    # 1
+    inner_instances_description = get_instances_description_no_setup(test_name=test_name)
+
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+    for query in get_default_setup_queries():
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    # 2
+
+    def show_instances_coord3():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    def show_instances_coord2():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+
+    data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    mg_sleep_and_assert(data, show_instances_coord3)
+    mg_sleep_and_assert(data, show_instances_coord1)
+    mg_sleep_and_assert(data, show_instances_coord2)
+
+    instance_3_cursor = connect(host="localhost", port=7689).cursor()
+
+    def show_replicas():
+        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+
+    replicas = [
+        (
+            "instance_1",
+            "localhost:10001",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+        (
+            "instance_2",
+            "localhost:10002",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+    ]
+    mg_sleep_and_assert_collection(replicas, show_replicas)
+
+    def get_vertex_count_func(cursor):
+        def get_vertex_count():
+            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+        return get_vertex_count
+
+    vertex_count = 0
+    instance_1_cursor = connect(port=7687, host="localhost").cursor()
+    instance_2_cursor = connect(port=7688, host="localhost").cursor()
+
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+
+    with pytest.raises(Exception) as e:
+        execute_and_fetch_all(
+            coord_cursor_3,
+            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': 'localhost:10050', 'replication_server': 'localhost:10051'};",
+        )
+
+    # This will trigger force reset and choosing of new instance as MAIN
+    data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
+    ]
+
+    leader_name = find_instance_and_assert_instances(instance_role="leader", num_coordinators=3)
+
+    main_name = find_instance_and_assert_instances(instance_role="main", num_coordinators=3)
+
+    assert leader_name is not None, "leader is None"
+    assert main_name is not None, "Main is None"
+
+    data = update_tuple_value(data, leader_name, 0, -1, "leader")
+    data = update_tuple_value(data, main_name, 0, -1, "main")
+
+    mg_sleep_and_assert(data, show_instances_coord3)
+    mg_sleep_and_assert(data, show_instances_coord1)
+    mg_sleep_and_assert(data, show_instances_coord2)
+
+    def get_port(instance_name):
+        mappings = {
+            "instance_1": 7687,
+            "instance_2": 7688,
+            "instance_3": 7689,
+        }
+        return mappings[instance_name]
+
+    instance_main_cursor = connect(port=get_port(main_name), host="localhost").cursor()
+    vertex_count = 10
+    for _ in range(vertex_count):
+        execute_and_fetch_all(instance_main_cursor, "CREATE ();")
+
+    def get_vertex_count_func(cursor):
+        def get_vertex_count():
+            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+        return get_vertex_count
+
+    for instance in ["instance_1", "instance_2", "instance_3"]:
+        cursor = connect(port=get_port(instance), host="localhost").cursor()
+        mg_sleep_and_assert(vertex_count, get_vertex_count_func(cursor))
+
+
+def test_force_reset_works_after_failed_registration_and_replica_down(test_name):
+    # Goal of this test is to check when action fails, that force reset happens
+    # and everything works correctly when REPLICA is down (can be demoted but doesn't have to - we demote it)
+    # 1. Start all instances.
+    # 2. Check everything works correctly
+    # 3. Kill replica
+    # 4. Try to register instance which doesn't exist
+    # 4. Enter force reset
+    # 5. Check that everything works correctly with two instances
+    # 6. Start replica instance
+    # 7. Check that replica is correctly demoted to replica
+
+    # 1
+    inner_instances_description = get_instances_description_no_setup(test_name=test_name)
+
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+    for query in get_default_setup_queries():
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    # 2
+
+    def show_instances_coord3():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    def show_instances_coord2():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+
+    data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    mg_sleep_and_assert(data, show_instances_coord3)
+    mg_sleep_and_assert(data, show_instances_coord1)
+    mg_sleep_and_assert(data, show_instances_coord2)
+
+    instance_3_cursor = connect(host="localhost", port=7689).cursor()
+
+    def show_replicas():
+        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+
+    replicas = [
+        (
+            "instance_1",
+            "localhost:10001",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+        (
+            "instance_2",
+            "localhost:10002",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+    ]
+    mg_sleep_and_assert_collection(replicas, show_replicas)
+
+    def get_vertex_count_func(cursor):
+        def get_vertex_count():
+            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+        return get_vertex_count
+
+    vertex_count = 0
+    instance_1_cursor = connect(port=7687, host="localhost").cursor()
+    instance_2_cursor = connect(port=7688, host="localhost").cursor()
+
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+
+    # 3
+
+    interactive_mg_runner.kill(inner_instances_description, "instance_2")
+
+    # 4
+
+    with pytest.raises(Exception) as e:
+        execute_and_fetch_all(
+            coord_cursor_3,
+            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': 'localhost:10050', 'replication_server': 'localhost:10051'};",
+        )
+
+    # 5
+    # This will trigger verify and correct cluster state, where we shouldn't choose new MAIN
+    data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    leader_name = "coordinator_3"
+
+    main_name = "instance_3"
+
+    assert leader_name is not None, "leader is None"
+    assert main_name is not None, "Main is None"
+
+    data = update_tuple_value(data, leader_name, 0, -1, "leader")
+    data = update_tuple_value(data, main_name, 0, -1, "main")
+
+    mg_sleep_and_assert(data, show_instances_coord3)
+    mg_sleep_and_assert(data, show_instances_coord1)
+    mg_sleep_and_assert(data, show_instances_coord2)
+
+    # 6
+
+    interactive_mg_runner.start(inner_instances_description, "instance_2")
+
+    # 7
+
+    data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
+    ]
+
+    data = update_tuple_value(data, leader_name, 0, -1, "leader")
+    data = update_tuple_value(data, main_name, 0, -1, "main")
+
+    mg_sleep_and_assert(data, show_instances_coord3)
+    mg_sleep_and_assert(data, show_instances_coord1)
+    mg_sleep_and_assert(data, show_instances_coord2)
+
+    def get_port(instance_name):
+        mappings = {
+            "instance_1": 7687,
+            "instance_2": 7688,
+            "instance_3": 7689,
+        }
+        return mappings[instance_name]
+
+    main_cursor = connect(port=get_port(main_name), host="localhost").cursor()
+
+    def show_replicas():
+        return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")))
+
+    replicas = [
+        (
+            "instance_1",
+            "localhost:10001",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+        (
+            "instance_2",
+            "localhost:10002",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+        (
+            "instance_3",
+            "localhost:10003",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+    ]
+    replicas = [replica for replica in replicas if replica[0] != main_name]
+    mg_sleep_and_assert_collection(replicas, show_replicas)
+
+    # 8
+
+    vertex_count = 10
+    for _ in range(vertex_count):
+        execute_and_fetch_all(main_cursor, "CREATE ();")
+
+    def get_vertex_count_func(cursor):
+        def get_vertex_count():
+            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+        return get_vertex_count
+
+    for instance in ["instance_1", "instance_2", "instance_3"]:
+        cursor = connect(port=get_port(instance), host="localhost").cursor()
+        mg_sleep_and_assert(vertex_count, get_vertex_count_func(cursor))
+
+
+def test_force_reset_works_after_failed_registration_and_2_coordinators_down(test_name):
+    # Goal of this test is to check when action fails, that force reset happens
+    # and everything works correctly after majority of coordinators is back up
+    # 1. Start all instances.
+    # 2. Check everything works correctly
+    # 3. Try to register instance which doesn't exist -> Enter force reset
+    # 4. Kill 2 coordinators
+    # 5. New action shouldn't succeed because of opened lock
+    # 6. Start one coordinator
+    # 7. Check that replica failover happens in force reset
+    # 8. Check that everything works correctly
+
+    # 1
+    inner_instances_description = get_instances_description_no_setup(test_name=test_name)
+
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+    for query in get_default_setup_queries():
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    # 2
+
+    def show_instances_coord3():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    def show_instances_coord2():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+
+    data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    mg_sleep_and_assert(data, show_instances_coord3)
+    mg_sleep_and_assert(data, show_instances_coord1)
+    mg_sleep_and_assert(data, show_instances_coord2)
+
+    instance_3_cursor = connect(host="localhost", port=7689).cursor()
+
+    def show_replicas():
+        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+
+    replicas = [
+        (
+            "instance_1",
+            "localhost:10001",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+        (
+            "instance_2",
+            "localhost:10002",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+    ]
+    mg_sleep_and_assert_collection(replicas, show_replicas)
+
+    def get_vertex_count_func(cursor):
+        def get_vertex_count():
+            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+        return get_vertex_count
+
+    vertex_count = 0
+    instance_1_cursor = connect(port=7687, host="localhost").cursor()
+    instance_2_cursor = connect(port=7688, host="localhost").cursor()
+
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+
+    # 3
+
+    with pytest.raises(Exception) as _:
+        execute_and_fetch_all(
+            coord_cursor_3,
+            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': 'localhost:10050', 'replication_server': 'localhost:10051'};",
+        )
+
+    # 4
+    interactive_mg_runner.kill(inner_instances_description, "coordinator_2")
+    interactive_mg_runner.kill(inner_instances_description, "coordinator_3")
+
+    # 5
+    with pytest.raises(Exception) as e:
+        execute_and_fetch_all(
+            coord_cursor_1,
+            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': "
+            "'localhost:10050', 'replication_server': 'localhost:10051'};",
+        )
+
+    assert "Couldn't register replica instance since coordinator is not a leader!" in str(e.value)
+
+    # 6
+
+    interactive_mg_runner.start(inner_instances_description, "coordinator_2")
+
+    # 7
+    # main must be the same after leader election as before, we can't demote old main
+    leader_data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    leader_name = find_instance_and_assert_instances(
+        instance_role="leader", num_coordinators=3, coord_ids_to_skip_validation={3}
+    )
+
+    leader_data = update_tuple_value(leader_data, leader_name, 0, -1, "leader")
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    def show_instances_coord2():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+
+    mg_sleep_and_assert(leader_data, show_instances_coord1)
+
+    mg_sleep_and_assert(leader_data, show_instances_coord2)
+
+    def show_replicas():
+        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+
+    replicas = [
+        (
+            "instance_1",
+            "localhost:10001",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+        (
+            "instance_2",
+            "localhost:10002",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+    ]
+    mg_sleep_and_assert_collection(replicas, show_replicas)
+
+    # 8
+
+    vertex_count = 10
+    for _ in range(vertex_count):
+        execute_and_fetch_all(instance_3_cursor, "CREATE ();")
+
+    def get_vertex_count_func(cursor):
+        def get_vertex_count():
+            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+        return get_vertex_count
+
+    def get_port(instance_name):
+        mappings = {
+            "instance_1": 7687,
+            "instance_2": 7688,
+            "instance_3": 7689,
+        }
+        return mappings[instance_name]
+
+    for instance in ["instance_1", "instance_2", "instance_3"]:
+        cursor = connect(port=get_port(instance), host="localhost").cursor()
+        mg_sleep_and_assert(vertex_count, get_vertex_count_func(cursor))
+
+
+def test_coordinator_gets_info_on_other_coordinators(test_name):
+    # Goal of this test is to check that coordinator which has cluster state
+    # after restart gets info on other cluster also which is added in meantime
+    # 1. Start all instances.
+    # 2. Check everything works correctly
+    # 3. Kill one coordinator
+    # 4. Wait until it is down
+    # 5. Register new coordinator
+    # 6. Check that leaders and followers see each other
+    # 7. Start coordinator which is down
+    # 8. Check that such coordinator has correct info
+
+    # 1
+
+    inner_instances_description = get_instances_description_no_setup(test_name=test_name)
+
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+    for query in get_default_setup_queries():
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    # 2
+
+    def show_instances_coord3():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    def show_instances_coord2():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+
+    data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    mg_sleep_and_assert(data, show_instances_coord3)
+    mg_sleep_and_assert(data, show_instances_coord1)
+    mg_sleep_and_assert(data, show_instances_coord2)
+
+    instance_3_cursor = connect(host="localhost", port=7689).cursor()
+
+    def show_replicas():
+        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+
+    replicas = [
+        (
+            "instance_1",
+            "localhost:10001",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+        (
+            "instance_2",
+            "localhost:10002",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+    ]
+    mg_sleep_and_assert_collection(replicas, show_replicas)
+
+    def get_vertex_count_func(cursor):
+        def get_vertex_count():
+            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+        return get_vertex_count
+
+    vertex_count = 0
+    instance_1_cursor = connect(port=7687, host="localhost").cursor()
+    instance_2_cursor = connect(port=7688, host="localhost").cursor()
+
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+
+    # 3
+
+    interactive_mg_runner.kill(inner_instances_description, "coordinator_2")
+
+    # 4
+
+    while True:
+        try:
+            execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")
+            time.sleep(0.1)
+        except Exception:
+            break
+
+    # 5
+
+    other_instances = {
+        "coordinator_4": {
+            "args": [
+                "--experimental-enabled=high-availability",
+                "--bolt-port",
+                "7693",
+                "--log-level=TRACE",
+                "--coordinator-id=4",
+                "--coordinator-port=10114",
+                "--management-port=10124",
+                "--coordinator-hostname",
+                "localhost",
+            ],
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_4.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_4",
+            "setup_queries": [],
+        },
+    }
+
+    interactive_mg_runner.start(other_instances, "coordinator_4")
+    execute_and_fetch_all(
+        coord_cursor_3,
+        "ADD COORDINATOR 4 WITH CONFIG {'bolt_server': 'localhost:7693', 'coordinator_server': 'localhost:10114', 'management_server': 'localhost:10124'};",
+    )
+
+    # 6
+
+    coord_cursor_4 = connect(host="localhost", port=7693).cursor()
+
+    def show_instances_coord4():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_4, "SHOW INSTANCES;"))))
+
+    coord2_down_data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "down", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+    mg_sleep_and_assert(coord2_down_data, show_instances_coord3)
+    mg_sleep_and_assert(coord2_down_data, show_instances_coord1)
+    mg_sleep_and_assert(coord2_down_data, show_instances_coord4)
+
+    # 7
+
+    interactive_mg_runner.start(inner_instances_description, "coordinator_2")
+
+    # 8
+
+    coord2_up_data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    mg_sleep_and_assert(coord2_up_data, show_instances_coord2)
+
+
+def test_registration_works_after_main_set(test_name):
+    # This test tries to register first main and set it to main and afterwards register other instances
+    # 1. Start all instances.
+    # 2. Check everything works correctly
+
+    # 1
+    inner_instances_description = get_instances_description_no_setup(test_name=test_name)
+
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+    for query in get_default_setup_queries():
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    # 2
+
+    def show_instances_coord3():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    def show_instances_coord2():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+
+    data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    mg_sleep_and_assert(data, show_instances_coord3)
+    mg_sleep_and_assert(data, show_instances_coord1)
+    mg_sleep_and_assert(data, show_instances_coord2)
+
+    instance_3_cursor = connect(host="localhost", port=7689).cursor()
+
+    def show_replicas():
+        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+
+    replicas = [
+        (
+            "instance_1",
+            "localhost:10001",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+        (
+            "instance_2",
+            "localhost:10002",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+    ]
+    mg_sleep_and_assert_collection(replicas, show_replicas)
+
+    def get_vertex_count_func(cursor):
+        def get_vertex_count():
+            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+        return get_vertex_count
+
+    vertex_count = 0
+    instance_1_cursor = connect(port=7687, host="localhost").cursor()
+    instance_2_cursor = connect(port=7688, host="localhost").cursor()
+
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+
+
+def test_coordinator_not_leader_registration_does_not_work(test_name):
+    # Goal of this test is to check that it is not possible to register instance on follower coord
+    # 1. Start all instances.
+    # 2. Check everything works correctly
+    # 3. Try to register instance on follower coord
+
+    # 1
+    inner_instances_description = get_instances_description_no_setup(test_name=test_name)
+
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+    for query in get_default_setup_queries():
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    # 2
+
+    def show_instances_coord3():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    def show_instances_coord2():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+
+    data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+    mg_sleep_and_assert(data, show_instances_coord3)
+    mg_sleep_and_assert(data, show_instances_coord1)
+    mg_sleep_and_assert(data, show_instances_coord2)
+
+    instance_3_cursor = connect(host="localhost", port=7689).cursor()
+
+    def show_replicas():
+        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+
+    replicas = [
+        (
+            "instance_1",
+            "localhost:10001",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+        (
+            "instance_2",
+            "localhost:10002",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+    ]
+    mg_sleep_and_assert_collection(replicas, show_replicas)
+
+    def get_vertex_count_func(cursor):
+        def get_vertex_count():
+            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+        return get_vertex_count
+
+    vertex_count = 0
+    instance_1_cursor = connect(port=7687, host="localhost").cursor()
+    instance_2_cursor = connect(port=7688, host="localhost").cursor()
+
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+
+    # 3
+
+    with pytest.raises(Exception) as e:
+        execute_and_fetch_all(
+            coord_cursor_1,
+            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': "
+            "'localhost:10050', 'replication_server': 'localhost:10051'};",
+        )
+
+    assert (
+        "Couldn't register replica instance since coordinator is not a leader! Current leader is coordinator with id 3 with bolt socket address localhost:7692"
+        == str(e.value)
+    )
+
+
+def test_coordinator_user_action_demote_instance_to_replica(test_name):
+    # Goal of this test is to check that it is not possible to register instance on follower coord
+    # 1. Start all instances.
+    # 2. Check everything works correctly
+    # 3. Try to demote instance to replica
+    # 4. Check we have correct state
+
+    # 1
+    inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
+
+    FAILOVER_PERIOD = 2
+    inner_instances_description["instance_1"]["args"].append(f"--instance-down-timeout-sec={FAILOVER_PERIOD}")
+    inner_instances_description["instance_2"]["args"].append(f"--instance-down-timeout-sec={FAILOVER_PERIOD}")
+    inner_instances_description["instance_3"]["args"].append(f"--instance-down-timeout-sec={FAILOVER_PERIOD}")
+
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+    for query in get_default_setup_queries():
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    # 2
+
+    def show_instances_coord3():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    def show_instances_coord2():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+
+    data_original = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    mg_sleep_and_assert(data_original, show_instances_coord3)
+    mg_sleep_and_assert(data_original, show_instances_coord1)
+    mg_sleep_and_assert(data_original, show_instances_coord2)
+
+    instance_3_cursor = connect(host="localhost", port=7689).cursor()
+
+    def show_replicas():
+        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+
+    replicas = [
+        (
+            "instance_1",
+            "localhost:10001",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+        (
+            "instance_2",
+            "localhost:10002",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+    ]
+    mg_sleep_and_assert_collection(replicas, show_replicas)
+
+    def get_vertex_count_func(cursor):
+        def get_vertex_count():
+            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+        return get_vertex_count
+
+    vertex_count = 0
+    instance_1_cursor = connect(port=7687, host="localhost").cursor()
+    instance_2_cursor = connect(port=7688, host="localhost").cursor()
+
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+
+    # 3
+
+    execute_and_fetch_all(
+        coord_cursor_3,
+        "DEMOTE INSTANCE instance_3",
+    )
+
+    # 4.
+
+    data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
+    ]
+
+    mg_sleep_and_assert(data, show_instances_coord3)
+    mg_sleep_and_assert(data, show_instances_coord1)
+    mg_sleep_and_assert(data, show_instances_coord2)
+
+    with pytest.raises(Exception) as e:
+        execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")
+    assert str(e.value) == "Replica can't show registered replicas (it shouldn't have any)!"
+
+    mg_assert_until(data, show_instances_coord3, FAILOVER_PERIOD + 1)
+    mg_sleep_and_assert(data, show_instances_coord1)
+    mg_sleep_and_assert(data, show_instances_coord2)
+
+    execute_and_fetch_all(coord_cursor_3, "SET INSTANCE instance_3 TO MAIN;")
+
+    mg_sleep_and_assert(data_original, show_instances_coord3)
+    mg_sleep_and_assert(data_original, show_instances_coord1)
+    mg_sleep_and_assert(data_original, show_instances_coord2)
+
+
+def test_coordinator_user_action_force_reset_works(test_name):
+    # Goal of this test is to check that it is not possible to register instance on follower coord
+    # 1. Start all instances.
+    # 2. Check everything works correctly
+    # 3. Try force reset
+    # 4. Check we have correct state
+
+    # 1
+    inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
+
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+    for query in get_default_setup_queries():
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    # 2
+
+    def show_instances_coord3():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    def show_instances_coord2():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+
+    data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    mg_sleep_and_assert(data, show_instances_coord3)
+    mg_sleep_and_assert(data, show_instances_coord1)
+    mg_sleep_and_assert(data, show_instances_coord2)
+
+    instance_3_cursor = connect(host="localhost", port=7689).cursor()
+
+    def show_replicas():
+        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+
+    replicas = [
+        (
+            "instance_1",
+            "localhost:10001",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+        (
+            "instance_2",
+            "localhost:10002",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+        ),
+    ]
+    mg_sleep_and_assert_collection(replicas, show_replicas)
+
+    def get_vertex_count_func(cursor):
+        def get_vertex_count():
+            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+        return get_vertex_count
+
+    vertex_count = 0
+    instance_1_cursor = connect(port=7687, host="localhost").cursor()
+    instance_2_cursor = connect(port=7688, host="localhost").cursor()
+
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+
+    # 3
+
+    execute_and_fetch_all(
+        coord_cursor_3,
+        "FORCE RESET CLUSTER STATE;",
+    )
+
+    # 4.
+
+    data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    mg_sleep_and_assert(data, show_instances_coord3)
+    mg_sleep_and_assert(data, show_instances_coord1)
+    mg_sleep_and_assert(data, show_instances_coord2)
+
+
+def test_all_coords_down_resume(test_name):
+    # Goal of this test is to check that coordinators are able to resume, if cluster is able to resume where it
+    # left off if all coordinators go down
+
+    # 1. Start cluster
+    # 2. Check everything works correctly
+    # 3. Stop all coordinators
+    # 4. Start 2 coordinators, one should be leader, and one follower
+    # 5. Check everything works correctly
+
+    # 1
+    inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
+
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+    for query in get_default_setup_queries():
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    # 2
+    def show_instances_coord3():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    def show_instances_coord2():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+
+    data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    mg_sleep_and_assert(data, show_instances_coord3)
+    mg_sleep_and_assert(data, show_instances_coord1)
+    mg_sleep_and_assert(data, show_instances_coord2)
+
+    # 3
+
+    interactive_mg_runner.kill(inner_instances_description, "coordinator_1")
+    interactive_mg_runner.kill(inner_instances_description, "coordinator_2")
+    interactive_mg_runner.kill(inner_instances_description, "coordinator_3")
+
+    # 4
+
+    with concurrent.futures.ThreadPoolExecutor(2) as executor:
+        executor.submit(interactive_mg_runner.start, inner_instances_description, "coordinator_2")
+        executor.submit(interactive_mg_runner.start, inner_instances_description, "coordinator_1")
+
+    # 5
+
+    leader_data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
+    ]
+
+    wait_for_status_change(show_instances_coord1, {"coordinator_1", "coordinator_2"}, "leader")
+
+    leader = find_instance_and_assert_instances(
+        instance_role="leader", num_coordinators=3, coord_ids_to_skip_validation={3}
+    )
+
+    main = find_instance_and_assert_instances(
+        instance_role="main", num_coordinators=3, coord_ids_to_skip_validation={3}
+    )
+    leader_data = update_tuple_value(leader_data, leader, 0, -1, "leader")
+    leader_data = update_tuple_value(leader_data, main, 0, -1, "main")
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    mg_sleep_and_assert(leader_data, show_instances_coord1)
+
+    mg_sleep_and_assert(leader_data, show_instances_coord2)
+
+    # 6
+    interactive_mg_runner.kill(inner_instances_description, "instance_3")
+    interactive_mg_runner.start(inner_instances_description, "coordinator_3")
+
+    # 7
+
+    leader_data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
+    ]
+
+    wait_for_status_change(show_instances_coord1, {"instance_3"}, "unknown")
+
+    leader = find_instance_and_assert_instances(instance_role="leader", num_coordinators=3)
+
+    main = find_instance_and_assert_instances(instance_role="main", num_coordinators=3)
+
+    leader_data = update_tuple_value(leader_data, leader, 0, -1, "leader")
+    leader_data = update_tuple_value(leader_data, main, 0, -1, "main")
+
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+
+    mg_sleep_and_assert(leader_data, show_instances_coord1)
+
+    mg_sleep_and_assert(leader_data, show_instances_coord2)
+
+    mg_sleep_and_assert(leader_data, show_instances_coord3)
+
+
+def test_one_coord_down_with_durability_resume(test_name):
+    # Goal of this test is to check that coordinators are able to resume, if cluster is able to resume where it
+    # left off if all coordinators go down
+
+    # 1. Start cluster
+    # 2. Check everything works correctly
+    # 3. Stop all coordinators
+    # 4. Start 2 coordinators, one should be leader, and one follower
+    # 5. Check everything works correctly
+
+    # 1
+    inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
+
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+
+    for query in get_default_setup_queries():
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    # 2
+    def show_instances_coord3():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    def show_instances_coord2():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+
+    data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    mg_sleep_and_assert(data, show_instances_coord3)
+    mg_sleep_and_assert(data, show_instances_coord1)
+    mg_sleep_and_assert(data, show_instances_coord2)
+
+    # 3
+
+    interactive_mg_runner.kill(inner_instances_description, "coordinator_1")
+
+    leader_data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "down", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+    mg_sleep_and_assert(leader_data, show_instances_coord3)
+
+    # 4
+    interactive_mg_runner.start(inner_instances_description, "coordinator_1")
+
+    # 5
+
+    data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    mg_sleep_and_assert(data, show_instances_coord3)
+    mg_sleep_and_assert(data, show_instances_coord1)
+    mg_sleep_and_assert(data, show_instances_coord2)
+
+    # 6
+    interactive_mg_runner.kill(inner_instances_description, "instance_3")
+
+    # 7
+
+    leader_data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
+    ]
+
+    mg_sleep_and_assert(leader_data, show_instances_coord3)
+    mg_sleep_and_assert(leader_data, show_instances_coord1)
+    mg_sleep_and_assert(leader_data, show_instances_coord2)
+
+
+def test_registration_does_not_deadlock_when_instance_is_down(test_name):
+    # Goal of this test is to assert that system doesn't deadlock in case of failure on registration
+
+    # 1
+    inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
+
+    interactive_mg_runner.start(inner_instances_description, "coordinator_1")
+    interactive_mg_runner.start(inner_instances_description, "coordinator_2")
+    interactive_mg_runner.start(inner_instances_description, "coordinator_3")
+
+    setup_queries = [
+        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111', 'management_server': 'localhost:10121'}",
+        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112', 'management_server': 'localhost:10122'}",
+    ]
+
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+    for query in setup_queries:
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    query = "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};"
+
+    with pytest.raises(Exception) as e:
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    assert "Couldn't register replica instance because setting instance to replica failed!" in str(e.value)
+
+    interactive_mg_runner.start(inner_instances_description, "instance_1")
+    execute_and_fetch_all(coord_cursor_3, query)
+
+    interactive_mg_runner.start(inner_instances_description, "instance_2")
+    interactive_mg_runner.start(inner_instances_description, "instance_3")
+
+    setup_queries = [
+        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
+        "SET INSTANCE instance_3 TO MAIN",
+    ]
+
+    for query in setup_queries:
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    def show_instances_coord3():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    def show_instances_coord2():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+
+    data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    mg_sleep_and_assert(data, show_instances_coord3)
+    mg_sleep_and_assert(data, show_instances_coord1)
+    mg_sleep_and_assert(data, show_instances_coord2)
+
+
+def test_follower_have_correct_health(test_name):
+    # Goal of this test is to check that coordinators are able to resume, if cluster is able to resume where it
+    # left off if all coordinators go down
+
+    # 1. Start cluster
+    # 2. Check everything works correctly
+    # 3. Stop all coordinators
+    # 4. Start 2 coordinators, one should be leader, and one follower
+    # 5. Check everything works correctly
+
+    # 1
+    inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
+
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+
+    setup_queries = get_default_setup_queries()
+
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+    for query in setup_queries:
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    # 2
+    def show_instances_coord3():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+
+    def show_instances_coord1():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+
+    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+
+    def show_instances_coord2():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+
+    data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    mg_sleep_and_assert(data, show_instances_coord3)
+    mg_sleep_and_assert(data, show_instances_coord1)
+    mg_sleep_and_assert(data, show_instances_coord2)
 
 
 def test_first_coord_restarts(test_name):

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -289,7 +289,7 @@ def test_even_number_coords(use_durability):
 
     # 1
     inner_instances_description = get_instances_description_no_setup_4_coords(
-        test_name="test_even_number_coords_" + str(use_durability), use_durability=use_durability
+        test_name=f"test_even_number_coords_{use_durability}", use_durability=use_durability
     )
 
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
@@ -2280,9 +2280,7 @@ def test_coordinator_gets_info_on_other_coordinators():
     # 1
     test_name = "test_coordinator_gets_info_on_other_coordinators"
 
-    inner_instances_description = get_instances_description_no_setup(
-        test_name="test_coordinator_gets_info_on_other_coordinators"
-    )
+    inner_instances_description = get_instances_description_no_setup(test_name=test_name)
 
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
 
@@ -3163,7 +3161,7 @@ def test_follower_have_correct_health():
 
     # 1
     inner_instances_description = get_instances_description_no_setup(
-        test_name="test_one_coord_down_with_durability_resume", use_durability=True
+        test_name="test_follower_have_correct_health", use_durability=True
     )
 
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -281,2896 +281,2852 @@ def cleanup_after_test():
     interactive_mg_runner.stop_all(keep_directories=False)
 
 
-@pytest.mark.parametrize("use_durability", [True, False])
-def test_even_number_coords(use_durability, test_name):
-    # Goal is to check that nothing gets broken on even number of coords when 2 coords are down
-    # 1. Start all instances.
-    # 2. Check that all instances are up and that one of the instances is a main.
-    # 3. Demote the main instance.
-    # 4. Kill two coordinators.
-    # 5. Wait for leader to become follower
-    # 6. Bring back up two coordinators.
-    # 7. Find leader
-    # 8.
-
-    # 1
-    inner_instances_description = get_instances_description_no_setup_4_coords(
-        test_name=test_name, use_durability=use_durability
-    )
-
-    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-
-    setup_queries = [
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111', 'management_server': 'localhost:10121'}",
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112', 'management_server': 'localhost:10122'}",
-        "ADD COORDINATOR 4 WITH CONFIG {'bolt_server': 'localhost:7693', 'coordinator_server': 'localhost:10114', 'management_server': 'localhost:10124'}",
-        "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
-        "SET INSTANCE instance_3 TO MAIN",
-    ]
-
-    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-    for query in setup_queries:
-        execute_and_fetch_all(coord_cursor_3, query)
-
-    # 2
-    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
-    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-
-    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
-    coord_cursor_4 = connect(host="localhost", port=7693).cursor()
-
-    def show_instances_coord4():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_4, "SHOW INSTANCES;"))))
-
-    leader_data_original = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "follower"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    mg_sleep_and_assert(leader_data_original, show_instances_coord3)
-    mg_sleep_and_assert(leader_data_original, show_instances_coord1)
-    mg_sleep_and_assert(leader_data_original, show_instances_coord2)
-    mg_sleep_and_assert(leader_data_original, show_instances_coord4)
-
-    instance_3_cursor = connect(host="localhost", port=7689).cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
-
-    replicas = [
-        (
-            "instance_1",
-            "localhost:10001",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-        (
-            "instance_2",
-            "localhost:10002",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-    ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    # 3
-
-    execute_and_fetch_all(
-        coord_cursor_3,
-        "DEMOTE INSTANCE instance_3",
-    )
-
-    leader_data_demoted = leader_data_original.copy()
-    leader_data_demoted = update_tuple_value(leader_data_demoted, "instance_3", 0, -1, "replica")
-
-    mg_sleep_and_assert(leader_data_demoted, show_instances_coord3)
-    mg_sleep_and_assert(leader_data_demoted, show_instances_coord1)
-    mg_sleep_and_assert(leader_data_demoted, show_instances_coord2)
-    mg_sleep_and_assert(leader_data_demoted, show_instances_coord4)
-
-    with pytest.raises(Exception) as e:
-        execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")
-    assert str(e.value) == "Replica can't show registered replicas (it shouldn't have any)!"
-
-    # 4
-    interactive_mg_runner.kill(inner_instances_description, "coordinator_1")
-    interactive_mg_runner.kill(inner_instances_description, "coordinator_2")
-
-    # 5
-
-    with pytest.raises(Exception) as e:
-        execute_and_fetch_all(coord_cursor_3, "SET INSTANCE instance_3 TO MAIN;")
-
-    assert "Couldn't set instance to main as cluster didn't accept start of action!" in str(e.value)
-
-    follower_data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "unknown", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "unknown", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "unknown", "follower"),
-        ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "unknown", "follower"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "replica"),
-    ]
-
-    mg_sleep_and_assert(follower_data, show_instances_coord3)
-
-    # 6
-    interactive_mg_runner.start(inner_instances_description, "coordinator_1")
-    interactive_mg_runner.start(inner_instances_description, "coordinator_2")
-
-    # 7
-
-    leader_data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
-        ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "follower"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
-    ]
-
-    leader_coord_instance_3_demoted = find_instance_and_assert_instances(instance_role="leader", num_coordinators=3)
-
-    main_instance_3_demoted = find_instance_and_assert_instances(instance_role="main", num_coordinators=3)
-
-    assert leader_coord_instance_3_demoted is not None, "Leader not found"
-
-    assert main_instance_3_demoted is not None, "Main not found"
-
-    leader_data = update_tuple_value(leader_data, leader_coord_instance_3_demoted, 0, -1, "leader")
-    leader_data = update_tuple_value(leader_data, main_instance_3_demoted, 0, -1, "main")
-
-    port_mappings = {
-        "coordinator_1": 7690,
-        "coordinator_2": 7691,
-        "coordinator_3": 7692,
-        "coordinator_4": 7693,
-    }
-
-    for coord, port in port_mappings.items():
-        coord_cursor = connect(host="localhost", port=port).cursor()
-
-        def show_instances():
-            return ignore_elapsed_time_from_results(
-                sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
-            )
-
-        mg_sleep_and_assert(leader_data, show_instances)
-
-    interactive_mg_runner.stop_all(keep_directories=False)
-
-
-def test_old_main_comes_back_on_new_leader_as_replica(test_name):
-    # 1. Start all instances.
-    # 2. Kill the main instance
-    # 3. Kill the leader
-    # 4. Start the old main instance
-    # 5. Run SHOW INSTANCES on the new leader and check that the old main instance is registered as a replica
-    # 6. Start again previous leader
-
-    inner_instances_description = get_instances_description_no_setup(test_name=test_name)
-
-    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-
-    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-    for query in get_default_setup_queries():
-        execute_and_fetch_all(coord_cursor_3, query)
-
-    interactive_mg_runner.kill(inner_instances_description, "coordinator_3")
-    interactive_mg_runner.kill(inner_instances_description, "instance_3")
-
-    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
-    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-
-    # Wait until failover happens
-    wait_for_status_change(show_instances_coord1, {"instance_1", "instance_2"}, "main")
-    wait_for_status_change(show_instances_coord1, {"instance_3"}, "unknown")
-
-    # Both instance_1 and instance_2 could become main depending on the order of pings in the system.
-    # Both coordinator_1 and coordinator_2 could become leader depending on the NuRaft election.
-    leader_data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
-    ]
-
-    leader_instance_3_down = find_instance_and_assert_instances(
-        instance_role="leader", num_coordinators=3, coord_ids_to_skip_validation={3}
-    )
-    main_instance_3_down = find_instance_and_assert_instances(
-        instance_role="main", num_coordinators=3, coord_ids_to_skip_validation={3}
-    )
-
-    leader_data = update_tuple_value(leader_data, leader_instance_3_down, 0, -1, "leader")
-    leader_data = update_tuple_value(leader_data, main_instance_3_down, 0, -1, "main")
-
-    def get_show_instances_to_coord(leader_instance):
-        show_instances_mapping = {
-            "coordinator_1": show_instances_coord1,
-            "coordinator_2": show_instances_coord2,
-        }
-
-        return show_instances_mapping.get(leader_instance)
-
-    all_live_coords = ["coordinator_1", "coordinator_2"]
-
-    for coord in all_live_coords:
-        mg_sleep_and_assert(leader_data, get_show_instances_to_coord(coord))
-
-    interactive_mg_runner.start(inner_instances_description, "instance_3")
-
-    coordinator_leader_instance = find_instance_and_assert_instances(
-        instance_role="leader", num_coordinators=3, coord_ids_to_skip_validation={3}
-    )
-    main_instance_id_instance_3_start = find_instance_and_assert_instances(
-        instance_role="main", num_coordinators=3, coord_ids_to_skip_validation={3}
-    )
-
-    assert (
-        main_instance_id_instance_3_start == main_instance_3_down
-    ), f"Main is not {main_instance_3_down} but {main_instance_id_instance_3_start}"
-    assert (
-        coordinator_leader_instance == leader_instance_3_down
-    ), f"Leader is not same as before {leader_instance_3_down}, but {coordinator_leader_instance}"
-
-    coord_leader_data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
-    ]
-
-    coord_leader_data = update_tuple_value(coord_leader_data, coordinator_leader_instance, 0, -1, "leader")
-    coord_leader_data = update_tuple_value(coord_leader_data, main_instance_id_instance_3_start, 0, -1, "main")
-
-    mg_sleep_and_assert(coord_leader_data, get_show_instances_to_coord(coordinator_leader_instance))
-
-    def connect_to_main_instance():
-        assert main_instance_id_instance_3_start is not None
-
-        port_mapping = {"instance_1": 7687, "instance_2": 7688, "instance_3": 7689}
-
-        assert (
-            main_instance_id_instance_3_start in port_mapping
-        ), f"Main is not in mappings, but main is {main_instance_id_instance_3_start}"
-
-        main_instance_port = port_mapping.get(main_instance_id_instance_3_start)
-
-        if main_instance_port is not None:
-            return connect(host="localhost", port=main_instance_port).cursor()
-
-        return None
-
-    new_main_cursor = connect_to_main_instance()
-    assert new_main_cursor is not None, "Main cursor is not found!"
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(new_main_cursor, "SHOW REPLICAS;")))
-
-    replicas = [
-        (
-            "instance_1",
-            "localhost:10001",
-            "sync",
-            {"ts": 0, "behind": None, "status": "ready"},
-            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-        ),
-        (
-            "instance_2",
-            "localhost:10002",
-            "sync",
-            {"ts": 0, "behind": None, "status": "ready"},
-            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-        ),
-        (
-            "instance_3",
-            "localhost:10003",
-            "sync",
-            {"ts": 0, "behind": None, "status": "ready"},
-            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-        ),
-    ]
-    replicas = [replica for replica in replicas if replica[0] != main_instance_id_instance_3_start]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    execute_and_fetch_all(new_main_cursor, "CREATE (n:Node {name: 'node'})")
-
-    replica_2_cursor = connect(host="localhost", port=7688).cursor()
-
-    def get_vertex_count():
-        return execute_and_fetch_all(replica_2_cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-    mg_sleep_and_assert(1, get_vertex_count)
-
-    replica_3_cursor = connect(host="localhost", port=7689).cursor()
-
-    def get_vertex_count():
-        return execute_and_fetch_all(replica_3_cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-    mg_sleep_and_assert(1, get_vertex_count)
-
-    interactive_mg_runner.start(inner_instances_description, "coordinator_3")
-
-    interactive_mg_runner.stop_all(keep_directories=False)
-
-
-def test_distributed_automatic_failover(test_name):
-    inner_instances_description = get_instances_description_no_setup(test_name=test_name)
-
-    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-
-    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-    for query in get_default_setup_queries():
-        execute_and_fetch_all(coord_cursor_3, query)
-
-    main_cursor = connect(host="localhost", port=7689).cursor()
-    expected_data_on_main = [
-        (
-            "instance_1",
-            "localhost:10001",
-            "sync",
-            {"ts": 0, "behind": None, "status": "ready"},
-            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-        ),
-        (
-            "instance_2",
-            "localhost:10002",
-            "sync",
-            {"ts": 0, "behind": None, "status": "ready"},
-            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-        ),
-    ]
-
-    def retrieve_data_show_replicas():
-        return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")))
-
-    mg_sleep_and_assert_collection(expected_data_on_main, retrieve_data_show_replicas)
-
-    interactive_mg_runner.kill(inner_instances_description, "instance_3")
-
-    coord_cursor = connect(host="localhost", port=7692).cursor()
-
-    def retrieve_data_show_repl_cluster():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
-
-    expected_data_on_coord = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
-    ]
-
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
-
-    new_main_cursor = connect(host="localhost", port=7687).cursor()
-
-    def retrieve_data_show_replicas():
-        return sorted(list(execute_and_fetch_all(new_main_cursor, "SHOW REPLICAS;")))
-
-    expected_data_on_new_main = [
-        (
-            "instance_2",
-            "localhost:10002",
-            "sync",
-            {"ts": 0, "behind": None, "status": "ready"},
-            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-        ),
-        (
-            "instance_3",
-            "localhost:10003",
-            "sync",
-            {"ts": 0, "behind": None, "status": "invalid"},
-            {"memgraph": {"ts": 0, "behind": 0, "status": "invalid"}},
-        ),
-    ]
-    mg_sleep_and_assert_collection(expected_data_on_new_main, retrieve_data_show_replicas)
-
-    interactive_mg_runner.start(inner_instances_description, "instance_3")
-    expected_data_on_new_main_old_alive = [
-        (
-            "instance_2",
-            "localhost:10002",
-            "sync",
-            {"ts": 0, "behind": None, "status": "ready"},
-            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-        ),
-        (
-            "instance_3",
-            "localhost:10003",
-            "sync",
-            {"ts": 0, "behind": None, "status": "ready"},
-            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-        ),
-    ]
-
-    mg_sleep_and_assert_collection(expected_data_on_new_main_old_alive, retrieve_data_show_replicas)
-
-    interactive_mg_runner.stop_all(keep_directories=False)
-
-
-def test_distributed_automatic_failover_with_leadership_change(test_name):
-    inner_instances_description = get_instances_description_no_setup(test_name=test_name)
-
-    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-
-    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-    for query in get_default_setup_queries():
-        execute_and_fetch_all(coord_cursor_3, query)
-
-    interactive_mg_runner.kill(inner_instances_description, "coordinator_3")
-    interactive_mg_runner.kill(inner_instances_description, "instance_3")
-
-    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
-    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-
-    leader_data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
-    ]
-
-    wait_for_status_change(show_instances_coord1, {"instance_1", "instance_2"}, "main")
-    wait_for_status_change(show_instances_coord1, {"instance_3"}, "unknown")
-
-    leader_name = find_instance_and_assert_instances(
-        instance_role="leader", num_coordinators=3, coord_ids_to_skip_validation={3}
-    )
-    main_name = find_instance_and_assert_instances(
-        instance_role="main", num_coordinators=3, coord_ids_to_skip_validation={3}
-    )
-
-    leader_data = update_tuple_value(leader_data, main_name, 0, -1, "main")
-    leader_data = update_tuple_value(leader_data, leader_name, 0, -1, "leader")
-
-    mg_sleep_and_assert(leader_data, show_instances_coord1)
-    mg_sleep_and_assert(leader_data, show_instances_coord2)
-
-    def connect_to_main_instance():
-        main_instance_name = main_name
-        assert main_instance_name is not None
-
-        port_mapping = {"instance_1": 7687, "instance_2": 7688}
-
-        assert main_instance_name in port_mapping, f"Main is not in mappings, but main is {main_instance_name}"
-
-        main_instance_port = port_mapping.get(main_instance_name)
-
-        if main_instance_port is not None:
-            return connect(host="localhost", port=main_instance_port).cursor()
-
-        return None
-
-    new_main_cursor = connect_to_main_instance()
-    assert new_main_cursor is not None, "Main cursor is not found!"
-
-    def retrieve_data_show_replicas():
-        return sorted(list(execute_and_fetch_all(new_main_cursor, "SHOW REPLICAS;")))
-
-    all_possible_states = [
-        (
-            "instance_1",
-            "localhost:10001",
-            "sync",
-            {"ts": 0, "behind": None, "status": "ready"},
-            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-        ),
-        (
-            "instance_2",
-            "localhost:10002",
-            "sync",
-            {"ts": 0, "behind": None, "status": "ready"},
-            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-        ),
-        (
-            "instance_3",
-            "localhost:10003",
-            "sync",
-            {"ts": 0, "behind": None, "status": "invalid"},
-            {"memgraph": {"ts": 0, "behind": 0, "status": "invalid"}},
-        ),
-    ]
-
-    expected_data_on_new_main = [state for state in all_possible_states if state[0] != main_name]
-    mg_sleep_and_assert_collection(expected_data_on_new_main, retrieve_data_show_replicas)
-
-    interactive_mg_runner.start(inner_instances_description, "instance_3")
-
-    all_possible_states = [
-        (
-            "instance_1",
-            "localhost:10001",
-            "sync",
-            {"ts": 0, "behind": None, "status": "ready"},
-            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-        ),
-        (
-            "instance_2",
-            "localhost:10002",
-            "sync",
-            {"ts": 0, "behind": None, "status": "ready"},
-            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-        ),
-        (
-            "instance_3",
-            "localhost:10003",
-            "sync",
-            {"ts": 0, "behind": None, "status": "ready"},
-            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-        ),
-    ]
-    expected_data_on_new_main_old_alive = [state for state in all_possible_states if state[0] != main_name]
-    mg_sleep_and_assert_collection(expected_data_on_new_main_old_alive, retrieve_data_show_replicas)
-
-    interactive_mg_runner.start(inner_instances_description, "coordinator_3")
-
-    interactive_mg_runner.stop_all(keep_directories=False)
-
-
-def test_no_leader_after_leader_and_follower_die(test_name):
-    # 1. Register all but one replication instance on the first leader.
-    # 2. Kill the leader and a follower.
-    # 3. Check that the remaining follower is not promoted to leader by trying to register remaining replication instance.
-
-    inner_memgraph_instances = get_instances_description_no_setup(test_name=test_name)
-    interactive_mg_runner.start_all(inner_memgraph_instances, keep_directories=False)
-
-    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-
-    for query in get_default_setup_queries():
-        execute_and_fetch_all(coord_cursor_3, query)
-
-    interactive_mg_runner.kill(inner_memgraph_instances, "coordinator_3")
-    interactive_mg_runner.kill(inner_memgraph_instances, "coordinator_2")
-
-    coord_1_data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "unknown", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "unknown", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "unknown", "follower"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
-    ]
-
-    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
-    mg_sleep_and_assert(coord_1_data, show_instances_coord1)
-
-    with pytest.raises(Exception) as e:
-        execute_and_fetch_all(
-            coord_cursor_1,
-            "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
-        )
-        assert "Couldn't register replica instance since coordinator is not a leader!" in str(e)
-
-    interactive_mg_runner.stop_all(keep_directories=False)
-
-
-def test_old_main_comes_back_on_new_leader_as_main(test_name):
-    # 1. Start all instances.
-    # 2. Kill all instances
-    # 3. Kill the leader
-    # 4. Start the old main instance
-    # 5. Run SHOW INSTANCES on the new leader and check that the old main instance is main once again
-
-    inner_memgraph_instances = get_instances_description_no_setup(test_name=test_name)
-    interactive_mg_runner.start_all(inner_memgraph_instances, keep_directories=False)
-
-    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-
-    for query in get_default_setup_queries():
-        execute_and_fetch_all(coord_cursor_3, query)
-
-    interactive_mg_runner.kill(inner_memgraph_instances, "instance_1")
-    interactive_mg_runner.kill(inner_memgraph_instances, "instance_2")
-    interactive_mg_runner.kill(inner_memgraph_instances, "instance_3")
-    interactive_mg_runner.kill(inner_memgraph_instances, "coordinator_3")
-
-    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
-    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-
-    interactive_mg_runner.start(inner_memgraph_instances, "instance_3")
-
-    coord1_leader_data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    coord2_leader_data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "leader"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    mg_sleep_and_assert_multiple(
-        [coord1_leader_data, coord2_leader_data], [show_instances_coord1, show_instances_coord2]
-    )
-    mg_sleep_and_assert_multiple(
-        [coord1_leader_data, coord2_leader_data], [show_instances_coord1, show_instances_coord2]
-    )
-
-    interactive_mg_runner.start(inner_memgraph_instances, "instance_1")
-    interactive_mg_runner.start(inner_memgraph_instances, "instance_2")
-
-    new_main_cursor = connect(host="localhost", port=7689).cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(new_main_cursor, "SHOW REPLICAS;")))
-
-    replicas = [
-        (
-            "instance_1",
-            "localhost:10001",
-            "sync",
-            {"ts": 0, "behind": None, "status": "ready"},
-            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-        ),
-        (
-            "instance_2",
-            "localhost:10002",
-            "sync",
-            {"ts": 0, "behind": None, "status": "ready"},
-            {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
-        ),
-    ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    execute_and_fetch_all(new_main_cursor, "CREATE (n:Node {name: 'node'})")
-
-    replica_1_cursor = connect(host="localhost", port=7687).cursor()
-    assert len(execute_and_fetch_all(replica_1_cursor, "MATCH (n) RETURN n;")) == 1
-
-    replica_2_cursor = connect(host="localhost", port=7688).cursor()
-    assert len(execute_and_fetch_all(replica_2_cursor, "MATCH (n) RETURN n;")) == 1
-
-    interactive_mg_runner.start(inner_memgraph_instances, "coordinator_3")
-
-    interactive_mg_runner.stop_all(keep_directories=False)
-
-
-def test_registering_4_coords(test_name):
-    # Goal of this test is to assure registering of multiple coordinators in row works
-    INSTANCES_DESCRIPTION = {
-        "instance_1": {
-            "args": [
-                "--experimental-enabled=high-availability",
-                "--bolt-port",
-                "7687",
-                "--log-level",
-                "TRACE",
-                "--management-port",
-                "10011",
-            ],
-            "log_file": f"{get_logs_path(file, test_name)}/instance_1.log",
-            "data_directory": f"{get_data_path(file, test_name)}/instance_1",
-            "setup_queries": [],
-        },
-        "instance_2": {
-            "args": [
-                "--experimental-enabled=high-availability",
-                "--bolt-port",
-                "7688",
-                "--log-level",
-                "TRACE",
-                "--management-port",
-                "10012",
-            ],
-            "log_file": f"{get_logs_path(file, test_name)}/instance_2.log",
-            "data_directory": f"{get_data_path(file, test_name)}/instance_2",
-            "setup_queries": [],
-        },
-        "instance_3": {
-            "args": [
-                "--experimental-enabled=high-availability",
-                "--bolt-port",
-                "7689",
-                "--log-level",
-                "TRACE",
-                "--management-port",
-                "10013",
-            ],
-            "log_file": f"{get_logs_path(file, test_name)}/instance_3.log",
-            "data_directory": f"{get_data_path(file, test_name)}/instance_3",
-            "setup_queries": [],
-        },
-        "coordinator_1": {
-            "args": [
-                "--experimental-enabled=high-availability",
-                "--bolt-port",
-                "7690",
-                "--log-level=TRACE",
-                "--coordinator-id=1",
-                "--coordinator-port=10111",
-                "--management-port=10121",
-                "--coordinator-hostname=localhost",
-            ],
-            "log_file": f"{get_logs_path(file, test_name)}/coordinator_1.log",
-            "data_directory": f"{get_data_path(file, test_name)}/coordinator_1",
-            "setup_queries": [],
-        },
-        "coordinator_2": {
-            "args": [
-                "--experimental-enabled=high-availability",
-                "--bolt-port",
-                "7691",
-                "--log-level=TRACE",
-                "--coordinator-id=2",
-                "--coordinator-port=10112",
-                "--management-port=10122",
-                "--coordinator-hostname=localhost",
-            ],
-            "log_file": f"{get_logs_path(file, test_name)}/coordinator_2.log",
-            "data_directory": f"{get_data_path(file, test_name)}/coordinator_2",
-            "setup_queries": [],
-        },
-        "coordinator_3": {
-            "args": [
-                "--experimental-enabled=high-availability",
-                "--bolt-port",
-                "7692",
-                "--log-level=TRACE",
-                "--coordinator-id=3",
-                "--coordinator-port=10113",
-                "--management-port=10123",
-                "--coordinator-hostname=localhost",
-            ],
-            "log_file": f"{get_logs_path(file, test_name)}/coordinator_3.log",
-            "data_directory": f"{get_data_path(file, test_name)}/coordinator_3",
-            "setup_queries": [],
-        },
-        "coordinator_4": {
-            "args": [
-                "--experimental-enabled=high-availability",
-                "--bolt-port",
-                "7693",
-                "--log-level=TRACE",
-                "--coordinator-id=4",
-                "--coordinator-port=10114",
-                "--management-port=10124",
-                "--coordinator-hostname=localhost",
-            ],
-            "log_file": f"{get_logs_path(file, test_name)}/coordinator_4.log",
-            "data_directory": f"{get_data_path(file, test_name)}/coordinator_4",
-            "setup_queries": [
-                "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111', 'management_server': 'localhost:10121'}",
-                "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112', 'management_server': 'localhost:10122'}",
-                "ADD COORDINATOR 3 WITH CONFIG {'bolt_server': 'localhost:7692', 'coordinator_server': 'localhost:10113', 'management_server': 'localhost:10123'}",
-                "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
-                "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
-                "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
-                "SET INSTANCE instance_3 TO MAIN",
-            ],
-        },
-    }
-
-    interactive_mg_runner.start_all(INSTANCES_DESCRIPTION, keep_directories=False)
-
-    coord_cursor = connect(host="localhost", port=7693).cursor()
-
-    def retrieve_data_show_repl_cluster():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
-
-    expected_data_on_coord = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
-        ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
-
-    interactive_mg_runner.stop_all(keep_directories=False)
-
-
-def test_registering_coord_log_store(test_name):
-    # Goal of this test is to assure registering a bunch of instances and de-registering works properly
-    # w.r.t nuRaft log
-    # 1. Start basic instances # 3 logs
-    # 2. Check all is there
-    # 3. Create 3 additional instances and add them to cluster # 3 logs -> 1st snapshot
-    # 4. Check everything is there
-    # 5. Set main # 1 log
-    # 6. Check correct state
-    # 7. Drop 2 new instances # 2 logs
-    # 8. Check correct state
-    # 9. Drop 1 new instance # 1 log -> 2nd snapshot
-    # 10. Check correct state
-
-    INSTANCES_DESCRIPTION = {
-        "instance_1": {
-            "args": [
-                "--experimental-enabled=high-availability",
-                "--bolt-port",
-                "7687",
-                "--log-level",
-                "TRACE",
-                "--management-port",
-                "10011",
-            ],
-            "log_file": f"{get_logs_path(file, test_name)}/instance_1.log",
-            "data_directory": f"{get_data_path(file, test_name)}/instance_1",
-            "setup_queries": [],
-        },
-        "instance_2": {
-            "args": [
-                "--experimental-enabled=high-availability",
-                "--bolt-port",
-                "7688",
-                "--log-level",
-                "TRACE",
-                "--management-port",
-                "10012",
-            ],
-            "log_file": f"{get_logs_path(file, test_name)}/instance_2.log",
-            "data_directory": f"{get_data_path(file, test_name)}/instance_2",
-            "setup_queries": [],
-        },
-        "instance_3": {
-            "args": [
-                "--experimental-enabled=high-availability",
-                "--bolt-port",
-                "7689",
-                "--log-level",
-                "TRACE",
-                "--management-port",
-                "10013",
-            ],
-            "log_file": f"{get_logs_path(file, test_name)}/instance_3.log",
-            "data_directory": f"{get_data_path(file, test_name)}/instance_3",
-            "setup_queries": [],
-        },
-        "coordinator_1": {
-            "args": [
-                "--experimental-enabled=high-availability",
-                "--bolt-port",
-                "7690",
-                "--log-level=TRACE",
-                "--coordinator-id=1",
-                "--coordinator-port=10111",
-                "--coordinator-hostname",
-                "localhost",
-                "--management-port=10121",
-            ],
-            "log_file": f"{get_logs_path(file, test_name)}/coordinator_1.log",
-            "data_directory": f"{get_data_path(file, test_name)}/coordinator_1",
-            "setup_queries": [],
-        },
-        "coordinator_2": {
-            "args": [
-                "--experimental-enabled=high-availability",
-                "--bolt-port",
-                "7691",
-                "--log-level=TRACE",
-                "--coordinator-id=2",
-                "--coordinator-port=10112",
-                "--coordinator-hostname",
-                "localhost",
-                "--management-port=10122",
-            ],
-            "log_file": f"{get_logs_path(file, test_name)}/coordinator_2.log",
-            "data_directory": f"{get_data_path(file, test_name)}/coordinator_2",
-            "setup_queries": [],
-        },
-        "coordinator_3": {
-            "args": [
-                "--experimental-enabled=high-availability",
-                "--bolt-port",
-                "7692",
-                "--log-level=TRACE",
-                "--coordinator-id=3",
-                "--coordinator-port=10113",
-                "--coordinator-hostname",
-                "localhost",
-                "--management-port=10123",
-            ],
-            "log_file": f"{get_logs_path(file, test_name)}/coordinator_3.log",
-            "data_directory": f"{get_data_path(file, test_name)}/coordinator_3",
-            "setup_queries": [],
-        },
-        "coordinator_4": {
-            "args": [
-                "--experimental-enabled=high-availability",
-                "--bolt-port",
-                "7693",
-                "--log-level=TRACE",
-                "--coordinator-id=4",
-                "--coordinator-port=10114",
-                "--coordinator-hostname",
-                "localhost",
-                "--management-port=10124",
-            ],
-            "log_file": f"{get_logs_path(file, test_name)}/coordinator_4.log",
-            "data_directory": f"{get_data_path(file, test_name)}/coordinator_4",
-            "setup_queries": [
-                "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111', 'management_server': 'localhost:10121'}",
-                "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112', 'management_server': 'localhost:10122'}",
-                "ADD COORDINATOR 3 WITH CONFIG {'bolt_server': 'localhost:7692', 'coordinator_server': 'localhost:10113',  'management_server': 'localhost:10123'}",
-                "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
-                "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
-                "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
-            ],
-        },
-    }
-    assert "SET INSTANCE instance_3 TO MAIN" not in INSTANCES_DESCRIPTION["coordinator_4"]["setup_queries"]
-
-    # 1
-    interactive_mg_runner.start_all(INSTANCES_DESCRIPTION, keep_directories=False)
-
-    # 2
-    coord_cursor = connect(host="localhost", port=7693).cursor()
-
-    def retrieve_data_show_repl_cluster():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
-
-    coordinators = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
-        ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "leader"),
-    ]
-
-    basic_instances = [
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
-    ]
-
-    expected_data_on_coord = []
-    expected_data_on_coord.extend(coordinators)
-    expected_data_on_coord.extend(basic_instances)
-
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
-
-    # 3
-    instances_ports_added = [10011, 10012, 10013]
-    bolt_port_id = 7700
-    manag_port_id = 10014
-
-    additional_instances = []
-    for i in range(4, 7):
-        instance_name = f"instance_{i}"
-        args_desc = [
-            "--experimental-enabled=high-availability",
-            "--log-level=TRACE",
-        ]
-
-        bolt_port = f"--bolt-port={bolt_port_id}"
-
-        manag_server_port = f"--management-port={manag_port_id}"
-
-        args_desc.append(bolt_port)
-        args_desc.append(manag_server_port)
-
-        instance_description = {
-            "args": args_desc,
-            "log_file": f"{get_logs_path(file, test_name)}/instance_{i}.log",
-            "data_directory": f"{get_data_path(file, test_name)}/instance_{i}",
-            "setup_queries": [],
-        }
-
-        full_instance_desc = {instance_name: instance_description}
-        interactive_mg_runner.start(full_instance_desc, instance_name)
-        repl_port_id = manag_port_id - 10
-        assert repl_port_id < 10011, "Wrong test setup, repl port must be smaller than smallest coord port id"
-
-        bolt_server = f"localhost:{bolt_port_id}"
-        management_server = f"localhost:{manag_port_id}"
-        repl_server = f"localhost:{repl_port_id}"
-
-        config_str = f"{{'bolt_server': '{bolt_server}', 'management_server': '{management_server}', 'replication_server': '{repl_server}'}}"
-
-        execute_and_fetch_all(
-            coord_cursor,
-            f"REGISTER INSTANCE {instance_name} WITH CONFIG {config_str}",
-        )
-
-        additional_instances.append((f"{instance_name}", bolt_server, "", management_server, "up", "replica"))
-        instances_ports_added.append(manag_port_id)
-        manag_port_id += 1
-        bolt_port_id += 1
-
-    # 4
-    expected_data_on_coord.extend(additional_instances)
-
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
-
-    # 5
-    execute_and_fetch_all(coord_cursor, "SET INSTANCE instance_3 TO MAIN")
-
-    # 6
-    basic_instances.pop()
-    basic_instances.append(("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"))
-
-    new_expected_data_on_coordinator = []
-
-    new_expected_data_on_coordinator.extend(coordinators)
-    new_expected_data_on_coordinator.extend(basic_instances)
-    new_expected_data_on_coordinator.extend(additional_instances)
-
-    mg_sleep_and_assert(new_expected_data_on_coordinator, retrieve_data_show_repl_cluster)
-
-    # 7
-    for i in range(6, 4, -1):
-        execute_and_fetch_all(coord_cursor, f"UNREGISTER INSTANCE instance_{i};")
-        additional_instances.pop()
-
-    new_expected_data_on_coordinator = []
-    new_expected_data_on_coordinator.extend(coordinators)
-    new_expected_data_on_coordinator.extend(basic_instances)
-    new_expected_data_on_coordinator.extend(additional_instances)
-
-    # 8
-    mg_sleep_and_assert(new_expected_data_on_coordinator, retrieve_data_show_repl_cluster)
-
-    # 9
-
-    new_expected_data_on_coordinator = []
-    new_expected_data_on_coordinator.extend(coordinators)
-    new_expected_data_on_coordinator.extend(basic_instances)
-
-    execute_and_fetch_all(coord_cursor, f"UNREGISTER INSTANCE instance_4;")
-
-    # 10
-    mg_sleep_and_assert(new_expected_data_on_coordinator, retrieve_data_show_repl_cluster)
-
-    interactive_mg_runner.stop_all(keep_directories=False)
-
-
-def test_multiple_failovers_in_row_no_leadership_change(test_name):
-    # Goal of this test is to assure multiple failovers in row work without leadership change
-    # 1. Start basic instances
-    # 2. Check all is there
-    # 3. Kill MAIN (instance_3)
-    # 4. Expect failover (instance_1)
-    # 5. Kill instance_1
-    # 6. Expect failover instance_2
-    # 7. Start instance_3
-    # 8. Expect instance_3 and instance_2 (MAIN) up
-    # 9. Kill instance_2
-    # 10. Expect instance_3 MAIN
-    # 11. Write some data on instance_3
-    # 12. Start instance_2 and instance_1
-    # 13. Expect instance_1 and instance2 to be up and cluster to have correct state
-    # 13. Expect data to be replicated
-
-    # 1
-    inner_memgraph_instances = get_instances_description_no_setup(test_name=test_name)
-    interactive_mg_runner.start_all(inner_memgraph_instances, keep_directories=False)
-
-    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-
-    for query in get_default_setup_queries():
-        execute_and_fetch_all(coord_cursor_3, query)
-
-    # 2
-
-    def get_func_show_instances(cursor):
-        def show_instances_follower_coord():
-            return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(cursor, "SHOW INSTANCES;"))))
-
-        return show_instances_follower_coord
-
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
-
-    # 3
-
-    interactive_mg_runner.kill(inner_memgraph_instances, "instance_3")
-
-    # 4
-
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
-    ]
-
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
-
-    # 5
-    interactive_mg_runner.kill(inner_memgraph_instances, "instance_1")
-
-    # 6
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "main"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
-    ]
-
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
-
-    # 7
-
-    interactive_mg_runner.start(inner_memgraph_instances, "instance_3")
-
-    # 8
-
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "main"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
-    ]
-
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
-
-    # 9
-    interactive_mg_runner.kill(inner_memgraph_instances, "instance_2")
-
-    # 10
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
-
-    # 11
-
-    instance_3_cursor = connect(port=7689, host="localhost").cursor()
-
-    with pytest.raises(Exception) as e:
-        execute_and_fetch_all(instance_3_cursor, "CREATE ();")
-    assert "At least one SYNC replica has not confirmed committing last transaction." in str(e.value)
-
-    # 12
-    interactive_mg_runner.start(inner_memgraph_instances, "instance_1")
-    interactive_mg_runner.start(inner_memgraph_instances, "instance_2")
-
-    # 13
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
-
-    # 14.
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
-
-    replicas = [
-        (
-            "instance_1",
-            "localhost:10001",
-            "sync",
-            {"ts": 0, "behind": None, "status": "ready"},
-            {"memgraph": {"ts": 2, "behind": 0, "status": "ready"}},
-        ),
-        (
-            "instance_2",
-            "localhost:10002",
-            "sync",
-            {"ts": 0, "behind": None, "status": "ready"},
-            {"memgraph": {"ts": 2, "behind": 0, "status": "ready"}},
-        ),
-    ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
-
-    mg_sleep_and_assert(1, get_vertex_count_func(connect(port=7687, host="localhost").cursor()))
-
-    mg_sleep_and_assert(1, get_vertex_count_func(connect(port=7688, host="localhost").cursor()))
-
-    interactive_mg_runner.stop_all(keep_directories=False)
-
-
-def test_multiple_old_mains_single_failover(test_name):
-    # Goal of this test is to check when leadership changes
-    # and we have old MAIN down, that we don't start failover
-    # 1. Start all instances.
-    # 2. Kill the main instance
-    # 3. Do failover
-    # 4. Kill other main
-    # 5. Kill leader
-    # 6. Leave first main down, and start second main
-    # 7. Second main should write data to new instance all the time
-
-    # 1
-    inner_instances_description = get_instances_description_no_setup(test_name=test_name)
-
-    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-
-    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-    for query in get_default_setup_queries():
-        execute_and_fetch_all(coord_cursor_3, query)
-
-    def retrieve_data_show_repl_cluster():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
-    coordinators = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-    ]
-
-    basic_instances = [
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    expected_data_on_coord = []
-    expected_data_on_coord.extend(coordinators)
-    expected_data_on_coord.extend(basic_instances)
-
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
-
-    # 2
-
-    interactive_mg_runner.kill(inner_instances_description, "instance_3")
-
-    # 3
-
-    basic_instances = [
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
-    ]
-
-    expected_data_on_coord = []
-    expected_data_on_coord.extend(coordinators)
-    expected_data_on_coord.extend(basic_instances)
-
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
-
-    # 4
-
-    interactive_mg_runner.kill(inner_instances_description, "instance_1")
-
-    # 5
-    interactive_mg_runner.kill(inner_instances_description, "coordinator_3")
-
-    # 6
-
-    interactive_mg_runner.start(inner_instances_description, "instance_1")
-
-    # 7
-
-    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
-    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-
-    coord1_leader_data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
-    ]
-
-    coord2_leader_data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "leader"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
-    ]
-
-    mg_sleep_and_assert_multiple(
-        [coord1_leader_data, coord2_leader_data], [show_instances_coord1, show_instances_coord2]
-    )
-    mg_sleep_and_assert_multiple(
-        [coord1_leader_data, coord2_leader_data], [show_instances_coord1, show_instances_coord2]
-    )
-
-    instance_1_cursor = connect(host="localhost", port=7687).cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_1_cursor, "SHOW REPLICAS;")))
-
-    replicas = [
-        (
-            "instance_2",
-            "localhost:10002",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-        (
-            "instance_3",
-            "localhost:10003",
-            "sync",
-            {"behind": None, "status": "invalid", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "invalid", "ts": 0}},
-        ),
-    ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
-
-    vertex_count = 0
-    instance_1_cursor = connect(port=7687, host="localhost").cursor()
-    instance_2_cursor = connect(port=7688, host="localhost").cursor()
-
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
-
-    time_slept = 0
-    failover_time = 5
-    while time_slept < failover_time:
-        with pytest.raises(Exception) as e:
-            execute_and_fetch_all(instance_1_cursor, "CREATE ();")
-        vertex_count += 1
-
-        assert vertex_count == execute_and_fetch_all(instance_1_cursor, "MATCH (n) RETURN count(n);")[0][0]
-        assert vertex_count == execute_and_fetch_all(instance_2_cursor, "MATCH (n) RETURN count(n);")[0][0]
-        time.sleep(0.1)
-        time_slept += 0.1
-
-    interactive_mg_runner.stop_all(keep_directories=False)
-
-
-def test_force_reset_works_after_failed_registration(test_name):
-    # Goal of this test is to check that force reset works after failed registration
-    # 1. Start all instances.
-    # 2. Check everything works correctly
-    # 3. Try register instance which doesn't exist
-    # 4. Enter force reset
-    # 5. Check that everything works correctly
-
-    # 1
-    inner_instances_description = get_instances_description_no_setup(test_name=test_name)
-
-    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-
-    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-    for query in get_default_setup_queries():
-        execute_and_fetch_all(coord_cursor_3, query)
-
-    # 2
-
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
-    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
-    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
-
-    instance_3_cursor = connect(host="localhost", port=7689).cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
-
-    replicas = [
-        (
-            "instance_1",
-            "localhost:10001",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-        (
-            "instance_2",
-            "localhost:10002",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-    ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
-
-    vertex_count = 0
-    instance_1_cursor = connect(port=7687, host="localhost").cursor()
-    instance_2_cursor = connect(port=7688, host="localhost").cursor()
-
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
-
-    with pytest.raises(Exception) as e:
-        execute_and_fetch_all(
-            coord_cursor_3,
-            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': 'localhost:10050', 'replication_server': 'localhost:10051'};",
-        )
-
-    # This will trigger force reset and choosing of new instance as MAIN
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
-    ]
-
-    leader_name = find_instance_and_assert_instances(instance_role="leader", num_coordinators=3)
-
-    main_name = find_instance_and_assert_instances(instance_role="main", num_coordinators=3)
-
-    assert leader_name is not None, "leader is None"
-    assert main_name is not None, "Main is None"
-
-    data = update_tuple_value(data, leader_name, 0, -1, "leader")
-    data = update_tuple_value(data, main_name, 0, -1, "main")
-
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
-
-    def get_port(instance_name):
-        mappings = {
-            "instance_1": 7687,
-            "instance_2": 7688,
-            "instance_3": 7689,
-        }
-        return mappings[instance_name]
-
-    instance_main_cursor = connect(port=get_port(main_name), host="localhost").cursor()
-    vertex_count = 10
-    for _ in range(vertex_count):
-        execute_and_fetch_all(instance_main_cursor, "CREATE ();")
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
-
-    for instance in ["instance_1", "instance_2", "instance_3"]:
-        cursor = connect(port=get_port(instance), host="localhost").cursor()
-        mg_sleep_and_assert(vertex_count, get_vertex_count_func(cursor))
-
-    interactive_mg_runner.stop_all(keep_directories=False)
-
-
-def test_force_reset_works_after_failed_registration_and_replica_down(test_name):
-    # Goal of this test is to check when action fails, that force reset happens
-    # and everything works correctly when REPLICA is down (can be demoted but doesn't have to - we demote it)
-    # 1. Start all instances.
-    # 2. Check everything works correctly
-    # 3. Kill replica
-    # 4. Try to register instance which doesn't exist
-    # 4. Enter force reset
-    # 5. Check that everything works correctly with two instances
-    # 6. Start replica instance
-    # 7. Check that replica is correctly demoted to replica
-
-    # 1
-    inner_instances_description = get_instances_description_no_setup(test_name=test_name)
-
-    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-
-    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-    for query in get_default_setup_queries():
-        execute_and_fetch_all(coord_cursor_3, query)
-
-    # 2
-
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
-    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
-    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
-
-    instance_3_cursor = connect(host="localhost", port=7689).cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
-
-    replicas = [
-        (
-            "instance_1",
-            "localhost:10001",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-        (
-            "instance_2",
-            "localhost:10002",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-    ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
-
-    vertex_count = 0
-    instance_1_cursor = connect(port=7687, host="localhost").cursor()
-    instance_2_cursor = connect(port=7688, host="localhost").cursor()
-
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
-
-    # 3
-
-    interactive_mg_runner.kill(inner_instances_description, "instance_2")
-
-    # 4
-
-    with pytest.raises(Exception) as e:
-        execute_and_fetch_all(
-            coord_cursor_3,
-            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': 'localhost:10050', 'replication_server': 'localhost:10051'};",
-        )
-
-    # 5
-    # This will trigger verify and correct cluster state, where we shouldn't choose new MAIN
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    leader_name = "coordinator_3"
-
-    main_name = "instance_3"
-
-    assert leader_name is not None, "leader is None"
-    assert main_name is not None, "Main is None"
-
-    data = update_tuple_value(data, leader_name, 0, -1, "leader")
-    data = update_tuple_value(data, main_name, 0, -1, "main")
-
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
-
-    # 6
-
-    interactive_mg_runner.start(inner_instances_description, "instance_2")
-
-    # 7
-
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
-    ]
-
-    data = update_tuple_value(data, leader_name, 0, -1, "leader")
-    data = update_tuple_value(data, main_name, 0, -1, "main")
-
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
-
-    def get_port(instance_name):
-        mappings = {
-            "instance_1": 7687,
-            "instance_2": 7688,
-            "instance_3": 7689,
-        }
-        return mappings[instance_name]
-
-    main_cursor = connect(port=get_port(main_name), host="localhost").cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")))
-
-    replicas = [
-        (
-            "instance_1",
-            "localhost:10001",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-        (
-            "instance_2",
-            "localhost:10002",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-        (
-            "instance_3",
-            "localhost:10003",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-    ]
-    replicas = [replica for replica in replicas if replica[0] != main_name]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    # 8
-
-    vertex_count = 10
-    for _ in range(vertex_count):
-        execute_and_fetch_all(main_cursor, "CREATE ();")
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
-
-    for instance in ["instance_1", "instance_2", "instance_3"]:
-        cursor = connect(port=get_port(instance), host="localhost").cursor()
-        mg_sleep_and_assert(vertex_count, get_vertex_count_func(cursor))
-
-    interactive_mg_runner.stop_all(keep_directories=False)
-
-
-def test_force_reset_works_after_failed_registration_and_2_coordinators_down(test_name):
-    # Goal of this test is to check when action fails, that force reset happens
-    # and everything works correctly after majority of coordinators is back up
-    # 1. Start all instances.
-    # 2. Check everything works correctly
-    # 3. Try to register instance which doesn't exist -> Enter force reset
-    # 4. Kill 2 coordinators
-    # 5. New action shouldn't succeed because of opened lock
-    # 6. Start one coordinator
-    # 7. Check that replica failover happens in force reset
-    # 8. Check that everything works correctly
-
-    # 1
-    inner_instances_description = get_instances_description_no_setup(test_name=test_name)
-
-    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-
-    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-    for query in get_default_setup_queries():
-        execute_and_fetch_all(coord_cursor_3, query)
-
-    # 2
-
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
-    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
-    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
-
-    instance_3_cursor = connect(host="localhost", port=7689).cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
-
-    replicas = [
-        (
-            "instance_1",
-            "localhost:10001",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-        (
-            "instance_2",
-            "localhost:10002",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-    ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
-
-    vertex_count = 0
-    instance_1_cursor = connect(port=7687, host="localhost").cursor()
-    instance_2_cursor = connect(port=7688, host="localhost").cursor()
-
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
-
-    # 3
-
-    with pytest.raises(Exception) as _:
-        execute_and_fetch_all(
-            coord_cursor_3,
-            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': 'localhost:10050', 'replication_server': 'localhost:10051'};",
-        )
-
-    # 4
-    interactive_mg_runner.kill(inner_instances_description, "coordinator_2")
-    interactive_mg_runner.kill(inner_instances_description, "coordinator_3")
-
-    # 5
-    with pytest.raises(Exception) as e:
-        execute_and_fetch_all(
-            coord_cursor_1,
-            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': "
-            "'localhost:10050', 'replication_server': 'localhost:10051'};",
-        )
-
-    assert "Couldn't register replica instance since coordinator is not a leader!" in str(e.value)
-
-    # 6
-
-    interactive_mg_runner.start(inner_instances_description, "coordinator_2")
-
-    # 7
-    # main must be the same after leader election as before, we can't demote old main
-    leader_data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    leader_name = find_instance_and_assert_instances(
-        instance_role="leader", num_coordinators=3, coord_ids_to_skip_validation={3}
-    )
-
-    leader_data = update_tuple_value(leader_data, leader_name, 0, -1, "leader")
-
-    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
-    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-
-    mg_sleep_and_assert(leader_data, show_instances_coord1)
-
-    mg_sleep_and_assert(leader_data, show_instances_coord2)
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
-
-    replicas = [
-        (
-            "instance_1",
-            "localhost:10001",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-        (
-            "instance_2",
-            "localhost:10002",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-    ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    # 8
-
-    vertex_count = 10
-    for _ in range(vertex_count):
-        execute_and_fetch_all(instance_3_cursor, "CREATE ();")
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
-
-    def get_port(instance_name):
-        mappings = {
-            "instance_1": 7687,
-            "instance_2": 7688,
-            "instance_3": 7689,
-        }
-        return mappings[instance_name]
-
-    for instance in ["instance_1", "instance_2", "instance_3"]:
-        cursor = connect(port=get_port(instance), host="localhost").cursor()
-        mg_sleep_and_assert(vertex_count, get_vertex_count_func(cursor))
-
-    interactive_mg_runner.stop_all(keep_directories=False)
-
-
-def test_coordinator_gets_info_on_other_coordinators(test_name):
-    # Goal of this test is to check that coordinator which has cluster state
-    # after restart gets info on other cluster also which is added in meantime
-    # 1. Start all instances.
-    # 2. Check everything works correctly
-    # 3. Kill one coordinator
-    # 4. Wait until it is down
-    # 5. Register new coordinator
-    # 6. Check that leaders and followers see each other
-    # 7. Start coordinator which is down
-    # 8. Check that such coordinator has correct info
-
-    # 1
-
-    inner_instances_description = get_instances_description_no_setup(test_name=test_name)
-
-    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-
-    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-    for query in get_default_setup_queries():
-        execute_and_fetch_all(coord_cursor_3, query)
-
-    # 2
-
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
-    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
-    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
-
-    instance_3_cursor = connect(host="localhost", port=7689).cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
-
-    replicas = [
-        (
-            "instance_1",
-            "localhost:10001",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-        (
-            "instance_2",
-            "localhost:10002",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-    ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
-
-    vertex_count = 0
-    instance_1_cursor = connect(port=7687, host="localhost").cursor()
-    instance_2_cursor = connect(port=7688, host="localhost").cursor()
-
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
-
-    # 3
-
-    interactive_mg_runner.kill(inner_instances_description, "coordinator_2")
-
-    # 4
-
-    while True:
-        try:
-            execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")
-            time.sleep(0.1)
-        except Exception:
-            break
-
-    # 5
-
-    other_instances = {
-        "coordinator_4": {
-            "args": [
-                "--experimental-enabled=high-availability",
-                "--bolt-port",
-                "7693",
-                "--log-level=TRACE",
-                "--coordinator-id=4",
-                "--coordinator-port=10114",
-                "--management-port=10124",
-                "--coordinator-hostname",
-                "localhost",
-            ],
-            "log_file": f"{get_logs_path(file, test_name)}/coordinator_4.log",
-            "data_directory": f"{get_data_path(file, test_name)}/coordinator_4",
-            "setup_queries": [],
-        },
-    }
-
-    interactive_mg_runner.start(other_instances, "coordinator_4")
-    execute_and_fetch_all(
-        coord_cursor_3,
-        "ADD COORDINATOR 4 WITH CONFIG {'bolt_server': 'localhost:7693', 'coordinator_server': 'localhost:10114', 'management_server': 'localhost:10124'};",
-    )
-
-    # 6
-
-    coord_cursor_4 = connect(host="localhost", port=7693).cursor()
-
-    def show_instances_coord4():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_4, "SHOW INSTANCES;"))))
-
-    coord2_down_data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "down", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "follower"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-    mg_sleep_and_assert(coord2_down_data, show_instances_coord3)
-    mg_sleep_and_assert(coord2_down_data, show_instances_coord1)
-    mg_sleep_and_assert(coord2_down_data, show_instances_coord4)
-
-    # 7
-
-    interactive_mg_runner.start(inner_instances_description, "coordinator_2")
-
-    # 8
-
-    coord2_up_data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "follower"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    mg_sleep_and_assert(coord2_up_data, show_instances_coord2)
-
-    interactive_mg_runner.stop_all(keep_directories=False)
-
-
-def test_registration_works_after_main_set(test_name):
-    # This test tries to register first main and set it to main and afterwards register other instances
-    # 1. Start all instances.
-    # 2. Check everything works correctly
-
-    # 1
-    inner_instances_description = get_instances_description_no_setup(test_name=test_name)
-
-    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-
-    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-    for query in get_default_setup_queries():
-        execute_and_fetch_all(coord_cursor_3, query)
-
-    # 2
-
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
-    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
-    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
-
-    instance_3_cursor = connect(host="localhost", port=7689).cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
-
-    replicas = [
-        (
-            "instance_1",
-            "localhost:10001",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-        (
-            "instance_2",
-            "localhost:10002",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-    ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
-
-    vertex_count = 0
-    instance_1_cursor = connect(port=7687, host="localhost").cursor()
-    instance_2_cursor = connect(port=7688, host="localhost").cursor()
-
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
-
-    interactive_mg_runner.stop_all(keep_directories=False)
-
-
-def test_coordinator_not_leader_registration_does_not_work(test_name):
-    # Goal of this test is to check that it is not possible to register instance on follower coord
-    # 1. Start all instances.
-    # 2. Check everything works correctly
-    # 3. Try to register instance on follower coord
-
-    # 1
-    inner_instances_description = get_instances_description_no_setup(test_name=test_name)
-
-    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-
-    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-    for query in get_default_setup_queries():
-        execute_and_fetch_all(coord_cursor_3, query)
-
-    # 2
-
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
-    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
-    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
-
-    instance_3_cursor = connect(host="localhost", port=7689).cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
-
-    replicas = [
-        (
-            "instance_1",
-            "localhost:10001",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-        (
-            "instance_2",
-            "localhost:10002",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-    ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
-
-    vertex_count = 0
-    instance_1_cursor = connect(port=7687, host="localhost").cursor()
-    instance_2_cursor = connect(port=7688, host="localhost").cursor()
-
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
-
-    # 3
-
-    with pytest.raises(Exception) as e:
-        execute_and_fetch_all(
-            coord_cursor_1,
-            "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': "
-            "'localhost:10050', 'replication_server': 'localhost:10051'};",
-        )
-
-    assert (
-        "Couldn't register replica instance since coordinator is not a leader! Current leader is coordinator with id 3 with bolt socket address localhost:7692"
-        == str(e.value)
-    )
-
-    interactive_mg_runner.stop_all(keep_directories=False)
-
-
-def test_coordinator_user_action_demote_instance_to_replica(test_name):
-    # Goal of this test is to check that it is not possible to register instance on follower coord
-    # 1. Start all instances.
-    # 2. Check everything works correctly
-    # 3. Try to demote instance to replica
-    # 4. Check we have correct state
-
-    # 1
-    inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
-
-    FAILOVER_PERIOD = 2
-    inner_instances_description["instance_1"]["args"].append(f"--instance-down-timeout-sec={FAILOVER_PERIOD}")
-    inner_instances_description["instance_2"]["args"].append(f"--instance-down-timeout-sec={FAILOVER_PERIOD}")
-    inner_instances_description["instance_3"]["args"].append(f"--instance-down-timeout-sec={FAILOVER_PERIOD}")
-
-    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-
-    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-    for query in get_default_setup_queries():
-        execute_and_fetch_all(coord_cursor_3, query)
-
-    # 2
-
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
-    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
-    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-
-    data_original = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    mg_sleep_and_assert(data_original, show_instances_coord3)
-    mg_sleep_and_assert(data_original, show_instances_coord1)
-    mg_sleep_and_assert(data_original, show_instances_coord2)
-
-    instance_3_cursor = connect(host="localhost", port=7689).cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
-
-    replicas = [
-        (
-            "instance_1",
-            "localhost:10001",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-        (
-            "instance_2",
-            "localhost:10002",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-    ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
-
-    vertex_count = 0
-    instance_1_cursor = connect(port=7687, host="localhost").cursor()
-    instance_2_cursor = connect(port=7688, host="localhost").cursor()
-
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
-
-    # 3
-
-    execute_and_fetch_all(
-        coord_cursor_3,
-        "DEMOTE INSTANCE instance_3",
-    )
-
-    # 4.
-
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
-    ]
-
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
-
-    with pytest.raises(Exception) as e:
-        execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")
-    assert str(e.value) == "Replica can't show registered replicas (it shouldn't have any)!"
-
-    mg_assert_until(data, show_instances_coord3, FAILOVER_PERIOD + 1)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
-
-    execute_and_fetch_all(coord_cursor_3, "SET INSTANCE instance_3 TO MAIN;")
-
-    mg_sleep_and_assert(data_original, show_instances_coord3)
-    mg_sleep_and_assert(data_original, show_instances_coord1)
-    mg_sleep_and_assert(data_original, show_instances_coord2)
-
-    interactive_mg_runner.stop_all(keep_directories=False)
-
-
-def test_coordinator_user_action_force_reset_works(test_name):
-    # Goal of this test is to check that it is not possible to register instance on follower coord
-    # 1. Start all instances.
-    # 2. Check everything works correctly
-    # 3. Try force reset
-    # 4. Check we have correct state
-
-    # 1
-    inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
-
-    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-
-    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-    for query in get_default_setup_queries():
-        execute_and_fetch_all(coord_cursor_3, query)
-
-    # 2
-
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
-    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
-    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
-
-    instance_3_cursor = connect(host="localhost", port=7689).cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
-
-    replicas = [
-        (
-            "instance_1",
-            "localhost:10001",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-        (
-            "instance_2",
-            "localhost:10002",
-            "sync",
-            {"behind": None, "status": "ready", "ts": 0},
-            {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
-        ),
-    ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
-
-    vertex_count = 0
-    instance_1_cursor = connect(port=7687, host="localhost").cursor()
-    instance_2_cursor = connect(port=7688, host="localhost").cursor()
-
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
-
-    # 3
-
-    execute_and_fetch_all(
-        coord_cursor_3,
-        "FORCE RESET CLUSTER STATE;",
-    )
-
-    # 4.
-
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
-
-    interactive_mg_runner.stop_all(keep_directories=False)
-
-
-def test_all_coords_down_resume(test_name):
-    # Goal of this test is to check that coordinators are able to resume, if cluster is able to resume where it
-    # left off if all coordinators go down
-
-    # 1. Start cluster
-    # 2. Check everything works correctly
-    # 3. Stop all coordinators
-    # 4. Start 2 coordinators, one should be leader, and one follower
-    # 5. Check everything works correctly
-
-    # 1
-    inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
-
-    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-
-    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-    for query in get_default_setup_queries():
-        execute_and_fetch_all(coord_cursor_3, query)
-
-    # 2
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
-    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
-    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
-
-    # 3
-
-    interactive_mg_runner.kill(inner_instances_description, "coordinator_1")
-    interactive_mg_runner.kill(inner_instances_description, "coordinator_2")
-    interactive_mg_runner.kill(inner_instances_description, "coordinator_3")
-
-    # 4
-
-    with concurrent.futures.ThreadPoolExecutor(2) as executor:
-        executor.submit(interactive_mg_runner.start, inner_instances_description, "coordinator_2")
-        executor.submit(interactive_mg_runner.start, inner_instances_description, "coordinator_1")
-
-    # 5
-
-    leader_data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
-    ]
-
-    wait_for_status_change(show_instances_coord1, {"coordinator_1", "coordinator_2"}, "leader")
-
-    leader = find_instance_and_assert_instances(
-        instance_role="leader", num_coordinators=3, coord_ids_to_skip_validation={3}
-    )
-
-    main = find_instance_and_assert_instances(
-        instance_role="main", num_coordinators=3, coord_ids_to_skip_validation={3}
-    )
-    leader_data = update_tuple_value(leader_data, leader, 0, -1, "leader")
-    leader_data = update_tuple_value(leader_data, main, 0, -1, "main")
-
-    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    mg_sleep_and_assert(leader_data, show_instances_coord1)
-
-    mg_sleep_and_assert(leader_data, show_instances_coord2)
-
-    # 6
-    interactive_mg_runner.kill(inner_instances_description, "instance_3")
-    interactive_mg_runner.start(inner_instances_description, "coordinator_3")
-
-    # 7
-
-    leader_data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
-    ]
-
-    wait_for_status_change(show_instances_coord1, {"instance_3"}, "unknown")
-
-    leader = find_instance_and_assert_instances(instance_role="leader", num_coordinators=3)
-
-    main = find_instance_and_assert_instances(instance_role="main", num_coordinators=3)
-
-    leader_data = update_tuple_value(leader_data, leader, 0, -1, "leader")
-    leader_data = update_tuple_value(leader_data, main, 0, -1, "main")
-
-    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-
-    mg_sleep_and_assert(leader_data, show_instances_coord1)
-
-    mg_sleep_and_assert(leader_data, show_instances_coord2)
-
-    mg_sleep_and_assert(leader_data, show_instances_coord3)
-
-    interactive_mg_runner.stop_all(keep_directories=False)
-
-
-def test_one_coord_down_with_durability_resume(test_name):
-    # Goal of this test is to check that coordinators are able to resume, if cluster is able to resume where it
-    # left off if all coordinators go down
-
-    # 1. Start cluster
-    # 2. Check everything works correctly
-    # 3. Stop all coordinators
-    # 4. Start 2 coordinators, one should be leader, and one follower
-    # 5. Check everything works correctly
-
-    # 1
-    inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
-
-    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-
-    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-
-    for query in get_default_setup_queries():
-        execute_and_fetch_all(coord_cursor_3, query)
-
-    # 2
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
-    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
-    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
-
-    # 3
-
-    interactive_mg_runner.kill(inner_instances_description, "coordinator_1")
-
-    leader_data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "down", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-    mg_sleep_and_assert(leader_data, show_instances_coord3)
-
-    # 4
-    interactive_mg_runner.start(inner_instances_description, "coordinator_1")
-
-    # 5
-
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
-
-    # 6
-    interactive_mg_runner.kill(inner_instances_description, "instance_3")
-
-    # 7
-
-    leader_data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
-    ]
-
-    mg_sleep_and_assert(leader_data, show_instances_coord3)
-    mg_sleep_and_assert(leader_data, show_instances_coord1)
-    mg_sleep_and_assert(leader_data, show_instances_coord2)
-
-    interactive_mg_runner.stop_all(keep_directories=False)
-
-
-def test_registration_does_not_deadlock_when_instance_is_down(test_name):
-    # Goal of this test is to assert that system doesn't deadlock in case of failure on registration
-
-    # 1
-    interactive_mg_runner.stop_all(keep_directories=False)
-    inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
-
-    interactive_mg_runner.start(inner_instances_description, "coordinator_1")
-    interactive_mg_runner.start(inner_instances_description, "coordinator_2")
-    interactive_mg_runner.start(inner_instances_description, "coordinator_3")
-
-    setup_queries = [
-        "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111', 'management_server': 'localhost:10121'}",
-        "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112', 'management_server': 'localhost:10122'}",
-    ]
-
-    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-    for query in setup_queries:
-        execute_and_fetch_all(coord_cursor_3, query)
-
-    query = "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};"
-
-    with pytest.raises(Exception) as e:
-        execute_and_fetch_all(coord_cursor_3, query)
-
-    assert "Couldn't register replica instance because setting instance to replica failed!" in str(e.value)
-
-    interactive_mg_runner.start(inner_instances_description, "instance_1")
-    execute_and_fetch_all(coord_cursor_3, query)
-
-    interactive_mg_runner.start(inner_instances_description, "instance_2")
-    interactive_mg_runner.start(inner_instances_description, "instance_3")
-
-    setup_queries = [
-        "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
-        "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
-        "SET INSTANCE instance_3 TO MAIN",
-    ]
-
-    for query in setup_queries:
-        execute_and_fetch_all(coord_cursor_3, query)
-
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
-    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
-    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
-
-    interactive_mg_runner.stop_all(keep_directories=False)
-
-
-def test_follower_have_correct_health(test_name):
-    # Goal of this test is to check that coordinators are able to resume, if cluster is able to resume where it
-    # left off if all coordinators go down
-
-    # 1. Start cluster
-    # 2. Check everything works correctly
-    # 3. Stop all coordinators
-    # 4. Start 2 coordinators, one should be leader, and one follower
-    # 5. Check everything works correctly
-
-    # 1
-    inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
-
-    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
-
-    setup_queries = get_default_setup_queries()
-
-    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-    for query in setup_queries:
-        execute_and_fetch_all(coord_cursor_3, query)
-
-    # 2
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
-    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
-    coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-
-    data = [
-        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
-        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
-        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
-        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
-    ]
-
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
-
-    interactive_mg_runner.stop_all(keep_directories=False)
+# @pytest.mark.parametrize("use_durability", [True, False])
+# def test_even_number_coords(use_durability, test_name):
+#     # Goal is to check that nothing gets broken on even number of coords when 2 coords are down
+#     # 1. Start all instances.
+#     # 2. Check that all instances are up and that one of the instances is a main.
+#     # 3. Demote the main instance.
+#     # 4. Kill two coordinators.
+#     # 5. Wait for leader to become follower
+#     # 6. Bring back up two coordinators.
+#     # 7. Find leader
+#     # 8.
+#
+#     # 1
+#     inner_instances_description = get_instances_description_no_setup_4_coords(
+#         test_name=test_name, use_durability=use_durability
+#     )
+#
+#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+#
+#     setup_queries = [
+#         "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111', 'management_server': 'localhost:10121'}",
+#         "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112', 'management_server': 'localhost:10122'}",
+#         "ADD COORDINATOR 4 WITH CONFIG {'bolt_server': 'localhost:7693', 'coordinator_server': 'localhost:10114', 'management_server': 'localhost:10124'}",
+#         "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+#         "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+#         "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
+#         "SET INSTANCE instance_3 TO MAIN",
+#     ]
+#
+#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+#     for query in setup_queries:
+#         execute_and_fetch_all(coord_cursor_3, query)
+#
+#     # 2
+#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+#
+#     def show_instances_coord1():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+#
+#     def show_instances_coord2():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+#
+#     def show_instances_coord3():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_4 = connect(host="localhost", port=7693).cursor()
+#
+#     def show_instances_coord4():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_4, "SHOW INSTANCES;"))))
+#
+#     leader_data_original = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "follower"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#
+#     mg_sleep_and_assert(leader_data_original, show_instances_coord3)
+#     mg_sleep_and_assert(leader_data_original, show_instances_coord1)
+#     mg_sleep_and_assert(leader_data_original, show_instances_coord2)
+#     mg_sleep_and_assert(leader_data_original, show_instances_coord4)
+#
+#     instance_3_cursor = connect(host="localhost", port=7689).cursor()
+#
+#     def show_replicas():
+#         return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+#
+#     replicas = [
+#         (
+#             "instance_1",
+#             "localhost:10001",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#         (
+#             "instance_2",
+#             "localhost:10002",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#     ]
+#     mg_sleep_and_assert_collection(replicas, show_replicas)
+#
+#     # 3
+#
+#     execute_and_fetch_all(
+#         coord_cursor_3,
+#         "DEMOTE INSTANCE instance_3",
+#     )
+#
+#     leader_data_demoted = leader_data_original.copy()
+#     leader_data_demoted = update_tuple_value(leader_data_demoted, "instance_3", 0, -1, "replica")
+#
+#     mg_sleep_and_assert(leader_data_demoted, show_instances_coord3)
+#     mg_sleep_and_assert(leader_data_demoted, show_instances_coord1)
+#     mg_sleep_and_assert(leader_data_demoted, show_instances_coord2)
+#     mg_sleep_and_assert(leader_data_demoted, show_instances_coord4)
+#
+#     with pytest.raises(Exception) as e:
+#         execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")
+#     assert str(e.value) == "Replica can't show registered replicas (it shouldn't have any)!"
+#
+#     # 4
+#     interactive_mg_runner.kill(inner_instances_description, "coordinator_1")
+#     interactive_mg_runner.kill(inner_instances_description, "coordinator_2")
+#
+#     # 5
+#
+#     with pytest.raises(Exception) as e:
+#         execute_and_fetch_all(coord_cursor_3, "SET INSTANCE instance_3 TO MAIN;")
+#
+#     assert "Couldn't set instance to main as cluster didn't accept start of action!" in str(e.value)
+#
+#     follower_data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "unknown", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "unknown", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "unknown", "follower"),
+#         ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "unknown", "follower"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "replica"),
+#     ]
+#
+#     mg_sleep_and_assert(follower_data, show_instances_coord3)
+#
+#     # 6
+#     interactive_mg_runner.start(inner_instances_description, "coordinator_1")
+#     interactive_mg_runner.start(inner_instances_description, "coordinator_2")
+#
+#     # 7
+#
+#     leader_data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
+#         ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "follower"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
+#     ]
+#
+#     leader_coord_instance_3_demoted = find_instance_and_assert_instances(instance_role="leader", num_coordinators=3)
+#
+#     main_instance_3_demoted = find_instance_and_assert_instances(instance_role="main", num_coordinators=3)
+#
+#     assert leader_coord_instance_3_demoted is not None, "Leader not found"
+#
+#     assert main_instance_3_demoted is not None, "Main not found"
+#
+#     leader_data = update_tuple_value(leader_data, leader_coord_instance_3_demoted, 0, -1, "leader")
+#     leader_data = update_tuple_value(leader_data, main_instance_3_demoted, 0, -1, "main")
+#
+#     port_mappings = {
+#         "coordinator_1": 7690,
+#         "coordinator_2": 7691,
+#         "coordinator_3": 7692,
+#         "coordinator_4": 7693,
+#     }
+#
+#     for coord, port in port_mappings.items():
+#         coord_cursor = connect(host="localhost", port=port).cursor()
+#
+#         def show_instances():
+#             return ignore_elapsed_time_from_results(
+#                 sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
+#             )
+#
+#         mg_sleep_and_assert(leader_data, show_instances)
+#
+#
+#
+# def test_old_main_comes_back_on_new_leader_as_replica(test_name):
+#     # 1. Start all instances.
+#     # 2. Kill the main instance
+#     # 3. Kill the leader
+#     # 4. Start the old main instance
+#     # 5. Run SHOW INSTANCES on the new leader and check that the old main instance is registered as a replica
+#     # 6. Start again previous leader
+#
+#     inner_instances_description = get_instances_description_no_setup(test_name=test_name)
+#
+#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+#
+#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+#     for query in get_default_setup_queries():
+#         execute_and_fetch_all(coord_cursor_3, query)
+#
+#     interactive_mg_runner.kill(inner_instances_description, "coordinator_3")
+#     interactive_mg_runner.kill(inner_instances_description, "instance_3")
+#
+#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+#
+#     def show_instances_coord1():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+#
+#     def show_instances_coord2():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+#
+#     # Wait until failover happens
+#     wait_for_status_change(show_instances_coord1, {"instance_1", "instance_2"}, "main")
+#     wait_for_status_change(show_instances_coord1, {"instance_3"}, "unknown")
+#
+#     # Both instance_1 and instance_2 could become main depending on the order of pings in the system.
+#     # Both coordinator_1 and coordinator_2 could become leader depending on the NuRaft election.
+#     leader_data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
+#     ]
+#
+#     leader_instance_3_down = find_instance_and_assert_instances(
+#         instance_role="leader", num_coordinators=3, coord_ids_to_skip_validation={3}
+#     )
+#     main_instance_3_down = find_instance_and_assert_instances(
+#         instance_role="main", num_coordinators=3, coord_ids_to_skip_validation={3}
+#     )
+#
+#     leader_data = update_tuple_value(leader_data, leader_instance_3_down, 0, -1, "leader")
+#     leader_data = update_tuple_value(leader_data, main_instance_3_down, 0, -1, "main")
+#
+#     def get_show_instances_to_coord(leader_instance):
+#         show_instances_mapping = {
+#             "coordinator_1": show_instances_coord1,
+#             "coordinator_2": show_instances_coord2,
+#         }
+#
+#         return show_instances_mapping.get(leader_instance)
+#
+#     all_live_coords = ["coordinator_1", "coordinator_2"]
+#
+#     for coord in all_live_coords:
+#         mg_sleep_and_assert(leader_data, get_show_instances_to_coord(coord))
+#
+#     interactive_mg_runner.start(inner_instances_description, "instance_3")
+#
+#     coordinator_leader_instance = find_instance_and_assert_instances(
+#         instance_role="leader", num_coordinators=3, coord_ids_to_skip_validation={3}
+#     )
+#     main_instance_id_instance_3_start = find_instance_and_assert_instances(
+#         instance_role="main", num_coordinators=3, coord_ids_to_skip_validation={3}
+#     )
+#
+#     assert (
+#         main_instance_id_instance_3_start == main_instance_3_down
+#     ), f"Main is not {main_instance_3_down} but {main_instance_id_instance_3_start}"
+#     assert (
+#         coordinator_leader_instance == leader_instance_3_down
+#     ), f"Leader is not same as before {leader_instance_3_down}, but {coordinator_leader_instance}"
+#
+#     coord_leader_data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
+#     ]
+#
+#     coord_leader_data = update_tuple_value(coord_leader_data, coordinator_leader_instance, 0, -1, "leader")
+#     coord_leader_data = update_tuple_value(coord_leader_data, main_instance_id_instance_3_start, 0, -1, "main")
+#
+#     mg_sleep_and_assert(coord_leader_data, get_show_instances_to_coord(coordinator_leader_instance))
+#
+#     def connect_to_main_instance():
+#         assert main_instance_id_instance_3_start is not None
+#
+#         port_mapping = {"instance_1": 7687, "instance_2": 7688, "instance_3": 7689}
+#
+#         assert (
+#             main_instance_id_instance_3_start in port_mapping
+#         ), f"Main is not in mappings, but main is {main_instance_id_instance_3_start}"
+#
+#         main_instance_port = port_mapping.get(main_instance_id_instance_3_start)
+#
+#         if main_instance_port is not None:
+#             return connect(host="localhost", port=main_instance_port).cursor()
+#
+#         return None
+#
+#     new_main_cursor = connect_to_main_instance()
+#     assert new_main_cursor is not None, "Main cursor is not found!"
+#
+#     def show_replicas():
+#         return sorted(list(execute_and_fetch_all(new_main_cursor, "SHOW REPLICAS;")))
+#
+#     replicas = [
+#         (
+#             "instance_1",
+#             "localhost:10001",
+#             "sync",
+#             {"ts": 0, "behind": None, "status": "ready"},
+#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+#         ),
+#         (
+#             "instance_2",
+#             "localhost:10002",
+#             "sync",
+#             {"ts": 0, "behind": None, "status": "ready"},
+#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+#         ),
+#         (
+#             "instance_3",
+#             "localhost:10003",
+#             "sync",
+#             {"ts": 0, "behind": None, "status": "ready"},
+#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+#         ),
+#     ]
+#     replicas = [replica for replica in replicas if replica[0] != main_instance_id_instance_3_start]
+#     mg_sleep_and_assert_collection(replicas, show_replicas)
+#
+#     execute_and_fetch_all(new_main_cursor, "CREATE (n:Node {name: 'node'})")
+#
+#     replica_2_cursor = connect(host="localhost", port=7688).cursor()
+#
+#     def get_vertex_count():
+#         return execute_and_fetch_all(replica_2_cursor, "MATCH (n) RETURN count(n)")[0][0]
+#
+#     mg_sleep_and_assert(1, get_vertex_count)
+#
+#     replica_3_cursor = connect(host="localhost", port=7689).cursor()
+#
+#     def get_vertex_count():
+#         return execute_and_fetch_all(replica_3_cursor, "MATCH (n) RETURN count(n)")[0][0]
+#
+#     mg_sleep_and_assert(1, get_vertex_count)
+#
+#     interactive_mg_runner.start(inner_instances_description, "coordinator_3")
+#
+#
+# def test_distributed_automatic_failover(test_name):
+#     inner_instances_description = get_instances_description_no_setup(test_name=test_name)
+#
+#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+#
+#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+#     for query in get_default_setup_queries():
+#         execute_and_fetch_all(coord_cursor_3, query)
+#
+#     main_cursor = connect(host="localhost", port=7689).cursor()
+#     expected_data_on_main = [
+#         (
+#             "instance_1",
+#             "localhost:10001",
+#             "sync",
+#             {"ts": 0, "behind": None, "status": "ready"},
+#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+#         ),
+#         (
+#             "instance_2",
+#             "localhost:10002",
+#             "sync",
+#             {"ts": 0, "behind": None, "status": "ready"},
+#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+#         ),
+#     ]
+#
+#     def retrieve_data_show_replicas():
+#         return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")))
+#
+#     mg_sleep_and_assert_collection(expected_data_on_main, retrieve_data_show_replicas)
+#
+#     interactive_mg_runner.kill(inner_instances_description, "instance_3")
+#
+#     coord_cursor = connect(host="localhost", port=7692).cursor()
+#
+#     def retrieve_data_show_repl_cluster():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
+#
+#     expected_data_on_coord = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
+#     ]
+#
+#     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
+#
+#     new_main_cursor = connect(host="localhost", port=7687).cursor()
+#
+#     def retrieve_data_show_replicas():
+#         return sorted(list(execute_and_fetch_all(new_main_cursor, "SHOW REPLICAS;")))
+#
+#     expected_data_on_new_main = [
+#         (
+#             "instance_2",
+#             "localhost:10002",
+#             "sync",
+#             {"ts": 0, "behind": None, "status": "ready"},
+#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+#         ),
+#         (
+#             "instance_3",
+#             "localhost:10003",
+#             "sync",
+#             {"ts": 0, "behind": None, "status": "invalid"},
+#             {"memgraph": {"ts": 0, "behind": 0, "status": "invalid"}},
+#         ),
+#     ]
+#     mg_sleep_and_assert_collection(expected_data_on_new_main, retrieve_data_show_replicas)
+#
+#     interactive_mg_runner.start(inner_instances_description, "instance_3")
+#     expected_data_on_new_main_old_alive = [
+#         (
+#             "instance_2",
+#             "localhost:10002",
+#             "sync",
+#             {"ts": 0, "behind": None, "status": "ready"},
+#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+#         ),
+#         (
+#             "instance_3",
+#             "localhost:10003",
+#             "sync",
+#             {"ts": 0, "behind": None, "status": "ready"},
+#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+#         ),
+#     ]
+#
+#     mg_sleep_and_assert_collection(expected_data_on_new_main_old_alive, retrieve_data_show_replicas)
+#
+#
+# def test_distributed_automatic_failover_with_leadership_change(test_name):
+#     inner_instances_description = get_instances_description_no_setup(test_name=test_name)
+#
+#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+#
+#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+#     for query in get_default_setup_queries():
+#         execute_and_fetch_all(coord_cursor_3, query)
+#
+#     interactive_mg_runner.kill(inner_instances_description, "coordinator_3")
+#     interactive_mg_runner.kill(inner_instances_description, "instance_3")
+#
+#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+#
+#     def show_instances_coord1():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+#
+#     def show_instances_coord2():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+#
+#     leader_data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
+#     ]
+#
+#     wait_for_status_change(show_instances_coord1, {"instance_1", "instance_2"}, "main")
+#     wait_for_status_change(show_instances_coord1, {"instance_3"}, "unknown")
+#
+#     leader_name = find_instance_and_assert_instances(
+#         instance_role="leader", num_coordinators=3, coord_ids_to_skip_validation={3}
+#     )
+#     main_name = find_instance_and_assert_instances(
+#         instance_role="main", num_coordinators=3, coord_ids_to_skip_validation={3}
+#     )
+#
+#     leader_data = update_tuple_value(leader_data, main_name, 0, -1, "main")
+#     leader_data = update_tuple_value(leader_data, leader_name, 0, -1, "leader")
+#
+#     mg_sleep_and_assert(leader_data, show_instances_coord1)
+#     mg_sleep_and_assert(leader_data, show_instances_coord2)
+#
+#     def connect_to_main_instance():
+#         main_instance_name = main_name
+#         assert main_instance_name is not None
+#
+#         port_mapping = {"instance_1": 7687, "instance_2": 7688}
+#
+#         assert main_instance_name in port_mapping, f"Main is not in mappings, but main is {main_instance_name}"
+#
+#         main_instance_port = port_mapping.get(main_instance_name)
+#
+#         if main_instance_port is not None:
+#             return connect(host="localhost", port=main_instance_port).cursor()
+#
+#         return None
+#
+#     new_main_cursor = connect_to_main_instance()
+#     assert new_main_cursor is not None, "Main cursor is not found!"
+#
+#     def retrieve_data_show_replicas():
+#         return sorted(list(execute_and_fetch_all(new_main_cursor, "SHOW REPLICAS;")))
+#
+#     all_possible_states = [
+#         (
+#             "instance_1",
+#             "localhost:10001",
+#             "sync",
+#             {"ts": 0, "behind": None, "status": "ready"},
+#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+#         ),
+#         (
+#             "instance_2",
+#             "localhost:10002",
+#             "sync",
+#             {"ts": 0, "behind": None, "status": "ready"},
+#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+#         ),
+#         (
+#             "instance_3",
+#             "localhost:10003",
+#             "sync",
+#             {"ts": 0, "behind": None, "status": "invalid"},
+#             {"memgraph": {"ts": 0, "behind": 0, "status": "invalid"}},
+#         ),
+#     ]
+#
+#     expected_data_on_new_main = [state for state in all_possible_states if state[0] != main_name]
+#     mg_sleep_and_assert_collection(expected_data_on_new_main, retrieve_data_show_replicas)
+#
+#     interactive_mg_runner.start(inner_instances_description, "instance_3")
+#
+#     all_possible_states = [
+#         (
+#             "instance_1",
+#             "localhost:10001",
+#             "sync",
+#             {"ts": 0, "behind": None, "status": "ready"},
+#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+#         ),
+#         (
+#             "instance_2",
+#             "localhost:10002",
+#             "sync",
+#             {"ts": 0, "behind": None, "status": "ready"},
+#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+#         ),
+#         (
+#             "instance_3",
+#             "localhost:10003",
+#             "sync",
+#             {"ts": 0, "behind": None, "status": "ready"},
+#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+#         ),
+#     ]
+#     expected_data_on_new_main_old_alive = [state for state in all_possible_states if state[0] != main_name]
+#     mg_sleep_and_assert_collection(expected_data_on_new_main_old_alive, retrieve_data_show_replicas)
+#
+#     interactive_mg_runner.start(inner_instances_description, "coordinator_3")
+#
+#
+# def test_no_leader_after_leader_and_follower_die(test_name):
+#     # 1. Register all but one replication instance on the first leader.
+#     # 2. Kill the leader and a follower.
+#     # 3. Check that the remaining follower is not promoted to leader by trying to register remaining replication instance.
+#
+#     inner_memgraph_instances = get_instances_description_no_setup(test_name=test_name)
+#     interactive_mg_runner.start_all(inner_memgraph_instances, keep_directories=False)
+#
+#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+#
+#     for query in get_default_setup_queries():
+#         execute_and_fetch_all(coord_cursor_3, query)
+#
+#     interactive_mg_runner.kill(inner_memgraph_instances, "coordinator_3")
+#     interactive_mg_runner.kill(inner_memgraph_instances, "coordinator_2")
+#
+#     coord_1_data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "unknown", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "unknown", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "unknown", "follower"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "unknown", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "unknown", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "main"),
+#     ]
+#
+#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+#
+#     def show_instances_coord1():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+#
+#     mg_sleep_and_assert(coord_1_data, show_instances_coord1)
+#
+#     with pytest.raises(Exception) as e:
+#         execute_and_fetch_all(
+#             coord_cursor_1,
+#             "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+#         )
+#         assert "Couldn't register replica instance since coordinator is not a leader!" in str(e)
+#
+#
+# def test_old_main_comes_back_on_new_leader_as_main(test_name):
+#     # 1. Start all instances.
+#     # 2. Kill all instances
+#     # 3. Kill the leader
+#     # 4. Start the old main instance
+#     # 5. Run SHOW INSTANCES on the new leader and check that the old main instance is main once again
+#
+#     inner_memgraph_instances = get_instances_description_no_setup(test_name=test_name)
+#     interactive_mg_runner.start_all(inner_memgraph_instances, keep_directories=False)
+#
+#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+#
+#     for query in get_default_setup_queries():
+#         execute_and_fetch_all(coord_cursor_3, query)
+#
+#     interactive_mg_runner.kill(inner_memgraph_instances, "instance_1")
+#     interactive_mg_runner.kill(inner_memgraph_instances, "instance_2")
+#     interactive_mg_runner.kill(inner_memgraph_instances, "instance_3")
+#     interactive_mg_runner.kill(inner_memgraph_instances, "coordinator_3")
+#
+#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+#
+#     def show_instances_coord1():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+#
+#     def show_instances_coord2():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+#
+#     interactive_mg_runner.start(inner_memgraph_instances, "instance_3")
+#
+#     coord1_leader_data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#
+#     coord2_leader_data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "leader"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#
+#     mg_sleep_and_assert_multiple(
+#         [coord1_leader_data, coord2_leader_data], [show_instances_coord1, show_instances_coord2]
+#     )
+#     mg_sleep_and_assert_multiple(
+#         [coord1_leader_data, coord2_leader_data], [show_instances_coord1, show_instances_coord2]
+#     )
+#
+#     interactive_mg_runner.start(inner_memgraph_instances, "instance_1")
+#     interactive_mg_runner.start(inner_memgraph_instances, "instance_2")
+#
+#     new_main_cursor = connect(host="localhost", port=7689).cursor()
+#
+#     def show_replicas():
+#         return sorted(list(execute_and_fetch_all(new_main_cursor, "SHOW REPLICAS;")))
+#
+#     replicas = [
+#         (
+#             "instance_1",
+#             "localhost:10001",
+#             "sync",
+#             {"ts": 0, "behind": None, "status": "ready"},
+#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+#         ),
+#         (
+#             "instance_2",
+#             "localhost:10002",
+#             "sync",
+#             {"ts": 0, "behind": None, "status": "ready"},
+#             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
+#         ),
+#     ]
+#     mg_sleep_and_assert_collection(replicas, show_replicas)
+#
+#     execute_and_fetch_all(new_main_cursor, "CREATE (n:Node {name: 'node'})")
+#
+#     replica_1_cursor = connect(host="localhost", port=7687).cursor()
+#     assert len(execute_and_fetch_all(replica_1_cursor, "MATCH (n) RETURN n;")) == 1
+#
+#     replica_2_cursor = connect(host="localhost", port=7688).cursor()
+#     assert len(execute_and_fetch_all(replica_2_cursor, "MATCH (n) RETURN n;")) == 1
+#
+#     interactive_mg_runner.start(inner_memgraph_instances, "coordinator_3")
+#
+#
+# def test_registering_4_coords(test_name):
+#     # Goal of this test is to assure registering of multiple coordinators in row works
+#     INSTANCES_DESCRIPTION = {
+#         "instance_1": {
+#             "args": [
+#                 "--experimental-enabled=high-availability",
+#                 "--bolt-port",
+#                 "7687",
+#                 "--log-level",
+#                 "TRACE",
+#                 "--management-port",
+#                 "10011",
+#             ],
+#             "log_file": f"{get_logs_path(file, test_name)}/instance_1.log",
+#             "data_directory": f"{get_data_path(file, test_name)}/instance_1",
+#             "setup_queries": [],
+#         },
+#         "instance_2": {
+#             "args": [
+#                 "--experimental-enabled=high-availability",
+#                 "--bolt-port",
+#                 "7688",
+#                 "--log-level",
+#                 "TRACE",
+#                 "--management-port",
+#                 "10012",
+#             ],
+#             "log_file": f"{get_logs_path(file, test_name)}/instance_2.log",
+#             "data_directory": f"{get_data_path(file, test_name)}/instance_2",
+#             "setup_queries": [],
+#         },
+#         "instance_3": {
+#             "args": [
+#                 "--experimental-enabled=high-availability",
+#                 "--bolt-port",
+#                 "7689",
+#                 "--log-level",
+#                 "TRACE",
+#                 "--management-port",
+#                 "10013",
+#             ],
+#             "log_file": f"{get_logs_path(file, test_name)}/instance_3.log",
+#             "data_directory": f"{get_data_path(file, test_name)}/instance_3",
+#             "setup_queries": [],
+#         },
+#         "coordinator_1": {
+#             "args": [
+#                 "--experimental-enabled=high-availability",
+#                 "--bolt-port",
+#                 "7690",
+#                 "--log-level=TRACE",
+#                 "--coordinator-id=1",
+#                 "--coordinator-port=10111",
+#                 "--management-port=10121",
+#                 "--coordinator-hostname=localhost",
+#             ],
+#             "log_file": f"{get_logs_path(file, test_name)}/coordinator_1.log",
+#             "data_directory": f"{get_data_path(file, test_name)}/coordinator_1",
+#             "setup_queries": [],
+#         },
+#         "coordinator_2": {
+#             "args": [
+#                 "--experimental-enabled=high-availability",
+#                 "--bolt-port",
+#                 "7691",
+#                 "--log-level=TRACE",
+#                 "--coordinator-id=2",
+#                 "--coordinator-port=10112",
+#                 "--management-port=10122",
+#                 "--coordinator-hostname=localhost",
+#             ],
+#             "log_file": f"{get_logs_path(file, test_name)}/coordinator_2.log",
+#             "data_directory": f"{get_data_path(file, test_name)}/coordinator_2",
+#             "setup_queries": [],
+#         },
+#         "coordinator_3": {
+#             "args": [
+#                 "--experimental-enabled=high-availability",
+#                 "--bolt-port",
+#                 "7692",
+#                 "--log-level=TRACE",
+#                 "--coordinator-id=3",
+#                 "--coordinator-port=10113",
+#                 "--management-port=10123",
+#                 "--coordinator-hostname=localhost",
+#             ],
+#             "log_file": f"{get_logs_path(file, test_name)}/coordinator_3.log",
+#             "data_directory": f"{get_data_path(file, test_name)}/coordinator_3",
+#             "setup_queries": [],
+#         },
+#         "coordinator_4": {
+#             "args": [
+#                 "--experimental-enabled=high-availability",
+#                 "--bolt-port",
+#                 "7693",
+#                 "--log-level=TRACE",
+#                 "--coordinator-id=4",
+#                 "--coordinator-port=10114",
+#                 "--management-port=10124",
+#                 "--coordinator-hostname=localhost",
+#             ],
+#             "log_file": f"{get_logs_path(file, test_name)}/coordinator_4.log",
+#             "data_directory": f"{get_data_path(file, test_name)}/coordinator_4",
+#             "setup_queries": [
+#                 "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111', 'management_server': 'localhost:10121'}",
+#                 "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112', 'management_server': 'localhost:10122'}",
+#                 "ADD COORDINATOR 3 WITH CONFIG {'bolt_server': 'localhost:7692', 'coordinator_server': 'localhost:10113', 'management_server': 'localhost:10123'}",
+#                 "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+#                 "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+#                 "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
+#                 "SET INSTANCE instance_3 TO MAIN",
+#             ],
+#         },
+#     }
+#
+#     interactive_mg_runner.start_all(INSTANCES_DESCRIPTION, keep_directories=False)
+#
+#     coord_cursor = connect(host="localhost", port=7693).cursor()
+#
+#     def retrieve_data_show_repl_cluster():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
+#
+#     expected_data_on_coord = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
+#         ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
+#
+#
+# def test_registering_coord_log_store(test_name):
+#     # Goal of this test is to assure registering a bunch of instances and de-registering works properly
+#     # w.r.t nuRaft log
+#     # 1. Start basic instances # 3 logs
+#     # 2. Check all is there
+#     # 3. Create 3 additional instances and add them to cluster # 3 logs -> 1st snapshot
+#     # 4. Check everything is there
+#     # 5. Set main # 1 log
+#     # 6. Check correct state
+#     # 7. Drop 2 new instances # 2 logs
+#     # 8. Check correct state
+#     # 9. Drop 1 new instance # 1 log -> 2nd snapshot
+#     # 10. Check correct state
+#
+#     INSTANCES_DESCRIPTION = {
+#         "instance_1": {
+#             "args": [
+#                 "--experimental-enabled=high-availability",
+#                 "--bolt-port",
+#                 "7687",
+#                 "--log-level",
+#                 "TRACE",
+#                 "--management-port",
+#                 "10011",
+#             ],
+#             "log_file": f"{get_logs_path(file, test_name)}/instance_1.log",
+#             "data_directory": f"{get_data_path(file, test_name)}/instance_1",
+#             "setup_queries": [],
+#         },
+#         "instance_2": {
+#             "args": [
+#                 "--experimental-enabled=high-availability",
+#                 "--bolt-port",
+#                 "7688",
+#                 "--log-level",
+#                 "TRACE",
+#                 "--management-port",
+#                 "10012",
+#             ],
+#             "log_file": f"{get_logs_path(file, test_name)}/instance_2.log",
+#             "data_directory": f"{get_data_path(file, test_name)}/instance_2",
+#             "setup_queries": [],
+#         },
+#         "instance_3": {
+#             "args": [
+#                 "--experimental-enabled=high-availability",
+#                 "--bolt-port",
+#                 "7689",
+#                 "--log-level",
+#                 "TRACE",
+#                 "--management-port",
+#                 "10013",
+#             ],
+#             "log_file": f"{get_logs_path(file, test_name)}/instance_3.log",
+#             "data_directory": f"{get_data_path(file, test_name)}/instance_3",
+#             "setup_queries": [],
+#         },
+#         "coordinator_1": {
+#             "args": [
+#                 "--experimental-enabled=high-availability",
+#                 "--bolt-port",
+#                 "7690",
+#                 "--log-level=TRACE",
+#                 "--coordinator-id=1",
+#                 "--coordinator-port=10111",
+#                 "--coordinator-hostname",
+#                 "localhost",
+#                 "--management-port=10121",
+#             ],
+#             "log_file": f"{get_logs_path(file, test_name)}/coordinator_1.log",
+#             "data_directory": f"{get_data_path(file, test_name)}/coordinator_1",
+#             "setup_queries": [],
+#         },
+#         "coordinator_2": {
+#             "args": [
+#                 "--experimental-enabled=high-availability",
+#                 "--bolt-port",
+#                 "7691",
+#                 "--log-level=TRACE",
+#                 "--coordinator-id=2",
+#                 "--coordinator-port=10112",
+#                 "--coordinator-hostname",
+#                 "localhost",
+#                 "--management-port=10122",
+#             ],
+#             "log_file": f"{get_logs_path(file, test_name)}/coordinator_2.log",
+#             "data_directory": f"{get_data_path(file, test_name)}/coordinator_2",
+#             "setup_queries": [],
+#         },
+#         "coordinator_3": {
+#             "args": [
+#                 "--experimental-enabled=high-availability",
+#                 "--bolt-port",
+#                 "7692",
+#                 "--log-level=TRACE",
+#                 "--coordinator-id=3",
+#                 "--coordinator-port=10113",
+#                 "--coordinator-hostname",
+#                 "localhost",
+#                 "--management-port=10123",
+#             ],
+#             "log_file": f"{get_logs_path(file, test_name)}/coordinator_3.log",
+#             "data_directory": f"{get_data_path(file, test_name)}/coordinator_3",
+#             "setup_queries": [],
+#         },
+#         "coordinator_4": {
+#             "args": [
+#                 "--experimental-enabled=high-availability",
+#                 "--bolt-port",
+#                 "7693",
+#                 "--log-level=TRACE",
+#                 "--coordinator-id=4",
+#                 "--coordinator-port=10114",
+#                 "--coordinator-hostname",
+#                 "localhost",
+#                 "--management-port=10124",
+#             ],
+#             "log_file": f"{get_logs_path(file, test_name)}/coordinator_4.log",
+#             "data_directory": f"{get_data_path(file, test_name)}/coordinator_4",
+#             "setup_queries": [
+#                 "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111', 'management_server': 'localhost:10121'}",
+#                 "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112', 'management_server': 'localhost:10122'}",
+#                 "ADD COORDINATOR 3 WITH CONFIG {'bolt_server': 'localhost:7692', 'coordinator_server': 'localhost:10113',  'management_server': 'localhost:10123'}",
+#                 "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
+#                 "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+#                 "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
+#             ],
+#         },
+#     }
+#     assert "SET INSTANCE instance_3 TO MAIN" not in INSTANCES_DESCRIPTION["coordinator_4"]["setup_queries"]
+#
+#     # 1
+#     interactive_mg_runner.start_all(INSTANCES_DESCRIPTION, keep_directories=False)
+#
+#     # 2
+#     coord_cursor = connect(host="localhost", port=7693).cursor()
+#
+#     def retrieve_data_show_repl_cluster():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
+#
+#     coordinators = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
+#         ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "leader"),
+#     ]
+#
+#     basic_instances = [
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
+#     ]
+#
+#     expected_data_on_coord = []
+#     expected_data_on_coord.extend(coordinators)
+#     expected_data_on_coord.extend(basic_instances)
+#
+#     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
+#
+#     # 3
+#     instances_ports_added = [10011, 10012, 10013]
+#     bolt_port_id = 7700
+#     manag_port_id = 10014
+#
+#     additional_instances = []
+#     for i in range(4, 7):
+#         instance_name = f"instance_{i}"
+#         args_desc = [
+#             "--experimental-enabled=high-availability",
+#             "--log-level=TRACE",
+#         ]
+#
+#         bolt_port = f"--bolt-port={bolt_port_id}"
+#
+#         manag_server_port = f"--management-port={manag_port_id}"
+#
+#         args_desc.append(bolt_port)
+#         args_desc.append(manag_server_port)
+#
+#         instance_description = {
+#             "args": args_desc,
+#             "log_file": f"{get_logs_path(file, test_name)}/instance_{i}.log",
+#             "data_directory": f"{get_data_path(file, test_name)}/instance_{i}",
+#             "setup_queries": [],
+#         }
+#
+#         full_instance_desc = {instance_name: instance_description}
+#         interactive_mg_runner.start(full_instance_desc, instance_name)
+#         repl_port_id = manag_port_id - 10
+#         assert repl_port_id < 10011, "Wrong test setup, repl port must be smaller than smallest coord port id"
+#
+#         bolt_server = f"localhost:{bolt_port_id}"
+#         management_server = f"localhost:{manag_port_id}"
+#         repl_server = f"localhost:{repl_port_id}"
+#
+#         config_str = f"{{'bolt_server': '{bolt_server}', 'management_server': '{management_server}', 'replication_server': '{repl_server}'}}"
+#
+#         execute_and_fetch_all(
+#             coord_cursor,
+#             f"REGISTER INSTANCE {instance_name} WITH CONFIG {config_str}",
+#         )
+#
+#         additional_instances.append((f"{instance_name}", bolt_server, "", management_server, "up", "replica"))
+#         instances_ports_added.append(manag_port_id)
+#         manag_port_id += 1
+#         bolt_port_id += 1
+#
+#     # 4
+#     expected_data_on_coord.extend(additional_instances)
+#
+#     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
+#
+#     # 5
+#     execute_and_fetch_all(coord_cursor, "SET INSTANCE instance_3 TO MAIN")
+#
+#     # 6
+#     basic_instances.pop()
+#     basic_instances.append(("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"))
+#
+#     new_expected_data_on_coordinator = []
+#
+#     new_expected_data_on_coordinator.extend(coordinators)
+#     new_expected_data_on_coordinator.extend(basic_instances)
+#     new_expected_data_on_coordinator.extend(additional_instances)
+#
+#     mg_sleep_and_assert(new_expected_data_on_coordinator, retrieve_data_show_repl_cluster)
+#
+#     # 7
+#     for i in range(6, 4, -1):
+#         execute_and_fetch_all(coord_cursor, f"UNREGISTER INSTANCE instance_{i};")
+#         additional_instances.pop()
+#
+#     new_expected_data_on_coordinator = []
+#     new_expected_data_on_coordinator.extend(coordinators)
+#     new_expected_data_on_coordinator.extend(basic_instances)
+#     new_expected_data_on_coordinator.extend(additional_instances)
+#
+#     # 8
+#     mg_sleep_and_assert(new_expected_data_on_coordinator, retrieve_data_show_repl_cluster)
+#
+#     # 9
+#
+#     new_expected_data_on_coordinator = []
+#     new_expected_data_on_coordinator.extend(coordinators)
+#     new_expected_data_on_coordinator.extend(basic_instances)
+#
+#     execute_and_fetch_all(coord_cursor, f"UNREGISTER INSTANCE instance_4;")
+#
+#     # 10
+#     mg_sleep_and_assert(new_expected_data_on_coordinator, retrieve_data_show_repl_cluster)
+#
+#
+# def test_multiple_failovers_in_row_no_leadership_change(test_name):
+#     # Goal of this test is to assure multiple failovers in row work without leadership change
+#     # 1. Start basic instances
+#     # 2. Check all is there
+#     # 3. Kill MAIN (instance_3)
+#     # 4. Expect failover (instance_1)
+#     # 5. Kill instance_1
+#     # 6. Expect failover instance_2
+#     # 7. Start instance_3
+#     # 8. Expect instance_3 and instance_2 (MAIN) up
+#     # 9. Kill instance_2
+#     # 10. Expect instance_3 MAIN
+#     # 11. Write some data on instance_3
+#     # 12. Start instance_2 and instance_1
+#     # 13. Expect instance_1 and instance2 to be up and cluster to have correct state
+#     # 13. Expect data to be replicated
+#
+#     # 1
+#     inner_memgraph_instances = get_instances_description_no_setup(test_name=test_name)
+#     interactive_mg_runner.start_all(inner_memgraph_instances, keep_directories=False)
+#
+#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+#
+#     for query in get_default_setup_queries():
+#         execute_and_fetch_all(coord_cursor_3, query)
+#
+#     # 2
+#
+#     def get_func_show_instances(cursor):
+#         def show_instances_follower_coord():
+#             return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(cursor, "SHOW INSTANCES;"))))
+#
+#         return show_instances_follower_coord
+#
+#     data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#
+#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+#
+#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
+#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
+#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
+#
+#     # 3
+#
+#     interactive_mg_runner.kill(inner_memgraph_instances, "instance_3")
+#
+#     # 4
+#
+#     data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
+#     ]
+#
+#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
+#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
+#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
+#
+#     # 5
+#     interactive_mg_runner.kill(inner_memgraph_instances, "instance_1")
+#
+#     # 6
+#     data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "main"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
+#     ]
+#
+#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
+#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
+#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
+#
+#     # 7
+#
+#     interactive_mg_runner.start(inner_memgraph_instances, "instance_3")
+#
+#     # 8
+#
+#     data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "main"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
+#     ]
+#
+#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
+#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
+#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
+#
+#     # 9
+#     interactive_mg_runner.kill(inner_memgraph_instances, "instance_2")
+#
+#     # 10
+#     data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#
+#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
+#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
+#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
+#
+#     # 11
+#
+#     instance_3_cursor = connect(port=7689, host="localhost").cursor()
+#
+#     with pytest.raises(Exception) as e:
+#         execute_and_fetch_all(instance_3_cursor, "CREATE ();")
+#     assert "At least one SYNC replica has not confirmed committing last transaction." in str(e.value)
+#
+#     # 12
+#     interactive_mg_runner.start(inner_memgraph_instances, "instance_1")
+#     interactive_mg_runner.start(inner_memgraph_instances, "instance_2")
+#
+#     # 13
+#     data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#
+#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
+#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
+#     mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
+#
+#     # 14.
+#
+#     def show_replicas():
+#         return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+#
+#     replicas = [
+#         (
+#             "instance_1",
+#             "localhost:10001",
+#             "sync",
+#             {"ts": 0, "behind": None, "status": "ready"},
+#             {"memgraph": {"ts": 2, "behind": 0, "status": "ready"}},
+#         ),
+#         (
+#             "instance_2",
+#             "localhost:10002",
+#             "sync",
+#             {"ts": 0, "behind": None, "status": "ready"},
+#             {"memgraph": {"ts": 2, "behind": 0, "status": "ready"}},
+#         ),
+#     ]
+#     mg_sleep_and_assert_collection(replicas, show_replicas)
+#
+#     def get_vertex_count_func(cursor):
+#         def get_vertex_count():
+#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+#
+#         return get_vertex_count
+#
+#     mg_sleep_and_assert(1, get_vertex_count_func(connect(port=7687, host="localhost").cursor()))
+#
+#     mg_sleep_and_assert(1, get_vertex_count_func(connect(port=7688, host="localhost").cursor()))
+#
+#
+# def test_multiple_old_mains_single_failover(test_name):
+#     # Goal of this test is to check when leadership changes
+#     # and we have old MAIN down, that we don't start failover
+#     # 1. Start all instances.
+#     # 2. Kill the main instance
+#     # 3. Do failover
+#     # 4. Kill other main
+#     # 5. Kill leader
+#     # 6. Leave first main down, and start second main
+#     # 7. Second main should write data to new instance all the time
+#
+#     # 1
+#     inner_instances_description = get_instances_description_no_setup(test_name=test_name)
+#
+#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+#
+#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+#     for query in get_default_setup_queries():
+#         execute_and_fetch_all(coord_cursor_3, query)
+#
+#     def retrieve_data_show_repl_cluster():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+#
+#     coordinators = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#     ]
+#
+#     basic_instances = [
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#
+#     expected_data_on_coord = []
+#     expected_data_on_coord.extend(coordinators)
+#     expected_data_on_coord.extend(basic_instances)
+#
+#     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
+#
+#     # 2
+#
+#     interactive_mg_runner.kill(inner_instances_description, "instance_3")
+#
+#     # 3
+#
+#     basic_instances = [
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
+#     ]
+#
+#     expected_data_on_coord = []
+#     expected_data_on_coord.extend(coordinators)
+#     expected_data_on_coord.extend(basic_instances)
+#
+#     mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
+#
+#     # 4
+#
+#     interactive_mg_runner.kill(inner_instances_description, "instance_1")
+#
+#     # 5
+#     interactive_mg_runner.kill(inner_instances_description, "coordinator_3")
+#
+#     # 6
+#
+#     interactive_mg_runner.start(inner_instances_description, "instance_1")
+#
+#     # 7
+#
+#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+#
+#     def show_instances_coord1():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+#
+#     def show_instances_coord2():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+#
+#     coord1_leader_data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
+#     ]
+#
+#     coord2_leader_data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "leader"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
+#     ]
+#
+#     mg_sleep_and_assert_multiple(
+#         [coord1_leader_data, coord2_leader_data], [show_instances_coord1, show_instances_coord2]
+#     )
+#     mg_sleep_and_assert_multiple(
+#         [coord1_leader_data, coord2_leader_data], [show_instances_coord1, show_instances_coord2]
+#     )
+#
+#     instance_1_cursor = connect(host="localhost", port=7687).cursor()
+#
+#     def show_replicas():
+#         return sorted(list(execute_and_fetch_all(instance_1_cursor, "SHOW REPLICAS;")))
+#
+#     replicas = [
+#         (
+#             "instance_2",
+#             "localhost:10002",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#         (
+#             "instance_3",
+#             "localhost:10003",
+#             "sync",
+#             {"behind": None, "status": "invalid", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "invalid", "ts": 0}},
+#         ),
+#     ]
+#     mg_sleep_and_assert_collection(replicas, show_replicas)
+#
+#     def get_vertex_count_func(cursor):
+#         def get_vertex_count():
+#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+#
+#         return get_vertex_count
+#
+#     vertex_count = 0
+#     instance_1_cursor = connect(port=7687, host="localhost").cursor()
+#     instance_2_cursor = connect(port=7688, host="localhost").cursor()
+#
+#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+#
+#     time_slept = 0
+#     failover_time = 5
+#     while time_slept < failover_time:
+#         with pytest.raises(Exception) as e:
+#             execute_and_fetch_all(instance_1_cursor, "CREATE ();")
+#         vertex_count += 1
+#
+#         assert vertex_count == execute_and_fetch_all(instance_1_cursor, "MATCH (n) RETURN count(n);")[0][0]
+#         assert vertex_count == execute_and_fetch_all(instance_2_cursor, "MATCH (n) RETURN count(n);")[0][0]
+#         time.sleep(0.1)
+#         time_slept += 0.1
+#
+#
+# def test_force_reset_works_after_failed_registration(test_name):
+#     # Goal of this test is to check that force reset works after failed registration
+#     # 1. Start all instances.
+#     # 2. Check everything works correctly
+#     # 3. Try register instance which doesn't exist
+#     # 4. Enter force reset
+#     # 5. Check that everything works correctly
+#
+#     # 1
+#     inner_instances_description = get_instances_description_no_setup(test_name=test_name)
+#
+#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+#
+#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+#     for query in get_default_setup_queries():
+#         execute_and_fetch_all(coord_cursor_3, query)
+#
+#     # 2
+#
+#     def show_instances_coord3():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+#
+#     def show_instances_coord1():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+#
+#     def show_instances_coord2():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+#
+#     data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#
+#     mg_sleep_and_assert(data, show_instances_coord3)
+#     mg_sleep_and_assert(data, show_instances_coord1)
+#     mg_sleep_and_assert(data, show_instances_coord2)
+#
+#     instance_3_cursor = connect(host="localhost", port=7689).cursor()
+#
+#     def show_replicas():
+#         return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+#
+#     replicas = [
+#         (
+#             "instance_1",
+#             "localhost:10001",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#         (
+#             "instance_2",
+#             "localhost:10002",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#     ]
+#     mg_sleep_and_assert_collection(replicas, show_replicas)
+#
+#     def get_vertex_count_func(cursor):
+#         def get_vertex_count():
+#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+#
+#         return get_vertex_count
+#
+#     vertex_count = 0
+#     instance_1_cursor = connect(port=7687, host="localhost").cursor()
+#     instance_2_cursor = connect(port=7688, host="localhost").cursor()
+#
+#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+#
+#     with pytest.raises(Exception) as e:
+#         execute_and_fetch_all(
+#             coord_cursor_3,
+#             "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': 'localhost:10050', 'replication_server': 'localhost:10051'};",
+#         )
+#
+#     # This will trigger force reset and choosing of new instance as MAIN
+#     data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
+#     ]
+#
+#     leader_name = find_instance_and_assert_instances(instance_role="leader", num_coordinators=3)
+#
+#     main_name = find_instance_and_assert_instances(instance_role="main", num_coordinators=3)
+#
+#     assert leader_name is not None, "leader is None"
+#     assert main_name is not None, "Main is None"
+#
+#     data = update_tuple_value(data, leader_name, 0, -1, "leader")
+#     data = update_tuple_value(data, main_name, 0, -1, "main")
+#
+#     mg_sleep_and_assert(data, show_instances_coord3)
+#     mg_sleep_and_assert(data, show_instances_coord1)
+#     mg_sleep_and_assert(data, show_instances_coord2)
+#
+#     def get_port(instance_name):
+#         mappings = {
+#             "instance_1": 7687,
+#             "instance_2": 7688,
+#             "instance_3": 7689,
+#         }
+#         return mappings[instance_name]
+#
+#     instance_main_cursor = connect(port=get_port(main_name), host="localhost").cursor()
+#     vertex_count = 10
+#     for _ in range(vertex_count):
+#         execute_and_fetch_all(instance_main_cursor, "CREATE ();")
+#
+#     def get_vertex_count_func(cursor):
+#         def get_vertex_count():
+#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+#
+#         return get_vertex_count
+#
+#     for instance in ["instance_1", "instance_2", "instance_3"]:
+#         cursor = connect(port=get_port(instance), host="localhost").cursor()
+#         mg_sleep_and_assert(vertex_count, get_vertex_count_func(cursor))
+#
+#
+# def test_force_reset_works_after_failed_registration_and_replica_down(test_name):
+#     # Goal of this test is to check when action fails, that force reset happens
+#     # and everything works correctly when REPLICA is down (can be demoted but doesn't have to - we demote it)
+#     # 1. Start all instances.
+#     # 2. Check everything works correctly
+#     # 3. Kill replica
+#     # 4. Try to register instance which doesn't exist
+#     # 4. Enter force reset
+#     # 5. Check that everything works correctly with two instances
+#     # 6. Start replica instance
+#     # 7. Check that replica is correctly demoted to replica
+#
+#     # 1
+#     inner_instances_description = get_instances_description_no_setup(test_name=test_name)
+#
+#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+#
+#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+#     for query in get_default_setup_queries():
+#         execute_and_fetch_all(coord_cursor_3, query)
+#
+#     # 2
+#
+#     def show_instances_coord3():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+#
+#     def show_instances_coord1():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+#
+#     def show_instances_coord2():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+#
+#     data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#
+#     mg_sleep_and_assert(data, show_instances_coord3)
+#     mg_sleep_and_assert(data, show_instances_coord1)
+#     mg_sleep_and_assert(data, show_instances_coord2)
+#
+#     instance_3_cursor = connect(host="localhost", port=7689).cursor()
+#
+#     def show_replicas():
+#         return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+#
+#     replicas = [
+#         (
+#             "instance_1",
+#             "localhost:10001",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#         (
+#             "instance_2",
+#             "localhost:10002",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#     ]
+#     mg_sleep_and_assert_collection(replicas, show_replicas)
+#
+#     def get_vertex_count_func(cursor):
+#         def get_vertex_count():
+#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+#
+#         return get_vertex_count
+#
+#     vertex_count = 0
+#     instance_1_cursor = connect(port=7687, host="localhost").cursor()
+#     instance_2_cursor = connect(port=7688, host="localhost").cursor()
+#
+#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+#
+#     # 3
+#
+#     interactive_mg_runner.kill(inner_instances_description, "instance_2")
+#
+#     # 4
+#
+#     with pytest.raises(Exception) as e:
+#         execute_and_fetch_all(
+#             coord_cursor_3,
+#             "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': 'localhost:10050', 'replication_server': 'localhost:10051'};",
+#         )
+#
+#     # 5
+#     # This will trigger verify and correct cluster state, where we shouldn't choose new MAIN
+#     data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#
+#     leader_name = "coordinator_3"
+#
+#     main_name = "instance_3"
+#
+#     assert leader_name is not None, "leader is None"
+#     assert main_name is not None, "Main is None"
+#
+#     data = update_tuple_value(data, leader_name, 0, -1, "leader")
+#     data = update_tuple_value(data, main_name, 0, -1, "main")
+#
+#     mg_sleep_and_assert(data, show_instances_coord3)
+#     mg_sleep_and_assert(data, show_instances_coord1)
+#     mg_sleep_and_assert(data, show_instances_coord2)
+#
+#     # 6
+#
+#     interactive_mg_runner.start(inner_instances_description, "instance_2")
+#
+#     # 7
+#
+#     data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
+#     ]
+#
+#     data = update_tuple_value(data, leader_name, 0, -1, "leader")
+#     data = update_tuple_value(data, main_name, 0, -1, "main")
+#
+#     mg_sleep_and_assert(data, show_instances_coord3)
+#     mg_sleep_and_assert(data, show_instances_coord1)
+#     mg_sleep_and_assert(data, show_instances_coord2)
+#
+#     def get_port(instance_name):
+#         mappings = {
+#             "instance_1": 7687,
+#             "instance_2": 7688,
+#             "instance_3": 7689,
+#         }
+#         return mappings[instance_name]
+#
+#     main_cursor = connect(port=get_port(main_name), host="localhost").cursor()
+#
+#     def show_replicas():
+#         return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")))
+#
+#     replicas = [
+#         (
+#             "instance_1",
+#             "localhost:10001",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#         (
+#             "instance_2",
+#             "localhost:10002",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#         (
+#             "instance_3",
+#             "localhost:10003",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#     ]
+#     replicas = [replica for replica in replicas if replica[0] != main_name]
+#     mg_sleep_and_assert_collection(replicas, show_replicas)
+#
+#     # 8
+#
+#     vertex_count = 10
+#     for _ in range(vertex_count):
+#         execute_and_fetch_all(main_cursor, "CREATE ();")
+#
+#     def get_vertex_count_func(cursor):
+#         def get_vertex_count():
+#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+#
+#         return get_vertex_count
+#
+#     for instance in ["instance_1", "instance_2", "instance_3"]:
+#         cursor = connect(port=get_port(instance), host="localhost").cursor()
+#         mg_sleep_and_assert(vertex_count, get_vertex_count_func(cursor))
+#
+#
+# def test_force_reset_works_after_failed_registration_and_2_coordinators_down(test_name):
+#     # Goal of this test is to check when action fails, that force reset happens
+#     # and everything works correctly after majority of coordinators is back up
+#     # 1. Start all instances.
+#     # 2. Check everything works correctly
+#     # 3. Try to register instance which doesn't exist -> Enter force reset
+#     # 4. Kill 2 coordinators
+#     # 5. New action shouldn't succeed because of opened lock
+#     # 6. Start one coordinator
+#     # 7. Check that replica failover happens in force reset
+#     # 8. Check that everything works correctly
+#
+#     # 1
+#     inner_instances_description = get_instances_description_no_setup(test_name=test_name)
+#
+#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+#
+#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+#     for query in get_default_setup_queries():
+#         execute_and_fetch_all(coord_cursor_3, query)
+#
+#     # 2
+#
+#     def show_instances_coord3():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+#
+#     def show_instances_coord1():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+#
+#     def show_instances_coord2():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+#
+#     data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#
+#     mg_sleep_and_assert(data, show_instances_coord3)
+#     mg_sleep_and_assert(data, show_instances_coord1)
+#     mg_sleep_and_assert(data, show_instances_coord2)
+#
+#     instance_3_cursor = connect(host="localhost", port=7689).cursor()
+#
+#     def show_replicas():
+#         return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+#
+#     replicas = [
+#         (
+#             "instance_1",
+#             "localhost:10001",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#         (
+#             "instance_2",
+#             "localhost:10002",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#     ]
+#     mg_sleep_and_assert_collection(replicas, show_replicas)
+#
+#     def get_vertex_count_func(cursor):
+#         def get_vertex_count():
+#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+#
+#         return get_vertex_count
+#
+#     vertex_count = 0
+#     instance_1_cursor = connect(port=7687, host="localhost").cursor()
+#     instance_2_cursor = connect(port=7688, host="localhost").cursor()
+#
+#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+#
+#     # 3
+#
+#     with pytest.raises(Exception) as _:
+#         execute_and_fetch_all(
+#             coord_cursor_3,
+#             "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': 'localhost:10050', 'replication_server': 'localhost:10051'};",
+#         )
+#
+#     # 4
+#     interactive_mg_runner.kill(inner_instances_description, "coordinator_2")
+#     interactive_mg_runner.kill(inner_instances_description, "coordinator_3")
+#
+#     # 5
+#     with pytest.raises(Exception) as e:
+#         execute_and_fetch_all(
+#             coord_cursor_1,
+#             "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': "
+#             "'localhost:10050', 'replication_server': 'localhost:10051'};",
+#         )
+#
+#     assert "Couldn't register replica instance since coordinator is not a leader!" in str(e.value)
+#
+#     # 6
+#
+#     interactive_mg_runner.start(inner_instances_description, "coordinator_2")
+#
+#     # 7
+#     # main must be the same after leader election as before, we can't demote old main
+#     leader_data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#
+#     leader_name = find_instance_and_assert_instances(
+#         instance_role="leader", num_coordinators=3, coord_ids_to_skip_validation={3}
+#     )
+#
+#     leader_data = update_tuple_value(leader_data, leader_name, 0, -1, "leader")
+#
+#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+#
+#     def show_instances_coord1():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+#
+#     def show_instances_coord2():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+#
+#     mg_sleep_and_assert(leader_data, show_instances_coord1)
+#
+#     mg_sleep_and_assert(leader_data, show_instances_coord2)
+#
+#     def show_replicas():
+#         return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+#
+#     replicas = [
+#         (
+#             "instance_1",
+#             "localhost:10001",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#         (
+#             "instance_2",
+#             "localhost:10002",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#     ]
+#     mg_sleep_and_assert_collection(replicas, show_replicas)
+#
+#     # 8
+#
+#     vertex_count = 10
+#     for _ in range(vertex_count):
+#         execute_and_fetch_all(instance_3_cursor, "CREATE ();")
+#
+#     def get_vertex_count_func(cursor):
+#         def get_vertex_count():
+#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+#
+#         return get_vertex_count
+#
+#     def get_port(instance_name):
+#         mappings = {
+#             "instance_1": 7687,
+#             "instance_2": 7688,
+#             "instance_3": 7689,
+#         }
+#         return mappings[instance_name]
+#
+#     for instance in ["instance_1", "instance_2", "instance_3"]:
+#         cursor = connect(port=get_port(instance), host="localhost").cursor()
+#         mg_sleep_and_assert(vertex_count, get_vertex_count_func(cursor))
+#
+#
+# def test_coordinator_gets_info_on_other_coordinators(test_name):
+#     # Goal of this test is to check that coordinator which has cluster state
+#     # after restart gets info on other cluster also which is added in meantime
+#     # 1. Start all instances.
+#     # 2. Check everything works correctly
+#     # 3. Kill one coordinator
+#     # 4. Wait until it is down
+#     # 5. Register new coordinator
+#     # 6. Check that leaders and followers see each other
+#     # 7. Start coordinator which is down
+#     # 8. Check that such coordinator has correct info
+#
+#     # 1
+#
+#     inner_instances_description = get_instances_description_no_setup(test_name=test_name)
+#
+#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+#
+#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+#     for query in get_default_setup_queries():
+#         execute_and_fetch_all(coord_cursor_3, query)
+#
+#     # 2
+#
+#     def show_instances_coord3():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+#
+#     def show_instances_coord1():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+#
+#     def show_instances_coord2():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+#
+#     data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#
+#     mg_sleep_and_assert(data, show_instances_coord3)
+#     mg_sleep_and_assert(data, show_instances_coord1)
+#     mg_sleep_and_assert(data, show_instances_coord2)
+#
+#     instance_3_cursor = connect(host="localhost", port=7689).cursor()
+#
+#     def show_replicas():
+#         return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+#
+#     replicas = [
+#         (
+#             "instance_1",
+#             "localhost:10001",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#         (
+#             "instance_2",
+#             "localhost:10002",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#     ]
+#     mg_sleep_and_assert_collection(replicas, show_replicas)
+#
+#     def get_vertex_count_func(cursor):
+#         def get_vertex_count():
+#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+#
+#         return get_vertex_count
+#
+#     vertex_count = 0
+#     instance_1_cursor = connect(port=7687, host="localhost").cursor()
+#     instance_2_cursor = connect(port=7688, host="localhost").cursor()
+#
+#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+#
+#     # 3
+#
+#     interactive_mg_runner.kill(inner_instances_description, "coordinator_2")
+#
+#     # 4
+#
+#     while True:
+#         try:
+#             execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;")
+#             time.sleep(0.1)
+#         except Exception:
+#             break
+#
+#     # 5
+#
+#     other_instances = {
+#         "coordinator_4": {
+#             "args": [
+#                 "--experimental-enabled=high-availability",
+#                 "--bolt-port",
+#                 "7693",
+#                 "--log-level=TRACE",
+#                 "--coordinator-id=4",
+#                 "--coordinator-port=10114",
+#                 "--management-port=10124",
+#                 "--coordinator-hostname",
+#                 "localhost",
+#             ],
+#             "log_file": f"{get_logs_path(file, test_name)}/coordinator_4.log",
+#             "data_directory": f"{get_data_path(file, test_name)}/coordinator_4",
+#             "setup_queries": [],
+#         },
+#     }
+#
+#     interactive_mg_runner.start(other_instances, "coordinator_4")
+#     execute_and_fetch_all(
+#         coord_cursor_3,
+#         "ADD COORDINATOR 4 WITH CONFIG {'bolt_server': 'localhost:7693', 'coordinator_server': 'localhost:10114', 'management_server': 'localhost:10124'};",
+#     )
+#
+#     # 6
+#
+#     coord_cursor_4 = connect(host="localhost", port=7693).cursor()
+#
+#     def show_instances_coord4():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_4, "SHOW INSTANCES;"))))
+#
+#     coord2_down_data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "down", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "follower"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#     mg_sleep_and_assert(coord2_down_data, show_instances_coord3)
+#     mg_sleep_and_assert(coord2_down_data, show_instances_coord1)
+#     mg_sleep_and_assert(coord2_down_data, show_instances_coord4)
+#
+#     # 7
+#
+#     interactive_mg_runner.start(inner_instances_description, "coordinator_2")
+#
+#     # 8
+#
+#     coord2_up_data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("coordinator_4", "localhost:7693", "localhost:10114", "localhost:10124", "up", "follower"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#
+#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+#
+#     mg_sleep_and_assert(coord2_up_data, show_instances_coord2)
+#
+#
+# def test_registration_works_after_main_set(test_name):
+#     # This test tries to register first main and set it to main and afterwards register other instances
+#     # 1. Start all instances.
+#     # 2. Check everything works correctly
+#
+#     # 1
+#     inner_instances_description = get_instances_description_no_setup(test_name=test_name)
+#
+#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+#
+#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+#     for query in get_default_setup_queries():
+#         execute_and_fetch_all(coord_cursor_3, query)
+#
+#     # 2
+#
+#     def show_instances_coord3():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+#
+#     def show_instances_coord1():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+#
+#     def show_instances_coord2():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+#
+#     data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#
+#     mg_sleep_and_assert(data, show_instances_coord3)
+#     mg_sleep_and_assert(data, show_instances_coord1)
+#     mg_sleep_and_assert(data, show_instances_coord2)
+#
+#     instance_3_cursor = connect(host="localhost", port=7689).cursor()
+#
+#     def show_replicas():
+#         return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+#
+#     replicas = [
+#         (
+#             "instance_1",
+#             "localhost:10001",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#         (
+#             "instance_2",
+#             "localhost:10002",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#     ]
+#     mg_sleep_and_assert_collection(replicas, show_replicas)
+#
+#     def get_vertex_count_func(cursor):
+#         def get_vertex_count():
+#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+#
+#         return get_vertex_count
+#
+#     vertex_count = 0
+#     instance_1_cursor = connect(port=7687, host="localhost").cursor()
+#     instance_2_cursor = connect(port=7688, host="localhost").cursor()
+#
+#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+#
+#
+# def test_coordinator_not_leader_registration_does_not_work(test_name):
+#     # Goal of this test is to check that it is not possible to register instance on follower coord
+#     # 1. Start all instances.
+#     # 2. Check everything works correctly
+#     # 3. Try to register instance on follower coord
+#
+#     # 1
+#     inner_instances_description = get_instances_description_no_setup(test_name=test_name)
+#
+#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+#
+#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+#     for query in get_default_setup_queries():
+#         execute_and_fetch_all(coord_cursor_3, query)
+#
+#     # 2
+#
+#     def show_instances_coord3():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+#
+#     def show_instances_coord1():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+#
+#     def show_instances_coord2():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+#
+#     data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#     mg_sleep_and_assert(data, show_instances_coord3)
+#     mg_sleep_and_assert(data, show_instances_coord1)
+#     mg_sleep_and_assert(data, show_instances_coord2)
+#
+#     instance_3_cursor = connect(host="localhost", port=7689).cursor()
+#
+#     def show_replicas():
+#         return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+#
+#     replicas = [
+#         (
+#             "instance_1",
+#             "localhost:10001",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#         (
+#             "instance_2",
+#             "localhost:10002",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#     ]
+#     mg_sleep_and_assert_collection(replicas, show_replicas)
+#
+#     def get_vertex_count_func(cursor):
+#         def get_vertex_count():
+#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+#
+#         return get_vertex_count
+#
+#     vertex_count = 0
+#     instance_1_cursor = connect(port=7687, host="localhost").cursor()
+#     instance_2_cursor = connect(port=7688, host="localhost").cursor()
+#
+#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+#
+#     # 3
+#
+#     with pytest.raises(Exception) as e:
+#         execute_and_fetch_all(
+#             coord_cursor_1,
+#             "REGISTER INSTANCE instance_4 WITH CONFIG {'bolt_server': 'localhost:7680', 'management_server': "
+#             "'localhost:10050', 'replication_server': 'localhost:10051'};",
+#         )
+#
+#     assert (
+#         "Couldn't register replica instance since coordinator is not a leader! Current leader is coordinator with id 3 with bolt socket address localhost:7692"
+#         == str(e.value)
+#     )
+#
+#
+# def test_coordinator_user_action_demote_instance_to_replica(test_name):
+#     # Goal of this test is to check that it is not possible to register instance on follower coord
+#     # 1. Start all instances.
+#     # 2. Check everything works correctly
+#     # 3. Try to demote instance to replica
+#     # 4. Check we have correct state
+#
+#     # 1
+#     inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
+#
+#     FAILOVER_PERIOD = 2
+#     inner_instances_description["instance_1"]["args"].append(f"--instance-down-timeout-sec={FAILOVER_PERIOD}")
+#     inner_instances_description["instance_2"]["args"].append(f"--instance-down-timeout-sec={FAILOVER_PERIOD}")
+#     inner_instances_description["instance_3"]["args"].append(f"--instance-down-timeout-sec={FAILOVER_PERIOD}")
+#
+#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+#
+#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+#     for query in get_default_setup_queries():
+#         execute_and_fetch_all(coord_cursor_3, query)
+#
+#     # 2
+#
+#     def show_instances_coord3():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+#
+#     def show_instances_coord1():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+#
+#     def show_instances_coord2():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+#
+#     data_original = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#
+#     mg_sleep_and_assert(data_original, show_instances_coord3)
+#     mg_sleep_and_assert(data_original, show_instances_coord1)
+#     mg_sleep_and_assert(data_original, show_instances_coord2)
+#
+#     instance_3_cursor = connect(host="localhost", port=7689).cursor()
+#
+#     def show_replicas():
+#         return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+#
+#     replicas = [
+#         (
+#             "instance_1",
+#             "localhost:10001",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#         (
+#             "instance_2",
+#             "localhost:10002",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#     ]
+#     mg_sleep_and_assert_collection(replicas, show_replicas)
+#
+#     def get_vertex_count_func(cursor):
+#         def get_vertex_count():
+#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+#
+#         return get_vertex_count
+#
+#     vertex_count = 0
+#     instance_1_cursor = connect(port=7687, host="localhost").cursor()
+#     instance_2_cursor = connect(port=7688, host="localhost").cursor()
+#
+#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+#
+#     # 3
+#
+#     execute_and_fetch_all(
+#         coord_cursor_3,
+#         "DEMOTE INSTANCE instance_3",
+#     )
+#
+#     # 4.
+#
+#     data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
+#     ]
+#
+#     mg_sleep_and_assert(data, show_instances_coord3)
+#     mg_sleep_and_assert(data, show_instances_coord1)
+#     mg_sleep_and_assert(data, show_instances_coord2)
+#
+#     with pytest.raises(Exception) as e:
+#         execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")
+#     assert str(e.value) == "Replica can't show registered replicas (it shouldn't have any)!"
+#
+#     mg_assert_until(data, show_instances_coord3, FAILOVER_PERIOD + 1)
+#     mg_sleep_and_assert(data, show_instances_coord1)
+#     mg_sleep_and_assert(data, show_instances_coord2)
+#
+#     execute_and_fetch_all(coord_cursor_3, "SET INSTANCE instance_3 TO MAIN;")
+#
+#     mg_sleep_and_assert(data_original, show_instances_coord3)
+#     mg_sleep_and_assert(data_original, show_instances_coord1)
+#     mg_sleep_and_assert(data_original, show_instances_coord2)
+#
+#
+# def test_coordinator_user_action_force_reset_works(test_name):
+#     # Goal of this test is to check that it is not possible to register instance on follower coord
+#     # 1. Start all instances.
+#     # 2. Check everything works correctly
+#     # 3. Try force reset
+#     # 4. Check we have correct state
+#
+#     # 1
+#     inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
+#
+#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+#
+#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+#     for query in get_default_setup_queries():
+#         execute_and_fetch_all(coord_cursor_3, query)
+#
+#     # 2
+#
+#     def show_instances_coord3():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+#
+#     def show_instances_coord1():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+#
+#     def show_instances_coord2():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+#
+#     data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#
+#     mg_sleep_and_assert(data, show_instances_coord3)
+#     mg_sleep_and_assert(data, show_instances_coord1)
+#     mg_sleep_and_assert(data, show_instances_coord2)
+#
+#     instance_3_cursor = connect(host="localhost", port=7689).cursor()
+#
+#     def show_replicas():
+#         return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+#
+#     replicas = [
+#         (
+#             "instance_1",
+#             "localhost:10001",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#         (
+#             "instance_2",
+#             "localhost:10002",
+#             "sync",
+#             {"behind": None, "status": "ready", "ts": 0},
+#             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
+#         ),
+#     ]
+#     mg_sleep_and_assert_collection(replicas, show_replicas)
+#
+#     def get_vertex_count_func(cursor):
+#         def get_vertex_count():
+#             return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+#
+#         return get_vertex_count
+#
+#     vertex_count = 0
+#     instance_1_cursor = connect(port=7687, host="localhost").cursor()
+#     instance_2_cursor = connect(port=7688, host="localhost").cursor()
+#
+#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
+#     mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+#
+#     # 3
+#
+#     execute_and_fetch_all(
+#         coord_cursor_3,
+#         "FORCE RESET CLUSTER STATE;",
+#     )
+#
+#     # 4.
+#
+#     data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#
+#     mg_sleep_and_assert(data, show_instances_coord3)
+#     mg_sleep_and_assert(data, show_instances_coord1)
+#     mg_sleep_and_assert(data, show_instances_coord2)
+#
+#
+# def test_all_coords_down_resume(test_name):
+#     # Goal of this test is to check that coordinators are able to resume, if cluster is able to resume where it
+#     # left off if all coordinators go down
+#
+#     # 1. Start cluster
+#     # 2. Check everything works correctly
+#     # 3. Stop all coordinators
+#     # 4. Start 2 coordinators, one should be leader, and one follower
+#     # 5. Check everything works correctly
+#
+#     # 1
+#     inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
+#
+#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+#
+#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+#     for query in get_default_setup_queries():
+#         execute_and_fetch_all(coord_cursor_3, query)
+#
+#     # 2
+#     def show_instances_coord3():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+#
+#     def show_instances_coord1():
+#         coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+#
+#     def show_instances_coord2():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+#
+#     data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#
+#     mg_sleep_and_assert(data, show_instances_coord3)
+#     mg_sleep_and_assert(data, show_instances_coord1)
+#     mg_sleep_and_assert(data, show_instances_coord2)
+#
+#     # 3
+#
+#     interactive_mg_runner.kill(inner_instances_description, "coordinator_1")
+#     interactive_mg_runner.kill(inner_instances_description, "coordinator_2")
+#     interactive_mg_runner.kill(inner_instances_description, "coordinator_3")
+#
+#     # 4
+#
+#     with concurrent.futures.ThreadPoolExecutor(2) as executor:
+#         executor.submit(interactive_mg_runner.start, inner_instances_description, "coordinator_2")
+#         executor.submit(interactive_mg_runner.start, inner_instances_description, "coordinator_1")
+#
+#     # 5
+#
+#     leader_data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
+#     ]
+#
+#     wait_for_status_change(show_instances_coord1, {"coordinator_1", "coordinator_2"}, "leader")
+#
+#     leader = find_instance_and_assert_instances(
+#         instance_role="leader", num_coordinators=3, coord_ids_to_skip_validation={3}
+#     )
+#
+#     main = find_instance_and_assert_instances(
+#         instance_role="main", num_coordinators=3, coord_ids_to_skip_validation={3}
+#     )
+#     leader_data = update_tuple_value(leader_data, leader, 0, -1, "leader")
+#     leader_data = update_tuple_value(leader_data, main, 0, -1, "main")
+#
+#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+#
+#     mg_sleep_and_assert(leader_data, show_instances_coord1)
+#
+#     mg_sleep_and_assert(leader_data, show_instances_coord2)
+#
+#     # 6
+#     interactive_mg_runner.kill(inner_instances_description, "instance_3")
+#     interactive_mg_runner.start(inner_instances_description, "coordinator_3")
+#
+#     # 7
+#
+#     leader_data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "follower"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
+#     ]
+#
+#     wait_for_status_change(show_instances_coord1, {"instance_3"}, "unknown")
+#
+#     leader = find_instance_and_assert_instances(instance_role="leader", num_coordinators=3)
+#
+#     main = find_instance_and_assert_instances(instance_role="main", num_coordinators=3)
+#
+#     leader_data = update_tuple_value(leader_data, leader, 0, -1, "leader")
+#     leader_data = update_tuple_value(leader_data, main, 0, -1, "main")
+#
+#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+#
+#     mg_sleep_and_assert(leader_data, show_instances_coord1)
+#
+#     mg_sleep_and_assert(leader_data, show_instances_coord2)
+#
+#     mg_sleep_and_assert(leader_data, show_instances_coord3)
+#
+#
+# def test_one_coord_down_with_durability_resume(test_name):
+#     # Goal of this test is to check that coordinators are able to resume, if cluster is able to resume where it
+#     # left off if all coordinators go down
+#
+#     # 1. Start cluster
+#     # 2. Check everything works correctly
+#     # 3. Stop all coordinators
+#     # 4. Start 2 coordinators, one should be leader, and one follower
+#     # 5. Check everything works correctly
+#
+#     # 1
+#     inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
+#
+#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+#
+#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+#
+#     for query in get_default_setup_queries():
+#         execute_and_fetch_all(coord_cursor_3, query)
+#
+#     # 2
+#     def show_instances_coord3():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+#
+#     def show_instances_coord1():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+#
+#     def show_instances_coord2():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+#
+#     data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#
+#     mg_sleep_and_assert(data, show_instances_coord3)
+#     mg_sleep_and_assert(data, show_instances_coord1)
+#     mg_sleep_and_assert(data, show_instances_coord2)
+#
+#     # 3
+#
+#     interactive_mg_runner.kill(inner_instances_description, "coordinator_1")
+#
+#     leader_data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "down", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#     mg_sleep_and_assert(leader_data, show_instances_coord3)
+#
+#     # 4
+#     interactive_mg_runner.start(inner_instances_description, "coordinator_1")
+#
+#     # 5
+#
+#     data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#
+#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+#
+#     mg_sleep_and_assert(data, show_instances_coord3)
+#     mg_sleep_and_assert(data, show_instances_coord1)
+#     mg_sleep_and_assert(data, show_instances_coord2)
+#
+#     # 6
+#     interactive_mg_runner.kill(inner_instances_description, "instance_3")
+#
+#     # 7
+#
+#     leader_data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "main"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
+#     ]
+#
+#     mg_sleep_and_assert(leader_data, show_instances_coord3)
+#     mg_sleep_and_assert(leader_data, show_instances_coord1)
+#     mg_sleep_and_assert(leader_data, show_instances_coord2)
+#
+#
+# def test_registration_does_not_deadlock_when_instance_is_down(test_name):
+#     # Goal of this test is to assert that system doesn't deadlock in case of failure on registration
+#
+#     # 1
+#     inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
+#
+#     interactive_mg_runner.start(inner_instances_description, "coordinator_1")
+#     interactive_mg_runner.start(inner_instances_description, "coordinator_2")
+#     interactive_mg_runner.start(inner_instances_description, "coordinator_3")
+#
+#     setup_queries = [
+#         "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111', 'management_server': 'localhost:10121'}",
+#         "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112', 'management_server': 'localhost:10122'}",
+#     ]
+#
+#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+#     for query in setup_queries:
+#         execute_and_fetch_all(coord_cursor_3, query)
+#
+#     query = "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7687', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};"
+#
+#     with pytest.raises(Exception) as e:
+#         execute_and_fetch_all(coord_cursor_3, query)
+#
+#     assert "Couldn't register replica instance because setting instance to replica failed!" in str(e.value)
+#
+#     interactive_mg_runner.start(inner_instances_description, "instance_1")
+#     execute_and_fetch_all(coord_cursor_3, query)
+#
+#     interactive_mg_runner.start(inner_instances_description, "instance_2")
+#     interactive_mg_runner.start(inner_instances_description, "instance_3")
+#
+#     setup_queries = [
+#         "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
+#         "REGISTER INSTANCE instance_3 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10013', 'replication_server': 'localhost:10003'};",
+#         "SET INSTANCE instance_3 TO MAIN",
+#     ]
+#
+#     for query in setup_queries:
+#         execute_and_fetch_all(coord_cursor_3, query)
+#
+#     def show_instances_coord3():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+#
+#     def show_instances_coord1():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+#
+#     def show_instances_coord2():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+#
+#     data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#
+#     mg_sleep_and_assert(data, show_instances_coord3)
+#     mg_sleep_and_assert(data, show_instances_coord1)
+#     mg_sleep_and_assert(data, show_instances_coord2)
+#
+#
+# def test_follower_have_correct_health(test_name):
+#     # Goal of this test is to check that coordinators are able to resume, if cluster is able to resume where it
+#     # left off if all coordinators go down
+#
+#     # 1. Start cluster
+#     # 2. Check everything works correctly
+#     # 3. Stop all coordinators
+#     # 4. Start 2 coordinators, one should be leader, and one follower
+#     # 5. Check everything works correctly
+#
+#     # 1
+#     inner_instances_description = get_instances_description_no_setup(test_name=test_name, use_durability=True)
+#
+#     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+#
+#     setup_queries = get_default_setup_queries()
+#
+#     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+#     for query in setup_queries:
+#         execute_and_fetch_all(coord_cursor_3, query)
+#
+#     # 2
+#     def show_instances_coord3():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+#
+#     def show_instances_coord1():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
+#
+#     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
+#
+#     def show_instances_coord2():
+#         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
+#
+#     data = [
+#         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+#         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+#         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+#         ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+#         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+#         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+#     ]
+#
+#     mg_sleep_and_assert(data, show_instances_coord3)
+#     mg_sleep_and_assert(data, show_instances_coord1)
+#     mg_sleep_and_assert(data, show_instances_coord2)
 
 
 def test_first_coord_restarts(test_name):
@@ -3188,7 +3144,7 @@ def test_first_coord_restarts(test_name):
     leader_data = [("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader")]
     mg_sleep_and_assert(leader_data, show_instances_coord1)
 
-    interactive_mg_runner.stop_all(keep_directories=True)
+    interactive_mg_runner.kill_all(keep_directories=True)
 
     interactive_mg_runner.start(inner_instances_description, "coordinator_1")
 
@@ -3196,8 +3152,6 @@ def test_first_coord_restarts(test_name):
 
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
     mg_sleep_and_assert(leader_data, show_instances_coord1)
-
-    interactive_mg_runner.stop_all(keep_directories=False)
 
 
 if __name__ == "__main__":

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -12,7 +12,6 @@
 import concurrent.futures
 import os
 import sys
-import tempfile
 import time
 
 import interactive_mg_runner
@@ -21,6 +20,8 @@ from common import (
     connect,
     execute_and_fetch_all,
     find_instance_and_assert_instances,
+    get_data_path,
+    get_logs_path,
     ignore_elapsed_time_from_results,
     update_tuple_value,
 )
@@ -39,8 +40,10 @@ interactive_mg_runner.PROJECT_DIR = os.path.normpath(
 interactive_mg_runner.BUILD_DIR = os.path.normpath(os.path.join(interactive_mg_runner.PROJECT_DIR, "build"))
 interactive_mg_runner.MEMGRAPH_BINARY = os.path.normpath(os.path.join(interactive_mg_runner.BUILD_DIR, "memgraph"))
 
+file = "distributed_coords"
 
-def get_instances_description_no_setup(temp_dir, test_name: str, use_durability: bool = True):
+
+def get_instances_description_no_setup(test_name: str, use_durability: bool = True):
     return {
         "instance_1": {
             "args": [
@@ -52,8 +55,8 @@ def get_instances_description_no_setup(temp_dir, test_name: str, use_durability:
                 "--management-port",
                 "10011",
             ],
-            f"log_file": f"high_availability/distributed_coords/{test_name}/instance_1.log",
-            "data_directory": f"{temp_dir}/instance_1",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_1",
             "setup_queries": [],
         },
         "instance_2": {
@@ -66,8 +69,8 @@ def get_instances_description_no_setup(temp_dir, test_name: str, use_durability:
                 "--management-port",
                 "10012",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/instance_2.log",
-            "data_directory": f"{temp_dir}/instance_2",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_2",
             "setup_queries": [],
         },
         "instance_3": {
@@ -80,8 +83,8 @@ def get_instances_description_no_setup(temp_dir, test_name: str, use_durability:
                 "--management-port",
                 "10013",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/instance_3.log",
-            "data_directory": f"{temp_dir}/instance_3",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_3.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_3",
             "setup_queries": [],
         },
         "coordinator_1": {
@@ -97,8 +100,8 @@ def get_instances_description_no_setup(temp_dir, test_name: str, use_durability:
                 "--coordinator-hostname",
                 "localhost",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/coordinator1.log",
-            "data_directory": f"{temp_dir}/coordinator_1",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_1",
             "setup_queries": [],
         },
         "coordinator_2": {
@@ -114,8 +117,8 @@ def get_instances_description_no_setup(temp_dir, test_name: str, use_durability:
                 "--coordinator-hostname",
                 "localhost",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/coordinator2.log",
-            "data_directory": f"{temp_dir}/coordinator_2",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_2",
             "setup_queries": [],
         },
         "coordinator_3": {
@@ -131,8 +134,8 @@ def get_instances_description_no_setup(temp_dir, test_name: str, use_durability:
                 "--coordinator-hostname",
                 "localhost",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/coordinator3.log",
-            "data_directory": f"{temp_dir}/coordinator_3",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_3.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_3",
             "setup_queries": [],
         },
     }
@@ -149,7 +152,7 @@ def get_default_setup_queries():
     ]
 
 
-def get_instances_description_no_setup_4_coords(temp_dir, test_name: str, use_durability: bool = True):
+def get_instances_description_no_setup_4_coords(test_name: str, use_durability: bool = True):
     use_durability_str = "true" if use_durability else "false"
     return {
         "instance_1": {
@@ -162,8 +165,8 @@ def get_instances_description_no_setup_4_coords(temp_dir, test_name: str, use_du
                 "--management-port",
                 "10011",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/instance_1.log",
-            "data_directory": f"{temp_dir}/instance_1",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_1",
             "setup_queries": [],
         },
         "instance_2": {
@@ -176,8 +179,8 @@ def get_instances_description_no_setup_4_coords(temp_dir, test_name: str, use_du
                 "--management-port",
                 "10012",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/instance_2.log",
-            "data_directory": f"{temp_dir}/instance_2",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_2",
             "setup_queries": [],
         },
         "instance_3": {
@@ -190,8 +193,8 @@ def get_instances_description_no_setup_4_coords(temp_dir, test_name: str, use_du
                 "--management-port",
                 "10013",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/instance_3.log",
-            "data_directory": f"{temp_dir}/instance_3",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_3.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_3",
             "setup_queries": [],
         },
         "coordinator_1": {
@@ -207,8 +210,8 @@ def get_instances_description_no_setup_4_coords(temp_dir, test_name: str, use_du
                 "localhost",
                 "--management-port=10121",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/coordinator1.log",
-            "data_directory": f"{temp_dir}/coordinator_1",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_1",
             "setup_queries": [],
         },
         "coordinator_2": {
@@ -224,8 +227,8 @@ def get_instances_description_no_setup_4_coords(temp_dir, test_name: str, use_du
                 "localhost",
                 "--management-port=10122",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/coordinator2.log",
-            "data_directory": f"{temp_dir}/coordinator_2",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_2",
             "setup_queries": [],
         },
         "coordinator_3": {
@@ -241,8 +244,8 @@ def get_instances_description_no_setup_4_coords(temp_dir, test_name: str, use_du
                 "localhost",
                 "--management-port=10123",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/coordinator3.log",
-            "data_directory": f"{temp_dir}/coordinator_3",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_3.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_3",
             "setup_queries": [],
         },
         "coordinator_4": {
@@ -258,8 +261,8 @@ def get_instances_description_no_setup_4_coords(temp_dir, test_name: str, use_du
                 "localhost",
                 "--management-port=10124",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/coordinator4.log",
-            "data_directory": f"{temp_dir}/coordinator_4",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_4.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_4",
             "setup_queries": [],
         },
     }
@@ -278,10 +281,8 @@ def test_even_number_coords(use_durability):
     # 8.
 
     # 1
-    temp_dir = tempfile.TemporaryDirectory()
-
     inner_instances_description = get_instances_description_no_setup_4_coords(
-        temp_dir.name, test_name="test_even_number_coords_" + str(use_durability), use_durability=use_durability
+        test_name="test_even_number_coords_" + str(use_durability), use_durability=use_durability
     )
 
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
@@ -456,10 +457,8 @@ def test_old_main_comes_back_on_new_leader_as_replica():
     # 5. Run SHOW INSTANCES on the new leader and check that the old main instance is registered as a replica
     # 6. Start again previous leader
 
-    temp_dir = tempfile.TemporaryDirectory()
-
     inner_instances_description = get_instances_description_no_setup(
-        temp_dir.name, test_name="test_old_main_comes_back_on_new_leader_as_replica"
+        test_name="test_old_main_comes_back_on_new_leader_as_replica"
     )
 
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
@@ -619,11 +618,7 @@ def test_old_main_comes_back_on_new_leader_as_replica():
 
 
 def test_distributed_automatic_failover():
-    temp_dir = tempfile.TemporaryDirectory()
-
-    inner_instances_description = get_instances_description_no_setup(
-        temp_dir.name, test_name="test_distributed_automatic_failover"
-    )
+    inner_instances_description = get_instances_description_no_setup(test_name="test_distributed_automatic_failover")
 
     interactive_mg_runner.start_all(inner_instances_description)
 
@@ -719,10 +714,8 @@ def test_distributed_automatic_failover():
 
 
 def test_distributed_automatic_failover_with_leadership_change():
-    temp_dir = tempfile.TemporaryDirectory()
-
     inner_instances_description = get_instances_description_no_setup(
-        temp_dir.name, test_name="test_distributed_automatic_failover_with_leadership_change"
+        test_name="test_distributed_automatic_failover_with_leadership_change"
     )
 
     interactive_mg_runner.start_all(inner_instances_description)
@@ -855,10 +848,8 @@ def test_no_leader_after_leader_and_follower_die():
     # 2. Kill the leader and a follower.
     # 3. Check that the remaining follower is not promoted to leader by trying to register remaining replication instance.
 
-    temp_dir = tempfile.TemporaryDirectory()
-
     inner_memgraph_instances = get_instances_description_no_setup(
-        temp_dir, test_name="test_no_leader_after_leader_and_follower_die"
+        test_name="test_no_leader_after_leader_and_follower_die"
     )
     interactive_mg_runner.start_all(inner_memgraph_instances)
 
@@ -903,10 +894,8 @@ def test_old_main_comes_back_on_new_leader_as_main():
     # 4. Start the old main instance
     # 5. Run SHOW INSTANCES on the new leader and check that the old main instance is main once again
 
-    temp_dir = tempfile.TemporaryDirectory()
-
     inner_memgraph_instances = get_instances_description_no_setup(
-        temp_dir.name, test_name="test_old_main_comes_back_on_new_leader_as_main"
+        test_name="test_old_main_comes_back_on_new_leader_as_main"
     )
     interactive_mg_runner.start_all(inner_memgraph_instances)
 
@@ -998,9 +987,6 @@ def test_old_main_comes_back_on_new_leader_as_main():
 
 def test_registering_4_coords():
     # Goal of this test is to assure registering of multiple coordinators in row works
-    temp_dir = tempfile.TemporaryDirectory()
-    temp_dir_name = temp_dir.name
-
     test_name = "test_registering_4_coords"
     INSTANCES_DESCRIPTION = {
         "instance_1": {
@@ -1013,8 +999,8 @@ def test_registering_4_coords():
                 "--management-port",
                 "10011",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/instance_1.log",
-            "data_directory": f"{temp_dir_name}/instance_1",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_1",
             "setup_queries": [],
         },
         "instance_2": {
@@ -1027,8 +1013,8 @@ def test_registering_4_coords():
                 "--management-port",
                 "10012",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/instance_2.log",
-            "data_directory": f"{temp_dir_name}/instance_2",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_2",
             "setup_queries": [],
         },
         "instance_3": {
@@ -1041,8 +1027,8 @@ def test_registering_4_coords():
                 "--management-port",
                 "10013",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/instance_3.log",
-            "data_directory": f"{temp_dir_name}/instance_3",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_3.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_3",
             "setup_queries": [],
         },
         "coordinator_1": {
@@ -1056,7 +1042,8 @@ def test_registering_4_coords():
                 "--management-port=10121",
                 "--coordinator-hostname=localhost",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/coordinator1.log",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_1",
             "setup_queries": [],
         },
         "coordinator_2": {
@@ -1070,7 +1057,8 @@ def test_registering_4_coords():
                 "--management-port=10122",
                 "--coordinator-hostname=localhost",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/coordinator2.log",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_2",
             "setup_queries": [],
         },
         "coordinator_3": {
@@ -1084,7 +1072,8 @@ def test_registering_4_coords():
                 "--management-port=10123",
                 "--coordinator-hostname=localhost",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/coordinator3.log",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_3.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_3",
             "setup_queries": [],
         },
         "coordinator_4": {
@@ -1098,7 +1087,8 @@ def test_registering_4_coords():
                 "--management-port=10124",
                 "--coordinator-hostname=localhost",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/coordinator4.log",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_4.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_4",
             "setup_queries": [
                 "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111', 'management_server': 'localhost:10121'}",
                 "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112', 'management_server': 'localhost:10122'}",
@@ -1145,8 +1135,6 @@ def test_registering_coord_log_store():
     # 8. Check correct state
     # 9. Drop 1 new instance # 1 log -> 2nd snapshot
     # 10. Check correct state
-    temp_dir = tempfile.TemporaryDirectory()
-    temp_dir_name = temp_dir.name
 
     test_name = "test_registering_coord_log_store"
     INSTANCES_DESCRIPTION = {
@@ -1160,8 +1148,8 @@ def test_registering_coord_log_store():
                 "--management-port",
                 "10011",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/instance_1.log",
-            "data_directory": f"{temp_dir_name}/instance_1",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_1",
             "setup_queries": [],
         },
         "instance_2": {
@@ -1174,8 +1162,8 @@ def test_registering_coord_log_store():
                 "--management-port",
                 "10012",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/instance_2.log",
-            "data_directory": f"{temp_dir_name}/instance_2",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_2",
             "setup_queries": [],
         },
         "instance_3": {
@@ -1188,8 +1176,8 @@ def test_registering_coord_log_store():
                 "--management-port",
                 "10013",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/instance_3.log",
-            "data_directory": f"{temp_dir_name}/instance_3",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_3.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_3",
             "setup_queries": [],
         },
         "coordinator_1": {
@@ -1204,7 +1192,8 @@ def test_registering_coord_log_store():
                 "localhost",
                 "--management-port=10121",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/coordinator1.log",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_1",
             "setup_queries": [],
         },
         "coordinator_2": {
@@ -1219,7 +1208,8 @@ def test_registering_coord_log_store():
                 "localhost",
                 "--management-port=10122",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/coordinator2.log",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_2",
             "setup_queries": [],
         },
         "coordinator_3": {
@@ -1234,7 +1224,8 @@ def test_registering_coord_log_store():
                 "localhost",
                 "--management-port=10123",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/coordinator3.log",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_3.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_3",
             "setup_queries": [],
         },
         "coordinator_4": {
@@ -1249,7 +1240,8 @@ def test_registering_coord_log_store():
                 "localhost",
                 "--management-port=10124",
             ],
-            "log_file": f"high_availability/distributed_coords/{test_name}/coordinator4.log",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_4.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_4",
             "setup_queries": [
                 "ADD COORDINATOR 1 WITH CONFIG {'bolt_server': 'localhost:7690', 'coordinator_server': 'localhost:10111', 'management_server': 'localhost:10121'}",
                 "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112', 'management_server': 'localhost:10122'}",
@@ -1312,8 +1304,8 @@ def test_registering_coord_log_store():
 
         instance_description = {
             "args": args_desc,
-            "log_file": f"high_availability/distributed_coords/{test_name}/instance_{i}.log",
-            "data_directory": f"{temp_dir_name}/instance_{i}",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_{i}.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_{i}",
             "setup_queries": [],
         }
 
@@ -1403,11 +1395,8 @@ def test_multiple_failovers_in_row_no_leadership_change():
     # 13. Expect data to be replicated
 
     # 1
-    temp_dir = tempfile.TemporaryDirectory()
-    temp_dir_name = temp_dir.name
-
     inner_memgraph_instances = get_instances_description_no_setup(
-        temp_dir_name, test_name="test_multiple_failovers_in_row_no_leadership_change"
+        test_name="test_multiple_failovers_in_row_no_leadership_change"
     )
     interactive_mg_runner.start_all(inner_memgraph_instances, keep_directories=False)
 
@@ -1586,11 +1575,8 @@ def test_multiple_old_mains_single_failover():
     # 7. Second main should write data to new instance all the time
 
     # 1
-    temp_dir = tempfile.TemporaryDirectory()
-    temp_dir_name = temp_dir.name
-
     inner_instances_description = get_instances_description_no_setup(
-        temp_dir_name, test_name="test_multiple_old_mains_single_failover"
+        test_name="test_multiple_old_mains_single_failover"
     )
 
     interactive_mg_runner.start_all(inner_instances_description)
@@ -1746,11 +1732,8 @@ def test_force_reset_works_after_failed_registration():
     # 5. Check that everything works correctly
 
     # 1
-    temp_dir = tempfile.TemporaryDirectory()
-    temp_dir_name = temp_dir.name
-
     inner_instances_description = get_instances_description_no_setup(
-        temp_dir_name, test_name="test_force_reset_works_after_failed_registration"
+        test_name="test_force_reset_works_after_failed_registration"
     )
 
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
@@ -1892,11 +1875,8 @@ def test_force_reset_works_after_failed_registration_and_replica_down():
     # 7. Check that replica is correctly demoted to replica
 
     # 1
-    temp_dir = tempfile.TemporaryDirectory()
-    temp_dir_name = temp_dir.name
-
     inner_instances_description = get_instances_description_no_setup(
-        temp_dir_name, test_name="test_force_reset_works_after_failed_registration_and_replica_down"
+        test_name="test_force_reset_works_after_failed_registration_and_replica_down"
     )
 
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
@@ -2099,11 +2079,8 @@ def test_force_reset_works_after_failed_registration_and_2_coordinators_down():
     # 8. Check that everything works correctly
 
     # 1
-    temp_dir = tempfile.TemporaryDirectory()
-    temp_dir_name = temp_dir.name
-
     inner_instances_description = get_instances_description_no_setup(
-        temp_dir_name, test_name="test_force_reset_works_after_failed_registration_and_2_coordinators_down"
+        test_name="test_force_reset_works_after_failed_registration_and_2_coordinators_down"
     )
 
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
@@ -2294,11 +2271,10 @@ def test_coordinator_gets_info_on_other_coordinators():
     # 8. Check that such coordinator has correct info
 
     # 1
-    temp_dir = tempfile.TemporaryDirectory()
-    temp_dir_name = temp_dir.name
+    test_name = "test_coordinator_gets_info_on_other_coordinators"
 
     inner_instances_description = get_instances_description_no_setup(
-        temp_dir_name, test_name="test_coordinator_gets_info_on_other_coordinators"
+        test_name="test_coordinator_gets_info_on_other_coordinators"
     )
 
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
@@ -2399,8 +2375,8 @@ def test_coordinator_gets_info_on_other_coordinators():
                 "--coordinator-hostname",
                 "localhost",
             ],
-            "log_file": "high_availability/distributed_coords/coordinator4.log",
-            "data_directory": f"{temp_dir_name}/coordinator_4",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator_4.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator_4",
             "setup_queries": [],
         },
     }
@@ -2460,12 +2436,7 @@ def test_registration_works_after_main_set():
     # 2. Check everything works correctly
 
     # 1
-    temp_dir = tempfile.TemporaryDirectory()
-    temp_dir_name = temp_dir.name
-
-    inner_instances_description = get_instances_description_no_setup(
-        temp_dir_name, test_name="test_registration_works_after_main_set"
-    )
+    inner_instances_description = get_instances_description_no_setup(test_name="test_registration_works_after_main_set")
 
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
 
@@ -2547,11 +2518,8 @@ def test_coordinator_not_leader_registration_does_not_work():
     # 3. Try to register instance on follower coord
 
     # 1
-    temp_dir = tempfile.TemporaryDirectory()
-    temp_dir_name = temp_dir.name
-
     inner_instances_description = get_instances_description_no_setup(
-        temp_dir_name, test_name="test_coordinator_not_leader_registration_does_not_work"
+        test_name="test_coordinator_not_leader_registration_does_not_work"
     )
 
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
@@ -2648,11 +2616,8 @@ def test_coordinator_user_action_demote_instance_to_replica():
     # 4. Check we have correct state
 
     # 1
-    temp_dir = tempfile.TemporaryDirectory()
-    temp_dir_name = temp_dir.name
-
     inner_instances_description = get_instances_description_no_setup(
-        temp_dir_name, test_name="test_coordinator_user_action_demote_instance_to_replica", use_durability=True
+        test_name="test_coordinator_user_action_demote_instance_to_replica", use_durability=True
     )
 
     FAILOVER_PERIOD = 2
@@ -2777,11 +2742,8 @@ def test_coordinator_user_action_force_reset_works():
     # 4. Check we have correct state
 
     # 1
-    temp_dir = tempfile.TemporaryDirectory()
-    temp_dir_name = temp_dir.name
-
     inner_instances_description = get_instances_description_no_setup(
-        temp_dir_name, test_name="test_coordinator_user_action_force_reset_works", use_durability=True
+        test_name="test_coordinator_user_action_force_reset_works", use_durability=True
     )
 
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
@@ -2890,11 +2852,8 @@ def test_all_coords_down_resume():
     # 5. Check everything works correctly
 
     # 1
-    temp_dir = tempfile.TemporaryDirectory()
-    temp_dir_name = temp_dir.name
-
     inner_instances_description = get_instances_description_no_setup(
-        temp_dir_name, test_name="test_all_coords_down_resume", use_durability=True
+        test_name="test_all_coords_down_resume", use_durability=True
     )
 
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
@@ -3019,11 +2978,8 @@ def test_one_coord_down_with_durability_resume():
     # 5. Check everything works correctly
 
     # 1
-    temp_dir = tempfile.TemporaryDirectory()
-    temp_dir_name = temp_dir.name
-
     inner_instances_description = get_instances_description_no_setup(
-        temp_dir_name, test_name="test_one_coord_down_with_durability_resume", use_durability=True
+        test_name="test_one_coord_down_with_durability_resume", use_durability=True
     )
 
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
@@ -3119,12 +3075,9 @@ def test_registration_does_not_deadlock_when_instance_is_down():
     # Goal of this test is to assert that system doesn't deadlock in case of failure on registration
 
     # 1
-    temp_dir = tempfile.TemporaryDirectory()
-    temp_dir_name = temp_dir.name
-
     interactive_mg_runner.stop_all(keep_directories=False)
     inner_instances_description = get_instances_description_no_setup(
-        temp_dir_name, test_name="test_registration_does_not_deadlock_when_instance_is_down", use_durability=True
+        test_name="test_registration_does_not_deadlock_when_instance_is_down", use_durability=True
     )
 
     interactive_mg_runner.start(inner_instances_description, "coordinator_1")
@@ -3202,11 +3155,8 @@ def test_follower_have_correct_health():
     # 5. Check everything works correctly
 
     # 1
-    temp_dir = tempfile.TemporaryDirectory()
-    temp_dir_name = temp_dir.name
-
     inner_instances_description = get_instances_description_no_setup(
-        temp_dir_name, test_name="test_one_coord_down_with_durability_resume", use_durability=True
+        test_name="test_one_coord_down_with_durability_resume", use_durability=True
     )
 
     interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
@@ -3251,12 +3201,7 @@ def test_first_coord_restarts():
     # Goal of this test is to check that first coordinator can restart without any issues
 
     # 1
-    temp_dir = tempfile.TemporaryDirectory()
-    temp_dir_name = temp_dir.name
-
-    inner_instances_description = get_instances_description_no_setup(
-        temp_dir_name, test_name="test_first_coord_restarts"
-    )
+    inner_instances_description = get_instances_description_no_setup(test_name="test_first_coord_restarts")
 
     interactive_mg_runner.start(inner_instances_description, "coordinator_1")
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -268,6 +268,13 @@ def get_instances_description_no_setup_4_coords(test_name: str, use_durability: 
     }
 
 
+@pytest.fixture(autouse=True)
+def cleanup_after_test():
+    yield
+    # Stop + delete directories
+    interactive_mg_runner.stop_all(keep_directories=False)
+
+
 @pytest.mark.parametrize("use_durability", [True, False])
 def test_even_number_coords(use_durability):
     # Goal is to check that nothing gets broken on even number of coords when 2 coords are down
@@ -620,7 +627,7 @@ def test_old_main_comes_back_on_new_leader_as_replica():
 def test_distributed_automatic_failover():
     inner_instances_description = get_instances_description_no_setup(test_name="test_distributed_automatic_failover")
 
-    interactive_mg_runner.start_all(inner_instances_description)
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
 
     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
     for query in get_default_setup_queries():
@@ -718,7 +725,7 @@ def test_distributed_automatic_failover_with_leadership_change():
         test_name="test_distributed_automatic_failover_with_leadership_change"
     )
 
-    interactive_mg_runner.start_all(inner_instances_description)
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
 
     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
     for query in get_default_setup_queries():
@@ -851,7 +858,7 @@ def test_no_leader_after_leader_and_follower_die():
     inner_memgraph_instances = get_instances_description_no_setup(
         test_name="test_no_leader_after_leader_and_follower_die"
     )
-    interactive_mg_runner.start_all(inner_memgraph_instances)
+    interactive_mg_runner.start_all(inner_memgraph_instances, keep_directories=False)
 
     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
 
@@ -897,7 +904,7 @@ def test_old_main_comes_back_on_new_leader_as_main():
     inner_memgraph_instances = get_instances_description_no_setup(
         test_name="test_old_main_comes_back_on_new_leader_as_main"
     )
-    interactive_mg_runner.start_all(inner_memgraph_instances)
+    interactive_mg_runner.start_all(inner_memgraph_instances, keep_directories=False)
 
     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
 
@@ -1101,7 +1108,7 @@ def test_registering_4_coords():
         },
     }
 
-    interactive_mg_runner.start_all(INSTANCES_DESCRIPTION)
+    interactive_mg_runner.start_all(INSTANCES_DESCRIPTION, keep_directories=False)
 
     coord_cursor = connect(host="localhost", port=7693).cursor()
 
@@ -1255,7 +1262,7 @@ def test_registering_coord_log_store():
     assert "SET INSTANCE instance_3 TO MAIN" not in INSTANCES_DESCRIPTION["coordinator_4"]["setup_queries"]
 
     # 1
-    interactive_mg_runner.start_all(INSTANCES_DESCRIPTION)
+    interactive_mg_runner.start_all(INSTANCES_DESCRIPTION, keep_directories=False)
 
     # 2
     coord_cursor = connect(host="localhost", port=7693).cursor()
@@ -1579,7 +1586,7 @@ def test_multiple_old_mains_single_failover():
         test_name="test_multiple_old_mains_single_failover"
     )
 
-    interactive_mg_runner.start_all(inner_instances_description)
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
 
     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
     for query in get_default_setup_queries():

--- a/tests/e2e/high_availability/manual_setting_replicas.py
+++ b/tests/e2e/high_availability/manual_setting_replicas.py
@@ -43,11 +43,18 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
 }
 
 
+@pytest.fixture(autouse=True)
+def cleanup_after_test():
+    yield
+    # Stop + delete directories
+    interactive_mg_runner.stop_all(keep_directories=False)
+
+
 def test_no_manual_setup_on_main():
     # Goal of this test is to check that all manual registration actions are disabled on instances with coordiantor server port
 
     # 1
-    interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION)
+    interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION, keep_directories=False)
 
     any_main = connect(host="localhost", port=7687).cursor()
     with pytest.raises(Exception) as e:

--- a/tests/e2e/high_availability/manual_setting_replicas.py
+++ b/tests/e2e/high_availability/manual_setting_replicas.py
@@ -11,11 +11,10 @@
 
 import os
 import sys
-import tempfile
 
 import interactive_mg_runner
 import pytest
-from common import connect, execute_and_fetch_all
+from common import connect, execute_and_fetch_all, get_data_path, get_logs_path
 
 interactive_mg_runner.SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 interactive_mg_runner.PROJECT_DIR = os.path.normpath(
@@ -24,7 +23,7 @@ interactive_mg_runner.PROJECT_DIR = os.path.normpath(
 interactive_mg_runner.BUILD_DIR = os.path.normpath(os.path.join(interactive_mg_runner.PROJECT_DIR, "build"))
 interactive_mg_runner.MEMGRAPH_BINARY = os.path.normpath(os.path.join(interactive_mg_runner.BUILD_DIR, "memgraph"))
 
-TEMP_DIR = tempfile.TemporaryDirectory().name
+file = "manual_setting_replicas"
 
 MEMGRAPH_INSTANCES_DESCRIPTION = {
     "instance_3": {
@@ -37,8 +36,8 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
             "--management-port",
             "10013",
         ],
-        "log_file": "high_availability/manual_setting_replicas/main.log",
-        "data_directory": f"{TEMP_DIR}/instance_3",
+        "log_file": f"{get_logs_path(file, 'test_no_manual_setup_on_main')}/instance_3.log",
+        "data_directory": f"{get_data_path(file, 'test_no_manual_setup_on_main')}/instance_3",
         "setup_queries": [],
     },
 }

--- a/tests/e2e/high_availability/manual_setting_replicas.py
+++ b/tests/e2e/high_availability/manual_setting_replicas.py
@@ -45,8 +45,9 @@ MEMGRAPH_INSTANCES_DESCRIPTION = {
 
 @pytest.fixture(autouse=True)
 def cleanup_after_test():
+    # Run the test
     yield
-    # Stop + delete directories
+    # Stop + delete directories after running the test
     interactive_mg_runner.stop_all(keep_directories=False)
 
 

--- a/tests/e2e/high_availability/not_replicate_from_old_main.py
+++ b/tests/e2e/high_availability/not_replicate_from_old_main.py
@@ -75,7 +75,7 @@ def test_replication_works_on_failover():
     # to be part of new cluster, `main` (old cluster) can't write any more to it
 
     # 1
-    interactive_mg_runner.start_all_keep_others(MEMGRAPH_FIRST_CLUSTER_DESCRIPTION, keep_directories=False)
+    interactive_mg_runner.start_all_keep_others(MEMGRAPH_FIRST_CLUSTER_DESCRIPTION)
 
     # 2
     main_cursor = connect(host="localhost", port=7687).cursor()
@@ -95,7 +95,7 @@ def test_replication_works_on_failover():
     mg_sleep_and_assert(expected_data_on_main, retrieve_data_show_replicas)
 
     # 3
-    interactive_mg_runner.start_all_keep_others(MEMGRAPH_SECOND_CLUSTER_DESCRIPTION, keep_directories=False)
+    interactive_mg_runner.start_all_keep_others(MEMGRAPH_SECOND_CLUSTER_DESCRIPTION)
 
     # 4
     new_main_cursor = connect(host="localhost", port=7690).cursor()
@@ -209,7 +209,7 @@ def test_not_replicate_old_main_register_new_cluster():
     }
 
     # 1
-    interactive_mg_runner.start_all_keep_others(MEMGRAPH_FISRT_COORD_CLUSTER_DESCRIPTION, keep_directories=False)
+    interactive_mg_runner.start_all_keep_others(MEMGRAPH_FISRT_COORD_CLUSTER_DESCRIPTION)
 
     # 2
 
@@ -262,7 +262,7 @@ def test_not_replicate_old_main_register_new_cluster():
         },
     }
 
-    interactive_mg_runner.start_all_keep_others(MEMGRAPH_SECOND_COORD_CLUSTER_DESCRIPTION, keep_directories=False)
+    interactive_mg_runner.start_all_keep_others(MEMGRAPH_SECOND_COORD_CLUSTER_DESCRIPTION)
     second_cluster_coord_cursor = connect(host="localhost", port=7691).cursor()
     execute_and_fetch_all(
         second_cluster_coord_cursor,

--- a/tests/e2e/high_availability/not_replicate_from_old_main.py
+++ b/tests/e2e/high_availability/not_replicate_from_old_main.py
@@ -11,7 +11,6 @@
 
 import os
 import sys
-import tempfile
 
 import interactive_mg_runner
 import pytest
@@ -76,7 +75,7 @@ def test_replication_works_on_failover():
     # to be part of new cluster, `main` (old cluster) can't write any more to it
 
     # 1
-    interactive_mg_runner.start_all_keep_others(MEMGRAPH_FIRST_CLUSTER_DESCRIPTION)
+    interactive_mg_runner.start_all_keep_others(MEMGRAPH_FIRST_CLUSTER_DESCRIPTION, keep_directories=False)
 
     # 2
     main_cursor = connect(host="localhost", port=7687).cursor()
@@ -96,7 +95,7 @@ def test_replication_works_on_failover():
     mg_sleep_and_assert(expected_data_on_main, retrieve_data_show_replicas)
 
     # 3
-    interactive_mg_runner.start_all_keep_others(MEMGRAPH_SECOND_CLUSTER_DESCRIPTION)
+    interactive_mg_runner.start_all_keep_others(MEMGRAPH_SECOND_CLUSTER_DESCRIPTION, keep_directories=False)
 
     # 4
     new_main_cursor = connect(host="localhost", port=7690).cursor()
@@ -210,7 +209,7 @@ def test_not_replicate_old_main_register_new_cluster():
     }
 
     # 1
-    interactive_mg_runner.start_all_keep_others(MEMGRAPH_FISRT_COORD_CLUSTER_DESCRIPTION)
+    interactive_mg_runner.start_all_keep_others(MEMGRAPH_FISRT_COORD_CLUSTER_DESCRIPTION, keep_directories=False)
 
     # 2
 
@@ -263,7 +262,7 @@ def test_not_replicate_old_main_register_new_cluster():
         },
     }
 
-    interactive_mg_runner.start_all_keep_others(MEMGRAPH_SECOND_COORD_CLUSTER_DESCRIPTION)
+    interactive_mg_runner.start_all_keep_others(MEMGRAPH_SECOND_COORD_CLUSTER_DESCRIPTION, keep_directories=False)
     second_cluster_coord_cursor = connect(host="localhost", port=7691).cursor()
     execute_and_fetch_all(
         second_cluster_coord_cursor,

--- a/tests/e2e/high_availability/not_replicate_from_old_main.py
+++ b/tests/e2e/high_availability/not_replicate_from_old_main.py
@@ -31,9 +31,16 @@ interactive_mg_runner.BUILD_DIR = os.path.normpath(os.path.join(interactive_mg_r
 interactive_mg_runner.MEMGRAPH_BINARY = os.path.normpath(os.path.join(interactive_mg_runner.BUILD_DIR, "memgraph"))
 
 
+@pytest.fixture
+def test_name(request):
+    return request.node.name
+
+
 @pytest.fixture(autouse=True)
 def cleanup_after_test():
+    # Run the test
     yield
+    # Stop and delete directories after running the test
     interactive_mg_runner.stop_all(keep_directories=False)
 
 
@@ -146,7 +153,7 @@ def test_replication_works_on_failover():
     interactive_mg_runner.stop_all()
 
 
-def test_not_replicate_old_main_register_new_cluster():
+def test_not_replicate_old_main_register_new_cluster(test_name):
     # Goal of this test is to check that although replica is registered in one cluster
     # it can be re-registered to new cluster
     # This flow checks if Registering replica is idempotent and that old main cannot talk to replica
@@ -157,7 +164,6 @@ def test_not_replicate_old_main_register_new_cluster():
     # 5. Old main should not talk to new replica
     # 6. New main should talk to replica
 
-    test_name = "test_not_replicate_old_main_register_new_cluster"
     MEMGRAPH_FISRT_COORD_CLUSTER_DESCRIPTION = {
         "shared_instance": {
             "args": [

--- a/tests/e2e/high_availability/single_coordinator.py
+++ b/tests/e2e/high_availability/single_coordinator.py
@@ -9,17 +9,16 @@
 # licenses/APL.txt.
 
 import os
-import shutil
 import sys
-import tempfile
 
 import interactive_mg_runner
 import pytest
 from common import (
     connect,
     execute_and_fetch_all,
+    get_data_path,
+    get_logs_path,
     ignore_elapsed_time_from_results,
-    safe_execute,
 )
 from mg_utils import mg_sleep_and_assert, mg_sleep_and_assert_collection
 
@@ -30,7 +29,7 @@ interactive_mg_runner.PROJECT_DIR = os.path.normpath(
 interactive_mg_runner.BUILD_DIR = os.path.normpath(os.path.join(interactive_mg_runner.PROJECT_DIR, "build"))
 interactive_mg_runner.MEMGRAPH_BINARY = os.path.normpath(os.path.join(interactive_mg_runner.BUILD_DIR, "memgraph"))
 
-TEMP_DIR = tempfile.TemporaryDirectory().name
+file = "single_coordinator"
 
 
 def get_memgraph_instances_description(test_name: str, data_recovery_on_startup: str = "false"):
@@ -47,8 +46,8 @@ def get_memgraph_instances_description(test_name: str, data_recovery_on_startup:
                 "--replication-restore-state-on-startup=true",
                 f"--data-recovery-on-startup={data_recovery_on_startup}",
             ],
-            "log_file": f"high_availability/single_coordinator/{test_name}/instance_1.log",
-            "data_directory": f"{TEMP_DIR}/instance_1",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_1",
             "setup_queries": [],
         },
         "instance_2": {
@@ -63,8 +62,8 @@ def get_memgraph_instances_description(test_name: str, data_recovery_on_startup:
                 "--replication-restore-state-on-startup=true",
                 f"--data-recovery-on-startup={data_recovery_on_startup}",
             ],
-            "log_file": f"high_availability/single_coordinator/{test_name}/instance_2.log",
-            "data_directory": f"{TEMP_DIR}/instance_2",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_2",
             "setup_queries": [],
         },
         "instance_3": {
@@ -79,8 +78,8 @@ def get_memgraph_instances_description(test_name: str, data_recovery_on_startup:
                 "--replication-restore-state-on-startup=true",
                 f"--data-recovery-on-startup={data_recovery_on_startup}",
             ],
-            "log_file": f"high_availability/single_coordinator/{test_name}/instance_3.log",
-            "data_directory": f"{TEMP_DIR}/instance_3",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_3.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_3",
             "setup_queries": [],
         },
         "coordinator": {
@@ -94,8 +93,8 @@ def get_memgraph_instances_description(test_name: str, data_recovery_on_startup:
                 "--coordinator-hostname=localhost",
                 "--management-port=10121",
             ],
-            "log_file": f"high_availability/single_coordinator/{test_name}/coordinator.log",
-            "data_directory": f"{TEMP_DIR}/coordinator",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator",
             "setup_queries": [
                 "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
                 "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
@@ -121,8 +120,8 @@ def get_memgraph_instances_description_4_instances(test_name: str, data_recovery
                 "true",
                 f"--data-recovery-on-startup={data_recovery_on_startup}",
             ],
-            "log_file": f"high_availability/single_coordinator/{test_name}/instance_1.log",
-            "data_directory": f"{TEMP_DIR}/instance_1",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_1",
             "setup_queries": [],
         },
         "instance_2": {
@@ -138,8 +137,8 @@ def get_memgraph_instances_description_4_instances(test_name: str, data_recovery
                 "true",
                 f"--data-recovery-on-startup={data_recovery_on_startup}",
             ],
-            "log_file": f"high_availability/single_coordinator/{test_name}/instance_2.log",
-            "data_directory": f"{TEMP_DIR}/instance_2",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_2",
             "setup_queries": [],
         },
         "instance_3": {
@@ -156,8 +155,8 @@ def get_memgraph_instances_description_4_instances(test_name: str, data_recovery
                 "--data-recovery-on-startup",
                 f"{data_recovery_on_startup}",
             ],
-            "log_file": f"high_availability/single_coordinator/{test_name}/instance_3.log",
-            "data_directory": f"{TEMP_DIR}/instance_3",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_3.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_3",
             "setup_queries": [],
         },
         "instance_4": {
@@ -174,8 +173,8 @@ def get_memgraph_instances_description_4_instances(test_name: str, data_recovery
                 "--data-recovery-on-startup",
                 f"{data_recovery_on_startup}",
             ],
-            "log_file": f"high_availability/single_coordinator/{test_name}/instance_4.log",
-            "data_directory": f"{TEMP_DIR}/instance_4",
+            "log_file": f"{get_logs_path(file, test_name)}/instance_4.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_4",
             "setup_queries": [],
         },
         "coordinator": {
@@ -189,8 +188,8 @@ def get_memgraph_instances_description_4_instances(test_name: str, data_recovery
                 "--coordinator-hostname=localhost",
                 "--management-port=10121",
             ],
-            "log_file": f"high_availability/single_coordinator/{test_name}/coordinator.log",
-            "data_directory": f"{TEMP_DIR}/coordinator",
+            "log_file": f"{get_logs_path(file, test_name)}/coordinator.log",
+            "data_directory": f"{get_data_path(file, test_name)}/coordinator",
             "setup_queries": [
                 "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7688', 'management_server': 'localhost:10011', 'replication_server': 'localhost:10001'};",
                 "REGISTER INSTANCE instance_2 WITH CONFIG {'bolt_server': 'localhost:7689', 'management_server': 'localhost:10012', 'replication_server': 'localhost:10002'};",
@@ -200,6 +199,12 @@ def get_memgraph_instances_description_4_instances(test_name: str, data_recovery
             ],
         },
     }
+
+
+@pytest.fixture(autouse=True)
+def cleanup_after_test():
+    yield
+    interactive_mg_runner.stop_all(keep_directories=False)
 
 
 @pytest.mark.parametrize("data_recovery", ["false", "true"])
@@ -219,7 +224,6 @@ def test_replication_works_on_failover_replica_1_epoch_2_commits_away(data_recov
     # 12. Start old MAIN (instance_3)
     # 13. Expect data to be copied to instance_3
 
-    safe_execute(shutil.rmtree, TEMP_DIR)
     memgraph_instances_description = get_memgraph_instances_description(
         test_name="test_replication_works_on_failover_replica_1_epoch_2_commits_away_data_recovery_"
         + str(data_recovery),
@@ -373,7 +377,6 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
     # 14. All other instances wake up
     # 15. Everything is replicated
 
-    safe_execute(shutil.rmtree, TEMP_DIR)
     memgraph_instances_description = get_memgraph_instances_description_4_instances(
         test_name="test_replication_works_on_failover_replica_2_epochs_more_commits_away_" + data_recovery,
         data_recovery_on_startup=data_recovery,
@@ -581,7 +584,6 @@ def test_replication_forcefully_works_on_failover_replica_misses_epoch(data_reco
     # 13 instance 2 up
     # 14 Force data from instance 1 to instance 2
 
-    safe_execute(shutil.rmtree, TEMP_DIR)
     memgraph_instances_description = get_memgraph_instances_description_4_instances(
         test_name="test_replication_forcefully_works_on_failover_replica_misses_epoch_" + data_recovery,
         data_recovery_on_startup=data_recovery,
@@ -779,7 +781,6 @@ def test_replication_correct_replica_chosen_up_to_date_data(data_recovery):
 
     # 1
 
-    safe_execute(shutil.rmtree, TEMP_DIR)
     memgraph_instances_description = get_memgraph_instances_description_4_instances(
         test_name="test_replication_correct_replica_chosen_up_to_date_data_" + str(data_recovery),
         data_recovery_on_startup=data_recovery,
@@ -948,7 +949,6 @@ def test_replication_works_on_failover_simple():
     # 6. We check that vertex appears on new replica
     # 7. We bring back main up
     # 8. Expect data to be copied to main
-    safe_execute(shutil.rmtree, TEMP_DIR)
     memgraph_instances_description = get_memgraph_instances_description(
         test_name="test_replication_works_on_failover_simple"
     )
@@ -1071,7 +1071,6 @@ def test_replication_works_on_replica_instance_restart():
     # 4. We check that main cannot replicate to replica
     # 5. We bring replica back up
     # 6. We check that replica gets data
-    safe_execute(shutil.rmtree, TEMP_DIR)
     memgraph_instances_description = get_memgraph_instances_description(
         test_name="test_replication_works_on_replica_instance_restart"
     )
@@ -1213,7 +1212,6 @@ def test_replication_works_on_replica_instance_restart():
 
 
 def test_show_instances():
-    safe_execute(shutil.rmtree, TEMP_DIR)
     memgraph_instances_description = get_memgraph_instances_description(test_name="test_show_instances")
     interactive_mg_runner.start_all(memgraph_instances_description, keep_directories=False)
 
@@ -1268,7 +1266,6 @@ def test_show_instances():
 
 
 def test_simple_automatic_failover():
-    safe_execute(shutil.rmtree, TEMP_DIR)
     memgraph_instances_description = get_memgraph_instances_description(test_name="test_simple_automatic_failover")
     interactive_mg_runner.start_all(memgraph_instances_description, keep_directories=False)
 
@@ -1355,8 +1352,6 @@ def test_simple_automatic_failover():
 
 
 def test_registering_replica_fails_name_exists():
-    safe_execute(shutil.rmtree, TEMP_DIR)
-
     memgraph_instances_description = get_memgraph_instances_description(
         test_name="test_registering_replica_fails_name_exists"
     )
@@ -1369,11 +1364,9 @@ def test_registering_replica_fails_name_exists():
             "REGISTER INSTANCE instance_1 WITH CONFIG {'bolt_server': 'localhost:7693', 'management_server': 'localhost:10051', 'replication_server': 'localhost:10111'};",
         )
     assert str(e.value) == "Couldn't register replica instance since instance with such name already exists!"
-    shutil.rmtree(TEMP_DIR)
 
 
 def test_registering_replica_fails_endpoint_exists():
-    safe_execute(shutil.rmtree, TEMP_DIR)
     memgraph_instances_description = get_memgraph_instances_description(
         test_name="test_registering_replica_fails_endpoint_exists"
     )
@@ -1392,7 +1385,6 @@ def test_registering_replica_fails_endpoint_exists():
 
 
 def test_replica_instance_restarts():
-    safe_execute(shutil.rmtree, TEMP_DIR)
     memgraph_instances_description = get_memgraph_instances_description(test_name="test_replica_instance_restarts")
     interactive_mg_runner.start_all(memgraph_instances_description, keep_directories=False)
 
@@ -1433,7 +1425,6 @@ def test_replica_instance_restarts():
 
 
 def test_automatic_failover_main_back_as_replica():
-    safe_execute(shutil.rmtree, TEMP_DIR)
     memgraph_instances_description = get_memgraph_instances_description(
         test_name="test_automatic_failover_main_back_as_replica"
     )
@@ -1474,8 +1465,6 @@ def test_automatic_failover_main_back_as_replica():
 
 
 def test_automatic_failover_main_back_as_main():
-    safe_execute(shutil.rmtree, TEMP_DIR)
-
     memgraph_instances_description = get_memgraph_instances_description(
         test_name="test_automatic_failover_main_back_as_main"
     )
@@ -1543,8 +1532,6 @@ def test_automatic_failover_main_back_as_main():
 
 
 def test_disable_multiple_mains():
-    safe_execute(shutil.rmtree, TEMP_DIR)
-
     memgraph_instances_description = get_memgraph_instances_description(test_name="disable_multiple_mains")
     interactive_mg_runner.start_all(memgraph_instances_description, keep_directories=False)
 

--- a/tests/e2e/high_availability/single_coordinator.py
+++ b/tests/e2e/high_availability/single_coordinator.py
@@ -839,7 +839,6 @@ def test_replication_correct_replica_chosen_up_to_date_data(data_recovery):
     def retrieve_data_show_instances():
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
-    # TODO(antoniofilipovic) Before fixing durability, if this is removed we also have an issue. Check after fix
     expected_data_on_coord = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
         ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),

--- a/tests/e2e/interactive_mg_runner.py
+++ b/tests/e2e/interactive_mg_runner.py
@@ -220,7 +220,7 @@ def cleanup():
     stop_all()
 
 
-def start(context, name, procdir):
+def start(context, name, procdir=""):
     mg_instances = {}
 
     for key, value in context.items():

--- a/tests/e2e/memgraph.py
+++ b/tests/e2e/memgraph.py
@@ -171,12 +171,15 @@ class MemgraphInstanceRunner:
         if args is not None:
             self.args = copy.deepcopy(args)
         self.args = [replace_paths(arg) for arg in self.args]
+
+        storage_snapshot_on_exit = "true" if storage_snapshot_on_exit else "false"
         args_mg = [
             self.binary_path,
             "--storage-wal-enabled",
             "--storage-snapshot-interval-sec",
             "300",
             "--storage-properties-on-edges",
+            f"--storage-snapshot-on-exit={storage_snapshot_on_exit}",
         ] + self.args
 
         if bolt_port:

--- a/tests/e2e/memgraph.py
+++ b/tests/e2e/memgraph.py
@@ -195,9 +195,7 @@ class MemgraphInstanceRunner:
             for folder in self.delete_on_stop or {}:
                 try:
                     shutil.rmtree(folder)
-                    print(f"Deleted folder: {folder}")
                 except Exception:
-                    print(f"Couldn't delete folder: {folder}")
                     pass  # couldn't delete folder, skip
 
     # TODO: (andi) Abstract into one function

--- a/tests/e2e/memgraph.py
+++ b/tests/e2e/memgraph.py
@@ -180,6 +180,9 @@ class MemgraphInstanceRunner:
         return True
 
     def stop(self, keep_directories=False):
+        """
+        Sends SIGTERM to the running process. If keep_directories is set to False, deletes --data-directory folder.
+        """
         if not self.is_running():
             return
 
@@ -200,6 +203,9 @@ class MemgraphInstanceRunner:
 
     # TODO: (andi) Abstract into one function
     def kill(self, keep_directories=False):
+        """
+        Sends kill signal to the running process. If keep_directories is set to False, deletes --data-directory folder.
+        """
         if not self.is_running():
             return
         self.proc_mg.kill()

--- a/tests/e2e/memgraph.py
+++ b/tests/e2e/memgraph.py
@@ -195,7 +195,9 @@ class MemgraphInstanceRunner:
             for folder in self.delete_on_stop or {}:
                 try:
                     shutil.rmtree(folder)
+                    print(f"Deleted folder: {folder}")
                 except Exception:
+                    print(f"Couldn't delete folder: {folder}")
                     pass  # couldn't delete folder, skip
 
     # TODO: (andi) Abstract into one function

--- a/tests/e2e/memgraph.py
+++ b/tests/e2e/memgraph.py
@@ -158,6 +158,7 @@ class MemgraphInstanceRunner:
         setup_queries=None,
         bolt_port: Optional[int] = None,
         ignore_auth_failure: bool = False,
+        storage_snapshot_on_exit: bool = False,
     ):
         """
         Starts an instance which is not already running. Before doing anything, calls `stop` on instance.
@@ -187,7 +188,8 @@ class MemgraphInstanceRunner:
         log.info(f"Subprocess started with args {args_mg}")
         conn = self.wait_for_succesful_connection(ignore_auth_failure=ignore_auth_failure)
         log.info(f"Server started on instance with bolt port {self.host}:{bolt_port}")
-        self.execute_setup_queries(conn, setup_queries)
+        if not ignore_auth_failure:
+            self.execute_setup_queries(conn, setup_queries)
 
         assert self.is_running(), "The Memgraph process died during start!"
 

--- a/tests/e2e/replication/common.py
+++ b/tests/e2e/replication/common.py
@@ -16,14 +16,14 @@ import mgclient
 
 def get_data_path(file: str, test: str):
     """
-    Data is stored in high_availabiity folder.
+    Data is stored in replication folder.
     """
     return f"replication/{file}/{test}"
 
 
 def get_logs_path(file: str, test: str):
     """
-    Logs are stored in high_availabiity folder.
+    Logs are stored in replication folder.
     """
     return f"replication/{file}/{test}"
 

--- a/tests/e2e/replication/common.py
+++ b/tests/e2e/replication/common.py
@@ -9,13 +9,26 @@
 # by the Apache License, Version 2.0, included in the file
 # licenses/APL.txt.
 
-import mgclient
 import typing
 
+import mgclient
 
-def execute_and_fetch_all(
-    cursor: mgclient.Cursor, query: str, params: dict = {}
-) -> typing.List[tuple]:
+
+def get_data_path(file: str, test: str):
+    """
+    Data is stored in high_availabiity folder.
+    """
+    return f"replication/{file}/{test}"
+
+
+def get_logs_path(file: str, test: str):
+    """
+    Logs are stored in high_availabiity folder.
+    """
+    return f"replication/{file}/{test}"
+
+
+def execute_and_fetch_all(cursor: mgclient.Cursor, query: str, params: dict = {}) -> typing.List[tuple]:
     cursor.execute(query, params)
     return cursor.fetchall()
 

--- a/tests/e2e/replication/replicate_enum.py
+++ b/tests/e2e/replication/replicate_enum.py
@@ -32,9 +32,15 @@ file = "replicate_enum"
 
 @pytest.fixture(autouse=True)
 def cleanup_after_test():
+    # Run the test
     yield
-    # Stop + delete directories
+    # Stop + delete directories after running the test
     interactive_mg_runner.stop_all(keep_directories=False)
+
+
+@pytest.fixture
+def test_name(request):
+    return request.node.name
 
 
 def show_replicas_func(cursor):
@@ -44,7 +50,7 @@ def show_replicas_func(cursor):
     return func
 
 
-def test_enum_replication(connection):
+def test_enum_replication(connection, test_name):
     # Goal: That Enum definition is replicated to REPLICAs
     # 0/ Setup replication
     # 1/ MAIN CREATE ENUM
@@ -55,8 +61,6 @@ def test_enum_replication(connection):
     # 6/ Validate Enum has updated at REPLICA
     # 7/ Alter Enum by updating value on MAIN
     # 8/ Validate Enum has updated at REPLICA
-
-    test_name = "test_enum_replication"
 
     MEMGRAPH_INSTANCES_DESCRIPTION_MANUAL = {
         "replica_1": {

--- a/tests/e2e/replication/replicate_enum.py
+++ b/tests/e2e/replication/replicate_enum.py
@@ -9,20 +9,13 @@
 # by the Apache License, Version 2.0, included in the file
 # licenses/APL.txt.
 
-import atexit
 import os
-import shutil
 import sys
-import tempfile
-import time
-from functools import partial
-from typing import Any, Dict
 
 import interactive_mg_runner
-import mgclient
 import pytest
-from common import execute_and_fetch_all
-from mg_utils import mg_sleep_and_assert, mg_sleep_and_assert_collection
+from common import execute_and_fetch_all, get_data_path, get_logs_path
+from mg_utils import mg_sleep_and_assert_collection
 
 interactive_mg_runner.SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 interactive_mg_runner.PROJECT_DIR = os.path.normpath(
@@ -34,6 +27,14 @@ interactive_mg_runner.MEMGRAPH_BINARY = os.path.normpath(os.path.join(interactiv
 
 BOLT_PORTS = {"main": 7687, "replica_1": 7688, "replica_2": 7689}
 REPLICATION_PORTS = {"replica_1": 10001, "replica_2": 10002}
+file = "replicate_enum"
+
+
+@pytest.fixture(autouse=True)
+def cleanup_after_test():
+    yield
+    # Stop + delete directories
+    interactive_mg_runner.stop_all(keep_directories=False)
 
 
 def show_replicas_func(cursor):
@@ -55,6 +56,8 @@ def test_enum_replication(connection):
     # 7/ Alter Enum by updating value on MAIN
     # 8/ Validate Enum has updated at REPLICA
 
+    test_name = "test_enum_replication"
+
     MEMGRAPH_INSTANCES_DESCRIPTION_MANUAL = {
         "replica_1": {
             "args": [
@@ -62,7 +65,8 @@ def test_enum_replication(connection):
                 f"{BOLT_PORTS['replica_1']}",
                 "--log-level=TRACE",
             ],
-            "log_file": "replica1.log",
+            "log_file": f"{get_logs_path(file, test_name)}/replica1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/replica1",
             "setup_queries": [
                 f"SET REPLICATION ROLE TO REPLICA WITH PORT {REPLICATION_PORTS['replica_1']};",
             ],
@@ -73,7 +77,8 @@ def test_enum_replication(connection):
                 f"{BOLT_PORTS['replica_2']}",
                 "--log-level=TRACE",
             ],
-            "log_file": "replica2.log",
+            "log_file": f"{get_logs_path(file, test_name)}/replica2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/replica2",
             "setup_queries": [
                 f"SET REPLICATION ROLE TO REPLICA WITH PORT {REPLICATION_PORTS['replica_2']};",
             ],
@@ -84,7 +89,8 @@ def test_enum_replication(connection):
                 f"{BOLT_PORTS['main']}",
                 "--log-level=TRACE",
             ],
-            "log_file": "main.log",
+            "log_file": f"{get_logs_path(file, test_name)}/main.log",
+            "data_directory": f"{get_data_path(file, test_name)}/main",
             "setup_queries": [
                 f"REGISTER REPLICA replica_1 SYNC TO '127.0.0.1:{REPLICATION_PORTS['replica_1']}';",
                 f"REGISTER REPLICA replica_2 ASYNC TO '127.0.0.1:{REPLICATION_PORTS['replica_2']}';",
@@ -93,7 +99,7 @@ def test_enum_replication(connection):
     }
 
     # 0/
-    interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION_MANUAL)
+    interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION_MANUAL, keep_directories=False)
     cursor = connection(BOLT_PORTS["main"], "main").cursor()
 
     # 1/

--- a/tests/e2e/replication/replicate_spatial_feature.py
+++ b/tests/e2e/replication/replicate_spatial_feature.py
@@ -29,10 +29,16 @@ REPLICATION_PORTS = {"replica_1": 10001, "replica_2": 10002}
 file = "replicate_point"
 
 
+@pytest.fixture
+def test_name(request):
+    return request.node.name
+
+
 @pytest.fixture(autouse=True)
 def cleanup_after_test():
+    # Run the test
     yield
-    # Stop + delete directories
+    # Stop + delete directories after running the test
     interactive_mg_runner.stop_all(keep_directories=False)
 
 
@@ -43,13 +49,11 @@ def show_replicas_func(cursor):
     return func
 
 
-def test_point_replication(connection):
+def test_point_replication(connection, test_name):
     # Goal: That point types are replicated to REPLICAs
     # 0/ Setup replication
     # 1/ Create Vertex with points property on MAIN
     # 2/ Validate points property has arrived at REPLICA
-
-    test_name = "test_point_replication"
 
     MEMGRAPH_INSTANCES_DESCRIPTION_MANUAL = {
         "replica_1": {

--- a/tests/e2e/replication/replicate_spatial_feature.py
+++ b/tests/e2e/replication/replicate_spatial_feature.py
@@ -9,20 +9,13 @@
 # by the Apache License, Version 2.0, included in the file
 # licenses/APL.txt.
 
-import atexit
 import os
-import shutil
 import sys
-import tempfile
-import time
-from functools import partial
-from typing import Any, Dict
 
 import interactive_mg_runner
-import mgclient
 import pytest
-from common import execute_and_fetch_all
-from mg_utils import mg_sleep_and_assert, mg_sleep_and_assert_collection
+from common import execute_and_fetch_all, get_data_path, get_logs_path
+from mg_utils import mg_sleep_and_assert_collection
 
 interactive_mg_runner.SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 interactive_mg_runner.PROJECT_DIR = os.path.normpath(
@@ -33,6 +26,14 @@ interactive_mg_runner.MEMGRAPH_BINARY = os.path.normpath(os.path.join(interactiv
 
 BOLT_PORTS = {"main": 7687, "replica_1": 7688, "replica_2": 7689}
 REPLICATION_PORTS = {"replica_1": 10001, "replica_2": 10002}
+file = "replicate_point"
+
+
+@pytest.fixture(autouse=True)
+def cleanup_after_test():
+    yield
+    # Stop + delete directories
+    interactive_mg_runner.stop_all(keep_directories=False)
 
 
 def show_replicas_func(cursor):
@@ -48,6 +49,8 @@ def test_point_replication(connection):
     # 1/ Create Vertex with points property on MAIN
     # 2/ Validate points property has arrived at REPLICA
 
+    test_name = "test_point_replication"
+
     MEMGRAPH_INSTANCES_DESCRIPTION_MANUAL = {
         "replica_1": {
             "args": [
@@ -55,7 +58,8 @@ def test_point_replication(connection):
                 f"{BOLT_PORTS['replica_1']}",
                 "--log-level=TRACE",
             ],
-            "log_file": "replica1.log",
+            "log_file": f"{get_logs_path(file, test_name)}/replica1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/replica1",
             "setup_queries": [
                 f"SET REPLICATION ROLE TO REPLICA WITH PORT {REPLICATION_PORTS['replica_1']};",
             ],
@@ -66,7 +70,8 @@ def test_point_replication(connection):
                 f"{BOLT_PORTS['replica_2']}",
                 "--log-level=TRACE",
             ],
-            "log_file": "replica2.log",
+            "log_file": f"{get_logs_path(file, test_name)}/replica2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/replica2",
             "setup_queries": [
                 f"SET REPLICATION ROLE TO REPLICA WITH PORT {REPLICATION_PORTS['replica_2']};",
             ],
@@ -77,7 +82,8 @@ def test_point_replication(connection):
                 f"{BOLT_PORTS['main']}",
                 "--log-level=TRACE",
             ],
-            "log_file": "main.log",
+            "log_file": f"{get_logs_path(file, test_name)}/main.log",
+            "data_directory": f"{get_data_path(file, test_name)}/main",
             "setup_queries": [
                 f"REGISTER REPLICA replica_1 SYNC TO '127.0.0.1:{REPLICATION_PORTS['replica_1']}';",
                 f"REGISTER REPLICA replica_2 ASYNC TO '127.0.0.1:{REPLICATION_PORTS['replica_2']}';",
@@ -86,7 +92,7 @@ def test_point_replication(connection):
     }
 
     # 0/
-    interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION_MANUAL)
+    interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION_MANUAL, keep_directories=False)
     cursor = connection(BOLT_PORTS["main"], "main").cursor()
 
     # 1/

--- a/tests/e2e/replication/replication_with_property_compression_used.py
+++ b/tests/e2e/replication/replication_with_property_compression_used.py
@@ -29,10 +29,16 @@ BOLT_PORTS = {"main": 7687, "replica_1": 7688, "replica_2": 7689}
 REPLICATION_PORTS = {"replica_1": 10001, "replica_2": 10002}
 
 
+@pytest.fixture
+def test_name(request):
+    return request.node.name
+
+
 @pytest.fixture(autouse=True)
 def cleanup_after_test():
+    # Run the test
     yield
-    # Stop + delete directories
+    # Stop + delete directories after running the test
     interactive_mg_runner.stop_all(keep_directories=False)
 
 
@@ -43,7 +49,7 @@ def show_replicas_func(cursor):
     return func
 
 
-def test_replication_with_compression_on(connection):
+def test_replication_with_compression_on(connection, test_name):
     # Goal: That data is correctly replicated while compression is used.
     # 0/ Setup replication
     # 1/ MAIN CREATE Vertex with compressible property
@@ -52,8 +58,6 @@ def test_replication_with_compression_on(connection):
     # 4/ Validate property has arrived at REPLICA
     # 5/ Delete property on MAIN
     # 6/ Validate property has been deleted at REPLICA
-
-    test_name = "test_replication_with_compression_on"
 
     MEMGRAPH_INSTANCES_DESCRIPTION_MANUAL = {
         "replica_1": {

--- a/tests/e2e/replication/replication_with_property_compression_used.py
+++ b/tests/e2e/replication/replication_with_property_compression_used.py
@@ -11,11 +11,10 @@
 
 import os
 import sys
-from typing import Any, Dict
 
 import interactive_mg_runner
 import pytest
-from common import execute_and_fetch_all
+from common import execute_and_fetch_all, get_data_path, get_logs_path
 from mg_utils import mg_sleep_and_assert_collection
 
 interactive_mg_runner.SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -24,10 +23,17 @@ interactive_mg_runner.PROJECT_DIR = os.path.normpath(
 )
 interactive_mg_runner.BUILD_DIR = os.path.normpath(os.path.join(interactive_mg_runner.PROJECT_DIR, "build"))
 interactive_mg_runner.MEMGRAPH_BINARY = os.path.normpath(os.path.join(interactive_mg_runner.BUILD_DIR, "memgraph"))
-
+file = "replication_with_property_compression_used"
 
 BOLT_PORTS = {"main": 7687, "replica_1": 7688, "replica_2": 7689}
 REPLICATION_PORTS = {"replica_1": 10001, "replica_2": 10002}
+
+
+@pytest.fixture(autouse=True)
+def cleanup_after_test():
+    yield
+    # Stop + delete directories
+    interactive_mg_runner.stop_all(keep_directories=False)
 
 
 def show_replicas_func(cursor):
@@ -47,6 +53,8 @@ def test_replication_with_compression_on(connection):
     # 5/ Delete property on MAIN
     # 6/ Validate property has been deleted at REPLICA
 
+    test_name = "test_replication_with_compression_on"
+
     MEMGRAPH_INSTANCES_DESCRIPTION_MANUAL = {
         "replica_1": {
             "args": [
@@ -55,7 +63,8 @@ def test_replication_with_compression_on(connection):
                 "--log-level=TRACE",
                 "--storage-property-store-compression-enabled=true",
             ],
-            "log_file": "replica1.log",
+            "log_file": f"{get_logs_path(file, test_name)}/replica1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/replica1",
             "setup_queries": [
                 f"SET REPLICATION ROLE TO REPLICA WITH PORT {REPLICATION_PORTS['replica_1']};",
             ],
@@ -66,7 +75,8 @@ def test_replication_with_compression_on(connection):
                 f"{BOLT_PORTS['replica_2']}",
                 "--log-level=TRACE",
             ],
-            "log_file": "replica2.log",
+            "log_file": f"{get_logs_path(file, test_name)}/replica2.log",
+            "data_directory": f"{get_data_path(file, test_name)}/replica2",
             "setup_queries": [
                 f"SET REPLICATION ROLE TO REPLICA WITH PORT {REPLICATION_PORTS['replica_2']};",
             ],
@@ -78,7 +88,8 @@ def test_replication_with_compression_on(connection):
                 "--log-level=TRACE",
                 "--storage-property-store-compression-enabled=true",
             ],
-            "log_file": "main.log",
+            "log_file": f"{get_logs_path(file, test_name)}/main.log",
+            "data_directory": f"{get_data_path(file, test_name)}/main",
             "setup_queries": [
                 f"REGISTER REPLICA replica_1 SYNC TO '127.0.0.1:{REPLICATION_PORTS['replica_1']}';",
                 f"REGISTER REPLICA replica_2 ASYNC TO '127.0.0.1:{REPLICATION_PORTS['replica_2']}';",
@@ -87,7 +98,7 @@ def test_replication_with_compression_on(connection):
     }
 
     # 0/
-    interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION_MANUAL)
+    interactive_mg_runner.start_all(MEMGRAPH_INSTANCES_DESCRIPTION_MANUAL, keep_directories=False)
     cursor = connection(BOLT_PORTS["main"], "main").cursor()
 
     # 1/

--- a/tests/e2e/replication/show_while_creating_invalid_state.py
+++ b/tests/e2e/replication/show_while_creating_invalid_state.py
@@ -1233,7 +1233,7 @@ def test_async_replication_when_main_is_killed():
             },
         }
         print(f"test_repetition: {test_repetition}")
-        interactive_mg_runner.kill_all(CONFIGURATION, keep_directories=False)
+        interactive_mg_runner.kill_all(keep_directories=False)
         interactive_mg_runner.start_all(CONFIGURATION, keep_directories=False)
 
         # 1/
@@ -1311,7 +1311,7 @@ def test_sync_replication_when_main_is_killed():
                 "log_file": f"{get_logs_path(file, test_name)}/main.log",
             },
         }
-        interactive_mg_runner.kill_all(CONFIGURATION, keep_directories=False)
+        interactive_mg_runner.kill_all(keep_directories=False)
         interactive_mg_runner.start_all(CONFIGURATION, keep_directories=False)
 
         # 1/

--- a/tests/e2e/replication/show_while_creating_invalid_state.py
+++ b/tests/e2e/replication/show_while_creating_invalid_state.py
@@ -1206,137 +1206,134 @@ def test_basic_recovery_when_replica_is_kill_when_main_is_down():
     assert all([x in actual_data for x in expected_data])
 
 
-# def test_async_replication_when_main_is_killed():
-#     # Goal of the test is to check that when main is randomly killed:
-#     # -the ASYNC replica always contains a valid subset of data of main.
-#     # We run the test 20 times, it should never fail.
-#
-#     # 0/ Start main and replicas.
-#     # 1/ Register replicas.
-#     # 2/ Insert data in main, and randomly kill it.
-#     # 3/ Check that the ASYNC replica has a valid subset.
-#
-#     test_name = "test_async_replication_when_main_is_killed"
-#
-#     for _ in range(20):
-#         # 0/
-#         CONFIGURATION = {
-#             "async_replica": {
-#                 "args": ["--bolt-port", "7688", "--log-level=TRACE"],
-#                 "setup_queries": ["SET REPLICATION ROLE TO REPLICA WITH PORT 10001;"],
-#                 "log_file": f"{get_logs_path(file, test_name)}/async_replica.log",
-#                 "data_directory": f"{get_data_path(file, test_name)}/async_replica",
-#             },
-#             "main": {
-#                 "args": ["--bolt-port", "7687", "--log-level=TRACE", "--data-recovery-on-startup=true"],
-#                 "setup_queries": [],
-#                 "log_file": f"{get_logs_path(file, test_name)}/main.log",
-#                 "data_directory": f"{get_data_path(file, test_name)}/main",
-#             },
-#         }
-#         interactive_mg_runner.kill_all(CONFIGURATION, keep_directories=False)
-#         interactive_mg_runner.start_all(CONFIGURATION, keep_directories=False)
-#
-#         # 1/
-#         interactive_mg_runner.MEMGRAPH_INSTANCES["main"].query(
-#             "REGISTER REPLICA async_replica ASYNC TO '127.0.0.1:10001';"
-#         )
-#
-#         # 2/
-#         # First make sure that anything has been replicated
-#         for index in range(0, 5):
-#             interactive_mg_runner.MEMGRAPH_INSTANCES["main"].query(f"CREATE (p:Number {{name:{index}}})")
-#         expected_data = [("async_replica", "127.0.0.1:10001", "async", "ready")]
-#
-#         def retrieve_data():
-#             replicas = interactive_mg_runner.MEMGRAPH_INSTANCES["main"].query("SHOW REPLICAS;")
-#             return [
-#                 (replica_name, ip, mode, info["memgraph"]["status"])
-#                 for replica_name, ip, mode, sys_info, info in replicas
-#             ]
-#
-#         actual_data = mg_sleep_and_assert_collection(expected_data, retrieve_data)
-#         assert all([x in actual_data for x in expected_data])
-#
-#         for index in range(5, 50):
-#             interactive_mg_runner.MEMGRAPH_INSTANCES["main"].query(f"CREATE (p:Number {{name:{index}}})")
-#             if random.randint(0, 100) > 95:
-#                 main_killed = f"Main was killed at index={index}"
-#                 print(main_killed)
-#                 interactive_mg_runner.kill(CONFIGURATION, "main")
-#                 break
-#
-#         # 3/
-#         # short explaination:
-#         # res_from_async_replica is an arithmetic sequence with:
-#         # -first term 0
-#         # -common difference 1
-#         # So we check its properties. If properties are fullfilled, it means the ASYNC replicas received a correct subset of messages
-#         # from main in the correct order.
-#         # In other word: res_from_async_replica is as [0, 1, ..., n-1, n] where values are consecutive integers. $
-#         # It should have the two properties:
-#         # -list is sorted
-#         # -the sum of all elements is equal to nOfTerms * (firstTerm + lastTerm) / 2
-#
-#         QUERY_TO_CHECK = "MATCH (n) RETURN COLLECT(n.name);"
-#         res_from_async_replica = interactive_mg_runner.MEMGRAPH_INSTANCES["async_replica"].query(QUERY_TO_CHECK)[0][0]
-#         assert res_from_async_replica == sorted(res_from_async_replica), main_killed
-#         total_sum = sum(res_from_async_replica)
-#         expected_sum = len(res_from_async_replica) * (res_from_async_replica[0] + res_from_async_replica[-1]) / 2
-#         assert total_sum == expected_sum, main_killed
-#
-#
-# def test_sync_replication_when_main_is_killed():
-#     # Goal of the test is to check that when main is randomly killed:
-#     # -the SYNC replica always contains the exact data that was in main.
-#     # We run the test 20 times, it should never fail.
-#
-#     # 0/ Start main and replica.
-#     # 1/ Register replica.
-#     # 2/ Insert data in main, and randomly kill it.
-#     # 3/ Check that the SYNC replica has exactly the same data than main.
-#
-#     test_name = "test_sync_replication_when_main_is_killed"
-#
-#     for _ in range(20):
-#         # 0/
-#         CONFIGURATION = {
-#             "sync_replica": {
-#                 "args": ["--bolt-port", "7688", "--log-level=TRACE"],
-#                 "setup_queries": ["SET REPLICATION ROLE TO REPLICA WITH PORT 10001;"],
-#                 "log_file": f"{get_logs_path(file, test_name)}/sync_replica.log",
-#                 "data_directory": f"{get_data_path(file, test_name)}/sync_replica",
-#             },
-#             "main": {
-#                 "args": ["--bolt-port", "7687", "--log-level=TRACE", "--data-recovery-on-startup=true"],
-#                 "setup_queries": [],
-#                 "log_file": f"{get_logs_path(file, test_name)}/main.log",
-#                 "data_directory": f"{get_data_path(file, test_name)}/main",
-#             },
-#         }
-#         interactive_mg_runner.kill_all(CONFIGURATION, keep_directories=False)
-#         interactive_mg_runner.start_all(CONFIGURATION, keep_directories=False)
-#
-#         # 1/
-#         interactive_mg_runner.MEMGRAPH_INSTANCES["main"].query(
-#             "REGISTER REPLICA sync_replica SYNC TO '127.0.0.1:10001';"
-#         )
-#
-#         # 2/
-#         QUERY_TO_CHECK = "MATCH (n) RETURN COUNT(n.name);"
-#         last_result_from_main = interactive_mg_runner.MEMGRAPH_INSTANCES["main"].query(QUERY_TO_CHECK)[0][0]
-#         for index in range(50):
-#             interactive_mg_runner.MEMGRAPH_INSTANCES["main"].query(f"CREATE (p:Number {{name:{index}}})")
-#             last_result_from_main = interactive_mg_runner.MEMGRAPH_INSTANCES["main"].query(QUERY_TO_CHECK)[0][0]
-#             if random.randint(0, 100) > 95:
-#                 main_killed = f"Main was killed at index={index}"
-#                 interactive_mg_runner.kill(CONFIGURATION, "main")
-#                 break
-#
-#         # 3/
-#         # The SYNC replica should have exactly the same data than main.
-#         res_from_sync_replica = interactive_mg_runner.MEMGRAPH_INSTANCES["sync_replica"].query(QUERY_TO_CHECK)[0][0]
-#         assert last_result_from_main == res_from_sync_replica, main_killed
+def test_async_replication_when_main_is_killed():
+    # Goal of the test is to check that when main is randomly killed:
+    # -the ASYNC replica always contains a valid subset of data of main.
+    # We run the test 20 times, it should never fail.
+
+    # 0/ Start main and replicas.
+    # 1/ Register replicas.
+    # 2/ Insert data in main, and randomly kill it.
+    # 3/ Check that the ASYNC replica has a valid subset.
+
+    test_name = "test_async_replication_when_main_is_killed"
+
+    for test_repetition in range(20):
+        # 0/
+        CONFIGURATION = {
+            "async_replica": {
+                "args": ["--bolt-port", "7688", "--log-level=TRACE"],
+                "setup_queries": ["SET REPLICATION ROLE TO REPLICA WITH PORT 10001;"],
+                "log_file": f"{get_logs_path(file, test_name)}/async_replica.log",
+            },
+            "main": {
+                "args": ["--bolt-port", "7687", "--log-level=TRACE", "--data-recovery-on-startup=true"],
+                "setup_queries": [],
+                "log_file": f"{get_logs_path(file, test_name)}/main.log",
+            },
+        }
+        print(f"test_repetition: {test_repetition}")
+        interactive_mg_runner.kill_all(CONFIGURATION, keep_directories=False)
+        interactive_mg_runner.start_all(CONFIGURATION, keep_directories=False)
+
+        # 1/
+        interactive_mg_runner.MEMGRAPH_INSTANCES["main"].query(
+            "REGISTER REPLICA async_replica ASYNC TO '127.0.0.1:10001';"
+        )
+
+        # 2/
+        # First make sure that anything has been replicated
+        for index in range(0, 5):
+            interactive_mg_runner.MEMGRAPH_INSTANCES["main"].query(f"CREATE (p:Number {{name:{index}}})")
+        expected_data = [("async_replica", "127.0.0.1:10001", "async", "ready")]
+
+        def retrieve_data():
+            replicas = interactive_mg_runner.MEMGRAPH_INSTANCES["main"].query("SHOW REPLICAS;")
+            return [
+                (replica_name, ip, mode, info["memgraph"]["status"])
+                for replica_name, ip, mode, sys_info, info in replicas
+            ]
+
+        actual_data = mg_sleep_and_assert_collection(expected_data, retrieve_data)
+        assert all([x in actual_data for x in expected_data])
+
+        for index in range(5, 50):
+            interactive_mg_runner.MEMGRAPH_INSTANCES["main"].query(f"CREATE (p:Number {{name:{index}}})")
+            if random.randint(0, 100) > 95:
+                main_killed = f"Main was killed at index={index}"
+                print(main_killed)
+                interactive_mg_runner.kill(CONFIGURATION, "main")
+                break
+
+        # 3/
+        # short explaination:
+        # res_from_async_replica is an arithmetic sequence with:
+        # -first term 0
+        # -common difference 1
+        # So we check its properties. If properties are fullfilled, it means the ASYNC replicas received a correct subset of messages
+        # from main in the correct order.
+        # In other word: res_from_async_replica is as [0, 1, ..., n-1, n] where values are consecutive integers. $
+        # It should have the two properties:
+        # -list is sorted
+        # -the sum of all elements is equal to nOfTerms * (firstTerm + lastTerm) / 2
+
+        QUERY_TO_CHECK = "MATCH (n) RETURN COLLECT(n.name);"
+        res_from_async_replica = interactive_mg_runner.MEMGRAPH_INSTANCES["async_replica"].query(QUERY_TO_CHECK)[0][0]
+        assert res_from_async_replica == sorted(res_from_async_replica), main_killed
+        total_sum = sum(res_from_async_replica)
+        expected_sum = len(res_from_async_replica) * (res_from_async_replica[0] + res_from_async_replica[-1]) / 2
+        assert total_sum == expected_sum, main_killed
+
+
+def test_sync_replication_when_main_is_killed():
+    # Goal of the test is to check that when main is randomly killed:
+    # -the SYNC replica always contains the exact data that was in main.
+    # We run the test 20 times, it should never fail.
+
+    # 0/ Start main and replica.
+    # 1/ Register replica.
+    # 2/ Insert data in main, and randomly kill it.
+    # 3/ Check that the SYNC replica has exactly the same data than main.
+
+    test_name = "test_sync_replication_when_main_is_killed"
+
+    for _ in range(20):
+        # 0/
+        CONFIGURATION = {
+            "sync_replica": {
+                "args": ["--bolt-port", "7688", "--log-level=TRACE"],
+                "setup_queries": ["SET REPLICATION ROLE TO REPLICA WITH PORT 10001;"],
+                "log_file": f"{get_logs_path(file, test_name)}/sync_replica.log",
+            },
+            "main": {
+                "args": ["--bolt-port", "7687", "--log-level=TRACE", "--data-recovery-on-startup=true"],
+                "setup_queries": [],
+                "log_file": f"{get_logs_path(file, test_name)}/main.log",
+            },
+        }
+        interactive_mg_runner.kill_all(CONFIGURATION, keep_directories=False)
+        interactive_mg_runner.start_all(CONFIGURATION, keep_directories=False)
+
+        # 1/
+        interactive_mg_runner.MEMGRAPH_INSTANCES["main"].query(
+            "REGISTER REPLICA sync_replica SYNC TO '127.0.0.1:10001';"
+        )
+
+        # 2/
+        QUERY_TO_CHECK = "MATCH (n) RETURN COUNT(n.name);"
+        last_result_from_main = interactive_mg_runner.MEMGRAPH_INSTANCES["main"].query(QUERY_TO_CHECK)[0][0]
+        for index in range(50):
+            interactive_mg_runner.MEMGRAPH_INSTANCES["main"].query(f"CREATE (p:Number {{name:{index}}})")
+            last_result_from_main = interactive_mg_runner.MEMGRAPH_INSTANCES["main"].query(QUERY_TO_CHECK)[0][0]
+            if random.randint(0, 100) > 95:
+                main_killed = f"Main was killed at index={index}"
+                interactive_mg_runner.kill(CONFIGURATION, "main")
+                break
+
+        # 3/
+        # The SYNC replica should have exactly the same data than main.
+        res_from_sync_replica = interactive_mg_runner.MEMGRAPH_INSTANCES["sync_replica"].query(QUERY_TO_CHECK)[0][0]
+        assert last_result_from_main == res_from_sync_replica, main_killed
 
 
 def test_attempt_to_write_data_on_main_when_async_replica_is_down():

--- a/tests/e2e/replication/ttl.py
+++ b/tests/e2e/replication/ttl.py
@@ -33,20 +33,24 @@ file = "ttl"
 
 @pytest.fixture(autouse=True)
 def cleanup_after_test():
+    # Run the test
     yield
-    # Stop + delete directories
+    # Stop + delete directories after running the test
     interactive_mg_runner.stop_all(keep_directories=False)
 
 
-def test_ttl_replication(connection):
+@pytest.fixture
+def test_name(request):
+    return request.node.name
+
+
+def test_ttl_replication(connection, test_name):
     # Goal: Execute TTL on MAIN and check results on REPLICA
     # 0/ Setup replication
     # 1/ MAIN Create dataset
     # 2/ MAIN Configure TTL
     # 3/ Validate that TTL is working on MAIN
     # 4/ Validate that nodes have been deleted on REPLICA as well
-
-    test_name = "test_ttl_replication"
 
     MEMGRAPH_INSTANCES_DESCRIPTION_MANUAL = {
         "replica_1": {
@@ -113,7 +117,7 @@ def test_ttl_replication(connection):
     mg_sleep_and_assert([(True,)], partial(n_deltas, cursor_replica2))
 
 
-def test_ttl_on_replica(connection):
+def test_ttl_on_replica(connection, test_name):
     # Goal: Check that TTL can be configured on REPLICA,
     #       but is executed only when the instance is MAIN
     # 0/ Setup MAIN
@@ -123,8 +127,6 @@ def test_ttl_on_replica(connection):
     # 4/ Verify that TTL is not running
     # 5/ Switch REPLICA back to MAIN
     # 6/ Verify that TTL is running
-
-    test_name = "test_ttl_on_replica"
 
     MEMGRAPH_INSTANCES_DESCRIPTION_MANUAL = {
         "main": {

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -4,7 +4,7 @@ cd "$SCRIPT_DIR"
 
 print_help() {
   echo "    run args   1. Positional argument, workload name as string"
-  echo "               2. If you specify --clean-data-dir, whole data directory will get deleted."
+  echo "               2. If you specify --save-data-dir, whole data directory will get preserved."
   echo "               3. If you specify --clean-logs-dir, all logs will get deleted."
   echo -e ""
   echo -e "  NOTE: some tests require enterprise licence key,"

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -3,7 +3,9 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR"
 
 print_help() {
-  echo -e "$0 ["workload name string"]"
+  echo "    run args   1. Positional argument, workload name as string"
+  echo "               2. If you specify --clean-data-dir, whole data directory will get deleted."
+  echo "               3. If you specify --clean-logs-dir, all logs will get deleted."
   echo -e ""
   echo -e "  NOTE: some tests require enterprise licence key,"
   echo -e "        to run those define the folowing env vars:"
@@ -20,13 +22,14 @@ check_license() {
 source "$SCRIPT_DIR/../util.sh"
 setup_node
 
-if [ "$#" -eq 0 ]; then
+num_args="$#"
+if [ $num_args -eq 0 ]; then
   check_license
   # NOTE: If you want to run all tests under specific folder/section just
   # replace the dot (root directory below) with the folder name, e.g.
   # `--workloads-root-directory replication`.
   python3 runner.py --workloads-root-directory "$SCRIPT_DIR/../../build/tests/e2e"
-elif [ "$#" -eq 1 ]; then
+elif [ $num_args -ge 1 ]; then
   if [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
     print_help
   fi
@@ -34,7 +37,8 @@ elif [ "$#" -eq 1 ]; then
   # NOTE: --workload-name comes from each individual folder/section
   # workloads.yaml file. E.g. `streams/workloads.yaml` has a list of
   # `workloads:` and each workload has it's `-name`.
-  python3 runner.py --workloads-root-directory "$SCRIPT_DIR/../../build/tests/e2e" --workload-name "$1"
+  # Python script will parse remaining args
+  python3 runner.py --workloads-root-directory "$SCRIPT_DIR/../../build/tests/e2e" --workload-name "$1" "${@:2}"
 else
   print_help
 fi

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -35,7 +35,7 @@ def load_args():
     parser.add_argument("--workloads-root-directory", required=True)
     parser.add_argument("--workload-name", default=None, required=False)
     parser.add_argument("--debug", default=False, required=False)
-    parser.add_argument("--clean-data-dir", default=True, required=False, action="store_true")
+    parser.add_argument("--save-data-dir", default=False, required=False, action="store_true")
     parser.add_argument("--clean-logs-dir", default=False, required=False, action="store_true")
     return parser.parse_args()
 
@@ -108,7 +108,13 @@ if __name__ == "__main__":
     args = load_args()
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(asctime)s %(name)s] %(message)s")
     run(args)
-    if args.clean_data_dir:
-        shutil.rmtree(os.path.join(BUILD_DIR, "e2e", "data"))
+    if not args.save_data_dir:
+        try:
+            shutil.rmtree(os.path.join(BUILD_DIR, "e2e", "data"))
+        except:
+            pass
     if args.clean_logs_dir:
-        shutil.rmtree(os.path.join(BUILD_DIR, "e2e", "logs"))
+        try:
+            shutil.rmtree(os.path.join(BUILD_DIR, "e2e", "logs"))
+        except:
+            pass

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -14,6 +14,7 @@
 import atexit
 import logging
 import os
+import shutil
 import subprocess
 import time
 from argparse import ArgumentParser
@@ -34,6 +35,8 @@ def load_args():
     parser.add_argument("--workloads-root-directory", required=True)
     parser.add_argument("--workload-name", default=None, required=False)
     parser.add_argument("--debug", default=False, required=False)
+    parser.add_argument("--clean-data-dir", default=True, required=False, action="store_true")
+    parser.add_argument("--clean-logs-dir", default=False, required=False, action="store_true")
     return parser.parse_args()
 
 
@@ -105,3 +108,7 @@ if __name__ == "__main__":
     args = load_args()
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(asctime)s %(name)s] %(message)s")
     run(args)
+    if args.clean_data_dir:
+        shutil.rmtree(os.path.join(BUILD_DIR, "e2e", "data"))
+    if args.clean_logs_dir:
+        shutil.rmtree(os.path.join(BUILD_DIR, "e2e", "logs"))

--- a/tests/e2e/sso/common.py
+++ b/tests/e2e/sso/common.py
@@ -3,14 +3,14 @@ import os
 
 def get_data_path(file: str, test: str):
     """
-    Data is stored in high_availabiity folder.
+    Data is stored in sso folder.
     """
     return f"sso/{file}/{test}"
 
 
 def get_logs_path(file: str, test: str):
     """
-    Logs are stored in high_availabiity folder.
+    Logs are stored in sso folder.
     """
     return f"sso/{file}/{test}"
 

--- a/tests/e2e/sso/common.py
+++ b/tests/e2e/sso/common.py
@@ -1,6 +1,20 @@
 import os
 
 
+def get_data_path(file: str, test: str):
+    """
+    Data is stored in high_availabiity folder.
+    """
+    return f"sso/{file}/{test}"
+
+
+def get_logs_path(file: str, test: str):
+    """
+    Logs are stored in high_availabiity folder.
+    """
+    return f"sso/{file}/{test}"
+
+
 def compose_path(filename: str):
     return os.path.normpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "data", filename))
 

--- a/tests/e2e/sso/test_sso.py
+++ b/tests/e2e/sso/test_sso.py
@@ -21,7 +21,7 @@ INSTANCE_NAME = "test_instance"
 file = "test_sso"
 
 
-def get_instances(test_name):
+def get_instances(test_name: str):
     return {
         INSTANCE_NAME: {
             "args": ["--bolt-port=7687", "--log-level=TRACE", "--data-recovery-on-startup=true"],

--- a/tests/e2e/sso/test_sso.py
+++ b/tests/e2e/sso/test_sso.py
@@ -5,6 +5,7 @@ import sys
 import interactive_mg_runner
 import neo4j.exceptions
 import pytest
+from common import get_data_path, get_logs_path
 from neo4j import Auth, GraphDatabase
 
 interactive_mg_runner.SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -16,14 +17,21 @@ interactive_mg_runner.MEMGRAPH_BINARY = os.path.normpath(os.path.join(interactiv
 
 AUTH_MODULE_PATH = os.path.normpath(os.path.join(interactive_mg_runner.SCRIPT_DIR, "dummy_sso_module.py"))
 INSTANCE_NAME = "test_instance"
-INSTANCE_DESCRIPTION = {
-    INSTANCE_NAME: {
-        "args": ["--bolt-port=7687", "--log-level=TRACE", "--data-recovery-on-startup=true"],
-        "log_file": "sso.log",
-        "setup_queries": [],
-        "ignore_auth_failure": True,
+
+file = "test_sso"
+
+
+def get_instances(test_name):
+    return {
+        INSTANCE_NAME: {
+            "args": ["--bolt-port=7687", "--log-level=TRACE", "--data-recovery-on-startup=true"],
+            "log_file": f"{get_logs_path(file, test_name)}/test_instance.log",
+            "data_directory": f"{get_data_path(file, test_name)}",
+            "setup_queries": [],
+            "ignore_auth_failure": True,
+        }
     }
-}
+
 
 MG_URI = "bolt://localhost:7687"
 CLIENT_ERROR_MESSAGE = "Authentication failure"
@@ -31,9 +39,12 @@ USERNAME = "anthony"
 
 
 @pytest.fixture(autouse=True)
-def wrapper():
+def wrapper(request):
     # 1. Create roles
-    interactive_mg_runner.start_all(INSTANCE_DESCRIPTION)
+
+    test_name = request.function.__name__
+    instances = get_instances(test_name)
+    interactive_mg_runner.start_all(instances)
 
     with GraphDatabase.driver(MG_URI, auth=("", "")) as client:
         client.verify_connectivity()
@@ -41,75 +52,21 @@ def wrapper():
             session.run("CREATE ROLE architect;")
             session.run("GRANT ALL PRIVILEGES TO architect;")
 
-    interactive_mg_runner.stop(INSTANCE_DESCRIPTION, INSTANCE_NAME)
+    interactive_mg_runner.stop(instances, INSTANCE_NAME)
 
     # 2. Restart to use SSO
-    INSTANCE_DESCRIPTION[INSTANCE_NAME]["args"].append(f"--auth-module-mappings=saml-entra-id:{AUTH_MODULE_PATH}")
-    interactive_mg_runner.start_all(INSTANCE_DESCRIPTION)
+    instances[INSTANCE_NAME]["args"].append(f"--auth-module-mappings=saml-entra-id:{AUTH_MODULE_PATH}")
+    interactive_mg_runner.start_all(instances)
 
     # 3. Run test
     yield None
 
     # 4. Stop intance
-    interactive_mg_runner.stop(INSTANCE_DESCRIPTION, INSTANCE_NAME, keep_directories=False)
-    INSTANCE_DESCRIPTION[INSTANCE_NAME]["args"].pop()
-
-    # 5. Start instance again and delete role
-
-    interactive_mg_runner.start_all(INSTANCE_DESCRIPTION)
-    with GraphDatabase.driver(MG_URI, auth=("", "")) as client:
-        client.verify_connectivity()
-        with client.session() as session:
-            session.run("DROP ROLE architect;")
-    interactive_mg_runner.stop(INSTANCE_DESCRIPTION, INSTANCE_NAME)
-
-
-def test_sso_with_no_module_provided():
-    response = base64.b64encode(b"dummy_value").decode("utf-8")
-    MG_AUTH = Auth(scheme="saml-entra-id", credentials=response, principal="")
-
-    with GraphDatabase.driver(MG_URI, auth=MG_AUTH) as client:
-        with pytest.raises(neo4j.exceptions.ServiceUnavailable, match=CLIENT_ERROR_MESSAGE) as _:
-            client.verify_connectivity()
-
-
-def test_sso_module_error():
-    response = base64.b64encode(b"send_error").decode("utf-8")
-    MG_AUTH = Auth(scheme="saml-entra-id", credentials=response, principal="")
-    with GraphDatabase.driver(MG_URI, auth=MG_AUTH) as client:
-        with pytest.raises(neo4j.exceptions.ServiceUnavailable, match=CLIENT_ERROR_MESSAGE) as _:
-            client.verify_connectivity()
-
-
-def test_sso_json_with_wrong_fields():
-    response = base64.b64encode(b"wrong_fields").decode("utf-8")
-    MG_AUTH = Auth(scheme="saml-entra-id", credentials=response, principal="")
-
-    with GraphDatabase.driver(MG_URI, auth=MG_AUTH) as client:
-        with pytest.raises(neo4j.exceptions.ServiceUnavailable, match=CLIENT_ERROR_MESSAGE) as _:
-            client.verify_connectivity()
-
-
-def test_sso_json_with_wrong_value_types():
-    response = base64.b64encode(b"wrong_value_types").decode("utf-8")
-    MG_AUTH = Auth(scheme="saml-entra-id", credentials=response, principal="")
-
-    with GraphDatabase.driver(MG_URI, auth=MG_AUTH) as client:
-        with pytest.raises(neo4j.exceptions.ServiceUnavailable, match=CLIENT_ERROR_MESSAGE) as _:
-            client.verify_connectivity()
+    interactive_mg_runner.stop(instances, INSTANCE_NAME, keep_directories=False)
 
 
 def test_sso_missing_username():
     response = base64.b64encode(b"skip_username").decode("utf-8")
-    MG_AUTH = Auth(scheme="saml-entra-id", credentials=response, principal="")
-
-    with GraphDatabase.driver(MG_URI, auth=MG_AUTH) as client:
-        with pytest.raises(neo4j.exceptions.ServiceUnavailable, match=CLIENT_ERROR_MESSAGE) as _:
-            client.verify_connectivity()
-
-
-def test_sso_role_does_not_exist():
-    response = base64.b64encode(b"nonexistent_role").decode("utf-8")
     MG_AUTH = Auth(scheme="saml-entra-id", credentials=response, principal="")
 
     with GraphDatabase.driver(MG_URI, auth=MG_AUTH) as client:

--- a/tests/e2e/sso/test_sso.py
+++ b/tests/e2e/sso/test_sso.py
@@ -1,7 +1,6 @@
 import base64
 import os
 import sys
-import tempfile
 
 import interactive_mg_runner
 import neo4j.exceptions
@@ -21,7 +20,6 @@ INSTANCE_DESCRIPTION = {
     INSTANCE_NAME: {
         "args": ["--bolt-port=7687", "--log-level=TRACE", "--data-recovery-on-startup=true"],
         "log_file": "sso.log",
-        "data_directory": "sso/test_sso",
         "setup_queries": [],
         "skip_auth": True,
     }
@@ -32,15 +30,8 @@ CLIENT_ERROR_MESSAGE = "Authentication failure"
 USERNAME = "anthony"
 
 
-@pytest.fixture(autouse=True)
-def cleanup_after_test():
-    yield
-    # Stop + delete directories
-    interactive_mg_runner.stop_all(keep_directories=False)
-
-
 def create_role():
-    interactive_mg_runner.start_all(INSTANCE_DESCRIPTION, keep_directories=False)
+    interactive_mg_runner.start_all(INSTANCE_DESCRIPTION)
 
     with GraphDatabase.driver(MG_URI, auth=("", "")) as client:
         client.verify_connectivity()
@@ -52,7 +43,7 @@ def create_role():
 
 
 def delete_role():
-    interactive_mg_runner.start_all(INSTANCE_DESCRIPTION, keep_directories=False)
+    interactive_mg_runner.start_all(INSTANCE_DESCRIPTION)
 
     with GraphDatabase.driver(MG_URI, auth=("", "")) as client:
         client.verify_connectivity()
@@ -68,7 +59,7 @@ class TestSSO:
         create_role()
 
         INSTANCE_DESCRIPTION[INSTANCE_NAME]["args"].append(f"--auth-module-mappings=saml-entra-id:{AUTH_MODULE_PATH}")
-        interactive_mg_runner.start_all(INSTANCE_DESCRIPTION, keep_directories=False)
+        interactive_mg_runner.start_all(INSTANCE_DESCRIPTION)
 
         yield None
 
@@ -79,7 +70,7 @@ class TestSSO:
         delete_role()
 
     def test_sso_with_no_module_provided(self):
-        interactive_mg_runner.start_all(INSTANCE_DESCRIPTION, keep_directories=False)
+        interactive_mg_runner.start_all(INSTANCE_DESCRIPTION)
         response = base64.b64encode(b"dummy_value").decode("utf-8")
         MG_AUTH = Auth(scheme="saml-entra-id", credentials=response, principal="")
 
@@ -145,7 +136,7 @@ def test_sso_create_owned():
     # 1. Create an owned object (trigger) while logged in via SSO
     create_role()
     INSTANCE_DESCRIPTION[INSTANCE_NAME]["args"].append(f"--auth-module-mappings=saml-entra-id:{AUTH_MODULE_PATH}")
-    interactive_mg_runner.start_all(INSTANCE_DESCRIPTION, keep_directories=False)
+    interactive_mg_runner.start_all(INSTANCE_DESCRIPTION)
 
     response = base64.b64encode(b"dummy_value").decode("utf-8")
     MG_AUTH = Auth(scheme="saml-entra-id", credentials=response, principal="")
@@ -164,7 +155,7 @@ def test_sso_create_owned():
     #  * Verify that Memgraph can start up without exceptions (loading streams & triggers)
 
     INSTANCE_DESCRIPTION[INSTANCE_NAME]["args"].pop()
-    interactive_mg_runner.start_all(INSTANCE_DESCRIPTION, keep_directories=False)
+    interactive_mg_runner.start_all(INSTANCE_DESCRIPTION)
 
     with GraphDatabase.driver(MG_URI, auth=("", "")) as client:
         client.verify_connectivity()

--- a/tests/e2e/sso/test_sso.py
+++ b/tests/e2e/sso/test_sso.py
@@ -30,7 +30,9 @@ CLIENT_ERROR_MESSAGE = "Authentication failure"
 USERNAME = "anthony"
 
 
-def create_role():
+@pytest.fixture(autouse=True)
+def wrapper():
+    # 1. Create roles
     interactive_mg_runner.start_all(INSTANCE_DESCRIPTION)
 
     with GraphDatabase.driver(MG_URI, auth=("", "")) as client:
@@ -39,105 +41,97 @@ def create_role():
             session.run("CREATE ROLE architect;")
             session.run("GRANT ALL PRIVILEGES TO architect;")
 
-    interactive_mg_runner.stop_instance(INSTANCE_DESCRIPTION, INSTANCE_NAME)
+    interactive_mg_runner.stop(INSTANCE_DESCRIPTION, INSTANCE_NAME)
 
-
-def delete_role():
+    # 2. Restart to use SSO
+    INSTANCE_DESCRIPTION[INSTANCE_NAME]["args"].append(f"--auth-module-mappings=saml-entra-id:{AUTH_MODULE_PATH}")
     interactive_mg_runner.start_all(INSTANCE_DESCRIPTION)
 
+    # 3. Run test
+    yield None
+
+    # 4. Stop intance
+    interactive_mg_runner.stop(INSTANCE_DESCRIPTION, INSTANCE_NAME, keep_directories=False)
+    INSTANCE_DESCRIPTION[INSTANCE_NAME]["args"].pop()
+
+    # 5. Start instance again and delete role
+
+    interactive_mg_runner.start_all(INSTANCE_DESCRIPTION)
     with GraphDatabase.driver(MG_URI, auth=("", "")) as client:
         client.verify_connectivity()
         with client.session() as session:
             session.run("DROP ROLE architect;")
+    interactive_mg_runner.stop(INSTANCE_DESCRIPTION, INSTANCE_NAME)
 
-    interactive_mg_runner.stop_instance(INSTANCE_DESCRIPTION, INSTANCE_NAME)
 
+def test_sso_with_no_module_provided():
+    response = base64.b64encode(b"dummy_value").decode("utf-8")
+    MG_AUTH = Auth(scheme="saml-entra-id", credentials=response, principal="")
 
-class TestSSO:
-    @pytest.fixture(scope="class")
-    def provide_role(self):
-        create_role()
-
-        INSTANCE_DESCRIPTION[INSTANCE_NAME]["args"].append(f"--auth-module-mappings=saml-entra-id:{AUTH_MODULE_PATH}")
-        interactive_mg_runner.start_all(INSTANCE_DESCRIPTION)
-
-        yield None
-
-        interactive_mg_runner.stop_instance(INSTANCE_DESCRIPTION, INSTANCE_NAME)
-        print("aaaaa", INSTANCE_DESCRIPTION)
-        INSTANCE_DESCRIPTION[INSTANCE_NAME]["args"].pop()
-
-        delete_role()
-
-    def test_sso_with_no_module_provided(self):
-        interactive_mg_runner.start_all(INSTANCE_DESCRIPTION)
-        response = base64.b64encode(b"dummy_value").decode("utf-8")
-        MG_AUTH = Auth(scheme="saml-entra-id", credentials=response, principal="")
-
-        with GraphDatabase.driver(MG_URI, auth=MG_AUTH) as client:
-            with pytest.raises(neo4j.exceptions.ServiceUnavailable, match=CLIENT_ERROR_MESSAGE) as _:
-                client.verify_connectivity()
-        interactive_mg_runner.stop_instance(INSTANCE_DESCRIPTION, INSTANCE_NAME)
-
-    def test_sso_module_error(self, provide_role):
-        response = base64.b64encode(b"send_error").decode("utf-8")
-        MG_AUTH = Auth(scheme="saml-entra-id", credentials=response, principal="")
-        with GraphDatabase.driver(MG_URI, auth=MG_AUTH) as client:
-            with pytest.raises(neo4j.exceptions.ServiceUnavailable, match=CLIENT_ERROR_MESSAGE) as _:
-                client.verify_connectivity()
-
-    def test_sso_json_with_wrong_fields(self, provide_role):
-        response = base64.b64encode(b"wrong_fields").decode("utf-8")
-        MG_AUTH = Auth(scheme="saml-entra-id", credentials=response, principal="")
-
-        with GraphDatabase.driver(MG_URI, auth=MG_AUTH) as client:
-            with pytest.raises(neo4j.exceptions.ServiceUnavailable, match=CLIENT_ERROR_MESSAGE) as _:
-                client.verify_connectivity()
-
-    def test_sso_json_with_wrong_value_types(self, provide_role):
-        response = base64.b64encode(b"wrong_value_types").decode("utf-8")
-        MG_AUTH = Auth(scheme="saml-entra-id", credentials=response, principal="")
-
-        with GraphDatabase.driver(MG_URI, auth=MG_AUTH) as client:
-            with pytest.raises(neo4j.exceptions.ServiceUnavailable, match=CLIENT_ERROR_MESSAGE) as _:
-                client.verify_connectivity()
-
-    def test_sso_missing_username(self, provide_role):
-        response = base64.b64encode(b"skip_username").decode("utf-8")
-        MG_AUTH = Auth(scheme="saml-entra-id", credentials=response, principal="")
-
-        with GraphDatabase.driver(MG_URI, auth=MG_AUTH) as client:
-            with pytest.raises(neo4j.exceptions.ServiceUnavailable, match=CLIENT_ERROR_MESSAGE) as _:
-                client.verify_connectivity()
-
-    def test_sso_role_does_not_exist(self, provide_role):
-        response = base64.b64encode(b"nonexistent_role").decode("utf-8")
-        MG_AUTH = Auth(scheme="saml-entra-id", credentials=response, principal="")
-
-        with GraphDatabase.driver(MG_URI, auth=MG_AUTH) as client:
-            with pytest.raises(neo4j.exceptions.ServiceUnavailable, match=CLIENT_ERROR_MESSAGE) as _:
-                client.verify_connectivity()
-
-    def test_sso_successful(self, provide_role):
-        response = base64.b64encode(b"dummy_value").decode("utf-8")
-        MG_AUTH = Auth(scheme="saml-entra-id", credentials=response, principal="")
-
-        with GraphDatabase.driver(MG_URI, auth=MG_AUTH) as client:
+    with GraphDatabase.driver(MG_URI, auth=MG_AUTH) as client:
+        with pytest.raises(neo4j.exceptions.ServiceUnavailable, match=CLIENT_ERROR_MESSAGE) as _:
             client.verify_connectivity()
-            with client.session() as session:
-                session.run("MATCH (n) RETURN n;")
-                current_user_result = list(session.run("SHOW CURRENT USER;"))
-                assert len(current_user_result) == 1 and current_user_result[0]["user"] == USERNAME
+
+
+def test_sso_module_error():
+    response = base64.b64encode(b"send_error").decode("utf-8")
+    MG_AUTH = Auth(scheme="saml-entra-id", credentials=response, principal="")
+    with GraphDatabase.driver(MG_URI, auth=MG_AUTH) as client:
+        with pytest.raises(neo4j.exceptions.ServiceUnavailable, match=CLIENT_ERROR_MESSAGE) as _:
+            client.verify_connectivity()
+
+
+def test_sso_json_with_wrong_fields():
+    response = base64.b64encode(b"wrong_fields").decode("utf-8")
+    MG_AUTH = Auth(scheme="saml-entra-id", credentials=response, principal="")
+
+    with GraphDatabase.driver(MG_URI, auth=MG_AUTH) as client:
+        with pytest.raises(neo4j.exceptions.ServiceUnavailable, match=CLIENT_ERROR_MESSAGE) as _:
+            client.verify_connectivity()
+
+
+def test_sso_json_with_wrong_value_types():
+    response = base64.b64encode(b"wrong_value_types").decode("utf-8")
+    MG_AUTH = Auth(scheme="saml-entra-id", credentials=response, principal="")
+
+    with GraphDatabase.driver(MG_URI, auth=MG_AUTH) as client:
+        with pytest.raises(neo4j.exceptions.ServiceUnavailable, match=CLIENT_ERROR_MESSAGE) as _:
+            client.verify_connectivity()
+
+
+def test_sso_missing_username():
+    response = base64.b64encode(b"skip_username").decode("utf-8")
+    MG_AUTH = Auth(scheme="saml-entra-id", credentials=response, principal="")
+
+    with GraphDatabase.driver(MG_URI, auth=MG_AUTH) as client:
+        with pytest.raises(neo4j.exceptions.ServiceUnavailable, match=CLIENT_ERROR_MESSAGE) as _:
+            client.verify_connectivity()
+
+
+def test_sso_role_does_not_exist():
+    response = base64.b64encode(b"nonexistent_role").decode("utf-8")
+    MG_AUTH = Auth(scheme="saml-entra-id", credentials=response, principal="")
+
+    with GraphDatabase.driver(MG_URI, auth=MG_AUTH) as client:
+        with pytest.raises(neo4j.exceptions.ServiceUnavailable, match=CLIENT_ERROR_MESSAGE) as _:
+            client.verify_connectivity()
+
+
+def test_sso_successful():
+    response = base64.b64encode(b"dummy_value").decode("utf-8")
+    MG_AUTH = Auth(scheme="saml-entra-id", credentials=response, principal="")
+
+    with GraphDatabase.driver(MG_URI, auth=MG_AUTH) as client:
+        client.verify_connectivity()
+        with client.session() as session:
+            session.run("MATCH (n) RETURN n;")
+            current_user_result = list(session.run("SHOW CURRENT USER;"))
+            assert len(current_user_result) == 1 and current_user_result[0]["user"] == USERNAME
 
 
 def test_sso_create_owned():
     # Triggers and streams are owned by the user who made them
-
     # 1. Create an owned object (trigger) while logged in via SSO
-    create_role()
-    INSTANCE_DESCRIPTION[INSTANCE_NAME]["args"].append(f"--auth-module-mappings=saml-entra-id:{AUTH_MODULE_PATH}")
-    interactive_mg_runner.start_all(INSTANCE_DESCRIPTION)
-
     response = base64.b64encode(b"dummy_value").decode("utf-8")
     MG_AUTH = Auth(scheme="saml-entra-id", credentials=response, principal="")
 
@@ -148,20 +142,6 @@ def test_sso_create_owned():
                 """CREATE TRIGGER exampleTrigger1 ON () CREATE AFTER COMMIT
                 EXECUTE UNWIND createdVertices AS newNodes SET newNodes.created = timestamp();"""
             )
-
-    interactive_mg_runner.stop_instance(INSTANCE_DESCRIPTION, INSTANCE_NAME)
-
-    # 2. Start a new session without SSO
-    #  * Verify that Memgraph can start up without exceptions (loading streams & triggers)
-
-    INSTANCE_DESCRIPTION[INSTANCE_NAME]["args"].pop()
-    interactive_mg_runner.start_all(INSTANCE_DESCRIPTION)
-
-    with GraphDatabase.driver(MG_URI, auth=("", "")) as client:
-        client.verify_connectivity()
-
-    interactive_mg_runner.stop_instance(INSTANCE_DESCRIPTION, INSTANCE_NAME)
-    delete_role()
 
 
 if __name__ == "__main__":

--- a/tests/e2e/sso/test_sso.py
+++ b/tests/e2e/sso/test_sso.py
@@ -21,7 +21,7 @@ INSTANCE_DESCRIPTION = {
         "args": ["--bolt-port=7687", "--log-level=TRACE", "--data-recovery-on-startup=true"],
         "log_file": "sso.log",
         "setup_queries": [],
-        "skip_auth": True,
+        "ignore_auth_failure": True,
     }
 }
 

--- a/tests/e2e/system_replication/auth.py
+++ b/tests/e2e/system_replication/auth.py
@@ -32,10 +32,16 @@ REPLICATION_PORTS = {"replica_1": 10001, "replica_2": 10002}
 file = "auth"
 
 
+@pytest.fixture
+def test_name(request):
+    return request.node.name
+
+
 @pytest.fixture(autouse=True)
 def cleanup_after_test():
+    # Run the test
     yield
-    # Stop + delete directories
+    # Stop + delete directories after running the test
     interactive_mg_runner.stop_all(keep_directories=False)
 
 
@@ -144,12 +150,10 @@ def main_and_repl_queries(cursor):
     return n_exceptions
 
 
-def test_auth_queries_on_replica(connection):
+def test_auth_queries_on_replica(connection, test_name):
     # Goal: check that write auth queries are forbidden on REPLICAs
     # 0/ Setup replication cluster
     # 1/ Check queries
-
-    test_name = "test_auth_queries_on_replica"
 
     MEMGRAPH_INSTANCES_DESCRIPTION_MANUAL = {
         "replica_1": {
@@ -206,15 +210,13 @@ def test_auth_queries_on_replica(connection):
     assert main_and_repl_queries(cursor_replica_2) == 0
 
 
-def test_manual_users_recovery(connection):
+def test_manual_users_recovery(connection, test_name):
     # Goal: show system recovery in action at registration time
     # 0/ MAIN CREATE USER user1, user2
     #    REPLICA CREATE USER user3, user4
     #    Setup replication cluster
     # 1/ Check that both MAIN and REPLICA have user1 and user2
     # 2/ Check connections on REPLICAS
-
-    test_name = "test_manual_users_recovery"
 
     MEMGRAPH_INSTANCES_DESCRIPTION_MANUAL = {
         "replica_1": {
@@ -280,14 +282,12 @@ def test_manual_users_recovery(connection):
     connection(BOLT_PORTS["replica_2"], "replica", "user2", "password").cursor()
 
 
-def test_env_users_recovery(connection):
+def test_env_users_recovery(connection, test_name):
     # Goal: show system recovery in action at registration time
     # 0/ Set users from the environment
     #    MAIN gets users from the environment
     #    Setup replication cluster
     # 1/ Check that both MAIN and REPLICA have user1
-
-    test_name = "test_env_users_recovery"
 
     MEMGRAPH_INSTANCES_DESCRIPTION_MANUAL = {
         "replica_1": {
@@ -358,7 +358,7 @@ def test_env_users_recovery(connection):
     )
 
 
-def test_manual_roles_recovery(connection):
+def test_manual_roles_recovery(connection, test_name):
     # Goal: show system recovery in action at registration time
     # 0/ MAIN CREATE USER user1, user2
     #    REPLICA CREATE USER user3, user4
@@ -366,8 +366,6 @@ def test_manual_roles_recovery(connection):
     # 1/ Check that both MAIN and REPLICA have user1 and user2
     # 2/ Check that role1 and role2 are replicated
     # 3/ Check that user1 has role1
-
-    test_name = "test_manual_roles_recovery"
 
     MEMGRAPH_INSTANCES_DESCRIPTION_MANUAL = {
         "replica_1": {
@@ -448,13 +446,11 @@ def test_manual_roles_recovery(connection):
     )
 
 
-def test_auth_config_recovery(connection):
+def test_auth_config_recovery(connection, test_name):
     # Goal: show we are replicating Auth::Config
     # 0/ Setup auth configuration and compliant users
     # 1/ Check that both MAIN and REPLICA have the same users
     # 2/ Check that REPLICAS have the same config
-
-    test_name = "test_auth_config_recovery"
 
     MEMGRAPH_INSTANCES_DESCRIPTION_MANUAL = {
         "replica_1": {
@@ -545,10 +541,8 @@ def test_auth_config_recovery(connection):
     user_test(cursor_replica_2)
 
 
-def test_auth_replication(connection):
+def test_auth_replication(connection, test_name):
     # Goal: show that individual auth queries get replicated
-
-    test_name = "test_auth_replication"
 
     MEMGRAPH_INSTANCES_DESCRIPTION_MANUAL = {
         "replica_1": {

--- a/tests/e2e/system_replication/auth.py
+++ b/tests/e2e/system_replication/auth.py
@@ -829,5 +829,4 @@ def test_auth_replication(connection):
 
 
 if __name__ == "__main__":
-    interactive_mg_runner.cleanup_directories_on_exit()
     sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/system_replication/common.py
+++ b/tests/e2e/system_replication/common.py
@@ -14,6 +14,20 @@ import typing
 import mgclient
 
 
+def get_data_path(file: str, test: str):
+    """
+    Data is stored in high_availabiity folder.
+    """
+    return f"system_replication/{file}/{test}"
+
+
+def get_logs_path(file: str, test: str):
+    """
+    Logs are stored in high_availabiity folder.
+    """
+    return f"system_replication/{file}/{test}"
+
+
 def execute_and_fetch_all(cursor: mgclient.Cursor, query: str, params: dict = {}) -> typing.List[tuple]:
     cursor.execute(query, params)
     return cursor.fetchall()

--- a/tests/e2e/system_replication/common.py
+++ b/tests/e2e/system_replication/common.py
@@ -16,14 +16,14 @@ import mgclient
 
 def get_data_path(file: str, test: str):
     """
-    Data is stored in high_availabiity folder.
+    Data is stored in system replication folder.
     """
     return f"system_replication/{file}/{test}"
 
 
 def get_logs_path(file: str, test: str):
     """
-    Logs are stored in high_availabiity folder.
+    Logs are stored in system replication folder.
     """
     return f"system_replication/{file}/{test}"
 

--- a/tests/e2e/system_replication/multitenancy.py
+++ b/tests/e2e/system_replication/multitenancy.py
@@ -1417,5 +1417,4 @@ def test_multitenancy_drop_and_recreate_while_replica_using(connection):
 
 
 if __name__ == "__main__":
-    interactive_mg_runner.cleanup_directories_on_exit()
     sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/jepsen/src/jepsen/memgraph/support.clj
+++ b/tests/jepsen/src/jepsen/memgraph/support.clj
@@ -114,5 +114,4 @@
        (c/exec :rm :-rf mgdata)
        (c/exec :rm :-rf mglog)))
     db/LogFiles
-    (log-files [_ _ _]
-      [mglog])))
+    (log-files [_ _ _] [mglog])))


### PR DESCRIPTION
Logs are now saved to build/e2e/logs and copied from there. All data directories are now inside build/e2e/data/. Developer should not generate new tmp folder. If she/he wants specific data directory, it can provide the name of it (e.g replica1). If user doesn't specify data_directory field, random 8-character long folder will be created for each test inside build/e2e/data/. All tests that were using tmp directory intentionally from system_replication, high_availability and replication are changed without changing the functionality. Interactive mg runner has now clearer API. The check if port is free is now improved in a way that the interactive_mg_runner will try pinging the socket for the maximum of 10s and if after 10s the socket is not free, it will throw an error that this port is already in use. Before we had an issue that we checked just once if the socket is free and that was often in data race conflict with the next test being run. All instances from e2e tests are now started by default with `--storage-snapshot-on-exit` set to false to avoid creating new folder after it has been already cleaned. run.sh script now accepts two more arguments: `--save-data-dir` which is False by default and `--clean-logs-dir` which is also False by default. These 2 flags are propagated to runner.py which accepts same two new flags. SSO tests are changed in a way that only one test which tests failed connection is kept to improve its performance and all tests use separate data directory, before tests were sharing data directories which caused problems. 