### PR TITLE
Bugfix: reconcile cluster state

### DIFF
--- a/src/coordination/coordinator_cluster_state.cpp
+++ b/src/coordination/coordinator_cluster_state.cpp
@@ -203,13 +203,6 @@ auto CoordinatorClusterState::TryGetCurrentMainName() const -> std::optional<std
 
 auto CoordinatorClusterState::GetCurrentMainUUID() const -> utils::UUID { return current_main_uuid_; }
 
-auto CoordinatorClusterState::GetInstanceUUID(std::string_view instance_name) const -> utils::UUID {
-  auto lock = std::shared_lock{log_lock_};
-  auto const it = repl_instances_.find(instance_name);
-  MG_ASSERT(it != repl_instances_.end(), "Instance with that name doesn't exist.");
-  return it->second.instance_uuid;
-}
-
 auto CoordinatorClusterState::GetIsLockOpened() const -> bool {
   auto lock = std::shared_lock{log_lock_};
   return is_lock_opened_;

--- a/src/coordination/coordinator_state_machine.cpp
+++ b/src/coordination/coordinator_state_machine.cpp
@@ -411,10 +411,6 @@ auto CoordinatorStateMachine::IsCurrentMain(std::string_view instance_name) cons
   return cluster_state_.IsCurrentMain(instance_name);
 }
 
-auto CoordinatorStateMachine::GetInstanceUUID(std::string_view instance_name) const -> utils::UUID {
-  return cluster_state_.GetInstanceUUID(instance_name);
-}
-
 auto CoordinatorStateMachine::IsLockOpened() const -> bool { return cluster_state_.GetIsLockOpened(); }
 
 auto CoordinatorStateMachine::TryGetCurrentMainName() const -> std::optional<std::string> {

--- a/src/coordination/include/coordination/raft_state.hpp
+++ b/src/coordination/include/coordination/raft_state.hpp
@@ -90,7 +90,6 @@ class RaftState {
   auto IsCurrentMain(std::string_view instance_name) const -> bool;
 
   auto GetCurrentMainUUID() const -> utils::UUID;
-  auto GetInstanceUUID(std::string_view) const -> utils::UUID;
 
   auto GetLeaderCoordinatorData() const -> std::optional<CoordinatorToCoordinatorConfig>;
 

--- a/src/coordination/include/coordination/replication_instance_connector.hpp
+++ b/src/coordination/include/coordination/replication_instance_connector.hpp
@@ -56,6 +56,7 @@ class ReplicationInstanceConnector {
   auto PromoteToMain(utils::UUID const &uuid, ReplicationClientsInfo repl_clients_info,
                      HealthCheckInstanceCallback main_succ_cb, HealthCheckInstanceCallback main_fail_cb) -> bool;
 
+  // If the instance is already in replica state, the request will succeed.
   auto SendDemoteToReplicaRpc() -> bool;
 
   auto SendFrequentHeartbeat() const -> bool;

--- a/src/coordination/include/nuraft/coordinator_cluster_state.hpp
+++ b/src/coordination/include/nuraft/coordinator_cluster_state.hpp
@@ -80,6 +80,7 @@ class CoordinatorClusterState {
 
   auto HasReplicaState(std::string_view instance_name) const -> bool;
 
+  // Designed in a way that there should always be just one CurrentMain
   auto IsCurrentMain(std::string_view instance_name) const -> bool;
 
   auto DoAction(TRaftLog const &log_entry, RaftLogAction log_action) -> void;

--- a/src/coordination/raft_state.cpp
+++ b/src/coordination/raft_state.cpp
@@ -538,10 +538,6 @@ auto RaftState::IsCurrentMain(std::string_view instance_name) const -> bool {
 
 auto RaftState::IsLockOpened() const -> bool { return state_machine_->IsLockOpened(); }
 
-auto RaftState::GetInstanceUUID(std::string_view instance_name) const -> utils::UUID {
-  return state_machine_->GetInstanceUUID(instance_name);
-}
-
 auto RaftState::TryGetCurrentMainName() const -> std::optional<std::string> {
   return state_machine_->TryGetCurrentMainName();
 }

--- a/src/coordination/replication_instance_client.cpp
+++ b/src/coordination/replication_instance_client.cpp
@@ -93,17 +93,16 @@ auto ReplicationInstanceClient::SendPromoteReplicaToMainRpc(const utils::UUID &u
                                                             ReplicationClientsInfo replication_clients_info) const
     -> bool {
   try {
-    spdlog::trace("Sending PromoteReplicaToMainRpc");
     auto stream{rpc_client_.Stream<PromoteReplicaToMainRpc>(uuid, std::move(replication_clients_info))};
-    spdlog::trace("Awaiting response after sending PromoteReplicaToMainRpc");
+    spdlog::trace("Sent PromoteReplicaToMainRpc request.");
     if (!stream.AwaitResponse().success) {
-      spdlog::error("Failed to receive successful PromoteReplicaToMainRpc response!");
+      spdlog::error("Received unsuccessful PromoteReplicaToMainRpc response.");
       return false;
     }
-    spdlog::trace("Received successful response to PromoteReplicaToMainRPC");
+    spdlog::trace("Received successful response to PromoteReplicaToMainRPC.");
     return true;
   } catch (rpc::RpcFailedException const &) {
-    spdlog::error("RPC error occurred while sending PromoteReplicaToMainRpc!");
+    spdlog::error("RPC error occurred while sending PromoteReplicaToMainRpc.");
   }
   return false;
 }
@@ -112,11 +111,11 @@ auto ReplicationInstanceClient::DemoteToReplica() const -> bool {
   auto const &instance_name = config_.instance_name;
   try {
     auto stream{rpc_client_.Stream<DemoteMainToReplicaRpc>(config_.replication_client_info)};
+    spdlog::info("Sent RPC request to set instance {} to replica.", instance_name);
     if (!stream.AwaitResponse().success) {
-      spdlog::error("Failed to receive successful RPC response for setting instance {} to replica!", instance_name);
+      spdlog::error("Received unsuccessful RPC response for setting instance {} to replica.", instance_name);
       return false;
     }
-    spdlog::info("Sent request RPC from coordinator to instance to set it as replica!");
     return true;
   } catch (rpc::RpcFailedException const &) {
     spdlog::error("Failed to receive RPC response when demoting instance {} to replica!", instance_name);

--- a/src/coordination/replication_instance_connector.cpp
+++ b/src/coordination/replication_instance_connector.cpp
@@ -69,7 +69,6 @@ auto ReplicationInstanceConnector::PromoteToMain(utils::UUID const &new_uuid, Re
   return true;
 }
 
-// TODO: (andi) Duplication. We have to refactor this
 auto ReplicationInstanceConnector::SendDemoteToReplicaRpc() -> bool { return client_->DemoteToReplica(); }
 
 auto ReplicationInstanceConnector::SendFrequentHeartbeat() const -> bool { return client_->SendFrequentHeartbeat(); }

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -142,7 +142,7 @@ void InMemoryReplicationHandlers::SwapMainUUIDHandler(dbms::DbmsHandler *dbms_ha
 
   replication_coordination_glue::SwapMainUUIDReq req;
   slk::Load(&req, req_reader);
-  spdlog::info("Set replica data UUID to main uuid {}", std::string(req.uuid));
+  spdlog::info("Set replica data uuid to main uuid {}.", std::string(req.uuid));
   dbms_handler->ReplicationState().TryPersistRoleReplica(role_replica_data.config, req.uuid);
   role_replica_data.uuid_ = req.uuid;
 

--- a/src/replication_coordination_glue/handler.hpp
+++ b/src/replication_coordination_glue/handler.hpp
@@ -17,16 +17,19 @@
 #include "rpc/messages.hpp"
 
 namespace memgraph::replication_coordination_glue {
+
+// If replica already has correct uuid, this action will be idempotent and it will return status code true.
+// If the request receives instance with the main state, it will return false.
 inline bool SendSwapMainUUIDRpc(memgraph::rpc::Client &rpc_client_, const memgraph::utils::UUID &uuid) {
   try {
     auto stream{rpc_client_.Stream<SwapMainUUIDRpc>(uuid)};
     if (!stream.AwaitResponse().success) {
-      spdlog::error("Failed to receive successful RPC swapping of uuid response!");
+      spdlog::error("Received unsuccessful RPC response for swapping uuid on instance.");
       return false;
     }
     return true;
   } catch (const memgraph::rpc::RpcFailedException &) {
-    spdlog::error("RPC error occurred while sending swapping uuid RPC!");
+    spdlog::error("RPC error occurred while sending RPC for swapping uuid.");
   }
   return false;
 }

--- a/src/replication_handler/include/replication_handler/replication_handler.hpp
+++ b/src/replication_handler/include/replication_handler/replication_handler.hpp
@@ -285,7 +285,9 @@ struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
       if (replica_data.config == config) {
         return true;
       }
-      repl_state_.SetReplicationRoleReplica(config, main_uuid);
+      if (!repl_state_.SetReplicationRoleReplica(config, main_uuid)) {
+        return false;
+      }
 #ifdef MG_ENTERPRISE
       return StartRpcServer(dbms_handler_, replica_data, auth_, system_);
 #else

--- a/src/replication_handler/replication_handler.cpp
+++ b/src/replication_handler/replication_handler.cpp
@@ -226,7 +226,7 @@ bool ReplicationHandler::DoReplicaToMainPromotion(const utils::UUID &main_uuid) 
     storage->repl_storage_state_.epoch_ = epoch;
 
     // Durability is tracking last durable timestamp from MAIN, whereas timestamp_ is dependent on MVCC
-    // We need to take bigger timestamp not to lose durability ordering
+    // We need to take bigger timestamp not to lose durability ordering.
     storage->timestamp_ =
         std::max(storage->timestamp_, storage->repl_storage_state_.last_durable_timestamp_.load() + 1);
     spdlog::trace("New timestamp on the MAIN is {} for the database {}.", storage->timestamp_, db_acc->name());


### PR DESCRIPTION
In reconcile cluster state we relied on a single health ping to determine whether the instance was alive or not. However, this isn't correct since it is possible that the instance was down all the time, woke up at some moment and we would assign it ReplicaSuccessCallback and ReplicaFailCallback without ever actually changing its UUID. Now all future replicas will get assigned demote callbacks.