### PR TITLE
Reduce frequency of AsyncTimer GC

### DIFF
--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -36,6 +36,7 @@
 #include "storage/v2/inmemory/edge_type_property_index.hpp"
 #include "storage/v2/metadata_delta.hpp"
 #include "storage/v2/schema_info_glue.hpp"
+#include "utils/async_timer.hpp"
 
 /// REPLICATION ///
 #include "dbms/inmemory/replication_handlers.hpp"
@@ -248,6 +249,10 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
       vertices_.run_gc();
       edges_.run_gc();
       edges_metadata_.run_gc();
+
+      // AsyncTimer resources are global, not particularly storage related, more query releated
+      // At some point in the future this should be scheduled by something else
+      utils::AsyncTimer::GCRun();
     };
   }
 

--- a/src/utils/async_timer.cpp
+++ b/src/utils/async_timer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -52,10 +52,9 @@ uint64_t AddFlag(std::weak_ptr<std::atomic<bool>> flag) {
   return id;
 }
 
-void EraseFlag(uint64_t flag_id) {
-  expiration_flags.access().remove(flag_id);
-  expiration_flags.run_gc();
-}
+void EraseFlag(uint64_t flag_id) { expiration_flags.access().remove(flag_id); }
+
+void ExpirationFlagsGC() { expiration_flags.run_gc(); }
 
 std::weak_ptr<std::atomic<bool>> GetFlag(uint64_t flag_id) {
   const auto flag_accessor = expiration_flags.access();
@@ -191,10 +190,12 @@ bool AsyncTimer::IsExpired() const noexcept {
 void AsyncTimer::ReleaseResources() {
   if (expiration_flag_ != nullptr) {
     timer_delete(timer_id_);
-    EraseFlag(flag_id_);
+    EraseFlag(flag_id_);  // not deleted, still held in skip_list gc
     flag_id_ = kInvalidFlagId;
     expiration_flag_.reset();
   }
 }
+
+void AsyncTimer::GCRun() { ExpirationFlagsGC(); }
 
 }  // namespace memgraph::utils

--- a/src/utils/async_timer.hpp
+++ b/src/utils/async_timer.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -34,6 +34,8 @@ class AsyncTimer {
 
   // Returns false if the object isn't associated with any timer.
   bool IsExpired() const noexcept;
+
+  static void GCRun();
 
  private:
   void ReleaseResources();


### PR DESCRIPTION
Recent fix for ensuring memory was being released caused a noticeable cost to throughput for single_vertex_write benchmark. Moving the GC work to be done less frequently (likely to improve batching).