### PR TITLE
Lock repl state before closing instance-level replication clients

### DIFF
--- a/src/coordination/data_instance_management_server_handlers.cpp
+++ b/src/coordination/data_instance_management_server_handlers.cpp
@@ -165,10 +165,6 @@ void DataInstanceManagementServerHandlers::PromoteToMainHandler(replication::Rep
   coordination::PromoteToMainReq req;
   slk::Load(&req, req_reader);
 
-  // Shutdown any remaining client
-  // Main can be promoted while being MAIN; we do this in order to update the uuid and epoch
-  if (replication_handler.IsMain()) replication_handler.ClientsShutdown();
-
   // This can fail because of disk. If it does, the cluster state could get inconsistent.
   // We don't handle disk issues. If I receive request to promote myself to main when I am already main
   // I will do it again, the action is idempotent.

--- a/src/replication_handler/include/replication_handler/replication_handler.hpp
+++ b/src/replication_handler/include/replication_handler/replication_handler.hpp
@@ -156,6 +156,7 @@ struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
 
   auto GetDatabasesHistories() -> replication_coordination_glue::DatabaseHistories;
 
+ private:
   void ClientsShutdown() {
     spdlog::trace("Shutting down instance level clients.");
 
@@ -177,7 +178,6 @@ struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
     spdlog::trace("Replication storage clients destroyed.");
   }
 
- private:
   template <bool SendSwapUUID>
   auto RegisterReplica_(const memgraph::replication::ReplicationClientConfig &config)
       -> memgraph::utils::BasicResult<memgraph::query::RegisterReplicaError> {


### PR DESCRIPTION
### Tracking
- [x] **[Link to Epic/Issue](https://github.com/memgraph/memgraph/issues/2484)**


### Standard development
- [x] Update unit/E2E tests
- [x] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch this branch


### CI Testing Labels
- [x] Select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_


### Documentation checklist
- [x] Add the documentation label
- [x] Add the bug / feature label
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [x] Write a release note, including added/changed clauses
    - **Bugfix: Instance-level clients can now safely be closed after committing. Before, a promotion request would execute in parallel with committing and would cause locking a data instance.*
- [ ] **[ Documentation PR link memgraph/documentation#XXXX ]**
    - [ ] Is back linked to this development PR
- [ ] **[ Tag someone from docs team ]**
