### PR TITLE
Add timeouts for force reset and system heartbeat RPC messages

### DIFF
--- a/.github/workflows/stress_jepsen.yaml
+++ b/.github/workflows/stress_jepsen.yaml
@@ -78,7 +78,7 @@ jobs:
           cd tests/jepsen
           ./run.sh test \
           --binary ../../build/memgraph \
-          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 36000 --concurrency 6" \
+          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 32400 --concurrency 6" \
           --ignore-run-stdout-logs \
           --ignore-run-stderr-logs \
           --nodes-no 6 \

--- a/src/dbms/dbms_handler.hpp
+++ b/src/dbms/dbms_handler.hpp
@@ -28,9 +28,6 @@
 #include "dbms/inmemory/replication_handlers.hpp"
 #include "dbms/rpc.hpp"
 #include "kvstore/kvstore.hpp"
-#include "license/license.hpp"
-#include "replication/replication_client.hpp"
-#include "replication_coordination_glue/handler.hpp"
 #include "storage/v2/config.hpp"
 #include "storage/v2/transaction.hpp"
 #include "system/system.hpp"
@@ -40,15 +37,12 @@
 #include "dbms/database_handler.hpp"
 #endif
 #include "global.hpp"
-#include "query/config.hpp"
 #include "query/interpreter_context.hpp"
 #include "spdlog/spdlog.h"
 #include "storage/v2/isolation_level.hpp"
-#include "system/system.hpp"
 #include "utils/logging.hpp"
 #include "utils/result.hpp"
 #include "utils/rw_lock.hpp"
-#include "utils/synchronized.hpp"
 #include "utils/uuid.hpp"
 
 namespace memgraph::dbms {

--- a/src/replication_handler/include/replication_handler/replication_handler.hpp
+++ b/src/replication_handler/include/replication_handler/replication_handler.hpp
@@ -18,6 +18,7 @@
 #include "flags/experimental.hpp"
 #include "replication/include/replication/state.hpp"
 #include "replication_coordination_glue/common.hpp"
+#include "replication_coordination_glue/handler.hpp"
 #include "replication_handler/system_replication.hpp"
 #include "replication_handler/system_rpc.hpp"
 #include "utils/result.hpp"

--- a/src/replication_handler/system_replication.cpp
+++ b/src/replication_handler/system_replication.cpp
@@ -24,27 +24,26 @@ namespace memgraph::replication {
 #ifdef MG_ENTERPRISE
 void SystemHeartbeatHandler(const uint64_t ts, const std::optional<utils::UUID> &current_main_uuid,
                             slk::Reader *req_reader, slk::Builder *res_builder) {
-  replication::SystemHeartbeatRes res{0};
-
   // Ignore if no license
   if (!license::global_license_checker.IsEnterpriseValidFast()) {
     spdlog::error(
         "Handling SystemHeartbeat, an enterprise RPC message, without license. Check your license status by running "
         "SHOW LICENSE INFO.");
+    SystemHeartbeatRes const res{0};
     memgraph::slk::Save(res, res_builder);
     return;
   }
-  replication::SystemHeartbeatReq req;
-  replication::SystemHeartbeatReq::Load(&req, req_reader);
+  SystemHeartbeatReq req;
+  SystemHeartbeatReq::Load(&req, req_reader);
 
   if (!current_main_uuid.has_value() || req.main_uuid != current_main_uuid) [[unlikely]] {
-    LogWrongMain(current_main_uuid, req.main_uuid, replication::SystemHeartbeatRes::kType.name);
-    replication::SystemHeartbeatRes res(-1);
+    LogWrongMain(current_main_uuid, req.main_uuid, SystemHeartbeatRes::kType.name);
+    SystemHeartbeatRes const res(-1);
     memgraph::slk::Save(res, res_builder);
     return;
   }
 
-  res = replication::SystemHeartbeatRes{ts};
+  SystemHeartbeatRes const res(ts);
   memgraph::slk::Save(res, res_builder);
 }
 
@@ -96,7 +95,7 @@ void Register(replication::RoleReplicaData const &data, system::System &system, 
         SystemHeartbeatHandler(system_state_access.LastCommitedTS(), data.uuid_, req_reader, res_builder);
       });
 
-  // Needed even with experimental_system_replication=false becasue
+  // Needed even with experimental_system_replication=false because
   // need to tell REPLICA the uuid to use for "memgraph" default database
   data.server->rpc_server_.Register<replication::SystemRecoveryRpc>(
       [&data, system_state_access, &dbms_handler, &auth](auto *req_reader, auto *res_builder) mutable {

--- a/src/rpc/client.hpp
+++ b/src/rpc/client.hpp
@@ -11,7 +11,6 @@
 
 #pragma once
 
-#include <memory>
 #include <mutex>
 #include <optional>
 #include <utility>
@@ -19,7 +18,7 @@
 #include "communication/client.hpp"
 #include "io/network/endpoint.hpp"
 #include "rpc/exceptions.hpp"
-#include "rpc/messages.hpp"
+#include "rpc/messages.hpp"  // necessary include
 #include "rpc/version.hpp"
 #include "slk/serialization.hpp"
 #include "slk/streams.hpp"
@@ -27,7 +26,7 @@
 #include "utils/on_scope_exit.hpp"
 #include "utils/typeinfo.hpp"
 
-#include "io/network/fmt.hpp"
+#include "io/network/fmt.hpp"  // necessary include
 
 namespace memgraph::rpc {
 
@@ -46,10 +45,13 @@ class Client {
       {"GetInstanceUUIDReq"sv, 10000},        // coordinator to data instances
       {"GetDatabaseHistoriesReq"sv, 10000},   // coordinator to data instances
       {"StateCheckReq"sv, 10000},             // coordinator to data instances
-      {"HeartbeatReq"sv, 10000},              // main to replica
-      {"TimestampReq"sv, 10000},              // main to replica
       {"SwapMainUUIDReq"sv, 10000},           // coord to data instances
       {"FrequentHeartbeatReq"sv, 10000},      // coord to data instances
+      {"HeartbeatReq"sv, 10000},              // main to replica
+      {"TimestampReq"sv, 10000},              // main to replica
+      {"SystemHeartbeatReq"sv, 10000},        // main to replica
+      {"ForceResetStorageReq"sv,
+       60000},  // main to replica. Longer timeout because we need to wait for all storage locks.
   };
   // Dependency injection of rpc_timeouts
   Client(io::network::Endpoint endpoint, communication::ClientContext *context,

--- a/src/storage/v2/config.hpp
+++ b/src/storage/v2/config.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -16,7 +16,6 @@
 #include <filesystem>
 
 #include "flags/coord_flag_env_handler.hpp"
-#include "flags/coordination.hpp"
 #include "flags/replication.hpp"
 #include "storage/v2/isolation_level.hpp"
 #include "storage/v2/storage_mode.hpp"

--- a/src/storage/v2/replication/replication_client.hpp
+++ b/src/storage/v2/replication/replication_client.hpp
@@ -207,7 +207,7 @@ class ReplicationStorageClient {
    *
    * @param storage pointer to the storage associated with the client
    */
-  std::pair<bool, uint64_t> ForceResetStorage(Storage *storage) const;
+  bool ForceResetStorage(Storage *storage) const;
 
   void LogRpcFailure() const;
 

--- a/src/storage/v2/replication/rpc.cpp
+++ b/src/storage/v2/replication/rpc.cpp
@@ -245,12 +245,10 @@ void Load(memgraph::storage::replication::HeartbeatReq *self, memgraph::slk::Rea
 
 void Save(const memgraph::storage::replication::AppendDeltasRes &self, memgraph::slk::Builder *builder) {
   memgraph::slk::Save(self.success, builder);
-  memgraph::slk::Save(self.current_commit_timestamp, builder);
 }
 
 void Load(memgraph::storage::replication::AppendDeltasRes *self, memgraph::slk::Reader *reader) {
   memgraph::slk::Load(&self->success, reader);
-  memgraph::slk::Load(&self->current_commit_timestamp, reader);
 }
 
 // Serialize code for AppendDeltasReq

--- a/src/storage/v2/replication/rpc.hpp
+++ b/src/storage/v2/replication/rpc.hpp
@@ -47,11 +47,10 @@ struct AppendDeltasRes {
   static void Load(AppendDeltasRes *self, memgraph::slk::Reader *reader);
   static void Save(const AppendDeltasRes &self, memgraph::slk::Builder *builder);
   AppendDeltasRes() = default;
-  AppendDeltasRes(bool success, uint64_t current_commit_timestamp)
-      : success(success), current_commit_timestamp(current_commit_timestamp) {}
+
+  explicit AppendDeltasRes(bool const success) : success(success) {}
 
   bool success;
-  uint64_t current_commit_timestamp;
 };
 
 using AppendDeltasRpc = rpc::RequestResponse<AppendDeltasReq, AppendDeltasRes>;


### PR DESCRIPTION
The AppendDeltas response message doesn't return current timestamp anymore since it wasn't used before. If a replica cannot read epoch id, the database won't crash, rather it will return negative response. System heartbeat RPC will now also use timeout set by default to 10''. Force reset RPC now also uses a pre-defined timeout of 10''. If resetting storage fails, the replica will be considered MAYBE_BEHIND and on the next ping, branching should be observed again and a new request for resetting storage should be created.