### PR TITLE
Release 3.1.1 fixes

### DIFF
--- a/.github/workflows/promote_rc_release.yml
+++ b/.github/workflows/promote_rc_release.yml
@@ -49,8 +49,10 @@ jobs:
         include:
           - os: docker
             arch: arm
+            malloc: false
           - os: ubuntu-24.04
             arch: arm
+            malloc: false
           - os: ubuntu-24.04
             arch: amd
             malloc: true

--- a/.github/workflows/promote_rc_release.yml
+++ b/.github/workflows/promote_rc_release.yml
@@ -43,17 +43,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [centos-9, debian-11, debian-12, docker, fedora-38, fedora-39, rocky-9.3, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [centos-9, centos-10, debian-11, debian-12, docker, fedora-41, ubuntu-22.04, ubuntu-24.04]
         arch: [amd]
         malloc: [false]
         include:
-          - os: debian-11
-            arch: arm
-          - os: debian-12
-            arch: arm
           - os: docker
-            arch: arm
-          - os: ubuntu-22.04
             arch: arm
           - os: ubuntu-24.04
             arch: arm

--- a/.github/workflows/release_build_test.yaml
+++ b/.github/workflows/release_build_test.yaml
@@ -107,6 +107,7 @@ jobs:
       s3_bucket: deps.memgraph.io
       s3_region: eu-west-1
       s3_dest_dir: "memgraph/${{ github.ref_name }}"
+      additional_build_args: ${{ matrix.additional_build_args }}
     secrets: inherit
 
   DockerArtifact:

--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -377,13 +377,6 @@ jobs:
           --organization-name $MEMGRAPH_ORGANIZATION_NAME \
           test-memgraph gql-behave
 
-      - name: Save quality assurance status
-        uses: actions/upload-artifact@v4
-        with:
-          name: "GQL Behave Status-${{ env.OS }}"
-          path: |
-            tests/gql_behave/gql_behave_status.csv
-            tests/gql_behave/gql_behave_status.html
 
       - name: Run unit tests
         run: |

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -453,6 +453,8 @@ endmacro()
 mg_build_if_needed(build_mgcxx "mgcxx")
 mg_create_linkable_if_no_cmake(tantivy_text_search STATIC "${MG_TOOLCHAIN_ROOT}/lib/libtantivy_text_search.a" "${MG_TOOLCHAIN_ROOT}/include")
 mg_create_linkable_if_no_cmake(mgcxx_text_search STATIC "${MG_TOOLCHAIN_ROOT}/lib/libmgcxx_text_search.a" "${MG_TOOLCHAIN_ROOT}/include")
+target_link_libraries(tantivy_text_search INTERFACE ${CMAKE_DL_LIBS})
+target_link_libraries(mgcxx_text_search INTERFACE ${CMAKE_DL_LIBS})
 
 # setup strong_type (cmake sub_directory tolerant)
 add_subdirectory(strong_type EXCLUDE_FROM_ALL)

--- a/release/docker/package_docker
+++ b/release/docker/package_docker
@@ -102,5 +102,5 @@ rm "${working_dir}/${package_name}.${extension}"
 if [[ -n "$src_path" ]]; then
   rm -rf "${working_dir}/src"
 fi
-docker image rm $image_name
+docker image rm $image_name || true
 echo "Built Docker image at '${working_dir}/${image_package_name}'"


### PR DESCRIPTION
Some fixes to get release v3.1.1 across the line....
- Fixed OS list in promote workflow
- Added missing argument to release build test
- Removed unneeded test step from `malloc` build
- Added fix for missing `dlsym` link

