### PR TITLE
Add .editorconfig for vim and .clangd clang symbols

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{c,cpp,cxx,h,hpp,hxx,py,cmake}]
+charset = utf-8
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[CMakeLists.txt]
+charset = utf-8
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/tests/.clang-tidy
+++ b/tests/.clang-tidy
@@ -38,6 +38,11 @@ Checks: '*,
          -hicpp-use-equals-default,
          -hicpp-vararg,
          -llvm-header-guard,
+         -llvm-include-order,
+         -llvmlibc-callee-namespace,
+         -llvmlibc-implementation-in-namespace,
+         -llvmlibc-restrict-system-libc-headers,
+         -llvmlibc-inline-function-decl,
          -misc-non-private-member-variables-in-classes,
          -modernize-avoid-c-arrays,
          -modernize-concat-nested-namespaces,
@@ -77,4 +82,3 @@ CheckOptions:
   - key:             modernize-use-nullptr.NullMacros
     value:           'NULL'
 ...
-


### PR DESCRIPTION
Added .editorconfig for nvim development and updated .clang-tidy for tests folder with llvm checks.