### PR TITLE
Bugfix: Unregister replication instance could deadlock

### DIFF
--- a/src/coordination/include/coordination/register_main_replica_coordinator_status.hpp
+++ b/src/coordination/include/coordination/register_main_replica_coordinator_status.hpp
@@ -34,6 +34,7 @@ enum class RegisterInstanceCoordinatorStatus : uint8_t {
 enum class UnregisterInstanceCoordinatorStatus : uint8_t {
   NO_INSTANCE_WITH_NAME,
   IS_MAIN,
+  NO_MAIN,
   NOT_COORDINATOR,
   RPC_FAILED,
   NOT_LEADER,

--- a/src/coordination/include/coordination/replication_instance_client.hpp
+++ b/src/coordination/include/coordination/replication_instance_client.hpp
@@ -72,8 +72,6 @@ class ReplicationInstanceClient {
   }
 
  private:
-  utils::Scheduler instance_checker_;
-
   communication::ClientContext rpc_context_;
   mutable rpc::Client rpc_client_;
 
@@ -81,6 +79,7 @@ class ReplicationInstanceClient {
   CoordinatorInstance *coord_instance_;
 
   std::chrono::seconds const instance_health_check_frequency_sec_{1};
+  utils::Scheduler instance_checker_;
 };
 
 }  // namespace memgraph::coordination

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -439,6 +439,10 @@ class CoordQueryHandler final : public query::CoordinatorQueryHandler {
       case IS_MAIN:
         throw QueryRuntimeException(
             "Alive main instance can't be unregistered! Shut it down to trigger failover and then unregister it!");
+      case NO_MAIN:
+        throw QueryRuntimeException(
+            "The replica cannot be unregisted because the current main is down. Retry when the cluster has an active "
+            "leader!");
       case NOT_COORDINATOR:
         throw QueryRuntimeException("UNREGISTER INSTANCE query can only be run on a coordinator!");
       case NOT_LEADER: {

--- a/tests/e2e/high_availability/common.py
+++ b/tests/e2e/high_availability/common.py
@@ -47,7 +47,7 @@ def wait_until_main_writeable_assert_replica_down(cursor, query):
             execute_and_fetch_all(cursor, query)
             break
         except Exception as e:
-            if "Write query forbidden on the main" in str(e):
+            if "Write queries currently forbidden on the main instance" in str(e):
                 continue
             assert "At least one SYNC replica has not confirmed committing last transaction." in str(e)
             break


### PR DESCRIPTION
Added timeouts for lock acquiring in success and fail callbacks. Unregistration is also forbidden in the case when there is no current main in the cluster to prevent drifting between in-memory and raft state on coordinators. 

Instance checker will now be destroyed before RPC client to prevent possible UB.