### PR TITLE
Increase Jepsen stress test to 10h

### DIFF
--- a/.github/workflows/stress_jepsen.yaml
+++ b/.github/workflows/stress_jepsen.yaml
@@ -17,7 +17,7 @@ jobs:
   core:
     name: "Jepsen stress tests"
     runs-on: [self-hosted, Linux, X64, DockerMgBuild]
-    timeout-minutes: 720
+    timeout-minutes: 900
     steps:
       - name: Set up repository
         uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
           cd tests/jepsen
           ./run.sh test \
           --binary ../../build/memgraph \
-          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 28800 --concurrency 6" \
+          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 36000 --concurrency 6" \
           --ignore-run-stdout-logs \
           --ignore-run-stderr-logs \
           --nodes-no 6 \


### PR DESCRIPTION
Stress test will now run for 10h with 15h timeout on GH.