### PR TITLE
Fix: ScanAllById regardless of function case

### DIFF
--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -2967,13 +2967,18 @@ antlrcpp::Any CypherMainVisitor::visitFunctionInvocation(MemgraphCypher::Functio
     }
   }
 
-  auto *function_expr = storage_->Create<Function>(upper_function_name, expressions);
+  auto *function_expr = storage_->Create<Function>(function_name, expressions);
 
   // Don't cache queries which call user-defined functions. For performance reasons we want to avoid
   // repeativly finding the function at call time, this means user-defined functions have there lifetime
   // tied to the ast Function operation. We do not want that cached, because we want to be able to reload
   // query module that is not currently being used.
   query_info_.is_cacheable &= !function_expr->IsUserDefined();
+
+  // user defined functions are case sensitive, built-in functions work only with upper case
+  if (!function_expr->IsUserDefined()) {
+    function_expr->function_name_ = upper_function_name;
+  }
 
   return static_cast<Expression *>(function_expr);
 }

--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -2923,13 +2923,13 @@ antlrcpp::Any CypherMainVisitor::visitNumberLiteral(MemgraphCypher::NumberLitera
 antlrcpp::Any CypherMainVisitor::visitFunctionInvocation(MemgraphCypher::FunctionInvocationContext *ctx) {
   const auto is_distinct = ctx->DISTINCT() != nullptr;
   auto function_name = std::any_cast<std::string>(ctx->functionName()->accept(this));
+  auto upper_function_name = utils::ToUpperCase(function_name);
   std::vector<Expression *> expressions;
   for (auto *expression : ctx->expression()) {
     expressions.push_back(std::any_cast<Expression *>(expression->accept(this)));
   }
 
   if (expressions.size() == 1U) {
-    auto upper_function_name = utils::ToUpperCase(function_name);
     if (upper_function_name == Aggregation::kCount) {
       return static_cast<Expression *>(
           storage_->Create<Aggregation>(expressions[0], nullptr, Aggregation::Op::COUNT, is_distinct));
@@ -2961,14 +2961,13 @@ antlrcpp::Any CypherMainVisitor::visitFunctionInvocation(MemgraphCypher::Functio
   }
 
   if (expressions.size() == 2U) {
-    auto upper_function_name = utils::ToUpperCase(function_name);
     if (upper_function_name == Aggregation::kCollect) {
       return static_cast<Expression *>(
           storage_->Create<Aggregation>(expressions[1], expressions[0], Aggregation::Op::COLLECT_MAP, is_distinct));
     }
   }
 
-  auto *function_expr = storage_->Create<Function>(function_name, expressions);
+  auto *function_expr = storage_->Create<Function>(upper_function_name, expressions);
 
   // Don't cache queries which call user-defined functions. For performance reasons we want to avoid
   // repeativly finding the function at call time, this means user-defined functions have there lifetime

--- a/tests/e2e/awesome_functions/CMakeLists.txt
+++ b/tests/e2e/awesome_functions/CMakeLists.txt
@@ -5,5 +5,6 @@ endfunction()
 copy_awesome_functions_e2e_python_files(common.py)
 copy_awesome_functions_e2e_python_files(property_size.py)
 copy_awesome_functions_e2e_python_files(value_type.py)
+copy_awesome_functions_e2e_python_files(id.py)
 
 copy_e2e_files(awesome_functions workloads.yaml)

--- a/tests/e2e/awesome_functions/id.py
+++ b/tests/e2e/awesome_functions/id.py
@@ -1,0 +1,57 @@
+# Copyright 2023 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+import sys
+
+import pytest
+from common import get_bytes, memgraph
+
+QUERY_PLAN = "QUERY PLAN"
+
+
+def test_id_planner_uppercase(memgraph):
+    memgraph.execute("CREATE ()")
+
+    expected_plan = [" * Produce {n}", " * ScanAllById (n)", " * Once"]
+
+    actual_plan = [
+        x[QUERY_PLAN] for x in list(memgraph.execute_and_fetch("EXPLAIN MATCH (n) WHERE ID(n) = 1 RETURN n"))
+    ]
+
+    assert actual_plan == expected_plan
+
+
+def test_id_planner_lowercase(memgraph):
+    memgraph.execute("CREATE ()")
+
+    expected_plan = [" * Produce {n}", " * ScanAllById (n)", " * Once"]
+
+    actual_plan = [
+        x[QUERY_PLAN] for x in list(memgraph.execute_and_fetch("EXPLAIN MATCH (n) WHERE id(n) = 1 RETURN n"))
+    ]
+
+    assert actual_plan == expected_plan
+
+
+def test_id_planner_pascal_case(memgraph):
+    memgraph.execute("CREATE ()")
+
+    expected_plan = [" * Produce {n}", " * ScanAllById (n)", " * Once"]
+
+    actual_plan = [
+        x[QUERY_PLAN] for x in list(memgraph.execute_and_fetch("EXPLAIN MATCH (n) WHERE Id(n) = 1 RETURN n"))
+    ]
+
+    assert actual_plan == expected_plan
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/awesome_functions/workloads.yaml
+++ b/tests/e2e/awesome_functions/workloads.yaml
@@ -1,7 +1,7 @@
 awesome_functions_cluster: &awesome_functions_cluster
   cluster:
     main:
-      args: ["--bolt-port", "7687", "--log-level=TRACE"]
+      args: ["--bolt-port", "7687", "--log-level=TRACE", "--query-plan-cache-max-size=0"]
       log_file: "awesome_functions.log"
       setup_queries: []
       validation_queries: []
@@ -15,4 +15,8 @@ workloads:
   - name: "Value type awesome function"
     binary: "tests/e2e/pytest_runner.sh"
     args: ["awesome_functions/value_type.py"]
+    <<: *awesome_functions_cluster
+  - name: "ID awesome function"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["awesome_functions/id.py"]
     <<: *awesome_functions_cluster


### PR DESCRIPTION
Bug was introduced when the function name was not passed as uppercase. It would result of ScanAllById operator not being utilized.

