### PR TITLE
Bugfix: Rely (almost) solely on last durable ts

### DIFF
--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -453,7 +453,7 @@ void InMemoryReplicationHandlers::SnapshotHandler(DbmsHandler *dbms_handler,
       storage->repl_storage_state_.epoch_.SetEpoch(std::move(snapshot_info.epoch_id));
       storage->vertex_id_ = recovery_info.next_vertex_id;
       storage->edge_id_ = recovery_info.next_edge_id;
-      storage->timestamp_ = snapshot_info.durable_timestamp + 1;
+      storage->timestamp_ = std::max(storage->timestamp_, recovery_info.next_timestamp);
       storage->repl_storage_state_.last_durable_timestamp_ = snapshot_info.durable_timestamp;
 
       storage::durability::RecoverIndicesStatsAndConstraints(

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -453,7 +453,7 @@ void InMemoryReplicationHandlers::SnapshotHandler(DbmsHandler *dbms_handler,
       storage->repl_storage_state_.epoch_.SetEpoch(std::move(snapshot_info.epoch_id));
       storage->vertex_id_ = recovery_info.next_vertex_id;
       storage->edge_id_ = recovery_info.next_edge_id;
-      storage->timestamp_ = std::max(storage->timestamp_, recovery_info.next_timestamp);
+      storage->timestamp_ = snapshot_info.durable_timestamp + 1;
       storage->repl_storage_state_.last_durable_timestamp_ = snapshot_info.durable_timestamp;
 
       storage::durability::RecoverIndicesStatsAndConstraints(

--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -588,6 +588,7 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
       try {
         auto info = LoadWal(wal_file.path, &indices_constraints, last_loaded_timestamp, vertices, edges, name_id_mapper,
                             edge_count, config.salient.items, enum_store, schema_info, find_edge);
+        // Update recovery info data only if WAL file was used and its deltas loaded
         if (info.has_value()) {
           recovery_info.next_vertex_id = std::max(recovery_info.next_vertex_id, info->next_vertex_id);
           recovery_info.next_edge_id = std::max(recovery_info.next_edge_id, info->next_edge_id);

--- a/src/storage/v2/durability/metadata.hpp
+++ b/src/storage/v2/durability/metadata.hpp
@@ -30,8 +30,8 @@ namespace memgraph::storage::durability {
 struct RecoveryInfo {
   uint64_t next_vertex_id{0};
   uint64_t next_edge_id{0};
-  uint64_t last_applied_delta_timestamp{0};
-  // last timestamp read from a WAL file that is committed
+  uint64_t next_timestamp{0};
+  // last timestamp read from a WAL file
   std::optional<uint64_t> last_durable_timestamp;
 
   std::vector<std::pair<Gid /*first vertex gid*/, uint64_t /*batch size*/>> vertex_batches;

--- a/src/storage/v2/durability/metadata.hpp
+++ b/src/storage/v2/durability/metadata.hpp
@@ -30,9 +30,8 @@ namespace memgraph::storage::durability {
 struct RecoveryInfo {
   uint64_t next_vertex_id{0};
   uint64_t next_edge_id{0};
-  uint64_t next_timestamp{0};
-
-  // last timestamp read from a WAL file
+  uint64_t last_applied_delta_timestamp{0};
+  // last timestamp read from a WAL file that is committed
   std::optional<uint64_t> last_durable_timestamp;
 
   std::vector<std::pair<Gid /*first vertex gid*/, uint64_t /*batch size*/>> vertex_batches;

--- a/src/storage/v2/durability/wal.cpp
+++ b/src/storage/v2/durability/wal.cpp
@@ -762,7 +762,7 @@ std::optional<RecoveryInfo> LoadWal(
   RecoveryInfo ret;
   ret.last_durable_timestamp = info.to_timestamp;
 
-  // Recover deltas.
+  // Recover deltas
   wal.SetPosition(info.offset_deltas);
   uint64_t deltas_applied = 0;
   auto edge_acc = edges->access();

--- a/src/storage/v2/durability/wal.cpp
+++ b/src/storage/v2/durability/wal.cpp
@@ -1143,7 +1143,7 @@ std::optional<RecoveryInfo> LoadWal(
       auto delta = ReadWalDeltaData(&wal, *version);
       std::visit(delta_apply, delta.data_);
       ++deltas_applied;
-      ret.last_applied_delta_timestamp = std::max(ret.last_applied_delta_timestamp, timestamp);
+      ret.next_timestamp = std::max(ret.next_timestamp, timestamp + 1);
     } else {
       // This delta should be skipped.
       SkipWalDeltaData(&wal, *version);

--- a/src/storage/v2/durability/wal.cpp
+++ b/src/storage/v2/durability/wal.cpp
@@ -736,13 +736,13 @@ void EncodeTransactionEnd(BaseEncoder *encoder, uint64_t timestamp) {
   encoder->WriteMarker(Marker::DELTA_TRANSACTION_END);
 }
 
-RecoveryInfo LoadWal(const std::filesystem::path &path, RecoveredIndicesAndConstraints *indices_constraints,
-                     const std::optional<uint64_t> last_loaded_timestamp, utils::SkipList<Vertex> *vertices,
-                     utils::SkipList<Edge> *edges, NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count,
-                     SalientConfig::Items items, EnumStore *enum_store, SharedSchemaTracking *schema_info,
-                     std::function<std::optional<std::tuple<EdgeRef, EdgeTypeId, Vertex *, Vertex *>>(Gid)> find_edge) {
+std::optional<RecoveryInfo> LoadWal(
+    const std::filesystem::path &path, RecoveredIndicesAndConstraints *indices_constraints,
+    const std::optional<uint64_t> last_applied_delta_timestamp, utils::SkipList<Vertex> *vertices,
+    utils::SkipList<Edge> *edges, NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count,
+    SalientConfig::Items items, EnumStore *enum_store, SharedSchemaTracking *schema_info,
+    std::function<std::optional<std::tuple<EdgeRef, EdgeTypeId, Vertex *, Vertex *>>(Gid)> find_edge) {
   spdlog::info("Trying to load WAL file {}.", path);
-  RecoveryInfo ret;
 
   Decoder wal;
   auto version = wal.Initialize(path, kWalMagic);
@@ -751,13 +751,15 @@ RecoveryInfo LoadWal(const std::filesystem::path &path, RecoveredIndicesAndConst
 
   // Read wal info.
   auto info = ReadWalInfo(path);
-  ret.last_durable_timestamp = info.to_timestamp;
 
   // Check timestamp.
-  if (last_loaded_timestamp && info.to_timestamp <= *last_loaded_timestamp) {
-    spdlog::info("Skip loading WAL file because it is too old. {} <= {}", info.to_timestamp, *last_loaded_timestamp);
-    return ret;
+  if (last_applied_delta_timestamp && info.to_timestamp <= *last_applied_delta_timestamp) {
+    spdlog::info("Skip loading WAL file because it is too old. {} <= {}", info.to_timestamp,
+                 *last_applied_delta_timestamp);
+    return std::nullopt;
   }
+
+  RecoveryInfo ret{.last_durable_timestamp = info.to_timestamp};
 
   // Recover deltas.
   wal.SetPosition(info.offset_deltas);
@@ -1136,12 +1138,12 @@ RecoveryInfo LoadWal(const std::filesystem::path &path, RecoveredIndicesAndConst
     // Read WAL delta header to find out the delta timestamp.
     auto timestamp = ReadWalDeltaHeader(&wal);
 
-    if (!last_loaded_timestamp || timestamp > *last_loaded_timestamp) {
+    if (!last_applied_delta_timestamp || timestamp > *last_applied_delta_timestamp) {
       // This delta should be loaded.
       auto delta = ReadWalDeltaData(&wal, *version);
       std::visit(delta_apply, delta.data_);
-      ret.next_timestamp = std::max(ret.next_timestamp, timestamp + 1);
       ++deltas_applied;
+      ret.last_applied_delta_timestamp = std::max(ret.last_applied_delta_timestamp, timestamp);
     } else {
       // This delta should be skipped.
       SkipWalDeltaData(&wal, *version);

--- a/src/storage/v2/durability/wal.cpp
+++ b/src/storage/v2/durability/wal.cpp
@@ -759,7 +759,8 @@ std::optional<RecoveryInfo> LoadWal(
     return std::nullopt;
   }
 
-  RecoveryInfo ret{.last_durable_timestamp = info.to_timestamp};
+  RecoveryInfo ret;
+  ret.last_durable_timestamp = info.to_timestamp;
 
   // Recover deltas.
   wal.SetPosition(info.offset_deltas);

--- a/src/storage/v2/durability/wal.hpp
+++ b/src/storage/v2/durability/wal.hpp
@@ -385,11 +385,12 @@ void EncodeOperationPreamble(BaseEncoder &encoder, StorageMetadataOperation Op, 
 
 /// Function used to load the WAL data into the storage.
 /// @throw RecoveryFailure
-RecoveryInfo LoadWal(std::filesystem::path const &path, RecoveredIndicesAndConstraints *indices_constraints,
-                     std::optional<uint64_t> last_loaded_timestamp, utils::SkipList<Vertex> *vertices,
-                     utils::SkipList<Edge> *edges, NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count,
-                     SalientConfig::Items items, EnumStore *enum_store, SharedSchemaTracking *schema_info,
-                     std::function<std::optional<std::tuple<EdgeRef, EdgeTypeId, Vertex *, Vertex *>>(Gid)> find_edge);
+std::optional<RecoveryInfo> LoadWal(
+    std::filesystem::path const &path, RecoveredIndicesAndConstraints *indices_constraints,
+    std::optional<uint64_t> last_applied_delta_timestamp, utils::SkipList<Vertex> *vertices,
+    utils::SkipList<Edge> *edges, NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count,
+    SalientConfig::Items items, EnumStore *enum_store, SharedSchemaTracking *schema_info,
+    std::function<std::optional<std::tuple<EdgeRef, EdgeTypeId, Vertex *, Vertex *>>(Gid)> find_edge);
 
 /// WalFile class used to append deltas and operations to the WAL file.
 class WalFile {

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -191,12 +191,11 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
     if (info) {
       vertex_id_ = info->next_vertex_id;
       edge_id_ = info->next_edge_id;
-      timestamp_ = kTimestampInitialId;
-      if (info->last_durable_timestamp.has_value()) {
+      timestamp_ = std::max(timestamp_, info->next_timestamp);
+      if (info->last_durable_timestamp) {
         repl_storage_state_.last_durable_timestamp_ = *info->last_durable_timestamp;
-        timestamp_ = *info->last_durable_timestamp + 1;
-        spdlog::trace("Last durable timestamp recovered with the value of {}. Timestamp recovered to {}.",
-                      *info->last_durable_timestamp, timestamp_);
+        spdlog::trace("Recovering last durable timestamp {}. Timestamp recovered to {}", *info->last_durable_timestamp,
+                      timestamp_);
       }
     }
   } else if (config_.durability.snapshot_wal_mode != Config::Durability::SnapshotWalMode::DISABLED ||
@@ -2621,16 +2620,16 @@ utils::BasicResult<InMemoryStorage::CreateSnapshotError> InMemoryStorage::Create
 // NOTE: Make sure this function is called while exclusively holding on to the main lock
 utils::BasicResult<InMemoryStorage::RecoverSnapshotError> InMemoryStorage::RecoverSnapshot(
     std::filesystem::path path, bool force, memgraph::replication_coordination_glue::ReplicationRole replication_role) {
-  using replication_coordination_glue::ReplicationRole;
+  using memgraph::replication_coordination_glue::ReplicationRole;
   if (replication_role == ReplicationRole::REPLICA) {
-    return RecoverSnapshotError::DisabledForReplica;
+    return InMemoryStorage::RecoverSnapshotError::DisabledForReplica;
   }
   if (!repl_storage_state_.replication_storage_clients_->empty()) {
     // MAIN would need to reset its storage handler and force update the replicas to this snapshot. ATM not supported!
-    return RecoverSnapshotError::DisabledForMainWithReplicas;
+    return InMemoryStorage::RecoverSnapshotError::DisabledForMainWithReplicas;
   }
   if (!std::filesystem::exists(path) || std::filesystem::is_directory(path)) {
-    return RecoverSnapshotError::MissingFile;
+    return InMemoryStorage::RecoverSnapshotError::MissingFile;
   }
 
   // Copy to local snapshot dir
@@ -2640,7 +2639,7 @@ utils::BasicResult<InMemoryStorage::RecoverSnapshotError> InMemoryStorage::Recov
     std::filesystem::copy_file(path, local_path, ec);
     if (ec) {
       spdlog::warn("Failed to copy snapshot into local snapshots directory.");
-      return RecoverSnapshotError::CopyFailure;
+      return InMemoryStorage::RecoverSnapshotError::CopyFailure;
     }
   }
 
@@ -2655,9 +2654,9 @@ utils::BasicResult<InMemoryStorage::RecoverSnapshotError> InMemoryStorage::Recov
   if (force) {
     Clear();
   } else {
-    if (repl_storage_state_.last_durable_timestamp_ != kTimestampInitialId) {
+    if (repl_storage_state_.last_durable_timestamp_ != storage::kTimestampInitialId) {
       handler_error();
-      return RecoverSnapshotError::NonEmptyStorage;
+      return InMemoryStorage::RecoverSnapshotError::NonEmptyStorage;
     }
   }
 
@@ -2679,7 +2678,7 @@ utils::BasicResult<InMemoryStorage::RecoverSnapshotError> InMemoryStorage::Recov
     const auto &recovery_info = recovered_snapshot.recovery_info;
     vertex_id_ = recovery_info.next_vertex_id;
     edge_id_ = recovery_info.next_edge_id;
-    timestamp_ = std::max(timestamp_, recovered_snapshot.snapshot_info.durable_timestamp + 1);
+    timestamp_ = std::max(timestamp_, recovery_info.next_timestamp);
     repl_storage_state_.last_durable_timestamp_ = recovered_snapshot.snapshot_info.durable_timestamp;
 
     spdlog::trace("Recovering indices and constraints from snapshot.");


### PR DESCRIPTION
Last applied timestamp is now updated only if WAL files are used in the recovery.