### PR TITLE
Fix convert.str2object to work for primitives

### DIFF
--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -1439,6 +1439,8 @@ class Result {
  public:
   explicit Result(mgp_func_result *result);
 
+  /// @brief Sets a null value to be returned.
+  inline void SetValue();
   /// @brief Sets a boolean value to be returned.
   inline void SetValue(bool value);
   /// @brief Sets an integer value to be returned.
@@ -4213,6 +4215,12 @@ inline void RecordFactory::SetErrorMessage(const char *error_msg) const {
 // Result:
 
 inline Result::Result(mgp_func_result *result) : result_(result) {}
+
+inline void Result::SetValue() {
+  auto *mgp_val = mgp::MemHandlerCallback(value_make_null);
+  { mgp::MemHandlerCallback(func_result_set_value, result_, mgp_val); }
+  mgp::value_destroy(mgp_val);
+}
 
 inline void Result::SetValue(bool value) {
   auto *mgp_val = mgp::MemHandlerCallback(value_make_bool, value);

--- a/query_modules/convert.cpp
+++ b/query_modules/convert.cpp
@@ -69,8 +69,22 @@ void str2object(mgp_list *args, mgp_func_context *ctx, mgp_func_result *res, mgp
       func_result.SetValue(result.ValueMap());
     } else if (result.IsList()) {
       func_result.SetValue(result.ValueList());
+    } else if (result.IsString()) {
+      func_result.SetValue(result.ValueString());
+    } else if (result.IsInt()) {
+      func_result.SetValue(result.ValueInt());
+    } else if (result.IsDouble()) {
+      func_result.SetValue(result.ValueDouble());
+    } else if (result.IsBool()) {
+      func_result.SetValue(result.ValueBool());
+    } else if (result.IsNull()) {
+      func_result.SetValue();
     } else {
-      mgp::func_result_set_error_msg(res, "The end result is not map or list!", memory);
+      mgp::func_result_set_error_msg(
+          res,
+          "The end result is not one of the following JSON-language data types: object, array, "
+          "number, string, boolean, or null.",
+          memory);
     }
   } catch (const std::exception &e) {
     mgp::func_result_set_error_msg(res, e.what(), memory);

--- a/query_modules/convert.cpp
+++ b/query_modules/convert.cpp
@@ -11,15 +11,16 @@
 
 #include <iostream>
 #include <mgp.hpp>
+#include <optional>
 #include "json/json.hpp"
 
-mgp::Value ParseJsonToMgpValue(const nlohmann::json &json_obj, mgp_memory *memory);
+std::optional<mgp::Value> ParseJsonToMgpValue(const nlohmann::json &json_obj, mgp_memory *memory);
 
 mgp::Value ParseJsonToMgpMap(const nlohmann::json &json_obj, mgp_memory *memory) {
   auto map = mgp::Map();
 
   for (auto &[key, value] : json_obj.items()) {
-    auto sub_value = ParseJsonToMgpValue(value, memory);
+    auto sub_value = ParseJsonToMgpValue(value, memory).value();
     map.Insert(key, std::move(sub_value));
   }
 
@@ -29,14 +30,14 @@ mgp::Value ParseJsonToMgpMap(const nlohmann::json &json_obj, mgp_memory *memory)
 mgp::Value ParseJsonToMgpList(const nlohmann::json &json_array, mgp_memory *memory) {
   auto list = mgp::List();
   for (const auto &element : json_array) {
-    auto value = ParseJsonToMgpValue(element, memory);
+    auto value = ParseJsonToMgpValue(element, memory).value();
     list.AppendExtend(std::move(value));
   }
 
   return mgp::Value(std::move(list));
 }
 
-mgp::Value ParseJsonToMgpValue(const nlohmann::json &json_obj, mgp_memory *memory) {
+std::optional<mgp::Value> ParseJsonToMgpValue(const nlohmann::json &json_obj, mgp_memory *memory) {
   if (json_obj.is_object()) {
     return ParseJsonToMgpMap(json_obj, memory);
   } else if (json_obj.is_array()) {
@@ -49,8 +50,10 @@ mgp::Value ParseJsonToMgpValue(const nlohmann::json &json_obj, mgp_memory *memor
     return mgp::Value(mgp::value_make_double(json_obj.get<double>(), memory));
   } else if (json_obj.is_boolean()) {
     return mgp::Value(mgp::value_make_bool(json_obj.get<bool>(), memory));
-  } else {
+  } else if (json_obj.is_null()) {
     return mgp::Value();
+  } else {
+    return std::nullopt;
   }
 }
 
@@ -61,10 +64,20 @@ void str2object(mgp_list *args, mgp_func_context *ctx, mgp_func_result *res, mgp
     // Retrieve the string argument
     const auto string_arg = mgp::Value(mgp::list_at(args, 0));
     const auto json_object = nlohmann::json::parse(string_arg.ValueString());
-    const auto result = ParseJsonToMgpValue(json_object, memory);
+    std::optional<mgp::Value> maybe_result = ParseJsonToMgpValue(json_object, memory);
+
+    if (!maybe_result.has_value()) {
+      mgp::func_result_set_error_msg(
+          res,
+          "The end result is not one of the following JSON-language data types: object, array, "
+          "number, string, boolean, or null.",
+          memory);
+      return;
+    }
 
     auto func_result = mgp::Result(res);
 
+    auto result = *maybe_result;
     if (result.IsMap()) {
       func_result.SetValue(result.ValueMap());
     } else if (result.IsList()) {
@@ -79,12 +92,6 @@ void str2object(mgp_list *args, mgp_func_context *ctx, mgp_func_result *res, mgp
       func_result.SetValue(result.ValueBool());
     } else if (result.IsNull()) {
       func_result.SetValue();
-    } else {
-      mgp::func_result_set_error_msg(
-          res,
-          "The end result is not one of the following JSON-language data types: object, array, "
-          "number, string, boolean, or null.",
-          memory);
     }
   } catch (const std::exception &e) {
     mgp::func_result_set_error_msg(res, e.what(), memory);

--- a/tests/e2e/query_modules/convert_test.py
+++ b/tests/e2e/query_modules/convert_test.py
@@ -103,7 +103,7 @@ def test_convert_string():
 def test_convert_invalid():
     cursor = connect().cursor()
     with pytest.raises(mgclient.DatabaseError):
-        result = execute_and_fetch_all(
+        execute_and_fetch_all(
             cursor,
             'RETURN convert.str2object("this is not a string since it is not escaped");',
         )

--- a/tests/e2e/query_modules/convert_test.py
+++ b/tests/e2e/query_modules/convert_test.py
@@ -11,6 +11,7 @@
 
 import sys
 
+import mgclient
 import pytest
 from common import connect, execute_and_fetch_all
 
@@ -97,6 +98,15 @@ def test_convert_string():
         0
     ][0]
     assert result == "Cool string"
+
+
+def test_convert_invalid():
+    cursor = connect().cursor()
+    with pytest.raises(mgclient.DatabaseError):
+        result = execute_and_fetch_all(
+            cursor,
+            'RETURN convert.str2object("this is not a string since it is not escaped");',
+        )
 
 
 if __name__ == "__main__":

--- a/tests/e2e/query_modules/convert_test.py
+++ b/tests/e2e/query_modules/convert_test.py
@@ -44,5 +44,60 @@ def test_convert_map():
     }
 
 
+def test_convert_null():
+    cursor = connect().cursor()
+    result = execute_and_fetch_all(
+        cursor,
+        'RETURN convert.str2object("null");',
+    )[
+        0
+    ][0]
+    assert result == None
+
+
+def test_convert_int():
+    cursor = connect().cursor()
+    result = execute_and_fetch_all(
+        cursor,
+        'RETURN convert.str2object("1");',
+    )[
+        0
+    ][0]
+    assert result == 1
+
+
+def test_convert_double():
+    cursor = connect().cursor()
+    result = execute_and_fetch_all(
+        cursor,
+        'RETURN convert.str2object("1.5");',
+    )[
+        0
+    ][0]
+    assert result == 1.5
+
+
+def test_convert_bool():
+    cursor = connect().cursor()
+    result = execute_and_fetch_all(
+        cursor,
+        'RETURN convert.str2object("true");',
+    )[
+        0
+    ][0]
+    assert result == True
+
+
+def test_convert_string():
+    cursor = connect().cursor()
+    result = execute_and_fetch_all(
+        cursor,
+        'RETURN convert.str2object("\\"Cool string\\"");',
+    )[
+        0
+    ][0]
+    assert result == "Cool string"
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-rA"]))


### PR DESCRIPTION
`convert.str2object` implementation in C++ is fixed to also work with primitive values

