### PR TITLE
Add RPC timeouts

### DIFF
--- a/src/communication/client.hpp
+++ b/src/communication/client.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2024 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -77,8 +77,9 @@ class Client final {
    * stores it in an internal buffer. If `exactly_len` is set to `false` then
    * less than `len` bytes can be received. It returns `true` if the read
    * succeeded and `false` if it didn't.
+   * Propagates timeout_ms to Socket::WaitForReadyRead.
    */
-  bool Read(size_t len, bool exactly_len = true);
+  bool Read(size_t len, bool exactly_len = true, std::optional<int> timeout_ms = std::nullopt);
 
   /**
    * This function returns a pointer to the read data that is currently stored
@@ -107,12 +108,12 @@ class Client final {
    * TODO (mferencevic): the `have_more` flag currently isn't supported when
    * using OpenSSL
    */
-  bool Write(const uint8_t *data, size_t len, bool have_more = false);
+  bool Write(const uint8_t *data, size_t len, bool have_more = false, std::optional<int> timeout_ms = std::nullopt);
 
   /**
    * This function writes data to the socket.
    */
-  bool Write(const std::string &str, bool have_more = false);
+  bool Write(const std::string &str, bool have_more = false, std::optional<int> timeout_ms = std::nullopt);
 
   const io::network::Endpoint &endpoint();
 

--- a/src/coordination/coordinator_instance_client.cpp
+++ b/src/coordination/coordinator_instance_client.cpp
@@ -15,6 +15,16 @@
 
 namespace memgraph::coordination {
 
+namespace {
+auto CreateClientContext(ManagementServerConfig const &config) -> communication::ClientContext {
+  return (config.ssl) ? communication::ClientContext{config.ssl->key_file, config.ssl->cert_file}
+                      : communication::ClientContext{};
+}
+}  // namespace
+
+CoordinatorInstanceClient::CoordinatorInstanceClient(ManagementServerConfig const &config)
+    : rpc_context_{CreateClientContext(config)}, rpc_client_{config.endpoint, &rpc_context_} {}
+
 auto CoordinatorInstanceClient::RpcClient() -> rpc::Client & { return rpc_client_; }
 }  // namespace memgraph::coordination
 #endif

--- a/src/coordination/include/coordination/coordinator_instance_client.hpp
+++ b/src/coordination/include/coordination/coordinator_instance_client.hpp
@@ -15,16 +15,9 @@
 #ifdef MG_ENTERPRISE
 namespace memgraph::coordination {
 
-namespace {
-static auto CreateClientContext(ManagementServerConfig const &config) -> communication::ClientContext {
-  return (config.ssl) ? communication::ClientContext{config.ssl->key_file, config.ssl->cert_file}
-                      : communication::ClientContext{};
-}
-}  // namespace
 class CoordinatorInstanceClient {
  public:
-  explicit CoordinatorInstanceClient(ManagementServerConfig const &config)
-      : rpc_context_{CreateClientContext(config)}, rpc_client_{config.endpoint, &rpc_context_} {}
+  explicit CoordinatorInstanceClient(ManagementServerConfig const &config);
 
   auto RpcClient() -> rpc::Client &;
 

--- a/src/coordination/replication_instance_client.cpp
+++ b/src/coordination/replication_instance_client.cpp
@@ -113,7 +113,7 @@ auto ReplicationInstanceClient::SendDemoteToReplicaRpc() const -> bool {
       spdlog::error("Failed to receive successful RPC response for setting instance {} to replica!", instance_name);
       return false;
     }
-    spdlog::info("Sent request RPC from coordinator to instance to set it as replica!");
+    spdlog::trace("Received successful response to DemoteMainToReplicaRpc!");
     return true;
   } catch (rpc::RpcFailedException const &) {
     spdlog::error("Failed to receive RPC response when demoting instance {} to replica!", instance_name);
@@ -131,7 +131,7 @@ auto ReplicationInstanceClient::SendRegisterReplicaRpc(utils::UUID const &uuid,
                     instance_name);
       return false;
     }
-    spdlog::trace("Sent request RPC from coordinator to register replica instance on main.");
+    spdlog::trace("Received successful response to RegisterReplicaOnMainRpc!");
     return true;
   } catch (rpc::RpcFailedException const &) {
     spdlog::error("Failed to receive RPC response when registering instance {} to replica!", instance_name);

--- a/src/io/network/socket.cpp
+++ b/src/io/network/socket.cpp
@@ -267,8 +267,8 @@ bool Socket::WaitForReadyRead(std::optional<int> timeout_ms) const {
   // event occurs.
 
   // -1 for blocking indefinitely, otherwise wait for timeout_ms.
-  int timeout = timeout_ms ? *timeout_ms : -1;
-  int ret = poll(&p, 1, timeout);
+  int const timeout = timeout_ms ? *timeout_ms : -1;
+  int const ret = poll(&p, 1, timeout);
   if (ret == -1) {
     spdlog::error("Error occurred while polling for file descriptors.");
     return false;
@@ -291,8 +291,8 @@ bool Socket::WaitForReadyWrite(std::optional<int> timeout_ms) const {
   // event occurs.
 
   // -1 for blocking indefinitely, otherwise wait for timeout_ms.
-  int timeout = timeout_ms ? *timeout_ms : -1;
-  int ret = poll(&p, 1, timeout);
+  int const timeout = timeout_ms ? *timeout_ms : -1;
+  int const ret = poll(&p, 1, timeout);
   if (ret == -1) {
     spdlog::error("Error occurred while polling for file descriptors.");
     return false;

--- a/src/io/network/socket.cpp
+++ b/src/io/network/socket.cpp
@@ -48,7 +48,7 @@ void Socket::Close() {
   socket_ = -1;
 }
 
-void Socket::Shutdown() {
+void Socket::Shutdown() const {
   if (socket_ == -1) return;
   shutdown(socket_, SHUT_RDWR);
 }
@@ -147,14 +147,14 @@ bool Socket::Bind(const Endpoint &endpoint) {
   return true;
 }
 
-void Socket::SetNonBlocking() {
+void Socket::SetNonBlocking() const {
   const unsigned flags = fcntl(socket_, F_GETFL);
   constexpr unsigned o_nonblock = O_NONBLOCK;
   MG_ASSERT(flags != -1, "Can't get socket mode");
   MG_ASSERT(fcntl(socket_, F_SETFL, flags | o_nonblock) != -1, "Can't set socket nonblocking");
 }
 
-void Socket::SetKeepAlive() {
+void Socket::SetKeepAlive() const {
   int optval = 1;
   MG_ASSERT(!setsockopt(socket_, SOL_SOCKET, SO_KEEPALIVE, &optval, sizeof(optval)), "Can't set socket keep alive");
 
@@ -170,7 +170,7 @@ void Socket::SetKeepAlive() {
             "Can't set socket keep alive");
 }
 
-void Socket::SetNoDelay() {
+void Socket::SetNoDelay() const {
   int optval = 1;
   MG_ASSERT(!setsockopt(socket_, SOL_TCP, TCP_NODELAY, (void *)&optval, sizeof(optval)), "Can't set socket no delay");
 }
@@ -194,9 +194,9 @@ int Socket::ErrorStatus() const {
   return optval;
 }
 
-bool Socket::Listen(int backlog) { return listen(socket_, backlog) == 0; }
+bool Socket::Listen(int backlog) const { return listen(socket_, backlog) == 0; }
 
-std::optional<Socket> Socket::Accept() {
+std::optional<Socket> Socket::Accept() const {
   sockaddr_storage addr;
   socklen_t addr_size = sizeof addr;
   char addr_decoded[INET6_ADDRSTRLEN];
@@ -222,7 +222,7 @@ std::optional<Socket> Socket::Accept() {
   return Socket(sfd, endpoint);
 }
 
-bool Socket::Write(const uint8_t *data, size_t len, bool have_more) {
+bool Socket::Write(const uint8_t *data, size_t len, bool have_more, std::optional<int> timeout_ms) const {
   // MSG_NOSIGNAL is here to disable raising a SIGPIPE signal when a
   // connection dies mid-write, the socket will only return an EPIPE error.
   constexpr unsigned msg_nosignal = MSG_NOSIGNAL;
@@ -238,7 +238,7 @@ bool Socket::Write(const uint8_t *data, size_t len, bool have_more) {
       // Non-fatal error, retry after the socket is ready. This is here to
       // implement a non-busy wait. If we just continue with the loop we have a
       // busy wait.
-      if (!WaitForReadyWrite()) return false;
+      if (!WaitForReadyWrite(timeout_ms)) return false;
     } else if (written == 0) {
       // The client closed the connection.
       return false;
@@ -250,36 +250,57 @@ bool Socket::Write(const uint8_t *data, size_t len, bool have_more) {
   return true;
 }
 
-bool Socket::Write(std::string_view s, bool have_more) {
-  return Write(reinterpret_cast<const uint8_t *>(s.data()), s.size(), have_more);
+bool Socket::Write(std::string_view s, bool have_more, std::optional<int> timeout_ms) const {
+  return Write(reinterpret_cast<const uint8_t *>(s.data()), s.size(), have_more, timeout_ms);
 }
 
-ssize_t Socket::Read(void *buffer, size_t len, bool nonblock) {
+ssize_t Socket::Read(void *buffer, size_t len, bool nonblock) const {
   return recv(socket_, buffer, len, nonblock ? MSG_DONTWAIT : 0);
 }
 
-bool Socket::WaitForReadyRead() {
+bool Socket::WaitForReadyRead(std::optional<int> timeout_ms) const {
   struct pollfd p;
   p.fd = socket_;
   p.events = POLLIN;
   // We call poll with one element in the poll fds array (first and second
   // arguments), also we set the timeout to -1 to block indefinitely until an
   // event occurs.
-  int ret = poll(&p, 1, -1);
-  if (ret < 1) return false;
+
+  // -1 for blocking indefinitely, otherwise wait for timeout_ms.
+  int timeout = timeout_ms ? *timeout_ms : -1;
+  int ret = poll(&p, 1, timeout);
+  if (ret == -1) {
+    spdlog::error("Error occurred while polling for file descriptors.");
+    return false;
+  }
+  if (ret == 0) {
+    spdlog::error("Waiting too long to get in ready state for reading. Timeout occurred.");
+    return false;
+  }
+
   constexpr unsigned pollin = POLLIN;
   return static_cast<unsigned>(p.revents) & pollin;
 }
 
-bool Socket::WaitForReadyWrite() {
+bool Socket::WaitForReadyWrite(std::optional<int> timeout_ms) const {
   struct pollfd p;
   p.fd = socket_;
   p.events = POLLOUT;
   // We call poll with one element in the poll fds array (first and second
   // arguments), also we set the timeout to -1 to block indefinitely until an
   // event occurs.
-  int ret = poll(&p, 1, -1);
-  if (ret < 1) return false;
+
+  // -1 for blocking indefinitely, otherwise wait for timeout_ms.
+  int timeout = timeout_ms ? *timeout_ms : -1;
+  int ret = poll(&p, 1, timeout);
+  if (ret == -1) {
+    spdlog::error("Error occurred while polling for file descriptors.");
+    return false;
+  }
+  if (ret == 0) {
+    spdlog::error("Waiting too long to get in ready state for writing. Timeout occurred.");
+    return false;
+  }
   constexpr unsigned pollout = POLLOUT;
   return static_cast<unsigned>(p.revents) & pollout;
 }

--- a/src/io/network/socket.hpp
+++ b/src/io/network/socket.hpp
@@ -43,7 +43,7 @@ class Socket {
   /**
    * Shutdown the socket if it is open.
    */
-  void Shutdown();
+  void Shutdown() const;
 
   /**
    * Checks whether the socket is open.
@@ -86,7 +86,7 @@ class Socket {
    *             true if the listen succeeded
    *             false if the listen failed
    */
-  bool Listen(int backlog);
+  bool Listen(int backlog) const;
 
   /**
    * Accepts a new connection.
@@ -94,24 +94,24 @@ class Socket {
    *
    * @return socket if accepted, nullopt otherwise.
    */
-  std::optional<Socket> Accept();
+  std::optional<Socket> Accept() const;
 
   /**
    * Sets the socket to non-blocking.
    */
-  void SetNonBlocking();
+  void SetNonBlocking() const;
 
   /**
    * Enables TCP keep-alive on the socket.
    */
-  void SetKeepAlive();
+  void SetKeepAlive() const;
 
   /**
    * Enables TCP no_delay on the socket.
    * When enabled, the socket doesn't wait for an ACK of every data packet
    * before sending the next packet.
    */
-  void SetNoDelay();
+  void SetNoDelay() const;
 
   /**
    * Sets the socket timeout.
@@ -145,12 +145,15 @@ class Socket {
    * @param have_more set to true if you plan to send more data to allow the
    * kernel to buffer the data instead of immediately sending it out
    *
+   * @param timeout_ms Timeout in miliseconds for writing operation
+   *
    * @return write success status:
    *             true if write succeeded
    *             false if write failed
    */
-  bool Write(const uint8_t *data, size_t len, bool have_more = false);
-  bool Write(std::string_view s, bool have_more = false);
+  bool Write(const uint8_t *data, size_t len, bool have_more = false,
+             std::optional<int> timeout_ms = std::nullopt) const;
+  bool Write(std::string_view s, bool have_more = false, std::optional<int> timeout_ms = std::nullopt) const;
 
   /**
    * Read data from the socket.
@@ -165,7 +168,7 @@ class Socket {
    *             == 0 if the client closed the connection
    *             < 0 if an error has occurred
    */
-  ssize_t Read(void *buffer, size_t len, bool nonblock = false);
+  ssize_t Read(void *buffer, size_t len, bool nonblock = false) const;
 
   /**
    * Wait until the socket becomes ready for a `Read` operation.
@@ -178,11 +181,13 @@ class Socket {
    * be read from the socket) and returns `false` if the wait failed (the socket
    * was closed or something else bad happened).
    *
+   * @param timeout_ms Timeout in miliseconds.
+   *
    * @return wait success status:
    *             true if the wait succeeded
    *             false if the wait failed
    */
-  bool WaitForReadyRead();
+  bool WaitForReadyRead(std::optional<int> timeout_ms = std::nullopt) const;
 
   /**
    * Wait until the socket becomes ready for a `Write` operation.
@@ -195,11 +200,15 @@ class Socket {
    * to) and returns `false` if the wait failed (the socket was closed or
    * something else bad happened).
    *
+   * @param timeout_ms Timeout in miliseconds. Max time allowed for waiting before socket becomes writeable.
+   *
    * @return wait success status:
    *             true if the wait succeeded
    *             false if the wait failed
    */
-  bool WaitForReadyWrite();
+  // TODO: (andi) Does this mean that if the RPC message needs to be sent but waits too long because some other requests
+  // are there from before, we won't send this RPC message?
+  bool WaitForReadyWrite(std::optional<int> timeout_ms = std::nullopt) const;
 
  private:
   Socket(int fd, Endpoint endpoint) : socket_(fd), endpoint_(std::move(endpoint)) {}

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -14,7 +14,7 @@
 namespace memgraph::rpc {
 
 Client::Client(io::network::Endpoint endpoint, communication::ClientContext *context,
-               std::map<std::string_view, int> const &rpc_timeouts_ms)
+               std::unordered_map<std::string_view, int> const &rpc_timeouts_ms)
     : endpoint_(std::move(endpoint)), context_(context), rpc_timeouts_ms_(rpc_timeouts_ms) {}
 
 void Client::Abort() {

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2024 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -13,8 +13,9 @@
 
 namespace memgraph::rpc {
 
-Client::Client(io::network::Endpoint endpoint, communication::ClientContext *context)
-    : endpoint_(std::move(endpoint)), context_(context) {}
+Client::Client(io::network::Endpoint endpoint, communication::ClientContext *context,
+               std::map<std::string_view, int> const &rpc_timeouts_ms)
+    : endpoint_(std::move(endpoint)), context_(context), rpc_timeouts_ms_(rpc_timeouts_ms) {}
 
 void Client::Abort() {
   if (!client_) return;

--- a/src/rpc/client.hpp
+++ b/src/rpc/client.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -36,7 +36,7 @@ using namespace std::string_view_literals;
 /// Client is thread safe, but it is recommended to use thread_local clients.
 class Client {
  public:
-  inline static std::map<std::string_view, int> const default_rpc_timeouts_ms{
+  inline static std::unordered_map<std::string_view, int> const default_rpc_timeouts_ms{
       {"ShowInstancesReq"sv, 10000},          // coordinator sending to coordinator
       {"DemoteMainToReplicaReq"sv, 10000},    // coordinator sending to main
       {"PromoteToMainReq"sv, 10000},          // coordinator sending to replica
@@ -53,7 +53,7 @@ class Client {
   };
   // Dependency injection of rpc_timeouts
   Client(io::network::Endpoint endpoint, communication::ClientContext *context,
-         std::map<std::string_view, int> const &rpc_timeouts_ms = Client::default_rpc_timeouts_ms);
+         std::unordered_map<std::string_view, int> const &rpc_timeouts_ms = Client::default_rpc_timeouts_ms);
 
   /// Object used to handle streaming of request data to the RPC server.
   template <class TRequestResponse>
@@ -109,13 +109,6 @@ class Client {
 
       spdlog::trace("[RpcClient] sent {} to {}", req_type_name, self_->client_->endpoint().SocketAddress());
 
-      std::optional<int> timeout_ms{std::nullopt};
-      auto const maybe_timeout = std::ranges::find_if(
-          self_->rpc_timeouts_ms_, [req_type_name](auto const &entry) { return entry.first == req_type_name; });
-      if (maybe_timeout != self_->rpc_timeouts_ms_.end()) {
-        timeout_ms.emplace(maybe_timeout->second);
-      }
-
       // Receive the response.
       uint64_t response_data_size = 0;
       while (true) {
@@ -128,7 +121,7 @@ class Client {
         }
         if (ret.status == slk::StreamStatus::PARTIAL) {
           if (!self_->client_->Read(ret.stream_size - self_->client_->GetDataSize(),
-                                    /* exactly_len = */ false, /* timeout_ms = */ timeout_ms)) {
+                                    /* exactly_len = */ false, /* timeout_ms = */ timeout_ms_)) {
             // Failed connection, abort and let somebody retry in the future.
             defunct_ = true;
             self_->Abort();
@@ -303,7 +296,7 @@ class Client {
   io::network::Endpoint endpoint_;
   communication::ClientContext *context_;
   std::optional<communication::Client> client_;
-  std::map<std::string_view, int> rpc_timeouts_ms_;
+  std::unordered_map<std::string_view, int> rpc_timeouts_ms_;
 
   std::mutex mutex_;
 };

--- a/src/rpc/client.hpp
+++ b/src/rpc/client.hpp
@@ -31,10 +31,14 @@
 
 namespace memgraph::rpc {
 
+using namespace std::string_view_literals;
+
 /// Client is thread safe, but it is recommended to use thread_local clients.
 class Client {
  public:
-  Client(io::network::Endpoint endpoint, communication::ClientContext *context);
+  // Dependency injection of rpc_timeouts
+  Client(io::network::Endpoint endpoint, communication::ClientContext *context,
+         std::map<std::string_view, int> const &rpc_timeouts_ms = {});
 
   /// Object used to handle streaming of request data to the RPC server.
   template <class TRequestResponse>
@@ -43,22 +47,29 @@ class Client {
     friend class Client;
 
     StreamHandler(Client *self, std::unique_lock<std::mutex> &&guard,
-                  std::function<typename TRequestResponse::Response(slk::Reader *)> res_load)
-        : self_(self), guard_(std::move(guard)), req_builder_(GenBuilderCallback(self, this)), res_load_(res_load) {}
+                  std::function<typename TRequestResponse::Response(slk::Reader *)> res_load,
+                  std::optional<int> timeout_ms)
+        : self_(self),
+          timeout_ms_(timeout_ms),
+          guard_(std::move(guard)),
+          req_builder_(GenBuilderCallback(self, this, timeout_ms_)),
+          res_load_(res_load) {}
 
    public:
     StreamHandler(StreamHandler &&other) noexcept
         : self_{std::exchange(other.self_, nullptr)},
+          timeout_ms_{std::move(other.timeout_ms_)},
           defunct_{std::exchange(other.defunct_, true)},
           guard_{std::move(other.guard_)},
-          req_builder_{std::move(other.req_builder_), GenBuilderCallback(self_, this)},
+          req_builder_{std::move(other.req_builder_), GenBuilderCallback(self_, this, timeout_ms_)},
           res_load_{std::move(other.res_load_)} {}
     StreamHandler &operator=(StreamHandler &&other) noexcept {
       if (&other != this) {
         self_ = std::exchange(other.self_, nullptr);
+        timeout_ms_ = std::move(other.timeout_ms_);
         defunct_ = std::exchange(other.defunct_, true);
         guard_ = std::move(other.guard_);
-        req_builder_ = slk::Builder(std::move(other.req_builder_, GenBuilderCallback(self_, this)));
+        req_builder_ = slk::Builder(std::move(other.req_builder_, GenBuilderCallback(self_, this, timeout_ms_)));
         res_load_ = std::move(other.res_load_);
       }
       return *this;
@@ -75,10 +86,20 @@ class Client {
       auto res_type = TRequestResponse::Response::kType;
       auto req_type = TRequestResponse::Request::kType;
 
+      auto req_type_name = std::string_view{req_type.name};
+      auto res_type_name = std::string_view{res_type.name};
+
       // Finalize the request.
       req_builder_.Finalize();
 
-      spdlog::trace("[RpcClient] sent {} to {}", req_type.name, self_->client_->endpoint().SocketAddress());
+      spdlog::trace("[RpcClient] sent {} to {}", req_type_name, self_->client_->endpoint().SocketAddress());
+
+      std::optional<int> timeout_ms{std::nullopt};
+      auto const maybe_timeout = std::ranges::find_if(
+          self_->rpc_timeouts_ms_, [req_type_name](auto const &entry) { return entry.first == req_type_name; });
+      if (maybe_timeout != self_->rpc_timeouts_ms_.end()) {
+        timeout_ms.emplace(maybe_timeout->second);
+      }
 
       // Receive the response.
       uint64_t response_data_size = 0;
@@ -92,8 +113,8 @@ class Client {
         }
         if (ret.status == slk::StreamStatus::PARTIAL) {
           if (!self_->client_->Read(ret.stream_size - self_->client_->GetDataSize(),
-                                    /* exactly_len = */ false)) {
-            // Failed connection, abort and let somebody retry in the future
+                                    /* exactly_len = */ false, /* timeout_ms = */ timeout_ms)) {
+            // Failed connection, abort and let somebody retry in the future.
             defunct_ = true;
             self_->Abort();
             guard_.unlock();
@@ -136,7 +157,7 @@ class Client {
         throw GenericRpcFailedException();
       }
 
-      spdlog::trace("[RpcClient] received {} from endpoint {}:{}.", res_type.name, self_->endpoint_.GetAddress(),
+      spdlog::trace("[RpcClient] received {} from endpoint {}:{}.", res_type_name, self_->endpoint_.GetAddress(),
                     self_->endpoint_.GetPort());
 
       return res_load_(&res_reader);
@@ -145,10 +166,10 @@ class Client {
     bool IsDefunct() const { return defunct_; }
 
    private:
-    static auto GenBuilderCallback(Client *client, StreamHandler *self) {
-      return [client, self](const uint8_t *data, size_t size, bool have_more) {
+    static auto GenBuilderCallback(Client *client, StreamHandler *self, std::optional<int> timeout_ms) {
+      return [client, self, timeout_ms](const uint8_t *data, size_t size, bool have_more) {
         if (self->defunct_) throw GenericRpcFailedException();
-        if (!client->client_->Write(data, size, have_more)) {
+        if (!client->client_->Write(data, size, have_more, timeout_ms)) {
           self->defunct_ = true;
           client->Abort();
           self->guard_.unlock();
@@ -158,6 +179,7 @@ class Client {
     }
 
     Client *self_;
+    std::optional<int> timeout_ms_;
     bool defunct_ = false;
     std::unique_lock<std::mutex> guard_;
     slk::Builder req_builder_;
@@ -213,8 +235,17 @@ class Client {
       }
     }
 
+    std::optional<int> timeout_ms{std::nullopt};
+
+    auto req_type_name = std::string_view{req_type.name};
+    auto const maybe_timeout = std::ranges::find_if(
+        rpc_timeouts_ms_, [req_type_name](auto const &entry) { return entry.first == req_type_name; });
+    if (maybe_timeout != rpc_timeouts_ms_.end()) {
+      timeout_ms.emplace(maybe_timeout->second);
+    }
+
     // Create the stream handler.
-    StreamHandler<TRequestResponse> handler(this, std::move(guard), load);
+    StreamHandler<TRequestResponse> handler(this, std::move(guard), load, timeout_ms);
 
     // Build and send the request.
     slk::Save(req_type.id, handler.GetBuilder());
@@ -257,6 +288,7 @@ class Client {
   io::network::Endpoint endpoint_;
   communication::ClientContext *context_;
   std::optional<communication::Client> client_;
+  std::map<std::string_view, int> rpc_timeouts_ms_;
 
   std::mutex mutex_;
 };

--- a/src/rpc/client.hpp
+++ b/src/rpc/client.hpp
@@ -48,6 +48,8 @@ class Client {
       {"StateCheckReq"sv, 10000},             // coordinator to data instances
       {"HeartbeatReq"sv, 10000},              // main to replica
       {"TimestampReq"sv, 10000},              // main to replica
+      {"SwapMainUUIDReq"sv, 10000},           // coord to data instances
+      {"FrequentHeartbeatReq"sv, 10000},      // coord to data instances
   };
   // Dependency injection of rpc_timeouts
   Client(io::network::Endpoint endpoint, communication::ClientContext *context,

--- a/src/rpc/client.hpp
+++ b/src/rpc/client.hpp
@@ -36,9 +36,22 @@ using namespace std::string_view_literals;
 /// Client is thread safe, but it is recommended to use thread_local clients.
 class Client {
  public:
+  inline static std::map<std::string_view, int> const default_rpc_timeouts_ms{
+      {"ShowInstancesReq"sv, 10000},          // coordinator sending to coordinator
+      {"DemoteMainToReplicaReq"sv, 10000},    // coordinator sending to main
+      {"PromoteToMainReq"sv, 10000},          // coordinator sending to replica
+      {"RegisterReplicaOnMainReq"sv, 10000},  // coordinator sending to main
+      {"UnregisterReplicaReq"sv, 10000},      // coordinator sending to main
+      {"EnableWritingOnMainReq"sv, 10000},    // coordinator to main
+      {"GetInstanceUUIDReq"sv, 10000},        // coordinator to data instances
+      {"GetDatabaseHistoriesReq"sv, 10000},   // coordinator to data instances
+      {"StateCheckReq"sv, 10000},             // coordinator to data instances
+      {"HeartbeatReq"sv, 10000},              // main to replica
+      {"TimestampReq"sv, 10000},              // main to replica
+  };
   // Dependency injection of rpc_timeouts
   Client(io::network::Endpoint endpoint, communication::ClientContext *context,
-         std::map<std::string_view, int> const &rpc_timeouts_ms = {});
+         std::map<std::string_view, int> const &rpc_timeouts_ms = Client::default_rpc_timeouts_ms);
 
   /// Object used to handle streaming of request data to the RPC server.
   template <class TRequestResponse>

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -39,7 +39,7 @@ void ReplicationStorageClient::UpdateReplicaState(Storage *storage, DatabaseAcce
   auto &replStorageState = storage->repl_storage_state_;
 
   // stream should be destroyed so that RPC lock is released before taking engine lock
-  replication::HeartbeatRes replica = std::invoke([&] {
+  replication::HeartbeatRes const replica = std::invoke([&] {
     // stream should be destroyed so that RPC lock is released
     // before taking engine lock
     auto hb_stream = client_.rpc_client_.Stream<replication::HeartbeatRpc>(main_uuid_, storage->uuid(),

--- a/src/utils/typeinfo.hpp
+++ b/src/utils/typeinfo.hpp
@@ -18,6 +18,9 @@ namespace memgraph::utils {
 
 enum class TypeId : uint64_t {
   UNKNOWN = 0,
+  SUM_REQ,       // used in unit tests
+  SUM_RES,       // used in unit tests
+  ECHO_MESSAGE,  // used in unit tests
 
   // Operators
   LOGICAL_OPERATOR = 1000,

--- a/src/utils/typeinfo.hpp
+++ b/src/utils/typeinfo.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -18,9 +18,6 @@ namespace memgraph::utils {
 
 enum class TypeId : uint64_t {
   UNKNOWN = 0,
-  SUM_REQ,       // used in unit tests
-  SUM_RES,       // used in unit tests
-  ECHO_MESSAGE,  // used in unit tests
 
   // Operators
   LOGICAL_OPERATOR = 1000,

--- a/tests/jepsen/src/memgraph/high_availability/bank/test.clj
+++ b/tests/jepsen/src/memgraph/high_availability/bank/test.clj
@@ -440,6 +440,18 @@
   [generator]
   (gen/each-thread (gen/phases (cycle [(gen/time-limit 5 generator)]))))
 
+(defn client-generator
+  "Client generator"
+  []
+  (gen/each-thread
+   (gen/phases
+    (gen/once setup-cluster)
+    (gen/sleep 5)
+    (gen/once initialize-data)
+    (gen/sleep 5)
+    (gen/delay 3
+               (gen/mix [show-instances-reads read-balances valid-transfer])))))
+
 (defn workload
   "Basic HA workload."
   [opts]
@@ -452,5 +464,5 @@
      :checker   (checker/compose
                  {:habank     (habank-checker)
                   :timeline (timeline/html)})
-     :generator (ha-gen (gen/mix [setup-cluster initialize-data show-instances-reads read-balances valid-transfer]))
+     :generator (client-generator)
      :nemesis-config (nemesis/create nodes-config)}))

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -429,6 +429,10 @@ target_link_libraries(${test_prefix}slk_streams mg-slk gflags fmt)
 add_unit_test(rpc.cpp)
 target_link_libraries(${test_prefix}rpc mg-rpc)
 
+# Test rpc-timeouts
+add_unit_test(rpc_timeouts.cpp)
+target_link_libraries(${test_prefix}rpc_timeouts mg-rpc)
+
 # Test websocket
 find_package(Boost REQUIRED CONFIG)
 

--- a/tests/unit/rpc_messages.hpp
+++ b/tests/unit/rpc_messages.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2024 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -30,7 +30,7 @@ struct SumReq {
   int y;
 };
 
-const memgraph::utils::TypeInfo SumReq::kType{memgraph::utils::TypeId::UNKNOWN, "SumReq"};
+const memgraph::utils::TypeInfo SumReq::kType{memgraph::utils::TypeId::SUM_REQ, "SumReq"};
 
 struct SumRes {
   static const memgraph::utils::TypeInfo kType;
@@ -44,7 +44,7 @@ struct SumRes {
   int sum;
 };
 
-const memgraph::utils::TypeInfo SumRes::kType{memgraph::utils::TypeId::UNKNOWN, "SumRes"};
+const memgraph::utils::TypeInfo SumRes::kType{memgraph::utils::TypeId::SUM_RES, "SumRes"};
 
 namespace memgraph::slk {
 void Save(const SumReq &sum, Builder *builder);
@@ -68,7 +68,7 @@ struct EchoMessage {
   std::string data;
 };
 
-const memgraph::utils::TypeInfo EchoMessage::kType{memgraph::utils::TypeId::UNKNOWN, "EchoMessage"};
+const memgraph::utils::TypeInfo EchoMessage::kType{memgraph::utils::TypeId::ECHO_MESSAGE, "EchoMessage"};
 
 namespace memgraph::slk {
 void Save(const EchoMessage &echo, Builder *builder);

--- a/tests/unit/rpc_messages.hpp
+++ b/tests/unit/rpc_messages.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -30,7 +30,7 @@ struct SumReq {
   int y;
 };
 
-const memgraph::utils::TypeInfo SumReq::kType{memgraph::utils::TypeId::SUM_REQ, "SumReq"};
+const memgraph::utils::TypeInfo SumReq::kType{memgraph::utils::TypeId::UNKNOWN, "SumReq"};
 
 struct SumRes {
   static const memgraph::utils::TypeInfo kType;
@@ -44,7 +44,7 @@ struct SumRes {
   int sum;
 };
 
-const memgraph::utils::TypeInfo SumRes::kType{memgraph::utils::TypeId::SUM_RES, "SumRes"};
+const memgraph::utils::TypeInfo SumRes::kType{memgraph::utils::TypeId::UNKNOWN, "SumRes"};
 
 namespace memgraph::slk {
 void Save(const SumReq &sum, Builder *builder);
@@ -68,7 +68,9 @@ struct EchoMessage {
   std::string data;
 };
 
-const memgraph::utils::TypeInfo EchoMessage::kType{memgraph::utils::TypeId::ECHO_MESSAGE, "EchoMessage"};
+// Intentionally set to a random value to avoid polluting typeinfo.hpp
+const memgraph::utils::TypeInfo EchoMessage::kType{memgraph::utils::TypeId::COORD_UNREGISTER_REPLICA_REQ,
+                                                   "EchoMessage"};
 
 namespace memgraph::slk {
 void Save(const EchoMessage &echo, Builder *builder);

--- a/tests/unit/rpc_timeouts.cpp
+++ b/tests/unit/rpc_timeouts.cpp
@@ -58,9 +58,11 @@ void SumRes::Save(const SumRes &obj, memgraph::slk::Builder *builder) { memgraph
 void EchoMessage::Load(EchoMessage *obj, memgraph::slk::Reader *reader) { memgraph::slk::Load(obj, reader); }
 void EchoMessage::Save(const EchoMessage &obj, memgraph::slk::Builder *builder) { memgraph::slk::Save(obj, builder); }
 
+constexpr int port{8181};
+
 // RPC client is setup with timeout but shouldn't be triggered.
 TEST(RpcTimeout, TimeoutNoFailure) {
-  Endpoint endpoint{"localhost", 10000};
+  Endpoint endpoint{"localhost", port};
 
   ServerContext server_context;
   Server rpc_server{endpoint, &server_context, /* workers */ 1};
@@ -91,7 +93,7 @@ TEST(RpcTimeout, TimeoutNoFailure) {
 
 // Simulate something long executing on server.
 TEST(RpcTimeout, TimeoutExecutionBlocks) {
-  Endpoint endpoint{"localhost", 10000};
+  Endpoint endpoint{"localhost", port};
 
   ServerContext server_context;
   Server rpc_server{endpoint, &server_context, /* workers */ 1};
@@ -122,7 +124,7 @@ TEST(RpcTimeout, TimeoutExecutionBlocks) {
 
 // Simulate server with one thread being busy processing other RPC message.
 TEST(RpcTimeout, TimeoutServerBusy) {
-  Endpoint endpoint{"localhost", 10000};
+  Endpoint endpoint{"localhost", port};
 
   ServerContext server_context;
   Server rpc_server{endpoint, &server_context, /* workers */ 1};
@@ -171,7 +173,7 @@ TEST(RpcTimeout, TimeoutServerBusy) {
 }
 
 TEST(RpcTimeout, SendingToWrongSocket) {
-  Endpoint endpoint{"localhost", 10000};
+  Endpoint endpoint{"localhost", port};
 
   ServerContext server_context;
   Server rpc_server{endpoint, &server_context, /* workers */ 1};

--- a/tests/unit/rpc_timeouts.cpp
+++ b/tests/unit/rpc_timeouts.cpp
@@ -1,0 +1,201 @@
+// Copyright 2024 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "rpc/client.hpp"
+#include "rpc/server.hpp"
+
+#include "rpc_messages.hpp"
+
+using memgraph::communication::ClientContext;
+using memgraph::communication::ServerContext;
+using memgraph::io::network::Endpoint;
+using memgraph::rpc::Client;
+using memgraph::rpc::GenericRpcFailedException;
+using memgraph::rpc::Server;
+using memgraph::slk::Load;
+using memgraph::slk::Save;
+
+using namespace std::string_view_literals;
+using namespace std::literals::chrono_literals;
+
+namespace memgraph::slk {
+void Save(const SumReq &sum, Builder *builder) {
+  Save(sum.x, builder);
+  Save(sum.y, builder);
+}
+
+void Load(SumReq *sum, Reader *reader) {
+  Load(&sum->x, reader);
+  Load(&sum->y, reader);
+}
+
+void Save(const SumRes &res, Builder *builder) { Save(res.sum, builder); }
+
+void Load(SumRes *res, Reader *reader) { Load(&res->sum, reader); }
+
+void Save(const EchoMessage &echo, Builder *builder) { Save(echo.data, builder); }
+
+void Load(EchoMessage *echo, Reader *reader) { Load(&echo->data, reader); }
+}  // namespace memgraph::slk
+
+void SumReq::Load(SumReq *obj, memgraph::slk::Reader *reader) { memgraph::slk::Load(obj, reader); }
+void SumReq::Save(const SumReq &obj, memgraph::slk::Builder *builder) { memgraph::slk::Save(obj, builder); }
+
+void SumRes::Load(SumRes *obj, memgraph::slk::Reader *reader) { memgraph::slk::Load(obj, reader); }
+void SumRes::Save(const SumRes &obj, memgraph::slk::Builder *builder) { memgraph::slk::Save(obj, builder); }
+
+void EchoMessage::Load(EchoMessage *obj, memgraph::slk::Reader *reader) { memgraph::slk::Load(obj, reader); }
+void EchoMessage::Save(const EchoMessage &obj, memgraph::slk::Builder *builder) { memgraph::slk::Save(obj, builder); }
+
+// RPC client is setup with timeout but shouldn't be triggered.
+TEST(RpcTimeout, TimeoutNoFailure) {
+  Endpoint endpoint{"localhost", 10000};
+
+  ServerContext server_context;
+  Server rpc_server{endpoint, &server_context, /* workers */ 1};
+  auto const on_exit = memgraph::utils::OnScopeExit{[&rpc_server] {
+    rpc_server.Shutdown();
+    rpc_server.AwaitShutdown();
+  }};
+
+  rpc_server.Register<Echo>([](auto *req_reader, auto *res_builder) {
+    EchoMessage req;
+    Load(&req, req_reader);
+
+    EchoMessage res{"Sending reply"};
+    Save(res, res_builder);
+  });
+
+  ASSERT_TRUE(rpc_server.Start());
+  std::this_thread::sleep_for(100ms);
+
+  auto const rpc_timeouts = std::map{std::make_pair("EchoMessage"sv, 2000)};
+  ClientContext client_context;
+  Client client{endpoint, &client_context, rpc_timeouts};
+
+  auto stream = client.Stream<Echo>("Sending request");
+  auto reply = stream.AwaitResponse();
+  EXPECT_EQ(reply.data, "Sending reply");
+}
+
+// Simulate something long executing on server.
+TEST(RpcTimeout, TimeoutExecutionBlocks) {
+  Endpoint endpoint{"localhost", 10000};
+
+  ServerContext server_context;
+  Server rpc_server{endpoint, &server_context, /* workers */ 1};
+  auto const on_exit = memgraph::utils::OnScopeExit{[&rpc_server] {
+    rpc_server.Shutdown();
+    rpc_server.AwaitShutdown();
+  }};
+
+  rpc_server.Register<Echo>([](auto *req_reader, auto *res_builder) {
+    EchoMessage req;
+    Load(&req, req_reader);
+
+    std::this_thread::sleep_for(1100ms);
+    EchoMessage res{"Sending reply"};
+    Save(res, res_builder);
+  });
+
+  ASSERT_TRUE(rpc_server.Start());
+  std::this_thread::sleep_for(100ms);
+
+  auto const rpc_timeouts = std::map{std::make_pair("EchoMessage"sv, 1000)};
+  ClientContext client_context;
+  Client client{endpoint, &client_context, rpc_timeouts};
+
+  auto stream = client.Stream<Echo>("Sending request");
+  EXPECT_THROW(stream.AwaitResponse(), GenericRpcFailedException);
+}
+
+// Simulate server with one thread being busy processing other RPC message.
+TEST(RpcTimeout, TimeoutServerBusy) {
+  Endpoint endpoint{"localhost", 10000};
+
+  ServerContext server_context;
+  Server rpc_server{endpoint, &server_context, /* workers */ 1};
+  auto const on_exit = memgraph::utils::OnScopeExit{[&rpc_server] {
+    rpc_server.Shutdown();
+    rpc_server.AwaitShutdown();
+  }};
+
+  rpc_server.Register<Sum>([](auto *req_reader, auto *res_builder) {
+    spdlog::trace("Received sum request.");
+    SumReq req;
+    Load(&req, req_reader);
+    std::this_thread::sleep_for(2500ms);
+    SumRes res(req.x + req.y);
+    Save(res, res_builder);
+  });
+
+  rpc_server.Register<Echo>([](auto *req_reader, auto *res_builder) {
+    spdlog::trace("Received echo request");
+    EchoMessage req;
+    Load(&req, req_reader);
+
+    EchoMessage res{"Sending reply"};
+    Save(res, res_builder);
+  });
+
+  ASSERT_TRUE(rpc_server.Start());
+  std::this_thread::sleep_for(100ms);
+
+  auto const rpc_timeouts = std::map{std::make_pair("EchoMessage"sv, 1000)};
+  ClientContext sum_client_context;
+  Client sum_client{endpoint, &sum_client_context};
+
+  ClientContext echo_client_context;
+  Client echo_client{endpoint, &echo_client_context, rpc_timeouts};
+
+  // Sum request won't timeout but Echo should timeout because server has only one
+  // processing thread.
+  auto sum_stream = sum_client.Stream<Sum>(10, 10);
+  auto echo_stream = echo_client.Stream<Echo>("Sending request");
+  // Don't block main test thread so echo_stream could timeout
+  auto sum_thread_ = std::jthread([&sum_stream]() { sum_stream.AwaitResponse(); });
+  // Wait so that server receives first SumReq and then EchoMessage
+  std::this_thread::sleep_for(100ms);
+  EXPECT_THROW(echo_stream.AwaitResponse(), GenericRpcFailedException);
+}
+
+TEST(RpcTimeout, SendingToWrongSocket) {
+  Endpoint endpoint{"localhost", 10000};
+
+  ServerContext server_context;
+  Server rpc_server{endpoint, &server_context, /* workers */ 1};
+  auto const on_exit = memgraph::utils::OnScopeExit{[&rpc_server] {
+    rpc_server.Shutdown();
+    rpc_server.AwaitShutdown();
+  }};
+
+  rpc_server.Register<Echo>([](auto *req_reader, auto *res_builder) {
+    EchoMessage req;
+    Load(&req, req_reader);
+
+    std::this_thread::sleep_for(1100ms);
+    EchoMessage res{"Sending reply"};
+    Save(res, res_builder);
+  });
+
+  ASSERT_TRUE(rpc_server.Start());
+  std::this_thread::sleep_for(100ms);
+
+  auto const rpc_timeouts = std::map{std::make_pair("EchoMessage"sv, 1000)};
+  ClientContext client_context;
+  Client client{endpoint, &client_context, rpc_timeouts};
+
+  auto stream = client.Stream<Echo>("Sending request");
+  EXPECT_THROW(stream.AwaitResponse(), GenericRpcFailedException);
+}

--- a/tests/unit/rpc_timeouts.cpp
+++ b/tests/unit/rpc_timeouts.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -82,7 +82,7 @@ TEST(RpcTimeout, TimeoutNoFailure) {
   ASSERT_TRUE(rpc_server.Start());
   std::this_thread::sleep_for(100ms);
 
-  auto const rpc_timeouts = std::map{std::make_pair("EchoMessage"sv, 2000)};
+  auto const rpc_timeouts = std::unordered_map{std::make_pair("EchoMessage"sv, 2000)};
   ClientContext client_context;
   Client client{endpoint, &client_context, rpc_timeouts};
 
@@ -114,7 +114,7 @@ TEST(RpcTimeout, TimeoutExecutionBlocks) {
   ASSERT_TRUE(rpc_server.Start());
   std::this_thread::sleep_for(100ms);
 
-  auto const rpc_timeouts = std::map{std::make_pair("EchoMessage"sv, 1000)};
+  auto const rpc_timeouts = std::unordered_map{std::make_pair("EchoMessage"sv, 1000)};
   ClientContext client_context;
   Client client{endpoint, &client_context, rpc_timeouts};
 
@@ -154,7 +154,7 @@ TEST(RpcTimeout, TimeoutServerBusy) {
   ASSERT_TRUE(rpc_server.Start());
   std::this_thread::sleep_for(100ms);
 
-  auto const rpc_timeouts = std::map{std::make_pair("EchoMessage"sv, 1000)};
+  auto const rpc_timeouts = std::unordered_map{std::make_pair("EchoMessage"sv, 1000)};
   ClientContext sum_client_context;
   Client sum_client{endpoint, &sum_client_context};
 
@@ -194,7 +194,7 @@ TEST(RpcTimeout, SendingToWrongSocket) {
   ASSERT_TRUE(rpc_server.Start());
   std::this_thread::sleep_for(100ms);
 
-  auto const rpc_timeouts = std::map{std::make_pair("EchoMessage"sv, 1000)};
+  auto const rpc_timeouts = std::unordered_map{std::make_pair("EchoMessage"sv, 1000)};
   ClientContext client_context;
   Client client{endpoint, &client_context, rpc_timeouts};
 


### PR DESCRIPTION
Adds RPC timeouts to the replication and coordination stack. Relies on WaitForReadyRead and WaitForReadyWrite capabilities of socket in Linux kernel. 
For all the following RPC messages, the timeout is set to 10s:
Messages used:
- ShowInstancesReq -> coordinator sending to coordinator
- DemoteMainToReplicaReq -> coordinator sending to main
- PromoteToMainReq -> coordinator sending to replica
- RegisterReplicaOnMainReq -> coordinator sending to main
- UnregisterReplicaReq -> coordinator sending to main
- EnableWritingOnMainReq -> coordinator to main
- GetInstanceUUIDReq -> coordinator to data instances
- GetDatabaseHistoriesReq -> coordinator to data instances
- StateCheckReq -> coordinator to data instances
- HeartbeatReq -> main to replica
- TimestampReq -> main to replica
- SwapMainUUIDReq -> coord to data instances
- FrequentHeartbeatReq -> coord to data instances
