### PR TITLE
Bugfix: swapping UUID does not update durability nor active clients

### DIFF
--- a/.github/workflows/stress_jepsen.yaml
+++ b/.github/workflows/stress_jepsen.yaml
@@ -78,7 +78,7 @@ jobs:
           cd tests/jepsen
           ./run.sh test \
           --binary ../../build/memgraph \
-          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 14400 --concurrency 6" \
+          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 18000 --concurrency 6" \
           --ignore-run-stdout-logs \
           --ignore-run-stderr-logs \
           --nodes-no 6 \

--- a/src/coordination/coordinator_rpc.cpp
+++ b/src/coordination/coordinator_rpc.cpp
@@ -20,19 +20,19 @@ namespace memgraph {
 
 namespace coordination {
 
-void PromoteReplicaToMainReq::Save(const PromoteReplicaToMainReq &self, memgraph::slk::Builder *builder) {
+void PromoteToMainReq::Save(const PromoteToMainReq &self, memgraph::slk::Builder *builder) {
   memgraph::slk::Save(self, builder);
 }
 
-void PromoteReplicaToMainReq::Load(PromoteReplicaToMainReq *self, memgraph::slk::Reader *reader) {
+void PromoteToMainReq::Load(PromoteToMainReq *self, memgraph::slk::Reader *reader) {
   memgraph::slk::Load(self, reader);
 }
 
-void PromoteReplicaToMainRes::Save(const PromoteReplicaToMainRes &self, memgraph::slk::Builder *builder) {
+void PromoteToMainRes::Save(const PromoteToMainRes &self, memgraph::slk::Builder *builder) {
   memgraph::slk::Save(self, builder);
 }
 
-void PromoteReplicaToMainRes::Load(PromoteReplicaToMainRes *self, memgraph::slk::Reader *reader) {
+void PromoteToMainRes::Load(PromoteToMainRes *self, memgraph::slk::Reader *reader) {
   memgraph::slk::Load(self, reader);
 }
 
@@ -164,11 +164,11 @@ void RegisterReplicaOnMainRes::Save(const RegisterReplicaOnMainRes &self, memgra
 
 }  // namespace coordination
 
-constexpr utils::TypeInfo coordination::PromoteReplicaToMainReq::kType{utils::TypeId::COORD_FAILOVER_REQ,
-                                                                       "CoordPromoteReplicaToMainReq", nullptr};
+constexpr utils::TypeInfo coordination::PromoteToMainReq::kType{utils::TypeId::COORD_FAILOVER_REQ,
+                                                                "CoordPromoteToMainReq", nullptr};
 
-constexpr utils::TypeInfo coordination::PromoteReplicaToMainRes::kType{utils::TypeId::COORD_FAILOVER_RES,
-                                                                       "CoordPromoteReplicaToMainRes", nullptr};
+constexpr utils::TypeInfo coordination::PromoteToMainRes::kType{utils::TypeId::COORD_FAILOVER_RES,
+                                                                "CoordPromoteToMainRes", nullptr};
 
 constexpr utils::TypeInfo coordination::DemoteMainToReplicaReq::kType{utils::TypeId::COORD_SET_REPL_MAIN_REQ,
                                                                       "CoordDemoteToReplicaReq", nullptr};
@@ -221,22 +221,22 @@ constexpr utils::TypeInfo coordination::StateCheckRes::kType{utils::TypeId::COOR
 
 namespace slk {
 
-// PromoteReplicaToMainRpc
+// PromoteToMainRpc
 
-void Save(const memgraph::coordination::PromoteReplicaToMainRes &self, memgraph::slk::Builder *builder) {
+void Save(const memgraph::coordination::PromoteToMainRes &self, memgraph::slk::Builder *builder) {
   memgraph::slk::Save(self.success, builder);
 }
 
-void Load(memgraph::coordination::PromoteReplicaToMainRes *self, memgraph::slk::Reader *reader) {
+void Load(memgraph::coordination::PromoteToMainRes *self, memgraph::slk::Reader *reader) {
   memgraph::slk::Load(&self->success, reader);
 }
 
-void Save(const memgraph::coordination::PromoteReplicaToMainReq &self, memgraph::slk::Builder *builder) {
+void Save(const memgraph::coordination::PromoteToMainReq &self, memgraph::slk::Builder *builder) {
   memgraph::slk::Save(self.main_uuid, builder);
   memgraph::slk::Save(self.replication_clients_info, builder);
 }
 
-void Load(memgraph::coordination::PromoteReplicaToMainReq *self, memgraph::slk::Reader *reader) {
+void Load(memgraph::coordination::PromoteToMainReq *self, memgraph::slk::Reader *reader) {
   memgraph::slk::Load(&self->main_uuid, reader);
   memgraph::slk::Load(&self->replication_clients_info, reader);
 }

--- a/src/coordination/data_instance_management_server_handlers.cpp
+++ b/src/coordination/data_instance_management_server_handlers.cpp
@@ -111,11 +111,16 @@ void DataInstanceManagementServerHandlers::SwapMainUUIDHandler(replication::Repl
   replication_coordination_glue::SwapMainUUIDReq req;
   slk::Load(&req, req_reader);
 
-  if (replication_handler.IsReplica()) {
-    std::get<replication::RoleReplicaData>(replication_handler.GetReplState().ReplicationData()).uuid_ = req.uuid;
-  } else {
-    std::get<replication::RoleMainData>(replication_handler.GetReplState().ReplicationData()).uuid_ = req.uuid;
+  if (!replication_handler.IsReplica()) {
+    spdlog::error("Setting uuid must be performed on replica.");
+    slk::Save(replication_coordination_glue::SwapMainUUIDRes{false}, res_builder);
+    return;
   }
+
+  auto &repl_data = std::get<replication::RoleReplicaData>(replication_handler.GetReplState().ReplicationData());
+  spdlog::info("Set replica data UUID to main uuid {}", std::string(req.uuid));
+  replication_handler.GetReplState().TryPersistRoleReplica(repl_data.config, req.uuid);
+  repl_data.uuid_ = req.uuid;
 
   slk::Save(replication_coordination_glue::SwapMainUUIDRes{true}, res_builder);
   spdlog::info("UUID successfully set to {}.", std::string(req.uuid));
@@ -160,6 +165,10 @@ void DataInstanceManagementServerHandlers::PromoteReplicaToMainHandler(
     replication::ReplicationHandler &replication_handler, slk::Reader *req_reader, slk::Builder *res_builder) {
   coordination::PromoteReplicaToMainReq req;
   slk::Load(&req, req_reader);
+
+  // Shutdown any remaining client
+  // Main can be promoted while being MAIN; we do this in order to update the uuid and epoch
+  if (replication_handler.IsMain()) replication_handler.ClientsShutdown();
 
   // This can fail because of disk. If it does, the cluster state could get inconsistent.
   // We don't handle disk issues. If I receive request to promote myself to main when I am already main

--- a/src/coordination/include/coordination/coordinator_rpc.hpp
+++ b/src/coordination/include/coordination/coordinator_rpc.hpp
@@ -22,36 +22,36 @@
 
 namespace memgraph::coordination {
 
-struct PromoteReplicaToMainReq {
+struct PromoteToMainReq {
   static const utils::TypeInfo kType;
   static const utils::TypeInfo &GetTypeInfo() { return kType; }
 
-  static void Load(PromoteReplicaToMainReq *self, memgraph::slk::Reader *reader);
-  static void Save(const PromoteReplicaToMainReq &self, memgraph::slk::Builder *builder);
+  static void Load(PromoteToMainReq *self, memgraph::slk::Reader *reader);
+  static void Save(const PromoteToMainReq &self, memgraph::slk::Builder *builder);
 
-  explicit PromoteReplicaToMainReq(const utils::UUID &uuid, std::vector<ReplicationClientInfo> replication_clients_info)
+  explicit PromoteToMainReq(const utils::UUID &uuid, std::vector<ReplicationClientInfo> replication_clients_info)
       : main_uuid(uuid), replication_clients_info(std::move(replication_clients_info)) {}
-  PromoteReplicaToMainReq() = default;
+  PromoteToMainReq() = default;
 
   // get uuid here
   utils::UUID main_uuid;
   std::vector<ReplicationClientInfo> replication_clients_info;
 };
 
-struct PromoteReplicaToMainRes {
+struct PromoteToMainRes {
   static const utils::TypeInfo kType;
   static const utils::TypeInfo &GetTypeInfo() { return kType; }
 
-  static void Load(PromoteReplicaToMainRes *self, memgraph::slk::Reader *reader);
-  static void Save(const PromoteReplicaToMainRes &self, memgraph::slk::Builder *builder);
+  static void Load(PromoteToMainRes *self, memgraph::slk::Reader *reader);
+  static void Save(const PromoteToMainRes &self, memgraph::slk::Builder *builder);
 
-  explicit PromoteReplicaToMainRes(bool success) : success(success) {}
-  PromoteReplicaToMainRes() = default;
+  explicit PromoteToMainRes(bool success) : success(success) {}
+  PromoteToMainRes() = default;
 
   bool success;
 };
 
-using PromoteReplicaToMainRpc = rpc::RequestResponse<PromoteReplicaToMainReq, PromoteReplicaToMainRes>;
+using PromoteToMainRpc = rpc::RequestResponse<PromoteToMainReq, PromoteToMainRes>;
 
 struct RegisterReplicaOnMainReq {
   static const utils::TypeInfo kType;
@@ -275,11 +275,11 @@ using StateCheckRpc = rpc::RequestResponse<StateCheckReq, StateCheckRes>;
 // SLK serialization declarations
 namespace memgraph::slk {
 
-// PromoteReplicaToMainRpc
-void Save(const memgraph::coordination::PromoteReplicaToMainRes &self, memgraph::slk::Builder *builder);
-void Load(memgraph::coordination::PromoteReplicaToMainRes *self, memgraph::slk::Reader *reader);
-void Save(const memgraph::coordination::PromoteReplicaToMainReq &self, memgraph::slk::Builder *builder);
-void Load(memgraph::coordination::PromoteReplicaToMainReq *self, memgraph::slk::Reader *reader);
+// PromoteToMainRpc
+void Save(const memgraph::coordination::PromoteToMainRes &self, memgraph::slk::Builder *builder);
+void Load(memgraph::coordination::PromoteToMainRes *self, memgraph::slk::Reader *reader);
+void Save(const memgraph::coordination::PromoteToMainReq &self, memgraph::slk::Builder *builder);
+void Load(memgraph::coordination::PromoteToMainReq *self, memgraph::slk::Reader *reader);
 
 // RegisterReplicaOnMainRpc
 void Save(const memgraph::coordination::RegisterReplicaOnMainReq &self, memgraph::slk::Builder *builder);

--- a/src/coordination/include/coordination/data_instance_management_server_handlers.hpp
+++ b/src/coordination/include/coordination/data_instance_management_server_handlers.hpp
@@ -32,8 +32,8 @@ class DataInstanceManagementServerHandlers {
   static void StateCheckHandler(replication::ReplicationHandler &replication_handler, slk::Reader *req_reader,
                                 slk::Builder *res_builder);
 
-  static void PromoteReplicaToMainHandler(replication::ReplicationHandler &replication_handler, slk::Reader *req_reader,
-                                          slk::Builder *res_builder);
+  static void PromoteToMainHandler(replication::ReplicationHandler &replication_handler, slk::Reader *req_reader,
+                                   slk::Builder *res_builder);
   static void RegisterReplicaOnMainHandler(replication::ReplicationHandler &replication_handler,
                                            slk::Reader *req_reader, slk::Builder *res_builder);
   static void DemoteMainToReplicaHandler(replication::ReplicationHandler &replication_handler, slk::Reader *req_reader,

--- a/src/coordination/include/coordination/replication_instance_client.hpp
+++ b/src/coordination/include/coordination/replication_instance_client.hpp
@@ -52,8 +52,8 @@ class ReplicationInstanceClient {
 
   virtual auto SendDemoteToReplicaRpc() const -> bool;
 
-  virtual auto SendPromoteReplicaToMainRpc(utils::UUID const &uuid,
-                                           ReplicationClientsInfo replication_clients_info) const -> bool;
+  virtual auto SendPromoteToMainRpc(utils::UUID const &uuid, ReplicationClientsInfo replication_clients_info) const
+      -> bool;
 
   virtual auto SendUnregisterReplicaRpc(std::string_view instance_name) const -> bool;
 

--- a/src/coordination/replication_instance_client.cpp
+++ b/src/coordination/replication_instance_client.cpp
@@ -87,21 +87,20 @@ auto ReplicationInstanceClient::GetReplicationClientInfo() const -> coordination
   return config_.replication_client_info;
 }
 
-auto ReplicationInstanceClient::SendPromoteReplicaToMainRpc(const utils::UUID &uuid,
-                                                            ReplicationClientsInfo replication_clients_info) const
-    -> bool {
+auto ReplicationInstanceClient::SendPromoteToMainRpc(const utils::UUID &uuid,
+                                                     ReplicationClientsInfo replication_clients_info) const -> bool {
   try {
-    spdlog::trace("Sending PromoteReplicaToMainRpc");
-    auto stream{rpc_client_.Stream<PromoteReplicaToMainRpc>(uuid, std::move(replication_clients_info))};
-    spdlog::trace("Awaiting response after sending PromoteReplicaToMainRpc");
+    spdlog::trace("Sending PromoteToMainRpc");
+    auto stream{rpc_client_.Stream<PromoteToMainRpc>(uuid, std::move(replication_clients_info))};
+    spdlog::trace("Awaiting response after sending PromoteToMainRpc");
     if (!stream.AwaitResponse().success) {
-      spdlog::error("Failed to receive successful PromoteReplicaToMainRpc response!");
+      spdlog::error("Failed to receive successful PromoteToMainRpc response!");
       return false;
     }
-    spdlog::trace("Received successful response to PromoteReplicaToMainRPC");
+    spdlog::trace("Received successful response to PromoteToMainRPC");
     return true;
   } catch (rpc::RpcFailedException const &) {
-    spdlog::error("RPC error occurred while sending PromoteReplicaToMainRpc!");
+    spdlog::error("RPC error occurred while sending PromoteToMainRpc!");
   }
   return false;
 }

--- a/src/coordination/replication_instance_connector.cpp
+++ b/src/coordination/replication_instance_connector.cpp
@@ -60,7 +60,7 @@ auto ReplicationInstanceConnector::ReplicationSocketAddress() const -> std::stri
 
 auto ReplicationInstanceConnector::SendPromoteToMainRpc(utils::UUID const &new_uuid,
                                                         ReplicationClientsInfo repl_clients_info) -> bool {
-  return client_.SendPromoteReplicaToMainRpc(new_uuid, std::move(repl_clients_info));
+  return client_.SendPromoteToMainRpc(new_uuid, std::move(repl_clients_info));
 }
 
 auto ReplicationInstanceConnector::SendDemoteToReplicaRpc() -> bool { return client_.SendDemoteToReplicaRpc(); }

--- a/src/replication_handler/include/replication_handler/replication_handler.hpp
+++ b/src/replication_handler/include/replication_handler/replication_handler.hpp
@@ -138,7 +138,7 @@ struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
   // as MAIN, remove a REPLICA connection
   auto UnregisterReplica(std::string_view name) -> memgraph::query::UnregisterReplicaResult override;
 
-  bool DoReplicaToMainPromotion(const utils::UUID &main_uuid);
+  bool DoToMainPromotion(const utils::UUID &main_uuid);
 
   // Helper pass-through (TODO: remove)
   auto GetRole() const -> memgraph::replication_coordination_glue::ReplicationRole override;

--- a/src/replication_handler/replication_handler.cpp
+++ b/src/replication_handler/replication_handler.cpp
@@ -187,7 +187,7 @@ bool ReplicationHandler::SetReplicationRoleMain() {
   };
 
   auto const replica_handler = [this](replication::RoleReplicaData const &) {
-    return DoReplicaToMainPromotion(utils::UUID{});
+    return DoToMainPromotion(utils::UUID{});
   };
 
   // TODO: under lock
@@ -204,7 +204,7 @@ bool ReplicationHandler::TrySetReplicationRoleReplica(const memgraph::replicatio
   return SetReplicationRoleReplica_<false>(config, main_uuid);
 }
 
-bool ReplicationHandler::DoReplicaToMainPromotion(const utils::UUID &main_uuid) {
+bool ReplicationHandler::DoToMainPromotion(const utils::UUID &main_uuid) {
   if (!repl_state_.TryLock()) {
     return false;
   }

--- a/tests/e2e/high_availability/CMakeLists.txt
+++ b/tests/e2e/high_availability/CMakeLists.txt
@@ -13,5 +13,7 @@ copy_e2e_python_files_from_parent_folder(high_availability ".." memgraph.py)
 copy_e2e_python_files_from_parent_folder(high_availability ".." interactive_mg_runner.py)
 copy_e2e_python_files_from_parent_folder(high_availability ".." mg_utils.py)
 
+if (MG_ENTERPRISE)
 add_executable(memgraph__e2e__high_availability_rpc_comm rpc_comm.cpp)
 target_link_libraries(memgraph__e2e__high_availability_rpc_comm mg-coordination mg-repl_coord_glue)
+endif()

--- a/tests/e2e/high_availability/CMakeLists.txt
+++ b/tests/e2e/high_availability/CMakeLists.txt
@@ -12,3 +12,6 @@ copy_e2e_python_files(high_availability workloads.yaml)
 copy_e2e_python_files_from_parent_folder(high_availability ".." memgraph.py)
 copy_e2e_python_files_from_parent_folder(high_availability ".." interactive_mg_runner.py)
 copy_e2e_python_files_from_parent_folder(high_availability ".." mg_utils.py)
+
+add_executable(memgraph__e2e__high_availability_rpc_comm rpc_comm.cpp)
+target_link_libraries(memgraph__e2e__high_availability_rpc_comm mg-coordination mg-repl_coord_glue)

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -3210,7 +3210,7 @@ def test_main_reselected_to_become_main(test_name):
     # 1. Start all instances.
     # 2. Kill replica instances
     # 3. Write to main
-    # 4. Kill main
+    # 4. Inject new main UUID
     # 5. Restart all data instances
 
     inner_instances_description = get_instances_description_no_setup(test_name=test_name)

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -11,6 +11,7 @@
 
 import concurrent.futures
 import os
+import subprocess
 import sys
 import time
 
@@ -3203,6 +3204,123 @@ def test_first_coord_restarts(test_name):
 
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
     mg_sleep_and_assert(leader_data, show_instances_coord1)
+
+
+def test_main_reselected_to_become_main(test_name):
+    # 1. Start all instances.
+    # 2. Kill replica instances
+    # 3. Write to main
+    # 4. Kill main
+    # 5. Restart all data instances
+
+    inner_instances_description = get_instances_description_no_setup(test_name=test_name)
+
+    interactive_mg_runner.start_all(inner_instances_description, keep_directories=False)
+
+    coord_cursor_3 = connect(host="localhost", port=7692).cursor()
+    for query in get_default_setup_queries():
+        execute_and_fetch_all(coord_cursor_3, query)
+
+    def show_instances():
+        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
+
+    # check cluster state
+    leader_data = [
+        ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
+        ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
+        ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
+        ("instance_1", "localhost:7687", "", "localhost:10011", "up", "replica"),
+        ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
+        ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
+    ]
+
+    mg_sleep_and_assert(leader_data, show_instances)
+
+    # kill replica instances
+    interactive_mg_runner.kill(inner_instances_description, "instance_1")
+    interactive_mg_runner.kill(inner_instances_description, "instance_2")
+
+    # Wait until failover happens
+    leader_data = update_tuple_value(leader_data, "instance_1", 0, -2, "down")
+    leader_data = update_tuple_value(leader_data, "instance_1", 0, -1, "unknown")
+    leader_data = update_tuple_value(leader_data, "instance_2", 0, -2, "down")
+    leader_data = update_tuple_value(leader_data, "instance_2", 0, -1, "unknown")
+    mg_sleep_and_assert(leader_data, show_instances)
+
+    # write to main
+    main_cursor = connect(host="localhost", port=7689).cursor()
+    with pytest.raises(Exception) as e:
+        execute_and_fetch_all(main_cursor, "CREATE (n:Node {name: 'node'})")
+    assert "At least one SYNC replica has not confirmed committing last transaction." in str(e.value)
+
+    # check it was written
+    def check_data():
+        return sorted(list(execute_and_fetch_all(main_cursor, "MATCH(n) RETURN count(*);")))
+
+    mg_sleep_and_assert_collection([(1,)], check_data)
+
+    # inject promote to main with a random uuid
+    script_path = os.path.realpath(__file__)
+    result = subprocess.run(
+        [
+            f"{os.path.dirname(script_path)}/memgraph__e2e__high_availability_rpc_comm",
+            "127.0.0.1",
+            "10013",
+            "c260a0a9-1aed-415d-aa1e-73f9e64faa33",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+
+    # Bring back all data instances
+    interactive_mg_runner.start(inner_instances_description, "instance_2")
+    interactive_mg_runner.start(inner_instances_description, "instance_1")
+    main_cursor = connect(host="localhost", port=7689).cursor()
+
+    # Wait for state check loop <- should see that main has the wrong UUID and re-promote it
+    time.sleep(5)
+    leader_data = update_tuple_value(leader_data, "instance_1", 0, -2, "up")
+    leader_data = update_tuple_value(leader_data, "instance_1", 0, -1, "replica")
+    leader_data = update_tuple_value(leader_data, "instance_2", 0, -2, "up")
+    leader_data = update_tuple_value(leader_data, "instance_2", 0, -1, "replica")
+    leader_data = update_tuple_value(leader_data, "instance_3", 0, -2, "up")
+    leader_data = update_tuple_value(leader_data, "instance_3", 0, -1, "main")
+    mg_sleep_and_assert(leader_data, show_instances)
+
+    # check that i1/2 are recovered
+    def show_replicas():
+        return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")))
+
+    replicas = [
+        (
+            "instance_1",
+            "localhost:10001",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 2}},
+        ),
+        (
+            "instance_2",
+            "localhost:10002",
+            "sync",
+            {"behind": None, "status": "ready", "ts": 0},
+            {"memgraph": {"behind": 0, "status": "ready", "ts": 2}},
+        ),
+    ]
+    mg_sleep_and_assert_collection(replicas, show_replicas)
+    cursor = connect(host="localhost", port=7687).cursor()
+
+    def check_data():
+        return sorted(list(execute_and_fetch_all(cursor, "MATCH(n) RETURN count(*);")))
+
+    mg_sleep_and_assert_collection([(1,)], check_data)
+    cursor = connect(host="localhost", port=7688).cursor()
+
+    def check_data():
+        return sorted(list(execute_and_fetch_all(cursor, "MATCH(n) RETURN count(*);")))
+
+    mg_sleep_and_assert_collection([(1,)], check_data)
 
 
 if __name__ == "__main__":

--- a/tests/e2e/high_availability/rpc_comm.cpp
+++ b/tests/e2e/high_availability/rpc_comm.cpp
@@ -1,0 +1,63 @@
+// Copyright 2024 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <iostream>
+
+#include <coordination/coordinator_rpc.hpp>
+#include <coordination/replication_instance_client.hpp>
+#include <replication_coordination_glue/handler.hpp>
+#include <replication_coordination_glue/mode.hpp>
+
+bool SendSwapUUID(const char *address, int port, const char *uuid) {
+  try {
+    memgraph::communication::ClientContext cntxt{};
+    memgraph::io::network::Endpoint endpoint{address, static_cast<uint16_t>(port)};
+    memgraph::rpc::Client rpc_client{endpoint, &cntxt};
+    memgraph::utils::UUID new_uuid{};
+    new_uuid.set(uuid);
+    std::cout << "Sending swap UUID " << std::string(new_uuid) << " to " << endpoint << std::endl;
+    return memgraph::replication_coordination_glue::SendSwapMainUUIDRpc(rpc_client, new_uuid);
+  } catch (...) {
+    return false;
+  }
+}
+
+bool SendPromoteToMain(const char *address, int port, const char *uuid) {
+  try {
+    memgraph::communication::ClientContext cntxt{};
+    memgraph::io::network::Endpoint endpoint{address, static_cast<uint16_t>(port)};
+    memgraph::rpc::Client rpc_client{endpoint, &cntxt};
+    memgraph::utils::UUID new_uuid{};
+    new_uuid.set(uuid);
+    // Hard code the cluster definition... change if needed
+    memgraph::coordination::ReplicationClientsInfo replication_clients_info;
+    replication_clients_info.push_back(memgraph::coordination::ReplicationClientInfo{
+        .instance_name = "instance_1",
+        .replication_mode = memgraph::replication_coordination_glue::ReplicationMode::SYNC,
+        .replication_server = {"127.0.0.1", 10001}});
+    replication_clients_info.push_back(memgraph::coordination::ReplicationClientInfo{
+        .instance_name = "instance_2",
+        .replication_mode = memgraph::replication_coordination_glue::ReplicationMode::SYNC,
+        .replication_server = {"127.0.0.1", 10002}});
+    auto stream{rpc_client.Stream<memgraph::coordination::PromoteReplicaToMainRpc>(
+        new_uuid, std::move(replication_clients_info))};
+    return stream.AwaitResponse().success;
+  } catch (...) {
+    return false;
+  }
+}
+
+int main(int argc, char **argv) {
+  if (!SendPromoteToMain(argv[1], std::stoi(argv[2]), argv[3])) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/e2e/high_availability/rpc_comm.cpp
+++ b/tests/e2e/high_availability/rpc_comm.cpp
@@ -47,8 +47,8 @@ bool SendPromoteToMain(const char *address, int port, const char *uuid) {
         .instance_name = "instance_2",
         .replication_mode = memgraph::replication_coordination_glue::ReplicationMode::SYNC,
         .replication_server = {"127.0.0.1", 10002}});
-    auto stream{rpc_client.Stream<memgraph::coordination::PromoteReplicaToMainRpc>(
-        new_uuid, std::move(replication_clients_info))};
+    auto stream{
+        rpc_client.Stream<memgraph::coordination::PromoteToMainRpc>(new_uuid, std::move(replication_clients_info))};
     return stream.AwaitResponse().success;
   } catch (...) {
     return false;


### PR DESCRIPTION
When a MAIN missed a failover and is selected to be the new main, raft generates a new UUID.
This is then sent to main and replicas. 
Before this fix:
- replicas wouldn't update their durability
- main wouldn't update its clients, so the old uuid would still be used in places
Now the coordinator re-promotes main to main (updating uuid and epoch).