### PR TITLE
Improving replication recovery process

### DIFF
--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -83,7 +83,6 @@ constexpr const char *kMgPassfile = "MEMGRAPH_PASSFILE";
 constexpr const char *kMgExperimentalEnabled = "MEMGRAPH_EXPERIMENTAL_ENABLED";
 constexpr const char *kMgBoltPort = "MEMGRAPH_BOLT_PORT";
 constexpr const char *kMgHaClusterInitQueries = "MEMGRAPH_HA_CLUSTER_INIT_QUERIES";
-constexpr const char *kRaftDataDir = "/high_availability/raft_data";
 
 constexpr uint64_t kMgVmMaxMapCount = 262144;
 
@@ -531,6 +530,7 @@ int main(int argc, char **argv) {
     }
 
     if (is_valid_coordinator_instance) {
+      constexpr auto kRaftDataDir = "/high_availability/raft_data";
       auto const high_availability_data_dir = FLAGS_data_directory + kRaftDataDir;
       memgraph::utils::EnsureDirOrDie(high_availability_data_dir);
       coordinator_state.emplace(CoordinatorInstanceInitConfig{

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -83,6 +83,7 @@ constexpr const char *kMgPassfile = "MEMGRAPH_PASSFILE";
 constexpr const char *kMgExperimentalEnabled = "MEMGRAPH_EXPERIMENTAL_ENABLED";
 constexpr const char *kMgBoltPort = "MEMGRAPH_BOLT_PORT";
 constexpr const char *kMgHaClusterInitQueries = "MEMGRAPH_HA_CLUSTER_INIT_QUERIES";
+constexpr const char *kRaftDataDir = "/high_availability/raft_data";
 
 constexpr uint64_t kMgVmMaxMapCount = 262144;
 
@@ -530,7 +531,7 @@ int main(int argc, char **argv) {
     }
 
     if (is_valid_coordinator_instance) {
-      auto const high_availability_data_dir = FLAGS_data_directory + "/high_availability/raft_data";
+      auto const high_availability_data_dir = FLAGS_data_directory + kRaftDataDir;
       memgraph::utils::EnsureDirOrDie(high_availability_data_dir);
       coordinator_state.emplace(CoordinatorInstanceInitConfig{
           .coordinator_id = coordination_setup.coordinator_id,

--- a/src/query/plan/hint_provider.hpp
+++ b/src/query/plan/hint_provider.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -304,7 +304,7 @@ class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
   }
 
   std::string ExtractAndJoin(auto &&collection, auto &&projection) {
-    auto elements = collection | ranges::views::transform(projection);
+    auto elements = collection | ranges::views::transform(std::forward<decltype(projection)>(projection));
     return boost::algorithm::join(elements, ", ");
   }
 };

--- a/src/storage/v2/inmemory/replication/recovery.cpp
+++ b/src/storage/v2/inmemory/replication/recovery.cpp
@@ -231,7 +231,7 @@ std::vector<RecoveryStep> GetRecoverySteps(uint64_t replica_commit, utils::FileR
       for (; first_useful_wal < wal_files->size(); ++first_useful_wal) {
         auto &wal = wal_files.value()[first_useful_wal];
         const auto lock_success = locker_acc.AddPath(wal.path);
-        MG_ASSERT(!lock_success.HasError(), "Tried to lock a nonexistant WAL path.");
+        MG_ASSERT(!lock_success.HasError(), "Tried to lock a nonexistent WAL path.");
         rw.emplace_back(std::move(wal.path));
       }
       recovery_steps.emplace_back(std::in_place_type_t<RecoveryWals>{}, std::move(rw));

--- a/src/storage/v2/inmemory/replication/recovery.cpp
+++ b/src/storage/v2/inmemory/replication/recovery.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -12,7 +12,6 @@
 #include "storage/v2/inmemory/replication/recovery.hpp"
 #include <algorithm>
 #include <cstdint>
-#include <iterator>
 #include <type_traits>
 #include "storage/v2/durability/durability.hpp"
 #include "storage/v2/inmemory/storage.hpp"
@@ -20,7 +19,6 @@
 #include "storage/v2/transaction.hpp"
 #include "utils/on_scope_exit.hpp"
 #include "utils/uuid.hpp"
-#include "utils/variant_helpers.hpp"
 
 namespace memgraph::storage {
 
@@ -72,10 +70,10 @@ void InMemoryCurrentWalHandler::AppendBufferData(const uint8_t *buffer, const si
 
 replication::CurrentWalRes InMemoryCurrentWalHandler::Finalize() { return stream_.AwaitResponse(); }
 
-////// ReplicationClient Helpers //////
+// ReplicationClient Helpers
+// Caller should make sure that wal files aren't empty
 replication::WalFilesRes TransferWalFiles(const utils::UUID &main_uuid, const utils::UUID &uuid, rpc::Client &client,
                                           const std::vector<std::filesystem::path> &wal_files) {
-  MG_ASSERT(!wal_files.empty(), "Wal files list is empty!");
   auto stream = client.Stream<replication::WalFilesRpc>(main_uuid, uuid, wal_files.size());
   replication::Encoder encoder(stream.GetBuilder());
   for (const auto &wal : wal_files) {
@@ -93,16 +91,15 @@ replication::SnapshotRes TransferSnapshot(const utils::UUID &main_uuid, const ut
   return stream.AwaitResponse();
 }
 
-uint64_t ReplicateCurrentWal(const utils::UUID &main_uuid, const InMemoryStorage *storage, rpc::Client &client,
-                             durability::WalFile const &wal_file) {
+replication::CurrentWalRes ReplicateCurrentWal(const utils::UUID &main_uuid, const InMemoryStorage *storage,
+                                               rpc::Client &client, durability::WalFile const &wal_file) {
   InMemoryCurrentWalHandler stream{main_uuid, storage, client};
   stream.AppendFilename(wal_file.Path().filename());
   utils::InputFile file;
   MG_ASSERT(file.Open(wal_file.Path()), "Failed to open current WAL file at {}!", wal_file.Path());
   stream.AppendSize(file.GetSize());
   stream.AppendFileData(&file);
-  auto response = stream.Finalize();
-  return response.current_commit_timestamp;
+  return stream.Finalize();
 }
 
 /// This method tries to find the optimal path for recovering a single replica.
@@ -134,7 +131,6 @@ std::vector<RecoveryStep> GetRecoverySteps(uint64_t replica_commit, utils::FileR
   // otherwise save the seq_num of the current wal file
   // This lock is also necessary to force the missed transaction to finish.
   std::optional<uint64_t> current_wal_seq_num;
-  std::optional<uint64_t> current_wal_from_timestamp;
   uint64_t last_durable_timestamp{kTimestampInitialId};
 
   std::unique_lock transaction_guard(
@@ -144,7 +140,6 @@ std::vector<RecoveryStep> GetRecoverySteps(uint64_t replica_commit, utils::FileR
   if (storage->wal_file_) {
     last_durable_timestamp = storage->wal_file_->ToTimestamp();
     current_wal_seq_num.emplace(storage->wal_file_->SequenceNumber());
-    current_wal_from_timestamp.emplace(storage->wal_file_->FromTimestamp());
     // No need to hold the lock since the current WAL is present and we can simply skip them
     transaction_guard.unlock();
   }
@@ -188,7 +183,7 @@ std::vector<RecoveryStep> GetRecoverySteps(uint64_t replica_commit, utils::FileR
     // Check what part of the WAL chain is needed
     bool covered_by_wals = false;
     auto prev_seq{wal_files->back().seq_num};
-    int64_t first_useful_wal = (int64_t)wal_files->size() - 1;
+    int64_t first_useful_wal = static_cast<int64_t>(wal_files->size()) - 1;
     // Going from newest to oldest
     for (; first_useful_wal >= 0; --first_useful_wal) {
       const auto &wal = wal_files.value()[first_useful_wal];
@@ -216,10 +211,10 @@ std::vector<RecoveryStep> GetRecoverySteps(uint64_t replica_commit, utils::FileR
         if (latest_snapshot->start_timestamp > replica_commit) {
           // There is some data we need in the snapshot
           add_snapshot();
-          // Go along the WAL chain and remove unecessary parts (going from oldest to newest WAL)
+          // Go along the WAL chain and remove necessary parts (going from oldest to newest WAL)
           for (; first_useful_wal < wal_files->size(); ++first_useful_wal) {
-            const auto &wal = wal_files.value()[first_useful_wal];
-            if (wal.to_timestamp > latest_snapshot->start_timestamp) {
+            const auto &local_wal = wal_files.value()[first_useful_wal];
+            if (local_wal.to_timestamp > latest_snapshot->start_timestamp) {
               // Got to the first WAL file with data not contained in the snapshot
               break;
             }

--- a/src/storage/v2/inmemory/replication/recovery.hpp
+++ b/src/storage/v2/inmemory/replication/recovery.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -25,8 +25,8 @@ replication::WalFilesRes TransferWalFiles(const utils::UUID &main_uuid, const ut
 replication::SnapshotRes TransferSnapshot(const utils::UUID &main_uuid, const utils::UUID &uuid, rpc::Client &client,
                                           const std::filesystem::path &path);
 
-uint64_t ReplicateCurrentWal(const utils::UUID &main_uuid, const InMemoryStorage *storage, rpc::Client &client,
-                             durability::WalFile const &wal_file);
+replication::CurrentWalRes ReplicateCurrentWal(const utils::UUID &main_uuid, const InMemoryStorage *storage,
+                                               rpc::Client &client, durability::WalFile const &wal_file);
 
 auto GetRecoverySteps(uint64_t replica_commit, utils::FileRetainer::FileLocker *file_locker,
                       const InMemoryStorage *storage) -> std::vector<RecoveryStep>;

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -293,9 +293,7 @@ bool ReplicationStorageClient::FinalizeTransactionReplication(Storage *storage, 
       return replica_state_.WithLock(
           [storage, response, db_acc = std::move(db_acc), this, &replica_stream_obj](auto &state) mutable {
             replica_stream_obj.reset();
-            // When async replica executes this part of the code, the state could've changed since the check
-            // at the beginning of the function happened.
-            if (!response.success || state == ReplicaState::RECOVERY) {
+            if (!response.success) {
               state = ReplicaState::RECOVERY;
               // NOLINTNEXTLINE
               client_.thread_pool_.AddTask([storage, response, db_acc = std::move(db_acc), this] {

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -300,7 +300,7 @@ bool ReplicationStorageClient::FinalizeTransactionReplication(Storage *storage, 
       return replica_state_.WithLock(
           [storage, response, db_acc = std::move(db_acc), this, &replica_stream_obj](auto &state) mutable {
             replica_stream_obj.reset();
-            // When async replica executes this part of the code, the state could've changes since the check
+            // When async replica executes this part of the code, the state could've changed since the check
             // at the beginning of the function happened.
             if (!response.success || state == replication::ReplicaState::RECOVERY) {
               state = ReplicaState::RECOVERY;
@@ -444,13 +444,13 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_commit, Storage *
   if (last_durable_timestamp <= replica_commit) {
     replica_state_.WithLock([name = client_.name_](auto &val) {
       val = ReplicaState::READY;
-      spdlog::info("Replica {} set to ready.", name);
+      spdlog::info("Replica {} set to READY after recovery.", name);
     });
   } else {
     // Someone could've committed in the meantime, hence we set the state to MAYBE_BEHIND
     replica_state_.WithLock([name = client_.name_](auto &val) {
       val = ReplicaState::MAYBE_BEHIND;
-      spdlog::info("Replica {} set to MAYBE_BEHIND.", name);
+      spdlog::info("Replica {} set to MAYBE_BEHIND after recovery.", name);
     });
   }
 }

--- a/src/storage/v2/replication/rpc.cpp
+++ b/src/storage/v2/replication/rpc.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -168,12 +168,10 @@ void Load(memgraph::storage::replication::CurrentWalReq *self, memgraph::slk::Re
 // Serialize code for WalFilesRes
 
 void Save(const memgraph::storage::replication::WalFilesRes &self, memgraph::slk::Builder *builder) {
-  memgraph::slk::Save(self.success, builder);
   memgraph::slk::Save(self.current_commit_timestamp, builder);
 }
 
 void Load(memgraph::storage::replication::WalFilesRes *self, memgraph::slk::Reader *reader) {
-  memgraph::slk::Load(&self->success, reader);
   memgraph::slk::Load(&self->current_commit_timestamp, reader);
 }
 
@@ -194,12 +192,10 @@ void Load(memgraph::storage::replication::WalFilesReq *self, memgraph::slk::Read
 // Serialize code for SnapshotRes
 
 void Save(const memgraph::storage::replication::SnapshotRes &self, memgraph::slk::Builder *builder) {
-  memgraph::slk::Save(self.success, builder);
   memgraph::slk::Save(self.current_commit_timestamp, builder);
 }
 
 void Load(memgraph::storage::replication::SnapshotRes *self, memgraph::slk::Reader *reader) {
-  memgraph::slk::Load(&self->success, reader);
   memgraph::slk::Load(&self->current_commit_timestamp, reader);
 }
 

--- a/src/storage/v2/replication/rpc.hpp
+++ b/src/storage/v2/replication/rpc.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -12,7 +12,6 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
 #include <string>
 #include <utility>
 
@@ -20,7 +19,6 @@
 #include "slk/serialization.hpp"
 #include "slk/streams.hpp"
 #include "storage/v2/config.hpp"
-#include "utils/enum.hpp"
 #include "utils/uuid.hpp"
 
 namespace memgraph::storage::replication {
@@ -109,14 +107,14 @@ struct SnapshotRes {
   static const utils::TypeInfo kType;
   static const utils::TypeInfo &GetTypeInfo() { return kType; }
 
-  static void Load(SnapshotRes *self, memgraph::slk::Reader *reader);
-  static void Save(const SnapshotRes &self, memgraph::slk::Builder *builder);
+  static void Load(SnapshotRes *self, slk::Reader *reader);
+  static void Save(const SnapshotRes &self, slk::Builder *builder);
   SnapshotRes() = default;
-  SnapshotRes(bool success, uint64_t current_commit_timestamp)
-      : success(success), current_commit_timestamp(current_commit_timestamp) {}
 
-  bool success;
-  uint64_t current_commit_timestamp;
+  explicit SnapshotRes(std::optional<uint64_t> current_commit_timestamp)
+      : current_commit_timestamp(std::move(current_commit_timestamp)) {}
+
+  std::optional<uint64_t> current_commit_timestamp;
 };
 
 using SnapshotRpc = rpc::RequestResponse<SnapshotReq, SnapshotRes>;
@@ -125,8 +123,8 @@ struct WalFilesReq {
   static const utils::TypeInfo kType;
   static const utils::TypeInfo &GetTypeInfo() { return kType; }
 
-  static void Load(WalFilesReq *self, memgraph::slk::Reader *reader);
-  static void Save(const WalFilesReq &self, memgraph::slk::Builder *builder);
+  static void Load(WalFilesReq *self, slk::Reader *reader);
+  static void Save(const WalFilesReq &self, slk::Builder *builder);
   WalFilesReq() = default;
   explicit WalFilesReq(const utils::UUID &main_uuid, const utils::UUID &uuid, uint64_t file_number)
       : main_uuid{main_uuid}, uuid{uuid}, file_number(file_number) {}
@@ -143,11 +141,10 @@ struct WalFilesRes {
   static void Load(WalFilesRes *self, memgraph::slk::Reader *reader);
   static void Save(const WalFilesRes &self, memgraph::slk::Builder *builder);
   WalFilesRes() = default;
-  WalFilesRes(bool success, uint64_t current_commit_timestamp)
-      : success(success), current_commit_timestamp(current_commit_timestamp) {}
+  explicit WalFilesRes(std::optional<uint64_t> current_commit_timestamp)
+      : current_commit_timestamp(std::move(current_commit_timestamp)) {}
 
-  bool success;
-  uint64_t current_commit_timestamp;
+  std::optional<uint64_t> current_commit_timestamp;
 };
 
 using WalFilesRpc = rpc::RequestResponse<WalFilesReq, WalFilesRes>;
@@ -172,9 +169,10 @@ struct CurrentWalRes {
   static void Load(CurrentWalRes *self, memgraph::slk::Reader *reader);
   static void Save(const CurrentWalRes &self, memgraph::slk::Builder *builder);
   CurrentWalRes() = default;
-  explicit CurrentWalRes(uint64_t current_commit_timestamp) : current_commit_timestamp(current_commit_timestamp) {}
+  explicit CurrentWalRes(std::optional<uint64_t> current_commit_timestamp)
+      : current_commit_timestamp(std::move(current_commit_timestamp)) {}
 
-  uint64_t current_commit_timestamp;
+  std::optional<uint64_t> current_commit_timestamp;
 };
 
 using CurrentWalRpc = rpc::RequestResponse<CurrentWalReq, CurrentWalRes>;

--- a/src/storage/v2/replication/rpc.hpp
+++ b/src/storage/v2/replication/rpc.hpp
@@ -134,7 +134,6 @@ struct WalFilesReq {
   uint64_t file_number;
 };
 
-// Continue recovery cannot be true without current_commit_timestamp having value
 struct WalFilesRes {
   static const utils::TypeInfo kType;
   static const utils::TypeInfo &GetTypeInfo() { return kType; }
@@ -142,12 +141,9 @@ struct WalFilesRes {
   static void Load(WalFilesRes *self, memgraph::slk::Reader *reader);
   static void Save(const WalFilesRes &self, memgraph::slk::Builder *builder);
   WalFilesRes() = default;
-  explicit WalFilesRes(bool continue_recovery, std::optional<uint64_t> current_commit_timestamp)
-      : continue_recovery(continue_recovery), current_commit_timestamp(current_commit_timestamp) {
-    MG_ASSERT(!(continue_recovery && !current_commit_timestamp), "Invalid combination for WalFilesRes received.");
-  }
+  explicit WalFilesRes(std::optional<uint64_t> current_commit_timestamp)
+      : current_commit_timestamp(current_commit_timestamp) {}
 
-  bool continue_recovery;
   std::optional<uint64_t> current_commit_timestamp;
 };
 

--- a/src/storage/v2/replication/rpc.hpp
+++ b/src/storage/v2/replication/rpc.hpp
@@ -134,6 +134,7 @@ struct WalFilesReq {
   uint64_t file_number;
 };
 
+// Continue recovery cannot be true without current_commit_timestamp having value
 struct WalFilesRes {
   static const utils::TypeInfo kType;
   static const utils::TypeInfo &GetTypeInfo() { return kType; }
@@ -141,9 +142,12 @@ struct WalFilesRes {
   static void Load(WalFilesRes *self, memgraph::slk::Reader *reader);
   static void Save(const WalFilesRes &self, memgraph::slk::Builder *builder);
   WalFilesRes() = default;
-  explicit WalFilesRes(std::optional<uint64_t> current_commit_timestamp)
-      : current_commit_timestamp(std::move(current_commit_timestamp)) {}
+  explicit WalFilesRes(bool continue_recovery, std::optional<uint64_t> current_commit_timestamp)
+      : continue_recovery(continue_recovery), current_commit_timestamp(current_commit_timestamp) {
+    MG_ASSERT(!(continue_recovery && !current_commit_timestamp), "Invalid combination for WalFilesRes received.");
+  }
 
+  bool continue_recovery;
   std::optional<uint64_t> current_commit_timestamp;
 };
 
@@ -170,7 +174,7 @@ struct CurrentWalRes {
   static void Save(const CurrentWalRes &self, memgraph::slk::Builder *builder);
   CurrentWalRes() = default;
   explicit CurrentWalRes(std::optional<uint64_t> current_commit_timestamp)
-      : current_commit_timestamp(std::move(current_commit_timestamp)) {}
+      : current_commit_timestamp(current_commit_timestamp) {}
 
   std::optional<uint64_t> current_commit_timestamp;
 };

--- a/tests/e2e/memgraph.py
+++ b/tests/e2e/memgraph.py
@@ -236,7 +236,7 @@ class MemgraphInstanceRunner:
                 break
             time.sleep(0.1)
 
-        assert self.is_running() is False, "Stopped instance still running."
+        assert self.is_running() is False, f"Stopped instance at {self.host}:{self.bolt_port} still running."
 
         if not keep_directories:
             self.safe_delete_data_directory()

--- a/tests/e2e/replication/workloads.yaml
+++ b/tests/e2e/replication/workloads.yaml
@@ -54,50 +54,11 @@ template_cluster: &template_cluster
           "REGISTER REPLICA replica_3 ASYNC TO '127.0.0.1:10003'",
         ]
 
-template_cluster_indexing: &template_cluster_indexing
-  cluster:
-    replica_1:
-      args: ["--bolt-port", "7688", "--log-level=TRACE"]
-      log_file: "replication-e2e-replica1.log"
-      setup_queries: ["SET REPLICATION ROLE TO REPLICA WITH PORT 10001;"]
-      <<: *template_validation_queries
-    replica_2:
-      args: ["--bolt-port", "7689", "--log-level=TRACE"]
-      log_file: "replication-e2e-replica2.log"
-      setup_queries: ["SET REPLICATION ROLE TO REPLICA WITH PORT 10002;"]
-      <<: *template_validation_queries
-    replica_3:
-      args: ["--bolt-port", "7690", "--log-level=TRACE"]
-      log_file: "replication-e2e-replica3.log"
-      setup_queries: ["SET REPLICATION ROLE TO REPLICA WITH PORT 10003;"]
-      <<: *template_validation_queries
-    main:
-      args:
-        [
-          "--bolt-port",
-          "7687",
-          "--log-level=TRACE",
-          "--storage-automatic-label-index-creation-enabled=TRUE",
-          "--storage-automatic-edge-type-index-creation-enabled=TRUE",
-        ]
-      log_file: "replication-e2e-main.log"
-      setup_queries:
-        [
-          "REGISTER REPLICA replica_1 SYNC TO '127.0.0.1:10001'",
-          "REGISTER REPLICA replica_2 SYNC TO '127.0.0.1:10002'",
-          "REGISTER REPLICA replica_3 ASYNC TO '127.0.0.1:10003'",
-        ]
-
 workloads:
   - name: "Constraints"
     binary: "tests/e2e/replication/memgraph__e2e__replication__constraints"
     args: []
     <<: *template_cluster
-      # Skip flaky https://github.com/memgraph/memgraph/issues/2356
-      #   - name: "Index replication"
-      #     binary: "tests/e2e/replication/memgraph__e2e__replication__indices"
-      #     args: []
-      #     <<: *template_cluster_indexing
 
   - name: "Read-write benchmark"
     binary: "tests/e2e/replication/memgraph__e2e__replication__read_write_benchmark"

--- a/tests/unit/storage_v2_replication.cpp
+++ b/tests/unit/storage_v2_replication.cpp
@@ -684,7 +684,7 @@ TEST_F(ReplicationTest, BasicAsynchronousReplicationTest) {
     if (i == 0) {
       ASSERT_EQ(main.db.storage()->GetReplicaState("REPLICA_ASYNC"), ReplicaState::REPLICATING);
     } else {
-      ASSERT_EQ(main.db.storage()->GetReplicaState("REPLICA_ASYNC"), ReplicaState::MAYBE_BEHIND);
+      ASSERT_EQ(main.db.storage()->GetReplicaState("REPLICA_ASYNC"), ReplicaState::RECOVERY);
     }
   }
 

--- a/tests/unit/storage_v2_replication.cpp
+++ b/tests/unit/storage_v2_replication.cpp
@@ -684,7 +684,7 @@ TEST_F(ReplicationTest, BasicAsynchronousReplicationTest) {
     if (i == 0) {
       ASSERT_EQ(main.db.storage()->GetReplicaState("REPLICA_ASYNC"), ReplicaState::REPLICATING);
     } else {
-      ASSERT_EQ(main.db.storage()->GetReplicaState("REPLICA_ASYNC"), ReplicaState::RECOVERY);
+      ASSERT_EQ(main.db.storage()->GetReplicaState("REPLICA_ASYNC"), ReplicaState::MAYBE_BEHIND);
     }
   }
 

--- a/tests/unit/storage_v2_replication.cpp
+++ b/tests/unit/storage_v2_replication.cpp
@@ -684,7 +684,8 @@ TEST_F(ReplicationTest, BasicAsynchronousReplicationTest) {
     if (i == 0) {
       ASSERT_EQ(main.db.storage()->GetReplicaState("REPLICA_ASYNC"), ReplicaState::REPLICATING);
     } else {
-      ASSERT_EQ(main.db.storage()->GetReplicaState("REPLICA_ASYNC"), ReplicaState::RECOVERY);
+      auto const state = main.db.storage()->GetReplicaState("REPLICA_ASYNC");
+      ASSERT_TRUE(state == ReplicaState::RECOVERY || state == ReplicaState::MAYBE_BEHIND);
     }
   }
 

--- a/tests/unit/utils_async_timer.cpp
+++ b/tests/unit/utils_async_timer.cpp
@@ -22,7 +22,7 @@ using AsyncTimer = memgraph::utils::AsyncTimer;
 inline constexpr auto kSecondsInMilis = 1000.0;
 inline constexpr auto kIntervalInSeconds = 0.05;
 inline constexpr auto kIntervalInMilis = kIntervalInSeconds * kSecondsInMilis;
-inline constexpr auto kAbsoluteErrorInMilis = 5;
+inline constexpr auto kAbsoluteErrorInMilis = 75;
 
 std::chrono::steady_clock::time_point Now() { return std::chrono::steady_clock::now(); }
 


### PR DESCRIPTION
The semantic of snapshot handler changed in the following way: Either handling snapshot request passes or it doesn't. If it passes we return the current commit timestamp of the replica. If it doesn't pass, we return optional which will signal to the caller that it shouldn't update the commit timestamp value. If loading snapshot file failed, it won't crash the database anymore. If an error happened during snapshot recovery, instead of crashing the database, we will now log a message and clear the storage. For recovery using WALFile, commit timestamp on main's side shouldn't be updated if:
1.) the database accessor couldn't be obtained
2.) UUID sent with the request is not the current MAIN's UUID which replica is listening to
Only if loading all WAL files succeeded then main can continue recovery if it should send more recovery steps. If loading WAL files partially succeeded then we cannot continue recovery because CurrentWAL could come at the wrong place in the replication queue. Similarly, recovery using CurrentWAL is only considered successful if it passed completely. Loading WAL file won't crash the database if the WAL file cannot be loaded. The recovery task won't spin in a while loop anymore until it completely recovers the replica. Instead, it will generate recovery steps, try to recover replica and set the state of replica to READY or MAYBE_BEHIND depending on the progress achieved. The state will be MAYBE_BEHIND if the MAIN committed since the start of the recovery. 

Before this PR, the ASYNC replication could deadlock since the same queue is used for both recovery and commit tasks. This can be a problem since both recovery and commit use the same rpc lock in the situation when commit task is added after the recovery task. In recovery task, we wait for commit task to release RPC lock but commit task is never executed because it is behind a single-threaded queue. This is now fixed by recovery task not executing if the replica has already been recovered.
