### PR TITLE
Bugfix: Deadlock when demoting data instance

### DIFF
--- a/.github/workflows/stress_jepsen.yaml
+++ b/.github/workflows/stress_jepsen.yaml
@@ -78,7 +78,7 @@ jobs:
           cd tests/jepsen
           ./run.sh test \
           --binary ../../build/memgraph \
-          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 7200 --concurrency 6" \
+          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 3600 --concurrency 6" \
           --ignore-run-stdout-logs \
           --ignore-run-stderr-logs \
           --nodes-no 6 \

--- a/.github/workflows/stress_jepsen.yaml
+++ b/.github/workflows/stress_jepsen.yaml
@@ -78,7 +78,7 @@ jobs:
           cd tests/jepsen
           ./run.sh test \
           --binary ../../build/memgraph \
-          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 3600 --concurrency 6" \
+          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 7200 --concurrency 6" \
           --ignore-run-stdout-logs \
           --ignore-run-stderr-logs \
           --nodes-no 6 \

--- a/src/communication/server.hpp
+++ b/src/communication/server.hpp
@@ -148,7 +148,8 @@ class Server final {
       // Connection is not available anymore or configuration failed.
       return;
     }
-    spdlog::info("Accepted a {} connection from {}", service_name_, s->endpoint());
+    auto const endpoint = s->endpoint();
+    spdlog::info("Accepted a {} connection from {}:{}.", service_name_, endpoint.GetAddress(), endpoint.GetPort());
     listener_.AddConnection(std::move(*s));
   }
 

--- a/src/coordination/data_instance_management_server_handlers.cpp
+++ b/src/coordination/data_instance_management_server_handlers.cpp
@@ -247,6 +247,10 @@ void DataInstanceManagementServerHandlers::UnregisterReplicaHandler(
       spdlog::error("Could not persist replica unregistration.");
       slk::Save(coordination::UnregisterReplicaRes{false}, res_builder);
       break;
+    case NO_ACCESS:
+      spdlog::error("Couldn't get unique access to ReplicationState when unregistering replica.");
+      slk::Save(coordination::UnregisterReplicaRes{false}, res_builder);
+      break;
   }
   spdlog::info("Replica {} successfully unregistered.", req.instance_name);
 }

--- a/src/coordination/include/coordination/data_instance_management_server_handlers.hpp
+++ b/src/coordination/include/coordination/data_instance_management_server_handlers.hpp
@@ -65,6 +65,12 @@ class DataInstanceManagementServerHandlers {
     if (instance_client.HasError()) {
       using memgraph::query::RegisterReplicaError;
       switch (instance_client.GetError()) {
+        case RegisterReplicaError::NO_ACCESS: {
+          spdlog::error(
+              "Error when registering instance {} as replica. Couldn't get unique access to ReplicationState.");
+          slk::Save(TResponse{false}, res_builder);
+          return false;
+        }
         case RegisterReplicaError::NOT_MAIN: {
           spdlog::error("Error when registering instance {} as replica. Instance not main anymore.",
                         config.instance_name);

--- a/src/dbms/dbms_handler.cpp
+++ b/src/dbms/dbms_handler.cpp
@@ -47,6 +47,8 @@ std::string RegisterReplicaErrorToString(query::RegisterReplicaError error) {
       return "COULD_NOT_BE_PERSISTED";
     case ERROR_ACCEPTING_MAIN:
       return "ERROR_ACCEPTING_MAIN";
+    case NO_ACCESS:
+      return "NO_ACCESS";
   }
 }
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -5987,8 +5987,8 @@ void Interpreter::Commit() {
 
   auto commit_confirmed_by_all_sync_replicas = true;
 
-  auto &repl_state_lock = interpreter_context_->repl_state->GetLock();
-  repl_state_lock.lock();
+  spdlog::trace("Trying to lock repl state in interpreter during commit.");
+  interpreter_context_->repl_state->Lock();
   spdlog::trace("Repl state locked in interpreter during commit.");
   bool const is_main = interpreter_context_->repl_state->IsMain();
   auto *curr_txn = current_db_.db_transactional_accessor_->GetTransaction();
@@ -5997,12 +5997,12 @@ void Interpreter::Commit() {
     spdlog::trace("Main with write txn became replica, aborting txn.");
     Abort();
     spdlog::trace("Txn aborted.");
-    repl_state_lock.unlock();
+    interpreter_context_->repl_state->Unlock();
     spdlog::trace("Repl state unlocked in interpreter during commit");
     return;
   }
   auto maybe_commit_error = current_db_.db_transactional_accessor_->Commit({.is_main = is_main}, current_db_.db_acc_);
-  repl_state_lock.unlock();
+  interpreter_context_->repl_state->Unlock();
   spdlog::trace("Repl state unlocked in interpreter during commit");
 
   if (maybe_commit_error.HasError()) {

--- a/src/query/replication_query_handler.hpp
+++ b/src/query/replication_query_handler.hpp
@@ -33,7 +33,8 @@ enum class RegisterReplicaError : uint8_t {
   ENDPOINT_EXISTS,
   CONNECTION_FAILED,
   COULD_NOT_BE_PERSISTED,
-  ERROR_ACCEPTING_MAIN
+  ERROR_ACCEPTING_MAIN,
+  NO_ACCESS
 };
 
 enum class UnregisterReplicaResult : uint8_t {
@@ -41,6 +42,7 @@ enum class UnregisterReplicaResult : uint8_t {
   COULD_NOT_BE_PERSISTED,
   CANNOT_UNREGISTER,
   SUCCESS,
+  NO_ACCESS
 };
 
 enum class ShowReplicaError : uint8_t {

--- a/src/replication/include/replication/replication_client.hpp
+++ b/src/replication/include/replication/replication_client.hpp
@@ -104,6 +104,8 @@ struct ReplicationClient {
     }
   };
 
+  void Shutdown();
+
   std::string name_;
   communication::ClientContext rpc_context_;
   rpc::Client rpc_client_;

--- a/src/replication/include/replication/state.hpp
+++ b/src/replication/include/replication/state.hpp
@@ -126,8 +126,8 @@ struct ReplicationState {
   bool SetReplicationRoleReplica(const ReplicationServerConfig &config,
                                  const std::optional<utils::UUID> &main_uuid = std::nullopt);
 
-  auto GetLock() -> std::mutex & { return mutex_; }
   auto TryLock() -> bool { return mutex_.try_lock(); }
+  auto Lock() -> void { mutex_.lock(); }
   auto Unlock() -> void { mutex_.unlock(); }
 
  private:

--- a/src/replication/replication_client.cpp
+++ b/src/replication/replication_client.cpp
@@ -31,6 +31,17 @@ ReplicationClient::ReplicationClient(const memgraph::replication::ReplicationCli
       replica_check_frequency_{config.replica_check_frequency},
       mode_{config.mode} {}
 
+void ReplicationClient::Shutdown() {
+  auto const &endpoint = rpc_client_.Endpoint();
+  spdlog::trace("Trying to stop scheduler when shutting down replication client on {}.", endpoint.SocketAddress());
+  replica_checker_.Stop();
+  spdlog::trace("Stopped scheduler when shutting down replication client on {}. Trying to shutdown thread pool.",
+                endpoint.SocketAddress());
+  thread_pool_.ShutDown();
+  spdlog::trace("Trying to shutdown thread pool when shutting down replication client on {}.",
+                endpoint.SocketAddress());
+}
+
 ReplicationClient::~ReplicationClient() {
   auto const &endpoint = rpc_client_.Endpoint();
   try {

--- a/src/replication/replication_client.cpp
+++ b/src/replication/replication_client.cpp
@@ -40,7 +40,8 @@ ReplicationClient::~ReplicationClient() {
   }
   spdlog::trace("Trying to stop scheduler in replication client on {}:{}.", endpoint.GetAddress(), endpoint.GetPort());
   replica_checker_.Stop();
-  spdlog::trace("Stopped scheduler in replication client on {}:{}.", endpoint.GetAddress(), endpoint.GetPort());
+  spdlog::trace("Stopped scheduler in replication client on {}:{}. Trying to shutdown thread pool.",
+                endpoint.GetAddress(), endpoint.GetPort());
   thread_pool_.ShutDown();
   spdlog::trace("Trying to shutdown thread pool in replication client on {}:{}.", endpoint.GetAddress(),
                 endpoint.GetPort());

--- a/src/replication/replication_client.cpp
+++ b/src/replication/replication_client.cpp
@@ -38,8 +38,12 @@ ReplicationClient::~ReplicationClient() {
   } catch (...) {
     // Logging can throw. Not a big deal, just ignore.
   }
+  spdlog::trace("Trying to stop scheduler in replication client on {}:{}.", endpoint.GetAddress(), endpoint.GetPort());
   replica_checker_.Stop();
+  spdlog::trace("Stopped scheduler in replication client on {}:{}.", endpoint.GetAddress(), endpoint.GetPort());
   thread_pool_.ShutDown();
+  spdlog::trace("Trying to shutdown thread pool in replication client on {}:{}.", endpoint.GetAddress(),
+                endpoint.GetPort());
 }
 
 }  // namespace memgraph::replication

--- a/src/replication/replication_client.cpp
+++ b/src/replication/replication_client.cpp
@@ -32,14 +32,8 @@ ReplicationClient::ReplicationClient(const memgraph::replication::ReplicationCli
       mode_{config.mode} {}
 
 void ReplicationClient::Shutdown() {
-  auto const &endpoint = rpc_client_.Endpoint();
-  spdlog::trace("Trying to stop scheduler when shutting down replication client on {}.", endpoint.SocketAddress());
   replica_checker_.Stop();
-  spdlog::trace("Stopped scheduler when shutting down replication client on {}. Trying to shutdown thread pool.",
-                endpoint.SocketAddress());
   thread_pool_.ShutDown();
-  spdlog::trace("Trying to shutdown thread pool when shutting down replication client on {}.",
-                endpoint.SocketAddress());
 }
 
 ReplicationClient::~ReplicationClient() {
@@ -49,13 +43,8 @@ ReplicationClient::~ReplicationClient() {
   } catch (...) {
     // Logging can throw. Not a big deal, just ignore.
   }
-  spdlog::trace("Trying to stop scheduler in replication client on {}:{}.", endpoint.GetAddress(), endpoint.GetPort());
   replica_checker_.Stop();
-  spdlog::trace("Stopped scheduler in replication client on {}:{}. Trying to shutdown thread pool.",
-                endpoint.GetAddress(), endpoint.GetPort());
   thread_pool_.ShutDown();
-  spdlog::trace("Trying to shutdown thread pool in replication client on {}:{}.", endpoint.GetAddress(),
-                endpoint.GetPort());
 }
 
 }  // namespace memgraph::replication

--- a/src/replication_handler/include/replication_handler/replication_handler.hpp
+++ b/src/replication_handler/include/replication_handler/replication_handler.hpp
@@ -25,7 +25,7 @@
 namespace memgraph::replication {
 
 inline std::optional<query::RegisterReplicaError> HandleRegisterReplicaStatus(
-    utils::BasicResult<replication::RegisterReplicaError, replication::ReplicationClient *> &instance_client);
+    utils::BasicResult<replication::RegisterReplicaStatus, replication::ReplicationClient *> &instance_client);
 
 #ifdef MG_ENTERPRISE
 void StartReplicaClient(replication::ReplicationClient &client, system::System &system, dbms::DbmsHandler &dbms_handler,
@@ -161,20 +161,26 @@ struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
   auto RegisterReplica_(const memgraph::replication::ReplicationClientConfig &config)
       -> memgraph::utils::BasicResult<memgraph::query::RegisterReplicaError> {
     using memgraph::query::RegisterReplicaError;
-    using ClientRegisterReplicaError = memgraph::replication::RegisterReplicaError;
+    using ClientRegisterReplicaStatus = memgraph::replication::RegisterReplicaStatus;
+
+    if (!repl_state_.TryLock()) {
+      return RegisterReplicaError::NO_ACCESS;
+    }
+
+    auto unlock_repl_state = utils::OnScopeExit([this]() { repl_state_.Unlock(); });
 
     auto maybe_client = repl_state_.RegisterReplica(config);
     if (maybe_client.HasError()) {
       switch (maybe_client.GetError()) {
-        case ClientRegisterReplicaError::NOT_MAIN:
+        case ClientRegisterReplicaStatus::NOT_MAIN:
           return RegisterReplicaError::NOT_MAIN;
-        case ClientRegisterReplicaError::NAME_EXISTS:
+        case ClientRegisterReplicaStatus::NAME_EXISTS:
           return RegisterReplicaError::NAME_EXISTS;
-        case ClientRegisterReplicaError::ENDPOINT_EXISTS:
+        case ClientRegisterReplicaStatus::ENDPOINT_EXISTS:
           return RegisterReplicaError::ENDPOINT_EXISTS;
-        case ClientRegisterReplicaError::COULD_NOT_BE_PERSISTED:
+        case ClientRegisterReplicaStatus::COULD_NOT_BE_PERSISTED:
           return RegisterReplicaError::COULD_NOT_BE_PERSISTED;
-        case ClientRegisterReplicaError::SUCCESS:
+        case ClientRegisterReplicaStatus::SUCCESS:
           break;
       }
     }
@@ -236,6 +242,10 @@ struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
       auto const unregister_res{UnregisterReplica(config.name)};
       switch (unregister_res) {
         using memgraph::query::UnregisterReplicaResult;
+        case UnregisterReplicaResult::NO_ACCESS:
+          spdlog::trace("Failed to unregister replica {} since we couldn't get unique access to ReplicationState.",
+                        config.name);
+          break;
         case UnregisterReplicaResult::NOT_MAIN:
           spdlog::trace(
               "Failed to unregister replica {} after failed registration process since the instance isn't main "
@@ -277,6 +287,13 @@ struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
   template <bool AllowIdempotency>
   bool SetReplicationRoleReplica_(const memgraph::replication::ReplicationServerConfig &config,
                                   const std::optional<utils::UUID> &main_uuid) {
+    // If we cannot acquire lock on repl_state, we cannot set role to replica.
+    if (!repl_state_.TryLock()) {
+      return false;
+    }
+
+    auto unlock_repl_state = utils::OnScopeExit([this]() { repl_state_.Unlock(); });
+
     if (repl_state_.IsReplica()) {
       if (!AllowIdempotency) {
         return false;
@@ -301,8 +318,6 @@ struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
       auto *storage = db_acc->storage();
       storage->repl_storage_state_.replication_clients_.WithLock([](auto &clients) { clients.clear(); });
     });
-    // Remove instance level clients
-    std::get<memgraph::replication::RoleMainData>(repl_state_.ReplicationData()).registered_replicas_.clear();
 
     // Creates the server
     repl_state_.SetReplicationRoleReplica(config, main_uuid);

--- a/src/replication_handler/include/replication_handler/replication_handler.hpp
+++ b/src/replication_handler/include/replication_handler/replication_handler.hpp
@@ -317,6 +317,13 @@ struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
 #endif
     }
 
+    spdlog::trace("Shutting down instance level clients when demoting replica.");
+
+    auto &repl_clients = std::get<RoleMainData>(repl_state_.ReplicationData()).registered_replicas_;
+    for (auto &client : repl_clients) {
+      client.Shutdown();
+    }
+
     // TODO StorageState needs to be synched. Could have a dangling reference if someone adds a database as we are
     //      deleting the replica.
     // Remove database specific clients

--- a/src/replication_handler/include/replication_handler/replication_handler.hpp
+++ b/src/replication_handler/include/replication_handler/replication_handler.hpp
@@ -292,13 +292,8 @@ struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
       spdlog::trace("Cannot acquire lock on repl state while setting role to replica.");
       return false;
     }
-    spdlog::trace("Acquired lock on repl state when setting role to replica.");
 
-    auto unlock_repl_state = utils::OnScopeExit([this]() {
-      spdlog::trace("Trying to unlock repl state while setting role to replica.");
-      repl_state_.Unlock();
-      spdlog::trace("Unlocked repl state while setting role to replica.");
-    });
+    auto unlock_repl_state = utils::OnScopeExit([this]() { repl_state_.Unlock(); });
 
     if (repl_state_.IsReplica()) {
       if (!AllowIdempotency) {

--- a/src/rpc/client.hpp
+++ b/src/rpc/client.hpp
@@ -73,9 +73,13 @@ class Client {
 
     typename TRequestResponse::Response AwaitResponse() {
       auto res_type = TRequestResponse::Response::kType;
+      auto req_type = TRequestResponse::Request::kType;
 
       // Finalize the request.
       req_builder_.Finalize();
+
+      spdlog::trace("[RpcClient] sent {} to {}:{}", req_type.name, self_->client_->endpoint().GetAddress(),
+                    self_->client_->endpoint().GetPort());
 
       // Receive the response.
       uint64_t response_data_size = 0;
@@ -133,7 +137,8 @@ class Client {
         throw GenericRpcFailedException();
       }
 
-      SPDLOG_TRACE("[RpcClient] received {}", res_type.name);
+      spdlog::trace("[RpcClient] received {} from endpoint {}:{}.", res_type.name, self_->endpoint_.GetAddress(),
+                    self_->endpoint_.GetPort());
 
       return res_load_(&res_reader);
     }
@@ -190,7 +195,6 @@ class Client {
                                                  Args &&...args) {
     typename TRequestResponse::Request request(std::forward<Args>(args)...);
     auto req_type = TRequestResponse::Request::kType;
-    spdlog::trace("[RpcClient] sent {}", req_type.name);
 
     auto guard = std::unique_lock{mutex_};
 

--- a/src/storage/v2/replication/replication_storage_state.cpp
+++ b/src/storage/v2/replication/replication_storage_state.cpp
@@ -36,7 +36,7 @@ bool ReplicationStorageState::FinalizeTransaction(uint64_t timestamp, Storage *s
                                                   std::vector<std::optional<ReplicaStream>> replica_streams) {
   return replication_clients_.WithLock([=, db_acc = std::move(db_acc),
                                         replica_streams = std::move(replica_streams)](auto &clients) mutable {
-    bool finalized_on_all_replicas = true;
+    bool finalized_on_all_replicas{true};
     MG_ASSERT(clients.empty() || db_acc.has_value(),
               "Any clients assumes we are MAIN, we should have gatekeeper_access_wrapper so we can correctly "
               "handle ASYNC tasks");

--- a/src/storage/v2/replication/replication_storage_state.cpp
+++ b/src/storage/v2/replication/replication_storage_state.cpp
@@ -34,6 +34,7 @@ auto ReplicationStorageState::InitializeTransaction(uint64_t seq_num, Storage *s
 
 bool ReplicationStorageState::FinalizeTransaction(uint64_t timestamp, Storage *storage, DatabaseAccessProtector db_acc,
                                                   std::vector<std::optional<ReplicaStream>> replica_streams) {
+  spdlog::trace("Finalizing txn in ReplicationStorageState.");
   return replication_clients_.WithLock([=, db_acc = std::move(db_acc),
                                         replica_streams = std::move(replica_streams)](auto &clients) mutable {
     bool finalized_on_all_replicas{true};
@@ -41,8 +42,11 @@ bool ReplicationStorageState::FinalizeTransaction(uint64_t timestamp, Storage *s
               "Any clients assumes we are MAIN, we should have gatekeeper_access_wrapper so we can correctly "
               "handle ASYNC tasks");
     for (auto &&[i, replica_stream] : ranges::views::enumerate(replica_streams)) {
+      spdlog::trace("Appending txn end for client {}.", i);
       clients[i]->IfStreamingTransaction([&](auto &stream) { stream.AppendTransactionEnd(timestamp); }, replica_stream);
+      spdlog::trace("Appended txn end for client {}.", i);
       const auto finalized = clients[i]->FinalizeTransactionReplication(storage, db_acc, std::move(replica_stream));
+      spdlog::trace("Finalized tnx replication on client {}.", i);
 
       if (clients[i]->Mode() == replication_coordination_glue::ReplicationMode::SYNC) {
         finalized_on_all_replicas = finalized && finalized_on_all_replicas;

--- a/src/utils/scheduler.hpp
+++ b/src/utils/scheduler.hpp
@@ -118,7 +118,9 @@ class Scheduler {
         is_paused_ = false;
       }
       condition_variable_.notify_one();
-      if (thread_.joinable()) thread_.join();
+      if (thread_.joinable()) {
+        thread_.join();
+      }
     }
   }
 

--- a/src/utils/scheduler.hpp
+++ b/src/utils/scheduler.hpp
@@ -112,22 +112,14 @@ class Scheduler {
   // actually stop the scheduler, the other one won't. We need to know which one is the successful
   // one so that we don't try to join thread concurrently since this could cause undefined behavior.
   void Stop() {
-    spdlog::trace("Trying to stop scheduler");
     if (thread_.request_stop()) {
-      spdlog::trace("requested stop on scheduler's thread.");
       {
         auto lk = std::unique_lock{mutex_};
         is_paused_ = false;
       }
-      spdlog::trace("is_paused_ set to false.");
       condition_variable_.notify_one();
-      spdlog::trace("cv notified.");
       if (thread_.joinable()) {
-        spdlog::trace("Trying to join thread in scheduler.");
         thread_.join();
-        spdlog::trace("thread successfully joined.");
-      } else {
-        spdlog::trace("Thread isn't joinable.");
       }
     }
   }
@@ -139,11 +131,7 @@ class Scheduler {
     return token.stop_possible() && !token.stop_requested();
   }
 
-  ~Scheduler() {
-    spdlog::trace("Stopping scheduler's thread on destruction.");
-    Stop();
-    spdlog::trace("Scheduler's thread stopped.");
-  }
+  ~Scheduler() { Stop(); }
 
  private:
   /**

--- a/src/utils/scheduler.hpp
+++ b/src/utils/scheduler.hpp
@@ -112,14 +112,22 @@ class Scheduler {
   // actually stop the scheduler, the other one won't. We need to know which one is the successful
   // one so that we don't try to join thread concurrently since this could cause undefined behavior.
   void Stop() {
+    spdlog::trace("Trying to stop scheduler");
     if (thread_.request_stop()) {
+      spdlog::trace("requested stop on scheduler's thread.");
       {
         auto lk = std::unique_lock{mutex_};
         is_paused_ = false;
       }
+      spdlog::trace("is_paused_ set to false.");
       condition_variable_.notify_one();
+      spdlog::trace("cv notified.");
       if (thread_.joinable()) {
+        spdlog::trace("Trying to join thread in scheduler.");
         thread_.join();
+        spdlog::trace("thread successfully joined.");
+      } else {
+        spdlog::trace("Thread isn't joinable.");
       }
     }
   }
@@ -131,7 +139,11 @@ class Scheduler {
     return token.stop_possible() && !token.stop_requested();
   }
 
-  ~Scheduler() { Stop(); }
+  ~Scheduler() {
+    spdlog::trace("Stopping scheduler's thread on destruction.");
+    Stop();
+    spdlog::trace("Scheduler's thread stopped.");
+  }
 
  private:
   /**

--- a/src/utils/thread_pool.cpp
+++ b/src/utils/thread_pool.cpp
@@ -20,21 +20,31 @@ ThreadPool::ThreadPool(const size_t pool_size) {
 
 void ThreadPool::AddTask(std::function<void()> new_task) {
   {
+    spdlog::trace("Trying to acquire lock when adding task to thread pool in thread {}.", std::this_thread::get_id());
     auto guard = std::unique_lock{pool_lock_};
-    if (pool_stop_source_.stop_requested()) return;
+    spdlog::trace("Acquired lock when adding task to thread pool in thread {}.", std::this_thread::get_id());
+    if (pool_stop_source_.stop_requested()) {
+      spdlog::trace("Released lock when adding task to thread pool in thread {}.", std::this_thread::get_id());
+      return;
+    }
     task_queue_.emplace(std::move(new_task));
   }
   unfinished_tasks_num_.fetch_add(1);
 
   queue_cv_.notify_one();
+  spdlog::trace("Released lock when adding task to thread pool in thread {}.", std::this_thread::get_id());
 }
 
 void ThreadPool::ShutDown() {
+  spdlog::trace("Shutting down thread pool in thread {}.", std::this_thread::get_id());
   {
+    spdlog::trace("Trying to acquire lock when shutting down thread pool in thread {}.", std::this_thread::get_id());
     auto guard = std::unique_lock{pool_lock_};
+    spdlog::trace("Acquired lock when shutting down thread pool in thread {}.", std::this_thread::get_id());
     pool_stop_source_.request_stop();
     auto empty_queue = std::queue<TaskSignature>{};
     task_queue_.swap(empty_queue);
+    spdlog::trace("Lock released when shutting down thread pool in thread {}.", std::this_thread::get_id());
   }
 
   queue_cv_.notify_all();
@@ -42,8 +52,13 @@ void ThreadPool::ShutDown() {
 }
 
 ThreadPool::~ThreadPool() {
+  spdlog::trace("Destroying thread pool in thread {}.", std::this_thread::get_id());
   if (!pool_stop_source_.stop_requested()) {
+    spdlog::trace("Stop not yet requested when destroying thread pool, shutting it down in thread {}.",
+                  std::this_thread::get_id());
     ShutDown();
+    spdlog::trace("Thread pool shut down while destroying thread pool, shutting it down in thread {}.",
+                  std::this_thread::get_id());
   }
 }
 
@@ -52,7 +67,9 @@ void ThreadPool::ThreadLoop() {
   while (true) {
     TaskSignature task;
     {
+      spdlog::trace("Trying to acquire lock in ThreadLoop in thread {}.", std::this_thread::get_id());
       auto guard = std::unique_lock{pool_lock_};
+      spdlog::trace("Lock acquired in ThreadLoop in thread {}.", std::this_thread::get_id());
       queue_cv_.wait(guard, token, [&] { return !task_queue_.empty(); });
       if (token.stop_requested()) return;
       task = std::move(task_queue_.front());

--- a/src/utils/thread_pool.cpp
+++ b/src/utils/thread_pool.cpp
@@ -20,11 +20,8 @@ ThreadPool::ThreadPool(const size_t pool_size) {
 
 void ThreadPool::AddTask(std::function<void()> new_task) {
   {
-    spdlog::trace("Trying to acquire lock when adding task to thread pool in thread {}.", std::this_thread::get_id());
     auto guard = std::unique_lock{pool_lock_};
-    spdlog::trace("Acquired lock when adding task to thread pool in thread {}.", std::this_thread::get_id());
     if (pool_stop_source_.stop_requested()) {
-      spdlog::trace("Released lock when adding task to thread pool in thread {}.", std::this_thread::get_id());
       return;
     }
     task_queue_.emplace(std::move(new_task));
@@ -32,19 +29,14 @@ void ThreadPool::AddTask(std::function<void()> new_task) {
   unfinished_tasks_num_.fetch_add(1);
 
   queue_cv_.notify_one();
-  spdlog::trace("Released lock when adding task to thread pool in thread {}.", std::this_thread::get_id());
 }
 
 void ThreadPool::ShutDown() {
-  spdlog::trace("Shutting down thread pool in thread {}.", std::this_thread::get_id());
   {
-    spdlog::trace("Trying to acquire lock when shutting down thread pool in thread {}.", std::this_thread::get_id());
     auto guard = std::unique_lock{pool_lock_};
-    spdlog::trace("Acquired lock when shutting down thread pool in thread {}.", std::this_thread::get_id());
     pool_stop_source_.request_stop();
     auto empty_queue = std::queue<TaskSignature>{};
     task_queue_.swap(empty_queue);
-    spdlog::trace("Lock released when shutting down thread pool in thread {}.", std::this_thread::get_id());
   }
 
   queue_cv_.notify_all();
@@ -52,13 +44,8 @@ void ThreadPool::ShutDown() {
 }
 
 ThreadPool::~ThreadPool() {
-  spdlog::trace("Destroying thread pool in thread {}.", std::this_thread::get_id());
   if (!pool_stop_source_.stop_requested()) {
-    spdlog::trace("Stop not yet requested when destroying thread pool, shutting it down in thread {}.",
-                  std::this_thread::get_id());
     ShutDown();
-    spdlog::trace("Thread pool shut down while destroying thread pool, shutting it down in thread {}.",
-                  std::this_thread::get_id());
   }
 }
 
@@ -67,9 +54,7 @@ void ThreadPool::ThreadLoop() {
   while (true) {
     TaskSignature task;
     {
-      spdlog::trace("Trying to acquire lock in ThreadLoop in thread {}.", std::this_thread::get_id());
       auto guard = std::unique_lock{pool_lock_};
-      spdlog::trace("Lock acquired in ThreadLoop in thread {}.", std::this_thread::get_id());
       queue_cv_.wait(guard, token, [&] { return !task_queue_.empty(); });
       if (token.stop_requested()) return;
       task = std::move(task_queue_.front());

--- a/tests/jepsen/src/memgraph/query.clj
+++ b/tests/jepsen/src/memgraph/query.clj
@@ -6,6 +6,11 @@
 (dbclient/defquery get-all-instances
   "SHOW INSTANCES;")
 
+
+(dbclient/defquery show-replication-role
+  "SHOW REPLICATION ROLE;")
+
+
 (dbclient/defquery detach-delete-all
   "MATCH (n) DETACH DELETE n;")
 


### PR DESCRIPTION
When a coordinator sends a request for promotion or demotion, the lock on replication state is taken so that it cannot be interleaved with commit. If main became a replica and was executing write txn, the txn will be aborted. Scheduler is now stopped before thread pool in rpc client.