### PR TITLE
Bugfix: MATCH is not allowed in the query containing CALL subquery

### DIFF
--- a/src/query/plan/planner.hpp
+++ b/src/query/plan/planner.hpp
@@ -126,6 +126,7 @@ auto MakeLogicalPlan(TPlanningContext *context, TPlanPostProcess *post_process, 
     auto plans = MakeLogicalPlanForSingleQuery<VariableStartPlanner>(query_parts, context);
     bool valid_plan_found = false;
     for (auto plan : plans) {
+      if (!plan) continue;
       // Plans are generated lazily and the current plan will disappear, so
       // it's ok to move it.
       auto rewritten_plan = post_process->Rewrite(std::move(plan), context);

--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -504,7 +504,9 @@ class RuleBasedPlanner {
       MG_ASSERT(utils::Contains(bound_symbols, named_path.first), "Expected generated named path to have bound symbol");
       match_context.new_symbols.emplace_back(named_path.first);
     }
-    MG_ASSERT(filters.empty(), "Expected to generate all filters");
+    if (!filters.empty()) {
+      throw QueryException("Expected to generate all filters");
+    }
     return last_op;
   }
 

--- a/src/query/plan/variable_start_planner.cpp
+++ b/src/query/plan/variable_start_planner.cpp
@@ -77,8 +77,8 @@ void AddNextExpansions(const Symbol &atom_symbol, const Matching &matching, cons
       const bool is_expanding_from_node2 = symbol_table.at(*expansion.node2->identifier_) == atom_symbol;
       const bool is_expanding_from_edge = symbol_table.at(*expansion.edge->identifier_) == atom_symbol;
 
-      DMG_ASSERT(expansion.node2 && (is_expanding_from_node2 || is_expanding_from_edge),
-                 "Expected node_symbol or edge_symbol to be bound");
+      MG_ASSERT(expansion.node2 && (is_expanding_from_node2 || is_expanding_from_edge),
+                "Expected node_symbol or edge_symbol to be bound");
 
       // if we are expanding from an edge, we will not do any change, but at some point need to throw
       // as expanding from edge in a path is invalid

--- a/src/query/plan/variable_start_planner.hpp
+++ b/src/query/plan/variable_start_planner.hpp
@@ -371,13 +371,18 @@ class VariableStartPlanner {
   /// @brief Generate multiple plans by varying the order of graph traversal.
   auto Plan(const QueryParts &query_parts) {
     return iter::imap(
-        [context = context_, old_query_parts = query_parts, this](const auto &alternative_query_parts) {
+        [context = context_, old_query_parts = query_parts,
+         this](const auto &alternative_query_parts) -> RuleBasedPlanner<TPlanningContext>::PlanResult {
           uint64_t index = 0;
           auto reconstructed_query_parts = ReconstructQueryParts(old_query_parts, alternative_query_parts, index);
 
           RuleBasedPlanner<TPlanningContext> rule_planner(context);
           context->bound_symbols.clear();
-          return rule_planner.Plan(reconstructed_query_parts);
+          try {
+            return rule_planner.Plan(reconstructed_query_parts);
+          } catch (QueryException const &e) {
+            return nullptr;
+          }
         },
         VaryQueryMatching(query_parts, *context_->symbol_table));
   }

--- a/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
@@ -420,3 +420,14 @@ Feature: Subqueries
         Then the result should be:
             | title          |
             | 'Forrest Gump' |
+    Scenario: Match after call
+        Given any graph
+        When executing query:
+            """
+            CALL {
+            	RETURN 0 AS x
+            }
+            MATCH ({n0:x})
+            RETURN 0;
+            """
+        Then an error should be raised


### PR DESCRIPTION
If no valid query plan can be generated, QueryException will be thrown. Currently our planner can put a match clause before call subquery clause even if match depends on call subquery.