### PR TITLE
Timing out storage access

### DIFF
--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <cstdint>
 #include <optional>
 #include <span>
@@ -42,6 +43,7 @@
 #include "utils/event_counter.hpp"
 #include "utils/event_gauge.hpp"
 #include "utils/event_histogram.hpp"
+#include "utils/exceptions.hpp"
 #include "utils/resource_lock.hpp"
 #include "utils/synchronized_metadata_store.hpp"
 #include "utils/timer.hpp"
@@ -58,6 +60,24 @@ extern const Event ActiveVectorIndices;
 }  // namespace memgraph::metrics
 
 namespace memgraph::storage {
+
+class SharedAccessTimeout : public utils::BasicException {
+ public:
+  SharedAccessTimeout()
+      : utils::BasicException("Cannot access storage, unique access query is running. Try again later.") {}
+  SPECIALIZE_GET_EXCEPTION_NAME(SharedAccessTimeout)
+};
+
+class UniqueAccessTimeout : public utils::BasicException {
+ public:
+  UniqueAccessTimeout()
+      : utils::BasicException(
+            "Cannot get unique access to the storage. Try stopping other queries that are running in parallel.") {}
+  SPECIALIZE_GET_EXCEPTION_NAME(UniqueAccessTimeout)
+};
+
+constexpr std::chrono::milliseconds kAccessTimeout{1000};
+
 struct Transaction;
 class EdgeAccessor;
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -328,6 +328,9 @@ target_link_libraries(${test_prefix}property_value_v2 mg-storage-v2 mg-utils)
 add_unit_test(storage_v2.cpp)
 target_link_libraries(${test_prefix}storage_v2 mg-storage-v2 storage_test_utils)
 
+add_unit_test(storage_v2_acc.cpp)
+target_link_libraries(${test_prefix}storage_v2_acc mg-storage-v2)
+
 add_unit_test(storage_v2_delta_container.cpp)
 target_link_libraries(${test_prefix}storage_v2_delta_container mg-storage-v2)
 

--- a/tests/unit/storage_v2_acc.cpp
+++ b/tests/unit/storage_v2_acc.cpp
@@ -1,0 +1,35 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "storage/v2/inmemory/storage.hpp"
+
+/// Test that unqiue/shared accessors can timeout and not deadlock
+TEST(StorageV2Acc, Timeouts) {
+  std::unique_ptr<memgraph::storage::Storage> storage(
+      std::make_unique<memgraph::storage::InMemoryStorage>(memgraph::storage::Config{}));
+
+  {
+    auto shared_acc = storage->Access();
+    ASSERT_TRUE(shared_acc);
+    ASSERT_THROW(storage->UniqueAccess(), memgraph::storage::UniqueAccessTimeout);
+    auto shared_acc2 = storage->Access();
+    ASSERT_TRUE(shared_acc2);
+  }
+  {
+    auto unique_acc = storage->UniqueAccess();
+    ASSERT_TRUE(unique_acc);
+    ASSERT_THROW(storage->Access(), memgraph::storage::SharedAccessTimeout);
+    ASSERT_THROW(storage->UniqueAccess(), memgraph::storage::UniqueAccessTimeout);
+  }
+}


### PR DESCRIPTION
Fixes a potential deadlock.
Deadlock is possible every time one query takes a unique lock during prepare.
This lock won't be released until pull. In the meantime, other requests can saturate the worker pool, which leads to all workers waiting on the lock  (unique or shared) during prepare and not letting any work (pull) through.