### PR TITLE
Bugfix: Insert new batch of nodes within one txn

### DIFF
--- a/.github/workflows/stress_jepsen.yaml
+++ b/.github/workflows/stress_jepsen.yaml
@@ -78,7 +78,7 @@ jobs:
           cd tests/jepsen
           ./run.sh test \
           --binary ../../build/memgraph \
-          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 25200 --concurrency 6" \
+          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 60 --concurrency 6" \
           --ignore-run-stdout-logs \
           --ignore-run-stderr-logs \
           --nodes-no 6 \

--- a/.github/workflows/stress_jepsen.yaml
+++ b/.github/workflows/stress_jepsen.yaml
@@ -17,7 +17,7 @@ jobs:
   core:
     name: "Jepsen stress tests"
     runs-on: [self-hosted, Linux, X64, DockerMgBuild]
-    timeout-minutes: 600
+    timeout-minutes: 720
     steps:
       - name: Set up repository
         uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
           cd tests/jepsen
           ./run.sh test \
           --binary ../../build/memgraph \
-          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 60 --concurrency 6" \
+          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 28800 --concurrency 6" \
           --ignore-run-stdout-logs \
           --ignore-run-stderr-logs \
           --nodes-no 6 \

--- a/tests/jepsen/src/memgraph/high_availability/create/test.clj
+++ b/tests/jepsen/src/memgraph/high_availability/create/test.clj
@@ -35,18 +35,6 @@
 
                        intervals)))
 
-(defn weighted-random
-  "Chooses random number from the collection based on the probabilities vector provided."
-  [coll probs]
-  (assert (= (reduce + probs) 1.0) "Sum of probabilities should equal to 1.")
-  (assert (= (count coll) (count probs)) "Not every element has its probability match.")
-  ; The code relies that `rand` will never generate exactly 1.0. True by the function specification.
-  (let [cumulative-probs (cum-probs probs)
-        rand-num (rand)
-        competent-idx (get-competent-idx cumulative-probs rand-num)
-        chosen-num (nth coll competent-idx)]
-    chosen-num))
-
 (defn hamming-sim
   "Calculates Hamming distance between two sequences. Used as a consistency measure when the order is important."
   [seq1 seq2]
@@ -157,11 +145,6 @@
   [max-id]
   (range 1 (inc max-id)))
 
-(defn batch-end-idx
-  "Calculates end index for the new batch. End index will not be included. E.g 1001, 2001"
-  [batch-start-idx]
-  (+ batch-start-idx (dec batch-size)))
-
 (defn random-coord
   "Get random leader."
   [nodes]
@@ -208,27 +191,10 @@
   ((mgquery/set-instance-to-main first-main) session)
   (info "Set instance" first-main "to main."))
 
-(defn mg-add-nodes
-  "Add nodes as part of the txn."
-  [start-idx end-idx txn]
-  ((mgquery/add-nodes start-idx end-idx) txn))
-
 (defn mg-get-nodes
   "Get all nodes as part of the txn."
   [txn]
   (mgquery/collect-ids txn))
-
-(defn mg-max-id
-  "Get max ID currently in the Memgraph."
-  [txn]
-  (mgquery/max-id txn))
-
-(defn first-or
-  "Returns first element from the collection if exists or default value."
-  [coll default]
-  (if-let [first-elem (first coll)]
-    first-elem
-    default))
 
 (defn is-main?
   "Tests if data instance is main. Returns bool true/false, catches all exceptions."
@@ -280,14 +246,10 @@
 
         :add-nodes (if (and (hautils/data-instance? node) (is-main? bolt-conn))
                      (try
-                       (dbclient/with-transaction bolt-conn txn
+                       (utils/with-session bolt-conn session
                            ; If query failed because the instance got killed, we should catch TransientException -> this will be logged as
                            ; fail result.
-                         (let [mg-res (->> (mg-max-id txn) (map :id) (reduce conj []))
-                               max-idx (first-or mg-res 0)
-                               start-idx (inc max-idx)
-                               end-idx (batch-end-idx start-idx)]
-                           (mg-add-nodes start-idx end-idx txn)))
+                           ((mgquery/add-nodes batch-size) session))
                        (assoc op :type :ok :value "Nodes created.")
 
                        (catch org.neo4j.driver.exceptions.ServiceUnavailableException _e

--- a/tests/jepsen/src/memgraph/high_availability/create/test.clj
+++ b/tests/jepsen/src/memgraph/high_availability/create/test.clj
@@ -249,7 +249,7 @@
                        (utils/with-session bolt-conn session
                            ; If query failed because the instance got killed, we should catch TransientException -> this will be logged as
                            ; fail result.
-                           (mgquery/add-nodes session {:batch-size batch-size}))
+                           (mgquery/add-nodes session {:batchSize batch-size}))
                        (assoc op :type :ok :value "Nodes created.")
 
                        (catch org.neo4j.driver.exceptions.ServiceUnavailableException _e

--- a/tests/jepsen/src/memgraph/high_availability/create/test.clj
+++ b/tests/jepsen/src/memgraph/high_availability/create/test.clj
@@ -249,7 +249,7 @@
                        (utils/with-session bolt-conn session
                            ; If query failed because the instance got killed, we should catch TransientException -> this will be logged as
                            ; fail result.
-                           ((mgquery/add-nodes batch-size) session))
+                           (mgquery/add-nodes session {:batch-size batch-size}))
                        (assoc op :type :ok :value "Nodes created.")
 
                        (catch org.neo4j.driver.exceptions.ServiceUnavailableException _e

--- a/tests/jepsen/src/memgraph/query.clj
+++ b/tests/jepsen/src/memgraph/query.clj
@@ -38,7 +38,7 @@
 (dbclient/defquery add-nodes
   "MATCH (n:Node)
   WITH coalesce(max(n.id), 0) as max_idx
-  FOREACH (i in range(max_idx + 1, max_idx + $batch-size)
+  FOREACH (i in range(max_idx + 1, max_idx + $batchSize)
     | CREATE (:Node {id: i}));
   ")
 

--- a/tests/jepsen/src/memgraph/query.clj
+++ b/tests/jepsen/src/memgraph/query.clj
@@ -6,10 +6,8 @@
 (dbclient/defquery get-all-instances
   "SHOW INSTANCES;")
 
-
 (dbclient/defquery show-replication-role
   "SHOW REPLICATION ROLE;")
-
 
 (dbclient/defquery detach-delete-all
   "MATCH (n) DETACH DELETE n;")
@@ -37,15 +35,16 @@
   RETURN n.id as id;
   ")
 
-(dbclient/defquery max-id
-  "MATCH (n:Node)
-  RETURN max(n.id) as id;
-  ")
-
 (defn add-nodes
-  [start-idx end-idx]
+  [batch-size]
   (dbclient/create-query
-   (str "FOREACH (i in range(" start-idx ", " end-idx ") | CREATE (:Node {id: i}));")))
+   (let [query
+         (str "MATCH (n:Node) WITH coalesce(max(n.id), 0) as max_idx "
+              "FOREACH (i in range(max_idx+1, max_idx+"
+              batch-size
+              ") | CREATE (:Node {id: i}));")]
+
+     (info "Create query" query))))
 
 (defn register-replication-instance
   [name node-config]

--- a/tests/jepsen/src/memgraph/query.clj
+++ b/tests/jepsen/src/memgraph/query.clj
@@ -35,16 +35,12 @@
   RETURN n.id as id;
   ")
 
-(defn add-nodes
-  [batch-size]
-  (dbclient/create-query
-   (let [query
-         (str "MATCH (n:Node) WITH coalesce(max(n.id), 0) as max_idx "
-              "FOREACH (i in range(max_idx+1, max_idx+"
-              batch-size
-              ") | CREATE (:Node {id: i}));")]
-
-     (info "Create query" query))))
+(dbclient/defquery add-nodes
+  "MATCH (n:Node)
+  WITH coalesce(max(n.id), 0) as max_idx
+  FOREACH (i in range(max_idx + 1, max_idx + $batch-size)
+    | CREATE (:Node {id: i}));
+  ")
 
 (defn register-replication-instance
   [name node-config]


### PR DESCRIPTION
Jepsen stress test is improved so that it doesn't use explicit transactions to find maximum id and then create a new batch based on that but rather all is done within one query (implicit transaction). This should prevent false-positives on Jepsen tests where multiple fast auto-failovers were done on data instances.