### PR TITLE
Bugfix: Edge index doesn't remove deleted edges

### DIFF
--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -137,6 +137,7 @@ void InMemoryEdgeTypeIndex::RemoveObsoleteEntries(uint64_t oldest_active_start_t
       }
 
       const bool vertices_deleted = it->from_vertex->deleted || it->to_vertex->deleted;
+      const bool edge_deleted = it->edge->deleted;
       const bool has_next = next_it != edges_acc.end();
 
       // When we update specific entries in the index, we don't delete the previous entry.
@@ -145,7 +146,7 @@ void InMemoryEdgeTypeIndex::RemoveObsoleteEntries(uint64_t oldest_active_start_t
       // should be removed here.
       const bool redundant_duplicate = has_next && it->from_vertex == next_it->from_vertex &&
                                        it->to_vertex == next_it->to_vertex && it->edge == next_it->edge;
-      if (redundant_duplicate || vertices_deleted) {
+      if (redundant_duplicate || vertices_deleted || edge_deleted) {
         edges_acc.remove(*it);
       }
 

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -163,6 +163,7 @@ void InMemoryEdgeTypePropertyIndex::RemoveObsoleteEntries(uint64_t oldest_active
       }
 
       const bool vertices_deleted = it->from_vertex->deleted || it->to_vertex->deleted;
+      const bool edge_deleted = it->edge->deleted;
       const bool has_next = next_it != edges_acc.end();
 
       // When we update specific entries in the index, we don't delete the previous entry.
@@ -172,7 +173,7 @@ void InMemoryEdgeTypePropertyIndex::RemoveObsoleteEntries(uint64_t oldest_active
       const bool redundant_duplicate = has_next && it->value == next_it->value &&
                                        it->from_vertex == next_it->from_vertex && it->to_vertex == next_it->to_vertex &&
                                        it->edge == next_it->edge;
-      if (redundant_duplicate || vertices_deleted ||
+      if (redundant_duplicate || vertices_deleted || edge_deleted ||
           !AnyVersionHasLabelProperty(*it->edge, specific_index.first.second, it->value,
                                       oldest_active_start_timestamp)) {
         edges_acc.remove(*it);


### PR DESCRIPTION
Edge index would not remove deleted (obsolete) entries, while the GC would delete the edge object.
Edge type index was impacted, while the property type would detect that the object was deleted due to it checking the property.