### PR TITLE
Bugfix: Replica should ignore old WAL data

### DIFF
--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -493,7 +493,7 @@ bool InMemoryReplicationHandlers::LoadWal(storage::InMemoryStorage *storage, sto
     }
 
     // If WAL file doesn't contain any changes that need to be applied, ignore it
-    if (wal_info.to_timestamp <= storage->repl_storage_state_.last_durable_timestamp_) {
+    if (wal_info.to_timestamp <= storage->repl_storage_state_.last_durable_timestamp_.load(std::memory_order_acquire)) {
       spdlog::trace("WAL file won't be applied since all changes already exist.");
       return true;
     }

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -74,6 +74,9 @@ void ReplicationStorageClient::UpdateReplicaState(Storage *storage, DatabaseAcce
       return main_epoch_info.first == replica.epoch_id;
     });
 
+    spdlog::trace("Found commit timestamp {} for epoch {} in history.", epoch_info_iter->second,
+                  epoch_info_iter->first);
+
     if (epoch_info_iter == history.crend()) {
       spdlog::trace("Couldn't find epoch {} in main, setting branching point to 0.", std::string(replica.epoch_id));
       branching_point = 0;

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -74,9 +74,6 @@ void ReplicationStorageClient::UpdateReplicaState(Storage *storage, DatabaseAcce
       return main_epoch_info.first == replica.epoch_id;
     });
 
-    spdlog::trace("Found commit timestamp {} for epoch {} in history.", epoch_info_iter->second,
-                  epoch_info_iter->first);
-
     if (epoch_info_iter == history.crend()) {
       spdlog::trace("Couldn't find epoch {} in main, setting branching point to 0.", std::string(replica.epoch_id));
       branching_point = 0;
@@ -89,7 +86,8 @@ void ReplicationStorageClient::UpdateReplicaState(Storage *storage, DatabaseAcce
       branching_point = epoch_info_iter->second;
     } else {
       branching_point = std::nullopt;
-      spdlog::trace("Found continuous history between replica {} and main.", client_.name_);
+      spdlog::trace("Found continuous history between replica {} and main. Our commit timestamp for epoch {} was {}.",
+                    client_.name_, epoch_info_iter->first, epoch_info_iter->second);
     }
   }
   if (branching_point) {


### PR DESCRIPTION
Replica could receive a WAL file which contains all old data. If that is the case, old epoch would be added to the history together with the current durable timestamp on replica causing a wrong information contained inside replica. Replicas shouldn't naively use data from WAL files recieved.