### PR TITLE
Increase running and recovery time for stress test

### DIFF
--- a/.github/workflows/stress_jepsen.yaml
+++ b/.github/workflows/stress_jepsen.yaml
@@ -78,7 +78,7 @@ jobs:
           cd tests/jepsen
           ./run.sh test \
           --binary ../../build/memgraph \
-          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 18000 --concurrency 6" \
+          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 21600 --concurrency 6" \
           --ignore-run-stdout-logs \
           --ignore-run-stderr-logs \
           --nodes-no 6 \

--- a/tests/jepsen/src/memgraph/high_availability/create/test.clj
+++ b/tests/jepsen/src/memgraph/high_availability/create/test.clj
@@ -589,5 +589,5 @@
                  {:hacreate     (checker)
                   :timeline (timeline/html)})
      :generator (client-generator)
-     :final-generator {:clients (gen/each-thread (gen/once get-nodes)) :recovery-time 300}
+     :final-generator {:clients (gen/each-thread (gen/once get-nodes)) :recovery-time 900}
      :nemesis-config (nemesis/create db nodes-config)}))


### PR DESCRIPTION
Recovery time increased to 15' since it's possible that at the end a lot of time is spent recovering from snapshot and WALs. Test will now run for 6h.
