### PR TITLE
Test network chaos in HA

### DIFF
--- a/.github/workflows/stress_jepsen.yaml
+++ b/.github/workflows/stress_jepsen.yaml
@@ -78,7 +78,7 @@ jobs:
           cd tests/jepsen
           ./run.sh test \
           --binary ../../build/memgraph \
-          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 5400 --concurrency 6" \
+          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 1800 --concurrency 6" \
           --ignore-run-stdout-logs \
           --ignore-run-stderr-logs \
           --nodes-no 6 \

--- a/.github/workflows/stress_jepsen.yaml
+++ b/.github/workflows/stress_jepsen.yaml
@@ -17,7 +17,7 @@ jobs:
   core:
     name: "Jepsen stress tests"
     runs-on: [self-hosted, Linux, X64, DockerMgBuild]
-    timeout-minutes: 120
+    timeout-minutes: 600
     steps:
       - name: Set up repository
         uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
           cd tests/jepsen
           ./run.sh test \
           --binary ../../build/memgraph \
-          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 600 --concurrency 6" \
+          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 5400 --concurrency 6" \
           --ignore-run-stdout-logs \
           --ignore-run-stderr-logs \
           --nodes-no 6 \

--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -290,6 +290,7 @@ auto CoordinatorInstance::ShowInstances() const -> std::vector<InstanceStatus> {
     spdlog::trace("No leader found, returning report as follower");
     return ShowInstancesStatusAsFollower();
   }
+
   CoordinatorInstanceConnector *leader{nullptr};
   {
     auto connectors = coordinator_connectors_.Lock();
@@ -300,6 +301,7 @@ auto CoordinatorInstance::ShowInstances() const -> std::vector<InstanceStatus> {
       leader = &connector->second;
     }
   }
+
   if (leader == nullptr) {
     spdlog::trace("Connection to leader not found, returning SHOW INSTANCES output as follower.");
     return ShowInstancesStatusAsFollower();
@@ -312,6 +314,7 @@ auto CoordinatorInstance::ShowInstances() const -> std::vector<InstanceStatus> {
     spdlog::trace("Couldn't get instances from leader {}. Returning result as a follower.", leader_id);
     return ShowInstancesStatusAsFollower();
   }
+
   spdlog::trace("Got instances from leader {}.", leader_id);
   return std::move(maybe_res.value());
 }

--- a/tests/jepsen/src/memgraph/core.clj
+++ b/tests/jepsen/src/memgraph/core.clj
@@ -91,7 +91,7 @@
             :checker         (checker/compose
                               {:stats      (checker/stats)
                                :exceptions (unhandled-exceptions)
-                               :log-checker (checker/log-file-pattern #"assert|NullPointerException|json.exception.parse_error" "memgraph.log")
+                               :log-checker (checker/log-file-pattern #"[Aa]ssert*|critical|NullPointerException|json.exception.parse_error" "memgraph.log")
                                :workload   (:checker workload)})
             :nodes           (keys (:nodes-config opts))
             :nemesis         (:nemesis nemesis-config)

--- a/tests/jepsen/src/memgraph/high_availability/create/nemesis.clj
+++ b/tests/jepsen/src/memgraph/high_availability/create/nemesis.clj
@@ -69,10 +69,11 @@
   "Returns the name of the main instance. If there is no main instance or more than one main, throws exception."
   [instances]
   (let [main-instances (filter main-instance? instances)
+        num-mains (count main-instances)
         main-instance
-        (if (= 1 (count main-instances))
-          (first main-instances)
-          (throw (Exception. "Expected exactly one main instance.")))
+        (cond (= num-mains 1) (first main-instances)
+              (= num-mains 0) nil
+              :else (throw (Exception. "Expected at most one main instance.")))
         main-instance-name (:name main-instance)]
     main-instance-name))
 
@@ -89,16 +90,17 @@
   "Returns the name of the current leader. If there is no leader or more than one leader, throws exception."
   [instances]
   (let [leaders (filter leader? instances)
+        num-leaders (count leaders)
         leader
-        (if (= 1 (count leaders))
-          (first leaders)
-          (throw (Exception. "Expected exactly one leader.")))
+        (cond (= num-leaders 1) (first leaders)
+              (= num-leaders 0) nil
+              :else (throw (Exception. "Expected at most one leader.")))
         leader-name (extract-coord-name (:bolt_server leader))]
     leader-name))
 
 (defn choose-node-to-kill
-  "Chooses between the current main and the current leader. We always connect to coordinator 'n4' (free choice).
-  We assume that node should always be up because even if it was killed at previous step, it should have enough time to come back
+  "Chooses between the current main and the current leader. If there are no clear MAIN and LEADER instance in the cluster, we choose random node. We always connect to
+  coordinator 'n4' (free choice). We assume that node should always be up because even if it was killed at previous step, it should have enough time to come back
   and to be able to receive requests for show instances.
   "
   [ns]

--- a/tests/jepsen/src/memgraph/high_availability/create/nemesis.clj
+++ b/tests/jepsen/src/memgraph/high_availability/create/nemesis.clj
@@ -74,7 +74,7 @@
         (cond (= num-mains 1) (first main-instances)
               (= num-mains 0) nil
               :else (throw (Exception. "Expected at most one main instance.")))
-        main-instance-name (:name main-instance)]
+        main-instance-name (if (nil? main-instance) nil (:name main-instance))]
     main-instance-name))
 
 (defn leader?
@@ -95,7 +95,7 @@
         (cond (= num-leaders 1) (first leaders)
               (= num-leaders 0) nil
               :else (throw (Exception. "Expected at most one leader.")))
-        leader-name (extract-coord-name (:bolt_server leader))]
+        leader-name (if (nil? leader) nil (extract-coord-name (:bolt_server leader)))]
     leader-name))
 
 (defn choose-node-to-kill

--- a/tests/jepsen/src/memgraph/high_availability/create/test.clj
+++ b/tests/jepsen/src/memgraph/high_availability/create/test.clj
@@ -539,6 +539,7 @@
   "Basic HA workload."
   [opts]
   (let [nodes-config (:nodes-config opts)
+        db (:db opts)
         first-leader (random-coord (keys nodes-config))
         first-main (random-data-instance (keys nodes-config))
         organization (:organization opts)
@@ -549,4 +550,4 @@
                   :timeline (timeline/html)})
      :generator (client-generator)
      :final-generator {:clients (gen/each-thread (gen/once get-nodes)) :recovery-time 30}
-     :nemesis-config (nemesis/create nodes-config)}))
+     :nemesis-config (nemesis/create db nodes-config)}))

--- a/tests/jepsen/src/memgraph/high_availability/create/test.clj
+++ b/tests/jepsen/src/memgraph/high_availability/create/test.clj
@@ -300,7 +300,7 @@
                                    (let [instances (reduce conj [] (mgquery/get-all-instances session))]
                                      (assoc op
                                             :type :ok
-                                            :value {:instances instances :node node})))
+                                            :value {:instances instances :node node :time (utils/current-local-time-formatted)})))
                                  (catch org.neo4j.driver.exceptions.ServiceUnavailableException _e
                                    (utils/process-service-unavailable-exc op node))
                                  (catch Exception e

--- a/tests/jepsen/src/memgraph/high_availability/create/test.clj
+++ b/tests/jepsen/src/memgraph/high_availability/create/test.clj
@@ -21,6 +21,32 @@
 
 (def batch-size 5000)
 
+(defn cum-probs
+  "Calculates cumulative probabilities for the vector of probabilities provided."
+  [probs]
+  (reductions + probs))
+
+(defn get-competent-idx
+  "Get idx which is in charge for the interval from which num comes."
+  [intervals num]
+  (first (keep-indexed (fn [idx end-interval]
+                         (when (> end-interval num)
+                           idx))
+
+                       intervals)))
+
+(defn weighted-random
+  "Chooses random number from the collection based on the probabilities vector provided."
+  [coll probs]
+  (assert (= (reduce + probs) 1.0) "Sum of probabilities should equal to 1.")
+  (assert (= (count coll) (count probs)) "Not every element has its probability match.")
+  ; The code relies that `rand` will never generate exactly 1.0. True by the function specification.
+  (let [cumulative-probs (cum-probs probs)
+        rand-num (rand)
+        competent-idx (get-competent-idx cumulative-probs rand-num)
+        chosen-num (nth coll competent-idx)]
+    chosen-num))
+
 (defn hamming-sim
   "Calculates Hamming distance between two sequences. Used as a consistency measure when the order is important."
   [seq1 seq2]

--- a/tests/jepsen/src/memgraph/high_availability/create/test.clj
+++ b/tests/jepsen/src/memgraph/high_availability/create/test.clj
@@ -575,5 +575,5 @@
                  {:hacreate     (checker)
                   :timeline (timeline/html)})
      :generator (client-generator)
-     :final-generator {:clients (gen/each-thread (gen/once get-nodes)) :recovery-time 30}
+     :final-generator {:clients (gen/each-thread (gen/once get-nodes)) :recovery-time 40}
      :nemesis-config (nemesis/create db nodes-config)}))

--- a/tests/jepsen/src/memgraph/utils.clj
+++ b/tests/jepsen/src/memgraph/utils.clj
@@ -16,7 +16,7 @@
 
 (defn random-nonempty-subset
   "Return a random nonempty subset of the input collection. Relies on the fact that first 3 instances from the collection are data instances
-  and last 3 are coordinators. It kills a random subset of data instances and with 50% probability 1 coordinator."
+  and last 3 are coordinators. It kills a random subset of data instances and coordinators."
   [coll]
   (let [data-instances (take 3 coll)
         coords (take-last 3 coll)

--- a/tests/jepsen/src/memgraph/utils.clj
+++ b/tests/jepsen/src/memgraph/utils.clj
@@ -1,8 +1,18 @@
 (ns memgraph.utils
   (:require
    [neo4j-clj.core :as dbclient]
-   [clojure.string :as string])
-  (:import (java.net URI)))
+   [clojure.string :as string]
+   )
+  (:import (java.net URI)
+           (java.time LocalTime)
+           (java.time.format DateTimeFormatter)
+           ))
+
+(defn current-local-time-formatted
+  "Get current time in HH:mm:ss.SSS"
+  []
+  (let [formatter (DateTimeFormatter/ofPattern "HH:mm:ss.SSS")]
+    (.format (LocalTime/now) formatter)))
 
 (defn bolt-url
   "Get Bolt server address for connecting to an instance on a particular port"

--- a/tests/jepsen/test/memgraph/memgraph_test.clj
+++ b/tests/jepsen/test/memgraph/memgraph_test.clj
@@ -153,6 +153,69 @@
 
       (is (= (hacreate/missing-intervals my-seq) [[10001 50000] [55001 110000]]))))
 
+  (testing "cum-probs1"
+    (let [my-probs [0.1 0.3 0.6]]
+
+      (is (= (hacreate/cum-probs my-probs) [0.1 0.4 1.0]))))
+
+  (testing "cum-probs2"
+    (let [my-probs [0.5 0.5]]
+
+      (is (= (hacreate/cum-probs my-probs) [0.5 1.0]))))
+
+  (testing "cum-probs3"
+    (let [my-probs [0.25 0.25 0.25 0.25]]
+
+      (is (= (hacreate/cum-probs my-probs) [0.25 0.5 0.75 1.0]))))
+
+  (testing "cum-probs4"
+    (let [my-probs [1.0]]
+
+      (is (= (hacreate/cum-probs my-probs) [1.0]))))
+
+  (testing "cum-probs5"
+    (let [my-probs []]
+
+      (is (= (hacreate/cum-probs my-probs) [0]))))
+
+  (testing "get-competent-idx1"
+    (let [cum-probs [0.1 0.4 1.0]]
+
+      (is (= (hacreate/get-competent-idx cum-probs 0.05) 0))))
+
+  (testing "get-competent-idx2"
+    (let [cum-probs [0.1 0.4 1.0]]
+
+      (is (= (hacreate/get-competent-idx cum-probs 0.1) 1))))
+
+  (testing "get-competent-idx3"
+    (let [cum-probs [0.1 0.4 1.0]]
+
+      (is (= (hacreate/get-competent-idx cum-probs 0.3) 1))))
+
+  (testing "get-competent-idx4"
+    (let [cum-probs [0.1 0.4 1.0]]
+
+      (is (= (hacreate/get-competent-idx cum-probs 0.4) 2))))
+
+  (testing "get-competent-idx5"
+    (let [cum-probs [0.1 0.4 1.0]]
+
+      (is (= (hacreate/get-competent-idx cum-probs 0.8) 2))))
+
+  (testing "get-competent-idx6"
+    (let [cum-probs [0.1 0.4 1.0]]
+
+      (is (= (hacreate/get-competent-idx cum-probs 0.99) 2))))
+
+  (testing "get-competent-idx7"
+    (let [cum-probs [0.5 1.0]]
+
+      (is (= (hacreate/get-competent-idx cum-probs 0.2) 0))))
+
+
+
+
 
 
   )


### PR DESCRIPTION
Test is now running for 30' since more types of failures are added. We add partitioning network in random halves, ring partitioning, isolating nodes and network failures which will corrupt, delay, duplicate and not send some TCP packages. Fixes the bug when choosing main or leader to kill when there is no main or leader in the cluster at that time. Added utility functions for calculating cumulative probabilities and choosing random number based on provided probabilities. Log checker now also checks for occurrences of the word 'critical'. Added unit tests for new functionalities. 