### PR TITLE
Upgrade python dependencies

### DIFF
--- a/init
+++ b/init
@@ -136,6 +136,7 @@ fi
 # packages.
 if [[ "$ci" == "false" ]]; then
   if [ "${DISTRO}" != "centos-7" ] && [ "$DISTRO" != "debian-10" ] && [ "${DISTRO}" != "ubuntu-18.04" ] && [ "${DISTRO}" != "amzn-2" ]; then
+    python3 -m pip install --upgrade pip
     python3 -m pip install --break-system-packages pre-commit
     python3 -m pre_commit install
     # Install py format tools for usage during the development.

--- a/src/auth/reference_modules/requirements.txt
+++ b/src/auth/reference_modules/requirements.txt
@@ -1,5 +1,5 @@
-cryptography==3.4.8
-PyJWT==2.3.0
+cryptography==44.0.0
+PyJWT==2.10.1
 requests==2.32.2
 ldap3==2.6
 pyyaml==6.0.1

--- a/src/auth/reference_modules/requirements.txt
+++ b/src/auth/reference_modules/requirements.txt
@@ -5,3 +5,4 @@ ldap3==2.6
 pyyaml==6.0.1
 python3-saml==1.16.0
 lxml==5.2.1
+setuptools==75.8.0


### PR DESCRIPTION
Due to security reasons memgraph should use latest versions of `cryptography` and `pyJWT` packages.
