### PR TITLE
Query modules memory improvements

### DIFF
--- a/include/mg_procedure.h
+++ b/include/mg_procedure.h
@@ -640,6 +640,10 @@ enum mgp_error mgp_result_record_insert(struct mgp_result_record *record, const 
                                         struct mgp_value *val);
 ///@}
 
+/// TODO
+enum mgp_error mgp_result_record_create_and_bulk_insert(mgp_result *res, const char *field_name[], mgp_value *val[],
+                                                        size_t n);
+
 /// @name Graph Constructs
 ///@{
 

--- a/include/mg_procedure.h
+++ b/include/mg_procedure.h
@@ -632,6 +632,10 @@ enum mgp_error mgp_result_set_error_msg(struct mgp_result *res, const char *erro
 /// Return mgp_error::MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate a mgp_result_record.
 enum mgp_error mgp_result_new_record(struct mgp_result *res, struct mgp_result_record **result);
 
+/// Reserve memory for n records in the result.
+/// Return mgp_error::MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate memory for the records.
+enum mgp_error mgp_result_reserve(struct mgp_result *res, size_t n);
+
 /// Assign a value to a field in the given record.
 /// Return mgp_error::MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate memory to copy the mgp_value to
 /// mgp_result_record. Return mgp_error::MGP_ERROR_OUT_OF_RANGE if there is no field named `field_name`. Return

--- a/include/mg_procedure.h
+++ b/include/mg_procedure.h
@@ -641,8 +641,8 @@ enum mgp_error mgp_result_record_insert(struct mgp_result_record *record, const 
 ///@}
 
 /// TODO
-enum mgp_error mgp_result_record_create_and_bulk_insert(mgp_result *res, const char *field_name[], mgp_value *val[],
-                                                        size_t n);
+// enum mgp_error mgp_result_record_create_and_bulk_insert(mgp_result *res, size_t N_param, size_t N_records,
+//                                                         const char *field_name[], mgp_value **val[]);
 
 /// @name Graph Constructs
 ///@{

--- a/include/mg_procedure.h
+++ b/include/mg_procedure.h
@@ -644,10 +644,6 @@ enum mgp_error mgp_result_record_insert(struct mgp_result_record *record, const 
                                         struct mgp_value *val);
 ///@}
 
-/// TODO
-// enum mgp_error mgp_result_record_create_and_bulk_insert(mgp_result *res, size_t N_param, size_t N_records,
-//                                                         const char *field_name[], mgp_value **val[]);
-
 /// @name Graph Constructs
 ///@{
 

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -5775,7 +5775,7 @@ class CallProcedureCursor : public Cursor {
       ExpressionEvaluator evaluator(&frame, context.symbol_table, context.evaluation_context, context.db_accessor,
                                     graph_view);
 
-      result_.signature = &proc->results;
+      result_.SetSignature(&proc->results);
       result_.is_transactional = storage::IsTransactional(context.db_accessor->GetStorageMode());
 
       auto *memory = context.evaluation_context.memory;
@@ -5792,7 +5792,7 @@ class CallProcedureCursor : public Cursor {
       // will no longer hold a lock on the `module`. If someone were to reload
       // it, the pointer would be invalid.
       result_signature_size_ = result_.signature->size();
-      result_.signature = nullptr;
+      result_.SetSignature(nullptr);
       if (result_.error_msg) {
         memgraph::utils::MemoryTracker::OutOfMemoryExceptionBlocker blocker;
         throw QueryRuntimeException("{}: {}", self_->procedure_name_, *result_.error_msg);

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -5810,7 +5810,7 @@ class CallProcedureCursor : public Cursor {
     // C API guarantees that it's impossible to set fields which are not part of
     // the result record, but it does not gurantee that some may be missing. See
     // `mgp_result_record_insert`.
-    // TODO Ivan: remove comment
+    // TODO Ivan: check missing
     if (values.size() != result_signature_size_) {
       throw QueryRuntimeException(
           "Procedure '{}' did not yield all fields as required by its "
@@ -5819,8 +5819,8 @@ class CallProcedureCursor : public Cursor {
     }
     for (size_t i = 0; i < self_->result_fields_.size(); ++i) {
       std::string_view field_name(self_->result_fields_[i]);
-      auto field_id_it = result_.signature->find(field_name);
-      MG_ASSERT(field_id_it != result_.signature->end());
+      auto field_id_it = result_.field_to_id.find(field_name);
+      MG_ASSERT(field_id_it != result_.field_to_id.end());
 
       frame[self_->result_symbols_[i]] = std::move(values[field_id_it->second.second]);
       if (context.frame_change_collector &&

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -5813,6 +5813,7 @@ class CallProcedureCursor : public Cursor {
           context.frame_change_collector->IsKeyTracked(self_->result_symbols_[iterator_index].name())) {
         context.frame_change_collector->ResetTrackingValue(self_->result_symbols_[iterator_index].name());
       }
+      iterator_index++;
     }
     ++result_row_it_;
     if (!result_.is_transactional) {

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -5727,10 +5727,7 @@ class CallProcedureCursor : public Cursor {
     }
 
     for (int i = 0; i < self_->result_fields_.size(); ++i) {
-      // TODO: is there a workaround to not create another string?
-      // results and result_fields have different allocator
-      auto signature_it =
-          proc_->results.find(memgraph::utils::pmr::string{self_->result_fields_[i], proc_->results.get_allocator()});
+      auto signature_it = proc_->results.find(self_->result_fields_[i]);
       result_.signature.emplace(self_->result_fields_[i],
                                 ResultsMetadata{signature_it->second.first, signature_it->second.second, i});
     }

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -5726,14 +5726,16 @@ class CallProcedureCursor : public Cursor {
                                   get_proc_type_str(proc_->info.is_write));
     }
 
-    for (int i = 0; i < self_->result_fields_.size(); ++i) {
-      auto signature_it = proc_->results.find(self_->result_fields_[i]);
-      result_.signature.emplace(self_->result_fields_[i],
-                                ResultsMetadata{signature_it->second.first, signature_it->second.second, i});
+    for (size_t i = 0; i < self_->result_fields_.size(); ++i) {
+      auto signature_it =
+          proc_->results.find(memgraph::utils::pmr::string{self_->result_fields_[i], proc_->results.get_allocator()});
+      result_.signature.emplace(
+          self_->result_fields_[i],
+          ResultsMetadata{signature_it->second.first, signature_it->second.second, static_cast<uint32_t>(i)});
     }
     if (proc_->results.size() == self_->result_fields_.size()) return;
     // Not all results were yielded but they still need to be inserted inside the signature
-    int index = self_->result_fields_.size();
+    uint32_t index = self_->result_fields_.size();
     for (auto const &[name, signature] : proc_->results) {
       if (result_.signature.find(name) == result_.signature.end()) {
         result_.signature.emplace(name, ResultsMetadata{signature.first, signature.second, index++});

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -5734,6 +5734,14 @@ class CallProcedureCursor : public Cursor {
       result_.signature.emplace(self_->result_fields_[i],
                                 ResultsMetadata(signature_it->second.first, signature_it->second.second, i));
     }
+    if (proc_->results.size() == self_->result_fields_.size()) return;
+    // Not all results were yielded but they still need to be inserted inside the signature
+    int index = self_->result_fields_.size();
+    for (auto const &[name, signature] : proc_->results) {
+      if (result_.signature.find(name) == result_.signature.end()) {
+        result_.signature.emplace(name, ResultsMetadata(signature.first, signature.second, index++));
+      }
+    }
   }
 
   bool Pull(Frame &frame, ExecutionContext &context) override {

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -5729,9 +5729,10 @@ class CallProcedureCursor : public Cursor {
     for (int i = 0; i < self_->result_fields_.size(); ++i) {
       // TODO: is there a workaround to not create another string?
       // results and result_fields have different allocator
-      auto signature_it = *proc_->results.find(memgraph::utils::pmr::string(self_->result_fields_[i], mem));
+      auto signature_it =
+          proc_->results.find(memgraph::utils::pmr::string(self_->result_fields_[i], proc_->results.get_allocator()));
       result_.signature.emplace(self_->result_fields_[i],
-                                ResultsMetadata(signature_it.second.first, signature_it.second.second, i));
+                                ResultsMetadata(signature_it->second.first, signature_it->second.second, i));
     }
   }
 

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -5810,6 +5810,7 @@ class CallProcedureCursor : public Cursor {
     // C API guarantees that it's impossible to set fields which are not part of
     // the result record, but it does not gurantee that some may be missing. See
     // `mgp_result_record_insert`.
+    // TODO Ivan: remove comment
     if (values.size() != result_signature_size_) {
       throw QueryRuntimeException(
           "Procedure '{}' did not yield all fields as required by its "
@@ -5818,12 +5819,10 @@ class CallProcedureCursor : public Cursor {
     }
     for (size_t i = 0; i < self_->result_fields_.size(); ++i) {
       std::string_view field_name(self_->result_fields_[i]);
-      auto result_it = values.find(field_name);
-      if (result_it == values.end()) {
-        throw QueryRuntimeException("Procedure '{}' did not yield a record with '{}' field.", self_->procedure_name_,
-                                    field_name);
-      }
-      frame[self_->result_symbols_[i]] = std::move(result_it->second);
+      auto field_id_it = result_.signature->find(field_name);
+      MG_ASSERT(field_id_it != result_.signature->end());
+
+      frame[self_->result_symbols_[i]] = std::move(values[field_id_it->second.second]);
       if (context.frame_change_collector &&
           context.frame_change_collector->IsKeyTracked(self_->result_symbols_[i].name())) {
         context.frame_change_collector->ResetTrackingValue(self_->result_symbols_[i].name());

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -5730,16 +5730,16 @@ class CallProcedureCursor : public Cursor {
       // TODO: is there a workaround to not create another string?
       // results and result_fields have different allocator
       auto signature_it =
-          proc_->results.find(memgraph::utils::pmr::string(self_->result_fields_[i], proc_->results.get_allocator()));
+          proc_->results.find(memgraph::utils::pmr::string{self_->result_fields_[i], proc_->results.get_allocator()});
       result_.signature.emplace(self_->result_fields_[i],
-                                ResultsMetadata(signature_it->second.first, signature_it->second.second, i));
+                                ResultsMetadata{signature_it->second.first, signature_it->second.second, i});
     }
     if (proc_->results.size() == self_->result_fields_.size()) return;
     // Not all results were yielded but they still need to be inserted inside the signature
     int index = self_->result_fields_.size();
     for (auto const &[name, signature] : proc_->results) {
       if (result_.signature.find(name) == result_.signature.end()) {
-        result_.signature.emplace(name, ResultsMetadata(signature.first, signature.second, index++));
+        result_.signature.emplace(name, ResultsMetadata{signature.first, signature.second, index++});
       }
     }
   }

--- a/src/query/procedure/mg_procedure_impl.cpp
+++ b/src/query/procedure/mg_procedure_impl.cpp
@@ -1703,32 +1703,6 @@ mgp_error mgp_result_record_insert(mgp_result_record *record, const char *field_
   });
 }
 
-// mgp_error mgp_result_record_create_and_bulk_insert(mgp_result *res, size_t N_param, size_t N_records,
-//                                                    const char *field_name[], mgp_value **val[]) {
-//   return WrapExceptions([=] {
-//     auto *memory = res->rows.get_allocator().GetMemoryResource();
-//     MG_ASSERT(res->signature, "Expected to have a valid signature");
-
-//     res->rows.reserve(res->rows.size() + N_records);
-
-//     for (size_t i = 0; i < N_records; ++i) {
-//       res->rows.push_back(mgp_result_record{
-//           .signature = res->signature,
-//           .values = memgraph::utils::pmr::map<memgraph::utils::pmr::string, memgraph::query::TypedValue>(memory),
-//           .ignore_deleted_values = !res->is_transactional});
-
-//       auto &record = res->rows.back();
-//       for (size_t j = 0; j < N_param; ++j) {
-//         if (record.ignore_deleted_values && ContainsDeleted(val[j][i])) [[unlikely]] {
-//           record.has_deleted_values = true;
-//           break;
-//         }
-//         record.values.emplace(field_name[j], ToTypedValue(*val[j][i], memory));
-//       }
-//     }
-//   });
-// }
-
 mgp_error mgp_func_result_set_error_msg(mgp_func_result *res, const char *msg, mgp_memory *memory) {
   return WrapExceptions([=] {
     // We are copying error message string here, that includes the out of memory message

--- a/src/query/procedure/mg_procedure_impl.cpp
+++ b/src/query/procedure/mg_procedure_impl.cpp
@@ -1675,6 +1675,10 @@ mgp_error mgp_result_new_record(mgp_result *res, mgp_result_record **result) {
       result);
 }
 
+mgp_error mgp_result_reserve(mgp_result *res, size_t n) {
+  return WrapExceptions([res, n] { res->rows.reserve(res->rows.size() + n); });
+}
+
 mgp_error mgp_result_record_insert(mgp_result_record *record, const char *field_name, mgp_value *val) {
   return WrapExceptions([=] {
     auto *memory = record->values.get_allocator().GetMemoryResource();

--- a/src/query/procedure/mg_procedure_impl.cpp
+++ b/src/query/procedure/mg_procedure_impl.cpp
@@ -1666,9 +1666,9 @@ mgp_error mgp_result_new_record(mgp_result *res, mgp_result_record **result) {
       [res] {
         auto *memory = res->rows.get_allocator().GetMemoryResource();
         MG_ASSERT(res->signature, "Expected to have a valid signature");
-        res->rows.push_back(mgp_result_record{.signature = &res->field_to_id,
+        res->rows.push_back(mgp_result_record{.signature = res->signature,
                                               .values = memgraph::utils::pmr::vector<memgraph::query::TypedValue>(
-                                                  res->field_to_id.size(), memgraph::query::TypedValue(memory), memory),
+                                                  res->signature->size(), memgraph::query::TypedValue(memory), memory),
                                               .ignore_deleted_values = !res->is_transactional});
         return &res->rows.back();
       },
@@ -1688,12 +1688,12 @@ mgp_error mgp_result_record_insert(mgp_result_record *record, const char *field_
     if (find_it == record->signature->end()) {
       throw std::out_of_range{fmt::format("The result doesn't have any field named '{}'.", field_name)};
     }
-    auto const field_id = find_it->second.second;
+    auto const field_id = find_it->second.id;
     if (record->ignore_deleted_values && ContainsDeleted(val)) [[unlikely]] {
       record->has_deleted_values = true;
       return;
     }
-    auto const *field_type = find_it->second.first;
+    auto const *field_type = find_it->second.type;
     if (!field_type->SatisfiesType(*val)) [[unlikely]] {
       throw std::logic_error{
           fmt::format("The type of value doesn't satisfy the type '{}'!", field_type->GetPresentableName())};
@@ -4062,6 +4062,8 @@ mgp_error AddResultToProp(T *prop, const char *name, mgp_type *type, bool is_dep
     };
     auto *memory = prop->results.get_allocator().GetMemoryResource();
     prop->results.emplace(memgraph::utils::pmr::string(name, memory), std::make_pair(type->impl.get(), is_deprecated));
+    prop->results_metadata.emplace(memgraph::utils::pmr::string(name, memory),
+                                   ResultsMetadata(type->impl.get(), is_deprecated, prop->results_metadata.size()));
   });
 }
 

--- a/src/query/procedure/mg_procedure_impl.cpp
+++ b/src/query/procedure/mg_procedure_impl.cpp
@@ -1665,10 +1665,12 @@ mgp_error mgp_result_new_record(mgp_result *res, mgp_result_record **result) {
   return WrapExceptions(
       [res] {
         auto *memory = res->rows.get_allocator().GetMemoryResource();
-        res->rows.push_back(mgp_result_record{.signature = &res->signature,
-                                              .values = memgraph::utils::pmr::vector<memgraph::query::TypedValue>(
-                                                  res->signature.size(), memgraph::query::TypedValue(memory), memory),
-                                              .ignore_deleted_values = !res->is_transactional});
+        res->rows.push_back(
+            mgp_result_record{.signature = &res->signature,
+                              .values =
+                                  memgraph::utils::pmr::vector<memgraph::query::TypedValue>{
+                                      res->signature.size(), memgraph::query::TypedValue(memory), memory},
+                              .ignore_deleted_values = !res->is_transactional});
         return &res->rows.back();
       },
       result);

--- a/src/query/procedure/mg_procedure_impl.cpp
+++ b/src/query/procedure/mg_procedure_impl.cpp
@@ -1677,7 +1677,7 @@ mgp_error mgp_result_new_record(mgp_result *res, mgp_result_record **result) {
 }
 
 mgp_error mgp_result_reserve(mgp_result *res, size_t n) {
-  return WrapExceptions([res, n] { res->rows.reserve(res->rows.size() + n); });
+  return WrapExceptions([res, n] { res->rows.reserve(n); });
 }
 
 mgp_error mgp_result_record_insert(mgp_result_record *record, const char *field_name, mgp_value *val) {

--- a/src/query/procedure/mg_procedure_impl.hpp
+++ b/src/query/procedure/mg_procedure_impl.hpp
@@ -594,7 +594,7 @@ struct mgp_graph {
 struct ResultsMetadata {
   const memgraph::query::procedure::CypherType *type;
   bool is_deprecated;
-  int32_t field_id;
+  uint32_t field_id;
 };
 
 struct mgp_result_record {

--- a/src/query/procedure/mg_procedure_impl.hpp
+++ b/src/query/procedure/mg_procedure_impl.hpp
@@ -604,10 +604,21 @@ struct mgp_result {
       const memgraph::utils::pmr::map<memgraph::utils::pmr::string,
                                       std::pair<const memgraph::query::procedure::CypherType *, bool>> *signature,
       memgraph::utils::MemoryResource *mem)
-      : signature(signature), field_to_id(mem), rows(mem) {
-    int id = 0;
-    for (const auto &[field, pair] : *signature) {
-      field_to_id.emplace(field, std::make_pair(pair.first, id++));
+      : field_to_id(mem), rows(mem) {
+    SetSignature(signature);
+  }
+
+  void SetSignature(const memgraph::utils::pmr::map<
+                    memgraph::utils::pmr::string, std::pair<const memgraph::query::procedure::CypherType *, bool>> *s) {
+    signature = s;
+
+    field_to_id.clear();
+    if (signature) {
+      // mg.procedures() don't have signature, so we need to check to not crash
+      int id = 0;
+      for (const auto &[field, pair] : *signature) {
+        field_to_id.emplace(field, std::make_pair(pair.first, id++));
+      }
     }
   }
 

--- a/src/query/procedure/mg_procedure_impl.hpp
+++ b/src/query/procedure/mg_procedure_impl.hpp
@@ -612,9 +612,12 @@ struct mgp_result {
                     memgraph::utils::pmr::string, std::pair<const memgraph::query::procedure::CypherType *, bool>> *s) {
     signature = s;
 
-    field_to_id.clear();
+    // at one point signature will get set to nullptr due to
+    // releasing the lock on the module
+    // but we still need to field_to_id map to insert results correctly
     if (signature) {
       // mg.procedures() don't have signature, so we need to check to not crash
+      field_to_id.clear();
       int id = 0;
       for (const auto &[field, pair] : *signature) {
         field_to_id.emplace(field, std::make_pair(pair.first, id++));

--- a/src/query/procedure/mg_procedure_impl.hpp
+++ b/src/query/procedure/mg_procedure_impl.hpp
@@ -607,30 +607,13 @@ struct mgp_result_record {
 struct mgp_result {
   explicit mgp_result(const memgraph::utils::pmr::map<memgraph::utils::pmr::string, ResultsMetadata> *signature,
                       memgraph::utils::MemoryResource *mem)
-      : signature(signature), rows(mem), lock_on_module(true) {}
-
-  void SetSignature(const memgraph::utils::pmr::map<memgraph::utils::pmr::string, ResultsMetadata> *s, bool lock) {
-    signature = s;
-    lock_on_module = lock;
-    // at one point signature will get set to nullptr due to
-    // releasing the lock on the module
-    // but we still need to field_to_id map to insert results correctly
-    // if (signature) {
-    //   // mg.procedures() don't have signature, so we need to check to not crash
-    //   field_to_id.clear();
-    //   int id = 0;
-    //   for (const auto &[field, pair] : *signature) {
-    //     field_to_id.emplace(field, std::make_pair(pair.first, id++));
-    //   }
-    // }
-  }
+      : signature(signature), rows(mem) {}
 
   /// Result record signature as defined for mgp_proc.
   const memgraph::utils::pmr::map<memgraph::utils::pmr::string, ResultsMetadata> *signature;
   memgraph::utils::pmr::vector<mgp_result_record> rows;
   std::optional<memgraph::utils::pmr::string> error_msg;
   bool is_transactional = true;
-  bool lock_on_module = false;
 };
 
 struct mgp_func_result {

--- a/src/query/procedure/module.cpp
+++ b/src/query/procedure/module.cpp
@@ -1369,8 +1369,8 @@ template <typename T>
 concept ModuleProperties = utils::SameAsAnyOf<T, mgp_proc, mgp_trans, mgp_func>;
 
 template <ModuleProperties T>
-auto MakePairIfPropFound(const ModuleRegistry &module_registry, std::string_view fully_qualified_name)
-    -> find_result<T> {
+auto MakePairIfPropFound(const ModuleRegistry &module_registry,
+                         std::string_view fully_qualified_name) -> find_result<T> {
   auto prop_fun = [](auto &module) {
     if constexpr (std::is_same_v<T, mgp_proc>) {
       return module->Procedures();
@@ -1411,18 +1411,18 @@ auto MakePairIfPropFound(const ModuleRegistry &module_registry, std::string_view
 }
 
 }  // namespace
-auto FindProcedure(const ModuleRegistry &module_registry, std::string_view fully_qualified_procedure_name)
-    -> find_result<mgp_proc> {
+auto FindProcedure(const ModuleRegistry &module_registry,
+                   std::string_view fully_qualified_procedure_name) -> find_result<mgp_proc> {
   return MakePairIfPropFound<mgp_proc>(module_registry, fully_qualified_procedure_name);
 }
 
-auto FindTransformation(const ModuleRegistry &module_registry, std::string_view fully_qualified_transformation_name)
-    -> find_result<mgp_trans> {
+auto FindTransformation(const ModuleRegistry &module_registry,
+                        std::string_view fully_qualified_transformation_name) -> find_result<mgp_trans> {
   return MakePairIfPropFound<mgp_trans>(module_registry, fully_qualified_transformation_name);
 }
 
-auto FindFunction(const ModuleRegistry &module_registry, std::string_view fully_qualified_function_name)
-    -> find_result<mgp_func> {
+auto FindFunction(const ModuleRegistry &module_registry,
+                  std::string_view fully_qualified_function_name) -> find_result<mgp_func> {
   return MakePairIfPropFound<mgp_func>(module_registry, fully_qualified_function_name);
 }
 void ConstructArguments(std::span<TypedValue const> args, mgp_func const &callable, mgp_list &args_list,

--- a/src/query/stream/streams.cpp
+++ b/src/query/stream/streams.cpp
@@ -104,9 +104,15 @@ void CallCustomTransformation(const std::string &transformation_name, const std:
     result.rows.clear();
     result.error_msg.reset();
 
-    result.signature.emplace(query_param_name, result.signature.at(query_param_name));
-    result.signature.emplace(params_param_name, result.signature.at(params_param_name));
-    MG_ASSERT(result.signature.size() == kExpectedTransformationResultSize);
+    auto signature_query_it = trans.results.find(query_param_name);
+    MG_ASSERT(signature_query_it != trans.results.end());
+    result.signature.emplace(query_param_name,
+                             ResultsMetadata{signature_query_it->second.first, signature_query_it->second.second, 0});
+
+    auto signature_params_it = trans.results.find(params_param_name);
+    MG_ASSERT(signature_params_it != trans.results.end());
+    result.signature.emplace(params_param_name,
+                             ResultsMetadata{signature_params_it->second.first, signature_params_it->second.second, 1});
 
     spdlog::trace("Calling transformation in stream '{}'", stream_name);
     trans.cb(&mgp_messages, &graph, &result, &memory);


### PR DESCRIPTION
- Change `mgp_result_record ` to use std::vector instead of std::map: 72 bytes -> 48 bytes + additional memory saved from not having map entries (strings)
- Instead of searching for the procedure on every pull cache it on cursor creation.
- Add `mgp_result_reserve`in C-API.
- As a consequence of the first entry procedures don't throw anymore if all results don't get inserted.