### PR TITLE
Fix subtle memory leak around AsyncTimer

### DIFF
--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -247,6 +247,7 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
       // SkipList is already threadsafe
       vertices_.run_gc();
       edges_.run_gc();
+      edges_metadata_.run_gc();
     };
   }
 
@@ -2381,13 +2382,13 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
     }
   }
 
-  {
+  if (!current_deleted_vertices.empty()) {
     auto vertex_acc = vertices_.access();
     for (auto vertex : current_deleted_vertices) {
       MG_ASSERT(vertex_acc.remove(vertex), "Invalid database state!");
     }
   }
-  {
+  if (!current_deleted_edges.empty()) {
     auto edge_acc = edges_.access();
     auto edge_metadata_acc = edges_metadata_.access();
     for (auto edge : current_deleted_edges) {

--- a/src/utils/async_timer.cpp
+++ b/src/utils/async_timer.cpp
@@ -52,7 +52,10 @@ uint64_t AddFlag(std::weak_ptr<std::atomic<bool>> flag) {
   return id;
 }
 
-void EraseFlag(uint64_t flag_id) { expiration_flags.access().remove(flag_id); }
+void EraseFlag(uint64_t flag_id) {
+  expiration_flags.access().remove(flag_id);
+  expiration_flags.run_gc();
+}
 
 std::weak_ptr<std::atomic<bool>> GetFlag(uint64_t flag_id) {
   const auto flag_accessor = expiration_flags.access();
@@ -190,7 +193,7 @@ void AsyncTimer::ReleaseResources() {
     timer_delete(timer_id_);
     EraseFlag(flag_id_);
     flag_id_ = kInvalidFlagId;
-    expiration_flag_ = std::shared_ptr<std::atomic<bool>>{};
+    expiration_flag_.reset();
   }
 }
 


### PR DESCRIPTION
--query-execution-timeout-sec causes an allocation which was small, but not being freed. This is now freed.
