### PR TITLE
Bugfix: prevent main from crashing while recovering replica due to disk failures

### DIFF
--- a/src/dbms/rpc.hpp
+++ b/src/dbms/rpc.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -18,6 +18,7 @@
 #include "rpc/messages.hpp"
 #include "slk/streams.hpp"
 #include "storage/v2/config.hpp"
+#include "utils/typeinfo.hpp"
 #include "utils/uuid.hpp"
 
 namespace memgraph::storage::replication {

--- a/src/rpc/messages.hpp
+++ b/src/rpc/messages.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -12,9 +12,6 @@
 #pragma once
 
 #include <cstdint>
-#include <memory>
-
-#include "utils/typeinfo.hpp"
 
 namespace memgraph::rpc {
 
@@ -32,6 +29,12 @@ template <typename TRequest, typename TResponse>
 struct RequestResponse {
   using Request = TRequest;
   using Response = TResponse;
+};
+
+template <typename T>
+concept IsRpc = requires {
+  typename T::Request;
+  typename T::Response;
 };
 
 }  // namespace memgraph::rpc

--- a/src/rpc/server.hpp
+++ b/src/rpc/server.hpp
@@ -20,6 +20,7 @@
 #include "rpc/messages.hpp"
 #include "rpc/protocol.hpp"
 #include "slk/streams.hpp"
+#include "utils/typeinfo.hpp"
 
 namespace memgraph::rpc {
 

--- a/src/storage/v2/replication/rpc.hpp
+++ b/src/storage/v2/replication/rpc.hpp
@@ -16,7 +16,6 @@
 #include <utility>
 
 #include "rpc/messages.hpp"
-#include "rpc/version.hpp"
 #include "slk/serialization.hpp"
 #include "slk/streams.hpp"
 #include "storage/v2/config.hpp"
@@ -134,13 +133,13 @@ struct WalFilesReq {
   static void Load(WalFilesReq *self, slk::Reader *reader);
   static void Save(const WalFilesReq &self, slk::Builder *builder);
   WalFilesReq() = default;
-  explicit WalFilesReq(const utils::UUID &main_uuid, const utils::UUID &storage_uuid, uint64_t file_number,
+  explicit WalFilesReq(uint64_t const file_number, const utils::UUID &main_uuid, const utils::UUID &storage_uuid,
                        bool const reset_needed)
-      : main_uuid{main_uuid}, uuid{storage_uuid}, file_number(file_number), reset_needed{reset_needed} {}
+      : file_number(file_number), main_uuid{main_uuid}, uuid{storage_uuid}, reset_needed{reset_needed} {}
 
+  uint64_t file_number;
   utils::UUID main_uuid;
   utils::UUID uuid;
-  uint64_t file_number;
   bool reset_needed;
 };
 

--- a/src/storage/v2/replication/serialization.cpp
+++ b/src/storage/v2/replication/serialization.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -68,16 +68,22 @@ void Encoder::WriteFileData(utils::InputFile *file) {
   }
 }
 
-void Encoder::WriteFile(const std::filesystem::path &path) {
+bool Encoder::WriteFile(const std::filesystem::path &path) {
   utils::InputFile file;
-  MG_ASSERT(file.Open(path), "Failed to open file {}", path);
-  MG_ASSERT(path.has_filename(), "Path does not have a filename!");
+  if (!file.Open(path)) {
+    spdlog::error("Failed to open file {}.", path);
+    return false;
+  }
+  if (!path.has_filename()) {
+    spdlog::error("Path {} does not have a filename.", path);
+    return false;
+  }
   const auto &filename = path.filename().generic_string();
   WriteString(filename);
-  auto file_size = file.GetSize();
+  auto const file_size = file.GetSize();
   WriteUint(file_size);
   WriteFileData(&file);
-  file.Close();
+  return true;
 }
 
 ////// Decoder //////

--- a/src/storage/v2/replication/serialization.hpp
+++ b/src/storage/v2/replication/serialization.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -47,7 +47,7 @@ class Encoder final : public durability::BaseEncoder {
 
   void WriteFileData(utils::InputFile *file);
 
-  void WriteFile(const std::filesystem::path &path);
+  bool WriteFile(const std::filesystem::path &path);
 
  private:
   slk::Builder *builder_;

--- a/tests/unit/replication_rpc_progress.cpp
+++ b/tests/unit/replication_rpc_progress.cpp
@@ -276,7 +276,7 @@ TEST_F(ReplicationRpcProgressTest, WalFilesNoTimeout) {
   ClientContext client_context;
   Client client{endpoint, &client_context, rpc_timeouts};
 
-  auto stream = client.Stream<memgraph::storage::replication::WalFilesRpc>(UUID{}, UUID{}, 1, false);
+  auto stream = client.Stream<memgraph::storage::replication::WalFilesRpc>(1, UUID{}, UUID{}, false);
   EXPECT_NO_THROW(stream.AwaitResponseWhileInProgress());
 }
 
@@ -311,7 +311,7 @@ TEST_F(ReplicationRpcProgressTest, WalFilesProgressTimeout) {
   ClientContext client_context;
   Client client{endpoint, &client_context, rpc_timeouts};
 
-  auto stream = client.Stream<memgraph::storage::replication::WalFilesRpc>(UUID{}, UUID{}, 1, false);
+  auto stream = client.Stream<memgraph::storage::replication::WalFilesRpc>(1, UUID{}, UUID{}, false);
   EXPECT_THROW(stream.AwaitResponseWhileInProgress(), GenericRpcFailedException);
 }
 
@@ -356,7 +356,7 @@ TEST_F(ReplicationRpcProgressTest, TestTTT) {
   }
 
   {
-    auto wal_files_stream = client.Stream<memgraph::storage::replication::WalFilesRpc>(UUID{}, UUID{}, 1, false);
+    auto wal_files_stream = client.Stream<memgraph::storage::replication::WalFilesRpc>(1, UUID{}, UUID{}, false);
     EXPECT_NO_THROW(wal_files_stream.AwaitResponseWhileInProgress());
   }
 }

--- a/tests/unit/replication_rpc_progress.cpp
+++ b/tests/unit/replication_rpc_progress.cpp
@@ -38,6 +38,7 @@ using memgraph::storage::Storage;
 using memgraph::storage::replication::AppendDeltasReq;
 using memgraph::storage::replication::AppendDeltasRes;
 using memgraph::storage::replication::AppendDeltasRpc;
+using memgraph::storage::replication::CurrentWalRpc;
 using memgraph::storage::replication::Decoder;
 using memgraph::utils::UUID;
 
@@ -208,9 +209,9 @@ TEST_F(ReplicationRpcProgressTest, CurrentWalNoTimeout) {
   ClientContext client_context;
   Client client{endpoint, &client_context, rpc_timeouts};
 
-  auto stream = memgraph::storage::InMemoryCurrentWalHandler{UUID{}, &main_storage, client, false};
+  auto stream = client.Stream<CurrentWalRpc>(UUID{}, main_storage.uuid(), false);
 
-  EXPECT_NO_THROW(stream.Finalize());
+  EXPECT_NO_THROW(stream.AwaitResponseWhileInProgress());
 }
 
 // First send progress, then timeout
@@ -244,9 +245,9 @@ TEST_F(ReplicationRpcProgressTest, CurrentWalProgressTimeout) {
   ClientContext client_context;
   Client client{endpoint, &client_context, rpc_timeouts};
 
-  auto stream = memgraph::storage::InMemoryCurrentWalHandler{UUID{}, &main_storage, client, false};
+  auto stream = client.Stream<CurrentWalRpc>(UUID{}, main_storage.uuid(), false);
 
-  EXPECT_THROW(stream.Finalize(), GenericRpcFailedException);
+  EXPECT_THROW(stream.AwaitResponseWhileInProgress(), GenericRpcFailedException);
 }
 
 // First send progress, then timeout
@@ -350,8 +351,8 @@ TEST_F(ReplicationRpcProgressTest, TestTTT) {
   Client client{endpoint, &client_context, rpc_timeouts};
 
   {
-    auto stream = memgraph::storage::InMemoryCurrentWalHandler{UUID{}, &main_storage, client, false};
-    EXPECT_THROW(stream.Finalize(), GenericRpcFailedException);
+    auto stream = client.Stream<CurrentWalRpc>(UUID{}, main_storage.uuid(), false);
+    EXPECT_THROW(stream.AwaitResponseWhileInProgress(), GenericRpcFailedException);
   }
 
   {


### PR DESCRIPTION
Replica won't crash anymore when performing recovery and when disk access to durability folder fails. Instead, it will return empty response which will signal to main that the recovery isn't completed. 