### PR TITLE
Bugfix: duplicated get instance timestamp requests

### DIFF
--- a/src/coordination/coordinator_cluster_state.cpp
+++ b/src/coordination/coordinator_cluster_state.cpp
@@ -81,11 +81,11 @@ auto CoordinatorClusterState::IsCurrentMain(std::string_view instance_name) cons
   return it != data_instances_.end() && it->status == ReplicationRole::MAIN && it->instance_uuid == current_main_uuid_;
 }
 
-auto CoordinatorClusterState::DoAction(std::pair<std::vector<DataInstanceState>, utils::UUID> log_entry) -> void {
+auto CoordinatorClusterState::DoAction(std::vector<DataInstanceState> data_instances, utils::UUID main_uuid) -> void {
   auto lock = std::lock_guard{log_lock_};
   spdlog::trace("DoAction: update cluster state.");
-  data_instances_ = std::move(log_entry.first);
-  current_main_uuid_ = log_entry.second;
+  data_instances_ = std::move(data_instances);
+  current_main_uuid_ = main_uuid;
 }
 
 auto CoordinatorClusterState::Serialize(ptr<buffer> &data) -> void {

--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -905,7 +905,7 @@ auto CoordinatorInstance::GetMostUpToDateInstanceFromHistories(std::list<Replica
   spdlog::trace("{} data instances can become new main.", instances.size());
 
   auto const get_ts = [](auto const &instance) {
-    spdlog::trace("Sending get instance timestamps to {}.", instance.InstanceName());
+    spdlog::trace("Sending get instance timestamp to {}.", instance.InstanceName());
     return instance.GetClient().SendGetInstanceTimestampsRpc();
   };
 
@@ -915,8 +915,10 @@ auto CoordinatorInstance::GetMostUpToDateInstanceFromHistories(std::list<Replica
     auto maybe_history = get_ts(instance);
 
     if (maybe_history.has_value()) {
-      spdlog::trace("Instance {} has history.", instance.InstanceName());
+      spdlog::trace("Received history for instance {}.", instance.InstanceName());
       instance_db_histories.emplace_back(instance.InstanceName(), *maybe_history);
+    } else {
+      spdlog::trace("Couldn't receive history for instance {}.", instance.InstanceName());
     }
   }
 

--- a/src/coordination/coordinator_state_machine.cpp
+++ b/src/coordination/coordinator_state_machine.cpp
@@ -183,8 +183,8 @@ auto CoordinatorStateMachine::pre_commit(ulong const /*log_idx*/, buffer & /*dat
 
 auto CoordinatorStateMachine::commit(ulong const log_idx, buffer &data) -> ptr<buffer> {
   logger_.Log(nuraft_log_level::TRACE, fmt::format("Commit: log_idx={}, data.size()={}", log_idx, data.size()));
-  auto parsed_data = DecodeLog(data);
-  cluster_state_.DoAction(std::move(parsed_data));
+  auto [data_instances, main_uuid] = DecodeLog(data);
+  cluster_state_.DoAction(std::move(data_instances), main_uuid);
   if (durability_) {
     durability_->Put(kLastCommitedIdx, std::to_string(log_idx));
   }

--- a/src/coordination/include/coordination/replication_instance_client.hpp
+++ b/src/coordination/include/coordination/replication_instance_client.hpp
@@ -63,8 +63,7 @@ class ReplicationInstanceClient {
 
   auto SendStateCheckRpc() const -> std::optional<InstanceState>;
 
-  auto SendGetInstanceTimestampsRpc() const
-      -> utils::BasicResult<GetInstanceTimestampsError, replication_coordination_glue::DatabaseHistories>;
+  auto SendGetInstanceTimestampsRpc() const -> std::optional<replication_coordination_glue::DatabaseHistories>;
 
   virtual auto InstanceDownTimeoutSec() const -> std::chrono::seconds;
 

--- a/src/coordination/include/coordination/replication_instance_connector.hpp
+++ b/src/coordination/include/coordination/replication_instance_connector.hpp
@@ -63,7 +63,7 @@ class ReplicationInstanceConnector {
   auto ResumeStateCheck() -> void;
 
   auto GetReplicationClientInfo() const -> ReplicationClientInfo;
-  auto GetClient() -> ReplicationInstanceClient &;
+  auto GetClient() const -> ReplicationInstanceClient const &;
 
  protected:
   ReplicationInstanceClient client_;

--- a/src/coordination/include/nuraft/coordinator_cluster_state.hpp
+++ b/src/coordination/include/nuraft/coordinator_cluster_state.hpp
@@ -71,7 +71,7 @@ class CoordinatorClusterState {
 
   auto IsCurrentMain(std::string_view instance_name) const -> bool;
 
-  auto DoAction(std::pair<std::vector<DataInstanceState>, utils::UUID> log_entry) -> void;
+  auto DoAction(std::vector<DataInstanceState> data_instances, utils::UUID main_uuid) -> void;
 
   auto Serialize(ptr<buffer> &data) -> void;
 

--- a/src/coordination/replication_instance_client.cpp
+++ b/src/coordination/replication_instance_client.cpp
@@ -181,7 +181,7 @@ auto ReplicationInstanceClient::SendEnableWritingOnMainRpc() const -> bool {
 auto ReplicationInstanceClient::SendGetInstanceTimestampsRpc() const
     -> std::optional<replication_coordination_glue::DatabaseHistories> {
   try {
-    auto stream{rpc_client_.Stream<coordination::GetDatabaseHistoriesRpc>()};
+    auto stream{rpc_client_.Stream<GetDatabaseHistoriesRpc>()};
     auto res = stream.AwaitResponse();
     return res.database_histories;
 

--- a/src/coordination/replication_instance_client.cpp
+++ b/src/coordination/replication_instance_client.cpp
@@ -179,14 +179,15 @@ auto ReplicationInstanceClient::SendEnableWritingOnMainRpc() const -> bool {
 }
 
 auto ReplicationInstanceClient::SendGetInstanceTimestampsRpc() const
-    -> utils::BasicResult<GetInstanceTimestampsError, replication_coordination_glue::DatabaseHistories> {
+    -> std::optional<replication_coordination_glue::DatabaseHistories> {
   try {
     auto stream{rpc_client_.Stream<coordination::GetDatabaseHistoriesRpc>()};
-    return stream.AwaitResponse().database_histories;
+    auto res = stream.AwaitResponse();
+    return res.database_histories;
 
   } catch (const rpc::RpcFailedException &) {
     spdlog::error("Failed to receive RPC response when sending GetInstanceTimestampRPC");
-    return GetInstanceTimestampsError::RPC_EXCEPTION;
+    return {};
   }
 }
 

--- a/src/coordination/replication_instance_connector.cpp
+++ b/src/coordination/replication_instance_connector.cpp
@@ -93,7 +93,7 @@ auto ReplicationInstanceConnector::GetReplicationClientInfo() const -> coordinat
   return client_.GetReplicationClientInfo();
 }
 
-auto ReplicationInstanceConnector::GetClient() -> ReplicationInstanceClient & { return client_; }
+auto ReplicationInstanceConnector::GetClient() const -> ReplicationInstanceClient const & { return client_; }
 
 }  // namespace memgraph::coordination
 #endif

--- a/tests/unit/coordinator_cluster_state.cpp
+++ b/tests/unit/coordinator_cluster_state.cpp
@@ -59,7 +59,7 @@ TEST_F(CoordinatorClusterStateTest, RegisterReplicationInstance) {
   auto const uuid = UUID{};
   data_instances.emplace_back(config, ReplicationRole::REPLICA, uuid);
 
-  cluster_state.DoAction(std::make_pair(data_instances, uuid));
+  cluster_state.DoAction(data_instances, uuid);
 
   auto instances = cluster_state.GetDataInstances();
   ASSERT_EQ(instances.size(), 1);
@@ -84,7 +84,7 @@ TEST_F(CoordinatorClusterStateTest, SetInstanceToReplica) {
                                    .ssl = std::nullopt};
     auto const uuid = UUID{};
     data_instances.emplace_back(config, ReplicationRole::MAIN, uuid);
-    cluster_state.DoAction(std::make_pair(data_instances, uuid));
+    cluster_state.DoAction(data_instances, uuid);
   }
   {
     auto config =
@@ -101,7 +101,7 @@ TEST_F(CoordinatorClusterStateTest, SetInstanceToReplica) {
 
     auto const uuid = UUID{};
     data_instances.emplace_back(config, ReplicationRole::REPLICA, uuid);
-    cluster_state.DoAction(std::make_pair(data_instances, uuid));
+    cluster_state.DoAction(data_instances, uuid);
   }
 
   auto const repl_instances = cluster_state.GetDataInstances();
@@ -153,7 +153,7 @@ TEST_F(CoordinatorClusterStateTest, Marshalling) {
 
   auto const uuid = UUID{};
   data_instances.emplace_back(config, ReplicationRole::REPLICA, uuid);
-  cluster_state.DoAction(std::make_pair(data_instances, uuid));
+  cluster_state.DoAction(data_instances, uuid);
 
   ptr<buffer> data{};
   cluster_state.Serialize(data);


### PR DESCRIPTION
Fixes the bug with c++ ranges and zipping when doing failover.