### PR TITLE
Use partial function application in e2e HA tests

### DIFF
--- a/tests/e2e/high_availability/common.py
+++ b/tests/e2e/high_availability/common.py
@@ -34,6 +34,34 @@ def ignore_elapsed_time_from_results(results: typing.List[tuple]) -> typing.List
     return [result[:-1] for result in results]
 
 
+def show_instances(cursor):
+    """
+    Accepts a cursor and returns a list of all instances using the `SHOW INSTANCES` query.
+    """
+    return sorted(ignore_elapsed_time_from_results(list(execute_and_fetch_all(cursor, "SHOW INSTANCES;"))))
+
+
+def show_replicas(cursor):
+    """
+    Accepts a cursor and returns a list of all replicas using the `SHOW REPLICAS` query.
+    """
+    return sorted(list(execute_and_fetch_all(cursor, "SHOW REPLICAS;")))
+
+
+def get_vertex_count(cursor):
+    """
+    Accepts a cursor and returns a count of vertices.
+    """
+    return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
+
+
+def show_replication_role(cursor):
+    """
+    Accepts a cursor and returns the replication role.
+    """
+    return sorted(list(execute_and_fetch_all(cursor, "SHOW REPLICATION ROLE;")))
+
+
 def execute_and_fetch_all(cursor: mgclient.Cursor, query: str, params: dict = {}) -> typing.List[tuple]:
     cursor.execute(query, params)
     return cursor.fetchall()

--- a/tests/e2e/high_availability/coord_cluster_registration.py
+++ b/tests/e2e/high_availability/coord_cluster_registration.py
@@ -8,8 +8,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0, included in the file
 # licenses/APL.txt.
+
 import os
 import sys
+from functools import partial
 
 import interactive_mg_runner
 import pytest
@@ -19,7 +21,9 @@ from common import (
     find_instance_and_assert_instances,
     get_data_path,
     get_logs_path,
-    ignore_elapsed_time_from_results,
+    get_vertex_count,
+    show_instances,
+    show_replicas,
     update_tuple_value,
 )
 from mg_utils import mg_sleep_and_assert, mg_sleep_and_assert_until_role_change
@@ -249,11 +253,6 @@ def test_register_repl_instances_then_coordinators(test_name):
         "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112', 'management_server': 'localhost:10122'}",
     )
 
-    def check_coordinator3():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
-        )
-
     leader_data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
@@ -262,25 +261,13 @@ def test_register_repl_instances_then_coordinators(test_name):
         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
-    mg_sleep_and_assert(leader_data, check_coordinator3)
+    mg_sleep_and_assert(leader_data, partial(show_instances, coordinator3_cursor))
 
     coordinator1_cursor = connect(host="localhost", port=7690).cursor()
-
-    def check_coordinator1():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
-        )
-
-    mg_sleep_and_assert(leader_data, check_coordinator1)
-
     coordinator2_cursor = connect(host="localhost", port=7691).cursor()
 
-    def check_coordinator2():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
-        )
-
-    mg_sleep_and_assert(leader_data, check_coordinator2)
+    mg_sleep_and_assert(leader_data, partial(show_instances, coordinator1_cursor))
+    mg_sleep_and_assert(leader_data, partial(show_instances, coordinator2_cursor))
 
 
 def test_register_coordinator_then_repl_instances(test_name):
@@ -311,11 +298,6 @@ def test_register_coordinator_then_repl_instances(test_name):
     )
     execute_and_fetch_all(coordinator3_cursor, "SET INSTANCE instance_3 TO MAIN")
 
-    def check_coordinator3():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
-        )
-
     data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
@@ -324,25 +306,13 @@ def test_register_coordinator_then_repl_instances(test_name):
         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
-    mg_sleep_and_assert(data, check_coordinator3)
+    mg_sleep_and_assert(data, partial(show_instances, coordinator3_cursor))
 
     coordinator1_cursor = connect(host="localhost", port=7690).cursor()
-
-    def check_coordinator1():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
-        )
-
-    mg_sleep_and_assert(data, check_coordinator1)
-
     coordinator2_cursor = connect(host="localhost", port=7691).cursor()
 
-    def check_coordinator2():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
-        )
-
-    mg_sleep_and_assert(data, check_coordinator2)
+    mg_sleep_and_assert(data, partial(show_instances, coordinator1_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator2_cursor))
 
 
 def test_coordinators_communication_with_restarts(test_name):
@@ -384,28 +354,16 @@ def test_coordinators_communication_with_restarts(test_name):
     ]
 
     coordinator1_cursor = connect(host="localhost", port=7690).cursor()
-
-    def check_coordinator1():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
-        )
-
-    mg_sleep_and_assert(coord3_leader_data, check_coordinator1)
-
     coordinator2_cursor = connect(host="localhost", port=7691).cursor()
 
-    def check_coordinator2():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
-        )
-
-    mg_sleep_and_assert(coord3_leader_data, check_coordinator2)
+    mg_sleep_and_assert(coord3_leader_data, partial(show_instances, coordinator1_cursor))
+    mg_sleep_and_assert(coord3_leader_data, partial(show_instances, coordinator2_cursor))
 
     interactive_mg_runner.kill(MEMGRAPH_INSTANCES_DESCRIPTION, "coordinator_1")
     interactive_mg_runner.start(MEMGRAPH_INSTANCES_DESCRIPTION, "coordinator_1")
     coordinator1_cursor = connect(host="localhost", port=7690).cursor()
 
-    mg_sleep_and_assert(coord3_leader_data, check_coordinator1)
+    mg_sleep_and_assert(coord3_leader_data, partial(show_instances, coordinator1_cursor))
 
     interactive_mg_runner.kill(MEMGRAPH_INSTANCES_DESCRIPTION, "coordinator_1")
     interactive_mg_runner.kill(MEMGRAPH_INSTANCES_DESCRIPTION, "coordinator_2")
@@ -430,8 +388,8 @@ def test_coordinators_communication_with_restarts(test_name):
     leader_data = update_tuple_value(leader_data, leader_name, 0, -1, "leader")
 
     # After killing 2/3 of coordinators, leadership can change
-    mg_sleep_and_assert(leader_data, check_coordinator1)
-    mg_sleep_and_assert(leader_data, check_coordinator2)
+    mg_sleep_and_assert(leader_data, partial(show_instances, coordinator1_cursor))
+    mg_sleep_and_assert(leader_data, partial(show_instances, coordinator2_cursor))
 
 
 @pytest.mark.parametrize(
@@ -468,25 +426,7 @@ def test_unregister_replicas(kill_instance, test_name):
     )
     execute_and_fetch_all(coordinator3_cursor, "SET INSTANCE instance_3 TO MAIN")
 
-    def check_coordinator1():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
-        )
-
-    def check_coordinator2():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
-        )
-
-    def check_coordinator3():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
-        )
-
     main_cursor = connect(host="localhost", port=7689).cursor()
-
-    def check_main():
-        return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS")))
 
     data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
@@ -514,10 +454,10 @@ def test_unregister_replicas(kill_instance, test_name):
         ),
     ]
 
-    mg_sleep_and_assert(data, check_coordinator1)
-    mg_sleep_and_assert(data, check_coordinator2)
-    mg_sleep_and_assert(data, check_coordinator3)
-    mg_sleep_and_assert(expected_replicas, check_main)
+    mg_sleep_and_assert(data, partial(show_instances, coordinator1_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator2_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator3_cursor))
+    mg_sleep_and_assert(expected_replicas, partial(show_replicas, main_cursor))
 
     if kill_instance:
         interactive_mg_runner.kill(MEMGRAPH_INSTANCES_DESCRIPTION, "instance_1")
@@ -541,10 +481,10 @@ def test_unregister_replicas(kill_instance, test_name):
         ),
     ]
 
-    mg_sleep_and_assert(data, check_coordinator1)
-    mg_sleep_and_assert(data, check_coordinator2)
-    mg_sleep_and_assert(data, check_coordinator3)
-    mg_sleep_and_assert(expected_replicas, check_main)
+    mg_sleep_and_assert(data, partial(show_instances, coordinator1_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator2_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator3_cursor))
+    mg_sleep_and_assert(expected_replicas, partial(show_replicas, main_cursor))
 
     if kill_instance:
         interactive_mg_runner.kill(MEMGRAPH_INSTANCES_DESCRIPTION, "instance_2")
@@ -559,10 +499,10 @@ def test_unregister_replicas(kill_instance, test_name):
 
     expected_replicas = []
 
-    mg_sleep_and_assert(data, check_coordinator1)
-    mg_sleep_and_assert(data, check_coordinator2)
-    mg_sleep_and_assert(data, check_coordinator3)
-    mg_sleep_and_assert(expected_replicas, check_main)
+    mg_sleep_and_assert(data, partial(show_instances, coordinator1_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator2_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator3_cursor))
+    mg_sleep_and_assert(expected_replicas, partial(show_replicas, main_cursor))
 
 
 def test_unregister_main(test_name):
@@ -595,21 +535,6 @@ def test_unregister_main(test_name):
     )
     execute_and_fetch_all(coordinator3_cursor, "SET INSTANCE instance_3 TO MAIN")
 
-    def check_coordinator1():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
-        )
-
-    def check_coordinator2():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
-        )
-
-    def check_coordinator3():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
-        )
-
     data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
@@ -619,9 +544,9 @@ def test_unregister_main(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
-    mg_sleep_and_assert(data, check_coordinator1)
-    mg_sleep_and_assert(data, check_coordinator2)
-    mg_sleep_and_assert(data, check_coordinator3)
+    mg_sleep_and_assert(data, partial(show_instances, coordinator1_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator2_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator3_cursor))
 
     try:
         execute_and_fetch_all(coordinator3_cursor, "UNREGISTER INSTANCE instance_3")
@@ -642,9 +567,9 @@ def test_unregister_main(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
-    mg_sleep_and_assert(data, check_coordinator1)
-    mg_sleep_and_assert(data, check_coordinator2)
-    mg_sleep_and_assert(data, check_coordinator3)
+    mg_sleep_and_assert(data, partial(show_instances, coordinator1_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator2_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator3_cursor))
 
     instance1_cursor = connect(host="localhost", port=7687).cursor()
     mg_sleep_and_assert_until_role_change(
@@ -673,13 +598,10 @@ def test_unregister_main(test_name):
 
     main_cursor = connect(host="localhost", port=7687).cursor()
 
-    def check_main():
-        return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS")))
-
-    mg_sleep_and_assert(data, check_coordinator1)
-    mg_sleep_and_assert(data, check_coordinator2)
-    mg_sleep_and_assert(data, check_coordinator3)
-    mg_sleep_and_assert(expected_replicas, check_main)
+    mg_sleep_and_assert(data, partial(show_instances, coordinator1_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator2_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator3_cursor))
+    mg_sleep_and_assert(expected_replicas, partial(show_replicas, main_cursor))
 
 
 def test_register_one_coord_with_env_vars(test_name):
@@ -723,21 +645,6 @@ def test_register_one_coord_with_env_vars(test_name):
     coordinator2_cursor = connect(host="localhost", port=7691).cursor()
     coordinator3_cursor = connect(host="localhost", port=7692).cursor()
 
-    def check_coordinator1():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
-        )
-
-    def check_coordinator2():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
-        )
-
-    def check_coordinator3():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
-        )
-
     data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
@@ -747,9 +654,9 @@ def test_register_one_coord_with_env_vars(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
-    mg_sleep_and_assert(data, check_coordinator1)
-    mg_sleep_and_assert(data, check_coordinator2)
-    mg_sleep_and_assert(data, check_coordinator3)
+    mg_sleep_and_assert(data, partial(show_instances, coordinator1_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator2_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator3_cursor))
 
     try:
         execute_and_fetch_all(coordinator3_cursor, "UNREGISTER INSTANCE instance_3")
@@ -770,9 +677,9 @@ def test_register_one_coord_with_env_vars(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
-    mg_sleep_and_assert(data, check_coordinator1)
-    mg_sleep_and_assert(data, check_coordinator2)
-    mg_sleep_and_assert(data, check_coordinator3)
+    mg_sleep_and_assert(data, partial(show_instances, coordinator1_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator2_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator3_cursor))
 
     instance1_cursor = connect(host="localhost", port=7687).cursor()
     mg_sleep_and_assert_until_role_change(
@@ -801,13 +708,10 @@ def test_register_one_coord_with_env_vars(test_name):
 
     main_cursor = connect(host="localhost", port=7687).cursor()
 
-    def check_main():
-        return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS")))
-
-    mg_sleep_and_assert(data, check_coordinator1)
-    mg_sleep_and_assert(data, check_coordinator2)
-    mg_sleep_and_assert(data, check_coordinator3)
-    mg_sleep_and_assert(expected_replicas, check_main)
+    mg_sleep_and_assert(data, partial(show_instances, coordinator1_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator2_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator3_cursor))
+    mg_sleep_and_assert(expected_replicas, partial(show_replicas, main_cursor))
 
     unset_env_flags()
 
@@ -937,21 +841,6 @@ def test_register_one_data_with_env_vars(test_name):
     for query in setup_queries:
         execute_and_fetch_all(coordinator3_cursor, query)
 
-    def check_coordinator1():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
-        )
-
-    def check_coordinator2():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
-        )
-
-    def check_coordinator3():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
-        )
-
     data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
@@ -961,26 +850,18 @@ def test_register_one_data_with_env_vars(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
-    mg_sleep_and_assert(data, check_coordinator1)
-    mg_sleep_and_assert(data, check_coordinator2)
-    mg_sleep_and_assert(data, check_coordinator3)
+    mg_sleep_and_assert(data, partial(show_instances, coordinator1_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator2_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator3_cursor))
 
     main_cursor = connect(host="localhost", port=7689).cursor()
     execute_and_fetch_all(main_cursor, "CREATE (n:Node {name: 'node'})")
 
     replica_2_cursor = connect(host="localhost", port=7688).cursor()
-
-    def get_vertex_count():
-        return execute_and_fetch_all(replica_2_cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-    mg_sleep_and_assert(1, get_vertex_count)
-
     replica_3_cursor = connect(host="localhost", port=7687).cursor()
 
-    def get_vertex_count():
-        return execute_and_fetch_all(replica_3_cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-    mg_sleep_and_assert(1, get_vertex_count)
+    mg_sleep_and_assert(1, partial(get_vertex_count, replica_2_cursor))
+    mg_sleep_and_assert(1, partial(get_vertex_count, replica_3_cursor))
 
     unset_env_flags()
     interactive_mg_runner.stop_all()
@@ -1042,12 +923,7 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start(test_name)
 
     expected_cluster = [("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader")]
 
-    def check_coordinator3():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
-        )
-
-    mg_sleep_and_assert(expected_cluster, check_coordinator3)
+    mg_sleep_and_assert(expected_cluster, partial(show_instances, coordinator3_cursor))
 
     interactive_mg_runner.kill(coordinator_3_description, "coordinator_3")
 
@@ -1071,21 +947,6 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start(test_name)
     )
     coordinator3_cursor = connect(host="localhost", port=7692).cursor()
 
-    def check_coordinator1():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator1_cursor, "SHOW INSTANCES")))
-        )
-
-    def check_coordinator2():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator2_cursor, "SHOW INSTANCES")))
-        )
-
-    def check_coordinator3():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
-        )
-
     data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
@@ -1095,9 +956,9 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start(test_name)
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
-    mg_sleep_and_assert(data, check_coordinator1)
-    mg_sleep_and_assert(data, check_coordinator2)
-    mg_sleep_and_assert(data, check_coordinator3)
+    mg_sleep_and_assert(data, partial(show_instances, coordinator1_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator2_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator3_cursor))
 
     try:
         execute_and_fetch_all(coordinator3_cursor, "UNREGISTER INSTANCE instance_3")
@@ -1118,9 +979,9 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start(test_name)
         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
-    mg_sleep_and_assert(data, check_coordinator1)
-    mg_sleep_and_assert(data, check_coordinator2)
-    mg_sleep_and_assert(data, check_coordinator3)
+    mg_sleep_and_assert(data, partial(show_instances, coordinator1_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator2_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator3_cursor))
 
     instance1_cursor = connect(host="localhost", port=7687).cursor()
     mg_sleep_and_assert_until_role_change(
@@ -1149,13 +1010,10 @@ def test_register_one_coord_with_env_vars_no_instances_alive_on_start(test_name)
 
     main_cursor = connect(host="localhost", port=7687).cursor()
 
-    def check_main():
-        return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS")))
-
-    mg_sleep_and_assert(data, check_coordinator1)
-    mg_sleep_and_assert(data, check_coordinator2)
-    mg_sleep_and_assert(data, check_coordinator3)
-    mg_sleep_and_assert(expected_replicas, check_main)
+    mg_sleep_and_assert(data, partial(show_instances, coordinator1_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator2_cursor))
+    mg_sleep_and_assert(data, partial(show_instances, coordinator3_cursor))
+    mg_sleep_and_assert(expected_replicas, partial(show_replicas, main_cursor))
 
     unset_env_flags()
 
@@ -1224,11 +1082,6 @@ def test_unregister_leader_instance(test_name):
         "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112', 'management_server': 'localhost:10122'}",
     )
 
-    def check_coordinator3():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
-        )
-
     leader_data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
@@ -1237,7 +1090,7 @@ def test_unregister_leader_instance(test_name):
         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
-    mg_sleep_and_assert(leader_data, check_coordinator3)
+    mg_sleep_and_assert(leader_data, partial(show_instances, coordinator3_cursor))
 
     with pytest.raises(Exception) as e:
         execute_and_fetch_all(coordinator3_cursor, "REMOVE COORDINATOR 3")
@@ -1272,11 +1125,6 @@ def test_unregister_follower_instance(test_name):
         "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112', 'management_server': 'localhost:10122'}",
     )
 
-    def check_coordinator3():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
-        )
-
     leader_data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
@@ -1285,7 +1133,7 @@ def test_unregister_follower_instance(test_name):
         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
-    mg_sleep_and_assert(leader_data, check_coordinator3)
+    mg_sleep_and_assert(leader_data, partial(show_instances, coordinator3_cursor))
 
     execute_and_fetch_all(coordinator3_cursor, "REMOVE COORDINATOR 1")
 
@@ -1296,7 +1144,7 @@ def test_unregister_follower_instance(test_name):
         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
-    mg_sleep_and_assert(leader_data, check_coordinator3)
+    mg_sleep_and_assert(leader_data, partial(show_instances, coordinator3_cursor))
 
     execute_and_fetch_all(coordinator3_cursor, "REMOVE COORDINATOR 2")
 
@@ -1306,7 +1154,7 @@ def test_unregister_follower_instance(test_name):
         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
-    mg_sleep_and_assert(leader_data, check_coordinator3)
+    mg_sleep_and_assert(leader_data, partial(show_instances, coordinator3_cursor))
 
 
 if __name__ == "__main__":

--- a/tests/e2e/high_availability/coordinator.py
+++ b/tests/e2e/high_availability/coordinator.py
@@ -11,6 +11,7 @@
 
 import os
 import sys
+from functools import partial
 
 import interactive_mg_runner
 import pytest
@@ -19,7 +20,7 @@ from common import (
     execute_and_fetch_all,
     get_data_path,
     get_logs_path,
-    ignore_elapsed_time_from_results,
+    show_instances,
 )
 from mg_utils import mg_sleep_and_assert
 
@@ -149,16 +150,13 @@ def test_coordinator_cannot_run_show_repl_role(test_name):
 def test_coordinator_show_instances(test_name):
     cursor = setup_test(test_name=test_name)
 
-    def retrieve_data():
-        return sorted(ignore_elapsed_time_from_results(list(execute_and_fetch_all(cursor, "SHOW INSTANCES;"))))
-
     expected_data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
         ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),
         ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
     ]
-    mg_sleep_and_assert(expected_data, retrieve_data)
+    mg_sleep_and_assert(expected_data, partial(show_instances, cursor))
 
 
 def test_coordinator_cannot_call_show_replicas(test_name):

--- a/tests/e2e/high_availability/disable_writing_on_main_after_restart.py
+++ b/tests/e2e/high_availability/disable_writing_on_main_after_restart.py
@@ -11,6 +11,7 @@
 
 import os
 import sys
+from functools import partial
 
 import interactive_mg_runner
 import pytest
@@ -19,7 +20,7 @@ from common import (
     execute_and_fetch_all,
     get_data_path,
     get_logs_path,
-    ignore_elapsed_time_from_results,
+    show_instances,
 )
 from mg_utils import mg_sleep_and_assert
 
@@ -162,18 +163,13 @@ def test_writing_disabled_on_main_restart():
         "ADD COORDINATOR 2 WITH CONFIG {'bolt_server': 'localhost:7691', 'coordinator_server': 'localhost:10112', 'management_server': 'localhost:10122'}",
     )
 
-    def check_coordinator3():
-        return ignore_elapsed_time_from_results(
-            sorted(list(execute_and_fetch_all(coordinator3_cursor, "SHOW INSTANCES")))
-        )
-
     expected_cluster_coord3 = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
         ("coordinator_3", "localhost:7692", "localhost:10113", "localhost:10123", "up", "leader"),
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
-    mg_sleep_and_assert(expected_cluster_coord3, check_coordinator3)
+    mg_sleep_and_assert(expected_cluster_coord3, partial(show_instances, coordinator3_cursor))
 
     interactive_mg_runner.kill(MEMGRAPH_INSTANCES_DESCRIPTION, "instance_3")
 
@@ -184,7 +180,7 @@ def test_writing_disabled_on_main_restart():
         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
-    mg_sleep_and_assert(expected_cluster_coord3, check_coordinator3)
+    mg_sleep_and_assert(expected_cluster_coord3, partial(show_instances, coordinator3_cursor))
 
     interactive_mg_runner.start(MEMGRAPH_INSTANCES_DESCRIPTION, "instance_3")
 
@@ -204,7 +200,7 @@ def test_writing_disabled_on_main_restart():
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
-    mg_sleep_and_assert(expected_cluster_coord3, check_coordinator3)
+    mg_sleep_and_assert(expected_cluster_coord3, partial(show_instances, coordinator3_cursor))
     execute_and_fetch_all(instance3_cursor, "CREATE (n:Node {name: 'node'})")
 
 

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -14,6 +14,7 @@ import os
 import subprocess
 import sys
 import time
+from functools import partial
 
 import interactive_mg_runner
 import pytest
@@ -23,7 +24,9 @@ from common import (
     find_instance_and_assert_instances,
     get_data_path,
     get_logs_path,
-    ignore_elapsed_time_from_results,
+    get_vertex_count,
+    show_instances,
+    show_replicas,
     update_tuple_value,
 )
 from mg_utils import (
@@ -282,14 +285,7 @@ def test_leadership_change(test_name):
     interactive_mg_runner.kill(inner_instances_description, "coordinator_3")
 
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     leader_data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
@@ -306,8 +302,8 @@ def test_leadership_change(test_name):
 
     leader_data = update_tuple_value(leader_data, leader_name, 0, -1, "leader")
 
-    mg_sleep_and_assert(leader_data, show_instances_coord1, time_between_attempt=3)
-    mg_sleep_and_assert(leader_data, show_instances_coord2, time_between_attempt=3)
+    mg_sleep_and_assert(leader_data, partial(show_instances, coord_cursor_1), time_between_attempt=3)
+    mg_sleep_and_assert(leader_data, partial(show_instances, coord_cursor_2), time_between_attempt=3)
 
     interactive_mg_runner.start(inner_instances_description, "coordinator_3")
 
@@ -347,24 +343,9 @@ def test_even_number_coords(use_durability, test_name):
 
     # 2
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-
     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
-
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
     coord_cursor_4 = connect(host="localhost", port=7693).cursor()
-
-    def show_instances_coord4():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_4, "SHOW INSTANCES;"))))
 
     leader_data_original = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
@@ -376,15 +357,12 @@ def test_even_number_coords(use_durability, test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
-    mg_sleep_and_assert(leader_data_original, show_instances_coord3)
-    mg_sleep_and_assert(leader_data_original, show_instances_coord1)
-    mg_sleep_and_assert(leader_data_original, show_instances_coord2)
-    mg_sleep_and_assert(leader_data_original, show_instances_coord4)
+    mg_sleep_and_assert(leader_data_original, partial(show_instances, coord_cursor_3))
+    mg_sleep_and_assert(leader_data_original, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(leader_data_original, partial(show_instances, coord_cursor_2))
+    mg_sleep_and_assert(leader_data_original, partial(show_instances, coord_cursor_4))
 
     instance_3_cursor = connect(host="localhost", port=7689).cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
 
     replicas = [
         (
@@ -402,7 +380,7 @@ def test_even_number_coords(use_durability, test_name):
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
     ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
+    mg_sleep_and_assert_collection(replicas, partial(show_replicas, instance_3_cursor))
 
     # 3
 
@@ -414,10 +392,10 @@ def test_even_number_coords(use_durability, test_name):
     leader_data_demoted = leader_data_original.copy()
     leader_data_demoted = update_tuple_value(leader_data_demoted, "instance_3", 0, -1, "replica")
 
-    mg_sleep_and_assert(leader_data_demoted, show_instances_coord3)
-    mg_sleep_and_assert(leader_data_demoted, show_instances_coord1)
-    mg_sleep_and_assert(leader_data_demoted, show_instances_coord2)
-    mg_sleep_and_assert(leader_data_demoted, show_instances_coord4)
+    mg_sleep_and_assert(leader_data_demoted, partial(show_instances, coord_cursor_3))
+    mg_sleep_and_assert(leader_data_demoted, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(leader_data_demoted, partial(show_instances, coord_cursor_2))
+    mg_sleep_and_assert(leader_data_demoted, partial(show_instances, coord_cursor_4))
 
     mg_sleep_and_assert_until_role_change(
         lambda: execute_and_fetch_all(instance_3_cursor, "SHOW REPLICATION ROLE;")[0][0], "replica"
@@ -448,7 +426,7 @@ def test_even_number_coords(use_durability, test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "unknown", "replica"),
     ]
 
-    mg_sleep_and_assert(follower_data, show_instances_coord3)
+    mg_sleep_and_assert(follower_data, partial(show_instances, coord_cursor_3))
 
     # 6
     interactive_mg_runner.start(inner_instances_description, "coordinator_1")
@@ -481,13 +459,7 @@ def test_even_number_coords(use_durability, test_name):
 
     for _, port in port_mappings.items():
         coord_cursor = connect(host="localhost", port=port).cursor()
-
-        def show_instances():
-            return ignore_elapsed_time_from_results(
-                sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;")))
-            )
-
-        mg_sleep_and_assert(leader_data, show_instances)
+        mg_sleep_and_assert(leader_data, partial(show_instances, coord_cursor))
 
 
 def test_old_main_comes_back_on_new_leader_as_replica(test_name):
@@ -510,18 +482,11 @@ def test_old_main_comes_back_on_new_leader_as_replica(test_name):
     interactive_mg_runner.kill(inner_instances_description, "instance_3")
 
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
 
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-
     # Wait until failover happens
-    wait_for_status_change(show_instances_coord1, {"instance_1", "instance_2"}, "main")
-    wait_for_status_change(show_instances_coord1, {"instance_3"}, "unknown")
+    wait_for_status_change(partial(show_instances, coord_cursor_1), {"instance_1", "instance_2"}, "main")
+    wait_for_status_change(partial(show_instances, coord_cursor_1), {"instance_3"}, "unknown")
 
     # Both instance_1 and instance_2 could become main depending on the order of pings in the system.
     # Both coordinator_1 and coordinator_2 could become leader depending on the NuRaft election.
@@ -546,8 +511,8 @@ def test_old_main_comes_back_on_new_leader_as_replica(test_name):
 
     def get_show_instances_to_coord(leader_instance):
         show_instances_mapping = {
-            "coordinator_1": show_instances_coord1,
-            "coordinator_2": show_instances_coord2,
+            "coordinator_1": partial(show_instances, coord_cursor_1),
+            "coordinator_2": partial(show_instances, coord_cursor_2),
         }
 
         return show_instances_mapping.get(leader_instance)
@@ -606,9 +571,6 @@ def test_old_main_comes_back_on_new_leader_as_replica(test_name):
     new_main_cursor = connect_to_main_instance()
     assert new_main_cursor is not None, "Main cursor is not found!"
 
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(new_main_cursor, "SHOW REPLICAS;")))
-
     replicas = [
         (
             "instance_1",
@@ -633,23 +595,15 @@ def test_old_main_comes_back_on_new_leader_as_replica(test_name):
         ),
     ]
     replicas = [replica for replica in replicas if replica[0] != main_instance_id_instance_3_start]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
+    mg_sleep_and_assert_collection(replicas, partial(show_replicas, new_main_cursor))
 
     execute_and_fetch_all(new_main_cursor, "CREATE (n:Node {name: 'node'})")
 
     replica_2_cursor = connect(host="localhost", port=7688).cursor()
-
-    def get_vertex_count():
-        return execute_and_fetch_all(replica_2_cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-    mg_sleep_and_assert(1, get_vertex_count)
-
     replica_3_cursor = connect(host="localhost", port=7689).cursor()
 
-    def get_vertex_count():
-        return execute_and_fetch_all(replica_3_cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-    mg_sleep_and_assert(1, get_vertex_count)
+    mg_sleep_and_assert(1, partial(get_vertex_count, replica_2_cursor))
+    mg_sleep_and_assert(1, partial(get_vertex_count, replica_3_cursor))
 
     interactive_mg_runner.start(inner_instances_description, "coordinator_3")
 
@@ -681,17 +635,11 @@ def test_distributed_automatic_failover(test_name):
         ),
     ]
 
-    def retrieve_data_show_replicas():
-        return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")))
-
-    mg_sleep_and_assert_collection(expected_data_on_main, retrieve_data_show_replicas)
+    mg_sleep_and_assert_collection(expected_data_on_main, partial(show_replicas, main_cursor))
 
     interactive_mg_runner.kill(inner_instances_description, "instance_3")
 
     coord_cursor = connect(host="localhost", port=7692).cursor()
-
-    def retrieve_data_show_repl_cluster():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_on_coord = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
@@ -702,12 +650,9 @@ def test_distributed_automatic_failover(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor))
 
     new_main_cursor = connect(host="localhost", port=7687).cursor()
-
-    def retrieve_data_show_replicas():
-        return sorted(list(execute_and_fetch_all(new_main_cursor, "SHOW REPLICAS;")))
 
     expected_data_on_new_main = [
         (
@@ -729,7 +674,7 @@ def test_distributed_automatic_failover(test_name):
     mg_sleep_and_assert_until_role_change(
         lambda: execute_and_fetch_all(new_main_cursor, "SHOW REPLICATION ROLE;")[0][0], "main"
     )
-    mg_sleep_and_assert_collection(expected_data_on_new_main, retrieve_data_show_replicas)
+    mg_sleep_and_assert_collection(expected_data_on_new_main, partial(show_replicas, new_main_cursor))
 
     interactive_mg_runner.start(inner_instances_description, "instance_3")
     expected_data_on_new_main_old_alive = [
@@ -749,7 +694,7 @@ def test_distributed_automatic_failover(test_name):
         ),
     ]
 
-    mg_sleep_and_assert_collection(expected_data_on_new_main_old_alive, retrieve_data_show_replicas)
+    mg_sleep_and_assert_collection(expected_data_on_new_main_old_alive, partial(show_replicas, new_main_cursor))
 
 
 def test_distributed_automatic_failover_with_leadership_change(test_name):
@@ -765,14 +710,7 @@ def test_distributed_automatic_failover_with_leadership_change(test_name):
     interactive_mg_runner.kill(inner_instances_description, "instance_3")
 
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     leader_data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
@@ -783,7 +721,7 @@ def test_distributed_automatic_failover_with_leadership_change(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
-    wait_for_status_change(show_instances_coord1, {"instance_1", "instance_2"}, "main")
+    wait_for_status_change(partial(show_instances, coord_cursor_1), {"instance_1", "instance_2"}, "main")
 
     leader_name = find_instance_and_assert_instances(
         instance_role="leader", num_coordinators=3, coord_ids_to_skip_validation={3}
@@ -795,8 +733,8 @@ def test_distributed_automatic_failover_with_leadership_change(test_name):
     leader_data = update_tuple_value(leader_data, main_name, 0, -1, "main")
     leader_data = update_tuple_value(leader_data, leader_name, 0, -1, "leader")
 
-    mg_sleep_and_assert(leader_data, show_instances_coord1)
-    mg_sleep_and_assert(leader_data, show_instances_coord2)
+    mg_sleep_and_assert(leader_data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(leader_data, partial(show_instances, coord_cursor_2))
 
     def connect_to_main_instance():
         main_instance_name = main_name
@@ -815,9 +753,6 @@ def test_distributed_automatic_failover_with_leadership_change(test_name):
 
     new_main_cursor = connect_to_main_instance()
     assert new_main_cursor is not None, "Main cursor is not found!"
-
-    def retrieve_data_show_replicas():
-        return sorted(list(execute_and_fetch_all(new_main_cursor, "SHOW REPLICAS;")))
 
     all_possible_states = [
         (
@@ -847,7 +782,7 @@ def test_distributed_automatic_failover_with_leadership_change(test_name):
         lambda: execute_and_fetch_all(new_main_cursor, "SHOW REPLICATION ROLE;")[0][0], "main"
     )
     expected_data_on_new_main = [state for state in all_possible_states if state[0] != main_name]
-    mg_sleep_and_assert_collection(expected_data_on_new_main, retrieve_data_show_replicas)
+    mg_sleep_and_assert_collection(expected_data_on_new_main, partial(show_replicas, new_main_cursor))
 
     interactive_mg_runner.start(inner_instances_description, "instance_3")
 
@@ -875,7 +810,7 @@ def test_distributed_automatic_failover_with_leadership_change(test_name):
         ),
     ]
     expected_data_on_new_main_old_alive = [state for state in all_possible_states if state[0] != main_name]
-    mg_sleep_and_assert_collection(expected_data_on_new_main_old_alive, retrieve_data_show_replicas)
+    mg_sleep_and_assert_collection(expected_data_on_new_main_old_alive, partial(show_replicas, new_main_cursor))
 
     interactive_mg_runner.start(inner_instances_description, "coordinator_3")
 
@@ -906,11 +841,7 @@ def test_no_leader_after_leader_and_follower_die(test_name):
     ]
 
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
-    mg_sleep_and_assert(coord_1_data, show_instances_coord1)
+    mg_sleep_and_assert(coord_1_data, partial(show_instances, coord_cursor_1))
 
     with pytest.raises(Exception) as e:
         execute_and_fetch_all(
@@ -941,14 +872,7 @@ def test_old_main_comes_back_on_new_leader_as_main(test_name):
     interactive_mg_runner.kill(inner_memgraph_instances, "coordinator_3")
 
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     interactive_mg_runner.start(inner_memgraph_instances, "instance_3")
     interactive_mg_runner.start(inner_memgraph_instances, "instance_1")
@@ -973,16 +897,15 @@ def test_old_main_comes_back_on_new_leader_as_main(test_name):
     ]
 
     mg_sleep_and_assert_multiple(
-        [coord1_leader_data, coord2_leader_data], [show_instances_coord1, show_instances_coord2]
+        [coord1_leader_data, coord2_leader_data],
+        [partial(show_instances, coord_cursor_1), partial(show_instances, coord_cursor_2)],
     )
     mg_sleep_and_assert_multiple(
-        [coord1_leader_data, coord2_leader_data], [show_instances_coord1, show_instances_coord2]
+        [coord1_leader_data, coord2_leader_data],
+        [partial(show_instances, coord_cursor_1), partial(show_instances, coord_cursor_2)],
     )
 
     new_main_cursor = connect(host="localhost", port=7689).cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(new_main_cursor, "SHOW REPLICAS;")))
 
     replicas = [
         (
@@ -1000,7 +923,7 @@ def test_old_main_comes_back_on_new_leader_as_main(test_name):
             {"memgraph": {"ts": 0, "behind": 0, "status": "ready"}},
         ),
     ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
+    mg_sleep_and_assert_collection(replicas, partial(show_replicas, new_main_cursor))
 
     execute_and_fetch_all(new_main_cursor, "CREATE (n:Node {name: 'node'})")
 
@@ -1125,9 +1048,6 @@ def test_registering_4_coords(test_name):
 
     coord_cursor = connect(host="localhost", port=7693).cursor()
 
-    def retrieve_data_show_repl_cluster():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
-
     expected_data_on_coord = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
@@ -1137,7 +1057,7 @@ def test_registering_4_coords(test_name):
         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor))
 
 
 def test_registering_coord_log_store(test_name):
@@ -1270,9 +1190,6 @@ def test_registering_coord_log_store(test_name):
     # 2
     coord_cursor = connect(host="localhost", port=7693).cursor()
 
-    def retrieve_data_show_repl_cluster():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
-
     coordinators = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
@@ -1290,7 +1207,7 @@ def test_registering_coord_log_store(test_name):
     expected_data_on_coord.extend(coordinators)
     expected_data_on_coord.extend(basic_instances)
 
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor))
 
     # 3
     instances_ports_added = [10011, 10012, 10013]
@@ -1342,7 +1259,7 @@ def test_registering_coord_log_store(test_name):
     # 4
     expected_data_on_coord.extend(additional_instances)
 
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor))
 
     # 5
     execute_and_fetch_all(coord_cursor, "SET INSTANCE instance_3 TO MAIN")
@@ -1357,7 +1274,7 @@ def test_registering_coord_log_store(test_name):
     new_expected_data_on_coordinator.extend(basic_instances)
     new_expected_data_on_coordinator.extend(additional_instances)
 
-    mg_sleep_and_assert(new_expected_data_on_coordinator, retrieve_data_show_repl_cluster)
+    mg_sleep_and_assert(new_expected_data_on_coordinator, partial(show_instances, coord_cursor))
 
     # 7
     for i in range(6, 4, -1):
@@ -1370,7 +1287,7 @@ def test_registering_coord_log_store(test_name):
     new_expected_data_on_coordinator.extend(additional_instances)
 
     # 8
-    mg_sleep_and_assert(new_expected_data_on_coordinator, retrieve_data_show_repl_cluster)
+    mg_sleep_and_assert(new_expected_data_on_coordinator, partial(show_instances, coord_cursor))
 
     # 9
 
@@ -1381,7 +1298,7 @@ def test_registering_coord_log_store(test_name):
     execute_and_fetch_all(coord_cursor, f"UNREGISTER INSTANCE instance_4;")
 
     # 10
-    mg_sleep_and_assert(new_expected_data_on_coordinator, retrieve_data_show_repl_cluster)
+    mg_sleep_and_assert(new_expected_data_on_coordinator, partial(show_instances, coord_cursor))
 
 
 def test_multiple_failovers_in_row_no_leadership_change(test_name):
@@ -1412,12 +1329,6 @@ def test_multiple_failovers_in_row_no_leadership_change(test_name):
 
     # 2
 
-    def get_func_show_instances(cursor):
-        def show_instances_follower_coord():
-            return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(cursor, "SHOW INSTANCES;"))))
-
-        return show_instances_follower_coord
-
     data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
@@ -1430,9 +1341,9 @@ def test_multiple_failovers_in_row_no_leadership_change(test_name):
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
 
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
+    mg_sleep_and_assert_collection(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert_collection(data, partial(show_instances, coord_cursor_2))
+    mg_sleep_and_assert_collection(data, partial(show_instances, coord_cursor_3))
 
     # 3
 
@@ -1449,9 +1360,9 @@ def test_multiple_failovers_in_row_no_leadership_change(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
+    mg_sleep_and_assert_collection(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert_collection(data, partial(show_instances, coord_cursor_2))
+    mg_sleep_and_assert_collection(data, partial(show_instances, coord_cursor_3))
 
     # 5
     interactive_mg_runner.kill(inner_memgraph_instances, "instance_1")
@@ -1466,9 +1377,9 @@ def test_multiple_failovers_in_row_no_leadership_change(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
+    mg_sleep_and_assert_collection(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert_collection(data, partial(show_instances, coord_cursor_2))
+    mg_sleep_and_assert_collection(data, partial(show_instances, coord_cursor_3))
 
     # 7
 
@@ -1485,9 +1396,9 @@ def test_multiple_failovers_in_row_no_leadership_change(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
     ]
 
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
+    mg_sleep_and_assert_collection(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert_collection(data, partial(show_instances, coord_cursor_2))
+    mg_sleep_and_assert_collection(data, partial(show_instances, coord_cursor_3))
 
     # 9
     interactive_mg_runner.kill(inner_memgraph_instances, "instance_2")
@@ -1502,9 +1413,9 @@ def test_multiple_failovers_in_row_no_leadership_change(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
+    mg_sleep_and_assert_collection(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert_collection(data, partial(show_instances, coord_cursor_2))
+    mg_sleep_and_assert_collection(data, partial(show_instances, coord_cursor_3))
 
     # 11
 
@@ -1532,14 +1443,11 @@ def test_multiple_failovers_in_row_no_leadership_change(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_1))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_2))
-    mg_sleep_and_assert_collection(data, get_func_show_instances(coord_cursor_3))
+    mg_sleep_and_assert_collection(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert_collection(data, partial(show_instances, coord_cursor_2))
+    mg_sleep_and_assert_collection(data, partial(show_instances, coord_cursor_3))
 
     # 14.
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
 
     replicas = [
         (
@@ -1557,17 +1465,12 @@ def test_multiple_failovers_in_row_no_leadership_change(test_name):
             {"memgraph": {"ts": 2, "behind": 0, "status": "ready"}},
         ),
     ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
+    mg_sleep_and_assert_collection(replicas, partial(show_replicas, instance_3_cursor))
 
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
-
-    mg_sleep_and_assert(1, get_vertex_count_func(connect(port=7687, host="localhost").cursor()))
-
-    mg_sleep_and_assert(1, get_vertex_count_func(connect(port=7688, host="localhost").cursor()))
+    instance1_cursor = connect(port=7687, host="localhost").cursor()
+    instance2_cursor = connect(port=7688, host="localhost").cursor()
+    mg_sleep_and_assert(1, partial(get_vertex_count, instance1_cursor))
+    mg_sleep_and_assert(1, partial(get_vertex_count, instance2_cursor))
 
 
 def test_multiple_old_mains_single_failover(test_name):
@@ -1590,9 +1493,6 @@ def test_multiple_old_mains_single_failover(test_name):
     for query in get_default_setup_queries():
         execute_and_fetch_all(coord_cursor_3, query)
 
-    def retrieve_data_show_repl_cluster():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
     coordinators = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "up", "follower"),
@@ -1609,7 +1509,7 @@ def test_multiple_old_mains_single_failover(test_name):
     expected_data_on_coord.extend(coordinators)
     expected_data_on_coord.extend(basic_instances)
 
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor_3))
 
     # 2
 
@@ -1627,7 +1527,7 @@ def test_multiple_old_mains_single_failover(test_name):
     expected_data_on_coord.extend(coordinators)
     expected_data_on_coord.extend(basic_instances)
 
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor_3))
 
     # 4
 
@@ -1643,14 +1543,7 @@ def test_multiple_old_mains_single_failover(test_name):
     # 7
 
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     coord1_leader_data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
@@ -1671,16 +1564,15 @@ def test_multiple_old_mains_single_failover(test_name):
     ]
 
     mg_sleep_and_assert_multiple(
-        [coord1_leader_data, coord2_leader_data], [show_instances_coord1, show_instances_coord2]
+        [coord1_leader_data, coord2_leader_data],
+        [partial(show_instances, coord_cursor_1), partial(show_instances, coord_cursor_2)],
     )
     mg_sleep_and_assert_multiple(
-        [coord1_leader_data, coord2_leader_data], [show_instances_coord1, show_instances_coord2]
+        [coord1_leader_data, coord2_leader_data],
+        [partial(show_instances, coord_cursor_1), partial(show_instances, coord_cursor_2)],
     )
 
     instance_1_cursor = connect(host="localhost", port=7687).cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_1_cursor, "SHOW REPLICAS;")))
 
     replicas = [
         (
@@ -1698,20 +1590,14 @@ def test_multiple_old_mains_single_failover(test_name):
             {"memgraph": {"behind": 0, "status": "invalid", "ts": 0}},
         ),
     ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
+    mg_sleep_and_assert_collection(replicas, partial(show_replicas, instance_1_cursor))
 
     vertex_count = 0
     instance_1_cursor = connect(port=7687, host="localhost").cursor()
     instance_2_cursor = connect(port=7688, host="localhost").cursor()
 
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+    mg_sleep_and_assert(vertex_count, partial(get_vertex_count, instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, partial(get_vertex_count, instance_2_cursor))
 
     time_slept = 0
     failover_time = 5
@@ -1745,18 +1631,8 @@ def test_force_reset_works_after_failed_registration(test_name):
 
     # 2
 
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
@@ -1767,14 +1643,11 @@ def test_force_reset_works_after_failed_registration(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_3))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_2))
 
     instance_3_cursor = connect(host="localhost", port=7689).cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
 
     replicas = [
         (
@@ -1792,20 +1665,14 @@ def test_force_reset_works_after_failed_registration(test_name):
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
     ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
+    mg_sleep_and_assert_collection(replicas, partial(show_replicas, instance_3_cursor))
 
     vertex_count = 0
     instance_1_cursor = connect(port=7687, host="localhost").cursor()
     instance_2_cursor = connect(port=7688, host="localhost").cursor()
 
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+    mg_sleep_and_assert(vertex_count, partial(get_vertex_count, instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, partial(get_vertex_count, instance_2_cursor))
 
     with pytest.raises(Exception):
         execute_and_fetch_all(
@@ -1833,9 +1700,9 @@ def test_force_reset_works_after_failed_registration(test_name):
     data = update_tuple_value(data, leader_name, 0, -1, "leader")
     data = update_tuple_value(data, main_name, 0, -1, "main")
 
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_3))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_2))
 
     def get_port(instance_name):
         mappings = {
@@ -1850,15 +1717,9 @@ def test_force_reset_works_after_failed_registration(test_name):
     for _ in range(vertex_count):
         execute_and_fetch_all(instance_main_cursor, "CREATE ();")
 
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
-
     for instance in ["instance_1", "instance_2", "instance_3"]:
         cursor = connect(port=get_port(instance), host="localhost").cursor()
-        mg_sleep_and_assert(vertex_count, get_vertex_count_func(cursor))
+        mg_sleep_and_assert(vertex_count, partial(get_vertex_count, cursor))
 
 
 def test_force_reset_works_after_failed_registration_and_replica_down(test_name):
@@ -1883,19 +1744,8 @@ def test_force_reset_works_after_failed_registration_and_replica_down(test_name)
         execute_and_fetch_all(coord_cursor_3, query)
 
     # 2
-
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
@@ -1906,14 +1756,11 @@ def test_force_reset_works_after_failed_registration_and_replica_down(test_name)
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_3))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_2))
 
     instance_3_cursor = connect(host="localhost", port=7689).cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
 
     replicas = [
         (
@@ -1931,20 +1778,14 @@ def test_force_reset_works_after_failed_registration_and_replica_down(test_name)
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
     ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
+    mg_sleep_and_assert_collection(replicas, partial(show_replicas, instance_3_cursor))
 
     vertex_count = 0
     instance_1_cursor = connect(port=7687, host="localhost").cursor()
     instance_2_cursor = connect(port=7688, host="localhost").cursor()
 
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+    mg_sleep_and_assert(vertex_count, partial(get_vertex_count, instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, partial(get_vertex_count, instance_2_cursor))
 
     # 3
 
@@ -1979,9 +1820,9 @@ def test_force_reset_works_after_failed_registration_and_replica_down(test_name)
     data = update_tuple_value(data, leader_name, 0, -1, "leader")
     data = update_tuple_value(data, main_name, 0, -1, "main")
 
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_3))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_2))
 
     # 6
 
@@ -2001,9 +1842,9 @@ def test_force_reset_works_after_failed_registration_and_replica_down(test_name)
     data = update_tuple_value(data, leader_name, 0, -1, "leader")
     data = update_tuple_value(data, main_name, 0, -1, "main")
 
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_3))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_2))
 
     def get_port(instance_name):
         mappings = {
@@ -2014,9 +1855,6 @@ def test_force_reset_works_after_failed_registration_and_replica_down(test_name)
         return mappings[instance_name]
 
     main_cursor = connect(port=get_port(main_name), host="localhost").cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")))
 
     replicas = [
         (
@@ -2042,7 +1880,7 @@ def test_force_reset_works_after_failed_registration_and_replica_down(test_name)
         ),
     ]
     replicas = [replica for replica in replicas if replica[0] != main_name]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
+    mg_sleep_and_assert_collection(replicas, partial(show_replicas, main_cursor))
 
     # 8
 
@@ -2050,15 +1888,9 @@ def test_force_reset_works_after_failed_registration_and_replica_down(test_name)
     for _ in range(vertex_count):
         execute_and_fetch_all(main_cursor, "CREATE ();")
 
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
-
     for instance in ["instance_1", "instance_2", "instance_3"]:
         cursor = connect(port=get_port(instance), host="localhost").cursor()
-        mg_sleep_and_assert(vertex_count, get_vertex_count_func(cursor))
+        mg_sleep_and_assert(vertex_count, partial(get_vertex_count, cursor))
 
 
 def test_force_reset_works_after_failed_registration_and_2_coordinators_down(test_name):
@@ -2083,19 +1915,8 @@ def test_force_reset_works_after_failed_registration_and_2_coordinators_down(tes
         execute_and_fetch_all(coord_cursor_3, query)
 
     # 2
-
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
@@ -2106,14 +1927,11 @@ def test_force_reset_works_after_failed_registration_and_2_coordinators_down(tes
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_3))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_2))
 
     instance_3_cursor = connect(host="localhost", port=7689).cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
 
     replicas = [
         (
@@ -2131,20 +1949,14 @@ def test_force_reset_works_after_failed_registration_and_2_coordinators_down(tes
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
     ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
+    mg_sleep_and_assert_collection(replicas, partial(show_replicas, instance_3_cursor))
 
     vertex_count = 0
     instance_1_cursor = connect(port=7687, host="localhost").cursor()
     instance_2_cursor = connect(port=7688, host="localhost").cursor()
 
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+    mg_sleep_and_assert(vertex_count, partial(get_vertex_count, instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, partial(get_vertex_count, instance_2_cursor))
 
     # 3
 
@@ -2190,21 +2002,10 @@ def test_force_reset_works_after_failed_registration_and_2_coordinators_down(tes
     leader_data = update_tuple_value(leader_data, leader_name, 0, -1, "leader")
 
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
 
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
-
-    mg_sleep_and_assert(leader_data, show_instances_coord1)
-
-    mg_sleep_and_assert(leader_data, show_instances_coord2)
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
+    mg_sleep_and_assert(leader_data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(leader_data, partial(show_instances, coord_cursor_1))
 
     replicas = [
         (
@@ -2222,19 +2023,13 @@ def test_force_reset_works_after_failed_registration_and_2_coordinators_down(tes
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
     ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
+    mg_sleep_and_assert_collection(replicas, partial(show_replicas, instance_3_cursor))
 
     # 8
 
     vertex_count = 10
     for _ in range(vertex_count):
         execute_and_fetch_all(instance_3_cursor, "CREATE ();")
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
 
     def get_port(instance_name):
         mappings = {
@@ -2246,7 +2041,7 @@ def test_force_reset_works_after_failed_registration_and_2_coordinators_down(tes
 
     for instance in ["instance_1", "instance_2", "instance_3"]:
         cursor = connect(port=get_port(instance), host="localhost").cursor()
-        mg_sleep_and_assert(vertex_count, get_vertex_count_func(cursor))
+        mg_sleep_and_assert(vertex_count, partial(get_vertex_count, cursor))
 
 
 def test_coordinator_gets_info_on_other_coordinators(test_name):
@@ -2273,18 +2068,8 @@ def test_coordinator_gets_info_on_other_coordinators(test_name):
 
     # 2
 
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
@@ -2295,14 +2080,11 @@ def test_coordinator_gets_info_on_other_coordinators(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_3))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_2))
 
     instance_3_cursor = connect(host="localhost", port=7689).cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
 
     replicas = [
         (
@@ -2320,20 +2102,14 @@ def test_coordinator_gets_info_on_other_coordinators(test_name):
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
     ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
+    mg_sleep_and_assert_collection(replicas, partial(show_replicas, instance_3_cursor))
 
     vertex_count = 0
     instance_1_cursor = connect(port=7687, host="localhost").cursor()
     instance_2_cursor = connect(port=7688, host="localhost").cursor()
 
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+    mg_sleep_and_assert(vertex_count, partial(get_vertex_count, instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, partial(get_vertex_count, instance_2_cursor))
 
     # 3
 
@@ -2378,9 +2154,6 @@ def test_coordinator_gets_info_on_other_coordinators(test_name):
 
     coord_cursor_4 = connect(host="localhost", port=7693).cursor()
 
-    def show_instances_coord4():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_4, "SHOW INSTANCES;"))))
-
     coord2_down_data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
         ("coordinator_2", "localhost:7691", "localhost:10112", "localhost:10122", "down", "follower"),
@@ -2390,9 +2163,9 @@ def test_coordinator_gets_info_on_other_coordinators(test_name):
         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
-    mg_sleep_and_assert(coord2_down_data, show_instances_coord3)
-    mg_sleep_and_assert(coord2_down_data, show_instances_coord1)
-    mg_sleep_and_assert(coord2_down_data, show_instances_coord4)
+    mg_sleep_and_assert(coord2_down_data, partial(show_instances, coord_cursor_3))
+    mg_sleep_and_assert(coord2_down_data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(coord2_down_data, partial(show_instances, coord_cursor_4))
 
     # 7
 
@@ -2411,8 +2184,7 @@ def test_coordinator_gets_info_on_other_coordinators(test_name):
     ]
 
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    mg_sleep_and_assert(coord2_up_data, show_instances_coord2)
+    mg_sleep_and_assert(coord2_up_data, partial(show_instances, coord_cursor_2))
 
 
 def test_registration_works_after_main_set(test_name):
@@ -2430,19 +2202,8 @@ def test_registration_works_after_main_set(test_name):
         execute_and_fetch_all(coord_cursor_3, query)
 
     # 2
-
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
@@ -2453,14 +2214,11 @@ def test_registration_works_after_main_set(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_3))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_2))
 
     instance_3_cursor = connect(host="localhost", port=7689).cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
 
     replicas = [
         (
@@ -2478,20 +2236,14 @@ def test_registration_works_after_main_set(test_name):
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
     ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
+    mg_sleep_and_assert_collection(replicas, partial(show_replicas, instance_3_cursor))
 
     vertex_count = 0
     instance_1_cursor = connect(port=7687, host="localhost").cursor()
     instance_2_cursor = connect(port=7688, host="localhost").cursor()
 
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+    mg_sleep_and_assert(vertex_count, partial(get_vertex_count, instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, partial(get_vertex_count, instance_2_cursor))
 
 
 def test_coordinator_not_leader_registration_does_not_work(test_name):
@@ -2510,19 +2262,8 @@ def test_coordinator_not_leader_registration_does_not_work(test_name):
         execute_and_fetch_all(coord_cursor_3, query)
 
     # 2
-
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
@@ -2532,14 +2273,11 @@ def test_coordinator_not_leader_registration_does_not_work(test_name):
         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_3))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_2))
 
     instance_3_cursor = connect(host="localhost", port=7689).cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
 
     replicas = [
         (
@@ -2557,20 +2295,14 @@ def test_coordinator_not_leader_registration_does_not_work(test_name):
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
     ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
+    mg_sleep_and_assert_collection(replicas, partial(show_replicas, instance_3_cursor))
 
     vertex_count = 0
     instance_1_cursor = connect(port=7687, host="localhost").cursor()
     instance_2_cursor = connect(port=7688, host="localhost").cursor()
 
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+    mg_sleep_and_assert(vertex_count, partial(get_vertex_count, instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, partial(get_vertex_count, instance_2_cursor))
 
     # 3
 
@@ -2609,19 +2341,8 @@ def test_coordinator_user_action_demote_instance_to_replica(test_name):
         execute_and_fetch_all(coord_cursor_3, query)
 
     # 2
-
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     data_original = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
@@ -2632,14 +2353,11 @@ def test_coordinator_user_action_demote_instance_to_replica(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
-    mg_sleep_and_assert(data_original, show_instances_coord3)
-    mg_sleep_and_assert(data_original, show_instances_coord1)
-    mg_sleep_and_assert(data_original, show_instances_coord2)
+    mg_sleep_and_assert(data_original, partial(show_instances, coord_cursor_3))
+    mg_sleep_and_assert(data_original, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(data_original, partial(show_instances, coord_cursor_2))
 
     instance_3_cursor = connect(host="localhost", port=7689).cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
 
     replicas = [
         (
@@ -2657,20 +2375,14 @@ def test_coordinator_user_action_demote_instance_to_replica(test_name):
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
     ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
+    mg_sleep_and_assert_collection(replicas, partial(show_replicas, instance_3_cursor))
 
     vertex_count = 0
     instance_1_cursor = connect(port=7687, host="localhost").cursor()
     instance_2_cursor = connect(port=7688, host="localhost").cursor()
 
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+    mg_sleep_and_assert(vertex_count, partial(get_vertex_count, instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, partial(get_vertex_count, instance_2_cursor))
 
     # 3
 
@@ -2690,9 +2402,9 @@ def test_coordinator_user_action_demote_instance_to_replica(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
     ]
 
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_3))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_2))
 
     mg_sleep_and_assert_until_role_change(
         lambda: execute_and_fetch_all(instance_3_cursor, "SHOW REPLICATION ROLE;")[0][0], "replica"
@@ -2702,15 +2414,15 @@ def test_coordinator_user_action_demote_instance_to_replica(test_name):
         execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")
     assert str(e.value) == "Replica can't show registered replicas (it shouldn't have any)!"
 
-    mg_assert_until(data, show_instances_coord3, FAILOVER_PERIOD + 1)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
+    mg_assert_until(data, partial(show_instances, coord_cursor_3), FAILOVER_PERIOD + 1)
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_2))
 
     execute_and_fetch_all(coord_cursor_3, "SET INSTANCE instance_3 TO MAIN;")
 
-    mg_sleep_and_assert(data_original, show_instances_coord3)
-    mg_sleep_and_assert(data_original, show_instances_coord1)
-    mg_sleep_and_assert(data_original, show_instances_coord2)
+    mg_sleep_and_assert(data_original, partial(show_instances, coord_cursor_3))
+    mg_sleep_and_assert(data_original, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(data_original, partial(show_instances, coord_cursor_2))
 
 
 def test_coordinator_user_action_force_reset_works(test_name):
@@ -2730,19 +2442,8 @@ def test_coordinator_user_action_force_reset_works(test_name):
         execute_and_fetch_all(coord_cursor_3, query)
 
     # 2
-
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
@@ -2753,14 +2454,11 @@ def test_coordinator_user_action_force_reset_works(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_3))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_2))
 
     instance_3_cursor = connect(host="localhost", port=7689).cursor()
-
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(instance_3_cursor, "SHOW REPLICAS;")))
 
     replicas = [
         (
@@ -2778,20 +2476,14 @@ def test_coordinator_user_action_force_reset_works(test_name):
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
     ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
-
-    def get_vertex_count_func(cursor):
-        def get_vertex_count():
-            return execute_and_fetch_all(cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-        return get_vertex_count
+    mg_sleep_and_assert_collection(replicas, partial(show_replicas, instance_3_cursor))
 
     vertex_count = 0
     instance_1_cursor = connect(port=7687, host="localhost").cursor()
     instance_2_cursor = connect(port=7688, host="localhost").cursor()
 
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_1_cursor))
-    mg_sleep_and_assert(vertex_count, get_vertex_count_func(instance_2_cursor))
+    mg_sleep_and_assert(vertex_count, partial(get_vertex_count, instance_1_cursor))
+    mg_sleep_and_assert(vertex_count, partial(get_vertex_count, instance_2_cursor))
 
     # 3
 
@@ -2811,9 +2503,9 @@ def test_coordinator_user_action_force_reset_works(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_3))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_2))
 
 
 def test_all_coords_down_resume(test_name):
@@ -2836,17 +2528,8 @@ def test_all_coords_down_resume(test_name):
         execute_and_fetch_all(coord_cursor_3, query)
 
     # 2
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
-    def show_instances_coord1():
-        coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
@@ -2857,9 +2540,9 @@ def test_all_coords_down_resume(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_3))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_2))
 
     # 3
 
@@ -2884,7 +2567,8 @@ def test_all_coords_down_resume(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "replica"),
     ]
 
-    wait_for_status_change(show_instances_coord1, {"coordinator_1", "coordinator_2"}, "leader")
+    coord_cursor_1 = connect(host="localhost", port=7690).cursor()
+    wait_for_status_change(partial(show_instances, coord_cursor_1), {"coordinator_1", "coordinator_2"}, "leader")
 
     leader = find_instance_and_assert_instances(
         instance_role="leader", num_coordinators=3, coord_ids_to_skip_validation={3}
@@ -2898,9 +2582,8 @@ def test_all_coords_down_resume(test_name):
 
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
 
-    mg_sleep_and_assert(leader_data, show_instances_coord1)
-
-    mg_sleep_and_assert(leader_data, show_instances_coord2)
+    mg_sleep_and_assert(leader_data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(leader_data, partial(show_instances, coord_cursor_2))
 
     # 6
     interactive_mg_runner.kill(inner_instances_description, "instance_3")
@@ -2917,7 +2600,7 @@ def test_all_coords_down_resume(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
-    wait_for_status_change(show_instances_coord1, {"instance_3"}, "unknown")
+    wait_for_status_change(partial(show_instances, coord_cursor_1), {"instance_3"}, "unknown")
 
     leader = find_instance_and_assert_instances(instance_role="leader", num_coordinators=3)
 
@@ -2928,11 +2611,9 @@ def test_all_coords_down_resume(test_name):
 
     coord_cursor_3 = connect(host="localhost", port=7692).cursor()
 
-    mg_sleep_and_assert(leader_data, show_instances_coord1)
-
-    mg_sleep_and_assert(leader_data, show_instances_coord2)
-
-    mg_sleep_and_assert(leader_data, show_instances_coord3)
+    mg_sleep_and_assert(leader_data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(leader_data, partial(show_instances, coord_cursor_2))
+    mg_sleep_and_assert(leader_data, partial(show_instances, coord_cursor_3))
 
 
 def test_one_coord_down_with_durability_resume(test_name):
@@ -2956,18 +2637,8 @@ def test_one_coord_down_with_durability_resume(test_name):
         execute_and_fetch_all(coord_cursor_3, query)
 
     # 2
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
@@ -2978,9 +2649,9 @@ def test_one_coord_down_with_durability_resume(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_3))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_2))
 
     # 3
 
@@ -2994,7 +2665,7 @@ def test_one_coord_down_with_durability_resume(test_name):
         ("instance_2", "localhost:7688", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
-    mg_sleep_and_assert(leader_data, show_instances_coord3)
+    mg_sleep_and_assert(leader_data, partial(show_instances, coord_cursor_3))
 
     # 4
     interactive_mg_runner.start(inner_instances_description, "coordinator_1")
@@ -3012,9 +2683,9 @@ def test_one_coord_down_with_durability_resume(test_name):
 
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
 
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_3))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_2))
 
     # 6
     interactive_mg_runner.kill(inner_instances_description, "instance_3")
@@ -3030,9 +2701,9 @@ def test_one_coord_down_with_durability_resume(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "down", "unknown"),
     ]
 
-    mg_sleep_and_assert(leader_data, show_instances_coord3)
-    mg_sleep_and_assert(leader_data, show_instances_coord1)
-    mg_sleep_and_assert(leader_data, show_instances_coord2)
+    mg_sleep_and_assert(leader_data, partial(show_instances, coord_cursor_3))
+    mg_sleep_and_assert(leader_data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(leader_data, partial(show_instances, coord_cursor_2))
 
 
 def test_registration_does_not_deadlock_when_instance_is_down(test_name):
@@ -3076,18 +2747,8 @@ def test_registration_does_not_deadlock_when_instance_is_down(test_name):
     for query in setup_queries:
         execute_and_fetch_all(coord_cursor_3, query)
 
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
@@ -3098,9 +2759,9 @@ def test_registration_does_not_deadlock_when_instance_is_down(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_3))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_2))
 
 
 def test_follower_have_correct_health(test_name):
@@ -3125,18 +2786,8 @@ def test_follower_have_correct_health(test_name):
         execute_and_fetch_all(coord_cursor_3, query)
 
     # 2
-    def show_instances_coord3():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
     coord_cursor_2 = connect(host="localhost", port=7691).cursor()
-
-    def show_instances_coord2():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_2, "SHOW INSTANCES;"))))
 
     data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
@@ -3147,9 +2798,9 @@ def test_follower_have_correct_health(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
-    mg_sleep_and_assert(data, show_instances_coord3)
-    mg_sleep_and_assert(data, show_instances_coord1)
-    mg_sleep_and_assert(data, show_instances_coord2)
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_3))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_1))
+    mg_sleep_and_assert(data, partial(show_instances, coord_cursor_2))
 
 
 def test_first_coord_restarts(test_name):
@@ -3161,11 +2812,8 @@ def test_first_coord_restarts(test_name):
     interactive_mg_runner.start(inner_instances_description, "coordinator_1")
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
 
-    def show_instances_coord1():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_1, "SHOW INSTANCES;"))))
-
     leader_data = [("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader")]
-    mg_sleep_and_assert(leader_data, show_instances_coord1)
+    mg_sleep_and_assert(leader_data, partial(show_instances, coord_cursor_1))
 
     interactive_mg_runner.kill_all(keep_directories=True)
 
@@ -3174,7 +2822,7 @@ def test_first_coord_restarts(test_name):
     leader_data = [("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader")]
 
     coord_cursor_1 = connect(host="localhost", port=7690).cursor()
-    mg_sleep_and_assert(leader_data, show_instances_coord1)
+    mg_sleep_and_assert(leader_data, partial(show_instances, coord_cursor_1))
 
 
 def test_main_reselected_to_become_main(test_name):
@@ -3192,9 +2840,6 @@ def test_main_reselected_to_become_main(test_name):
     for query in get_default_setup_queries():
         execute_and_fetch_all(coord_cursor_3, query)
 
-    def show_instances():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor_3, "SHOW INSTANCES;"))))
-
     # check cluster state
     leader_data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "follower"),
@@ -3205,7 +2850,7 @@ def test_main_reselected_to_become_main(test_name):
         ("instance_3", "localhost:7689", "", "localhost:10013", "up", "main"),
     ]
 
-    mg_sleep_and_assert(leader_data, show_instances)
+    mg_sleep_and_assert(leader_data, partial(show_instances, coord_cursor_3))
 
     # kill replica instances
     interactive_mg_runner.kill(inner_instances_description, "instance_1")
@@ -3216,7 +2861,7 @@ def test_main_reselected_to_become_main(test_name):
     leader_data = update_tuple_value(leader_data, "instance_1", 0, -1, "unknown")
     leader_data = update_tuple_value(leader_data, "instance_2", 0, -2, "down")
     leader_data = update_tuple_value(leader_data, "instance_2", 0, -1, "unknown")
-    mg_sleep_and_assert(leader_data, show_instances)
+    mg_sleep_and_assert(leader_data, partial(show_instances, coord_cursor_3))
 
     # write to main
     main_cursor = connect(host="localhost", port=7689).cursor()
@@ -3257,12 +2902,9 @@ def test_main_reselected_to_become_main(test_name):
     leader_data = update_tuple_value(leader_data, "instance_2", 0, -1, "replica")
     leader_data = update_tuple_value(leader_data, "instance_3", 0, -2, "up")
     leader_data = update_tuple_value(leader_data, "instance_3", 0, -1, "main")
-    mg_sleep_and_assert(leader_data, show_instances)
+    mg_sleep_and_assert(leader_data, partial(show_instances, coord_cursor_3))
 
     # check that i1/2 are recovered
-    def show_replicas():
-        return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")))
-
     replicas = [
         (
             "instance_1",
@@ -3279,7 +2921,7 @@ def test_main_reselected_to_become_main(test_name):
             {"memgraph": {"behind": 0, "status": "ready", "ts": 2}},
         ),
     ]
-    mg_sleep_and_assert_collection(replicas, show_replicas)
+    mg_sleep_and_assert_collection(replicas, partial(show_replicas, main_cursor))
     cursor = connect(host="localhost", port=7687).cursor()
 
     def check_data():

--- a/tests/e2e/high_availability/distributed_coords.py
+++ b/tests/e2e/high_availability/distributed_coords.py
@@ -28,6 +28,7 @@ from common import (
     show_instances,
     show_replicas,
     update_tuple_value,
+    wait_until_main_writeable_assert_replica_down,
 )
 from mg_utils import (
     mg_assert_until,
@@ -1425,9 +1426,7 @@ def test_multiple_failovers_in_row_no_leadership_change(test_name):
         lambda: execute_and_fetch_all(instance_3_cursor, "SHOW REPLICATION ROLE;")[0][0], "main"
     )
 
-    with pytest.raises(Exception) as e:
-        execute_and_fetch_all(instance_3_cursor, "CREATE ();")
-    assert "At least one SYNC replica has not confirmed committing last transaction." in str(e.value)
+    wait_until_main_writeable_assert_replica_down(instance_3_cursor, "CREATE ();")
 
     # 12
     interactive_mg_runner.start(inner_memgraph_instances, "instance_1")

--- a/tests/e2e/high_availability/single_coordinator.py
+++ b/tests/e2e/high_availability/single_coordinator.py
@@ -10,6 +10,7 @@
 
 import os
 import sys
+from functools import partial
 
 import interactive_mg_runner
 import pytest
@@ -18,7 +19,10 @@ from common import (
     execute_and_fetch_all,
     get_data_path,
     get_logs_path,
-    ignore_elapsed_time_from_results,
+    get_vertex_count,
+    show_instances,
+    show_replicas,
+    show_replication_role,
 )
 from mg_utils import (
     mg_sleep_and_assert,
@@ -236,22 +240,16 @@ def test_replication_works_on_failover_replica_1_epoch_2_commits_away(data_recov
 
     coord_cursor = connect(host="localhost", port=7690).cursor()
 
-    def retrieve_data_show_instances():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
-
     expected_data_on_coord = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
         ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),
         ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
     ]
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor))
 
     # 2
     main_cursor = connect(host="localhost", port=7687).cursor()
-
-    def retrieve_data_show_replicas():
-        return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")))
 
     expected_data_on_main = [
         (
@@ -269,7 +267,7 @@ def test_replication_works_on_failover_replica_1_epoch_2_commits_away(data_recov
             {"memgraph": {"behind": 0, "status": "ready", "ts": 0}},
         ),
     ]
-    mg_sleep_and_assert_collection(expected_data_on_main, retrieve_data_show_replicas)
+    mg_sleep_and_assert_collection(expected_data_on_main, partial(show_replicas, main_cursor))
 
     # 3
     execute_and_fetch_all(main_cursor, "CREATE (:EpochVertex1 {prop:1});")
@@ -299,16 +297,13 @@ def test_replication_works_on_failover_replica_1_epoch_2_commits_away(data_recov
     # 8.
     coord_cursor = connect(host="localhost", port=7690).cursor()
 
-    def retrieve_data_show_instances():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
-
     expected_data_on_coord = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
         ("instance_1", "localhost:7688", "", "localhost:10011", "down", "unknown"),
         ("instance_2", "localhost:7689", "", "localhost:10012", "up", "main"),
         ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
     ]
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor))
 
     # 9
     mg_sleep_and_assert_until_role_change(
@@ -328,15 +323,12 @@ def test_replication_works_on_failover_replica_1_epoch_2_commits_away(data_recov
         ("instance_2", "localhost:7689", "", "localhost:10012", "up", "main"),
         ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
     ]
-    mg_sleep_and_assert(new_expected_data_on_coord, retrieve_data_show_instances)
+    mg_sleep_and_assert(new_expected_data_on_coord, partial(show_instances, coord_cursor))
 
     # 11
     instance_1_cursor = connect(host="localhost", port=7688).cursor()
 
-    def get_vertex_count():
-        return execute_and_fetch_all(instance_1_cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-    mg_sleep_and_assert(3, get_vertex_count)
+    mg_sleep_and_assert(3, partial(get_vertex_count, instance_1_cursor))
 
     # 12
 
@@ -348,16 +340,13 @@ def test_replication_works_on_failover_replica_1_epoch_2_commits_away(data_recov
         ("instance_2", "localhost:7689", "", "localhost:10012", "up", "main"),
         ("instance_3", "localhost:7687", "", "localhost:10013", "up", "replica"),
     ]
-    mg_sleep_and_assert(new_expected_data_on_coord, retrieve_data_show_instances)
+    mg_sleep_and_assert(new_expected_data_on_coord, partial(show_instances, coord_cursor))
 
     # 13
 
     instance_3_cursor = connect(host="localhost", port=7687).cursor()
 
-    def get_vertex_count():
-        return execute_and_fetch_all(instance_3_cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-    mg_sleep_and_assert(3, get_vertex_count)
+    mg_sleep_and_assert(3, partial(get_vertex_count, instance_3_cursor))
 
 
 @pytest.mark.parametrize("data_recovery", ["false", "true"])
@@ -390,9 +379,6 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
     interactive_mg_runner.start_all(memgraph_instances_description, keep_directories=False)
     coord_cursor = connect(host="localhost", port=7690).cursor()
 
-    def retrieve_data_show_instances():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
-
     expected_data_on_coord = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
         ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),
@@ -400,7 +386,7 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
         ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
         ("instance_4", "localhost:7691", "", "localhost:10014", "up", "replica"),
     ]
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor))
 
     expected_data_on_main = [
         (
@@ -428,10 +414,7 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
 
     main_cursor = connect(host="localhost", port=7687).cursor()
 
-    def retrieve_data_show_replicas():
-        return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")))
-
-    mg_sleep_and_assert_collection(expected_data_on_main, retrieve_data_show_replicas)
+    mg_sleep_and_assert_collection(expected_data_on_main, partial(show_replicas, main_cursor))
 
     # 2
 
@@ -452,9 +435,6 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
 
     coord_cursor = connect(host="localhost", port=7690).cursor()
 
-    def retrieve_data_show_instances():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
-
     expected_data_on_coord = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
         ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),
@@ -462,7 +442,7 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
         ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
         ("instance_4", "localhost:7691", "", "localhost:10014", "up", "replica"),
     ]
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor))
 
     # 4
 
@@ -486,7 +466,7 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
         ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
         ("instance_4", "localhost:7691", "", "localhost:10014", "up", "replica"),
     ]
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor))
 
     # 7
 
@@ -500,10 +480,7 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
 
     # 8
 
-    def get_vertex_count():
-        return execute_and_fetch_all(instance_4_cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-    mg_sleep_and_assert(4, get_vertex_count)
+    mg_sleep_and_assert(4, partial(get_vertex_count, instance_4_cursor))
 
     # 9
 
@@ -518,7 +495,7 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
         ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
         ("instance_4", "localhost:7691", "", "localhost:10014", "up", "main"),
     ]
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor))
 
     # 11
 
@@ -541,16 +518,13 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
         ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
         ("instance_4", "localhost:7691", "", "localhost:10014", "up", "main"),
     ]
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor))
 
     # 13
 
     instance_2_cursor = connect(host="localhost", port=7689).cursor()
 
-    def get_vertex_count():
-        return execute_and_fetch_all(instance_2_cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-    mg_sleep_and_assert(5, get_vertex_count)
+    mg_sleep_and_assert(5, partial(get_vertex_count, instance_2_cursor))
 
     # 14
 
@@ -564,21 +538,14 @@ def test_replication_works_on_failover_replica_2_epochs_more_commits_away(data_r
         ("instance_3", "localhost:7687", "", "localhost:10013", "up", "replica"),
         ("instance_4", "localhost:7691", "", "localhost:10014", "up", "main"),
     ]
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor))
 
     # 15
     instance_1_cursor = connect(host="localhost", port=7688).cursor()
     instance_4_cursor = connect(host="localhost", port=7691).cursor()
 
-    def get_vertex_count():
-        return execute_and_fetch_all(instance_1_cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-    mg_sleep_and_assert(5, get_vertex_count)
-
-    def get_vertex_count():
-        return execute_and_fetch_all(instance_4_cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-    mg_sleep_and_assert(5, get_vertex_count)
+    mg_sleep_and_assert(5, partial(get_vertex_count, instance_1_cursor))
+    mg_sleep_and_assert(5, partial(get_vertex_count, instance_4_cursor))
 
 
 @pytest.mark.parametrize("data_recovery", ["true"])
@@ -637,15 +604,9 @@ def test_replication_forcefully_works_on_failover_replica_misses_epoch(data_reco
 
     main_cursor = connect(host="localhost", port=7687).cursor()
 
-    def retrieve_data_show_replicas():
-        return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")))
-
-    mg_sleep_and_assert_collection(expected_data_on_main, retrieve_data_show_replicas)
+    mg_sleep_and_assert_collection(expected_data_on_main, partial(show_replicas, main_cursor))
 
     coord_cursor = connect(host="localhost", port=7690).cursor()
-
-    def retrieve_data_show_instances():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_on_coord = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
@@ -654,7 +615,7 @@ def test_replication_forcefully_works_on_failover_replica_misses_epoch(data_reco
         ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
         ("instance_4", "localhost:7691", "", "localhost:10014", "up", "replica"),
     ]
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor))
 
     # 3
 
@@ -686,7 +647,7 @@ def test_replication_forcefully_works_on_failover_replica_misses_epoch(data_reco
         ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
         ("instance_4", "localhost:7691", "", "localhost:10014", "up", "replica"),
     ]
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor))
 
     # 8
 
@@ -698,15 +659,8 @@ def test_replication_forcefully_works_on_failover_replica_misses_epoch(data_reco
         execute_and_fetch_all(instance_2_cursor, "CREATE (:Epoch2Vertex {prop:1});")
     assert "At least one SYNC replica has not confirmed committing last transaction." in str(e.value)
 
-    def get_vertex_count():
-        return execute_and_fetch_all(instance_4_cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-    mg_sleep_and_assert(3, get_vertex_count)
-
-    def get_vertex_count():
-        return execute_and_fetch_all(instance_2_cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-    mg_sleep_and_assert(3, get_vertex_count)
+    mg_sleep_and_assert(3, partial(get_vertex_count, instance_4_cursor))
+    mg_sleep_and_assert(3, partial(get_vertex_count, instance_2_cursor))
 
     # 9
 
@@ -728,7 +682,7 @@ def test_replication_forcefully_works_on_failover_replica_misses_epoch(data_reco
         ("instance_4", "localhost:7691", "", "localhost:10014", "down", "unknown"),
     ]
 
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor))
 
     # 12
 
@@ -738,10 +692,7 @@ def test_replication_forcefully_works_on_failover_replica_misses_epoch(data_reco
         lambda: execute_and_fetch_all(instance_1_cursor, "SHOW REPLICATION ROLE;")[0][0], "main"
     )
 
-    def get_vertex_count():
-        return execute_and_fetch_all(instance_1_cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-    mg_sleep_and_assert(2, get_vertex_count)
+    mg_sleep_and_assert(2, partial(get_vertex_count, instance_1_cursor))
 
     interactive_mg_runner.start(memgraph_instances_description, "instance_2")
 
@@ -754,7 +705,7 @@ def test_replication_forcefully_works_on_failover_replica_misses_epoch(data_reco
         ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
         ("instance_4", "localhost:7691", "", "localhost:10014", "down", "unknown"),
     ]
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor))
 
     instance_2_cursor = connect(host="localhost", port=7689).cursor()
 
@@ -762,10 +713,7 @@ def test_replication_forcefully_works_on_failover_replica_misses_epoch(data_reco
         lambda: execute_and_fetch_all(instance_2_cursor, "SHOW REPLICATION ROLE;")[0][0], "replica"
     )
 
-    def get_vertex_count():
-        return execute_and_fetch_all(instance_2_cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-    mg_sleep_and_assert(2, get_vertex_count)
+    mg_sleep_and_assert(2, partial(get_vertex_count, instance_2_cursor))
 
     # 13
 
@@ -819,9 +767,6 @@ def test_replication_correct_replica_chosen_up_to_date_data(data_recovery, test_
 
     coord_cursor = connect(host="localhost", port=7690).cursor()
 
-    def retrieve_data_show_instances():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
-
     expected_data_on_coord = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
         ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),
@@ -829,7 +774,7 @@ def test_replication_correct_replica_chosen_up_to_date_data(data_recovery, test_
         ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
         ("instance_4", "localhost:7691", "", "localhost:10014", "up", "replica"),
     ]
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor))
 
     # 2
 
@@ -860,10 +805,7 @@ def test_replication_correct_replica_chosen_up_to_date_data(data_recovery, test_
 
     main_cursor = connect(host="localhost", port=7687).cursor()
 
-    def retrieve_data_show_replicas():
-        return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")))
-
-    mg_sleep_and_assert_collection(expected_data_on_main, retrieve_data_show_replicas)
+    mg_sleep_and_assert_collection(expected_data_on_main, partial(show_replicas, main_cursor))
 
     # 3
 
@@ -896,7 +838,7 @@ def test_replication_correct_replica_chosen_up_to_date_data(data_recovery, test_
         ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
         ("instance_4", "localhost:7691", "", "localhost:10014", "down", "unknown"),
     ]
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor))
 
     # 8
 
@@ -911,10 +853,7 @@ def test_replication_correct_replica_chosen_up_to_date_data(data_recovery, test_
     interactive_mg_runner.start(memgraph_instances_description, "instance_4")
     instance_4_cursor = connect(host="localhost", port=7691).cursor()
 
-    def get_vertex_count():
-        return execute_and_fetch_all(instance_4_cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-    mg_sleep_and_assert(3, get_vertex_count)
+    mg_sleep_and_assert(3, partial(get_vertex_count, instance_4_cursor))
 
     # 9
 
@@ -930,16 +869,12 @@ def test_replication_correct_replica_chosen_up_to_date_data(data_recovery, test_
         ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
         ("instance_4", "localhost:7691", "", "localhost:10014", "up", "main"),
     ]
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_instances)
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor))
 
     # 11
     instance_1_cursor = connect(host="localhost", port=7688).cursor()
-    instance_4_cursor = connect(host="localhost", port=7691).cursor()
 
-    def get_vertex_count():
-        return execute_and_fetch_all(instance_1_cursor, "MATCH (n) RETURN count(n)")[0][0]
-
-    mg_sleep_and_assert(3, get_vertex_count)
+    mg_sleep_and_assert(3, partial(get_vertex_count, instance_1_cursor))
 
 
 def test_replication_works_on_failover_simple(test_name):
@@ -975,10 +910,7 @@ def test_replication_works_on_failover_simple(test_name):
         ),
     ]
 
-    def main_cursor_show_replicas():
-        return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")))
-
-    mg_sleep_and_assert_collection(expected_data_on_main, main_cursor_show_replicas)
+    mg_sleep_and_assert_collection(expected_data_on_main, partial(show_replicas, main_cursor))
 
     # 3
     interactive_mg_runner.kill(memgraph_instances_description, "instance_3")
@@ -986,21 +918,15 @@ def test_replication_works_on_failover_simple(test_name):
     # 4
     coord_cursor = connect(host="localhost", port=7690).cursor()
 
-    def retrieve_data_show_repl_cluster():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
-
     expected_data_on_coord = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
         ("instance_1", "localhost:7688", "", "localhost:10011", "up", "main"),
         ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
     ]
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor))
 
     new_main_cursor = connect(host="localhost", port=7688).cursor()
-
-    def retrieve_data_show_replicas():
-        return sorted(list(execute_and_fetch_all(new_main_cursor, "SHOW REPLICAS;")))
 
     expected_data_on_new_main = [
         (
@@ -1022,7 +948,7 @@ def test_replication_works_on_failover_simple(test_name):
     mg_sleep_and_assert_until_role_change(
         lambda: execute_and_fetch_all(new_main_cursor, "SHOW REPLICATION ROLE;")[0][0], "main"
     )
-    mg_sleep_and_assert_collection(expected_data_on_new_main, retrieve_data_show_replicas)
+    mg_sleep_and_assert_collection(expected_data_on_new_main, partial(show_replicas, new_main_cursor))
 
     # 5
 
@@ -1032,16 +958,10 @@ def test_replication_works_on_failover_simple(test_name):
     # 6
     alive_replica_cursor = connect(host="localhost", port=7689).cursor()
 
-    def get_vertex_count():
-        return execute_and_fetch_all(alive_replica_cursor, "MATCH (n) RETURN count(n) as count;")[0][0]
-
-    mg_sleep_and_assert(1, get_vertex_count)
+    mg_sleep_and_assert(1, partial(get_vertex_count, alive_replica_cursor))
 
     # 7
     interactive_mg_runner.start(memgraph_instances_description, "instance_3")
-
-    def retrieve_data_show_replicas():
-        return sorted(list(execute_and_fetch_all(new_main_cursor, "SHOW REPLICAS;")))
 
     new_main_cursor = connect(host="localhost", port=7688).cursor()
 
@@ -1061,15 +981,12 @@ def test_replication_works_on_failover_simple(test_name):
             {"memgraph": {"ts": 2, "behind": 0, "status": "ready"}},
         ),
     ]
-    mg_sleep_and_assert(expected_data_on_new_main, retrieve_data_show_replicas)
+    mg_sleep_and_assert(expected_data_on_new_main, partial(show_replicas, new_main_cursor))
 
     # 8
     alive_main = connect(host="localhost", port=7687).cursor()
 
-    def retrieve_vertices_count():
-        return execute_and_fetch_all(alive_main, "MATCH (n) RETURN count(n) as count;")[0][0]
-
-    mg_sleep_and_assert(1, retrieve_vertices_count)
+    mg_sleep_and_assert(1, partial(get_vertex_count, alive_main))
 
 
 def test_replication_works_on_replica_instance_restart(test_name):
@@ -1103,18 +1020,12 @@ def test_replication_works_on_replica_instance_restart(test_name):
         ),
     ]
 
-    def main_cursor_show_replicas():
-        return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")))
-
-    mg_sleep_and_assert_collection(expected_data_on_main, main_cursor_show_replicas)
+    mg_sleep_and_assert_collection(expected_data_on_main, partial(show_replicas, main_cursor))
 
     # 3
     coord_cursor = connect(host="localhost", port=7690).cursor()
 
     interactive_mg_runner.kill(memgraph_instances_description, "instance_2")
-
-    def retrieve_data_show_repl_cluster():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_on_coord = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
@@ -1122,10 +1033,7 @@ def test_replication_works_on_replica_instance_restart(test_name):
         ("instance_2", "localhost:7689", "", "localhost:10012", "down", "unknown"),
         ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
     ]
-    mg_sleep_and_assert_collection(expected_data_on_coord, retrieve_data_show_repl_cluster)
-
-    def retrieve_data_show_replicas():
-        return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")))
+    mg_sleep_and_assert_collection(expected_data_on_coord, partial(show_instances, coord_cursor))
 
     expected_data_on_main = [
         (
@@ -1143,7 +1051,7 @@ def test_replication_works_on_replica_instance_restart(test_name):
             {"memgraph": {"ts": 0, "behind": 0, "status": "invalid"}},
         ),
     ]
-    mg_sleep_and_assert_collection(expected_data_on_main, retrieve_data_show_replicas)
+    mg_sleep_and_assert_collection(expected_data_on_main, partial(show_replicas, main_cursor))
 
     # 4
     instance_1_cursor = connect(host="localhost", port=7688).cursor()
@@ -1153,9 +1061,6 @@ def test_replication_works_on_replica_instance_restart(test_name):
 
     res_instance_1 = execute_and_fetch_all(instance_1_cursor, "MATCH (n) RETURN count(n)")[0][0]
     assert res_instance_1 == 1
-
-    def retrieve_data_show_replicas():
-        return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")))
 
     expected_data_on_main = [
         (
@@ -1173,14 +1078,11 @@ def test_replication_works_on_replica_instance_restart(test_name):
             {"memgraph": {"ts": 0, "behind": 0, "status": "invalid"}},
         ),
     ]
-    mg_sleep_and_assert_collection(expected_data_on_main, retrieve_data_show_replicas)
+    mg_sleep_and_assert_collection(expected_data_on_main, partial(show_replicas, main_cursor))
 
     # 5.
 
     interactive_mg_runner.start(memgraph_instances_description, "instance_2")
-
-    def retrieve_data_show_repl_cluster():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_on_coord = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
@@ -1188,10 +1090,7 @@ def test_replication_works_on_replica_instance_restart(test_name):
         ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
     ]
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
-
-    def retrieve_data_show_replicas():
-        return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")))
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor))
 
     expected_data_on_main = [
         (
@@ -1209,7 +1108,7 @@ def test_replication_works_on_replica_instance_restart(test_name):
             {"memgraph": {"ts": 2, "behind": 0, "status": "ready"}},
         ),
     ]
-    mg_sleep_and_assert_collection(expected_data_on_main, retrieve_data_show_replicas)
+    mg_sleep_and_assert_collection(expected_data_on_main, partial(show_replicas, main_cursor))
 
     # 6.
     instance_2_cursor = connect(port=7689, host="localhost").cursor()
@@ -1227,29 +1126,17 @@ def test_show_instances(test_name):
     instance3_cursor = connect(host="localhost", port=7687).cursor()
     coord_cursor = connect(host="localhost", port=7690).cursor()
 
-    def show_repl_cluster():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
-
     expected_data = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
         ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),
         ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
     ]
-    mg_sleep_and_assert(expected_data, show_repl_cluster)
+    mg_sleep_and_assert(expected_data, partial(show_instances, coord_cursor))
 
-    def retrieve_data_show_repl_role_instance1():
-        return sorted(list(execute_and_fetch_all(instance1_cursor, "SHOW REPLICATION ROLE;")))
-
-    def retrieve_data_show_repl_role_instance2():
-        return sorted(list(execute_and_fetch_all(instance2_cursor, "SHOW REPLICATION ROLE;")))
-
-    def retrieve_data_show_repl_role_instance3():
-        return sorted(list(execute_and_fetch_all(instance3_cursor, "SHOW REPLICATION ROLE;")))
-
-    mg_sleep_and_assert([("replica",)], retrieve_data_show_repl_role_instance1)
-    mg_sleep_and_assert([("replica",)], retrieve_data_show_repl_role_instance2)
-    mg_sleep_and_assert([("main",)], retrieve_data_show_repl_role_instance3)
+    mg_sleep_and_assert([("replica",)], partial(show_replication_role, instance1_cursor))
+    mg_sleep_and_assert([("replica",)], partial(show_replication_role, instance2_cursor))
+    mg_sleep_and_assert([("main",)], partial(show_replication_role, instance3_cursor))
 
     interactive_mg_runner.kill(memgraph_instances_description, "instance_1")
 
@@ -1259,7 +1146,7 @@ def test_show_instances(test_name):
         ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
     ]
-    mg_sleep_and_assert(expected_data, show_repl_cluster)
+    mg_sleep_and_assert(expected_data, partial(show_instances, coord_cursor))
 
     interactive_mg_runner.kill(memgraph_instances_description, "instance_2")
 
@@ -1269,7 +1156,7 @@ def test_show_instances(test_name):
         ("instance_2", "localhost:7689", "", "localhost:10012", "down", "unknown"),
         ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
     ]
-    mg_sleep_and_assert(expected_data, show_repl_cluster)
+    mg_sleep_and_assert(expected_data, partial(show_instances, coord_cursor))
 
 
 def test_simple_automatic_failover(test_name):
@@ -1294,17 +1181,11 @@ def test_simple_automatic_failover(test_name):
         ),
     ]
 
-    def main_cursor_show_replicas():
-        return sorted(list(execute_and_fetch_all(main_cursor, "SHOW REPLICAS;")))
-
-    mg_sleep_and_assert_collection(expected_data_on_main, main_cursor_show_replicas)
+    mg_sleep_and_assert_collection(expected_data_on_main, partial(show_replicas, main_cursor))
 
     interactive_mg_runner.kill(memgraph_instances_description, "instance_3")
 
     coord_cursor = connect(host="localhost", port=7690).cursor()
-
-    def retrieve_data_show_repl_cluster():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
 
     expected_data_on_coord = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
@@ -1312,12 +1193,9 @@ def test_simple_automatic_failover(test_name):
         ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
     ]
-    mg_sleep_and_assert(expected_data_on_coord, retrieve_data_show_repl_cluster)
+    mg_sleep_and_assert(expected_data_on_coord, partial(show_instances, coord_cursor))
 
     new_main_cursor = connect(host="localhost", port=7688).cursor()
-
-    def retrieve_data_show_replicas():
-        return sorted(list(execute_and_fetch_all(new_main_cursor, "SHOW REPLICAS;")))
 
     expected_data_on_new_main = [
         (
@@ -1339,7 +1217,7 @@ def test_simple_automatic_failover(test_name):
     mg_sleep_and_assert_until_role_change(
         lambda: execute_and_fetch_all(new_main_cursor, "SHOW REPLICATION ROLE;")[0][0], "main"
     )
-    mg_sleep_and_assert_collection(expected_data_on_new_main, retrieve_data_show_replicas)
+    mg_sleep_and_assert_collection(expected_data_on_new_main, partial(show_replicas, new_main_cursor))
 
     interactive_mg_runner.start(memgraph_instances_description, "instance_3")
     expected_data_on_new_main_old_alive = [
@@ -1359,7 +1237,7 @@ def test_simple_automatic_failover(test_name):
         ),
     ]
 
-    mg_sleep_and_assert_collection(expected_data_on_new_main_old_alive, retrieve_data_show_replicas)
+    mg_sleep_and_assert_collection(expected_data_on_new_main_old_alive, partial(show_replicas, new_main_cursor))
 
 
 def test_registering_replica_fails_name_exists(test_name):
@@ -1397,16 +1275,13 @@ def test_replica_instance_restarts(test_name):
 
     cursor = connect(host="localhost", port=7690).cursor()
 
-    def show_repl_cluster():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(cursor, "SHOW INSTANCES;"))))
-
     expected_data_up = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
         ("instance_1", "localhost:7688", "", "localhost:10011", "up", "replica"),
         ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
     ]
-    mg_sleep_and_assert(expected_data_up, show_repl_cluster)
+    mg_sleep_and_assert(expected_data_up, partial(show_instances, cursor))
 
     interactive_mg_runner.kill(memgraph_instances_description, "instance_1")
 
@@ -1416,19 +1291,15 @@ def test_replica_instance_restarts(test_name):
         ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
     ]
-    mg_sleep_and_assert(expected_data_down, show_repl_cluster)
+    mg_sleep_and_assert(expected_data_down, partial(show_instances, cursor))
 
     interactive_mg_runner.start(memgraph_instances_description, "instance_1")
 
-    mg_sleep_and_assert(expected_data_up, show_repl_cluster)
+    mg_sleep_and_assert(expected_data_up, partial(show_instances, cursor))
 
     instance1_cursor = connect(host="localhost", port=7688).cursor()
 
-    def retrieve_data_show_repl_role_instance1():
-        return sorted(list(execute_and_fetch_all(instance1_cursor, "SHOW REPLICATION ROLE;")))
-
-    expected_data_replica = [("replica",)]
-    mg_sleep_and_assert(expected_data_replica, retrieve_data_show_repl_role_instance1)
+    mg_sleep_and_assert([("replica",)], partial(show_replication_role, instance1_cursor))
 
 
 def test_automatic_failover_main_back_as_replica(test_name):
@@ -1440,16 +1311,13 @@ def test_automatic_failover_main_back_as_replica(test_name):
 
     coord_cursor = connect(host="localhost", port=7690).cursor()
 
-    def retrieve_data_show_repl_cluster():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
-
     expected_data_after_failover = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
         ("instance_1", "localhost:7688", "", "localhost:10011", "up", "main"),
         ("instance_2", "localhost:7689", "", "localhost:10012", "up", "replica"),
         ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
     ]
-    mg_sleep_and_assert(expected_data_after_failover, retrieve_data_show_repl_cluster)
+    mg_sleep_and_assert(expected_data_after_failover, partial(show_instances, coord_cursor))
 
     expected_data_after_main_coming_back = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
@@ -1459,14 +1327,11 @@ def test_automatic_failover_main_back_as_replica(test_name):
     ]
 
     interactive_mg_runner.start(memgraph_instances_description, "instance_3")
-    mg_sleep_and_assert(expected_data_after_main_coming_back, retrieve_data_show_repl_cluster)
+    mg_sleep_and_assert(expected_data_after_main_coming_back, partial(show_instances, coord_cursor))
 
     instance3_cursor = connect(host="localhost", port=7687).cursor()
 
-    def retrieve_data_show_repl_role_instance3():
-        return sorted(list(execute_and_fetch_all(instance3_cursor, "SHOW REPLICATION ROLE;")))
-
-    mg_sleep_and_assert([("replica",)], retrieve_data_show_repl_role_instance3)
+    mg_sleep_and_assert([("replica",)], partial(show_replication_role, instance3_cursor))
 
 
 def test_automatic_failover_main_back_as_main(test_name):
@@ -1480,9 +1345,6 @@ def test_automatic_failover_main_back_as_main(test_name):
 
     coord_cursor = connect(host="localhost", port=7690).cursor()
 
-    def retrieve_data_show_repl_cluster():
-        return ignore_elapsed_time_from_results(sorted(list(execute_and_fetch_all(coord_cursor, "SHOW INSTANCES;"))))
-
     expected_data_all_down = [
         ("coordinator_1", "localhost:7690", "localhost:10111", "localhost:10121", "up", "leader"),
         ("instance_1", "localhost:7688", "", "localhost:10011", "down", "unknown"),
@@ -1490,7 +1352,7 @@ def test_automatic_failover_main_back_as_main(test_name):
         ("instance_3", "localhost:7687", "", "localhost:10013", "down", "unknown"),
     ]
 
-    mg_sleep_and_assert(expected_data_all_down, retrieve_data_show_repl_cluster)
+    mg_sleep_and_assert(expected_data_all_down, partial(show_instances, coord_cursor))
 
     interactive_mg_runner.start(memgraph_instances_description, "instance_3")
     expected_data_main_back = [
@@ -1499,14 +1361,11 @@ def test_automatic_failover_main_back_as_main(test_name):
         ("instance_2", "localhost:7689", "", "localhost:10012", "down", "unknown"),
         ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
     ]
-    mg_sleep_and_assert(expected_data_main_back, retrieve_data_show_repl_cluster)
+    mg_sleep_and_assert(expected_data_main_back, partial(show_instances, coord_cursor))
 
     instance3_cursor = connect(host="localhost", port=7687).cursor()
 
-    def retrieve_data_show_repl_role_instance3():
-        return sorted(list(execute_and_fetch_all(instance3_cursor, "SHOW REPLICATION ROLE;")))
-
-    mg_sleep_and_assert([("main",)], retrieve_data_show_repl_role_instance3)
+    mg_sleep_and_assert([("main",)], partial(show_replication_role, instance3_cursor))
 
     interactive_mg_runner.start(memgraph_instances_description, "instance_1")
     interactive_mg_runner.start(memgraph_instances_description, "instance_2")
@@ -1518,20 +1377,14 @@ def test_automatic_failover_main_back_as_main(test_name):
         ("instance_3", "localhost:7687", "", "localhost:10013", "up", "main"),
     ]
 
-    mg_sleep_and_assert(expected_data_replicas_back, retrieve_data_show_repl_cluster)
+    mg_sleep_and_assert(expected_data_replicas_back, partial(show_instances, coord_cursor))
 
     instance1_cursor = connect(host="localhost", port=7688).cursor()
     instance2_cursor = connect(host="localhost", port=7689).cursor()
 
-    def retrieve_data_show_repl_role_instance1():
-        return sorted(list(execute_and_fetch_all(instance1_cursor, "SHOW REPLICATION ROLE;")))
-
-    def retrieve_data_show_repl_role_instance2():
-        return sorted(list(execute_and_fetch_all(instance2_cursor, "SHOW REPLICATION ROLE;")))
-
-    mg_sleep_and_assert([("replica",)], retrieve_data_show_repl_role_instance1)
-    mg_sleep_and_assert([("replica",)], retrieve_data_show_repl_role_instance2)
-    mg_sleep_and_assert([("main",)], retrieve_data_show_repl_role_instance3)
+    mg_sleep_and_assert([("replica",)], partial(show_replication_role, instance1_cursor))
+    mg_sleep_and_assert([("replica",)], partial(show_replication_role, instance2_cursor))
+    mg_sleep_and_assert([("main",)], partial(show_replication_role, instance3_cursor))
 
 
 def test_disable_multiple_mains(test_name):


### PR DESCRIPTION
Isolated coordinator queries in e2e tests to reduce duplication and make code more readable.