### PR TITLE
Fix memory leak in query modules

### DIFF
--- a/include/mgp.hpp
+++ b/include/mgp.hpp
@@ -4225,6 +4225,7 @@ inline void Result::SetValue(const List &list) {
 inline void Result::SetValue(List &&list) {
   auto *mgp_val = mgp::value_make_list(list.ptr_);
   mgp::MemHandlerCallback(func_result_set_value, result_, mgp_val);
+  mgp::value_destroy(mgp_val);
   list.ptr_ = nullptr;
 }
 
@@ -4237,6 +4238,7 @@ inline void Result::SetValue(const Map &map) {
 inline void Result::SetValue(Map &&map) {
   auto *mgp_val = mgp::value_make_map(map.ptr_);
   mgp::MemHandlerCallback(func_result_set_value, result_, mgp_val);
+  mgp::value_destroy(mgp_val);
   map.ptr_ = nullptr;
 }
 

--- a/query_modules/convert.cpp
+++ b/query_modules/convert.cpp
@@ -43,13 +43,13 @@ std::optional<mgp::Value> ParseJsonToMgpValue(const nlohmann::json &json_obj, mg
   } else if (json_obj.is_array()) {
     return ParseJsonToMgpList(json_obj, memory);
   } else if (json_obj.is_string()) {
-    return mgp::Value(mgp::value_make_string(json_obj.get<std::string>().c_str(), memory));
+    return mgp::Value(mgp::steal_type, mgp::value_make_string(json_obj.get<std::string>().c_str(), memory));
   } else if (json_obj.is_number_integer()) {
-    return mgp::Value(mgp::value_make_int(json_obj.get<int64_t>(), memory));
+    return mgp::Value(mgp::steal_type, mgp::value_make_int(json_obj.get<int64_t>(), memory));
   } else if (json_obj.is_number_float()) {
-    return mgp::Value(mgp::value_make_double(json_obj.get<double>(), memory));
+    return mgp::Value(mgp::steal_type, mgp::value_make_double(json_obj.get<double>(), memory));
   } else if (json_obj.is_boolean()) {
-    return mgp::Value(mgp::value_make_bool(json_obj.get<bool>(), memory));
+    return mgp::Value(mgp::steal_type, mgp::value_make_bool(json_obj.get<bool>(), memory));
   } else if (json_obj.is_null()) {
     return mgp::Value();
   } else {


### PR DESCRIPTION
C++ API results had issue with list & map. `convert.str2object` also leaked.
