### PR TITLE
Add Ubuntu 24.04 to supported os list

### DIFF
--- a/environment/os/install_deps.sh
+++ b/environment/os/install_deps.sh
@@ -7,7 +7,7 @@ SUPPORTED_OS=(
     debian-10 debian-11 debian-11-arm debian-12 debian-12-arm
     fedora-36 fedora-38 fedora-39
     rocky-9.3
-    ubuntu-18.04 ubuntu-20.04 ubuntu-22.04 ubuntu-22.04-arm
+    ubuntu-18.04 ubuntu-20.04 ubuntu-22.04 ubuntu-22.04-arm ubuntu-24.04 ubuntu-24.04-arm
 )
 
 # Define toolchain download URLs for supported OS and architectures


### PR DESCRIPTION
Extend `environment/os/install_deps.sh` supported OS list with Ubuntu 24.04 to align with setup instruction from https://memgraph.com/docs/getting-started/build-memgraph-from-source
---
__*Leave above in PR description, copy the below into a comment*__
___


### Tracking
- [ ] **[Link to Epic/Issue]**


### Standard development
- [ ] Update unit/E2E tests
- [ ] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch this branch


### CI Testing Labels
- [ ] Select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_


### Documentation checklist
- [ ] Add the documentation label
- [ ] Add the bug / feature label
- [ ] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - **[ Release note text ]**
- [ ] **[ Documentation PR link memgraph/documentation#XXXX ]**
    - [ ] Is back linked to this development PR
- [ ] **[ Tag someone from docs team ]**
