### PR TITLE
Schema info speed up

### DIFF
--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -798,7 +798,7 @@ utils::BasicResult<StorageManipulationError, void> InMemoryStorage::InMemoryAcce
 
           if (config_.enable_schema_info) {
             mem_storage->schema_info_.ProcessTransaction(transaction_.schema_diff_, transaction_.post_process_,
-                                                         transaction_.transaction_id,
+                                                         transaction_.start_timestamp, transaction_.transaction_id,
                                                          mem_storage->config_.salient.items.properties_on_edges);
           }
 

--- a/src/storage/v2/schema_info.hpp
+++ b/src/storage/v2/schema_info.hpp
@@ -61,6 +61,9 @@ struct SchemaTrackingInterface {
                            const ExtendedPropertyType &before) = 0;
   virtual void SetProperty(EdgeTypeId type, Vertex *from, Vertex *to, PropertyId property,
                            const ExtendedPropertyType &now, const ExtendedPropertyType &before, bool prop_on_edges) = 0;
+  virtual void SetProperty(EdgeTypeId type, const utils::small_vector<LabelId> &from,
+                           const utils::small_vector<LabelId> &to, PropertyId property, const ExtendedPropertyType &now,
+                           const ExtendedPropertyType &before, bool prop_on_edges) = 0;
 };
 
 template <template <class...> class TContainer = utils::ConcurrentUnorderedMap>
@@ -72,9 +75,8 @@ using SharedSchemaTracking = SchemaTracking<utils::ConcurrentUnorderedMap>;
 template <template <class...> class TContainer>
 struct SchemaTracking final : public SchemaTrackingInterface {
   template <template <class...> class TOtherContainer>
-  void ProcessTransaction(const SchemaTracking<TOtherContainer> &diff,
-                          std::unordered_set<SchemaInfoPostProcess> &post_process, uint64_t commit_ts,
-                          bool property_on_edges);
+  void ProcessTransaction(const SchemaTracking<TOtherContainer> &diff, SchemaInfoPostProcess &post_process,
+                          uint64_t start_ts, uint64_t commit_ts, bool property_on_edges);
 
   void Clear() override;
 
@@ -111,9 +113,17 @@ struct SchemaTracking final : public SchemaTrackingInterface {
   void SetProperty(EdgeTypeId type, Vertex *from, Vertex *to, PropertyId property, const ExtendedPropertyType &now,
                    const ExtendedPropertyType &before, bool prop_on_edges, auto &&guard, auto &&other_guard);
 
+  void SetProperty(EdgeTypeId type, const utils::small_vector<LabelId> &from, const utils::small_vector<LabelId> &to,
+                   PropertyId property, const ExtendedPropertyType &now, const ExtendedPropertyType &before,
+                   bool prop_on_edges) override;
+
   void UpdateEdgeStats(EdgeRef edge_ref, EdgeTypeId edge_type, const VertexKey &new_from_labels,
                        const VertexKey &new_to_labels, const VertexKey &old_from_labels, const VertexKey &old_to_labels,
                        bool prop_on_edges);
+
+  void UpdateEdgeStats(EdgeRef edge_ref, EdgeTypeId edge_type, const VertexKey &new_from_labels,
+                       const VertexKey &new_to_labels, const VertexKey &old_from_labels, const VertexKey &old_to_labels,
+                       const std::map<PropertyId, ExtendedPropertyType> &edge_props);
 
  private:
   friend LocalSchemaTracking;
@@ -126,6 +136,9 @@ struct SchemaTracking final : public SchemaTrackingInterface {
 
   void UpdateEdgeStats(auto &new_tracking, auto &old_tracking, EdgeRef edge_ref, bool prop_on_edges);
 
+  void UpdateEdgeStats(auto &new_tracking, auto &old_tracking, EdgeRef edge_ref,
+                       const std::map<PropertyId, ExtendedPropertyType> &edge_props);
+
   TContainer<VertexKey, TrackingInfo<TContainer>> vertex_state_;  //!< vertex statistics
   TContainer<EdgeKey, TrackingInfo<TContainer>> edge_state_;      //!< edge statistics
 };
@@ -137,10 +150,10 @@ struct SchemaInfo {
     return tracking_.ToJson(name_id_mapper, enum_store);
   }
 
-  void ProcessTransaction(LocalSchemaTracking &tracking, std::unordered_set<SchemaInfoPostProcess> &post_process,
+  void ProcessTransaction(LocalSchemaTracking &tracking, SchemaInfoPostProcess &post_process, uint64_t start_ts,
                           uint64_t commit_ts, bool property_on_edges) {
     auto lock = std::unique_lock{operation_ordering_mutex_};
-    tracking_.ProcessTransaction(tracking, post_process, commit_ts, property_on_edges);
+    tracking_.ProcessTransaction(tracking, post_process, start_ts, commit_ts, property_on_edges);
   }
 
   void Clear() {
@@ -164,25 +177,27 @@ struct SchemaInfo {
   // Advanced modification accessors
   class TransactionalEdgeModifyingAccessor {
    public:
-    TransactionalEdgeModifyingAccessor(LocalSchemaTracking &tracking,
-                                       std::unordered_set<SchemaInfoPostProcess> *post_process, bool prop_on_edges,
-                                       uint64_t commit_ts)
+    TransactionalEdgeModifyingAccessor(LocalSchemaTracking &tracking, SchemaInfoPostProcess *post_process,
+                                       uint64_t start_ts, uint64_t commit_ts, bool prop_on_edges)
         : tracking_{&tracking},
           properties_on_edges_{prop_on_edges},
-          commit_ts_{commit_ts},
-          post_process_{post_process} {}
+          post_process_{post_process},
+          start_ts_{start_ts},
+          commit_ts_{commit_ts} {}
 
-    void AddLabel(Vertex *vertex, LabelId label);
+    void AddLabel(Vertex *vertex, LabelId label, std::unique_lock<utils::RWSpinLock> v_lock);
 
-    void RemoveLabel(Vertex *vertex, LabelId label);
+    void RemoveLabel(Vertex *vertex, LabelId label, std::unique_lock<utils::RWSpinLock> v_lock);
 
    private:
-    void UpdateTransactionalEdges(Vertex *vertex, const utils::small_vector<LabelId> &old_labels);
+    void UpdateTransactionalEdges(Vertex *vertex, const utils::small_vector<LabelId> &old_labels,
+                                  std::unique_lock<utils::RWSpinLock> v_lock);
 
     LocalSchemaTracking *tracking_{};
     bool properties_on_edges_{};  //!< As defined by the storage configuration
+    SchemaInfoPostProcess *post_process_{};
+    uint64_t start_ts_{};
     uint64_t commit_ts_{};
-    std::unordered_set<SchemaInfoPostProcess> *post_process_{};
   };
 
   /**
@@ -223,12 +238,12 @@ struct SchemaInfo {
         : tracking_{&si.tracking_}, ordering_lock_{si.operation_ordering_mutex_}, properties_on_edges_(prop_on_edges) {}
 
     // TRANSACTIONAL
-    explicit VertexModifyingAccessor(LocalSchemaTracking &tracking,
-                                     std::unordered_set<SchemaInfoPostProcess> *post_process, uint64_t commit_ts,
-                                     bool prop_on_edges)
+    explicit VertexModifyingAccessor(LocalSchemaTracking &tracking, SchemaInfoPostProcess *post_process,
+                                     uint64_t start_ts, uint64_t commit_ts, bool prop_on_edges)
         : tracking_{&tracking},
           properties_on_edges_{prop_on_edges},
           post_process_{post_process},
+          start_ts_{start_ts},
           commit_ts_{commit_ts} {}
 
     void CreateVertex(Vertex *vertex);
@@ -253,7 +268,8 @@ struct SchemaInfo {
     SchemaTrackingInterface *tracking_{};
     std::shared_lock<std::shared_mutex> ordering_lock_;  //!< Order guaranteeing lock
     bool properties_on_edges_{};                         //!< As defined by the storage configuration
-    std::unordered_set<SchemaInfoPostProcess> *post_process_{};
+    SchemaInfoPostProcess *post_process_{};
+    uint64_t start_ts_{};
     uint64_t commit_ts_{};
   };
 
@@ -268,20 +284,24 @@ struct SchemaInfo {
     return AnalyticalEdgeModifyingAccessor{*this, prop_on_edges};
   }
 
-  static ModifyingAccessor CreateVertexModifyingAccessor(auto &tracking, auto &post_process, uint64_t commit_ts,
-                                                         bool prop_on_edges) {
-    return VertexModifyingAccessor{tracking, &post_process, commit_ts, prop_on_edges};
+  static ModifyingAccessor CreateVertexModifyingAccessor(auto &tracking, auto &post_process, uint64_t start_ts,
+                                                         uint64_t commit_ts, bool prop_on_edges) {
+    return VertexModifyingAccessor{tracking, &post_process, start_ts, commit_ts, prop_on_edges};
   }
-  static ModifyingAccessor CreateEdgeModifyingAccessor(auto &tracking,
-                                                       std::unordered_set<SchemaInfoPostProcess> *post_process,
-                                                       bool prop_on_edges, uint64_t commit_ts) {
-    return TransactionalEdgeModifyingAccessor{tracking, post_process, prop_on_edges, commit_ts};
+  static ModifyingAccessor CreateEdgeModifyingAccessor(auto &tracking, SchemaInfoPostProcess *post_process,
+                                                       uint64_t start_ts, uint64_t commit_ts, bool prop_on_edges) {
+    return TransactionalEdgeModifyingAccessor{tracking, post_process, start_ts, commit_ts, prop_on_edges};
   }
 
   static std::optional<std::pair<std::shared_lock<utils::RWSpinLock>, std::shared_lock<utils::RWSpinLock>>>
   ReadLockFromTo(auto &schema_acc, StorageMode mode, Vertex *from, Vertex *to) {
-    if (!schema_acc || mode != StorageMode::IN_MEMORY_ANALYTICAL) return {};
+    if (!schema_acc) return {};
+    return ReadLockFromTo(from, to);
+  }
 
+  static std::pair<std::shared_lock<utils::RWSpinLock>, std::shared_lock<utils::RWSpinLock>> ReadLockFromTo(
+      Vertex *from, Vertex *to) {
+    // Direct modification in both analytical and transactional
     auto from_lock = std::shared_lock{from->lock, std::defer_lock};
     auto to_lock = std::shared_lock{to->lock, std::defer_lock};
 

--- a/src/storage/v2/schema_info_glue.hpp
+++ b/src/storage/v2/schema_info_glue.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -21,7 +21,8 @@ inline std::optional<SchemaInfo::ModifyingAccessor> SchemaInfoAccessor(Storage *
   const auto prop_on_edges = storage->config_.salient.items.properties_on_edges;
   if (storage->GetStorageMode() == StorageMode::IN_MEMORY_TRANSACTIONAL) {
     return SchemaInfo::CreateVertexModifyingAccessor(transaction->schema_diff_, transaction->post_process_,
-                                                     transaction->transaction_id, prop_on_edges);
+                                                     transaction->start_timestamp, transaction->transaction_id,
+                                                     prop_on_edges);
   }
   return storage->schema_info_.CreateVertexModifyingAccessor(prop_on_edges);
 }
@@ -32,7 +33,8 @@ inline std::optional<SchemaInfo::ModifyingAccessor> SchemaInfoUniqueAccessor(Sto
   const auto prop_on_edges = storage->config_.salient.items.properties_on_edges;
   if (storage->GetStorageMode() == StorageMode::IN_MEMORY_TRANSACTIONAL) {
     return SchemaInfo::CreateEdgeModifyingAccessor(transaction->schema_diff_, &transaction->post_process_,
-                                                   prop_on_edges, transaction->transaction_id);
+                                                   transaction->start_timestamp, transaction->transaction_id,
+                                                   prop_on_edges);
   }
   return storage->schema_info_.CreateEdgeModifyingAccessor(prop_on_edges);
 }

--- a/src/storage/v2/transaction.hpp
+++ b/src/storage/v2/transaction.hpp
@@ -152,7 +152,7 @@ struct Transaction {
   PointIndexChangeCollector point_index_change_collector_;
   /// Tracking schema changes done during the transaction
   LocalSchemaTracking schema_diff_;
-  std::unordered_set<SchemaInfoPostProcess> post_process_;
+  SchemaInfoPostProcess post_process_;
 
   /// Query memory tracker
   std::unique_ptr<utils::QueryMemoryTracker> query_memory_tracker_{};

--- a/tests/integration/audit/runner.py
+++ b/tests/integration/audit/runner.py
@@ -161,7 +161,7 @@ def execute_test(memgraph_binary, tester_binary):
         all_queries = mt_queries
         all_queries += mt_queries2
         all_queries += mt_queries3
-        assert queries == all_queries, "Logged queries don't match " "executed queries!"
+        assert queries == all_queries, f"Logged queries:\n{queries}\ndon't match executed queries:\n{all_queries}\n"
     print("\033[1;36m~~ Finished log verification ~~\033[0m\n")
 
 

--- a/tests/unit/storage_v2_schema_info.cpp
+++ b/tests/unit/storage_v2_schema_info.cpp
@@ -2440,7 +2440,9 @@ TYPED_TEST(SchemaInfoTestWEdgeProp, EdgePropertyStressTest) {
             can_commit &= edge->SetProperty(p1, PropertyValue{true}).HasValue();
           }
           if (can_commit) ASSERT_FALSE(acc->Commit().HasError());
-        } else {
+        } else if (in_memory->storage_mode_ ==
+                   memgraph::storage::StorageMode::IN_MEMORY_TRANSACTIONAL) {  // Analytical doesn't support mt
+                                                                               // deletion/modification
           // Delete/Create edge
           auto acc = in_memory->Access();
           auto edge = acc->FindEdge(edge_gid, View::NEW);

--- a/tests/unit/storage_v2_schema_info.cpp
+++ b/tests/unit/storage_v2_schema_info.cpp
@@ -2327,202 +2327,225 @@ TYPED_TEST(SchemaInfoTestWEdgeProp, BigCommit) {
   }
 }
 
-// // NOLINTNEXTLINE(hicpp-special-member-functions)
-// TYPED_TEST(SchemaInfoTestWEdgeProp, EdgePropertyStressTest) {
-//   auto *in_memory = static_cast<memgraph::storage::InMemoryStorage *>(this->storage.get());
-//   auto &schema_info = in_memory->schema_info_;
+// NOLINTNEXTLINE(hicpp-special-member-functions)
+TYPED_TEST(SchemaInfoTestWEdgeProp, EdgePropertyStressTest) {
+  auto *in_memory = static_cast<memgraph::storage::InMemoryStorage *>(this->storage.get());
+  auto &schema_info = in_memory->schema_info_;
 
-//   auto l1 = in_memory->NameToLabel("L1");
-//   auto l2 = in_memory->NameToLabel("L2");
-//   auto p1 = in_memory->NameToProperty("p1");
-//   auto e1 = in_memory->NameToEdgeType("E1");
+  auto l1 = in_memory->NameToLabel("L1");
+  auto l2 = in_memory->NameToLabel("L2");
+  auto p1 = in_memory->NameToProperty("p1");
+  auto e1 = in_memory->NameToEdgeType("E1");
 
-//   // Empty
-//   {
-//     const auto json = schema_info.ToJson(*in_memory->name_id_mapper_, in_memory->enum_store_);
-//     ASSERT_TRUE(json["nodes"].empty());
-//     ASSERT_TRUE(json["edges"].empty());
-//   }
+  // Empty
+  {
+    const auto json = schema_info.ToJson(*in_memory->name_id_mapper_, in_memory->enum_store_);
+    ASSERT_TRUE(json["nodes"].empty());
+    ASSERT_TRUE(json["edges"].empty());
+  }
 
-//   // setup CREATE ()-[:E]->();
-//   // Running 2 write threads 1 read thread
-//   // t1 modify from and/or to labels
-//   // t2 modify edge property
-//   // t3 read schema
+  // setup CREATE ()-[:E]->();
+  // Running 2 write threads 1 read thread
+  // t1 modify from and/or to labels
+  // t2 modify edge property
+  // t3 read schema
 
-//   Gid from_gid;
-//   Gid to_gid;
-//   Gid edge_gid;
+  Gid from_gid;
+  Gid to_gid;
+  std::atomic<Gid> edge_gid;
 
-//   // SETUP
-//   {
-//     auto acc = in_memory->Access();
-//     auto v1 = acc->CreateVertex();
-//     auto v2 = acc->CreateVertex();
-//     auto edge = acc->CreateEdge(&v1, &v2, e1);
-//     from_gid = v1.Gid();
-//     to_gid = v2.Gid();
-//     edge_gid = edge->Gid();
-//     ASSERT_FALSE(acc->Commit().HasError());
-//   }
+  // SETUP
+  {
+    auto acc = in_memory->Access();
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    auto edge = acc->CreateEdge(&v1, &v2, e1);
+    from_gid = v1.Gid();
+    to_gid = v2.Gid();
+    edge_gid = edge->Gid();
+    ASSERT_FALSE(acc->Commit().HasError());
+  }
 
-//   std::atomic_bool running = true;
+  std::atomic_bool running = true;
 
-//   auto modify_labels = [&]() {
-//     uint8_t i = 0;
-//     while (running) {
-//       ++i;
-//       auto acc = in_memory->Access();
-//       if (i % 2 == 0) {
-//         auto v = acc->FindVertex(from_gid, View::NEW);
-//         const auto labels = v->Labels(View::NEW);
-//         if (labels.HasError()) return;
-//         if (labels->empty()) {
-//           ASSERT_FALSE(v->AddLabel(l1).HasError());
-//         } else {
-//           ASSERT_FALSE(v->RemoveLabel(l1).HasError());
-//         }
-//       }
-//       if (i % 3 == 0) {
-//         auto v = acc->FindVertex(to_gid, View::NEW);
-//         const auto labels = v->Labels(View::NEW);
-//         if (labels.HasError()) return;
-//         if (labels->empty()) {
-//           ASSERT_FALSE(v->AddLabel(l2).HasError());
-//         } else {
-//           ASSERT_FALSE(v->RemoveLabel(l2).HasError());
-//         }
-//       }
-//       ASSERT_FALSE(acc->Commit().HasError());
-//       std::this_thread::sleep_for(std::chrono::milliseconds(1));
-//     }
-//   };
+  auto modify_labels = [&]() {
+    uint8_t i = 0;
+    while (running) {
+      ++i;
+      auto acc = in_memory->Access();
+      if (i % 2 == 0) {
+        auto v = acc->FindVertex(from_gid, View::NEW);
+        const auto labels = v->Labels(View::NEW);
+        if (labels.HasError()) continue;
+        if (labels->empty()) {
+          ASSERT_FALSE(v->AddLabel(l1).HasError());
+        } else {
+          ASSERT_FALSE(v->RemoveLabel(l1).HasError());
+        }
+      }
+      if (i % 3 == 0) {
+        auto v = acc->FindVertex(to_gid, View::NEW);
+        const auto labels = v->Labels(View::NEW);
+        if (labels.HasError()) continue;
+        if (labels->empty()) {
+          ASSERT_FALSE(v->AddLabel(l2).HasError());
+        } else {
+          ASSERT_FALSE(v->RemoveLabel(l2).HasError());
+        }
+      }
+      ASSERT_FALSE(acc->Commit().HasError());
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  };
 
-//   auto modify_edge = [&]() {
-//     uint8_t i = 0;
-//     while (running) {
-//       ++i;
-//       if (i % 5 == 0) {
-//         auto acc = in_memory->Access();
-//         auto edge = acc->FindEdge(edge_gid, View::NEW);
-//         const auto props = edge->Properties(View::NEW);
-//         if (props.HasError()) return;
-//         bool can_commit = true;
-//         if (props->empty()) {
-//           can_commit = edge->SetProperty(p1, PropertyValue{""}).HasValue();
-//         } else {
-//           can_commit = edge->ClearProperties().HasValue();
-//         }
-//         if (can_commit) ASSERT_FALSE(acc->Commit().HasError());
-//       }
-//       std::this_thread::sleep_for(std::chrono::milliseconds(1));
-//     }
-//   };
+  auto modify_edge = [&]() {
+    uint8_t i = 0;
+    while (running) {
+      ++i;
+      if (i % 5 == 0) {
+        auto acc = in_memory->Access();
+        auto edge = acc->FindEdge(edge_gid, View::NEW);
+        const auto props = edge->Properties(View::NEW);
+        if (props.HasError()) continue;
+        bool can_commit = true;
+        if (props->empty()) {
+          can_commit = edge->SetProperty(p1, PropertyValue{""}).HasValue();
+        } else {
+          can_commit = edge->ClearProperties().HasValue();
+        }
+        if (can_commit) ASSERT_FALSE(acc->Commit().HasError());
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  };
 
-//   auto modify_edge2 = [&]() {
-//     uint8_t i = 0;
-//     while (running) {
-//       ++i;
-//       if (i % 7 == 0) {
-//         auto acc = in_memory->Access();
-//         auto edge = acc->FindEdge(edge_gid, View::NEW);
-//         const auto props = edge->Properties(View::NEW);
-//         if (props.HasError()) return;
-//         bool can_commit = true;
-//         if (i % 2) {
-//           can_commit = edge->SetProperty(p1, PropertyValue{123}).HasValue();
-//         } else {
-//           can_commit = edge->SetProperty(p1, PropertyValue{true}).HasValue();
-//         }
-//         if (can_commit) ASSERT_FALSE(acc->Commit().HasError());
-//       }
-//       std::this_thread::sleep_for(std::chrono::milliseconds(1));
-//     }
-//   };
+  auto modify_edge2 = [&]() {
+    uint8_t i = 0;
+    while (running) {
+      ++i;
+      if (i % 7 == 0) {
+        if (i % 2 == 0) {
+          // Modify property
+          auto acc = in_memory->Access();
+          auto edge = acc->FindEdge(edge_gid, View::NEW);
+          const auto props = edge->Properties(View::NEW);
+          if (props.HasError()) continue;
+          bool can_commit = true;
+          if (i % 2) {
+            can_commit = edge->SetProperty(p1, PropertyValue{123}).HasValue();
+          } else {
+            can_commit = edge->SetProperty(p1, PropertyValue{true}).HasValue();
+          }
+          if (can_commit) ASSERT_FALSE(acc->Commit().HasError());
+        } else {
+          // Delete edge
+          auto acc = in_memory->Access();
+          auto edge = acc->FindEdge(edge_gid, View::NEW);
+          if (!edge) continue;
+          bool can_commit = true;
+          if (i % 3) {
+            can_commit = acc->DeleteEdge(&*edge).HasValue();
+          } else {
+            auto v1 = acc->CreateVertex();
+            auto v2 = acc->CreateVertex();
+            auto edge = acc->CreateEdge(&v1, &v2, e1);
+            if (edge.HasError()) continue;
+            edge_gid = edge->Gid();
+          }
+          if (can_commit) ASSERT_FALSE(acc->Commit().HasError());
+        }
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  };
 
-//   auto read_schema = [&]() {
-//     auto stop = memgraph::utils::OnScopeExit{[&]() { running = false; }};
-//     uint16_t i = 0;
-//     while (i++ < 15000) {
-//       const auto json = in_memory->schema_info_.ToJson(*in_memory->name_id_mapper_, in_memory->enum_store_);
-//       // Possible schemas:
+  auto read_schema = [&]() {
+    auto stop = memgraph::utils::OnScopeExit{[&]() { running = false; }};
+    uint16_t i = 0;
+    while (i++ < 15000) {
+      const auto json = in_memory->schema_info_.ToJson(*in_memory->name_id_mapper_, in_memory->enum_store_);
+      // Possible schemas:
+      static const auto no_labels_no_prop = nlohmann::json::parse(
+          R"({"edges":[{"count":1,"end_node_labels":[],"properties":[],"start_node_labels":[],"type":"E1"}],"nodes":[{"count":2,"labels":[],"properties":[]}]})");
+      static const auto from_label_no_prop = nlohmann::json::parse(
+          R"({"edges":[{"count":1,"end_node_labels":[],"properties":[],"start_node_labels":["L1"],"type":"E1"}],"nodes":[{"count":1,"labels":[],"properties":[]},{"count":1,"labels":["L1"],"properties":[]}]})");
+      static const auto to_label_no_prop = nlohmann::json::parse(
+          R"({"edges":[{"count":1,"end_node_labels":["L2"],"properties":[],"start_node_labels":[],"type":"E1"}],"nodes":[{"count":1,"labels":[],"properties":[]},{"count":1,"labels":["L2"],"properties":[]}]})");
+      static const auto both_labels_no_prop = nlohmann::json::parse(
+          R"({"edges":[{"count":1,"end_node_labels":["L2"],"properties":[],"start_node_labels":["L1"],"type":"E1"}],"nodes":[{"count":1,"labels":["L1"],"properties":[]},{"count":1,"labels":["L2"],"properties":[]}]})");
+      static const auto no_labels_w_prop = nlohmann::json::parse(
+          R"({"edges":[{"count":1,"end_node_labels":[],"properties":[{"count" : 1, "filling_factor" : 100.0, "key" :
+          "p1", "types" : [ {"count" : 1, "type" : "String"}
+          ]}],"start_node_labels":[],"type":"E1"}],"nodes":[{"count":2,"labels":[],"properties":[]}]})");
+      static const auto no_labels_w_prop2 = nlohmann::json::parse(
+          R"({"edges":[{"count":1,"end_node_labels":[],"properties":[{"count" : 1, "filling_factor" : 100.0, "key" :
+          "p1", "types" : [ {"count" : 1, "type" : "Integer"}
+          ]}],"start_node_labels":[],"type":"E1"}],"nodes":[{"count":2,"labels":[],"properties":[]}]})");
+      static const auto no_labels_w_prop3 = nlohmann::json::parse(
+          R"({"edges":[{"count":1,"end_node_labels":[],"properties":[{"count" : 1, "filling_factor" : 100.0, "key" :
+          "p1", "types" : [ {"count" : 1, "type" : "Boolean"}
+          ]}],"start_node_labels":[],"type":"E1"}],"nodes":[{"count":2,"labels":[],"properties":[]}]})");
+      static const auto from_label_w_prop = nlohmann::json::parse(
+          R"({"edges":[{"count":1,"end_node_labels":[],"properties":[{"count" : 1, "filling_factor" : 100.0, "key" :
+          "p1", "types" : [ {"count" : 1, "type" : "String"}
+          ]}],"start_node_labels":["L1"],"type":"E1"}],"nodes":[{"count":1,"labels":[],"properties":[]},{"count":1,"labels":["L1"],"properties":[]}]})");
+      static const auto from_label_w_prop2 = nlohmann::json::parse(
+          R"({"edges":[{"count":1,"end_node_labels":[],"properties":[{"count" : 1, "filling_factor" : 100.0, "key" :
+          "p1", "types" : [ {"count" : 1, "type" : "Integer"}
+          ]}],"start_node_labels":["L1"],"type":"E1"}],"nodes":[{"count":1,"labels":[],"properties":[]},{"count":1,"labels":["L1"],"properties":[]}]})");
+      static const auto from_label_w_prop3 = nlohmann::json::parse(
+          R"({"edges":[{"count":1,"end_node_labels":[],"properties":[{"count" : 1, "filling_factor" : 100.0, "key" :
+          "p1", "types" : [ {"count" : 1, "type" : "Boolean"}
+          ]}],"start_node_labels":["L1"],"type":"E1"}],"nodes":[{"count":1,"labels":[],"properties":[]},{"count":1,"labels":["L1"],"properties":[]}]})");
+      static const auto to_label_w_prop = nlohmann::json::parse(
+          R"({"edges":[{"count":1,"end_node_labels":["L2"],"properties":[{"count" : 1, "filling_factor" : 100.0,
+          "key" : "p1", "types" : [ {"count" : 1, "type" : "String"}
+          ]}],"start_node_labels":[],"type":"E1"}],"nodes":[{"count":1,"labels":[],"properties":[]},{"count":1,"labels":["L2"],"properties":[]}]})");
+      static const auto to_label_w_prop2 = nlohmann::json::parse(
+          R"({"edges":[{"count":1,"end_node_labels":["L2"],"properties":[{"count" : 1, "filling_factor" : 100.0,
+          "key" : "p1", "types" : [ {"count" : 1, "type" : "Integer"}
+          ]}],"start_node_labels":[],"type":"E1"}],"nodes":[{"count":1,"labels":[],"properties":[]},{"count":1,"labels":["L2"],"properties":[]}]})");
+      static const auto to_label_w_prop3 = nlohmann::json::parse(
+          R"({"edges":[{"count":1,"end_node_labels":["L2"],"properties":[{"count" : 1, "filling_factor" : 100.0,
+          "key" : "p1", "types" : [ {"count" : 1, "type" : "Boolean"}
+          ]}],"start_node_labels":[],"type":"E1"}],"nodes":[{"count":1,"labels":[],"properties":[]},{"count":1,"labels":["L2"],"properties":[]}]})");
+      static const auto both_labels_w_prop = nlohmann::json::parse(
+          R"({"edges":[{"count":1,"end_node_labels":["L2"],"properties":[{"count" : 1, "filling_factor" : 100.0,
+          "key" : "p1", "types" : [ {"count" : 1, "type" : "String"}
+          ]}],"start_node_labels":["L1"],"type":"E1"}],"nodes":[{"count":1,"labels":["L1"],"properties":[]},{"count":1,"labels":["L2"],"properties":[]}]})");
+      static const auto both_labels_w_prop2 = nlohmann::json::parse(
+          R"({"edges":[{"count":1,"end_node_labels":["L2"],"properties":[{"count" : 1, "filling_factor" : 100.0,
+          "key" : "p1", "types" : [ {"count" : 1, "type" : "Integer"}
+          ]}],"start_node_labels":["L1"],"type":"E1"}],"nodes":[{"count":1,"labels":["L1"],"properties":[]},{"count":1,"labels":["L2"],"properties":[]}]})");
+      static const auto both_labels_w_prop3 = nlohmann::json::parse(
+          R"({"edges":[{"count":1,"end_node_labels":["L2"],"properties":[{"count" : 1, "filling_factor" : 100.0,
+          "key" : "p1", "types" : [ {"count" : 1, "type" : "Boolean"}
+          ]}],"start_node_labels":["L1"],"type":"E1"}],"nodes":[{"count":1,"labels":["L1"],"properties":[]},{"count":1,"labels":["L2"],"properties":[]}]})");
 
-//       static const auto no_labels_no_prop = nlohmann::json::parse(
-//           R"({"edges":[{"count":1,"end_node_labels":[],"properties":[],"start_node_labels":[],"type":"E1"}],"nodes":[{"count":2,"labels":[],"properties":[]}]})");
-//       static const auto from_label_no_prop = nlohmann::json::parse(
-//           R"({"edges":[{"count":1,"end_node_labels":[],"properties":[],"start_node_labels":["L1"],"type":"E1"}],"nodes":[{"count":1,"labels":[],"properties":[]},{"count":1,"labels":["L1"],"properties":[]}]})");
-//       static const auto to_label_no_prop = nlohmann::json::parse(
-//           R"({"edges":[{"count":1,"end_node_labels":["L2"],"properties":[],"start_node_labels":[],"type":"E1"}],"nodes":[{"count":1,"labels":[],"properties":[]},{"count":1,"labels":["L2"],"properties":[]}]})");
-//       static const auto both_labels_no_prop = nlohmann::json::parse(
-//           R"({"edges":[{"count":1,"end_node_labels":["L2"],"properties":[],"start_node_labels":["L1"],"type":"E1"}],"nodes":[{"count":1,"labels":["L1"],"properties":[]},{"count":1,"labels":["L2"],"properties":[]}]})");
-//       static const auto no_labels_w_prop = nlohmann::json::parse(
-//           R"({"edges":[{"count":1,"end_node_labels":[],"properties":[{"count" : 1, "filling_factor" : 100.0, "key" :
-//           "p1", "types" : [ {"count" : 1, "type" : "String"}
-//           ]}],"start_node_labels":[],"type":"E1"}],"nodes":[{"count":2,"labels":[],"properties":[]}]})");
-//       static const auto no_labels_w_prop2 = nlohmann::json::parse(
-//           R"({"edges":[{"count":1,"end_node_labels":[],"properties":[{"count" : 1, "filling_factor" : 100.0, "key" :
-//           "p1", "types" : [ {"count" : 1, "type" : "Integer"}
-//           ]}],"start_node_labels":[],"type":"E1"}],"nodes":[{"count":2,"labels":[],"properties":[]}]})");
-//       static const auto no_labels_w_prop3 = nlohmann::json::parse(
-//           R"({"edges":[{"count":1,"end_node_labels":[],"properties":[{"count" : 1, "filling_factor" : 100.0, "key" :
-//           "p1", "types" : [ {"count" : 1, "type" : "Boolean"}
-//           ]}],"start_node_labels":[],"type":"E1"}],"nodes":[{"count":2,"labels":[],"properties":[]}]})");
-//       static const auto from_label_w_prop = nlohmann::json::parse(
-//           R"({"edges":[{"count":1,"end_node_labels":[],"properties":[{"count" : 1, "filling_factor" : 100.0, "key" :
-//           "p1", "types" : [ {"count" : 1, "type" : "String"}
-//           ]}],"start_node_labels":["L1"],"type":"E1"}],"nodes":[{"count":1,"labels":[],"properties":[]},{"count":1,"labels":["L1"],"properties":[]}]})");
-//       static const auto from_label_w_prop2 = nlohmann::json::parse(
-//           R"({"edges":[{"count":1,"end_node_labels":[],"properties":[{"count" : 1, "filling_factor" : 100.0, "key" :
-//           "p1", "types" : [ {"count" : 1, "type" : "Integer"}
-//           ]}],"start_node_labels":["L1"],"type":"E1"}],"nodes":[{"count":1,"labels":[],"properties":[]},{"count":1,"labels":["L1"],"properties":[]}]})");
-//       static const auto from_label_w_prop3 = nlohmann::json::parse(
-//           R"({"edges":[{"count":1,"end_node_labels":[],"properties":[{"count" : 1, "filling_factor" : 100.0, "key" :
-//           "p1", "types" : [ {"count" : 1, "type" : "Boolean"}
-//           ]}],"start_node_labels":["L1"],"type":"E1"}],"nodes":[{"count":1,"labels":[],"properties":[]},{"count":1,"labels":["L1"],"properties":[]}]})");
-//       static const auto to_label_w_prop = nlohmann::json::parse(
-//           R"({"edges":[{"count":1,"end_node_labels":["L2"],"properties":[{"count" : 1, "filling_factor" : 100.0,
-//           "key" : "p1", "types" : [ {"count" : 1, "type" : "String"}
-//           ]}],"start_node_labels":[],"type":"E1"}],"nodes":[{"count":1,"labels":[],"properties":[]},{"count":1,"labels":["L2"],"properties":[]}]})");
-//       static const auto to_label_w_prop2 = nlohmann::json::parse(
-//           R"({"edges":[{"count":1,"end_node_labels":["L2"],"properties":[{"count" : 1, "filling_factor" : 100.0,
-//           "key" : "p1", "types" : [ {"count" : 1, "type" : "Integer"}
-//           ]}],"start_node_labels":[],"type":"E1"}],"nodes":[{"count":1,"labels":[],"properties":[]},{"count":1,"labels":["L2"],"properties":[]}]})");
-//       static const auto to_label_w_prop3 = nlohmann::json::parse(
-//           R"({"edges":[{"count":1,"end_node_labels":["L2"],"properties":[{"count" : 1, "filling_factor" : 100.0,
-//           "key" : "p1", "types" : [ {"count" : 1, "type" : "Boolean"}
-//           ]}],"start_node_labels":[],"type":"E1"}],"nodes":[{"count":1,"labels":[],"properties":[]},{"count":1,"labels":["L2"],"properties":[]}]})");
-//       static const auto both_labels_w_prop = nlohmann::json::parse(
-//           R"({"edges":[{"count":1,"end_node_labels":["L2"],"properties":[{"count" : 1, "filling_factor" : 100.0,
-//           "key" : "p1", "types" : [ {"count" : 1, "type" : "String"}
-//           ]}],"start_node_labels":["L1"],"type":"E1"}],"nodes":[{"count":1,"labels":["L1"],"properties":[]},{"count":1,"labels":["L2"],"properties":[]}]})");
-//       static const auto both_labels_w_prop2 = nlohmann::json::parse(
-//           R"({"edges":[{"count":1,"end_node_labels":["L2"],"properties":[{"count" : 1, "filling_factor" : 100.0,
-//           "key" : "p1", "types" : [ {"count" : 1, "type" : "Integer"}
-//           ]}],"start_node_labels":["L1"],"type":"E1"}],"nodes":[{"count":1,"labels":["L1"],"properties":[]},{"count":1,"labels":["L2"],"properties":[]}]})");
-//       static const auto both_labels_w_prop3 = nlohmann::json::parse(
-//           R"({"edges":[{"count":1,"end_node_labels":["L2"],"properties":[{"count" : 1, "filling_factor" : 100.0,
-//           "key" : "p1", "types" : [ {"count" : 1, "type" : "Boolean"}
-//           ]}],"start_node_labels":["L1"],"type":"E1"}],"nodes":[{"count":1,"labels":["L1"],"properties":[]},{"count":1,"labels":["L2"],"properties":[]}]})");
+      static const std::array<nlohmann::json, 16> possible_schemas = {
+          no_labels_no_prop, from_label_no_prop, to_label_no_prop, both_labels_no_prop,
+          no_labels_w_prop,  from_label_w_prop,  to_label_w_prop,  both_labels_w_prop,
+          no_labels_w_prop2, from_label_w_prop2, to_label_w_prop2, both_labels_w_prop2,
+          no_labels_w_prop3, from_label_w_prop3, to_label_w_prop3, both_labels_w_prop3};
 
-//       static const std::array<nlohmann::json, 16> possible_schemas = {
-//           no_labels_no_prop, from_label_no_prop, to_label_no_prop, both_labels_no_prop,
-//           no_labels_w_prop,  from_label_w_prop,  to_label_w_prop,  both_labels_w_prop,
-//           no_labels_w_prop2, from_label_w_prop2, to_label_w_prop2, both_labels_w_prop2,
-//           no_labels_w_prop3, from_label_w_prop3, to_label_w_prop3, both_labels_w_prop3};
+      auto itr = std::find_if(possible_schemas.begin(), possible_schemas.end(), [&json](auto &in) {
+        // Support no edges as well
+        if (json["edges"].empty()) {
+          return ConfrontJSON(json["nodes"], in["nodes"]);
+        }
+        return ConfrontJSON(json, in);
+      });
 
-//       auto itr = std::find_if(possible_schemas.begin(), possible_schemas.end(),
-//                               [&json](auto &in) { return ConfrontJSON(json, in); });
+      ASSERT_NE(itr, possible_schemas.end()) << json;
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  };
 
-//       ASSERT_NE(itr, possible_schemas.end()) << json;
-//       std::this_thread::sleep_for(std::chrono::milliseconds(1));
-//     }
-//   };
-
-//   auto t1 = std::jthread(modify_labels);
-//   auto t2 = std::jthread(modify_edge);
-//   auto t3 = std::jthread(modify_edge2);
-//   auto t4 = std::jthread(read_schema);
-// }
+  auto t1 = std::jthread(modify_labels);
+  auto t2 = std::jthread(modify_edge);
+  auto t3 = std::jthread(modify_edge2);
+  auto t4 = std::jthread(read_schema);
+}
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TYPED_TEST(SchemaInfoTest, AllPropertyTypes) {


### PR DESCRIPTION
Changed how post-processing work. Previous implementation was too pessimistic. 
Now checking when and who made changes in order to better figure out if edge post-processing is needed.
In addition, added caching for vertex labels, so no need to re-create the object every time.