### PR TITLE
Consecutive raft failover

### DIFF
--- a/.github/workflows/stress_jepsen.yaml
+++ b/.github/workflows/stress_jepsen.yaml
@@ -78,7 +78,7 @@ jobs:
           cd tests/jepsen
           ./run.sh test \
           --binary ../../build/memgraph \
-          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 1800 --concurrency 6" \
+          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 14400 --concurrency 6" \
           --ignore-run-stdout-logs \
           --ignore-run-stderr-logs \
           --nodes-no 6 \

--- a/.github/workflows/stress_jepsen.yaml
+++ b/.github/workflows/stress_jepsen.yaml
@@ -78,7 +78,7 @@ jobs:
           cd tests/jepsen
           ./run.sh test \
           --binary ../../build/memgraph \
-          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 14400 --concurrency 6" \
+          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 1800 --concurrency 6" \
           --ignore-run-stdout-logs \
           --ignore-run-stderr-logs \
           --nodes-no 6 \

--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -694,8 +694,8 @@ auto CoordinatorInstance::GetFailCallbackTypeName(ReplicationInstanceConnector c
 }
 
 auto CoordinatorInstance::TryVerifyOrCorrectClusterState() -> ReconcileClusterStateStatus {
-  // Follows nomenclature from replication handler where Try<> means doing action from
-  // user query
+  // Follows nomenclature from replication handler where Try<> means doing action from the
+  // user query.
   return ReconcileClusterState_();
 }
 
@@ -722,7 +722,7 @@ auto CoordinatorInstance::TryFailover() -> void {
   }
 
   auto &new_main = FindReplicationInstance(*maybe_most_up_to_date_instance);
-  spdlog::trace("Found new main {} to do failover", new_main.InstanceName());
+  spdlog::trace("Found new main {} to do failover.", new_main.InstanceName());
   if (!raft_state_->AppendOpenLock()) {
     spdlog::error("Aborting failover as instance is not anymore leader.");
     return;
@@ -789,9 +789,9 @@ auto CoordinatorInstance::TryFailover() -> void {
 
   if (!new_main.EnableWritingOnMain()) {
     spdlog::error("Failover successful but couldn't enable writing on instance.");
+  } else {
+    spdlog::info("Failover successful! Instance {} promoted to main.", new_main.InstanceName());
   }
-
-  spdlog::info("Failover successful! Instance {} promoted to main.", new_main.InstanceName());
 }
 
 auto CoordinatorInstance::SetReplicationInstanceToMain(std::string_view instance_name)

--- a/src/coordination/data_instance_management_server_handlers.cpp
+++ b/src/coordination/data_instance_management_server_handlers.cpp
@@ -30,42 +30,42 @@ void DataInstanceManagementServerHandlers::Register(memgraph::coordination::Data
 
   server.Register<coordination::DemoteMainToReplicaRpc>(
       [&replication_handler](slk::Reader *req_reader, slk::Builder *res_builder) -> void {
-        spdlog::info("Received DemoteMainToReplicaRpc from coordinator server");
+        spdlog::info("Received DemoteMainToReplicaRpc");
         DataInstanceManagementServerHandlers::DemoteMainToReplicaHandler(replication_handler, req_reader, res_builder);
       });
 
   server.Register<replication_coordination_glue::SwapMainUUIDRpc>(
       [&replication_handler](slk::Reader *req_reader, slk::Builder *res_builder) -> void {
-        spdlog::info("Received SwapMainUUIDRPC on coordinator server");
+        spdlog::info("Received SwapMainUUIDRPC");
         DataInstanceManagementServerHandlers::SwapMainUUIDHandler(replication_handler, req_reader, res_builder);
       });
 
   server.Register<coordination::UnregisterReplicaRpc>(
       [&replication_handler](slk::Reader *req_reader, slk::Builder *res_builder) -> void {
-        spdlog::info("Received UnregisterReplicaRpc on coordinator server");
+        spdlog::info("Received UnregisterReplicaRpc");
         DataInstanceManagementServerHandlers::UnregisterReplicaHandler(replication_handler, req_reader, res_builder);
       });
 
   server.Register<coordination::EnableWritingOnMainRpc>(
       [&replication_handler](slk::Reader *req_reader, slk::Builder *res_builder) -> void {
-        spdlog::info("Received EnableWritingOnMainRpc on coordinator server");
+        spdlog::info("Received EnableWritingOnMainRpc");
         DataInstanceManagementServerHandlers::EnableWritingOnMainHandler(replication_handler, req_reader, res_builder);
       });
 
   server.Register<coordination::GetInstanceUUIDRpc>(
       [&replication_handler](slk::Reader *req_reader, slk::Builder *res_builder) -> void {
-        spdlog::info("Received GetInstanceUUIDRpc on coordinator server");
+        spdlog::info("Received GetInstanceUUIDRpc");
         DataInstanceManagementServerHandlers::GetInstanceUUIDHandler(replication_handler, req_reader, res_builder);
       });
 
   server.Register<coordination::GetDatabaseHistoriesRpc>(
       [&replication_handler](slk::Reader *req_reader, slk::Builder *res_builder) -> void {
-        spdlog::info("Received GetDatabasesHistoryRpc on coordinator server");
+        spdlog::info("Received GetDatabasesHistoryRpc");
         DataInstanceManagementServerHandlers::GetDatabaseHistoriesHandler(replication_handler, req_reader, res_builder);
       });
   server.Register<coordination::RegisterReplicaOnMainRpc>([&replication_handler](slk::Reader *req_reader,
                                                                                  slk::Builder *res_builder) -> void {
-    spdlog::info("Received RegisterReplicaOnMainRpc on coordinator server");
+    spdlog::info("Received RegisterReplicaOnMainRpc");
     DataInstanceManagementServerHandlers::RegisterReplicaOnMainHandler(replication_handler, req_reader, res_builder);
   });
 }
@@ -73,29 +73,29 @@ void DataInstanceManagementServerHandlers::Register(memgraph::coordination::Data
 void DataInstanceManagementServerHandlers::GetDatabaseHistoriesHandler(
     replication::ReplicationHandler &replication_handler, slk::Reader * /*req_reader*/, slk::Builder *res_builder) {
   slk::Save(coordination::GetDatabaseHistoriesRes{replication_handler.GetDatabasesHistories()}, res_builder);
+  spdlog::info("Database's history returned successfully.");
 }
 
 void DataInstanceManagementServerHandlers::SwapMainUUIDHandler(replication::ReplicationHandler &replication_handler,
                                                                slk::Reader *req_reader, slk::Builder *res_builder) {
+  // TODO: (andi) Assert false here.
   if (!replication_handler.IsReplica()) {
-    spdlog::error("Setting main uuid must be performed on replica.");
+    spdlog::error("Setting uuid must be performed on replica.");
     slk::Save(replication_coordination_glue::SwapMainUUIDRes{false}, res_builder);
     return;
   }
 
   replication_coordination_glue::SwapMainUUIDReq req;
   slk::Load(&req, req_reader);
-  spdlog::info(fmt::format("Set replica data UUID  to main uuid {}", std::string(req.uuid)));
   std::get<memgraph::replication::RoleReplicaData>(replication_handler.GetReplState().ReplicationData()).uuid_ =
       req.uuid;
 
   slk::Save(replication_coordination_glue::SwapMainUUIDRes{true}, res_builder);
+  spdlog::info("UUID successfully set to {}.", std::string(req.uuid));
 }
 
 void DataInstanceManagementServerHandlers::DemoteMainToReplicaHandler(
     replication::ReplicationHandler &replication_handler, slk::Reader *req_reader, slk::Builder *res_builder) {
-  spdlog::info("Executing DemoteMainToReplicaHandler");
-
   coordination::DemoteMainToReplicaReq req;
   slk::Load(&req, req_reader);
 
@@ -110,14 +110,15 @@ void DataInstanceManagementServerHandlers::DemoteMainToReplicaHandler(
   }
 
   slk::Save(coordination::DemoteMainToReplicaRes{true}, res_builder);
+  spdlog::info("MAIN successfully demoted to REPLICA.");
 }
 
 void DataInstanceManagementServerHandlers::GetInstanceUUIDHandler(replication::ReplicationHandler &replication_handler,
                                                                   slk::Reader * /*req_reader*/,
                                                                   slk::Builder *res_builder) {
-  spdlog::info("Executing GetInstanceUUIDHandler");
-
-  slk::Save(coordination::GetInstanceUUIDRes{replication_handler.GetReplicaUUID()}, res_builder);
+  auto const replica_uuid = replication_handler.GetReplicaUUID();
+  slk::Save(coordination::GetInstanceUUIDRes{replica_uuid}, res_builder);
+  spdlog::info("Replica's UUID returned successfully: {}", replica_uuid ? std::string(*replica_uuid) : "");
 }
 
 void DataInstanceManagementServerHandlers::PromoteReplicaToMainHandler(
@@ -144,8 +145,8 @@ void DataInstanceManagementServerHandlers::PromoteReplicaToMainHandler(
       return;
     }
   }
-  spdlog::info("Promote replica to main was success {}", std::string(req.main_uuid));
   slk::Save(coordination::PromoteReplicaToMainRes{true}, res_builder);
+  spdlog::info("Promoting replica to main finished successfully. New MAIN's uuid: {}", std::string(req.main_uuid));
 }
 
 void DataInstanceManagementServerHandlers::RegisterReplicaOnMainHandler(
@@ -162,7 +163,7 @@ void DataInstanceManagementServerHandlers::RegisterReplicaOnMainHandler(
   // We don't handle disk issues.
   auto const &main_uuid = replication_handler.GetReplState().GetMainRole().uuid_;
   if (req.main_uuid != main_uuid) {
-    spdlog::error("Registering replica to main failed because MAIN has uuid {} and coordinator has sent uuid {}!",
+    spdlog::error("Registering replica to main failed because MAIN's uuid {} != from coordinator's uuid {}!",
                   std::string(req.main_uuid), std::string(main_uuid));
     slk::Save(coordination::RegisterReplicaOnMainRes{false}, res_builder);
     return;
@@ -170,11 +171,12 @@ void DataInstanceManagementServerHandlers::RegisterReplicaOnMainHandler(
 
   if (!DoRegisterReplica<coordination::RegisterReplicaOnMainRes>(replication_handler, req.replication_client_info,
                                                                  res_builder)) {
+    spdlog::error("Replica {} couldn't be registered.", req.replication_client_info.instance_name);
     return;
   }
 
-  spdlog::info("Registering replica {} to main was success ", req.replication_client_info.instance_name);
   slk::Save(coordination::RegisterReplicaOnMainRes{true}, res_builder);
+  spdlog::info("Registering replica {} to main finished successfully.", req.replication_client_info.instance_name);
 }
 
 void DataInstanceManagementServerHandlers::UnregisterReplicaHandler(
@@ -207,6 +209,7 @@ void DataInstanceManagementServerHandlers::UnregisterReplicaHandler(
       slk::Save(coordination::UnregisterReplicaRes{false}, res_builder);
       break;
   }
+  spdlog::info("Replica {} successfully unregistered.", req.instance_name);
 }
 
 void DataInstanceManagementServerHandlers::EnableWritingOnMainHandler(
@@ -224,6 +227,7 @@ void DataInstanceManagementServerHandlers::EnableWritingOnMainHandler(
   }
 
   slk::Save(coordination::EnableWritingOnMainRes{true}, res_builder);
+  spdlog::info("Enabled writing on main.");
 }
 
 }  // namespace memgraph::dbms

--- a/src/coordination/data_instance_management_server_handlers.cpp
+++ b/src/coordination/data_instance_management_server_handlers.cpp
@@ -78,7 +78,6 @@ void DataInstanceManagementServerHandlers::GetDatabaseHistoriesHandler(
 
 void DataInstanceManagementServerHandlers::SwapMainUUIDHandler(replication::ReplicationHandler &replication_handler,
                                                                slk::Reader *req_reader, slk::Builder *res_builder) {
-  // TODO: (andi) Assert false here.
   if (!replication_handler.IsReplica()) {
     spdlog::error("Setting uuid must be performed on replica.");
     slk::Save(replication_coordination_glue::SwapMainUUIDRes{false}, res_builder);
@@ -118,13 +117,13 @@ void DataInstanceManagementServerHandlers::GetInstanceUUIDHandler(replication::R
                                                                   slk::Builder *res_builder) {
   auto const replica_uuid = replication_handler.GetReplicaUUID();
   slk::Save(coordination::GetInstanceUUIDRes{replica_uuid}, res_builder);
-  spdlog::info("Replica's UUID returned successfully: {}", replica_uuid ? std::string(*replica_uuid) : "");
+  spdlog::info("Replica's UUID returned successfully: {}.", replica_uuid ? std::string{*replica_uuid} : "");
 }
 
 void DataInstanceManagementServerHandlers::PromoteReplicaToMainHandler(
     replication::ReplicationHandler &replication_handler, slk::Reader *req_reader, slk::Builder *res_builder) {
   if (!replication_handler.IsReplica()) {
-    spdlog::error("Promote to main must be performed on replica!");
+    spdlog::error("Promote to main must be performed on replica.");
     slk::Save(coordination::PromoteReplicaToMainRes{false}, res_builder);
     return;
   }
@@ -134,7 +133,7 @@ void DataInstanceManagementServerHandlers::PromoteReplicaToMainHandler(
   // This can fail because of disk. If it does, the cluster state could get inconsistent.
   // We don't handle disk issues.
   if (const bool success = replication_handler.DoReplicaToMainPromotion(req.main_uuid); !success) {
-    spdlog::error("Promoting replica to main failed!");
+    spdlog::error("Promoting replica to main failed.");
     slk::Save(coordination::PromoteReplicaToMainRes{false}, res_builder);
     return;
   }
@@ -200,7 +199,7 @@ void DataInstanceManagementServerHandlers::UnregisterReplicaHandler(
       spdlog::error("Unregistering replica must be performed on main.");
       slk::Save(coordination::UnregisterReplicaRes{false}, res_builder);
       break;
-    case CAN_NOT_UNREGISTER:
+    case CANNOT_UNREGISTER:
       spdlog::error("Could not unregister replica.");
       slk::Save(coordination::UnregisterReplicaRes{false}, res_builder);
       break;

--- a/src/coordination/include/coordination/data_instance_management_server_handlers.hpp
+++ b/src/coordination/include/coordination/data_instance_management_server_handlers.hpp
@@ -60,32 +60,50 @@ class DataInstanceManagementServerHandlers {
 
     auto instance_client = replication_handler.RegisterReplica(converter(config));
     if (instance_client.HasError()) {
-      using enum memgraph::replication::RegisterReplicaError;
+      using memgraph::query::RegisterReplicaError;
       switch (instance_client.GetError()) {
-        // Can't happen, checked on the coordinator side
-        case memgraph::query::RegisterReplicaError::NAME_EXISTS:
-          spdlog::error("Replica with the same name already exists!");
+        case RegisterReplicaError::NOT_MAIN: {
+          spdlog::error("Error when registering instance {} as replica. Instance not main anymore.",
+                        config.instance_name);
           slk::Save(TResponse{false}, res_builder);
           return false;
-        // Can't happen, checked on the coordinator side
-        case memgraph::query::RegisterReplicaError::ENDPOINT_EXISTS:
-          spdlog::error("Replica with the same endpoint already exists!");
+        }
+        case RegisterReplicaError::NAME_EXISTS: {
+          spdlog::error(
+              "Error when registering instance {} as replica. Instance with the same name already registered.",
+              config.instance_name);
           slk::Save(TResponse{false}, res_builder);
           return false;
-        // We don't handle disk issues
-        case memgraph::query::RegisterReplicaError::COULD_NOT_BE_PERSISTED:
-          spdlog::error("Registered replica could not be persisted!");
+        }
+        case RegisterReplicaError::ENDPOINT_EXISTS: {
+          spdlog::error(
+              "Error when registering instance {} as replica. Instance with the same endpoint already exists.",
+              config.instance_name);
           slk::Save(TResponse{false}, res_builder);
           return false;
-        case memgraph::query::RegisterReplicaError::ERROR_ACCEPTING_MAIN:
-          spdlog::error("Replica didn't accept change of main!");
+        }
+        case RegisterReplicaError::COULD_NOT_BE_PERSISTED: {
+          spdlog::error("Error when registering instance {} as replica. Registering instance could not be persisted.",
+                        config.instance_name);
           slk::Save(TResponse{false}, res_builder);
           return false;
-        case memgraph::query::RegisterReplicaError::CONNECTION_FAILED:
-          // Connection failure is not a fatal error
-          break;
+        }
+        case RegisterReplicaError::ERROR_ACCEPTING_MAIN: {
+          spdlog::error("Error when registering instance {} as replica. Instance couldn't accept change of main.",
+                        config.instance_name);
+          slk::Save(TResponse{false}, res_builder);
+          return false;
+        }
+        case RegisterReplicaError::CONNECTION_FAILED: {
+          spdlog::error(
+              "Error when registering instance {} as replica. Instance couldn't register all databases successfully.",
+              config.instance_name);
+          slk::Save(TResponse{false}, res_builder);
+          return false;
+        }
       }
     }
+    spdlog::trace("Instance {} successfully registered as replica.", config.instance_name);
     return true;
   }
 };

--- a/src/coordination/replication_instance_client.cpp
+++ b/src/coordination/replication_instance_client.cpp
@@ -173,7 +173,7 @@ auto ReplicationInstanceClient::SendGetInstanceUUIDRpc() const
     auto res = stream.AwaitResponse();
     return res.uuid;
   } catch (const rpc::RpcFailedException &) {
-    spdlog::error("Failed to receive RPC response when sending GetInstance UUID RPC");
+    spdlog::error("Failed to receive RPC response when sending GetInstanceUUIDRPC");
     return GetInstanceUUIDError::RPC_EXCEPTION;
   }
 }

--- a/src/coordination/replication_instance_connector.cpp
+++ b/src/coordination/replication_instance_connector.cpp
@@ -106,25 +106,34 @@ auto ReplicationInstanceConnector::GetFailCallback() const -> HealthCheckInstanc
 auto ReplicationInstanceConnector::GetClient() -> ReplicationInstanceClient & { return *client_; }
 
 auto ReplicationInstanceConnector::EnsureReplicaHasCorrectMainUUID(utils::UUID const &curr_main_uuid) -> bool {
+  auto const instance_name{InstanceName()};
+  auto const main_uuid_str{std::string{curr_main_uuid}};
   if (!IsReadyForUUIDPing()) {
-    spdlog::trace("Replica's cached MAIN uuid still valid, not sending GetInstanceUUID");
+    spdlog::trace(
+        "Instance {}'s cached MAIN uuid didn't expire yet, not sending GetInstanceUUIDRpc. Curr main uuid {}.",
+        instance_name, main_uuid_str);
     return true;
   }
-  spdlog::trace("Replica's cached MAIN uuid expired, sending GetInstanceUUIDRpc.");
-  auto res = SendGetInstanceUUID();
+  spdlog::trace("Instance {}'s cached MAIN uuid expired, sending GetInstanceUUIDRpc.", instance_name);
+
+  auto const res = SendGetInstanceUUID();
   if (res.HasError()) {
-    spdlog::trace("Couldn't verify that replica still knows about the correct main uuid");
+    spdlog::trace("Couldn't verify that instance {} still has correct cached view of main uuid {}.", instance_name,
+                  main_uuid_str);
     return false;
   }
   UpdateReplicaLastResponseUUID();
 
   // NOLINTNEXTLINE
-  if (res.GetValue().has_value() && res.GetValue().value() == curr_main_uuid) {
-    spdlog::trace("Replica's view of the main uuid is still valid. Not sending request for swaping and updating UUID.");
+  if (res.GetValue().has_value() && *res.GetValue() == curr_main_uuid) {
+    spdlog::trace(
+        "Instance {}'s view of the main uuid {} is still valid. Not sending request for swaping and updating UUID.",
+        instance_name, main_uuid_str);
     return true;
   }
 
-  spdlog::trace("Replica's view of the main uuid not valid anymore. Sending request for updating UUID.");
+  spdlog::trace("Instance {}'s view of the main uuid {} not valid anymore. Sending request for updating UUID to {}.",
+                instance_name, std::string{*res.GetValue()}, main_uuid_str);
   return SendSwapAndUpdateUUID(curr_main_uuid);
 }
 

--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -35,6 +35,8 @@ constexpr std::string_view kDBPrefix = "database:";  // Key prefix for database 
 std::string RegisterReplicaErrorToString(query::RegisterReplicaError error) {
   switch (error) {
     using enum query::RegisterReplicaError;
+    case NOT_MAIN:
+      return "NOT_MAIN";
     case NAME_EXISTS:
       return "NAME_EXISTS";
     case ENDPOINT_EXISTS:

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -142,7 +142,7 @@ void InMemoryReplicationHandlers::SwapMainUUIDHandler(dbms::DbmsHandler *dbms_ha
 
   replication_coordination_glue::SwapMainUUIDReq req;
   slk::Load(&req, req_reader);
-  spdlog::info("Set replica data UUID  to main uuid {}", std::string(req.uuid));
+  spdlog::info("Set replica data UUID to main uuid {}", std::string(req.uuid));
   dbms_handler->ReplicationState().TryPersistRoleReplica(role_replica_data.config, req.uuid);
   role_replica_data.uuid_ = req.uuid;
 
@@ -291,7 +291,7 @@ void InMemoryReplicationHandlers::SnapshotHandler(dbms::DbmsHandler *dbms_handle
     spdlog::debug("Snapshot loaded successfully");
     // If this step is present it should always be the first step of
     // the recovery so we use the UUID we read from snasphost
-    storage->uuid_ = std::move(recovered_snapshot.snapshot_info.uuid);
+    storage->config_.salient.uuid.set(recovered_snapshot.snapshot_info.uuid);
     storage->repl_storage_state_.epoch_.SetEpoch(std::move(recovered_snapshot.snapshot_info.epoch_id));
     const auto &recovery_info = recovered_snapshot.recovery_info;
     storage->vertex_id_ = recovery_info.next_vertex_id;
@@ -318,8 +318,10 @@ void InMemoryReplicationHandlers::SnapshotHandler(dbms::DbmsHandler *dbms_handle
   slk::Save(res, res_builder);
 
   spdlog::trace("Deleting old snapshot files due to snapshot recovery.");
+
+  auto uuid_str = std::string{storage->config_.salient.uuid};
   // Delete other durability files
-  auto snapshot_files = storage::durability::GetSnapshotFiles(storage->recovery_.snapshot_directory_, storage->uuid_);
+  auto snapshot_files = storage::durability::GetSnapshotFiles(storage->recovery_.snapshot_directory_, uuid_str);
   for (const auto &[path, uuid, _] : snapshot_files) {
     if (path != *maybe_snapshot_path) {
       spdlog::trace("Deleting snapshot file {}", path);
@@ -328,7 +330,7 @@ void InMemoryReplicationHandlers::SnapshotHandler(dbms::DbmsHandler *dbms_handle
   }
 
   spdlog::trace("Deleting old WAL files due to snapshot recovery.");
-  auto wal_files = storage::durability::GetWalFiles(storage->recovery_.wal_directory_, storage->uuid_);
+  auto wal_files = storage::durability::GetWalFiles(storage->recovery_.wal_directory_, uuid_str);
   if (wal_files) {
     for (const auto &wal_file : *wal_files) {
       spdlog::trace("Deleting WAL file {}", wal_file.path);
@@ -394,15 +396,17 @@ void InMemoryReplicationHandlers::ForceResetStorageHandler(dbms::DbmsHandler *db
   slk::Save(res, res_builder);
 
   spdlog::trace("Deleting old snapshot files.");
+
+  auto const uuid_str = std::string{storage->config_.salient.uuid};
   // Delete other durability files
-  auto snapshot_files = storage::durability::GetSnapshotFiles(storage->recovery_.snapshot_directory_, storage->uuid_);
+  auto snapshot_files = storage::durability::GetSnapshotFiles(storage->recovery_.snapshot_directory_, uuid_str);
   for (const auto &[path, uuid, _] : snapshot_files) {
     spdlog::trace("Deleting snapshot file {}", path);
     storage->file_retainer_.DeleteFile(path);
   }
 
   spdlog::trace("Deleting old WAL files.");
-  auto wal_files = storage::durability::GetWalFiles(storage->recovery_.wal_directory_, storage->uuid_);
+  auto wal_files = storage::durability::GetWalFiles(storage->recovery_.wal_directory_, uuid_str);
   if (wal_files) {
     for (const auto &wal_file : *wal_files) {
       spdlog::trace("Deleting WAL file {}", wal_file.path);
@@ -488,9 +492,12 @@ void InMemoryReplicationHandlers::LoadWal(storage::InMemoryStorage *storage, sto
   spdlog::trace("Received WAL saved to {}", *maybe_wal_path);
   try {
     auto wal_info = storage::durability::ReadWalInfo(*maybe_wal_path);
-    if (wal_info.seq_num == 0) {
-      storage->uuid_ = wal_info.uuid;
+
+    // We have to check if this is our 1st wal, not what main is sending
+    if (storage->wal_seq_num_ == 0) {
+      storage->config_.salient.uuid.set(wal_info.uuid);
     }
+
     auto &replica_epoch = storage->repl_storage_state_.epoch_;
     if (wal_info.epoch_id != replica_epoch.id()) {
       // questionable behaviour, we trust that any change in epoch implies change in who is MAIN

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -356,7 +356,7 @@ class ReplQueryHandler {
       const auto error = handler_->TryRegisterReplica(replication_config).HasError();
 
       if (error) {
-        throw QueryRuntimeException(fmt::format("Couldn't register replica '{}'!", name));
+        throw QueryRuntimeException("Couldn't register replica {}.", name);
       }
 
     } else {
@@ -373,8 +373,8 @@ class ReplQueryHandler {
         throw QueryRuntimeException("Replica can't unregister a replica!");
       case COULD_NOT_BE_PERSISTED:
         [[fallthrough]];
-      case CAN_NOT_UNREGISTER:
-        throw QueryRuntimeException(fmt::format("Couldn't unregister the replica '{}'", replica_name));
+      case CANNOT_UNREGISTER:
+        throw QueryRuntimeException("Couldn't unregister the replica {}.", replica_name);
       case SUCCESS:
         break;
     }

--- a/src/query/replication_query_handler.hpp
+++ b/src/query/replication_query_handler.hpp
@@ -28,6 +28,7 @@ struct ReplicationClientConfig;
 namespace memgraph::query {
 
 enum class RegisterReplicaError : uint8_t {
+  NOT_MAIN,
   NAME_EXISTS,
   ENDPOINT_EXISTS,
   CONNECTION_FAILED,
@@ -38,7 +39,7 @@ enum class RegisterReplicaError : uint8_t {
 enum class UnregisterReplicaResult : uint8_t {
   NOT_MAIN,
   COULD_NOT_BE_PERSISTED,
-  CAN_NOT_UNREGISTER,
+  CANNOT_UNREGISTER,
   SUCCESS,
 };
 

--- a/src/replication_handler/include/replication_handler/replication_handler.hpp
+++ b/src/replication_handler/include/replication_handler/replication_handler.hpp
@@ -234,11 +234,11 @@ struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
       switch (unregister_res) {
         using memgraph::query::UnregisterReplicaResult;
         case UnregisterReplicaResult::NOT_MAIN:
-          MG_ASSERT(false,
-                    "Failed to unregister replica {} after failed registration process since the instance isn't main "
-                    "anymore. The instance left in unconsistent state, the administrator should manually delete the "
-                    "data and restart process.",
-                    config.name);
+          spdlog::trace(
+              "Failed to unregister replica {} after failed registration process since the instance isn't main "
+              "anymore. The instance left in unconsistent state, the administrator should manually delete the "
+              "data and restart process.",
+              config.name);
           break;
         case UnregisterReplicaResult::COULD_NOT_BE_PERSISTED:
           MG_ASSERT(
@@ -249,8 +249,7 @@ struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
               config.name);
           break;
         case UnregisterReplicaResult::CANNOT_UNREGISTER:
-          MG_ASSERT(
-              false,
+          spdlog::trace(
               "Failed to unregister replica {} after failed registration process since unregistration unsuccessful for "
               "all database clients. The instance left in unconsistent state, the administrator should manually delete "
               "the data and restart process.",

--- a/src/replication_handler/include/replication_handler/replication_handler.hpp
+++ b/src/replication_handler/include/replication_handler/replication_handler.hpp
@@ -47,9 +47,8 @@ void SystemRestore(replication::ReplicationClient &client, system::System &syste
     return;
 
   // Try to recover...
-  client.state_.WithLock(
-      [](auto &state) { return state != memgraph::replication::ReplicationClient::State::RECOVERY; });
-  {
+  if (client.state_.WithLock(
+          [](auto &state) { return state != memgraph::replication::ReplicationClient::State::RECOVERY; })) {
     bool is_enterprise = license::global_license_checker.IsEnterpriseValidFast();
     // We still need to system replicate
     struct DbInfo {
@@ -197,7 +196,7 @@ struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
 
     auto &instance_client_ptr = maybe_client.GetValue();
     bool all_clients_good{true};
-    // Add database specific clients (NOTE Currently all databases are connected to each replica)
+    // Add database specific clients (NOTE: Currently all databases are connected to each replica)
     dbms_handler_.ForEach([&](dbms::DatabaseAccess db_acc) {
       auto *storage = db_acc->storage();
       // TODO: ATM only IN_MEMORY_TRANSACTIONAL, fix other modes

--- a/src/replication_handler/include/replication_handler/replication_handler.hpp
+++ b/src/replication_handler/include/replication_handler/replication_handler.hpp
@@ -157,24 +157,26 @@ struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
   template <bool SendSwapUUID>
   auto RegisterReplica_(const memgraph::replication::ReplicationClientConfig &config)
       -> memgraph::utils::BasicResult<memgraph::query::RegisterReplicaError> {
-    MG_ASSERT(repl_state_.IsMain(), "Only main instance can register a replica!");
+    using memgraph::query::RegisterReplicaError;
+    using ClientRegisterReplicaError = memgraph::replication::RegisterReplicaError;
+
     auto maybe_client = repl_state_.RegisterReplica(config);
     if (maybe_client.HasError()) {
       switch (maybe_client.GetError()) {
-        case memgraph::replication::RegisterReplicaError::NOT_MAIN:
-          MG_ASSERT(false, "Only main instance can register a replica!");
-          return {};
-        case memgraph::replication::RegisterReplicaError::NAME_EXISTS:
-          return memgraph::query::RegisterReplicaError::NAME_EXISTS;
-        case memgraph::replication::RegisterReplicaError::ENDPOINT_EXISTS:
-          return memgraph::query::RegisterReplicaError::ENDPOINT_EXISTS;
-        case memgraph::replication::RegisterReplicaError::COULD_NOT_BE_PERSISTED:
-          return memgraph::query::RegisterReplicaError::COULD_NOT_BE_PERSISTED;
-        case memgraph::replication::RegisterReplicaError::SUCCESS:
+        case ClientRegisterReplicaError::NOT_MAIN:
+          return RegisterReplicaError::NOT_MAIN;
+        case ClientRegisterReplicaError::NAME_EXISTS:
+          return RegisterReplicaError::NAME_EXISTS;
+        case ClientRegisterReplicaError::ENDPOINT_EXISTS:
+          return RegisterReplicaError::ENDPOINT_EXISTS;
+        case ClientRegisterReplicaError::COULD_NOT_BE_PERSISTED:
+          return RegisterReplicaError::COULD_NOT_BE_PERSISTED;
+        case ClientRegisterReplicaError::SUCCESS:
           break;
       }
     }
-    const auto main_uuid =
+
+    auto const main_uuid =
         std::get<memgraph::replication::RoleMainData>(dbms_handler_.ReplicationState().ReplicationData()).uuid_;
     if constexpr (SendSwapUUID) {
       if (!memgraph::replication_coordination_glue::SendSwapMainUUIDRpc(maybe_client.GetValue()->rpc_client_,
@@ -182,21 +184,25 @@ struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
         return memgraph::query::RegisterReplicaError::ERROR_ACCEPTING_MAIN;
       }
     }
+
 #ifdef MG_ENTERPRISE
     // Update system before enabling individual storage <-> replica clients
     SystemRestore(*maybe_client.GetValue(), system_, dbms_handler_, main_uuid, auth_);
 #endif
+
     const auto dbms_error = HandleRegisterReplicaStatus(maybe_client);
     if (dbms_error.has_value()) {
       return *dbms_error;
     }
+
     auto &instance_client_ptr = maybe_client.GetValue();
-    bool all_clients_good = true;
+    bool all_clients_good{true};
     // Add database specific clients (NOTE Currently all databases are connected to each replica)
     dbms_handler_.ForEach([&](dbms::DatabaseAccess db_acc) {
       auto *storage = db_acc->storage();
       // TODO: ATM only IN_MEMORY_TRANSACTIONAL, fix other modes
       if (storage->storage_mode_ != storage::StorageMode::IN_MEMORY_TRANSACTIONAL) return;
+
       all_clients_good &= storage->repl_storage_state_.replication_clients_.WithLock(
           [is_data_instance_managed_by_coord = flags::CoordinationSetupInstance().IsDataInstanceManagedByCoordinator(),
            storage, &instance_client_ptr, db_acc = std::move(db_acc),
@@ -221,12 +227,42 @@ struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
             return success;
           });
     });
-    // NOTE Currently if any databases fails, we revert back
+
     if (!all_clients_good) {
-      spdlog::error("Failed to register all databases on the REPLICA \"{}\"", config.name);
-      UnregisterReplica(config.name);
-      return memgraph::query::RegisterReplicaError::CONNECTION_FAILED;
+      spdlog::error("Failed to register all databases for the replica {}. Started unregistering replica.", config.name);
+      auto const unregister_res{UnregisterReplica(config.name)};
+      switch (unregister_res) {
+        using memgraph::query::UnregisterReplicaResult;
+        case UnregisterReplicaResult::NOT_MAIN:
+          MG_ASSERT(false,
+                    "Failed to unregister replica {} after failed registration process since the instance isn't main "
+                    "anymore. The instance left in unconsistent state, the administrator should manually delete the "
+                    "data and restart process.",
+                    config.name);
+          break;
+        case UnregisterReplicaResult::COULD_NOT_BE_PERSISTED:
+          MG_ASSERT(
+              false,
+              "Failed to unregister replica {} after failed registration process since unregistration couldn't be "
+              "persisted. The instance left in unconsistent state, the administrator should manually delete the data "
+              "and restart process.",
+              config.name);
+          break;
+        case UnregisterReplicaResult::CANNOT_UNREGISTER:
+          MG_ASSERT(
+              false,
+              "Failed to unregister replica {} after failed registration process since unregistration unsuccessful for "
+              "all database clients. The instance left in unconsistent state, the administrator should manually delete "
+              "the data and restart process.",
+              config.name);
+          break;
+        case UnregisterReplicaResult::SUCCESS:
+          spdlog::trace("Replica {} successfully unregistered after failed registration process.", config.name);
+          break;
+      }
+      return RegisterReplicaError::CONNECTION_FAILED;
     }
+
     // No client error, start instance level client
 #ifdef MG_ENTERPRISE
     StartReplicaClient(*instance_client_ptr, system_, dbms_handler_, main_uuid, auth_);

--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -474,12 +474,15 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
       return std::nullopt;
     }
 
+    // sort by path
     std::sort(wal_files.begin(), wal_files.end());
 
     // UUID used for durability is the UUID of the last WAL file.
     // Same for the epoch id.
     *uuid = std::move(wal_files.back().uuid);
     repl_storage_state.epoch_.SetEpoch(std::move(wal_files.back().epoch_id));
+    spdlog::trace("UUID of the last WAL file: {}. Epoch id from the last WAL file: {}.", *uuid,
+                  repl_storage_state.epoch_.id());
   }
 
   auto maybe_wal_files = GetWalFiles(wal_directory_, *uuid);

--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -128,12 +128,18 @@ std::optional<std::vector<WalDurabilityInfo>> GetWalFiles(const std::filesystem:
     try {
       auto info = ReadWalInfo(item.path());
       spdlog::trace(
-          "Getting wal file with following info: uuid: {}, epoch id: {}, from timestamp {}, to_timestamp {}, sequence "
+          "Reading wal file {} with following info: uuid: {}, epoch id: {}, from timestamp {}, to_timestamp {}, "
+          "sequence "
           "number {}.",
-          info.uuid, info.epoch_id, info.from_timestamp, info.to_timestamp, info.seq_num);
+          item.path(), info.uuid, info.epoch_id, info.from_timestamp, info.to_timestamp, info.seq_num);
       if ((uuid.empty() || info.uuid == uuid) && (!current_seq_num || info.seq_num < *current_seq_num)) {
         wal_files.emplace_back(info.seq_num, info.from_timestamp, info.to_timestamp, std::move(info.uuid),
                                std::move(info.epoch_id), item.path());
+        spdlog::trace("Wal file {} will be used for recovery.", item.path());
+      } else {
+        spdlog::trace(
+            "Wal file {} won't be used for recovery. UUID: {}. Info UUID: {}. Current seq num: {}. Info seq num: {}.",
+            item.path(), uuid, info.uuid, current_seq_num, info.seq_num);
       }
     } catch (const RecoveryFailure &e) {
       spdlog::warn("Failed to read WAL file {}.", item.path());

--- a/src/storage/v2/durability/durability.hpp
+++ b/src/storage/v2/durability/durability.hpp
@@ -136,7 +136,7 @@ struct Recovery {
   /// @throw RecoveryFailure
   /// @throw std::bad_alloc
   std::optional<RecoveryInfo> RecoverData(
-      std::string *uuid, ReplicationStorageState &repl_storage_state, utils::SkipList<Vertex> *vertices,
+      utils::UUID *uuid, ReplicationStorageState &repl_storage_state, utils::SkipList<Vertex> *vertices,
       utils::SkipList<Edge> *edges, utils::SkipList<EdgeMetadata> *edges_metadata, std::atomic<uint64_t> *edge_count,
       NameIdMapper *name_id_mapper, Indices *indices, Constraints *constraints, Config const &config,
       uint64_t *wal_seq_num, EnumStore *enum_store, SchemaInfo *schema_info,

--- a/src/storage/v2/durability/snapshot.hpp
+++ b/src/storage/v2/durability/snapshot.hpp
@@ -74,7 +74,7 @@ RecoveredSnapshot LoadSnapshot(std::filesystem::path const &path, utils::SkipLis
 
 void CreateSnapshot(Storage *storage, Transaction *transaction, const std::filesystem::path &snapshot_directory,
                     const std::filesystem::path &wal_directory, utils::SkipList<Vertex> *vertices,
-                    utils::SkipList<Edge> *edges, const std::string &uuid,
+                    utils::SkipList<Edge> *edges, utils::UUID const &uuid,
                     const memgraph::replication::ReplicationEpoch &epoch,
                     const std::deque<std::pair<std::string, uint64_t>> &epoch_history,
                     utils::FileRetainer *file_retainer);

--- a/src/storage/v2/durability/wal.cpp
+++ b/src/storage/v2/durability/wal.cpp
@@ -1242,9 +1242,9 @@ RecoveryInfo LoadWal(const std::filesystem::path &path, RecoveredIndicesAndConst
   return ret;
 }
 
-WalFile::WalFile(const std::filesystem::path &wal_directory, const std::string_view uuid,
-                 const std::string_view epoch_id, SalientConfig::Items items, NameIdMapper *name_id_mapper,
-                 uint64_t seq_num, utils::FileRetainer *file_retainer)
+WalFile::WalFile(const std::filesystem::path &wal_directory, utils::UUID const &uuid, const std::string_view epoch_id,
+                 SalientConfig::Items items, NameIdMapper *name_id_mapper, uint64_t seq_num,
+                 utils::FileRetainer *file_retainer)
     : items_(items),
       name_id_mapper_(name_id_mapper),
       path_(wal_directory / MakeWalName()),
@@ -1271,7 +1271,7 @@ WalFile::WalFile(const std::filesystem::path &wal_directory, const std::string_v
   // Write metadata.
   offset_metadata = wal_.GetPosition();
   wal_.WriteMarker(Marker::SECTION_METADATA);
-  wal_.WriteString(uuid);
+  wal_.WriteString(std::string{uuid});
   wal_.WriteString(epoch_id);
   wal_.WriteUint(seq_num);
 

--- a/src/storage/v2/durability/wal.hpp
+++ b/src/storage/v2/durability/wal.hpp
@@ -300,7 +300,7 @@ RecoveryInfo LoadWal(std::filesystem::path const &path, RecoveredIndicesAndConst
 /// WalFile class used to append deltas and operations to the WAL file.
 class WalFile {
  public:
-  WalFile(const std::filesystem::path &wal_directory, const std::string_view uuid, const std::string_view epoch_id,
+  WalFile(const std::filesystem::path &wal_directory, utils::UUID const &uuid, const std::string_view epoch_id,
           SalientConfig::Items items, NameIdMapper *name_id_mapper, uint64_t seq_num,
           utils::FileRetainer *file_retainer);
   WalFile(std::filesystem::path current_wal_path, SalientConfig::Items items, NameIdMapper *name_id_mapper,

--- a/src/storage/v2/inmemory/replication/recovery.cpp
+++ b/src/storage/v2/inmemory/replication/recovery.cpp
@@ -154,7 +154,8 @@ std::vector<RecoveryStep> GetRecoverySteps(uint64_t replica_commit, utils::FileR
       release_wal_dir(  // Each individually used file will be locked, so at the end, the dir can be released
           [&locker_acc, &wal_dir = storage->recovery_.wal_directory_]() { (void)locker_acc.RemovePath(wal_dir); });
   // Get WAL files, ordered by timestamp, from oldest to newest
-  auto wal_files = durability::GetWalFiles(storage->recovery_.wal_directory_, storage->uuid_, current_wal_seq_num);
+  auto wal_files =
+      durability::GetWalFiles(storage->recovery_.wal_directory_, std::string{storage->uuid()}, current_wal_seq_num);
   MG_ASSERT(wal_files, "Wal files could not be loaded");
   if (transaction_guard.owns_lock())
     transaction_guard.unlock();  // In case we didn't have a current wal file, we can unlock only now since there is no
@@ -167,7 +168,8 @@ std::vector<RecoveryStep> GetRecoverySteps(uint64_t replica_commit, utils::FileR
           [&locker_acc, &snapshot_dir = storage->recovery_.snapshot_directory_]() {
             (void)locker_acc.RemovePath(snapshot_dir);
           });
-  auto snapshot_files = durability::GetSnapshotFiles(storage->recovery_.snapshot_directory_, storage->uuid_);
+  auto snapshot_files =
+      durability::GetSnapshotFiles(storage->recovery_.snapshot_directory_, std::string{storage->uuid()});
   std::optional<durability::SnapshotDurabilityInfo> latest_snapshot{};
   if (!snapshot_files.empty()) {
     latest_snapshot.emplace(std::move(snapshot_files.back()));

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -160,7 +160,7 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
       timestamp_ = std::max(timestamp_, info->next_timestamp);
       if (info->last_durable_timestamp) {
         repl_storage_state_.last_durable_timestamp_ = *info->last_durable_timestamp;
-        spdlog::trace("Recovering last durable timestamp {}", *info->last_durable_timestamp);
+        spdlog::trace("Recovering last durable timestamp {}.", *info->last_durable_timestamp);
       }
     }
   } else if (config_.durability.snapshot_wal_mode != Config::Durability::SnapshotWalMode::DISABLED ||

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -121,7 +121,6 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
       recovery_{config.durability.storage_directory / durability::kSnapshotDirectory,
                 config.durability.storage_directory / durability::kWalDirectory},
       lock_file_path_(config.durability.storage_directory / durability::kLockFile),
-      uuid_(utils::GenerateUUID()),
       global_locker_(file_retainer_.AddLocker()) {
   MG_ASSERT(config.salient.storage_mode != StorageMode::ON_DISK_TRANSACTIONAL,
             "Invalid storage mode sent to InMemoryStorage constructor!");
@@ -151,9 +150,10 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
               config_.durability.storage_directory);
   }
   if (config_.durability.recover_on_startup) {
-    auto info = recovery_.RecoverData(&uuid_, repl_storage_state_, &vertices_, &edges_, &edges_metadata_, &edge_count_,
-                                      name_id_mapper_.get(), &indices_, &constraints_, config_, &wal_seq_num_,
-                                      &enum_store_, &schema_info_, [this](Gid edge_gid) { return FindEdge(edge_gid); });
+    auto info =
+        recovery_.RecoverData(&config_.salient.uuid, repl_storage_state_, &vertices_, &edges_, &edges_metadata_,
+                              &edge_count_, name_id_mapper_.get(), &indices_, &constraints_, config_, &wal_seq_num_,
+                              &enum_store_, &schema_info_, [this](Gid edge_gid) { return FindEdge(edge_gid); });
     if (info) {
       vertex_id_ = info->next_vertex_id;
       edge_id_ = info->next_edge_id;
@@ -2330,12 +2330,15 @@ StorageInfo InMemoryStorage::GetInfo() {
 }
 
 bool InMemoryStorage::InitializeWalFile(memgraph::replication::ReplicationEpoch &epoch) {
-  if (config_.durability.snapshot_wal_mode != Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL)
+  if (config_.durability.snapshot_wal_mode != Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL) {
     return false;
-  if (!wal_file_) {
-    wal_file_.emplace(recovery_.wal_directory_, uuid_, epoch.id(), config_.salient.items, name_id_mapper_.get(),
-                      wal_seq_num_++, &file_retainer_);
   }
+
+  if (!wal_file_) {
+    wal_file_.emplace(recovery_.wal_directory_, config_.salient.uuid, epoch.id(), config_.salient.items,
+                      name_id_mapper_.get(), wal_seq_num_++, &file_retainer_);
+  }
+
   return true;
 }
 
@@ -2674,7 +2677,7 @@ utils::BasicResult<InMemoryStorage::CreateSnapshotError> InMemoryStorage::Create
   Transaction *transaction = accessor->GetTransaction();
   auto const &epoch = repl_storage_state_.epoch_;
   durability::CreateSnapshot(this, transaction, recovery_.snapshot_directory_, recovery_.wal_directory_, &vertices_,
-                             &edges_, uuid_, epoch, repl_storage_state_.history, &file_retainer_);
+                             &edges_, config_.salient.uuid, epoch, repl_storage_state_.history, &file_retainer_);
 
   memgraph::metrics::Measure(memgraph::metrics::SnapshotCreationLatency_us,
                              std::chrono::duration_cast<std::chrono::microseconds>(timer.Elapsed()).count());
@@ -2740,7 +2743,7 @@ void InMemoryStorage::CreateSnapshotHandler(
           spdlog::warn(utils::MessageWithLink("Snapshots are disabled for replicas.", "https://memgr.ph/replication"));
           break;
         case CreateSnapshotError::ReachedMaxNumTries:
-          spdlog::warn("Failed to create snapshot. Reached max number of tries. Please contact support");
+          spdlog::warn("Failed to create snapshot. Reached max number of tries. Please contact support.");
           break;
       }
     }

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -563,8 +563,6 @@ class InMemoryStorage final : public Storage {
   utils::Scheduler snapshot_runner_;
   utils::SpinLock snapshot_lock_;
 
-  // UUID used to distinguish snapshots and to link snapshots to WALs
-  std::string uuid_;
   // Sequence number used to keep track of the chain of WALs.
   uint64_t wal_seq_num_{0};
 

--- a/src/storage/v2/replication/replication_client.hpp
+++ b/src/storage/v2/replication/replication_client.hpp
@@ -86,7 +86,7 @@ class ReplicaStream {
 
 class ReplicaStreamExecutor {
  public:
-  ReplicaStreamExecutor(std::optional<ReplicaStream> stream) : stream_(std::move(stream)) {}
+  explicit ReplicaStreamExecutor(std::optional<ReplicaStream> stream) : stream_(std::move(stream)) {}
   void operator()() const {}
 
  private:

--- a/src/utils/scheduler.hpp
+++ b/src/utils/scheduler.hpp
@@ -42,11 +42,10 @@ class Scheduler {
   template <typename TRep, typename TPeriod>
   void Run(const std::string &service_name, const std::chrono::duration<TRep, TPeriod> &pause,
            const std::function<void()> &f, std::optional<std::chrono::system_clock::time_point> start_time = {}) {
-    DMG_ASSERT(is_working_ == false, "Thread already running.");
-    DMG_ASSERT(pause > std::chrono::seconds(0), "Pause is invalid.");
+    DMG_ASSERT(!thread_.joinable(), "Thread already running.");
+    DMG_ASSERT(pause > std::chrono::seconds(0), "Pause is invalid. Expected > 0, got {}.", pause.count());
 
-    is_working_ = true;
-    thread_ = std::jthread([this, pause, f, service_name, start_time]() mutable {
+    thread_ = std::jthread([this, pause, f, service_name, start_time](std::stop_token token) mutable {
       auto find_first_execution = [&]() {
         if (start_time) {              // Custom start time; execute as soon as possible
           return *start_time - pause;  // -= simplifies the logic later on
@@ -67,7 +66,7 @@ class Scheduler {
 
       utils::ThreadSetName(service_name);
 
-      while (true) {
+      while (!token.stop_requested()) {
         // First wait then execute the function. We do that in that order
         // because most of the schedulers are started at the beginning of the
         // program and there is probably no work to do in scheduled function at
@@ -76,56 +75,49 @@ class Scheduler {
         // waiting that function f will not log before it.
         // Check for pause also.
         auto lk = std::unique_lock{mutex_};
-        auto now = std::chrono::system_clock::now();
         next_execution += pause;
+        auto now = std::chrono::system_clock::now();
         if (next_execution > now) {
-          condition_variable_.wait_until(lk, next_execution,
-                                         [&] { return !is_working_.load(std::memory_order_acquire); });
+          condition_variable_.wait_until(lk, next_execution, [&] { return token.stop_requested(); });
         } else {
           next_execution = find_next_execution(now);  // Compensate for time drift when using a start time
         }
-
+        // This check must come also before checking if scheduler is paused.
+        // Otherwise deadlock could happen, e.g
+        // t1 calls Stop on scheduler thread t3
+        // t2 calls Pause on scheduler thread t3 right after wait_until finished
+        // scheduler then waits until is_paused is false but this possibly won't ever happen
+        if (token.stop_requested()) break;
         pause_cv_.wait(lk, [&] { return !is_paused_.load(std::memory_order_acquire); });
 
-        if (!is_working_.load(std::memory_order_acquire)) break;
+        // This check is to allow the stopping thread to stop paused scheduler before executing function one more time.
+        if (token.stop_requested()) break;
+
         f();
       }
     });
   }
 
   void Resume() {
-    is_paused_.store(false);
+    is_paused_.store(false, std::memory_order_release);
     pause_cv_.notify_one();
   }
 
-  void Pause() { is_paused_.store(true); }
+  void Pause() { is_paused_.store(true, std::memory_order_release); }
 
-  /**
-   * @brief Stops the thread execution. This is a blocking call and may take as
-   * much time as one call to the function given previously to Run takes.
-   * @throw std::system_error
-   */
   void Stop() {
-    is_paused_.store(false);
-    is_working_.store(false);
+    is_paused_.store(false, std::memory_order_release);
+    thread_.request_stop();
     pause_cv_.notify_one();
     condition_variable_.notify_one();
     if (thread_.joinable()) thread_.join();
   }
 
-  /**
-   * Returns whether the scheduler is running.
-   */
-  bool IsRunning() { return is_working_; }
+  bool IsRunning() { return thread_.joinable(); }
 
   ~Scheduler() { Stop(); }
 
  private:
-  /**
-   * Variable is true when thread is running.
-   */
-  std::atomic<bool> is_working_{false};
-
   /**
    * Variable is true when thread is paused.
    */

--- a/src/utils/thread_pool.hpp
+++ b/src/utils/thread_pool.hpp
@@ -25,7 +25,7 @@ namespace memgraph::utils {
 
 template <typename Func>
 struct CopyMovableFunctionWrapper {
-  CopyMovableFunctionWrapper(Func &&func) : func_{std::make_shared<Func>(std::move(func))} {}
+  explicit CopyMovableFunctionWrapper(Func &&func) : func_{std::make_shared<Func>(std::move(func))} {}
 
   void operator()() { (*func_)(); }
 

--- a/src/utils/uuid.cpp
+++ b/src/utils/uuid.cpp
@@ -20,7 +20,7 @@ std::string GenerateUUID() {
   char decoded[37];  // magic size from: man 2 uuid_unparse
   uuid_generate(uuid);
   uuid_unparse(uuid, decoded);
-  return std::string(decoded);
+  return {decoded};
 }
 
 }  // namespace memgraph::utils

--- a/src/utils/uuid.hpp
+++ b/src/utils/uuid.hpp
@@ -13,13 +13,15 @@
 
 #include <uuid/uuid.h>
 
+#include "fmt/format.h"
+
 #include <array>
 #include <json/json.hpp>
 #include <string>
 
 namespace memgraph::utils {
 struct UUID;
-}
+}  // namespace memgraph::utils
 
 namespace memgraph::slk {
 class Reader;
@@ -44,6 +46,16 @@ struct UUID {
     auto decoded = std::array<char, 37 /*UUID_STR_LEN*/>{};
     uuid_unparse(uuid.data(), decoded.data());
     return std::string{decoded.data(), 37 /*UUID_STR_LEN*/ - 1};
+  }
+
+  void set(std::string const &uuid_str) {
+    if (uuid_str.length() != 36) {
+      throw std::invalid_argument(
+          fmt::format("Invalid UUID argument length. Length is {} and expected to be 36.", uuid_str.length()));
+    }
+    if (uuid_parse(uuid_str.c_str(), uuid.data()) != 0) {
+      throw std::invalid_argument("Invalid UUID formatwhen setting new uuid string.");
+    }
   }
 
   explicit operator arr_t() const { return uuid; }

--- a/tests/jepsen/test/memgraph/memgraph_test.clj
+++ b/tests/jepsen/test/memgraph/memgraph_test.clj
@@ -211,14 +211,7 @@
   (testing "get-competent-idx7"
     (let [cum-probs [0.5 1.0]]
 
-      (is (= (hacreate/get-competent-idx cum-probs 0.2) 0))))
-
-
-
-
-
-
-  )
+      (is (= (hacreate/get-competent-idx cum-probs 0.2) 0)))))
 
 (deftest get-instance-url
   (testing "Get instance URL."

--- a/tests/unit/utils_scheduler.cpp
+++ b/tests/unit/utils_scheduler.cpp
@@ -95,3 +95,65 @@ TEST(Scheduler, StartTimeRestart) {
   }
   ASSERT_EQ(x, 2);
 }
+
+TEST(Scheduler, IsRunningFalse) {
+  memgraph::utils::Scheduler scheduler;
+  EXPECT_FALSE(scheduler.IsRunning());
+}
+
+TEST(Scheduler, StopIdleScheduler) {
+  memgraph::utils::Scheduler scheduler;
+  ASSERT_NO_THROW(scheduler.Stop());
+}
+
+TEST(Scheduler, PauseIdleScheduler) {
+  memgraph::utils::Scheduler scheduler;
+  ASSERT_NO_THROW(scheduler.Pause());
+  ASSERT_NO_THROW(scheduler.Resume());
+}
+
+TEST(Scheduler, RunStop) {
+  std::atomic<int> x{0};
+  std::function<void()> func{[&x]() { ++x; }};
+  memgraph::utils::Scheduler scheduler;
+  scheduler.Run("Test", std::chrono::milliseconds(100), func);
+  EXPECT_TRUE(scheduler.IsRunning());
+  scheduler.Stop();
+  EXPECT_FALSE(scheduler.IsRunning());
+}
+
+TEST(Scheduler, StopStoppedScheduler) {
+  std::atomic<int> x{0};
+  std::function<void()> func{[&x]() { ++x; }};
+  memgraph::utils::Scheduler scheduler;
+  scheduler.Run("Test", std::chrono::milliseconds(100), func);
+  ASSERT_NO_THROW({
+    scheduler.Stop();
+    scheduler.Stop();
+  });
+}
+
+TEST(Scheduler, PauseStoppedScheduler) {
+  std::atomic<int> x{0};
+  std::function<void()> func{[&x]() { ++x; }};
+  memgraph::utils::Scheduler scheduler;
+  scheduler.Run("Test", std::chrono::milliseconds(100), func);
+  EXPECT_TRUE(scheduler.IsRunning());
+  scheduler.Stop();
+  EXPECT_FALSE(scheduler.IsRunning());
+  scheduler.Pause();
+  EXPECT_FALSE(scheduler.IsRunning());
+}
+
+TEST(Scheduler, StopPausedScheduler) {
+  std::atomic<int> x{0};
+  std::function<void()> func{[&x]() { ++x; }};
+  memgraph::utils::Scheduler scheduler;
+  scheduler.Run("Test", std::chrono::milliseconds(100), func);
+  EXPECT_TRUE(scheduler.IsRunning());
+  scheduler.Pause();
+  EXPECT_TRUE(scheduler.IsRunning());  // note pausing the scheduler doesn't cause
+                                       // return false for IsRunning
+  scheduler.Stop();
+  EXPECT_FALSE(scheduler.IsRunning());
+}


### PR DESCRIPTION
Unit test scheduler...

```
auto const test_fnc = []() {
    std::atomic<int> x{0};
    std::function<void()> func{[&x]() { ++x; }};
    memgraph::utils::Scheduler scheduler;
    scheduler.Run("Test", std::chrono::seconds(1), func);

    std::this_thread::sleep_for(std::chrono::milliseconds(300));

    std::jthread stopper([&scheduler]() { scheduler.Stop(); });

    std::jthread pauser([&scheduler]() {
      // NOLINTNEXTLINE
      while (scheduler.IsRunning()) {
        std::this_thread::sleep_for(std::chrono::milliseconds(5));
      }
      scheduler.Pause();
    });
  };

  std::future<void> future = std::async(std::launch::async, test_fnc);

  if (future.wait_for(std::chrono::seconds(2)) == std::future_status::timeout) {
    FAIL() << "The test PauseAfterStop didn't complete in time.";
    std::terminate();
  }
  try {
    future.get();
    SUCCEED();
  } catch (std::exception const &e) {
    FAIL() << "Exception thrown during test: " << e.what();
  }

```


---
__*Leave above in PR description, copy the below into a comment*__
___


### Tracking
- [ ] **[Link to Epic/Issue]**


### Standard development
- [ ] Update unit/E2E tests
- [ ] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch this branch


### CI Testing Labels
- [ ] Select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_


### Documentation checklist
- [ ] Add the documentation label
- [ ] Add the bug / feature label
- [ ] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - **[ Release note text ]**
- [ ] **[ Documentation PR link memgraph/documentation#XXXX ]**
    - [ ] Is back linked to this development PR
- [ ] **[ Tag someone from docs team ]**
