### PR TITLE
Remove unused ReplicasInfo method

### DIFF
--- a/src/query/replication_query_handler.hpp
+++ b/src/query/replication_query_handler.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -75,7 +75,7 @@ struct ReplicasInfo {
 
   std::string name_;
   std::string socket_address_;
-  memgraph::replication_coordination_glue::ReplicationMode sync_mode_;
+  replication_coordination_glue::ReplicationMode sync_mode_;
   ReplicaSystemInfoState system_info_;
   std::map<std::string, ReplicaInfoState> data_info_;
 };

--- a/src/replication/include/replication/replication_client.hpp
+++ b/src/replication/include/replication/replication_client.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -16,12 +16,10 @@
 #include "rpc/client.hpp"
 #include "utils/rw_lock.hpp"
 #include "utils/scheduler.hpp"
-#include "utils/spin_lock.hpp"
 #include "utils/synchronized.hpp"
 #include "utils/thread_pool.hpp"
 
 #include <concepts>
-#include <string_view>
 
 namespace memgraph::replication {
 

--- a/src/replication_handler/include/replication_handler/replication_handler.hpp
+++ b/src/replication_handler/include/replication_handler/replication_handler.hpp
@@ -107,11 +107,10 @@ void SystemRestore(replication::ReplicationClient &client, system::System &syste
 #endif
 
 /// A handler type that keep in sync current ReplicationState and the MAIN/REPLICA-ness of Storage
-struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
+struct ReplicationHandler : public query::ReplicationQueryHandler {
 #ifdef MG_ENTERPRISE
-  explicit ReplicationHandler(memgraph::replication::ReplicationState &repl_state,
-                              memgraph::dbms::DbmsHandler &dbms_handler, memgraph::system::System &system,
-                              memgraph::auth::SynchedAuth &auth);
+  explicit ReplicationHandler(ReplicationState &repl_state, memgraph::dbms::DbmsHandler &dbms_handler,
+                              memgraph::system::System &system, memgraph::auth::SynchedAuth &auth);
 #else
   explicit ReplicationHandler(memgraph::replication::ReplicationState &repl_state,
                               memgraph::dbms::DbmsHandler &dbms_handler);
@@ -145,8 +144,7 @@ struct ReplicationHandler : public memgraph::query::ReplicationQueryHandler {
   bool IsMain() const override;
   bool IsReplica() const override;
 
-  auto ShowReplicas() const
-      -> utils::BasicResult<memgraph::query::ShowReplicaError, memgraph::query::ReplicasInfos> override;
+  auto ShowReplicas() const -> utils::BasicResult<query::ShowReplicaError, query::ReplicasInfos> override;
 
   auto GetReplState() const -> const memgraph::replication::ReplicationState &;
   auto GetReplState() -> memgraph::replication::ReplicationState &;

--- a/src/replication_handler/include/replication_handler/system_replication.hpp
+++ b/src/replication_handler/include/replication_handler/system_replication.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -13,7 +13,6 @@
 
 #include "auth/auth.hpp"
 #include "dbms/dbms_handler.hpp"
-#include "slk/streams.hpp"
 #include "system/state.hpp"
 
 namespace memgraph::replication {

--- a/src/replication_handler/replication_handler.cpp
+++ b/src/replication_handler/replication_handler.cpp
@@ -328,9 +328,9 @@ auto ReplicationHandler::GetReplicaUUID() const -> std::optional<utils::UUID> {
   return std::get<RoleReplicaData>(repl_state_.ReplicationData()).uuid_;
 }
 
-auto ReplicationHandler::GetReplState() const -> const memgraph::replication::ReplicationState & { return repl_state_; }
+auto ReplicationHandler::GetReplState() const -> const ReplicationState & { return repl_state_; }
 
-auto ReplicationHandler::GetReplState() -> replication::ReplicationState & { return repl_state_; }
+auto ReplicationHandler::GetReplState() -> ReplicationState & { return repl_state_; }
 
 bool ReplicationHandler::IsMain() const { return repl_state_.IsMain(); }
 

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -22,7 +22,6 @@
 #include "storage/v2/inmemory/replication/recovery.hpp"
 #include "storage/v2/inmemory/snapshot_info.hpp"
 #include "storage/v2/replication/replication_client.hpp"
-#include "storage/v2/schema_info.hpp"
 #include "storage/v2/storage.hpp"
 
 /// REPLICATION ///

--- a/src/storage/v2/replication/replication_storage_state.cpp
+++ b/src/storage/v2/replication/replication_storage_state.cpp
@@ -36,19 +36,6 @@ std::optional<replication::ReplicaState> ReplicationStorageState::GetReplicaStat
   });
 }
 
-std::vector<ReplicaInfo> ReplicationStorageState::ReplicasInfo(const Storage *storage) const {
-  return replication_clients_.WithReadLock([storage](auto const &clients) {
-    std::vector<ReplicaInfo> replica_infos;
-    replica_infos.reserve(clients.size());
-    auto const asReplicaInfo = [storage](ReplicationClientPtr const &client) -> ReplicaInfo {
-      const auto ts = client->GetTimestampInfo(storage);
-      return {client->Name(), client->Mode(), client->Endpoint(), client->State(), ts};
-    };
-    std::transform(clients.begin(), clients.end(), std::back_inserter(replica_infos), asReplicaInfo);
-    return replica_infos;
-  });
-}
-
 void ReplicationStorageState::Reset() {
   replication_clients_.WithLock([](auto &clients) { clients.clear(); });
 }

--- a/src/storage/v2/replication/replication_storage_state.hpp
+++ b/src/storage/v2/replication/replication_storage_state.hpp
@@ -50,7 +50,6 @@ struct ReplicationStorageState {
 
   // Getters
   auto GetReplicaState(std::string_view name) const -> std::optional<replication::ReplicaState>;
-  auto ReplicasInfo(const Storage *storage) const -> std::vector<ReplicaInfo>;
 
   // History
   void TrackLatestHistory();

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -15,7 +15,6 @@
 #include <optional>
 #include <span>
 
-#include "io/network/endpoint.hpp"
 #include "mg_procedure.h"
 #include "query/exceptions.hpp"
 #include "storage/v2/commit_log.hpp"
@@ -550,7 +549,6 @@ class Storage {
 
   virtual void PrepareForNewEpoch() = 0;
 
-  auto ReplicasInfo() const { return repl_storage_state_.ReplicasInfo(this); }
   auto GetReplicaState(std::string_view name) const -> std::optional<replication::ReplicaState> {
     return repl_storage_state_.GetReplicaState(name);
   }


### PR DESCRIPTION
`ReplicasInfo` method from the storage and repl storage state wasn't used.