### PR TITLE
Compilation error if module tries to set mgp::memory

### DIFF
--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -126,11 +126,12 @@ inline bool IsThisThreadRegistered() noexcept { return current_memory.has_value(
 
 // Leaving "memory" variable here in order to generate a better module compilation error.
 // It should never be used; instead use MemoryDispatcherGuard.
-inline struct UnsupportedMgpMemory {
+struct UnsupportedMgpMemory {
   UnsupportedMgpMemory() = default;
   void operator=(mgp_memory *)
       __attribute__((error("mgp::memory must not be used as of v2.18.1. Please use MemoryDispatcherGuard instead.")));
-} memory;
+};
+inline UnsupportedMgpMemory memory;  // NOSONAR
 
 class MemoryDispatcherGuard final {
  public:

--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -124,14 +124,13 @@ inline void UnRegister() noexcept { current_memory.reset(); }
 inline bool IsThisThreadRegistered() noexcept { return current_memory.has_value(); }
 };  // namespace MemoryDispatcher
 
-// The use of MemoryDispatcherGuard should be the prefered way to pass
-// the memory pointer to this header. The use of the 'mgp_memory *memory'
-// pointer is deprecated and will be removed in upcoming releases.
-
-// TODO - Once we deprecate this we should remove this
-// and make sure nothing relies on it anymore. This alone
-// can not guarantee threadsafe use of query procedures.
-inline mgp_memory *memory{nullptr};
+// Leaving "memory" variable here in order to generate a better module compilation error.
+// It should never be used; instead use MemoryDispatcherGuard.
+inline struct UnsupportedMgpMemory {
+  UnsupportedMgpMemory() = default;
+  void operator=(mgp_memory *)
+      __attribute__((error("mgp::memory must not be used as of v2.18.1. Please use MemoryDispatcherGuard instead.")));
+} memory;
 
 class MemoryDispatcherGuard final {
  public:
@@ -145,18 +144,9 @@ class MemoryDispatcherGuard final {
   ~MemoryDispatcherGuard() { MemoryDispatcher::UnRegister(); }
 };
 
-// Currently we want to preserve both ways(using mgp::memory and
-// MemoryDispatcherGuard) of setting the correct memory resource
-// from the shared object files. This forwarding function is a
-// helper function for that purpose. Once we get rid of the
-// 'mgp_memory *memory' pointer this function will not be needed
-// anymore and the calls to the memory resource should rely on
-// the mapping instead.
+// Thread must be registered, otherwise the function will segfault.
 template <typename Func, typename... Args>
 inline decltype(auto) MemHandlerCallback(Func &&func, Args &&...args) {
-  if (!MemoryDispatcher::IsThisThreadRegistered()) {
-    return std::forward<Func>(func)(std::forward<Args>(args)..., memory);
-  }
   return std::forward<Func>(func)(std::forward<Args>(args)..., MemoryDispatcher::GetMemoryResource());
 }
 

--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -128,8 +128,8 @@ inline bool IsThisThreadRegistered() noexcept { return current_memory.has_value(
 // It should never be used; instead use MemoryDispatcherGuard.
 struct UnsupportedMgpMemory {
   UnsupportedMgpMemory() = default;
-  void operator=(mgp_memory *)
-      __attribute__((error("mgp::memory must not be used as of v2.18.1. Please use MemoryDispatcherGuard instead.")));
+  void operator=(mgp_memory *) __attribute__((diagnose_if(
+      true, "mgp::memory must not be used as of v2.18.1. Please use MemoryDispatcherGuard instead.", "error")));
 };
 inline UnsupportedMgpMemory memory;  // NOSONAR
 

--- a/query_modules/example.cpp
+++ b/query_modules/example.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2024 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -18,10 +18,6 @@ void ProcImpl(std::vector<mgp::Value> arguments, mgp::Graph graph, mgp::RecordFa
 
 void SampleReadProc(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory) {
   try {
-    // The outcommented way of assigning the memory pointer is still
-    // working, but it is deprecated because of certain concurrency
-    // issues. Please use the guard instead.
-    // mgp::memory = memory;
     mgp::MemoryDispatcherGuard guard(memory);
 
     std::vector<mgp::Value> arguments;
@@ -38,10 +34,6 @@ void SampleReadProc(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *resul
 }
 
 void AddXNodes(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory) {
-  // The outcommented way of assigning the memory pointer is still
-  // working, but it is deprecated because of certain concurrency
-  // issues. Please use the guard instead.
-  // mgp::memory = memory;
   mgp::MemoryDispatcherGuard guard(memory);
   auto graph = mgp::Graph(memgraph_graph);
 
@@ -57,10 +49,6 @@ void AddXNodes(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mg
 }
 
 void Multiply(mgp_list *args, mgp_func_context *ctx, mgp_func_result *res, mgp_memory *memory) {
-  // The outcommented way of assigning the memory pointer is still
-  // working, but it is deprecated because of certain concurrency
-  // issues. Please use the guard instead.
-  // mgp::memory = memory;
   mgp::MemoryDispatcherGuard guard(memory);
 
   std::vector<mgp::Value> arguments;
@@ -79,10 +67,6 @@ void Multiply(mgp_list *args, mgp_func_context *ctx, mgp_func_result *res, mgp_m
 
 extern "C" int mgp_init_module(struct mgp_module *module, struct mgp_memory *memory) {
   try {
-    // The outcommented way of assigning the memory pointer is still
-    // working, but it is deprecated because of certain concurrency
-    // issues. Please use the guard instead.
-    // mgp::memory = memory;
     mgp::MemoryDispatcherGuard guard(memory);
 
     AddProcedure(SampleReadProc, "return_true", mgp::ProcedureType::Read,
@@ -93,10 +77,6 @@ extern "C" int mgp_init_module(struct mgp_module *module, struct mgp_memory *mem
   }
 
   try {
-    // The outcommented way of assigning the memory pointer is still
-    // working, but it is deprecated because of certain concurrency
-    // issues. Please use the guard instead.
-    // mgp::memory = memory;
     mgp::MemoryDispatcherGuard guard(memory);
 
     mgp::AddProcedure(AddXNodes, "add_x_nodes", mgp::ProcedureType::Write, {mgp::Parameter("param_1", mgp::Type::Int)},
@@ -107,10 +87,6 @@ extern "C" int mgp_init_module(struct mgp_module *module, struct mgp_memory *mem
   }
 
   try {
-    // The outcommented way of assigning the memory pointer is still
-    // working, but it is deprecated because of certain concurrency
-    // issues. Please use the guard instead.
-    // mgp::memory = memory;
     mgp::MemoryDispatcherGuard guard(memory);
 
     mgp::AddFunction(Multiply, "multiply",

--- a/tests/e2e/memory/procedures/global_memory_limit_thread_proc.cpp
+++ b/tests/e2e/memory/procedures/global_memory_limit_thread_proc.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2024 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -77,8 +77,7 @@ void Thread(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_m
 
 extern "C" int mgp_init_module(struct mgp_module *module, struct mgp_memory *memory) {
   try {
-    mgp::memory = memory;
-
+    mgp::MemoryDispatcherGuard guard(memory);
     AddProcedure(Thread, std::string("thread").c_str(), mgp::ProcedureType::Read, {},
                  {mgp::Return(std::string("allocated_all").c_str(), mgp::Type::Bool)}, module, memory);
 

--- a/tests/e2e/memory/procedures/query_memory_limit_proc_multi_thread.cpp
+++ b/tests/e2e/memory/procedures/query_memory_limit_proc_multi_thread.cpp
@@ -136,8 +136,7 @@ void DualThread(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, m
 
 extern "C" int mgp_init_module(struct mgp_module *module, struct mgp_memory *memory) {
   try {
-    mgp::memory = memory;
-
+    mgp::MemoryDispatcherGuard guard(memory);
     AddProcedure(DualThread, std::string("dual_thread").c_str(), mgp::ProcedureType::Read, {},
                  {mgp::Return(std::string("test_passed").c_str(), mgp::Type::Bool)}, module, memory);
 


### PR DESCRIPTION
Will cause compilation errors when compiling modules that set `mgp::memory`.
Module implementations must use `MemoryDispatcherGuard`, otherwise instance will segfault.