### PR TITLE
Add multitenancy HA stress test

### DIFF
--- a/.github/workflows/stress_jepsen.yaml
+++ b/.github/workflows/stress_jepsen.yaml
@@ -78,7 +78,7 @@ jobs:
           cd tests/jepsen
           ./run.sh test \
           --binary ../../build/memgraph \
-          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 32400 --concurrency 6 --leave-db-running" \
+          --run-args "--workload hacreate --nodes-config resources/cluster.edn --time-limit 32400 --concurrency 6" \
           --ignore-run-stdout-logs \
           --ignore-run-stderr-logs \
           --nodes-no 6 \

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ src/transactions/distributed/engine_rpc_messages.hpp
 /tests/manual/js/transaction_timeout/node_modules/
 .vscode/
 src/query/frontend/opencypher/grammar/.antlr/*
+tests/jepsen/src/memgraph/mtenancy/datasets/

--- a/tests/jepsen/resources/ha-mt.edn
+++ b/tests/jepsen/resources/ha-mt.edn
@@ -1,0 +1,5 @@
+{"n1" {:management-port 10000 :replication-port 20000}
+ "n2" {:management-port 10000 :replication-port 20000}
+ "n3" {:management-port 10000 :coordinator-port 12000 :coordinator-id 1}
+ "n4" {:management-port 10000 :coordinator-port 12000 :coordinator-id 2}
+ "n5" {:management-port 10000 :coordinator-port 12000 :coordinator-id 3}}

--- a/tests/jepsen/run.sh
+++ b/tests/jepsen/run.sh
@@ -5,7 +5,7 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 MEMGRAPH_BUILD_PATH="$script_dir/../../build"
 MEMGRAPH_BINARY_PATH="$MEMGRAPH_BUILD_PATH/memgraph"
 MEMGRAPH_MODULE_SUPPORT_LIB_PATH="$MEMGRAPH_BUILD_PATH/src/query/libmemgraph_module_support.so"
-MEMGRAPH_MTENANCY_DATASETES="$script_dir/../../tests/jepsen/src/memgraph/mtenancy/datasets/"
+MEMGRAPH_MTENANCY_DATASETS="$script_dir/../../tests/jepsen/src/memgraph/mtenancy/datasets/"
 # NOTE: Jepsen Git tags are not consistent, there are: 0.2.4, v0.3.0, 0.3.2, ...
 JEPSEN_VERSION="${JEPSEN_VERSION:-v0.3.5}"
 JEPSEN_ACTIVE_NODES_NO=5
@@ -142,7 +142,13 @@ COPY_BINARIES() {
        $docker_exec "rm -rf /opt/memgraph/ && mkdir -p /opt/memgraph/src/query"
        docker cp "$binary_path" "$jepsen_node_name":/opt/memgraph/"$_binary_name"
        docker cp "$support_lib" "$jepsen_node_name":"/opt/memgraph/src/query/${support_lib_name}"
-       docker cp "$MEMGRAPH_MTENANCY_DATASETES" "$jepsen_node_name":"/opt/memgraph"
+
+       if [ -d "$MEMGRAPH_MTENANCY_DATASETS" ]; then
+           docker cp "$MEMGRAPH_MTENANCY_DATASETS" "$jepsen_node_name:/opt/memgraph"
+           INFO "Datasets copied successfully."
+       else
+           INFO "Datasets won't be copied."
+       fi
        $docker_exec "ln -s /opt/memgraph/$_binary_name /opt/memgraph/memgraph"
        $docker_exec "touch /opt/memgraph/memgraph.log"
        INFO "Copying $binary_name to $jepsen_node_name DONE."

--- a/tests/jepsen/run.sh
+++ b/tests/jepsen/run.sh
@@ -5,6 +5,7 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 MEMGRAPH_BUILD_PATH="$script_dir/../../build"
 MEMGRAPH_BINARY_PATH="$MEMGRAPH_BUILD_PATH/memgraph"
 MEMGRAPH_MODULE_SUPPORT_LIB_PATH="$MEMGRAPH_BUILD_PATH/src/query/libmemgraph_module_support.so"
+MEMGRAPH_MTENANCY_DATASETES="$script_dir/../../tests/jepsen/src/memgraph/mtenancy/datasets/"
 # NOTE: Jepsen Git tags are not consistent, there are: 0.2.4, v0.3.0, 0.3.2, ...
 JEPSEN_VERSION="${JEPSEN_VERSION:-v0.3.5}"
 JEPSEN_ACTIVE_NODES_NO=5
@@ -141,6 +142,7 @@ COPY_BINARIES() {
        $docker_exec "rm -rf /opt/memgraph/ && mkdir -p /opt/memgraph/src/query"
        docker cp "$binary_path" "$jepsen_node_name":/opt/memgraph/"$_binary_name"
        docker cp "$support_lib" "$jepsen_node_name":"/opt/memgraph/src/query/${support_lib_name}"
+       docker cp "$MEMGRAPH_MTENANCY_DATASETES" "$jepsen_node_name":"/opt/memgraph"
        $docker_exec "ln -s /opt/memgraph/$_binary_name /opt/memgraph/memgraph"
        $docker_exec "touch /opt/memgraph/memgraph.log"
        INFO "Copying $binary_name to $jepsen_node_name DONE."

--- a/tests/jepsen/src/memgraph/core.clj
+++ b/tests/jepsen/src/memgraph/core.clj
@@ -155,7 +155,7 @@
         organization (when (:organization opts)
                        (:organization opts))
         num-tenants (when (:num-tenants opts)
-                      (:num-tenants opts))
+                      (Integer/parseInt (:num-tenants opts)))
         test-opts (merge opts
                          {:workload workload
                           :nodes-config nodes-config

--- a/tests/jepsen/src/memgraph/core.clj
+++ b/tests/jepsen/src/memgraph/core.clj
@@ -156,13 +156,22 @@
                        (:organization opts))
         num-tenants (when (:num-tenants opts)
                       (Integer/parseInt (:num-tenants opts)))
+
+        recovery-time (when (:recovery-time opts)
+                        (Integer/parseInt (:recovery-time opts)))
+
+        nemesis-start-sleep (when (:nemesis-start-sleep opts)
+                              (Integer/parseInt (:nemesis-start-sleep opts)))
         test-opts (merge opts
                          {:workload workload
                           :nodes-config nodes-config
                           :sync-after-n-txn sync-after-n-txn
                           :license licence
                           :organization organization
-                          :num-tenants num-tenants})]
+                          :num-tenants num-tenants
+                          :recovery-time recovery-time
+                          :nemesis-start-sleep nemesis-start-sleep})]
+
     (memgraph-test test-opts)))
 
 (def cli-opts
@@ -181,7 +190,9 @@
    ["-o" "--organization ORGANIZATION" "Memgraph organization name" :default nil]
    [nil "--nodes-config PATH" "Path to a file containing the config for each node."
     :parse-fn #(-> % load-configuration)]
-   ["-nt" "--num-tenants NUMBER" "Number of tenants that will be used in multi-tenant env." :default 5]])
+   ["-nt" "--num-tenants NUMBER" "Number of tenants that will be used in multi-tenant env." :default 5]
+   ["-rt" "--recovery-time SECONDS" "Recovery time before calling final generator." :default 600]
+   ["-nss" "--nemesis-start-sleep SECONDS" "The number of seconds nemesis will sleep before starting its disruptions." :default 300]])
 
 (defn -main
   "Handles command line arguments. Can either run a test, or a web server for

--- a/tests/jepsen/src/memgraph/core.clj
+++ b/tests/jepsen/src/memgraph/core.clj
@@ -154,12 +154,15 @@
                   (:license opts))
         organization (when (:organization opts)
                        (:organization opts))
+        num-tenants (when (:num-tenants opts)
+                      (:num-tenants opts))
         test-opts (merge opts
                          {:workload workload
                           :nodes-config nodes-config
                           :sync-after-n-txn sync-after-n-txn
                           :license licence
-                          :organization organization})]
+                          :organization organization
+                          :num-tenants num-tenants})]
     (memgraph-test test-opts)))
 
 (def cli-opts
@@ -177,7 +180,8 @@
     :default nil]
    ["-o" "--organization ORGANIZATION" "Memgraph organization name" :default nil]
    [nil "--nodes-config PATH" "Path to a file containing the config for each node."
-    :parse-fn #(-> % load-configuration)]])
+    :parse-fn #(-> % load-configuration)]
+   ["-nt" "--num-tenants NUMBER" "Number of tenants that will be used in multi-tenant env." :default 5]])
 
 (defn -main
   "Handles command line arguments. Can either run a test, or a web server for

--- a/tests/jepsen/src/memgraph/core.clj
+++ b/tests/jepsen/src/memgraph/core.clj
@@ -11,6 +11,7 @@
    [tesser.core :as tesser]
    [memgraph.high-availability.bank.test :as habank]
    [memgraph.high-availability.create.test :as hacreate]
+   [memgraph.mtenancy.test :as ha-mt] ; multitenancy + HA test
    [memgraph.replication.bank :as bank]
    [memgraph.replication.large :as large]
    [memgraph.support :as support]))
@@ -56,7 +57,8 @@
   {:bank                      bank/workload
    :large                     large/workload
    :habank                    habank/workload
-   :hacreate                  hacreate/workload})
+   :hacreate                  hacreate/workload
+   :ha-mt                     ha-mt/workload})
 
 (defn compose-gen
   "Composes final generator used in the test from client generator and nemesis generator."
@@ -140,7 +142,7 @@
                    (:workload opts)
                    (throw (Exception. "Workload undefined!")))
         nodes-config (if (:nodes-config opts)
-                       (if (or (= workload :habank) (= workload :hacreate))
+                       (if (or (= workload :habank) (= workload :hacreate) (= workload :ha-mt))
                          (:nodes-config opts)
                          (validate-nodes-configuration (:nodes-config opts))) ; validate only for replication tests.
                        (throw (Exception. "Nodes config flag undefined!")))

--- a/tests/jepsen/src/memgraph/core.clj
+++ b/tests/jepsen/src/memgraph/core.clj
@@ -190,9 +190,9 @@
    ["-o" "--organization ORGANIZATION" "Memgraph organization name" :default nil]
    [nil "--nodes-config PATH" "Path to a file containing the config for each node."
     :parse-fn #(-> % load-configuration)]
-   ["-nt" "--num-tenants NUMBER" "Number of tenants that will be used in multi-tenant env." :default 5]
-   ["-rt" "--recovery-time SECONDS" "Recovery time before calling final generator." :default 600]
-   ["-nss" "--nemesis-start-sleep SECONDS" "The number of seconds nemesis will sleep before starting its disruptions." :default 300]])
+   ["-nt" "--num-tenants NUMBER" "Number of tenants that will be used in multi-tenant env." :default nil]
+   ["-rt" "--recovery-time SECONDS" "Recovery time before calling final generator." :default nil]
+   ["-nss" "--nemesis-start-sleep SECONDS" "The number of seconds nemesis will sleep before starting its disruptions." :default nil]])
 
 (defn -main
   "Handles command line arguments. Can either run a test, or a web server for

--- a/tests/jepsen/src/memgraph/mtenancy/nemesis.clj
+++ b/tests/jepsen/src/memgraph/mtenancy/nemesis.clj
@@ -197,10 +197,10 @@
 
 (defn create
   "Create a map which contains a nemesis configuration for running HA create test."
-  [db nodes-config]
+  [db nodes-config nemesis-start-sleep]
   {:nemesis (full-nemesis db nodes-config)
    :generator (gen/phases
-               (gen/sleep 240) ; Enough time for cluster setup to finish
+               (gen/sleep nemesis-start-sleep) ; Enough time for cluster setup to finish
                (nemesis-events nodes-config))
    ; :final-generator (map utils/op [:stop-partition-ring :stop-partition-halves :stop-partition-node :heal-node :stop-network-disruption])
    :final-generator (map utils/op [:heal-node])})

--- a/tests/jepsen/src/memgraph/mtenancy/nemesis.clj
+++ b/tests/jepsen/src/memgraph/mtenancy/nemesis.clj
@@ -200,7 +200,7 @@
   [db nodes-config]
   {:nemesis (full-nemesis db nodes-config)
    :generator (gen/phases
-               (gen/sleep 45) ; Enough time for cluster setup to finish
+               (gen/sleep 120) ; Enough time for cluster setup to finish
                (nemesis-events nodes-config))
    ; :final-generator (map utils/op [:stop-partition-ring :stop-partition-halves :stop-partition-node :heal-node :stop-network-disruption])
    :final-generator (map utils/op [:heal-node])})

--- a/tests/jepsen/src/memgraph/mtenancy/nemesis.clj
+++ b/tests/jepsen/src/memgraph/mtenancy/nemesis.clj
@@ -200,7 +200,7 @@
   [db nodes-config]
   {:nemesis (full-nemesis db nodes-config)
    :generator (gen/phases
-               (gen/sleep 120) ; Enough time for cluster setup to finish
+               (gen/sleep 240) ; Enough time for cluster setup to finish
                (nemesis-events nodes-config))
    ; :final-generator (map utils/op [:stop-partition-ring :stop-partition-halves :stop-partition-node :heal-node :stop-network-disruption])
    :final-generator (map utils/op [:heal-node])})

--- a/tests/jepsen/src/memgraph/mtenancy/nemesis.clj
+++ b/tests/jepsen/src/memgraph/mtenancy/nemesis.clj
@@ -167,31 +167,30 @@
 (defn nemesis-events
   "Create a random sequence of nemesis events. Disruptions last [10-60] seconds, and the system remains undisrupted for some time afterwards."
   [nodes-config]
-  (let [events [;[{:type :info :f :start-partition-halves}
-                ; (gen/sleep (+ 10 (rand-int 51))) ; [10, 60]
-                ; {:type :info :f :stop-partition-halves}
-                ; (gen/sleep 5)]
+  (let [events [[{:type :info :f :start-partition-halves}
+                 (gen/sleep (+ 10 (rand-int 51))) ; [10, 60]
+                 {:type :info :f :stop-partition-halves}
+                 (gen/sleep 5)]
 
-                ;[{:type :info :f :start-partition-ring}
-                ; (gen/sleep (+ 10 (rand-int 51))) ; [10, 60]
-                ; {:type :info :f :stop-partition-ring}
-                ; (gen/sleep 5)]
+                [{:type :info :f :start-partition-ring}
+                 (gen/sleep (+ 10 (rand-int 51))) ; [10, 60]
+                 {:type :info :f :stop-partition-ring}
+                 (gen/sleep 5)]
 
-                ;[{:type :info :f :start-partition-node}
-                ; (gen/sleep (+ 10 (rand-int 51))) ; [10, 60]
-                ; {:type :info :f :stop-partition-node}
-                ; (gen/sleep 5)]
+                [{:type :info :f :start-partition-node}
+                 (gen/sleep (+ 10 (rand-int 51))) ; [10, 60]
+                 {:type :info :f :stop-partition-node}
+                 (gen/sleep 5)]
 
                 [{:type :info :f :kill-node}
                  (gen/sleep (+ 10 (rand-int 51))) ; [10, 60]
                  {:type :info :f :heal-node}
                  (gen/sleep 5)]
 
-                ; [{:type :info :f :start-network-disruption :value [(keys nodes-config) net/all-packet-behaviors]}
-                ;  (gen/sleep (+ 10 (rand-int 51))) ; [10, 60]
-                ;  {:type :info :f :stop-network-disruption}
-                ;  (gen/sleep 5)]
-                ]]
+                [{:type :info :f :start-network-disruption :value [(keys nodes-config) net/all-packet-behaviors]}
+                 (gen/sleep (+ 10 (rand-int 51))) ; [10, 60]
+                 {:type :info :f :stop-network-disruption}
+                 (gen/sleep 5)]]]
 
     (mapcat identity (repeatedly #(rand-nth events)))))
 
@@ -202,5 +201,4 @@
    :generator (gen/phases
                (gen/sleep nemesis-start-sleep) ; Enough time for cluster setup to finish
                (nemesis-events nodes-config))
-   ; :final-generator (map utils/op [:stop-partition-ring :stop-partition-halves :stop-partition-node :heal-node :stop-network-disruption])
-   :final-generator (map utils/op [:heal-node])})
+   :final-generator (map utils/op [:stop-partition-ring :stop-partition-halves :stop-partition-node :heal-node :stop-network-disruption])})

--- a/tests/jepsen/src/memgraph/mtenancy/nemesis.clj
+++ b/tests/jepsen/src/memgraph/mtenancy/nemesis.clj
@@ -1,0 +1,206 @@
+(ns memgraph.mtenancy.nemesis
+  "Memgraph nemesis for HA+MT test."
+  (:require [jepsen
+             [nemesis :as nemesis]
+             [generator :as gen]
+             [net :as net]
+             [util :as util]
+             [control :as c]]
+            [jepsen.nemesis.combined :as nemesis-combined]
+            [clojure.tools.logging :refer [info]]
+            [clojure.string :as str]
+            [memgraph.mtenancy.utils :as mutils]
+            [memgraph
+             [support :as s]
+             [query :as mgquery]
+             [utils :as utils]]))
+
+(defn node-start-stopper
+  "Takes a targeting function which, given a list of nodes, returns a single
+  node or collection of nodes to affect, and two functions `(start! test node)`
+  invoked on nemesis start, and `(stop! test node nodes-config)` invoked on nemesis stop.
+  Also takes a nodes-config map needed to restart nodes.
+  Returns a nemesis which responds to :start and :stop by running the start!
+  and stop! fns on each of the given nodes. During `start!` and `stop!`, binds
+  the `jepsen.control` session to the given node, so you can just call `(c/exec
+  ...)`.
+
+  The targeter can take either (targeter test nodes) or, if that fails,
+  (targeter nodes).
+
+  Re-selects a fresh node (or nodes) for each start--if targeter returns nil,
+  skips the start. The return values from the start and stop fns will become
+  the :values of the returned :info operations from the nemesis, e.g.:
+
+      {:value {:n1 [:killed \"java\"]}}"
+  [targeter start! stop! nodes-config]
+  (let [nodes (atom nil)]
+    (reify nemesis/Nemesis
+      (setup! [this _] this)
+
+      (invoke! [_ test op]
+        (locking nodes
+          (assoc op :type :info, :value
+                 (case (:f op)
+                   :start (let [ns (:nodes test)
+                                ns (try (targeter test ns)
+                                        (catch clojure.lang.ArityException _
+                                          (targeter ns)))
+                                ns (util/coll ns)]
+                            (if ns
+                              (if (compare-and-set! nodes nil ns)
+                                (c/on-many ns (start! test c/*host*))
+                                (str "nemesis already disrupting "
+                                     (pr-str @nodes)))
+                              :no-target))
+                   :stop (if-let [ns @nodes]
+                           (let [value (c/on-many ns (stop! test c/*host* nodes-config))]
+                             (reset! nodes nil)
+                             value)
+                           :not-started)))))
+
+      (teardown! [_ _]))))
+
+(defn main-instance?
+  [instance]
+  (= (:role instance) "main"))
+
+(defn get-current-main
+  "Returns the name of the main instance. If there is no main instance or more than one main, throws exception."
+  [instances]
+  (let [main-instances (filter main-instance? instances)
+        num-mains (count main-instances)
+        main-instance
+        (cond (= num-mains 1) (first main-instances)
+              (= num-mains 0) nil
+              :else (throw (Exception. "Expected at most one main instance.")))
+        main-instance-name (if (nil? main-instance) nil (:name main-instance))]
+    main-instance-name))
+
+(defn leader?
+  [instance]
+  (= (:role instance) "leader"))
+
+(defn extract-coord-name
+  "We could use any server. We cannot just use name because in Memgraph coordinator's name is written as 'coordinator_{id}'."
+  [bolt-server]
+  (first (str/split bolt-server #":")))
+
+(defn get-current-leader
+  "Returns the name of the current leader. If there is no leader or more than one leader, throws exception."
+  [instances]
+  (let [leaders (filter leader? instances)
+        num-leaders (count leaders)
+        leader
+        (cond (= num-leaders 1) (first leaders)
+              (= num-leaders 0) nil
+              :else (throw (Exception. "Expected at most one leader.")))
+        leader-name (if (nil? leader) nil (extract-coord-name (:bolt_server leader)))]
+    leader-name))
+
+(defn choose-node-to-kill-on-coord
+  "Chooses between the current main and the current leader. If there are no clear MAIN and LEADER instance in the cluster, we choose random node.
+  We connect to a random coordinator. "
+  [ns coord]
+  (let [conn (utils/open-bolt coord)]
+    (try
+      (utils/with-session conn session
+        (let [instances (->> (mgquery/get-all-instances session) (reduce conj []))
+              main (get-current-main instances)
+              leader (get-current-leader instances)
+              node-to-kill (cond
+                             (and (nil? main) (nil? leader)) (rand-nth ns)
+                             (nil? main) leader
+                             (nil? leader) main
+                             :else (rand-nth [main leader]))
+              node-desc (cond
+                          (mutils/data-instance? node-to-kill) "current main"
+                          (mutils/coord-instance? node-to-kill) "current leader"
+                          :else "random node")]
+
+          (info "Killing" node-desc ":" node-to-kill)
+
+          node-to-kill))
+      (catch org.neo4j.driver.exceptions.ServiceUnavailableException _e
+        nil))))
+
+(defn choose-node-to-kill
+  [ns]
+  (let [coordinators ["n3" "n4" "n5"]
+        chooser (partial choose-node-to-kill-on-coord ns)]
+    (or
+     (some chooser coordinators)
+     (rand-nth ns)))) ; fallback to default node if all goes wrong
+
+(defn node-killer
+  "Responds to :start by killing a random node."
+  [nodes-config]
+  (node-start-stopper choose-node-to-kill
+                      s/stop-node!
+                      s/start-memgraph-node!
+                      nodes-config))
+
+(defn network-disruptor
+  "Responds to :start by disrupting network on chosen nodes and to :stop by restoring network configuration."
+  [db]
+  (nemesis-combined/packet-nemesis db))
+
+(defn full-nemesis
+  "Can kill, restart all processess and initiate network partitions."
+  [db nodes-config]
+  (nemesis/compose
+   {{:kill-node    :start
+     :heal-node :stop} (node-killer nodes-config)
+
+    {:start-partition-halves :start
+     :stop-partition-halves :stop} (nemesis/partition-random-halves)
+
+    {:start-partition-ring :start
+     :stop-partition-ring :stop} (nemesis/partition-majorities-ring)
+
+    {:start-partition-node :start
+     :stop-partition-node :stop} (nemesis/partition-random-node)
+
+    {:start-network-disruption :start-packet
+     :stop-network-disruption :stop-packet} (network-disruptor db)}))
+
+(defn nemesis-events
+  "Create a random sequence of nemesis events. Disruptions last [10-60] seconds, and the system remains undisrupted for some time afterwards."
+  [nodes-config]
+  (let [events [;[{:type :info :f :start-partition-halves}
+                ; (gen/sleep (+ 10 (rand-int 51))) ; [10, 60]
+                ; {:type :info :f :stop-partition-halves}
+                ; (gen/sleep 5)]
+
+                ;[{:type :info :f :start-partition-ring}
+                ; (gen/sleep (+ 10 (rand-int 51))) ; [10, 60]
+                ; {:type :info :f :stop-partition-ring}
+                ; (gen/sleep 5)]
+
+                ;[{:type :info :f :start-partition-node}
+                ; (gen/sleep (+ 10 (rand-int 51))) ; [10, 60]
+                ; {:type :info :f :stop-partition-node}
+                ; (gen/sleep 5)]
+
+                [{:type :info :f :kill-node}
+                 (gen/sleep (+ 10 (rand-int 51))) ; [10, 60]
+                 {:type :info :f :heal-node}
+                 (gen/sleep 5)]
+
+                ; [{:type :info :f :start-network-disruption :value [(keys nodes-config) net/all-packet-behaviors]}
+                ;  (gen/sleep (+ 10 (rand-int 51))) ; [10, 60]
+                ;  {:type :info :f :stop-network-disruption}
+                ;  (gen/sleep 5)]
+                ]]
+
+    (mapcat identity (repeatedly #(rand-nth events)))))
+
+(defn create
+  "Create a map which contains a nemesis configuration for running HA create test."
+  [db nodes-config]
+  {:nemesis (full-nemesis db nodes-config)
+   :generator (gen/phases
+               (gen/sleep 5) ; Enough time for cluster setup to finish
+               (nemesis-events nodes-config))
+   ; :final-generator (map utils/op [:stop-partition-ring :stop-partition-halves :stop-partition-node :heal-node :stop-network-disruption])
+   :final-generator (map utils/op [:heal-node])})

--- a/tests/jepsen/src/memgraph/mtenancy/nemesis.clj
+++ b/tests/jepsen/src/memgraph/mtenancy/nemesis.clj
@@ -200,7 +200,7 @@
   [db nodes-config]
   {:nemesis (full-nemesis db nodes-config)
    :generator (gen/phases
-               (gen/sleep 5) ; Enough time for cluster setup to finish
+               (gen/sleep 45) ; Enough time for cluster setup to finish
                (nemesis-events nodes-config))
    ; :final-generator (map utils/op [:stop-partition-ring :stop-partition-halves :stop-partition-node :heal-node :stop-network-disruption])
    :final-generator (map utils/op [:heal-node])})

--- a/tests/jepsen/src/memgraph/mtenancy/test.clj
+++ b/tests/jepsen/src/memgraph/mtenancy/test.clj
@@ -181,7 +181,7 @@
         :import-edges (if (and (mutils/data-instance? node) (is-main? bolt-conn))
                         (try
                           (utils/with-session bolt-conn session
-                            ; (mgquery/import-pokec-medium-nodes session)
+                            (mgquery/import-pokec-medium-edges session)
                             (assoc op :type :ok :value {:str "pokec_medium edges imported"}))
 
                           (catch org.neo4j.driver.exceptions.ServiceUnavailableException _e

--- a/tests/jepsen/src/memgraph/mtenancy/test.clj
+++ b/tests/jepsen/src/memgraph/mtenancy/test.clj
@@ -484,12 +484,14 @@
         first-main (random-data-instance (keys nodes-config))
         organization (:organization opts)
         license (:license opts)
-        num-tenants (:num-tenants opts)]
+        num-tenants (:num-tenants opts)
+        recovery-time (:recovery-time opts)
+        nemesis-start-sleep (:nemesis-start-sleep opts)
+        ]
     {:client    (Client. nodes-config first-leader first-main license organization num-tenants)
      :checker   (checker/compose
                  {:ha-mt     (checker)
                   :timeline (timeline/html)})
      :generator (client-generator)
-     :final-generator {:clients (final-client-generator) :recovery-time 15}
-     ; TODO: (andi) Add configuration parameter how much to sleep
-     :nemesis-config (nemesis/create db nodes-config)}))
+     :final-generator {:clients (final-client-generator) :recovery-time recovery-time}
+     :nemesis-config (nemesis/create db nodes-config nemesis-start-sleep)}))

--- a/tests/jepsen/src/memgraph/mtenancy/utils.clj
+++ b/tests/jepsen/src/memgraph/mtenancy/utils.clj
@@ -9,3 +9,26 @@
   "Is node coordinator instances?"
   [node]
   (some #(= % node) #{"n3" "n4" "n5"}))
+
+(defn generate-db-name
+  "Generates db name"
+  [id]
+  (str "db" id))
+
+(defn get-new-dbs
+  "Generates names for all newly created databases, excluding the default database 'memgraph'. Returns num-tenants - 1 names because of the
+  excluded default database.
+  "
+  [num-tenants]
+  (let
+   [ids (range 1 num-tenants)
+    dbs (map generate-db-name ids)]
+    dbs))
+
+(defn get-all-dbs
+  "Generates names for all databases, including the default database 'memgraph'.
+  Returns num-tenants names."
+  [num-tenants]
+  (let [dbs (get-new-dbs num-tenants)
+        dbs (conj dbs "memgraph")]
+    dbs))

--- a/tests/jepsen/src/memgraph/mtenancy/utils.clj
+++ b/tests/jepsen/src/memgraph/mtenancy/utils.clj
@@ -1,0 +1,11 @@
+(ns memgraph.mtenancy.utils)
+
+(defn data-instance?
+  "Is node data instances?"
+  [node]
+  (some #(= % node) #{"n1" "n2"}))
+
+(defn coord-instance?
+  "Is node coordinator instances?"
+  [node]
+  (some #(= % node) #{"n3" "n4" "n5"}))

--- a/tests/jepsen/src/memgraph/query.clj
+++ b/tests/jepsen/src/memgraph/query.clj
@@ -10,13 +10,6 @@
    (let [query (str "CREATE DATABASE " db)]
      query)))
 
-(defn use-database
-  "Creates DB with name 'db'."
-  [db]
-  (dbclient/create-query
-   (let [query (str "USE DATABASE " db)]
-     query)))
-
 (dbclient/defquery create-label-idx
   "
   CREATE INDEX ON :User;

--- a/tests/jepsen/src/memgraph/query.clj
+++ b/tests/jepsen/src/memgraph/query.clj
@@ -23,6 +23,15 @@
   CREATE (:User {id: row.id});
   ")
 
+; Path inside the container
+(dbclient/defquery import-pokec-medium-edges
+  "
+  LOAD CSV FROM '/opt/memgraph/datasets/pokec_medium/relationships.csv' WITH HEADER AS row
+  MATCH (n1:User {id: row.from_id})
+  MATCH (n2:User {id: row.to_id})
+  CREATE (n1)-[:KNOWS]->(n2);
+  ")
+
 (dbclient/defquery get-all-instances
   "SHOW INSTANCES;")
 

--- a/tests/jepsen/src/memgraph/query.clj
+++ b/tests/jepsen/src/memgraph/query.clj
@@ -3,6 +3,20 @@
   (:require [neo4j-clj.core :as dbclient]
             [clojure.tools.logging :refer [info]]))
 
+(defn create-database
+  "Creates DB with name 'db'."
+  [db]
+  (dbclient/create-query
+   (let [query (str "CREATE DATABASE " db)]
+     query)))
+
+(defn use-database
+  "Creates DB with name 'db'."
+  [db]
+  (dbclient/create-query
+   (let [query (str "USE DATABASE " db)]
+     query)))
+
 (dbclient/defquery create-label-idx
   "
   CREATE INDEX ON :User;

--- a/tests/jepsen/src/memgraph/query.clj
+++ b/tests/jepsen/src/memgraph/query.clj
@@ -3,18 +3,15 @@
   (:require [neo4j-clj.core :as dbclient]
             [clojure.tools.logging :refer [info]]))
 
-
 (dbclient/defquery create-label-idx
   "
   CREATE INDEX ON :User;
-  "
-)
+  ")
 
 (dbclient/defquery create-label-property-idx
   "
   CREATE INDEX ON :User(id);
-  "
-)
+  ")
 
 ; Path inside the container
 (dbclient/defquery import-pokec-medium-nodes
@@ -30,6 +27,16 @@
   MATCH (n1:User {id: row.from_id})
   MATCH (n2:User {id: row.to_id})
   CREATE (n1)-[:KNOWS]->(n2);
+  ")
+
+(dbclient/defquery get-num-nodes
+  "
+  MATCH (n) RETURN count(n) as c;
+  ")
+
+(dbclient/defquery get-num-edges
+  "
+  MATCH (n)-[e]->(m) RETURN count(e) as c;
   ")
 
 (dbclient/defquery get-all-instances

--- a/tests/jepsen/src/memgraph/query.clj
+++ b/tests/jepsen/src/memgraph/query.clj
@@ -3,6 +3,26 @@
   (:require [neo4j-clj.core :as dbclient]
             [clojure.tools.logging :refer [info]]))
 
+
+(dbclient/defquery create-label-idx
+  "
+  CREATE INDEX ON :User;
+  "
+)
+
+(dbclient/defquery create-label-property-idx
+  "
+  CREATE INDEX ON :User(id);
+  "
+)
+
+; Path inside the container
+(dbclient/defquery import-pokec-medium-nodes
+  "
+  LOAD CSV FROM '/opt/memgraph/datasets/pokec_medium/nodes.csv' WITH HEADER AS row
+  CREATE (:User {id: row.id});
+  ")
+
 (dbclient/defquery get-all-instances
   "SHOW INSTANCES;")
 

--- a/tests/jepsen/test/memgraph/memgraph_test.clj
+++ b/tests/jepsen/test/memgraph/memgraph_test.clj
@@ -151,67 +151,7 @@
   (testing "missing-intervals5"
     (let [my-seq (apply vector (concat (range 5001 10001) (range 50001 55001) (range 110001 115001)))]
 
-      (is (= (hacreate/missing-intervals my-seq) [[10001 50000] [55001 110000]]))))
-
-  (testing "cum-probs1"
-    (let [my-probs [0.1 0.3 0.6]]
-
-      (is (= (hacreate/cum-probs my-probs) [0.1 0.4 1.0]))))
-
-  (testing "cum-probs2"
-    (let [my-probs [0.5 0.5]]
-
-      (is (= (hacreate/cum-probs my-probs) [0.5 1.0]))))
-
-  (testing "cum-probs3"
-    (let [my-probs [0.25 0.25 0.25 0.25]]
-
-      (is (= (hacreate/cum-probs my-probs) [0.25 0.5 0.75 1.0]))))
-
-  (testing "cum-probs4"
-    (let [my-probs [1.0]]
-
-      (is (= (hacreate/cum-probs my-probs) [1.0]))))
-
-  (testing "cum-probs5"
-    (let [my-probs []]
-
-      (is (= (hacreate/cum-probs my-probs) [0]))))
-
-  (testing "get-competent-idx1"
-    (let [cum-probs [0.1 0.4 1.0]]
-
-      (is (= (hacreate/get-competent-idx cum-probs 0.05) 0))))
-
-  (testing "get-competent-idx2"
-    (let [cum-probs [0.1 0.4 1.0]]
-
-      (is (= (hacreate/get-competent-idx cum-probs 0.1) 1))))
-
-  (testing "get-competent-idx3"
-    (let [cum-probs [0.1 0.4 1.0]]
-
-      (is (= (hacreate/get-competent-idx cum-probs 0.3) 1))))
-
-  (testing "get-competent-idx4"
-    (let [cum-probs [0.1 0.4 1.0]]
-
-      (is (= (hacreate/get-competent-idx cum-probs 0.4) 2))))
-
-  (testing "get-competent-idx5"
-    (let [cum-probs [0.1 0.4 1.0]]
-
-      (is (= (hacreate/get-competent-idx cum-probs 0.8) 2))))
-
-  (testing "get-competent-idx6"
-    (let [cum-probs [0.1 0.4 1.0]]
-
-      (is (= (hacreate/get-competent-idx cum-probs 0.99) 2))))
-
-  (testing "get-competent-idx7"
-    (let [cum-probs [0.5 1.0]]
-
-      (is (= (hacreate/get-competent-idx cum-probs 0.2) 0)))))
+      (is (= (hacreate/missing-intervals my-seq) [[10001 50000] [55001 110000]])))))
 
 (deftest get-instance-url
   (testing "Get instance URL."


### PR DESCRIPTION
Adds multi-tenancy with HA test. Currently, we create N tenants and import nodes and edges on all of them. Nemesis is run with network and killing disruptions turned on. Throughout the execution, we only run `SHOW INSTANCES`. 

Additionally, the PR also removes `--leave-db-running` when running HA tests since the issue for which the flag was added is fixed. Hence, no need anymore to keep the logs more than necessary.

Related PR https://github.com/gorillalabs/neo4j-clj/pulls.