### PR TITLE
Rename newly added count mgp functions for better clarity

### DIFF
--- a/include/_mgp.hpp
+++ b/include/_mgp.hpp
@@ -334,9 +334,13 @@ inline mgp_vertices_iterator *graph_iter_vertices(mgp_graph *g, mgp_memory *memo
   return MgInvoke<mgp_vertices_iterator *>(mgp_graph_iter_vertices, g, memory);
 }
 
-inline size_t graph_count_vertices(mgp_graph *g) { return MgInvoke<size_t>(mgp_graph_count_vertices, g); }
+inline size_t graph_approximate_vertex_count(mgp_graph *g) {
+  return MgInvoke<size_t>(mgp_graph_approximate_vertex_count, g);
+}
 
-inline size_t graph_count_edges(mgp_graph *g) { return MgInvoke<size_t>(mgp_graph_count_edges, g); }
+inline size_t graph_approximate_edge_count(mgp_graph *g) {
+  return MgInvoke<size_t>(mgp_graph_approximate_edge_count, g);
+}
 
 // vector index
 

--- a/include/mg_procedure.h
+++ b/include/mg_procedure.h
@@ -1069,11 +1069,11 @@ enum mgp_error mgp_vertices_iterator_underlying_graph_is_mutable(struct mgp_vert
 /// Result is NULL if the end of the iteration has been reached.
 enum mgp_error mgp_vertices_iterator_get(struct mgp_vertices_iterator *it, struct mgp_vertex **result);
 
-/// Gets number of vertices in the graph.
-enum mgp_error mgp_graph_count_vertices(struct mgp_graph *graph, size_t *result);
+/// Gets the approximate number of vertices in the graph.
+enum mgp_error mgp_graph_approximate_vertex_count(struct mgp_graph *graph, size_t *result);
 
-/// Gets number of edges in the graph.
-enum mgp_error mgp_graph_count_edges(struct mgp_graph *graph, size_t *result);
+/// Gets the approximate number of edges in the graph.
+enum mgp_error mgp_graph_approximate_edge_count(struct mgp_graph *graph, size_t *result);
 
 /// @name Temporal Types
 ///

--- a/src/query/procedure/mg_procedure_impl.cpp
+++ b/src/query/procedure/mg_procedure_impl.cpp
@@ -3747,11 +3747,11 @@ mgp_error mgp_graph_iter_vertices(mgp_graph *graph, mgp_memory *memory, mgp_vert
   return WrapExceptions([graph, memory] { return NewRawMgpObject<mgp_vertices_iterator>(memory, graph); }, result);
 }
 
-mgp_error mgp_graph_count_vertices(mgp_graph *graph, size_t *result) {
+mgp_error mgp_graph_approximate_vertex_count(mgp_graph *graph, size_t *result) {
   return WrapExceptions([graph, result] { *result = graph->getImpl()->VerticesCount(); });
 }
 
-mgp_error mgp_graph_count_edges(mgp_graph *graph, size_t *result) {
+mgp_error mgp_graph_approximate_edge_count(mgp_graph *graph, size_t *result) {
   return WrapExceptions([graph, result] { *result = graph->getImpl()->EdgesCount(); });
 }
 
@@ -4413,7 +4413,7 @@ mgp_error mgp_untrack_current_thread_allocations(mgp_graph *graph) {
 }
 
 mgp_execution_headers::mgp_execution_headers(memgraph::utils::pmr::vector<memgraph::utils::pmr::string> &&storage)
-    : headers(std::move(storage)) {};
+    : headers(std::move(storage)){};
 
 mgp_error mgp_execution_headers_size(mgp_execution_headers *headers, size_t *result) {
   static_assert(noexcept(headers->headers.size()));


### PR DESCRIPTION
Rename `graph_count_vertices` and `graph_count_edges` to `approximate_x_count` to show they are approximative. Functions were added in [PR2762](https://github.com/memgraph/memgraph/pull/2762) and docs are handled there.


