### PR TITLE
Correct async timer memory order

### DIFF
--- a/src/utils/async_timer.cpp
+++ b/src/utils/async_timer.cpp
@@ -46,7 +46,7 @@ bool operator<(const ExpirationFlagInfo &flag_info, const uint64_t id) { return 
 memgraph::utils::SkipList<ExpirationFlagInfo> expiration_flags{};
 
 uint64_t AddFlag(std::weak_ptr<std::atomic<bool>> flag) {
-  const auto id = expiration_flag_counter.fetch_add(1, std::memory_order_relaxed);
+  const auto id = expiration_flag_counter.fetch_add(1, std::memory_order_acq_rel);
   expiration_flags.access().insert({id, std::move(flag)});
   return id;
 }
@@ -71,7 +71,7 @@ void MarkDone(const uint64_t flag_id) {
   }
   auto flag = weak_flag.lock();
   if (flag != nullptr) {
-    flag->store(true, std::memory_order_relaxed);
+    flag->store(true, std::memory_order_release);
   }
 }
 }  // namespace
@@ -180,10 +180,7 @@ AsyncTimer &AsyncTimer::operator=(AsyncTimer &&other) {
 };
 
 bool AsyncTimer::IsExpired() const noexcept {
-  if (expiration_flag_ != nullptr) {
-    return expiration_flag_->load(std::memory_order_relaxed);
-  }
-  return false;
+  return expiration_flag_ && expiration_flag_->load(std::memory_order_acquire);
 }
 
 void AsyncTimer::ReleaseResources() {

--- a/tests/unit/utils_async_timer.cpp
+++ b/tests/unit/utils_async_timer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -20,9 +20,9 @@
 using AsyncTimer = memgraph::utils::AsyncTimer;
 
 inline constexpr auto kSecondsInMilis = 1000.0;
-inline constexpr auto kIntervalInSeconds = 0.3;
+inline constexpr auto kIntervalInSeconds = 0.05;
 inline constexpr auto kIntervalInMilis = kIntervalInSeconds * kSecondsInMilis;
-inline constexpr auto kAbsoluteErrorInMilis = 50;
+inline constexpr auto kAbsoluteErrorInMilis = 5;
 
 std::chrono::steady_clock::time_point Now() { return std::chrono::steady_clock::now(); }
 


### PR DESCRIPTION
Async timer was causing flaky unit test results. This was because of incorrect memory ordering. To make it more predictable the memory ordering has been changed. 