### PR TITLE
Add xmlsec to requirements for auth modules

### DIFF
--- a/src/auth/reference_modules/requirements.txt
+++ b/src/auth/reference_modules/requirements.txt
@@ -6,3 +6,4 @@ pyyaml==6.0.1
 python3-saml==1.16.0
 lxml==5.2.1
 setuptools==75.8.0
+xmlsec==1.3.14


### PR DESCRIPTION
Add xmlsec to requirements so the correct version gets installed on MAGE which fixes SAML not working on MAGE.