### PR TITLE
Fix txn handling

### DIFF
--- a/src/rpc/client.hpp
+++ b/src/rpc/client.hpp
@@ -190,7 +190,7 @@ class Client {
                                                  Args &&...args) {
     typename TRequestResponse::Request request(std::forward<Args>(args)...);
     auto req_type = TRequestResponse::Request::kType;
-    SPDLOG_TRACE("[RpcClient] sent {}", req_type.name);
+    spdlog::trace("[RpcClient] sent {}", req_type.name);
 
     auto guard = std::unique_lock{mutex_};
 
@@ -204,7 +204,7 @@ class Client {
     if (!client_) {
       client_.emplace(context_);
       if (!client_->Connect(endpoint_)) {
-        SPDLOG_ERROR("Couldn't connect to remote address {}", endpoint_);
+        spdlog::error("Couldn't connect to remote address {}", endpoint_);
         client_ = std::nullopt;
         throw GenericRpcFailedException();
       }

--- a/tests/jepsen/src/memgraph/query.clj
+++ b/tests/jepsen/src/memgraph/query.clj
@@ -32,6 +32,11 @@
   RETURN n.id as id;
   ")
 
+(dbclient/defquery max-id
+  "MATCH (n:Node)
+  RETURN max(n.id) as id;
+  ")
+
 (defn add-nodes
   [start-idx end-idx]
   (dbclient/create-query


### PR DESCRIPTION
Nemesis could kill the thread between committing a transaction and incrementing the atomic counter. This caused the issue because multiple requests for creating same range of indices could be sent when the txn got committed and we didn't register that change. The issue is solved by finding the maximum current vertex id and creating nodes in the same transaction.