### PR TITLE
Avoid reloading dgl and numpy modules; remove deprecated python C-API function

### DIFF
--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -197,7 +197,6 @@ int main(int argc, char **argv) {
   Py_SetProgramName(program_name);
   PyImport_AppendInittab("_mgp", &memgraph::query::procedure::PyInitMgpModule);
   Py_InitializeEx(0 /* = initsigs */);
-  PyEval_InitThreads();
   Py_BEGIN_ALLOW_THREADS;
 
   // Add our Python modules to sys.path

--- a/src/query/procedure/module.cpp
+++ b/src/query/procedure/module.cpp
@@ -23,6 +23,7 @@ extern "C" {
 #include <fmt/format.h>
 #include <unistd.h>
 
+#include "absl/strings/match.h"
 #include "license/license.hpp"
 #include "py/py.hpp"
 #include "query/procedure/callable_alias_mapper.hpp"
@@ -34,7 +35,6 @@ extern "C" {
 #include "utils/logging.hpp"
 #include "utils/memory.hpp"
 #include "utils/message.hpp"
-#include "utils/string.hpp"
 
 #include <mutex>
 #include <shared_mutex>
@@ -47,7 +47,7 @@ namespace memgraph::query::procedure {
 
 constexpr const char *func_code =
     "import ast\n\n"
-    "no_removals = ['collections', 'abc', 'sys', 'torch', 'torch_geometric', 'igraph']\n"
+    "no_removals = ['collections', 'abc', 'sys', 'torch', 'torch_geometric', 'igraph', 'dgl']\n"
     "modules = set()\n\n"
     "def visit_Import(node):\n"
     "  for name in node.names:\n"
@@ -1099,7 +1099,7 @@ void ProcessFileDependencies(std::filesystem::path file_path_, const char *modul
           while ((sys_mod_key = PyIter_Next(sys_iterator))) {
             const char *sys_mod_key_name = PyUnicode_AsUTF8(sys_mod_key);
             auto sys_mod_key_name_str = std::string(sys_mod_key_name);
-            if (sys_mod_key_name_str.rfind(module_name_str, 0) == 0 && sys_mod_key_name_str.compare(module_path) != 0) {
+            if (absl::StartsWith(sys_mod_key_name_str, module_name_str) && sys_mod_key_name_str != module_path) {
               PyDict_DelItemString(sys_mod_ref, sys_mod_key_name);  // don't test output
             }
             Py_DECREF(sys_mod_key);

--- a/src/query/procedure/module.cpp
+++ b/src/query/procedure/module.cpp
@@ -23,7 +23,6 @@ extern "C" {
 #include <fmt/format.h>
 #include <unistd.h>
 
-#include "absl/strings/match.h"
 #include "license/license.hpp"
 #include "py/py.hpp"
 #include "query/procedure/callable_alias_mapper.hpp"
@@ -1099,7 +1098,7 @@ void ProcessFileDependencies(std::filesystem::path file_path_, const char *modul
           while ((sys_mod_key = PyIter_Next(sys_iterator))) {
             const char *sys_mod_key_name = PyUnicode_AsUTF8(sys_mod_key);
             auto sys_mod_key_name_str = std::string(sys_mod_key_name);
-            if (absl::StartsWith(sys_mod_key_name_str, module_name_str) && sys_mod_key_name_str != module_path) {
+            if (sys_mod_key_name_str.starts_with(module_name_str) && sys_mod_key_name_str != module_path) {
               PyDict_DelItemString(sys_mod_ref, sys_mod_key_name);  // don't test output
             }
             Py_DECREF(sys_mod_key);

--- a/src/query/procedure/module.cpp
+++ b/src/query/procedure/module.cpp
@@ -47,7 +47,7 @@ namespace memgraph::query::procedure {
 
 constexpr const char *func_code =
     "import ast\n\n"
-    "no_removals = ['collections', 'abc', 'sys', 'torch', 'torch_geometric', 'igraph', 'dgl']\n"
+    "no_removals = ['collections', 'abc', 'sys', 'torch', 'torch_geometric', 'igraph', 'dgl', 'numpy']\n"
     "modules = set()\n\n"
     "def visit_Import(node):\n"
     "  for name in node.names:\n"


### PR DESCRIPTION
Some Python modules should not be loaded more than once. This PR adds `numpy` and `dgl` to that list to avoid potential issues. This is mandatory to use latest versions of mentioned packages. 
Additionally, a deprecated call to `PyEval_InitThreads` has been removed, as it no longer has any effect starting from [Python 3.9](https://docs.python.org/3/whatsnew/3.9.html).