### PR TITLE
utils::Scheduler now skips backed up tasks

### DIFF
--- a/src/utils/scheduler.cpp
+++ b/src/utils/scheduler.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -70,7 +70,14 @@ void Scheduler::SetInterval_(std::chrono::milliseconds pause,
   // Function to calculate next
   *find_next_.Lock() = [=](const auto &now, bool incr) mutable {
     if (next_execution > now) return next_execution;
-    if (incr) next_execution += pause;
+    if (incr) {
+      next_execution += pause;
+      // If multiple periods are missed, execute as soon as possible once
+      if (now > next_execution) {
+        next_execution = now;
+      }
+      return next_execution;
+    }
     return std::max(now, next_execution);
   };
 }


### PR DESCRIPTION
If a task takes longer than the period, scheduler will execute one task immediately, instead of N backed up tasks