### PR TITLE
Bugfix: Unregister replication instance wasn't durable

### DIFF
--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -701,9 +701,11 @@ auto CoordinatorInstance::UnregisterReplicationInstance(std::string_view instanc
   }
 
   auto cluster_state = raft_state_->GetDataInstancesContext();
-  std::ranges::remove_if(cluster_state, [instance_name](auto &&data_instance) {
+  auto const [first, last] = std::ranges::remove_if(cluster_state, [instance_name](auto &&data_instance) {
     return data_instance.config.instance_name == instance_name;
   });
+  cluster_state.erase(first, last);
+
   auto const curr_main_uuid = raft_state_->GetCurrentMainUUID();
 
   auto coordinator_instances = raft_state_->GetCoordinatorInstancesContext();

--- a/src/coordination/data_instance_management_server_handlers.cpp
+++ b/src/coordination/data_instance_management_server_handlers.cpp
@@ -23,7 +23,7 @@ namespace memgraph::dbms {
 void DataInstanceManagementServerHandlers::Register(memgraph::coordination::DataInstanceManagementServer &server,
                                                     replication::ReplicationHandler &replication_handler) {
   server.Register<coordination::StateCheckRpc>([&](slk::Reader *req_reader, slk::Builder *res_builder) -> void {
-    spdlog::info("Received StateCheckRpc");
+    spdlog::trace("Received StateCheckRpc");
     DataInstanceManagementServerHandlers::StateCheckHandler(replication_handler, req_reader, res_builder);
   });
 


### PR DESCRIPTION
Issue in the C++ code, using remove without erase. Unregistering now works correctly even after restarting instances.
