### PR TITLE
Bugfix: Parallel recovery doesn't work with WAL files

### DIFF
--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -315,10 +315,9 @@ void InMemoryReplicationHandlers::SnapshotHandler(dbms::DbmsHandler *dbms_handle
       storage->repl_storage_state_.last_durable_timestamp_ = recovery_info.next_timestamp - 1;
 
       spdlog::trace("Recovering indices and constraints from snapshot.");
-      RecoverIndicesAndStats(indices_constraints.indices, &storage->indices_, &storage->vertices_,
-                             storage->name_id_mapper_.get(), storage->config_.salient.items.properties_on_edges);
-      RecoverConstraints(indices_constraints.constraints, &storage->constraints_, &storage->vertices_,
-                         storage->name_id_mapper_.get());
+      storage::durability::RecoverIndicesStatsAndConstraints(
+          &storage->vertices_, storage->name_id_mapper_.get(), &storage->indices_, &storage->constraints_,
+          storage->config_, recovery_info, indices_constraints, storage->config_.salient.items.properties_on_edges);
     } catch (const storage::durability::RecoveryFailure &e) {
       spdlog::error("Couldn't load the snapshot from {} because of: {}. Storage will be cleared.", *maybe_snapshot_path,
                     e.what());

--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -222,6 +222,7 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
             "Trying to recover edge type indices while properties on edges are disabled.");
   auto *mem_edge_type_index = static_cast<InMemoryEdgeTypeIndex *>(indices->edge_type_index_.get());
   for (const auto &item : indices_metadata.edge) {
+    // TODO: parallel execution
     if (!mem_edge_type_index->CreateIndex(item, vertices->access())) {
       throw RecoveryFailure("The edge-type index must be created here!");
     }
@@ -236,6 +237,7 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
   auto *mem_edge_type_property_index =
       static_cast<InMemoryEdgeTypePropertyIndex *>(indices->edge_type_property_index_.get());
   for (const auto &item : indices_metadata.edge_property) {
+    // TODO: parallel execution
     if (!mem_edge_type_property_index->CreateIndex(item.first, item.second, vertices->access())) {
       throw RecoveryFailure("The edge-type property index must be created here!");
     }
@@ -253,7 +255,7 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
         if (!storage_dir.has_value()) {
           throw RecoveryFailure("There must exist a storage directory in order to recover text indices!");
         }
-
+        // TODO: parallel execution
         mem_text_index.RecoverIndex(index_name, label, vertices->access(), name_id_mapper);
       } catch (...) {
         throw RecoveryFailure("The text index must be created here!");

--- a/src/storage/v2/durability/durability.hpp
+++ b/src/storage/v2/durability/durability.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -112,11 +112,14 @@ void RecoverConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadat
                         Constraints *constraints, utils::SkipList<Vertex> *vertices, NameIdMapper *name_id_mapper,
                         const std::optional<ParallelizedSchemaCreationInfo> &parallel_exec_info = std::nullopt);
 
+void RecoverIndicesStatsAndConstraints(utils::SkipList<Vertex> *vertices, NameIdMapper *name_id_mapper,
+                                       Indices *indices, Constraints *constraints, Config const &config,
+                                       RecoveryInfo const &recovery_info,
+                                       RecoveredIndicesAndConstraints const &indices_constraints,
+                                       bool properties_on_edges);
+
 std::optional<ParallelizedSchemaCreationInfo> GetParallelExecInfo(const RecoveryInfo &recovery_info,
                                                                   const Config &config);
-
-std::optional<ParallelizedSchemaCreationInfo> GetParallelExecInfoIndices(const RecoveryInfo &recovery_info,
-                                                                         const Config &config);
 
 void RecoverExistenceConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &, Constraints *,
                                  utils::SkipList<Vertex> *, NameIdMapper *,

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2628,10 +2628,9 @@ utils::BasicResult<InMemoryStorage::RecoverSnapshotError> InMemoryStorage::Recov
     repl_storage_state_.last_durable_timestamp_ = recovery_info.next_timestamp - 1;
 
     spdlog::trace("Recovering indices and constraints from snapshot.");
-    durability::RecoverIndicesAndStats(recovered_snapshot.indices_constraints.indices, &indices_, &vertices_,
-                                       name_id_mapper_.get(), config_.salient.items.properties_on_edges);
-    durability::RecoverConstraints(recovered_snapshot.indices_constraints.constraints, &constraints_, &vertices_,
-                                   name_id_mapper_.get());
+    storage::durability::RecoverIndicesStatsAndConstraints(
+        &vertices_, name_id_mapper_.get(), &indices_, &constraints_, config_, recovery_info,
+        recovered_snapshot.indices_constraints, config_.salient.items.properties_on_edges);
 
     spdlog::trace("Successfully recovered from snapshot {}", local_path);
 


### PR DESCRIPTION
Recalculating vertex batches if WALs are present <- fixes indices/constraints recovery
Using parallel recovery only is vertex batches > 1 <- fixes recovery without snapshots
Replication and RECOVER SNAPSHOT now recover indices/constraints in parallel as well
A bit simpler RecoverData logic