### PR TITLE
fix: Convert between temporal types (#2572)

### DIFF
--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -1347,13 +1347,24 @@ void MapNumericParameters(auto &parameter_mappings, const auto &input_parameters
 }
 
 TypedValue Date(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
-  FType<Optional<Or<String, Map, LocalDateTime>>>("date", args, nargs);
+  FType<Optional<Or<String, Map, struct Date, LocalDateTime, ZonedDateTime>>>("date", args, nargs);
   if (nargs == 0) {
     return TypedValue(utils::LocalDateTime(ctx.timestamp).date(), ctx.memory);
   }
 
+  if (args[0].IsDate()) {
+    return args[0];
+  }
+
   if (args[0].IsLocalDateTime()) {
     return TypedValue(utils::Date{args[0].ValueLocalDateTime().date()}, ctx.memory);
+  }
+
+  if (args[0].IsZonedDateTime()) {
+    auto const &zdt{args[0].ValueZonedDateTime()};
+    return TypedValue(
+        utils::Date{{zdt.LocalYear(), static_cast<int64_t>(zdt.LocalMonth()), static_cast<int64_t>(zdt.LocalDay())}},
+        ctx.memory);
   }
 
   if (args[0].IsString()) {
@@ -1373,14 +1384,25 @@ TypedValue Date(const TypedValue *args, int64_t nargs, const FunctionContext &ct
 }
 
 TypedValue LocalTime(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
-  FType<Optional<Or<String, Map, LocalDateTime>>>("localtime", args, nargs);
+  FType<Optional<Or<String, Map, struct LocalTime, LocalDateTime, ZonedDateTime>>>("localtime", args, nargs);
 
   if (nargs == 0) {
     return TypedValue(utils::LocalDateTime(ctx.timestamp).local_time(), ctx.memory);
   }
 
+  if (args[0].IsLocalTime()) {
+    return args[0];
+  }
+
   if (args[0].IsLocalDateTime()) {
     return TypedValue(utils::LocalTime{args[0].ValueLocalDateTime().local_time()}, ctx.memory);
+  }
+
+  if (args[0].IsZonedDateTime()) {
+    auto const &zdt{args[0].ValueZonedDateTime()};
+    return TypedValue(utils::LocalTime{{zdt.LocalHour(), zdt.LocalMinute(), zdt.LocalSecond(), zdt.LocalMillisecond(),
+                                        zdt.LocalMicrosecond()}},
+                      ctx.memory);
   }
 
   if (args[0].IsString()) {
@@ -1404,10 +1426,23 @@ TypedValue LocalTime(const TypedValue *args, int64_t nargs, const FunctionContex
 }
 
 TypedValue LocalDateTime(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
-  FType<Optional<Or<String, Map>>>("localdatetime", args, nargs);
+  FType<Optional<Or<String, Map, struct LocalDateTime, ZonedDateTime>>>("localdatetime", args, nargs);
 
   if (nargs == 0) {
     return TypedValue(utils::LocalDateTime(ctx.timestamp), ctx.memory);
+  }
+
+  if (args[0].IsLocalDateTime()) {
+    return args[0];
+  }
+
+  if (args[0].IsZonedDateTime()) {
+    auto const &zdt{args[0].ValueZonedDateTime()};
+    return TypedValue(
+        utils::LocalDateTime{
+            {zdt.LocalYear(), static_cast<int64_t>(zdt.LocalMonth()), static_cast<int64_t>(zdt.LocalDay())},
+            {zdt.LocalHour(), zdt.LocalMinute(), zdt.LocalSecond(), zdt.LocalMillisecond(), zdt.LocalMicrosecond()}},
+        ctx.memory);
   }
 
   if (args[0].IsString()) {
@@ -1469,10 +1504,14 @@ utils::Timezone GetTimezone(const memgraph::query::TypedValue::TMap &input_param
 
 // Refers to ZonedDateTime; called DateTime for compatibility with Cypher
 TypedValue DateTime(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
-  FType<Optional<Or<String, Map>>>("datetime", args, nargs);
+  FType<Optional<Or<String, Map, ZonedDateTime>>>("datetime", args, nargs);
 
   if (nargs == 0) {
     return TypedValue(utils::ZonedDateTime(utils::AsSysTime(ctx.timestamp), utils::DefaultTimezone()), ctx.memory);
+  }
+
+  if (args[0].IsZonedDateTime()) {
+    return args[0];
   }
 
   if (args[0].IsString()) {

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -2568,6 +2568,15 @@ TYPED_TEST(FunctionTest, Date) {
                QueryRuntimeException);
   EXPECT_THROW(this->EvaluateFunction("DATE", std::map<std::string, TypedValue>{{"dayz", TypedValue(1970)}}),
                QueryRuntimeException);
+
+  EXPECT_EQ(this->EvaluateFunction("DATE", memgraph::utils::Date({1977, 1, 11})).ValueDate(),
+            memgraph::utils::Date({1977, 1, 11}));
+
+  EXPECT_EQ(this->EvaluateFunction(
+                    "DATE", memgraph::utils::ZonedDateTime(
+                                {{2013, 2, 1}, {12, 52, 34, 12, 11}, memgraph::utils::Timezone("America/Barbados")}))
+                .ValueDate(),
+            memgraph::utils::Date({2013, 2, 1}));
 }
 
 TYPED_TEST(FunctionTest, LocalTime) {
@@ -2595,6 +2604,16 @@ TYPED_TEST(FunctionTest, LocalTime) {
   EXPECT_THROW(
       this->EvaluateFunction("LOCALTIME", TypedValue(std::map<std::string, TypedValue>{{"seconds", TypedValue(1970)}})),
       QueryRuntimeException);
+
+  EXPECT_EQ(this->EvaluateFunction("LOCALTIME", memgraph::utils::LocalTime({10, 33, 23, 42, 123})).ValueLocalTime(),
+            memgraph::utils::LocalTime({10, 33, 23, 42, 123}));
+
+  EXPECT_EQ(
+      this->EvaluateFunction("LOCALTIME",
+                             memgraph::utils::ZonedDateTime(
+                                 {{2013, 2, 1}, {13, 52, 34, 12, 11}, memgraph::utils::Timezone("America/Barbados")}))
+          .ValueLocalTime(),
+      memgraph::utils::LocalTime({13, 52, 34, 12, 11}));
 }
 
 TYPED_TEST(FunctionTest, LocalDateTime) {
@@ -2625,6 +2644,18 @@ TYPED_TEST(FunctionTest, LocalDateTime) {
     EXPECT_THROW(this->EvaluateFunction("LOCALDATETIME",
                                         TypedValue(std::map<std::string, TypedValue>{{"seconds", TypedValue(1970)}})),
                  QueryRuntimeException);
+
+    EXPECT_EQ(
+        this->EvaluateFunction("LOCALDATETIME", memgraph::utils::LocalDateTime({2025, 1, 22}, {10, 33, 23, 42, 123}))
+            .ValueLocalDateTime(),
+        memgraph::utils::LocalDateTime({2025, 1, 22}, {10, 33, 23, 42, 123}));
+
+    EXPECT_EQ(
+        this->EvaluateFunction("LOCALDATETIME",
+                               memgraph::utils::ZonedDateTime(
+                                   {{2013, 2, 1}, {13, 52, 34, 12, 11}, memgraph::utils::Timezone("America/Barbados")}))
+            .ValueLocalDateTime(),
+        memgraph::utils::LocalDateTime({2013, 2, 1}, {13, 52, 34, 12, 11}));
   };
 
   HandleTimezone htz;
@@ -2723,5 +2754,13 @@ TYPED_TEST(FunctionTest, ZonedDateTime) {
                                                    {"timezone", TypedValue("America/Los_Angeles")}}))
                 .ValueZonedDateTime(),
             memgraph::utils::ZonedDateTime({{}, {}, memgraph::utils::Timezone("America/Los_Angeles")}));
+
+  EXPECT_EQ(
+      this->EvaluateFunction(
+              "DATETIME", memgraph::utils::ZonedDateTime(
+                              {{2025, 1, 22}, {10, 33, 23, 42, 123}, memgraph::utils::Timezone("America/Los_Angeles")}))
+          .ValueZonedDateTime(),
+      memgraph::utils::ZonedDateTime(
+          {{2025, 1, 22}, {10, 33, 23, 42, 123}, memgraph::utils::Timezone("America/Los_Angeles")}));
 }
 }  // namespace


### PR DESCRIPTION
This adds the following explicit conversions between compatible temporal types:

- Date from Date and DateTime via `date()`
- LocalTime from LocalTime and DateTime via `localtime()`
- LocalDateTime from and DateTime via `localdatetime()`
- DateTime from DateTime via `datetime()`