### PR TITLE
Robust handling around memory limits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 cmake_minimum_required(VERSION 3.12)
 cmake_policy(SET CMP0076 NEW)
+cmake_policy(SET CMP0135 NEW)
 
 # !! IMPORTANT !! run ./project_root/init.sh before cmake command
 # to download dependencies

--- a/include/mg_exceptions.hpp
+++ b/include/mg_exceptions.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -36,23 +36,18 @@ struct UnknownException : public std::exception {
 };
 
 struct NotEnoughMemoryException : public std::exception {
-  NotEnoughMemoryException()
-      : message_{
-            StringSerialize("Not enough memory! For more details please visit", "https://memgr.ph/memory-control")} {}
-  const char *what() const noexcept override { return message_.c_str(); }
-
- private:
-  std::string message_;
+  NotEnoughMemoryException() {}
+  const char *what() const noexcept override {
+    return "Not enough memory! For more details please visit https://memgr.ph/memory-control";
+  }
 };
 
 struct AllocationException : public std::exception {
-  AllocationException()
-      : message_{StringSerialize("Could not allocate memory. For more details please visit",
-                                 "https://memgr.ph/memory-control")} {}
-  const char *what() const noexcept override { return message_.c_str(); }
-
- private:
-  std::string message_;
+  AllocationException(){};
+  const char *what() const noexcept override {
+    return "Could not allocate memory. For more details please visit "
+           "https://memgr.ph/memory-control";
+  }
 };
 
 struct InsufficientBufferException : public std::exception {

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -291,7 +291,7 @@ import_external_library(rocksdb STATIC
 macro(build_bcrypt)
   import_external_library(libbcrypt STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/libbcrypt/bcrypt.a
-    ${CMAKE_CURRENT_SOURCE_DIR}/libbcrypt
+    ${CMAKE_CURRENT_SOURCE_DIR}
     CONFIGURE_COMMAND sed s/-Wcast-align// -i ${CMAKE_CURRENT_SOURCE_DIR}/libbcrypt/crypt_blowfish/Makefile
     BUILD_COMMAND make -C ${CMAKE_CURRENT_SOURCE_DIR}/libbcrypt
     CC=${CMAKE_C_COMPILER}

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,5 +1,5 @@
 include(ExternalProject)
-
+include(FetchContent)
 include(GNUInstallDirs)
 
 include(ProcessorCount)
@@ -268,7 +268,14 @@ mg_create_linkable_if_no_cmake(gmock_main STATIC "${MG_TOOLCHAIN_ROOT}/lib/libgm
 import_header_library(cppitertools ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Setup json
-import_header_library(json ${CMAKE_CURRENT_SOURCE_DIR})
+FetchContent_Declare(
+    nlohmann_json
+    URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
+    URL_HASH SHA256=d6c65aca6b1ed68e7a182f4757257b107ae403032760ed6ef121c9d55e81757d
+    PATCH_COMMAND patch -p1 < "${CMAKE_CURRENT_SOURCE_DIR}/nlohmann_json3.11.3.patch"
+    # FIND_PACKAGE_ARGS # maybe needed for FETCHCONTENT_TRY_FIND_PACKAGE_MODE OPT_IN
+)
+FetchContent_MakeAvailable(nlohmann_json)
 
 import_external_library(rocksdb STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/rocksdb/lib/librocksdb.a

--- a/libs/nlohmann_json3.11.3.patch
+++ b/libs/nlohmann_json3.11.3.patch
@@ -1,0 +1,208 @@
+diff --git a/include/nlohmann/json.hpp b/include/nlohmann/json.hpp
+index 95d6bf1d..65d0ce3e 100644
+--- a/include/nlohmann/json.hpp
++++ b/include/nlohmann/json.hpp
+@@ -565,51 +565,65 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
+             }
+             if (t == value_t::array || t == value_t::object)
+             {
+-                // flatten the current json_value to a heap-allocated stack
+-                std::vector<basic_json> stack;
+-
+-                // move the top-level items to stack
+-                if (t == value_t::array)
+-                {
+-                    stack.reserve(array->size());
+-                    std::move(array->begin(), array->end(), std::back_inserter(stack));
+-                }
+-                else
++#if (defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND))
++                try
+                 {
+-                    stack.reserve(object->size());
+-                    for (auto&& it : *object)
+-                    {
+-                        stack.push_back(std::move(it.second));
+-                    }
+-                }
+-
+-                while (!stack.empty())
+-                {
+-                    // move the last item to local variable to be processed
+-                    basic_json current_item(std::move(stack.back()));
+-                    stack.pop_back();
++#endif
++                    // flatten the current json_value to a heap-allocated stack
++                    std::vector<basic_json, allocator_type> stack;
+
+-                    // if current_item is array/object, move
+-                    // its children to the stack to be processed later
+-                    if (current_item.is_array())
++                    // move the top-level items to stack
++                    if (t == value_t::array)
+                     {
+-                        std::move(current_item.m_data.m_value.array->begin(), current_item.m_data.m_value.array->end(), std::back_inserter(stack));
+-
+-                        current_item.m_data.m_value.array->clear();
++                        stack.reserve(array->size());
++                        std::move(array->begin(), array->end(), std::back_inserter(stack));
+                     }
+-                    else if (current_item.is_object())
++                    else
+                     {
+-                        for (auto&& it : *current_item.m_data.m_value.object)
++                        stack.reserve(object->size());
++                        for (auto&& it : *object)
+                         {
+                             stack.push_back(std::move(it.second));
+                         }
+-
+-                        current_item.m_data.m_value.object->clear();
+                     }
+
+-                    // it's now safe that current_item get destructed
+-                    // since it doesn't have any children
++                    while (!stack.empty())
++                    {
++                        // move the last item to local variable to be processed
++                        basic_json current_item(std::move(stack.back()));
++                        stack.pop_back();
++
++                        // if current_item is array/object, move
++                        // its children to the stack to be processed later
++                        if (current_item.is_array())
++                        {
++                            std::move(current_item.m_data.m_value.array->begin(), current_item.m_data.m_value.array->end(), std::back_inserter(stack));
++
++                            current_item.m_data.m_value.array->clear();
++                        }
++                        else if (current_item.is_object())
++                        {
++                            for (auto&& it : *current_item.m_data.m_value.object)
++                            {
++                                stack.push_back(std::move(it.second));
++                            }
++
++                            current_item.m_data.m_value.object->clear();
++                        }
++
++                        // it's now safe that current_item get destructed
++                        // since it doesn't have any children
++                    }
++#if (defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND))
+                 }
++                catch (...)     // NOLINT(bugprone-empty-catch)
++                {
++                    // Recursion avoidance has issue allocating temporary space. This may have been `std::bad_alloc`
++                    // or any other exception thrown by a custom allocator.
++                    // RAII will correctly clean up anything moved into `stack`.
++                    // Then we continue with regular recursion based destroy, which will not heap allocate.
++                }
++#endif
+             }
+
+             switch (t)
+diff --git a/single_include/nlohmann/json.hpp b/single_include/nlohmann/json.hpp
+index 8b72ea65..09a23168 100644
+--- a/single_include/nlohmann/json.hpp
++++ b/single_include/nlohmann/json.hpp
+@@ -19867,51 +19867,65 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
+             }
+             if (t == value_t::array || t == value_t::object)
+             {
+-                // flatten the current json_value to a heap-allocated stack
+-                std::vector<basic_json> stack;
+-
+-                // move the top-level items to stack
+-                if (t == value_t::array)
+-                {
+-                    stack.reserve(array->size());
+-                    std::move(array->begin(), array->end(), std::back_inserter(stack));
+-                }
+-                else
+-                {
+-                    stack.reserve(object->size());
+-                    for (auto&& it : *object)
+-                    {
+-                        stack.push_back(std::move(it.second));
+-                    }
+-                }
+-
+-                while (!stack.empty())
++#if (defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND))
++                try
+                 {
+-                    // move the last item to local variable to be processed
+-                    basic_json current_item(std::move(stack.back()));
+-                    stack.pop_back();
++#endif
++                    // flatten the current json_value to a heap-allocated stack
++                    std::vector<basic_json, allocator_type> stack;
+
+-                    // if current_item is array/object, move
+-                    // its children to the stack to be processed later
+-                    if (current_item.is_array())
++                    // move the top-level items to stack
++                    if (t == value_t::array)
+                     {
+-                        std::move(current_item.m_data.m_value.array->begin(), current_item.m_data.m_value.array->end(), std::back_inserter(stack));
+-
+-                        current_item.m_data.m_value.array->clear();
++                        stack.reserve(array->size());
++                        std::move(array->begin(), array->end(), std::back_inserter(stack));
+                     }
+-                    else if (current_item.is_object())
++                    else
+                     {
+-                        for (auto&& it : *current_item.m_data.m_value.object)
++                        stack.reserve(object->size());
++                        for (auto&& it : *object)
+                         {
+                             stack.push_back(std::move(it.second));
+                         }
+-
+-                        current_item.m_data.m_value.object->clear();
+                     }
+
+-                    // it's now safe that current_item get destructed
+-                    // since it doesn't have any children
++                    while (!stack.empty())
++                    {
++                        // move the last item to local variable to be processed
++                        basic_json current_item(std::move(stack.back()));
++                        stack.pop_back();
++
++                        // if current_item is array/object, move
++                        // its children to the stack to be processed later
++                        if (current_item.is_array())
++                        {
++                            std::move(current_item.m_data.m_value.array->begin(), current_item.m_data.m_value.array->end(), std::back_inserter(stack));
++
++                            current_item.m_data.m_value.array->clear();
++                        }
++                        else if (current_item.is_object())
++                        {
++                            for (auto&& it : *current_item.m_data.m_value.object)
++                            {
++                                stack.push_back(std::move(it.second));
++                            }
++
++                            current_item.m_data.m_value.object->clear();
++                        }
++
++                        // it's now safe that current_item get destructed
++                        // since it doesn't have any children
++                    }
++#if (defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND))
+                 }
++                catch (...)     // NOLINT(bugprone-empty-catch)
++                {
++                    // Recursion avoidance has issue allocating temporary space. This may have been `std::bad_alloc`
++                    // or any other exception thrown by a custom allocator.
++                    // RAII will correctly clean up anything moved into `stack`.
++                    // Then we continue with regular recursion based destroy, which will not heap allocate.
++                }
++#endif
+             }
+
+             switch (t)

--- a/libs/setup.sh
+++ b/libs/setup.sh
@@ -149,7 +149,6 @@ declare -A primary_urls=(
   ["mgclient"]="http://$local_cache_host/git/mgclient.git"
   ["mgconsole"]="http://$local_cache_host/git/mgconsole.git"
   ["spdlog"]="http://$local_cache_host/git/spdlog"
-  ["nlohmann"]="http://$local_cache_host/file/nlohmann/json/4f8fba14066156b73f1189a2b8bd568bde5284c5/single_include/nlohmann/json.hpp"
   ["neo4j"]="http://$local_cache_host/file/neo4j-community-5.6.0-unix.tar.gz"
   ["librdkafka"]="http://$local_cache_host/git/librdkafka.git"
   ["protobuf"]="http://$local_cache_host/git/protobuf.git"
@@ -183,7 +182,6 @@ declare -A secondary_urls=(
   ["mgclient"]="https://github.com/memgraph/mgclient.git"
   ["mgconsole"]="https://github.com/memgraph/mgconsole.git"
   ["spdlog"]="https://github.com/gabime/spdlog"
-  ["nlohmann"]="https://raw.githubusercontent.com/nlohmann/json/4f8fba14066156b73f1189a2b8bd568bde5284c5/single_include/nlohmann/json.hpp"
   ["neo4j"]="https://dist.neo4j.org/neo4j-community-5.6.0-unix.tar.gz"
   ["librdkafka"]="https://github.com/edenhill/librdkafka.git"
   ["protobuf"]="https://github.com/protocolbuffers/protobuf.git"
@@ -239,14 +237,6 @@ file_get_try_double "${primary_urls[neo4j]}" "${secondary_urls[neo4j]}"
 tar -xzf neo4j-community-5.6.0-unix.tar.gz
 mv neo4j-community-5.6.0 neo4j
 rm neo4j-community-5.6.0-unix.tar.gz
-
-# nlohmann json
-# We wget header instead of cloning repo since repo is huge (lots of test data).
-# We use head on Sep 1, 2017 instead of last release since it was long time ago.
-mkdir -p json
-cd json
-file_get_try_double "${primary_urls[nlohmann]}" "${secondary_urls[nlohmann]}"
-cd ..
 
 rocksdb_tag="v8.1.1" # (2023-04-21)
 repo_clone_try_double "${primary_urls[rocksdb]}" "${secondary_urls[rocksdb]}" "rocksdb" "$rocksdb_tag" true

--- a/query_modules/CMakeLists.txt
+++ b/query_modules/CMakeLists.txt
@@ -89,7 +89,7 @@ install(FILES vector_search_module.cpp DESTINATION lib/memgraph/query_modules/sr
 add_library(convert SHARED convert.cpp)
 target_include_directories(convert PRIVATE ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/libs)
 target_compile_options(convert PRIVATE -Wall)
-target_link_libraries(convert PRIVATE -static-libgcc -static-libstdc++ fmt::fmt json)
+target_link_libraries(convert PRIVATE -static-libgcc -static-libstdc++ fmt::fmt nlohmann_json::nlohmann_json)
 
 add_post_build_strip_in_release(convert CMAKE_BUILD_TYPE)
 

--- a/query_modules/convert.cpp
+++ b/query_modules/convert.cpp
@@ -12,7 +12,8 @@
 #include <iostream>
 #include <mgp.hpp>
 #include <optional>
-#include "json/json.hpp"
+
+#include <nlohmann/json.hpp>
 
 std::optional<mgp::Value> ParseJsonToMgpValue(const nlohmann::json &json_obj, mgp_memory *memory);
 

--- a/src/audit/CMakeLists.txt
+++ b/src/audit/CMakeLists.txt
@@ -4,5 +4,5 @@ find_package(fmt REQUIRED)
 find_package(gflags REQUIRED)
 
 add_library(mg-audit STATIC ${audit_src_files})
-target_link_libraries(mg-audit json gflags fmt::fmt)
+target_link_libraries(mg-audit nlohmann_json::nlohmann_json gflags fmt::fmt)
 target_link_libraries(mg-audit mg-utils mg-communication)

--- a/src/audit/log.cpp
+++ b/src/audit/log.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Licensed as a Memgraph Enterprise file under the Memgraph Enterprise
 // License (the "License"); by using this file, you agree to be bound by the terms of the License, and you may not use
@@ -11,7 +11,7 @@
 #include <sstream>
 
 #include <fmt/format.h>
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 #include <utility>
 
 #include "communication/bolt/v1/mg_types.hpp"

--- a/src/auth/CMakeLists.txt
+++ b/src/auth/CMakeLists.txt
@@ -1,18 +1,18 @@
-set(auth_src_files
+add_library(mg-auth STATIC)
+target_sources(mg-auth PRIVATE
     auth.cpp
     crypto.cpp
     models.cpp
     module.cpp
     rpc.cpp
-    replication_handlers.cpp)
+    replication_handlers.cpp
+)
 
 find_package(Seccomp REQUIRED)
 find_package(fmt REQUIRED)
 find_package(gflags REQUIRED)
 
-
-add_library(mg-auth STATIC ${auth_src_files})
-target_link_libraries(mg-auth json libbcrypt gflags fmt::fmt)
+target_link_libraries(mg-auth nlohmann_json::nlohmann_json libbcrypt gflags fmt::fmt)
 target_link_libraries(mg-auth mg-utils mg-kvstore mg-license mg::system mg-replication)
 
 target_link_libraries(mg-auth ${Seccomp_LIBRARIES})

--- a/src/auth/crypto.hpp
+++ b/src/auth/crypto.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Licensed as a Memgraph Enterprise file under the Memgraph Enterprise
 // License (the "License"); by using this file, you agree to be bound by the terms of the License, and you may not use
@@ -12,7 +12,7 @@
 #include <optional>
 #include <string>
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 namespace memgraph::auth {
 /// Need to be stable, auth durability depends on this

--- a/src/auth/models.hpp
+++ b/src/auth/models.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Licensed as a Memgraph Enterprise file under the Memgraph Enterprise
 // License (the "License"); by using this file, you agree to be bound by the terms of the License, and you may not use
@@ -13,7 +13,7 @@
 #include <string>
 #include <unordered_map>
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 #include <utility>
 #include "crypto.hpp"
 #include "dbms/constants.hpp"

--- a/src/auth/module.hpp
+++ b/src/auth/module.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Licensed as a Memgraph Enterprise file under the Memgraph Enterprise
 // License (the "License"); by using this file, you agree to be bound by the terms of the License, and you may not use
@@ -14,7 +14,7 @@
 #include <mutex>
 #include <string>
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 namespace memgraph::auth {
 struct TargetArguments {

--- a/src/auth/rpc.cpp
+++ b/src/auth/rpc.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -11,7 +11,7 @@
 
 #include "auth/rpc.hpp"
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 #include "auth/auth.hpp"
 #include "slk/serialization.hpp"
 #include "slk/streams.hpp"

--- a/src/communication/CMakeLists.txt
+++ b/src/communication/CMakeLists.txt
@@ -18,7 +18,7 @@ set(communication_src_files
 find_package(Boost REQUIRED CONFIG)
 
 add_library(mg-communication-metrics STATIC metrics.cpp)
-target_link_libraries(mg-communication-metrics json)
+target_link_libraries(mg-communication-metrics nlohmann_json::nlohmann_json)
 
 add_library(mg-communication STATIC ${communication_src_files})
 target_link_libraries(mg-communication Boost::headers Threads::Threads mg-utils mg-io mg-auth fmt::fmt gflags mg-communication-metrics mg-events mg-storage-v2)

--- a/src/communication/http/session.hpp
+++ b/src/communication/http/session.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -28,7 +28,7 @@
 #include <boost/beast/http.hpp>
 #include <boost/beast/ssl.hpp>
 #include <boost/beast/version.hpp>
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "communication/context.hpp"
 #include "utils/logging.hpp"

--- a/src/communication/metrics.hpp
+++ b/src/communication/metrics.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -18,7 +18,7 @@
 #include <string>
 #include <vector>
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 namespace memgraph::communication {
 

--- a/src/communication/websocket/session.cpp
+++ b/src/communication/websocket/session.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -20,7 +20,7 @@
 #include <boost/asio/bind_executor.hpp>
 #include <boost/beast/core/buffers_to_string.hpp>
 #include <boost/beast/core/stream_traits.hpp>
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "communication/context.hpp"
 #include "communication/websocket/auth.hpp"

--- a/src/communication/websocket/session.hpp
+++ b/src/communication/websocket/session.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -22,7 +22,7 @@
 #include <boost/beast/core/tcp_stream.hpp>
 #include <boost/beast/ssl.hpp>
 #include <boost/beast/websocket.hpp>
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "communication/context.hpp"
 #include "communication/websocket/auth.hpp"

--- a/src/coordination/coordination_observer.cpp
+++ b/src/coordination/coordination_observer.cpp
@@ -14,7 +14,7 @@
 #include "coordination/coordination_observer.hpp"
 #include "coordination/coordinator_instance.hpp"
 
-#include "json/json.hpp"
+#include <nlohmann/json.hpp>
 
 namespace memgraph::coordination {
 

--- a/src/coordination/coordinator_communication_config.cpp
+++ b/src/coordination/coordinator_communication_config.cpp
@@ -14,7 +14,7 @@
 #include "coordination/coordinator_communication_config.hpp"
 #include "utils/uuid.hpp"
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 #include <string>
 
 namespace memgraph::coordination {

--- a/src/coordination/coordinator_log_store.cpp
+++ b/src/coordination/coordinator_log_store.cpp
@@ -20,7 +20,8 @@
 #include "kvstore/kvstore.hpp"
 
 #include <ranges>
-#include "json/json.hpp"
+
+#include <nlohmann/json.hpp>
 
 namespace memgraph::coordination {
 using nuraft::buffer_serializer;

--- a/src/coordination/include/coordination/coordinator_cluster_state.hpp
+++ b/src/coordination/include/coordination/coordinator_cluster_state.hpp
@@ -21,8 +21,8 @@
 #include "utils/uuid.hpp"
 
 #include <libnuraft/nuraft.hxx>
+#include <nlohmann/json.hpp>
 #include <range/v3/view.hpp>
-#include "json/json.hpp"
 
 #include <string>
 

--- a/src/coordination/include/coordination/coordinator_communication_config.hpp
+++ b/src/coordination/include/coordination/coordinator_communication_config.hpp
@@ -25,7 +25,7 @@
 #include <string>
 #include <utility>
 
-#include "json/json.hpp"
+#include <nlohmann/json.hpp>
 
 namespace memgraph::coordination {
 

--- a/src/coordination/include/coordination/coordinator_instance_aux.hpp
+++ b/src/coordination/include/coordination/coordinator_instance_aux.hpp
@@ -14,7 +14,7 @@
 #include <cstdint>
 #include <string>
 
-#include "json/json.hpp"
+#include <nlohmann/json.hpp>
 
 #ifdef MG_ENTERPRISE
 

--- a/src/coordination/include/coordination/coordinator_instance_context.hpp
+++ b/src/coordination/include/coordination/coordinator_instance_context.hpp
@@ -14,7 +14,7 @@
 #include <cstdint>
 #include <string>
 
-#include "json/json.hpp"
+#include <nlohmann/json.hpp>
 
 #ifdef MG_ENTERPRISE
 

--- a/src/coordination/include/coordination/data_instance_context.hpp
+++ b/src/coordination/include/coordination/data_instance_context.hpp
@@ -15,7 +15,7 @@
 #include "replication_coordination_glue/role.hpp"
 #include "utils/uuid.hpp"
 
-#include "json/json.hpp"
+#include <nlohmann/json.hpp>
 
 #ifdef MG_ENTERPRISE
 

--- a/src/coordination/raft_state.cpp
+++ b/src/coordination/raft_state.cpp
@@ -30,7 +30,7 @@
 #include "utils/logging.hpp"
 
 #include <spdlog/spdlog.h>
-#include "json/json.hpp"
+#include <nlohmann/json.hpp>
 
 namespace {
 constexpr std::string_view kStateMgrDurabilityPath = "network";

--- a/src/flags/experimental.cpp
+++ b/src/flags/experimental.cpp
@@ -14,7 +14,7 @@
 #include <string_view>
 #include <type_traits>
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 #include "flags/experimental.hpp"
 #include "range/v3/all.hpp"
 #include "utils/flag_validation.hpp"

--- a/src/flags/experimental.hpp
+++ b/src/flags/experimental.hpp
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 #include <string>
 
 #include "gflags/gflags.h"

--- a/src/http_handlers/metrics.hpp
+++ b/src/http_handlers/metrics.hpp
@@ -18,7 +18,7 @@
 #include <spdlog/spdlog.h>
 #include <boost/beast/http.hpp>
 #include <boost/beast/version.hpp>
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include <utils/event_counter.hpp>
 #include <utils/event_gauge.hpp>

--- a/src/io/network/endpoint.cpp
+++ b/src/io/network/endpoint.cpp
@@ -31,7 +31,7 @@
 #include <netinet/in.h>
 #include <spdlog/spdlog.h>
 #include <sys/socket.h>
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 namespace {
 constexpr std::string_view delimiter = ":";

--- a/src/io/network/endpoint.hpp
+++ b/src/io/network/endpoint.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -17,7 +17,7 @@
 #include <optional>
 #include <string>
 
-#include "json/json.hpp"
+#include <nlohmann/json.hpp>
 
 namespace memgraph::io::network {
 

--- a/src/license/license_sender.hpp
+++ b/src/license/license_sender.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -15,7 +15,7 @@
 #include <cstdint>
 #include <string>
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "license/license.hpp"
 #include "utils/scheduler.hpp"

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -5720,13 +5720,13 @@ std::vector<Symbol> LoadCsv::ModifiedSymbols(const SymbolTable &sym_table) const
 namespace {
 // copy-pasted from interpreter.cpp
 TypedValue EvaluateOptionalExpression(Expression *expression, ExpressionEvaluator *eval) {
-  return expression ? expression->Accept(*eval) : TypedValue();
+  return expression ? expression->Accept(*eval) : TypedValue(eval->GetMemoryResource());
 }
 
 auto ToOptionalString(ExpressionEvaluator *evaluator, Expression *expression) -> std::optional<utils::pmr::string> {
-  const auto evaluated_expr = EvaluateOptionalExpression(expression, evaluator);
+  auto evaluated_expr = EvaluateOptionalExpression(expression, evaluator);
   if (evaluated_expr.IsString()) {
-    return utils::pmr::string(evaluated_expr.ValueString(), utils::NewDeleteResource());
+    return utils::pmr::string(std::move(evaluated_expr).ValueString(), evaluator->GetMemoryResource());
   }
   return std::nullopt;
 };
@@ -5832,13 +5832,10 @@ class LoadCsvCursor : public Cursor {
 
     // No need to check if maybe_file is std::nullopt, as the parser makes sure
     // we can't get a nullptr for the 'file_' member in the LoadCsv clause.
-    // Note that the reader has to be given its own memory resource, as it
-    // persists between pulls, so it can't use the evalutation context memory
-    // resource.
     return csv::Reader(
         csv::CsvSource::Create(*maybe_file),
         csv::Reader::Config(self_->with_header_, self_->ignore_bad_, std::move(maybe_delim), std::move(maybe_quote)),
-        utils::NewDeleteResource());
+        eval_context->memory);
   }
 
   std::optional<utils::pmr::string> ParseNullif(EvaluationContext *eval_context) {

--- a/src/query/plan/pretty_print.hpp
+++ b/src/query/plan/pretty_print.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -14,7 +14,7 @@
 
 #include <iosfwd>
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "query/plan/operator.hpp"
 

--- a/src/query/plan/profile.cpp
+++ b/src/query/plan/profile.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -15,7 +15,7 @@
 #include <chrono>
 
 #include <fmt/format.h>
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "query/context.hpp"
 #include "utils/likely.hpp"

--- a/src/query/plan/profile.hpp
+++ b/src/query/plan/profile.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -14,7 +14,7 @@
 #include <cstdint>
 #include <vector>
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "query/typed_value.hpp"
 

--- a/src/query/procedure/callable_alias_mapper.cpp
+++ b/src/query/procedure/callable_alias_mapper.cpp
@@ -15,7 +15,7 @@
 #include <fstream>
 
 #include <spdlog/spdlog.h>
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "utils/logging.hpp"
 

--- a/src/query/procedure/mg_procedure_impl.cpp
+++ b/src/query/procedure/mg_procedure_impl.cpp
@@ -1700,7 +1700,7 @@ mgp_error mgp_result_record_insert(mgp_result_record *record, const char *field_
 mgp_error mgp_func_result_set_error_msg(mgp_func_result *res, const char *msg, mgp_memory *memory) {
   return WrapExceptions([=] {
     // We are copying error message string here, that includes the out of memory message
-    memgraph::utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_blocker;
+    memgraph::utils::MemoryTracker::OutOfMemoryExceptionBlocker const oom_blocker;
     res->error_msg.emplace(msg, memory->impl);
   });
 }

--- a/src/query/procedure/mg_procedure_impl.cpp
+++ b/src/query/procedure/mg_procedure_impl.cpp
@@ -1698,7 +1698,11 @@ mgp_error mgp_result_record_insert(mgp_result_record *record, const char *field_
 }
 
 mgp_error mgp_func_result_set_error_msg(mgp_func_result *res, const char *msg, mgp_memory *memory) {
-  return WrapExceptions([=] { res->error_msg.emplace(msg, memory->impl); });
+  return WrapExceptions([=] {
+    // We are copying error message string here, that includes the out of memory message
+    memgraph::utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_blocker;
+    res->error_msg.emplace(msg, memory->impl);
+  });
 }
 
 mgp_error mgp_func_result_set_value(mgp_func_result *res, mgp_value *value, mgp_memory *memory) {

--- a/src/query/serialization/property_value.cpp
+++ b/src/query/serialization/property_value.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -13,7 +13,7 @@
 #include <cstdint>
 #include <string>
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "query/serialization/property_value.hpp"
 #include "storage/v2/property_value.hpp"

--- a/src/query/serialization/property_value.hpp
+++ b/src/query/serialization/property_value.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/storage.hpp"

--- a/src/query/stream/common.cpp
+++ b/src/query/stream/common.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -11,7 +11,7 @@
 
 #include "query/stream/common.hpp"
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 namespace memgraph::query::stream {
 namespace {

--- a/src/query/stream/common.hpp
+++ b/src/query/stream/common.hpp
@@ -17,7 +17,7 @@
 #include <optional>
 #include <string>
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 namespace memgraph::query::stream {
 

--- a/src/query/stream/sources.cpp
+++ b/src/query/stream/sources.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -11,7 +11,7 @@
 
 #include "query/stream/sources.hpp"
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "integrations/constants.hpp"
 

--- a/src/query/stream/streams.cpp
+++ b/src/query/stream/streams.cpp
@@ -16,7 +16,7 @@
 #include <utility>
 
 #include <spdlog/spdlog.h>
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "dbms/database.hpp"
 #include "dbms/dbms_handler.hpp"
@@ -162,9 +162,10 @@ void from_json(const nlohmann::json &data, StreamStatus<TStream> &status) {
   if (const auto &owner = data.at(kOwner); !owner.is_null()) {
     status.owner = owner.get<typename decltype(status.owner)::value_type>();
     if (const auto &owner_role = data.at(kOwnerRole); !owner_role.is_null()) {
-      owner_role.get_to(status.owner_role);
+      status.owner_role.emplace();
+      owner_role.get_to(*status.owner_role);
     } else {
-      status.owner_role = {};
+      status.owner_role.reset();
     }
   } else {
     status.owner = {};

--- a/src/query/stream/streams.hpp
+++ b/src/query/stream/streams.hpp
@@ -18,7 +18,7 @@
 #include <type_traits>
 #include <unordered_map>
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "integrations/kafka/consumer.hpp"
 #include "kvstore/kvstore.hpp"

--- a/src/query/time_to_live/time_to_live.hpp
+++ b/src/query/time_to_live/time_to_live.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -18,7 +18,7 @@
 
 #include <fmt/core.h>
 #include <chrono>
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 #include <optional>
 
 #include "kvstore/kvstore.hpp"

--- a/src/replication/CMakeLists.txt
+++ b/src/replication/CMakeLists.txt
@@ -23,6 +23,6 @@ target_sources(mg-replication
 
 find_package(fmt REQUIRED)
 target_link_libraries(mg-replication
-    PUBLIC mg::utils mg::kvstore lib::json mg::rpc mg::slk mg::io mg::repl_coord_glue mg-flags
+    PUBLIC mg::utils mg::kvstore nlohmann_json::nlohmann_json mg::rpc mg::slk mg::io mg::repl_coord_glue mg-flags
     PRIVATE fmt::fmt
 )

--- a/src/replication/include/replication/status.hpp
+++ b/src/replication/include/replication/status.hpp
@@ -17,7 +17,7 @@
 #include <string>
 #include <variant>
 
-#include "json/json.hpp"
+#include <nlohmann/json.hpp>
 
 #include "replication/config.hpp"
 #include "replication/epoch.hpp"

--- a/src/replication_coordination_glue/mode.hpp
+++ b/src/replication_coordination_glue/mode.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -16,7 +16,7 @@
 #include <stdexcept>
 #include <string>
 
-#include "json/json.hpp"
+#include <nlohmann/json.hpp>
 
 namespace memgraph::replication_coordination_glue {
 

--- a/src/replication_coordination_glue/role.hpp
+++ b/src/replication_coordination_glue/role.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -13,7 +13,7 @@
 
 #include <cstdint>
 
-#include "json/json.hpp"
+#include <nlohmann/json.hpp>
 
 namespace memgraph::replication_coordination_glue {
 

--- a/src/requests/CMakeLists.txt
+++ b/src/requests/CMakeLists.txt
@@ -8,6 +8,6 @@ find_package(gflags REQUIRED)
 
 add_library(mg-requests STATIC ${requests_src_files})
 target_link_libraries(mg-requests
-        PUBLIC mg-utils lib::json
+        PUBLIC mg-utils nlohmann_json::nlohmann_json
         PRIVATE lib::ctre spdlog::spdlog ${CURL_LIBRARIES} fmt::fmt gflags)
 target_include_directories(mg-requests PRIVATE ${CURL_INCLUDE_DIRS})

--- a/src/requests/requests.hpp
+++ b/src/requests/requests.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -14,7 +14,7 @@
 #include <ostream>
 #include <string>
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 namespace memgraph::requests {
 

--- a/src/storage/v2/indices/text_index.hpp
+++ b/src/storage/v2/indices/text_index.hpp
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 #include "mg_procedure.h"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/name_id_mapper.hpp"

--- a/src/storage/v2/indices/vector_index.hpp
+++ b/src/storage/v2/indices/vector_index.hpp
@@ -13,7 +13,7 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 #include <string>
 
 #include "storage/v2/id_types.hpp"

--- a/src/storage/v2/schema_info.hpp
+++ b/src/storage/v2/schema_info.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -33,7 +33,7 @@
 #include "utils/rw_spin_lock.hpp"
 #include "utils/small_vector.hpp"
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 namespace memgraph::storage {
 

--- a/src/storage/v2/schema_info_types.hpp
+++ b/src/storage/v2/schema_info_types.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -14,7 +14,7 @@
 #include <boost/container_hash/hash_fwd.hpp>
 #include <cstdint>
 #include <functional>
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 #include <tuple>
 #include <utility>
 

--- a/src/telemetry/collectors.hpp
+++ b/src/telemetry/collectors.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 namespace memgraph::telemetry {
 

--- a/src/telemetry/telemetry.hpp
+++ b/src/telemetry/telemetry.hpp
@@ -14,7 +14,7 @@
 #include <mutex>
 #include <string>
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 #include "dbms/dbms_handler.hpp"
 #include "kvstore/kvstore.hpp"
 #include "utils/scheduler.hpp"

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -48,7 +48,7 @@ find_package(gflags REQUIRED)
 find_package(Threads REQUIRED)
 find_package(ZLIB REQUIRED)
 
-target_link_libraries(mg-utils PUBLIC Boost::headers fmt::fmt spdlog::spdlog json ZLIB::ZLIB croncpp::croncpp)
+target_link_libraries(mg-utils PUBLIC Boost::headers fmt::fmt spdlog::spdlog nlohmann_json::nlohmann_json ZLIB::ZLIB croncpp::croncpp)
 target_link_libraries(mg-utils PRIVATE librdtsc stdc++fs Threads::Threads gflags uuid rt mg-flags)
 
 add_library(mg-settings STATIC)
@@ -67,4 +67,4 @@ target_sources(mg-events
     event_trigger.cpp
     event_map.cpp
 )
-target_link_libraries(mg-events mg-utils json)
+target_link_libraries(mg-events mg-utils nlohmann_json::nlohmann_json)

--- a/src/utils/event_map.hpp
+++ b/src/utils/event_map.hpp
@@ -15,7 +15,7 @@
 #include <cstdlib>
 #include <memory>
 
-#include "json/json.hpp"
+#include <nlohmann/json.hpp>
 
 namespace memgraph::metrics {
 using Count = uint64_t;

--- a/src/utils/system_info.hpp
+++ b/src/utils/system_info.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -14,7 +14,7 @@
 #include <cstdint>
 #include <string>
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 namespace memgraph::utils {
 

--- a/src/utils/uuid.hpp
+++ b/src/utils/uuid.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -16,7 +16,7 @@
 #include "fmt/format.h"
 
 #include <array>
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 #include <string>
 
 namespace memgraph::utils {

--- a/tests/e2e/monitoring_server/CMakeLists.txt
+++ b/tests/e2e/monitoring_server/CMakeLists.txt
@@ -2,9 +2,9 @@ find_package(gflags REQUIRED)
 find_package(Boost REQUIRED CONFIG)
 
 add_executable(memgraph__e2e__monitoring_server monitoring.cpp)
-target_link_libraries(memgraph__e2e__monitoring_server mgclient mg-utils json gflags Boost::headers)
+target_link_libraries(memgraph__e2e__monitoring_server mgclient mg-utils nlohmann_json::nlohmann_json gflags Boost::headers)
 
 add_executable(memgraph__e2e__monitoring_server_ssl monitoring_ssl.cpp)
-target_link_libraries(memgraph__e2e__monitoring_server_ssl mgclient mg-utils json gflags Boost::headers)
+target_link_libraries(memgraph__e2e__monitoring_server_ssl mgclient mg-utils nlohmann_json::nlohmann_json gflags Boost::headers)
 
 copy_e2e_files(monitoring_server workloads.yaml)

--- a/tests/e2e/monitoring_server/common.hpp
+++ b/tests/e2e/monitoring_server/common.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -29,8 +29,8 @@
 #include <boost/beast/core/buffers_to_string.hpp>
 #include <boost/beast/ssl/ssl_stream.hpp>
 #include <boost/beast/websocket.hpp>
-#include <json/json.hpp>
 #include <mgclient.hpp>
+#include <nlohmann/json.hpp>
 
 #include "utils/logging.hpp"
 

--- a/tests/e2e/replication/CMakeLists.txt
+++ b/tests/e2e/replication/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(memgraph__e2e__replication__indices indices.cpp)
 target_link_libraries(memgraph__e2e__replication__indices gflags mgclient mg-utils mg-io Threads::Threads)
 
 add_executable(memgraph__e2e__replication__read_write_benchmark read_write_benchmark.cpp)
-target_link_libraries(memgraph__e2e__replication__read_write_benchmark gflags json mgclient mg-utils mg-io Threads::Threads)
+target_link_libraries(memgraph__e2e__replication__read_write_benchmark gflags nlohmann_json::nlohmann_json mgclient mg-utils mg-io Threads::Threads)
 
 copy_e2e_python_files(replication common.py)
 copy_e2e_python_files(replication conftest.py)

--- a/tests/e2e/replication/read_write_benchmark.cpp
+++ b/tests/e2e/replication/read_write_benchmark.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -16,7 +16,7 @@
 
 #include <fmt/format.h>
 #include <gflags/gflags.h>
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "common.hpp"
 #include "io/network/fmt.hpp"

--- a/tests/integration/audit/CMakeLists.txt
+++ b/tests/integration/audit/CMakeLists.txt
@@ -3,4 +3,4 @@ set(tester_target_name ${target_name}__tester)
 
 add_executable(${tester_target_name} tester.cpp)
 set_target_properties(${tester_target_name} PROPERTIES OUTPUT_NAME tester)
-target_link_libraries(${tester_target_name} mg-communication json)
+target_link_libraries(${tester_target_name} mg-communication nlohmann_json::nlohmann_json)

--- a/tests/integration/audit/tester.cpp
+++ b/tests/integration/audit/tester.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -12,7 +12,7 @@
 #include <fmt/core.h>
 #include <gflags/gflags.h>
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "communication/bolt/client.hpp"
 #include "io/network/endpoint.hpp"

--- a/tests/integration/ldap/CMakeLists.txt
+++ b/tests/integration/ldap/CMakeLists.txt
@@ -3,4 +3,4 @@ set(tester_target_name ${target_name}__tester)
 
 add_executable(${tester_target_name} tester.cpp)
 set_target_properties(${tester_target_name} PROPERTIES OUTPUT_NAME tester)
-target_link_libraries(${tester_target_name} mg-communication json)
+target_link_libraries(${tester_target_name} mg-communication nlohmann_json::nlohmann_json)

--- a/tests/integration/ldap/tester.cpp
+++ b/tests/integration/ldap/tester.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -10,7 +10,7 @@
 // licenses/APL.txt.
 
 #include <gflags/gflags.h>
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "communication/bolt/client.hpp"
 #include "io/network/endpoint.hpp"

--- a/tests/integration/mg_import_csv/CMakeLists.txt
+++ b/tests/integration/mg_import_csv/CMakeLists.txt
@@ -3,4 +3,4 @@ set(tester_target_name ${target_name}__tester)
 
 add_executable(${tester_target_name} tester.cpp)
 set_target_properties(${tester_target_name} PROPERTIES OUTPUT_NAME tester)
-target_link_libraries(${tester_target_name} mg-communication json)
+target_link_libraries(${tester_target_name} mg-communication nlohmann_json::nlohmann_json)

--- a/tests/macro_benchmark/CMakeLists.txt
+++ b/tests/macro_benchmark/CMakeLists.txt
@@ -15,16 +15,16 @@ function(add_macro_benchmark test_cpp)
 endfunction(add_macro_benchmark)
 
 add_macro_benchmark(clients/pokec_client.cpp)
-target_link_libraries(${test_prefix}pokec_client mg-communication mg-io mg-utils json)
+target_link_libraries(${test_prefix}pokec_client mg-communication mg-io mg-utils nlohmann_json::nlohmann_json)
 
 add_macro_benchmark(clients/graph_500_bfs.cpp)
-target_link_libraries(${test_prefix}graph_500_bfs mg-communication mg-io mg-utils json)
+target_link_libraries(${test_prefix}graph_500_bfs mg-communication mg-io mg-utils nlohmann_json::nlohmann_json)
 
 add_macro_benchmark(clients/bfs_pokec_client.cpp)
-target_link_libraries(${test_prefix}bfs_pokec_client mg-communication mg-io mg-utils json)
+target_link_libraries(${test_prefix}bfs_pokec_client mg-communication mg-io mg-utils nlohmann_json::nlohmann_json)
 
 add_macro_benchmark(clients/query_client.cpp)
 target_link_libraries(${test_prefix}query_client mg-communication mg-io mg-utils)
 
 add_macro_benchmark(clients/card_fraud_client.cpp)
-target_link_libraries(${test_prefix}card_fraud_client mg-communication mg-io mg-utils json)
+target_link_libraries(${test_prefix}card_fraud_client mg-communication mg-io mg-utils nlohmann_json::nlohmann_json)

--- a/tests/macro_benchmark/clients/bfs_pokec_client.cpp
+++ b/tests/macro_benchmark/clients/bfs_pokec_client.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -21,7 +21,7 @@
 #include <vector>
 
 #include <gflags/gflags.h>
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "io/network/utils.hpp"
 #include "utils/algorithm.hpp"

--- a/tests/macro_benchmark/clients/long_running_common.hpp
+++ b/tests/macro_benchmark/clients/long_running_common.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -23,7 +23,7 @@
 #include <utility>
 #include <vector>
 
-#include "json/json.hpp"
+#include <nlohmann/json.hpp>
 
 #include "utils/logging.hpp"
 #include "utils/timer.hpp"

--- a/tests/macro_benchmark/clients/pokec_client.cpp
+++ b/tests/macro_benchmark/clients/pokec_client.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -22,7 +22,7 @@
 #include <vector>
 
 #include <gflags/gflags.h>
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "communication/bolt/v1/value.hpp"
 #include "io/network/utils.hpp"

--- a/tests/mgbench/CMakeLists.txt
+++ b/tests/mgbench/CMakeLists.txt
@@ -2,4 +2,4 @@ set(test_prefix memgraph__mgbench__)
 
 add_executable(${test_prefix}client client.cpp)
 set_target_properties(${test_prefix}client PROPERTIES OUTPUT_NAME client)
-target_link_libraries(${test_prefix}client mg-communication json)
+target_link_libraries(${test_prefix}client mg-communication nlohmann_json::nlohmann_json)

--- a/tests/mgbench/client.cpp
+++ b/tests/mgbench/client.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -24,7 +24,7 @@
 
 #include <gflags/gflags.h>
 #include <math.h>
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 
 #include <iostream>
 #include "communication/bolt/client.hpp"

--- a/tests/unit/coordinator_raft_log_serialization.cpp
+++ b/tests/unit/coordinator_raft_log_serialization.cpp
@@ -16,7 +16,7 @@
 
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
-#include "json/json.hpp"
+#include <nlohmann/json.hpp>
 
 using memgraph::coordination::CoordinatorInstanceContext;
 using memgraph::coordination::CoordinatorStateMachine;

--- a/tests/unit/coordinator_raft_state.cpp
+++ b/tests/unit/coordinator_raft_state.cpp
@@ -14,7 +14,7 @@
 
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
-#include "json/json.hpp"
+#include <nlohmann/json.hpp>
 
 #include "libnuraft/nuraft.hxx"
 

--- a/tests/unit/coordinator_state_machine.cpp
+++ b/tests/unit/coordinator_state_machine.cpp
@@ -17,7 +17,7 @@
 
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
-#include "json/json.hpp"
+#include <nlohmann/json.hpp>
 
 #include "libnuraft/nuraft.hxx"
 

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -22,7 +22,7 @@
 // "json.hpp" uses libc's EOF macro while
 // "antlr4-runtime.h" contains a static variable of the
 // same name, EOF.
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 // Same is true for <boost/geometry.hpp> that is included by ast.hpp
 #include "query/frontend/ast/ast.hpp"
 //////////////////////////////////////////////////////

--- a/tests/unit/storage_v2_schema_info.cpp
+++ b/tests/unit/storage_v2_schema_info.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -27,7 +27,7 @@
 #include "storage/v2/view.hpp"
 #include "storage_test_utils.hpp"
 
-#include <json/json.hpp>
+#include <nlohmann/json.hpp>
 #include <stdexcept>
 #include <thread>
 


### PR DESCRIPTION
- NotEnoughMemoryException and AllocationException did not need allocation.
- mgp_func_result_set_error_msg now allows temporary allocation above the memory limits.
- Use query allocator for LOAD CSV. The old reason for using different allocator because of lifetime issues no longer valid. Using query allocator will allow memory to be moved rather than copied, so should be more efficient.
- patched `nlohmann/json` to handle exception during `~basic_json`

breaking: `include/mg_exceptions.hpp` had ABI break which requires C++ modules to be rebuilt.
