### PR TITLE
Eagerly return if registering one of replicas fail upon promotion.

### DIFF
--- a/src/coordination/include/coordination/data_instance_management_server_handlers.hpp
+++ b/src/coordination/include/coordination/data_instance_management_server_handlers.hpp
@@ -17,7 +17,6 @@
 #include "coordination/coordinator_rpc.hpp"
 #include "coordination/data_instance_management_server.hpp"
 #include "replication_handler/replication_handler.hpp"
-#include "slk/streams.hpp"
 
 namespace memgraph::dbms {
 
@@ -25,7 +24,7 @@ class DbmsHandler;
 
 class DataInstanceManagementServerHandlers {
  public:
-  static void Register(memgraph::coordination::DataInstanceManagementServer &server,
+  static void Register(coordination::DataInstanceManagementServer &server,
                        replication::ReplicationHandler &replication_handler);
 
  private:
@@ -49,69 +48,8 @@ class DataInstanceManagementServerHandlers {
   static void GetDatabaseHistoriesHandler(replication::ReplicationHandler const &replication_handler,
                                           slk::Reader *req_reader, slk::Builder *res_builder);
 
-  template <typename TResponse>
   static auto DoRegisterReplica(replication::ReplicationHandler &replication_handler,
-                                coordination::ReplicationClientInfo const &config, slk::Builder *res_builder) -> bool {
-    auto const converter = [&config](const auto &repl_info_config) {
-      return replication::ReplicationClientConfig{.name = repl_info_config.instance_name,
-                                                  .mode = repl_info_config.replication_mode,
-                                                  .repl_server_endpoint = config.replication_server};
-    };
-
-    auto instance_client = replication_handler.RegisterReplica(converter(config));
-    if (instance_client.HasError()) {
-      using memgraph::query::RegisterReplicaError;
-      switch (instance_client.GetError()) {
-        case RegisterReplicaError::NO_ACCESS: {
-          spdlog::error(
-              "Error when registering instance {} as replica. Couldn't get unique access to ReplicationState.");
-          slk::Save(TResponse{false}, res_builder);
-          return false;
-        }
-        case RegisterReplicaError::NOT_MAIN: {
-          spdlog::error("Error when registering instance {} as replica. Instance not main anymore.",
-                        config.instance_name);
-          slk::Save(TResponse{false}, res_builder);
-          return false;
-        }
-        case RegisterReplicaError::NAME_EXISTS: {
-          spdlog::error(
-              "Error when registering instance {} as replica. Instance with the same name already registered.",
-              config.instance_name);
-          slk::Save(TResponse{false}, res_builder);
-          return false;
-        }
-        case RegisterReplicaError::ENDPOINT_EXISTS: {
-          spdlog::error(
-              "Error when registering instance {} as replica. Instance with the same endpoint already exists.",
-              config.instance_name);
-          slk::Save(TResponse{false}, res_builder);
-          return false;
-        }
-        case RegisterReplicaError::COULD_NOT_BE_PERSISTED: {
-          spdlog::error("Error when registering instance {} as replica. Registering instance could not be persisted.",
-                        config.instance_name);
-          slk::Save(TResponse{false}, res_builder);
-          return false;
-        }
-        case RegisterReplicaError::ERROR_ACCEPTING_MAIN: {
-          spdlog::error("Error when registering instance {} as replica. Instance couldn't accept change of main.",
-                        config.instance_name);
-          slk::Save(TResponse{false}, res_builder);
-          return false;
-        }
-        case RegisterReplicaError::CONNECTION_FAILED: {
-          spdlog::error(
-              "Error when registering instance {} as replica. Instance couldn't register all databases successfully.",
-              config.instance_name);
-          slk::Save(TResponse{false}, res_builder);
-          return false;
-        }
-      }
-    }
-    spdlog::trace("Instance {} successfully registered as replica.", config.instance_name);
-    return true;
-  }
+                                coordination::ReplicationClientInfo const &config) -> bool;
 };
 
 }  // namespace memgraph::dbms


### PR DESCRIPTION
When a replica gets promoted to main, it tries to register all other replicas. If registering one of replicas failed, there was a bug in SLK where the buffer would contain both false + true. When an error is encountered during promotion, promote is aborted and this information is returned back to coordinator. The coordinator should then try to repeat the registration process.