### PR TITLE
Reduce contention around socket send

### DIFF
--- a/src/communication/bolt/v1/decoder/chunked_decoder_buffer.hpp
+++ b/src/communication/bolt/v1/decoder/chunked_decoder_buffer.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -51,7 +51,7 @@ enum class ChunkState : uint8_t {
 template <typename TBuffer>
 class ChunkedDecoderBuffer {
  public:
-  explicit ChunkedDecoderBuffer(TBuffer &buffer) : buffer_(buffer) { data_.reserve(kChunkMaxDataSize); }
+  explicit ChunkedDecoderBuffer(TBuffer &buffer) : buffer_(buffer) { data_.reserve(kChunkWholeSize); }
 
   /**
    * Reads data from the internal buffer.

--- a/src/communication/bolt/v1/encoder/chunked_encoder_buffer.hpp
+++ b/src/communication/bolt/v1/encoder/chunked_encoder_buffer.hpp
@@ -63,21 +63,21 @@ class ChunkedEncoderBuffer {
     while (n > 0) {
       // Define the number of bytes which will be copied into the chunk because
       // the internal storage is a fixed length array.
-      const size_t size = std::min(n, kChunkMaxDataSize - have_);
+      const size_t size = std::min(n, kChunkWholeSize - pos_);
 
       // Copy `size` values to the chunk array.
-      std::memcpy(chunk_.data() + kChunkHeaderSize + have_, values + written, size);
+      std::memcpy(chunk_.data() + pos_, values + written, size);
 
       // Update positions. The position pointer and incoming size have to be
       // updated because all incoming values have to be processed.
       written += size;
-      have_ += size;
+      pos_ += size;
       n -= size;
 
       // If the chunk is full, send it to the output stream and clear the
       // internal storage to make space for other incoming values that are left
       // in the values array.
-      if (have_ == kChunkMaxDataSize) Flush(true);
+      if (pos_ == kChunkWholeSize) Flush(true);
     }
   }
 
@@ -91,27 +91,35 @@ class ChunkedEncoderBuffer {
    */
   bool Flush(bool have_more = false) {
     // Write the size of the chunk.
-    chunk_[0] = have_ >> 8;
-    chunk_[1] = have_ & 0xFF;
+    chunk_[chunk_start_] = (pos_ - chunk_start_ - kChunkHeaderSize) >> 8;
+    chunk_[chunk_start_ + 1] = (pos_ - chunk_start_ - kChunkHeaderSize) & 0xFF;
 
     // Write the data to the stream.
-    auto ret = output_stream_.Write(chunk_.data(), kChunkHeaderSize + have_, have_more);
+    if (!have_more || (kChunkWholeSize - pos_ <= kChunkHeaderSize)) {
+      auto ret = output_stream_.Write(chunk_.data(), pos_, have_more);
 
-    // Cleanup.
-    Clear();
-
-    return ret;
+      // Cleanup.
+      Clear();
+      return ret;
+    } else {
+      chunk_start_ = pos_;
+      pos_ = chunk_start_ + kChunkHeaderSize;
+    }
+    return true;
   }
 
   /** Clears the internal buffers. */
-  void Clear() { have_ = 0; }
+  void Clear() {
+    pos_ = kChunkHeaderSize;
+    chunk_start_ = 0;
+  }
 
   /**
    * Returns a boolean indicating whether there is data in the buffer.
    * @returns true if there is data in the buffer,
    *          false otherwise
    */
-  bool HasData() { return have_ > 0; }
+  bool HasData() const { return (pos_ - chunk_start_) > kChunkHeaderSize; }
 
  private:
   // The output stream used.
@@ -121,6 +129,7 @@ class ChunkedEncoderBuffer {
   std::array<uint8_t, kChunkWholeSize> chunk_;
 
   // Amount of data in chunk array.
-  size_t have_{0};
+  size_t pos_{kChunkHeaderSize};
+  size_t chunk_start_{0};
 };
 }  // namespace memgraph::communication::bolt

--- a/src/communication/bolt/v1/encoder/client_encoder.hpp
+++ b/src/communication/bolt/v1/encoder/client_encoder.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -62,7 +62,7 @@ class ClientEncoder : private BaseEncoder<Buffer> {
     WriteMap(extra);
     // Try to flush all remaining data in the buffer, but tell it that we will
     // send more data (the end of message chunk).
-    if (!buffer_.Flush(true)) return false;
+    if (buffer_.HasData() && !buffer_.Flush(true)) return false;
     // Flush an empty chunk to indicate that the message is done.
     return buffer_.Flush();
   }
@@ -90,7 +90,7 @@ class ClientEncoder : private BaseEncoder<Buffer> {
     WriteMap(extra);
     // Try to flush all remaining data in the buffer, but tell it that we will
     // send more data (the end of message chunk).
-    if (!buffer_.Flush(true)) return false;
+    if (buffer_.HasData() && !buffer_.Flush(true)) return false;
     // Flush an empty chunk to indicate that the message is done. Here we
     // forward the `have_more` flag to indicate if there is more data that will
     // be sent.
@@ -114,7 +114,7 @@ class ClientEncoder : private BaseEncoder<Buffer> {
     WriteMap(extra);
     // Try to flush all remaining data in the buffer, but tell it that we will
     // send more data (the end of message chunk).
-    if (!buffer_.Flush(true)) return false;
+    if (buffer_.HasData() && !buffer_.Flush(true)) return false;
     // Flush an empty chunk to indicate that the message is done.
     return buffer_.Flush();
   }
@@ -136,7 +136,7 @@ class ClientEncoder : private BaseEncoder<Buffer> {
     WriteMap(extra);
     // Try to flush all remaining data in the buffer, but tell it that we will
     // send more data (the end of message chunk).
-    if (!buffer_.Flush(true)) return false;
+    if (buffer_.HasData() && !buffer_.Flush(true)) return false;
     // Flush an empty chunk to indicate that the message is done.
     return buffer_.Flush();
   }
@@ -156,7 +156,7 @@ class ClientEncoder : private BaseEncoder<Buffer> {
     WriteRAW(utils::UnderlyingCast(Signature::Reset));
     // Try to flush all remaining data in the buffer, but tell it that we will
     // send more data (the end of message chunk).
-    if (!buffer_.Flush(true)) return false;
+    if (buffer_.HasData() && !buffer_.Flush(true)) return false;
     // Flush an empty chunk to indicate that the message is done.
     return buffer_.Flush();
   }
@@ -186,7 +186,7 @@ class ClientEncoder : private BaseEncoder<Buffer> {
     }
     // Try to flush all remaining data in the buffer, but tell it that we will
     // send more data (the end of message chunk).
-    if (!buffer_.Flush(true)) return false;
+    if (buffer_.HasData() && !buffer_.Flush(true)) return false;
     // Flush an empty chunk to indicate that the message is done.
     return buffer_.Flush();
   }

--- a/src/communication/bolt/v1/encoder/encoder.hpp
+++ b/src/communication/bolt/v1/encoder/encoder.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -52,7 +52,7 @@ class Encoder : private BaseEncoder<Buffer> {
     WriteList(values);
     // Try to flush all remaining data in the buffer, but tell it that we will
     // send more data (the end of message chunk).
-    if (!buffer_.Flush(true)) return false;
+    if (buffer_.HasData() && !buffer_.Flush(true)) return false;
     // Flush an empty chunk to indicate that the message is done. Here we tell
     // the buffer that there will be more data because this is a Record message
     // and it will surely be followed by either a Record, Success or Failure
@@ -78,7 +78,7 @@ class Encoder : private BaseEncoder<Buffer> {
     WriteMap(metadata);
     // Try to flush all remaining data in the buffer, but tell it that we will
     // send more data (the end of message chunk).
-    if (!buffer_.Flush(true)) return false;
+    if (buffer_.HasData() && !buffer_.Flush(true)) return false;
     // Flush an empty chunk to indicate that the message is done.
     return buffer_.Flush();
   }
@@ -114,7 +114,7 @@ class Encoder : private BaseEncoder<Buffer> {
     WriteMap(metadata);
     // Try to flush all remaining data in the buffer, but tell it that we will
     // send more data (the end of message chunk).
-    if (!buffer_.Flush(true)) return false;
+    if (buffer_.HasData() && !buffer_.Flush(true)) return false;
     // Flush an empty chunk to indicate that the message is done.
     return buffer_.Flush();
   }
@@ -132,7 +132,7 @@ class Encoder : private BaseEncoder<Buffer> {
     WriteRAW(utils::UnderlyingCast(Signature::Ignored));
     // Try to flush all remaining data in the buffer, but tell it that we will
     // send more data (the end of message chunk).
-    if (!buffer_.Flush(true)) return false;
+    if (buffer_.HasData() && !buffer_.Flush(true)) return false;
     // Flush an empty chunk to indicate that the message is done.
     return buffer_.Flush();
   }

--- a/src/glue/communication.cpp
+++ b/src/glue/communication.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -125,25 +125,25 @@ storage::Result<Value> ToBoltValue(const query::TypedValue &value, const storage
   switch (value.type()) {
     // No database needed
     case query::TypedValue::Type::Null:
-      return Value();
+      return storage::Result<Value>{std::in_place};
     case query::TypedValue::Type::Bool:
-      return Value(value.ValueBool());
+      return storage::Result<Value>{std::in_place, value.ValueBool()};
     case query::TypedValue::Type::Int:
-      return Value(value.ValueInt());
+      return storage::Result<Value>{std::in_place, value.ValueInt()};
     case query::TypedValue::Type::Double:
-      return Value(value.ValueDouble());
+      return storage::Result<Value>{std::in_place, value.ValueDouble()};
     case query::TypedValue::Type::String:
-      return Value(std::string(value.ValueString()));
+      return storage::Result<Value>{std::in_place, std::string_view(value.ValueString())};
     case query::TypedValue::Type::Date:
-      return Value(value.ValueDate());
+      return storage::Result<Value>{std::in_place, value.ValueDate()};
     case query::TypedValue::Type::LocalTime:
-      return Value(value.ValueLocalTime());
+      return storage::Result<Value>{std::in_place, value.ValueLocalTime()};
     case query::TypedValue::Type::LocalDateTime:
-      return Value(value.ValueLocalDateTime());
+      return storage::Result<Value>{std::in_place, value.ValueLocalDateTime()};
     case query::TypedValue::Type::Duration:
-      return Value(value.ValueDuration());
+      return storage::Result<Value>{std::in_place, value.ValueDuration()};
     case query::TypedValue::Type::ZonedDateTime:
-      return Value(value.ValueZonedDateTime());
+      return storage::Result<Value>{std::in_place, value.ValueZonedDateTime()};
 
     // Database potentially not required
     case query::TypedValue::Type::Map: {
@@ -153,7 +153,7 @@ storage::Result<Value> ToBoltValue(const query::TypedValue &value, const storage
         if (maybe_value.HasError()) return maybe_value.GetError();
         map.emplace(kv.first, std::move(*maybe_value));
       }
-      return Value(std::move(map));
+      return storage::Result<Value>{std::in_place, std::move(map)};
     }
 
     // Database is required
@@ -166,31 +166,31 @@ storage::Result<Value> ToBoltValue(const query::TypedValue &value, const storage
         if (maybe_value.HasError()) return maybe_value.GetError();
         values.emplace_back(std::move(*maybe_value));
       }
-      return Value(std::move(values));
+      return storage::Result<Value>{std::in_place, std::move(values)};
     }
     case query::TypedValue::Type::Vertex: {
       check_db();
       auto maybe_vertex = ToBoltVertex(value.ValueVertex(), *db, view);
       if (maybe_vertex.HasError()) return maybe_vertex.GetError();
-      return Value(std::move(*maybe_vertex));
+      return storage::Result<Value>{std::in_place, std::move(*maybe_vertex)};
     }
     case query::TypedValue::Type::Edge: {
       check_db();
       auto maybe_edge = ToBoltEdge(value.ValueEdge(), *db, view);
       if (maybe_edge.HasError()) return maybe_edge.GetError();
-      return Value(std::move(*maybe_edge));
+      return storage::Result<Value>{std::in_place, std::move(*maybe_edge)};
     }
     case query::TypedValue::Type::Path: {
       check_db();
       auto maybe_path = ToBoltPath(value.ValuePath(), *db, view);
       if (maybe_path.HasError()) return maybe_path.GetError();
-      return Value(std::move(*maybe_path));
+      return storage::Result<Value>{std::in_place, std::move(*maybe_path)};
     }
     case query::TypedValue::Type::Graph: {
       check_db();
       auto maybe_graph = ToBoltGraph(value.ValueGraph(), *db, view);
       if (maybe_graph.HasError()) return maybe_graph.GetError();
-      return Value(std::move(*maybe_graph));
+      return storage::Result<Value>{std::in_place, std::move(*maybe_graph)};
     }
     case query::TypedValue::Type::Enum: {
       check_db();
@@ -201,13 +201,13 @@ storage::Result<Value> ToBoltValue(const query::TypedValue &value, const storage
       auto map = bolt_map_t{};
       map.emplace(kMgTypeType, memgraph::communication::bolt::kMgTypeEnum);
       map.emplace(kMgTypeValue, *std::move(maybe_enum_value_str));
-      return Value(std::move(map));
+      return storage::Result<Value>{std::in_place, std::move(map)};
     }
     case query::TypedValue::Type::Point2d: {
-      return Value(value.ValuePoint2d());
+      return storage::Result<Value>{std::in_place, value.ValuePoint2d()};
     }
     case query::TypedValue::Type::Point3d: {
-      return Value(value.ValuePoint3d());
+      return storage::Result<Value>{std::in_place, value.ValuePoint3d()};
     }
 
     // Unsupported conversions

--- a/src/utils/result.hpp
+++ b/src/utils/result.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -23,8 +23,10 @@ class [[nodiscard]] BasicResult final {
  public:
   using ErrorType = TError;
   using ValueType = TValue;
-  BasicResult(const TValue &value) : value_(value) {}
-  BasicResult(TValue &&value) noexcept : value_(std::move(value)) {}
+  template <typename... Args>
+  explicit BasicResult(std::in_place_t, Args &&...args) : value_{std::in_place, std::forward<Args>(args)...} {}
+  BasicResult(const TValue &value) : value_{std::in_place, value} {}
+  BasicResult(TValue &&value) noexcept : value_{std::in_place, std::move(value)} {}
   BasicResult(const TError &error) : error_(error) {}
   BasicResult(TError &&error) noexcept : error_(std::move(error)) {}
 

--- a/tests/unit/bolt_common.hpp
+++ b/tests/unit/bolt_common.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -78,6 +78,7 @@ class TestBuffer {
 
   void Write(const uint8_t *data, size_t n) { output_stream_.Write(data, n); }
   bool Flush(bool have_more = false) { return true; }
+  bool HasData() const { return false; }
 
  private:
   TestOutputStream &output_stream_;

--- a/tests/unit/bolt_common.hpp
+++ b/tests/unit/bolt_common.hpp
@@ -57,7 +57,7 @@ class TestOutputStream {
  public:
   bool Write(const uint8_t *data, size_t len, bool have_more = false) {
     if (!write_success_) return false;
-    for (size_t i = 0; i < len; ++i) output.push_back(data[i]);
+    output.insert(output.end(), data, data + len);
     return true;
   }
 
@@ -87,7 +87,7 @@ class TestBuffer {
 /**
  * TODO (mferencevic): document
  */
-void PrintOutput(std::vector<uint8_t> &output) {
+void PrintOutput(std::span<uint8_t const> output) {
   fprintf(stderr, "output: ");
   for (size_t i = 0; i < output.size(); ++i) {
     fprintf(stderr, "%02X ", output[i]);
@@ -98,7 +98,7 @@ void PrintOutput(std::vector<uint8_t> &output) {
 /**
  * TODO (mferencevic): document
  */
-void CheckOutput(std::vector<uint8_t> &output, const uint8_t *data, uint64_t len, bool clear = true) {
+void CheckOutput(std::span<uint8_t const> &output, const uint8_t *data, uint64_t len, bool clear = true) {
   if (clear) {
     ASSERT_EQ(len, output.size());
   } else {
@@ -108,9 +108,9 @@ void CheckOutput(std::vector<uint8_t> &output, const uint8_t *data, uint64_t len
     EXPECT_EQ(output[i], data[i]) << i;
   }
   if (clear) {
-    output.clear();
+    output = std::span<uint8_t const>{};
   } else {
-    output.erase(output.begin(), output.begin() + len);
+    output = output.subspan(len);
   }
 }
 

--- a/tests/unit/bolt_session.cpp
+++ b/tests/unit/bolt_session.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -263,7 +263,9 @@ void ExecuteHandshake(TestInputStream &input_stream, TestSession &session, std::
   session.Execute();
   ASSERT_EQ(session.state_, State::Init);
   PrintOutput(output);
-  CheckOutput(output, expected_resp, 4);
+  auto to_validate = std::span<uint8_t const>{output};
+  CheckOutput(to_validate, expected_resp, 4);
+  output.clear();
 }
 
 // Write bolt chunk and execute command
@@ -284,7 +286,9 @@ void ExecuteInit(TestInputStream &input_stream, TestSession &session, std::vecto
   ASSERT_EQ(session.state_, State::Idle);
   PrintOutput(output);
   const auto *response = is_v4 ? v4::init_resp : init_resp;
-  CheckOutput(output, response, 28);
+  auto to_validate = std::span<uint8_t const>{output};
+  CheckOutput(to_validate, response, 28);
+  output.clear();
 }
 
 // Write bolt encoded run request
@@ -342,7 +346,9 @@ TEST(BoltSession, HandshakeInTwoPackets) {
 
   ASSERT_EQ(session.state_, State::Init);
   PrintOutput(output);
-  CheckOutput(output, handshake_resp, 4);
+  auto to_validate = std::span<uint8_t const>{output};
+  CheckOutput(to_validate, handshake_resp, 4);
+  output.clear();
 }
 
 TEST(BoltSession, HandshakeWriteFail) {
@@ -700,7 +706,9 @@ TEST(BoltSession, ErrorIgnoreMessage) {
 
     if (i == 0) {
       ASSERT_EQ(session.state_, State::Error);
-      CheckOutput(output, ignored_resp, sizeof(ignored_resp));
+      auto to_validate = std::span<uint8_t const>{output};
+      CheckOutput(to_validate, ignored_resp, sizeof(ignored_resp));
+      output.clear();
     } else {
       ASSERT_EQ(session.state_, State::Close);
       ASSERT_EQ(output.size(), 0);
@@ -804,7 +812,9 @@ TEST(BoltSession, ErrorOK) {
 
         if (write_success) {
           EXPECT_EQ(session.state_, State::Idle);
-          CheckOutput(output, success_resp, sizeof(success_resp));
+          auto to_validate = std::span<uint8_t const>{output};
+          CheckOutput(to_validate, success_resp, sizeof(success_resp));
+          output.clear();
         } else {
           EXPECT_EQ(session.state_, State::Close);
           EXPECT_EQ(output.size(), 0);
@@ -845,10 +855,14 @@ TEST(BoltSession, ErrorOK) {
         if (write_success) {
           if (is_reset) {
             EXPECT_EQ(session.state_, State::Idle);
-            CheckOutput(output, success_resp, sizeof(success_resp));
+            auto to_validate = std::span<uint8_t const>{output};
+            CheckOutput(to_validate, success_resp, sizeof(success_resp));
+            output.clear();
           } else {
             ASSERT_EQ(session.state_, State::Error);
-            CheckOutput(output, ignored_resp, sizeof(ignored_resp));
+            auto to_validate = std::span<uint8_t const>{output};
+            CheckOutput(to_validate, ignored_resp, sizeof(ignored_resp));
+            output.clear();
           }
         } else {
           EXPECT_EQ(session.state_, State::Close);

--- a/tests/unit/bolt_session.cpp
+++ b/tests/unit/bolt_session.cpp
@@ -1147,13 +1147,18 @@ EXPECT_EQ(session.state_, State::Close);
       0x00,
   };
   EXPECT_EQ(input_stream.size(), 0U);
-  CheckOutput(output, expected_resp, sizeof(expected_resp));
+  auto to_validate = std::span<uint8_t const>{output};
+  CheckOutput(to_validate, expected_resp, sizeof(expected_resp));
+  output.clear();
+
   EXPECT_EQ(session.state_, State::Error);
 
   SCOPED_TRACE("Try to reset connection after ROUTE failed");
   ASSERT_NO_THROW(ExecuteCommand(input_stream, session, v4::reset_req, sizeof(v4::reset_req)));
   EXPECT_EQ(input_stream.size(), 0U);
-  CheckOutput(output, success_resp, sizeof(success_resp));
+  to_validate = std::span<uint8_t const>{output};
+  CheckOutput(to_validate, success_resp, sizeof(success_resp));
+  output.clear();
   EXPECT_EQ(session.state_, State::Idle);
 }
 #endif

--- a/tests/unit/storage_v2_indices.cpp
+++ b/tests/unit/storage_v2_indices.cpp
@@ -1489,7 +1489,7 @@ TYPED_TEST(IndexTest, EdgeTypeIndexCreate) {
             }
           }
         }
-        acc->Commit();
+        ASSERT_NO_ERROR(acc->Commit());
       }
       this->storage->FreeMemory({}, false);
       this->storage->FreeMemory({}, false);
@@ -1510,7 +1510,7 @@ TYPED_TEST(IndexTest, EdgeTypeIndexCreate) {
             }
           }
         }
-        acc->Commit();
+        ASSERT_NO_ERROR(acc->Commit());
       }
       this->storage->FreeMemory({}, false);
       this->storage->FreeMemory({}, false);
@@ -1799,7 +1799,7 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexCreate) {
       auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
       auto edge_acc =
           this->CreateEdge(&vertex_from, &vertex_to, i % 2 ? this->edge_type_id1 : this->edge_type_id2, acc.get());
-      edge_acc.SetProperty(this->edge_prop_id1, memgraph::storage::PropertyValue(i));
+      ASSERT_NO_ERROR(edge_acc.SetProperty(this->edge_prop_id1, memgraph::storage::PropertyValue(i)));
     }
     ASSERT_NO_ERROR(acc->Commit());
     EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_type_id1, this->edge_prop_id1), 0);
@@ -1827,7 +1827,7 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexCreate) {
       auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
       auto edge_acc =
           this->CreateEdge(&vertex_from, &vertex_to, i % 2 ? this->edge_type_id1 : this->edge_type_id2, acc.get());
-      edge_acc.SetProperty(this->edge_prop_id1, memgraph::storage::PropertyValue(i));
+      ASSERT_NO_ERROR(edge_acc.SetProperty(this->edge_prop_id1, memgraph::storage::PropertyValue(i)));
     }
 
     EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, this->edge_prop_id1, View::OLD), View::OLD),
@@ -1854,7 +1854,7 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexCreate) {
       auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
       auto edge_acc =
           this->CreateEdge(&vertex_from, &vertex_to, i % 2 ? this->edge_type_id1 : this->edge_type_id2, acc.get());
-      edge_acc.SetProperty(this->edge_prop_id1, memgraph::storage::PropertyValue(i));
+      ASSERT_NO_ERROR(edge_acc.SetProperty(this->edge_prop_id1, memgraph::storage::PropertyValue(i)));
     }
 
     EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, this->edge_prop_id1, View::OLD), View::OLD),
@@ -1913,7 +1913,7 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexCreate) {
           }
         }
       }
-      acc->Commit();
+      ASSERT_NO_ERROR(acc->Commit());
     }
     this->storage->FreeMemory({}, false);
     this->storage->FreeMemory({}, false);
@@ -1934,7 +1934,7 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexCreate) {
           }
         }
       }
-      acc->Commit();
+      ASSERT_NO_ERROR(acc->Commit());
     }
     this->storage->FreeMemory({}, false);
     this->storage->FreeMemory({}, false);
@@ -1962,7 +1962,7 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexDrop) {
       auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
       auto edge_acc =
           this->CreateEdge(&vertex_from, &vertex_to, i % 2 ? this->edge_type_id1 : this->edge_type_id2, acc.get());
-      edge_acc.SetProperty(this->edge_prop_id1, memgraph::storage::PropertyValue(i));
+      ASSERT_NO_ERROR(edge_acc.SetProperty(this->edge_prop_id1, memgraph::storage::PropertyValue(i)));
     }
     ASSERT_NO_ERROR(acc->Commit());
   }
@@ -2010,7 +2010,7 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexDrop) {
       auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
       auto edge_acc =
           this->CreateEdge(&vertex_from, &vertex_to, i % 2 ? this->edge_type_id1 : this->edge_type_id2, acc.get());
-      edge_acc.SetProperty(this->edge_prop_id1, memgraph::storage::PropertyValue(i));
+      ASSERT_NO_ERROR(edge_acc.SetProperty(this->edge_prop_id1, memgraph::storage::PropertyValue(i)));
     }
     ASSERT_NO_ERROR(acc->Commit());
   }
@@ -2079,10 +2079,10 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexBasic) {
     auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
     if (i % 2) {
       auto edge_acc = this->CreateEdge(&vertex_from, &vertex_to, this->edge_type_id1, acc.get());
-      edge_acc.SetProperty(this->edge_prop_id1, memgraph::storage::PropertyValue(i));
+      ASSERT_NO_ERROR(edge_acc.SetProperty(this->edge_prop_id1, memgraph::storage::PropertyValue(i)));
     } else {
       auto edge_acc = this->CreateEdge(&vertex_from, &vertex_to, this->edge_type_id2, acc.get());
-      edge_acc.SetProperty(this->edge_prop_id2, memgraph::storage::PropertyValue(i));
+      ASSERT_NO_ERROR(edge_acc.SetProperty(this->edge_prop_id2, memgraph::storage::PropertyValue(i)));
     }
   }
 
@@ -2156,7 +2156,7 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexTransactionalIsolation) {
     auto vertex_from = this->CreateVertexWithoutProperties(acc.get());
     auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
     auto edge_acc = this->CreateEdge(&vertex_from, &vertex_to, this->edge_type_id1, acc.get());
-    edge_acc.SetProperty(this->edge_prop_id1, memgraph::storage::PropertyValue(i));
+    ASSERT_NO_ERROR(edge_acc.SetProperty(this->edge_prop_id1, memgraph::storage::PropertyValue(i)));
   }
 
   EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, this->edge_prop_id1, View::NEW), View::NEW),
@@ -2204,10 +2204,10 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexCountEstimate) {
     auto vertex_to = this->CreateVertexWithoutProperties(acc.get());
     if (i % 3) {
       auto edge_acc = this->CreateEdge(&vertex_from, &vertex_to, this->edge_type_id1, acc.get());
-      edge_acc.SetProperty(this->edge_prop_id1, memgraph::storage::PropertyValue(i));
+      ASSERT_NO_ERROR(edge_acc.SetProperty(this->edge_prop_id1, memgraph::storage::PropertyValue(i)));
     } else {
       auto edge_acc = this->CreateEdge(&vertex_from, &vertex_to, this->edge_type_id2, acc.get());
-      edge_acc.SetProperty(this->edge_prop_id2, memgraph::storage::PropertyValue(i));
+      ASSERT_NO_ERROR(edge_acc.SetProperty(this->edge_prop_id2, memgraph::storage::PropertyValue(i)));
     }
   }
 
@@ -2232,7 +2232,7 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexRepeatingEdgeTypesBetweenSameVertices
 
   for (int i = 0; i < 5; ++i) {
     auto edge_acc = this->CreateEdge(&vertex_from, &vertex_to, this->edge_type_id1, acc.get());
-    edge_acc.SetProperty(this->edge_prop_id1, memgraph::storage::PropertyValue(i));
+    ASSERT_NO_ERROR(edge_acc.SetProperty(this->edge_prop_id1, memgraph::storage::PropertyValue(i)));
   }
 
   EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_type_id1, this->edge_prop_id1), 5);
@@ -2243,7 +2243,7 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexRepeatingEdgeTypesBetweenSameVertices
   auto edges = acc->Edges(this->edge_type_id1, this->edge_prop_id1, View::NEW);
   for (auto edge : edges) {
     auto prop_val = edge.GetProperty(this->prop_id, View::NEW)->ValueInt();
-    edge.SetProperty(this->prop_id, memgraph::storage::PropertyValue(prop_val + 1));
+    ASSERT_NO_ERROR(edge.SetProperty(this->prop_id, memgraph::storage::PropertyValue(prop_val + 1)));
   }
 
   EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, this->edge_prop_id1, View::NEW), View::NEW),

--- a/tests/unit/storage_v2_wal_file.cpp
+++ b/tests/unit/storage_v2_wal_file.cpp
@@ -95,7 +95,7 @@ class DeltaGenerator final {
         // generates multiple `SetProperty` deltas using only the final values
         // of the property. The intermediate values aren't encoded. The value is
         // later determined in the `Finalize` function.
-        data_.emplace_back(memgraph::storage::durability::WalVertexSetProperty{vertex->gid, property});
+        data_.emplace_back(memgraph::storage::durability::WalVertexSetProperty{vertex->gid, property, {}});
       }
     }
 

--- a/tests/unit/ttl.cpp
+++ b/tests/unit/ttl.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -257,7 +257,7 @@ TYPED_TEST(TTLFixture, StartTime) {
 TYPED_TEST(TTLFixture, Durability) {
   const auto path = GetCleanDataDirectory();
   ASSERT_TRUE(memgraph::utils::EnsureDir(path));
-  memgraph::utils::OnScopeExit([&]() { std::filesystem::remove_all(path); });
+  auto clean_up = memgraph::utils::OnScopeExit([&] { std::filesystem::remove_all(path); });
   memgraph::query::ttl::TtlInfo ttl_info;
   {
     {


### PR DESCRIPTION
```sh
N=12
tmux new-session -d -s mysession
for ((i=1; i<N; i++)); do
    tmux split-window -h
    tmux select-layout tiled
done
tmux set-window-option synchronize-panes on
tmux attach-session -t mysession

mgconsole
unwind range(1,1000000) as a with a, 1 as b, 1 as c return *;
```

|       | before    | after     |
| ----- | --------- | --------- |
| N=1   | 1.715 sec | 1.725 sec |
| N=12  | 2.490 sec | 1.990 sec |
| N=24  | 4.810 sec | 2.925 sec |