### PR TITLE
Bugfix: Storage access timeout allowed everywhere

### DIFF
--- a/src/dbms/database.hpp
+++ b/src/dbms/database.hpp
@@ -61,13 +61,15 @@ class Database {
    * @return std::unique_ptr<storage::Storage::Accessor>
    */
   std::unique_ptr<storage::Storage::Accessor> Access(
-      std::optional<storage::IsolationLevel> override_isolation_level = {}) {
-    return storage_->Access(override_isolation_level);
+      std::optional<storage::IsolationLevel> override_isolation_level = {},
+      std::optional<std::chrono::milliseconds> timeout = std::nullopt) {
+    return storage_->Access(override_isolation_level, timeout);
   }
 
   std::unique_ptr<storage::Storage::Accessor> UniqueAccess(
-      std::optional<storage::IsolationLevel> override_isolation_level = {}) {
-    return storage_->UniqueAccess(override_isolation_level);
+      std::optional<storage::IsolationLevel> override_isolation_level = {},
+      std::optional<std::chrono::milliseconds> timeout = std::nullopt) {
+    return storage_->UniqueAccess(override_isolation_level, timeout);
   }
 
   /**

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -269,10 +269,12 @@ class DiskStorage final : public Storage {
   };
 
   using Storage::Access;
-  std::unique_ptr<Accessor> Access(std::optional<IsolationLevel> override_isolation_level) override;
+  std::unique_ptr<Accessor> Access(std::optional<IsolationLevel> override_isolation_level,
+                                   std::optional<std::chrono::milliseconds> timeout) override;
 
   using Storage::UniqueAccess;
-  std::unique_ptr<Accessor> UniqueAccess(std::optional<IsolationLevel> override_isolation_level) override;
+  std::unique_ptr<Accessor> UniqueAccess(std::optional<IsolationLevel> override_isolation_level,
+                                         std::optional<std::chrono::milliseconds> timeout) override;
 
   /// Flushing methods
   [[nodiscard]] utils::BasicResult<StorageManipulationError, void> FlushIndexCache(Transaction *transaction);

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -125,7 +125,8 @@ class InMemoryStorage final : public Storage {
     friend class InMemoryStorage;
 
     explicit InMemoryAccessor(auto tag, InMemoryStorage *storage, IsolationLevel isolation_level,
-                              StorageMode storage_mode);
+                              StorageMode storage_mode,
+                              std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
    public:
     InMemoryAccessor(const InMemoryAccessor &) = delete;
@@ -505,9 +506,11 @@ class InMemoryStorage final : public Storage {
   };
 
   using Storage::Access;
-  std::unique_ptr<Accessor> Access(std::optional<IsolationLevel> override_isolation_level) override;
+  std::unique_ptr<Accessor> Access(std::optional<IsolationLevel> override_isolation_level,
+                                   std::optional<std::chrono::milliseconds> timeout) override;
   using Storage::UniqueAccess;
-  std::unique_ptr<Accessor> UniqueAccess(std::optional<IsolationLevel> override_isolation_level) override;
+  std::unique_ptr<Accessor> UniqueAccess(std::optional<IsolationLevel> override_isolation_level,
+                                         std::optional<std::chrono::milliseconds> timeout) override;
 
   void FreeMemory(std::unique_lock<utils::ResourceLock> main_guard, bool periodic) override;
 

--- a/tests/unit/storage_v2_acc.cpp
+++ b/tests/unit/storage_v2_acc.cpp
@@ -14,22 +14,26 @@
 
 #include "storage/v2/inmemory/storage.hpp"
 
+namespace {
+constexpr auto kTimeout = std::chrono::milliseconds(100);
+}  // namespace
+
 /// Test that unqiue/shared accessors can timeout and not deadlock
 TEST(StorageV2Acc, Timeouts) {
   std::unique_ptr<memgraph::storage::Storage> storage(
       std::make_unique<memgraph::storage::InMemoryStorage>(memgraph::storage::Config{}));
 
   {
-    auto shared_acc = storage->Access();
+    auto shared_acc = storage->Access({}, kTimeout);
     ASSERT_TRUE(shared_acc);
-    ASSERT_THROW(storage->UniqueAccess(), memgraph::storage::UniqueAccessTimeout);
-    auto shared_acc2 = storage->Access();
+    ASSERT_THROW(storage->UniqueAccess({}, kTimeout), memgraph::storage::UniqueAccessTimeout);
+    auto shared_acc2 = storage->Access({}, kTimeout);
     ASSERT_TRUE(shared_acc2);
   }
   {
-    auto unique_acc = storage->UniqueAccess();
+    auto unique_acc = storage->UniqueAccess({}, kTimeout);
     ASSERT_TRUE(unique_acc);
-    ASSERT_THROW(storage->Access(), memgraph::storage::SharedAccessTimeout);
-    ASSERT_THROW(storage->UniqueAccess(), memgraph::storage::UniqueAccessTimeout);
+    ASSERT_THROW(storage->Access({}, kTimeout), memgraph::storage::SharedAccessTimeout);
+    ASSERT_THROW(storage->UniqueAccess({}, kTimeout), memgraph::storage::UniqueAccessTimeout);
   }
 }


### PR DESCRIPTION
Recent changes made possible for Storage::Access to timeout.
This is needed for Cypher queries, as their execution is split into Prepare and multiple Pulls. Not timing out could lead to a deadlock.
On the other hand, this is not fine in other circumstances (ex. SnapshotCreate).
This fixes the issue by allowing the access timeout only for Prepare.