### PR TITLE
Feat/add exponentiation operator

### DIFF
--- a/src/query/frontend/ast/ast.cpp
+++ b/src/query/frontend/ast/ast.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -56,6 +56,9 @@ constexpr utils::TypeInfo query::DivisionOperator::kType{utils::TypeId::AST_DIVI
 
 constexpr utils::TypeInfo query::ModOperator::kType{utils::TypeId::AST_MOD_OPERATOR, "ModOperator",
                                                     &query::BinaryOperator::kType};
+
+constexpr utils::TypeInfo query::ExponentiationOperator::kType{utils::TypeId::AST_EXPONENTIATION_OPERATOR,
+                                                               "ExponentiationOperator", &query::BinaryOperator::kType};
 
 constexpr utils::TypeInfo query::NotEqualOperator::kType{utils::TypeId::AST_NOT_EQUAL_OPERATOR, "NotEqualOperator",
                                                          &query::BinaryOperator::kType};

--- a/src/query/frontend/ast/ast.hpp
+++ b/src/query/frontend/ast/ast.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -465,6 +465,35 @@ class ModOperator : public memgraph::query::BinaryOperator {
 
   ModOperator *Clone(AstStorage *storage) const override {
     ModOperator *object = storage->Create<ModOperator>();
+    object->expression1_ = expression1_ ? expression1_->Clone(storage) : nullptr;
+    object->expression2_ = expression2_ ? expression2_->Clone(storage) : nullptr;
+    return object;
+  }
+
+ protected:
+  using BinaryOperator::BinaryOperator;
+
+ private:
+  friend class AstStorage;
+};
+
+class ExponentiationOperator : public memgraph::query::BinaryOperator {
+ public:
+  static const utils::TypeInfo kType;
+  const utils::TypeInfo &GetTypeInfo() const override { return kType; }
+
+  DEFVISITABLE(ExpressionVisitor<TypedValue>);
+  DEFVISITABLE(ExpressionVisitor<TypedValue *>);
+  DEFVISITABLE(ExpressionVisitor<void>);
+  bool Accept(HierarchicalTreeVisitor &visitor) override {
+    if (visitor.PreVisit(*this)) {
+      expression1_->Accept(visitor) && expression2_->Accept(visitor);
+    }
+    return visitor.PostVisit(*this);
+  }
+
+  ExponentiationOperator *Clone(AstStorage *storage) const override {
+    ExponentiationOperator *object = storage->Create<ExponentiationOperator>();
     object->expression1_ = expression1_ ? expression1_->Clone(storage) : nullptr;
     object->expression2_ = expression2_ ? expression2_->Clone(storage) : nullptr;
     return object;

--- a/src/query/frontend/ast/ast_visitor.hpp
+++ b/src/query/frontend/ast/ast_visitor.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -56,6 +56,7 @@ class SubtractionOperator;
 class MultiplicationOperator;
 class DivisionOperator;
 class ModOperator;
+class ExponentiationOperator;
 class UnaryPlusOperator;
 class UnaryMinusOperator;
 class IsNullOperator;
@@ -129,13 +130,14 @@ class SessionTraceQuery;
 
 using TreeCompositeVisitor = utils::CompositeVisitor<
     SingleQuery, CypherUnion, NamedExpression, OrOperator, XorOperator, AndOperator, NotOperator, AdditionOperator,
-    SubtractionOperator, MultiplicationOperator, DivisionOperator, ModOperator, NotEqualOperator, EqualOperator,
-    LessOperator, GreaterOperator, LessEqualOperator, GreaterEqualOperator, RangeOperator, InListOperator,
-    SubscriptOperator, ListSlicingOperator, IfOperator, UnaryPlusOperator, UnaryMinusOperator, IsNullOperator,
-    ListLiteral, MapLiteral, MapProjectionLiteral, PropertyLookup, AllPropertiesLookup, LabelsTest, Aggregation,
-    Function, Reduce, Coalesce, Extract, All, Single, Any, None, CallProcedure, Create, Match, Return, With, Pattern,
-    NodeAtom, EdgeAtom, Delete, Where, SetProperty, SetProperties, SetLabels, RemoveProperty, RemoveLabels, Merge,
-    Unwind, RegexMatch, LoadCsv, Foreach, Exists, CallSubquery, CypherQuery, PatternComprehension>;
+    SubtractionOperator, MultiplicationOperator, DivisionOperator, ModOperator, ExponentiationOperator,
+    NotEqualOperator, EqualOperator, LessOperator, GreaterOperator, LessEqualOperator, GreaterEqualOperator,
+    RangeOperator, InListOperator, SubscriptOperator, ListSlicingOperator, IfOperator, UnaryPlusOperator,
+    UnaryMinusOperator, IsNullOperator, ListLiteral, MapLiteral, MapProjectionLiteral, PropertyLookup,
+    AllPropertiesLookup, LabelsTest, Aggregation, Function, Reduce, Coalesce, Extract, All, Single, Any, None,
+    CallProcedure, Create, Match, Return, With, Pattern, NodeAtom, EdgeAtom, Delete, Where, SetProperty, SetProperties,
+    SetLabels, RemoveProperty, RemoveLabels, Merge, Unwind, RegexMatch, LoadCsv, Foreach, Exists, CallSubquery,
+    CypherQuery, PatternComprehension>;
 
 using TreeLeafVisitor = utils::LeafVisitor<Identifier, PrimitiveLiteral, ParameterLookup, EnumValueAccess>;
 
@@ -151,12 +153,12 @@ template <class TResult>
 class ExpressionVisitor
     : public utils::Visitor<
           TResult, NamedExpression, OrOperator, XorOperator, AndOperator, NotOperator, AdditionOperator,
-          SubtractionOperator, MultiplicationOperator, DivisionOperator, ModOperator, NotEqualOperator, EqualOperator,
-          LessOperator, GreaterOperator, LessEqualOperator, GreaterEqualOperator, RangeOperator, InListOperator,
-          SubscriptOperator, ListSlicingOperator, IfOperator, UnaryPlusOperator, UnaryMinusOperator, IsNullOperator,
-          ListLiteral, MapLiteral, MapProjectionLiteral, PropertyLookup, AllPropertiesLookup, LabelsTest, Aggregation,
-          Function, Reduce, Coalesce, Extract, All, Single, Any, None, ParameterLookup, Identifier, PrimitiveLiteral,
-          RegexMatch, Exists, PatternComprehension, EnumValueAccess> {};
+          SubtractionOperator, MultiplicationOperator, DivisionOperator, ModOperator, ExponentiationOperator,
+          NotEqualOperator, EqualOperator, LessOperator, GreaterOperator, LessEqualOperator, GreaterEqualOperator,
+          RangeOperator, InListOperator, SubscriptOperator, ListSlicingOperator, IfOperator, UnaryPlusOperator,
+          UnaryMinusOperator, IsNullOperator, ListLiteral, MapLiteral, MapProjectionLiteral, PropertyLookup,
+          AllPropertiesLookup, LabelsTest, Aggregation, Function, Reduce, Coalesce, Extract, All, Single, Any, None,
+          ParameterLookup, Identifier, PrimitiveLiteral, RegexMatch, Exists, PatternComprehension, EnumValueAccess> {};
 
 template <class TResult>
 class QueryVisitor

--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -2671,12 +2671,10 @@ antlrcpp::Any CypherMainVisitor::visitExpression6(MemgraphCypher::Expression6Con
                                            {MemgraphCypher::ASTERISK, MemgraphCypher::SLASH, MemgraphCypher::PERCENT});
 }
 
-// Power.
+// Exponentiation.
 antlrcpp::Any CypherMainVisitor::visitExpression5(MemgraphCypher::Expression5Context *ctx) {
   if (ctx->expression4().size() > 1U) {
-    // TODO: implement power operator. In neo4j power is left associative and
-    // int^int -> float.
-    throw utils::NotYetImplemented("power (^) operator");
+    return LeftAssociativeOperatorExpression(ctx->expression4(), ctx->children, {MemgraphCypher::CARET});
   }
   return visitChildren(ctx);
 }

--- a/src/query/frontend/ast/cypher_main_visitor.hpp
+++ b/src/query/frontend/ast/cypher_main_visitor.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -58,6 +58,8 @@ class CypherMainVisitor : public antlropencypher::MemgraphCypherBaseVisitor {
         return storage_->Create<DivisionOperator>(e1, e2);
       case MemgraphCypher::PERCENT:
         return storage_->Create<ModOperator>(e1, e2);
+      case MemgraphCypher::CARET:
+        return storage_->Create<ExponentiationOperator>(e1, e2);
       case MemgraphCypher::EQ:
         return storage_->Create<EqualOperator>(e1, e2);
       case MemgraphCypher::NEQ1:
@@ -925,7 +927,7 @@ class CypherMainVisitor : public antlropencypher::MemgraphCypherBaseVisitor {
   antlrcpp::Any visitExpression6(MemgraphCypher::Expression6Context *ctx) override;
 
   /**
-   * Power.
+   * Exponentiation.
    *
    * @return Expression*
    */

--- a/src/query/frontend/ast/pretty_print.cpp
+++ b/src/query/frontend/ast/pretty_print.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -43,6 +43,7 @@ class ExpressionPrettyPrinter : public ExpressionVisitor<void> {
   void Visit(MultiplicationOperator &op) override;
   void Visit(DivisionOperator &op) override;
   void Visit(ModOperator &op) override;
+  void Visit(ExponentiationOperator &op) override;
   void Visit(NotEqualOperator &op) override;
   void Visit(EqualOperator &op) override;
   void Visit(LessOperator &op) override;
@@ -299,6 +300,7 @@ BINARY_OPERATOR_VISIT(SubtractionOperator, "-");
 BINARY_OPERATOR_VISIT(MultiplicationOperator, "*");
 BINARY_OPERATOR_VISIT(DivisionOperator, "/");
 BINARY_OPERATOR_VISIT(ModOperator, "%");
+BINARY_OPERATOR_VISIT(ExponentiationOperator, "^");
 BINARY_OPERATOR_VISIT(NotEqualOperator, "!=");
 BINARY_OPERATOR_VISIT(EqualOperator, "==");
 BINARY_OPERATOR_VISIT(LessOperator, "<");

--- a/src/query/frontend/semantic/symbol_generator.hpp
+++ b/src/query/frontend/semantic/symbol_generator.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -239,6 +239,7 @@ class PropertyLookupEvaluationModeVisitor : public ExpressionVisitor<void> {
   void Visit(MultiplicationOperator &op) override{};
   void Visit(DivisionOperator &op) override{};
   void Visit(ModOperator &op) override{};
+  void Visit(ExponentiationOperator &op) override{};
   void Visit(LessOperator &op) override{};
   void Visit(GreaterOperator &op) override{};
   void Visit(LessEqualOperator &op) override{};

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -62,6 +62,7 @@ class ReferenceExpressionEvaluator : public ExpressionVisitor<TypedValue *> {
   UNSUCCESSFUL_VISIT(MultiplicationOperator);
   UNSUCCESSFUL_VISIT(DivisionOperator);
   UNSUCCESSFUL_VISIT(ModOperator);
+  UNSUCCESSFUL_VISIT(ExponentiationOperator);
   UNSUCCESSFUL_VISIT(NotEqualOperator);
   UNSUCCESSFUL_VISIT(EqualOperator);
   UNSUCCESSFUL_VISIT(LessOperator);
@@ -142,6 +143,7 @@ class PrimitiveLiteralExpressionEvaluator : public ExpressionVisitor<TypedValue>
   INVALID_VISIT(MultiplicationOperator)
   INVALID_VISIT(DivisionOperator)
   INVALID_VISIT(ModOperator)
+  INVALID_VISIT(ExponentiationOperator)
   INVALID_VISIT(NotEqualOperator)
   INVALID_VISIT(EqualOperator)
   INVALID_VISIT(LessOperator)
@@ -277,6 +279,16 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
       return value1 || value2;
     } catch (const TypedValueException &) {
       throw QueryRuntimeException("Invalid types: {} and {} for OR.", value1.type(), value2.type());
+    }
+  }
+
+  TypedValue Visit(ExponentiationOperator &op) override {
+    auto value1 = op.expression1_->Accept(*this);
+    auto value2 = op.expression2_->Accept(*this);
+    try {
+      return pow(value1, value2);
+    } catch (const TypedValueException &) {
+      throw QueryRuntimeException("Invalid types: {} and {} for ^.", value1.type(), value2.type());
     }
   }
 

--- a/src/query/plan/preprocess.hpp
+++ b/src/query/plan/preprocess.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -232,6 +232,11 @@ class PatternVisitor : public ExpressionVisitor<void> {
   }
 
   void Visit(ModOperator &op) override {
+    op.expression1_->Accept(*this);
+    op.expression2_->Accept(*this);
+  }
+
+  void Visit(ExponentiationOperator &op) override {
     op.expression1_->Accept(*this);
     op.expression2_->Accept(*this);
   }

--- a/src/query/plan/rewrite/enum.hpp
+++ b/src/query/plan/rewrite/enum.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -27,9 +27,9 @@ class ExpressionEnumAccessRewriter : public ExpressionVisitor<void> {
   void Visit(EnumValueAccess &enum_value_access) override {
     auto maybe_enum = dba_->GetEnumValue(enum_value_access.enum_name_, enum_value_access.enum_value_);
     if (maybe_enum.HasError()) [[unlikely]] {
-        throw QueryRuntimeException("Enum value '{}' in enum '{}' not found.", enum_value_access.enum_value_,
-                                    enum_value_access.enum_name_);
-      }
+      throw QueryRuntimeException("Enum value '{}' in enum '{}' not found.", enum_value_access.enum_value_,
+                                  enum_value_access.enum_name_);
+    }
     prev_expressions_.back() = storage_->Create<PrimitiveLiteral>(*maybe_enum);
   }
 
@@ -102,6 +102,11 @@ class ExpressionEnumAccessRewriter : public ExpressionVisitor<void> {
   }
 
   void Visit(ModOperator &op) override {
+    AcceptExpression(op.expression1_);
+    AcceptExpression(op.expression2_);
+  }
+
+  void Visit(ExponentiationOperator &op) override {
     AcceptExpression(op.expression1_);
     AcceptExpression(op.expression2_);
   }

--- a/src/query/plan/rule_based_planner.cpp
+++ b/src/query/plan/rule_based_planner.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -339,11 +339,11 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
     MG_ASSERT(has_aggregation_.size() >= 2U, "Expected at least 2 has_aggregation_ flags."); \
     /* has_aggregation_ stack is reversed, last result is from the 2nd */                    \
     /* expression. */                                                                        \
-    bool aggr2 = has_aggregation_.back();                                                    \
+    bool const aggr2 = has_aggregation_.back();                                              \
     has_aggregation_.pop_back();                                                             \
-    bool aggr1 = has_aggregation_.back();                                                    \
+    bool const aggr1 = has_aggregation_.back();                                              \
     has_aggregation_.pop_back();                                                             \
-    bool has_aggr = aggr1 || aggr2;                                                          \
+    bool const has_aggr = aggr1 || aggr2;                                                    \
     if (has_aggr && !(aggr1 && aggr2)) {                                                     \
       /* Group by the expression which does not contain aggregation. */                      \
       if (aggr1 && !IsConstantLiteral(op.expression2_)) {                                    \
@@ -365,6 +365,7 @@ class ReturnBodyContext : public HierarchicalTreeVisitor {
   VISIT_BINARY_OPERATOR(MultiplicationOperator)
   VISIT_BINARY_OPERATOR(DivisionOperator)
   VISIT_BINARY_OPERATOR(ModOperator)
+  VISIT_BINARY_OPERATOR(ExponentiationOperator)
   VISIT_BINARY_OPERATOR(NotEqualOperator)
   VISIT_BINARY_OPERATOR(EqualOperator)
   VISIT_BINARY_OPERATOR(LessOperator)

--- a/src/query/typed_value.cpp
+++ b/src/query/typed_value.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -1298,6 +1298,13 @@ TypedValue operator%(const TypedValue &a, const TypedValue &b) {
     if (b.ValueInt() == 0LL) throw TypedValueException("Mod with zero");
     return TypedValue(a.ValueInt() % b.ValueInt(), a.GetMemoryResource());
   }
+}
+
+TypedValue pow(const TypedValue &a, const TypedValue &b) {
+  if (a.IsNull() || b.IsNull()) return TypedValue(a.GetMemoryResource());
+  EnsureArithmeticallyOk(a, b, false, "^");
+
+  return TypedValue(std::pow(ToDouble(a), ToDouble(b)), a.GetMemoryResource());
 }
 
 inline void EnsureLogicallyOk(const TypedValue &a, const TypedValue &b, const std::string &op_name) {

--- a/src/query/typed_value.hpp
+++ b/src/query/typed_value.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -810,6 +810,18 @@ TypedValue operator*(const TypedValue &a, const TypedValue &b);
  * @throw TypedValueException if the values are not numeric or Null.
  */
 TypedValue operator%(const TypedValue &a, const TypedValue &b);
+
+/**
+ * Perform an exponentation operation on two values.
+ *
+ * If any of the values is Null, then Null is returned. The return value
+ * is always a floating-point value, even when called with integers.
+ * The resulting value uses the same MemoryResource as the left hand side
+ * argument.
+ *
+ * @throw TypedValueException if the values are not numeric or Null.
+ */
+TypedValue pow(const TypedValue &a, const TypedValue &b);
 
 /** Output the TypedValue::Type value as a string */
 std::ostream &operator<<(std::ostream &os, const TypedValue::Type &type);

--- a/src/utils/typeinfo.hpp
+++ b/src/utils/typeinfo.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -153,6 +153,7 @@ enum class TypeId : uint64_t {
   AST_MULTIPLICATION_OPERATOR,
   AST_DIVISION_OPERATOR,
   AST_MOD_OPERATOR,
+  AST_EXPONENTIATION_OPERATOR,
   AST_NOT_EQUAL_OPERATOR,
   AST_EQUAL_OPERATOR,
   AST_LESS_OPERATOR,

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -657,6 +657,18 @@ TEST_P(CypherMainVisitorTest, ModOperator) {
   auto *mod_operator = dynamic_cast<ModOperator *>(return_clause->body_.named_expressions[0]->expression_);
   ast_generator.CheckLiteral(mod_operator->expression1_, 2);
   ast_generator.CheckLiteral(mod_operator->expression2_, 3);
+}
+
+TEST_P(CypherMainVisitorTest, ExponentiationOperator) {
+  auto &ast_generator = *GetParam();
+  auto *query = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("RETURN 2 ^ 3"));
+  ASSERT_TRUE(query);
+  ASSERT_TRUE(query->single_query_);
+  auto *single_query = query->single_query_;
+  auto *return_clause = dynamic_cast<Return *>(single_query->clauses_[0]);
+  auto *exp_operator = dynamic_cast<ExponentiationOperator *>(return_clause->body_.named_expressions[0]->expression_);
+  ast_generator.CheckLiteral(exp_operator->expression1_, 2);
+  ast_generator.CheckLiteral(exp_operator->expression2_, 3);
 }
 
 #define CHECK_COMPARISON(TYPE, VALUE1, VALUE2)                             \

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -247,6 +247,19 @@ TYPED_TEST(ExpressionEvaluatorTest, ModOperator) {
   ASSERT_EQ(value.ValueInt(), 5);
 }
 
+TYPED_TEST(ExpressionEvaluatorTest, ExponentiationOperator) {
+  auto *op = this->storage.template Create<ExponentiationOperator>(
+      this->storage.template Create<PrimitiveLiteral>(2.0), this->storage.template Create<PrimitiveLiteral>(3.0));
+  auto val1 = this->Eval(op);
+  ASSERT_EQ(val1.ValueDouble(), 8.0);
+
+  // `a ^ b` always yields a double, even if both `a` and `b` are integers.
+  op = this->storage.template Create<ExponentiationOperator>(this->storage.template Create<PrimitiveLiteral>(3),
+                                                             this->storage.template Create<PrimitiveLiteral>(4));
+  auto val2 = this->Eval(op);
+  ASSERT_EQ(val2.ValueDouble(), 81.0);
+}
+
 TYPED_TEST(ExpressionEvaluatorTest, EqualOperator) {
   auto *op = this->storage.template Create<EqualOperator>(this->storage.template Create<PrimitiveLiteral>(10),
                                                           this->storage.template Create<PrimitiveLiteral>(15));


### PR DESCRIPTION
a ^ b` computes a to the power of b. Unlike most languages, Cypher's exponentiation is left-associative, i.e.:

```
RETURN 2 ^ 3 ^ 2;    // 64.0
RETURN (2 ^ 3) ^ 2;  // 64.0
RETURN 2 ^ (3 ^ 2);  // 512.0
```

The numeric return type is always double, even if either (or both) operands are integers.