### PR TITLE
Fix durability around the point index

### DIFF
--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -2125,11 +2125,13 @@ RecoveredSnapshot LoadSnapshotVersion17(const std::filesystem::path &path, utils
   return {info, recovery_info, std::move(indices_constraints)};
 }
 
-RecoveredSnapshot LoadSnapshotVersion18(const std::filesystem::path &path, utils::SkipList<Vertex> *vertices,
-                                        utils::SkipList<Edge> *edges, utils::SkipList<EdgeMetadata> *edges_metadata,
-                                        std::deque<std::pair<std::string, uint64_t>> *epoch_history,
-                                        NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count,
-                                        const Config &config, memgraph::storage::EnumStore *enum_store) {
+/// We messed up and accidentally introduced a version bump in a release it was not needed for
+/// hence same load for 18 will work for 19
+RecoveredSnapshot LoadSnapshotVersion18or19(const std::filesystem::path &path, utils::SkipList<Vertex> *vertices,
+                                            utils::SkipList<Edge> *edges, utils::SkipList<EdgeMetadata> *edges_metadata,
+                                            std::deque<std::pair<std::string, uint64_t>> *epoch_history,
+                                            NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count,
+                                            const Config &config, memgraph::storage::EnumStore *enum_store) {
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
 
@@ -2595,9 +2597,9 @@ RecoveredSnapshot LoadSnapshot(const std::filesystem::path &path, utils::SkipLis
     return LoadSnapshotVersion17(path, vertices, edges, edges_metadata, epoch_history, name_id_mapper, edge_count,
                                  config);
   }
-  if (*version == 18U) {
-    return LoadSnapshotVersion18(path, vertices, edges, edges_metadata, epoch_history, name_id_mapper, edge_count,
-                                 config, enum_store);
+  if (*version == 18U || *version == 19U) {
+    return LoadSnapshotVersion18or19(path, vertices, edges, edges_metadata, epoch_history, name_id_mapper, edge_count,
+                                     config, enum_store);
   }
 
   // Cleanup of loaded data in case of failure.

--- a/src/storage/v2/durability/version.hpp
+++ b/src/storage/v2/durability/version.hpp
@@ -20,7 +20,7 @@ namespace memgraph::storage::durability {
 // The current version of snapshot and WAL encoding / decoding.
 // IMPORTANT: Please bump this version for every snapshot and/or WAL format
 // change!!!
-const uint64_t kVersion{19};
+const uint64_t kVersion{20};
 
 const uint64_t kOldestSupportedVersion{14};
 const uint64_t kUniqueConstraintVersion{13};
@@ -28,7 +28,9 @@ const uint64_t kUniqueConstraintVersion{13};
 // But they are written in the same section.
 const uint64_t kEdgeIndicesVersion{17};
 const uint64_t kEnumsVersion{18};
-const uint64_t kPointIndex{19};
+// We prematurely bumped the version when making the point datatype as part of 2.19
+const uint64_t kAccidentalVersionBump1{19};
+const uint64_t kPointIndex{20};
 
 // Magic values written to the start of a snapshot/WAL file to identify it.
 const std::string kSnapshotMagic{"MGsn"};


### PR DESCRIPTION
In 2.19 we prematurely bumped the version unnecessarily. Hence 18 and 19 snapshot load versions are one and the same. Bump to 20 to distinguish new snapshots from those saved with 2.19.