### PR TITLE
Bugfix: PeriodicCommit crashes if commit generates replication error

### DIFF
--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -176,17 +176,9 @@ TimestampInfo ReplicationStorageClient::GetTimestampInfo(Storage const *storage)
     // Exclusive access to client
     auto stream{client_.rpc_client_.Stream<replication::TimestampRpc>(main_uuid_, storage->uuid())};
     const auto response = stream.AwaitResponse();
-    const auto is_success = response.success;
-
     auto main_time_stamp = storage->repl_storage_state_.last_durable_timestamp_.load();
     info.current_timestamp_of_replica = response.current_commit_timestamp;
     info.current_number_of_timestamp_behind_main = response.current_commit_timestamp - main_time_stamp;
-
-    if (!is_success || info.current_number_of_timestamp_behind_main != 0) {
-      // Still under client lock, all good
-      replica_state_.WithLock([](auto &val) { val = replication::ReplicaState::MAYBE_BEHIND; });
-      LogRpcFailure();
-    }
   } catch (const rpc::RpcFailedException &) {
     replica_state_.WithLock([](auto &val) { val = replication::ReplicaState::MAYBE_BEHIND; });
     LogRpcFailure();  // mutex already unlocked, if the new enqueued task dispatches immediately it probably


### PR DESCRIPTION
PeriodicCommit now handles commit errors.
On error the last commit is aborted, while everything committed previously is still permanent.
Ignoring the replication error, since it does not influence the data in any way (unlike other commit errors).