### PR TITLE
Fix graph cleanup in GQL Behave tests

### DIFF
--- a/tests/gql_behave/steps/graph.py
+++ b/tests/gql_behave/steps/graph.py
@@ -22,10 +22,7 @@ def clear_graph(context):
     if context.exception is not None:
         context.exception = None
         database.query("MATCH (n) DETACH DELETE n", context)
-    database.query("DROP INDEX ON :Person", context)
-    context.exception = None
-    database.query("DROP INDEX ON :Node(name)", context)
-    context.exception = None
+    database.query("FREE MEMORY", context)
 
 
 @given("an empty graph")

--- a/tests/gql_behave/steps/graph.py
+++ b/tests/gql_behave/steps/graph.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Memgraph Ltd.
+# Copyright 2025 Memgraph Ltd.
 #
 # Use of this software is governed by the Business Source License
 # included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -22,7 +22,10 @@ def clear_graph(context):
     if context.exception is not None:
         context.exception = None
         database.query("MATCH (n) DETACH DELETE n", context)
-    database.query("FREE MEMORY", context)
+    result = database.query("SHOW STORAGE INFO", context)
+    storage_mode = next(record["value"] for record in result if record["storage info"] == "storage_mode")
+    if storage_mode != "ON_DISK_TRANSACTIONAL":
+        database.query("FREE MEMORY", context)
 
 
 @given("an empty graph")


### PR DESCRIPTION
If you're testing indices and checking the number of entries in the index, you might get the wrong impression of what's happening. This is because the "correct" entry count is only visible after a GC run, not immediately after a node is marked as deleted.