### PR TITLE
Fix Abort() on Edge Index

### DIFF
--- a/src/storage/v2/delta.hpp
+++ b/src/storage/v2/delta.hpp
@@ -216,6 +216,15 @@ struct Delta {
             .key = key,
             .value = std::pmr::polymorphic_allocator<Delta>{res}.new_object<pmr::PropertyValue>(std::move(value))} {}
 
+  Delta(SetPropertyTag /*tag*/, Vertex *out_vertex, PropertyId key, PropertyValue value,
+        std::atomic<uint64_t> *timestamp, uint64_t command_id, utils::PageSlabMemoryResource *res)
+      : timestamp(timestamp),
+        command_id(command_id),
+        property{.action = Action::SET_PROPERTY,
+                 .key = key,
+                 .value = std::pmr::polymorphic_allocator<Delta>{res}.new_object<pmr::PropertyValue>(std::move(value)),
+                 .out_vertex = out_vertex} {}
+
   Delta(AddInEdgeTag /*tag*/, EdgeTypeId edge_type, Vertex *vertex, EdgeRef edge, std::atomic<uint64_t> *timestamp,
         uint64_t command_id)
       : timestamp(timestamp),
@@ -267,6 +276,7 @@ struct Delta {
       Action action;
       PropertyId key;
       storage::pmr::PropertyValue *value = nullptr;
+      Vertex *out_vertex{nullptr};  // Used by edge's delta to easily rebuild the edge
     } property;
     struct {
       Action action;

--- a/src/storage/v2/indices/edge_type_property_index.hpp
+++ b/src/storage/v2/indices/edge_type_property_index.hpp
@@ -19,6 +19,11 @@ namespace memgraph::storage {
 
 class EdgeTypePropertyIndex {
  public:
+  struct IndexStats {
+    std::map<EdgeTypeId, std::vector<PropertyId>> et2p;
+    std::map<PropertyId, std::vector<EdgeTypeId>> p2et;
+  };
+
   EdgeTypePropertyIndex() = default;
 
   EdgeTypePropertyIndex(const EdgeTypePropertyIndex &) = delete;

--- a/src/storage/v2/indices/indices.cpp
+++ b/src/storage/v2/indices/indices.cpp
@@ -44,6 +44,13 @@ void Indices::AbortEntries(EdgeTypeId edge_type,
   static_cast<InMemoryEdgeTypeIndex *>(edge_type_index_.get())->AbortEntries(edge_type, edges, exact_start_timestamp);
 }
 
+void Indices::AbortEntries(std::pair<EdgeTypeId, PropertyId> edge_type_property,
+                           std::span<std::tuple<Vertex *const, Vertex *const, Edge *const, PropertyValue> const> edges,
+                           uint64_t exact_start_timestamp) const {
+  static_cast<InMemoryEdgeTypePropertyIndex *>(edge_type_property_index_.get())
+      ->AbortEntries(edge_type_property, edges, exact_start_timestamp);
+}
+
 void Indices::RemoveObsoleteVertexEntries(uint64_t oldest_active_start_timestamp, std::stop_token token) const {
   static_cast<InMemoryLabelIndex *>(label_index_.get())->RemoveObsoleteEntries(oldest_active_start_timestamp, token);
   static_cast<InMemoryLabelPropertyIndex *>(label_property_index_.get())

--- a/src/storage/v2/indices/indices.cpp
+++ b/src/storage/v2/indices/indices.cpp
@@ -38,6 +38,12 @@ void Indices::AbortEntries(LabelId label, std::span<std::pair<PropertyValue, Ver
       ->AbortEntries(label, vertices, exact_start_timestamp);
 }
 
+void Indices::AbortEntries(EdgeTypeId edge_type,
+                           std::span<std::tuple<Vertex *const, Vertex *const, Edge *const> const> edges,
+                           uint64_t exact_start_timestamp) const {
+  static_cast<InMemoryEdgeTypeIndex *>(edge_type_index_.get())->AbortEntries(edge_type, edges, exact_start_timestamp);
+}
+
 void Indices::RemoveObsoleteVertexEntries(uint64_t oldest_active_start_timestamp, std::stop_token token) const {
   static_cast<InMemoryLabelIndex *>(label_index_.get())->RemoveObsoleteEntries(oldest_active_start_timestamp, token);
   static_cast<InMemoryLabelPropertyIndex *>(label_property_index_.get())

--- a/src/storage/v2/indices/indices.cpp
+++ b/src/storage/v2/indices/indices.cpp
@@ -109,6 +109,9 @@ Indices::Indices(const Config &config, StorageMode storage_mode) {
 
 Indices::IndexStats Indices::Analysis() const {
   return {static_cast<InMemoryLabelIndex *>(label_index_.get())->Analysis(),
-          static_cast<InMemoryLabelPropertyIndex *>(label_property_index_.get())->Analysis()};
+          static_cast<InMemoryLabelPropertyIndex *>(label_property_index_.get())->Analysis(),
+          static_cast<InMemoryEdgeTypeIndex *>(edge_type_index_.get())->Analysis(),
+          static_cast<InMemoryEdgeTypePropertyIndex *>(edge_type_property_index_.get())->Analysis()};
 }
+
 }  // namespace memgraph::storage

--- a/src/storage/v2/indices/indices.hpp
+++ b/src/storage/v2/indices/indices.hpp
@@ -59,6 +59,8 @@ struct Indices {
   struct IndexStats {
     std::vector<LabelId> label;
     LabelPropertyIndex::IndexStats property_label;
+    std::vector<EdgeTypeId> edge_type;
+    EdgeTypePropertyIndex::IndexStats property_edge_type;
   };
   IndexStats Analysis() const;
 

--- a/src/storage/v2/indices/indices.hpp
+++ b/src/storage/v2/indices/indices.hpp
@@ -53,6 +53,9 @@ struct Indices {
                     uint64_t exact_start_timestamp) const;
   void AbortEntries(EdgeTypeId edge_type, std::span<std::tuple<Vertex *const, Vertex *const, Edge *const> const> edges,
                     uint64_t exact_start_timestamp) const;
+  void AbortEntries(std::pair<EdgeTypeId, PropertyId> edge_type_property,
+                    std::span<std::tuple<Vertex *const, Vertex *const, Edge *const, PropertyValue> const> edges,
+                    uint64_t exact_start_timestamp) const;
 
   void DropGraphClearIndices();
 

--- a/src/storage/v2/indices/indices.hpp
+++ b/src/storage/v2/indices/indices.hpp
@@ -51,6 +51,8 @@ struct Indices {
                     uint64_t exact_start_timestamp) const;
   void AbortEntries(LabelId label, std::span<std::pair<PropertyValue, Vertex *> const> vertices,
                     uint64_t exact_start_timestamp) const;
+  void AbortEntries(EdgeTypeId edge_type, std::span<std::tuple<Vertex *const, Vertex *const, Edge *const> const> edges,
+                    uint64_t exact_start_timestamp) const;
 
   void DropGraphClearIndices();
 

--- a/src/storage/v2/indices/label_property_index.hpp
+++ b/src/storage/v2/indices/label_property_index.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "storage/v2/constraints/constraints.hpp"
+#include "storage/v2/id_types.hpp"
 #include "storage/v2/vertex.hpp"
 #include "storage/v2/vertex_accessor.hpp"
 

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -164,8 +164,8 @@ void InMemoryEdgeTypeIndex::AbortEntries(EdgeTypeId edge_type,
 
   auto &index_storage = it->second;
   auto acc = index_storage.access();
-  for (auto &edge : edges) {
-    acc.remove(Entry{std::get<0>(edge), std::get<1>(edge), std::get<2>(edge), exact_start_timestamp});
+  for (const auto &[from_vertex, to_vertex, edge] : edges) {
+    acc.remove(Entry{from_vertex, to_vertex, edge, exact_start_timestamp});
   }
 }
 

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -157,7 +157,7 @@ uint64_t InMemoryEdgeTypeIndex::ApproximateEdgeCount(EdgeTypeId edge_type) const
 }
 
 void InMemoryEdgeTypeIndex::AbortEntries(EdgeTypeId edge_type,
-                                         std::span<std::tuple<Vertex *const, Vertex *const, Edge *const>> edges,
+                                         std::span<std::tuple<Vertex *const, Vertex *const, Edge *const> const> edges,
                                          uint64_t exact_start_timestamp) {
   auto const it = index_.find(edge_type);
   if (it == index_.end()) return;

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -156,6 +156,19 @@ uint64_t InMemoryEdgeTypeIndex::ApproximateEdgeCount(EdgeTypeId edge_type) const
   return 0;
 }
 
+void InMemoryEdgeTypeIndex::AbortEntries(EdgeTypeId edge_type,
+                                         std::span<std::tuple<Vertex *const, Vertex *const, Edge *const>> edges,
+                                         uint64_t exact_start_timestamp) {
+  auto const it = index_.find(edge_type);
+  if (it == index_.end()) return;
+
+  auto &index_storage = it->second;
+  auto acc = index_storage.access();
+  for (auto &edge : edges) {
+    acc.remove(Entry{std::get<0>(edge), std::get<1>(edge), std::get<2>(edge), exact_start_timestamp});
+  }
+}
+
 void InMemoryEdgeTypeIndex::UpdateOnEdgeCreation(Vertex *from, Vertex *to, EdgeRef edge_ref, EdgeTypeId edge_type,
                                                  const Transaction &tx) {
   auto it = index_.find(edge_type);

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -298,4 +298,13 @@ InMemoryEdgeTypeIndex::Iterable InMemoryEdgeTypeIndex::Edges(EdgeTypeId edge_typ
   return {it->second.access(), view, storage, transaction};
 }
 
+std::vector<EdgeTypeId> InMemoryEdgeTypeIndex::Analysis() const {
+  std::vector<EdgeTypeId> res;
+  res.reserve(index_.size());
+  for (const auto &[edge_type, _] : index_) {
+    res.emplace_back(edge_type);
+  }
+  return res;
+}
+
 }  // namespace memgraph::storage

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -66,6 +66,8 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
 
   void DropGraphClearIndices() override;
 
+  std::vector<EdgeTypeId> Analysis() const;
+
   static constexpr std::size_t kEdgeTypeIdPos = 0U;
   static constexpr std::size_t kVertexPos = 1U;
   static constexpr std::size_t kEdgeRefPos = 2U;

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -53,7 +53,7 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
 
   void RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token);
 
-  void AbortEntries(EdgeTypeId edge_type, std::span<std::tuple<Vertex *const, Vertex *const, Edge *const>> edges,
+  void AbortEntries(EdgeTypeId edge_type, std::span<std::tuple<Vertex *const, Vertex *const, Edge *const> const> edges,
                     uint64_t exact_start_timestamp);
 
   uint64_t ApproximateEdgeCount(EdgeTypeId edge_type) const override;

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -112,7 +112,8 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
   Iterable Edges(EdgeTypeId edge_type, View view, Storage *storage, Transaction *transaction);
 
  private:
-  std::map<EdgeTypeId, utils::SkipList<Entry>> index_;
+  std::map<EdgeTypeId, utils::SkipList<Entry>> index_;  // This should be a std::map because we use it with assumption
+                                                        // that it's sorted
 };
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -53,6 +53,9 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
 
   void RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token);
 
+  void AbortEntries(EdgeTypeId edge_type, std::span<std::tuple<Vertex *const, Vertex *const, Edge *const>> edges,
+                    uint64_t exact_start_timestamp);
+
   uint64_t ApproximateEdgeCount(EdgeTypeId edge_type) const override;
 
   void UpdateOnEdgeCreation(Vertex *from, Vertex *to, EdgeRef edge_ref, EdgeTypeId edge_type,

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -15,6 +15,7 @@
 #include "storage/v2/edge_info_helpers.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indices/indices_utils.hpp"
+#include "storage/v2/property_value.hpp"
 #include "utils/counter.hpp"
 
 namespace {
@@ -188,6 +189,21 @@ void InMemoryEdgeTypePropertyIndex::RemoveObsoleteEntries(uint64_t oldest_active
 
       it = next_it;
     }
+  }
+}
+
+void InMemoryEdgeTypePropertyIndex::AbortEntries(
+    std::pair<EdgeTypeId, PropertyId> edge_type_property,
+    std::span<std::tuple<Vertex *const, Vertex *const, Edge *const, PropertyValue> const> edges,
+    uint64_t exact_start_timestamp) {
+  auto it = index_.find(edge_type_property);
+  if (it == index_.end()) {
+    return;
+  }
+
+  auto acc = it->second.access();
+  for (const auto &[from_vertex, to_vertex, edge, value] : edges) {
+    acc.remove(Entry{value, from_vertex, to_vertex, edge, exact_start_timestamp});
   }
 }
 

--- a/src/storage/v2/inmemory/edge_type_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.hpp
@@ -57,6 +57,10 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
 
   void RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token);
 
+  void AbortEntries(std::pair<EdgeTypeId, PropertyId> edge_type_property,
+                    std::span<std::tuple<Vertex *const, Vertex *const, Edge *const, PropertyValue> const> edges,
+                    uint64_t exact_start_timestamp);
+
   uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property) const override;
 
   // Functions that update the index

--- a/src/storage/v2/inmemory/edge_type_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.hpp
@@ -68,6 +68,15 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
 
   void DropGraphClearIndices() override;
 
+  IndexStats Analysis() const {
+    IndexStats stats;
+    for (const auto &[key, _] : index_) {
+      stats.et2p[key.first].push_back(key.second);
+      stats.p2et[key.second].push_back(key.first);
+    }
+    return stats;
+  }
+
   static constexpr std::size_t kEdgeTypeIdPos = 0U;
   static constexpr std::size_t kVertexPos = 1U;
   static constexpr std::size_t kEdgeRefPos = 2U;

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1356,10 +1356,10 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
                   if (!current_value.IsNull()) {
                     for (const auto &edge_type : edge_types->second) {
                       auto *from_vertex = current->property.out_vertex;
-                      for (const auto &out_edge : from_vertex->out_edges) {
-                        if (std::get<0>(out_edge) == edge_type) {
-                          edge_property_cleanup[std::make_pair(edge_type, current->property.key)].emplace_back(
-                              from_vertex, std::get<1>(out_edge), edge, current_value);
+                      for (const auto &[edge_type_out_edge, target_vertex, _] : from_vertex->out_edges) {
+                        if (edge_type_out_edge == edge_type) {
+                          edge_property_cleanup[{edge_type, current->property.key}].emplace_back(
+                              from_vertex, target_vertex, edge, current_value);
                         }
                       }
                     }

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1356,10 +1356,10 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
                   if (!current_value.IsNull()) {
                     for (const auto &edge_type : edge_types->second) {
                       auto *from_vertex = current->property.out_vertex;
-                      for (const auto &in_edge : from_vertex->out_edges) {
-                        if (std::get<0>(in_edge) == edge_type) {
+                      for (const auto &out_edge : from_vertex->out_edges) {
+                        if (std::get<0>(out_edge) == edge_type) {
                           edge_property_cleanup[std::make_pair(edge_type, current->property.key)].emplace_back(
-                              from_vertex, std::get<1>(in_edge), edge, std::move(current_value));
+                              from_vertex, std::get<1>(out_edge), edge, std::move(current_value));
                         }
                       }
                     }

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1356,7 +1356,7 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
                   if (!current_value.IsNull()) {
                     for (const auto &edge_type : edge_types->second) {
                       auto *from_vertex = current->property.out_vertex;
-                      for (const auto &in_edge : from_vertex->in_edges) {
+                      for (const auto &in_edge : from_vertex->out_edges) {
                         if (std::get<0>(in_edge) == edge_type) {
                           edge_property_cleanup[std::make_pair(edge_type, current->property.key)].emplace_back(
                               from_vertex, std::get<1>(in_edge), edge, std::move(current_value));

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1359,7 +1359,7 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
                       for (const auto &out_edge : from_vertex->out_edges) {
                         if (std::get<0>(out_edge) == edge_type) {
                           edge_property_cleanup[std::make_pair(edge_type, current->property.key)].emplace_back(
-                              from_vertex, std::get<1>(out_edge), edge, std::move(current_value));
+                              from_vertex, std::get<1>(out_edge), edge, current_value);
                         }
                       }
                     }


### PR DESCRIPTION
There were issues around cleanup of the edge index when Abort was called. Potentially leading to a segfault. We added code to perform correct cleanup during Abort.