### PR TITLE
Fix flaky Kafka consumer test 2

### DIFF
--- a/tests/unit/integrations_kafka_consumer.cpp
+++ b/tests/unit/integrations_kafka_consumer.cpp
@@ -164,9 +164,8 @@ TEST_F(ConsumerTest, BatchInterval) {
   };
 
   ASSERT_FALSE(received_timestamps.empty());
-  auto first_batch_message_count = received_timestamps[0].first;
-  EXPECT_EQ(1, first_batch_message_count);
-  EXPECT_LE(3, received_timestamps.size());
+  // Check that not all messages are received in one batch
+  EXPECT_LE(2, received_timestamps.size());
 
   int msgsCnt = received_timestamps[0].first;
   for (auto i = 1; i < received_timestamps.size(); ++i) {


### PR DESCRIPTION
Remove batch check that doesn't need to be true due to reasons explained in the previous [PR](https://github.com/memgraph/memgraph/pull/2881).