### PR TITLE
Optimize filtering operator

### DIFF
--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -512,8 +512,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
             // `OLD` view: `return old ? old : new`. That means that if the
             // `OLD` view didn't exist, it returned the NEW view. With this hack
             // we simulate that behavior.
-            // TODO (mferencevic, teon.banek): Remove once MERGE is
-            // reimplemented.
+            // TODO: Remove once MERGE is reimplemented.
             has_label = vertex.HasLabel(storage::View::NEW, GetLabel(label));
           }
           if (has_label.HasError()) {

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -2479,7 +2479,7 @@ PreparedQuery PrepareCypherQuery(ParsedQuery parsed_query, std::map<std::string,
   auto plan = CypherQueryToPlan(parsed_query.stripped_query.hash(), std::move(parsed_query.ast_storage), cypher_query,
                                 parsed_query.parameters, plan_cache, dba);
 
-  auto hints = plan::ProvidePlanHints(&plan->plan(), plan->symbol_table());
+  auto hints = plan::ProvidePlanHints(&plan->plan(), plan->symbol_table(), dba);
   for (const auto &hint : hints) {
     notifications->emplace_back(SeverityLevel::INFO, NotificationCode::PLAN_HINTING, hint);
     interpreter.LogQueryMessage(hint);
@@ -2562,7 +2562,7 @@ PreparedQuery PrepareExplainQuery(ParsedQuery parsed_query, std::map<std::string
       CypherQueryToPlan(parsed_inner_query.stripped_query.hash(), std::move(parsed_inner_query.ast_storage),
                         cypher_query, parsed_inner_query.parameters, plan_cache, dba);
 
-  auto hints = plan::ProvidePlanHints(&cypher_query_plan->plan(), cypher_query_plan->symbol_table());
+  auto hints = plan::ProvidePlanHints(&cypher_query_plan->plan(), cypher_query_plan->symbol_table(), dba);
   for (const auto &hint : hints) {
     notifications->emplace_back(SeverityLevel::INFO, NotificationCode::PLAN_HINTING, hint);
     interpreter.LogQueryMessage(hint);
@@ -2652,7 +2652,7 @@ PreparedQuery PrepareProfileQuery(ParsedQuery parsed_query, bool in_explicit_tra
                         cypher_query, parsed_inner_query.parameters, plan_cache, dba);
   TryCaching(cypher_query_plan->ast_storage(), frame_change_collector);
 
-  auto hints = plan::ProvidePlanHints(&cypher_query_plan->plan(), cypher_query_plan->symbol_table());
+  auto hints = plan::ProvidePlanHints(&cypher_query_plan->plan(), cypher_query_plan->symbol_table(), dba);
   for (const auto &hint : hints) {
     notifications->emplace_back(SeverityLevel::INFO, NotificationCode::PLAN_HINTING, hint);
     interpreter.LogQueryMessage(hint);

--- a/src/query/plan/hint_provider.cpp
+++ b/src/query/plan/hint_provider.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -13,8 +13,9 @@
 
 namespace memgraph::query::plan {
 
-std::vector<std::string> ProvidePlanHints(const LogicalOperator *plan_root, const SymbolTable &symbol_table) {
-  PlanHintsProvider plan_hinter(symbol_table);
+std::vector<std::string> ProvidePlanHints(const LogicalOperator *plan_root, const SymbolTable &symbol_table,
+                                          DbAccessor *db_accessor) {
+  PlanHintsProvider plan_hinter(symbol_table, db_accessor);
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   const_cast<LogicalOperator *>(plan_root)->Accept(plan_hinter);
 

--- a/src/query/plan/preprocess.cpp
+++ b/src/query/plan/preprocess.cpp
@@ -276,6 +276,9 @@ void Filters::EraseLabelFilter(const Symbol &symbol, const LabelIx &label, std::
       continue;
     }
     filter_it->labels.erase(label_it);
+    auto *labels_test = dynamic_cast<LabelsTest *>(filter_it->expression);
+    labels_test->labels_.erase(std::remove(labels_test->labels_.begin(), labels_test->labels_.end(), label),
+                               labels_test->labels_.end());
     DMG_ASSERT(!utils::Contains(filter_it->labels, label), "Didn't expect duplicated labels");
     if (filter_it->labels.empty()) {
       // If there are no labels to filter, then erase the whole FilterInfo.

--- a/src/query/plan/preprocess.hpp
+++ b/src/query/plan/preprocess.hpp
@@ -486,7 +486,8 @@ class Filters final {
   /// If removed_filters is not nullptr, fills the vector with original
   /// `Expression *` which are now completely removed.
   void EraseLabelFilter(const Symbol &symbol, const LabelIx &label,
-                        std::vector<Expression *> *removed_filters = nullptr);
+                        std::vector<Expression *> *removed_filters = nullptr,
+                        std::unordered_set<LabelIx> *removed_labels_ = nullptr);
 
   /// Returns a vector of FilterInfo for properties.
   auto PropertyFilters(const Symbol &symbol) const -> std::vector<FilterInfo>;
@@ -515,11 +516,13 @@ class Filters final {
   /// Takes the where expression and stores it, then analyzes the expression for
   /// additional information. The additional information is used to populate
   /// label filters and property filters, so that indexed scanning can use it.
-  void CollectFilterExpression(Expression *, const SymbolTable &);
+  void CollectFilterExpression(Expression *, const SymbolTable &,
+                               const std::unordered_set<std::string> &removed_labels = {});
 
  private:
   std::vector<FilterInfo> all_filters_;
-  void AnalyzeAndStoreFilter(Expression *, const SymbolTable &);
+  void AnalyzeAndStoreFilter(Expression *, const SymbolTable &,
+                             const std::unordered_set<std::string> &removed_labels = {});
 };
 
 /// Normalized representation of a single or multiple Match clauses.

--- a/tests/e2e/filter_info/filter_info.py
+++ b/tests/e2e/filter_info/filter_info.py
@@ -19,10 +19,9 @@ def test_label_index_hint(memgraph):
     memgraph.execute("CREATE (n:Label1:Label2 {prop: 1});")
     memgraph.execute("CREATE INDEX ON :Label1;")
 
-    # TODO: Fix this test since it should only filter on :Label2 and prop
     expected_explain = [
         " * Produce {n}",
-        " * Filter (n :Label1:Label2), {n.prop}",
+        " * Filter (n :Label2), {n.prop}",
         " * ScanAllByLabel (n :Label1)",
         " * Once",
     ]

--- a/tests/unit/query_hint_provider.cpp
+++ b/tests/unit/query_hint_provider.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -46,7 +46,7 @@ class HintProviderSuite : public ::testing::Test {
   Symbol NextSymbol() { return symbol_table.CreateSymbol("Symbol" + std::to_string(symbol_count++), true); }
 
   void VerifyHintMessages(LogicalOperator *plan, const std::vector<std::string> &expected_messages) {
-    auto messages = ProvidePlanHints(plan, symbol_table);
+    auto messages = ProvidePlanHints(plan, symbol_table, &dba.value());
 
     ASSERT_EQ(expected_messages.size(), messages.size());
 


### PR DESCRIPTION
When we create an index like this: 
```
CREATE INDEX ON :L1;
EXPLAIN MATCH (n:L1:L2) RETURN n;
```

and then run a query with label filtering:
```
+-----------------------------+
| QUERY PLAN                  |
+-----------------------------+
| " * Produce {n}"            |
| " * Filter (n :L1:L2)"      |   <--------- still filters by L1 (redundant work)
| " * ScanAllByLabel (n :L1)" |
| " * Once"                   |
+-----------------------------+
```
This PR aims to remove the redundant label filter to improve query efficiency.