### PR TITLE
Throw when schema.assert in explicit txn. Restore schema tests

### DIFF
--- a/src/communication/bolt/v1/states/handlers.hpp
+++ b/src/communication/bolt/v1/states/handlers.hpp
@@ -403,6 +403,7 @@ State HandleReset(TSession &session, const Marker marker) {
 
 template <typename TSession>
 State HandleBegin(TSession &session, const State state, const Marker marker) {
+  spdlog::trace("Received BEGIN message");
   if (marker != Marker::TinyStruct1) {
     spdlog::trace("Expected TinyStruct1 marker, but received 0x{:02x}!", utils::UnderlyingCast(marker));
     return State::Close;

--- a/src/communication/bolt/v1/states/handlers.hpp
+++ b/src/communication/bolt/v1/states/handlers.hpp
@@ -359,16 +359,19 @@ State HandlePullV5(TSession &session, const State state, const Marker marker) {
 
 template <typename TSession>
 State HandleDiscardV1(TSession &session, const State state, const Marker marker) {
+  spdlog::trace("Received DISCARD message");
   return details::HandlePullDiscardV1<false>(session, state, marker);
 }
 
 template <typename TSession>
 State HandleDiscardV4(TSession &session, const State state, const Marker marker) {
+  spdlog::trace("Received DISCARD message");
   return details::HandlePullDiscardV4<false>(session, state, marker);
 }
 
 template <typename TSession>
 State HandleDiscardV5(TSession &session, const State state, const Marker marker) {
+  spdlog::trace("Received DISCARD message");
   // Using V4 on purpose
   return HandleDiscardV4<TSession>(session, state, marker);
 }
@@ -384,6 +387,7 @@ State HandleReset(TSession &session, const Marker marker) {
   // so we cannot simply "kill" a transaction while it is running. So
   // now this command only resets the session to a clean state. It
   // does not IGNORE running and pending commands as it should.
+  spdlog::trace("Received RESET message");
   if (marker != Marker::TinyStruct) {
     spdlog::trace("Expected TinyStruct marker, but received 0x{:02X}!", utils::UnderlyingCast(marker));
     return State::Close;
@@ -437,6 +441,7 @@ State HandleBegin(TSession &session, const State state, const Marker marker) {
 
 template <typename TSession>
 State HandleCommit(TSession &session, const State state, const Marker marker) {
+  spdlog::trace("Received COMMIT message");
   if (marker != Marker::TinyStruct) {
     spdlog::trace("Expected TinyStruct marker, but received 0x{:02x}!", utils::UnderlyingCast(marker));
     return State::Close;

--- a/src/query/exceptions.hpp
+++ b/src/query/exceptions.hpp
@@ -109,6 +109,13 @@ class IndexInMulticommandTxException : public QueryException {
   SPECIALIZE_GET_EXCEPTION_NAME(IndexInMulticommandTxException)
 };
 
+class SchemaAssertInMulticommandTxException : public QueryException {
+ public:
+  using QueryException::QueryException;
+  SchemaAssertInMulticommandTxException() : QueryException("SCHEMA.ASSERT not allowed in multicommand transactions.") {}
+  SPECIALIZE_GET_EXCEPTION_NAME(SchemaAssertInMulticommandTxException)
+};
+
 class ConstraintInMulticommandTxException : public QueryException {
  public:
   using QueryException::QueryException;

--- a/tests/e2e/query_modules/workloads.yaml
+++ b/tests/e2e/query_modules/workloads.yaml
@@ -26,3 +26,9 @@ workloads:
     proc: "query_modules/"
     args: ["query_modules/mgps_test.py"]
     <<: *in_memory_cluster
+
+  - name: "Schema query module test"
+    binary: "tests/e2e/pytest_runner.sh"
+    proc: "query_modules/"
+    args: ["query_modules/schema_test.py"]
+    <<: *in_memory_cluster


### PR DESCRIPTION
schema.assert will now fail when ran in explicit txn, before it was crashing Memgraph. Added log when handling BEGIN message. Restored schema tests which weren't running. One test disabled since it has non-deterministic execution path.


