### PR TITLE
Fix edge type index cleanup on Abort

### DIFF
--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -122,10 +122,10 @@ std::vector<EdgeTypeId> InMemoryEdgeTypeIndex::ListIndices() const {
 void InMemoryEdgeTypeIndex::RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token) {
   auto maybe_stop = utils::ResettableCounter<2048>();
 
-  for (auto &label_storage : index_) {
+  for (auto &[_, et_index] : index_) {
     if (token.stop_requested()) return;
 
-    auto edges_acc = label_storage.second.access();
+    auto edges_acc = et_index.access();
     for (auto it = edges_acc.begin(); it != edges_acc.end();) {
       if (maybe_stop() && token.stop_requested()) return;
 

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -31,16 +31,17 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
     Vertex *from_vertex;
     Vertex *to_vertex;
 
-    Edge *edge;
+    Edge *edge;  // TODO: Generalise to EdgeRef?
 
     uint64_t timestamp;
 
-    bool operator<(const Entry &rhs) const {
-      return std::tie(edge->gid, from_vertex->gid, to_vertex->gid, timestamp) <
-             std::tie(rhs.edge->gid, rhs.from_vertex->gid, rhs.to_vertex->gid, rhs.timestamp);
+    friend bool operator<(Entry const &lhs, Entry const &rhs) {
+      return std::tie(lhs.edge, lhs.from_vertex, lhs.to_vertex, lhs.timestamp) <
+             std::tie(rhs.edge, rhs.from_vertex, rhs.to_vertex, rhs.timestamp);
     }
-    bool operator==(const Entry &rhs) const {
-      return std::tie(edge, from_vertex, to_vertex, timestamp) ==
+
+    friend bool operator==(Entry const &lhs, Entry const &rhs) {
+      return std::tie(lhs.edge, lhs.from_vertex, lhs.to_vertex, lhs.timestamp) ==
              std::tie(rhs.edge, rhs.from_vertex, rhs.to_vertex, rhs.timestamp);
     }
   };

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -76,16 +76,6 @@ ReturnType VertexDeletedConnectedEdges(Vertex *vertex, Edge *edge, const Transac
 
 namespace memgraph::storage {
 
-bool InMemoryEdgeTypePropertyIndex::Entry::operator<(const Entry &rhs) const {
-  return std::tie(value, edge->gid, from_vertex->gid, to_vertex->gid, timestamp) <
-         std::tie(rhs.value, rhs.edge->gid, rhs.from_vertex->gid, rhs.to_vertex->gid, rhs.timestamp);
-}
-
-bool InMemoryEdgeTypePropertyIndex::Entry::operator==(const Entry &rhs) const {
-  return std::tie(value, edge, from_vertex, to_vertex, timestamp) ==
-         std::tie(rhs.value, rhs.edge, rhs.from_vertex, rhs.to_vertex, rhs.timestamp);
-}
-
 bool InMemoryEdgeTypePropertyIndex::Entry::operator<(const PropertyValue &rhs) const { return value < rhs; }
 
 bool InMemoryEdgeTypePropertyIndex::Entry::operator==(const PropertyValue &rhs) const { return value == rhs; }

--- a/src/storage/v2/inmemory/edge_type_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.hpp
@@ -37,8 +37,16 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
 
     uint64_t timestamp;
 
-    bool operator<(const Entry &rhs) const;
-    bool operator==(const Entry &rhs) const;
+    friend bool operator<(Entry const &lhs, Entry const &rhs) {
+      return std::tie(lhs.value, lhs.edge, lhs.from_vertex, lhs.to_vertex, lhs.timestamp) <
+             std::tie(rhs.value, rhs.edge, rhs.from_vertex, rhs.to_vertex, rhs.timestamp);
+    };
+
+    friend bool operator==(Entry const &lhs, Entry const &rhs) {
+      return std::tie(lhs.value, lhs.edge, lhs.from_vertex, lhs.to_vertex, lhs.timestamp) ==
+             std::tie(rhs.value, rhs.edge, rhs.from_vertex, rhs.to_vertex, rhs.timestamp);
+    }
+
     bool operator<(const PropertyValue &rhs) const;
     bool operator==(const PropertyValue &rhs) const;
   };

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -997,14 +997,89 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
     std::map<EdgeTypeId, std::vector<std::tuple<Vertex *const, Vertex *const, Edge *const>>> edge_type_cleanup;
     std::map<std::pair<EdgeTypeId, PropertyId>,
              std::vector<std::tuple<Vertex *const, Vertex *const, Edge *const, PropertyValue>>>
-        edge_type_property_cleanup;
-    std::map<std::pair<EdgeTypeId, PropertyId>,
-             std::vector<std::tuple<Vertex *const, Vertex *const, Edge *const, PropertyValue>>>
         edge_property_cleanup;
 
     std::map<LabelPropKey, std::vector<Vertex *>> vector_label_property_cleanup;
     std::map<LabelPropKey, std::vector<std::pair<PropertyValue, Vertex *>>> vector_label_property_restore;
 
+    // TWO passes needed here
+    // Abort will modify objects to restore state to how they were before this txn
+    // The passes will find the head delta for each object and process the whole object,
+    // To track which edge type indexes need cleaning up, we need the edge type which is held in vertices in/out edges
+    // Hence need to first once to modify edges, so it can read vectices information intact.
+
+    // Edges pass
+    for (const auto &delta : transaction_.deltas) {
+      auto prev = delta.prev.Get();
+      switch (prev.type) {
+        case PreviousPtr::Type::EDGE: {
+          auto *edge = prev.edge;
+          auto guard = std::lock_guard{edge->lock};
+          Delta *current = edge->delta;
+          while (current != nullptr &&
+                 current->timestamp->load(std::memory_order_acquire) == transaction_.transaction_id) {
+            switch (current->action) {
+              case Delta::Action::SET_PROPERTY: {
+                DMG_ASSERT(mem_storage->config_.salient.items.properties_on_edges, "Invalid database state!");
+
+                const auto &edge_types = index_stats.property_edge_type.p2et.find(current->property.key);
+                if (edge_types != index_stats.property_edge_type.p2et.end()) {
+                  auto old_value = edge->properties.GetProperty(current->property.key);
+                  if (!old_value.IsNull()) {
+                    for (const auto &edge_type : edge_types->second) {
+                      auto *from_vertex = current->property.out_vertex;
+                      for (const auto &[edge_type_out_edge, target_vertex, _] : from_vertex->out_edges) {
+                        if (edge_type_out_edge == edge_type) {
+                          edge_property_cleanup[{edge_type, current->property.key}].emplace_back(
+                              from_vertex, target_vertex, edge, old_value);
+                        }
+                      }
+                    }
+                  }
+                }
+
+                edge->properties.SetProperty(current->property.key, *current->property.value);
+
+                break;
+              }
+              case Delta::Action::DELETE_DESERIALIZED_OBJECT:
+              case Delta::Action::DELETE_OBJECT: {
+                edge->deleted = true;
+                my_deleted_edges.push_back(edge->gid);
+                break;
+              }
+              case Delta::Action::RECREATE_OBJECT: {
+                edge->deleted = false;
+                break;
+              }
+              case Delta::Action::REMOVE_LABEL:
+              case Delta::Action::ADD_LABEL:
+              case Delta::Action::ADD_IN_EDGE:
+              case Delta::Action::ADD_OUT_EDGE:
+              case Delta::Action::REMOVE_IN_EDGE:
+              case Delta::Action::REMOVE_OUT_EDGE: {
+                LOG_FATAL("Invalid database state!");
+                break;
+              }
+            }
+            current = current->next.load(std::memory_order_acquire);
+          }
+          edge->delta = current;
+          if (current != nullptr) {
+            current->prev.Set(edge);
+          }
+
+          break;
+        }
+        case PreviousPtr::Type::VERTEX:
+        case PreviousPtr::Type::DELTA:
+        // pointer probably couldn't be set because allocation failed
+        case PreviousPtr::Type::NULLPTR:
+          break;
+      }
+    }
+
+    // Vertices pass
     for (const auto &delta : transaction_.deltas) {
       auto prev = delta.prev.Get();
       switch (prev.type) {
@@ -1158,22 +1233,15 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
                 // properties are disabled.
                 storage_->edge_count_.fetch_add(-1, std::memory_order_acq_rel);
 
-                if (!FLAGS_storage_properties_on_edges) break;
+                // TODO: Change edge type index to work with EdgeRef rather than Edge *
+                if (!mem_storage->config_.salient.items.properties_on_edges) break;
+
                 if (std::binary_search(index_stats.edge_type.begin(), index_stats.edge_type.end(),
                                        current->vertex_edge.edge_type)) {
                   edge_type_cleanup[current->vertex_edge.edge_type].emplace_back(vertex, current->vertex_edge.vertex,
                                                                                  current->vertex_edge.edge.ptr);
                 }
-                const auto &properties = index_stats.property_edge_type.et2p.find(current->vertex_edge.edge_type);
-                if (properties != index_stats.property_edge_type.et2p.end()) {
-                  for (const auto &property : properties->second) {
-                    auto current_value = current->vertex_edge.edge.ptr->properties.GetProperty(property);
-                    if (!current_value.IsNull()) {
-                      edge_type_property_cleanup[std::make_pair(current->vertex_edge.edge_type, property)].emplace_back(
-                          vertex, current->vertex_edge.vertex, current->vertex_edge.edge.ptr, std::move(current_value));
-                    }
-                  }
-                }
+
                 break;
               }
               case Delta::Action::DELETE_DESERIALIZED_OBJECT:
@@ -1196,64 +1264,7 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
 
           break;
         }
-        case PreviousPtr::Type::EDGE: {
-          auto *edge = prev.edge;
-          auto guard = std::lock_guard{edge->lock};
-          Delta *current = edge->delta;
-          while (current != nullptr &&
-                 current->timestamp->load(std::memory_order_acquire) == transaction_.transaction_id) {
-            switch (current->action) {
-              case Delta::Action::SET_PROPERTY: {
-                edge->properties.SetProperty(current->property.key, *current->property.value);
-                if (!FLAGS_storage_properties_on_edges) break;
-
-                const auto &edge_types = index_stats.property_edge_type.p2et.find(current->property.key);
-                if (edge_types != index_stats.property_edge_type.p2et.end()) {
-                  auto current_value = edge->properties.GetProperty(current->property.key);
-                  if (!current_value.IsNull()) {
-                    for (const auto &edge_type : edge_types->second) {
-                      auto *from_vertex = current->property.out_vertex;
-                      for (const auto &[edge_type_out_edge, target_vertex, _] : from_vertex->out_edges) {
-                        if (edge_type_out_edge == edge_type) {
-                          edge_property_cleanup[{edge_type, current->property.key}].emplace_back(
-                              from_vertex, target_vertex, edge, current_value);
-                        }
-                      }
-                    }
-                  }
-                }
-
-                break;
-              }
-              case Delta::Action::DELETE_DESERIALIZED_OBJECT:
-              case Delta::Action::DELETE_OBJECT: {
-                edge->deleted = true;
-                my_deleted_edges.push_back(edge->gid);
-                break;
-              }
-              case Delta::Action::RECREATE_OBJECT: {
-                edge->deleted = false;
-                break;
-              }
-              case Delta::Action::REMOVE_LABEL:
-              case Delta::Action::ADD_LABEL:
-              case Delta::Action::ADD_IN_EDGE:
-              case Delta::Action::ADD_OUT_EDGE:
-              case Delta::Action::REMOVE_IN_EDGE:
-              case Delta::Action::REMOVE_OUT_EDGE: {
-                LOG_FATAL("Invalid database state!");
-                break;
-              }
-            }
-            current = current->next.load(std::memory_order_acquire);
-          }
-          edge->delta = current;
-          if (current != nullptr) {
-            current->prev.Set(edge);
-          }
-
-          break;
-        }
+        case PreviousPtr::Type::EDGE:
         case PreviousPtr::Type::DELTA:
         // pointer probably couldn't be set because allocation failed
         case PreviousPtr::Type::NULLPTR:
@@ -1314,9 +1325,6 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
     }
     for (auto const &[edge_type, edge] : edge_type_cleanup) {
       storage_->indices_.AbortEntries(edge_type, edge, transaction_.start_timestamp);
-    }
-    for (auto const &[edge_type_property, edge] : edge_type_property_cleanup) {
-      storage_->indices_.AbortEntries(edge_type_property, edge, transaction_.start_timestamp);
     }
     for (auto const &[edge_type_property, edge] : edge_property_cleanup) {
       storage_->indices_.AbortEntries(edge_type_property, edge, transaction_.start_timestamp);
@@ -1427,6 +1435,12 @@ utils::BasicResult<StorageIndexDefinitionError, void> InMemoryStorage::InMemoryA
   auto *in_memory = static_cast<InMemoryStorage *>(storage_);
   auto *mem_edge_type_property_index =
       static_cast<InMemoryEdgeTypePropertyIndex *>(in_memory->indices_.edge_type_property_index_.get());
+
+  if (!in_memory->config_.salient.items.properties_on_edges) {
+    // Not possible to create the index, no properties on edges
+    return StorageIndexDefinitionError{IndexDefinitionConfigError{}};
+  }
+
   if (!mem_edge_type_property_index->CreateIndex(edge_type, property, in_memory->vertices_.access())) {
     return StorageIndexDefinitionError{IndexDefinitionError{}};
   }
@@ -2017,12 +2031,7 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
     if (aggressive or mark_timestamp == oldest_active_start_timestamp) {
       guard.unlock();
       // if lucky, there are no active transactions, hence nothing looking at the deltas
-      // remove them now
-      auto const released_delta_count =
-          std::accumulate(unlinked_undo_buffers.cbegin(), unlinked_undo_buffers.cend(), uint64_t{0},
-                          [](uint64_t curr, GCDeltas const &gc_deltas) { return curr + gc_deltas.deltas_.size(); });
-
-      // Now total_deltas contains the sum of all deltas in the unlinked_undo_buffers list
+      // remove them all now
       unlinked_undo_buffers.clear();
     } else {
       // Take garbage_undo_buffers lock while holding the engine lock to make

--- a/src/storage/v2/storage_error.hpp
+++ b/src/storage/v2/storage_error.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -23,6 +23,7 @@ struct PersistenceError {};  // TODO: Generalize and add to InMemory durability 
                              // asserts and terminated if failed)
 
 struct IndexDefinitionError {};
+struct IndexDefinitionConfigError {};
 
 struct ConstraintsPersistenceError {};
 
@@ -32,7 +33,7 @@ inline bool operator==(const SerializationError & /*err1*/, const SerializationE
 using StorageManipulationError =
     std::variant<ConstraintViolation, ReplicationError, SerializationError, PersistenceError>;
 
-using StorageIndexDefinitionError = IndexDefinitionError;
+using StorageIndexDefinitionError = std::variant<IndexDefinitionError, IndexDefinitionConfigError>;
 
 struct ConstraintDefinitionError {};
 

--- a/tests/e2e/edge_indices/edge_indices.py
+++ b/tests/e2e/edge_indices/edge_indices.py
@@ -42,12 +42,12 @@ def test_scan_all_by_edge_type_index_plan(memgraph):
         " * ScanAllByEdgeType (n)-[r:TYPE]->(m)",
         " * Once",
     ]
-    expected_results = [1, 2, 3, 4, 5, 6, 7]
+    expected_results = {1, 2, 3, 4, 5, 6, 7}
     actual_explain = get_explain(memgraph, query)
 
     assert expected_explain == actual_explain
 
-    actual_results = [x["prop"] for x in memgraph.execute_and_fetch(query)]
+    actual_results = {x["prop"] for x in memgraph.execute_and_fetch(query)}
     assert expected_results == actual_results
 
 
@@ -61,12 +61,12 @@ def test_scan_all_by_edge_type_property_index_plan(memgraph):
         " * ScanAllByEdgeTypeProperty (n)-[r:TYPE {prop}]->(m)",
         " * Once",
     ]
-    expected_results = [1, 2, 3, 4, 5, 6, 7]
+    expected_results = {1, 2, 3, 4, 5, 6, 7}
     actual_explain = get_explain(memgraph, query)
 
     assert expected_explain == actual_explain
 
-    actual_results = [x["prop"] for x in memgraph.execute_and_fetch(query)]
+    actual_results = {x["prop"] for x in memgraph.execute_and_fetch(query)}
     assert expected_results == actual_results
 
 
@@ -80,12 +80,12 @@ def test_scan_all_by_edge_type_property_value_index_plan(memgraph):
         " * ScanAllByEdgeTypePropertyValue (n)-[r:TYPE {prop}]->(m)",
         " * Once",
     ]
-    expected_results = [2]
+    expected_results = {2}
     actual_explain = get_explain(memgraph, query)
 
     assert expected_explain == actual_explain
 
-    actual_results = [x["prop"] for x in memgraph.execute_and_fetch(query)]
+    actual_results = {x["prop"] for x in memgraph.execute_and_fetch(query)}
     assert expected_results == actual_results
 
 
@@ -99,12 +99,12 @@ def test_scan_all_by_edge_type_property_range_index_plan(memgraph):
         " * ScanAllByEdgeTypePropertyRange (n)-[r:TYPE {prop}]->(m)",
         " * Once",
     ]
-    expected_results = [2]
+    expected_results = {2}
     actual_explain = get_explain(memgraph, query)
 
     assert expected_explain == actual_explain
 
-    actual_results = [x["prop"] for x in memgraph.execute_and_fetch(query)]
+    actual_results = {x["prop"] for x in memgraph.execute_and_fetch(query)}
     assert expected_results == actual_results
 
 
@@ -123,12 +123,12 @@ def test_scan_all_by_edge_type_property_range_cartesian_index_plan(memgraph):
         " * ScanAllByEdgeTypePropertyValue (n)-[r:TYPE {prop}]->(m)",
         " * Once",
     ]
-    expected_results = [(1, 2)]
+    expected_results = {(1, 2)}
     actual_explain = get_explain(memgraph, query)
 
     assert expected_explain == actual_explain
 
-    actual_results = [(x["prop1"], x["prop2"]) for x in memgraph.execute_and_fetch(query)]
+    actual_results = {(x["prop1"], x["prop2"]) for x in memgraph.execute_and_fetch(query)}
     assert expected_results == actual_results
 
 

--- a/tests/unit/storage_v2_indices.cpp
+++ b/tests/unit/storage_v2_indices.cpp
@@ -1371,6 +1371,7 @@ TYPED_TEST(IndexTest, EdgeTypeIndexCreate) {
       auto acc = this->storage->Access();
       EXPECT_FALSE(acc->EdgeTypeIndexExists(this->edge_type_id1));
       EXPECT_EQ(acc->ListAllIndices().edge_type.size(), 0);
+      EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_type_id1), 0);
     }
 
     {
@@ -1381,12 +1382,14 @@ TYPED_TEST(IndexTest, EdgeTypeIndexCreate) {
         this->CreateEdge(&vertex_from, &vertex_to, i % 2 ? this->edge_type_id1 : this->edge_type_id2, acc.get());
       }
       ASSERT_NO_ERROR(acc->Commit());
+      EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_type_id1), 0);
     }
 
     {
       auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
+      EXPECT_EQ(unique_acc->ApproximateEdgeCount(this->edge_type_id1), 5);
     }
 
     {
@@ -1417,7 +1420,9 @@ TYPED_TEST(IndexTest, EdgeTypeIndexCreate) {
       EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, View::NEW), View::NEW),
                   UnorderedElementsAre(1, 3, 5, 7, 9, 11, 13, 15, 17, 19));
 
+      EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_type_id1), 10);
       acc->Abort();
+      EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_type_id1), 5);
     }
 
     {
@@ -1441,6 +1446,7 @@ TYPED_TEST(IndexTest, EdgeTypeIndexCreate) {
                   UnorderedElementsAre(1, 3, 5, 7, 9, 21, 23, 25, 27, 29));
 
       ASSERT_NO_ERROR(acc->Commit());
+      EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_type_id1), 10);
     }
 
     {
@@ -1546,28 +1552,20 @@ TYPED_TEST(IndexTest, EdgeTypeIndexDrop) {
                   UnorderedElementsAre(1, 3, 5, 7, 9));
       EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, View::NEW), View::NEW),
                   UnorderedElementsAre(1, 3, 5, 7, 9));
+      EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_type_id1), 5);
     }
 
     {
       auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->DropIndex(this->edge_type_id1).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
+      EXPECT_EQ(unique_acc->ApproximateEdgeCount(this->edge_type_id1), 0);
     }
     {
       auto acc = this->storage->Access();
       EXPECT_FALSE(acc->EdgeTypeIndexExists(this->edge_type_id1));
-      EXPECT_EQ(acc->ListAllIndices().label.size(), 0);
-    }
-
-    {
-      auto unique_acc = this->storage->UniqueAccess();
-      EXPECT_TRUE(unique_acc->DropIndex(this->edge_type_id1).HasError());
-      ASSERT_NO_ERROR(unique_acc->Commit());
-    }
-    {
-      auto acc = this->storage->Access();
-      EXPECT_FALSE(acc->EdgeTypeIndexExists(this->edge_type_id1));
-      EXPECT_EQ(acc->ListAllIndices().label.size(), 0);
+      EXPECT_EQ(acc->ListAllIndices().edge_type.size(), 0);
+      EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_type_id1), 0);
     }
 
     {
@@ -1791,6 +1789,7 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexCreate) {
     auto acc = this->storage->Access();
     EXPECT_FALSE(acc->EdgeTypePropertyIndexExists(this->edge_type_id1, this->edge_prop_id1));
     EXPECT_EQ(acc->ListAllIndices().edge_type_property.size(), 0);
+    EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_type_id1, this->edge_prop_id1), 0);
   }
 
   {
@@ -1803,12 +1802,14 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexCreate) {
       edge_acc.SetProperty(this->edge_prop_id1, memgraph::storage::PropertyValue(i));
     }
     ASSERT_NO_ERROR(acc->Commit());
+    EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_type_id1, this->edge_prop_id1), 0);
   }
 
   {
     auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
+    EXPECT_EQ(unique_acc->ApproximateEdgeCount(this->edge_type_id1, this->edge_prop_id1), 5);
   }
 
   {
@@ -1841,7 +1842,9 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexCreate) {
     EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, this->edge_prop_id1, View::NEW), View::NEW),
                 UnorderedElementsAre(1, 3, 5, 7, 9, 11, 13, 15, 17, 19));
 
+    EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_type_id1, this->edge_prop_id1), 10);
     acc->Abort();
+    EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_type_id1, this->edge_prop_id1), 5);
   }
 
   {
@@ -1867,6 +1870,7 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexCreate) {
                 UnorderedElementsAre(1, 3, 5, 7, 9, 21, 23, 25, 27, 29));
 
     ASSERT_NO_ERROR(acc->Commit());
+    EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_type_id1, this->edge_prop_id1), 10);
   }
 
   {

--- a/tests/unit/storage_v2_indices.cpp
+++ b/tests/unit/storage_v2_indices.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -15,6 +15,7 @@
 #include <gtest/internal/gtest-type-util.h>
 
 #include "disk_test_utils.hpp"
+#include "flags/general.hpp"
 #include "storage/v2/disk/label_index.hpp"
 #include "storage/v2/disk/label_property_index.hpp"
 #include "storage/v2/disk/storage.hpp"
@@ -36,6 +37,8 @@ template <typename StorageType>
 class IndexTest : public testing::Test {
  protected:
   void SetUp() override {
+    FLAGS_storage_properties_on_edges = true;
+    config_.salient.items.properties_on_edges = true;
     config_ = disk_test_utils::GenerateOnDiskConfig(testSuite);
     this->storage = std::make_unique<StorageType>(config_);
     auto acc = this->storage->Access();


### PR DESCRIPTION
Abort does cleanup of objects and indexes. To work out what entries to remove from the index the current value of the entry needs to be figured out from the object as it is and the delta. The edge type information is held on the Vertex, not the Edge, hence need to process all edges first, otherwise we loose the information held on vertex which is needed to know which index entries need cleaning up.
