### PR TITLE
Add RPC timeouts for AppendDeltas, CurrentWal and WalFiles

### DIFF
--- a/src/coordination/coordinator_instance_management_server_handlers.cpp
+++ b/src/coordination/coordinator_instance_management_server_handlers.cpp
@@ -9,6 +9,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+#ifdef MG_ENTERPRISE
+
 #include "coordination/coordinator_instance_management_server_handlers.hpp"
 #include "coordination/coordinator_rpc.hpp"
 
@@ -16,7 +18,6 @@
 
 namespace memgraph::coordination {
 
-#ifdef MG_ENTERPRISE
 void CoordinatorInstanceManagementServerHandlers::Register(CoordinatorInstanceManagementServer &server,
                                                            CoordinatorInstance &coordinator_instance) {
   server.Register<coordination::ShowInstancesRpc>([&](slk::Reader *req_reader, slk::Builder *res_builder) -> void {
@@ -34,5 +35,6 @@ void CoordinatorInstanceManagementServerHandlers::ShowInstancesHandler(Coordinat
   rpc::SendFinalResponse(rpc_res, res_builder);
   spdlog::trace("Replying to ShowInstancesRpc.");
 }
-#endif
+
 }  // namespace memgraph::coordination
+#endif

--- a/src/coordination/include/coordination/coordinator_instance_management_server_handlers.hpp
+++ b/src/coordination/include/coordination/coordinator_instance_management_server_handlers.hpp
@@ -11,11 +11,12 @@
 
 #pragma once
 
+#ifdef MG_ENTERPRISE
+
 #include "coordination/coordinator_instance.hpp"
 #include "coordination/coordinator_instance_management_server.hpp"
 
 namespace memgraph::coordination {
-#ifdef MG_ENTERPRISE
 class CoordinatorInstanceManagementServerHandlers {
  public:
   static void Register(memgraph::coordination::CoordinatorInstanceManagementServer &server,
@@ -26,5 +27,5 @@ class CoordinatorInstanceManagementServerHandlers {
                                    slk::Builder *res_builder);
 };
 
-#endif
 }  // namespace memgraph::coordination
+#endif

--- a/src/dbms/inmemory/replication_handlers.hpp
+++ b/src/dbms/inmemory/replication_handlers.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -11,7 +11,6 @@
 
 #pragma once
 
-#include "replication/replication_server.hpp"
 #include "replication/state.hpp"
 #include "storage/v2/replication/serialization.hpp"
 
@@ -53,10 +52,13 @@ class InMemoryReplicationHandlers {
                                        const std::optional<utils::UUID> &current_main_uuid, slk::Reader *req_reader,
                                        slk::Builder *res_builder);
 
-  static bool LoadWal(storage::InMemoryStorage *storage, storage::replication::Decoder *decoder);
+  static std::pair<bool, uint32_t> LoadWal(storage::InMemoryStorage *storage, storage::replication::Decoder *decoder,
+                                           slk::Builder *res_builder, uint32_t start_batch_counter = 0);
 
-  static uint64_t ReadAndApplyDeltas(storage::InMemoryStorage *storage, storage::durability::BaseDecoder *decoder,
-                                     uint64_t version);
+  static std::pair<uint64_t, uint32_t> ReadAndApplyDeltasSingleTxn(storage::InMemoryStorage *storage,
+                                                                   storage::durability::BaseDecoder *decoder,
+                                                                   uint64_t version, slk::Builder *,
+                                                                   uint32_t start_batch_counter = 0);
 };
 
 }  // namespace memgraph::dbms

--- a/src/rpc/client.hpp
+++ b/src/rpc/client.hpp
@@ -52,8 +52,11 @@ class Client {
       {"TimestampReq"sv, 10000},              // main to replica
       {"SystemHeartbeatReq"sv, 10000},        // main to replica
       {"ForceResetStorageReq"sv,
-       60000},                        // main to replica. Longer timeout because we need to wait for all storage locks.
-      {"SystemRecoveryReq"sv, 30000}  // main to replica when MT is used. Recovering 1000DBs should take around 25''.
+       60000},                         // main to replica. Longer timeout because we need to wait for all storage locks.
+      {"SystemRecoveryReq"sv, 30000},  // main to replica when MT is used. Recovering 1000DBs should take around 25''
+      {"AppendDeltasReq"sv, 30000},    // Waiting 30'' on a progress/final response
+      {"CurrentWalReq"sv, 30000},      // Waiting 30'' on a progress/final response
+      {"WalFilesReq"sv, 30000}         // Waiting 30'' on a progress/final response
   };
   // Dependency injection of rpc_timeouts
   Client(io::network::Endpoint endpoint, communication::ClientContext *context,

--- a/src/rpc/utils.hpp
+++ b/src/rpc/utils.hpp
@@ -27,4 +27,13 @@ void SendFinalResponse(TResponse const &res, slk::Builder *builder) {
   spdlog::trace("[RpcServer] sent {}", TResponse::kType.name);
 }
 
+inline void SendInProgressMsg(slk::Builder *builder) {
+  if (!builder->IsEmpty()) {
+    throw slk::SlkBuilderException("InProgress RPC message can only be sent when the builder's buffer is empty.");
+  }
+  Save(storage::replication::InProgressRes::kType.id, builder);
+  Save(rpc::current_version, builder);
+  builder->Finalize();
+}
+
 }  // namespace memgraph::rpc

--- a/src/rpc/utils.hpp
+++ b/src/rpc/utils.hpp
@@ -34,6 +34,7 @@ inline void SendInProgressMsg(slk::Builder *builder) {
   Save(storage::replication::InProgressRes::kType.id, builder);
   Save(rpc::current_version, builder);
   builder->Finalize();
+  spdlog::trace("[RpcServer] sent {}", storage::replication::InProgressRes::kType.name);
 }
 
 }  // namespace memgraph::rpc

--- a/src/storage/v2/inmemory/replication/recovery.cpp
+++ b/src/storage/v2/inmemory/replication/recovery.cpp
@@ -68,7 +68,7 @@ void InMemoryCurrentWalHandler::AppendBufferData(const uint8_t *buffer, const si
   encoder.WriteBuffer(buffer, buffer_size);
 }
 
-replication::CurrentWalRes InMemoryCurrentWalHandler::Finalize() { return stream_.AwaitResponse(); }
+replication::CurrentWalRes InMemoryCurrentWalHandler::Finalize() { return stream_.AwaitResponseWhileInProgress(); }
 
 // ReplicationClient Helpers
 // Caller should make sure that wal files aren't empty
@@ -80,7 +80,7 @@ replication::WalFilesRes TransferWalFiles(const utils::UUID &main_uuid, const ut
     spdlog::debug("Sending wal file: {}", wal);
     encoder.WriteFile(wal);
   }
-  return stream.AwaitResponse();
+  return stream.AwaitResponseWhileInProgress();
 }
 
 replication::SnapshotRes TransferSnapshot(const utils::UUID &main_uuid, const utils::UUID &storage_uuid,

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -521,5 +521,5 @@ void ReplicaStream::AppendTransactionEnd(uint64_t final_commit_timestamp) {
   EncodeTransactionEnd(&encoder, final_commit_timestamp);
 }
 
-replication::AppendDeltasRes ReplicaStream::Finalize() { return stream_.AwaitResponse(); }
+replication::AppendDeltasRes ReplicaStream::Finalize() { return stream_.AwaitResponseWhileInProgress(); }
 }  // namespace memgraph::storage

--- a/src/storage/v2/replication/rpc.cpp
+++ b/src/storage/v2/replication/rpc.cpp
@@ -274,15 +274,6 @@ void Load(memgraph::storage::replication::AppendDeltasReq *self, memgraph::slk::
   memgraph::slk::Load(&self->seq_num, reader);
 }
 
-void SendInProgressMsg(Builder *builder) {
-  if (!builder->IsEmpty()) {
-    throw SlkBuilderException("InProgress RPC message can only be sent when the builder's buffer is empty.");
-  }
-  Save(storage::replication::InProgressRes::kType.id, builder);
-  Save(rpc::current_version, builder);
-  builder->Finalize();
-}
-
 // Serialize code for ForceResetStorageReq
 
 void Save(const memgraph::storage::replication::ForceResetStorageReq &self, memgraph::slk::Builder *builder) {

--- a/src/storage/v2/replication/rpc.hpp
+++ b/src/storage/v2/replication/rpc.hpp
@@ -289,8 +289,6 @@ void Save(const memgraph::storage::replication::HeartbeatReq &self, memgraph::sl
 
 void Load(memgraph::storage::replication::HeartbeatReq *self, memgraph::slk::Reader *reader);
 
-void SendInProgressMsg(Builder *builder);
-
 void Save(const memgraph::storage::replication::AppendDeltasRes &self, memgraph::slk::Builder *builder);
 
 void Load(memgraph::storage::replication::AppendDeltasRes *self, memgraph::slk::Reader *reader);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -443,6 +443,10 @@ target_link_libraries(${test_prefix}rpc_timeouts mg-rpc)
 add_unit_test(rpc_in_progress.cpp)
 target_link_libraries(${test_prefix}rpc_in_progress mg-rpc)
 
+# Test replication-rpc-progress
+add_unit_test(replication_rpc_progress.cpp)
+target_link_libraries(${test_prefix}replication_rpc_progress mg-rpc)
+
 # Test websocket
 find_package(Boost REQUIRED CONFIG)
 

--- a/tests/unit/replication_rpc_progress.cpp
+++ b/tests/unit/replication_rpc_progress.cpp
@@ -1,0 +1,142 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "dbms/inmemory/replication_handlers.hpp"
+#include "storage/v2/inmemory/storage.hpp"
+#include "storage/v2/storage.hpp"
+
+#include "rpc/client.hpp"
+#include "rpc/server.hpp"
+#include "rpc/utils.hpp"  // Needs to be included last so that SLK definitions are seen
+
+using memgraph::communication::ClientContext;
+using memgraph::communication::ServerContext;
+using memgraph::dbms::InMemoryReplicationHandlers;
+using memgraph::io::network::Endpoint;
+using memgraph::rpc::Client;
+using memgraph::rpc::GenericRpcFailedException;
+using memgraph::rpc::Server;
+using memgraph::slk::Load;
+using memgraph::slk::Save;
+using memgraph::storage::Config;
+using memgraph::storage::Delta;
+using memgraph::storage::InMemoryStorage;
+using memgraph::storage::ReplicaStream;
+using memgraph::storage::Storage;
+using memgraph::storage::replication::AppendDeltasReq;
+using memgraph::storage::replication::AppendDeltasRes;
+using memgraph::storage::replication::AppendDeltasRpc;
+using memgraph::utils::UUID;
+
+using namespace std::string_view_literals;
+using namespace std::literals::chrono_literals;
+
+constexpr int port{8183};
+
+class ReplicationRpcProgressTest : public ::testing::Test {
+ public:
+  std::filesystem::path main_directory{std::filesystem::temp_directory_path() /
+                                       "MG_test_unit_replication_rpc_progress_main"};
+
+  void SetUp() override { Clear(); }
+
+  void TearDown() override { Clear(); }
+
+  void Clear() const {
+    if (std::filesystem::exists(main_directory)) {
+      std::filesystem::remove_all(main_directory);
+    }
+  }
+
+  Config main_conf = [&] {
+    Config config{
+        .durability =
+            {
+                .snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
+            },
+        .salient.items = {.properties_on_edges = false},
+    };
+    UpdatePaths(config, main_directory);
+    return config;
+  }();
+
+  InMemoryStorage main_storage{main_conf};
+};
+
+// Timeout immediately
+TEST_F(ReplicationRpcProgressTest, AppendDeltasTimeout) {
+  Endpoint endpoint{"localhost", port};
+
+  ServerContext server_context;
+  Server rpc_server{endpoint, &server_context, /* workers */ 1};
+  auto const on_exit = memgraph::utils::OnScopeExit{[&rpc_server] {
+    rpc_server.Shutdown();
+    rpc_server.AwaitShutdown();
+  }};
+
+  rpc_server.Register<memgraph::storage::replication::AppendDeltasRpc>([](auto *req_reader, auto *res_builder) {
+    AppendDeltasReq req;
+    Load(&req, req_reader);
+
+    // Simulate done
+    std::this_thread::sleep_for(150ms);
+    AppendDeltasRes res{true};
+    memgraph::rpc::SendFinalResponse(res, res_builder);
+  });
+
+  ASSERT_TRUE(rpc_server.Start());
+  std::this_thread::sleep_for(100ms);
+
+  auto const rpc_timeouts = std::unordered_map{std::make_pair("AppendDeltasReq"sv, 100)};
+  ClientContext client_context;
+  Client client{endpoint, &client_context, rpc_timeouts};
+
+  ReplicaStream stream{&main_storage, client, 1, UUID{}};
+  EXPECT_THROW(stream.Finalize(), GenericRpcFailedException);
+}
+
+// First send progress, then timeout
+TEST_F(ReplicationRpcProgressTest, AppendDeltasProgressTimeout) {
+  Endpoint endpoint{"localhost", port};
+
+  ServerContext server_context;
+  Server rpc_server{endpoint, &server_context, /* workers */ 1};
+  auto const on_exit = memgraph::utils::OnScopeExit{[&rpc_server] {
+    rpc_server.Shutdown();
+    rpc_server.AwaitShutdown();
+  }};
+
+  rpc_server.Register<AppendDeltasRpc>([](auto *req_reader, auto *res_builder) {
+    AppendDeltasReq req;
+    Load(&req, req_reader);
+
+    std::this_thread::sleep_for(100ms);
+    memgraph::rpc::SendInProgressMsg(res_builder);
+    std::this_thread::sleep_for(200ms);
+    AppendDeltasRes res{true};
+    memgraph::rpc::SendFinalResponse(res, res_builder);
+  });
+
+  ASSERT_TRUE(rpc_server.Start());
+  std::this_thread::sleep_for(100ms);
+
+  auto const rpc_timeouts = std::unordered_map{std::make_pair("AppendDeltasReq"sv, 150)};
+  ClientContext client_context;
+  Client client{endpoint, &client_context, rpc_timeouts};
+
+  ReplicaStream stream{&main_storage, client, 1, UUID{}};
+  Delta delta{Delta::DeleteObjectTag{}, (std::atomic<uint64_t> *)nullptr, 0};
+
+  EXPECT_THROW(stream.Finalize(), GenericRpcFailedException);
+}

--- a/tests/unit/rpc_in_progress.cpp
+++ b/tests/unit/rpc_in_progress.cpp
@@ -74,7 +74,7 @@ TEST(RpcInProgress, SingleProgress) {
 
     // Simulate work
     std::this_thread::sleep_for(100ms);
-    memgraph::slk::SendInProgressMsg(res_builder);
+    memgraph::rpc::SendInProgressMsg(res_builder);
     spdlog::trace("Saved InProgressRes");
 
     // Simulate done
@@ -116,17 +116,17 @@ TEST(RpcInProgress, MultipleProgresses) {
 
     // Simulate work
     std::this_thread::sleep_for(100ms);
-    memgraph::slk::SendInProgressMsg(res_builder);
+    memgraph::rpc::SendInProgressMsg(res_builder);
     spdlog::trace("Saved InProgressRes");
 
     // Simulate work
     std::this_thread::sleep_for(200ms);
-    memgraph::slk::SendInProgressMsg(res_builder);
+    memgraph::rpc::SendInProgressMsg(res_builder);
     spdlog::trace("Saved InProgressRes");
 
     // Simulate work
     std::this_thread::sleep_for(250ms);
-    memgraph::slk::SendInProgressMsg(res_builder);
+    memgraph::rpc::SendInProgressMsg(res_builder);
     spdlog::trace("Saved InProgressRes");
 
     // Simulate done
@@ -167,7 +167,7 @@ TEST(RpcInProgress, Timeout) {
 
     // Simulate work
     std::this_thread::sleep_for(100ms);
-    memgraph::slk::SendInProgressMsg(res_builder);
+    memgraph::rpc::SendInProgressMsg(res_builder);
     spdlog::trace("Saved InProgressRes");
 
     // Simulate done

--- a/tests/unit/rpc_in_progress.cpp
+++ b/tests/unit/rpc_in_progress.cpp
@@ -9,6 +9,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+#include <storage/v2/replication/replication_client.hpp>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/tests/unit/rpc_in_progress.cpp
+++ b/tests/unit/rpc_in_progress.cpp
@@ -189,3 +189,35 @@ TEST(RpcInProgress, Timeout) {
   auto stream = client.Stream<Sum>(2, 3);
   EXPECT_THROW(stream.AwaitResponseWhileInProgress(), GenericRpcFailedException);
 }
+
+TEST(RpcInProgress, NoTimeout) {
+  Endpoint endpoint{"localhost", port};
+
+  ServerContext server_context;
+  Server rpc_server{endpoint, &server_context, /* workers */ 1};
+  auto const on_exit = memgraph::utils::OnScopeExit{[&rpc_server] {
+    rpc_server.Shutdown();
+    rpc_server.AwaitShutdown();
+  }};
+
+  rpc_server.Register<Sum>([](auto *req_reader, auto *res_builder) {
+    spdlog::trace("Started executing sum callback");
+    SumReq req;
+    Load(&req, req_reader);
+
+    spdlog::trace("Loaded sum req request");
+    SumRes res{5};
+    memgraph::rpc::SendFinalResponse(res, res_builder);
+    spdlog::trace("Saved SumRes response");
+  });
+
+  ASSERT_TRUE(rpc_server.Start());
+  std::this_thread::sleep_for(100ms);
+
+  auto const rpc_timeouts = std::unordered_map{std::make_pair("SumReq"sv, 200)};
+  ClientContext client_context;
+  Client client{endpoint, &client_context, rpc_timeouts};
+
+  auto stream = client.Stream<Sum>(2, 3);
+  EXPECT_NO_THROW(stream.AwaitResponseWhileInProgress());
+}


### PR DESCRIPTION
Added timeouts to AppendDeltas, CurrentWal and WalFiles RPC messages. For every 100k processed deltas, we send InProgressRes back to the client. If there are mutliple txns or multiple WAL files, the whole context is taken into account for counting deltas.