### PR TITLE
Bugfix: Fix deadlock by releasing RPC lock before acquiring engine lock

### DIFF
--- a/.github/workflows/stress_jepsen.yaml
+++ b/.github/workflows/stress_jepsen.yaml
@@ -78,7 +78,7 @@ jobs:
           cd tests/jepsen
           ./run.sh test \
           --binary ../../build/memgraph \
-          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 21600 --concurrency 6" \
+          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 25200 --concurrency 6" \
           --ignore-run-stdout-logs \
           --ignore-run-stderr-logs \
           --nodes-no 6 \

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -38,10 +38,16 @@ ReplicationStorageClient::ReplicationStorageClient(::memgraph::replication::Repl
 void ReplicationStorageClient::UpdateReplicaState(Storage *storage, DatabaseAccessProtector db_acc) {
   auto &replStorageState = storage->repl_storage_state_;
 
-  auto hb_stream{client_.rpc_client_.Stream<replication::HeartbeatRpc>(main_uuid_, storage->uuid(),
-                                                                       replStorageState.last_durable_timestamp_,
-                                                                       std::string{replStorageState.epoch_.id()})};
-  const auto replica = hb_stream.AwaitResponse();
+  // default-constructed HeartbeatRpc
+  replication::HeartbeatRes replica;
+
+  // stream should be destroyed so that RPC lock is released before taking engine lock
+  {
+    auto hb_stream{client_.rpc_client_.Stream<replication::HeartbeatRpc>(main_uuid_, storage->uuid(),
+                                                                         replStorageState.last_durable_timestamp_,
+                                                                         std::string{replStorageState.epoch_.id()})};
+    replica = hb_stream.AwaitResponse();
+  }
 
 #ifdef MG_ENTERPRISE       // Multi-tenancy is only supported in enterprise
   if (!replica.success) {  // Replica is missing the current database


### PR DESCRIPTION
When main instance checks the state of the replica because frequent check failed, it should release rpc lock before taking engine lock.

### Tracking
- [x] **[[Link to Epic/Issue]](https://github.com/memgraph/memgraph/issues/2514)**


### Standard development
- [x] Update unit/E2E tests
- [x] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch this branch


### CI Testing Labels
- [x] Select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_


### Documentation checklist
- [x] Add the documentation label
- [x] Add the bug / feature label
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [x] Write a release note, including added/changed clauses
    - **Bugfix: When checking replica state, main will release RPC lock before taking engine lock to avoid deadlock with commit thread.**
- [ ] **[ Documentation PR link memgraph/documentation#XXXX ]**
    - [ ] Is back linked to this development PR
- [ ] **[ Tag someone from docs team ]**
