### PR TITLE
Fix ordering in show instances

### DIFF
--- a/.github/workflows/stress_jepsen.yaml
+++ b/.github/workflows/stress_jepsen.yaml
@@ -78,7 +78,7 @@ jobs:
           cd tests/jepsen
           ./run.sh test \
           --binary ../../build/memgraph \
-          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 10800 --concurrency 6" \
+          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 14400 --concurrency 6" \
           --ignore-run-stdout-logs \
           --ignore-run-stderr-logs \
           --nodes-no 6 \


### PR DESCRIPTION
Jepsen stress test time increased to 4h. In ShowInstancesAsLeader, coord_instance_lock_ will be taken now before checking the status of a coordinator so we cannot get into situation where we check that the leader is ready but then whole become follower callback executes.