### PR TITLE
Add strict typing on point index creation

### DIFF
--- a/src/query/exceptions.hpp
+++ b/src/query/exceptions.hpp
@@ -542,4 +542,9 @@ class ShowSchemaInfoInMulticommandTxException : public MulticommandTxException {
   SPECIALIZE_GET_EXCEPTION_NAME(ShowSchemaInfoInMulticommandTxException)
 };
 
+class PointIndexException : public QueryException {
+  using QueryException::QueryException;
+  SPECIALIZE_GET_EXCEPTION_NAME(PointIndexException)
+};
+
 }  // namespace memgraph::query


### PR DESCRIPTION
Throw exception if property is not of correct type when creating a point index

