### PR TITLE
Restore recovery time on Jepsen, use leave-db-running and ignore-fail-read to prevent tar from early exit

### DIFF
--- a/.github/workflows/stress_jepsen.yaml
+++ b/.github/workflows/stress_jepsen.yaml
@@ -78,7 +78,7 @@ jobs:
           cd tests/jepsen
           ./run.sh test \
           --binary ../../build/memgraph \
-          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 32400 --concurrency 6" \
+          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 32400 --concurrency 6 --leave-db-running" \
           --ignore-run-stdout-logs \
           --ignore-run-stderr-logs \
           --nodes-no 6 \

--- a/tests/jepsen/run.sh
+++ b/tests/jepsen/run.sh
@@ -188,7 +188,7 @@ PROCESS_RESULTS() {
         all_workload_run_folders="$all_workload_run_folders /jepsen/memgraph/store/$workload/latest"
     done
     INFO "Packing results..."
-    docker exec jepsen-control bash -c "tar -czvf /jepsen/memgraph/Jepsen.tar.gz -h $all_workload_run_folders"
+    docker exec jepsen-control bash -c "tar --ignore-failed-read -czvf /jepsen/memgraph/Jepsen.tar.gz -h $all_workload_run_folders"
     docker cp jepsen-control:/jepsen/memgraph/Jepsen.tar.gz ./
     INFO "Result processing (printing and packing) DONE."
 }

--- a/tests/jepsen/src/memgraph/high_availability/create/test.clj
+++ b/tests/jepsen/src/memgraph/high_availability/create/test.clj
@@ -575,5 +575,5 @@
                  {:hacreate     (checker)
                   :timeline (timeline/html)})
      :generator (client-generator)
-     :final-generator {:clients (gen/each-thread (gen/once get-nodes)) :recovery-time 9}
+     :final-generator {:clients (gen/each-thread (gen/once get-nodes)) :recovery-time 900}
      :nemesis-config (nemesis/create db nodes-config)}))


### PR DESCRIPTION
Run Jepsen stress test with arg `--leave-db-running`. Returns recovery time to 900s which was change due to error. Runs tar with `--ignore-failed-read` to prevent the command from exiting.
