### PR TITLE
Bugfix: Forcing streams and tll to stop before destroying InterpreterContext

### DIFF
--- a/tests/unit/query_streams.cpp
+++ b/tests/unit/query_streams.cpp
@@ -133,6 +133,7 @@ class StreamsTestFixture : public ::testing::Test {
   std::optional<StreamsTest> proxyStreams_;
 
   void TearDown() override {
+    db_->StopAllBackgroundTasks();
     if (std::is_same<StorageType, memgraph::storage::DiskStorage>::value) {
       disk_test_utils::RemoveRocksDbDirs(testSuite);
     }

--- a/tests/unit/ttl.cpp
+++ b/tests/unit/ttl.cpp
@@ -96,6 +96,7 @@ class TTLFixture : public ::testing::Test {
   }
 
   void TearDown() override {
+    db_->StopAllBackgroundTasks();
     if (std::is_same<StorageType, memgraph::storage::DiskStorage>::value) {
       disk_test_utils::RemoveRocksDbDirs(testSuite);
     }


### PR DESCRIPTION
Streams and TTL have their own interpreters that run in the background.
These interpreters prepare queries and execute them.
When shutting down, the InterpreterContext would be destroyed before stopping streams and TTL.
There was a possibility they would be preparing queries while the IC was being destroyed.
While Pulls are protected by the abort signal, Prepare is not.