### PR TITLE
Overhaul of the query memory tracker

### DIFF
--- a/src/memory/global_memory_control.cpp
+++ b/src/memory/global_memory_control.cpp
@@ -63,11 +63,11 @@ void *my_alloc(extent_hooks_t *extent_hooks, void *new_addr, size_t size, size_t
   // This needs to be before, to throw exception in case of too big alloc
   if (*commit) [[likely]] {
     if (IsThreadTracked()) [[unlikely]] {
-      bool ok = TrackAllocOnCurrentThread(size);
+      const bool ok = TrackAllocOnCurrentThread(size);
       if (!ok) return nullptr;
     }
     // This needs to be here so it doesn't get incremented in case the first TrackAlloc throws an exception
-    bool ok = memgraph::utils::total_memory_tracker.Alloc(static_cast<int64_t>(size));
+    const bool ok = memgraph::utils::total_memory_tracker.Alloc(static_cast<int64_t>(size));
     if (!ok) return nullptr;
   }
 
@@ -124,11 +124,11 @@ static bool my_commit(extent_hooks_t *extent_hooks, void *addr, size_t size, siz
 
   [[maybe_unused]] auto blocker = memgraph::utils::MemoryTracker::OutOfMemoryExceptionBlocker{};
   if (IsThreadTracked()) [[unlikely]] {
-    [[maybe_unused]] bool ok = TrackAllocOnCurrentThread(length);
+    [[maybe_unused]] const bool ok = TrackAllocOnCurrentThread(length);
     DMG_ASSERT(ok);
   }
 
-  [[maybe_unused]] auto ok = memgraph::utils::total_memory_tracker.Alloc(static_cast<int64_t>(length));
+  [[maybe_unused]] const auto ok = memgraph::utils::total_memory_tracker.Alloc(static_cast<int64_t>(length));
   DMG_ASSERT(ok);
 
   return false;

--- a/src/memory/global_memory_control.cpp
+++ b/src/memory/global_memory_control.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -62,8 +62,8 @@ void *my_alloc(extent_hooks_t *extent_hooks, void *new_addr, size_t size, size_t
                unsigned arena_ind) {
   // This needs to be before, to throw exception in case of too big alloc
   if (*commit) [[likely]] {
-    if (GetQueriesMemoryControl().IsThreadTracked()) [[unlikely]] {
-      bool ok = GetQueriesMemoryControl().TrackAllocOnCurrentThread(size);
+    if (IsThreadTracked()) [[unlikely]] {
+      bool ok = TrackAllocOnCurrentThread(size);
       if (!ok) return nullptr;
     }
     // This needs to be here so it doesn't get incremented in case the first TrackAlloc throws an exception
@@ -75,8 +75,8 @@ void *my_alloc(extent_hooks_t *extent_hooks, void *new_addr, size_t size, size_t
   if (ptr == nullptr) [[unlikely]] {
     if (*commit) {
       memgraph::utils::total_memory_tracker.Free(static_cast<int64_t>(size));
-      if (GetQueriesMemoryControl().IsThreadTracked()) [[unlikely]] {
-        GetQueriesMemoryControl().TrackFreeOnCurrentThread(size);
+      if (IsThreadTracked()) [[unlikely]] {
+        TrackFreeOnCurrentThread(size);
       }
     }
     return ptr;
@@ -95,8 +95,8 @@ static bool my_dalloc(extent_hooks_t *extent_hooks, void *addr, size_t size, boo
   if (committed) [[likely]] {
     memgraph::utils::total_memory_tracker.Free(static_cast<int64_t>(size));
 
-    if (GetQueriesMemoryControl().IsThreadTracked()) [[unlikely]] {
-      GetQueriesMemoryControl().TrackFreeOnCurrentThread(size);
+    if (IsThreadTracked()) [[unlikely]] {
+      TrackFreeOnCurrentThread(size);
     }
   }
 
@@ -106,8 +106,8 @@ static bool my_dalloc(extent_hooks_t *extent_hooks, void *addr, size_t size, boo
 static void my_destroy(extent_hooks_t *extent_hooks, void *addr, size_t size, bool committed, unsigned arena_ind) {
   if (committed) [[likely]] {
     memgraph::utils::total_memory_tracker.Free(static_cast<int64_t>(size));
-    if (GetQueriesMemoryControl().IsThreadTracked()) [[unlikely]] {
-      GetQueriesMemoryControl().TrackFreeOnCurrentThread(size);
+    if (IsThreadTracked()) [[unlikely]] {
+      TrackFreeOnCurrentThread(size);
     }
   }
 
@@ -123,8 +123,8 @@ static bool my_commit(extent_hooks_t *extent_hooks, void *addr, size_t size, siz
   }
 
   [[maybe_unused]] auto blocker = memgraph::utils::MemoryTracker::OutOfMemoryExceptionBlocker{};
-  if (GetQueriesMemoryControl().IsThreadTracked()) [[unlikely]] {
-    [[maybe_unused]] bool ok = GetQueriesMemoryControl().TrackAllocOnCurrentThread(length);
+  if (IsThreadTracked()) [[unlikely]] {
+    [[maybe_unused]] bool ok = TrackAllocOnCurrentThread(length);
     DMG_ASSERT(ok);
   }
 
@@ -144,8 +144,8 @@ static bool my_decommit(extent_hooks_t *extent_hooks, void *addr, size_t size, s
   }
 
   memgraph::utils::total_memory_tracker.Free(static_cast<int64_t>(length));
-  if (GetQueriesMemoryControl().IsThreadTracked()) [[unlikely]] {
-    GetQueriesMemoryControl().TrackFreeOnCurrentThread(size);
+  if (IsThreadTracked()) [[unlikely]] {
+    TrackFreeOnCurrentThread(size);
   }
 
   return false;
@@ -161,8 +161,8 @@ static bool my_purge_forced(extent_hooks_t *extent_hooks, void *addr, size_t siz
   }
   memgraph::utils::total_memory_tracker.Free(static_cast<int64_t>(length));
 
-  if (GetQueriesMemoryControl().IsThreadTracked()) [[unlikely]] {
-    GetQueriesMemoryControl().TrackFreeOnCurrentThread(size);
+  if (IsThreadTracked()) [[unlikely]] {
+    TrackFreeOnCurrentThread(size);
   }
 
   return false;
@@ -187,10 +187,6 @@ void SetHooks() {
   if (nullptr != old_hooks) {
     return;
   }
-
-  // Needs init due to error we might encounter otherwise
-  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=13684
-  [[maybe_unused]] const auto &queries_memory_control = GetQueriesMemoryControl();
 
   for (int i = 0; i < n_arenas; i++) {
     std::string func_name = "arena." + std::to_string(i) + ".extent_hooks";

--- a/src/memory/query_memory_control.cpp
+++ b/src/memory/query_memory_control.cpp
@@ -27,6 +27,7 @@ inline int &GetThreadTracked() {
 }
 
 inline auto &GetQueryTracker() {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static thread_local utils::QueryMemoryTracker *query_memory_tracker_ = nullptr;
   return query_memory_tracker_;
 }

--- a/src/memory/query_memory_control.hpp
+++ b/src/memory/query_memory_control.hpp
@@ -42,16 +42,16 @@ struct ThreadTrackingBlocker {
   ThreadTrackingBlocker &operator=(ThreadTrackingBlocker &&) = delete;
 
  private:
-  int prev_state_;
+  void *prev_state_;
 };
 
 #endif
 
-// API function call for to start tracking current thread.
+// API function call to start tracking current thread.
 // Does nothing if jemalloc is not enabled
 void StartTrackingCurrentThread(utils::QueryMemoryTracker *tracker);
 
-// API function call for to stop tracking current thread.
+// API function call to stop tracking current thread.
 // Does nothing if jemalloc is not enabled
 void StopTrackingCurrentThread();
 

--- a/src/memory/query_memory_control.hpp
+++ b/src/memory/query_memory_control.hpp
@@ -33,18 +33,6 @@ void TrackFreeOnCurrentThread(size_t size);
 
 bool IsThreadTracked();
 
-struct ThreadTrackingBlocker {
-  ThreadTrackingBlocker();
-  ~ThreadTrackingBlocker();
-  ThreadTrackingBlocker(ThreadTrackingBlocker &) = delete;
-  ThreadTrackingBlocker &operator=(ThreadTrackingBlocker &) = delete;
-  ThreadTrackingBlocker(ThreadTrackingBlocker &&) = delete;
-  ThreadTrackingBlocker &operator=(ThreadTrackingBlocker &&) = delete;
-
- private:
-  void *prev_state_;
-};
-
 #endif
 
 // API function call to start tracking current thread.

--- a/src/memory/query_memory_control.hpp
+++ b/src/memory/query_memory_control.hpp
@@ -12,12 +12,8 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <thread>
-#include <unordered_map>
 
-#include "utils/memory_tracker.hpp"
 #include "utils/query_memory_tracker.hpp"
-#include "utils/skip_list.hpp"
 
 namespace memgraph::memory {
 
@@ -25,143 +21,49 @@ static constexpr int64_t UNLIMITED_MEMORY{0};
 
 #if USE_JEMALLOC
 
-// Track memory allocations per query.
-// Multiple threads can allocate inside one transaction.
-// If user forgets to unregister tracking for that thread before it dies, it will continue to
-// track allocations for that arena indefinitely.
-// As multiple queries can be executed inside one transaction, one by one (multi-transaction)
-// it is necessary to restart tracking at the beginning of new query for that transaction.
-class QueriesMemoryControl {
- public:
-  /*
-    Transaction id <-> tracker
-  */
+// Find tracker for current thread if exists, track
+// query allocation and procedure allocation if
+// necessary
+bool TrackAllocOnCurrentThread(size_t size);
 
-  // Create new tracker for transaction_id with initial limit
-  void CreateTransactionIdTracker(uint64_t, size_t);
+// Find tracker for current thread if exists, track
+// query allocation and procedure allocation if
+// necessary
+void TrackFreeOnCurrentThread(size_t size);
 
-  // Check if tracker for given transaction id exists
-  bool CheckTransactionIdTrackerExists(uint64_t);
+bool IsThreadTracked();
 
-  // Remove current tracker for transaction_id
-  bool EraseTransactionIdTracker(uint64_t);
-
-  /*
-  Thread handlings
-  */
-
-  // Map thread to transaction with given id
-  // This way we can know which thread belongs to which transaction
-  // and get correct tracker for given transaction
-  void UpdateThreadToTransactionId(const std::thread::id &, uint64_t);
-
-  // Remove tracking of thread from transaction.
-  // Important to reset if one thread gets reused for different transaction
-  void EraseThreadToTransactionId(const std::thread::id &, uint64_t);
-
-  // Find tracker for current thread if exists, track
-  // query allocation and procedure allocation if
-  // necessary
-  bool TrackAllocOnCurrentThread(size_t size);
-
-  // Find tracker for current thread if exists, track
-  // query allocation and procedure allocation if
-  // necessary
-  void TrackFreeOnCurrentThread(size_t size);
-
-  void TryCreateTransactionProcTracker(uint64_t, int64_t, size_t);
-
-  void SetActiveProcIdTracker(uint64_t, int64_t);
-
-  void PauseProcedureTracking(uint64_t);
-
-  bool IsThreadTracked();
+struct ThreadTrackingBlocker {
+  ThreadTrackingBlocker();
+  ~ThreadTrackingBlocker();
+  ThreadTrackingBlocker(ThreadTrackingBlocker &) = delete;
+  ThreadTrackingBlocker &operator=(ThreadTrackingBlocker &) = delete;
+  ThreadTrackingBlocker(ThreadTrackingBlocker &&) = delete;
+  ThreadTrackingBlocker &operator=(ThreadTrackingBlocker &&) = delete;
 
  private:
-  struct TransactionId {
-    uint64_t id;
-    uint64_t cnt;
-
-    bool operator<(const TransactionId &other) const { return id < other.id; }
-    bool operator==(const TransactionId &other) const { return id == other.id; }
-
-    bool operator<(uint64_t other) const { return id < other; }
-    bool operator==(uint64_t other) const { return id == other; }
-  };
-
-  struct ThreadIdToTransactionId {
-    std::thread::id thread_id;
-    TransactionId transaction_id;
-
-    bool operator<(const ThreadIdToTransactionId &other) const { return thread_id < other.thread_id; }
-    bool operator==(const ThreadIdToTransactionId &other) const { return thread_id == other.thread_id; }
-
-    bool operator<(const std::thread::id other) const { return thread_id < other; }
-    bool operator==(const std::thread::id other) const { return thread_id == other; }
-  };
-
-  struct TransactionIdToTracker {
-    uint64_t transaction_id;
-    utils::QueryMemoryTracker tracker;
-
-    bool operator<(const TransactionIdToTracker &other) const { return transaction_id < other.transaction_id; }
-    bool operator==(const TransactionIdToTracker &other) const { return transaction_id == other.transaction_id; }
-
-    bool operator<(uint64_t other) const { return transaction_id < other; }
-    bool operator==(uint64_t other) const { return transaction_id == other; }
-
-    bool operator<(TransactionId other) const { return transaction_id < other.id; }
-    bool operator==(TransactionId other) const { return transaction_id == other.id; }
-  };
-
-  struct ThreadTrackingBlocker {
-    ThreadTrackingBlocker();
-    ~ThreadTrackingBlocker();
-    ThreadTrackingBlocker(ThreadTrackingBlocker &) = delete;
-    ThreadTrackingBlocker &operator=(ThreadTrackingBlocker &) = delete;
-    ThreadTrackingBlocker(ThreadTrackingBlocker &&) = delete;
-    ThreadTrackingBlocker &operator=(ThreadTrackingBlocker &&) = delete;
-
-   private:
-    int prev_state_;
-  };
-
-  utils::SkipList<ThreadIdToTransactionId> thread_id_to_transaction_id;
-  utils::SkipList<TransactionIdToTracker> transaction_id_to_tracker;
+  int prev_state_;
 };
-
-inline QueriesMemoryControl &GetQueriesMemoryControl() {
-  static QueriesMemoryControl queries_memory_control_;
-  return queries_memory_control_;
-}
 
 #endif
 
-// API function call for to start tracking current thread for given transaction.
+// API function call for to start tracking current thread.
 // Does nothing if jemalloc is not enabled
-void StartTrackingCurrentThreadTransaction(uint64_t transaction_id);
+void StartTrackingCurrentThread(utils::QueryMemoryTracker *tracker);
 
-// API function call for to stop tracking current thread for given transaction.
+// API function call for to stop tracking current thread.
 // Does nothing if jemalloc is not enabled
-void StopTrackingCurrentThreadTransaction(uint64_t transaction_id);
+void StopTrackingCurrentThread();
 
-// API function call for try to create tracker for transaction and set it to given limit.
-// Does nothing if jemalloc is not enabled. Does nothing if tracker already exists
-void TryStartTrackingOnTransaction(uint64_t transaction_id, size_t limit);
-
-// API function call to stop tracking for given transaction.
-// Does nothing if jemalloc is not enabled. Does nothing if tracker doesn't exist
-void TryStopTrackingOnTransaction(uint64_t transaction_id);
-
-// Is transaction with given id tracked in memory tracker
-bool IsTransactionTracked(uint64_t transaction_id);
+// Is query's memory tracked
+bool IsQueryTracked();
 
 // Creates tracker on procedure if doesn't exist. Sets query tracker
 // to track procedure with id.
-void CreateOrContinueProcedureTracking(uint64_t transaction_id, int64_t procedure_id, size_t limit);
+void CreateOrContinueProcedureTracking(int64_t procedure_id, size_t limit);
 
 // Pauses procedure tracking. This enables to continue
 // tracking on procedure once procedure execution resumes.
-void PauseProcedureTracking(uint64_t transaction_id);
+void PauseProcedureTracking();
 
 }  // namespace memgraph::memory

--- a/src/query/db_accessor.cpp
+++ b/src/query/db_accessor.cpp
@@ -24,7 +24,7 @@ SubgraphDbAccessor::SubgraphDbAccessor(query::DbAccessor db_accessor, Graph *gra
 
 void SubgraphDbAccessor::TrackCurrentThreadAllocations() { return db_accessor_.TrackCurrentThreadAllocations(); }
 
-void SubgraphDbAccessor::UntrackCurrentThreadAllocations() { return db_accessor_.TrackCurrentThreadAllocations(); }
+void SubgraphDbAccessor::UntrackCurrentThreadAllocations() { return db_accessor_.UntrackCurrentThreadAllocations(); }
 
 storage::PropertyId SubgraphDbAccessor::NameToProperty(const std::string_view name) {
   return db_accessor_.NameToProperty(name);

--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -280,14 +280,14 @@ class DbAccessor final {
   void FinalizeTransaction() { accessor_->FinalizeTransaction(); }
 
   void TrackCurrentThreadAllocations() {
-    memgraph::memory::StartTrackingCurrentThreadTransaction(*accessor_->GetTransactionId());
+    memgraph::memory::StartTrackingCurrentThread(accessor_->GetQueryMemoryTracker().get());
   }
 
-  void UntrackCurrentThreadAllocations() {
-    memgraph::memory::StopTrackingCurrentThreadTransaction(*accessor_->GetTransactionId());
-  }
+  void UntrackCurrentThreadAllocations() { memgraph::memory::StopTrackingCurrentThread(); }
 
-  std::optional<uint64_t> GetTransactionId() { return accessor_->GetTransactionId(); }
+  auto &GetQueryMemoryTracker() { return accessor_->GetQueryMemoryTracker(); }
+
+  auto GetTransactionId() { return accessor_->GetTransactionId(); }
 
   VerticesIterable Vertices(storage::View view) { return VerticesIterable(accessor_->Vertices(view)); }
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -2134,7 +2134,7 @@ std::optional<plan::ProfilingStatsWithTotalTime> PullPlan::Pull(AnyStream *strea
     memgraph::memory::StartTrackingCurrentThread(memory_tracker.get());
   }
 
-  const utils::OnScopeExit<std::function<void()>> reset_query_limit{[this]() {
+  const utils::OnScopeExit reset_query_limit{[this]() {
     if (memory_limit_.has_value()) {
       // Stopping tracking of transaction occurs in interpreter::pull
       // Exception can occur so we need to handle that case there.

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -96,6 +96,7 @@
 #include "utils/memory.hpp"
 #include "utils/memory_tracker.hpp"
 #include "utils/on_scope_exit.hpp"
+#include "utils/query_memory_tracker.hpp"
 #include "utils/readable_size.hpp"
 #include "utils/settings.hpp"
 #include "utils/stat.hpp"
@@ -2126,23 +2127,27 @@ PullPlan::PullPlan(const std::shared_ptr<PlanWrapper> plan, const Parameters &pa
 std::optional<plan::ProfilingStatsWithTotalTime> PullPlan::Pull(AnyStream *stream, std::optional<int> n,
                                                                 const std::vector<Symbol> &output_symbols,
                                                                 std::map<std::string, TypedValue> *summary) {
-  std::optional<uint64_t> transaction_id = ctx_.db_accessor->GetTransactionId();
-  MG_ASSERT(transaction_id.has_value());
-
   if (memory_limit_) {
-    memgraph::memory::TryStartTrackingOnTransaction(*transaction_id, *memory_limit_);
-    memgraph::memory::StartTrackingCurrentThreadTransaction(*transaction_id);
+    auto &memory_tracker = ctx_.db_accessor->GetQueryMemoryTracker();
+    if (!memory_tracker) memory_tracker = std::make_unique<utils::QueryMemoryTracker>();
+    memory_tracker->SetQueryLimit(*memory_limit_);
+    memgraph::memory::StartTrackingCurrentThread(memory_tracker.get());
   }
-  utils::OnScopeExit<std::function<void()>> reset_query_limit{
-      [memory_limit = memory_limit_, transaction_id = *transaction_id]() {
-        if (memory_limit) {
-          // Stopping tracking of transaction occurs in interpreter::pull
-          // Exception can occur so we need to handle that case there.
-          // We can't stop tracking here as there can be multiple pulls
-          // so we need to take care of that after everything was pulled
-          memgraph::memory::StopTrackingCurrentThreadTransaction(transaction_id);
-        }
-      }};
+
+  utils::OnScopeExit<std::function<void()>> reset_query_limit{[this]() {
+    if (memory_limit_.has_value()) {
+      // Stopping tracking of transaction occurs in interpreter::pull
+      // Exception can occur so we need to handle that case there.
+      // We can't stop tracking here as there can be multiple pulls
+      // so we need to take care of that after everything was pulled
+      memgraph::memory::StopTrackingCurrentThread();
+      // Pull has completted or has thrown an exception; either way, reset the query tracker
+      if (!has_unsent_results_ || std::uncaught_exceptions()) {
+        auto &memory_tracker = ctx_.db_accessor->GetQueryMemoryTracker();
+        memory_tracker.reset();
+      }
+    }
+  }};
 
   // Returns true if a result was pulled.
   const auto pull_result = [&]() -> bool { return cursor_->Pull(frame_, ctx_); };

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -2134,7 +2134,7 @@ std::optional<plan::ProfilingStatsWithTotalTime> PullPlan::Pull(AnyStream *strea
     memgraph::memory::StartTrackingCurrentThread(memory_tracker.get());
   }
 
-  utils::OnScopeExit<std::function<void()>> reset_query_limit{[this]() {
+  const utils::OnScopeExit<std::function<void()>> reset_query_limit{[this]() {
     if (memory_limit_.has_value()) {
       // Stopping tracking of transaction occurs in interpreter::pull
       // Exception can occur so we need to handle that case there.

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -491,9 +491,6 @@ std::map<std::string, TypedValue> Interpreter::Pull(TStream *result_stream, std:
     // If the query finished executing, we have received a value which tells
     // us what to do after.
     if (maybe_res) {
-      if (current_transaction_) {
-        memgraph::memory::TryStopTrackingOnTransaction(*current_transaction_);
-      }
       // Save its summary
       maybe_summary.emplace(std::move(query_execution->summary));
       if (!query_execution->notifications.empty()) {
@@ -532,16 +529,10 @@ std::map<std::string, TypedValue> Interpreter::Pull(TStream *result_stream, std:
     }
   } catch (const ExplicitTransactionUsageException &e) {
     LogQueryMessage(e.what());
-    if (current_transaction_) {
-      memgraph::memory::TryStopTrackingOnTransaction(*current_transaction_);
-    }
     query_execution.reset(nullptr);
     throw;
   } catch (const utils::BasicException &e) {
     LogQueryMessage(e.what());
-    if (current_transaction_) {
-      memgraph::memory::TryStopTrackingOnTransaction(*current_transaction_);
-    }
     // Trigger first failed query
     metrics::FirstFailedQuery();
     memgraph::metrics::IncrementCounter(memgraph::metrics::FailedQuery);

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -65,6 +65,7 @@
 #include "utils/pmr/unordered_map.hpp"
 #include "utils/pmr/unordered_set.hpp"
 #include "utils/pmr/vector.hpp"
+#include "utils/query_memory_tracker.hpp"
 #include "utils/readable_size.hpp"
 #include "utils/tag.hpp"
 #include "utils/temporal.hpp"
@@ -5379,26 +5380,28 @@ void CallCustomProcedure(const std::string_view fully_qualified_procedure_name, 
     // can disable tracking on that arena if it is not
     // once we are done with procedure tracking
 
-    bool is_transaction_tracked = memgraph::memory::IsTransactionTracked(transaction_id);
+    bool is_transaction_tracked = memgraph::memory::IsQueryTracked();
 
+    std::unique_ptr<utils::QueryMemoryTracker> tmp_query_tracker{};
     if (!is_transaction_tracked) {
       // start tracking with unlimited limit on query
       // which is same as not being tracked at all
-      memgraph::memory::TryStartTrackingOnTransaction(transaction_id, memgraph::memory::UNLIMITED_MEMORY);
+      tmp_query_tracker = std::make_unique<utils::QueryMemoryTracker>();
+      tmp_query_tracker->SetQueryLimit(memgraph::memory::UNLIMITED_MEMORY);
+      memgraph::memory::StartTrackingCurrentThread(tmp_query_tracker.get());
     }
-    memgraph::memory::StartTrackingCurrentThreadTransaction(transaction_id);
 
     // due to mgp_batch_read_proc and mgp_batch_write_proc
     // we can return to execution without exhausting whole
     // memory. Here we need to update tracking
-    memgraph::memory::CreateOrContinueProcedureTracking(transaction_id, procedure_id, *memory_limit);
+    memgraph::memory::CreateOrContinueProcedureTracking(procedure_id, *memory_limit);
 
     mgp_memory proc_memory{&memory_tracking_resource};
     MG_ASSERT(result->signature == &proc.results);
 
-    utils::OnScopeExit on_scope_exit{[transaction_id = transaction_id]() {
-      memgraph::memory::StopTrackingCurrentThreadTransaction(transaction_id);
-      memgraph::memory::PauseProcedureTracking(transaction_id);
+    utils::OnScopeExit on_scope_exit{[is_transaction_tracked]() {
+      memgraph::memory::PauseProcedureTracking();
+      if (!is_transaction_tracked) memgraph::memory::StopTrackingCurrentThread();
     }};
 
     // TODO: What about cross library boundary exceptions? OMG C++?!

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -5380,7 +5380,7 @@ void CallCustomProcedure(const std::string_view fully_qualified_procedure_name, 
     // can disable tracking on that arena if it is not
     // once we are done with procedure tracking
 
-    bool is_transaction_tracked = memgraph::memory::IsQueryTracked();
+    const bool is_transaction_tracked = memgraph::memory::IsQueryTracked();
 
     std::unique_ptr<utils::QueryMemoryTracker> tmp_query_tracker{};
     if (!is_transaction_tracked) {
@@ -5396,13 +5396,13 @@ void CallCustomProcedure(const std::string_view fully_qualified_procedure_name, 
     // memory. Here we need to update tracking
     memgraph::memory::CreateOrContinueProcedureTracking(procedure_id, *memory_limit);
 
-    mgp_memory proc_memory{&memory_tracking_resource};
-    MG_ASSERT(result->signature == &proc.results);
-
-    utils::OnScopeExit on_scope_exit{[is_transaction_tracked]() {
+    const utils::OnScopeExit on_scope_exit{[is_transaction_tracked]() {
       memgraph::memory::PauseProcedureTracking();
       if (!is_transaction_tracked) memgraph::memory::StopTrackingCurrentThread();
     }};
+
+    mgp_memory proc_memory{&memory_tracking_resource};
+    MG_ASSERT(result->signature == &proc.results);
 
     // TODO: What about cross library boundary exceptions? OMG C++?!
     proc.cb(&proc_args, &graph, result, &proc_memory);

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -5380,6 +5380,7 @@ void CallCustomProcedure(const std::string_view fully_qualified_procedure_name, 
     // can disable tracking on that arena if it is not
     // once we are done with procedure tracking
 
+#if USE_JEMALLOC
     const bool is_transaction_tracked = memgraph::memory::IsQueryTracked();
 
     std::unique_ptr<utils::QueryMemoryTracker> tmp_query_tracker{};
@@ -5400,6 +5401,7 @@ void CallCustomProcedure(const std::string_view fully_qualified_procedure_name, 
       memgraph::memory::PauseProcedureTracking();
       if (!is_transaction_tracked) memgraph::memory::StopTrackingCurrentThread();
     }};
+#endif
 
     mgp_memory proc_memory{&memory_tracking_resource};
     MG_ASSERT(result->signature == &proc.results);

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -139,6 +139,10 @@ std::optional<uint64_t> Storage::Accessor::GetTransactionId() const {
   return {};
 }
 
+std::unique_ptr<utils::QueryMemoryTracker> &Storage::Accessor::GetQueryMemoryTracker() {
+  return transaction_.query_memory_tracker_;
+}
+
 std::vector<LabelId> Storage::Accessor::ListAllPossiblyPresentVertexLabels() const {
   std::vector<LabelId> vertex_labels;
   storage_->stored_node_labels_.for_each([&vertex_labels](const auto &label) { vertex_labels.push_back(label); });

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -320,6 +320,8 @@ class Storage {
 
     std::optional<uint64_t> GetTransactionId() const;
 
+    std::unique_ptr<utils::QueryMemoryTracker> &GetQueryMemoryTracker();
+
     void AdvanceCommand();
 
     const std::string &LabelToName(LabelId label) const { return storage_->LabelToName(label); }

--- a/src/storage/v2/transaction.hpp
+++ b/src/storage/v2/transaction.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -13,11 +13,11 @@
 
 #include <atomic>
 #include <memory>
-#include <unordered_map>
 
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/schema_info.hpp"
 #include "utils/memory.hpp"
+#include "utils/query_memory_tracker.hpp"
 #include "utils/skip_list.hpp"
 
 #include "delta_container.hpp"
@@ -151,6 +151,9 @@ struct Transaction {
   /// Tracking schema changes done during the transaction
   LocalSchemaTracking schema_diff_;
   std::unordered_set<SchemaInfoPostProcess> post_process_;
+
+  /// Query memory tracker
+  std::unique_ptr<utils::QueryMemoryTracker> query_memory_tracker_{};
 };
 
 inline bool operator==(const Transaction &first, const Transaction &second) {

--- a/src/utils/query_memory_tracker.hpp
+++ b/src/utils/query_memory_tracker.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -10,7 +10,6 @@
 // licenses/APL.txt.
 #pragma once
 
-#include <atomic>
 #include <optional>
 #include <unordered_map>
 #include <utility>

--- a/tests/e2e/memory/procedures/proc_memory_limit.cpp
+++ b/tests/e2e/memory/procedures/proc_memory_limit.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -38,7 +38,7 @@ void Alloc_256_MiB(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result
   try {
     void *ptr{nullptr};
 
-    memgraph::utils::OnScopeExit<std::function<void(void)>> cleanup{[&memory, &ptr]() {
+    memgraph::utils::OnScopeExit cleanup{[&memory, &ptr]() {
       if (nullptr == ptr) {
         return;
       }
@@ -67,7 +67,7 @@ void Alloc_32_MiB(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result,
   try {
     void *ptr{nullptr};
 
-    memgraph::utils::OnScopeExit<std::function<void(void)>> cleanup{[&ptr]() {
+    memgraph::utils::OnScopeExit cleanup{[&ptr]() {
       if (nullptr == ptr) {
         return;
       }

--- a/tests/e2e/memory/procedures/query_memory_limit_proc.cpp
+++ b/tests/e2e/memory/procedures/query_memory_limit_proc.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -38,7 +38,7 @@ void Regular(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_
   try {
     void *ptr{nullptr};
 
-    memgraph::utils::OnScopeExit<std::function<void(void)>> cleanup{[&ptr]() {
+    memgraph::utils::OnScopeExit cleanup{[&ptr]() {
       if (nullptr == ptr) {
         return;
       }

--- a/tests/unit/utils_query_memory_tracker.cpp
+++ b/tests/unit/utils_query_memory_tracker.cpp
@@ -13,12 +13,14 @@
 
 #include "memory/global_memory_control.hpp"
 #include "memory/query_memory_control.hpp"
+#include "utils/query_memory_tracker.hpp"
 
 TEST(MemoryTrackerTest, ExceptionEnabler) {
 #ifdef USE_JEMALLOC
   memgraph::memory::SetHooks();
-  memgraph::memory::StartTrackingCurrentThreadTransaction(1);
-  memgraph::memory::TryStartTrackingOnTransaction(1, 100000);
+  memgraph::utils::QueryMemoryTracker qmt;
+  qmt.SetQueryLimit(memgraph::memory::UNLIMITED_MEMORY);
+  memgraph::memory::StartTrackingCurrentThread(&qmt);
 
   for (int i = 0; i < 1e6; i++) {
     std::vector<int> vi;


### PR DESCRIPTION
Removed skip lists and using thread locals to point to the correct tracker 
Simpler logic and better locality
Bugfixes, including calls to wrong functions or misaligned calls