### PR TITLE
Bugfix, timestamp didn't check nargs

### DIFF
--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -1163,6 +1163,11 @@ TypedValue ToStringOrNull(const TypedValue *args, int64_t nargs, const FunctionC
 
 TypedValue Timestamp(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
   FType<Optional<Or<Date, LocalTime, LocalDateTime, ZonedDateTime, Duration>>>("timestamp", args, nargs);
+
+  if (nargs == 0) {
+    return TypedValue(ctx.timestamp, ctx.memory);
+  }
+
   const auto &arg = *args;
   if (arg.IsDate()) {
     return TypedValue(arg.ValueDate().MicrosecondsSinceEpoch(), ctx.memory);


### PR DESCRIPTION
This lead to non-determanistic behaviour when combined with other recent changes around improving performance of function calls.
