### PR TITLE
Fix crash in point function when wrong CRS is provided

### DIFF
--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -1530,7 +1530,14 @@ TypedValue Point(const TypedValue *args, int64_t nargs, const FunctionContext &c
   }
 
   if (!z_opt.has_value()) {
+    if (!storage::valid2d(*mg_crs)) {
+      throw QueryRuntimeException("Concluded point type is 2D but CRS/SRID says it is 3D.");
+    }
     return TypedValue(storage::Point2d{*mg_crs, x, y}, ctx.memory);
+  }
+
+  if (!storage::valid3d(*mg_crs)) {
+    throw QueryRuntimeException("Concluded point type is 3D but CRS/SRID says it is 2D.");
   }
   return TypedValue(storage::Point3d{*mg_crs, x, y, z_opt->first}, ctx.memory);
 }

--- a/tests/gql_behave/tests/memgraph_V1/features/spatial.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/spatial.feature
@@ -91,6 +91,48 @@ Feature: Spatial related features
             """
         Then an error should be raised
 
+    Scenario: Point creation failure 8:
+        When executing query:
+            """
+            RETURN point({longitude:1, latitude:2, crs:'cartesian-3d'}) as result;
+            """
+        Then an error should be raised
+
+    Scenario: Point creation failure 9:
+        When executing query:
+            """
+            RETURN point({longitude:1, latitude:2, crs:'wgs-84-3d'}) as result;
+            """
+        Then an error should be raised
+
+    Scenario: Point creation failure 10:
+        When executing query:
+            """
+            RETURN point({longitude:1, latitude:2, height:3, crs:'wgs-84'}) as result;
+            """
+        Then an error should be raised
+
+    Scenario: Point creation failure 11:
+        When executing query:
+            """
+            RETURN point({longitude:1, latitude:2, height:3, crs:'cartesian'}) as result;
+            """
+        Then an error should be raised
+
+    Scenario: Point creation failure 12:
+        When executing query:
+            """
+            RETURN point({x:1, y:2, z:3, crs:'cartesian'}) as result;
+            """
+        Then an error should be raised
+
+    Scenario: Point creation failure 13:
+        When executing query:
+            """
+            RETURN point({x:1, y:2, crs:'cartesian-3d'}) as result;
+            """
+        Then an error should be raised
+
     Scenario: Point2d-WGS48 lookup:
         Given an empty graph
         When executing query:


### PR DESCRIPTION
When using point function and for example providing x, y, z and crs for 2D point and vice versa Memgraph would crash (only in debug mode) due to concluding point type is 2D but CRS being 3D (and vice versa).
