### PR TITLE
Bugfix: Ignore hidden files when symlinking data directory

### DIFF
--- a/src/dbms/dbms_handler.hpp
+++ b/src/dbms/dbms_handler.hpp
@@ -534,10 +534,16 @@ class DbmsHandler {
 
     // Add in-memory paths
     // Some directories are redundant (skip those)
-    const std::vector<std::string> skip{".lock", "audit_log", "auth", "databases", "internal_modules", "settings"};
+    using namespace std::string_view_literals;
+    constexpr std::array<std::string_view, 5> skip{"audit_log"sv, "auth"sv, "databases"sv, "internal_modules"sv,
+                                                   "settings"sv};
     for (auto const &item : std::filesystem::directory_iterator{*dir}) {
       const auto dir_name = std::filesystem::relative(item.path(), item.path().parent_path());
-      if (std::find(skip.begin(), skip.end(), dir_name) != skip.end()) continue;
+      auto const dir_name_str = dir_name.string();
+      if (std::find(skip.begin(), skip.end(), dir_name_str) != skip.end() || dir_name_str.starts_with(".")) {
+        spdlog::trace("{} won't be used for symlinking.", dir_name_str);
+        continue;
+      }
       to_link.push_back(item.path());
     }
 

--- a/tests/e2e/durability/CMakeLists.txt
+++ b/tests/e2e/durability/CMakeLists.txt
@@ -5,6 +5,7 @@ copy_e2e_python_files(durability common.py)
 copy_e2e_python_files(durability durability_with_property_compression_used.py)
 copy_e2e_python_files(durability periodic_snapshot.py)
 copy_e2e_python_files(durability snapshot_recovery.py)
+copy_e2e_python_files(durability multitenancy.py)
 
 copy_e2e_python_files_from_parent_folder(durability ".." memgraph.py)
 copy_e2e_python_files_from_parent_folder(durability ".." interactive_mg_runner.py)

--- a/tests/e2e/durability/common.py
+++ b/tests/e2e/durability/common.py
@@ -14,6 +14,20 @@ import typing
 import mgclient
 
 
+def get_data_path(file: str, test: str):
+    """
+    Data is stored in durability folder.
+    """
+    return f"durability/{file}/{test}"
+
+
+def get_logs_path(file: str, test: str):
+    """
+    Logs are stored in durability folder.
+    """
+    return f"durability/{file}/{test}"
+
+
 def execute_and_fetch_all(cursor: mgclient.Cursor, query: str, params: dict = {}) -> typing.List[tuple]:
     cursor.execute(query, params)
     return cursor.fetchall()

--- a/tests/e2e/durability/multitenancy.py
+++ b/tests/e2e/durability/multitenancy.py
@@ -1,0 +1,93 @@
+# Copyright 2025 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+import os
+import sys
+
+import interactive_mg_runner
+import pytest
+from common import connect, execute_and_fetch_all, get_data_path, get_logs_path
+
+interactive_mg_runner.SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+interactive_mg_runner.PROJECT_DIR = os.path.normpath(
+    os.path.join(interactive_mg_runner.SCRIPT_DIR, "..", "..", "..", "..")
+)
+interactive_mg_runner.BUILD_DIR = os.path.normpath(os.path.join(interactive_mg_runner.PROJECT_DIR, "build"))
+interactive_mg_runner.MEMGRAPH_BINARY = os.path.normpath(os.path.join(interactive_mg_runner.BUILD_DIR, "memgraph"))
+file = "multitenancy"
+
+
+def instance_description(test_name: str):
+    return {
+        "instance_1": {
+            "args": [
+                "--bolt-port",
+                "7687",
+                "--log-level",
+                "TRACE",
+                "--replication-restore-state-on-startup=true",
+                "--data-recovery-on-startup=true",
+            ],
+            "log_file": f"{get_logs_path(file, test_name)}/instance_1.log",
+            "data_directory": f"{get_data_path(file, test_name)}/instance_1",
+            "setup_queries": [],
+        },
+    }
+
+
+@pytest.fixture(autouse=True)
+def cleanup_after_test():
+    # Run the test
+    yield
+    # Stop and delete directories after cleaning the test
+    interactive_mg_runner.kill_all(keep_directories=False)
+
+
+@pytest.fixture
+def test_name(request):
+    return request.node.name
+
+
+def test_mt_with_hidden_files(test_name):
+    instance = instance_description(
+        test_name=test_name,
+    )
+
+    build_dir = os.path.join(interactive_mg_runner.PROJECT_DIR, "build", "e2e", "data")
+    data_dir_instance_1 = f"{build_dir}/{get_data_path(file, test_name)}/instance_1"
+    filename = ".snapshot"
+
+    # Create an empty .snapshot file in the root of data directory
+    root_file = f"{data_dir_instance_1}/{filename}"
+    root_dir = os.path.dirname(root_file)
+    if not os.path.exists(root_dir):
+        os.makedirs(root_dir)
+
+    with open(root_file, "a"):
+        pass
+
+    default_db_file = f"{data_dir_instance_1}/databases/memgraph/{filename}"
+    default_db_dir = os.path.dirname(default_db_file)
+    if not os.path.exists(default_db_dir):
+        os.makedirs(default_db_dir)
+
+    # Create an empty .snapshot file in the default DB data directory
+    with open(default_db_file, "a"):
+        pass
+
+    interactive_mg_runner.start_all(instance, keep_directories=False)
+
+    cursor = connect(host="localhost", port=7687).cursor()
+    execute_and_fetch_all(cursor, "RETURN 0")
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/durability/snapshot_recovery.py
+++ b/tests/e2e/durability/snapshot_recovery.py
@@ -13,8 +13,6 @@ import os
 import shutil
 import sys
 import tempfile
-import time
-from typing import Any, Dict
 
 import interactive_mg_runner
 import pytest

--- a/tests/e2e/durability/workloads.yaml
+++ b/tests/e2e/durability/workloads.yaml
@@ -8,3 +8,6 @@ workloads:
   - name: "Periodic snapshot"
     binary: "tests/e2e/pytest_runner.sh"
     args: ["durability/periodic_snapshot.py"]
+  - name: "MT durability"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["durability/multitenancy.py"]


### PR DESCRIPTION
Memgraph can be started in K8s environment with various storage providers. Some of them create `.snapshot` file which was preventing the database from starting. When Memgraph is started in a single-tenant mode, durability files are linked to those from the root for the back-compatibility. All hidden files should be ignored.