### PR TITLE
Fix release build tests

### DIFF
--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -45,6 +45,8 @@ jobs:
       arch: amd
       threads: 24
       build_type: 'Release'
+      run_release_tests: 'true'
+      run_stress_large: 'true'
     secrets: inherit
 
 

--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -764,7 +764,7 @@ jobs:
 
   release_jepsen_test:
     continue-on-error: true
-    if: ${{ inputs.run_release_tests == 'true' && inputs.os == 'debian-12' }}
+    if: ${{ inputs.run_release_tests == 'true' }}
     name: "Release Jepsen Test"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
     timeout-minutes: 60
@@ -785,7 +785,7 @@ jobs:
         run: |
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
-          --os $OS \
+          --os debian-12 \
           --arch $ARCH \
           run
 
@@ -793,7 +793,7 @@ jobs:
         run: |
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
-          --os $OS \
+          --os debian-12 \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
           --threads $THREADS \
@@ -803,7 +803,7 @@ jobs:
         run: |
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
-          --os $OS \
+          --os debian-12 \
           --arch $ARCH \
           copy --binary
 
@@ -829,7 +829,7 @@ jobs:
         run: |
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
-          --os $OS \
+          --os debian-12 \
           --arch $ARCH \
           stop --remove
 

--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -958,7 +958,9 @@ jobs:
       - release_benchmark_tests
       - release_e2e_test
       - release_durability_stress_tests
+      - release_jepsen_test
       - release_query_modules_test
+      - stress_test_large
     if: always() && ${{ inputs.run_release_tests == 'true' }}
     outputs:
       test_status: ${{ steps.aggregate.outputs.test_status }}
@@ -976,6 +978,8 @@ jobs:
              [ "${{ needs.release_benchmark_tests.result }}" == "failure" ] || \
              [ "${{ needs.release_e2e_test.result }}" == "failure" ] || \
              [ "${{ needs.release_durability_stress_tests.result }}" == "failure" ] || \
+             [ "${{ needs.release_jepsen_test.result }}" == "failure" ] || \
+             [ "${{ needs.stress_test_large.result }}" == "failure" ] || \
              [ "${{ needs.release_query_modules_test.result }}" == "failure" ]; then
             echo "test_status=fail" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/stress_test_large.yaml
+++ b/.github/workflows/stress_test_large.yaml
@@ -43,7 +43,7 @@ on:
 
 jobs:
   StressTestLargeIndividual:
-    if: ${{ !github.event.inputs.os || github.event.inputs.os != 'all' }}
+    if: ${{ !github.event.inputs.os || github.event.inputs.os != 'all'  && !contains(github.event.head_commit.message, '[skip tests]') }}
     uses: ./.github/workflows/reusable_release_tests.yaml
     with:
       os: ${{ github.event.inputs.os || 'ubuntu-24.04' }}

--- a/.github/workflows/stress_test_large.yaml
+++ b/.github/workflows/stress_test_large.yaml
@@ -40,8 +40,6 @@ on:
     tags:
       - "v*.*.*-rc*"
       - "v*.*-rc*"
-  schedule:
-    - cron: "0 22 * * *"
 
 jobs:
   StressTestLargeIndividual:


### PR DESCRIPTION
Make daily builds run the large stress test and release Jepsen test.
- Jepsen was being skipped because the input OS was being set to `ubuntu-24.04` - this input is now ignored
- Large stress test was being skipped because `run_stress_large` was not set in the `TestBuild` job, this is now fixed
- removed `cron` job for stress test large, as this will take it's place

The downside of this is that daily builds will now take 8-9 hours before triggering MAGE builds; the upside is that the previously skipped tests will be included in the aggregated test result and therefore count towards the overall result displayed on the daily build page.

