### PR TITLE
Add rewrite to STShortest path

### DIFF
--- a/src/query/plan/planner.hpp
+++ b/src/query/plan/planner.hpp
@@ -67,7 +67,9 @@ class PostProcessor final {
     auto &db = context->db;
 
     return std::move(plan) | [&](auto p) { return RewriteEnumAccess(std::move(p), symbol_table, ast, db); } |
-           [&](auto p) { return RewriteWithIndexLookup(std::move(p), symbol_table, ast, db, index_hints_); } |
+           [&](auto p) {
+             return RewriteWithIndexLookup(std::move(p), symbol_table, ast, db, parameters_, index_hints_);
+           } |
            [&](auto p) { return RewriteWithJoinRewriter(std::move(p), symbol_table, ast, db); } |
            [&](auto p) { return RewriteWithEdgeIndexRewriter(std::move(p), symbol_table, ast, db); } |
            [&](auto p) { return RewritePeriodicDelete(std::move(p), symbol_table, ast, db); };

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -347,6 +347,7 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
       expand.set_input(std::move(indexed_scan));
       expand.common_.existing_node = true;
     }
+
     return true;
   }
 

--- a/tests/e2e/query_planning/CMakeLists.txt
+++ b/tests/e2e/query_planning/CMakeLists.txt
@@ -7,5 +7,6 @@ copy_query_planning_e2e_python_files(query_planning_cartesian.py)
 copy_query_planning_e2e_python_files(query_planning_point_index.py)
 copy_query_planning_e2e_python_files(query_planning_valid_query_plans.py)
 copy_query_planning_e2e_python_files(query_planning_optional.py)
+copy_query_planning_e2e_python_files(query_planning_stshortest.py)
 
 copy_e2e_files(query_planning workloads.yaml)

--- a/tests/e2e/query_planning/query_planning_stshortest.py
+++ b/tests/e2e/query_planning/query_planning_stshortest.py
@@ -1,0 +1,67 @@
+# Copyright 2023 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+import sys
+
+import pytest
+from common import memgraph
+
+QUERY_PLAN = "QUERY PLAN"
+
+
+def test_single_source_shortest_executes_when_having_high_amount_of_destination_nodes(memgraph):
+    memgraph.execute("CREATE INDEX ON :Node;")
+    memgraph.execute("CREATE INDEX ON :Node(id);")
+
+    memgraph.execute("UNWIND range(1, 20) as x CREATE (:Node {id: x})-[:TO]->(:Node {id: 100 + x})")
+
+    expected_explain = [
+        f" * Produce {{p}}",
+        f" * ConstructNamedPath",
+        f" * Filter (b :Node)",
+        f" * BFSExpand (a)-[anon1:TYPE]->(b)",
+        f" * ScanAllByLabelPropertyValue (a :Node {{id}})",
+        f" * Once",
+    ]
+
+    results = list(memgraph.execute_and_fetch("EXPLAIN MATCH p=(a:Node {id: 1})-[:TYPE *bfs]->(b:Node) RETURN p"))
+    print(results)
+    actual_explain = [x[QUERY_PLAN] for x in results]
+
+    assert expected_explain == actual_explain
+
+
+def test_stshortest_executes_when_having_low_amount_of_destination_nodes(memgraph):
+    memgraph.execute("CREATE INDEX ON :Node;")
+    memgraph.execute("CREATE INDEX ON :Node(id);")
+
+    memgraph.execute("UNWIND range(1, 20) as x CREATE (:Node {id: x})-[:TO]->(:Node {id: 100 + x})")
+
+    expected_explain = [
+        f" * Produce {{p}}",
+        f" * ConstructNamedPath",
+        f" * STShortestPath (a)-[anon1:TYPE]->(b)",
+        f" * ScanAllByLabelPropertyValue (b :Node {{id}})",
+        f" * ScanAllByLabelPropertyValue (a :Node {{id}})",
+        f" * Once",
+    ]
+
+    results = list(
+        memgraph.execute_and_fetch("EXPLAIN MATCH p=(a:Node {id: 1})-[:TYPE *bfs]->(b:Node {id: 2}) RETURN p")
+    )
+    print(results)
+    actual_explain = [x[QUERY_PLAN] for x in results]
+
+    assert expected_explain == actual_explain
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/query_planning/workloads.yaml
+++ b/tests/e2e/query_planning/workloads.yaml
@@ -1,7 +1,7 @@
 queries_cluster: &queries_cluster
   cluster:
     main:
-      args: ["--bolt-port", "7687", "--log-level=TRACE"]
+      args: ["--bolt-port", "7687", "--log-level=TRACE", "--query-plan-cache-max-size=0"]
       log_file: "query_planning.log"
       setup_queries: []
       validation_queries: []

--- a/tests/e2e/query_planning/workloads.yaml
+++ b/tests/e2e/query_planning/workloads.yaml
@@ -27,3 +27,8 @@ workloads:
     binary: "tests/e2e/pytest_runner.sh"
     args: ["query_planning/query_planning_optional.py"]
     <<: *queries_cluster
+
+  - name: "Query planning STShortest"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["query_planning/query_planning_stshortest.py"]
+    <<: *queries_cluster

--- a/tests/unit/query_plan_checker.hpp
+++ b/tests/unit/query_plan_checker.hpp
@@ -706,6 +706,17 @@ class FakeDbAccessor {
     return 0;
   }
 
+  int64_t VerticesCount(memgraph::storage::LabelId label, memgraph::storage::PropertyId property,
+                        std::optional<utils::Bound<memgraph::storage::PropertyValue>> lower,
+                        std::optional<utils::Bound<memgraph::storage::PropertyValue>> upper) const {
+    for (const auto &index : label_property_index_) {
+      if (std::get<0>(index) == label && std::get<1>(index) == property) {
+        return std::get<2>(index);
+      }
+    }
+    return 0;
+  }
+
   bool PointIndexExists(memgraph::storage::LabelId label, memgraph::storage::PropertyId property) const {
     return false;
   }

--- a/tests/unit/query_plan_checker.hpp
+++ b/tests/unit/query_plan_checker.hpp
@@ -696,6 +696,16 @@ class FakeDbAccessor {
     return 0;
   }
 
+  int64_t VerticesCount(memgraph::storage::LabelId label, memgraph::storage::PropertyId property,
+                        memgraph::storage::PropertyValue value) const {
+    for (const auto &index : label_property_index_) {
+      if (std::get<0>(index) == label && std::get<1>(index) == property) {
+        return std::get<2>(index);
+      }
+    }
+    return 0;
+  }
+
   bool PointIndexExists(memgraph::storage::LabelId label, memgraph::storage::PropertyId property) const {
     return false;
   }


### PR DESCRIPTION
Rewriting STShortest path to expand the unknown node only if the cardinality is low enough.