### PR TITLE
Save logs from GQL behave tests on CI

### DIFF
--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -92,22 +92,22 @@ jobs:
           --organization-name $MEMGRAPH_ORGANIZATION_NAME \
           test-memgraph gql-behave
 
-      - name: Copy memgraph logs
+      - name: Copy gql behave logs
         if: always()
         run: |
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
-          copy --memgraph-logs --dest-dir build/memgraph-logs-core-tests
+          copy --memgraph-logs --memgraph-logs-dir /home/mg/memgraph/tests/gql_behave --dest-dir build/memgraph-logs-gql-behave-tests
 
       - name: Save test data
         continue-on-error: true
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: "Core tests(Release build)-${{ inputs.run_id }}"
-          path: build/memgraph-logs-core-tests
+          name: "GQL Behave Tests(Release build)-${{ inputs.run_id }}"
+          path: build/memgraph-logs-gql-behave-tests
 
       - name: Save quality assurance status
         continue-on-error: true

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -106,7 +106,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: "GQL Behave Tests(Release build)-${{ inputs.run_id }}"
+          name: "GQL Behave Tests(Release build)-${{ github.run_id }}"
           path: build/memgraph-logs-gql-behave-tests
 
       - name: Save quality assurance status
@@ -492,7 +492,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: "Query modules tests(Release build)-${{ inputs.run_id }}"
+          name: "Query modules tests(Release build)-${{ github.run_id }}"
           path: build/memgraph-logs-query-modules
 
       - name: Stop mgbuild container

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -134,6 +134,23 @@ jobs:
           name: "Enterprise DEB package-${{ inputs.run_id }}"
           path: build/output/${{ env.OS }}/memgraph*.deb
 
+      - name: Copy memgraph logs
+        if: always()
+        run: |
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN \
+          --os $OS \
+          --arch $ARCH \
+          copy --memgraph-logs --dest-dir build/memgraph-logs-core-tests
+
+      - name: Save test data
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: "Core tests(Release build)-${{ inputs.run_id }}"
+          path: build/memgraph-logs-core-tests
+
       - name: Stop mgbuild container
         if: always()
         run: |
@@ -461,22 +478,22 @@ jobs:
           --organization-name $MEMGRAPH_ORGANIZATION_NAME \
           test-memgraph query_modules_e2e
 
-      - name: Copy build logs
+      - name: Copy memgraph logs
         if: always()
         run: |
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
-          copy --memgraph-logs --dest-dir build/memgraph-logs
+          copy --memgraph-logs --dest-dir build/memgraph-logs-query-modules
 
       - name: Save test data
         continue-on-error: true
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: "Test data(Release build)-${{ inputs.run_id }}"
-          path: build/memgraph-logs
+          name: "Query modules tests(Release build)-${{ inputs.run_id }}"
+          path: build/memgraph-logs-query-modules
 
       - name: Stop mgbuild container
         if: always()

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -479,7 +479,7 @@ jobs:
           test-memgraph query_modules_e2e
 
       - name: Copy memgraph logs
-        if: always()
+        if: failure()
         run: |
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
@@ -490,7 +490,7 @@ jobs:
       - name: Save test data
         continue-on-error: true
         uses: actions/upload-artifact@v4
-        if: always()
+        if: failure()
         with:
           name: "Query modules tests(Release build)-${{ inputs.run_id }}"
           path: build/memgraph-logs-query-modules

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -99,7 +99,7 @@ jobs:
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
-          copy --memgraph-logs --memgraph-logs-dir /home/mg/memgraph/tests/gql_behave --dest-dir build/memgraph-logs-gql-behave-tests
+          copy --memgraph-logs --logs-dir /home/mg/memgraph/tests/gql_behave/memgraph-logs --dest-dir build/memgraph-logs-gql-behave-tests
 
       - name: Save test data
         continue-on-error: true

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -92,6 +92,23 @@ jobs:
           --organization-name $MEMGRAPH_ORGANIZATION_NAME \
           test-memgraph gql-behave
 
+      - name: Copy memgraph logs
+        if: always()
+        run: |
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN \
+          --os $OS \
+          --arch $ARCH \
+          copy --memgraph-logs --dest-dir build/memgraph-logs-core-tests
+
+      - name: Save test data
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: "Core tests(Release build)-${{ inputs.run_id }}"
+          path: build/memgraph-logs-core-tests
+
       - name: Save quality assurance status
         continue-on-error: true
         uses: actions/upload-artifact@v4
@@ -133,23 +150,6 @@ jobs:
         with:
           name: "Enterprise DEB package-${{ inputs.run_id }}"
           path: build/output/${{ env.OS }}/memgraph*.deb
-
-      - name: Copy memgraph logs
-        if: always()
-        run: |
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os $OS \
-          --arch $ARCH \
-          copy --memgraph-logs --dest-dir build/memgraph-logs-core-tests
-
-      - name: Save test data
-        continue-on-error: true
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: "Core tests(Release build)-${{ inputs.run_id }}"
-          path: build/memgraph-logs-core-tests
 
       - name: Stop mgbuild container
         if: always()

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -93,7 +93,7 @@ jobs:
           test-memgraph gql-behave
 
       - name: Copy gql behave logs
-        if: always()
+        if: failure()
         run: |
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
@@ -104,7 +104,7 @@ jobs:
       - name: Save test data
         continue-on-error: true
         uses: actions/upload-artifact@v4
-        if: always()
+        if: failure()
         with:
           name: "GQL Behave Tests(Release build)-${{ inputs.run_id }}"
           path: build/memgraph-logs-gql-behave-tests

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -576,6 +576,10 @@ copy_memgraph() {
         host_dir="$PROJECT_BUILD_DIR/src/query"
         shift 1
       ;;
+      --memgraph-logs-dir)#cp -L
+        container_artifact_path=$2
+        shift 2
+      ;;
       --dest-dir)
         host_dir_override=$2
         shift 2

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -576,7 +576,7 @@ copy_memgraph() {
         host_dir="$PROJECT_BUILD_DIR/src/query"
         shift 1
       ;;
-      --memgraph-logs-dir)#cp -L
+      --logs-dir)#cp -L
         container_artifact_path=$2
         shift 2
       ;;

--- a/tests/gql_behave/continuous_integration
+++ b/tests/gql_behave/continuous_integration
@@ -28,6 +28,7 @@ SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 TESTS_DIR = os.path.join(SCRIPT_DIR, "tests")
 BASE_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, "..", ".."))
 BUILD_DIR = os.path.join(BASE_DIR, "build")
+LOG_LEVEL = "TRACE"
 
 
 def wait_for_server(port, delay=0.01):
@@ -102,13 +103,17 @@ class MemgraphRunner:
 
         self.data_directory = tempfile.TemporaryDirectory()
         memgraph_binary = os.path.join(self.build_directory, "memgraph")
+        log_dir = os.path.join(BASE_DIR, "tests", "gql_behave", "memgraph-logs")
+        os.makedirs(log_dir, exist_ok=True)
         args_mg = [
             memgraph_binary,
             "--storage-properties-on-edges=true",
             "--data-directory",
             self.data_directory.name,
             "--log-file",
-            str(os.path.join(BASE_DIR, "tests", "gql_behave", "memgraph.log")),
+            str(os.path.join(log_dir, "memgraph.log")),
+            "--log-level",
+            LOG_LEVEL,
             "--query-modules-directory",
             str(os.path.join(BUILD_DIR, "query_modules")),
         ]

--- a/tests/gql_behave/tests/memgraph_V1/features/match.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/match.feature
@@ -847,4 +847,4 @@ Feature: Match
             """
         Then the result should be:
             | n        |
-            | ({k: 1}) |
+            | ({k: 2}) |

--- a/tests/gql_behave/tests/memgraph_V1/features/match.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/match.feature
@@ -847,4 +847,4 @@ Feature: Match
             """
         Then the result should be:
             | n        |
-            | ({k: 2}) |
+            | ({k: 1}) |


### PR DESCRIPTION
Currently, we don't save logs from GQL Behave test CI runs. Since these tests are executed by running queries in Memgraph, we have no log data to diagnose failing tests. This PR adds log saving after the job finishes.