### PR TITLE
Handle allowed failures in MT Jepsen test

### DIFF
--- a/tests/jepsen/src/memgraph/high_availability/create/test.clj
+++ b/tests/jepsen/src/memgraph/high_availability/create/test.clj
@@ -245,7 +245,8 @@
 
                          (catch Exception e
                            ; Even if sync replica is down, nodes will get created on the main.
-                           (cond (utils/sync-replica-down? e)
+                           (cond
+                                 (utils/sync-replica-down? e)
                                  (assoc op :type :ok :value {:str "Nodes created. SYNC replica is down." :max-idx @max-idx})
 
                                  (utils/main-became-replica? e)

--- a/tests/jepsen/src/memgraph/mtenancy/test.clj
+++ b/tests/jepsen/src/memgraph/mtenancy/test.clj
@@ -169,7 +169,7 @@
                           (catch org.neo4j.driver.exceptions.ServiceUnavailableException _e
                             (utils/process-service-unavailable-exc op node))
 
-                          (catch Exception e
+                          (catch org.neo4j.driver.exceptions.ClientException e
                             (cond
                               (utils/sync-replica-down? e)
                               (assoc op :type :ok :value {:str "Nodes updated. SYNC replica is down."})
@@ -185,8 +185,9 @@
                               (assoc op :type :info :value (str e))
 
                               :else
-                              (assoc op :type :fail :value (str e)))
+                              (assoc op :type :fail :value (str e))))
 
+                          (catch Exception e
                             (assoc op :type :fail :value (str e))))
 
                         (assoc op :type :info :value "Not main data instance."))
@@ -203,7 +204,7 @@
                               (catch org.neo4j.driver.exceptions.ServiceUnavailableException _e
                                 (utils/process-service-unavailable-exc op node))
 
-                              (catch Exception e
+                              (catch org.neo4j.driver.exceptions.ClientException e
                                 (cond
                                   (utils/sync-replica-down? e)
                                   (assoc op :type :ok :value {:str "TTL edges created. SYNC replica is down."})
@@ -222,8 +223,9 @@
                                   (assoc op :type :info :value (str e))
 
                                   :else
-                                  (assoc op :type :fail :value (str e)))
+                                  (assoc op :type :fail :value (str e))))
 
+                              (catch Exception e
                                 (assoc op :type :fail :value (str e))))
 
                             (assoc op :type :info :value "Not main data instance."))
@@ -239,7 +241,7 @@
                               (catch org.neo4j.driver.exceptions.ServiceUnavailableException _e
                                 (utils/process-service-unavailable-exc op node))
 
-                              (catch Exception e
+                              (catch org.neo4j.driver.exceptions.ClientException e
                                 (cond
                                   (utils/sync-replica-down? e)
                                   (assoc op :type :ok :value {:str "Edges deleted. SYNC replica is down."})
@@ -258,8 +260,9 @@
                                   (assoc op :type :info :value (str e))
 
                                   :else
-                                  (assoc op :type :fail :value (str e)))
+                                  (assoc op :type :fail :value (str e))))
 
+                              (catch Exception e
                                 (assoc op :type :fail :value (str e))))
 
                             (assoc op :type :info :value "Not main data instance."))
@@ -313,14 +316,15 @@
                               (catch org.neo4j.driver.exceptions.ServiceUnavailableException _e
                                 (utils/process-service-unavailable-exc op node))
 
-                              (catch Exception e
+                              (catch org.neo4j.driver.exceptions.ClientException e
                                 (cond
                                   (utils/concurrent-system-queries? e)
                                   (assoc op :type :info :value {:str "Concurrent system queries are not allowed"})
 
                                   :else
-                                  (assoc op :type :fail :value (str e)))
+                                  (assoc op :type :fail :value (str e))))
 
+                              (catch Exception e
                                 (assoc op :type :fail :value (str e))))
 
                             (assoc op :type :info :value "Not main data instance."))
@@ -357,7 +361,7 @@
                           (catch org.neo4j.driver.exceptions.ServiceUnavailableException _e
                             (utils/process-service-unavailable-exc op node))
 
-                          (catch Exception e
+                          (catch org.neo4j.driver.exceptions.TransientException e
                             (cond
                               (utils/sync-replica-down? e)
                               (assoc op :type :ok :value {:str "Edges deleted. SYNC replica is down."})
@@ -366,8 +370,9 @@
                               (assoc op :type :info :value {:str "Conflicting txns"})
 
                               :else
-                              (assoc op :type :fail :value (str e)))
+                              (assoc op :type :fail :value (str e))))
 
+                          (catch Exception e
                             (assoc op :type :fail :value (str e))))
 
                         (assoc op :type :info :value "Not main data instance.")))))

--- a/tests/jepsen/src/memgraph/mtenancy/test.clj
+++ b/tests/jepsen/src/memgraph/mtenancy/test.clj
@@ -361,6 +361,14 @@
                           (catch org.neo4j.driver.exceptions.ServiceUnavailableException _e
                             (utils/process-service-unavailable-exc op node))
 
+                          (catch org.neo4j.driver.exceptions.ClientException e
+                            (cond
+                              (utils/not-main-anymore? e)
+                              (assoc op :type :info :value {:str "Not main anymore"})
+
+                              :else
+                              (assoc op :type :fail :value (str e))))
+
                           (catch org.neo4j.driver.exceptions.TransientException e
                             (cond
                               (utils/sync-replica-down? e)

--- a/tests/jepsen/src/memgraph/utils.clj
+++ b/tests/jepsen/src/memgraph/utils.clj
@@ -102,6 +102,21 @@
   [e]
   (string/includes? (str e) "Cannot resolve conflicting transactions."))
 
+(defn concurrent-system-queries?
+  "Concurrent system queries error message is allowed on some queries."
+  [e]
+  (string/includes? (str e) "Multiple concurrent system queries are not supported."))
+
+(defn not-leader?
+  "Not a leader error message is allowed when doing a cluster setup."
+  [e]
+  (string/includes? (str e) "not a leader"))
+
+(defn adding-coordinator-failed?
+  "If concurrently trying to add coordinators, that could cause issues."
+  [e]
+  (string/includes? (str e) "Failed to accept request to add server"))
+
 (defn process-service-unavailable-exc
   "Return a map as the result of ServiceUnavailableException."
   [op node]

--- a/tests/jepsen/src/memgraph/utils.clj
+++ b/tests/jepsen/src/memgraph/utils.clj
@@ -67,6 +67,12 @@
   [f]
   {:type :info :f f})
 
+(defn not-main-anymore?
+  "Accepts exception e as argument."
+  [e]
+  (string/includes? (str e) "Cannot commit because instance is not main anymore")
+  )
+
 (defn node-is-down
   "Log that a node is down"
   [node]


### PR DESCRIPTION
Some exceptions are normal and expected. We want to catch them in the test so we don't need to reason about whether something was expected or not.