### PR TITLE
Support swapping uuid on main instances

### DIFF
--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -776,6 +776,14 @@ void CoordinatorInstance::InstanceSuccessCallback(std::string_view instance_name
           spdlog::error("Failed to enable writing on main instance {}.", instance_name);
         }
       }
+
+      if (!instance_state->uuid || *instance_state->uuid != curr_main_uuid) {
+        if (!instance.SendSwapAndUpdateUUID(curr_main_uuid)) {
+          spdlog::error("Failed to set new uuid for main instance {} to {}.", instance_name,
+                        std::string{curr_main_uuid});
+          return;
+        }
+      }
     }
   } else {
     // The instance should be replica.


### PR DESCRIPTION
The system can get in a situation in which main gets re-elected as main again and hence, new uuid gets chosen. Before, swap uuid wouldn't be sent to main which would then cause issues on the replication side.