### PR TITLE
Use ubuntu 24.04 for (almost) everything

### DIFF
--- a/.github/workflows/diff_community.yaml
+++ b/.github/workflows/diff_community.yaml
@@ -9,8 +9,8 @@ on:
         default: 'amd'
       os:
         type: string
-        description: "Target os. Default value is debian-12."
-        default: 'debian-12'
+        description: "Target os. Default value is ubuntu-24.04."
+        default: 'ubuntu-24.04'
       toolchain:
         type: string
         description: "Toolchain version (v4, v5, v6). Default value is v6."

--- a/.github/workflows/diff_coverage.yaml
+++ b/.github/workflows/diff_coverage.yaml
@@ -9,8 +9,8 @@ on:
         default: 'amd'
       os:
         type: string
-        description: "Target os. Default value is debian-12."
-        default: 'debian-12'
+        description: "Target os. Default value is ubuntu-24.04."
+        default: 'ubuntu-24.04'
       toolchain:
         type: string
         description: "Toolchain version (v4, v5, v6). Default value is v6."

--- a/.github/workflows/diff_debug.yaml
+++ b/.github/workflows/diff_debug.yaml
@@ -9,8 +9,8 @@ on:
         default: 'amd'
       os:
         type: string
-        description: "Target os. Default value is debian-12."
-        default: 'debian-12'
+        description: "Target os. Default value is ubuntu-24.04."
+        default: 'ubuntu-24.04'
       toolchain:
         type: string
         description: "Toolchain version (v4, v5, v6). Default value is v6."

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -9,8 +9,8 @@ on:
         default: 'amd'
       os:
         type: string
-        description: "Target os. Default value is debian-12."
-        default: 'debian-12'
+        description: "Target os. Default value is ubuntu-24.04."
+        default: 'ubuntu-24.04'
       toolchain:
         type: string
         description: "Toolchain version (v4, v5, v6). Default value is v6."

--- a/.github/workflows/release_build_test.yaml
+++ b/.github/workflows/release_build_test.yaml
@@ -22,7 +22,7 @@ on:
       os:
         type: choice
         description: "Target OS on which the release tests will be run."
-        default: debian-11
+        default: ubuntu-24.04
         options:
           - all
           - centos-9
@@ -40,7 +40,7 @@ jobs:
     if: ${{ !github.event.inputs.os || github.event.inputs.os != 'all' }}
     uses: ./.github/workflows/reusable_release_tests.yaml
     with:
-      os: ${{ github.event.inputs.os || 'debian-11' }}
+      os: ${{ github.event.inputs.os || 'ubuntu-24.04' }}
       toolchain: v6
       arch: amd
       threads: 24

--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -5,8 +5,8 @@ on:
     inputs:
       os:
         type: string
-        description: "Target os. Default value is debian-12."
-        default: 'debian-12'
+        description: "Target os. Default value is ubuntu-24.04."
+        default: 'ubuntu-24.04'
       arch:
         type: string
         description: "Target architecture. Default value is amd."

--- a/.github/workflows/stress_test_large.yaml
+++ b/.github/workflows/stress_test_large.yaml
@@ -16,7 +16,7 @@ on:
       os:
         type: choice
         description: "Target OS on which the release tests will be run. Select 'all' if you want to package for every listed OS."
-        default: 'debian-11'
+        default: 'ubuntu-24.04'
         options:
           - all
           - amzn-2
@@ -48,7 +48,7 @@ jobs:
     if: ${{ !github.event.inputs.os || github.event.inputs.os != 'all' }}
     uses: ./.github/workflows/reusable_release_tests.yaml
     with:
-      os: ${{ github.event.inputs.os || 'debian-11' }}
+      os: ${{ github.event.inputs.os || 'ubuntu-24.04' }}
       toolchain: ${{ github.event.inputs.toolchain || 'v6' }}
       arch: "amd"
       threads: 24


### PR DESCRIPTION
Use Ubuntu 24.04 by default for every workflow except for `jepsen`.