### PR TITLE
Add SHOW INSTANCE coordinator query

### DIFF
--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -256,6 +256,19 @@ auto CoordinatorInstance::ShowInstancesAsLeader() const -> std::optional<std::ve
   return instances_status;
 }
 
+auto CoordinatorInstance::ShowInstance() const -> InstanceStatus {
+  auto const my_config = raft_state_->SelfCoordinatorConfig();
+  auto const curr_leader_id = raft_state_->GetLeaderId();
+  std::string const role = std::invoke(
+      [curr_leader_id, my_id = my_config.coordinator_id]() { return my_id == curr_leader_id ? "leader" : "follower"; });
+
+  return InstanceStatus{.instance_name = raft_state_->InstanceName(),
+                        .coordinator_server = my_config.coordinator_server.SocketAddress(),  // show non-resolved IP
+                        .management_server = my_config.management_server.SocketAddress(),    // show non-resolved IP
+                        .bolt_server = my_config.bolt_server.SocketAddress(),                // show non-resolved IP
+                        .cluster_role = role};
+}
+
 auto CoordinatorInstance::ShowInstances() const -> std::vector<InstanceStatus> {
   auto const leader_results = ShowInstancesAsLeader();
   if (leader_results.has_value()) {

--- a/src/coordination/coordinator_state.cpp
+++ b/src/coordination/coordinator_state.cpp
@@ -116,6 +116,12 @@ auto CoordinatorState::SetReplicationInstanceToMain(std::string_view instance_na
       data_);
 }
 
+auto CoordinatorState::ShowInstance() const -> InstanceStatus {
+  MG_ASSERT(std::holds_alternative<CoordinatorInstance>(data_),
+            "Can't call show instance on data_, as variant holds wrong alternative");
+  return std::get<CoordinatorInstance>(data_).ShowInstance();
+}
+
 auto CoordinatorState::ShowInstances() const -> std::vector<InstanceStatus> {
   MG_ASSERT(std::holds_alternative<CoordinatorInstance>(data_),
             "Can't call show instances on data_, as variant holds wrong alternative");

--- a/src/coordination/coordinator_state_manager.cpp
+++ b/src/coordination/coordinator_state_manager.cpp
@@ -117,6 +117,11 @@ CoordinatorStateManager::CoordinatorStateManager(CoordinatorStateManagerConfig c
   TryUpdateClusterConfigFromDisk();
 }
 
+auto CoordinatorStateManager::SelfCoordinatorConfig() const -> CoordinatorToCoordinatorConfig {
+  auto const config = cluster_config_->get_server(my_id_);
+  return nlohmann::json::parse(config->get_aux()).template get<CoordinatorToCoordinatorConfig>();
+}
+
 auto CoordinatorStateManager::GetCoordinatorToCoordinatorConfigs() const
     -> std::vector<CoordinatorToCoordinatorConfig> {
   std::vector<CoordinatorToCoordinatorConfig> coordinator_to_coordinator_mappings;

--- a/src/coordination/include/coordination/coordinator_instance.hpp
+++ b/src/coordination/include/coordination/coordinator_instance.hpp
@@ -86,6 +86,8 @@ class CoordinatorInstance {
 
   [[nodiscard]] auto TryVerifyOrCorrectClusterState() -> ReconcileClusterStateStatus;
 
+  auto ShowInstance() const -> InstanceStatus;
+
   auto ShowInstances() const -> std::vector<InstanceStatus>;
 
   auto ShowInstancesAsLeader() const -> std::optional<std::vector<InstanceStatus>>;

--- a/src/coordination/include/coordination/coordinator_state.hpp
+++ b/src/coordination/include/coordination/coordinator_state.hpp
@@ -49,6 +49,8 @@ class CoordinatorState {
 
   [[nodiscard]] auto SetReplicationInstanceToMain(std::string_view instance_name) -> SetInstanceToMainCoordinatorStatus;
 
+  [[nodiscard]] auto ShowInstance() const -> InstanceStatus;
+
   [[nodiscard]] auto ShowInstances() const -> std::vector<InstanceStatus>;
 
   auto AddCoordinatorInstance(coordination::CoordinatorToCoordinatorConfig const &config)

--- a/src/coordination/include/coordination/raft_state.hpp
+++ b/src/coordination/include/coordination/raft_state.hpp
@@ -89,6 +89,8 @@ class RaftState {
 
   auto GetLeaderId() const -> uint32_t;
 
+  auto SelfCoordinatorConfig() const -> CoordinatorToCoordinatorConfig;
+
   auto GetCoordinatorToCoordinatorConfigs() const -> std::vector<CoordinatorToCoordinatorConfig>;
 
  private:

--- a/src/coordination/include/nuraft/coordinator_state_manager.hpp
+++ b/src/coordination/include/nuraft/coordinator_state_manager.hpp
@@ -59,6 +59,7 @@ class CoordinatorStateManager : public state_mgr {
 
   [[nodiscard]] auto GetSrvConfig() const -> ptr<srv_config>;
 
+  auto SelfCoordinatorConfig() const -> CoordinatorToCoordinatorConfig;
   auto GetCoordinatorToCoordinatorConfigs() const -> std::vector<CoordinatorToCoordinatorConfig>;
 
  private:

--- a/src/coordination/raft_state.cpp
+++ b/src/coordination/raft_state.cpp
@@ -255,6 +255,10 @@ auto RaftState::InstanceName() const -> std::string { return fmt::format("coordi
 
 auto RaftState::GetCoordinatorId() const -> uint32_t { return coordinator_id_; }
 
+auto RaftState::SelfCoordinatorConfig() const -> CoordinatorToCoordinatorConfig {
+  return state_manager_->SelfCoordinatorConfig();
+}
+
 auto RaftState::GetCoordinatorToCoordinatorConfigs() const -> std::vector<CoordinatorToCoordinatorConfig> {
   return state_manager_->GetCoordinatorToCoordinatorConfigs();
 }

--- a/src/dbms/coordinator_handler.cpp
+++ b/src/dbms/coordinator_handler.cpp
@@ -49,6 +49,10 @@ auto CoordinatorHandler::ForceResetClusterState() -> coordination::ReconcileClus
   return coordinator_state_.ReconcileClusterState();
 }
 
+auto CoordinatorHandler::ShowInstance() const -> coordination::InstanceStatus {
+  return coordinator_state_.ShowInstance();
+}
+
 auto CoordinatorHandler::ShowInstances() const -> std::vector<coordination::InstanceStatus> {
   return coordinator_state_.ShowInstances();
 }

--- a/src/dbms/coordinator_handler.hpp
+++ b/src/dbms/coordinator_handler.hpp
@@ -31,8 +31,6 @@ class CoordinatorHandler {
  public:
   explicit CoordinatorHandler(coordination::CoordinatorState &coordinator_state);
 
-  // TODO: (andi) When moving coordinator state on same instances, rename from RegisterReplicationInstance to
-  // RegisterInstance
   auto RegisterReplicationInstance(coordination::CoordinatorToReplicaConfig const &config)
       -> coordination::RegisterInstanceCoordinatorStatus;
 
@@ -45,6 +43,7 @@ class CoordinatorHandler {
 
   auto ForceResetClusterState() -> coordination::ReconcileClusterStateStatus;
 
+  auto ShowInstance() const -> coordination::InstanceStatus;
   auto ShowInstances() const -> std::vector<coordination::InstanceStatus>;
 
   auto AddCoordinatorInstance(coordination::CoordinatorToCoordinatorConfig const &config)

--- a/src/query/frontend/ast/ast.hpp
+++ b/src/query/frontend/ast/ast.hpp
@@ -3284,6 +3284,7 @@ class CoordinatorQuery : public memgraph::query::Query {
     REGISTER_INSTANCE,
     UNREGISTER_INSTANCE,
     SET_INSTANCE_TO_MAIN,
+    SHOW_INSTANCE,
     SHOW_INSTANCES,
     ADD_COORDINATOR_INSTANCE,
     DEMOTE_INSTANCE,

--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -599,6 +599,13 @@ antlrcpp::Any CypherMainVisitor::visitAddCoordinatorInstance(MemgraphCypher::Add
 }
 
 // License check is done in the interpreter
+antlrcpp::Any CypherMainVisitor::visitShowInstance(MemgraphCypher::ShowInstanceContext * /*ctx*/) {
+  auto *coordinator_query = storage_->Create<CoordinatorQuery>();
+  coordinator_query->action_ = CoordinatorQuery::Action::SHOW_INSTANCE;
+  return coordinator_query;
+}
+
+// License check is done in the interpreter
 antlrcpp::Any CypherMainVisitor::visitShowInstances(MemgraphCypher::ShowInstancesContext * /*ctx*/) {
   auto *coordinator_query = storage_->Create<CoordinatorQuery>();
   coordinator_query->action_ = CoordinatorQuery::Action::SHOW_INSTANCES;

--- a/src/query/frontend/ast/cypher_main_visitor.hpp
+++ b/src/query/frontend/ast/cypher_main_visitor.hpp
@@ -308,6 +308,11 @@ class CypherMainVisitor : public antlropencypher::MemgraphCypherBaseVisitor {
   /**
    * @return CoordinatorQuery*
    */
+  antlrcpp::Any visitShowInstance(MemgraphCypher::ShowInstanceContext *ctx) override;
+
+  /**
+   * @return CoordinatorQuery*
+   */
   antlrcpp::Any visitShowInstances(MemgraphCypher::ShowInstancesContext *ctx) override;
 
   /**

--- a/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
+++ b/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
@@ -274,6 +274,7 @@ replicationQuery : setReplicationRole
 coordinatorQuery : registerInstanceOnCoordinator
                  | unregisterInstanceOnCoordinator
                  | setInstanceToMain
+                 | showInstance
                  | showInstances
                  | addCoordinatorInstance
                  | forceResetClusterStateOnCoordinator
@@ -482,6 +483,7 @@ setReplicationRole : SET REPLICATION ROLE TO ( MAIN | REPLICA )
 
 showReplicationRole : SHOW REPLICATION ROLE ;
 
+showInstance : SHOW INSTANCE ;
 showInstances : SHOW INSTANCES ;
 
 instanceName : symbolicName ;

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -158,6 +158,9 @@ class CoordinatorQueryHandler {
   virtual void SetReplicationInstanceToMain(std::string_view instance_name) = 0;
 
   /// @throw QueryRuntimeException if an error occurred.
+  virtual coordination::InstanceStatus ShowInstance() const = 0;
+
+  /// @throw QueryRuntimeException if an error occurred.
   virtual std::vector<coordination::InstanceStatus> ShowInstances() const = 0;
 
   /// @throw QueryRuntimeException if an error occurred.

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -2748,6 +2748,14 @@ TEST_P(CypherMainVisitorTest, TestAddCoordinatorInstance) {
   EXPECT_EQ(config_map.find(kBoltServer)->second, "127.0.0.1:7688");
   EXPECT_EQ(config_map.find(kCoordinatorServer)->second, "127.0.0.1:10111");
 }
+
+TEST_P(CypherMainVisitorTest, TestShowInstance) {
+  auto &ast_generator = *GetParam();
+  std::string const query = "SHOW INSTANCE";
+  auto *parsed_query = dynamic_cast<CoordinatorQuery *>(ast_generator.ParseQuery(query));
+  EXPECT_EQ(parsed_query->action_, CoordinatorQuery::Action::SHOW_INSTANCE);
+}
+
 #endif
 
 TEST_P(CypherMainVisitorTest, TestDeleteReplica) {

--- a/tests/unit/query_required_privileges.cpp
+++ b/tests/unit/query_required_privileges.cpp
@@ -194,6 +194,11 @@ TEST_F(TestPrivilegeExtractor, ShowSnapshotsQuery) {
   EXPECT_THAT(GetRequiredPrivileges(query), UnorderedElementsAre(AuthQuery::Privilege::DURABILITY));
 }
 
+TEST_F(TestPrivilegeExtractor, CoordinatorQuery) {
+  auto *query = storage.Create<CoordinatorQuery>();
+  EXPECT_THAT(GetRequiredPrivileges(query), UnorderedElementsAre(AuthQuery::Privilege::COORDINATOR));
+}
+
 TEST_F(TestPrivilegeExtractor, StreamQuery) {
   auto *query = storage.Create<StreamQuery>();
   EXPECT_THAT(GetRequiredPrivileges(query), UnorderedElementsAre(AuthQuery::Privilege::STREAM));


### PR DESCRIPTION
Added `show instance` query which returns the state of the instance: instance_name, bolt_server, management_server and role.