### PR TITLE
Stop build tests from failing successfully

### DIFF
--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -69,7 +69,6 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -128,7 +127,6 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -202,7 +200,6 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -300,7 +297,6 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -358,7 +354,6 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -429,7 +424,6 @@ jobs:
           stop --remove
 
   release_build:
-    continue-on-error: true
     name: "Release build"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
     timeout-minutes: 60
@@ -448,7 +442,6 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -545,7 +538,6 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -621,7 +613,6 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -696,7 +687,6 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -785,7 +775,6 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -856,7 +845,6 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -912,7 +900,6 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
-          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \

--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -50,7 +50,6 @@ env:
 
 jobs:
   community_build:
-    continue-on-error: true
     if: ${{ inputs.run_release_tests == 'true' }}
     name: "Community build"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
@@ -107,7 +106,6 @@ jobs:
           stop --remove
 
   coverage_build:
-    continue-on-error: true
     if: ${{ inputs.run_release_tests == 'true' }}
     name: "Coverage build"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
@@ -181,7 +179,6 @@ jobs:
           stop --remove
 
   debug_build:
-    continue-on-error: true
     if: ${{ inputs.run_release_tests == 'true' }}
     name: "Debug build"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
@@ -279,7 +276,6 @@ jobs:
           stop --remove
 
   debug_integration_test:
-    continue-on-error: true
     if: ${{ inputs.run_release_tests == 'true' }}
     name: "Debug integration tests"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
@@ -339,7 +335,6 @@ jobs:
 
 
   malloc_build:
-    continue-on-error: true
     if: ${{ inputs.run_release_tests == 'true' }}
     name: "Malloc build"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
@@ -430,7 +425,6 @@ jobs:
 
   release_build:
     continue-on-error: true
-    if: ${{ inputs.run_release_tests == 'true' }}
     name: "Release build"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
     timeout-minutes: 60
@@ -526,7 +520,6 @@ jobs:
           stop --remove
 
   release_benchmark_tests:
-    continue-on-error: true
     if: ${{ inputs.run_release_tests == 'true' }}
     name: "Release Benchmark Tests"
     runs-on: [self-hosted, DockerMgBuild, Gen7, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
@@ -602,7 +595,6 @@ jobs:
           stop --remove
 
   release_e2e_test:
-    continue-on-error: true
     if: ${{ inputs.run_release_tests == 'true' }}
     name: "Release End-to-end Test"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
@@ -677,7 +669,6 @@ jobs:
           stop --remove
 
   release_durability_stress_tests:
-    continue-on-error: true
     if: ${{ inputs.run_release_tests == 'true' }}
     name: "Release durability and stress tests"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
@@ -763,7 +754,6 @@ jobs:
           stop --remove
 
   release_jepsen_test:
-    continue-on-error: true
     if: ${{ inputs.run_release_tests == 'true' }}
     name: "Release Jepsen Test"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
@@ -837,7 +827,6 @@ jobs:
           stop --remove
 
   stress_test_large:
-    continue-on-error: true
     if: ${{ inputs.run_stress_large == 'true' }}
     name: "Stress test large"
     runs-on: [self-hosted, DockerMgBuild, BigMemory, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
@@ -893,7 +882,6 @@ jobs:
           stop --remove
 
   release_query_modules_test:
-    continue-on-error: true
     if: ${{ inputs.run_release_tests == 'true' }}
     name: "Release Query Modules Test"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]

--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -964,7 +964,7 @@ jobs:
       - release_jepsen_test
       - release_query_modules_test
       - stress_test_large
-    if: always() && ${{ inputs.run_release_tests == 'true' }}
+    if: ${{ always() && inputs.run_release_tests == 'true' }}
     outputs:
       test_status: ${{ steps.aggregate.outputs.test_status }}
     steps:

--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -69,6 +69,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
+          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -127,6 +128,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
+          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -200,6 +202,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
+          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -297,6 +300,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
+          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -354,6 +358,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
+          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -443,6 +448,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
+          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -539,6 +545,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
+          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -614,6 +621,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
+          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -688,6 +696,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
+          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -776,6 +785,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
+          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -846,6 +856,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
+          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
@@ -901,6 +912,7 @@ jobs:
 
       - name: Spin up mgbuild container
         run: |
+          exit 1
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \


### PR DESCRIPTION
Remove `continue-on-error` on daily build tests to stop failing tests being marked as successful.
