### PR TITLE
Bugfix: Prevent deadlock on data instance

### DIFF
--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -33,13 +33,13 @@
 using memgraph::storage::Delta;
 using memgraph::storage::EdgeAccessor;
 using memgraph::storage::EdgeRef;
-using memgraph::storage::EdgeTypeId;
 using memgraph::storage::LabelIndexStats;
 using memgraph::storage::LabelPropertyIndexStats;
 using memgraph::storage::PropertyId;
 using memgraph::storage::UniqueConstraints;
 using memgraph::storage::View;
 using memgraph::storage::durability::WalDeltaData;
+using namespace std::chrono_literals;
 
 namespace memgraph::dbms {
 
@@ -58,6 +58,8 @@ class SnapshotObserver final : public utils::Observer<void> {
 };
 
 namespace {
+
+constexpr auto kWaitForMainLockTimeout = 30s;
 
 auto GenerateOldDir() -> std::string {
   return ".old_" + std::to_string(std::chrono::system_clock::now().time_since_epoch().count());
@@ -421,7 +423,13 @@ void InMemoryReplicationHandlers::SnapshotHandler(DbmsHandler *dbms_handler,
 
   spdlog::info("Received snapshot saved to {}", recovery_snapshot_path);
   {
-    auto storage_guard = std::lock_guard{storage->main_lock_};
+    auto storage_guard = std::unique_lock{storage->main_lock_, std::defer_lock};
+    if (!storage_guard.try_lock_for(kWaitForMainLockTimeout)) {
+      spdlog::error("Failed to acquire main lock in {}", kWaitForMainLockTimeout);
+      rpc::SendFinalResponse(storage::replication::SnapshotRes{}, res_builder, fmt::format("db: {}", storage->name()));
+      return;
+    }
+
     spdlog::trace("Clearing database {} before recovering from snapshot.", storage->name());
 
     // Clear the database
@@ -532,7 +540,13 @@ void InMemoryReplicationHandlers::WalFilesHandler(dbms::DbmsHandler *dbms_handle
 
   if (req.reset_needed) {
     {
-      auto storage_guard = std::lock_guard{storage->main_lock_};
+      auto storage_guard = std::unique_lock{storage->main_lock_, std::defer_lock};
+      if (!storage_guard.try_lock_for(kWaitForMainLockTimeout)) {
+        spdlog::error("Failed to acquire main lock in {}", kWaitForMainLockTimeout);
+        rpc::SendFinalResponse(storage::replication::WalFilesRes{}, res_builder, storage->name());
+        return;
+      }
+
       spdlog::trace("Clearing replica storage for db {} because the reset is needed while recovering from WalFiles.",
                     storage->name());
       storage->Clear();
@@ -621,7 +635,12 @@ void InMemoryReplicationHandlers::CurrentWalHandler(dbms::DbmsHandler *dbms_hand
 
   if (req.reset_needed) {
     {
-      auto storage_guard = std::lock_guard{storage->main_lock_};
+      auto storage_guard = std::unique_lock{storage->main_lock_, std::defer_lock};
+      if (!storage_guard.try_lock_for(kWaitForMainLockTimeout)) {
+        spdlog::error("Failed to acquire main lock in {}", kWaitForMainLockTimeout);
+        rpc::SendFinalResponse(storage::replication::CurrentWalRes{}, res_builder);
+        return;
+      }
       spdlog::trace("Clearing replica storage for db {} because the reset is needed while recovering from WalFiles.",
                     storage->name());
       storage->Clear();

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -425,7 +425,7 @@ void InMemoryReplicationHandlers::SnapshotHandler(DbmsHandler *dbms_handler,
   {
     auto storage_guard = std::unique_lock{storage->main_lock_, std::defer_lock};
     if (!storage_guard.try_lock_for(kWaitForMainLockTimeout)) {
-      spdlog::error("Failed to acquire main lock in {}", kWaitForMainLockTimeout);
+      spdlog::error("Failed to acquire main lock in {}s", kWaitForMainLockTimeout.count());
       rpc::SendFinalResponse(storage::replication::SnapshotRes{}, res_builder, fmt::format("db: {}", storage->name()));
       return;
     }
@@ -542,7 +542,7 @@ void InMemoryReplicationHandlers::WalFilesHandler(dbms::DbmsHandler *dbms_handle
     {
       auto storage_guard = std::unique_lock{storage->main_lock_, std::defer_lock};
       if (!storage_guard.try_lock_for(kWaitForMainLockTimeout)) {
-        spdlog::error("Failed to acquire main lock in {}", kWaitForMainLockTimeout);
+        spdlog::error("Failed to acquire main lock in {}s", kWaitForMainLockTimeout.count());
         rpc::SendFinalResponse(storage::replication::WalFilesRes{}, res_builder, storage->name());
         return;
       }
@@ -637,7 +637,7 @@ void InMemoryReplicationHandlers::CurrentWalHandler(dbms::DbmsHandler *dbms_hand
     {
       auto storage_guard = std::unique_lock{storage->main_lock_, std::defer_lock};
       if (!storage_guard.try_lock_for(kWaitForMainLockTimeout)) {
-        spdlog::error("Failed to acquire main lock in {}", kWaitForMainLockTimeout);
+        spdlog::error("Failed to acquire main lock in {}s", kWaitForMainLockTimeout.count());
         rpc::SendFinalResponse(storage::replication::CurrentWalRes{}, res_builder);
         return;
       }

--- a/src/io/network/addrinfo.cpp
+++ b/src/io/network/addrinfo.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -30,7 +30,9 @@ AddrInfo::AddrInfo(const std::string &addr, uint16_t port) : info_{nullptr, null
   };
   addrinfo *info = nullptr;
   auto status = getaddrinfo(addr.c_str(), std::to_string(port).c_str(), &hints, &info);
-  if (status != 0) throw NetworkError(gai_strerror(status));
+  if (status != 0) {
+    throw NetworkError(gai_strerror(status));
+  }
   info_ = std::unique_ptr<addrinfo, decltype(&freeaddrinfo)>(info, &freeaddrinfo);
 }
 

--- a/src/io/network/endpoint.cpp
+++ b/src/io/network/endpoint.cpp
@@ -121,7 +121,8 @@ std::optional<Endpoint::RetValue> Endpoint::TryResolveAddress(std::string_view a
 
     auto status = getaddrinfo(std::string(address).c_str(), std::to_string(port).c_str(), &hints, &info);
     if (status != 0) {
-      spdlog::error("getaddrinfo finished unsuccessfully while resolving {}:{}", address, port);
+      spdlog::error("getaddrinfo finished unsuccessfully while resolving {}:{}. Error occurred: {}", address, port,
+                    gai_strerror(status));
       return std::nullopt;
     }
 

--- a/src/io/network/socket.cpp
+++ b/src/io/network/socket.cpp
@@ -46,7 +46,7 @@ Socket &Socket::operator=(Socket &&other) noexcept {
 
 Socket::~Socket() noexcept { Close(); }
 
-void Socket::Close() {
+void Socket::Close() noexcept {
   if (socket_ == -1) return;
   if (close(socket_) != 0) {
     int err_sc = errno;

--- a/src/io/network/socket.cpp
+++ b/src/io/network/socket.cpp
@@ -44,13 +44,15 @@ Socket &Socket::operator=(Socket &&other) noexcept {
   return *this;
 }
 
-Socket::~Socket() noexcept {
-  if (socket_ != -1) close(socket_);
-}
+Socket::~Socket() noexcept { Close(); }
 
 void Socket::Close() {
   if (socket_ == -1) return;
-  close(socket_);
+  if (close(socket_) != 0) {
+    int err_sc = errno;
+    spdlog::error("Failed to close fd for {}. Closing because 'socket_' is trying to get closed. Errno: {}",
+                  endpoint_.SocketAddress(), err_sc);
+  }
   socket_ = -1;
 }
 
@@ -69,13 +71,14 @@ bool Socket::Connect(const Endpoint &endpoint) {
     return false;
   }
 
+  auto const socket_addr = endpoint.SocketAddress();
+
   try {
     for (const auto &it : AddrInfo{endpoint}) {
       utils::MetricsTimer const timer{metrics::SocketConnect_us};
       int sfd = socket(it.ai_family, it.ai_socktype, it.ai_protocol);
       if (sfd == -1) {
-        spdlog::trace("Socket creation failed in Socket::Connect for socket address {}. File descriptor is -1",
-                      endpoint.SocketAddress());
+        spdlog::trace("Socket creation failed while connecting to {}. File descriptor is -1", socket_addr);
         continue;
       }
       if (connect(sfd, it.ai_addr, it.ai_addrlen) == 0) {
@@ -83,14 +86,18 @@ bool Socket::Connect(const Endpoint &endpoint) {
         endpoint_ = endpoint;
         break;
       }
-      spdlog::trace("Connect failed, closing file descriptor in Socket::Connect for socket address {}",
-                    endpoint.SocketAddress());
+      int err_sc = errno;
+      spdlog::error("Connect failed, closing fd for {}. Errno: {}", socket_addr, err_sc);
       // If the connect failed close the file descriptor to prevent file
       // descriptors being leaked
-      close(sfd);
+      if (close(sfd) != 0) {
+        err_sc = errno;
+        spdlog::error("Failed to close fd for {}. Closing started because 'connect' failed. Errno: {}", socket_addr,
+                      err_sc);
+      }
     }
   } catch (const NetworkError &e) {
-    spdlog::trace("Error in Socket::Connect {}", e.what());
+    spdlog::error("Error while connecting to {}. {}", socket_addr, e.what());
     return false;
   }
 
@@ -103,6 +110,8 @@ bool Socket::Bind(const Endpoint &endpoint) {
     return false;
   }
 
+  auto const socket_addr = endpoint.SocketAddress();
+
   for (const auto &it : AddrInfo{endpoint}) {
     int sfd = socket(it.ai_family, it.ai_socktype, it.ai_protocol);
     if (sfd == -1) {
@@ -113,10 +122,14 @@ bool Socket::Bind(const Endpoint &endpoint) {
 
     int on = 1;
     if (setsockopt(sfd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) != 0) {
-      spdlog::trace("setsockopt in Socket::Bind failed for socket address {}", endpoint.SocketAddress());
+      spdlog::trace("setsockopt in Socket::Bind failed for socket address {}", socket_addr);
       // If the setsockopt failed close the file descriptor to prevent file
       // descriptors being leaked
-      close(sfd);
+      if (close(sfd) != 0) {
+        int err_sc = errno;
+        spdlog::error("Failed to close fd for {}. Closing started because 'setsockopt' failed while binding. Errno: {}",
+                      socket_addr, err_sc);
+      }
       continue;
     }
 
@@ -127,7 +140,10 @@ bool Socket::Bind(const Endpoint &endpoint) {
     // If the bind failed close the file descriptor to prevent file
     // descriptors being leaked
     spdlog::trace("Socket::Bind failed. Closing file descriptor for socket address {}", endpoint.SocketAddress());
-    close(sfd);
+    if (close(sfd) != 0) {
+      int err_sc = errno;
+      spdlog::error("Failed to close fd for {} while trying to bind. Errno: {}", socket_addr, err_sc);
+    }
   }
 
   if (socket_ == -1) {
@@ -141,7 +157,11 @@ bool Socket::Bind(const Endpoint &endpoint) {
   if (getsockname(socket_, reinterpret_cast<sockaddr *>(&portdata), &portdatalen) < 0) {
     // If the getsockname failed close the file descriptor to prevent file
     // descriptors being leaked
-    close(socket_);
+    if (close(socket_) != 0) {
+      int err_sc = errno;
+      spdlog::error("Failed to close fd for {}. Closing started because 'getsockname' failed. Errno: {}", socket_addr,
+                    err_sc);
+    }
     socket_ = -1;
     spdlog::trace("Socket::Bind failed. getsockname failed, closing file descriptor for socket address {}",
                   endpoint.SocketAddress());

--- a/src/io/network/socket.hpp
+++ b/src/io/network/socket.hpp
@@ -38,7 +38,7 @@ class Socket {
   /**
    * Closes the socket if it is open.
    */
-  void Close();
+  void Close() noexcept;
 
   /**
    * Shutdown the socket if it is open.

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -74,7 +74,8 @@ void Session::Execute() {
   // over them.
   auto const it = server_->callbacks_.find(req_id);
   if (it == server_->callbacks_.end()) {
-    throw SessionException("Session trying to execute an unregistered RPC call!");
+    throw SessionException("Session trying to execute an unregistered RPC call!. Request id: {}",
+                           static_cast<uint64_t>(req_id));
   }
 
   spdlog::trace("[RpcServer] received {}", it->second.req_type.name);

--- a/tests/jepsen/src/memgraph/core.clj
+++ b/tests/jepsen/src/memgraph/core.clj
@@ -93,7 +93,7 @@
             :checker         (checker/compose
                               {:stats      (checker/stats)
                                :exceptions (unhandled-exceptions)
-                               :log-checker (checker/log-file-pattern #"[Aa]ssert*|Segmentation fault|core dumped|critical|NullPointerException|json.exception.parse_error|Message response was of unexpected type|Received malformed message from cluster|There is still leftover data in the SLK stream" "memgraph.log")
+                               :log-checker (checker/log-file-pattern #"[Aa]ssert*|Segmentation fault|core dumped|critical|NullPointerException|json.exception.parse_error|Message response was of unexpected type|Received malformed message from cluster|There is still leftover data in the SLK stream|Failed to close fd for" "memgraph.log")
                                :workload   (:checker workload)})
             :nodes           (keys (:nodes-config opts))
             :nemesis         (:nemesis nemesis-config)


### PR DESCRIPTION
The following set of events caused a deadlock in our HA:

1. MAIN receives query to commit as implicit txn.  Main lock is hold all the time because of query,
2. While executing and before the commit, main is demoted to replica.
3. Replica receives snapshot rpc and tries to acquire the main lock.
4. Replica receives request to get promoted. RPC server cannot be closed because snapshot rpc isn't finished.

The fix consists of waiting for a lock in replication handlers for SnapshotRpc, WalFilesRpc and CurrentWalRpc but with a predefined timeout. Additionally, log message for addrinfo is now added, same as log message when trying to close Socket.
