### PR TITLE
Perf improvement for Abort

### DIFF
--- a/src/storage/v2/edge_ref.hpp
+++ b/src/storage/v2/edge_ref.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -29,6 +29,11 @@ struct EdgeRef {
     Gid gid;
     Edge *ptr;
   };
+
+  template <typename H>
+  friend H AbslHashValue(H h, EdgeRef const &edge_ref) {
+    return H::combine(std::move(h), edge_ref.gid);
+  }
 };
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1262,6 +1262,7 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
               return !remove_in_edges.contains(std::get<EdgeRef>(edge_tuple));
             });
             vertex->in_edges.erase(mid, vertex->in_edges.end());
+            vertex->in_edges.shrink_to_fit();
           }
 
           // bulk remove out_edges
@@ -1270,6 +1271,7 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
               return !remove_out_edges.contains(std::get<EdgeRef>(edge_tuple));
             });
             vertex->out_edges.erase(mid, vertex->out_edges.end());
+            vertex->out_edges.shrink_to_fit();
           }
 
           vertex->delta = current;

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -246,9 +246,9 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
       static_cast<InMemoryEdgeTypePropertyIndex *>(indices_.edge_type_property_index_.get())->RunGC();
 
       // SkipList is already threadsafe
+      edges_metadata_.run_gc();
       vertices_.run_gc();
       edges_.run_gc();
-      edges_metadata_.run_gc();
 
       // AsyncTimer resources are global, not particularly storage related, more query releated
       // At some point in the future this should be scheduled by something else
@@ -988,8 +988,8 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
     // We collect vertices and edges we've created here and then splice them into
     // `deleted_vertices_` and `deleted_edges_` lists, instead of adding them one
     // by one and acquiring lock every time.
-    std::list<Gid> my_deleted_vertices;
-    std::list<Gid> my_deleted_edges;
+    std::vector<Gid> my_deleted_vertices;
+    std::vector<Gid> my_deleted_edges;
 
     std::map<LabelId, std::vector<Vertex *>> label_cleanup;
     std::map<LabelId, std::vector<std::pair<PropertyValue, Vertex *>>> label_property_cleanup;
@@ -1087,6 +1087,10 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
           auto *vertex = prev.vertex;
           auto guard = std::unique_lock{vertex->lock};
           Delta *current = vertex->delta;
+
+          auto remove_in_edges = absl::flat_hash_set<EdgeRef>{};
+          auto remove_out_edges = absl::flat_hash_set<EdgeRef>{};
+
           while (current != nullptr &&
                  current->timestamp->load(std::memory_order_acquire) == transaction_.transaction_id) {
             switch (current->action) {
@@ -1191,18 +1195,19 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
                 break;
               }
               case Delta::Action::ADD_IN_EDGE: {
-                std::tuple<EdgeTypeId, Vertex *, EdgeRef> link{current->vertex_edge.edge_type,
-                                                               current->vertex_edge.vertex, current->vertex_edge.edge};
-                auto it = std::find(vertex->in_edges.begin(), vertex->in_edges.end(), link);
-                MG_ASSERT(it == vertex->in_edges.end(), "Invalid database state!");
+                auto link =
+                    std::tuple{current->vertex_edge.edge_type, current->vertex_edge.vertex, current->vertex_edge.edge};
+                DMG_ASSERT(std::find(vertex->in_edges.begin(), vertex->in_edges.end(), link) == vertex->in_edges.end(),
+                           "Invalid database state!");
                 vertex->in_edges.push_back(link);
                 break;
               }
               case Delta::Action::ADD_OUT_EDGE: {
-                std::tuple<EdgeTypeId, Vertex *, EdgeRef> link{current->vertex_edge.edge_type,
-                                                               current->vertex_edge.vertex, current->vertex_edge.edge};
-                auto it = std::find(vertex->out_edges.begin(), vertex->out_edges.end(), link);
-                MG_ASSERT(it == vertex->out_edges.end(), "Invalid database state!");
+                auto link =
+                    std::tuple{current->vertex_edge.edge_type, current->vertex_edge.vertex, current->vertex_edge.edge};
+                DMG_ASSERT(
+                    std::find(vertex->out_edges.begin(), vertex->out_edges.end(), link) == vertex->out_edges.end(),
+                    "Invalid database state!");
                 vertex->out_edges.push_back(link);
                 // Increment edge count. We only increment the count here because
                 // the information in `ADD_IN_EDGE` and `Edge/RECREATE_OBJECT` is
@@ -1212,21 +1217,14 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
                 break;
               }
               case Delta::Action::REMOVE_IN_EDGE: {
-                std::tuple<EdgeTypeId, Vertex *, EdgeRef> link{current->vertex_edge.edge_type,
-                                                               current->vertex_edge.vertex, current->vertex_edge.edge};
-                auto it = std::find(vertex->in_edges.begin(), vertex->in_edges.end(), link);
-                MG_ASSERT(it != vertex->in_edges.end(), "Invalid database state!");
-                std::swap(*it, *vertex->in_edges.rbegin());
-                vertex->in_edges.pop_back();
+                // EdgeRef is unique
+                remove_in_edges.insert(current->vertex_edge.edge);
                 break;
               }
               case Delta::Action::REMOVE_OUT_EDGE: {
-                std::tuple<EdgeTypeId, Vertex *, EdgeRef> link{current->vertex_edge.edge_type,
-                                                               current->vertex_edge.vertex, current->vertex_edge.edge};
-                auto it = std::find(vertex->out_edges.begin(), vertex->out_edges.end(), link);
-                MG_ASSERT(it != vertex->out_edges.end(), "Invalid database state!");
-                std::swap(*it, *vertex->out_edges.rbegin());
-                vertex->out_edges.pop_back();
+                // EdgeRef is unique
+                remove_out_edges.insert(current->vertex_edge.edge);
+
                 // Decrement edge count. We only decrement the count here because
                 // the information in `REMOVE_IN_EDGE` and `Edge/DELETE_OBJECT` is
                 // redundant. Also, `Edge/DELETE_OBJECT` isn't available when edge
@@ -1257,6 +1255,23 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
             }
             current = current->next.load(std::memory_order_acquire);
           }
+
+          // bulk remove in_edges
+          if (!remove_in_edges.empty()) {
+            auto mid = std::partition(vertex->in_edges.begin(), vertex->in_edges.end(), [&](auto const &edge_tuple) {
+              return !remove_in_edges.contains(std::get<EdgeRef>(edge_tuple));
+            });
+            vertex->in_edges.erase(mid, vertex->in_edges.end());
+          }
+
+          // bulk remove out_edges
+          if (!remove_out_edges.empty()) {
+            auto mid = std::partition(vertex->out_edges.begin(), vertex->out_edges.end(), [&](auto const &edge_tuple) {
+              return !remove_out_edges.contains(std::get<EdgeRef>(edge_tuple));
+            });
+            vertex->out_edges.erase(mid, vertex->out_edges.end());
+          }
+
           vertex->delta = current;
           if (current != nullptr) {
             current->prev.Set(vertex);
@@ -1338,27 +1353,27 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
       }
     }
 
-    // VERTICES
+    // EDGES METADATA (has ptr to Vertices, must be before removing verticies)
+    if (!my_deleted_edges.empty() && mem_storage->config_.salient.items.enable_edges_metadata) {
+      auto edges_metadata_acc = mem_storage->edges_metadata_.access();
+      for (auto gid : my_deleted_edges) {
+        edges_metadata_acc.remove(gid);
+      }
+    }
+
+    // VERTICES (has ptr to Edges, must be before removing edges)
     if (!my_deleted_vertices.empty()) {
-      auto vertices_acc = mem_storage->vertices_.access();
+      auto acc = mem_storage->vertices_.access();
       for (auto gid : my_deleted_vertices) {
-        vertices_acc.remove(gid);
+        acc.remove(gid);
       }
     }
 
     // EDGES
     if (!my_deleted_edges.empty()) {
       auto edges_acc = mem_storage->edges_.access();
-      if (mem_storage->config_.salient.items.enable_edges_metadata) {
-        auto edges_metadata_acc = mem_storage->edges_metadata_.access();
-        for (auto gid : my_deleted_edges) {
-          edges_acc.remove(gid);
-          edges_metadata_acc.remove(gid);
-        }
-      } else {
-        for (auto gid : my_deleted_edges) {
-          edges_acc.remove(gid);
-        }
+      for (auto gid : my_deleted_edges) {
+        edges_acc.remove(gid);
       }
     }
   }
@@ -2050,24 +2065,27 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
     }
   }
 
+  // EDGES METADATA (has ptr to Vertices, must be before removing verticies)
+  if (!current_deleted_edges.empty() && config_.salient.items.enable_edges_metadata) {
+    auto edge_metadata_acc = edges_metadata_.access();
+    for (auto edge : current_deleted_edges) {
+      MG_ASSERT(edge_metadata_acc.remove(edge), "Invalid database state!");
+    }
+  }
+
+  // VERTICES (has ptr to Edges, must be before removing edges)
   if (!current_deleted_vertices.empty()) {
     auto vertex_acc = vertices_.access();
     for (auto vertex : current_deleted_vertices) {
       MG_ASSERT(vertex_acc.remove(vertex), "Invalid database state!");
     }
   }
+
+  // EDGES
   if (!current_deleted_edges.empty()) {
     auto edge_acc = edges_.access();
-    if (config_.salient.items.enable_edges_metadata) {
-      auto edge_metadata_acc = edges_metadata_.access();
-      for (auto edge : current_deleted_edges) {
-        MG_ASSERT(edge_acc.remove(edge), "Invalid database state!");
-        MG_ASSERT(edge_metadata_acc.remove(edge), "Invalid database state!");
-      }
-    } else {
-      for (auto edge : current_deleted_edges) {
-        MG_ASSERT(edge_acc.remove(edge), "Invalid database state!");
-      }
+    for (auto edge : current_deleted_edges) {
+      MG_ASSERT(edge_acc.remove(edge), "Invalid database state!");
     }
   }
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(mg-utils
     logging.cpp
     string.cpp
     scheduler.cpp
+    skip_list.cpp
 
     PUBLIC
     FILE_SET HEADERS

--- a/src/utils/skip_list.cpp
+++ b/src/utils/skip_list.cpp
@@ -1,0 +1,17 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "utils/skip_list.hpp"
+
+auto memgraph::utils::detail::thread_local_mt19937() -> std::mt19937 & {
+  thread_local std::mt19937 gen{std::random_device{}()};
+  return gen;
+}

--- a/tests/unit/small_vector.cpp
+++ b/tests/unit/small_vector.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -485,6 +485,33 @@ TYPED_TEST(SmallVectorCommon, GrowShrink) {
   }
   vec.pop_back();
   EXPECT_TRUE(vec.empty());
+
+  vec.shrink_to_fit();
+  EXPECT_EQ(vec.capacity(), small_vector<TypeParam>::kSmallCapacity);
+}
+
+TYPED_TEST(SmallVectorCommon, ShrinkToFit) {
+  auto vec = small_vector<TypeParam>{};
+  for (auto i : rv::iota(0, 30)) {
+    vec.push_back(this->make_value(i));
+  }
+  vec.erase(vec.begin() + 10, vec.end());
+  vec.shrink_to_fit();
+  EXPECT_EQ(vec.size(), 10);
+  EXPECT_EQ(vec.capacity(), 10);
+  EXPECT_FALSE(vec.usingSmallBuffer());
+  for (auto j : rv::iota(0, 10)) {
+    EXPECT_EQ(vec[j], j);
+  }
+
+  vec.erase(vec.begin() + small_vector<TypeParam>::kSmallCapacity, vec.end());
+  vec.shrink_to_fit();
+  EXPECT_EQ(vec.capacity(), small_vector<TypeParam>::kSmallCapacity);
+  if constexpr (std::same_as<TypeParam, LargeType>) {
+    EXPECT_FALSE(vec.usingSmallBuffer());
+  } else {
+    EXPECT_TRUE(vec.usingSmallBuffer());
+  }
 }
 
 template <typename It, typename ConstIt>


### PR DESCRIPTION
- Remove the linear seach validation when in release build
- Bulk edge removal O(nm) -> O(n+m)
- Disable skiplist GC during bulk removal
- Probabilistically run skiplist GC on accessor dtr
- Use vector rather than list
