### PR TITLE
Bugfix: New leader will elect a main in the case when there is no previously set-up main

### DIFF
--- a/src/coordination/include/coordination/register_main_replica_coordinator_status.hpp
+++ b/src/coordination/include/coordination/register_main_replica_coordinator_status.hpp
@@ -52,7 +52,6 @@ enum class SetInstanceToMainCoordinatorStatus : uint8_t {
   NOT_LEADER,
   RAFT_LOG_ERROR,
   COULD_NOT_PROMOTE_TO_MAIN,
-  SWAP_UUID_FAILED,
   SUCCESS,
   LOCK_OPENED,
   FAILED_TO_OPEN_LOCK,

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -692,8 +692,6 @@ class CoordQueryHandler final : public query::CoordinatorQueryHandler {
       case COULD_NOT_PROMOTE_TO_MAIN:
         throw QueryRuntimeException(
             "Couldn't set replica instance to main! Check coordinator and replica for more logs");
-      case SWAP_UUID_FAILED:
-        throw QueryRuntimeException("Couldn't set replica instance to main. Replicas didn't swap uuid of new main.");
       case FAILED_TO_OPEN_LOCK:
         throw QueryRuntimeException("Couldn't set instance to main as cluster didn't accept start of action!");
       case LOCK_OPENED:

--- a/tests/e2e/high_availability/common.py
+++ b/tests/e2e/high_availability/common.py
@@ -16,6 +16,14 @@ import typing
 import mgclient
 
 
+def has_main(data):
+    return any("main" in entry for entry in data)
+
+
+def has_leader(data):
+    return any("leader" in entry for entry in data)
+
+
 def get_data_path(file: str, test: str):
     """
     Data is stored in high_availability folder.

--- a/tests/e2e/mg_utils.py
+++ b/tests/e2e/mg_utils.py
@@ -1,5 +1,26 @@
 import time
-from typing import List, Set
+from typing import Set
+
+
+def mg_sleep_and_assert_eval_function(
+    eval_function, function_to_retrieve_data, max_duration=20, time_between_attempt=0.2
+):
+    """
+    Check if eval_function executed on the result of function_to_retrieve_data return true;
+    """
+    result = function_to_retrieve_data()
+    start_time = time.time()
+    while eval_function(result) is not True:
+        duration = time.time() - start_time
+        if duration > max_duration:
+            assert (
+                False
+            ), f" mg_sleep_and_assert_eval_function has tried for too long and did not get the expected result! Last result was: {result}."
+
+        time.sleep(time_between_attempt)
+        result = function_to_retrieve_data()
+
+    return result
 
 
 def mg_sleep_and_assert(expected_value, function_to_retrieve_data, max_duration=20, time_between_attempt=0.2):


### PR DESCRIPTION
A coordinator can become leader with the raft state containing only replica instances. This is possible if user demoted main instance and then coordinator crashed. In that case, the new leader should do a failover but this wasn't before. 
When promoting instance, data instances can now be down and promote will still succeed. Previously, all data instances had to be alive for manual promotion to be done.