### PR TITLE
Prevent server crash

### DIFF
--- a/src/query/plan/planner.hpp
+++ b/src/query/plan/planner.hpp
@@ -151,8 +151,7 @@ auto MakeLogicalPlan(TPlanningContext *context, TPlanPostProcess *post_process, 
         total_cost = plan_cost.cost;
       }
     }
-
-    MG_ASSERT(valid_plan_found, "Could not create a valid query plan!");
+    if (!valid_plan_found) throw QueryException("Could not create a valid query plan, possible ill-formed query");
   } else {
     auto plan = MakeLogicalPlanForSingleQuery<RuleBasedPlanner>(query_parts, context);
     auto rewritten_plan = post_process->Rewrite(std::move(plan), context);


### PR DESCRIPTION
Don't ASSERT, throw query exception. It is possible that an ill formed query can lead to problems during planning. Analysis and good error reporting is difficult for this case, for now we will in general just throw. In future we will improve planner.