### PR TITLE
Add property lookup cache for `WHERE`

### DIFF
--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -308,10 +308,12 @@ bool SymbolGenerator::PreVisit(With &with) {
   return false;  // We handled the traversal ourselves.
 }
 
-bool SymbolGenerator::PreVisit(Where &) {
+bool SymbolGenerator::PreVisit(Where &where) {
   scopes_.back().in_where = true;
+  SetEvaluationModeOnPropertyLookups(where);
   return true;
 }
+
 bool SymbolGenerator::PostVisit(Where &) {
   scopes_.back().in_where = false;
   return true;

--- a/src/query/frontend/semantic/symbol_generator.hpp
+++ b/src/query/frontend/semantic/symbol_generator.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -234,33 +234,81 @@ class PropertyLookupEvaluationModeVisitor : public ExpressionVisitor<void> {
     op.expression1_->Accept(*this);
     op.expression2_->Accept(*this);
   };
-  void Visit(AdditionOperator &op) override{};
-  void Visit(SubtractionOperator &op) override{};
-  void Visit(MultiplicationOperator &op) override{};
-  void Visit(DivisionOperator &op) override{};
-  void Visit(ModOperator &op) override{};
-  void Visit(LessOperator &op) override{};
-  void Visit(GreaterOperator &op) override{};
-  void Visit(LessEqualOperator &op) override{};
-  void Visit(GreaterEqualOperator &op) override{};
+  void Visit(AdditionOperator &op) override {
+    op.expression1_->Accept(*this);
+    op.expression2_->Accept(*this);
+  };
+  void Visit(SubtractionOperator &op) override {
+    op.expression1_->Accept(*this);
+    op.expression2_->Accept(*this);
+  };
+  void Visit(MultiplicationOperator &op) override {
+    op.expression1_->Accept(*this);
+    op.expression2_->Accept(*this);
+  };
+  void Visit(DivisionOperator &op) override {
+    op.expression1_->Accept(*this);
+    op.expression2_->Accept(*this);
+  };
+  void Visit(ModOperator &op) override {
+    op.expression1_->Accept(*this);
+    op.expression2_->Accept(*this);
+  };
+  void Visit(LessOperator &op) override {
+    op.expression1_->Accept(*this);
+    op.expression2_->Accept(*this);
+  };
+  void Visit(GreaterOperator &op) override {
+    op.expression1_->Accept(*this);
+    op.expression2_->Accept(*this);
+  };
+  void Visit(LessEqualOperator &op) override {
+    op.expression1_->Accept(*this);
+    op.expression2_->Accept(*this);
+  };
+  void Visit(GreaterEqualOperator &op) override {
+    op.expression1_->Accept(*this);
+    op.expression2_->Accept(*this);
+  };
   void Visit(RangeOperator &op) override{};
   void Visit(SubscriptOperator &op) override{};
   void Visit(ListSlicingOperator &op) override{};
-  void Visit(IfOperator &op) override{};
+  void Visit(IfOperator &op) override {
+    op.condition_->Accept(*this);
+    op.then_expression_->Accept(*this);
+    if (op.else_expression_) {
+      op.else_expression_->Accept(*this);
+    }
+  };
   void Visit(ListLiteral &op) override{};
   void Visit(MapLiteral &op) override{};
   void Visit(MapProjectionLiteral &op) override{};
   void Visit(LabelsTest &op) override{};
-  void Visit(Aggregation &op) override{};
-  void Visit(Function &op) override{};
+  void Visit(Aggregation &op) override {
+    if (op.expression1_) {
+      op.expression1_->Accept(*this);
+    }
+    if (op.expression2_) {
+      op.expression2_->Accept(*this);
+    }
+  };
+  void Visit(Function &op) override {
+    for (auto *argument : op.arguments_) {
+      argument->Accept(*this);
+    }
+  };
   void Visit(Reduce &op) override{};
-  void Visit(Coalesce &op) override{};
-  void Visit(Extract &op) override{};
+  void Visit(Coalesce &op) override {
+    for (auto *expression : op.expressions_) {
+      expression->Accept(*this);
+    }
+  };
+  void Visit(Extract &op) override { op.expression_->Accept(*this); };
   void Visit(Exists &op) override{};
-  void Visit(All &op) override{};
-  void Visit(Single &op) override{};
-  void Visit(Any &op) override{};
-  void Visit(None &op) override{};
+  void Visit(All &op) override { op.where_->expression_->Accept(*this); };
+  void Visit(Single &op) override { op.where_->expression_->Accept(*this); };
+  void Visit(Any &op) override { op.where_->expression_->Accept(*this); };
+  void Visit(None &op) override { op.where_->expression_->Accept(*this); };
   void Visit(Identifier &op) override{};
   void Visit(PrimitiveLiteral &op) override{};
   void Visit(AllPropertiesLookup &op) override{};
@@ -315,6 +363,18 @@ inline void SetEvaluationModeOnPropertyLookups(MapLiteral &map_literal) {
   for (auto &pair : map_literal.elements_) {
     pair.second->Accept(visitor);
   }
+  visitor.assign_property_lookup_evaluations = false;
+}
+
+inline void SetEvaluationModeOnPropertyLookups(Where &where) {
+  PropertyLookupEvaluationModeVisitor visitor;
+
+  visitor.gather_property_lookup_counts = true;
+  where.expression_->Accept(visitor);
+  visitor.gather_property_lookup_counts = false;
+
+  visitor.assign_property_lookup_evaluations = true;
+  where.expression_->Accept(visitor);
   visitor.assign_property_lookup_evaluations = false;
 }
 

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -697,6 +697,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
     bool has_null_elements = false;
     bool has_value = false;
     for (const auto &element : list) {
+      property_lookup_cache_.erase(symbol.position());
       frame_->at(symbol) = element;
       auto result = all.where_->expression_->Accept(*this);
       if (!result.IsNull() && result.type() != TypedValue::Type::Bool) {
@@ -734,6 +735,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
     bool predicate_satisfied = false;
     bool has_null_elements = false;
     for (const auto &element : list) {
+      property_lookup_cache_.erase(symbol.position());
       frame_->at(symbol) = element;
       auto result = single.where_->expression_->Accept(*this);
       if (!result.IsNull() && result.type() != TypedValue::Type::Bool) {
@@ -778,6 +780,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
     bool has_null_elements = false;
     bool has_value = false;
     for (const auto &element : list) {
+      property_lookup_cache_.erase(symbol.position());
       frame_->at(symbol) = element;
       auto result = any.where_->expression_->Accept(*this);
       if (!result.IsNull() && result.type() != TypedValue::Type::Bool) {
@@ -815,6 +818,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
     bool has_null_elements = false;
     bool has_value = false;
     for (const auto &element : list) {
+      property_lookup_cache_.erase(symbol.position());
       frame_->at(symbol) = element;
       auto result = none.where_->expression_->Accept(*this);
       if (!result.IsNull() && result.type() != TypedValue::Type::Bool) {

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -3014,12 +3014,18 @@ bool Filter::FilterCursor::Pull(Frame &frame, ExecutionContext &context) {
   // nodes and edges.
   ExpressionEvaluator evaluator(&frame, context.symbol_table, context.evaluation_context, context.db_accessor,
                                 storage::View::OLD, context.frame_change_collector);
+
+  utils::OnScopeExit([&evaluator] { evaluator.ResetPropertyLookupCache(); });
+
   while (input_cursor_->Pull(frame, context)) {
     for (const auto &pattern_filter_cursor : pattern_filter_cursors_) {
       pattern_filter_cursor->Pull(frame, context);
     }
+
+    evaluator.ResetPropertyLookupCache();
     if (EvaluateFilter(evaluator, self_.expression_)) return true;
   }
+
   return false;
 }
 


### PR DESCRIPTION
Property lookup cache for WHERE expressions to minimize number of times going to storage
