### PR TITLE
Bugfix: Inconsistent storage UUID on replica

### DIFF
--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -142,7 +142,7 @@ void InMemoryReplicationHandlers::SwapMainUUIDHandler(dbms::DbmsHandler *dbms_ha
 
   replication_coordination_glue::SwapMainUUIDReq req;
   slk::Load(&req, req_reader);
-  spdlog::info("Set replica data UUID  to main uuid {}", std::string(req.uuid));
+  spdlog::info("Set replica data UUID to main uuid {}", std::string(req.uuid));
   dbms_handler->ReplicationState().TryPersistRoleReplica(role_replica_data.config, req.uuid);
   role_replica_data.uuid_ = req.uuid;
 
@@ -291,7 +291,7 @@ void InMemoryReplicationHandlers::SnapshotHandler(dbms::DbmsHandler *dbms_handle
     spdlog::debug("Snapshot loaded successfully");
     // If this step is present it should always be the first step of
     // the recovery so we use the UUID we read from snasphost
-    storage->uuid_ = std::move(recovered_snapshot.snapshot_info.uuid);
+    storage->config_.salient.uuid.set(recovered_snapshot.snapshot_info.uuid);
     storage->repl_storage_state_.epoch_.SetEpoch(std::move(recovered_snapshot.snapshot_info.epoch_id));
     const auto &recovery_info = recovered_snapshot.recovery_info;
     storage->vertex_id_ = recovery_info.next_vertex_id;
@@ -318,8 +318,10 @@ void InMemoryReplicationHandlers::SnapshotHandler(dbms::DbmsHandler *dbms_handle
   slk::Save(res, res_builder);
 
   spdlog::trace("Deleting old snapshot files due to snapshot recovery.");
+
+  auto uuid_str = std::string{storage->config_.salient.uuid};
   // Delete other durability files
-  auto snapshot_files = storage::durability::GetSnapshotFiles(storage->recovery_.snapshot_directory_, storage->uuid_);
+  auto snapshot_files = storage::durability::GetSnapshotFiles(storage->recovery_.snapshot_directory_, uuid_str);
   for (const auto &[path, uuid, _] : snapshot_files) {
     if (path != *maybe_snapshot_path) {
       spdlog::trace("Deleting snapshot file {}", path);
@@ -328,7 +330,7 @@ void InMemoryReplicationHandlers::SnapshotHandler(dbms::DbmsHandler *dbms_handle
   }
 
   spdlog::trace("Deleting old WAL files due to snapshot recovery.");
-  auto wal_files = storage::durability::GetWalFiles(storage->recovery_.wal_directory_, storage->uuid_);
+  auto wal_files = storage::durability::GetWalFiles(storage->recovery_.wal_directory_, uuid_str);
   if (wal_files) {
     for (const auto &wal_file : *wal_files) {
       spdlog::trace("Deleting WAL file {}", wal_file.path);
@@ -394,15 +396,17 @@ void InMemoryReplicationHandlers::ForceResetStorageHandler(dbms::DbmsHandler *db
   slk::Save(res, res_builder);
 
   spdlog::trace("Deleting old snapshot files.");
+
+  auto const uuid_str = std::string{storage->config_.salient.uuid};
   // Delete other durability files
-  auto snapshot_files = storage::durability::GetSnapshotFiles(storage->recovery_.snapshot_directory_, storage->uuid_);
+  auto snapshot_files = storage::durability::GetSnapshotFiles(storage->recovery_.snapshot_directory_, uuid_str);
   for (const auto &[path, uuid, _] : snapshot_files) {
     spdlog::trace("Deleting snapshot file {}", path);
     storage->file_retainer_.DeleteFile(path);
   }
 
   spdlog::trace("Deleting old WAL files.");
-  auto wal_files = storage::durability::GetWalFiles(storage->recovery_.wal_directory_, storage->uuid_);
+  auto wal_files = storage::durability::GetWalFiles(storage->recovery_.wal_directory_, uuid_str);
   if (wal_files) {
     for (const auto &wal_file : *wal_files) {
       spdlog::trace("Deleting WAL file {}", wal_file.path);
@@ -488,9 +492,12 @@ void InMemoryReplicationHandlers::LoadWal(storage::InMemoryStorage *storage, sto
   spdlog::trace("Received WAL saved to {}", *maybe_wal_path);
   try {
     auto wal_info = storage::durability::ReadWalInfo(*maybe_wal_path);
-    if (wal_info.seq_num == 0) {
-      storage->uuid_ = wal_info.uuid;
+
+    // We have to check if this is our 1st wal, not what main is sending
+    if (storage->wal_seq_num_ == 0) {
+      storage->config_.salient.uuid.set(wal_info.uuid);
     }
+
     auto &replica_epoch = storage->repl_storage_state_.epoch_;
     if (wal_info.epoch_id != replica_epoch.id()) {
       // questionable behaviour, we trust that any change in epoch implies change in who is MAIN

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -291,7 +291,7 @@ void InMemoryReplicationHandlers::SnapshotHandler(dbms::DbmsHandler *dbms_handle
     spdlog::debug("Snapshot loaded successfully");
     // If this step is present it should always be the first step of
     // the recovery so we use the UUID we read from snasphost
-    storage->config_.salient.uuid.set(recovered_snapshot.snapshot_info.uuid);
+    storage->uuid().set(recovered_snapshot.snapshot_info.uuid);
     storage->repl_storage_state_.epoch_.SetEpoch(std::move(recovered_snapshot.snapshot_info.epoch_id));
     const auto &recovery_info = recovered_snapshot.recovery_info;
     storage->vertex_id_ = recovery_info.next_vertex_id;
@@ -319,7 +319,7 @@ void InMemoryReplicationHandlers::SnapshotHandler(dbms::DbmsHandler *dbms_handle
 
   spdlog::trace("Deleting old snapshot files due to snapshot recovery.");
 
-  auto uuid_str = std::string{storage->config_.salient.uuid};
+  auto uuid_str = std::string{storage->uuid()};
   // Delete other durability files
   auto snapshot_files = storage::durability::GetSnapshotFiles(storage->recovery_.snapshot_directory_, uuid_str);
   for (const auto &[path, uuid, _] : snapshot_files) {
@@ -397,7 +397,7 @@ void InMemoryReplicationHandlers::ForceResetStorageHandler(dbms::DbmsHandler *db
 
   spdlog::trace("Deleting old snapshot files.");
 
-  auto const uuid_str = std::string{storage->config_.salient.uuid};
+  auto const uuid_str = std::string{storage->uuid()};
   // Delete other durability files
   auto snapshot_files = storage::durability::GetSnapshotFiles(storage->recovery_.snapshot_directory_, uuid_str);
   for (const auto &[path, uuid, _] : snapshot_files) {
@@ -495,7 +495,7 @@ void InMemoryReplicationHandlers::LoadWal(storage::InMemoryStorage *storage, sto
 
     // We have to check if this is our 1st wal, not what main is sending
     if (storage->wal_seq_num_ == 0) {
-      storage->config_.salient.uuid.set(wal_info.uuid);
+      storage->uuid().set(wal_info.uuid);
     }
 
     auto &replica_epoch = storage->repl_storage_state_.epoch_;

--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -114,29 +114,41 @@ std::optional<std::vector<WalDurabilityInfo>> GetWalFiles(const std::filesystem:
 
   std::vector<WalDurabilityInfo> wal_files;
   std::error_code error_code;
+
   // There could be multiple "current" WAL files, the "_current" tag just means that the previous session didn't
   // finalize. We cannot skip based on name, will be able to skip based on invalid data or sequence number, so the
   // actual current wal will be skipped
+
+  // TODO: (andi) Inefficient to use I/O again, you already read infos.
   for (const auto &item : std::filesystem::directory_iterator(wal_directory, error_code)) {
-    if (!item.is_regular_file()) continue;
+    if (!item.is_regular_file()) {
+      spdlog::trace("Non-regular file {} found in the wal directory. Skipping it.", item.path());
+      continue;
+    }
     try {
       auto info = ReadWalInfo(item.path());
       spdlog::trace(
-          "Getting wal file with following info: uuid: {}, epoch id: {}, from timestamp {}, to_timestamp {}, sequence "
-          "number {} ",
-          info.uuid, info.epoch_id, info.from_timestamp, info.to_timestamp, info.seq_num);
+          "Reading wal file {} with following info: uuid: {}, epoch id: {}, from timestamp {}, to_timestamp {}, "
+          "sequence "
+          "number {}.",
+          item.path(), info.uuid, info.epoch_id, info.from_timestamp, info.to_timestamp, info.seq_num);
       if ((uuid.empty() || info.uuid == uuid) && (!current_seq_num || info.seq_num < *current_seq_num)) {
         wal_files.emplace_back(info.seq_num, info.from_timestamp, info.to_timestamp, std::move(info.uuid),
                                std::move(info.epoch_id), item.path());
+        spdlog::trace("Wal file {} will be used for recovery.", item.path());
+      } else {
+        spdlog::trace(
+            "Wal file {} won't be used for recovery. UUID: {}. Info UUID: {}. Current seq num: {}. Info seq num: {}.",
+            item.path(), uuid, info.uuid, current_seq_num, info.seq_num);
       }
     } catch (const RecoveryFailure &e) {
-      spdlog::warn("Failed to read {}", item.path());
+      spdlog::warn("Failed to read WAL file {}.", item.path());
       continue;
     }
   }
   MG_ASSERT(!error_code, "Couldn't recover data because an error occurred: {}!", error_code.message());
 
-  // Sort based on the sequence number, not the file name
+  // Sort based on the sequence number, not the file name.
   std::sort(wal_files.begin(), wal_files.end());
   return std::move(wal_files);
 }
@@ -428,6 +440,7 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
     spdlog::info("No snapshot file was found, collecting information from WAL directory {}.", wal_directory_);
     std::error_code error_code;
     if (!utils::DirExists(wal_directory_)) return std::nullopt;
+
     // We use this smaller struct that contains only a subset of information
     // necessary for the rest of the recovery function.
     // Also, the struct is sorted primarily on the path it contains.
@@ -440,9 +453,13 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
 
       auto operator<=>(const WalFileInfo &) const = default;
     };
+
     std::vector<WalFileInfo> wal_files;
     for (const auto &item : std::filesystem::directory_iterator(wal_directory_, error_code)) {
-      if (!item.is_regular_file()) continue;
+      if (!item.is_regular_file()) {
+        spdlog::trace("Non-regular WAL file {} found in the wal directory. Skipping it.", item.path());
+        continue;
+      }
       try {
         auto info = ReadWalInfo(item.path());
         wal_files.emplace_back(item.path(), std::move(info.uuid), std::move(info.epoch_id));
@@ -451,15 +468,21 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
       }
     }
     MG_ASSERT(!error_code, "Couldn't recover data because an error occurred: {}!", error_code.message());
+
     if (wal_files.empty()) {
       spdlog::warn(utils::MessageWithLink("No snapshot or WAL file found.", "https://memgr.ph/durability"));
       return std::nullopt;
     }
+
+    // sort by path
     std::sort(wal_files.begin(), wal_files.end());
+
     // UUID used for durability is the UUID of the last WAL file.
     // Same for the epoch id.
     *uuid = std::move(wal_files.back().uuid);
     repl_storage_state.epoch_.SetEpoch(std::move(wal_files.back().epoch_id));
+    spdlog::trace("UUID of the last WAL file: {}. Epoch id from the last WAL file: {}.", *uuid,
+                  repl_storage_state.epoch_.id());
   }
 
   auto maybe_wal_files = GetWalFiles(wal_directory_, *uuid);
@@ -485,9 +508,14 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
 
   if (!wal_files.empty()) {
     spdlog::info("Checking WAL files.");
+    std::ranges::for_each(wal_files, [](auto &&wal_file) {
+      spdlog::trace("Wal file: {}. Seq num: {}.", wal_file.path, wal_file.seq_num);
+    });
     {
       const auto &first_wal = wal_files[0];
+      spdlog::trace("Checking 1st wal file: {}.", first_wal.path);
       if (first_wal.seq_num != 0) {
+        spdlog::trace("1st wal file {} has sequence number {} which is != 0.", first_wal.path, first_wal.seq_num);
         // We don't have all WAL files. We need to see whether we need them all.
         if (!snapshot_timestamp) {
           // We didn't recover from a snapshot and we must have all WAL files
@@ -561,11 +589,12 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
 
   memgraph::metrics::Measure(memgraph::metrics::SnapshotRecoveryLatency_us,
                              std::chrono::duration_cast<std::chrono::microseconds>(timer.Elapsed()).count());
-  spdlog::trace("Set epoch id: {}  with commit timestamp {}", std::string(repl_storage_state.epoch_.id()),
+  spdlog::trace("Epoch id: {}. Last durable commit timestamp: {}.", std::string(repl_storage_state.epoch_.id()),
                 repl_storage_state.last_durable_timestamp_);
 
-  std::for_each(repl_storage_state.history.begin(), repl_storage_state.history.end(), [](auto &history) {
-    spdlog::trace("epoch id: {}  with commit timestamp {}", std::string(history.first), history.second);
+  spdlog::trace("History with its epochs and attached commit timestamps.");
+  std::ranges::for_each(repl_storage_state.history, [](auto &&history) {
+    spdlog::trace("Epoch id: {}. Commit timestamp: {}.", std::string(history.first), history.second);
   });
   return recovery_info;
 }

--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -374,7 +374,7 @@ std::optional<ParallelizedSchemaCreationInfo> GetParallelExecInfoIndices(const R
 }
 
 std::optional<RecoveryInfo> Recovery::RecoverData(
-    utils::UUID *uuid, ReplicationStorageState &repl_storage_state, utils::SkipList<Vertex> *vertices,
+    utils::UUID &uuid, ReplicationStorageState &repl_storage_state, utils::SkipList<Vertex> *vertices,
     utils::SkipList<Edge> *edges, utils::SkipList<EdgeMetadata> *edges_metadata, std::atomic<uint64_t> *edge_count,
     NameIdMapper *name_id_mapper, Indices *indices, Constraints *constraints, Config const &config,
     uint64_t *wal_seq_num, EnumStore *enum_store, SchemaInfo *schema_info,
@@ -400,8 +400,8 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
     spdlog::info("Try recovering from snapshot directory {}.", wal_directory_);
 
     // UUID used for durability is the UUID of the last snapshot file.
-    uuid->set(snapshot_files.back().uuid);
-    auto const last_snapshot_uuid_str = std::string{*uuid};
+    uuid.set(snapshot_files.back().uuid);
+    auto const last_snapshot_uuid_str = std::string{uuid};
 
     spdlog::trace("UUID of the last snapshot file: {}");
     std::optional<RecoveredSnapshot> recovered_snapshot;
@@ -483,13 +483,13 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
 
     // UUID used for durability is the UUID of the last WAL file.
     // Same for the epoch id.
-    uuid->set(wal_files.back().uuid);
+    uuid.set(wal_files.back().uuid);
     repl_storage_state.epoch_.SetEpoch(std::move(wal_files.back().epoch_id));
-    spdlog::trace("UUID of the last WAL file: {}. Epoch id from the last WAL file: {}.", std::string{*uuid},
+    spdlog::trace("UUID of the last WAL file: {}. Epoch id from the last WAL file: {}.", std::string{uuid},
                   repl_storage_state.epoch_.id());
   }
 
-  auto maybe_wal_files = GetWalFiles(wal_directory_, std::string{*uuid});
+  auto maybe_wal_files = GetWalFiles(wal_directory_, std::string{uuid});
   if (!maybe_wal_files) {
     spdlog::warn(
         utils::MessageWithLink("Couldn't get WAL file info from the WAL directory.", "https://memgr.ph/durability"));

--- a/src/storage/v2/durability/durability.hpp
+++ b/src/storage/v2/durability/durability.hpp
@@ -136,7 +136,7 @@ struct Recovery {
   /// @throw RecoveryFailure
   /// @throw std::bad_alloc
   std::optional<RecoveryInfo> RecoverData(
-      utils::UUID *uuid, ReplicationStorageState &repl_storage_state, utils::SkipList<Vertex> *vertices,
+      utils::UUID &uuid, ReplicationStorageState &repl_storage_state, utils::SkipList<Vertex> *vertices,
       utils::SkipList<Edge> *edges, utils::SkipList<EdgeMetadata> *edges_metadata, std::atomic<uint64_t> *edge_count,
       NameIdMapper *name_id_mapper, Indices *indices, Constraints *constraints, Config const &config,
       uint64_t *wal_seq_num, EnumStore *enum_store, SchemaInfo *schema_info,

--- a/src/storage/v2/durability/durability.hpp
+++ b/src/storage/v2/durability/durability.hpp
@@ -136,7 +136,7 @@ struct Recovery {
   /// @throw RecoveryFailure
   /// @throw std::bad_alloc
   std::optional<RecoveryInfo> RecoverData(
-      std::string *uuid, ReplicationStorageState &repl_storage_state, utils::SkipList<Vertex> *vertices,
+      utils::UUID *uuid, ReplicationStorageState &repl_storage_state, utils::SkipList<Vertex> *vertices,
       utils::SkipList<Edge> *edges, utils::SkipList<EdgeMetadata> *edges_metadata, std::atomic<uint64_t> *edge_count,
       NameIdMapper *name_id_mapper, Indices *indices, Constraints *constraints, Config const &config,
       uint64_t *wal_seq_num, EnumStore *enum_store, SchemaInfo *schema_info,

--- a/src/storage/v2/durability/snapshot.hpp
+++ b/src/storage/v2/durability/snapshot.hpp
@@ -74,7 +74,7 @@ RecoveredSnapshot LoadSnapshot(std::filesystem::path const &path, utils::SkipLis
 
 void CreateSnapshot(Storage *storage, Transaction *transaction, const std::filesystem::path &snapshot_directory,
                     const std::filesystem::path &wal_directory, utils::SkipList<Vertex> *vertices,
-                    utils::SkipList<Edge> *edges, const std::string &uuid,
+                    utils::SkipList<Edge> *edges, utils::UUID const &uuid,
                     const memgraph::replication::ReplicationEpoch &epoch,
                     const std::deque<std::pair<std::string, uint64_t>> &epoch_history,
                     utils::FileRetainer *file_retainer);

--- a/src/storage/v2/durability/wal.cpp
+++ b/src/storage/v2/durability/wal.cpp
@@ -1242,9 +1242,9 @@ RecoveryInfo LoadWal(const std::filesystem::path &path, RecoveredIndicesAndConst
   return ret;
 }
 
-WalFile::WalFile(const std::filesystem::path &wal_directory, const std::string_view uuid,
-                 const std::string_view epoch_id, SalientConfig::Items items, NameIdMapper *name_id_mapper,
-                 uint64_t seq_num, utils::FileRetainer *file_retainer)
+WalFile::WalFile(const std::filesystem::path &wal_directory, utils::UUID const &uuid, const std::string_view epoch_id,
+                 SalientConfig::Items items, NameIdMapper *name_id_mapper, uint64_t seq_num,
+                 utils::FileRetainer *file_retainer)
     : items_(items),
       name_id_mapper_(name_id_mapper),
       path_(wal_directory / MakeWalName()),
@@ -1271,7 +1271,7 @@ WalFile::WalFile(const std::filesystem::path &wal_directory, const std::string_v
   // Write metadata.
   offset_metadata = wal_.GetPosition();
   wal_.WriteMarker(Marker::SECTION_METADATA);
-  wal_.WriteString(uuid);
+  wal_.WriteString(std::string{uuid});
   wal_.WriteString(epoch_id);
   wal_.WriteUint(seq_num);
 

--- a/src/storage/v2/durability/wal.hpp
+++ b/src/storage/v2/durability/wal.hpp
@@ -300,7 +300,7 @@ RecoveryInfo LoadWal(std::filesystem::path const &path, RecoveredIndicesAndConst
 /// WalFile class used to append deltas and operations to the WAL file.
 class WalFile {
  public:
-  WalFile(const std::filesystem::path &wal_directory, const std::string_view uuid, const std::string_view epoch_id,
+  WalFile(const std::filesystem::path &wal_directory, utils::UUID const &uuid, const std::string_view epoch_id,
           SalientConfig::Items items, NameIdMapper *name_id_mapper, uint64_t seq_num,
           utils::FileRetainer *file_retainer);
   WalFile(std::filesystem::path current_wal_path, SalientConfig::Items items, NameIdMapper *name_id_mapper,

--- a/src/storage/v2/inmemory/replication/recovery.cpp
+++ b/src/storage/v2/inmemory/replication/recovery.cpp
@@ -154,7 +154,8 @@ std::vector<RecoveryStep> GetRecoverySteps(uint64_t replica_commit, utils::FileR
       release_wal_dir(  // Each individually used file will be locked, so at the end, the dir can be released
           [&locker_acc, &wal_dir = storage->recovery_.wal_directory_]() { (void)locker_acc.RemovePath(wal_dir); });
   // Get WAL files, ordered by timestamp, from oldest to newest
-  auto wal_files = durability::GetWalFiles(storage->recovery_.wal_directory_, storage->uuid_, current_wal_seq_num);
+  auto wal_files =
+      durability::GetWalFiles(storage->recovery_.wal_directory_, std::string{storage->uuid()}, current_wal_seq_num);
   MG_ASSERT(wal_files, "Wal files could not be loaded");
   if (transaction_guard.owns_lock())
     transaction_guard.unlock();  // In case we didn't have a current wal file, we can unlock only now since there is no
@@ -167,7 +168,8 @@ std::vector<RecoveryStep> GetRecoverySteps(uint64_t replica_commit, utils::FileR
           [&locker_acc, &snapshot_dir = storage->recovery_.snapshot_directory_]() {
             (void)locker_acc.RemovePath(snapshot_dir);
           });
-  auto snapshot_files = durability::GetSnapshotFiles(storage->recovery_.snapshot_directory_, storage->uuid_);
+  auto snapshot_files =
+      durability::GetSnapshotFiles(storage->recovery_.snapshot_directory_, std::string{storage->uuid()});
   std::optional<durability::SnapshotDurabilityInfo> latest_snapshot{};
   if (!snapshot_files.empty()) {
     latest_snapshot.emplace(std::move(snapshot_files.back()));

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -160,7 +160,7 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
       timestamp_ = std::max(timestamp_, info->next_timestamp);
       if (info->last_durable_timestamp) {
         repl_storage_state_.last_durable_timestamp_ = *info->last_durable_timestamp;
-        spdlog::trace("Recovering last durable timestamp {}", *info->last_durable_timestamp);
+        spdlog::trace("Recovering last durable timestamp {}.", *info->last_durable_timestamp);
       }
     }
   } else if (config_.durability.snapshot_wal_mode != Config::Durability::SnapshotWalMode::DISABLED ||

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -121,7 +121,6 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
       recovery_{config.durability.storage_directory / durability::kSnapshotDirectory,
                 config.durability.storage_directory / durability::kWalDirectory},
       lock_file_path_(config.durability.storage_directory / durability::kLockFile),
-      uuid_(utils::GenerateUUID()),
       global_locker_(file_retainer_.AddLocker()) {
   MG_ASSERT(config.salient.storage_mode != StorageMode::ON_DISK_TRANSACTIONAL,
             "Invalid storage mode sent to InMemoryStorage constructor!");
@@ -151,9 +150,10 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
               config_.durability.storage_directory);
   }
   if (config_.durability.recover_on_startup) {
-    auto info = recovery_.RecoverData(&uuid_, repl_storage_state_, &vertices_, &edges_, &edges_metadata_, &edge_count_,
-                                      name_id_mapper_.get(), &indices_, &constraints_, config_, &wal_seq_num_,
-                                      &enum_store_, &schema_info_, [this](Gid edge_gid) { return FindEdge(edge_gid); });
+    auto info =
+        recovery_.RecoverData(&config_.salient.uuid, repl_storage_state_, &vertices_, &edges_, &edges_metadata_,
+                              &edge_count_, name_id_mapper_.get(), &indices_, &constraints_, config_, &wal_seq_num_,
+                              &enum_store_, &schema_info_, [this](Gid edge_gid) { return FindEdge(edge_gid); });
     if (info) {
       vertex_id_ = info->next_vertex_id;
       edge_id_ = info->next_edge_id;
@@ -2330,12 +2330,15 @@ StorageInfo InMemoryStorage::GetInfo() {
 }
 
 bool InMemoryStorage::InitializeWalFile(memgraph::replication::ReplicationEpoch &epoch) {
-  if (config_.durability.snapshot_wal_mode != Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL)
+  if (config_.durability.snapshot_wal_mode != Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL) {
     return false;
-  if (!wal_file_) {
-    wal_file_.emplace(recovery_.wal_directory_, uuid_, epoch.id(), config_.salient.items, name_id_mapper_.get(),
-                      wal_seq_num_++, &file_retainer_);
   }
+
+  if (!wal_file_) {
+    wal_file_.emplace(recovery_.wal_directory_, config_.salient.uuid, epoch.id(), config_.salient.items,
+                      name_id_mapper_.get(), wal_seq_num_++, &file_retainer_);
+  }
+
   return true;
 }
 
@@ -2674,7 +2677,7 @@ utils::BasicResult<InMemoryStorage::CreateSnapshotError> InMemoryStorage::Create
   Transaction *transaction = accessor->GetTransaction();
   auto const &epoch = repl_storage_state_.epoch_;
   durability::CreateSnapshot(this, transaction, recovery_.snapshot_directory_, recovery_.wal_directory_, &vertices_,
-                             &edges_, uuid_, epoch, repl_storage_state_.history, &file_retainer_);
+                             &edges_, config_.salient.uuid, epoch, repl_storage_state_.history, &file_retainer_);
 
   memgraph::metrics::Measure(memgraph::metrics::SnapshotCreationLatency_us,
                              std::chrono::duration_cast<std::chrono::microseconds>(timer.Elapsed()).count());
@@ -2740,7 +2743,7 @@ void InMemoryStorage::CreateSnapshotHandler(
           spdlog::warn(utils::MessageWithLink("Snapshots are disabled for replicas.", "https://memgr.ph/replication"));
           break;
         case CreateSnapshotError::ReachedMaxNumTries:
-          spdlog::warn("Failed to create snapshot. Reached max number of tries. Please contact support");
+          spdlog::warn("Failed to create snapshot. Reached max number of tries. Please contact support.");
           break;
       }
     }

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -563,8 +563,6 @@ class InMemoryStorage final : public Storage {
   utils::Scheduler snapshot_runner_;
   utils::SpinLock snapshot_lock_;
 
-  // UUID used to distinguish snapshots and to link snapshots to WALs
-  std::string uuid_;
   // Sequence number used to keep track of the chain of WALs.
   uint64_t wal_seq_num_{0};
 

--- a/src/storage/v2/replication/replication_client.hpp
+++ b/src/storage/v2/replication/replication_client.hpp
@@ -86,7 +86,7 @@ class ReplicaStream {
 
 class ReplicaStreamExecutor {
  public:
-  ReplicaStreamExecutor(std::optional<ReplicaStream> stream) : stream_(std::move(stream)) {}
+  explicit ReplicaStreamExecutor(std::optional<ReplicaStream> stream) : stream_(std::move(stream)) {}
   void operator()() const {}
 
  private:

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -167,7 +167,9 @@ class Storage {
 
   const std::string &name() const { return config_.salient.name; }
 
-  const utils::UUID &uuid() const { return config_.salient.uuid; }
+  auto uuid() const -> utils::UUID const & { return config_.salient.uuid; }
+
+  auto uuid() -> utils::UUID & { return config_.salient.uuid; }
 
   class Accessor {
    public:

--- a/src/utils/uuid.cpp
+++ b/src/utils/uuid.cpp
@@ -20,7 +20,7 @@ std::string GenerateUUID() {
   char decoded[37];  // magic size from: man 2 uuid_unparse
   uuid_generate(uuid);
   uuid_unparse(uuid, decoded);
-  return std::string(decoded);
+  return {decoded};
 }
 
 }  // namespace memgraph::utils

--- a/src/utils/uuid.hpp
+++ b/src/utils/uuid.hpp
@@ -48,12 +48,12 @@ struct UUID {
     return std::string{decoded.data(), 37 /*UUID_STR_LEN*/ - 1};
   }
 
-  void set(std::string const &uuid_str) {
+  void set(std::string_view uuid_str) {
     if (uuid_str.length() != 36) {
       throw std::invalid_argument(
           fmt::format("Invalid UUID argument length. Length is {} and expected to be 36.", uuid_str.length()));
     }
-    if (uuid_parse(uuid_str.c_str(), uuid.data()) != 0) {
+    if (uuid_parse(uuid_str.data(), uuid.data()) != 0) {
       throw std::invalid_argument("Invalid UUID formatwhen setting new uuid string.");
     }
   }

--- a/src/utils/uuid.hpp
+++ b/src/utils/uuid.hpp
@@ -13,13 +13,15 @@
 
 #include <uuid/uuid.h>
 
+#include "fmt/format.h"
+
 #include <array>
 #include <json/json.hpp>
 #include <string>
 
 namespace memgraph::utils {
 struct UUID;
-}
+}  // namespace memgraph::utils
 
 namespace memgraph::slk {
 class Reader;
@@ -44,6 +46,16 @@ struct UUID {
     auto decoded = std::array<char, 37 /*UUID_STR_LEN*/>{};
     uuid_unparse(uuid.data(), decoded.data());
     return std::string{decoded.data(), 37 /*UUID_STR_LEN*/ - 1};
+  }
+
+  void set(std::string const &uuid_str) {
+    if (uuid_str.length() != 36) {
+      throw std::invalid_argument(
+          fmt::format("Invalid UUID argument length. Length is {} and expected to be 36.", uuid_str.length()));
+    }
+    if (uuid_parse(uuid_str.c_str(), uuid.data()) != 0) {
+      throw std::invalid_argument("Invalid UUID formatwhen setting new uuid string.");
+    }
   }
 
   explicit operator arr_t() const { return uuid; }

--- a/tests/unit/storage_v2_durability_inmemory.cpp
+++ b/tests/unit/storage_v2_durability_inmemory.cpp
@@ -3157,7 +3157,7 @@ TEST_P(DurabilityTest, ConstraintsRecoveryFunctionSetting) {
       config.durability.storage_directory / memgraph::storage::durability::kWalDirectory};
 
   // Recover snapshot.
-  const auto info = recovery.RecoverData(&uuid, repl_storage_state, &vertices, &edges, &edges_metadata, &edge_count,
+  const auto info = recovery.RecoverData(uuid, repl_storage_state, &vertices, &edges, &edges_metadata, &edge_count,
                                          name_id_mapper.get(), &indices, &constraints, config, &wal_seq_num,
                                          &enum_store, nullptr /* schema_info */, [](auto in) { return std::nullopt; });
 

--- a/tests/unit/storage_v2_durability_inmemory.cpp
+++ b/tests/unit/storage_v2_durability_inmemory.cpp
@@ -3146,7 +3146,7 @@ TEST_P(DurabilityTest, ConstraintsRecoveryFunctionSetting) {
   std::unique_ptr<memgraph::storage::NameIdMapper> name_id_mapper = std::make_unique<memgraph::storage::NameIdMapper>();
   std::atomic<uint64_t> edge_count{0};
   uint64_t wal_seq_num{0};
-  std::string uuid{memgraph::utils::GenerateUUID()};
+  memgraph::utils::UUID uuid;
   memgraph::storage::Indices indices{config, memgraph::storage::StorageMode::IN_MEMORY_TRANSACTIONAL};
   memgraph::storage::Constraints constraints{config, memgraph::storage::StorageMode::IN_MEMORY_TRANSACTIONAL};
   memgraph::storage::ReplicationStorageState repl_storage_state;

--- a/tests/unit/storage_v2_wal_file.cpp
+++ b/tests/unit/storage_v2_wal_file.cpp
@@ -223,8 +223,7 @@ class DeltaGenerator final {
 
   DeltaGenerator(const std::filesystem::path &data_directory, bool properties_on_edges, uint64_t seq_num,
                  memgraph::storage::StorageMode storage_mode = memgraph::storage::StorageMode::IN_MEMORY_TRANSACTIONAL)
-      : uuid_(memgraph::utils::GenerateUUID()),
-        epoch_id_(memgraph::utils::GenerateUUID()),
+      : epoch_id_(memgraph::utils::GenerateUUID()),
         seq_num_(seq_num),
         wal_file_(data_directory, uuid_, epoch_id_, {.properties_on_edges = properties_on_edges}, &mapper_, seq_num,
                   &file_retainer_),
@@ -462,7 +461,7 @@ class DeltaGenerator final {
   memgraph::storage::durability::WalInfo GetInfo() {
     return {.offset_metadata = 0,
             .offset_deltas = 0,
-            .uuid = uuid_,
+            .uuid = std::string{uuid_},
             .epoch_id = epoch_id_,
             .seq_num = seq_num_,
             .from_timestamp = tx_from_,
@@ -481,7 +480,7 @@ class DeltaGenerator final {
     deltas_count_ += count;
   }
 
-  std::string uuid_;
+  memgraph::utils::UUID uuid_;
   std::string epoch_id_;
   uint64_t seq_num_;
 


### PR DESCRIPTION
Combined storage's private and configured UUIDs. 
Bugfix: When replicating using current WAL, replica would change its uuid if the incoming WAL was MAIN's first WAL file. The correct check however is for replica to change uuid if this is REPLICA's 1st WAL. 
Bugfix: Possibility to have multiple SystemRestore executed in parallel.