### PR TITLE
Mg query log folder fix

### DIFF
--- a/config/flags.yaml
+++ b/config/flags.yaml
@@ -131,6 +131,10 @@ modifications:
     value: "/etc/memgraph/apoc_compatibility_mappings.json"
     override: true
 
+  - name: "query_log_directory"
+    value: "/var/log/memgraph/session_trace"
+    override: true
+
 undocumented:
   - "flag_file"
   - "also_log_to_stderr"

--- a/src/flags/query.cpp
+++ b/src/flags/query.cpp
@@ -12,7 +12,3 @@
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 // DEFINE_bool(cartesian_product_enabled, true, "Enable cartesian product expansion.");  Moved to run_time_configurable
-
-// Logging flags
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-// DEFINE_string(query_log_directory, "", "Path to directory where the query logs should be stored.");

--- a/src/flags/query.cpp
+++ b/src/flags/query.cpp
@@ -15,4 +15,4 @@
 
 // Logging flags
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_string(query_log_directory, "mg_query_log", "Path to directory where the query logs should be stored.");
+DEFINE_string(query_log_directory, "", "Path to directory where the query logs should be stored.");

--- a/src/flags/query.cpp
+++ b/src/flags/query.cpp
@@ -15,4 +15,4 @@
 
 // Logging flags
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_string(query_log_directory, "", "Path to directory where the query logs should be stored.");
+// DEFINE_string(query_log_directory, "", "Path to directory where the query logs should be stored.");

--- a/src/flags/query.hpp
+++ b/src/flags/query.hpp
@@ -14,5 +14,3 @@
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 // DECLARE_bool(cartesian_product_enabled);  Moved to run_time_configurable
-
-// DECLARE_string(query_log_directory);

--- a/src/flags/query.hpp
+++ b/src/flags/query.hpp
@@ -15,4 +15,4 @@
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 // DECLARE_bool(cartesian_product_enabled);  Moved to run_time_configurable
 
-DECLARE_string(query_log_directory);
+// DECLARE_string(query_log_directory);

--- a/src/flags/run_time_configurable.cpp
+++ b/src/flags/run_time_configurable.cpp
@@ -62,6 +62,9 @@ DEFINE_bool(cartesian_product_enabled, true, "Enable cartesian product expansion
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, misc-unused-parameters)
 DEFINE_VALIDATED_string(timezone, "UTC", "Define instance's timezone (IANA format).", { return ValidTimezone(value); });
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_string(query_log_directory, "", "Path to directory where the query logs should be stored.");
+
 namespace {
 // Bolt server name
 constexpr auto kServerNameSettingKey = "server.name";
@@ -85,6 +88,9 @@ constexpr auto kLogToStderrGFlagsKey = "also_log_to_stderr";
 
 constexpr auto kCartesianProductEnabledSettingKey = "cartesian-product-enabled";
 constexpr auto kCartesianProductEnabledGFlagsKey = "cartesian-product-enabled";
+
+constexpr auto kQueryLogDirectorySettingKey = "query-log-directory";
+constexpr auto kQueryLogDirectoryGFlagsKey = "query-log-directory";
 
 constexpr auto kTimezoneSettingKey = "timezone";
 constexpr auto kTimezoneGFlagsKey = kTimezoneSettingKey;
@@ -234,6 +240,11 @@ void Initialize() {
         timezone_ = ::GetTimezone(val);  // Cache for faster access
       },
       ValidTimezone);
+
+  /*
+   * Register query log directory setting
+   */
+  register_flag(kQueryLogDirectoryGFlagsKey, kQueryLogDirectorySettingKey, kRestore);
 }
 
 std::string GetServerName() {
@@ -250,5 +261,12 @@ bool GetHopsLimitPartialResults() { return hops_limit_partial_results; }
 bool GetCartesianProductEnabled() { return cartesian_product_enabled_; }
 
 const std::chrono::time_zone *GetTimezone() { return timezone_; }
+
+std::string GetQueryLogDirectory() {
+  std::string s;
+  // Thread safe read of gflag
+  gflags::GetCommandLineOption(kQueryLogDirectoryGFlagsKey, &s);
+  return s;
+}
 
 }  // namespace memgraph::flags::run_time

--- a/src/flags/run_time_configurable.hpp
+++ b/src/flags/run_time_configurable.hpp
@@ -56,4 +56,11 @@ bool GetCartesianProductEnabled();
  */
 const std::chrono::time_zone *GetTimezone();
 
+/**
+ * @brief Get the query log directory value
+ *
+ * @return std::string
+ */
+std::string GetQueryLogDirectory();
+
 }  // namespace memgraph::flags::run_time

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -5074,10 +5074,16 @@ PreparedQuery PrepareSessionTraceQuery(ParsedQuery parsed_query, CurrentDB &curr
   std::function<std::pair<std::vector<std::vector<TypedValue>>, QueryHandlerResult>()> handler;
   handler = [interpreter, enabled = session_trace_query->enabled_] {
     std::vector<std::vector<TypedValue>> results;
+
+    auto query_log_directory = flags::run_time::GetQueryLogDirectory();
+
+    if (query_log_directory.empty()) {
+      throw QueryException("The flag --query-log-directory has to be present in order to enable session trace.");
+    }
+
     if (enabled) {
-      interpreter->query_logger_.emplace(
-          fmt::format("{}/{}.log", FLAGS_query_log_directory, interpreter->session_info_.uuid),
-          interpreter->session_info_.uuid, interpreter->session_info_.username);
+      interpreter->query_logger_.emplace(fmt::format("{}/{}.log", query_log_directory, interpreter->session_info_.uuid),
+                                         interpreter->session_info_.uuid, interpreter->session_info_.username);
       interpreter->LogQueryMessage("Session initialized!");
     } else {
       interpreter->query_logger_.reset();

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -273,6 +273,6 @@ startup_config_dict = {
         "",
         "Experimental features to be used, comma-separated. Options [text-search, high-availability]",
     ),
-    "query_log_directory": ("mg_query_log", "mg_query_log", "Path to directory where the query logs should be stored."),
+    "query_log_directory": ("", "", "Path to directory where the query logs should be stored."),
     "schema_info_enabled": ("false", "false", "Set to true to enable run-time schema info tracking."),
 }

--- a/tests/e2e/query_log/workloads.yaml
+++ b/tests/e2e/query_log/workloads.yaml
@@ -1,7 +1,7 @@
 query_log: &query_log
   cluster:
     main:
-      args: ["--bolt-port", "7687", "--log-level=TRACE", "--also-log-to-stderr"]
+      args: ["--bolt-port", "7687", "--log-level=TRACE", "--also-log-to-stderr", "--query-log-directory=something"]
       log_file: "query_log.log"
       setup_queries: []
       validation_queries: []


### PR DESCRIPTION
`--query-log-directory` set to be empty at the beginning so it is not generated inside the data directory. Also set query log directory to be a runtime flag so it can be set easily.
