### PR TITLE
Bugfix: Various issues with edge index

### DIFF
--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -303,9 +303,9 @@ void InMemoryReplicationHandlers::SnapshotHandler(dbms::DbmsHandler *dbms_handle
     storage->wal_seq_num_ = 0;
 
     spdlog::trace("Recovering indices and constraints from snapshot.");
-    memgraph::storage::durability::RecoverIndicesAndStats(recovered_snapshot.indices_constraints.indices,
-                                                          &storage->indices_, &storage->vertices_,
-                                                          storage->name_id_mapper_.get());
+    memgraph::storage::durability::RecoverIndicesAndStats(
+        recovered_snapshot.indices_constraints.indices, &storage->indices_, &storage->vertices_,
+        storage->name_id_mapper_.get(), storage->config_.salient.items.properties_on_edges);
     memgraph::storage::durability::RecoverConstraints(recovered_snapshot.indices_constraints.constraints,
                                                       &storage->constraints_, &storage->vertices_,
                                                       storage->name_id_mapper_.get());

--- a/src/query/exceptions.hpp
+++ b/src/query/exceptions.hpp
@@ -109,6 +109,14 @@ class IndexInMulticommandTxException : public QueryException {
   SPECIALIZE_GET_EXCEPTION_NAME(IndexInMulticommandTxException)
 };
 
+class EdgeIndexDisabledPropertiesOnEdgesException : public QueryException {
+ public:
+  using QueryException::QueryException;
+  EdgeIndexDisabledPropertiesOnEdgesException()
+      : QueryException("Edge indices are allowed only if properties are allowed on edges.") {}
+  SPECIALIZE_GET_EXCEPTION_NAME(EdgeIndexDisabledPropertiesOnEdgesException)
+};
+
 class SchemaAssertInMulticommandTxException : public QueryException {
  public:
   using QueryException::QueryException;

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -2930,6 +2930,10 @@ PreparedQuery PrepareEdgeIndexQuery(ParsedQuery parsed_query, bool in_explicit_t
     throw IndexInMulticommandTxException();
   }
 
+  if (!current_db.db_acc_->get()->config().salient.items.properties_on_edges) {
+    throw EdgeIndexDisabledPropertiesOnEdgesException();
+  }
+
   auto *index_query = utils::Downcast<EdgeIndexQuery>(parsed_query.query);
   std::function<void(Notification &)> handler;
 

--- a/src/storage/v2/durability/durability.hpp
+++ b/src/storage/v2/durability/durability.hpp
@@ -102,7 +102,7 @@ std::optional<std::vector<WalDurabilityInfo>> GetWalFiles(const std::filesystem:
 // recovery process.
 /// @throw RecoveryFailure
 void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadata &indices_metadata, Indices *indices,
-                            utils::SkipList<Vertex> *vertices, NameIdMapper *name_id_mapper,
+                            utils::SkipList<Vertex> *vertices, NameIdMapper *name_id_mapper, bool properties_on_edges,
                             const std::optional<ParallelizedSchemaCreationInfo> &parallel_exec_info = std::nullopt,
                             const std::optional<std::filesystem::path> &storage_dir = std::nullopt);
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -23,6 +23,7 @@
 #include "storage/v2/durability/snapshot.hpp"
 #include "storage/v2/edge_direction.hpp"
 #include "storage/v2/id_types.hpp"
+#include "storage/v2/indices/edge_type_property_index.hpp"
 #include "storage/v2/inmemory/edge_type_index.hpp"
 #include "storage/v2/inmemory/edge_type_property_index.hpp"
 #include "storage/v2/metadata_delta.hpp"
@@ -201,6 +202,7 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
       static_cast<InMemoryLabelIndex *>(indices_.label_index_.get())->RunGC();
       static_cast<InMemoryLabelPropertyIndex *>(indices_.label_property_index_.get())->RunGC();
       static_cast<InMemoryEdgeTypeIndex *>(indices_.edge_type_index_.get())->RunGC();
+      static_cast<InMemoryEdgeTypePropertyIndex *>(indices_.edge_type_property_index_.get())->RunGC();
 
       // SkipList is already threadsafe
       vertices_.run_gc();

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -554,6 +554,9 @@ Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdgeEx(VertexAcces
         transaction_.manyDeltasCache.Invalidate(from_vertex, edge_type, EdgeDirection::OUT);
         transaction_.manyDeltasCache.Invalidate(to_vertex, edge_type, EdgeDirection::IN);
 
+        // Update indices if they exist.
+        storage_->indices_.UpdateOnEdgeCreation(from_vertex, to_vertex, edge, edge_type, transaction_);
+
         // Increment edge count.
         storage_->edge_count_.fetch_add(1, std::memory_order_acq_rel);
 

--- a/tests/unit/storage_v2_indices.cpp
+++ b/tests/unit/storage_v2_indices.cpp
@@ -1456,6 +1456,16 @@ TYPED_TEST(IndexTest, EdgeTypeIndexCreate) {
 
       ASSERT_NO_ERROR(acc->Commit());
     }
+
+    // Check that GC doesn't remove useful elements
+    {
+      this->storage->FreeMemory({}, false);
+      auto acc = this->storage->Access();
+      EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, View::OLD), View::OLD),
+                  UnorderedElementsAre(1, 3, 5, 7, 9, 21, 23, 25, 27, 29));
+      EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, View::NEW), View::NEW),
+                  UnorderedElementsAre(1, 3, 5, 7, 9, 21, 23, 25, 27, 29));
+    }
   }
 }
 
@@ -1828,6 +1838,16 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexCreate) {
                 UnorderedElementsAre(1, 3, 5, 7, 9, 21, 23, 25, 27, 29));
 
     ASSERT_NO_ERROR(acc->Commit());
+  }
+
+  // Check that GC doesn't remove useful elements
+  {
+    this->storage->FreeMemory({}, false);
+    auto acc = this->storage->Access();
+    EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, this->edge_prop_id1, View::OLD), View::OLD),
+                UnorderedElementsAre(1, 3, 5, 7, 9, 21, 23, 25, 27, 29));
+    EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, this->edge_prop_id1, View::NEW), View::NEW),
+                UnorderedElementsAre(1, 3, 5, 7, 9, 21, 23, 25, 27, 29));
   }
 }
 


### PR DESCRIPTION
EdgeType index would assign every element as obsolete
EdgeTypeProperty index did not run GC
Allowed edge index creation even when properties on edges was false
Recovered edge indices even if properties on edges was false
EdgeType was not updated via `CreateEdgeEx`