### PR TITLE
Add timeouts to SnapshotRpc

### DIFF
--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -317,7 +317,7 @@ void InMemoryReplicationHandlers::SnapshotHandler(DbmsHandler *dbms_handler,
   }
   spdlog::info("Received snapshot saved to {}", *maybe_snapshot_path);
 
-  auto snapshot_observer = std::make_shared<SnapshotObserver>(res_builder);
+  auto snapshot_progress_observer = std::make_shared<SnapshotObserver>(res_builder);
 
   {
     auto storage_guard = std::lock_guard{storage->main_lock_};
@@ -333,7 +333,7 @@ void InMemoryReplicationHandlers::SnapshotHandler(DbmsHandler *dbms_handler,
           &storage->repl_storage_state_.history, storage->name_id_mapper_.get(), &storage->edge_count_,
           storage->config_, &storage->enum_store_,
           storage->config_.salient.items.enable_schema_info ? &storage->schema_info_.Get() : nullptr,
-          snapshot_observer);
+          snapshot_progress_observer);
       // If this step is present it should always be the first step of
       // the recovery so we use the UUID we read from snapshot
       storage->uuid().set(snapshot_info.uuid);
@@ -347,7 +347,7 @@ void InMemoryReplicationHandlers::SnapshotHandler(DbmsHandler *dbms_handler,
       storage::durability::RecoverIndicesStatsAndConstraints(
           &storage->vertices_, storage->name_id_mapper_.get(), &storage->indices_, &storage->constraints_,
           storage->config_, recovery_info, indices_constraints, storage->config_.salient.items.properties_on_edges,
-          snapshot_observer);
+          snapshot_progress_observer);
     } catch (const storage::durability::RecoveryFailure &e) {
       spdlog::error("Couldn't load the snapshot from {} because of: {}. Storage will be cleared.", *maybe_snapshot_path,
                     e.what());

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -53,7 +53,7 @@ class SnapshotObserver final : public utils::Observer<void> {
 
  private:
   slk::Builder *res_builder_;
-  // Mutex is needed because multiple RPC calls could be executed in parallel
+  // Mutex is needed because RPC execution could be concurrent
   mutable std::mutex mtx_;
 };
 

--- a/src/rpc/client.hpp
+++ b/src/rpc/client.hpp
@@ -56,7 +56,8 @@ class Client {
       {"SystemRecoveryReq"sv, 30000},  // main to replica when MT is used. Recovering 1000DBs should take around 25''
       {"AppendDeltasReq"sv, 30000},    // Waiting 30'' on a progress/final response
       {"CurrentWalReq"sv, 30000},      // Waiting 30'' on a progress/final response
-      {"WalFilesReq"sv, 30000}         // Waiting 30'' on a progress/final response
+      {"WalFilesReq"sv, 30000},        // Waiting 30'' on a progress/final response
+      {"SnapshotReq"sv, 60000}         // Waiting 60'' on a progress/final response
   };
   // Dependency injection of rpc_timeouts
   Client(io::network::Endpoint endpoint, communication::ClientContext *context,

--- a/src/storage/v2/commit_log.hpp
+++ b/src/storage/v2/commit_log.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -13,7 +13,6 @@
 #pragma once
 
 #include <cstdint>
-#include <mutex>
 
 #include "utils/memory.hpp"
 #include "utils/spin_lock.hpp"

--- a/src/storage/v2/constraints/existence_constraints.cpp
+++ b/src/storage/v2/constraints/existence_constraints.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -14,8 +14,14 @@
 #include "storage/v2/constraints/utils.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/mvcc.hpp"
+#include "utils/counter.hpp"
 #include "utils/logging.hpp"
 #include "utils/rw_spin_lock.hpp"
+
+namespace {
+constexpr uint32_t kExistenceConstraintsVerticesSnapshotProgressSize = 1'000'000;
+}  // namespace
+
 namespace memgraph::storage {
 
 bool ExistenceConstraints::ConstraintExists(LabelId label, PropertyId property) const {
@@ -76,15 +82,17 @@ ExistenceConstraints::GetCreationFunction(
 
 [[nodiscard]] std::optional<ConstraintViolation> ExistenceConstraints::ValidateVerticesOnConstraint(
     utils::SkipList<Vertex>::Accessor vertices, LabelId label, PropertyId property,
-    const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info) {
+    const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info,
+    std::shared_ptr<utils::Observer<void>> const snapshot_observer) {
   auto calling_existence_validation_function = GetCreationFunction(parallel_exec_info);
-  return std::visit(
-      [&vertices, &label, &property](auto &calling_object) { return calling_object(vertices, label, property); },
-      calling_existence_validation_function);
+  return std::visit([&vertices, &label, &property, snapshot_observer](
+                        auto &calling_object) { return calling_object(vertices, label, property, snapshot_observer); },
+                    calling_existence_validation_function);
 }
 
 std::optional<ConstraintViolation> ExistenceConstraints::MultipleThreadsConstraintValidation::operator()(
-    const utils::SkipList<Vertex>::Accessor &vertices, const LabelId &label, const PropertyId &property) {
+    const utils::SkipList<Vertex>::Accessor &vertices, const LabelId &label, const PropertyId &property,
+    std::shared_ptr<utils::Observer<void>> const snapshot_observer) {
   utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
 
   const auto &vertex_batches = parallel_exec_info.vertex_recovery_info;
@@ -94,16 +102,17 @@ std::optional<ConstraintViolation> ExistenceConstraints::MultipleThreadsConstrai
   const auto thread_count = std::min(parallel_exec_info.thread_count, vertex_batches.size());
 
   std::atomic<uint64_t> batch_counter = 0;
-  memgraph::utils::Synchronized<std::optional<ConstraintViolation>, utils::RWSpinLock> maybe_error{};
+  utils::Synchronized<std::optional<ConstraintViolation>, utils::RWSpinLock> maybe_error{};
   {
     std::vector<std::jthread> threads;
     threads.reserve(thread_count);
 
     for (auto i{0U}; i < thread_count; ++i) {
-      threads.emplace_back([&maybe_error, &vertex_batches, &batch_counter, &vertices, &label, &property]() {
-        do_per_thread_validation(maybe_error, ValidateVertexOnConstraint, vertex_batches, batch_counter, vertices,
-                                 label, property);
-      });
+      threads.emplace_back(
+          [&maybe_error, &vertex_batches, &batch_counter, &vertices, &label, &property, snapshot_observer]() {
+            do_per_thread_validation(maybe_error, ValidateVertexOnConstraint, vertex_batches, batch_counter, vertices,
+                                     snapshot_observer, label, property);
+          });
     }
   }
   if (maybe_error.Lock()->has_value()) {
@@ -113,10 +122,15 @@ std::optional<ConstraintViolation> ExistenceConstraints::MultipleThreadsConstrai
 }
 
 std::optional<ConstraintViolation> ExistenceConstraints::SingleThreadConstraintValidation::operator()(
-    const utils::SkipList<Vertex>::Accessor &vertices, const LabelId &label, const PropertyId &property) {
+    const utils::SkipList<Vertex>::Accessor &vertices, const LabelId &label, const PropertyId &property,
+    std::shared_ptr<utils::Observer<void>> const snapshot_observer) {
+  auto batch_counter = utils::ResettableCounter<kExistenceConstraintsVerticesSnapshotProgressSize>();
   for (const Vertex &vertex : vertices) {
     if (auto violation = ValidateVertexOnConstraint(vertex, label, property); violation.has_value()) {
       return violation;
+    }
+    if (snapshot_observer != nullptr && batch_counter()) {
+      snapshot_observer->Update();
     }
   }
   return std::nullopt;

--- a/src/storage/v2/constraints/existence_constraints.cpp
+++ b/src/storage/v2/constraints/existence_constraints.cpp
@@ -14,7 +14,6 @@
 #include "storage/v2/constraints/utils.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/mvcc.hpp"
-#include "utils/counter.hpp"
 #include "utils/logging.hpp"
 #include "utils/rw_spin_lock.hpp"
 
@@ -124,7 +123,7 @@ std::optional<ConstraintViolation> ExistenceConstraints::SingleThreadConstraintV
     if (auto violation = ValidateVertexOnConstraint(vertex, label, property); violation.has_value()) {
       return violation;
     }
-    if (snapshot_info && snapshot_info->IncrementCounter()) {
+    if (snapshot_info) {
       snapshot_info->Update();
     }
   }

--- a/src/storage/v2/constraints/existence_constraints.hpp
+++ b/src/storage/v2/constraints/existence_constraints.hpp
@@ -28,16 +28,16 @@ class ExistenceConstraints {
 
  public:
   struct MultipleThreadsConstraintValidation {
-    std::optional<ConstraintViolation> operator()(const utils::SkipList<Vertex>::Accessor &vertices,
-                                                  const LabelId &label, const PropertyId &property,
-                                                  std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
+    std::optional<ConstraintViolation> operator()(
+        const utils::SkipList<Vertex>::Accessor &vertices, const LabelId &label, const PropertyId &property,
+        std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
     const durability::ParallelizedSchemaCreationInfo &parallel_exec_info;
   };
   struct SingleThreadConstraintValidation {
-    std::optional<ConstraintViolation> operator()(const utils::SkipList<Vertex>::Accessor &vertices,
-                                                  const LabelId &label, const PropertyId &property,
-                                                  std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
+    std::optional<ConstraintViolation> operator()(
+        const utils::SkipList<Vertex>::Accessor &vertices, const LabelId &label, const PropertyId &property,
+        std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
   };
 
   bool empty() const { return constraints_.empty(); }
@@ -49,7 +49,7 @@ class ExistenceConstraints {
   [[nodiscard]] static std::optional<ConstraintViolation> ValidateVerticesOnConstraint(
       utils::SkipList<Vertex>::Accessor vertices, LabelId label, PropertyId property,
       const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info = std::nullopt,
-      std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
+      std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
   static std::variant<MultipleThreadsConstraintValidation, SingleThreadConstraintValidation> GetCreationFunction(
       const std::optional<durability::ParallelizedSchemaCreationInfo> &);

--- a/src/storage/v2/constraints/existence_constraints.hpp
+++ b/src/storage/v2/constraints/existence_constraints.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -11,16 +11,14 @@
 
 #pragma once
 
-#include <atomic>
 #include <optional>
-#include <thread>
 #include <variant>
 
 #include "storage/v2/constraints/constraint_violation.hpp"
 #include "storage/v2/durability/recovery_type.hpp"
 #include "storage/v2/vertex.hpp"
+#include "utils/observer.hpp"
 #include "utils/skip_list.hpp"
-#include "utils/synchronized.hpp"
 
 namespace memgraph::storage {
 
@@ -31,13 +29,15 @@ class ExistenceConstraints {
  public:
   struct MultipleThreadsConstraintValidation {
     std::optional<ConstraintViolation> operator()(const utils::SkipList<Vertex>::Accessor &vertices,
-                                                  const LabelId &label, const PropertyId &property);
+                                                  const LabelId &label, const PropertyId &property,
+                                                  std::shared_ptr<utils::Observer<void>> const snapshot_observer);
 
     const durability::ParallelizedSchemaCreationInfo &parallel_exec_info;
   };
   struct SingleThreadConstraintValidation {
     std::optional<ConstraintViolation> operator()(const utils::SkipList<Vertex>::Accessor &vertices,
-                                                  const LabelId &label, const PropertyId &property);
+                                                  const LabelId &label, const PropertyId &property,
+                                                  std::shared_ptr<utils::Observer<void>> const snapshot_observer);
   };
 
   bool empty() const { return constraints_.empty(); }
@@ -48,7 +48,8 @@ class ExistenceConstraints {
 
   [[nodiscard]] static std::optional<ConstraintViolation> ValidateVerticesOnConstraint(
       utils::SkipList<Vertex>::Accessor vertices, LabelId label, PropertyId property,
-      const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info = std::nullopt);
+      const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info = std::nullopt,
+      std::shared_ptr<utils::Observer<void>> const snapshot_observer = nullptr);
 
   static std::variant<MultipleThreadsConstraintValidation, SingleThreadConstraintValidation> GetCreationFunction(
       const std::optional<durability::ParallelizedSchemaCreationInfo> &);

--- a/src/storage/v2/constraints/existence_constraints.hpp
+++ b/src/storage/v2/constraints/existence_constraints.hpp
@@ -16,8 +16,8 @@
 
 #include "storage/v2/constraints/constraint_violation.hpp"
 #include "storage/v2/durability/recovery_type.hpp"
+#include "storage/v2/snapshot_observer_info.hpp"
 #include "storage/v2/vertex.hpp"
-#include "utils/observer.hpp"
 #include "utils/skip_list.hpp"
 
 namespace memgraph::storage {
@@ -30,14 +30,14 @@ class ExistenceConstraints {
   struct MultipleThreadsConstraintValidation {
     std::optional<ConstraintViolation> operator()(const utils::SkipList<Vertex>::Accessor &vertices,
                                                   const LabelId &label, const PropertyId &property,
-                                                  std::shared_ptr<utils::Observer<void>> const snapshot_observer);
+                                                  std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
 
     const durability::ParallelizedSchemaCreationInfo &parallel_exec_info;
   };
   struct SingleThreadConstraintValidation {
     std::optional<ConstraintViolation> operator()(const utils::SkipList<Vertex>::Accessor &vertices,
                                                   const LabelId &label, const PropertyId &property,
-                                                  std::shared_ptr<utils::Observer<void>> const snapshot_observer);
+                                                  std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
   };
 
   bool empty() const { return constraints_.empty(); }
@@ -49,7 +49,7 @@ class ExistenceConstraints {
   [[nodiscard]] static std::optional<ConstraintViolation> ValidateVerticesOnConstraint(
       utils::SkipList<Vertex>::Accessor vertices, LabelId label, PropertyId property,
       const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info = std::nullopt,
-      std::shared_ptr<utils::Observer<void>> const snapshot_observer = nullptr);
+      std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
 
   static std::variant<MultipleThreadsConstraintValidation, SingleThreadConstraintValidation> GetCreationFunction(
       const std::optional<durability::ParallelizedSchemaCreationInfo> &);

--- a/src/storage/v2/constraints/type_constraints.cpp
+++ b/src/storage/v2/constraints/type_constraints.cpp
@@ -121,13 +121,13 @@ TypeConstraintKind PropertyValueToTypeConstraintKind(const PropertyValue &proper
 }
 
 [[nodiscard]] std::optional<ConstraintViolation> TypeConstraints::ValidateVertices(
-    utils::SkipList<Vertex>::Accessor vertices, std::optional<SnapshotObserverInfo> snapshot_info) const {
+    utils::SkipList<Vertex>::Accessor vertices, std::optional<SnapshotObserverInfo> const &snapshot_info) const {
   for (auto const &vertex : vertices) {
     if (auto violation = Validate(vertex); violation.has_value()) {
       return violation;
     }
     if (snapshot_info) {
-      snapshot_info->Update();
+      snapshot_info->Update(UpdateType::VERTICES);
     }
   }
   return std::nullopt;

--- a/src/storage/v2/constraints/type_constraints.cpp
+++ b/src/storage/v2/constraints/type_constraints.cpp
@@ -123,17 +123,12 @@ TypeConstraintKind PropertyValueToTypeConstraintKind(const PropertyValue &proper
 
 [[nodiscard]] std::optional<ConstraintViolation> TypeConstraints::ValidateVertices(
     utils::SkipList<Vertex>::Accessor vertices, std::optional<SnapshotObserverInfo> snapshot_info) const {
-  std::optional<utils::ResettableRuntimeCounter> maybe_batch_counter;
-  if (snapshot_info) {
-    maybe_batch_counter.emplace(utils::ResettableRuntimeCounter{snapshot_info->item_batch_size});
-  }
-
   for (auto const &vertex : vertices) {
     if (auto violation = Validate(vertex); violation.has_value()) {
       return violation;
     }
-    if (maybe_batch_counter && (*maybe_batch_counter)()) {
-      snapshot_info->observer->Update();
+    if (snapshot_info && snapshot_info->IncrementCounter()) {
+      snapshot_info->Update();
     }
   }
   return std::nullopt;

--- a/src/storage/v2/constraints/type_constraints.cpp
+++ b/src/storage/v2/constraints/type_constraints.cpp
@@ -16,7 +16,6 @@
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/property_value.hpp"
 #include "utils/algorithm.hpp"
-#include "utils/counter.hpp"
 
 #include <optional>
 #include <set>
@@ -127,7 +126,7 @@ TypeConstraintKind PropertyValueToTypeConstraintKind(const PropertyValue &proper
     if (auto violation = Validate(vertex); violation.has_value()) {
       return violation;
     }
-    if (snapshot_info && snapshot_info->IncrementCounter()) {
+    if (snapshot_info) {
       snapshot_info->Update();
     }
   }

--- a/src/storage/v2/constraints/type_constraints.hpp
+++ b/src/storage/v2/constraints/type_constraints.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -18,6 +18,8 @@
 #include "storage/v2/durability/recovery_type.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/vertex.hpp"
+#include "utils/counter.hpp"
+#include "utils/observer.hpp"
 #include "utils/skip_list.hpp"
 
 namespace memgraph::storage {
@@ -42,7 +44,9 @@ class TypeConstraints {
   [[nodiscard]] std::optional<ConstraintViolation> Validate(const Vertex &vertex, LabelId label) const;
   [[nodiscard]] std::optional<ConstraintViolation> Validate(const Vertex &vertex, PropertyId property_id,
                                                             const PropertyValue &property_value) const;
-  [[nodiscard]] std::optional<ConstraintViolation> ValidateVertices(utils::SkipList<Vertex>::Accessor vertices) const;
+  [[nodiscard]] std::optional<ConstraintViolation> ValidateVertices(
+      utils::SkipList<Vertex>::Accessor vertices,
+      std::shared_ptr<utils::Observer<void>> snapshot_observer = nullptr) const;
 
   bool empty() const;
   bool ConstraintExists(LabelId label, PropertyId property) const;

--- a/src/storage/v2/constraints/type_constraints.hpp
+++ b/src/storage/v2/constraints/type_constraints.hpp
@@ -17,8 +17,8 @@
 #include "storage/v2/constraints/constraint_violation.hpp"
 #include "storage/v2/durability/recovery_type.hpp"
 #include "storage/v2/id_types.hpp"
+#include "storage/v2/snapshot_observer_info.hpp"
 #include "storage/v2/vertex.hpp"
-#include "utils/counter.hpp"
 #include "utils/observer.hpp"
 #include "utils/skip_list.hpp"
 
@@ -46,7 +46,7 @@ class TypeConstraints {
                                                             const PropertyValue &property_value) const;
   [[nodiscard]] std::optional<ConstraintViolation> ValidateVertices(
       utils::SkipList<Vertex>::Accessor vertices,
-      std::shared_ptr<utils::Observer<void>> snapshot_observer = nullptr) const;
+      std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt) const;
 
   bool empty() const;
   bool ConstraintExists(LabelId label, PropertyId property) const;

--- a/src/storage/v2/constraints/type_constraints.hpp
+++ b/src/storage/v2/constraints/type_constraints.hpp
@@ -46,7 +46,7 @@ class TypeConstraints {
                                                             const PropertyValue &property_value) const;
   [[nodiscard]] std::optional<ConstraintViolation> ValidateVertices(
       utils::SkipList<Vertex>::Accessor vertices,
-      std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt) const;
+      std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt) const;
 
   bool empty() const;
   bool ConstraintExists(LabelId label, PropertyId property) const;

--- a/src/storage/v2/constraints/utils.hpp
+++ b/src/storage/v2/constraints/utils.hpp
@@ -12,6 +12,8 @@
 
 #include <vector>
 #include "storage/v2/vertex.hpp"
+#include "utils/counter.hpp"
+#include "utils/observer.hpp"
 #include "utils/skip_list.hpp"
 
 namespace memgraph::storage {
@@ -20,7 +22,7 @@ void do_per_thread_validation(ErrorType &maybe_error, Func &&func,
                               const std::vector<std::pair<Gid, uint64_t>> &vertex_batches,
                               std::atomic<uint64_t> &batch_counter,
                               const memgraph::utils::SkipList<memgraph::storage::Vertex>::Accessor &vertices,
-                              Args &&...args) {
+                              std::shared_ptr<utils::Observer<void>> const snapshot_observer, Args &&...args) {
   while (!maybe_error.ReadLock()->has_value()) {
     const auto batch_index = batch_counter.fetch_add(1, std::memory_order_acquire);
     if (batch_index >= vertex_batches.size()) {
@@ -30,9 +32,15 @@ void do_per_thread_validation(ErrorType &maybe_error, Func &&func,
 
     auto vertex_curr = vertices.find(gid_start);
     DMG_ASSERT(vertex_curr != vertices.end(), "No vertex was found with given gid");
+
+    constexpr uint32_t kConstraintsVerticesSnapshotProgressSize = 1'000'000;
+    auto local_batch_counter = utils::ResettableCounter<kConstraintsVerticesSnapshotProgressSize>();
     for (auto i{0U}; i < batch_size; ++i, ++vertex_curr) {
       const auto violation = func(*vertex_curr, std::forward<Args>(args)...);
       if (!violation.has_value()) [[likely]] {
+        if (snapshot_observer != nullptr && local_batch_counter()) {
+          snapshot_observer->Update();
+        }
         continue;
       }
       maybe_error.WithLock([&violation](auto &maybe_error) { maybe_error = *violation; });

--- a/src/storage/v2/constraints/utils.hpp
+++ b/src/storage/v2/constraints/utils.hpp
@@ -12,7 +12,6 @@
 
 #include <vector>
 #include "storage/v2/vertex.hpp"
-#include "utils/counter.hpp"
 #include "utils/skip_list.hpp"
 
 namespace memgraph::storage {
@@ -33,7 +32,7 @@ void do_per_thread_validation(ErrorType &maybe_error, Func &&func,
     for (auto i{0U}; i < batch_size; ++i, ++vertex_curr) {
       const auto violation = func(*vertex_curr, std::forward<Args>(args)...);
       if (!violation.has_value()) [[likely]] {
-        if (snapshot_info && snapshot_info->IncrementCounter()) {
+        if (snapshot_info) {
           snapshot_info->Update();
         }
         continue;

--- a/src/storage/v2/constraints/utils.hpp
+++ b/src/storage/v2/constraints/utils.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
+#pragma once
 
 #include <vector>
 #include "storage/v2/vertex.hpp"

--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -227,7 +227,7 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
   auto *mem_edge_type_index = static_cast<InMemoryEdgeTypeIndex *>(indices->edge_type_index_.get());
   for (const auto &item : indices_metadata.edge) {
     // TODO: parallel execution
-    if (!mem_edge_type_index->CreateIndex(item, vertices->access())) {
+    if (!mem_edge_type_index->CreateIndex(item, vertices->access(), snapshot_observer)) {
       throw RecoveryFailure("The edge-type index must be created here!");
     }
     spdlog::info("Index on :{} is recreated from metadata", name_id_mapper->IdToName(item.AsUint()));
@@ -242,7 +242,7 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
       static_cast<InMemoryEdgeTypePropertyIndex *>(indices->edge_type_property_index_.get());
   for (const auto &item : indices_metadata.edge_property) {
     // TODO: parallel execution
-    if (!mem_edge_type_property_index->CreateIndex(item.first, item.second, vertices->access())) {
+    if (!mem_edge_type_property_index->CreateIndex(item.first, item.second, vertices->access(), snapshot_observer)) {
       throw RecoveryFailure("The edge-type property index must be created here!");
     }
     spdlog::info("Index on :{} + {} is recreated from metadata", name_id_mapper->IdToName(item.first.AsUint()),
@@ -260,7 +260,7 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
           throw RecoveryFailure("There must exist a storage directory in order to recover text indices!");
         }
         // TODO: parallel execution
-        mem_text_index.RecoverIndex(index_name, label, vertices->access(), name_id_mapper);
+        mem_text_index.RecoverIndex(index_name, label, vertices->access(), name_id_mapper, snapshot_observer);
       } catch (...) {
         throw RecoveryFailure("The text index must be created here!");
       }
@@ -273,7 +273,7 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
   spdlog::info("Recreating {} point indices statistics from metadata.", indices_metadata.point_label_property.size());
   for (const auto &[label, property] : indices_metadata.point_label_property) {
     // TODO: parallel execution
-    if (!indices->point_index_.CreatePointIndex(label, property, vertices->access()))
+    if (!indices->point_index_.CreatePointIndex(label, property, vertices->access(), snapshot_observer))
       throw RecoveryFailure("The point index must be created here!");
     spdlog::info("Point index on :{}({}) is recreated from metadata", name_id_mapper->IdToName(label.AsUint()),
                  name_id_mapper->IdToName(property.AsUint()));
@@ -283,7 +283,7 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
   spdlog::info("Recreating {} vector indices from metadata.", indices_metadata.vector_indices.size());
   auto vertices_acc = vertices->access();
   for (const auto &spec : indices_metadata.vector_indices) {
-    if (!indices->vector_index_.CreateIndex(spec, vertices_acc)) {
+    if (!indices->vector_index_.CreateIndex(spec, vertices_acc, snapshot_observer)) {
       throw RecoveryFailure("The vector index must be created here!");
     }
     spdlog::info("Vector index on :{}({}) is recreated from metadata", name_id_mapper->IdToName(spec.label.AsUint()),

--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -172,8 +172,7 @@ void RecoverConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadat
                         std::shared_ptr<utils::Observer<void>> const snapshot_progress_observer) {
   std::optional<SnapshotObserverInfo> snapshot_info;
   if (snapshot_progress_observer != nullptr) {
-    snapshot_info.emplace(
-        SnapshotObserverInfo{.observer = snapshot_progress_observer, .item_batch_size = kVerticesSnapshotProgressSize});
+    snapshot_info.emplace(SnapshotObserverInfo(snapshot_progress_observer, kVerticesSnapshotProgressSize));
   }
 
   RecoverExistenceConstraints(constraints_metadata, constraints, vertices, name_id_mapper, parallel_exec_info,
@@ -194,8 +193,7 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
     spdlog::info("Recreating {} label indices from metadata.", indices_metadata.label.size());
     std::optional<SnapshotObserverInfo> snapshot_info;
     if (snapshot_progress_observer != nullptr) {
-      snapshot_info.emplace(SnapshotObserverInfo{.observer = snapshot_progress_observer,
-                                                 .item_batch_size = kVerticesSnapshotProgressSize});
+      snapshot_info.emplace(SnapshotObserverInfo(snapshot_progress_observer, kVerticesSnapshotProgressSize));
     }
 
     for (const auto &item : indices_metadata.label) {
@@ -223,8 +221,7 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
     spdlog::info("Recreating {} label+property indices from metadata.", indices_metadata.label_property.size());
     std::optional<SnapshotObserverInfo> snapshot_info;
     if (snapshot_progress_observer != nullptr) {
-      snapshot_info.emplace(SnapshotObserverInfo{.observer = snapshot_progress_observer,
-                                                 .item_batch_size = kVerticesSnapshotProgressSize});
+      snapshot_info.emplace(SnapshotObserverInfo(snapshot_progress_observer, kVerticesSnapshotProgressSize));
     }
     for (const auto &item : indices_metadata.label_property) {
       if (!mem_label_property_index->CreateIndex(item.first, item.second, vertices->access(), parallel_exec_info,
@@ -259,8 +256,7 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
               "Trying to recover edge type indices while properties on edges are disabled.");
     std::optional<SnapshotObserverInfo> snapshot_info;
     if (snapshot_progress_observer != nullptr) {
-      snapshot_info.emplace(
-          SnapshotObserverInfo{.observer = snapshot_progress_observer, .item_batch_size = kEdgesSnapshotProgressSize});
+      snapshot_info.emplace(SnapshotObserverInfo(snapshot_progress_observer, kEdgesSnapshotProgressSize));
     }
     for (const auto &item : indices_metadata.edge) {
       // TODO: parallel execution
@@ -281,8 +277,7 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
         static_cast<InMemoryEdgeTypePropertyIndex *>(indices->edge_type_property_index_.get());
     std::optional<SnapshotObserverInfo> snapshot_info;
     if (snapshot_progress_observer != nullptr) {
-      snapshot_info.emplace(
-          SnapshotObserverInfo{.observer = snapshot_progress_observer, .item_batch_size = kEdgesSnapshotProgressSize});
+      snapshot_info.emplace(SnapshotObserverInfo(snapshot_progress_observer, kEdgesSnapshotProgressSize));
     }
     for (const auto &item : indices_metadata.edge_property) {
       // TODO: parallel execution
@@ -302,8 +297,7 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
     auto &mem_text_index = indices->text_index_;
     std::optional<SnapshotObserverInfo> snapshot_info;
     if (snapshot_progress_observer != nullptr) {
-      snapshot_info.emplace(SnapshotObserverInfo{.observer = snapshot_progress_observer,
-                                                 .item_batch_size = kVerticesTextIdxSnapshotProgressSize});
+      snapshot_info.emplace(SnapshotObserverInfo(snapshot_progress_observer, kVerticesTextIdxSnapshotProgressSize));
     }
     for (const auto &[index_name, label] : indices_metadata.text_indices) {
       try {
@@ -326,8 +320,7 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
     spdlog::info("Recreating {} point indices statistics from metadata.", indices_metadata.point_label_property.size());
     std::optional<SnapshotObserverInfo> snapshot_info;
     if (snapshot_progress_observer != nullptr) {
-      snapshot_info.emplace(SnapshotObserverInfo{.observer = snapshot_progress_observer,
-                                                 .item_batch_size = kVerticesPointIdxSnapshotProgressSize});
+      snapshot_info.emplace(SnapshotObserverInfo(snapshot_progress_observer, kVerticesPointIdxSnapshotProgressSize));
     }
     for (const auto &[label, property] : indices_metadata.point_label_property) {
       // TODO: parallel execution
@@ -344,8 +337,7 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
     spdlog::info("Recreating {} vector indices from metadata.", indices_metadata.vector_indices.size());
     std::optional<SnapshotObserverInfo> snapshot_info;
     if (snapshot_progress_observer != nullptr) {
-      snapshot_info.emplace(SnapshotObserverInfo{.observer = snapshot_progress_observer,
-                                                 .item_batch_size = kVerticesVectorIdxSnapshotProgressSize});
+      snapshot_info.emplace(SnapshotObserverInfo(snapshot_progress_observer, kVerticesVectorIdxSnapshotProgressSize));
     }
     auto vertices_acc = vertices->access();
     for (const auto &spec : indices_metadata.vector_indices) {

--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -179,7 +179,9 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
   spdlog::info("Recreating {} label indices from metadata.", indices_metadata.label.size());
   auto *mem_label_index = static_cast<InMemoryLabelIndex *>(indices->label_index_.get());
   for (const auto &item : indices_metadata.label) {
-    if (!mem_label_index->CreateIndex(item, vertices->access(), parallel_exec_info, snapshot_observer)) {
+    if (!mem_label_index->CreateIndex(
+            item, vertices->access(), parallel_exec_info,
+            SnapshotObserverInfo{.observer = snapshot_observer, .vertices_snapshot_progress_size = 1'000'000})) {
       throw RecoveryFailure("The label index must be created here!");
     }
     spdlog::info("Index on :{} is recreated from metadata", name_id_mapper->IdToName(item.AsUint()));
@@ -201,8 +203,9 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
   spdlog::info("Recreating {} label+property indices from metadata.", indices_metadata.label_property.size());
   auto *mem_label_property_index = static_cast<InMemoryLabelPropertyIndex *>(indices->label_property_index_.get());
   for (const auto &item : indices_metadata.label_property) {
-    if (!mem_label_property_index->CreateIndex(item.first, item.second, vertices->access(), parallel_exec_info,
-                                               snapshot_observer))
+    if (!mem_label_property_index->CreateIndex(
+            item.first, item.second, vertices->access(), parallel_exec_info,
+            SnapshotObserverInfo{.observer = snapshot_observer, .vertices_snapshot_progress_size = 1'000'000}))
       throw RecoveryFailure("The label+property index must be created here!");
     spdlog::info("Index on :{}({}) is recreated from metadata", name_id_mapper->IdToName(item.first.AsUint()),
                  name_id_mapper->IdToName(item.second.AsUint()));

--- a/src/storage/v2/durability/durability.hpp
+++ b/src/storage/v2/durability/durability.hpp
@@ -112,7 +112,7 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
 void RecoverConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &constraints_metadata,
                         Constraints *constraints, utils::SkipList<Vertex> *vertices, NameIdMapper *name_id_mapper,
                         const std::optional<ParallelizedSchemaCreationInfo> &parallel_exec_info = std::nullopt,
-                        std::shared_ptr<utils::Observer<void>> snapshot_observer = nullptr);
+                        std::shared_ptr<utils::Observer<void>> const snapshot_observer = nullptr);
 
 void RecoverIndicesStatsAndConstraints(utils::SkipList<Vertex> *vertices, NameIdMapper *name_id_mapper,
                                        Indices *indices, Constraints *constraints, Config const &config,
@@ -126,13 +126,16 @@ std::optional<ParallelizedSchemaCreationInfo> GetParallelExecInfo(const Recovery
 
 void RecoverExistenceConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &, Constraints *,
                                  utils::SkipList<Vertex> *, NameIdMapper *,
-                                 const std::optional<ParallelizedSchemaCreationInfo> &);
+                                 const std::optional<ParallelizedSchemaCreationInfo> &,
+                                 std::shared_ptr<utils::Observer<void>> snapshot_observer = nullptr);
 
 void RecoverUniqueConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &, Constraints *,
                               utils::SkipList<Vertex> *, NameIdMapper *,
-                              const std::optional<ParallelizedSchemaCreationInfo> &);
+                              const std::optional<ParallelizedSchemaCreationInfo> &,
+                              std::shared_ptr<utils::Observer<void>> snapshot_observer = nullptr);
 void RecoverTypeConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &, Constraints *,
-                            utils::SkipList<Vertex> *, const std::optional<ParallelizedSchemaCreationInfo> &);
+                            utils::SkipList<Vertex> *, const std::optional<ParallelizedSchemaCreationInfo> &,
+                            std::shared_ptr<utils::Observer<void>> snapshot_observer = nullptr);
 struct Recovery {
  public:
   /// Recovers data either from a snapshot and/or WAL files.

--- a/src/storage/v2/durability/durability.hpp
+++ b/src/storage/v2/durability/durability.hpp
@@ -102,7 +102,7 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
                             utils::SkipList<Vertex> *vertices, NameIdMapper *name_id_mapper, bool properties_on_edges,
                             const std::optional<ParallelizedSchemaCreationInfo> &parallel_exec_info = std::nullopt,
                             const std::optional<std::filesystem::path> &storage_dir = std::nullopt,
-                            std::shared_ptr<utils::Observer<void>> const snapshot_progress_observer = nullptr);
+                            std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
 // Helper function used to recover all discovered constraints. The
 // constraints must be recovered after the data recovery is done
@@ -112,12 +112,14 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
 void RecoverConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &constraints_metadata,
                         Constraints *constraints, utils::SkipList<Vertex> *vertices, NameIdMapper *name_id_mapper,
                         const std::optional<ParallelizedSchemaCreationInfo> &parallel_exec_info = std::nullopt,
-                        std::shared_ptr<utils::Observer<void>> const snapshot_progress_observer = nullptr);
+                        std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
-void RecoverIndicesStatsAndConstraints(
-    utils::SkipList<Vertex> *vertices, NameIdMapper *name_id_mapper, Indices *indices, Constraints *constraints,
-    Config const &config, RecoveryInfo const &recovery_info, RecoveredIndicesAndConstraints const &indices_constraints,
-    bool properties_on_edges, std::shared_ptr<utils::Observer<void>> const snapshot_progress_observer = nullptr);
+void RecoverIndicesStatsAndConstraints(utils::SkipList<Vertex> *vertices, NameIdMapper *name_id_mapper,
+                                       Indices *indices, Constraints *constraints, Config const &config,
+                                       RecoveryInfo const &recovery_info,
+                                       RecoveredIndicesAndConstraints const &indices_constraints,
+                                       bool properties_on_edges,
+                                       std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
 std::optional<ParallelizedSchemaCreationInfo> GetParallelExecInfo(const RecoveryInfo &recovery_info,
                                                                   const Config &config);
@@ -125,15 +127,15 @@ std::optional<ParallelizedSchemaCreationInfo> GetParallelExecInfo(const Recovery
 void RecoverExistenceConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &, Constraints *,
                                  utils::SkipList<Vertex> *, NameIdMapper *,
                                  const std::optional<ParallelizedSchemaCreationInfo> &,
-                                 std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
+                                 std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
 void RecoverUniqueConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &, Constraints *,
                               utils::SkipList<Vertex> *, NameIdMapper *,
                               const std::optional<ParallelizedSchemaCreationInfo> &,
-                              std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
+                              std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 void RecoverTypeConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &, Constraints *,
                             utils::SkipList<Vertex> *, const std::optional<ParallelizedSchemaCreationInfo> &,
-                            std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
+                            std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 struct Recovery {
  public:
   /// Recovers data either from a snapshot and/or WAL files.

--- a/src/storage/v2/durability/durability.hpp
+++ b/src/storage/v2/durability/durability.hpp
@@ -102,7 +102,7 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
                             utils::SkipList<Vertex> *vertices, NameIdMapper *name_id_mapper, bool properties_on_edges,
                             const std::optional<ParallelizedSchemaCreationInfo> &parallel_exec_info = std::nullopt,
                             const std::optional<std::filesystem::path> &storage_dir = std::nullopt,
-                            std::shared_ptr<utils::Observer<void>> const snapshot_observer = nullptr);
+                            std::shared_ptr<utils::Observer<void>> const snapshot_progress_observer = nullptr);
 
 // Helper function used to recover all discovered constraints. The
 // constraints must be recovered after the data recovery is done
@@ -112,14 +112,12 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
 void RecoverConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &constraints_metadata,
                         Constraints *constraints, utils::SkipList<Vertex> *vertices, NameIdMapper *name_id_mapper,
                         const std::optional<ParallelizedSchemaCreationInfo> &parallel_exec_info = std::nullopt,
-                        std::shared_ptr<utils::Observer<void>> const snapshot_observer = nullptr);
+                        std::shared_ptr<utils::Observer<void>> const snapshot_progress_observer = nullptr);
 
-void RecoverIndicesStatsAndConstraints(utils::SkipList<Vertex> *vertices, NameIdMapper *name_id_mapper,
-                                       Indices *indices, Constraints *constraints, Config const &config,
-                                       RecoveryInfo const &recovery_info,
-                                       RecoveredIndicesAndConstraints const &indices_constraints,
-                                       bool properties_on_edges,
-                                       std::shared_ptr<utils::Observer<void>> const snapshot_observer = nullptr);
+void RecoverIndicesStatsAndConstraints(
+    utils::SkipList<Vertex> *vertices, NameIdMapper *name_id_mapper, Indices *indices, Constraints *constraints,
+    Config const &config, RecoveryInfo const &recovery_info, RecoveredIndicesAndConstraints const &indices_constraints,
+    bool properties_on_edges, std::shared_ptr<utils::Observer<void>> const snapshot_progress_observer = nullptr);
 
 std::optional<ParallelizedSchemaCreationInfo> GetParallelExecInfo(const RecoveryInfo &recovery_info,
                                                                   const Config &config);

--- a/src/storage/v2/durability/durability.hpp
+++ b/src/storage/v2/durability/durability.hpp
@@ -127,15 +127,15 @@ std::optional<ParallelizedSchemaCreationInfo> GetParallelExecInfo(const Recovery
 void RecoverExistenceConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &, Constraints *,
                                  utils::SkipList<Vertex> *, NameIdMapper *,
                                  const std::optional<ParallelizedSchemaCreationInfo> &,
-                                 std::shared_ptr<utils::Observer<void>> snapshot_observer = nullptr);
+                                 std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
 
 void RecoverUniqueConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &, Constraints *,
                               utils::SkipList<Vertex> *, NameIdMapper *,
                               const std::optional<ParallelizedSchemaCreationInfo> &,
-                              std::shared_ptr<utils::Observer<void>> snapshot_observer = nullptr);
+                              std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
 void RecoverTypeConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &, Constraints *,
                             utils::SkipList<Vertex> *, const std::optional<ParallelizedSchemaCreationInfo> &,
-                            std::shared_ptr<utils::Observer<void>> snapshot_observer = nullptr);
+                            std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
 struct Recovery {
  public:
   /// Recovers data either from a snapshot and/or WAL files.

--- a/src/storage/v2/durability/durability.hpp
+++ b/src/storage/v2/durability/durability.hpp
@@ -101,7 +101,8 @@ std::optional<std::vector<WalDurabilityInfo>> GetWalFiles(const std::filesystem:
 void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadata &indices_metadata, Indices *indices,
                             utils::SkipList<Vertex> *vertices, NameIdMapper *name_id_mapper, bool properties_on_edges,
                             const std::optional<ParallelizedSchemaCreationInfo> &parallel_exec_info = std::nullopt,
-                            const std::optional<std::filesystem::path> &storage_dir = std::nullopt);
+                            const std::optional<std::filesystem::path> &storage_dir = std::nullopt,
+                            std::shared_ptr<utils::Observer<void>> const snapshot_observer = nullptr);
 
 // Helper function used to recover all discovered constraints. The
 // constraints must be recovered after the data recovery is done
@@ -110,13 +111,15 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
 /// @throw RecoveryFailure
 void RecoverConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &constraints_metadata,
                         Constraints *constraints, utils::SkipList<Vertex> *vertices, NameIdMapper *name_id_mapper,
-                        const std::optional<ParallelizedSchemaCreationInfo> &parallel_exec_info = std::nullopt);
+                        const std::optional<ParallelizedSchemaCreationInfo> &parallel_exec_info = std::nullopt,
+                        std::shared_ptr<utils::Observer<void>> snapshot_observer = nullptr);
 
 void RecoverIndicesStatsAndConstraints(utils::SkipList<Vertex> *vertices, NameIdMapper *name_id_mapper,
                                        Indices *indices, Constraints *constraints, Config const &config,
                                        RecoveryInfo const &recovery_info,
                                        RecoveredIndicesAndConstraints const &indices_constraints,
-                                       bool properties_on_edges);
+                                       bool properties_on_edges,
+                                       std::shared_ptr<utils::Observer<void>> const snapshot_observer = nullptr);
 
 std::optional<ParallelizedSchemaCreationInfo> GetParallelExecInfo(const RecoveryInfo &recovery_info,
                                                                   const Config &config);

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -3192,7 +3192,8 @@ RecoveredSnapshot LoadSnapshot(const std::filesystem::path &path, utils::SkipLis
                                utils::SkipList<Edge> *edges, utils::SkipList<EdgeMetadata> *edges_metadata,
                                std::deque<std::pair<std::string, uint64_t>> *epoch_history,
                                NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count, const Config &config,
-                               memgraph::storage::EnumStore *enum_store, SharedSchemaTracking *schema_info) {
+                               memgraph::storage::EnumStore *enum_store, SharedSchemaTracking *schema_info,
+                               std::unique_ptr<utils::Observer<void>> snapshot_observer) {
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
 
@@ -3349,7 +3350,7 @@ RecoveredSnapshot LoadSnapshot(const std::filesystem::path &path, utils::SkipLis
     spdlog::info("Edges are recovered.");
 
     // Recover vertices (labels and properties).
-    spdlog::info("Recovering vertices.", info.vertices_count);
+    spdlog::info("Recovering vertices.");
     uint64_t last_vertex_gid{0};
 
     if (!snapshot.SetPosition(info.offset_vertex_batches)) {

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -38,8 +38,6 @@
 #include "storage/v2/storage.hpp"
 #include "storage/v2/vertex.hpp"
 #include "storage/v2/vertex_accessor.hpp"
-#include "utils/concepts.hpp"
-#include "utils/counter.hpp"
 #include "utils/file.hpp"
 #include "utils/file_locker.hpp"
 #include "utils/logging.hpp"
@@ -340,7 +338,7 @@ std::vector<BatchInfo> ReadBatchInfos(Decoder &snapshot) {
 template <typename TFunc>
 void LoadPartialEdges(const std::filesystem::path &path, utils::SkipList<Edge> &edges, const uint64_t from_offset,
                       const uint64_t edges_count, const SalientConfig::Items items, TFunc get_property_from_id,
-                      std::shared_ptr<utils::Observer<void>> const snapshot_progress_observer = nullptr) {
+                      std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt) {
   Decoder snapshot;
   snapshot.Initialize(path, kSnapshotMagic);
 
@@ -359,7 +357,6 @@ void LoadPartialEdges(const std::filesystem::path &path, utils::SkipList<Edge> &
   }
 
   uint64_t percentage_delta = 0;
-  auto batch_counter = utils::ResettableCounter<kEdgesSnapshotProgressSize>();
   for (uint64_t i = 0; i < edges_count; ++i) {
     if (five_percent_chunk != 0) {
       if (i > 0 && i % five_percent_chunk == 0 && percentage_delta != 100) {
@@ -414,8 +411,8 @@ void LoadPartialEdges(const std::filesystem::path &path, utils::SkipList<Edge> &
               "configured without properties on edges!");
       }
     }
-    if (snapshot_progress_observer != nullptr && batch_counter()) {
-      snapshot_progress_observer->Update();
+    if (snapshot_info) {
+      snapshot_info->Update();
     }
   }
   spdlog::info("Process of recovering {} edges is finished.", edges_count);
@@ -427,7 +424,7 @@ uint64_t LoadPartialVertices(const std::filesystem::path &path, utils::SkipList<
                              SharedSchemaTracking *schema_info, const uint64_t from_offset,
                              const uint64_t vertices_count, TLabelFromIdFunc get_label_from_id,
                              TPropertyFromIdFunc get_property_from_id,
-                             std::shared_ptr<utils::Observer<void>> const snapshot_progress_observer = nullptr) {
+                             std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt) {
   Decoder snapshot;
   snapshot.Initialize(path, kSnapshotMagic);
   if (!snapshot.SetPosition(from_offset))
@@ -445,7 +442,6 @@ uint64_t LoadPartialVertices(const std::filesystem::path &path, utils::SkipList<
   }
 
   uint64_t percentage_delta = 0;
-  auto batch_counter = utils::ResettableCounter<kVerticesSnapshotProgressSize>();
   for (uint64_t i = 0; i < vertices_count; ++i) {
     if (five_percent_chunk != 0) {
       if (i > 0 && i % five_percent_chunk == 0 && percentage_delta != 100) {
@@ -530,8 +526,8 @@ uint64_t LoadPartialVertices(const std::filesystem::path &path, utils::SkipList<
       auto edge_type = snapshot.ReadUint();
       if (!edge_type) throw RecoveryFailure("Couldn't read out edge type!");
     }
-    if (snapshot_progress_observer != nullptr && batch_counter()) {
-      snapshot_progress_observer->Update();
+    if (snapshot_info) {
+      snapshot_info->Update();
     }
   }
   spdlog::info("Process of recovering {} vertices is finished.", vertices_count);
@@ -552,8 +548,7 @@ LoadPartialConnectivityResult LoadPartialConnectivity(
     const std::filesystem::path &path, utils::SkipList<Vertex> &vertices, utils::SkipList<Edge> &edges,
     utils::SkipList<EdgeMetadata> &edges_metadata, SharedSchemaTracking *schema_info, const uint64_t from_offset,
     const uint64_t vertices_count, const SalientConfig::Items items, const bool snapshot_has_edges,
-    TEdgeTypeFromIdFunc get_edge_type_from_id,
-    std::shared_ptr<utils::Observer<void>> const snapshot_progress_observer = nullptr) {
+    TEdgeTypeFromIdFunc get_edge_type_from_id, std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt) {
   Decoder snapshot;
   snapshot.Initialize(path, kSnapshotMagic);
   if (!snapshot.SetPosition(from_offset))
@@ -595,7 +590,6 @@ LoadPartialConnectivityResult LoadPartialConnectivity(
   }
 
   uint64_t percentage_delta = 0;
-  auto batch_counter = utils::ResettableCounter<kVerticesSnapshotProgressSize>();
   for (uint64_t i = 0; i < vertices_count; ++i) {
     if (five_percent_chunk != 0) {
       if (i > 0 && i % five_percent_chunk == 0 && percentage_delta != 100) {
@@ -673,8 +667,8 @@ LoadPartialConnectivityResult LoadPartialConnectivity(
           }
         }
         vertex.in_edges.emplace_back(get_edge_type_from_id(*edge_type), &*from_vertex, edge_ref);
-        if (snapshot_progress_observer != nullptr && batch_counter()) {
-          snapshot_progress_observer->Update();
+        if (snapshot_info) {
+          snapshot_info->Update();
         }
       }
     }
@@ -723,8 +717,8 @@ LoadPartialConnectivityResult LoadPartialConnectivity(
           schema_info->RecoverEdge(get_edge_type_from_id(*edge_type), edge_ref, &vertex, &*to_vertex,
                                    items.properties_on_edges);
         }
-        if (snapshot_progress_observer != nullptr && batch_counter()) {
-          snapshot_progress_observer->Update();
+        if (snapshot_info) {
+          snapshot_info->Update();
         }
       }
     }
@@ -3364,10 +3358,10 @@ RecoveredSnapshot LoadSnapshot(const std::filesystem::path &path, utils::SkipLis
 
       RecoverOnMultipleThreads(
           config.durability.recovery_thread_count,
-          [path, edges, items = config.salient.items, &get_property_from_id, snapshot_progress_observer](
+          [path, edges, items = config.salient.items, &get_property_from_id,
+           snapshot_info = SnapshotObserverInfo(snapshot_progress_observer, kEdgesSnapshotProgressSize)](
               const size_t /*batch_index*/, const BatchInfo &batch) {
-            LoadPartialEdges(path, *edges, batch.offset, batch.count, items, get_property_from_id,
-                             snapshot_progress_observer);
+            LoadPartialEdges(path, *edges, batch.offset, batch.count, items, get_property_from_id, snapshot_info);
           },
           edge_batches);
     }
@@ -3382,13 +3376,15 @@ RecoveredSnapshot LoadSnapshot(const std::filesystem::path &path, utils::SkipLis
     }
 
     const auto vertex_batches = ReadBatchInfos(snapshot);
+
     RecoverOnMultipleThreads(
         config.durability.recovery_thread_count,
         [path, vertices, schema_info, &vertex_batches, &get_label_from_id, &get_property_from_id, &last_vertex_gid,
-         snapshot_progress_observer](const size_t batch_index, const BatchInfo &batch) {
+         snapshot_info = SnapshotObserverInfo(snapshot_progress_observer, kVerticesSnapshotProgressSize)](
+            const size_t batch_index, const BatchInfo &batch) {
           const auto last_vertex_gid_in_batch =
               LoadPartialVertices(path, *vertices, schema_info, batch.offset, batch.count, get_label_from_id,
-                                  get_property_from_id, snapshot_progress_observer);
+                                  get_property_from_id, snapshot_info);
           if (batch_index == vertex_batches.size() - 1) {
             last_vertex_gid = last_vertex_gid_in_batch;
           }
@@ -3409,10 +3405,11 @@ RecoveredSnapshot LoadSnapshot(const std::filesystem::path &path, utils::SkipLis
         config.durability.recovery_thread_count,
         [path, vertices, edges, edges_metadata, schema_info, edge_count, items = config.salient.items,
          snapshot_has_edges, &get_edge_type_from_id, &highest_edge_gid, &recovery_info,
-         snapshot_progress_observer](const size_t batch_index, const BatchInfo &batch) {
+         snapshot_info = SnapshotObserverInfo(snapshot_progress_observer, kEdgesSnapshotProgressSize)](
+            const size_t batch_index, const BatchInfo &batch) {
           const auto result =
               LoadPartialConnectivity(path, *vertices, *edges, *edges_metadata, schema_info, batch.offset, batch.count,
-                                      items, snapshot_has_edges, get_edge_type_from_id, snapshot_progress_observer);
+                                      items, snapshot_has_edges, get_edge_type_from_id, snapshot_info);
           edge_count->fetch_add(result.edge_count);
           auto known_highest_edge_gid = highest_edge_gid.load();
           while (known_highest_edge_gid < result.highest_edge_id) {

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -673,6 +673,9 @@ LoadPartialConnectivityResult LoadPartialConnectivity(
           }
         }
         vertex.in_edges.emplace_back(get_edge_type_from_id(*edge_type), &*from_vertex, edge_ref);
+        if (snapshot_observer != nullptr && batch_counter()) {
+          snapshot_observer->Update();
+        }
       }
     }
 
@@ -695,7 +698,7 @@ LoadPartialConnectivityResult LoadPartialConnectivity(
 
         EdgeRef edge_ref(Gid::FromUint(*edge_gid));
         if (items.properties_on_edges) {
-          // The snapshot contains the individiual edges only if it was created with a config where properties are
+          // The snapshot contains the individual edges only if it was created with a config where properties are
           // allowed on edges. That means the snapshots that were created without edge properties will only contain the
           // edges in the in/out edges list of vertices, therefore the edges has to be created here.
           if (snapshot_has_edges) {
@@ -716,15 +719,16 @@ LoadPartialConnectivityResult LoadPartialConnectivity(
         edge_count++;
 
         // Update schema info
-        if (schema_info)
+        if (schema_info) {
           schema_info->RecoverEdge(get_edge_type_from_id(*edge_type), edge_ref, &vertex, &*to_vertex,
                                    items.properties_on_edges);
+        }
+        if (snapshot_observer != nullptr && batch_counter()) {
+          snapshot_observer->Update();
+        }
       }
     }
     ++vertex_it;
-    if (snapshot_observer != nullptr && batch_counter()) {
-      snapshot_observer->Update();
-    }
   }
   spdlog::info("Process of recovering connectivity for {} vertices is finished.", vertices_count);
 

--- a/src/storage/v2/durability/snapshot.hpp
+++ b/src/storage/v2/durability/snapshot.hpp
@@ -73,7 +73,7 @@ RecoveredSnapshot LoadSnapshot(std::filesystem::path const &path, utils::SkipLis
                                NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count, Config const &config,
                                memgraph::storage::EnumStore *enum_store,
                                memgraph::storage::SharedSchemaTracking *schema_info,
-                               std::unique_ptr<utils::Observer<void>> snapshot_observer = nullptr);
+                               std::shared_ptr<utils::Observer<void>> snapshot_observer = nullptr);
 
 void CreateSnapshot(Storage *storage, Transaction *transaction, const std::filesystem::path &snapshot_directory,
                     const std::filesystem::path &wal_directory, utils::SkipList<Vertex> *vertices,

--- a/src/storage/v2/durability/snapshot.hpp
+++ b/src/storage/v2/durability/snapshot.hpp
@@ -73,7 +73,7 @@ RecoveredSnapshot LoadSnapshot(std::filesystem::path const &path, utils::SkipLis
                                NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count, Config const &config,
                                memgraph::storage::EnumStore *enum_store,
                                memgraph::storage::SharedSchemaTracking *schema_info,
-                               std::shared_ptr<utils::Observer<void>> snapshot_progress_observer = nullptr);
+                               std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
 void CreateSnapshot(Storage *storage, Transaction *transaction, const std::filesystem::path &snapshot_directory,
                     const std::filesystem::path &wal_directory, utils::SkipList<Vertex> *vertices,

--- a/src/storage/v2/durability/snapshot.hpp
+++ b/src/storage/v2/durability/snapshot.hpp
@@ -17,7 +17,6 @@
 
 #include "replication/epoch.hpp"
 #include "storage/v2/config.hpp"
-#include "storage/v2/constraints/constraints.hpp"
 #include "storage/v2/durability/metadata.hpp"
 #include "storage/v2/edge.hpp"
 #include "storage/v2/enum_store.hpp"
@@ -27,6 +26,7 @@
 #include "storage/v2/transaction.hpp"
 #include "storage/v2/vertex.hpp"
 #include "utils/file_locker.hpp"
+#include "utils/observer.hpp"
 #include "utils/skip_list.hpp"
 
 namespace memgraph::storage::durability {
@@ -72,7 +72,8 @@ RecoveredSnapshot LoadSnapshot(std::filesystem::path const &path, utils::SkipLis
                                std::deque<std::pair<std::string, uint64_t>> *epoch_history,
                                NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count, Config const &config,
                                memgraph::storage::EnumStore *enum_store,
-                               memgraph::storage::SharedSchemaTracking *schema_info);
+                               memgraph::storage::SharedSchemaTracking *schema_info,
+                               std::unique_ptr<utils::Observer<void>> snapshot_observer = nullptr);
 
 void CreateSnapshot(Storage *storage, Transaction *transaction, const std::filesystem::path &snapshot_directory,
                     const std::filesystem::path &wal_directory, utils::SkipList<Vertex> *vertices,

--- a/src/storage/v2/durability/snapshot.hpp
+++ b/src/storage/v2/durability/snapshot.hpp
@@ -73,7 +73,7 @@ RecoveredSnapshot LoadSnapshot(std::filesystem::path const &path, utils::SkipLis
                                NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count, Config const &config,
                                memgraph::storage::EnumStore *enum_store,
                                memgraph::storage::SharedSchemaTracking *schema_info,
-                               std::shared_ptr<utils::Observer<void>> snapshot_observer = nullptr);
+                               std::shared_ptr<utils::Observer<void>> snapshot_progress_observer = nullptr);
 
 void CreateSnapshot(Storage *storage, Transaction *transaction, const std::filesystem::path &snapshot_directory,
                     const std::filesystem::path &wal_directory, utils::SkipList<Vertex> *vertices,

--- a/src/storage/v2/indices/indices_utils.hpp
+++ b/src/storage/v2/indices/indices_utils.hpp
@@ -351,7 +351,7 @@ inline void CreateIndexOnSingleThread(utils::SkipList<Vertex>::Accessor &vertice
     auto acc = it->second.access();
     for (Vertex &vertex : vertices) {
       func(vertex, key, acc);
-      if (snapshot_info && snapshot_info->IncrementCounter()) {
+      if (snapshot_info) {
         snapshot_info->Update();
       }
     }
@@ -399,7 +399,7 @@ inline void CreateIndexOnMultipleThreads(utils::SkipList<Vertex>::Accessor &vert
           try {
             for (auto i{0U}; i < batch.second; ++i, ++it) {
               func(*it, key, index_accessor);
-              if (snapshot_info && snapshot_info->IncrementCounter()) {
+              if (snapshot_info) {
                 snapshot_info->Update();
               }
             }

--- a/src/storage/v2/indices/point_index.cpp
+++ b/src/storage/v2/indices/point_index.cpp
@@ -21,7 +21,6 @@
 #include "storage/v2/indices/point_iterator.hpp"
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/vertex.hpp"
-#include "utils/counter.hpp"
 #include "utils/logging.hpp"
 
 namespace memgraph::storage {
@@ -141,7 +140,7 @@ bool PointIndexStorage::CreatePointIndex(LabelId label, PropertyId property,
         continue;
     }
 
-    if (snapshot_info && snapshot_info->IncrementCounter()) {
+    if (snapshot_info) {
       snapshot_info->Update();
     }
   }

--- a/src/storage/v2/indices/point_index.cpp
+++ b/src/storage/v2/indices/point_index.cpp
@@ -95,9 +95,8 @@ auto update_internal(index_container_t const &src, TrackedChanges const &tracked
 }
 }  // namespace
 
-bool PointIndexStorage::CreatePointIndex(LabelId label, PropertyId property,
-                                         memgraph::utils::SkipList<Vertex>::Accessor vertices,
-                                         std::optional<SnapshotObserverInfo> snapshot_info) {
+bool PointIndexStorage::CreatePointIndex(LabelId label, PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
+                                         std::optional<SnapshotObserverInfo> const &snapshot_info) {
   // indexes_ protected by unique storage access
   auto &indexes = *indexes_;
   auto key = LabelPropKey{label, property};
@@ -141,7 +140,7 @@ bool PointIndexStorage::CreatePointIndex(LabelId label, PropertyId property,
     }
 
     if (snapshot_info) {
-      snapshot_info->Update();
+      snapshot_info->Update(UpdateType::POINT_IDX);
     }
   }
   auto new_index = std::make_shared<PointIndex>(points_2d_WGS, points_2d_Crt, points_3d_WGS, points_3d_Crt);

--- a/src/storage/v2/indices/point_index.cpp
+++ b/src/storage/v2/indices/point_index.cpp
@@ -109,11 +109,6 @@ bool PointIndexStorage::CreatePointIndex(LabelId label, PropertyId property,
   auto points_3d_WGS = std::vector<Entry<IndexPointWGS3d>>{};
   auto points_3d_Crt = std::vector<Entry<IndexPointCartesian3d>>{};
 
-  std::optional<utils::ResettableRuntimeCounter> maybe_batch_counter;
-  if (snapshot_info) {
-    maybe_batch_counter.emplace(utils::ResettableRuntimeCounter{snapshot_info->item_batch_size});
-  }
-
   for (auto const &v : vertices) {
     if (v.deleted) continue;
     if (!utils::Contains(v.labels, label)) continue;
@@ -146,8 +141,8 @@ bool PointIndexStorage::CreatePointIndex(LabelId label, PropertyId property,
         continue;
     }
 
-    if (maybe_batch_counter && (*maybe_batch_counter)()) {
-      snapshot_info->observer->Update();
+    if (snapshot_info && snapshot_info->IncrementCounter()) {
+      snapshot_info->Update();
     }
   }
   auto new_index = std::make_shared<PointIndex>(points_2d_WGS, points_2d_Crt, points_3d_WGS, points_3d_Crt);

--- a/src/storage/v2/indices/point_index.hpp
+++ b/src/storage/v2/indices/point_index.hpp
@@ -89,7 +89,7 @@ struct PointIndexStorage {
 
   // Query (modify index set)
   bool CreatePointIndex(LabelId label, PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
-                        std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
+                        std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
   bool DropPointIndex(LabelId label, PropertyId property);
 
   // Transaction (establish what to collect + able to build next index)

--- a/src/storage/v2/indices/point_index.hpp
+++ b/src/storage/v2/indices/point_index.hpp
@@ -14,8 +14,8 @@
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indices/point_index_change_collector.hpp"
 #include "storage/v2/property_value.hpp"
+#include "storage/v2/snapshot_observer_info.hpp"
 #include "storage/v2/vertex_accessor.hpp"
-#include "utils/observer.hpp"
 #include "utils/skip_list.hpp"
 
 namespace memgraph::storage {
@@ -89,10 +89,10 @@ struct PointIndexStorage {
 
   // Query (modify index set)
   bool CreatePointIndex(LabelId label, PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
-                        std::shared_ptr<utils::Observer<void>> const snapshot_observer = nullptr);
+                        std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
   bool DropPointIndex(LabelId label, PropertyId property);
 
-  // Transaction (estabilish what to collect + able to build next index)
+  // Transaction (establish what to collect + able to build next index)
   auto CreatePointIndexContext() const -> PointIndexContext { return PointIndexContext{indexes_}; }
 
   // Commit

--- a/src/storage/v2/indices/point_index.hpp
+++ b/src/storage/v2/indices/point_index.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -15,6 +15,7 @@
 #include "storage/v2/indices/point_index_change_collector.hpp"
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/vertex_accessor.hpp"
+#include "utils/observer.hpp"
 #include "utils/skip_list.hpp"
 
 namespace memgraph::storage {
@@ -87,7 +88,8 @@ struct PointIndexStorage {
   // TODO: consider passkey idiom
 
   // Query (modify index set)
-  bool CreatePointIndex(LabelId label, PropertyId property, utils::SkipList<Vertex>::Accessor vertices);
+  bool CreatePointIndex(LabelId label, PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
+                        std::shared_ptr<utils::Observer<void>> const snapshot_observer = nullptr);
   bool DropPointIndex(LabelId label, PropertyId property);
 
   // Transaction (estabilish what to collect + able to build next index)

--- a/src/storage/v2/indices/text_index.cpp
+++ b/src/storage/v2/indices/text_index.cpp
@@ -250,7 +250,7 @@ void TextIndex::CreateIndex(std::string const &index_name, LabelId label, storag
 
 void TextIndex::RecoverIndex(const std::string &index_name, LabelId label,
                              memgraph::utils::SkipList<Vertex>::Accessor vertices, NameIdMapper *name_id_mapper,
-                             std::optional<SnapshotObserverInfo> snapshot_info) {
+                             std::optional<SnapshotObserverInfo> const &snapshot_info) {
   if (!flags::AreExperimentsEnabled(flags::Experiments::TEXT_SEARCH)) {
     throw query::TextSearchDisabledException();
   }
@@ -270,7 +270,7 @@ void TextIndex::RecoverIndex(const std::string &index_name, LabelId label,
                           StringifyProperties(vertex_properties), {&index_.at(index_name).context_});
 
     if (snapshot_info) {
-      snapshot_info->Update();
+      snapshot_info->Update(UpdateType::TEXT_IDX);
     }
   }
 

--- a/src/storage/v2/indices/text_index.cpp
+++ b/src/storage/v2/indices/text_index.cpp
@@ -17,7 +17,6 @@
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/view.hpp"
-#include "utils/counter.hpp"
 
 #include <span>
 #include <vector>
@@ -270,7 +269,7 @@ void TextIndex::RecoverIndex(const std::string &index_name, LabelId label,
     LoadNodeToTextIndices(v.gid.AsInt(), SerializeProperties(vertex_properties, name_id_mapper),
                           StringifyProperties(vertex_properties), {&index_.at(index_name).context_});
 
-    if (snapshot_info && snapshot_info->IncrementCounter()) {
+    if (snapshot_info) {
       snapshot_info->Update();
     }
   }

--- a/src/storage/v2/indices/text_index.cpp
+++ b/src/storage/v2/indices/text_index.cpp
@@ -261,11 +261,6 @@ void TextIndex::RecoverIndex(const std::string &index_name, LabelId label,
 
   CreateEmptyIndex(index_name, label);
 
-  std::optional<utils::ResettableRuntimeCounter> maybe_batch_counter;
-  if (snapshot_info) {
-    maybe_batch_counter.emplace(utils::ResettableRuntimeCounter{snapshot_info->item_batch_size});
-  }
-
   for (const auto &v : vertices) {
     if (std::find(v.labels.begin(), v.labels.end(), label) == v.labels.end()) {
       continue;
@@ -275,8 +270,8 @@ void TextIndex::RecoverIndex(const std::string &index_name, LabelId label,
     LoadNodeToTextIndices(v.gid.AsInt(), SerializeProperties(vertex_properties, name_id_mapper),
                           StringifyProperties(vertex_properties), {&index_.at(index_name).context_});
 
-    if (maybe_batch_counter && (*maybe_batch_counter)()) {
-      snapshot_info->observer->Update();
+    if (snapshot_info && snapshot_info->IncrementCounter()) {
+      snapshot_info->Update();
     }
   }
 

--- a/src/storage/v2/indices/text_index.hpp
+++ b/src/storage/v2/indices/text_index.hpp
@@ -15,6 +15,7 @@
 #include "mg_procedure.h"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/name_id_mapper.hpp"
+#include "storage/v2/snapshot_observer_info.hpp"
 #include "storage/v2/vertex.hpp"
 #include "storage/v2/vertices_iterable.hpp"
 #include "text_search.hpp"
@@ -86,8 +87,7 @@ class TextIndex {
   void CreateIndex(std::string const &index_name, LabelId label, VerticesIterable vertices, NameIdMapper *nameIdMapper);
 
   void RecoverIndex(const std::string &index_name, LabelId label, utils::SkipList<Vertex>::Accessor vertices,
-                    NameIdMapper *name_id_mapper,
-                    std::shared_ptr<utils::Observer<void>> const snapshot_observer = nullptr);
+                    NameIdMapper *name_id_mapper, std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
 
   LabelId DropIndex(const std::string &index_name);
 

--- a/src/storage/v2/indices/text_index.hpp
+++ b/src/storage/v2/indices/text_index.hpp
@@ -87,7 +87,8 @@ class TextIndex {
   void CreateIndex(std::string const &index_name, LabelId label, VerticesIterable vertices, NameIdMapper *nameIdMapper);
 
   void RecoverIndex(const std::string &index_name, LabelId label, utils::SkipList<Vertex>::Accessor vertices,
-                    NameIdMapper *name_id_mapper, std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
+                    NameIdMapper *name_id_mapper,
+                    std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
   LabelId DropIndex(const std::string &index_name);
 

--- a/src/storage/v2/indices/text_index.hpp
+++ b/src/storage/v2/indices/text_index.hpp
@@ -83,11 +83,11 @@ class TextIndex {
       Vertex *vertex,
       const std::optional<std::vector<mgcxx::text_search::Context *>> &maybe_applicable_text_indices = std::nullopt);
 
-  void CreateIndex(std::string const &index_name, LabelId label, memgraph::storage::VerticesIterable vertices,
-                   NameIdMapper *nameIdMapper);
+  void CreateIndex(std::string const &index_name, LabelId label, VerticesIterable vertices, NameIdMapper *nameIdMapper);
 
-  void RecoverIndex(const std::string &index_name, LabelId label, memgraph::utils::SkipList<Vertex>::Accessor vertices,
-                    NameIdMapper *name_id_mapper);
+  void RecoverIndex(const std::string &index_name, LabelId label, utils::SkipList<Vertex>::Accessor vertices,
+                    NameIdMapper *name_id_mapper,
+                    std::shared_ptr<utils::Observer<void>> const snapshot_observer = nullptr);
 
   LabelId DropIndex(const std::string &index_name);
 

--- a/src/storage/v2/indices/vector_index.cpp
+++ b/src/storage/v2/indices/vector_index.cpp
@@ -171,15 +171,11 @@ bool VectorIndex::CreateIndex(const VectorIndexSpec &spec, utils::SkipList<Verte
                                             std::move(mg_vector_index.index)),
                                         spec});
 
-    std::optional<utils::ResettableRuntimeCounter> maybe_batch_counter;
-    if (snapshot_info) {
-      maybe_batch_counter.emplace(utils::ResettableRuntimeCounter{snapshot_info->item_batch_size});
-    }
     // Update the index with the vertices
     for (auto &vertex : vertices) {
       UpdateVectorIndex(&vertex, LabelPropKey{spec.label, spec.property});
-      if (maybe_batch_counter && (*maybe_batch_counter)()) {
-        snapshot_info->observer->Update();
+      if (snapshot_info && snapshot_info->IncrementCounter()) {
+        snapshot_info->Update();
       }
     }
   } catch (const std::exception &e) {

--- a/src/storage/v2/indices/vector_index.cpp
+++ b/src/storage/v2/indices/vector_index.cpp
@@ -140,7 +140,7 @@ unum::usearch::metric_kind_t VectorIndex::MetricFromName(std::string_view name) 
 }
 
 bool VectorIndex::CreateIndex(const VectorIndexSpec &spec, utils::SkipList<Vertex>::Accessor &vertices,
-                              std::optional<SnapshotObserverInfo> snapshot_info) {
+                              std::optional<SnapshotObserverInfo> const &snapshot_info) {
   try {
     // Create the index
     const unum::usearch::metric_punned_t metric(spec.dimension, spec.metric_kind, unum::usearch::scalar_kind_t::f32_k);
@@ -171,9 +171,11 @@ bool VectorIndex::CreateIndex(const VectorIndexSpec &spec, utils::SkipList<Verte
 
     // Update the index with the vertices
     for (auto &vertex : vertices) {
-      UpdateVectorIndex(&vertex, LabelPropKey{spec.label, spec.property});
-      if (snapshot_info) {
-        snapshot_info->Update();
+      if (!utils::Contains(vertex.labels, spec.label)) {
+        continue;
+      }
+      if (UpdateVectorIndex(&vertex, LabelPropKey{spec.label, spec.property}) && snapshot_info) {
+        snapshot_info->Update(UpdateType::VECTOR_IDX);
       }
     }
   } catch (const std::exception &e) {
@@ -200,7 +202,7 @@ void VectorIndex::Clear() {
   pimpl->index_.clear();
 }
 
-void VectorIndex::UpdateVectorIndex(Vertex *vertex, const LabelPropKey &label_prop, const PropertyValue *value) {
+bool VectorIndex::UpdateVectorIndex(Vertex *vertex, const LabelPropKey &label_prop, const PropertyValue *value) {
   auto &[mg_index, spec] = pimpl->index_.at(label_prop);
   bool is_index_full = false;
   // try to remove entry (if it exists) and then add a new one + check if index is full
@@ -213,7 +215,7 @@ void VectorIndex::UpdateVectorIndex(Vertex *vertex, const LabelPropKey &label_pr
   const auto &property = (value != nullptr ? *value : vertex->properties.GetProperty(label_prop.property()));
   if (property.IsNull()) {
     // if property is null, that means that the vertex should not be in the index and we shouldn't do any other updates
-    return;
+    return false;
   }
   if (!property.IsList()) {
     throw query::VectorSearchException("Vector index property must be a list.");
@@ -250,6 +252,7 @@ void VectorIndex::UpdateVectorIndex(Vertex *vertex, const LabelPropKey &label_pr
     auto locked_index = mg_index->MutableSharedLock();
     locked_index->add(vertex, vector.data(), mg_vector_index_t::any_thread(), false);
   }
+  return true;
 }
 
 void VectorIndex::UpdateOnAddLabel(LabelId added_label, Vertex *vertex_after_update) {

--- a/src/storage/v2/indices/vector_index.cpp
+++ b/src/storage/v2/indices/vector_index.cpp
@@ -23,8 +23,6 @@
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indices/vector_index.hpp"
 
-#include <utils/observer.hpp>
-
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/vertex.hpp"
 #include "usearch/index_dense.hpp"
@@ -174,7 +172,7 @@ bool VectorIndex::CreateIndex(const VectorIndexSpec &spec, utils::SkipList<Verte
     // Update the index with the vertices
     for (auto &vertex : vertices) {
       UpdateVectorIndex(&vertex, LabelPropKey{spec.label, spec.property});
-      if (snapshot_info && snapshot_info->IncrementCounter()) {
+      if (snapshot_info) {
         snapshot_info->Update();
       }
     }

--- a/src/storage/v2/indices/vector_index.hpp
+++ b/src/storage/v2/indices/vector_index.hpp
@@ -13,13 +13,14 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <nlohmann/json.hpp>
+#include <json/json.hpp>
 #include <string>
 
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/vertex.hpp"
 #include "usearch/index_plugins.hpp"
+#include "utils/observer.hpp"
 #include "utils/skip_list.hpp"
 
 namespace memgraph::storage {
@@ -106,8 +107,11 @@ class VectorIndex {
 
   /// @brief Creates a new index based on the provided specification.
   /// @param spec The specification for the index to be created.
+  /// @param snapshot_observer
+  /// @param vertices vertices from which to create vector index
   /// @return true if the index was created successfully, false otherwise.
-  bool CreateIndex(const VectorIndexSpec &spec, utils::SkipList<Vertex>::Accessor &vertices);
+  bool CreateIndex(const VectorIndexSpec &spec, utils::SkipList<Vertex>::Accessor &vertices,
+                   std::shared_ptr<utils::Observer<void>> const snapshot_observer = nullptr);
 
   /// @brief Drops an existing index.
   /// @param index_name The name of the index to be dropped.
@@ -149,7 +153,6 @@ class VectorIndex {
 
   /// @brief Searches for nodes in the specified index using a query vector.
   /// @param index_name The name of the index to search.
-  /// @param start_timestamp The timestamp of transaction in which the search is performed.
   /// @param result_set_size The number of results to return.
   /// @param query_vector The vector to be used for the search query.
   /// @return A vector of tuples containing the vertex, distance, and similarity of the search results.
@@ -163,7 +166,7 @@ class VectorIndex {
 
   /// @brief Restores the entries that were removed in the specified transaction.
   /// @param label_prop The label and property of the vertices to be restored.
-  /// @param vertices The vertices to be restored.
+  /// @param prop_vertices The vertices to be restored.
   void RestoreEntries(const LabelPropKey &label_prop,
                       std::span<std::pair<PropertyValue, Vertex *> const> prop_vertices);
 

--- a/src/storage/v2/indices/vector_index.hpp
+++ b/src/storage/v2/indices/vector_index.hpp
@@ -13,7 +13,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <nlohmann/json.hpp>
 #include <string>
 
 #include "storage/v2/id_types.hpp"

--- a/src/storage/v2/indices/vector_index.hpp
+++ b/src/storage/v2/indices/vector_index.hpp
@@ -18,9 +18,9 @@
 
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/property_value.hpp"
+#include "storage/v2/snapshot_observer_info.hpp"
 #include "storage/v2/vertex.hpp"
 #include "usearch/index_plugins.hpp"
-#include "utils/observer.hpp"
 #include "utils/skip_list.hpp"
 
 namespace memgraph::storage {
@@ -107,11 +107,11 @@ class VectorIndex {
 
   /// @brief Creates a new index based on the provided specification.
   /// @param spec The specification for the index to be created.
-  /// @param snapshot_observer
+  /// @param snapshot_info
   /// @param vertices vertices from which to create vector index
   /// @return true if the index was created successfully, false otherwise.
   bool CreateIndex(const VectorIndexSpec &spec, utils::SkipList<Vertex>::Accessor &vertices,
-                   std::shared_ptr<utils::Observer<void>> const snapshot_observer = nullptr);
+                   std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
 
   /// @brief Drops an existing index.
   /// @param index_name The name of the index to be dropped.

--- a/src/storage/v2/indices/vector_index.hpp
+++ b/src/storage/v2/indices/vector_index.hpp
@@ -110,7 +110,7 @@ class VectorIndex {
   /// @param vertices vertices from which to create vector index
   /// @return true if the index was created successfully, false otherwise.
   bool CreateIndex(const VectorIndexSpec &spec, utils::SkipList<Vertex>::Accessor &vertices,
-                   std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
+                   std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
   /// @brief Drops an existing index.
   /// @param index_name The name of the index to be dropped.
@@ -185,7 +185,7 @@ class VectorIndex {
   /// @param label_prop The label and property key for the index.
   /// @param value The value of the property.
   /// @throw query::VectorSearchException
-  void UpdateVectorIndex(Vertex *vertex, const LabelPropKey &label_prop, const PropertyValue *value = nullptr);
+  bool UpdateVectorIndex(Vertex *vertex, const LabelPropKey &label_prop, const PropertyValue *value = nullptr);
 
   struct Impl;
   std::unique_ptr<Impl> pimpl;

--- a/src/storage/v2/indices/vector_index.hpp
+++ b/src/storage/v2/indices/vector_index.hpp
@@ -13,7 +13,7 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 #include <string>
 
 #include "storage/v2/id_types.hpp"

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -26,12 +26,6 @@ bool InMemoryEdgeTypeIndex::CreateIndex(EdgeTypeId edge_type, utils::SkipList<Ve
     return false;
   }
 
-  // Count edges in general, not specific vertices cause vertex could be a supernode
-  std::optional<utils::ResettableRuntimeCounter> maybe_batch_counter;
-  if (snapshot_info) {
-    maybe_batch_counter.emplace(utils::ResettableRuntimeCounter{snapshot_info->item_batch_size});
-  }
-
   utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
   try {
     auto edge_acc = it->second.access();
@@ -48,8 +42,8 @@ bool InMemoryEdgeTypeIndex::CreateIndex(EdgeTypeId edge_type, utils::SkipList<Ve
             continue;
           }
           edge_acc.insert({&from_vertex, to_vertex, std::get<kEdgeRefPos>(edge).ptr, 0});
-          if (snapshot_info && (*maybe_batch_counter)()) {
-            snapshot_info->observer->Update();
+          if (snapshot_info && snapshot_info->IncrementCounter()) {
+            snapshot_info->Update();
           }
         }
       }

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -20,7 +20,7 @@
 namespace memgraph::storage {
 
 bool InMemoryEdgeTypeIndex::CreateIndex(EdgeTypeId edge_type, utils::SkipList<Vertex>::Accessor vertices,
-                                        std::optional<SnapshotObserverInfo> snapshot_info) {
+                                        std::optional<SnapshotObserverInfo> const &snapshot_info) {
   auto [it, emplaced] = index_.try_emplace(edge_type);
   if (!emplaced) {
     return false;
@@ -43,7 +43,7 @@ bool InMemoryEdgeTypeIndex::CreateIndex(EdgeTypeId edge_type, utils::SkipList<Ve
           }
           edge_acc.insert({&from_vertex, to_vertex, std::get<kEdgeRefPos>(edge).ptr, 0});
           if (snapshot_info) {
-            snapshot_info->Update();
+            snapshot_info->Update(UpdateType::EDGES);
           }
         }
       }

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -42,7 +42,7 @@ bool InMemoryEdgeTypeIndex::CreateIndex(EdgeTypeId edge_type, utils::SkipList<Ve
             continue;
           }
           edge_acc.insert({&from_vertex, to_vertex, std::get<kEdgeRefPos>(edge).ptr, 0});
-          if (snapshot_info && snapshot_info->IncrementCounter()) {
+          if (snapshot_info) {
             snapshot_info->Update();
           }
         }

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -49,7 +49,7 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
 
   /// @throw std::bad_alloc
   bool CreateIndex(EdgeTypeId edge_type, utils::SkipList<Vertex>::Accessor vertices,
-                   std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
+                   std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
   /// Returns false if there was no index to drop
   bool DropIndex(EdgeTypeId edge_type) override;

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -12,15 +12,15 @@
 #pragma once
 
 #include <map>
+#include <storage/v2/indices/indices_utils.hpp>
 #include <utility>
 
 #include "storage/v2/constraints/constraints.hpp"
 #include "storage/v2/edge_accessor.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indices/edge_type_index.hpp"
-#include "storage/v2/indices/label_index_stats.hpp"
+#include "storage/v2/snapshot_observer_info.hpp"
 #include "storage/v2/vertex_accessor.hpp"
-#include "utils/observer.hpp"
 
 namespace memgraph::storage {
 
@@ -50,7 +50,7 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
 
   /// @throw std::bad_alloc
   bool CreateIndex(EdgeTypeId edge_type, utils::SkipList<Vertex>::Accessor vertices,
-                   std::shared_ptr<utils::Observer<void>> snapshot_observer = nullptr);
+                   std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
 
   /// Returns false if there was no index to drop
   bool DropIndex(EdgeTypeId edge_type) override;

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -12,7 +12,6 @@
 #pragma once
 
 #include <map>
-#include <storage/v2/indices/indices_utils.hpp>
 #include <utility>
 
 #include "storage/v2/constraints/constraints.hpp"

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -20,8 +20,7 @@
 #include "storage/v2/indices/edge_type_index.hpp"
 #include "storage/v2/indices/label_index_stats.hpp"
 #include "storage/v2/vertex_accessor.hpp"
-#include "utils/rw_lock.hpp"
-#include "utils/synchronized.hpp"
+#include "utils/observer.hpp"
 
 namespace memgraph::storage {
 
@@ -50,7 +49,8 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
   InMemoryEdgeTypeIndex() = default;
 
   /// @throw std::bad_alloc
-  bool CreateIndex(EdgeTypeId edge_type, utils::SkipList<Vertex>::Accessor vertices);
+  bool CreateIndex(EdgeTypeId edge_type, utils::SkipList<Vertex>::Accessor vertices,
+                   std::shared_ptr<utils::Observer<void>> snapshot_observer = nullptr);
 
   /// Returns false if there was no index to drop
   bool DropIndex(EdgeTypeId edge_type) override;

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -34,12 +34,6 @@ bool InMemoryEdgeTypePropertyIndex::CreateIndex(EdgeTypeId edge_type, PropertyId
     return false;
   }
 
-  // Count edges in general, not specific vertices cause vertex could be a supernode
-  std::optional<utils::ResettableRuntimeCounter> maybe_batch_counter;
-  if (snapshot_info) {
-    maybe_batch_counter.emplace(utils::ResettableRuntimeCounter{snapshot_info->item_batch_size});
-  }
-
   const utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
   try {
     auto edge_acc = it->second.access();
@@ -59,8 +53,8 @@ bool InMemoryEdgeTypePropertyIndex::CreateIndex(EdgeTypeId edge_type, PropertyId
         }
         auto *edge_ptr = std::get<kEdgeRefPos>(edge).ptr;
         edge_acc.insert({edge_ptr->properties.GetProperty(property), &from_vertex, to_vertex, edge_ptr, 0});
-        if (snapshot_info && (*maybe_batch_counter)()) {
-          snapshot_info->observer->Update();
+        if (snapshot_info && snapshot_info->IncrementCounter()) {
+          snapshot_info->Update();
         }
       }
     }

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -53,7 +53,7 @@ bool InMemoryEdgeTypePropertyIndex::CreateIndex(EdgeTypeId edge_type, PropertyId
         }
         auto *edge_ptr = std::get<kEdgeRefPos>(edge).ptr;
         edge_acc.insert({edge_ptr->properties.GetProperty(property), &from_vertex, to_vertex, edge_ptr, 0});
-        if (snapshot_info && snapshot_info->IncrementCounter()) {
+        if (snapshot_info) {
           snapshot_info->Update();
         }
       }

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -28,7 +28,7 @@ bool InMemoryEdgeTypePropertyIndex::Entry::operator==(const PropertyValue &rhs) 
 
 bool InMemoryEdgeTypePropertyIndex::CreateIndex(EdgeTypeId edge_type, PropertyId property,
                                                 utils::SkipList<Vertex>::Accessor vertices,
-                                                std::optional<SnapshotObserverInfo> snapshot_info) {
+                                                std::optional<SnapshotObserverInfo> const &snapshot_info) {
   auto [it, emplaced] = index_.try_emplace({edge_type, property});
   if (!emplaced) {
     return false;
@@ -54,7 +54,7 @@ bool InMemoryEdgeTypePropertyIndex::CreateIndex(EdgeTypeId edge_type, PropertyId
         auto *edge_ptr = std::get<kEdgeRefPos>(edge).ptr;
         edge_acc.insert({edge_ptr->properties.GetProperty(property), &from_vertex, to_vertex, edge_ptr, 0});
         if (snapshot_info) {
-          snapshot_info->Update();
+          snapshot_info->Update(UpdateType::EDGES);
         }
       }
     }

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -22,56 +22,8 @@
 
 namespace {
 
-using Delta = memgraph::storage::Delta;
-using Vertex = memgraph::storage::Vertex;
-using Edge = memgraph::storage::Edge;
-using EdgeRef = memgraph::storage::EdgeRef;
-using EdgeTypeId = memgraph::storage::EdgeTypeId;
-using PropertyId = memgraph::storage::PropertyId;
-using PropertyValue = memgraph::storage::PropertyValue;
-using Transaction = memgraph::storage::Transaction;
-using View = memgraph::storage::View;
+constexpr uint32_t kEdgesSnapshotProgressSize = 1'000'000;
 
-using ReturnType = std::optional<std::tuple<EdgeTypeId, Vertex *, EdgeRef>>;
-ReturnType VertexDeletedConnectedEdges(Vertex *vertex, Edge *edge, const Transaction *transaction, View view) {
-  ReturnType link;
-  Delta *delta = nullptr;
-  {
-    auto guard = std::shared_lock{vertex->lock};
-    delta = vertex->delta;
-  }
-  ApplyDeltasForRead(transaction, delta, view, [&edge, &vertex, &link](const Delta &delta) {
-    switch (delta.action) {
-      case Delta::Action::ADD_LABEL:
-      case Delta::Action::REMOVE_LABEL:
-      case Delta::Action::SET_PROPERTY:
-        break;
-      case Delta::Action::ADD_IN_EDGE: {
-        if (edge == delta.vertex_edge.edge.ptr) {
-          link = {delta.vertex_edge.edge_type, delta.vertex_edge.vertex, delta.vertex_edge.edge};
-          auto it = std::find(vertex->in_edges.begin(), vertex->in_edges.end(), link);
-          MG_ASSERT(it == vertex->in_edges.end(), "Invalid database state!");
-        }
-        break;
-      }
-      case Delta::Action::ADD_OUT_EDGE: {
-        if (edge == delta.vertex_edge.edge.ptr) {
-          link = {delta.vertex_edge.edge_type, delta.vertex_edge.vertex, delta.vertex_edge.edge};
-          auto it = std::find(vertex->out_edges.begin(), vertex->out_edges.end(), link);
-          MG_ASSERT(it == vertex->out_edges.end(), "Invalid database state!");
-        }
-        break;
-      }
-      case Delta::Action::REMOVE_IN_EDGE:
-      case Delta::Action::REMOVE_OUT_EDGE:
-      case Delta::Action::RECREATE_OBJECT:
-      case Delta::Action::DELETE_DESERIALIZED_OBJECT:
-      case Delta::Action::DELETE_OBJECT:
-        break;
-    }
-  });
-  return link;
-}
 }  // namespace
 
 namespace memgraph::storage {
@@ -81,11 +33,15 @@ bool InMemoryEdgeTypePropertyIndex::Entry::operator<(const PropertyValue &rhs) c
 bool InMemoryEdgeTypePropertyIndex::Entry::operator==(const PropertyValue &rhs) const { return value == rhs; }
 
 bool InMemoryEdgeTypePropertyIndex::CreateIndex(EdgeTypeId edge_type, PropertyId property,
-                                                utils::SkipList<Vertex>::Accessor vertices) {
+                                                utils::SkipList<Vertex>::Accessor vertices,
+                                                std::shared_ptr<utils::Observer<void>> const snapshot_observer) {
   auto [it, emplaced] = index_.try_emplace({edge_type, property});
   if (!emplaced) {
     return false;
   }
+
+  // Count edges in general, not specific vertices cause vertex could be a supernode
+  auto batch_counter = utils::ResettableCounter<kEdgesSnapshotProgressSize>();
 
   const utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
   try {
@@ -106,6 +62,9 @@ bool InMemoryEdgeTypePropertyIndex::CreateIndex(EdgeTypeId edge_type, PropertyId
         }
         auto *edge_ptr = std::get<kEdgeRefPos>(edge).ptr;
         edge_acc.insert({edge_ptr->properties.GetProperty(property), &from_vertex, to_vertex, edge_ptr, 0});
+        if (snapshot_observer != nullptr && batch_counter()) {
+          snapshot_observer->Update();
+        }
       }
     }
   } catch (const utils::OutOfMemoryException &) {

--- a/src/storage/v2/inmemory/edge_type_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.hpp
@@ -55,7 +55,7 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
 
   /// @throw std::bad_alloc
   bool CreateIndex(EdgeTypeId edge_type, PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
-                   std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
+                   std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
   /// Returns false if there was no index to drop
   bool DropIndex(EdgeTypeId edge_type, PropertyId property) override;

--- a/src/storage/v2/inmemory/edge_type_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.hpp
@@ -22,8 +22,7 @@
 #include "storage/v2/indices/label_index_stats.hpp"
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/vertex_accessor.hpp"
-#include "utils/rw_lock.hpp"
-#include "utils/synchronized.hpp"
+#include "utils/observer.hpp"
 
 namespace memgraph::storage {
 
@@ -55,7 +54,8 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
   InMemoryEdgeTypePropertyIndex() = default;
 
   /// @throw std::bad_alloc
-  bool CreateIndex(EdgeTypeId edge_type, PropertyId property, utils::SkipList<Vertex>::Accessor vertices);
+  bool CreateIndex(EdgeTypeId edge_type, PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
+                   std::shared_ptr<utils::Observer<void>> const snapshot_observer = nullptr);
 
   /// Returns false if there was no index to drop
   bool DropIndex(EdgeTypeId edge_type, PropertyId property) override;

--- a/src/storage/v2/inmemory/edge_type_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.hpp
@@ -21,8 +21,8 @@
 #include "storage/v2/indices/edge_type_property_index.hpp"
 #include "storage/v2/indices/label_index_stats.hpp"
 #include "storage/v2/property_value.hpp"
+#include "storage/v2/snapshot_observer_info.hpp"
 #include "storage/v2/vertex_accessor.hpp"
-#include "utils/observer.hpp"
 
 namespace memgraph::storage {
 
@@ -55,7 +55,7 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
 
   /// @throw std::bad_alloc
   bool CreateIndex(EdgeTypeId edge_type, PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
-                   std::shared_ptr<utils::Observer<void>> const snapshot_observer = nullptr);
+                   std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
 
   /// Returns false if there was no index to drop
   bool DropIndex(EdgeTypeId edge_type, PropertyId property) override;

--- a/src/storage/v2/inmemory/label_index.cpp
+++ b/src/storage/v2/inmemory/label_index.cpp
@@ -29,7 +29,7 @@ void InMemoryLabelIndex::UpdateOnAddLabel(LabelId added_label, Vertex *vertex_af
 bool InMemoryLabelIndex::CreateIndex(
     LabelId label, utils::SkipList<Vertex>::Accessor vertices,
     const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info,
-    std::optional<SnapshotObserverInfo> snapshot_info) {
+    std::optional<SnapshotObserverInfo> const &snapshot_info) {
   const auto create_index_seq = [this, &snapshot_info](LabelId label, utils::SkipList<Vertex>::Accessor &vertices,
                                                        std::map<LabelId, utils::SkipList<Entry>>::iterator it) {
     using IndexAccessor = decltype(it->second.access());

--- a/src/storage/v2/inmemory/label_index.hpp
+++ b/src/storage/v2/inmemory/label_index.hpp
@@ -18,6 +18,7 @@
 #include "storage/v2/indices/label_index.hpp"
 #include "storage/v2/indices/label_index_stats.hpp"
 #include "storage/v2/vertex.hpp"
+#include "utils/observer.hpp"
 #include "utils/rw_lock.hpp"
 #include "utils/synchronized.hpp"
 
@@ -44,7 +45,8 @@ class InMemoryLabelIndex : public LabelIndex {
 
   /// @throw std::bad_alloc
   bool CreateIndex(LabelId label, utils::SkipList<Vertex>::Accessor vertices,
-                   const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info);
+                   const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info,
+                   std::shared_ptr<utils::Observer<void>> const snapshot_observer = nullptr);
 
   /// Returns false if there was no index to drop
   bool DropIndex(LabelId label) override;

--- a/src/storage/v2/inmemory/label_index.hpp
+++ b/src/storage/v2/inmemory/label_index.hpp
@@ -15,6 +15,7 @@
 
 #include "storage/v2/constraints/constraints.hpp"
 #include "storage/v2/durability/recovery_type.hpp"
+#include "storage/v2/indices/indices_utils.hpp"
 #include "storage/v2/indices/label_index.hpp"
 #include "storage/v2/indices/label_index_stats.hpp"
 #include "storage/v2/vertex.hpp"
@@ -46,7 +47,7 @@ class InMemoryLabelIndex : public LabelIndex {
   /// @throw std::bad_alloc
   bool CreateIndex(LabelId label, utils::SkipList<Vertex>::Accessor vertices,
                    const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info,
-                   std::shared_ptr<utils::Observer<void>> const snapshot_observer = nullptr);
+                   std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
 
   /// Returns false if there was no index to drop
   bool DropIndex(LabelId label) override;

--- a/src/storage/v2/inmemory/label_index.hpp
+++ b/src/storage/v2/inmemory/label_index.hpp
@@ -46,7 +46,7 @@ class InMemoryLabelIndex : public LabelIndex {
   /// @throw std::bad_alloc
   bool CreateIndex(LabelId label, utils::SkipList<Vertex>::Accessor vertices,
                    const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info,
-                   std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
+                   std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
   /// Returns false if there was no index to drop
   bool DropIndex(LabelId label) override;

--- a/src/storage/v2/inmemory/label_index.hpp
+++ b/src/storage/v2/inmemory/label_index.hpp
@@ -19,7 +19,6 @@
 #include "storage/v2/indices/label_index.hpp"
 #include "storage/v2/indices/label_index_stats.hpp"
 #include "storage/v2/vertex.hpp"
-#include "utils/observer.hpp"
 #include "utils/rw_lock.hpp"
 #include "utils/synchronized.hpp"
 

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -36,7 +36,7 @@ bool InMemoryLabelPropertyIndex::Entry::operator==(const PropertyValue &rhs) con
 bool InMemoryLabelPropertyIndex::CreateIndex(
     LabelId label, PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
     const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info,
-    std::optional<SnapshotObserverInfo> snapshot_info) {
+    std::optional<SnapshotObserverInfo> const &snapshot_info) {
   spdlog::trace("Vertices size when creating index: {}", vertices.size());
   auto create_index_seq = [this, &snapshot_info](
                               LabelId label, PropertyId property, utils::SkipList<Vertex>::Accessor &vertices,

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -16,6 +16,7 @@
 #include "storage/v2/constraints/constraints.hpp"
 #include "storage/v2/durability/recovery_type.hpp"
 #include "storage/v2/id_types.hpp"
+#include "storage/v2/indices/indices_utils.hpp"
 #include "storage/v2/indices/label_property_index.hpp"
 #include "storage/v2/indices/label_property_index_stats.hpp"
 #include "storage/v2/property_value.hpp"
@@ -45,7 +46,7 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
   /// @throw std::bad_alloc
   bool CreateIndex(LabelId label, PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
                    const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info,
-                   std::shared_ptr<utils::Observer<void>> const snapshot_observer = nullptr);
+                   std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
 
   /// @throw std::bad_alloc
   void UpdateOnAddLabel(LabelId added_label, Vertex *vertex_after_update, const Transaction &tx) override;

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -20,7 +20,6 @@
 #include "storage/v2/indices/label_property_index.hpp"
 #include "storage/v2/indices/label_property_index_stats.hpp"
 #include "storage/v2/property_value.hpp"
-#include "utils/observer.hpp"
 #include "utils/rw_lock.hpp"
 #include "utils/synchronized.hpp"
 

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -19,6 +19,7 @@
 #include "storage/v2/indices/label_property_index.hpp"
 #include "storage/v2/indices/label_property_index_stats.hpp"
 #include "storage/v2/property_value.hpp"
+#include "utils/observer.hpp"
 #include "utils/rw_lock.hpp"
 #include "utils/synchronized.hpp"
 
@@ -43,7 +44,8 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
 
   /// @throw std::bad_alloc
   bool CreateIndex(LabelId label, PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
-                   const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info);
+                   const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info,
+                   std::shared_ptr<utils::Observer<void>> const snapshot_observer = nullptr);
 
   /// @throw std::bad_alloc
   void UpdateOnAddLabel(LabelId added_label, Vertex *vertex_after_update, const Transaction &tx) override;

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -45,7 +45,7 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
   /// @throw std::bad_alloc
   bool CreateIndex(LabelId label, PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
                    const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info,
-                   std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
+                   std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
   /// @throw std::bad_alloc
   void UpdateOnAddLabel(LabelId added_label, Vertex *vertex_after_update, const Transaction &tx) override;

--- a/src/storage/v2/inmemory/replication/recovery.cpp
+++ b/src/storage/v2/inmemory/replication/recovery.cpp
@@ -88,7 +88,7 @@ replication::SnapshotRes TransferSnapshot(const utils::UUID &main_uuid, const ut
   auto stream = client.Stream<replication::SnapshotRpc>(main_uuid, storage_uuid);
   replication::Encoder encoder(stream.GetBuilder());
   encoder.WriteFile(path);
-  return stream.AwaitResponse();
+  return stream.AwaitResponseWhileInProgress();
 }
 
 replication::CurrentWalRes ReplicateCurrentWal(const utils::UUID &main_uuid, const InMemoryStorage *storage,

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1563,7 +1563,7 @@ InMemoryStorage::InMemoryAccessor::CreateExistenceConstraint(LabelId label, Prop
     return StorageExistenceConstraintDefinitionError{ConstraintDefinitionError{}};
   }
   if (auto violation = ExistenceConstraints::ValidateVerticesOnConstraint(in_memory->vertices_.access(), label,
-                                                                          property, std::nullopt);
+                                                                          property, std::nullopt, std::nullopt);
       violation.has_value()) {
     return StorageExistenceConstraintDefinitionError{violation.value()};
   }

--- a/src/storage/v2/inmemory/unique_constraints.cpp
+++ b/src/storage/v2/inmemory/unique_constraints.cpp
@@ -22,6 +22,7 @@
 namespace memgraph::storage {
 
 namespace {
+constexpr uint32_t kUniqueConstraintsVerticesSnapshotProgressSize = 1'000'000;
 
 /// Helper function that determines position of the given `property` in the
 /// sorted `property_array` using binary search. In the case that `property`
@@ -292,7 +293,8 @@ InMemoryUniqueConstraints::GetCreationFunction(
 
 bool InMemoryUniqueConstraints::MultipleThreadsConstraintValidation::operator()(
     const utils::SkipList<Vertex>::Accessor &vertex_accessor, utils::SkipList<Entry>::Accessor &constraint_accessor,
-    const LabelId &label, const std::set<PropertyId> &properties) {
+    const LabelId &label, const std::set<PropertyId> &properties,
+    std::shared_ptr<utils::Observer<void>> const snapshot_observer) {
   utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
   const auto &vertex_batches = parallel_exec_info.vertex_recovery_info;
   MG_ASSERT(!vertex_batches.empty(),
@@ -301,16 +303,16 @@ bool InMemoryUniqueConstraints::MultipleThreadsConstraintValidation::operator()(
   const auto thread_count = std::min(parallel_exec_info.thread_count, vertex_batches.size());
 
   std::atomic<uint64_t> batch_counter = 0;
-  memgraph::utils::Synchronized<std::optional<ConstraintViolation>, utils::RWSpinLock> has_error;
+  utils::Synchronized<std::optional<ConstraintViolation>, utils::RWSpinLock> has_error;
   {
     std::vector<std::jthread> threads;
     threads.reserve(thread_count);
     for (auto i{0U}; i < thread_count; ++i) {
-      threads.emplace_back(
-          [&has_error, &vertex_batches, &batch_counter, &vertex_accessor, &constraint_accessor, &label, &properties]() {
-            do_per_thread_validation(has_error, DoValidate, vertex_batches, batch_counter, vertex_accessor,
-                                     constraint_accessor, label, properties);
-          });
+      threads.emplace_back([&has_error, &vertex_batches, &batch_counter, &vertex_accessor, &constraint_accessor, &label,
+                            &properties, snapshot_observer]() {
+        do_per_thread_validation(has_error, DoValidate, vertex_batches, batch_counter, vertex_accessor,
+                                 snapshot_observer, constraint_accessor, label, properties);
+      });
     }
   }
   return has_error.Lock()->has_value();
@@ -318,10 +320,15 @@ bool InMemoryUniqueConstraints::MultipleThreadsConstraintValidation::operator()(
 
 bool InMemoryUniqueConstraints::SingleThreadConstraintValidation::operator()(
     const utils::SkipList<Vertex>::Accessor &vertex_accessor, utils::SkipList<Entry>::Accessor &constraint_accessor,
-    const LabelId &label, const std::set<PropertyId> &properties) {
+    const LabelId &label, const std::set<PropertyId> &properties,
+    std::shared_ptr<utils::Observer<void>> const snapshot_observer) {
+  auto batch_counter = utils::ResettableCounter<kUniqueConstraintsVerticesSnapshotProgressSize>();
   for (const Vertex &vertex : vertex_accessor) {
     if (const auto violation = DoValidate(vertex, constraint_accessor, label, properties); violation.has_value()) {
       return true;
+    }
+    if (snapshot_observer != nullptr && batch_counter()) {
+      snapshot_observer->Update();
     }
   }
   return false;
@@ -374,7 +381,8 @@ void InMemoryUniqueConstraints::AbortEntries(std::span<Vertex const *const> vert
 utils::BasicResult<ConstraintViolation, InMemoryUniqueConstraints::CreationStatus>
 InMemoryUniqueConstraints::CreateConstraint(
     LabelId label, const std::set<PropertyId> &properties, const utils::SkipList<Vertex>::Accessor &vertex_accessor,
-    const std::optional<durability::ParallelizedSchemaCreationInfo> &par_exec_info) {
+    const std::optional<durability::ParallelizedSchemaCreationInfo> &par_exec_info,
+    std::shared_ptr<utils::Observer<void>> const snapshot_observer) {
   if (properties.empty()) {
     return CreationStatus::EMPTY_PROPERTIES;
   }
@@ -385,14 +393,16 @@ InMemoryUniqueConstraints::CreateConstraint(
   if (constraints_.contains({label, properties})) {
     return CreationStatus::ALREADY_EXISTS;
   }
-  memgraph::utils::SkipList<Entry> constraints_skip_list;
+  utils::SkipList<Entry> constraints_skip_list;
   utils::SkipList<Entry>::Accessor constraint_accessor{constraints_skip_list.access()};
 
   auto multi_single_thread_processing = GetCreationFunction(par_exec_info);
 
-  bool violation_found = std::visit(
-      [&vertex_accessor, &constraint_accessor, &label, &properties](auto &multi_single_thread_processing) {
-        return multi_single_thread_processing(vertex_accessor, constraint_accessor, label, properties);
+  bool const violation_found = std::visit(
+      [&vertex_accessor, &constraint_accessor, &label, &properties,
+       snapshot_observer](auto &multi_single_thread_processing) {
+        return multi_single_thread_processing(vertex_accessor, constraint_accessor, label, properties,
+                                              snapshot_observer);
       },
       multi_single_thread_processing);
 

--- a/src/storage/v2/inmemory/unique_constraints.cpp
+++ b/src/storage/v2/inmemory/unique_constraints.cpp
@@ -322,7 +322,7 @@ bool InMemoryUniqueConstraints::SingleThreadConstraintValidation::operator()(
     if (const auto violation = DoValidate(vertex, constraint_accessor, label, properties); violation.has_value()) {
       return true;
     }
-    if (snapshot_info && snapshot_info->IncrementCounter()) {
+    if (snapshot_info) {
       snapshot_info->Update();
     }
   }

--- a/src/storage/v2/inmemory/unique_constraints.hpp
+++ b/src/storage/v2/inmemory/unique_constraints.hpp
@@ -19,8 +19,8 @@
 #include "storage/v2/constraints/unique_constraints.hpp"
 #include "storage/v2/durability/recovery_type.hpp"
 #include "storage/v2/id_types.hpp"
+#include "storage/v2/snapshot_observer_info.hpp"
 #include "utils/logging.hpp"
-#include "utils/observer.hpp"
 #include "utils/rw_spin_lock.hpp"
 #include "utils/skip_list.hpp"
 #include "utils/synchronized.hpp"
@@ -70,7 +70,7 @@ class InMemoryUniqueConstraints : public UniqueConstraints {
     bool operator()(const utils::SkipList<Vertex>::Accessor &vertex_accessor,
                     utils::SkipList<Entry>::Accessor &constraint_accessor, const LabelId &label,
                     const std::set<PropertyId> &properties,
-                    std::shared_ptr<utils::Observer<void>> const snapshot_observer = nullptr);
+                    std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
 
     const durability::ParallelizedSchemaCreationInfo &parallel_exec_info;
   };
@@ -78,7 +78,7 @@ class InMemoryUniqueConstraints : public UniqueConstraints {
     bool operator()(const utils::SkipList<Vertex>::Accessor &vertex_accessor,
                     utils::SkipList<Entry>::Accessor &constraint_accessor, const LabelId &label,
                     const std::set<PropertyId> &properties,
-                    std::shared_ptr<utils::Observer<void>> const snapshot_observer = nullptr);
+                    std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
   };
 
   /// Indexes the given vertex for relevant labels and properties.
@@ -101,7 +101,7 @@ class InMemoryUniqueConstraints : public UniqueConstraints {
   utils::BasicResult<ConstraintViolation, CreationStatus> CreateConstraint(
       LabelId label, const std::set<PropertyId> &properties, const utils::SkipList<Vertex>::Accessor &vertex_accessor,
       const std::optional<durability::ParallelizedSchemaCreationInfo> &par_exec_info,
-      std::shared_ptr<utils::Observer<void>> const snapshot_observer = nullptr);
+      std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
 
   /// Deletes the specified constraint. Returns `DeletionStatus::NOT_FOUND` if
   /// there is not such constraint in the storage,

--- a/src/storage/v2/inmemory/unique_constraints.hpp
+++ b/src/storage/v2/inmemory/unique_constraints.hpp
@@ -70,7 +70,7 @@ class InMemoryUniqueConstraints : public UniqueConstraints {
     bool operator()(const utils::SkipList<Vertex>::Accessor &vertex_accessor,
                     utils::SkipList<Entry>::Accessor &constraint_accessor, const LabelId &label,
                     const std::set<PropertyId> &properties,
-                    std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
+                    std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
     const durability::ParallelizedSchemaCreationInfo &parallel_exec_info;
   };
@@ -78,7 +78,7 @@ class InMemoryUniqueConstraints : public UniqueConstraints {
     bool operator()(const utils::SkipList<Vertex>::Accessor &vertex_accessor,
                     utils::SkipList<Entry>::Accessor &constraint_accessor, const LabelId &label,
                     const std::set<PropertyId> &properties,
-                    std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
+                    std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
   };
 
   /// Indexes the given vertex for relevant labels and properties.
@@ -101,7 +101,7 @@ class InMemoryUniqueConstraints : public UniqueConstraints {
   utils::BasicResult<ConstraintViolation, CreationStatus> CreateConstraint(
       LabelId label, const std::set<PropertyId> &properties, const utils::SkipList<Vertex>::Accessor &vertex_accessor,
       const std::optional<durability::ParallelizedSchemaCreationInfo> &par_exec_info,
-      std::optional<SnapshotObserverInfo> snapshot_info = std::nullopt);
+      std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
   /// Deletes the specified constraint. Returns `DeletionStatus::NOT_FOUND` if
   /// there is not such constraint in the storage,

--- a/src/storage/v2/snapshot_observer_info.hpp
+++ b/src/storage/v2/snapshot_observer_info.hpp
@@ -22,9 +22,11 @@ struct SnapshotObserverInfo {
   explicit SnapshotObserverInfo(std::shared_ptr<utils::Observer<void>> observer, uint32_t const item_batch_size)
       : observer_(std::move(observer)), cnt_(item_batch_size) {}
 
-  auto IncrementCounter() -> bool { return cnt_(); }
-
-  void Update() { observer_->Update(); }
+  void Update() {
+    if (cnt_()) {
+      observer_->Update();
+    }
+  }
 
  private:
   std::shared_ptr<utils::Observer<void>> observer_{nullptr};

--- a/src/storage/v2/snapshot_observer_info.hpp
+++ b/src/storage/v2/snapshot_observer_info.hpp
@@ -14,14 +14,20 @@
 #include <cstdint>
 #include <memory>
 
+#include "utils/counter.hpp"
 #include "utils/observer.hpp"
 
 namespace memgraph::storage {
-
 struct SnapshotObserverInfo {
-  std::shared_ptr<utils::Observer<void>> observer{nullptr};
-  // Used both for edges and vertices
-  uint32_t item_batch_size{1'000'000};
-};
+  explicit SnapshotObserverInfo(std::shared_ptr<utils::Observer<void>> observer, uint32_t const item_batch_size)
+      : observer_(std::move(observer)), cnt_(item_batch_size) {}
 
+  auto IncrementCounter() -> bool { return cnt_(); }
+
+  void Update() { observer_->Update(); }
+
+ private:
+  std::shared_ptr<utils::Observer<void>> observer_{nullptr};
+  utils::ResettableRuntimeCounter cnt_;
+};
 }  // namespace memgraph::storage

--- a/src/storage/v2/snapshot_observer_info.hpp
+++ b/src/storage/v2/snapshot_observer_info.hpp
@@ -1,0 +1,27 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+#include "utils/observer.hpp"
+
+namespace memgraph::storage {
+
+struct SnapshotObserverInfo {
+  std::shared_ptr<utils::Observer<void>> observer{nullptr};
+  // Used both for edges and vertices
+  uint32_t item_batch_size{1'000'000};
+};
+
+}  // namespace memgraph::storage

--- a/src/utils/counter.hpp
+++ b/src/utils/counter.hpp
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace memgraph::utils {
 
 /// A resettable counter, every Nth call returns true
@@ -23,5 +25,21 @@ auto ResettableCounter() {
     return true;
   };
 }
+
+struct ResettableRuntimeCounter {
+ public:
+  explicit ResettableRuntimeCounter(uint64_t original_size) : original_size_(original_size), current_(original_size) {}
+
+  bool operator()() {
+    --current_;
+    if (current_ != 0) return false;
+    current_ = original_size_;
+    return true;
+  }
+
+ private:
+  uint64_t original_size_;
+  uint64_t current_;
+};
 
 }  // namespace memgraph::utils

--- a/src/utils/counter.hpp
+++ b/src/utils/counter.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -11,11 +11,9 @@
 
 #pragma once
 
-#include <cstdint>
-
 namespace memgraph::utils {
 
-/// A resetable counter, every Nth call returns true
+/// A resettable counter, every Nth call returns true
 template <std::size_t N>
 auto ResettableCounter() {
   return [counter = N]() mutable {

--- a/src/utils/observer.hpp
+++ b/src/utils/observer.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -23,6 +23,14 @@ class Observer {
  public:
   virtual ~Observer() = default;
   virtual void Update(const T &) = 0;
+};
+
+template <>
+// Specialize for T = void
+class Observer<void> {
+ public:
+  virtual ~Observer() = default;
+  virtual void Update() = 0;
 };
 
 template <typename T>

--- a/tests/jepsen/src/memgraph/core.clj
+++ b/tests/jepsen/src/memgraph/core.clj
@@ -91,7 +91,7 @@
             :checker         (checker/compose
                               {:stats      (checker/stats)
                                :exceptions (unhandled-exceptions)
-                               :log-checker (checker/log-file-pattern #"[Aa]ssert*|Segmentation fault|core dumped|critical|NullPointerException|json.exception.parse_error" "memgraph.log")
+                               :log-checker (checker/log-file-pattern #"[Aa]ssert*|Segmentation fault|core dumped|critical|NullPointerException|json.exception.parse_error|Message response was of unexpected type|Received malformed message from cluster" "memgraph.log")
                                :workload   (:checker workload)})
             :nodes           (keys (:nodes-config opts))
             :nemesis         (:nemesis nemesis-config)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -447,6 +447,10 @@ target_link_libraries(${test_prefix}rpc_in_progress mg-rpc)
 add_unit_test(replication_rpc_progress.cpp)
 target_link_libraries(${test_prefix}replication_rpc_progress mg-rpc)
 
+# Test snapshot-rpc-progress
+add_unit_test(snapshot_rpc_progress.cpp)
+target_link_libraries(${test_prefix}snapshot_rpc_progress mg-rpc)
+
 # Test websocket
 find_package(Boost REQUIRED CONFIG)
 
@@ -476,6 +480,9 @@ target_include_directories(${test_prefix}distributed_lamport_clock PRIVATE ${CMA
 add_unit_test(query_hint_provider.cpp)
 target_link_libraries(${test_prefix}query_hint_provider mg-query mg-glue)
 
+
+add_unit_test(counter.cpp)
+target_link_libraries(${test_prefix}counter mg-utils)
 
 # Test coordination
 if(MG_ENTERPRISE)

--- a/tests/unit/counter.cpp
+++ b/tests/unit/counter.cpp
@@ -13,15 +13,36 @@
 
 #include "utils/counter.hpp"
 
+using memgraph::utils::ResettableAtomicCounter;
 using memgraph::utils::ResettableCounter;
-using memgraph::utils::ResettableRuntimeCounter;
 
-TEST(Counter, RuntimeCounter) {
-  auto cnt = ResettableRuntimeCounter{2};
-  ASSERT_FALSE(cnt());
-  ASSERT_TRUE(cnt());
-  ASSERT_FALSE(cnt());
-  ASSERT_TRUE(cnt());
+TEST(Counter, RuntimeCounterInc) {
+  auto cnt = ResettableAtomicCounter{2};
+  ASSERT_FALSE(cnt(1));
+  ASSERT_TRUE(cnt(1));
+  ASSERT_FALSE(cnt(1));
+  ASSERT_TRUE(cnt(1));
+}
+
+TEST(Counter, RuntimeCounterLarge) {
+  auto cnt = ResettableAtomicCounter{100};
+  ASSERT_FALSE(cnt(50));
+  ASSERT_FALSE(cnt(40));
+  ASSERT_TRUE(cnt(10));
+}
+
+TEST(Counter, RuntimeCounterLarge2) {
+  auto cnt = ResettableAtomicCounter{100};
+  ASSERT_TRUE(cnt(101));
+}
+
+TEST(Counter, RuntimeCounterLarge3) {
+  auto cnt = ResettableAtomicCounter{100};
+  ASSERT_FALSE(cnt(20));
+  ASSERT_FALSE(cnt(30));
+  ASSERT_FALSE(cnt(30));
+  ASSERT_FALSE(cnt(19));
+  ASSERT_TRUE(cnt(2));
 }
 
 TEST(Counter, CompiletimeCounter) {

--- a/tests/unit/counter.cpp
+++ b/tests/unit/counter.cpp
@@ -1,0 +1,33 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "gtest/gtest.h"
+
+#include "utils/counter.hpp"
+
+using memgraph::utils::ResettableCounter;
+using memgraph::utils::ResettableRuntimeCounter;
+
+TEST(Counter, RuntimeCounter) {
+  auto cnt = ResettableRuntimeCounter{2};
+  ASSERT_FALSE(cnt());
+  ASSERT_TRUE(cnt());
+  ASSERT_FALSE(cnt());
+  ASSERT_TRUE(cnt());
+}
+
+TEST(Counter, CompiletimeCounter) {
+  auto cnt = ResettableCounter<2>();
+  ASSERT_FALSE(cnt());
+  ASSERT_TRUE(cnt());
+  ASSERT_FALSE(cnt());
+  ASSERT_TRUE(cnt());
+}

--- a/tests/unit/snapshot_rpc_progress.cpp
+++ b/tests/unit/snapshot_rpc_progress.cpp
@@ -18,7 +18,10 @@
 #include "rpc/server.hpp"
 #include "rpc/utils.hpp"  // Needs to be included last so that SLK definitions are seen
 #include "storage/v2/indices/indices_utils.hpp"
+#include "storage/v2/inmemory/edge_type_index.hpp"
+#include "storage/v2/inmemory/edge_type_property_index.hpp"
 #include "storage/v2/inmemory/label_index.hpp"
+#include "storage/v2/inmemory/label_property_index.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "utils/observer.hpp"
 
@@ -31,10 +34,17 @@ using memgraph::rpc::Server;
 using memgraph::slk::Load;
 using memgraph::slk::Save;
 using memgraph::storage::Config;
+using memgraph::storage::Edge;
+using memgraph::storage::EdgeRef;
+using memgraph::storage::EdgeTypeId;
 using memgraph::storage::Gid;
+using memgraph::storage::InMemoryEdgeTypeIndex;
+using memgraph::storage::InMemoryEdgeTypePropertyIndex;
 using memgraph::storage::InMemoryLabelIndex;
+using memgraph::storage::InMemoryLabelPropertyIndex;
 using memgraph::storage::InMemoryStorage;
 using memgraph::storage::LabelId;
+using memgraph::storage::PropertyId;
 using memgraph::storage::SnapshotObserverInfo;
 using memgraph::storage::Vertex;
 using memgraph::storage::durability::ParallelizedSchemaCreationInfo;
@@ -48,7 +58,34 @@ using memgraph::utils::UUID;
 using namespace std::string_view_literals;
 using namespace std::literals::chrono_literals;
 
-class SnapshotRpcProgressTest : public ::testing::Test {};
+class SnapshotRpcProgressTest : public ::testing::Test {
+ public:
+  std::filesystem::path main_directory{std::filesystem::temp_directory_path() /
+                                       "MG_test_unit_snapshot_rpc_progress_main"};
+  void SetUp() override { Clear(); }
+
+  void TearDown() override { Clear(); }
+
+  void Clear() const {
+    if (std::filesystem::exists(main_directory)) {
+      std::filesystem::remove_all(main_directory);
+    }
+  }
+
+  Config main_conf = [&] {
+    Config config{
+        .durability =
+            {
+                .snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
+            },
+        .salient.items = {.properties_on_edges = false},
+    };
+    UpdatePaths(config, main_directory);
+    return config;
+  }();
+
+  InMemoryStorage storage{main_conf};
+};
 
 class MockedSnapshotObserver final : public Observer<void> {
  public:
@@ -64,10 +101,10 @@ TEST_F(SnapshotRpcProgressTest, TestLabelIndexSingleThreadedNoVertices) {
   auto vertices = SkipList<Vertex>();
   std::optional<ParallelizedSchemaCreationInfo> par_schema_info = std::nullopt;
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .vertices_snapshot_progress_size = 3};
+  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 3};
 
   EXPECT_CALL(*mocked_observer, Update()).Times(0);
-  label_idx.CreateIndex(label, vertices.access(), par_schema_info, snapshot_info);
+  ASSERT_TRUE(label_idx.CreateIndex(label, vertices.access(), par_schema_info, snapshot_info));
 }
 
 TEST_F(SnapshotRpcProgressTest, TestLabelIndexSingleThreadedVertices) {
@@ -86,9 +123,9 @@ TEST_F(SnapshotRpcProgressTest, TestLabelIndexSingleThreadedVertices) {
   std::optional<ParallelizedSchemaCreationInfo> par_schema_info = std::nullopt;
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .vertices_snapshot_progress_size = 2};
+  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 2};
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
-  label_idx.CreateIndex(label, vertices.access(), par_schema_info, snapshot_info);
+  ASSERT_TRUE(label_idx.CreateIndex(label, vertices.access(), par_schema_info, snapshot_info));
 }
 
 TEST_F(SnapshotRpcProgressTest, TestLabelIndexMultiThreadedVertices) {
@@ -109,9 +146,69 @@ TEST_F(SnapshotRpcProgressTest, TestLabelIndexMultiThreadedVertices) {
       .thread_count = 2};
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .vertices_snapshot_progress_size = 2};
+  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 2};
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
-  label_idx.CreateIndex(label, vertices.access(), par_schema_info, snapshot_info);
+  ASSERT_TRUE(label_idx.CreateIndex(label, vertices.access(), par_schema_info, snapshot_info));
+}
+
+TEST_F(SnapshotRpcProgressTest, TestLabelPropertyIndexSingleThreadedNoVertices) {
+  InMemoryLabelPropertyIndex label_prop_idx;
+
+  auto label = LabelId::FromUint(1);
+  auto prop = PropertyId::FromUint(1);
+  auto vertices = SkipList<Vertex>();
+  std::optional<ParallelizedSchemaCreationInfo> par_schema_info = std::nullopt;
+  auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
+  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 3};
+
+  EXPECT_CALL(*mocked_observer, Update()).Times(0);
+  ASSERT_TRUE(label_prop_idx.CreateIndex(label, prop, vertices.access(), par_schema_info, snapshot_info));
+}
+
+TEST_F(SnapshotRpcProgressTest, TestLabelPropertyIndexSingleThreadedVertices) {
+  InMemoryLabelPropertyIndex label_prop_idx;
+
+  auto label = LabelId::FromUint(1);
+  auto prop = PropertyId::FromUint(1);
+  auto vertices = SkipList<Vertex>();
+  {
+    auto acc = vertices.access();
+    for (uint32_t i = 1; i <= 5; i++) {
+      auto [_, inserted] = acc.insert(Vertex{Gid::FromUint(i), nullptr});
+      ASSERT_TRUE(inserted);
+    }
+  }
+
+  std::optional<ParallelizedSchemaCreationInfo> par_schema_info = std::nullopt;
+
+  auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
+  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 2};
+  EXPECT_CALL(*mocked_observer, Update()).Times(2);
+  ASSERT_TRUE(label_prop_idx.CreateIndex(label, prop, vertices.access(), par_schema_info, snapshot_info));
+}
+
+TEST_F(SnapshotRpcProgressTest, TestLabelPropertyIndexMultiThreadedVertices) {
+  InMemoryLabelPropertyIndex label_prop_idx;
+
+  auto label = LabelId::FromUint(1);
+  auto prop = PropertyId::FromUint(1);
+  auto vertices = SkipList<Vertex>();
+  {
+    auto acc = vertices.access();
+    for (uint32_t i = 1; i <= 5; i++) {
+      auto [_, inserted] = acc.insert(Vertex{Gid::FromUint(i), nullptr});
+      ASSERT_TRUE(inserted);
+    }
+  }
+
+  auto par_schema_info = ParallelizedSchemaCreationInfo{
+      .vertex_recovery_info = std::vector<std::pair<Gid, uint64_t>>{{Gid::FromUint(1), 2}, {Gid::FromUint(3), 3}},
+      .thread_count = 2};
+
+  auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
+  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 2};
+  EXPECT_CALL(*mocked_observer, Update()).Times(2);
+  ASSERT_TRUE(label_prop_idx.CreateIndex(label, prop, vertices.access(), par_schema_info, snapshot_info));
 }
 
 TEST_F(SnapshotRpcProgressTest, SnapshotRpcNoTimeout) {
@@ -204,4 +301,78 @@ TEST_F(SnapshotRpcProgressTest, SnapshotRpcTimeout) {
 
   auto stream = client.Stream<SnapshotRpc>(UUID{}, UUID{});
   EXPECT_THROW(stream.AwaitResponseWhileInProgress(), GenericRpcFailedException);
+}
+
+TEST_F(SnapshotRpcProgressTest, TestEdgeTypeIndexSingleThreadedNoVertices) {
+  InMemoryEdgeTypeIndex etype_idx;
+
+  auto etype = EdgeTypeId::FromUint(1);
+  auto vertices = SkipList<Vertex>();
+  auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
+  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 3};
+
+  EXPECT_CALL(*mocked_observer, Update()).Times(0);
+  ASSERT_TRUE(etype_idx.CreateIndex(etype, vertices.access(), snapshot_info));
+}
+
+TEST_F(SnapshotRpcProgressTest, TestEdgeTypeIndexSingleThreadedVerticesEdges) {
+  InMemoryEdgeTypeIndex etype_idx;
+
+  auto etype = EdgeTypeId::FromUint(1);
+  auto vertices = SkipList<Vertex>();
+  {
+    auto acc = vertices.access();
+    for (uint32_t i = 1; i <= 11; i++) {
+      auto vertex = Vertex{Gid::FromUint(i), nullptr};
+      EdgeRef edge_ref(Gid::FromUint(1));
+      vertex.out_edges.emplace_back(etype, &vertex, edge_ref);
+      auto [_, inserted] = acc.insert(std::move(vertex));
+      ASSERT_TRUE(inserted);
+    }
+  }
+  auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
+  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 3};
+
+  EXPECT_CALL(*mocked_observer, Update()).Times(3);
+  ASSERT_TRUE(etype_idx.CreateIndex(etype, vertices.access(), snapshot_info));
+}
+
+TEST_F(SnapshotRpcProgressTest, TestEdgeTypePropertyIndexSingleThreadedNoVertices) {
+  InMemoryEdgeTypePropertyIndex etype_idx;
+
+  auto etype = EdgeTypeId::FromUint(1);
+  auto prop = PropertyId::FromUint(1);
+  auto vertices = SkipList<Vertex>();
+  auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
+  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 3};
+
+  EXPECT_CALL(*mocked_observer, Update()).Times(0);
+  ASSERT_TRUE(etype_idx.CreateIndex(etype, prop, vertices.access(), snapshot_info));
+}
+
+TEST_F(SnapshotRpcProgressTest, TestEdgeTypePropertyIndexSingleThreadedVerticesEdges) {
+  InMemoryEdgeTypePropertyIndex etype_idx;
+
+  auto etype = EdgeTypeId::FromUint(1);
+  auto prop = PropertyId::FromUint(1);
+  auto vertices = SkipList<Vertex>();
+  auto edges = SkipList<Edge>();
+  {
+    auto acc = vertices.access();
+    auto edge_acc = edges.access();
+    for (uint32_t i = 1; i <= 7; i++) {
+      auto vertex = Vertex{Gid::FromUint(i), nullptr};
+      auto [edge, inserted] = edge_acc.insert(Edge{Gid::FromUint(i), nullptr});
+      ASSERT_TRUE(inserted);
+      auto edge_ref = EdgeRef{&*edge};
+      vertex.out_edges.emplace_back(etype, &vertex, edge_ref);
+      auto [_, ver_inserted] = acc.insert(std::move(vertex));
+      ASSERT_TRUE(ver_inserted);
+    }
+  }
+  auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
+  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 3};
+
+  EXPECT_CALL(*mocked_observer, Update()).Times(2);
+  ASSERT_TRUE(etype_idx.CreateIndex(etype, prop, vertices.access(), snapshot_info));
 }

--- a/tests/unit/snapshot_rpc_progress.cpp
+++ b/tests/unit/snapshot_rpc_progress.cpp
@@ -124,7 +124,8 @@ TEST_F(SnapshotRpcProgressTest, TestLabelIndexSingleThreadedNoVertices) {
   auto vertices = SkipList<Vertex>();
   std::optional<ParallelizedSchemaCreationInfo> par_schema_info = std::nullopt;
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
+  std::optional<SnapshotObserverInfo> snapshot_info;
+  snapshot_info.emplace(mocked_observer, 3);
 
   EXPECT_CALL(*mocked_observer, Update()).Times(0);
   ASSERT_TRUE(label_idx.CreateIndex(label, vertices.access(), par_schema_info, snapshot_info));
@@ -146,7 +147,8 @@ TEST_F(SnapshotRpcProgressTest, TestLabelIndexSingleThreadedVertices) {
   std::optional<ParallelizedSchemaCreationInfo> par_schema_info = std::nullopt;
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{mocked_observer, 2};
+  std::optional<SnapshotObserverInfo> snapshot_info;
+  snapshot_info.emplace(mocked_observer, 2);
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
   ASSERT_TRUE(label_idx.CreateIndex(label, vertices.access(), par_schema_info, snapshot_info));
 }
@@ -169,7 +171,8 @@ TEST_F(SnapshotRpcProgressTest, TestLabelIndexMultiThreadedVertices) {
       .thread_count = 2};
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{mocked_observer, 2};
+  std::optional<SnapshotObserverInfo> snapshot_info;
+  snapshot_info.emplace(mocked_observer, 2);
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
   ASSERT_TRUE(label_idx.CreateIndex(label, vertices.access(), par_schema_info, snapshot_info));
 }
@@ -182,7 +185,8 @@ TEST_F(SnapshotRpcProgressTest, TestLabelPropertyIndexSingleThreadedNoVertices) 
   auto vertices = SkipList<Vertex>();
   std::optional<ParallelizedSchemaCreationInfo> par_schema_info = std::nullopt;
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
+  std::optional<SnapshotObserverInfo> snapshot_info;
+  snapshot_info.emplace(mocked_observer, 3);
 
   EXPECT_CALL(*mocked_observer, Update()).Times(0);
   ASSERT_TRUE(label_prop_idx.CreateIndex(label, prop, vertices.access(), par_schema_info, snapshot_info));
@@ -205,7 +209,8 @@ TEST_F(SnapshotRpcProgressTest, TestLabelPropertyIndexSingleThreadedVertices) {
   std::optional<ParallelizedSchemaCreationInfo> par_schema_info = std::nullopt;
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{mocked_observer, 2};
+  std::optional<SnapshotObserverInfo> snapshot_info;
+  snapshot_info.emplace(mocked_observer, 2);
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
   ASSERT_TRUE(label_prop_idx.CreateIndex(label, prop, vertices.access(), par_schema_info, snapshot_info));
 }
@@ -229,7 +234,8 @@ TEST_F(SnapshotRpcProgressTest, TestLabelPropertyIndexMultiThreadedVertices) {
       .thread_count = 2};
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{mocked_observer, 2};
+  std::optional<SnapshotObserverInfo> snapshot_info;
+  snapshot_info.emplace(mocked_observer, 2);
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
   ASSERT_TRUE(label_prop_idx.CreateIndex(label, prop, vertices.access(), par_schema_info, snapshot_info));
 }
@@ -332,7 +338,8 @@ TEST_F(SnapshotRpcProgressTest, TestEdgeTypeIndexSingleThreadedNoVertices) {
   auto etype = EdgeTypeId::FromUint(1);
   auto vertices = SkipList<Vertex>();
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
+  std::optional<SnapshotObserverInfo> snapshot_info;
+  snapshot_info.emplace(mocked_observer, 3);
 
   EXPECT_CALL(*mocked_observer, Update()).Times(0);
   ASSERT_TRUE(etype_idx.CreateIndex(etype, vertices.access(), snapshot_info));
@@ -354,7 +361,8 @@ TEST_F(SnapshotRpcProgressTest, TestEdgeTypeIndexSingleThreadedVerticesEdges) {
     }
   }
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
+  std::optional<SnapshotObserverInfo> snapshot_info;
+  snapshot_info.emplace(mocked_observer, 3);
 
   EXPECT_CALL(*mocked_observer, Update()).Times(3);
   ASSERT_TRUE(etype_idx.CreateIndex(etype, vertices.access(), snapshot_info));
@@ -367,7 +375,8 @@ TEST_F(SnapshotRpcProgressTest, TestEdgeTypePropertyIndexSingleThreadedNoVertice
   auto prop = PropertyId::FromUint(1);
   auto vertices = SkipList<Vertex>();
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
+  std::optional<SnapshotObserverInfo> snapshot_info;
+  snapshot_info.emplace(mocked_observer, 3);
 
   EXPECT_CALL(*mocked_observer, Update()).Times(0);
   ASSERT_TRUE(etype_idx.CreateIndex(etype, prop, vertices.access(), snapshot_info));
@@ -394,7 +403,8 @@ TEST_F(SnapshotRpcProgressTest, TestEdgeTypePropertyIndexSingleThreadedVerticesE
     }
   }
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
+  std::optional<SnapshotObserverInfo> snapshot_info;
+  snapshot_info.emplace(mocked_observer, 3);
 
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
   ASSERT_TRUE(etype_idx.CreateIndex(etype, prop, vertices.access(), snapshot_info));
@@ -407,7 +417,8 @@ TEST_F(SnapshotRpcProgressTest, TestPointIndexSingleThreadedNoVertices) {
   auto prop = PropertyId::FromUint(1);
   auto vertices = SkipList<Vertex>();
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
+  std::optional<SnapshotObserverInfo> snapshot_info;
+  snapshot_info.emplace(mocked_observer, 3);
 
   EXPECT_CALL(*mocked_observer, Update()).Times(0);
   ASSERT_TRUE(point_idx.CreatePointIndex(label, prop, vertices.access(), snapshot_info));
@@ -434,7 +445,8 @@ TEST_F(SnapshotRpcProgressTest, TestPointIndexSingleThreadedVertices) {
   }
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{mocked_observer, 4};
+  std::optional<SnapshotObserverInfo> snapshot_info;
+  snapshot_info.emplace(mocked_observer, 40);
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
   ASSERT_TRUE(point_idx.CreatePointIndex(label, prop, vertices.access(), snapshot_info));
 }
@@ -450,7 +462,8 @@ TEST_F(SnapshotRpcProgressTest, TestVectorIndexSingleThreadedNoVertices) {
   auto vertices = SkipList<Vertex>();
   auto vertices_acc = vertices.access();
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
+  std::optional<SnapshotObserverInfo> snapshot_info;
+  snapshot_info.emplace(mocked_observer, 3);
 
   EXPECT_CALL(*mocked_observer, Update()).Times(0);
   ASSERT_TRUE(vector_idx.CreateIndex(spec, vertices_acc, snapshot_info));
@@ -477,7 +490,8 @@ TEST_F(SnapshotRpcProgressTest, TestVectorIndexSingleThreadedVertices) {
   }
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{mocked_observer, 4};
+  std::optional<SnapshotObserverInfo> snapshot_info;
+  snapshot_info.emplace(mocked_observer, 4000);
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
   ASSERT_TRUE(vector_idx.CreateIndex(spec, vertices_acc, snapshot_info));
 }
@@ -487,7 +501,8 @@ TEST_F(SnapshotRpcProgressTest, TestExistenceConstraintsSingleThreadedNoVertices
   auto prop = PropertyId::FromUint(1);
   auto vertices = SkipList<Vertex>();
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
+  std::optional<SnapshotObserverInfo> snapshot_info;
+  snapshot_info.emplace(mocked_observer, 3);
 
   EXPECT_CALL(*mocked_observer, Update()).Times(0);
 
@@ -516,7 +531,8 @@ TEST_F(SnapshotRpcProgressTest, TestExistenceConstraintsSingleThreadedVertices) 
   }
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{mocked_observer, 4};
+  std::optional<SnapshotObserverInfo> snapshot_info;
+  snapshot_info.emplace(mocked_observer, 4);
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
 
   auto maybe_violation =
@@ -544,7 +560,8 @@ TEST_F(SnapshotRpcProgressTest, TestExistenceConstraintsMultiThreadedVertices) {
   }
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
+  std::optional<SnapshotObserverInfo> snapshot_info;
+  snapshot_info.emplace(mocked_observer, 3);
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
 
   auto par_schema_info = ParallelizedSchemaCreationInfo{
@@ -562,7 +579,8 @@ TEST_F(SnapshotRpcProgressTest, TestUniqueConstraintsSingleThreadedNoVertices) {
   auto vertices = SkipList<Vertex>();
   auto vertices_acc = vertices.access();
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
+  std::optional<SnapshotObserverInfo> snapshot_info;
+  snapshot_info.emplace(mocked_observer, 3);
 
   EXPECT_CALL(*mocked_observer, Update()).Times(0);
 
@@ -594,7 +612,8 @@ TEST_F(SnapshotRpcProgressTest, TestUniqueConstraintsSingleThreadedVertices) {
   }
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{mocked_observer, 4};
+  std::optional<SnapshotObserverInfo> snapshot_info;
+  snapshot_info.emplace(mocked_observer, 4);
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
 
   InMemoryUniqueConstraints unique_constraints;
@@ -625,7 +644,8 @@ TEST_F(SnapshotRpcProgressTest, TestUniqueConstraintsMultiThreadedVertices) {
   }
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
+  std::optional<SnapshotObserverInfo> snapshot_info;
+  snapshot_info.emplace(mocked_observer, 3);
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
 
   auto par_schema_info = ParallelizedSchemaCreationInfo{
@@ -645,7 +665,8 @@ TEST_F(SnapshotRpcProgressTest, TestTypeConstraintsSingleThreadedNoVertices) {
   auto vertices = SkipList<Vertex>();
   auto vertices_acc = vertices.access();
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
+  std::optional<SnapshotObserverInfo> snapshot_info;
+  snapshot_info.emplace(mocked_observer, 3);
 
   EXPECT_CALL(*mocked_observer, Update()).Times(0);
 
@@ -676,7 +697,8 @@ TEST_F(SnapshotRpcProgressTest, TestTypeConstraintsSingleThreadedVertices) {
   }
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{mocked_observer, 4};
+  std::optional<SnapshotObserverInfo> snapshot_info;
+  snapshot_info.emplace(mocked_observer, 4);
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
 
   TypeConstraints type_constraints;

--- a/tests/unit/snapshot_rpc_progress.cpp
+++ b/tests/unit/snapshot_rpc_progress.cpp
@@ -348,9 +348,9 @@ TEST_F(SnapshotRpcProgressTest, TestEdgeTypeIndexSingleThreadedVerticesEdges) {
     for (uint32_t i = 1; i <= 11; i++) {
       auto vertex = Vertex{Gid::FromUint(i), nullptr};
       EdgeRef edge_ref(Gid::FromUint(1));
-      vertex.out_edges.emplace_back(etype, &vertex, edge_ref);
-      auto [_, inserted] = acc.insert(std::move(vertex));
+      auto [it, inserted] = acc.insert(std::move(vertex));
       ASSERT_TRUE(inserted);
+      it->out_edges.emplace_back(etype, &*it, edge_ref);
     }
   }
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
@@ -388,9 +388,9 @@ TEST_F(SnapshotRpcProgressTest, TestEdgeTypePropertyIndexSingleThreadedVerticesE
       auto [edge, inserted] = edge_acc.insert(Edge{Gid::FromUint(i), nullptr});
       ASSERT_TRUE(inserted);
       auto edge_ref = EdgeRef{&*edge};
-      vertex.out_edges.emplace_back(etype, &vertex, edge_ref);
-      auto [_, ver_inserted] = acc.insert(std::move(vertex));
+      auto [it, ver_inserted] = acc.insert(std::move(vertex));
       ASSERT_TRUE(ver_inserted);
+      it->out_edges.emplace_back(etype, &*it, edge_ref);
     }
   }
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();

--- a/tests/unit/snapshot_rpc_progress.cpp
+++ b/tests/unit/snapshot_rpc_progress.cpp
@@ -14,11 +14,22 @@
 
 #include <optional>
 
+#include "rpc/client.hpp"
+#include "rpc/server.hpp"
+#include "rpc/utils.hpp"  // Needs to be included last so that SLK definitions are seen
 #include "storage/v2/indices/indices_utils.hpp"
 #include "storage/v2/inmemory/label_index.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "utils/observer.hpp"
 
+using memgraph::communication::ClientContext;
+using memgraph::communication::ServerContext;
+using memgraph::io::network::Endpoint;
+using memgraph::rpc::Client;
+using memgraph::rpc::GenericRpcFailedException;
+using memgraph::rpc::Server;
+using memgraph::slk::Load;
+using memgraph::slk::Save;
 using memgraph::storage::Config;
 using memgraph::storage::Gid;
 using memgraph::storage::InMemoryLabelIndex;
@@ -27,8 +38,12 @@ using memgraph::storage::LabelId;
 using memgraph::storage::SnapshotObserverInfo;
 using memgraph::storage::Vertex;
 using memgraph::storage::durability::ParallelizedSchemaCreationInfo;
+using memgraph::storage::replication::SnapshotReq;
+using memgraph::storage::replication::SnapshotRes;
+using memgraph::storage::replication::SnapshotRpc;
 using memgraph::utils::Observer;
 using memgraph::utils::SkipList;
+using memgraph::utils::UUID;
 
 using namespace std::string_view_literals;
 using namespace std::literals::chrono_literals;
@@ -39,6 +54,8 @@ class MockedSnapshotObserver final : public Observer<void> {
  public:
   MOCK_METHOD(void, Update, (), (override));
 };
+
+constexpr int port{8184};
 
 TEST_F(SnapshotRpcProgressTest, TestLabelIndexSingleThreadedNoVertices) {
   InMemoryLabelIndex label_idx;
@@ -72,4 +89,119 @@ TEST_F(SnapshotRpcProgressTest, TestLabelIndexSingleThreadedVertices) {
   SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .vertices_snapshot_progress_size = 2};
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
   label_idx.CreateIndex(label, vertices.access(), par_schema_info, snapshot_info);
+}
+
+TEST_F(SnapshotRpcProgressTest, TestLabelIndexMultiThreadedVertices) {
+  InMemoryLabelIndex label_idx;
+
+  auto label = LabelId::FromUint(1);
+  auto vertices = SkipList<Vertex>();
+  {
+    auto acc = vertices.access();
+    for (uint32_t i = 1; i <= 5; i++) {
+      auto [_, inserted] = acc.insert(Vertex{Gid::FromUint(i), nullptr});
+      ASSERT_TRUE(inserted);
+    }
+  }
+
+  auto par_schema_info = ParallelizedSchemaCreationInfo{
+      .vertex_recovery_info = std::vector<std::pair<Gid, uint64_t>>{{Gid::FromUint(1), 2}, {Gid::FromUint(3), 3}},
+      .thread_count = 2};
+
+  auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
+  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .vertices_snapshot_progress_size = 2};
+  EXPECT_CALL(*mocked_observer, Update()).Times(2);
+  label_idx.CreateIndex(label, vertices.access(), par_schema_info, snapshot_info);
+}
+
+TEST_F(SnapshotRpcProgressTest, SnapshotRpcNoTimeout) {
+  Endpoint endpoint{"localhost", port};
+
+  ServerContext server_context;
+  Server rpc_server{endpoint, &server_context, /* workers */ 1};
+  auto const on_exit = memgraph::utils::OnScopeExit{[&rpc_server] {
+    rpc_server.Shutdown();
+    rpc_server.AwaitShutdown();
+  }};
+
+  rpc_server.Register<SnapshotRpc>([](auto *req_reader, auto *res_builder) {
+    SnapshotReq req;
+    Load(&req, req_reader);
+    SnapshotRes res{true};
+    memgraph::rpc::SendFinalResponse(res, res_builder);
+  });
+
+  ASSERT_TRUE(rpc_server.Start());
+  std::this_thread::sleep_for(100ms);
+
+  auto const rpc_timeouts = std::unordered_map{std::make_pair("SnapshotReq"sv, 150)};
+  ClientContext client_context;
+  Client client{endpoint, &client_context, rpc_timeouts};
+
+  auto stream = client.Stream<SnapshotRpc>(UUID{}, UUID{});
+  EXPECT_NO_THROW(stream.AwaitResponseWhileInProgress());
+}
+
+TEST_F(SnapshotRpcProgressTest, SnapshotRpcProgress) {
+  Endpoint endpoint{"localhost", port};
+
+  ServerContext server_context;
+  Server rpc_server{endpoint, &server_context, /* workers */ 1};
+  auto const on_exit = memgraph::utils::OnScopeExit{[&rpc_server] {
+    rpc_server.Shutdown();
+    rpc_server.AwaitShutdown();
+  }};
+
+  rpc_server.Register<SnapshotRpc>([](auto *req_reader, auto *res_builder) {
+    SnapshotReq req;
+    Load(&req, req_reader);
+    std::this_thread::sleep_for(10ms);
+    memgraph::rpc::SendInProgressMsg(res_builder);
+    std::this_thread::sleep_for(10ms);
+    memgraph::rpc::SendInProgressMsg(res_builder);
+    std::this_thread::sleep_for(10ms);
+    SnapshotRes res{true};
+    memgraph::rpc::SendFinalResponse(res, res_builder);
+  });
+
+  ASSERT_TRUE(rpc_server.Start());
+  std::this_thread::sleep_for(100ms);
+
+  auto const rpc_timeouts = std::unordered_map{std::make_pair("SnapshotReq"sv, 150)};
+  ClientContext client_context;
+  Client client{endpoint, &client_context, rpc_timeouts};
+
+  auto stream = client.Stream<SnapshotRpc>(UUID{}, UUID{});
+  EXPECT_NO_THROW(stream.AwaitResponseWhileInProgress());
+}
+
+TEST_F(SnapshotRpcProgressTest, SnapshotRpcTimeout) {
+  Endpoint endpoint{"localhost", port};
+
+  ServerContext server_context;
+  Server rpc_server{endpoint, &server_context, /* workers */ 1};
+  auto const on_exit = memgraph::utils::OnScopeExit{[&rpc_server] {
+    rpc_server.Shutdown();
+    rpc_server.AwaitShutdown();
+  }};
+
+  rpc_server.Register<SnapshotRpc>([](auto *req_reader, auto *res_builder) {
+    SnapshotReq req;
+    Load(&req, req_reader);
+    std::this_thread::sleep_for(75ms);
+    memgraph::rpc::SendInProgressMsg(res_builder);
+    std::this_thread::sleep_for(10ms);
+    SnapshotRes res{true};
+    memgraph::rpc::SendFinalResponse(res, res_builder);
+  });
+
+  ASSERT_TRUE(rpc_server.Start());
+  std::this_thread::sleep_for(100ms);
+
+  auto const rpc_timeouts = std::unordered_map{std::make_pair("SnapshotReq"sv, 25)};
+  ClientContext client_context;
+  Client client{endpoint, &client_context, rpc_timeouts};
+
+  auto stream = client.Stream<SnapshotRpc>(UUID{}, UUID{});
+  EXPECT_THROW(stream.AwaitResponseWhileInProgress(), GenericRpcFailedException);
 }

--- a/tests/unit/snapshot_rpc_progress.cpp
+++ b/tests/unit/snapshot_rpc_progress.cpp
@@ -124,7 +124,7 @@ TEST_F(SnapshotRpcProgressTest, TestLabelIndexSingleThreadedNoVertices) {
   auto vertices = SkipList<Vertex>();
   std::optional<ParallelizedSchemaCreationInfo> par_schema_info = std::nullopt;
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 3};
+  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
 
   EXPECT_CALL(*mocked_observer, Update()).Times(0);
   ASSERT_TRUE(label_idx.CreateIndex(label, vertices.access(), par_schema_info, snapshot_info));
@@ -146,7 +146,7 @@ TEST_F(SnapshotRpcProgressTest, TestLabelIndexSingleThreadedVertices) {
   std::optional<ParallelizedSchemaCreationInfo> par_schema_info = std::nullopt;
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 2};
+  SnapshotObserverInfo snapshot_info{mocked_observer, 2};
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
   ASSERT_TRUE(label_idx.CreateIndex(label, vertices.access(), par_schema_info, snapshot_info));
 }
@@ -169,7 +169,7 @@ TEST_F(SnapshotRpcProgressTest, TestLabelIndexMultiThreadedVertices) {
       .thread_count = 2};
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 2};
+  SnapshotObserverInfo snapshot_info{mocked_observer, 2};
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
   ASSERT_TRUE(label_idx.CreateIndex(label, vertices.access(), par_schema_info, snapshot_info));
 }
@@ -182,7 +182,7 @@ TEST_F(SnapshotRpcProgressTest, TestLabelPropertyIndexSingleThreadedNoVertices) 
   auto vertices = SkipList<Vertex>();
   std::optional<ParallelizedSchemaCreationInfo> par_schema_info = std::nullopt;
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 3};
+  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
 
   EXPECT_CALL(*mocked_observer, Update()).Times(0);
   ASSERT_TRUE(label_prop_idx.CreateIndex(label, prop, vertices.access(), par_schema_info, snapshot_info));
@@ -205,7 +205,7 @@ TEST_F(SnapshotRpcProgressTest, TestLabelPropertyIndexSingleThreadedVertices) {
   std::optional<ParallelizedSchemaCreationInfo> par_schema_info = std::nullopt;
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 2};
+  SnapshotObserverInfo snapshot_info{mocked_observer, 2};
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
   ASSERT_TRUE(label_prop_idx.CreateIndex(label, prop, vertices.access(), par_schema_info, snapshot_info));
 }
@@ -229,7 +229,7 @@ TEST_F(SnapshotRpcProgressTest, TestLabelPropertyIndexMultiThreadedVertices) {
       .thread_count = 2};
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 2};
+  SnapshotObserverInfo snapshot_info{mocked_observer, 2};
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
   ASSERT_TRUE(label_prop_idx.CreateIndex(label, prop, vertices.access(), par_schema_info, snapshot_info));
 }
@@ -332,7 +332,7 @@ TEST_F(SnapshotRpcProgressTest, TestEdgeTypeIndexSingleThreadedNoVertices) {
   auto etype = EdgeTypeId::FromUint(1);
   auto vertices = SkipList<Vertex>();
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 3};
+  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
 
   EXPECT_CALL(*mocked_observer, Update()).Times(0);
   ASSERT_TRUE(etype_idx.CreateIndex(etype, vertices.access(), snapshot_info));
@@ -354,7 +354,7 @@ TEST_F(SnapshotRpcProgressTest, TestEdgeTypeIndexSingleThreadedVerticesEdges) {
     }
   }
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 3};
+  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
 
   EXPECT_CALL(*mocked_observer, Update()).Times(3);
   ASSERT_TRUE(etype_idx.CreateIndex(etype, vertices.access(), snapshot_info));
@@ -367,7 +367,7 @@ TEST_F(SnapshotRpcProgressTest, TestEdgeTypePropertyIndexSingleThreadedNoVertice
   auto prop = PropertyId::FromUint(1);
   auto vertices = SkipList<Vertex>();
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 3};
+  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
 
   EXPECT_CALL(*mocked_observer, Update()).Times(0);
   ASSERT_TRUE(etype_idx.CreateIndex(etype, prop, vertices.access(), snapshot_info));
@@ -394,7 +394,7 @@ TEST_F(SnapshotRpcProgressTest, TestEdgeTypePropertyIndexSingleThreadedVerticesE
     }
   }
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 3};
+  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
 
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
   ASSERT_TRUE(etype_idx.CreateIndex(etype, prop, vertices.access(), snapshot_info));
@@ -407,7 +407,7 @@ TEST_F(SnapshotRpcProgressTest, TestPointIndexSingleThreadedNoVertices) {
   auto prop = PropertyId::FromUint(1);
   auto vertices = SkipList<Vertex>();
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 3};
+  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
 
   EXPECT_CALL(*mocked_observer, Update()).Times(0);
   ASSERT_TRUE(point_idx.CreatePointIndex(label, prop, vertices.access(), snapshot_info));
@@ -434,7 +434,7 @@ TEST_F(SnapshotRpcProgressTest, TestPointIndexSingleThreadedVertices) {
   }
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 4};
+  SnapshotObserverInfo snapshot_info{mocked_observer, 4};
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
   ASSERT_TRUE(point_idx.CreatePointIndex(label, prop, vertices.access(), snapshot_info));
 }
@@ -450,7 +450,7 @@ TEST_F(SnapshotRpcProgressTest, TestVectorIndexSingleThreadedNoVertices) {
   auto vertices = SkipList<Vertex>();
   auto vertices_acc = vertices.access();
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 3};
+  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
 
   EXPECT_CALL(*mocked_observer, Update()).Times(0);
   ASSERT_TRUE(vector_idx.CreateIndex(spec, vertices_acc, snapshot_info));
@@ -477,7 +477,7 @@ TEST_F(SnapshotRpcProgressTest, TestVectorIndexSingleThreadedVertices) {
   }
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 4};
+  SnapshotObserverInfo snapshot_info{mocked_observer, 4};
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
   ASSERT_TRUE(vector_idx.CreateIndex(spec, vertices_acc, snapshot_info));
 }
@@ -487,7 +487,7 @@ TEST_F(SnapshotRpcProgressTest, TestExistenceConstraintsSingleThreadedNoVertices
   auto prop = PropertyId::FromUint(1);
   auto vertices = SkipList<Vertex>();
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 3};
+  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
 
   EXPECT_CALL(*mocked_observer, Update()).Times(0);
 
@@ -516,7 +516,7 @@ TEST_F(SnapshotRpcProgressTest, TestExistenceConstraintsSingleThreadedVertices) 
   }
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 4};
+  SnapshotObserverInfo snapshot_info{mocked_observer, 4};
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
 
   auto maybe_violation =
@@ -544,7 +544,7 @@ TEST_F(SnapshotRpcProgressTest, TestExistenceConstraintsMultiThreadedVertices) {
   }
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 3};
+  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
 
   auto par_schema_info = ParallelizedSchemaCreationInfo{
@@ -562,7 +562,7 @@ TEST_F(SnapshotRpcProgressTest, TestUniqueConstraintsSingleThreadedNoVertices) {
   auto vertices = SkipList<Vertex>();
   auto vertices_acc = vertices.access();
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 3};
+  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
 
   EXPECT_CALL(*mocked_observer, Update()).Times(0);
 
@@ -594,7 +594,7 @@ TEST_F(SnapshotRpcProgressTest, TestUniqueConstraintsSingleThreadedVertices) {
   }
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 4};
+  SnapshotObserverInfo snapshot_info{mocked_observer, 4};
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
 
   InMemoryUniqueConstraints unique_constraints;
@@ -625,7 +625,7 @@ TEST_F(SnapshotRpcProgressTest, TestUniqueConstraintsMultiThreadedVertices) {
   }
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 3};
+  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
 
   auto par_schema_info = ParallelizedSchemaCreationInfo{
@@ -645,7 +645,7 @@ TEST_F(SnapshotRpcProgressTest, TestTypeConstraintsSingleThreadedNoVertices) {
   auto vertices = SkipList<Vertex>();
   auto vertices_acc = vertices.access();
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 3};
+  SnapshotObserverInfo snapshot_info{mocked_observer, 3};
 
   EXPECT_CALL(*mocked_observer, Update()).Times(0);
 
@@ -676,7 +676,7 @@ TEST_F(SnapshotRpcProgressTest, TestTypeConstraintsSingleThreadedVertices) {
   }
 
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
-  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .item_batch_size = 4};
+  SnapshotObserverInfo snapshot_info{mocked_observer, 4};
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
 
   TypeConstraints type_constraints;

--- a/tests/unit/snapshot_rpc_progress.cpp
+++ b/tests/unit/snapshot_rpc_progress.cpp
@@ -78,7 +78,7 @@ using namespace std::literals::chrono_literals;
 
 static constexpr unum::usearch::metric_kind_t metric = unum::usearch::metric_kind_t::l2sq_k;
 static constexpr std::size_t resize_coefficient = 2;
-static constexpr uint16_t kDimension = 16;
+static constexpr uint16_t kDimension = 2;
 static constexpr uint16_t kCapacity = 16;
 
 class SnapshotRpcProgressTest : public ::testing::Test {
@@ -480,10 +480,15 @@ TEST_F(SnapshotRpcProgressTest, TestVectorIndexSingleThreadedVertices) {
   auto vertices = SkipList<Vertex>();
   auto vertices_acc = vertices.access();
 
+  const std::vector<std::pair<PropertyId, PropertyValue>> prop_data{
+      std::pair{prop, PropertyValue{std::vector<PropertyValue>{PropertyValue(1.0), PropertyValue(1.0)}}}};
+
   {
     auto acc = vertices.access();
     for (uint32_t i = 1; i <= 8; i++) {
       auto vertex = Vertex{Gid::FromUint(i), nullptr};
+      vertex.labels.emplace_back(label);
+      vertex.properties.InitProperties(prop_data);
       auto [_, inserted] = acc.insert(std::move(vertex));
       ASSERT_TRUE(inserted);
     }

--- a/tests/unit/snapshot_rpc_progress.cpp
+++ b/tests/unit/snapshot_rpc_progress.cpp
@@ -1,0 +1,75 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include <optional>
+
+#include "storage/v2/indices/indices_utils.hpp"
+#include "storage/v2/inmemory/label_index.hpp"
+#include "storage/v2/inmemory/storage.hpp"
+#include "utils/observer.hpp"
+
+using memgraph::storage::Config;
+using memgraph::storage::Gid;
+using memgraph::storage::InMemoryLabelIndex;
+using memgraph::storage::InMemoryStorage;
+using memgraph::storage::LabelId;
+using memgraph::storage::SnapshotObserverInfo;
+using memgraph::storage::Vertex;
+using memgraph::storage::durability::ParallelizedSchemaCreationInfo;
+using memgraph::utils::Observer;
+using memgraph::utils::SkipList;
+
+using namespace std::string_view_literals;
+using namespace std::literals::chrono_literals;
+
+class SnapshotRpcProgressTest : public ::testing::Test {};
+
+class MockedSnapshotObserver final : public Observer<void> {
+ public:
+  MOCK_METHOD(void, Update, (), (override));
+};
+
+TEST_F(SnapshotRpcProgressTest, TestLabelIndexSingleThreadedNoVertices) {
+  InMemoryLabelIndex label_idx;
+
+  auto label = LabelId::FromUint(1);
+  auto vertices = SkipList<Vertex>();
+  std::optional<ParallelizedSchemaCreationInfo> par_schema_info = std::nullopt;
+  auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
+  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .vertices_snapshot_progress_size = 3};
+
+  EXPECT_CALL(*mocked_observer, Update()).Times(0);
+  label_idx.CreateIndex(label, vertices.access(), par_schema_info, snapshot_info);
+}
+
+TEST_F(SnapshotRpcProgressTest, TestLabelIndexSingleThreadedVertices) {
+  InMemoryLabelIndex label_idx;
+
+  auto label = LabelId::FromUint(1);
+  auto vertices = SkipList<Vertex>();
+  {
+    auto acc = vertices.access();
+    for (uint32_t i = 1; i <= 5; i++) {
+      auto [_, inserted] = acc.insert(Vertex{Gid::FromUint(i), nullptr});
+      ASSERT_TRUE(inserted);
+    }
+  }
+
+  std::optional<ParallelizedSchemaCreationInfo> par_schema_info = std::nullopt;
+
+  auto mocked_observer = std::make_shared<MockedSnapshotObserver>();
+  SnapshotObserverInfo snapshot_info{.observer = mocked_observer, .vertices_snapshot_progress_size = 2};
+  EXPECT_CALL(*mocked_observer, Update()).Times(2);
+  label_idx.CreateIndex(label, vertices.access(), par_schema_info, snapshot_info);
+}

--- a/tests/unit/vector_index.cpp
+++ b/tests/unit/vector_index.cpp
@@ -50,6 +50,7 @@ class VectorSearchTest : public testing::Test {
     // Create a specification for the index
     const auto spec =
         VectorIndexSpec{test_index.data(), label, property, metric, dimension, resize_coefficient, capacity};
+
     EXPECT_FALSE(unique_acc->CreateVectorIndex(spec).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
   }

--- a/tests/unit/vector_index.cpp
+++ b/tests/unit/vector_index.cpp
@@ -453,9 +453,12 @@ TYPED_TEST(VectorSearchTest, CreateIndexWhenNodesExistsAlreadyTest) {
     auto acc = this->storage->Access();
 
     PropertyValue properties(std::vector<PropertyValue>{PropertyValue(1.0), PropertyValue(1.0)});
-    [[maybe_unused]] const auto vertex = this->CreateVertex(acc.get(), test_property, properties, test_label);
+    static constexpr std::string_view test_label_2 = "test_label2";
+    [[maybe_unused]] const auto vertex1 = this->CreateVertex(acc.get(), test_property, properties, test_label);
+    [[maybe_unused]] const auto vertex2 = this->CreateVertex(acc.get(), test_property, properties, test_label_2);
     ASSERT_NO_ERROR(acc->Commit());
   }
+  // Index created with test_label. The vertex vertex2 shouldn't be seen
   this->CreateIndex(2, 10);
 
   // Expect the index to have 1 entry


### PR DESCRIPTION
Added timeout to SnaphotRpc message. The in-progress response message will be sent for every 1'000'000 units of work performed. Processing vertices, edges, vertices inside label index, vertices inside property index, edges inside edge type index, edges inside edge type property index is worth one unit of work. Processing vertices inside point and text indices takes a bit more time so it's worth 10 units of work. The processing of vertices inside vector indices takes longest so it's worth 1000 units of work. 

Delivered also a multi threaded circular counter using lock-free techniques. Progress observer is implemented using push observer design pattern. 

Replica should approximately send updates every 2-3s. Hence, a timeout of 60s should be more than enough.


Also delivered the bugfix for vector indices which didn't check whether vertices contain labels.

