### PR TITLE
Fix after commit triggers bug

### DIFF
--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -5883,7 +5883,7 @@ void RunTriggersAfterCommit(dbms::DatabaseAccess db_acc, InterpreterContext *int
     trigger_context.AdaptForAccessor(&db_accessor);
     try {
       trigger.Execute(&db_accessor, db_acc, execution_memory.resource(), flags::run_time::GetExecutionTimeout(),
-                      &interpreter_context->is_shutting_down, &transaction_status, trigger_context);
+                      &interpreter_context->is_shutting_down, transaction_status, trigger_context);
     } catch (const utils::BasicException &exception) {
       spdlog::warn("Trigger '{}' failed with exception:\n{}", trigger.Name(), exception.what());
       db_accessor.Abort();

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -5881,7 +5881,7 @@ void RunTriggersAfterCommit(dbms::DatabaseAccess db_acc, InterpreterContext *int
     trigger_context.AdaptForAccessor(&db_accessor);
     try {
       trigger.Execute(&db_accessor, db_acc, execution_memory.resource(), flags::run_time::GetExecutionTimeout(),
-                      &interpreter_context->is_shutting_down, /*transaction_status*/ nullptr, trigger_context);
+                      &interpreter_context->is_shutting_down, /* transaction_status = */ nullptr, trigger_context);
     } catch (const utils::BasicException &exception) {
       spdlog::warn("Trigger '{}' failed with exception:\n{}", trigger.Name(), exception.what());
       db_accessor.Abort();

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -15,7 +15,6 @@
 
 #include <algorithm>
 #include <atomic>
-#include <boost/move/default_delete.hpp>
 #include <chrono>
 #include <concepts>
 #include <cstddef>

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -5867,7 +5867,6 @@ void Interpreter::Abort() {
 namespace {
 void RunTriggersAfterCommit(dbms::DatabaseAccess db_acc, InterpreterContext *interpreter_context,
                             TriggerContext original_trigger_context) {
-  std::atomic<TransactionStatus> *transaction_status{nullptr};  // dummy value -> not used in after commit triggers
   // Run the triggers
   for (const auto &trigger : db_acc->trigger_store()->AfterCommitTriggers().access()) {
     QueryAllocator execution_memory{};
@@ -5882,7 +5881,7 @@ void RunTriggersAfterCommit(dbms::DatabaseAccess db_acc, InterpreterContext *int
     trigger_context.AdaptForAccessor(&db_accessor);
     try {
       trigger.Execute(&db_accessor, db_acc, execution_memory.resource(), flags::run_time::GetExecutionTimeout(),
-                      &interpreter_context->is_shutting_down, transaction_status, trigger_context);
+                      &interpreter_context->is_shutting_down, /*transaction_status*/ nullptr, trigger_context);
     } catch (const utils::BasicException &exception) {
       spdlog::warn("Trigger '{}' failed with exception:\n{}", trigger.Name(), exception.what());
       db_accessor.Abort();

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <boost/move/default_delete.hpp>
 #include <chrono>
 #include <concepts>
 #include <cstddef>
@@ -5867,7 +5868,7 @@ void Interpreter::Abort() {
 namespace {
 void RunTriggersAfterCommit(dbms::DatabaseAccess db_acc, InterpreterContext *interpreter_context,
                             TriggerContext original_trigger_context) {
-  std::atomic<TransactionStatus> transaction_status{TransactionStatus::ACTIVE};  // dummy value -> not used
+  std::atomic<TransactionStatus> *transaction_status{nullptr};  // dummy value -> not used in after commit triggers
   // Run the triggers
   for (const auto &trigger : db_acc->trigger_store()->AfterCommitTriggers().access()) {
     QueryAllocator execution_memory{};

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -5867,7 +5867,7 @@ void Interpreter::Abort() {
 namespace {
 void RunTriggersAfterCommit(dbms::DatabaseAccess db_acc, InterpreterContext *interpreter_context,
                             TriggerContext original_trigger_context) {
-  std::atomic<TransactionStatus> transaction_status{TransactionStatus::ACTIVE};
+  std::atomic<TransactionStatus> transaction_status{TransactionStatus::ACTIVE};  // dummy value -> not used
   // Run the triggers
   for (const auto &trigger : db_acc->trigger_store()->AfterCommitTriggers().access()) {
     QueryAllocator execution_memory{};


### PR DESCRIPTION
This PR fixes a bug in after-commit triggers where the database accessor becomes invalid after the transaction finishes.
closes #2238 
