### PR TITLE
Bugfix: Concurrent recovery and promotion crash database

### DIFF
--- a/src/replication/include/replication/replication_server.hpp
+++ b/src/replication/include/replication/replication_server.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2024 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -25,9 +25,10 @@ class ReplicationServer {
   ReplicationServer &operator=(const ReplicationServer &) = delete;
   ReplicationServer &operator=(ReplicationServer &&) = delete;
 
-  virtual ~ReplicationServer();
+  ~ReplicationServer();
 
   bool Start();
+  void Shutdown();
 
  protected:
   communication::ServerContext rpc_server_context_;

--- a/src/replication/include/replication/state.hpp
+++ b/src/replication/include/replication/state.hpp
@@ -111,6 +111,11 @@ struct ReplicationState {
     return std::get<RoleMainData>(replication_data_);
   }
 
+  auto GetReplicaRole() -> RoleReplicaData & {
+    MG_ASSERT(!IsMain(), "Instance is MAIN");
+    return std::get<RoleReplicaData>(replication_data_);
+  }
+
   bool HasDurability() const { return nullptr != durability_; }
 
   bool TryPersistRoleMain(std::string new_epoch, utils::UUID main_uuid);

--- a/src/replication/replication_server.cpp
+++ b/src/replication/replication_server.cpp
@@ -45,9 +45,13 @@ bool ReplicationServer::Start() { return rpc_server_.Start(); }
 
 void ReplicationServer::Shutdown() {
   if (rpc_server_.IsRunning()) {
-    auto const &endpoint = rpc_server_.endpoint();
-    spdlog::trace("Closing replication server on {}", endpoint.SocketAddress());
-    rpc_server_.Shutdown();
+    try {
+      // trace can throw
+      auto const &endpoint = rpc_server_.endpoint();
+      spdlog::trace("Closing replication server on {}", endpoint.SocketAddress());
+      rpc_server_.Shutdown();
+    } catch (std::exception const &) {
+    }
   }
   rpc_server_.AwaitShutdown();
 }

--- a/src/replication/replication_server.cpp
+++ b/src/replication/replication_server.cpp
@@ -39,7 +39,11 @@ ReplicationServer::ReplicationServer(const memgraph::replication::ReplicationSer
   });
 }
 
-ReplicationServer::~ReplicationServer() {
+ReplicationServer::~ReplicationServer() { Shutdown(); }
+
+bool ReplicationServer::Start() { return rpc_server_.Start(); }
+
+void ReplicationServer::Shutdown() {
   if (rpc_server_.IsRunning()) {
     auto const &endpoint = rpc_server_.endpoint();
     spdlog::trace("Closing replication server on {}", endpoint.SocketAddress());
@@ -47,7 +51,5 @@ ReplicationServer::~ReplicationServer() {
   }
   rpc_server_.AwaitShutdown();
 }
-
-bool ReplicationServer::Start() { return rpc_server_.Start(); }
 
 }  // namespace memgraph::replication

--- a/src/replication/replication_server.cpp
+++ b/src/replication/replication_server.cpp
@@ -50,6 +50,7 @@ void ReplicationServer::Shutdown() {
       auto const &endpoint = rpc_server_.endpoint();
       spdlog::trace("Closing replication server on {}", endpoint.SocketAddress());
       rpc_server_.Shutdown();
+      // NOLINTNEXTLINE(bugprone-empty-catch)
     } catch (std::exception const &) {
     }
   }


### PR DESCRIPTION
When replica concurrently executes recovery and promotion, WAL file can be accessed concurrently which could cause flushing a closed file. The fix contains of waiting for recovery to finish before preparing storage for new epoch.