### PR TITLE
Add create ha test

### DIFF
--- a/.github/workflows/check_flakiness.yaml
+++ b/.github/workflows/check_flakiness.yaml
@@ -11,27 +11,35 @@ on:
       community_core:
         type: boolean
         default: true
+        description: ""
       coverage_core:
         type: boolean
         default: true
+        description: ""
       debug_core:
         type: boolean
         default: true
+        description: ""
       debug_integration:
         type: boolean
         default: true
+        description: ""
       jepsen_core:
         type: boolean
         default: true
+        description: ""
       release_core:
         type: boolean
         default: true
+        description: ""
       release_e2e:
         type: boolean
         default: true
+        description: ""
       release_stress:
         type: boolean
         default: true
+        description: ""
       flakiness_runs:
         type: number
         default: 3

--- a/.github/workflows/stress_jepsen.yaml
+++ b/.github/workflows/stress_jepsen.yaml
@@ -1,0 +1,110 @@
+name: "Jepsen stress test"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+env:
+  ARCH: 'amd'
+  BUILD_TYPE: 'RelWithDebInfo'
+  MEMGRAPH_ENTERPRISE_LICENSE: ${{ secrets.MEMGRAPH_ENTERPRISE_LICENSE }}
+  MEMGRAPH_ORGANIZATION_NAME: ${{ secrets.MEMGRAPH_ORGANIZATION_NAME }}
+  OS: 'debian-12'
+  TOOLCHAIN: 'v5'
+
+jobs:
+  core:
+    name: "Jepsen stress tests"
+    runs-on: [self-hosted, Linux, X64, DockerMgBuild]
+    timeout-minutes: 120
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Refresh Jepsen Cluster
+        run: |
+          cd tests/jepsen
+          ./run.sh cluster-refresh --nodes-no 6
+
+      - name: Spin up mgbuild container
+        run: |
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN \
+          --os $OS \
+          --arch $ARCH \
+          run
+
+      - name: Build release binary
+        run: |
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN \
+          --os $OS \
+          --arch $ARCH \
+          --build-type $BUILD_TYPE \
+          build-memgraph
+
+      - name: Copy memgraph binary
+        run: |
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN \
+          --os $OS \
+          --arch $ARCH \
+          copy --binary --dest-dir build
+
+      - name: Copy libmemgraph_module_support.so
+        run: |
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN \
+          --os $OS \
+          --arch $ARCH \
+          copy --libs --dest-dir build/src/query
+
+      - name: Run unit tests for Jepsen code
+        run: |
+          cd tests/jepsen
+          ./run.sh unit-tests --binary ../../build/memgraph
+
+      - name: Run HA create test
+        run: |
+          cd tests/jepsen
+          ./run.sh test \
+          --binary ../../build/memgraph \
+          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 600 --concurrency 6" \
+          --ignore-run-stdout-logs \
+          --ignore-run-stderr-logs \
+          --nodes-no 6 \
+          --enterprise-license $MEMGRAPH_ENTERPRISE_LICENSE \
+          --organization-name $MEMGRAPH_ORGANIZATION_NAME
+
+      - name: Process Jepsen results
+        continue-on-error: true
+        if: always()
+        run: |
+          cd tests/jepsen
+          ./run.sh process-results
+
+      - name: Save Jepsen report
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: "Jepsen Report-${{ inputs.run_id }}"
+          path: tests/jepsen/Jepsen.tar.gz
+
+      - name: Stop mgbuild container
+        if: always()
+        run: |
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN \
+          --os $OS \
+          --arch $ARCH \
+          stop --remove

--- a/tests/jepsen/src/memgraph/core.clj
+++ b/tests/jepsen/src/memgraph/core.clj
@@ -10,6 +10,7 @@
     [tests :as tests]]
    [tesser.core :as tesser]
    [memgraph.high-availability.bank.test :as habank]
+   [memgraph.high-availability.create.test :as hacreate]
    [memgraph.replication.bank :as bank]
    [memgraph.replication.large :as large]
    [memgraph.support :as support]))
@@ -54,7 +55,8 @@
    workloads."
   {:bank                      bank/workload
    :large                     large/workload
-   :habank                    habank/workload})
+   :habank                    habank/workload
+   :hacreate                  hacreate/workload})
 
 (defn compose-gen
   "Composes final generator used in the test from client generator and nemesis generator."
@@ -138,9 +140,9 @@
                    (:workload opts)
                    (throw (Exception. "Workload undefined!")))
         nodes-config (if (:nodes-config opts)
-                       (if (or (= workload :high_availability) (= workload :habank))
+                       (if (or (= workload :habank) (= workload :hacreate))
                          (:nodes-config opts)
-                         (validate-nodes-configuration (:nodes-config opts))) ; validate only if not HA
+                         (validate-nodes-configuration (:nodes-config opts))) ; validate only for replication tests.
                        (throw (Exception. "Nodes config flag undefined!")))
         ; Bank test relies on 100% durable Memgraph, fsyncing after every txn.
         sync-after-n-txn (if (or (= workload :bank) (= workload :habank))

--- a/tests/jepsen/src/memgraph/high_availability/bank/test.clj
+++ b/tests/jepsen/src/memgraph/high_availability/bank/test.clj
@@ -10,6 +10,7 @@
              [client :as jclient]]
             [jepsen.checker.timeline :as timeline]
             [memgraph.high-availability.bank.nemesis :as nemesis]
+            [memgraph.high-availability.utils :as hautils]
             [memgraph.utils :as utils]
             [memgraph.query :as mgquery]))
 
@@ -46,16 +47,6 @@
   (gen/filter (fn [op] (not= (-> op :value :from)
                              (-> op :value :to)))
               transfer))
-
-(defn data-instance?
-  "Is node data instances?"
-  [node]
-  (some #(= % node) #{"n1" "n2" "n3"}))
-
-(defn coord-instance?
-  "Is node coordinator instances?"
-  [node]
-  (some #(= % node) #{"n4" "n5" "n6"}))
 
 (defn random-coord
   "Get random leader."
@@ -158,7 +149,7 @@
           node (:node this)]
       (case (:f op)
       ; Show instances should be run only on coordinator.
-        :show-instances-read (if (coord-instance? node)
+        :show-instances-read (if (hautils/coord-instance? node)
                                (try
                                  (utils/with-session bolt-conn session ; Use bolt connection for running show instances.
                                    (let [instances (->> (mgquery/get-all-instances session) (reduce conj []))]
@@ -171,7 +162,7 @@
                                    (assoc op :type :fail :value (str e))))
                                (assoc op :type :info :value "Not coord"))
       ; Reading balances should be done only on data instances -> use bolt connection.
-        :read-balances (if (data-instance? node)
+        :read-balances (if (hautils/data-instance? node)
                          (try
                            (utils/with-session bolt-conn session
                              (let [accounts (->> (mgquery/get-all-accounts session) (map :n) (reduce conj []))
@@ -192,7 +183,7 @@
         ; If the transferring succeeds, return :ok, otherwise return :fail.
         ; Allow the exception due to down sync replica.
         :transfer
-        (if (data-instance? node)
+        (if (hautils/data-instance? node)
           (let [transfer-info (:value op)]
             (try
               (dbclient/with-transaction bolt-conn txn
@@ -248,7 +239,7 @@
           (assoc op :type :info :value "Not coordinator"))
 
         :initialize-data
-        (if (data-instance? node)
+        (if (hautils/data-instance? node)
 
           (try
             (dbclient/with-transaction bolt-conn txn

--- a/tests/jepsen/src/memgraph/high_availability/bank/test.clj
+++ b/tests/jepsen/src/memgraph/high_availability/bank/test.clj
@@ -160,7 +160,7 @@
                                    (utils/process-service-unavailable-exc op node))
                                  (catch Exception e
                                    (assoc op :type :fail :value (str e))))
-                               (assoc op :type :info :value "Not coord"))
+                               (assoc op :type :info :value "Not coordinator"))
       ; Reading balances should be done only on data instances -> use bolt connection.
         :read-balances (if (hautils/data-instance? node)
                          (try

--- a/tests/jepsen/src/memgraph/high_availability/create/nemesis.clj
+++ b/tests/jepsen/src/memgraph/high_availability/create/nemesis.clj
@@ -140,9 +140,9 @@
   (gen/phases
    (gen/sleep 5)
    (cycle [{:type :info, :f :kill-node}
-           (gen/sleep 5)
+           (gen/sleep 10)
            {:type :info, :f :heal-node}
-           (gen/sleep 5)])))
+           (gen/sleep 20)])))
 
 (defn create
   "Create a map which contains a nemesis configuration for running HA bank test."

--- a/tests/jepsen/src/memgraph/high_availability/create/nemesis.clj
+++ b/tests/jepsen/src/memgraph/high_availability/create/nemesis.clj
@@ -5,8 +5,12 @@
              [generator :as gen]
              [util :as util]
              [control :as c]]
+            [clojure.tools.logging :refer [info]]
+            [clojure.string :as str]
+            [memgraph.high-availability.utils :as hautils]
             [memgraph
              [support :as s]
+             [query :as mgquery]
              [utils :as utils]]))
 
 (defn node-start-stopper
@@ -55,10 +59,70 @@
 
       (teardown! [_ _]))))
 
+(defn main-instance?
+  [instance]
+  (= (:role instance) "main"))
+
+(defn get-current-main
+  "Returns the name of the main instance. If there is no main instance or more than one main, throws exception."
+  [instances]
+  (let [main-instances (filter main-instance? instances)
+        main-instance
+        (if (= 1 (count main-instances))
+          (first main-instances)
+          (throw (Exception. "Expected exactly one main instance.")))
+        main-instance-name (:name main-instance)]
+    main-instance-name))
+
+(defn leader?
+  [instance]
+  (= (:role instance) "leader"))
+
+(defn extract-coord-name
+  "We could use any server. We cannot just use name because in Memgraph coordinator's name is written as 'coordinator_{id}'."
+  [bolt-server]
+  (first (str/split bolt-server #":")))
+
+(defn get-current-leader
+  "Returns the name of the current leader. If there is no leader or more than one leader, throws exception."
+  [instances]
+  (let [leaders (filter leader? instances)
+        leader
+        (if (= 1 (count leaders))
+          (first leaders)
+          (throw (Exception. "Expected exactly one leader.")))
+        leader-name (extract-coord-name (:bolt_server leader)) ]
+    leader-name))
+
+(defn choose-node-to-kill
+  "Chooses between the current main and the current leader. We always connect to coordinator 'n4' (free choice).
+  We assume that node should always be up because even if it was killed at previous step, it should have enough time to come back
+  and to be able to receive requests for show instances.
+  "
+  [ns]
+  (let [conn (utils/open-bolt "n4")]
+    (utils/with-session conn session
+      (let [instances (->> (mgquery/get-all-instances session) (reduce conj []))
+            main (get-current-main instances)
+            leader (get-current-leader instances)
+            node-to-kill (cond
+                           (and (nil? main) (nil? leader)) (rand-nth ns)
+                           (nil? main) leader
+                           (nil? leader) main
+                           :else (rand-nth [main leader]))
+            node-desc (cond
+                        (hautils/data-instance? node-to-kill) "current main"
+                        (hautils/coord-instance? node-to-kill) "current leader"
+                        :else "random node")]
+
+        (info "Killing" node-desc ":" node-to-kill)
+
+        node-to-kill))))
+
 (defn node-killer
   "Responds to :start by killing a random node"
   [nodes-config]
-  (node-start-stopper rand-nth
+  (node-start-stopper choose-node-to-kill
                       s/stop-node!
                       s/start-memgraph-node!
                       nodes-config))
@@ -68,17 +132,16 @@
   [nodes-config]
   (nemesis/compose
    {{:kill-node    :start
-     :restart-node :stop} (node-killer nodes-config)}))
+     :heal-node :stop} (node-killer nodes-config)}))
 
 (defn nemesis-generator
   "Construct nemesis generator."
   []
   (gen/phases
    (gen/sleep 5)
-   (cycle [(gen/sleep 5)
-           {:type :info, :f :kill-node}
+   (cycle [{:type :info, :f :kill-node}
            (gen/sleep 5)
-           {:type :info, :f :restart-node}
+           {:type :info, :f :heal-node}
            (gen/sleep 5)])))
 
 (defn create
@@ -86,4 +149,4 @@
   [nodes-config]
   {:nemesis (full-nemesis nodes-config)
    :generator (nemesis-generator)
-   :final-generator (map utils/op [:restart-node])})
+   :final-generator (map utils/op [:heal-node])})

--- a/tests/jepsen/src/memgraph/high_availability/create/nemesis.clj
+++ b/tests/jepsen/src/memgraph/high_availability/create/nemesis.clj
@@ -1,0 +1,89 @@
+(ns memgraph.high-availability.create.nemesis
+  "Memgraph nemesis for HA cluster"
+  (:require [jepsen
+             [nemesis :as nemesis]
+             [generator :as gen]
+             [util :as util]
+             [control :as c]]
+            [memgraph
+             [support :as s]
+             [utils :as utils]]))
+
+(defn node-start-stopper
+  "Takes a targeting function which, given a list of nodes, returns a single
+  node or collection of nodes to affect, and two functions `(start! test node)`
+  invoked on nemesis start, and `(stop! test node nodes-config)` invoked on nemesis stop.
+  Also takes a nodes-config map needed to restart nodes.
+  Returns a nemesis which responds to :start and :stop by running the start!
+  and stop! fns on each of the given nodes. During `start!` and `stop!`, binds
+  the `jepsen.control` session to the given node, so you can just call `(c/exec
+  ...)`.
+
+  The targeter can take either (targeter test nodes) or, if that fails,
+  (targeter nodes).
+
+  Re-selects a fresh node (or nodes) for each start--if targeter returns nil,
+  skips the start. The return values from the start and stop fns will become
+  the :values of the returned :info operations from the nemesis, e.g.:
+
+      {:value {:n1 [:killed \"java\"]}}"
+  [targeter start! stop! nodes-config]
+  (let [nodes (atom nil)]
+    (reify nemesis/Nemesis
+      (setup! [this _] this)
+
+      (invoke! [_ test op]
+        (locking nodes
+          (assoc op :type :info, :value
+                 (case (:f op)
+                   :start (let [ns (:nodes test)
+                                ns (try (targeter test ns)
+                                        (catch clojure.lang.ArityException _
+                                          (targeter ns)))
+                                ns (util/coll ns)]
+                            (if ns
+                              (if (compare-and-set! nodes nil ns)
+                                (c/on-many ns (start! test c/*host*))
+                                (str "nemesis already disrupting "
+                                     (pr-str @nodes)))
+                              :no-target))
+                   :stop (if-let [ns @nodes]
+                           (let [value (c/on-many ns (stop! test c/*host* nodes-config))]
+                             (reset! nodes nil)
+                             value)
+                           :not-started)))))
+
+      (teardown! [_ _]))))
+
+(defn node-killer
+  "Responds to :start by killing a random node"
+  [nodes-config]
+  (node-start-stopper rand-nth
+                      s/stop-node!
+                      s/start-memgraph-node!
+                      nodes-config))
+
+(defn full-nemesis
+  "Can kill, restart all processess and initiate network partitions."
+  [nodes-config]
+  (nemesis/compose
+   {{:kill-node    :start
+     :restart-node :stop} (node-killer nodes-config)}))
+
+(defn nemesis-generator
+  "Construct nemesis generator."
+  []
+  (gen/phases
+   (gen/sleep 5)
+   (cycle [(gen/sleep 5)
+           {:type :info, :f :kill-node}
+           (gen/sleep 5)
+           {:type :info, :f :restart-node}
+           (gen/sleep 5)])))
+
+(defn create
+  "Create a map which contains a nemesis configuration for running HA bank test."
+  [nodes-config]
+  {:nemesis (full-nemesis nodes-config)
+   :generator (nemesis-generator)
+   :final-generator (map utils/op [:restart-node])})

--- a/tests/jepsen/src/memgraph/high_availability/create/test.clj
+++ b/tests/jepsen/src/memgraph/high_availability/create/test.clj
@@ -79,11 +79,6 @@
 
       coll-intervals)))
 
-(defn missing-intervals
-  "Finds missing intervals from the sequence. Accepts expected number of indices which serves as the largest number from the interval and
-  the sequence to be analyzed."
-  [seq max-idx])
-
 (defn batch-start-idx
   "Calculates start index for the new batch. E.g 1, 1001, 2001..."
   []
@@ -323,6 +318,8 @@
 
             n1-duplicates (duplicates n1-ids)
 
+            n1-duplicates-intervals (sequence->intervals n1-duplicates)
+
             n1-hamming-consistency (hamming-sim expected-ids n1-ids)
 
             n1-jaccard-consistency (jaccard-sim expected-ids n1-ids)
@@ -334,6 +331,8 @@
 
             n2-duplicates (duplicates n2-ids)
 
+            n2-duplicates-intervals (sequence->intervals n2-duplicates)
+
             n2-hamming-consistency (hamming-sim expected-ids n2-ids)
 
             n2-jaccard-consistency (jaccard-sim expected-ids n2-ids)
@@ -344,6 +343,8 @@
                         (:indices))
 
             n3-duplicates (duplicates n3-ids)
+
+            n3-duplicates-intervals (sequence->intervals n3-duplicates)
 
             n3-hamming-consistency (hamming-sim expected-ids n3-ids)
 
@@ -413,9 +414,9 @@
 
             updates [{:key :coordinators :condition (not (:correct-coordinators? initial-result)) :value coordinators}
                      {:key :partial-instances :condition (not (:empty-partial-instances? initial-result)) :value partial-instances}
-                     {:key :n1-duplicates :condition (false? (:empty-n1-duplicates? initial-result)) :value n1-duplicates}
-                     {:key :n2-duplicates :condition (false? (:empty-n2-duplicates? initial-result)) :value n2-duplicates}
-                     {:key :n3-duplicates :condition (false? (:empty-n3-duplicates? initial-result)) :value n3-duplicates}
+                     {:key :n1-duplicates-intervals :condition (false? (:empty-n1-duplicates? initial-result)) :value n1-duplicates-intervals}
+                     {:key :n2-duplicates-intervals :condition (false? (:empty-n2-duplicates? initial-result)) :value n2-duplicates-intervals}
+                     {:key :n3-duplicates-intervals :condition (false? (:empty-n3-duplicates? initial-result)) :value n3-duplicates-intervals}
                      {:key :failed-setup-cluster :condition (not (:empty-failed-setup-cluster? initial-result)) :value failed-setup-cluster}
                      {:key :failed-show-instances :condition (not (:empty-failed-show-instances? initial-result)) :value failed-show-instances}]]
 

--- a/tests/jepsen/src/memgraph/high_availability/create/test.clj
+++ b/tests/jepsen/src/memgraph/high_availability/create/test.clj
@@ -135,7 +135,7 @@
                 (assoc op :type :info :value "Not a leader")
                 (assoc op :type :fail :value (str e)))))
 
-          (assoc op :type :info :value "Not coordinator")))))
+          (assoc op :type :info :value "Not first leader")))))
 
   (teardown! [_this _test])
   (close! [this _test]
@@ -188,7 +188,7 @@
                            (filter #(= :show-instances-read (:f %)))
                            (map :value))
             partial-instances (->> si-reads
-                                  (filter #(not= 6 (count (:instances %)))))
+                                   (filter #(not= 6 (count (:instances %)))))
             ; All reads grouped by node {node->instances}
             coord->instances (->> si-reads
                                   (group-by :node)
@@ -243,13 +243,14 @@
   {:type :invoke :f :setup-cluster :value nil})
 
 (defn client-generator
-  "Client generator. On each thread first sleep for 5s so that cluster setup can finish and then mix operations."
+  "Client generator."
   []
   (gen/each-thread
    (gen/phases
+    (gen/once setup-cluster)
     (gen/sleep 5)
     (cycle
-     [(gen/mix [setup-cluster show-instances-reads])]))))
+     [(gen/mix [show-instances-reads])]))))
 
 (defn workload
   "Basic HA workload."

--- a/tests/jepsen/src/memgraph/high_availability/create/test.clj
+++ b/tests/jepsen/src/memgraph/high_availability/create/test.clj
@@ -1,0 +1,267 @@
+(ns memgraph.high-availability.create.test
+  "Create test for HA."
+  (:require [neo4j-clj.core :as dbclient]
+            [clojure.tools.logging :refer [info]]
+            [clojure.core :as c]
+            [clojure.string :as string]
+            [jepsen
+             [checker :as checker]
+             [generator :as gen]
+             [client :as jclient]]
+            [jepsen.checker.timeline :as timeline]
+            [memgraph.high-availability.create.nemesis :as nemesis]
+            [memgraph.utils :as utils]
+            [memgraph.query :as mgquery]))
+
+(def registered-replication-instances? (atom false))
+(def added-coordinator-instances? (atom false))
+(def main-set? (atom false))
+
+(defn coord-instance?
+  "Is node coordinator instances?"
+  [node]
+  (some #(= % node) #{"n4" "n5" "n6"}))
+
+(defn random-coord
+  "Get random leader."
+  [nodes]
+  (nth nodes (+ 3 (rand-int 3)))) ; Assumes that first 3 instances are data instances and last 3 are coordinators.
+
+(defn random-data-instance
+  "Get random data instance."
+  [nodes]
+  (nth nodes (rand-int 3)))
+
+(defn register-replication-instances
+  "Register replication instances."
+  [session nodes-config]
+  (doseq [repl-config (filter #(contains? (val %) :replication-port)
+                              nodes-config)]
+    (try
+      ((mgquery/register-replication-instance
+        (first repl-config)
+        (second repl-config)) session)
+      (info "Registered replication instance:" (first repl-config))
+      (catch Exception e
+        (if (string/includes? (str e) "name already exists") ; It means already registered
+          (info "Replication instance" (first repl-config) "already registered, continuing to register other replication instances.")
+          (throw e))))))
+
+(defn add-coordinator-instances
+  "Add coordinator instances."
+  [session myself nodes-config]
+  (doseq [coord-config (->> nodes-config
+                            (filter #(not= (key %) myself)) ; Don't register itself
+                            (filter #(contains? (val %) :coordinator-id)))]
+    (try
+      ((mgquery/add-coordinator-instance
+        (first coord-config) (second coord-config)) session)
+      (info "Added coordinator:" (first coord-config))
+      (catch Exception e
+        (if (string/includes? (str e) "id already exists")
+          (info "Coordinator instance" (first coord-config) "already exists, continuing to add other coordinator instances.")
+          (throw e))))))
+
+(defn set-instance-to-main
+  "Set instance to main."
+  [session first-main]
+  ((mgquery/set-instance-to-main first-main) session)
+  (info "Set instance" first-main "to main."))
+
+(defrecord Client [nodes-config first-leader first-main license organization]
+  jclient/Client
+  ; Open Bolt connection to all nodes.
+  (open! [this _test node]
+    (info "Opening bolt connection to node..." node)
+    (let [bolt-conn (utils/open-bolt node)
+          node-config (get nodes-config node)]
+      (assoc this
+             :bolt-conn bolt-conn
+             :node-config node-config
+             :node node)))
+  ; Use Bolt connection to set enterprise.license and organization.name.
+  (setup! [this _test]
+    (try
+      (utils/with-session (:bolt-conn this) session
+        ((mgquery/set-db-setting "enterprise.license" license) session)
+        ((mgquery/set-db-setting "organization.name" organization) session))
+      (catch org.neo4j.driver.exceptions.ServiceUnavailableException _e
+        (info (utils/node-is-down (:node this))))))
+
+  (invoke! [this _test op]
+    (let [bolt-conn (:bolt-conn this)
+          node (:node this)]
+      (case (:f op)
+      ; Show instances should be run only on coordinator.
+        :show-instances-read (if (coord-instance? node)
+                               (try
+                                 (utils/with-session bolt-conn session ; Use bolt connection for running show instances.
+                                   (let [instances (->> (mgquery/get-all-instances session) (reduce conj []))]
+                                     (assoc op
+                                            :type :ok
+                                            :value {:instances instances :node node})))
+                                 (catch org.neo4j.driver.exceptions.ServiceUnavailableException _e
+                                   (utils/process-service-unavailable-exc op node))
+                                 (catch Exception e
+                                   (assoc op :type :fail :value (str e))))
+                               (assoc op :type :info :value "Not coord"))
+        :setup-cluster
+        ; If nothing was done before, registration will be done on the 1st leader and all good.
+        ; If leader didn't change but registration was done, we won't even try to register -> all good again.
+        ; If leader changes, registration should already be done or not a leader will be printed.
+        (if (= first-leader node)
+
+          (try
+            (utils/with-session bolt-conn session
+              (when (not @registered-replication-instances?)
+                (register-replication-instances session nodes-config)
+                (reset! registered-replication-instances? true))
+
+              (when (not @added-coordinator-instances?)
+                (add-coordinator-instances session node nodes-config)
+                (reset! added-coordinator-instances? true))
+
+              (when (not @main-set?)
+                (set-instance-to-main session first-main)
+                (reset! main-set? true))
+
+              (assoc op :type :ok)) ; NOTE: This doesn't necessarily mean all instances were successfully registered.
+
+            (catch org.neo4j.driver.exceptions.ServiceUnavailableException _e
+              (info "Registering instances failed because node" node "is down.")
+              (utils/process-service-unavailable-exc op node))
+            (catch Exception e
+              (if (string/includes? (str e) "not a leader")
+                (assoc op :type :info :value "Not a leader")
+                (assoc op :type :fail :value (str e)))))
+
+          (assoc op :type :info :value "Not coordinator")))))
+
+  (teardown! [_this _test])
+  (close! [this _test]
+    (dbclient/disconnect (:bolt-conn this))))
+
+(defn single-read-to-roles
+  "Convert single read to roles. Single read is a list of instances."
+  [single-read]
+  (map :role single-read))
+
+(defn get-coordinators
+  "From list of roles, returns those which are coordinators."
+  [roles]
+  (let [leader-followers #{"leader"
+                           "follower"}]
+
+    (filter leader-followers roles)))
+
+(defn get-mains
+  "From list of roles, returns those which are main."
+  [roles]
+  (filter #(= "main" %) roles))
+
+(defn less-than-three-coordinators
+  "Check if there aren't exactly 3 coordinators in single read where single-read is a read list of instances. Single-read here is already processed list of roles."
+  [roles]
+  (< (count (get-coordinators roles)) 3))
+
+(defn more-than-one-main
+  "Check if there is more than one main in single read where single-read is a read list of instances. Single-read here is already processed list of roles."
+  [roles]
+  (> (count (get-mains roles)) 1))
+
+(defn checker
+  "Checker."
+  []
+  (reify checker/Checker
+    (check [_checker _test history _opts]
+      ; si prefix stands for show-instances
+      (let [failed-setup-cluster (->> history
+                                      (filter #(= :fail (:type %)))
+                                      (filter #(= :setup-cluster (:f %)))
+                                      (map :value))
+            failed-show-instances (->> history
+                                       (filter #(= :fail (:type %)))
+                                       (filter #(= :show-instances-read (:f %)))
+                                       (map :value))
+            si-reads  (->> history
+                           (filter #(= :ok (:type %)))
+                           (filter #(= :show-instances-read (:f %)))
+                           (map :value))
+            partial-instances (->> si-reads
+                                  (filter #(not= 6 (count (:instances %)))))
+            ; All reads grouped by node {node->instances}
+            coord->instances (->> si-reads
+                                  (group-by :node)
+                                  (map (fn [[node values]] [node (map :instances values)]))
+                                  (into {}))
+            coord->roles (->> coord->instances
+                              (map (fn [[node reads]]
+                                     [node (map single-read-to-roles reads)]))
+                              (into {}))
+            partial-coordinators (->> coord->roles
+                                      (filter (fn [[_ reads]] (some less-than-three-coordinators reads)))
+                                      (keys))
+            more-than-one-main (->> coord->roles
+                                    (filter (fn [[_ reads]] (some more-than-one-main reads)))
+                                    (keys))
+            coordinators (set (keys coord->instances))
+
+            initial-result {:valid? (and
+                                     (= coordinators #{"n4" "n5" "n6"})
+                                     (empty? partial-coordinators)
+                                     (empty? more-than-one-main)
+                                     (empty? partial-instances)
+                                     (empty? failed-setup-cluster)
+                                     (empty? failed-show-instances))
+                            :empty-partial-coordinators? (empty? partial-coordinators) ; coordinators which have missing coordinators in their reads
+                            :empty-more-than-one-main-nodes? (empty? more-than-one-main) ; nodes on which more-than-one-main was detected
+                            :correct-coordinators? (= coordinators #{"n4" "n5" "n6"})
+                            :empty-failed-setup-cluster? (empty? failed-setup-cluster) ; There shouldn't be any failed setup cluster operations.
+                            :empty-failed-show-instances? (empty? failed-show-instances) ; There shouldn't be any failed show instances operations.
+                            :empty-partial-instances? (empty? partial-instances)}
+
+            updates [{:key :coordinators :condition (not (:correct-coordinators? initial-result)) :value coordinators}
+                     {:key :partial-instances :condition (not (:empty-partial-instances? initial-result)) :value partial-instances}
+                     {:key :failed-setup-cluster :condition (not (:empty-failed-setup-cluster? initial-result)) :value failed-setup-cluster}
+                     {:key :failed-show-instances :condition (not (:empty-failed-show-instances? initial-result)) :value failed-show-instances}]]
+
+        (reduce (fn [result update]
+                  (if (:condition update)
+                    (assoc result (:key update) (:value update))
+                    result))
+                initial-result
+                updates)))))
+
+(defn show-instances-reads
+  "Create read action."
+  [_ _]
+  {:type :invoke, :f :show-instances-read, :value nil})
+
+(defn setup-cluster
+  "Setup cluster operation."
+  [_ _]
+  {:type :invoke :f :setup-cluster :value nil})
+
+(defn client-generator
+  "Client generator. On each thread first sleep for 5s so that cluster setup can finish and then mix operations."
+  []
+  (gen/each-thread
+   (gen/phases
+    (gen/sleep 5)
+    (cycle
+     [(gen/mix [setup-cluster show-instances-reads])]))))
+
+(defn workload
+  "Basic HA workload."
+  [opts]
+  (let [nodes-config (:nodes-config opts)
+        first-leader (random-coord (keys nodes-config))
+        first-main (random-data-instance (keys nodes-config))
+        organization (:organization opts)
+        license (:license opts)]
+    {:client    (Client. nodes-config first-leader first-main license organization)
+     :checker   (checker/compose
+                 {:hacreate     (checker)
+                  :timeline (timeline/html)})
+     :generator (client-generator)
+     :nemesis-config (nemesis/create nodes-config)}))

--- a/tests/jepsen/src/memgraph/high_availability/create/test.clj
+++ b/tests/jepsen/src/memgraph/high_availability/create/test.clj
@@ -187,6 +187,7 @@
                            (filter #(= :ok (:type %)))
                            (filter #(= :show-instances-read (:f %)))
                            (map :value))
+
             partial-instances (->> si-reads
                                    (filter #(not= 6 (count (:instances %)))))
             ; All reads grouped by node {node->instances}

--- a/tests/jepsen/src/memgraph/high_availability/utils.clj
+++ b/tests/jepsen/src/memgraph/high_availability/utils.clj
@@ -1,0 +1,11 @@
+(ns memgraph.high-availability.utils)
+
+(defn data-instance?
+  "Is node data instances?"
+  [node]
+  (some #(= % node) #{"n1" "n2" "n3"}))
+
+(defn coord-instance?
+  "Is node coordinator instances?"
+  [node]
+  (some #(= % node) #{"n4" "n5" "n6"}))

--- a/tests/jepsen/src/memgraph/query.clj
+++ b/tests/jepsen/src/memgraph/query.clj
@@ -29,7 +29,7 @@
 
 (dbclient/defquery collect-ids
   "MATCH (n:Node)
-  RETURN collect(n.id);
+  RETURN n.id as id;
   ")
 
 (defn add-nodes

--- a/tests/jepsen/src/memgraph/query.clj
+++ b/tests/jepsen/src/memgraph/query.clj
@@ -27,6 +27,16 @@
    SET n.balance = n.balance + $amount
    RETURN n")
 
+(dbclient/defquery collect-ids
+  "MATCH (n:Node)
+  RETURN collect(n.id);
+  ")
+
+(defn add-nodes
+  [start-idx end-idx]
+  (dbclient/create-query
+   (str "FOREACH (i in range(" start-idx ", " end-idx ") | CREATE (:Node {id: i}));")))
+
 (defn register-replication-instance
   [name node-config]
   (info "name" name "node-config" node-config)

--- a/tests/jepsen/src/memgraph/utils.clj
+++ b/tests/jepsen/src/memgraph/utils.clj
@@ -1,8 +1,7 @@
 (ns memgraph.utils
   (:require
    [neo4j-clj.core :as dbclient]
-   [clojure.string :as string]
-   [clojure.tools.logging :refer [info]])
+   [clojure.string :as string])
   (:import (java.net URI)))
 
 (defn bolt-url
@@ -26,7 +25,6 @@
         coords-to-kill (rand-int (+ 1 (count coords)))
         chosen-coords (take coords-to-kill (shuffle coords))
         chosen-instances (concat chosen-data-instances chosen-coords)]
-    (info "Chosen instances" chosen-instances)
     chosen-instances))
 
 ; neo4j-clj related utils.

--- a/tests/jepsen/test/memgraph/memgraph_test.clj
+++ b/tests/jepsen/test/memgraph/memgraph_test.clj
@@ -1,9 +1,24 @@
 (ns memgraph.memgraph-test
   (:require [clojure.test :refer :all]
             [memgraph.high-availability.bank.test :as habank]
+            [memgraph.high-availability.create.test :as hacreate]
             [memgraph
              [utils :as utils]
              [query :as query]]))
+
+(deftest hamming
+  (testing "H1"
+    (is (= hacreate/hamming-sim [1 2 3] [1 2 3]) 1))
+
+  (testing "H2"
+    (is (= hacreate/hamming-sim [1 2 3] [1 2]) 2/3))
+
+  (testing "H3"
+    (is (= hacreate/hamming-sim (range 1 11) (range 1 21)) 1/2))
+
+  (testing "H3"
+    (is (= hacreate/hamming-sim (range 1 11) (range 2 16)) 0))
+  )
 
 (deftest get-instance-url
   (testing "Get instance URL."

--- a/tests/jepsen/test/memgraph/memgraph_test.clj
+++ b/tests/jepsen/test/memgraph/memgraph_test.clj
@@ -22,7 +22,6 @@
   (testing "Hamming5"
     (is (= (hacreate/hamming-sim (range 1 11) (range 2 16)) 0)))
 
-
   (testing "Jaccard1"
     (is (= (hacreate/jaccard-sim [1 2 3] [1 2 3]) 1)))
 
@@ -35,14 +34,13 @@
   (testing "Jaccard4"
     (is (= (hacreate/jaccard-sim (range 1 11) (range 1 16)) 2/3)))
 
-
   (testing "sequence->intervals1"
     (let [my-seq [1 2 3 4 5 8 9 10]]
       (is (= (hacreate/sequence->intervals my-seq) [[1 5] [8 10]]))))
 
   (testing "sequence->intervals2"
-    (let [my-seq [1 2 3 4 5 8 9 9 10 12]]
-      (is (= (hacreate/sequence->intervals my-seq) [[1 5] [8 9] [9 10] [12 12]]))))
+    (let [my-seq [1 2 3 4 5 8 9 10 12]]
+      (is (= (hacreate/sequence->intervals my-seq) [[1 5] [8 10] [12 12]]))))
 
   (testing "sequence->intervals3"
     (let [my-seq (apply vector (concat (range 1 5001) (range 10001 15001)))]
@@ -56,6 +54,10 @@
     (let [my-seq []]
       (is (= (hacreate/sequence->intervals my-seq) []))))
 
+  (testing "sequence->intervals6"
+    (let [my-seq [1 2 3 4 5 6 7 8 9 10]]
+      (is (= (hacreate/sequence->intervals my-seq) [[1 10]]))))
+
   (testing "duplicates1"
     (let [my-seq [1 1 2 2 3 3]]
 
@@ -64,7 +66,96 @@
   (testing "duplicates2"
     (let [my-seq '(1 2 2 3 3 4 4 4 10 12 100 100 76541 76541)]
 
-      (is (= (hacreate/duplicates my-seq) [2 3 4 100 76541])))))
+      (is (= (hacreate/duplicates my-seq) [2 3 4 100 76541]))))
+
+  (testing "duplicated_intervals1"
+    (let [my-seq '(1 2 2 3 3 4 4 4 10 12 100 100 76541 76541)]
+
+      (is (= (hacreate/sequence->intervals (hacreate/duplicates my-seq)) [[2 4] [100 100] [76541 76541]]))))
+
+  (testing "duplicated_intervals2"
+    (let [my-seq '(1 2 3 4 5 6 7 8 9 10)]
+
+      (is (= (hacreate/sequence->intervals (hacreate/duplicates my-seq)) []))))
+
+  (testing "mono-increasing-seq-empty"
+    (let [my-seq []]
+
+      (is (= (hacreate/seq->monotonically-incr-seq my-seq) []))))
+
+  (testing "mono-increasing-seq1"
+    (let [my-seq [1 2 3]]
+
+      (is (= (hacreate/seq->monotonically-incr-seq my-seq) [1 2 3]))))
+
+  (testing "mono-increasing-seq2"
+    (let [my-seq [1 2 1]]
+
+      (is (= (hacreate/seq->monotonically-incr-seq my-seq) [1 2]))))
+
+  (testing "mono-increasing-seq3"
+    (let [my-seq [1 2 2]]
+
+      (is (= (hacreate/seq->monotonically-incr-seq my-seq) [1 2]))))
+
+  (testing "mono-increasing-seq4"
+    (let [my-seq [1 2 4 4 2 2 7 9 10]]
+
+      (is (= (hacreate/seq->monotonically-incr-seq my-seq) [1 2 4 7 9 10]))))
+
+  (testing "is-mono-increasing-seq?1"
+    (let [my-seq []]
+
+      (is (= (hacreate/is-mono-increasing-seq? my-seq) true))))
+
+  (testing "is-mono-increasing-seq?2"
+    (let [my-seq [1]]
+
+      (is (= (hacreate/is-mono-increasing-seq? my-seq) true))))
+
+  (testing "is-mono-increasing-seq?3"
+    (let [my-seq [1 5 5]]
+
+      (is (= (hacreate/is-mono-increasing-seq? my-seq) false))))
+
+  (testing "is-mono-increasing-seq?4"
+    (let [my-seq [1 5 6 7 9 11]]
+
+      (is (= (hacreate/is-mono-increasing-seq? my-seq) true))))
+
+  (testing "is-mono-increasing-seq?4"
+    (let [my-seq [1 5 5 7 8 9 9 10 10]]
+
+      (is (= (hacreate/is-mono-increasing-seq? my-seq) false))))
+
+  (testing "missing-intervals1"
+    (let [my-seq []]
+
+      (is (= (hacreate/missing-intervals my-seq) []))))
+
+  (testing "missing-intervals2"
+    (let [my-seq [1 2 3 4 5]]
+
+      (is (= (hacreate/missing-intervals my-seq) []))))
+
+  (testing "missing-intervals3"
+    (let [my-seq [1 2 3 5 6]]
+
+      (is (= (hacreate/missing-intervals my-seq) [[4 4]]))))
+
+  (testing "missing-intervals4"
+    (let [my-seq [1 2 3 9 10 11 15 16 17 20 21 22]]
+
+      (is (= (hacreate/missing-intervals my-seq) [[4 8] [12 14] [18 19]]))))
+
+  (testing "missing-intervals5"
+    (let [my-seq (apply vector (concat (range 5001 10001) (range 50001 55001) (range 110001 115001)))]
+
+      (is (= (hacreate/missing-intervals my-seq) [[10001 50000] [55001 110000]]))))
+
+
+
+  )
 
 (deftest get-instance-url
   (testing "Get instance URL."

--- a/tests/jepsen/test/memgraph/memgraph_test.clj
+++ b/tests/jepsen/test/memgraph/memgraph_test.clj
@@ -6,19 +6,65 @@
              [utils :as utils]
              [query :as query]]))
 
-(deftest hamming
-  (testing "H1"
-    (is (= hacreate/hamming-sim [1 2 3] [1 2 3]) 1))
+(deftest hacreate-test
+  (testing "Hamming1"
+    (is (= (hacreate/hamming-sim [1 2 3] [1 2 3]) 1)))
 
-  (testing "H2"
-    (is (= hacreate/hamming-sim [1 2 3] [1 2]) 2/3))
+  (testing "Hamming2"
+    (is (= (hacreate/hamming-sim [1 2 3] [1 2]) 2/3)))
 
-  (testing "H3"
-    (is (= hacreate/hamming-sim (range 1 11) (range 1 21)) 1/2))
+  (testing "Hamming3"
+    (is (= (hacreate/hamming-sim [1 2 3] [2 3]) 0)))
 
-  (testing "H3"
-    (is (= hacreate/hamming-sim (range 1 11) (range 2 16)) 0))
-  )
+  (testing "Hamming4"
+    (is (= (hacreate/hamming-sim (range 1 11) (range 1 21)) 1/2)))
+
+  (testing "Hamming5"
+    (is (= (hacreate/hamming-sim (range 1 11) (range 2 16)) 0)))
+
+
+  (testing "Jaccard1"
+    (is (= (hacreate/jaccard-sim [1 2 3] [1 2 3]) 1)))
+
+  (testing "Jaccard2"
+    (is (= (hacreate/jaccard-sim [1 2 3] [1 2]) 2/3)))
+
+  (testing "Jaccard3"
+    (is (= (hacreate/jaccard-sim [1 2 3] [2 3]) 2/3)))
+
+  (testing "Jaccard4"
+    (is (= (hacreate/jaccard-sim (range 1 11) (range 1 16)) 2/3)))
+
+
+  (testing "sequence->intervals1"
+    (let [my-seq [1 2 3 4 5 8 9 10]]
+      (is (= (hacreate/sequence->intervals my-seq) [[1 5] [8 10]]))))
+
+  (testing "sequence->intervals2"
+    (let [my-seq [1 2 3 4 5 8 9 9 10 12]]
+      (is (= (hacreate/sequence->intervals my-seq) [[1 5] [8 9] [9 10] [12 12]]))))
+
+  (testing "sequence->intervals3"
+    (let [my-seq (apply vector (concat (range 1 5001) (range 10001 15001)))]
+      (is (= (hacreate/sequence->intervals my-seq) [[1 5000] [10001 15000]]))))
+
+  (testing "sequence->intervals4"
+    (let [my-seq (apply vector (concat (range 5001 10001) (range 50001 55001) (range 110001 115001)))]
+      (is (= (hacreate/sequence->intervals my-seq) [[5001 10000] [50001 55000] [110001 115000]]))))
+
+  (testing "sequence->intervals5"
+    (let [my-seq []]
+      (is (= (hacreate/sequence->intervals my-seq) []))))
+
+  (testing "duplicates1"
+    (let [my-seq [1 1 2 2 3 3]]
+
+      (is (= (hacreate/duplicates my-seq) [1 2 3]))))
+
+  (testing "duplicates2"
+    (let [my-seq '(1 2 2 3 3 4 4 4 10 12 100 100 76541 76541)]
+
+      (is (= (hacreate/duplicates my-seq) [2 3 4 100 76541])))))
 
 (deftest get-instance-url
   (testing "Get instance URL."


### PR DESCRIPTION
Added `hacreate` test meant to test high availability capabilities of Memgraph. Test starts 6 instances (3 data instances and 3 coordinators) and uses 2 generators to generate operations. Client generator starts one thread per instance and every 2 seconds chooses between `add-nodes` operation (run on data instances) and `show-instances` operations (run on coordinators). Operation `add-nodes` creates a batch of nodes with monotonically increasing IDs and operation `show-instances` runs `SHOW INSTANCES` query. Nemesis generator turns on every ~30'' and then randomly chooses between killing current cluster's leader and cluster's main instance. The test is considered valid if all coordinators have the same view of the cluster (`show-instances` successful), if there are no `show-instances` results where less than 3 coordinators are seen, if there is never more than one main in the cluster (as seen by coordinators), if there are never less than 6 instances in the result of `SHOW INSTANCES`, if there are no failed `setup-cluster` and `show-instances` operations and if several consistency guarantees hold. At the end of the test we retrieve all nodes with `MATCH (n:Node) RETURN n.id as id`. Ideally, we get on MAIN and all REPLICAS exactly the same result with monotonically increasing ids `e.g [1, 2, 3, .... 1000000]`. However, many things can go wrong, hence we check: 
1. There are no duplicated IDs returned because that would mean some vertices got replicated multiple times
2. There are no missing IDs because that would mean some vertices didn't get replicated at all.
3. We have 2 measures of consistency, 1st is based on Jaccard similarity and the 2nd on Hamming similarity.
  a) Jaccard similarity tests that all IDs that should exist (based on client's request for creation) actually do exist
  b) Hamming similarity tests additionally to Jaccard similarity also that the order in which IDs get replicated is correct.

Test will be run every night at 12:00 AM as part of new workflow `stress_jepsen.yaml`.
