### PR TITLE
Compatibility bugfix for any, all, none, single

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NPROC EQUAL 0)
   set(NPROC 1)
 endif()
 
-find_package(Boost 1.78 REQUIRED)
+find_package(Boost 1.78 REQUIRED CONFIG)
 find_package(BZip2 1.0.6 REQUIRED)
 find_package(Threads REQUIRED)
 set(GFLAGS_NOTHREADS OFF)

--- a/src/communication/CMakeLists.txt
+++ b/src/communication/CMakeLists.txt
@@ -15,7 +15,7 @@ set(communication_src_files
     helpers.cpp
     init.cpp)
 
-find_package(Boost REQUIRED)
+find_package(Boost REQUIRED CONFIG)
 
 add_library(mg-communication-metrics STATIC metrics.cpp)
 target_link_libraries(mg-communication-metrics json)

--- a/src/csv/CMakeLists.txt
+++ b/src/csv/CMakeLists.txt
@@ -9,7 +9,7 @@ target_sources(mg-csv
         )
 target_include_directories(mg-csv PUBLIC include)
 
-find_package(Boost REQUIRED COMPONENTS iostreams)
+find_package(Boost REQUIRED CONFIG COMPONENTS iostreams)
 target_link_libraries(mg-csv
         PUBLIC mg-utils
         PRIVATE lib::ctre mg-requests Boost::iostreams

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -521,6 +521,23 @@ size_t UnwrapDegreeResult(storage::Result<size_t> maybe_degree) {
 
 }  // namespace
 
+TypedValue IsEmpty(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
+  FType<Or<Null, List, Map, String>>("isempty", args, nargs);
+  auto const &arg = args[0];
+  if (arg.IsNull()) return TypedValue(ctx.memory);
+  switch (arg.type()) {
+    using enum TypedValue::Type;
+    case List:
+      return TypedValue(arg.UnsafeValueList().empty(), ctx.memory);
+    case Map:
+      return TypedValue(arg.UnsafeValueMap().empty(), ctx.memory);
+    case String:
+      return TypedValue(arg.UnsafeValueString().empty(), ctx.memory);
+    default:
+      return TypedValue(ctx.memory);
+  }
+}
+
 TypedValue Degree(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
   FType<Or<Null, Vertex>>("degree", args, nargs);
   if (args[0].IsNull()) return TypedValue(ctx.memory);
@@ -1597,6 +1614,9 @@ TypedValue WithinBBox(const TypedValue *args, int64_t nargs, const FunctionConte
 }
 
 auto const builtin_functions = absl::flat_hash_map<std::string, func_impl>{
+    // Predicate functions
+    {"ISEMPTY", IsEmpty},
+
     // Scalar functions
     {"DEGREE", Degree},
     {"INDEGREE", InDegree},

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -39,7 +39,7 @@ target_sources(mg-utils
     string.hpp
 )
 
-find_package(Boost REQUIRED)
+find_package(Boost REQUIRED CONFIG)
 find_package(fmt REQUIRED)
 find_package(gflags REQUIRED)
 find_package(Threads REQUIRED)

--- a/tests/e2e/monitoring_server/CMakeLists.txt
+++ b/tests/e2e/monitoring_server/CMakeLists.txt
@@ -1,5 +1,5 @@
 find_package(gflags REQUIRED)
-find_package(Boost REQUIRED)
+find_package(Boost REQUIRED CONFIG)
 
 add_executable(memgraph__e2e__monitoring_server monitoring.cpp)
 target_link_libraries(memgraph__e2e__monitoring_server mgclient mg-utils json gflags Boost::headers)

--- a/tests/e2e/server/CMakeLists.txt
+++ b/tests/e2e/server/CMakeLists.txt
@@ -1,5 +1,5 @@
 find_package(gflags REQUIRED)
-find_package(Boost REQUIRED)
+find_package(Boost REQUIRED CONFIG)
 
 add_executable(memgraph__e2e__server_connection server_connection.cpp)
 target_link_libraries(memgraph__e2e__server_connection mgclient mg-utils gflags)

--- a/tests/gql_behave/tests/memgraph_V1/features/functions.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/functions.feature
@@ -730,8 +730,8 @@ Feature: Functions
             RETURN all(x IN [Null, Null, 0] WHERE x = 0) AS a
             """
         Then the result should be:
-            | a     |
-            | false |
+            | a    |
+            | null |
 
     Scenario: All test 06:
         When executing query:
@@ -818,8 +818,8 @@ Feature: Functions
             RETURN single(x IN [Null, Null, 0] WHERE x > 0) AS a
             """
         Then the result should be:
-            | a     |
-            | false |
+            | a    |
+            | null |
 
     Scenario: Single test 08:
         When executing query:
@@ -900,8 +900,8 @@ Feature: Functions
             RETURN any(x IN [Null, Null, 0] WHERE x > 0) AS a
             """
         Then the result should be:
-            | a     |
-            | false |
+            | a    |
+            | null |
 
    Scenario: Any test 07:
         When executing query:
@@ -964,7 +964,7 @@ Feature: Functions
             """
         Then the result should be:
             | a    |
-            | true |
+            | null |
 
     Scenario: None test 06:
         When executing query:

--- a/tests/gql_behave/tests/memgraph_V1_on_disk/features/functions.feature
+++ b/tests/gql_behave/tests/memgraph_V1_on_disk/features/functions.feature
@@ -702,8 +702,8 @@ Feature: Functions
             RETURN all(x IN [Null, Null, 0] WHERE x = 0) AS a
             """
         Then the result should be:
-            | a     |
-            | false |
+            | a    |
+            | null |
 
     Scenario: All test 06:
         When executing query:
@@ -790,8 +790,8 @@ Feature: Functions
             RETURN single(x IN [Null, Null, 0] WHERE x > 0) AS a
             """
         Then the result should be:
-            | a     |
-            | false |
+            | a    |
+            | null |
 
     Scenario: Single test 08:
         When executing query:
@@ -872,8 +872,8 @@ Feature: Functions
             RETURN any(x IN [Null, Null, 0] WHERE x > 0) AS a
             """
         Then the result should be:
-            | a     |
-            | false |
+            | a    |
+            | null |
 
    Scenario: Any test 07:
         When executing query:
@@ -936,7 +936,7 @@ Feature: Functions
             """
         Then the result should be:
             | a    |
-            | true |
+            | null |
 
     Scenario: None test 06:
         When executing query:

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -427,7 +427,7 @@ add_unit_test(rpc.cpp)
 target_link_libraries(${test_prefix}rpc mg-rpc)
 
 # Test websocket
-find_package(Boost REQUIRED)
+find_package(Boost REQUIRED CONFIG)
 
 add_unit_test(monitoring.cpp)
 target_link_libraries(${test_prefix}monitoring mg-communication Boost::headers)

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -897,6 +897,18 @@ TYPED_TEST(ExpressionEvaluatorTest, FunctionAll2) {
   EXPECT_FALSE(value.ValueBool());
 }
 
+TYPED_TEST(ExpressionEvaluatorTest, FunctionAllEmptyList) {
+  AstStorage storage;
+  auto *ident_x = IDENT("x");
+  auto *all = ALL("x", LIST(), WHERE(LITERAL(true)));
+  const auto x_sym = this->symbol_table.CreateSymbol("x", true);
+  all->identifier_->MapTo(x_sym);
+  ident_x->MapTo(x_sym);
+  auto value = this->Eval(all);
+  ASSERT_TRUE(value.IsBool());
+  EXPECT_TRUE(value.ValueBool());
+}
+
 TYPED_TEST(ExpressionEvaluatorTest, FunctionAllNullList) {
   AstStorage storage;
   auto *all = ALL("x", LITERAL(memgraph::storage::PropertyValue()), WHERE(LITERAL(true)));
@@ -909,19 +921,18 @@ TYPED_TEST(ExpressionEvaluatorTest, FunctionAllNullList) {
 TYPED_TEST(ExpressionEvaluatorTest, FunctionAllNullElementInList1) {
   AstStorage storage;
   auto *ident_x = IDENT("x");
-  auto *all = ALL("x", LIST(LITERAL(1), LITERAL(memgraph::storage::PropertyValue())), WHERE(EQ(ident_x, LITERAL(1))));
+  auto *all = ALL("x", LIST(LITERAL(true), LITERAL(memgraph::storage::PropertyValue())), WHERE(ident_x));
   const auto x_sym = this->symbol_table.CreateSymbol("x", true);
   all->identifier_->MapTo(x_sym);
   ident_x->MapTo(x_sym);
   auto value = this->Eval(all);
-  ASSERT_TRUE(value.IsBool());
-  EXPECT_FALSE(value.ValueBool());
+  EXPECT_TRUE(value.IsNull());
 }
 
 TYPED_TEST(ExpressionEvaluatorTest, FunctionAllNullElementInList2) {
   AstStorage storage;
   auto *ident_x = IDENT("x");
-  auto *all = ALL("x", LIST(LITERAL(2), LITERAL(memgraph::storage::PropertyValue())), WHERE(EQ(ident_x, LITERAL(1))));
+  auto *all = ALL("x", LIST(LITERAL(false), LITERAL(memgraph::storage::PropertyValue())), WHERE(ident_x));
   const auto x_sym = this->symbol_table.CreateSymbol("x", true);
   all->identifier_->MapTo(x_sym);
   ident_x->MapTo(x_sym);
@@ -962,6 +973,18 @@ TYPED_TEST(ExpressionEvaluatorTest, FunctionSingle2) {
   EXPECT_FALSE(value.ValueBool());
 }
 
+TYPED_TEST(ExpressionEvaluatorTest, FunctionSingleEmptyList) {
+  AstStorage storage;
+  auto *ident_x = IDENT("x");
+  auto *single = SINGLE("x", LIST(), WHERE(LITERAL(true)));
+  const auto x_sym = this->symbol_table.CreateSymbol("x", true);
+  single->identifier_->MapTo(x_sym);
+  ident_x->MapTo(x_sym);
+  auto value = this->Eval(single);
+  ASSERT_TRUE(value.IsBool());
+  EXPECT_FALSE(value.ValueBool());
+}
+
 TYPED_TEST(ExpressionEvaluatorTest, FunctionSingleNullList) {
   AstStorage storage;
   auto *single = SINGLE("x", LITERAL(memgraph::storage::PropertyValue()), WHERE(LITERAL(true)));
@@ -974,8 +997,7 @@ TYPED_TEST(ExpressionEvaluatorTest, FunctionSingleNullList) {
 TYPED_TEST(ExpressionEvaluatorTest, FunctionSingleNullElementInList1) {
   AstStorage storage;
   auto *ident_x = IDENT("x");
-  auto *single =
-      SINGLE("x", LIST(LITERAL(1), LITERAL(memgraph::storage::PropertyValue())), WHERE(EQ(ident_x, LITERAL(1))));
+  auto *single = SINGLE("x", LIST(LITERAL(true), LITERAL(memgraph::storage::PropertyValue())), WHERE(ident_x));
   const auto x_sym = this->symbol_table.CreateSymbol("x", true);
   single->identifier_->MapTo(x_sym);
   ident_x->MapTo(x_sym);
@@ -987,8 +1009,19 @@ TYPED_TEST(ExpressionEvaluatorTest, FunctionSingleNullElementInList1) {
 TYPED_TEST(ExpressionEvaluatorTest, FunctionSingleNullElementInList2) {
   AstStorage storage;
   auto *ident_x = IDENT("x");
+  auto *single = SINGLE("x", LIST(LITERAL(false), LITERAL(memgraph::storage::PropertyValue())), WHERE(ident_x));
+  const auto x_sym = this->symbol_table.CreateSymbol("x", true);
+  single->identifier_->MapTo(x_sym);
+  ident_x->MapTo(x_sym);
+  auto value = this->Eval(single);
+  EXPECT_TRUE(value.IsNull());
+}
+
+TYPED_TEST(ExpressionEvaluatorTest, FunctionSingleNullElementInList3) {
+  AstStorage storage;
+  auto *ident_x = IDENT("x");
   auto *single =
-      SINGLE("x", LIST(LITERAL(2), LITERAL(memgraph::storage::PropertyValue())), WHERE(EQ(ident_x, LITERAL(1))));
+      SINGLE("x", LIST(LITERAL(memgraph::storage::PropertyValue()), LITERAL(true), LITERAL(true)), WHERE(ident_x));
   const auto x_sym = this->symbol_table.CreateSymbol("x", true);
   single->identifier_->MapTo(x_sym);
   ident_x->MapTo(x_sym);
@@ -1021,6 +1054,18 @@ TYPED_TEST(ExpressionEvaluatorTest, FunctionAny2) {
   EXPECT_FALSE(value.ValueBool());
 }
 
+TYPED_TEST(ExpressionEvaluatorTest, FunctionAnyEmptyList) {
+  AstStorage storage;
+  auto *ident_x = IDENT("x");
+  auto *any = ANY("x", LIST(), WHERE(LITERAL(true)));
+  const auto x_sym = this->symbol_table.CreateSymbol("x", true);
+  any->identifier_->MapTo(x_sym);
+  ident_x->MapTo(x_sym);
+  auto value = this->Eval(any);
+  ASSERT_TRUE(value.IsBool());
+  EXPECT_FALSE(value.ValueBool());
+}
+
 TYPED_TEST(ExpressionEvaluatorTest, FunctionAnyNullList) {
   AstStorage storage;
   auto *any = ANY("x", LITERAL(memgraph::storage::PropertyValue()), WHERE(LITERAL(true)));
@@ -1033,7 +1078,7 @@ TYPED_TEST(ExpressionEvaluatorTest, FunctionAnyNullList) {
 TYPED_TEST(ExpressionEvaluatorTest, FunctionAnyNullElementInList1) {
   AstStorage storage;
   auto *ident_x = IDENT("x");
-  auto *any = ANY("x", LIST(LITERAL(0), LITERAL(memgraph::storage::PropertyValue())), WHERE(EQ(ident_x, LITERAL(0))));
+  auto *any = ANY("x", LIST(LITERAL(true), LITERAL(memgraph::storage::PropertyValue())), WHERE(ident_x));
   const auto x_sym = this->symbol_table.CreateSymbol("x", true);
   any->identifier_->MapTo(x_sym);
   ident_x->MapTo(x_sym);
@@ -1044,12 +1089,12 @@ TYPED_TEST(ExpressionEvaluatorTest, FunctionAnyNullElementInList1) {
 TYPED_TEST(ExpressionEvaluatorTest, FunctionAnyNullElementInList2) {
   AstStorage storage;
   auto *ident_x = IDENT("x");
-  auto *any = ANY("x", LIST(LITERAL(1), LITERAL(memgraph::storage::PropertyValue())), WHERE(EQ(ident_x, LITERAL(0))));
+  auto *any = ANY("x", LIST(LITERAL(false), LITERAL(memgraph::storage::PropertyValue())), WHERE(ident_x));
   const auto x_sym = this->symbol_table.CreateSymbol("x", true);
   any->identifier_->MapTo(x_sym);
   ident_x->MapTo(x_sym);
   auto value = this->Eval(any);
-  EXPECT_FALSE(value.ValueBool());
+  EXPECT_TRUE(value.IsNull());
 }
 
 TYPED_TEST(ExpressionEvaluatorTest, FunctionAnyWhereWrongType) {
@@ -1084,6 +1129,18 @@ TYPED_TEST(ExpressionEvaluatorTest, FunctionNone2) {
   EXPECT_FALSE(value.ValueBool());
 }
 
+TYPED_TEST(ExpressionEvaluatorTest, FunctionNoneEmptyList) {
+  AstStorage storage;
+  auto *ident_x = IDENT("x");
+  auto *none = NONE("x", LIST(), WHERE(LITERAL(true)));
+  const auto x_sym = this->symbol_table.CreateSymbol("x", true);
+  none->identifier_->MapTo(x_sym);
+  ident_x->MapTo(x_sym);
+  auto value = this->Eval(none);
+  ASSERT_TRUE(value.IsBool());
+  EXPECT_TRUE(value.ValueBool());
+}
+
 TYPED_TEST(ExpressionEvaluatorTest, FunctionNoneNullList) {
   AstStorage storage;
   auto *none = NONE("x", LITERAL(memgraph::storage::PropertyValue()), WHERE(LITERAL(true)));
@@ -1096,18 +1153,18 @@ TYPED_TEST(ExpressionEvaluatorTest, FunctionNoneNullList) {
 TYPED_TEST(ExpressionEvaluatorTest, FunctionNoneNullElementInList1) {
   AstStorage storage;
   auto *ident_x = IDENT("x");
-  auto *any = NONE("x", LIST(LITERAL(1), LITERAL(memgraph::storage::PropertyValue())), WHERE(EQ(ident_x, LITERAL(0))));
+  auto *any = NONE("x", LIST(LITERAL(false), LITERAL(memgraph::storage::PropertyValue())), WHERE(ident_x));
   const auto x_sym = this->symbol_table.CreateSymbol("x", true);
   any->identifier_->MapTo(x_sym);
   ident_x->MapTo(x_sym);
   auto value = this->Eval(any);
-  EXPECT_TRUE(value.ValueBool());
+  EXPECT_TRUE(value.IsNull());
 }
 
 TYPED_TEST(ExpressionEvaluatorTest, FunctionNoneNullElementInList2) {
   AstStorage storage;
   auto *ident_x = IDENT("x");
-  auto *none = NONE("x", LIST(LITERAL(0), LITERAL(memgraph::storage::PropertyValue())), WHERE(EQ(ident_x, LITERAL(0))));
+  auto *none = NONE("x", LIST(LITERAL(true), LITERAL(memgraph::storage::PropertyValue())), WHERE(ident_x));
   const auto x_sym = this->symbol_table.CreateSymbol("x", true);
   none->identifier_->MapTo(x_sym);
   ident_x->MapTo(x_sym);

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -1771,6 +1771,30 @@ TYPED_TEST(FunctionTest, StartNode) {
   ASSERT_THROW(this->EvaluateFunction("STARTNODE", 2), QueryRuntimeException);
 }
 
+TYPED_TEST(FunctionTest, IsEmpty) {
+  ASSERT_THROW(this->EvaluateFunction("ISEMPTY"), QueryRuntimeException);
+
+  auto null = TypedValue{};
+
+  ASSERT_TRUE(this->EvaluateFunction("ISEMPTY", null).IsNull());
+
+  auto empty_list = TypedValue(std::vector<TypedValue>{});
+  auto empty_map = TypedValue(std::map<std::string, TypedValue>{});
+  auto empty_string = TypedValue("");
+
+  ASSERT_TRUE(this->EvaluateFunction("ISEMPTY", empty_list).ValueBool());
+  ASSERT_TRUE(this->EvaluateFunction("ISEMPTY", empty_map).ValueBool());
+  ASSERT_TRUE(this->EvaluateFunction("ISEMPTY", empty_string).ValueBool());
+
+  auto non_empty_list = TypedValue(std::vector{null});
+  auto non_empty_map = TypedValue(std::map{std::pair<std::string, TypedValue>{"key", null}});
+  auto non_empty_string = TypedValue("nonempty");
+
+  ASSERT_FALSE(this->EvaluateFunction("ISEMPTY", non_empty_list).ValueBool());
+  ASSERT_FALSE(this->EvaluateFunction("ISEMPTY", non_empty_map).ValueBool());
+  ASSERT_FALSE(this->EvaluateFunction("ISEMPTY", non_empty_string).ValueBool());
+}
+
 TYPED_TEST(FunctionTest, Degree) {
   ASSERT_THROW(this->EvaluateFunction("DEGREE"), QueryRuntimeException);
   ASSERT_TRUE(this->EvaluateFunction("DEGREE", TypedValue()).IsNull());


### PR DESCRIPTION
There was compatibility issues noticed with `any` function.
`any(v IN [] WHERE v)` was returning NULL rather than false.
This also highlighted other compatibility issues in any, all, none, single. Mainly around handling of nulls within the list.

Also added the IsEmpty function
