### PR TITLE
Bugfix: Concurrent snapshot creation and demotion cause replica to crash on restart

### DIFF
--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -4286,6 +4286,8 @@ PreparedQuery PrepareCreateSnapshotQuery(ParsedQuery parsed_query, bool in_expli
             case storage::InMemoryStorage::CreateSnapshotError::ReachedMaxNumTries:
               spdlog::warn("Failed to create snapshot. Reached max number of tries. Please contact support");
               break;
+            case storage::InMemoryStorage::CreateSnapshotError::AbortSnapshot:
+              throw utils::BasicException("Failed to create snapshot. The current snapshot needs to be aborted.");
           }
         }
         return QueryHandlerResult::COMMIT;

--- a/src/storage/v2/durability/snapshot.hpp
+++ b/src/storage/v2/durability/snapshot.hpp
@@ -75,7 +75,7 @@ RecoveredSnapshot LoadSnapshot(std::filesystem::path const &path, utils::SkipLis
                                memgraph::storage::SharedSchemaTracking *schema_info,
                                std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
-void CreateSnapshot(Storage *storage, Transaction *transaction, const std::filesystem::path &snapshot_directory,
+bool CreateSnapshot(Storage *storage, Transaction *transaction, const std::filesystem::path &snapshot_directory,
                     const std::filesystem::path &wal_directory, utils::SkipList<Vertex> *vertices,
                     utils::SkipList<Edge> *edges, utils::UUID const &uuid,
                     const memgraph::replication::ReplicationEpoch &epoch,

--- a/src/storage/v2/durability/snapshot.hpp
+++ b/src/storage/v2/durability/snapshot.hpp
@@ -80,6 +80,6 @@ void CreateSnapshot(Storage *storage, Transaction *transaction, const std::files
                     utils::SkipList<Edge> *edges, utils::UUID const &uuid,
                     const memgraph::replication::ReplicationEpoch &epoch,
                     const std::deque<std::pair<std::string, uint64_t>> &epoch_history,
-                    utils::FileRetainer *file_retainer);
+                    utils::FileRetainer *file_retainer, std::atomic_bool *abort_snapshot = nullptr);
 
 }  // namespace memgraph::storage::durability

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2619,7 +2619,6 @@ utils::BasicResult<InMemoryStorage::CreateSnapshotError> InMemoryStorage::Create
   }
 
   std::lock_guard snapshot_guard(snapshot_lock_);
-  spdlog::trace("Snapshot lock taken");
 
   auto accessor = std::invoke([&]() {
     if (storage_mode_ == StorageMode::IN_MEMORY_ANALYTICAL) {
@@ -2758,7 +2757,6 @@ utils::BasicResult<InMemoryStorage::RecoverSnapshotError> InMemoryStorage::Recov
 // Note:
 std::vector<SnapshotFileInfo> InMemoryStorage::ShowSnapshots() {
   auto lock = std::unique_lock{snapshot_lock_};
-  spdlog::trace("Snapshot lock taken");
 
   std::vector<SnapshotFileInfo> res;
   auto file_locker = file_retainer_.AddLocker();

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2615,6 +2615,7 @@ utils::BasicResult<InMemoryStorage::CreateSnapshotError> InMemoryStorage::Create
   }
 
   std::lock_guard snapshot_guard(snapshot_lock_);
+  spdlog::trace("Snapshot lock taken");
 
   auto accessor = std::invoke([&]() {
     if (storage_mode_ == StorageMode::IN_MEMORY_ANALYTICAL) {
@@ -2753,6 +2754,7 @@ utils::BasicResult<InMemoryStorage::RecoverSnapshotError> InMemoryStorage::Recov
 // Note:
 std::vector<SnapshotFileInfo> InMemoryStorage::ShowSnapshots() {
   auto lock = std::unique_lock{snapshot_lock_};
+  spdlog::trace("Snapshot lock taken");
 
   std::vector<SnapshotFileInfo> res;
   auto file_locker = file_retainer_.AddLocker();

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2624,17 +2624,17 @@ utils::BasicResult<InMemoryStorage::CreateSnapshotError> InMemoryStorage::Create
     return Access(IsolationLevel::SNAPSHOT_ISOLATION);
   });
 
-  // TODO: Think about role check here
-  // What will happen if MAIN is being demoted at this point?
-
   utils::Timer timer;
   Transaction *transaction = accessor->GetTransaction();
   auto const &epoch = repl_storage_state_.epoch_;
   durability::CreateSnapshot(this, transaction, recovery_.snapshot_directory_, recovery_.wal_directory_, &vertices_,
-                             &edges_, uuid(), epoch, repl_storage_state_.history, &file_retainer_);
+                             &edges_, uuid(), epoch, repl_storage_state_.history, &file_retainer_, &abort_snapshot_);
 
   memgraph::metrics::Measure(memgraph::metrics::SnapshotCreationLatency_us,
                              std::chrono::duration_cast<std::chrono::microseconds>(timer.Elapsed()).count());
+
+  abort_snapshot_.store(false, std::memory_order_release);
+
   return {};
 }
 

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -106,7 +106,7 @@ class InMemoryStorage final : public Storage {
 
  public:
   using free_mem_fn = std::function<void(std::unique_lock<utils::ResourceLock>, bool)>;
-  enum class CreateSnapshotError : uint8_t { DisabledForReplica, ReachedMaxNumTries };
+  enum class CreateSnapshotError : uint8_t { DisabledForReplica, ReachedMaxNumTries, AbortSnapshot };
   enum class RecoverSnapshotError : uint8_t {
     DisabledForReplica,
     DisabledForMainWithReplicas,
@@ -627,7 +627,7 @@ class InMemoryStorage final : public Storage {
   std::unique_ptr<utils::OutputFile> lock_file_handle_ = std::make_unique<utils::OutputFile>();
 
   utils::Scheduler snapshot_runner_;
-  utils::ResourceLock snapshot_lock_;
+  std::mutex snapshot_lock_;
   std::atomic_bool abort_snapshot_{false};
 
   std::shared_ptr<utils::Observer<utils::SchedulerInterval>> snapshot_periodic_observer_;

--- a/src/utils/timer.hpp
+++ b/src/utils/timer.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -24,6 +24,8 @@ class Timer {
   TDuration Elapsed() const {
     return std::chrono::duration_cast<TDuration>(std::chrono::steady_clock::now() - start_time_);
   }
+
+  void ResetStartTime() { start_time_ = std::chrono::steady_clock::now(); }
 
  private:
   std::chrono::steady_clock::time_point start_time_;


### PR DESCRIPTION
When main becomes replica, snapshot scheduler is paused and all snapshot locks are taken. When replica gets promoted, abort is set to false and scheduler resumed. On demotion, if there is a snapshot currently getting created, it will get aborted.