### PR TITLE
Handle failure in WAL replication

### DIFF
--- a/.github/workflows/stress_jepsen.yaml
+++ b/.github/workflows/stress_jepsen.yaml
@@ -78,7 +78,7 @@ jobs:
           cd tests/jepsen
           ./run.sh test \
           --binary ../../build/memgraph \
-          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 7200 --concurrency 6" \
+          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 10800 --concurrency 6" \
           --ignore-run-stdout-logs \
           --ignore-run-stderr-logs \
           --nodes-no 6 \

--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -729,9 +729,7 @@ void CoordinatorInstance::InstanceSuccessCallback(std::string_view instance_name
     return;
   }
 
-  spdlog::trace("Trying to take lock on coord_instance_lock_in InstanceSuccessCallback for instance {}", instance_name);
   auto lock = std::unique_lock{coord_instance_lock_};
-  spdlog::trace("Lock taken on coord_instance_lock_ in InstanceSuccessCallback for instance {}", instance_name);
 
   auto &instance = FindReplicationInstance(instance_name);
 
@@ -807,9 +805,7 @@ void CoordinatorInstance::InstanceFailCallback(std::string_view instance_name,
     return;
   }
 
-  spdlog::trace("Trying to take lock on coord_instance_lock_in InstanceFailCallback for instance {}", instance_name);
   auto lock = std::unique_lock{coord_instance_lock_};
-  spdlog::trace("Lock taken on coord_instance_lock_ in InstanceFailCallback for instance {}", instance_name);
 
   auto &instance = FindReplicationInstance(instance_name);
 

--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -247,9 +247,7 @@ auto CoordinatorInstance::ShowInstancesAsLeader() const -> std::optional<std::ve
   };
 
   {
-    spdlog::trace("Trying to take shared lock on coord_instance_lock_.");
     auto lock = std::shared_lock{coord_instance_lock_};
-    spdlog::trace("Shared lock taken on coord_instance_lock_.");
     std::ranges::transform(repl_instances_, std::back_inserter(instances_status), process_repl_instance_as_leader);
   }
 
@@ -277,9 +275,7 @@ auto CoordinatorInstance::ShowInstances() const -> std::vector<InstanceStatus> {
 
   CoordinatorInstanceConnector *leader{nullptr};
   {
-    spdlog::trace("Trying to take lock on coordinator instance connectors.");
     auto connectors = coordinator_connectors_.Lock();
-    spdlog::trace("Lock taken on coordinator instance connectors.");
 
     auto connector =
         std::ranges::find_if(*connectors, [&leader_id](auto &&connector) { return connector.first == leader_id; });

--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -105,7 +105,6 @@ auto CoordinatorInstance::GetBecomeLeaderCallback() -> std::function<void()> {
   };
 }
 
-// TODO: (andi) refactor reconcile cluster state and the way how we create checkers.
 auto CoordinatorInstance::GetBecomeFollowerCallback() -> std::function<void()> {
   return [this]() {
     status.store(CoordinatorStatus::FOLLOWER, std::memory_order_release);

--- a/src/coordination/coordinator_instance_connector.cpp
+++ b/src/coordination/coordinator_instance_connector.cpp
@@ -18,6 +18,7 @@ auto CoordinatorInstanceConnector::SendShowInstances() const -> std::optional<st
   try {
     spdlog::trace("Sending ShowInstancesRPC to endpoint {}", client_.RpcClient().Endpoint());
     auto stream{client_.RpcClient().Stream<ShowInstancesRpc>()};
+    spdlog::trace("Waiting response to ShowInstancesRpc.");
     auto res = stream.AwaitResponse();
     spdlog::trace("Received ShowInstancesRPC response");
     return res.instances_status_;

--- a/src/coordination/coordinator_instance_management_server_handlers.cpp
+++ b/src/coordination/coordinator_instance_management_server_handlers.cpp
@@ -29,6 +29,7 @@ void CoordinatorInstanceManagementServerHandlers::ShowInstancesHandler(Coordinat
   coordination::ShowInstancesReq req;
   slk::Load(&req, req_reader);
   slk::Save(coordination::ShowInstancesRes{coordinator_instance.ShowInstancesAsLeader()}, res_builder);
+  spdlog::trace("Replying to ShowInstancesRpc.");
 }
 #endif
 }  // namespace memgraph::coordination

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -929,10 +929,8 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
             throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
           break;
         }
-        case WalDeltaData::Type::TEXT_INDEX_CREATE: {
-          // NOTE: Text search doesn’t have replication in scope yet (Phases 1 and 2)
-          break;
-        }
+        case WalDeltaData::Type::TEXT_INDEX_CREATE:
+          [[fallthrough]];
         case WalDeltaData::Type::TEXT_INDEX_DROP: {
           // NOTE: Text search doesn’t have replication in scope yet (Phases 1 and 2)
           break;

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -249,6 +249,7 @@ void InMemoryReplicationHandlers::AppendDeltasHandler(dbms::DbmsHandler *dbms_ha
         e.what());
     const storage::replication::AppendDeltasRes res{false, 0};
     slk::Save(res, res_builder);
+    return;
   }
 
   const storage::replication::AppendDeltasRes res{true, repl_storage_state.last_durable_timestamp_.load()};
@@ -427,7 +428,12 @@ void InMemoryReplicationHandlers::WalFilesHandler(dbms::DbmsHandler *dbms_handle
   utils::EnsureDirOrDie(storage->recovery_.wal_directory_);
 
   for (auto i = 0; i < wal_file_number; ++i) {
-    LoadWal(storage, &decoder);
+    if (!LoadWal(storage, &decoder)) {
+      const storage::replication::WalFilesRes res{false, storage->repl_storage_state_.last_durable_timestamp_.load()};
+      slk::Save(res, res_builder);
+      spdlog::debug("Replication recovery from WAL files didn't end successfully, returning response...");
+      return;
+    }
   }
 
   const storage::replication::WalFilesRes res{true, storage->repl_storage_state_.last_durable_timestamp_.load()};
@@ -459,6 +465,8 @@ void InMemoryReplicationHandlers::CurrentWalHandler(dbms::DbmsHandler *dbms_hand
   auto *storage = static_cast<storage::InMemoryStorage *>(db_acc->get()->storage());
   utils::EnsureDirOrDie(storage->recovery_.wal_directory_);
 
+  // Even if loading wal file failed, we return last_durable_timestamp which is used on MAIN's side to figure out
+  // whether the replication ended successfully or not.
   LoadWal(storage, &decoder);
 
   const storage::replication::CurrentWalRes res{storage->repl_storage_state_.last_durable_timestamp_.load()};
@@ -466,7 +474,7 @@ void InMemoryReplicationHandlers::CurrentWalHandler(dbms::DbmsHandler *dbms_hand
   spdlog::debug("Replication recovery from current WAL ended successfully, replica is now up to date!");
 }
 
-void InMemoryReplicationHandlers::LoadWal(storage::InMemoryStorage *storage, storage::replication::Decoder *decoder) {
+bool InMemoryReplicationHandlers::LoadWal(storage::InMemoryStorage *storage, storage::replication::Decoder *decoder) {
   const auto temp_wal_directory =
       std::filesystem::temp_directory_path() / "memgraph" / storage::durability::kWalDirectory;
   utils::EnsureDir(temp_wal_directory);
@@ -513,10 +521,13 @@ void InMemoryReplicationHandlers::LoadWal(storage::InMemoryStorage *storage, sto
     }
 
     spdlog::debug("Replication from current WAL successful!");
+    return true;
   } catch (const storage::durability::RecoveryFailure &e) {
     spdlog::error("Couldn't recover WAL deltas from {} because of: {}.", *maybe_wal_path, e.what());
+    return false;
   } catch (const utils::BasicException &e) {
     spdlog::error("Loading WAL from {} failed because of {}.", *maybe_wal_path, e.what());
+    return false;
   }
 }
 
@@ -580,506 +591,533 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
   auto max_delta_timestamp = storage->repl_storage_state_.last_durable_timestamp_.load();
   auto current_durable_commit_timestamp = max_delta_timestamp;
 
-  try {
-    for (bool transaction_complete = false; !transaction_complete; ++current_delta_idx) {
-      const auto [delta_timestamp, delta] = ReadDelta(decoder, version);
-      if (delta_timestamp > max_delta_timestamp) {
-        max_delta_timestamp = delta_timestamp;
+  for (bool transaction_complete = false; !transaction_complete; ++current_delta_idx) {
+    const auto [delta_timestamp, delta] = ReadDelta(decoder, version);
+    if (delta_timestamp > max_delta_timestamp) {
+      max_delta_timestamp = delta_timestamp;
+    }
+
+    transaction_complete = storage::durability::IsWalDeltaDataTypeTransactionEnd(delta.type, version);
+
+    if (delta_timestamp <= current_durable_commit_timestamp) {
+      spdlog::trace("Skipping delta with timestamp: {}, current durable commit timestamp: {}", delta_timestamp,
+                    current_durable_commit_timestamp);
+      continue;
+    }
+    spdlog::trace("  Delta {}", current_delta_idx);
+    switch (delta.type) {
+      case WalDeltaData::Type::VERTEX_CREATE: {
+        auto const gid = delta.vertex_create_delete.gid.AsUint();
+        spdlog::trace("       Create vertex {}", gid);
+        auto *transaction = get_transaction_accessor(delta_timestamp);
+        if (!transaction->CreateVertexEx(delta.vertex_create_delete.gid).has_value()) {
+          throw utils::BasicException("Vertex with gid {} already exists at replica.", gid);
+        }
+        break;
       }
-
-      transaction_complete = storage::durability::IsWalDeltaDataTypeTransactionEnd(delta.type, version);
-
-      if (delta_timestamp <= current_durable_commit_timestamp) {
-        spdlog::trace("Skipping delta with timestamp: {}, current durable commit timestamp: {}", delta_timestamp,
-                      current_durable_commit_timestamp);
-        continue;
+      case WalDeltaData::Type::VERTEX_DELETE: {
+        auto const gid = delta.vertex_create_delete.gid.AsUint();
+        spdlog::trace("       Delete vertex {}", gid);
+        auto *transaction = get_transaction_accessor(delta_timestamp);
+        auto vertex = transaction->FindVertex(delta.vertex_create_delete.gid, View::NEW);
+        if (!vertex) {
+          throw utils::BasicException("Vertex with gid {} couldn't be found while trying to delete vertex.", gid);
+        }
+        auto ret = transaction->DeleteVertex(&*vertex);
+        if (ret.HasError() || !ret.GetValue()) {
+          throw utils::BasicException("Deleting vertex with gid {} failed.", gid);
+        }
+        break;
       }
-      spdlog::trace("  Delta {}", current_delta_idx);
-      switch (delta.type) {
-        case WalDeltaData::Type::VERTEX_CREATE: {
-          auto const gid = delta.vertex_create_delete.gid.AsUint();
-          spdlog::trace("       Create vertex {}", gid);
-          auto *transaction = get_transaction_accessor(delta_timestamp);
-          if (!transaction->CreateVertexEx(delta.vertex_create_delete.gid).has_value()) {
-            throw utils::BasicException("Vertex with gid {} already exists at replica.", gid);
-          }
-          break;
+      case WalDeltaData::Type::VERTEX_ADD_LABEL: {
+        auto const gid = delta.vertex_add_remove_label.gid.AsUint();
+        spdlog::trace("       Vertex {} add label {}", gid, delta.vertex_add_remove_label.label);
+        auto *transaction = get_transaction_accessor(delta_timestamp);
+        auto vertex = transaction->FindVertex(delta.vertex_add_remove_label.gid, View::NEW);
+        if (!vertex) {
+          throw utils::BasicException("Couldn't find vertex {} when adding label.", gid);
         }
-        case WalDeltaData::Type::VERTEX_DELETE: {
-          auto const gid = delta.vertex_create_delete.gid.AsUint();
-          spdlog::trace("       Delete vertex {}", gid);
-          auto *transaction = get_transaction_accessor(delta_timestamp);
-          auto vertex = transaction->FindVertex(delta.vertex_create_delete.gid, View::NEW);
-          if (!vertex) {
-            throw utils::BasicException("Vertex with gid {} couldn't be found while trying to delete vertex.", gid);
-          }
-          auto ret = transaction->DeleteVertex(&*vertex);
-          if (ret.HasError() || !ret.GetValue()) {
-            throw utils::BasicException("Deleting vertex with gid {} failed.", gid);
-          }
-          break;
+        // NOTE: Text search doesn’t have replication in scope yet (Phases 1 and 2)
+        auto ret = vertex->AddLabel(transaction->NameToLabel(delta.vertex_add_remove_label.label));
+        if (ret.HasError() || !ret.GetValue()) {
+          throw utils::BasicException("Failed to add label to vertex {}.", gid);
         }
-        case WalDeltaData::Type::VERTEX_ADD_LABEL: {
-          auto const gid = delta.vertex_add_remove_label.gid.AsUint();
-          spdlog::trace("       Vertex {} add label {}", gid, delta.vertex_add_remove_label.label);
-          auto *transaction = get_transaction_accessor(delta_timestamp);
-          auto vertex = transaction->FindVertex(delta.vertex_add_remove_label.gid, View::NEW);
-          if (!vertex) {
-            throw utils::BasicException("Couldn't find vertex {} when adding label.", gid);
-          }
-          // NOTE: Text search doesn’t have replication in scope yet (Phases 1 and 2)
-          auto ret = vertex->AddLabel(transaction->NameToLabel(delta.vertex_add_remove_label.label));
-          if (ret.HasError() || !ret.GetValue()) {
-            throw utils::BasicException("Failed to add label to vertex {}.", gid);
-          }
-          break;
+        break;
+      }
+      case WalDeltaData::Type::VERTEX_REMOVE_LABEL: {
+        auto const gid = delta.vertex_add_remove_label.gid.AsUint();
+        spdlog::trace("       Vertex {} remove label {}", gid, delta.vertex_add_remove_label.label);
+        auto *transaction = get_transaction_accessor(delta_timestamp);
+        auto vertex = transaction->FindVertex(delta.vertex_add_remove_label.gid, View::NEW);
+        if (!vertex) throw utils::BasicException("Failed to find vertex {} when removing label.", gid);
+        // NOTE: Text search doesn’t have replication in scope yet (Phases 1 and 2)
+        auto ret = vertex->RemoveLabel(transaction->NameToLabel(delta.vertex_add_remove_label.label));
+        if (ret.HasError() || !ret.GetValue()) {
+          throw utils::BasicException("Failed to remove label from vertex {}.", gid);
         }
-        case WalDeltaData::Type::VERTEX_REMOVE_LABEL: {
-          auto const gid = delta.vertex_add_remove_label.gid.AsUint();
-          spdlog::trace("       Vertex {} remove label {}", gid, delta.vertex_add_remove_label.label);
-          auto *transaction = get_transaction_accessor(delta_timestamp);
-          auto vertex = transaction->FindVertex(delta.vertex_add_remove_label.gid, View::NEW);
-          if (!vertex) throw utils::BasicException("Failed to find vertex {} when removing label.", gid);
-          // NOTE: Text search doesn’t have replication in scope yet (Phases 1 and 2)
-          auto ret = vertex->RemoveLabel(transaction->NameToLabel(delta.vertex_add_remove_label.label));
-          if (ret.HasError() || !ret.GetValue()) {
-            throw utils::BasicException("Failed to remove label from vertex {}.", gid);
-          }
-          break;
+        break;
+      }
+      case WalDeltaData::Type::VERTEX_SET_PROPERTY: {
+        auto const gid = delta.vertex_edge_set_property.gid.AsUint();
+        spdlog::trace("       Vertex {} set property", gid);
+        // NOLINTNEXTLINE
+        auto *transaction = get_transaction_accessor(delta_timestamp);
+        // NOLINTNEXTLINE
+        auto vertex = transaction->FindVertex(delta.vertex_edge_set_property.gid, View::NEW);
+        if (!vertex) {
+          throw utils::BasicException("Failed to find vertex {} when setting property.", gid);
         }
-        case WalDeltaData::Type::VERTEX_SET_PROPERTY: {
-          auto const gid = delta.vertex_edge_set_property.gid.AsUint();
-          spdlog::trace("       Vertex {} set property", gid);
-          // NOLINTNEXTLINE
-          auto *transaction = get_transaction_accessor(delta_timestamp);
-          // NOLINTNEXTLINE
-          auto vertex = transaction->FindVertex(delta.vertex_edge_set_property.gid, View::NEW);
-          if (!vertex) {
-            throw utils::BasicException("Failed to find vertex {} when setting property.", gid);
-          }
-          // NOTE: Phase 1 of the text search feature doesn't have replication in scope
-          auto ret = vertex->SetProperty(transaction->NameToProperty(delta.vertex_edge_set_property.property),
-                                         delta.vertex_edge_set_property.value);
-          if (ret.HasError()) {
-            throw utils::BasicException("Failed to set property label from vertex {}.", gid);
-          }
-          break;
+        // NOTE: Phase 1 of the text search feature doesn't have replication in scope
+        auto ret = vertex->SetProperty(transaction->NameToProperty(delta.vertex_edge_set_property.property),
+                                       delta.vertex_edge_set_property.value);
+        if (ret.HasError()) {
+          throw utils::BasicException("Failed to set property label from vertex {}.", gid);
         }
-        case WalDeltaData::Type::EDGE_CREATE: {
-          auto const edge_gid = delta.edge_create_delete.gid.AsUint();
-          auto const from_vertex_gid = delta.edge_create_delete.from_vertex.AsUint();
-          auto const to_vertex_gid = delta.edge_create_delete.to_vertex.AsUint();
-          spdlog::trace("       Create edge {} of type {} from vertex {} to vertex {}", edge_gid,
-                        delta.edge_create_delete.edge_type, from_vertex_gid, to_vertex_gid);
-          auto *transaction = get_transaction_accessor(delta_timestamp);
-          auto from_vertex = transaction->FindVertex(delta.edge_create_delete.from_vertex, View::NEW);
-          if (!from_vertex) {
-            throw utils::BasicException("Failed to find vertex {} when adding edge {}.", from_vertex_gid, edge_gid);
-          }
-          auto to_vertex = transaction->FindVertex(delta.edge_create_delete.to_vertex, View::NEW);
-          if (!to_vertex) {
-            throw utils::BasicException("Failed to find vertex {} when adding edge {}.", to_vertex_gid, edge_gid);
-          }
-          auto edge = transaction->CreateEdgeEx(&*from_vertex, &*to_vertex,
-                                                transaction->NameToEdgeType(delta.edge_create_delete.edge_type),
-                                                delta.edge_create_delete.gid);
-          if (edge.HasError()) {
-            throw utils::BasicException("Failed to add edge {} between vertices {} and {}.", edge_gid, from_vertex_gid,
-                                        to_vertex_gid);
-          }
-          break;
+        break;
+      }
+      case WalDeltaData::Type::EDGE_CREATE: {
+        auto const edge_gid = delta.edge_create_delete.gid.AsUint();
+        auto const from_vertex_gid = delta.edge_create_delete.from_vertex.AsUint();
+        auto const to_vertex_gid = delta.edge_create_delete.to_vertex.AsUint();
+        spdlog::trace("       Create edge {} of type {} from vertex {} to vertex {}", edge_gid,
+                      delta.edge_create_delete.edge_type, from_vertex_gid, to_vertex_gid);
+        auto *transaction = get_transaction_accessor(delta_timestamp);
+        auto from_vertex = transaction->FindVertex(delta.edge_create_delete.from_vertex, View::NEW);
+        if (!from_vertex) {
+          throw utils::BasicException("Failed to find vertex {} when adding edge {}.", from_vertex_gid, edge_gid);
         }
-        case WalDeltaData::Type::EDGE_DELETE: {
-          auto const edge_gid = delta.edge_create_delete.gid.AsUint();
-          auto const from_vertex_gid = delta.edge_create_delete.from_vertex.AsUint();
-          auto const to_vertex_gid = delta.edge_create_delete.to_vertex.AsUint();
-          spdlog::trace("       Delete edge {} of type {} from vertex {} to vertex {}", edge_gid,
-                        delta.edge_create_delete.edge_type, from_vertex_gid, to_vertex_gid);
-          auto *transaction = get_transaction_accessor(delta_timestamp);
-          auto from_vertex = transaction->FindVertex(delta.edge_create_delete.from_vertex, View::NEW);
-          if (!from_vertex) {
-            throw utils::BasicException("Failed to find vertex {} when deleting edge {}.", from_vertex_gid, edge_gid);
-          }
-          auto to_vertex = transaction->FindVertex(delta.edge_create_delete.to_vertex, View::NEW);
-          if (!to_vertex) {
-            throw utils::BasicException("Failed to find vertex {} when deleting edge {}.", from_vertex_gid, edge_gid);
-          }
-          auto edgeType = transaction->NameToEdgeType(delta.edge_create_delete.edge_type);
-          auto edge =
-              transaction->FindEdge(delta.edge_create_delete.gid, View::NEW, edgeType, &*from_vertex, &*to_vertex);
-          if (!edge) {
-            throw utils::BasicException("Couldn't find edge {} when deleting edge.", edge_gid);
-          }
-          if (auto ret = transaction->DeleteEdge(&*edge); ret.HasError()) {
-            throw utils::BasicException("Failed to delete edge {} between vertices {} and {}.", edge_gid,
-                                        from_vertex_gid, to_vertex_gid);
-          }
-          break;
+        auto to_vertex = transaction->FindVertex(delta.edge_create_delete.to_vertex, View::NEW);
+        if (!to_vertex) {
+          throw utils::BasicException("Failed to find vertex {} when adding edge {}.", to_vertex_gid, edge_gid);
         }
-        // TODO: (andi) Finish changing error messages.
-        case WalDeltaData::Type::EDGE_SET_PROPERTY: {
-          spdlog::trace(" Edge {} set property", delta.vertex_edge_set_property.gid.AsUint());
-          if (!storage->config_.salient.items.properties_on_edges)
-            throw utils::BasicException(
-                "Can't set properties on edges because properties on edges "
-                "are disabled!");
+        auto edge = transaction->CreateEdgeEx(&*from_vertex, &*to_vertex,
+                                              transaction->NameToEdgeType(delta.edge_create_delete.edge_type),
+                                              delta.edge_create_delete.gid);
+        if (edge.HasError()) {
+          throw utils::BasicException("Failed to add edge {} between vertices {} and {}.", edge_gid, from_vertex_gid,
+                                      to_vertex_gid);
+        }
+        break;
+      }
+      case WalDeltaData::Type::EDGE_DELETE: {
+        auto const edge_gid = delta.edge_create_delete.gid.AsUint();
+        auto const from_vertex_gid = delta.edge_create_delete.from_vertex.AsUint();
+        auto const to_vertex_gid = delta.edge_create_delete.to_vertex.AsUint();
+        spdlog::trace("       Delete edge {} of type {} from vertex {} to vertex {}", edge_gid,
+                      delta.edge_create_delete.edge_type, from_vertex_gid, to_vertex_gid);
+        auto *transaction = get_transaction_accessor(delta_timestamp);
+        auto from_vertex = transaction->FindVertex(delta.edge_create_delete.from_vertex, View::NEW);
+        if (!from_vertex) {
+          throw utils::BasicException("Failed to find vertex {} when deleting edge {}.", from_vertex_gid, edge_gid);
+        }
+        auto to_vertex = transaction->FindVertex(delta.edge_create_delete.to_vertex, View::NEW);
+        if (!to_vertex) {
+          throw utils::BasicException("Failed to find vertex {} when deleting edge {}.", from_vertex_gid, edge_gid);
+        }
+        auto edgeType = transaction->NameToEdgeType(delta.edge_create_delete.edge_type);
+        auto edge =
+            transaction->FindEdge(delta.edge_create_delete.gid, View::NEW, edgeType, &*from_vertex, &*to_vertex);
+        if (!edge) {
+          throw utils::BasicException("Couldn't find edge {} when deleting edge.", edge_gid);
+        }
+        if (auto ret = transaction->DeleteEdge(&*edge); ret.HasError()) {
+          throw utils::BasicException("Failed to delete edge {} between vertices {} and {}.", edge_gid, from_vertex_gid,
+                                      to_vertex_gid);
+        }
+        break;
+      }
+      case WalDeltaData::Type::EDGE_SET_PROPERTY: {
+        auto const edge_gid = delta.vertex_edge_set_property.gid.AsUint();
+        spdlog::trace(" Edge {} set property", edge_gid);
+        if (!storage->config_.salient.items.properties_on_edges)
+          throw utils::BasicException(
+              "Can't set properties on edges because properties on edges "
+              "are disabled!");
 
-          auto *transaction = get_transaction_accessor(delta_timestamp);
+        auto *transaction = get_transaction_accessor(delta_timestamp);
 
-          // The following block of code effectively implements `FindEdge` and
-          // yields an accessor that is only valid for managing the edge's
-          // properties.
-          auto edge = edge_acc.find(delta.vertex_edge_set_property.gid);
-          if (edge == edge_acc.end())
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          // The edge visibility check must be done here manually because we
-          // don't allow direct access to the edges through the public API.
+        // The following block of code effectively implements `FindEdge` and
+        // yields an accessor that is only valid for managing the edge's
+        // properties.
+        auto edge = edge_acc.find(delta.vertex_edge_set_property.gid);
+        if (edge == edge_acc.end()) {
+          throw utils::BasicException("Failed to find edge {} when setting property.", edge_gid);
+        }
+        // The edge visibility check must be done here manually because we
+        // don't allow direct access to the edges through the public API.
+        {
+          bool is_visible = true;
+          Delta *delta = nullptr;
           {
-            bool is_visible = true;
-            Delta *delta = nullptr;
-            {
-              auto guard = std::shared_lock{edge->lock};
-              is_visible = !edge->deleted;
-              delta = edge->delta;
-            }
-            ApplyDeltasForRead(&transaction->GetTransaction(), delta, View::NEW, [&is_visible](const Delta &delta) {
-              switch (delta.action) {
-                case Delta::Action::ADD_LABEL:
-                case Delta::Action::REMOVE_LABEL:
-                case Delta::Action::SET_PROPERTY:
-                case Delta::Action::ADD_IN_EDGE:
-                case Delta::Action::ADD_OUT_EDGE:
-                case Delta::Action::REMOVE_IN_EDGE:
-                case Delta::Action::REMOVE_OUT_EDGE:
-                  break;
-                case Delta::Action::RECREATE_OBJECT: {
-                  is_visible = true;
-                  break;
-                }
-                case Delta::Action::DELETE_DESERIALIZED_OBJECT:
-                case Delta::Action::DELETE_OBJECT: {
-                  is_visible = false;
-                  break;
-                }
+            auto guard = std::shared_lock{edge->lock};
+            is_visible = !edge->deleted;
+            delta = edge->delta;
+          }
+          ApplyDeltasForRead(&transaction->GetTransaction(), delta, View::NEW, [&is_visible](const Delta &delta) {
+            switch (delta.action) {
+              case Delta::Action::ADD_LABEL:
+              case Delta::Action::REMOVE_LABEL:
+              case Delta::Action::SET_PROPERTY:
+              case Delta::Action::ADD_IN_EDGE:
+              case Delta::Action::ADD_OUT_EDGE:
+              case Delta::Action::REMOVE_IN_EDGE:
+              case Delta::Action::REMOVE_OUT_EDGE:
+                break;
+              case Delta::Action::RECREATE_OBJECT: {
+                is_visible = true;
+                break;
               }
-            });
-            if (!is_visible)
-              throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+              case Delta::Action::DELETE_DESERIALIZED_OBJECT:
+              case Delta::Action::DELETE_OBJECT: {
+                is_visible = false;
+                break;
+              }
+            }
+          });
+          if (!is_visible) {
+            throw utils::BasicException("Edge {} isn't visible when setting property.", edge_gid);
           }
-          EdgeRef edge_ref(&*edge);
-          // Here we create an edge accessor that we will use to get the
-          // properties of the edge. The accessor is created with an invalid
-          // type and invalid from/to pointers because we don't know them
-          // here, but that isn't an issue because we won't use that part of
-          // the API here.
+        }
+        EdgeRef edge_ref(&*edge);
+        // Here we create an edge accessor that we will use to get the
+        // properties of the edge. The accessor is created with an invalid
+        // type and invalid from/to pointers because we don't know them
+        // here, but that isn't an issue because we won't use that part of
+        // the API here.
 
-          if (version >= storage::durability::kEdgeSetDeltaWithVertexInfo) {
-            auto vacc = storage->vertices_.access();
-            auto from_v = vacc.find(delta.vertex_edge_set_property.from_gid);
-            if (from_v == vacc.end())
-              throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-            auto found_edge = std::find_if(from_v->out_edges.begin(), from_v->out_edges.end(),
-                                           [&edge_ref](auto &in) { return std::get<2>(in) == edge_ref; });
-            if (found_edge == from_v->out_edges.end())
-              throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-            const auto &[edge_type, to, edge_ref] = *found_edge;
-            auto ea = EdgeAccessor{edge_ref, edge_type, &*from_v, to, storage, &transaction->GetTransaction()};
-            auto ret = ea.SetProperty(transaction->NameToProperty(delta.vertex_edge_set_property.property),
-                                      delta.vertex_edge_set_property.value);
-            if (ret.HasError())
-              throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          } else {
-            auto found_edge = storage->FindEdge(edge->gid);
-            if (!found_edge)
-              throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-            const auto &[edge_ref, edge_type, from, to] = *found_edge;
-            auto ea = EdgeAccessor{edge_ref, edge_type, from, to, storage, &transaction->GetTransaction()};
-            auto ret = ea.SetProperty(transaction->NameToProperty(delta.vertex_edge_set_property.property),
-                                      delta.vertex_edge_set_property.value);
-            if (ret.HasError())
-              throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+        if (version >= storage::durability::kEdgeSetDeltaWithVertexInfo) {
+          auto vacc = storage->vertices_.access();
+          auto from_v = vacc.find(delta.vertex_edge_set_property.from_gid);
+          if (from_v == vacc.end())
+            throw utils::BasicException("Failed to find from vertex {} when setting edge property.",
+                                        from_v->gid.AsUint());
+          auto found_edge = std::find_if(from_v->out_edges.begin(), from_v->out_edges.end(),
+                                         [&edge_ref](auto &in) { return std::get<2>(in) == edge_ref; });
+          if (found_edge == from_v->out_edges.end()) {
+            throw utils::BasicException("Couldn't find edge {} in vertex {}'s out edge collection.", edge_gid,
+                                        from_v->gid.AsUint());
           }
-          break;
-        }
-
-        case WalDeltaData::Type::TRANSACTION_END: {
-          spdlog::trace("       Transaction end");
-          if (!commit_timestamp_and_accessor || commit_timestamp_and_accessor->first != delta_timestamp)
-            throw utils::BasicException("Invalid commit data!");
-          auto ret = commit_timestamp_and_accessor->second.Commit(
-              {.desired_commit_timestamp = commit_timestamp_and_accessor->first, .is_main = false});
-          if (ret.HasError())
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          commit_timestamp_and_accessor = std::nullopt;
-          break;
-        }
-
-        case WalDeltaData::Type::LABEL_INDEX_CREATE: {
-          spdlog::trace("       Create label index on :{}", delta.operation_label.label);
-          // Need to send the timestamp
-          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-          if (transaction->CreateIndex(storage->NameToLabel(delta.operation_label.label)).HasError())
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          break;
-        }
-        case WalDeltaData::Type::LABEL_INDEX_DROP: {
-          spdlog::trace("       Drop label index on :{}", delta.operation_label.label);
-          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-          if (transaction->DropIndex(storage->NameToLabel(delta.operation_label.label)).HasError())
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          break;
-        }
-        case WalDeltaData::Type::LABEL_INDEX_STATS_SET: {
-          spdlog::trace("       Set label index statistics on :{}", delta.operation_label_stats.label);
-          // Need to send the timestamp
-          auto *transaction = get_transaction_accessor(delta_timestamp);
-          const auto label = storage->NameToLabel(delta.operation_label_stats.label);
-          LabelIndexStats stats{};
-          if (!FromJson(delta.operation_label_stats.stats, stats)) {
-            throw utils::BasicException("Failed to read statistics!");
-          }
-          transaction->SetIndexStats(label, stats);
-          break;
-        }
-        case WalDeltaData::Type::LABEL_INDEX_STATS_CLEAR: {
-          const auto &info = delta.operation_label;
-          spdlog::trace("       Clear label index statistics on :{}", info.label);
-          // Need to send the timestamp
-          auto *transaction = get_transaction_accessor(delta_timestamp);
-          transaction->DeleteLabelIndexStats(storage->NameToLabel(info.label));
-          break;
-        }
-        case WalDeltaData::Type::LABEL_PROPERTY_INDEX_CREATE: {
-          spdlog::trace("       Create label+property index on :{} ({})", delta.operation_label_property.label,
-                        delta.operation_label_property.property);
-          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-          if (transaction
-                  ->CreateIndex(storage->NameToLabel(delta.operation_label_property.label),
-                                storage->NameToProperty(delta.operation_label_property.property))
-                  .HasError())
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          break;
-        }
-        case WalDeltaData::Type::LABEL_PROPERTY_INDEX_DROP: {
-          spdlog::trace("       Drop label+property index on :{} ({})", delta.operation_label_property.label,
-                        delta.operation_label_property.property);
-          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-          if (transaction
-                  ->DropIndex(storage->NameToLabel(delta.operation_label_property.label),
-                              storage->NameToProperty(delta.operation_label_property.property))
-                  .HasError())
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          break;
-        }
-        case WalDeltaData::Type::LABEL_PROPERTY_INDEX_STATS_SET: {
-          const auto &info = delta.operation_label_property_stats;
-          spdlog::trace("       Set label-property index statistics on :{}", info.label);
-          // Need to send the timestamp
-          auto *transaction = get_transaction_accessor(delta_timestamp);
-          const auto label = storage->NameToLabel(info.label);
-          const auto property = storage->NameToProperty(info.property);
-          LabelPropertyIndexStats stats{};
-          if (!FromJson(info.stats, stats)) {
-            throw utils::BasicException("Failed to read statistics!");
-          }
-          transaction->SetIndexStats(label, property, stats);
-          break;
-        }
-        case WalDeltaData::Type::LABEL_PROPERTY_INDEX_STATS_CLEAR: {
-          const auto &info = delta.operation_label;
-          spdlog::trace("       Clear label-property index statistics on :{}", info.label);
-          // Need to send the timestamp
-          auto *transaction = get_transaction_accessor(delta_timestamp);
-          transaction->DeleteLabelPropertyIndexStats(storage->NameToLabel(info.label));
-          break;
-        }
-        case WalDeltaData::Type::EDGE_INDEX_CREATE: {
-          spdlog::trace("       Create edge index on :{}", delta.operation_edge_type.edge_type);
-          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-          if (transaction->CreateIndex(storage->NameToEdgeType(delta.operation_edge_type.edge_type)).HasError())
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          break;
-        }
-        case WalDeltaData::Type::EDGE_INDEX_DROP: {
-          spdlog::trace("       Drop edge index on :{}", delta.operation_edge_type.edge_type);
-          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-          if (transaction->DropIndex(storage->NameToEdgeType(delta.operation_edge_type.edge_type)).HasError())
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          break;
-        }
-        case WalDeltaData::Type::EDGE_PROPERTY_INDEX_CREATE: {
-          spdlog::trace("       Create edge index on :{}({})", delta.operation_edge_type_property.edge_type,
-                        delta.operation_edge_type_property.property);
-          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-          if (transaction
-                  ->CreateIndex(storage->NameToEdgeType(delta.operation_edge_type_property.edge_type),
-                                storage->NameToProperty(delta.operation_edge_type_property.property))
-                  .HasError())
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          break;
-        }
-        case WalDeltaData::Type::EDGE_PROPERTY_INDEX_DROP: {
-          spdlog::trace("       Drop edge index on :{}({})", delta.operation_edge_type_property.edge_type,
-                        delta.operation_edge_type_property.property);
-          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-          if (transaction
-                  ->DropIndex(storage->NameToEdgeType(delta.operation_edge_type_property.edge_type),
-                              storage->NameToProperty(delta.operation_edge_type_property.property))
-                  .HasError())
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          break;
-        }
-        case WalDeltaData::Type::TEXT_INDEX_CREATE:
-          [[fallthrough]];
-        case WalDeltaData::Type::TEXT_INDEX_DROP: {
-          // NOTE: Text search doesn’t have replication in scope yet (Phases 1 and 2)
-          break;
-        }
-        case WalDeltaData::Type::EXISTENCE_CONSTRAINT_CREATE: {
-          spdlog::trace("       Create existence constraint on :{} ({})", delta.operation_label_property.label,
-                        delta.operation_label_property.property);
-          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-          auto ret =
-              transaction->CreateExistenceConstraint(storage->NameToLabel(delta.operation_label_property.label),
-                                                     storage->NameToProperty(delta.operation_label_property.property));
-          if (ret.HasError())
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          break;
-        }
-        case WalDeltaData::Type::EXISTENCE_CONSTRAINT_DROP: {
-          spdlog::trace("       Drop existence constraint on :{} ({})", delta.operation_label_property.label,
-                        delta.operation_label_property.property);
-          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-          if (transaction
-                  ->DropExistenceConstraint(storage->NameToLabel(delta.operation_label_property.label),
-                                            storage->NameToProperty(delta.operation_label_property.property))
-                  .HasError())
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          break;
-        }
-        case WalDeltaData::Type::UNIQUE_CONSTRAINT_CREATE: {
-          std::stringstream ss;
-          utils::PrintIterable(ss, delta.operation_label_properties.properties);
-          spdlog::trace("       Create unique constraint on :{} ({})", delta.operation_label_properties.label,
-                        ss.str());
-          std::set<PropertyId> properties;
-          for (const auto &prop : delta.operation_label_properties.properties) {
-            properties.emplace(storage->NameToProperty(prop));
-          }
-          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-          auto ret = transaction->CreateUniqueConstraint(storage->NameToLabel(delta.operation_label_properties.label),
-                                                         properties);
-          if (!ret.HasValue() || ret.GetValue() != UniqueConstraints::CreationStatus::SUCCESS)
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          break;
-        }
-        case WalDeltaData::Type::UNIQUE_CONSTRAINT_DROP: {
-          std::stringstream ss;
-          utils::PrintIterable(ss, delta.operation_label_properties.properties);
-          spdlog::trace("       Drop unique constraint on :{} ({})", delta.operation_label_properties.label, ss.str());
-          std::set<PropertyId> properties;
-          for (const auto &prop : delta.operation_label_properties.properties) {
-            properties.emplace(storage->NameToProperty(prop));
-          }
-          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-          auto ret = transaction->DropUniqueConstraint(storage->NameToLabel(delta.operation_label_properties.label),
-                                                       properties);
-          if (ret != UniqueConstraints::DeletionStatus::SUCCESS) {
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          }
-          break;
-        }
-        case storage::durability::WalDeltaData::Type::TYPE_CONSTRAINT_CREATE: {
-          spdlog::trace("       Create IS TYPED {} constraint on :{} ({})",
-                        storage::TypeConstraintKindToString(delta.operation_label_property_type.type),
-                        delta.operation_label_property_type.label, delta.operation_label_property_type.property);
-
-          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-          auto ret =
-              transaction->CreateTypeConstraint(storage->NameToLabel(delta.operation_label_property_type.label),
-                                                storage->NameToProperty(delta.operation_label_property_type.property),
-                                                delta.operation_label_property_type.type);
+          const auto &[edge_type, to, edge_ref] = *found_edge;
+          auto ea = EdgeAccessor{edge_ref, edge_type, &*from_v, to, storage, &transaction->GetTransaction()};
+          auto ret = ea.SetProperty(transaction->NameToProperty(delta.vertex_edge_set_property.property),
+                                    delta.vertex_edge_set_property.value);
           if (ret.HasError()) {
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+            throw utils::BasicException("Setting property on edge {} failed.", edge_gid);
           }
-          break;
+        } else {
+          auto found_edge = storage->FindEdge(edge->gid);
+          if (!found_edge)
+            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          const auto &[edge_ref, edge_type, from, to] = *found_edge;
+          auto ea = EdgeAccessor{edge_ref, edge_type, from, to, storage, &transaction->GetTransaction()};
+          auto ret = ea.SetProperty(transaction->NameToProperty(delta.vertex_edge_set_property.property),
+                                    delta.vertex_edge_set_property.value);
+          if (ret.HasError()) {
+            throw utils::BasicException("Setting property on edge {} failed.", edge_gid);
+          }
         }
-        case storage::durability::WalDeltaData::Type::TYPE_CONSTRAINT_DROP: {
-          spdlog::trace("       Drop IS TYPED {} constraint on :{} ({})",
-                        storage::TypeConstraintKindToString(delta.operation_label_property_type.type),
-                        delta.operation_label_property_type.label, delta.operation_label_property_type.property);
+        break;
+      }
 
-          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-          auto ret =
-              transaction->DropTypeConstraint(storage->NameToLabel(delta.operation_label_property_type.label),
+      case WalDeltaData::Type::TRANSACTION_END: {
+        spdlog::trace("       Transaction end");
+        if (!commit_timestamp_and_accessor || commit_timestamp_and_accessor->first != delta_timestamp)
+          throw utils::BasicException("Invalid commit data!");
+        auto ret = commit_timestamp_and_accessor->second.Commit(
+            {.desired_commit_timestamp = commit_timestamp_and_accessor->first, .is_main = false});
+        if (ret.HasError()) throw utils::BasicException("Committing failed on receiving transaction end delta.");
+        commit_timestamp_and_accessor = std::nullopt;
+        break;
+      }
+
+      case WalDeltaData::Type::LABEL_INDEX_CREATE: {
+        spdlog::trace("       Create label index on :{}", delta.operation_label.label);
+        // Need to send the timestamp
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+        if (transaction->CreateIndex(storage->NameToLabel(delta.operation_label.label)).HasError())
+          throw utils::BasicException("Failed to create label index on :{}.", delta.operation_label.label);
+        break;
+      }
+      case WalDeltaData::Type::LABEL_INDEX_DROP: {
+        spdlog::trace("       Drop label index on :{}", delta.operation_label.label);
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+        if (transaction->DropIndex(storage->NameToLabel(delta.operation_label.label)).HasError())
+          throw utils::BasicException("Failed to drop label index on :{}.", delta.operation_label.label);
+        break;
+      }
+      case WalDeltaData::Type::LABEL_INDEX_STATS_SET: {
+        spdlog::trace("       Set label index statistics on :{}", delta.operation_label_stats.label);
+        // Need to send the timestamp
+        auto *transaction = get_transaction_accessor(delta_timestamp);
+        const auto label = storage->NameToLabel(delta.operation_label_stats.label);
+        LabelIndexStats stats{};
+        if (!FromJson(delta.operation_label_stats.stats, stats)) {
+          throw utils::BasicException("Failed to read statistics!");
+        }
+        transaction->SetIndexStats(label, stats);
+        break;
+      }
+      case WalDeltaData::Type::LABEL_INDEX_STATS_CLEAR: {
+        const auto &info = delta.operation_label;
+        spdlog::trace("       Clear label index statistics on :{}", info.label);
+        // Need to send the timestamp
+        auto *transaction = get_transaction_accessor(delta_timestamp);
+        if (!transaction->DeleteLabelIndexStats(storage->NameToLabel(info.label))) {
+          throw utils::BasicException("Failed to clear label index statistics on :{}.", info.label);
+        }
+        break;
+      }
+      case WalDeltaData::Type::LABEL_PROPERTY_INDEX_CREATE: {
+        spdlog::trace("       Create label+property index on :{} ({})", delta.operation_label_property.label,
+                      delta.operation_label_property.property);
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+        if (transaction
+                ->CreateIndex(storage->NameToLabel(delta.operation_label_property.label),
+                              storage->NameToProperty(delta.operation_label_property.property))
+                .HasError())
+          throw utils::BasicException("Failed to create label+property index on :{} ({}).",
+                                      delta.operation_label_property.label, delta.operation_label_property.property);
+        break;
+      }
+      case WalDeltaData::Type::LABEL_PROPERTY_INDEX_DROP: {
+        spdlog::trace("       Drop label+property index on :{} ({})", delta.operation_label_property.label,
+                      delta.operation_label_property.property);
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+        if (transaction
+                ->DropIndex(storage->NameToLabel(delta.operation_label_property.label),
+                            storage->NameToProperty(delta.operation_label_property.property))
+                .HasError()) {
+          throw utils::BasicException("Failed to drop label+property index on :{} ({}).",
+                                      delta.operation_label_property.label, delta.operation_label_property.property);
+        }
+        break;
+      }
+      case WalDeltaData::Type::LABEL_PROPERTY_INDEX_STATS_SET: {
+        const auto &info = delta.operation_label_property_stats;
+        spdlog::trace("       Set label-property index statistics on :{}", info.label);
+        // Need to send the timestamp
+        auto *transaction = get_transaction_accessor(delta_timestamp);
+        const auto label = storage->NameToLabel(info.label);
+        const auto property = storage->NameToProperty(info.property);
+        LabelPropertyIndexStats stats{};
+        if (!FromJson(info.stats, stats)) {
+          throw utils::BasicException("Failed to read statistics!");
+        }
+        transaction->SetIndexStats(label, property, stats);
+        break;
+      }
+      case WalDeltaData::Type::LABEL_PROPERTY_INDEX_STATS_CLEAR: {
+        const auto &info = delta.operation_label;
+        spdlog::trace("       Clear label-property index statistics on :{}", info.label);
+        // Need to send the timestamp
+        auto *transaction = get_transaction_accessor(delta_timestamp);
+        transaction->DeleteLabelPropertyIndexStats(storage->NameToLabel(info.label));
+        break;
+      }
+      case WalDeltaData::Type::EDGE_INDEX_CREATE: {
+        spdlog::trace("       Create edge index on :{}", delta.operation_edge_type.edge_type);
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+        if (transaction->CreateIndex(storage->NameToEdgeType(delta.operation_edge_type.edge_type)).HasError()) {
+          throw utils::BasicException("Failed to create edge index on :{}.", delta.operation_edge_type.edge_type);
+        }
+        break;
+      }
+      case WalDeltaData::Type::EDGE_INDEX_DROP: {
+        spdlog::trace("       Drop edge index on :{}", delta.operation_edge_type.edge_type);
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+        if (transaction->DropIndex(storage->NameToEdgeType(delta.operation_edge_type.edge_type)).HasError()) {
+          throw utils::BasicException("Failed to drop edge index on :{}.", delta.operation_edge_type.edge_type);
+        }
+        break;
+      }
+      case WalDeltaData::Type::EDGE_PROPERTY_INDEX_CREATE: {
+        spdlog::trace("       Create edge index on :{}({})", delta.operation_edge_type_property.edge_type,
+                      delta.operation_edge_type_property.property);
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+        if (transaction
+                ->CreateIndex(storage->NameToEdgeType(delta.operation_edge_type_property.edge_type),
+                              storage->NameToProperty(delta.operation_edge_type_property.property))
+                .HasError()) {
+          throw utils::BasicException("Failed to create edge property index on :{}({}).",
+                                      delta.operation_edge_type_property.edge_type,
+                                      delta.operation_edge_type_property.property);
+        }
+        break;
+      }
+      case WalDeltaData::Type::EDGE_PROPERTY_INDEX_DROP: {
+        spdlog::trace("       Drop edge index on :{}({})", delta.operation_edge_type_property.edge_type,
+                      delta.operation_edge_type_property.property);
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+        if (transaction
+                ->DropIndex(storage->NameToEdgeType(delta.operation_edge_type_property.edge_type),
+                            storage->NameToProperty(delta.operation_edge_type_property.property))
+                .HasError()) {
+          throw utils::BasicException("Failed to drop edge property index on :{}({}).",
+                                      delta.operation_edge_type_property.edge_type,
+                                      delta.operation_edge_type_property.property);
+        }
+        break;
+      }
+      case WalDeltaData::Type::TEXT_INDEX_CREATE:
+        [[fallthrough]];
+      case WalDeltaData::Type::TEXT_INDEX_DROP: {
+        // NOTE: Text search doesn’t have replication in scope yet (Phases 1 and 2)
+        break;
+      }
+      case WalDeltaData::Type::EXISTENCE_CONSTRAINT_CREATE: {
+        spdlog::trace("       Create existence constraint on :{} ({})", delta.operation_label_property.label,
+                      delta.operation_label_property.property);
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+        auto ret =
+            transaction->CreateExistenceConstraint(storage->NameToLabel(delta.operation_label_property.label),
+                                                   storage->NameToProperty(delta.operation_label_property.property));
+        if (ret.HasError()) {
+          throw utils::BasicException("Failed to create existence constraint on :{} ({}).",
+                                      delta.operation_label_property.label, delta.operation_label_property.property);
+        }
+        break;
+      }
+      case WalDeltaData::Type::EXISTENCE_CONSTRAINT_DROP: {
+        spdlog::trace("       Drop existence constraint on :{} ({})", delta.operation_label_property.label,
+                      delta.operation_label_property.property);
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+        if (transaction
+                ->DropExistenceConstraint(storage->NameToLabel(delta.operation_label_property.label),
+                                          storage->NameToProperty(delta.operation_label_property.property))
+                .HasError()) {
+          throw utils::BasicException("Failed to drop existence constraint on :{} ({}).",
+                                      delta.operation_label_property.label, delta.operation_label_property.property);
+        }
+        break;
+      }
+      case WalDeltaData::Type::UNIQUE_CONSTRAINT_CREATE: {
+        std::stringstream ss;
+        utils::PrintIterable(ss, delta.operation_label_properties.properties);
+        spdlog::trace("       Create unique constraint on :{} ({})", delta.operation_label_properties.label, ss.str());
+        std::set<PropertyId> properties;
+        for (const auto &prop : delta.operation_label_properties.properties) {
+          properties.emplace(storage->NameToProperty(prop));
+        }
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+        auto ret = transaction->CreateUniqueConstraint(storage->NameToLabel(delta.operation_label_properties.label),
+                                                       properties);
+        if (!ret.HasValue() || ret.GetValue() != UniqueConstraints::CreationStatus::SUCCESS) {
+          throw utils::BasicException("Failed to create unique constraint on :{} ({}).",
+                                      delta.operation_label_properties.label, ss.str());
+        }
+        break;
+      }
+      case WalDeltaData::Type::UNIQUE_CONSTRAINT_DROP: {
+        std::stringstream ss;
+        utils::PrintIterable(ss, delta.operation_label_properties.properties);
+        spdlog::trace("       Drop unique constraint on :{} ({})", delta.operation_label_properties.label, ss.str());
+        std::set<PropertyId> properties;
+        for (const auto &prop : delta.operation_label_properties.properties) {
+          properties.emplace(storage->NameToProperty(prop));
+        }
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+        auto ret =
+            transaction->DropUniqueConstraint(storage->NameToLabel(delta.operation_label_properties.label), properties);
+        if (ret != UniqueConstraints::DeletionStatus::SUCCESS) {
+          throw utils::BasicException("Failed to create unique constraint on :{} ({}).",
+                                      delta.operation_label_properties.label, ss.str());
+        }
+        break;
+      }
+      case storage::durability::WalDeltaData::Type::TYPE_CONSTRAINT_CREATE: {
+        spdlog::trace("       Create IS TYPED {} constraint on :{} ({})",
+                      storage::TypeConstraintKindToString(delta.operation_label_property_type.type),
+                      delta.operation_label_property_type.label, delta.operation_label_property_type.property);
+
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+        auto ret =
+            transaction->CreateTypeConstraint(storage->NameToLabel(delta.operation_label_property_type.label),
                                               storage->NameToProperty(delta.operation_label_property_type.property),
                                               delta.operation_label_property_type.type);
-          if (ret.HasError()) {
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          }
-          break;
+        if (ret.HasError()) {
+          throw utils::BasicException("Failed to create IS TYPED {} constraint on :{} ({}).",
+                                      storage::TypeConstraintKindToString(delta.operation_label_property_type.type),
+                                      delta.operation_label_property_type.label,
+                                      delta.operation_label_property_type.property);
         }
-        case WalDeltaData::Type::ENUM_CREATE: {
-          std::stringstream ss;
-          utils::PrintIterable(ss, delta.operation_enum_create.evalues);
-          spdlog::trace("       Create enum {} with values {}", delta.operation_enum_create.etype, ss.str());
-          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-          auto res = transaction->CreateEnum(delta.operation_enum_create.etype, delta.operation_enum_create.evalues);
-          if (res.HasError()) {
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          }
-          break;
-        }
-        case WalDeltaData::Type::ENUM_ALTER_ADD: {
-          auto const &[name, evalue] = delta.operation_enum_alter_add;
-          spdlog::trace("       Alter enum {} add value {}", name, evalue);
-          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-          auto res = transaction->EnumAlterAdd(name, evalue);
-          if (res.HasError()) {
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          }
-          break;
-        }
-        case WalDeltaData::Type::ENUM_ALTER_UPDATE: {
-          auto const &[name, evalue_old, evalue_new] = delta.operation_enum_alter_update;
-          spdlog::trace("       Alter enum {} update {} to {}", name, evalue_old, evalue_new);
-          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-          auto res = transaction->EnumAlterUpdate(name, evalue_old, evalue_new);
-          if (res.HasError()) {
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          }
-          break;
-        }
-        case WalDeltaData::Type::POINT_INDEX_CREATE: {
-          auto const &[label, property] = delta.operation_label_property;
-          spdlog::trace("       Create point index on :{}({})", label, property);
-          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-          auto labelId = storage->NameToLabel(label);
-          auto propId = storage->NameToProperty(property);
-          auto res = transaction->CreatePointIndex(labelId, propId);
-          if (res.HasError()) {
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          }
-          break;
-        }
-        case WalDeltaData::Type::POINT_INDEX_DROP: {
-          auto const &[label, property] = delta.operation_label_property;
-          spdlog::trace("       Drop point index on :{}({})", label, property);
-          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-          auto labelId = storage->NameToLabel(label);
-          auto propId = storage->NameToProperty(property);
-          auto res = transaction->DropPointIndex(labelId, propId);
-          if (res.HasError()) {
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          }
-          break;
-        }
+        break;
       }
-      applied_deltas++;
+      case storage::durability::WalDeltaData::Type::TYPE_CONSTRAINT_DROP: {
+        spdlog::trace("       Drop IS TYPED {} constraint on :{} ({})",
+                      storage::TypeConstraintKindToString(delta.operation_label_property_type.type),
+                      delta.operation_label_property_type.label, delta.operation_label_property_type.property);
+
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+        auto ret =
+            transaction->DropTypeConstraint(storage->NameToLabel(delta.operation_label_property_type.label),
+                                            storage->NameToProperty(delta.operation_label_property_type.property),
+                                            delta.operation_label_property_type.type);
+        if (ret.HasError()) {
+          throw utils::BasicException("Failed to drop IS TYPED {} constraint on :{} ({}).",
+                                      storage::TypeConstraintKindToString(delta.operation_label_property_type.type),
+                                      delta.operation_label_property_type.label,
+                                      delta.operation_label_property_type.property);
+        }
+        break;
+      }
+      case WalDeltaData::Type::ENUM_CREATE: {
+        std::stringstream ss;
+        utils::PrintIterable(ss, delta.operation_enum_create.evalues);
+        spdlog::trace("       Create enum {} with values {}", delta.operation_enum_create.etype, ss.str());
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+        auto res = transaction->CreateEnum(delta.operation_enum_create.etype, delta.operation_enum_create.evalues);
+        if (res.HasError()) {
+          throw utils::BasicException("Failed to create enum {} with values {}.", delta.operation_enum_create.etype,
+                                      ss.str());
+        }
+        break;
+      }
+      case WalDeltaData::Type::ENUM_ALTER_ADD: {
+        auto const &[name, evalue] = delta.operation_enum_alter_add;
+        spdlog::trace("       Alter enum {} add value {}", name, evalue);
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+        auto res = transaction->EnumAlterAdd(name, evalue);
+        if (res.HasError()) {
+          throw utils::BasicException("Failed to alter enum {} add value {}.", name, evalue);
+        }
+        break;
+      }
+      case WalDeltaData::Type::ENUM_ALTER_UPDATE: {
+        auto const &[name, evalue_old, evalue_new] = delta.operation_enum_alter_update;
+        spdlog::trace("       Alter enum {} update {} to {}", name, evalue_old, evalue_new);
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+        auto res = transaction->EnumAlterUpdate(name, evalue_old, evalue_new);
+        if (res.HasError()) {
+          throw utils::BasicException("Failed to alter enum {} update {} to {}.", name, evalue_old, evalue_new);
+        }
+        break;
+      }
+      case WalDeltaData::Type::POINT_INDEX_CREATE: {
+        auto const &[label, property] = delta.operation_label_property;
+        spdlog::trace("       Create point index on :{}({})", label, property);
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+        auto labelId = storage->NameToLabel(label);
+        auto propId = storage->NameToProperty(property);
+        auto res = transaction->CreatePointIndex(labelId, propId);
+        if (res.HasError()) {
+          throw utils::BasicException("Failed to create point index on :{}({})", label, property);
+        }
+        break;
+      }
+      case WalDeltaData::Type::POINT_INDEX_DROP: {
+        auto const &[label, property] = delta.operation_label_property;
+        spdlog::trace("       Drop point index on :{}({})", label, property);
+        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+        auto labelId = storage->NameToLabel(label);
+        auto propId = storage->NameToProperty(property);
+        auto res = transaction->DropPointIndex(labelId, propId);
+        if (res.HasError()) {
+          throw utils::BasicException("Failed to drop point index on :{}({})", label, property);
+        }
+        break;
+      }
     }
-  } catch (const utils::BasicException &e) {
-    commit_timestamp_and_accessor->second.Abort();
-    throw;
+    applied_deltas++;
   }
 
   if (commit_timestamp_and_accessor) throw utils::BasicException("Did not finish the transaction!");

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -238,9 +238,18 @@ void InMemoryReplicationHandlers::AppendDeltasHandler(dbms::DbmsHandler *dbms_ha
     return;
   }
 
-  ReadAndApplyDeltas(
-      storage, &decoder,
-      storage::durability::kVersion);  // TODO: Check if we are always using the latest version when replicating
+  try {
+    ReadAndApplyDeltas(
+        storage, &decoder,
+        storage::durability::kVersion);  // TODO: Check if we are always using the latest version when replicating
+  } catch (const utils::BasicException &e) {
+    spdlog::error(
+        "Error occurred while trying to apply deltas because of {}. Replication recovery from append deltas finished "
+        "unsuccessfully.",
+        e.what());
+    const storage::replication::AppendDeltasRes res{false, 0};
+    slk::Save(res, res_builder);
+  }
 
   const storage::replication::AppendDeltasRes res{true, repl_storage_state.last_durable_timestamp_.load()};
   slk::Save(res, res_builder);
@@ -433,14 +442,14 @@ void InMemoryReplicationHandlers::CurrentWalHandler(dbms::DbmsHandler *dbms_hand
   slk::Load(&req, req_reader);
   auto db_acc = GetDatabaseAccessor(dbms_handler, req.uuid);
   if (!db_acc) {
-    const storage::replication::CurrentWalRes res{false, 0};
+    const storage::replication::CurrentWalRes res{0};
     slk::Save(res, res_builder);
     return;
   }
 
   if (!current_main_uuid.has_value() || req.main_uuid != current_main_uuid) [[unlikely]] {
     LogWrongMain(current_main_uuid, req.main_uuid, storage::replication::CurrentWalReq::kType.name);
-    const storage::replication::CurrentWalRes res{false, 0};
+    const storage::replication::CurrentWalRes res{0};
     slk::Save(res, res_builder);
     return;
   }
@@ -452,7 +461,7 @@ void InMemoryReplicationHandlers::CurrentWalHandler(dbms::DbmsHandler *dbms_hand
 
   LoadWal(storage, &decoder);
 
-  const storage::replication::CurrentWalRes res{true, storage->repl_storage_state_.last_durable_timestamp_.load()};
+  const storage::replication::CurrentWalRes res{storage->repl_storage_state_.last_durable_timestamp_.load()};
   slk::Save(res, res_builder);
   spdlog::debug("Replication recovery from current WAL ended successfully, replica is now up to date!");
 }
@@ -505,7 +514,9 @@ void InMemoryReplicationHandlers::LoadWal(storage::InMemoryStorage *storage, sto
 
     spdlog::debug("Replication from current WAL successful!");
   } catch (const storage::durability::RecoveryFailure &e) {
-    LOG_FATAL("Couldn't recover WAL deltas from {} because of: {}", *maybe_wal_path, e.what());
+    spdlog::error("Couldn't recover WAL deltas from {} because of: {}.", *maybe_wal_path, e.what());
+  } catch (const utils::BasicException &e) {
+    spdlog::error("Loading WAL from {} failed because of {}.", *maybe_wal_path, e.what());
   }
 }
 
@@ -523,7 +534,7 @@ void InMemoryReplicationHandlers::TimestampHandler(dbms::DbmsHandler *dbms_handl
 
   if (!current_main_uuid.has_value() || req.main_uuid != current_main_uuid) [[unlikely]] {
     LogWrongMain(current_main_uuid, req.main_uuid, storage::replication::TimestampReq::kType.name);
-    const storage::replication::CurrentWalRes res{false, 0};
+    const storage::replication::CurrentWalRes res{0};
     slk::Save(res, res_builder);
     return;
   }
@@ -568,476 +579,509 @@ uint64_t InMemoryReplicationHandlers::ReadAndApplyDeltas(storage::InMemoryStorag
   uint64_t applied_deltas = 0;     // Non-skipped deltas
   auto max_delta_timestamp = storage->repl_storage_state_.last_durable_timestamp_.load();
   auto current_durable_commit_timestamp = max_delta_timestamp;
-  for (bool transaction_complete = false; !transaction_complete; ++current_delta_idx) {
-    const auto [delta_timestamp, delta] = ReadDelta(decoder, version);
-    if (delta_timestamp > max_delta_timestamp) {
-      max_delta_timestamp = delta_timestamp;
-    }
 
-    transaction_complete = storage::durability::IsWalDeltaDataTypeTransactionEnd(delta.type, version);
+  try {
+    for (bool transaction_complete = false; !transaction_complete; ++current_delta_idx) {
+      const auto [delta_timestamp, delta] = ReadDelta(decoder, version);
+      if (delta_timestamp > max_delta_timestamp) {
+        max_delta_timestamp = delta_timestamp;
+      }
 
-    if (delta_timestamp <= current_durable_commit_timestamp) {
-      spdlog::trace("Skipping delta with timestamp: {}, current durable commit timestamp: {}", delta_timestamp,
-                    current_durable_commit_timestamp);
-      continue;
-    }
-    spdlog::trace("  Delta {}", current_delta_idx);
-    switch (delta.type) {
-      case WalDeltaData::Type::VERTEX_CREATE: {
-        spdlog::trace("       Create vertex {}", delta.vertex_create_delete.gid.AsUint());
-        auto *transaction = get_transaction_accessor(delta_timestamp);
-        transaction->CreateVertexEx(delta.vertex_create_delete.gid);
-        break;
-      }
-      case WalDeltaData::Type::VERTEX_DELETE: {
-        spdlog::trace("       Delete vertex {}", delta.vertex_create_delete.gid.AsUint());
-        auto *transaction = get_transaction_accessor(delta_timestamp);
-        auto vertex = transaction->FindVertex(delta.vertex_create_delete.gid, View::NEW);
-        if (!vertex)
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        auto ret = transaction->DeleteVertex(&*vertex);
-        if (ret.HasError() || !ret.GetValue())
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        break;
-      }
-      case WalDeltaData::Type::VERTEX_ADD_LABEL: {
-        spdlog::trace("       Vertex {} add label {}", delta.vertex_add_remove_label.gid.AsUint(),
-                      delta.vertex_add_remove_label.label);
-        auto *transaction = get_transaction_accessor(delta_timestamp);
-        auto vertex = transaction->FindVertex(delta.vertex_add_remove_label.gid, View::NEW);
-        if (!vertex)
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        // NOTE: Text search doesn’t have replication in scope yet (Phases 1 and 2)
-        auto ret = vertex->AddLabel(transaction->NameToLabel(delta.vertex_add_remove_label.label));
-        if (ret.HasError() || !ret.GetValue())
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        break;
-      }
-      case WalDeltaData::Type::VERTEX_REMOVE_LABEL: {
-        spdlog::trace("       Vertex {} remove label {}", delta.vertex_add_remove_label.gid.AsUint(),
-                      delta.vertex_add_remove_label.label);
-        auto *transaction = get_transaction_accessor(delta_timestamp);
-        auto vertex = transaction->FindVertex(delta.vertex_add_remove_label.gid, View::NEW);
-        if (!vertex)
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        // NOTE: Text search doesn’t have replication in scope yet (Phases 1 and 2)
-        auto ret = vertex->RemoveLabel(transaction->NameToLabel(delta.vertex_add_remove_label.label));
-        if (ret.HasError() || !ret.GetValue())
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        break;
-      }
-      case WalDeltaData::Type::VERTEX_SET_PROPERTY: {
-        spdlog::trace("       Vertex {} set property", delta.vertex_edge_set_property.gid.AsUint());
-        // NOLINTNEXTLINE
-        auto *transaction = get_transaction_accessor(delta_timestamp);
-        // NOLINTNEXTLINE
-        auto vertex = transaction->FindVertex(delta.vertex_edge_set_property.gid, View::NEW);
-        if (!vertex)
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        // NOTE: Phase 1 of the text search feature doesn't have replication in scope
-        auto ret = vertex->SetProperty(transaction->NameToProperty(delta.vertex_edge_set_property.property),
-                                       delta.vertex_edge_set_property.value);
-        if (ret.HasError())
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        break;
-      }
-      case WalDeltaData::Type::EDGE_CREATE: {
-        spdlog::trace("       Create edge {} of type {} from vertex {} to vertex {}",
-                      delta.edge_create_delete.gid.AsUint(), delta.edge_create_delete.edge_type,
-                      delta.edge_create_delete.from_vertex.AsUint(), delta.edge_create_delete.to_vertex.AsUint());
-        auto *transaction = get_transaction_accessor(delta_timestamp);
-        auto from_vertex = transaction->FindVertex(delta.edge_create_delete.from_vertex, View::NEW);
-        if (!from_vertex)
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        auto to_vertex = transaction->FindVertex(delta.edge_create_delete.to_vertex, View::NEW);
-        if (!to_vertex)
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        auto edge = transaction->CreateEdgeEx(&*from_vertex, &*to_vertex,
-                                              transaction->NameToEdgeType(delta.edge_create_delete.edge_type),
-                                              delta.edge_create_delete.gid);
-        if (edge.HasError())
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        break;
-      }
-      case WalDeltaData::Type::EDGE_DELETE: {
-        spdlog::trace("       Delete edge {} of type {} from vertex {} to vertex {}",
-                      delta.edge_create_delete.gid.AsUint(), delta.edge_create_delete.edge_type,
-                      delta.edge_create_delete.from_vertex.AsUint(), delta.edge_create_delete.to_vertex.AsUint());
-        auto *transaction = get_transaction_accessor(delta_timestamp);
-        auto from_vertex = transaction->FindVertex(delta.edge_create_delete.from_vertex, View::NEW);
-        if (!from_vertex)
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        auto to_vertex = transaction->FindVertex(delta.edge_create_delete.to_vertex, View::NEW);
-        if (!to_vertex)
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        auto edgeType = transaction->NameToEdgeType(delta.edge_create_delete.edge_type);
-        auto edge =
-            transaction->FindEdge(delta.edge_create_delete.gid, View::NEW, edgeType, &*from_vertex, &*to_vertex);
-        if (!edge) throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        if (auto ret = transaction->DeleteEdge(&*edge); ret.HasError())
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        break;
-      }
-      case WalDeltaData::Type::EDGE_SET_PROPERTY: {
-        spdlog::trace(" Edge {} set property", delta.vertex_edge_set_property.gid.AsUint());
-        if (!storage->config_.salient.items.properties_on_edges)
-          throw utils::BasicException(
-              "Can't set properties on edges because properties on edges "
-              "are disabled!");
+      transaction_complete = storage::durability::IsWalDeltaDataTypeTransactionEnd(delta.type, version);
 
-        auto *transaction = get_transaction_accessor(delta_timestamp);
-
-        // The following block of code effectively implements `FindEdge` and
-        // yields an accessor that is only valid for managing the edge's
-        // properties.
-        auto edge = edge_acc.find(delta.vertex_edge_set_property.gid);
-        if (edge == edge_acc.end())
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        // The edge visibility check must be done here manually because we
-        // don't allow direct access to the edges through the public API.
-        {
-          bool is_visible = true;
-          Delta *delta = nullptr;
-          {
-            auto guard = std::shared_lock{edge->lock};
-            is_visible = !edge->deleted;
-            delta = edge->delta;
+      if (delta_timestamp <= current_durable_commit_timestamp) {
+        spdlog::trace("Skipping delta with timestamp: {}, current durable commit timestamp: {}", delta_timestamp,
+                      current_durable_commit_timestamp);
+        continue;
+      }
+      spdlog::trace("  Delta {}", current_delta_idx);
+      switch (delta.type) {
+        case WalDeltaData::Type::VERTEX_CREATE: {
+          auto const gid = delta.vertex_create_delete.gid.AsUint();
+          spdlog::trace("       Create vertex {}", gid);
+          auto *transaction = get_transaction_accessor(delta_timestamp);
+          if (!transaction->CreateVertexEx(delta.vertex_create_delete.gid).has_value()) {
+            throw utils::BasicException("Vertex with gid {} already exists at replica.", gid);
           }
-          ApplyDeltasForRead(&transaction->GetTransaction(), delta, View::NEW, [&is_visible](const Delta &delta) {
-            switch (delta.action) {
-              case Delta::Action::ADD_LABEL:
-              case Delta::Action::REMOVE_LABEL:
-              case Delta::Action::SET_PROPERTY:
-              case Delta::Action::ADD_IN_EDGE:
-              case Delta::Action::ADD_OUT_EDGE:
-              case Delta::Action::REMOVE_IN_EDGE:
-              case Delta::Action::REMOVE_OUT_EDGE:
-                break;
-              case Delta::Action::RECREATE_OBJECT: {
-                is_visible = true;
-                break;
-              }
-              case Delta::Action::DELETE_DESERIALIZED_OBJECT:
-              case Delta::Action::DELETE_OBJECT: {
-                is_visible = false;
-                break;
-              }
+          break;
+        }
+        case WalDeltaData::Type::VERTEX_DELETE: {
+          auto const gid = delta.vertex_create_delete.gid.AsUint();
+          spdlog::trace("       Delete vertex {}", gid);
+          auto *transaction = get_transaction_accessor(delta_timestamp);
+          auto vertex = transaction->FindVertex(delta.vertex_create_delete.gid, View::NEW);
+          if (!vertex) {
+            throw utils::BasicException("Vertex with gid {} couldn't be found while trying to delete vertex.", gid);
+          }
+          auto ret = transaction->DeleteVertex(&*vertex);
+          if (ret.HasError() || !ret.GetValue()) {
+            throw utils::BasicException("Deleting vertex with gid {} failed.", gid);
+          }
+          break;
+        }
+        case WalDeltaData::Type::VERTEX_ADD_LABEL: {
+          auto const gid = delta.vertex_add_remove_label.gid.AsUint();
+          spdlog::trace("       Vertex {} add label {}", gid, delta.vertex_add_remove_label.label);
+          auto *transaction = get_transaction_accessor(delta_timestamp);
+          auto vertex = transaction->FindVertex(delta.vertex_add_remove_label.gid, View::NEW);
+          if (!vertex) {
+            throw utils::BasicException("Couldn't find vertex {} when adding label.", gid);
+          }
+          // NOTE: Text search doesn’t have replication in scope yet (Phases 1 and 2)
+          auto ret = vertex->AddLabel(transaction->NameToLabel(delta.vertex_add_remove_label.label));
+          if (ret.HasError() || !ret.GetValue()) {
+            throw utils::BasicException("Failed to add label to vertex {}.", gid);
+          }
+          break;
+        }
+        case WalDeltaData::Type::VERTEX_REMOVE_LABEL: {
+          auto const gid = delta.vertex_add_remove_label.gid.AsUint();
+          spdlog::trace("       Vertex {} remove label {}", gid, delta.vertex_add_remove_label.label);
+          auto *transaction = get_transaction_accessor(delta_timestamp);
+          auto vertex = transaction->FindVertex(delta.vertex_add_remove_label.gid, View::NEW);
+          if (!vertex) throw utils::BasicException("Failed to find vertex {} when removing label.", gid);
+          // NOTE: Text search doesn’t have replication in scope yet (Phases 1 and 2)
+          auto ret = vertex->RemoveLabel(transaction->NameToLabel(delta.vertex_add_remove_label.label));
+          if (ret.HasError() || !ret.GetValue()) {
+            throw utils::BasicException("Failed to remove label from vertex {}.", gid);
+          }
+          break;
+        }
+        case WalDeltaData::Type::VERTEX_SET_PROPERTY: {
+          auto const gid = delta.vertex_edge_set_property.gid.AsUint();
+          spdlog::trace("       Vertex {} set property", gid);
+          // NOLINTNEXTLINE
+          auto *transaction = get_transaction_accessor(delta_timestamp);
+          // NOLINTNEXTLINE
+          auto vertex = transaction->FindVertex(delta.vertex_edge_set_property.gid, View::NEW);
+          if (!vertex) {
+            throw utils::BasicException("Failed to find vertex {} when setting property.", gid);
+          }
+          // NOTE: Phase 1 of the text search feature doesn't have replication in scope
+          auto ret = vertex->SetProperty(transaction->NameToProperty(delta.vertex_edge_set_property.property),
+                                         delta.vertex_edge_set_property.value);
+          if (ret.HasError()) {
+            throw utils::BasicException("Failed to set property label from vertex {}.", gid);
+          }
+          break;
+        }
+        case WalDeltaData::Type::EDGE_CREATE: {
+          auto const edge_gid = delta.edge_create_delete.gid.AsUint();
+          auto const from_vertex_gid = delta.edge_create_delete.from_vertex.AsUint();
+          auto const to_vertex_gid = delta.edge_create_delete.to_vertex.AsUint();
+          spdlog::trace("       Create edge {} of type {} from vertex {} to vertex {}", edge_gid,
+                        delta.edge_create_delete.edge_type, from_vertex_gid, to_vertex_gid);
+          auto *transaction = get_transaction_accessor(delta_timestamp);
+          auto from_vertex = transaction->FindVertex(delta.edge_create_delete.from_vertex, View::NEW);
+          if (!from_vertex) {
+            throw utils::BasicException("Failed to find vertex {} when adding edge {}.", from_vertex_gid, edge_gid);
+          }
+          auto to_vertex = transaction->FindVertex(delta.edge_create_delete.to_vertex, View::NEW);
+          if (!to_vertex) {
+            throw utils::BasicException("Failed to find vertex {} when adding edge {}.", to_vertex_gid, edge_gid);
+          }
+          auto edge = transaction->CreateEdgeEx(&*from_vertex, &*to_vertex,
+                                                transaction->NameToEdgeType(delta.edge_create_delete.edge_type),
+                                                delta.edge_create_delete.gid);
+          if (edge.HasError()) {
+            throw utils::BasicException("Failed to add edge {} between vertices {} and {}.", edge_gid, from_vertex_gid,
+                                        to_vertex_gid);
+          }
+          break;
+        }
+        case WalDeltaData::Type::EDGE_DELETE: {
+          auto const edge_gid = delta.edge_create_delete.gid.AsUint();
+          auto const from_vertex_gid = delta.edge_create_delete.from_vertex.AsUint();
+          auto const to_vertex_gid = delta.edge_create_delete.to_vertex.AsUint();
+          spdlog::trace("       Delete edge {} of type {} from vertex {} to vertex {}", edge_gid,
+                        delta.edge_create_delete.edge_type, from_vertex_gid, to_vertex_gid);
+          auto *transaction = get_transaction_accessor(delta_timestamp);
+          auto from_vertex = transaction->FindVertex(delta.edge_create_delete.from_vertex, View::NEW);
+          if (!from_vertex) {
+            throw utils::BasicException("Failed to find vertex {} when deleting edge {}.", from_vertex_gid, edge_gid);
+          }
+          auto to_vertex = transaction->FindVertex(delta.edge_create_delete.to_vertex, View::NEW);
+          if (!to_vertex) {
+            throw utils::BasicException("Failed to find vertex {} when deleting edge {}.", from_vertex_gid, edge_gid);
+          }
+          auto edgeType = transaction->NameToEdgeType(delta.edge_create_delete.edge_type);
+          auto edge =
+              transaction->FindEdge(delta.edge_create_delete.gid, View::NEW, edgeType, &*from_vertex, &*to_vertex);
+          if (!edge) {
+            throw utils::BasicException("Couldn't find edge {} when deleting edge.", edge_gid);
+          }
+          if (auto ret = transaction->DeleteEdge(&*edge); ret.HasError()) {
+            throw utils::BasicException("Failed to delete edge {} between vertices {} and {}.", edge_gid,
+                                        from_vertex_gid, to_vertex_gid);
+          }
+          break;
+        }
+        // TODO: (andi) Finish changing error messages.
+        case WalDeltaData::Type::EDGE_SET_PROPERTY: {
+          spdlog::trace(" Edge {} set property", delta.vertex_edge_set_property.gid.AsUint());
+          if (!storage->config_.salient.items.properties_on_edges)
+            throw utils::BasicException(
+                "Can't set properties on edges because properties on edges "
+                "are disabled!");
+
+          auto *transaction = get_transaction_accessor(delta_timestamp);
+
+          // The following block of code effectively implements `FindEdge` and
+          // yields an accessor that is only valid for managing the edge's
+          // properties.
+          auto edge = edge_acc.find(delta.vertex_edge_set_property.gid);
+          if (edge == edge_acc.end())
+            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          // The edge visibility check must be done here manually because we
+          // don't allow direct access to the edges through the public API.
+          {
+            bool is_visible = true;
+            Delta *delta = nullptr;
+            {
+              auto guard = std::shared_lock{edge->lock};
+              is_visible = !edge->deleted;
+              delta = edge->delta;
             }
-          });
-          if (!is_visible)
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        }
-        EdgeRef edge_ref(&*edge);
-        // Here we create an edge accessor that we will use to get the
-        // properties of the edge. The accessor is created with an invalid
-        // type and invalid from/to pointers because we don't know them
-        // here, but that isn't an issue because we won't use that part of
-        // the API here.
+            ApplyDeltasForRead(&transaction->GetTransaction(), delta, View::NEW, [&is_visible](const Delta &delta) {
+              switch (delta.action) {
+                case Delta::Action::ADD_LABEL:
+                case Delta::Action::REMOVE_LABEL:
+                case Delta::Action::SET_PROPERTY:
+                case Delta::Action::ADD_IN_EDGE:
+                case Delta::Action::ADD_OUT_EDGE:
+                case Delta::Action::REMOVE_IN_EDGE:
+                case Delta::Action::REMOVE_OUT_EDGE:
+                  break;
+                case Delta::Action::RECREATE_OBJECT: {
+                  is_visible = true;
+                  break;
+                }
+                case Delta::Action::DELETE_DESERIALIZED_OBJECT:
+                case Delta::Action::DELETE_OBJECT: {
+                  is_visible = false;
+                  break;
+                }
+              }
+            });
+            if (!is_visible)
+              throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          }
+          EdgeRef edge_ref(&*edge);
+          // Here we create an edge accessor that we will use to get the
+          // properties of the edge. The accessor is created with an invalid
+          // type and invalid from/to pointers because we don't know them
+          // here, but that isn't an issue because we won't use that part of
+          // the API here.
 
-        if (version >= storage::durability::kEdgeSetDeltaWithVertexInfo) {
-          auto vacc = storage->vertices_.access();
-          auto from_v = vacc.find(delta.vertex_edge_set_property.from_gid);
-          if (from_v == vacc.end())
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          auto found_edge = std::find_if(from_v->out_edges.begin(), from_v->out_edges.end(),
-                                         [&edge_ref](auto &in) { return std::get<2>(in) == edge_ref; });
-          if (found_edge == from_v->out_edges.end())
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          const auto &[edge_type, to, edge_ref] = *found_edge;
-          auto ea = EdgeAccessor{edge_ref, edge_type, &*from_v, to, storage, &transaction->GetTransaction()};
-          auto ret = ea.SetProperty(transaction->NameToProperty(delta.vertex_edge_set_property.property),
-                                    delta.vertex_edge_set_property.value);
+          if (version >= storage::durability::kEdgeSetDeltaWithVertexInfo) {
+            auto vacc = storage->vertices_.access();
+            auto from_v = vacc.find(delta.vertex_edge_set_property.from_gid);
+            if (from_v == vacc.end())
+              throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+            auto found_edge = std::find_if(from_v->out_edges.begin(), from_v->out_edges.end(),
+                                           [&edge_ref](auto &in) { return std::get<2>(in) == edge_ref; });
+            if (found_edge == from_v->out_edges.end())
+              throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+            const auto &[edge_type, to, edge_ref] = *found_edge;
+            auto ea = EdgeAccessor{edge_ref, edge_type, &*from_v, to, storage, &transaction->GetTransaction()};
+            auto ret = ea.SetProperty(transaction->NameToProperty(delta.vertex_edge_set_property.property),
+                                      delta.vertex_edge_set_property.value);
+            if (ret.HasError())
+              throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          } else {
+            auto found_edge = storage->FindEdge(edge->gid);
+            if (!found_edge)
+              throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+            const auto &[edge_ref, edge_type, from, to] = *found_edge;
+            auto ea = EdgeAccessor{edge_ref, edge_type, from, to, storage, &transaction->GetTransaction()};
+            auto ret = ea.SetProperty(transaction->NameToProperty(delta.vertex_edge_set_property.property),
+                                      delta.vertex_edge_set_property.value);
+            if (ret.HasError())
+              throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          }
+          break;
+        }
+
+        case WalDeltaData::Type::TRANSACTION_END: {
+          spdlog::trace("       Transaction end");
+          if (!commit_timestamp_and_accessor || commit_timestamp_and_accessor->first != delta_timestamp)
+            throw utils::BasicException("Invalid commit data!");
+          auto ret = commit_timestamp_and_accessor->second.Commit(
+              {.desired_commit_timestamp = commit_timestamp_and_accessor->first, .is_main = false});
           if (ret.HasError())
             throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        } else {
-          auto found_edge = storage->FindEdge(edge->gid);
-          if (!found_edge)
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-          const auto &[edge_ref, edge_type, from, to] = *found_edge;
-          auto ea = EdgeAccessor{edge_ref, edge_type, from, to, storage, &transaction->GetTransaction()};
-          auto ret = ea.SetProperty(transaction->NameToProperty(delta.vertex_edge_set_property.property),
-                                    delta.vertex_edge_set_property.value);
-          if (ret.HasError())
-            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          commit_timestamp_and_accessor = std::nullopt;
+          break;
         }
-        break;
-      }
 
-      case WalDeltaData::Type::TRANSACTION_END: {
-        spdlog::trace("       Transaction end");
-        if (!commit_timestamp_and_accessor || commit_timestamp_and_accessor->first != delta_timestamp)
-          throw utils::BasicException("Invalid commit data!");
-        auto ret = commit_timestamp_and_accessor->second.Commit(
-            {.desired_commit_timestamp = commit_timestamp_and_accessor->first, .is_main = false});
-        if (ret.HasError())
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        commit_timestamp_and_accessor = std::nullopt;
-        break;
-      }
-
-      case WalDeltaData::Type::LABEL_INDEX_CREATE: {
-        spdlog::trace("       Create label index on :{}", delta.operation_label.label);
-        // Need to send the timestamp
-        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-        if (transaction->CreateIndex(storage->NameToLabel(delta.operation_label.label)).HasError())
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        break;
-      }
-      case WalDeltaData::Type::LABEL_INDEX_DROP: {
-        spdlog::trace("       Drop label index on :{}", delta.operation_label.label);
-        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-        if (transaction->DropIndex(storage->NameToLabel(delta.operation_label.label)).HasError())
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        break;
-      }
-      case WalDeltaData::Type::LABEL_INDEX_STATS_SET: {
-        spdlog::trace("       Set label index statistics on :{}", delta.operation_label_stats.label);
-        // Need to send the timestamp
-        auto *transaction = get_transaction_accessor(delta_timestamp);
-        const auto label = storage->NameToLabel(delta.operation_label_stats.label);
-        LabelIndexStats stats{};
-        if (!FromJson(delta.operation_label_stats.stats, stats)) {
-          throw utils::BasicException("Failed to read statistics!");
+        case WalDeltaData::Type::LABEL_INDEX_CREATE: {
+          spdlog::trace("       Create label index on :{}", delta.operation_label.label);
+          // Need to send the timestamp
+          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+          if (transaction->CreateIndex(storage->NameToLabel(delta.operation_label.label)).HasError())
+            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          break;
         }
-        transaction->SetIndexStats(label, stats);
-        break;
-      }
-      case WalDeltaData::Type::LABEL_INDEX_STATS_CLEAR: {
-        const auto &info = delta.operation_label;
-        spdlog::trace("       Clear label index statistics on :{}", info.label);
-        // Need to send the timestamp
-        auto *transaction = get_transaction_accessor(delta_timestamp);
-        transaction->DeleteLabelIndexStats(storage->NameToLabel(info.label));
-        break;
-      }
-      case WalDeltaData::Type::LABEL_PROPERTY_INDEX_CREATE: {
-        spdlog::trace("       Create label+property index on :{} ({})", delta.operation_label_property.label,
-                      delta.operation_label_property.property);
-        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-        if (transaction
-                ->CreateIndex(storage->NameToLabel(delta.operation_label_property.label),
+        case WalDeltaData::Type::LABEL_INDEX_DROP: {
+          spdlog::trace("       Drop label index on :{}", delta.operation_label.label);
+          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+          if (transaction->DropIndex(storage->NameToLabel(delta.operation_label.label)).HasError())
+            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          break;
+        }
+        case WalDeltaData::Type::LABEL_INDEX_STATS_SET: {
+          spdlog::trace("       Set label index statistics on :{}", delta.operation_label_stats.label);
+          // Need to send the timestamp
+          auto *transaction = get_transaction_accessor(delta_timestamp);
+          const auto label = storage->NameToLabel(delta.operation_label_stats.label);
+          LabelIndexStats stats{};
+          if (!FromJson(delta.operation_label_stats.stats, stats)) {
+            throw utils::BasicException("Failed to read statistics!");
+          }
+          transaction->SetIndexStats(label, stats);
+          break;
+        }
+        case WalDeltaData::Type::LABEL_INDEX_STATS_CLEAR: {
+          const auto &info = delta.operation_label;
+          spdlog::trace("       Clear label index statistics on :{}", info.label);
+          // Need to send the timestamp
+          auto *transaction = get_transaction_accessor(delta_timestamp);
+          transaction->DeleteLabelIndexStats(storage->NameToLabel(info.label));
+          break;
+        }
+        case WalDeltaData::Type::LABEL_PROPERTY_INDEX_CREATE: {
+          spdlog::trace("       Create label+property index on :{} ({})", delta.operation_label_property.label,
+                        delta.operation_label_property.property);
+          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+          if (transaction
+                  ->CreateIndex(storage->NameToLabel(delta.operation_label_property.label),
+                                storage->NameToProperty(delta.operation_label_property.property))
+                  .HasError())
+            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          break;
+        }
+        case WalDeltaData::Type::LABEL_PROPERTY_INDEX_DROP: {
+          spdlog::trace("       Drop label+property index on :{} ({})", delta.operation_label_property.label,
+                        delta.operation_label_property.property);
+          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+          if (transaction
+                  ->DropIndex(storage->NameToLabel(delta.operation_label_property.label),
                               storage->NameToProperty(delta.operation_label_property.property))
-                .HasError())
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        break;
-      }
-      case WalDeltaData::Type::LABEL_PROPERTY_INDEX_DROP: {
-        spdlog::trace("       Drop label+property index on :{} ({})", delta.operation_label_property.label,
-                      delta.operation_label_property.property);
-        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-        if (transaction
-                ->DropIndex(storage->NameToLabel(delta.operation_label_property.label),
-                            storage->NameToProperty(delta.operation_label_property.property))
-                .HasError())
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        break;
-      }
-      case WalDeltaData::Type::LABEL_PROPERTY_INDEX_STATS_SET: {
-        const auto &info = delta.operation_label_property_stats;
-        spdlog::trace("       Set label-property index statistics on :{}", info.label);
-        // Need to send the timestamp
-        auto *transaction = get_transaction_accessor(delta_timestamp);
-        const auto label = storage->NameToLabel(info.label);
-        const auto property = storage->NameToProperty(info.property);
-        LabelPropertyIndexStats stats{};
-        if (!FromJson(info.stats, stats)) {
-          throw utils::BasicException("Failed to read statistics!");
+                  .HasError())
+            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          break;
         }
-        transaction->SetIndexStats(label, property, stats);
-        break;
-      }
-      case WalDeltaData::Type::LABEL_PROPERTY_INDEX_STATS_CLEAR: {
-        const auto &info = delta.operation_label;
-        spdlog::trace("       Clear label-property index statistics on :{}", info.label);
-        // Need to send the timestamp
-        auto *transaction = get_transaction_accessor(delta_timestamp);
-        transaction->DeleteLabelPropertyIndexStats(storage->NameToLabel(info.label));
-        break;
-      }
-      case WalDeltaData::Type::EDGE_INDEX_CREATE: {
-        spdlog::trace("       Create edge index on :{}", delta.operation_edge_type.edge_type);
-        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-        if (transaction->CreateIndex(storage->NameToEdgeType(delta.operation_edge_type.edge_type)).HasError())
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        break;
-      }
-      case WalDeltaData::Type::EDGE_INDEX_DROP: {
-        spdlog::trace("       Drop edge index on :{}", delta.operation_edge_type.edge_type);
-        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-        if (transaction->DropIndex(storage->NameToEdgeType(delta.operation_edge_type.edge_type)).HasError())
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        break;
-      }
-      case WalDeltaData::Type::EDGE_PROPERTY_INDEX_CREATE: {
-        spdlog::trace("       Create edge index on :{}({})", delta.operation_edge_type_property.edge_type,
-                      delta.operation_edge_type_property.property);
-        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-        if (transaction
-                ->CreateIndex(storage->NameToEdgeType(delta.operation_edge_type_property.edge_type),
+        case WalDeltaData::Type::LABEL_PROPERTY_INDEX_STATS_SET: {
+          const auto &info = delta.operation_label_property_stats;
+          spdlog::trace("       Set label-property index statistics on :{}", info.label);
+          // Need to send the timestamp
+          auto *transaction = get_transaction_accessor(delta_timestamp);
+          const auto label = storage->NameToLabel(info.label);
+          const auto property = storage->NameToProperty(info.property);
+          LabelPropertyIndexStats stats{};
+          if (!FromJson(info.stats, stats)) {
+            throw utils::BasicException("Failed to read statistics!");
+          }
+          transaction->SetIndexStats(label, property, stats);
+          break;
+        }
+        case WalDeltaData::Type::LABEL_PROPERTY_INDEX_STATS_CLEAR: {
+          const auto &info = delta.operation_label;
+          spdlog::trace("       Clear label-property index statistics on :{}", info.label);
+          // Need to send the timestamp
+          auto *transaction = get_transaction_accessor(delta_timestamp);
+          transaction->DeleteLabelPropertyIndexStats(storage->NameToLabel(info.label));
+          break;
+        }
+        case WalDeltaData::Type::EDGE_INDEX_CREATE: {
+          spdlog::trace("       Create edge index on :{}", delta.operation_edge_type.edge_type);
+          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+          if (transaction->CreateIndex(storage->NameToEdgeType(delta.operation_edge_type.edge_type)).HasError())
+            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          break;
+        }
+        case WalDeltaData::Type::EDGE_INDEX_DROP: {
+          spdlog::trace("       Drop edge index on :{}", delta.operation_edge_type.edge_type);
+          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+          if (transaction->DropIndex(storage->NameToEdgeType(delta.operation_edge_type.edge_type)).HasError())
+            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          break;
+        }
+        case WalDeltaData::Type::EDGE_PROPERTY_INDEX_CREATE: {
+          spdlog::trace("       Create edge index on :{}({})", delta.operation_edge_type_property.edge_type,
+                        delta.operation_edge_type_property.property);
+          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+          if (transaction
+                  ->CreateIndex(storage->NameToEdgeType(delta.operation_edge_type_property.edge_type),
+                                storage->NameToProperty(delta.operation_edge_type_property.property))
+                  .HasError())
+            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          break;
+        }
+        case WalDeltaData::Type::EDGE_PROPERTY_INDEX_DROP: {
+          spdlog::trace("       Drop edge index on :{}({})", delta.operation_edge_type_property.edge_type,
+                        delta.operation_edge_type_property.property);
+          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+          if (transaction
+                  ->DropIndex(storage->NameToEdgeType(delta.operation_edge_type_property.edge_type),
                               storage->NameToProperty(delta.operation_edge_type_property.property))
-                .HasError())
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        break;
-      }
-      case WalDeltaData::Type::EDGE_PROPERTY_INDEX_DROP: {
-        spdlog::trace("       Drop edge index on :{}({})", delta.operation_edge_type_property.edge_type,
-                      delta.operation_edge_type_property.property);
-        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-        if (transaction
-                ->DropIndex(storage->NameToEdgeType(delta.operation_edge_type_property.edge_type),
-                            storage->NameToProperty(delta.operation_edge_type_property.property))
-                .HasError())
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        break;
-      }
-      case WalDeltaData::Type::TEXT_INDEX_CREATE: {
-        // NOTE: Text search doesn’t have replication in scope yet (Phases 1 and 2)
-        break;
-      }
-      case WalDeltaData::Type::TEXT_INDEX_DROP: {
-        // NOTE: Text search doesn’t have replication in scope yet (Phases 1 and 2)
-        break;
-      }
-      case WalDeltaData::Type::EXISTENCE_CONSTRAINT_CREATE: {
-        spdlog::trace("       Create existence constraint on :{} ({})", delta.operation_label_property.label,
-                      delta.operation_label_property.property);
-        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-        auto ret =
-            transaction->CreateExistenceConstraint(storage->NameToLabel(delta.operation_label_property.label),
-                                                   storage->NameToProperty(delta.operation_label_property.property));
-        if (ret.HasError())
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        break;
-      }
-      case WalDeltaData::Type::EXISTENCE_CONSTRAINT_DROP: {
-        spdlog::trace("       Drop existence constraint on :{} ({})", delta.operation_label_property.label,
-                      delta.operation_label_property.property);
-        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-        if (transaction
-                ->DropExistenceConstraint(storage->NameToLabel(delta.operation_label_property.label),
-                                          storage->NameToProperty(delta.operation_label_property.property))
-                .HasError())
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        break;
-      }
-      case WalDeltaData::Type::UNIQUE_CONSTRAINT_CREATE: {
-        std::stringstream ss;
-        utils::PrintIterable(ss, delta.operation_label_properties.properties);
-        spdlog::trace("       Create unique constraint on :{} ({})", delta.operation_label_properties.label, ss.str());
-        std::set<PropertyId> properties;
-        for (const auto &prop : delta.operation_label_properties.properties) {
-          properties.emplace(storage->NameToProperty(prop));
+                  .HasError())
+            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          break;
         }
-        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-        auto ret = transaction->CreateUniqueConstraint(storage->NameToLabel(delta.operation_label_properties.label),
+        case WalDeltaData::Type::TEXT_INDEX_CREATE: {
+          // NOTE: Text search doesn’t have replication in scope yet (Phases 1 and 2)
+          break;
+        }
+        case WalDeltaData::Type::TEXT_INDEX_DROP: {
+          // NOTE: Text search doesn’t have replication in scope yet (Phases 1 and 2)
+          break;
+        }
+        case WalDeltaData::Type::EXISTENCE_CONSTRAINT_CREATE: {
+          spdlog::trace("       Create existence constraint on :{} ({})", delta.operation_label_property.label,
+                        delta.operation_label_property.property);
+          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+          auto ret =
+              transaction->CreateExistenceConstraint(storage->NameToLabel(delta.operation_label_property.label),
+                                                     storage->NameToProperty(delta.operation_label_property.property));
+          if (ret.HasError())
+            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          break;
+        }
+        case WalDeltaData::Type::EXISTENCE_CONSTRAINT_DROP: {
+          spdlog::trace("       Drop existence constraint on :{} ({})", delta.operation_label_property.label,
+                        delta.operation_label_property.property);
+          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+          if (transaction
+                  ->DropExistenceConstraint(storage->NameToLabel(delta.operation_label_property.label),
+                                            storage->NameToProperty(delta.operation_label_property.property))
+                  .HasError())
+            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          break;
+        }
+        case WalDeltaData::Type::UNIQUE_CONSTRAINT_CREATE: {
+          std::stringstream ss;
+          utils::PrintIterable(ss, delta.operation_label_properties.properties);
+          spdlog::trace("       Create unique constraint on :{} ({})", delta.operation_label_properties.label,
+                        ss.str());
+          std::set<PropertyId> properties;
+          for (const auto &prop : delta.operation_label_properties.properties) {
+            properties.emplace(storage->NameToProperty(prop));
+          }
+          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+          auto ret = transaction->CreateUniqueConstraint(storage->NameToLabel(delta.operation_label_properties.label),
+                                                         properties);
+          if (!ret.HasValue() || ret.GetValue() != UniqueConstraints::CreationStatus::SUCCESS)
+            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          break;
+        }
+        case WalDeltaData::Type::UNIQUE_CONSTRAINT_DROP: {
+          std::stringstream ss;
+          utils::PrintIterable(ss, delta.operation_label_properties.properties);
+          spdlog::trace("       Drop unique constraint on :{} ({})", delta.operation_label_properties.label, ss.str());
+          std::set<PropertyId> properties;
+          for (const auto &prop : delta.operation_label_properties.properties) {
+            properties.emplace(storage->NameToProperty(prop));
+          }
+          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+          auto ret = transaction->DropUniqueConstraint(storage->NameToLabel(delta.operation_label_properties.label),
                                                        properties);
-        if (!ret.HasValue() || ret.GetValue() != UniqueConstraints::CreationStatus::SUCCESS)
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        break;
-      }
-      case WalDeltaData::Type::UNIQUE_CONSTRAINT_DROP: {
-        std::stringstream ss;
-        utils::PrintIterable(ss, delta.operation_label_properties.properties);
-        spdlog::trace("       Drop unique constraint on :{} ({})", delta.operation_label_properties.label, ss.str());
-        std::set<PropertyId> properties;
-        for (const auto &prop : delta.operation_label_properties.properties) {
-          properties.emplace(storage->NameToProperty(prop));
+          if (ret != UniqueConstraints::DeletionStatus::SUCCESS) {
+            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          }
+          break;
         }
-        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-        auto ret =
-            transaction->DropUniqueConstraint(storage->NameToLabel(delta.operation_label_properties.label), properties);
-        if (ret != UniqueConstraints::DeletionStatus::SUCCESS) {
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        }
-        break;
-      }
-      case storage::durability::WalDeltaData::Type::TYPE_CONSTRAINT_CREATE: {
-        spdlog::trace("       Create IS TYPED {} constraint on :{} ({})",
-                      storage::TypeConstraintKindToString(delta.operation_label_property_type.type),
-                      delta.operation_label_property_type.label, delta.operation_label_property_type.property);
+        case storage::durability::WalDeltaData::Type::TYPE_CONSTRAINT_CREATE: {
+          spdlog::trace("       Create IS TYPED {} constraint on :{} ({})",
+                        storage::TypeConstraintKindToString(delta.operation_label_property_type.type),
+                        delta.operation_label_property_type.label, delta.operation_label_property_type.property);
 
-        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-        auto ret =
-            transaction->CreateTypeConstraint(storage->NameToLabel(delta.operation_label_property_type.label),
+          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+          auto ret =
+              transaction->CreateTypeConstraint(storage->NameToLabel(delta.operation_label_property_type.label),
+                                                storage->NameToProperty(delta.operation_label_property_type.property),
+                                                delta.operation_label_property_type.type);
+          if (ret.HasError()) {
+            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          }
+          break;
+        }
+        case storage::durability::WalDeltaData::Type::TYPE_CONSTRAINT_DROP: {
+          spdlog::trace("       Drop IS TYPED {} constraint on :{} ({})",
+                        storage::TypeConstraintKindToString(delta.operation_label_property_type.type),
+                        delta.operation_label_property_type.label, delta.operation_label_property_type.property);
+
+          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+          auto ret =
+              transaction->DropTypeConstraint(storage->NameToLabel(delta.operation_label_property_type.label),
                                               storage->NameToProperty(delta.operation_label_property_type.property),
                                               delta.operation_label_property_type.type);
-        if (ret.HasError()) {
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          if (ret.HasError()) {
+            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          }
+          break;
         }
-        break;
-      }
-      case storage::durability::WalDeltaData::Type::TYPE_CONSTRAINT_DROP: {
-        spdlog::trace("       Drop IS TYPED {} constraint on :{} ({})",
-                      storage::TypeConstraintKindToString(delta.operation_label_property_type.type),
-                      delta.operation_label_property_type.label, delta.operation_label_property_type.property);
-
-        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-        auto ret =
-            transaction->DropTypeConstraint(storage->NameToLabel(delta.operation_label_property_type.label),
-                                            storage->NameToProperty(delta.operation_label_property_type.property),
-                                            delta.operation_label_property_type.type);
-        if (ret.HasError()) {
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+        case WalDeltaData::Type::ENUM_CREATE: {
+          std::stringstream ss;
+          utils::PrintIterable(ss, delta.operation_enum_create.evalues);
+          spdlog::trace("       Create enum {} with values {}", delta.operation_enum_create.etype, ss.str());
+          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+          auto res = transaction->CreateEnum(delta.operation_enum_create.etype, delta.operation_enum_create.evalues);
+          if (res.HasError()) {
+            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          }
+          break;
         }
-        break;
-      }
-      case WalDeltaData::Type::ENUM_CREATE: {
-        std::stringstream ss;
-        utils::PrintIterable(ss, delta.operation_enum_create.evalues);
-        spdlog::trace("       Create enum {} with values {}", delta.operation_enum_create.etype, ss.str());
-        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-        auto res = transaction->CreateEnum(delta.operation_enum_create.etype, delta.operation_enum_create.evalues);
-        if (res.HasError()) {
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+        case WalDeltaData::Type::ENUM_ALTER_ADD: {
+          auto const &[name, evalue] = delta.operation_enum_alter_add;
+          spdlog::trace("       Alter enum {} add value {}", name, evalue);
+          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+          auto res = transaction->EnumAlterAdd(name, evalue);
+          if (res.HasError()) {
+            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          }
+          break;
         }
-        break;
-      }
-      case WalDeltaData::Type::ENUM_ALTER_ADD: {
-        auto const &[name, evalue] = delta.operation_enum_alter_add;
-        spdlog::trace("       Alter enum {} add value {}", name, evalue);
-        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-        auto res = transaction->EnumAlterAdd(name, evalue);
-        if (res.HasError()) {
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+        case WalDeltaData::Type::ENUM_ALTER_UPDATE: {
+          auto const &[name, evalue_old, evalue_new] = delta.operation_enum_alter_update;
+          spdlog::trace("       Alter enum {} update {} to {}", name, evalue_old, evalue_new);
+          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+          auto res = transaction->EnumAlterUpdate(name, evalue_old, evalue_new);
+          if (res.HasError()) {
+            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          }
+          break;
         }
-        break;
-      }
-      case WalDeltaData::Type::ENUM_ALTER_UPDATE: {
-        auto const &[name, evalue_old, evalue_new] = delta.operation_enum_alter_update;
-        spdlog::trace("       Alter enum {} update {} to {}", name, evalue_old, evalue_new);
-        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-        auto res = transaction->EnumAlterUpdate(name, evalue_old, evalue_new);
-        if (res.HasError()) {
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+        case WalDeltaData::Type::POINT_INDEX_CREATE: {
+          auto const &[label, property] = delta.operation_label_property;
+          spdlog::trace("       Create point index on :{}({})", label, property);
+          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+          auto labelId = storage->NameToLabel(label);
+          auto propId = storage->NameToProperty(property);
+          auto res = transaction->CreatePointIndex(labelId, propId);
+          if (res.HasError()) {
+            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          }
+          break;
         }
-        break;
-      }
-      case WalDeltaData::Type::POINT_INDEX_CREATE: {
-        auto const &[label, property] = delta.operation_label_property;
-        spdlog::trace("       Create point index on :{}({})", label, property);
-        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-        auto labelId = storage->NameToLabel(label);
-        auto propId = storage->NameToProperty(property);
-        auto res = transaction->CreatePointIndex(labelId, propId);
-        if (res.HasError()) {
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+        case WalDeltaData::Type::POINT_INDEX_DROP: {
+          auto const &[label, property] = delta.operation_label_property;
+          spdlog::trace("       Drop point index on :{}({})", label, property);
+          auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
+          auto labelId = storage->NameToLabel(label);
+          auto propId = storage->NameToProperty(property);
+          auto res = transaction->DropPointIndex(labelId, propId);
+          if (res.HasError()) {
+            throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
+          }
+          break;
         }
-        break;
       }
-      case WalDeltaData::Type::POINT_INDEX_DROP: {
-        auto const &[label, property] = delta.operation_label_property;
-        spdlog::trace("       Drop point index on :{}({})", label, property);
-        auto *transaction = get_transaction_accessor(delta_timestamp, kUniqueAccess);
-        auto labelId = storage->NameToLabel(label);
-        auto propId = storage->NameToProperty(property);
-        auto res = transaction->DropPointIndex(labelId, propId);
-        if (res.HasError()) {
-          throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-        }
-        break;
-      }
+      applied_deltas++;
     }
-    applied_deltas++;
+  } catch (const utils::BasicException &e) {
+    commit_timestamp_and_accessor->second.Abort();
+    throw;
   }
 
   if (commit_timestamp_and_accessor) throw utils::BasicException("Did not finish the transaction!");

--- a/src/dbms/inmemory/replication_handlers.hpp
+++ b/src/dbms/inmemory/replication_handlers.hpp
@@ -53,7 +53,7 @@ class InMemoryReplicationHandlers {
                                        const std::optional<utils::UUID> &current_main_uuid, slk::Reader *req_reader,
                                        slk::Builder *res_builder);
 
-  static void LoadWal(storage::InMemoryStorage *storage, storage::replication::Decoder *decoder);
+  static bool LoadWal(storage::InMemoryStorage *storage, storage::replication::Decoder *decoder);
 
   static uint64_t ReadAndApplyDeltas(storage::InMemoryStorage *storage, storage::durability::BaseDecoder *decoder,
                                      uint64_t version);

--- a/src/dbms/inmemory/replication_handlers.hpp
+++ b/src/dbms/inmemory/replication_handlers.hpp
@@ -17,7 +17,8 @@
 
 namespace memgraph::storage {
 class InMemoryStorage;
-}
+}  // namespace memgraph::storage
+
 namespace memgraph::dbms {
 
 class DbmsHandler;

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -5992,9 +5992,8 @@ void Interpreter::Commit() {
   auto *curr_txn = current_db_.db_transactional_accessor_->GetTransaction();
   // if I was main with write txn which became replica, abort.
   if (!is_main && !curr_txn->deltas.empty()) {
-    Abort();
     interpreter_context_->repl_state->Unlock();
-    return;
+    throw QueryException("Cannot commit because instance is not main anymore.");
   }
   auto maybe_commit_error = current_db_.db_transactional_accessor_->Commit({.is_main = is_main}, current_db_.db_acc_);
   interpreter_context_->repl_state->Unlock();

--- a/src/replication_handler/include/replication_handler/replication_handler.hpp
+++ b/src/replication_handler/include/replication_handler/replication_handler.hpp
@@ -319,6 +319,8 @@ struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
       client.Shutdown();
     }
 
+    // spdlog::trace("Instance-level clients stopped, trying to destroy replication storage clients.");
+
     // TODO StorageState needs to be synched. Could have a dangling reference if someone adds a database as we are
     //      deleting the replica.
     // Remove database specific clients

--- a/src/replication_handler/include/replication_handler/replication_handler.hpp
+++ b/src/replication_handler/include/replication_handler/replication_handler.hpp
@@ -196,9 +196,7 @@ struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
 
 #ifdef MG_ENTERPRISE
     // Update system before enabling individual storage <-> replica clients
-    spdlog::trace("Starting system restore for {}", config.repl_server_endpoint.SocketAddress());
     SystemRestore(*maybe_client.GetValue(), system_, dbms_handler_, main_uuid, auth_);
-    spdlog::trace("Finished system restore for {}", config.repl_server_endpoint.SocketAddress());
 #endif
 
     const auto dbms_error = HandleRegisterReplicaStatus(maybe_client);
@@ -278,13 +276,11 @@ struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
     }
 
     // No client error, start instance level client
-    spdlog::trace("Starting replica client.");
 #ifdef MG_ENTERPRISE
     StartReplicaClient(*instance_client_ptr, system_, dbms_handler_, main_uuid, auth_);
 #else
     StartReplicaClient(*instance_client_ptr, dbms_handler_, main_uuid);
 #endif
-    spdlog::trace("Finished replica client.");
     return {};
   }
 

--- a/src/replication_handler/include/replication_handler/replication_handler.hpp
+++ b/src/replication_handler/include/replication_handler/replication_handler.hpp
@@ -319,7 +319,7 @@ struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
       client.Shutdown();
     }
 
-    // spdlog::trace("Instance-level clients stopped, trying to destroy replication storage clients.");
+    spdlog::trace("Instance-level clients stopped, trying to destroy replication storage clients.");
 
     // TODO StorageState needs to be synched. Could have a dangling reference if someone adds a database as we are
     //      deleting the replica.

--- a/src/replication_handler/include/replication_handler/replication_handler.hpp
+++ b/src/replication_handler/include/replication_handler/replication_handler.hpp
@@ -196,7 +196,9 @@ struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
 
 #ifdef MG_ENTERPRISE
     // Update system before enabling individual storage <-> replica clients
+    spdlog::trace("Starting system restore for {}", config.repl_server_endpoint.SocketAddress());
     SystemRestore(*maybe_client.GetValue(), system_, dbms_handler_, main_uuid, auth_);
+    spdlog::trace("Finished system restore for {}", config.repl_server_endpoint.SocketAddress());
 #endif
 
     const auto dbms_error = HandleRegisterReplicaStatus(maybe_client);
@@ -276,11 +278,13 @@ struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
     }
 
     // No client error, start instance level client
+    spdlog::trace("Starting replica client.");
 #ifdef MG_ENTERPRISE
     StartReplicaClient(*instance_client_ptr, system_, dbms_handler_, main_uuid, auth_);
 #else
     StartReplicaClient(*instance_client_ptr, dbms_handler_, main_uuid);
 #endif
+    spdlog::trace("Finished replica client.");
     return {};
   }
 

--- a/src/rpc/client.hpp
+++ b/src/rpc/client.hpp
@@ -78,8 +78,7 @@ class Client {
       // Finalize the request.
       req_builder_.Finalize();
 
-      spdlog::trace("[RpcClient] sent {} to {}:{}", req_type.name, self_->client_->endpoint().GetAddress(),
-                    self_->client_->endpoint().GetPort());
+      spdlog::trace("[RpcClient] sent {} to {}", req_type.name, self_->client_->endpoint().SocketAddress());
 
       // Receive the response.
       uint64_t response_data_size = 0;
@@ -196,7 +195,11 @@ class Client {
     typename TRequestResponse::Request request(std::forward<Args>(args)...);
     auto req_type = TRequestResponse::Request::kType;
 
+    spdlog::trace("Trying to take lock on rpc client when sending {} request to {}", req_type.name,
+                  endpoint_.SocketAddress());
     auto guard = std::unique_lock{mutex_};
+
+    spdlog::trace("Lock taken on rpc client when sending {} request to {}", req_type.name, endpoint_.SocketAddress());
 
     // Check if the connection is broken (if we haven't used the client for a
     // long time the server could have died).

--- a/src/rpc/client.hpp
+++ b/src/rpc/client.hpp
@@ -195,11 +195,7 @@ class Client {
     typename TRequestResponse::Request request(std::forward<Args>(args)...);
     auto req_type = TRequestResponse::Request::kType;
 
-    spdlog::trace("Trying to take lock on rpc client when sending {} request to {}", req_type.name,
-                  endpoint_.SocketAddress());
     auto guard = std::unique_lock{mutex_};
-
-    spdlog::trace("Lock taken on rpc client when sending {} request to {}", req_type.name, endpoint_.SocketAddress());
 
     // Check if the connection is broken (if we haven't used the client for a
     // long time the server could have died).

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -450,11 +450,11 @@ class InMemoryStorage final : public Storage {
    protected:
     // TODO Better naming
     /// @throw std::bad_alloc
-    VertexAccessor CreateVertexEx(storage::Gid gid);
+    std::optional<VertexAccessor> CreateVertexEx(storage::Gid gid);
     /// @throw std::bad_alloc
     Result<EdgeAccessor> CreateEdgeEx(VertexAccessor *from, VertexAccessor *to, EdgeTypeId edge_type, storage::Gid gid);
 
-    /// Duiring commit, in some cases you do not need to hand over deltas to GC
+    /// During commit, in some cases you do not need to hand over deltas to GC
     /// in those cases this method is a light weight way to unlink and discard our deltas
     void FastDiscardOfDeltas(std::unique_lock<std::mutex> gc_guard);
     void GCRapidDeltaCleanup(std::list<Gid> &current_deleted_edges, std::list<Gid> &current_deleted_vertices,
@@ -467,7 +467,7 @@ class InMemoryStorage final : public Storage {
     explicit ReplicationAccessor(InMemoryAccessor &&inmem) : InMemoryAccessor(std::move(inmem)) {}
 
     /// @throw std::bad_alloc
-    VertexAccessor CreateVertexEx(storage::Gid gid) { return InMemoryAccessor::CreateVertexEx(gid); }
+    std::optional<VertexAccessor> CreateVertexEx(storage::Gid gid) { return InMemoryAccessor::CreateVertexEx(gid); }
 
     /// @throw std::bad_alloc
     Result<EdgeAccessor> CreateEdgeEx(VertexAccessor *from, VertexAccessor *to, EdgeTypeId edge_type,

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -357,6 +357,7 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_commit, memgraph:
                     transaction_guard.unlock();
                     spdlog::debug("Sending current wal file to {}", client_.name_);
                     replica_commit = ReplicateCurrentWal(main_uuid, mem_storage, rpcClient, *mem_storage->wal_file_);
+                    // TODO (andi): print happened. Return
                     spdlog::debug("Replica commit after replicating current wal: {}", replica_commit);
                   } else {
                     spdlog::debug("Cannot recover using current wal file {}", client_.name_);
@@ -384,11 +385,11 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_commit, memgraph:
     // and we will go to recovery.
     // By adding this lock, we can avoid that, and go to RECOVERY immediately.
     const auto last_durable_timestamp = storage->repl_storage_state_.last_durable_timestamp_.load();
-    SPDLOG_INFO("Replica {} timestamp: {}, Last commit: {}", client_.name_, replica_commit, last_durable_timestamp);
+    spdlog::info("Replica {} timestamp: {}, Last commit: {}", client_.name_, replica_commit, last_durable_timestamp);
     // ldt can be larger on replica due to a snapshot
     if (last_durable_timestamp <= replica_commit) {
       replica_state_.WithLock([name = client_.name_](auto &val) {
-        spdlog::trace("Replica {} set to ready", name);
+        spdlog::info("Replica {} set to ready.", name);
         val = replication::ReplicaState::READY;
       });
       return;

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -357,7 +357,6 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_commit, memgraph:
                     transaction_guard.unlock();
                     spdlog::debug("Sending current wal file to {}", client_.name_);
                     replica_commit = ReplicateCurrentWal(main_uuid, mem_storage, rpcClient, *mem_storage->wal_file_);
-                    // TODO (andi): print happened. Return
                     spdlog::debug("Replica commit after replicating current wal: {}", replica_commit);
                   } else {
                     spdlog::debug("Cannot recover using current wal file {}", client_.name_);

--- a/src/storage/v2/replication/rpc.cpp
+++ b/src/storage/v2/replication/rpc.cpp
@@ -146,12 +146,10 @@ void Load(memgraph::storage::replication::TimestampReq *self, memgraph::slk::Rea
 // Serialize code for CurrentWalRes
 
 void Save(const memgraph::storage::replication::CurrentWalRes &self, memgraph::slk::Builder *builder) {
-  memgraph::slk::Save(self.success, builder);
   memgraph::slk::Save(self.current_commit_timestamp, builder);
 }
 
 void Load(memgraph::storage::replication::CurrentWalRes *self, memgraph::slk::Reader *reader) {
-  memgraph::slk::Load(&self->success, reader);
   memgraph::slk::Load(&self->current_commit_timestamp, reader);
 }
 

--- a/src/storage/v2/replication/rpc.hpp
+++ b/src/storage/v2/replication/rpc.hpp
@@ -172,10 +172,8 @@ struct CurrentWalRes {
   static void Load(CurrentWalRes *self, memgraph::slk::Reader *reader);
   static void Save(const CurrentWalRes &self, memgraph::slk::Builder *builder);
   CurrentWalRes() = default;
-  CurrentWalRes(bool success, uint64_t current_commit_timestamp)
-      : success(success), current_commit_timestamp(current_commit_timestamp) {}
+  explicit CurrentWalRes(uint64_t current_commit_timestamp) : current_commit_timestamp(current_commit_timestamp) {}
 
-  bool success;
   uint64_t current_commit_timestamp;
 };
 

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -963,13 +963,15 @@ def test_old_main_comes_back_on_new_leader_as_main(test_name):
         return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     interactive_mg_runner.start(inner_memgraph_instances, "instance_3")
+    interactive_mg_runner.start(inner_memgraph_instances, "instance_1")
+    interactive_mg_runner.start(inner_memgraph_instances, "instance_2")
 
     coord1_leader_data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
@@ -977,8 +979,8 @@ def test_old_main_comes_back_on_new_leader_as_main(test_name):
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "leader"),
         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "down", "follower"),
-        ("instance_1", "localhost:7687", "", "localhost:10011", "down", "unknown"),
-        ("instance_2", "localhost:7688", "", "localhost:10012", "down", "unknown"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
@@ -988,9 +990,6 @@ def test_old_main_comes_back_on_new_leader_as_main(test_name):
     mg_sleep_and_assert_multiple(
         [coord1_leader_data, coord2_leader_data], [show_instances_coord1, show_instances_coord2]
     )
-
-    interactive_mg_runner.start(inner_memgraph_instances, "instance_1")
-    interactive_mg_runner.start(inner_memgraph_instances, "instance_2")
 
     new_main_cursor = connect(host="localhost", port=7689).cursor()
 

--- a/tests/jepsen/src/memgraph/high_availability/create/test.clj
+++ b/tests/jepsen/src/memgraph/high_availability/create/test.clj
@@ -589,5 +589,5 @@
                  {:hacreate     (checker)
                   :timeline (timeline/html)})
      :generator (client-generator)
-     :final-generator {:clients (gen/each-thread (gen/once get-nodes)) :recovery-time 40}
+     :final-generator {:clients (gen/each-thread (gen/once get-nodes)) :recovery-time 300}
      :nemesis-config (nemesis/create db nodes-config)}))


### PR DESCRIPTION
Time for running Jepsen stress test increased to 3h. When replica receives a WAL file and has to create a vertex, it won't crash database if such vertex already exists. Rather it will throw an exception which will abort replication transaction and return the information to main instance which sent the WAL request. Main instance will then decide whether replica needs to go to recovery or some other state. If main becomes a replica with a write txn to commit, instead of calling Abort directly, the code will throw when exception and the interpreter will then abort through that exception. Otherwise we have a problem with transaction status.