### PR TITLE
Improve perf around snapshot

### DIFF
--- a/src/coordination/raft_state.cpp
+++ b/src/coordination/raft_state.cpp
@@ -197,7 +197,7 @@ auto RaftState::InitRaftServer() -> void {
   // In the meantime, the election timer will trigger and the follower will enter the pre-vote protocol which should
   // fail because the leader is actually alive. So even if rpc listener is created (on follower), the initialization
   // isn't complete until leader sends him append_entries_request.
-  auto maybe_stop = utils::ResettableCounter<1200>();
+  auto maybe_stop = utils::ResettableCounter{1200};
   while (!maybe_stop()) {
     // Initialized is set to true after raft_callback_ is being executed (role as leader or follower)
     if (raft_server_->is_initialized()) {
@@ -286,7 +286,7 @@ auto RaftState::RemoveCoordinatorInstance(int32_t coordinator_id) const -> void 
 
   // Waiting for server to join
   constexpr int max_tries{10};
-  auto maybe_stop = utils::ResettableCounter<max_tries>();
+  auto maybe_stop = utils::ResettableCounter(max_tries);
   std::chrono::milliseconds const waiting_period{200};
   bool removed{false};
   while (!maybe_stop()) {
@@ -326,7 +326,7 @@ auto RaftState::AddCoordinatorInstance(CoordinatorInstanceConfig const &config) 
   }
   // Waiting for server to join
   constexpr int max_tries{10};
-  auto maybe_stop = utils::ResettableCounter<max_tries>();
+  auto maybe_stop = utils::ResettableCounter(max_tries);
   std::chrono::milliseconds const waiting_period{200};
   while (!maybe_stop()) {
     std::this_thread::sleep_for(waiting_period);

--- a/src/kvstore/kvstore.cpp
+++ b/src/kvstore/kvstore.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -14,6 +14,7 @@
 
 #include "kvstore/kvstore.hpp"
 #include "utils/file.hpp"
+#include "utils/logging.hpp"
 
 namespace memgraph::kvstore {
 

--- a/src/query/context.hpp
+++ b/src/query/context.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -21,6 +21,7 @@
 #include "query/plan/profile.hpp"
 #include "query/trigger.hpp"
 #include "utils/async_timer.hpp"
+#include "utils/counter.hpp"
 
 #include "query/frame_change.hpp"
 #include "query/hops_limit.hpp"
@@ -85,6 +86,9 @@ struct ExecutionContext {
   std::unique_ptr<FineGrainedAuthChecker> auth_checker{nullptr};
 #endif
   DatabaseAccessProtector db_acc;
+  utils::ResettableCounter maybe_check_abort_{20};  // Checking abort is a cheap check but is still an atomic
+                                                    //  read. Reducing the frequency should reduce its impact
+                                                    //  on performance for the expected (non-abort) case
 };
 
 static_assert(std::is_move_assignable_v<ExecutionContext>, "ExecutionContext must be move assignable!");

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -4406,6 +4406,8 @@ PreparedQuery PrepareCreateSnapshotQuery(ParsedQuery parsed_query, bool in_expli
               throw utils::BasicException("Failed to create snapshot. The current snapshot needs to be aborted.");
             case storage::InMemoryStorage::CreateSnapshotError::AlreadyRunning:
               throw utils::BasicException("Another snapshot creation is already in progress.");
+            case storage::InMemoryStorage::CreateSnapshotError::NothingNewToWrite:
+              throw utils::BasicException("Nothing has been written since the last snapshot.");
           }
         }
         return QueryHandlerResult::COMMIT;

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -4404,6 +4404,8 @@ PreparedQuery PrepareCreateSnapshotQuery(ParsedQuery parsed_query, bool in_expli
               break;
             case storage::InMemoryStorage::CreateSnapshotError::AbortSnapshot:
               throw utils::BasicException("Failed to create snapshot. The current snapshot needs to be aborted.");
+            case storage::InMemoryStorage::CreateSnapshotError::AlreadyRunning:
+              throw utils::BasicException("Another snapshot creation is already in progress.");
           }
         }
         return QueryHandlerResult::COMMIT;

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -355,6 +355,7 @@ uint64_t ComputeProfilingKey(const T *obj) {
 }
 
 inline void AbortCheck(ExecutionContext const &context) {
+  if (!context.maybe_check_abort_()) return;
   if (auto const reason = MustAbort(context); reason != AbortReason::NO_ABORT) throw HintedAbortError(reason);
 }
 
@@ -3664,15 +3665,13 @@ SetProperties::SetPropertiesCursor::SetPropertiesCursor(const SetProperties &sel
 namespace {
 
 template <typename T>
-concept AccessorWithProperties =
-    requires(T value, storage::PropertyId property_id, storage::PropertyValue property_value,
-             std::map<storage::PropertyId, storage::PropertyValue> properties) {
-      {
-        value.ClearProperties()
-      } -> std::same_as<storage::Result<std::map<storage::PropertyId, storage::PropertyValue>>>;
-      { value.SetProperty(property_id, property_value) };
-      { value.UpdateProperties(properties) };
-    };
+concept AccessorWithProperties = requires(T value, storage::PropertyId property_id,
+                                          storage::PropertyValue property_value,
+                                          std::map<storage::PropertyId, storage::PropertyValue> properties) {
+  { value.ClearProperties() } -> std::same_as<storage::Result<std::map<storage::PropertyId, storage::PropertyValue>>>;
+  {value.SetProperty(property_id, property_value)};
+  {value.UpdateProperties(properties)};
+};
 
 /// Helper function that sets the given values on either a Vertex or an Edge.
 ///
@@ -4668,7 +4667,7 @@ class AggregateCursor : public Cursor {
           value_it->ValueMap().emplace(key.ValueString(), std::move(input_value));
           break;
       }  // end switch over Aggregation::Op enum
-    }  // end loop over all aggregations
+    }    // end loop over all aggregations
   }
 
   /** Project a subgraph from lists of nodes and lists of edges. Any nulls in these lists are ignored.
@@ -4914,8 +4913,9 @@ class OrderByCursor : public Cursor {
       // sorting with range zip
       // we compare on just the projection of the 1st range (order_by)
       // this will also permute the 2nd range (output)
-      ranges::sort(ranges::views::zip(order_by, output), self_.compare_.lex_cmp(),
-                   [](auto const &value) -> auto const & { return std::get<0>(value); });
+      ranges::sort(
+          ranges::views::zip(order_by, output), self_.compare_.lex_cmp(),
+          [](auto const &value) -> auto const & { return std::get<0>(value); });
 
       // no longer need the order_by terms
       order_by.clear();

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -394,9 +394,16 @@ storage::EdgeTypeId EvaluateEdgeType(const StorageEdgeType &edge_type, Expressio
 }  // namespace
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define SCOPED_PROFILE_OP(name) ScopedProfile profile{ComputeProfilingKey(this), name, &context};
+#define SCOPED_PROFILE_OP(name)                                                                    \
+  std::optional<ScopedProfile> profile =                                                           \
+      context.is_profile_query                                                                     \
+          ? std::optional<ScopedProfile>(std::in_place, ComputeProfilingKey(this), name, &context) \
+          : std::nullopt;
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define SCOPED_PROFILE_OP_BY_REF(ref) ScopedProfile profile{ComputeProfilingKey(this), ref, &context};
+#define SCOPED_PROFILE_OP_BY_REF(ref)                                                                                  \
+  std::optional<ScopedProfile> profile =                                                                               \
+      context.is_profile_query ? std::optional<ScopedProfile>(std::in_place, ComputeProfilingKey(this), ref, &context) \
+                               : std::nullopt;
 
 bool Once::OnceCursor::Pull(Frame &, ExecutionContext &context) {
   OOMExceptionEnabler oom_exception;

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -4496,6 +4496,8 @@ class AggregateCursor : public Cursor {
     reused_group_by_.clear();
     evaluator->ResetPropertyLookupCache();
 
+    // TODO: if self_.group_by_.size() == 0, aggregation_ -> there is only one (becasue we are doing *)
+    //       can this be optimised so we don't need to do aggregation_.try_emplace which has a hash cost
     for (Expression *expression : self_.group_by_) {
       reused_group_by_.emplace_back(expression->Accept(*evaluator));
     }

--- a/src/storage/v2/durability/serialization.hpp
+++ b/src/storage/v2/durability/serialization.hpp
@@ -42,6 +42,7 @@ class BaseEncoder {
 };
 
 /// Encoder that is used to generate a snapshot/WAL.
+template <typename FileType>
 class Encoder final : public BaseEncoder {
  public:
   void Initialize(const std::filesystem::path &path);
@@ -72,11 +73,11 @@ class Encoder final : public BaseEncoder {
   void Finalize();
 
   // Disable flushing of the internal buffer.
-  void DisableFlushing();
+  void DisableFlushing() requires std::same_as<FileType, utils::OutputFile>;
   // Enable flushing of the internal buffer.
-  void EnableFlushing();
+  void EnableFlushing() requires std::same_as<FileType, utils::OutputFile>;
   // Try flushing the internal buffer.
-  void TryFlushing();
+  void TryFlushing() requires std::same_as<FileType, utils::OutputFile>;
   // Get the current internal buffer with its size.
   std::pair<const uint8_t *, size_t> CurrentFileBuffer() const;
 
@@ -87,7 +88,7 @@ class Encoder final : public BaseEncoder {
   auto native_handle() const { return file_.fd(); }
 
  private:
-  utils::OutputFile file_;
+  FileType file_;
 };
 
 /// Decoder interface class. Used to implement streams from different sources

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -4682,7 +4682,6 @@ bool CreateSnapshot(Storage *storage, Transaction *transaction, const std::files
   spdlog::info("Starting snapshot creation to {}", path);
   SnapshotEncoder snapshot;
   snapshot.Initialize(path, kSnapshotMagic, kVersion);
-  // TODO: snapshot is single threaded write...yet internally has a flush_lock_ protecting its buffer
 
   // Write placeholder offsets.
   uint64_t offset_offsets = 0;

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -4678,6 +4678,7 @@ bool CreateSnapshot(Storage *storage, Transaction *transaction, const std::files
   spdlog::info("Starting snapshot creation to {}", path);
   Encoder snapshot;
   snapshot.Initialize(path, kSnapshotMagic, kVersion);
+  // TODO: snapshot is single threaded write...yet internally has a flush_lock_ protecting its buffer
 
   // Write placeholder offsets.
   uint64_t offset_offsets = 0;

--- a/src/storage/v2/durability/wal.hpp
+++ b/src/storage/v2/durability/wal.hpp
@@ -455,7 +455,7 @@ class WalFile {
  private:
   SalientConfig::Items items_;
   NameIdMapper *name_id_mapper_;
-  Encoder wal_;
+  Encoder<utils::OutputFile> wal_;
   std::filesystem::path path_;
   uint64_t from_timestamp_;
   uint64_t to_timestamp_;

--- a/src/storage/v2/indices/vector_index.cpp
+++ b/src/storage/v2/indices/vector_index.cpp
@@ -358,7 +358,7 @@ void VectorIndex::RestoreEntries(const LabelPropKey &label_prop,
 }
 
 void VectorIndex::RemoveObsoleteEntries(std::stop_token token) const {
-  auto maybe_stop = utils::ResettableCounter<2048>();
+  auto maybe_stop = utils::ResettableCounter(2048);
   for (auto &[_, index_item] : pimpl->index_) {
     if (maybe_stop() && token.stop_requested()) {
       return;

--- a/src/storage/v2/inmemory/edge_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_property_index.cpp
@@ -91,7 +91,7 @@ std::vector<PropertyId> InMemoryEdgePropertyIndex::ListIndices() const {
 }
 
 void InMemoryEdgePropertyIndex::RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token) {
-  auto maybe_stop = utils::ResettableCounter<2048>();
+  auto maybe_stop = utils::ResettableCounter(2048);
 
   for (auto &[property_id, index] : index_) {
     if (token.stop_requested()) return;

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -71,7 +71,7 @@ std::vector<EdgeTypeId> InMemoryEdgeTypeIndex::ListIndices() const {
 }
 
 void InMemoryEdgeTypeIndex::RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token) {
-  auto maybe_stop = utils::ResettableCounter<2048>();
+  auto maybe_stop = utils::ResettableCounter(2048);
 
   for (auto &[_, et_index] : index_) {
     if (token.stop_requested()) return;

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -87,7 +87,7 @@ std::vector<std::pair<EdgeTypeId, PropertyId>> InMemoryEdgeTypePropertyIndex::Li
 
 void InMemoryEdgeTypePropertyIndex::RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp,
                                                           std::stop_token token) {
-  auto maybe_stop = utils::ResettableCounter<2048>();
+  auto maybe_stop = utils::ResettableCounter(2048);
 
   for (auto &[key, index] : index_) {
     if (token.stop_requested()) return;

--- a/src/storage/v2/inmemory/label_index.cpp
+++ b/src/storage/v2/inmemory/label_index.cpp
@@ -61,7 +61,7 @@ std::vector<LabelId> InMemoryLabelIndex::ListIndices() const {
 }
 
 void InMemoryLabelIndex::RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token) {
-  auto maybe_stop = utils::ResettableCounter<2048>();
+  auto maybe_stop = utils::ResettableCounter(2048);
 
   for (auto &label_storage : index_) {
     // before starting index, check if stop_requested

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -465,7 +465,7 @@ std::vector<std::pair<LabelId, std::vector<PropertyId>>> InMemoryLabelPropertyIn
 }
 
 void InMemoryLabelPropertyIndex::RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token) {
-  auto maybe_stop = utils::ResettableCounter<2048>();
+  auto maybe_stop = utils::ResettableCounter(2048);
 
   for (auto &[label_id, by_properties] : index_) {
     for (auto &[property_ids, index] : by_properties) {

--- a/src/storage/v2/inmemory/replication/recovery.cpp
+++ b/src/storage/v2/inmemory/replication/recovery.cpp
@@ -61,6 +61,7 @@ std::optional<std::vector<RecoveryStep>> GetRecoverySteps(uint64_t replica_commi
   // otherwise save the seq_num of the current wal file
   // This lock is also necessary to force the missed transaction to finish.
   std::optional<uint64_t> current_wal_seq_num;
+  std::optional<uint64_t> current_wal_timestamp;
   uint64_t last_durable_timestamp{kTimestampInitialId};
 
   std::unique_lock transaction_guard(
@@ -68,7 +69,7 @@ std::optional<std::vector<RecoveryStep>> GetRecoverySteps(uint64_t replica_commi
   (void)locker_acc.AddPath(main_storage->recovery_.wal_directory_);  // Protect all WALs from being deleted
 
   if (main_storage->wal_file_) {
-    last_durable_timestamp = main_storage->wal_file_->ToTimestamp();
+    current_wal_timestamp.emplace(main_storage->wal_file_->ToTimestamp());
     current_wal_seq_num.emplace(main_storage->wal_file_->SequenceNumber());
     // No need to hold the lock since the current WAL is present
     transaction_guard.unlock();
@@ -201,7 +202,7 @@ std::optional<std::vector<RecoveryStep>> GetRecoverySteps(uint64_t replica_commi
   }
 
   // If we have a current wal file we need to use it
-  if (current_wal_seq_num) {
+  if (last_durable_timestamp < current_wal_timestamp && current_wal_seq_num) {
     // NOTE: File not handled directly, so no need to lock it
     recovery_steps.emplace_back(RecoveryCurrentWal{*current_wal_seq_num});
   }

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -102,8 +102,8 @@ constexpr auto ActionToStorageOperation(MetadataDelta::Action action) -> durabil
 #undef add_case
 }
 
-auto FindEdges(const View view, EdgeTypeId edge_type, const VertexAccessor *from_vertex, VertexAccessor *to_vertex)
-    -> Result<EdgesVertexAccessorResult> {
+auto FindEdges(const View view, EdgeTypeId edge_type, const VertexAccessor *from_vertex,
+               VertexAccessor *to_vertex) -> Result<EdgesVertexAccessorResult> {
   auto use_out_edges = [](Vertex const *from_vertex, Vertex const *to_vertex) {
     // Obtain the locks by `gid` order to avoid lock cycles.
     auto guard_from = std::unique_lock{from_vertex->lock, std::defer_lock};
@@ -2989,6 +2989,8 @@ void InMemoryStorage::Clear() {
   repl_storage_state_.epoch_.SetEpoch(std::string(utils::UUID{}));
   repl_storage_state_.last_durable_timestamp_ = 0;
   repl_storage_state_.history.clear();
+
+  last_snapshot_digest_ = std::nullopt;
 }
 
 bool InMemoryStorage::InMemoryAccessor::PointIndexExists(LabelId label, PropertyId property) const {

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2608,13 +2608,10 @@ utils::BasicResult<InMemoryStorage::CreateSnapshotError> InMemoryStorage::Create
   auto accessor = std::invoke([&]() {
     if (storage_mode_ == StorageMode::IN_MEMORY_ANALYTICAL) {
       // For analytical no other write txn can be in play
-      return ReadOnlyAccess(IsolationLevel::SNAPSHOT_ISOLATION);  // Do we need snapshot isolation? // timeout?
+      return ReadOnlyAccess(IsolationLevel::SNAPSHOT_ISOLATION);  // Do we need snapshot isolation?
     }
-    return Access(IsolationLevel::SNAPSHOT_ISOLATION);  // timeout?
+    return Access(IsolationLevel::SNAPSHOT_ISOLATION);
   });
-
-  // is it even worth it?
-  // what was the last snapshot, has their been writes since?
 
   utils::Timer timer;
   Transaction *transaction = accessor->GetTransaction();

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2593,15 +2593,19 @@ utils::BasicResult<InMemoryStorage::CreateSnapshotError> InMemoryStorage::Create
     return CreateSnapshotError::AbortSnapshot;
   }
 
+  // Only one at a time? timeout?
   std::lock_guard snapshot_guard(snapshot_lock_);
 
   auto accessor = std::invoke([&]() {
     if (storage_mode_ == StorageMode::IN_MEMORY_ANALYTICAL) {
       // For analytical no other write txn can be in play
-      return ReadOnlyAccess(IsolationLevel::SNAPSHOT_ISOLATION);  // Do we need snapshot isolation?
+      return ReadOnlyAccess(IsolationLevel::SNAPSHOT_ISOLATION);  // Do we need snapshot isolation? // timeout?
     }
-    return Access(IsolationLevel::SNAPSHOT_ISOLATION);
+    return Access(IsolationLevel::SNAPSHOT_ISOLATION);// timeout?
   });
+
+  // is it even worth it?
+  // what was the last snapshot, has their been writes since?
 
   utils::Timer timer;
   Transaction *transaction = accessor->GetTransaction();

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -106,7 +106,7 @@ class InMemoryStorage final : public Storage {
 
  public:
   using free_mem_fn = std::function<void(std::unique_lock<utils::ResourceLock>, bool)>;
-  enum class CreateSnapshotError : uint8_t { DisabledForReplica, ReachedMaxNumTries, AbortSnapshot };
+  enum class CreateSnapshotError : uint8_t { DisabledForReplica, ReachedMaxNumTries, AbortSnapshot, AlreadyRunning };
   enum class RecoverSnapshotError : uint8_t {
     DisabledForReplica,
     DisabledForMainWithReplicas,

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -492,8 +492,8 @@ class InMemoryStorage final : public Storage {
     /// View is not needed because a new rtree gets created for each transaction and it is always
     /// using the latest version
     auto PointVertices(LabelId label, PropertyId property, CoordinateReferenceSystem crs,
-                       PropertyValue const &bottom_left, PropertyValue const &top_right,
-                       WithinBBoxCondition condition) -> PointIterable override;
+                       PropertyValue const &bottom_left, PropertyValue const &top_right, WithinBBoxCondition condition)
+        -> PointIterable override;
 
     std::vector<std::tuple<VertexAccessor, double, double>> VectorIndexSearch(
         const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector) override;
@@ -610,6 +610,7 @@ class InMemoryStorage final : public Storage {
 
   utils::Scheduler snapshot_runner_;
   std::mutex snapshot_lock_;
+  std::atomic_bool snapshot_running_{false};
   std::atomic_bool abort_snapshot_{false};
 
   std::shared_ptr<utils::Observer<utils::SchedulerInterval>> snapshot_periodic_observer_;

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -492,8 +492,8 @@ class InMemoryStorage final : public Storage {
     /// View is not needed because a new rtree gets created for each transaction and it is always
     /// using the latest version
     auto PointVertices(LabelId label, PropertyId property, CoordinateReferenceSystem crs,
-                       PropertyValue const &bottom_left, PropertyValue const &top_right, WithinBBoxCondition condition)
-        -> PointIterable override;
+                       PropertyValue const &bottom_left, PropertyValue const &top_right,
+                       WithinBBoxCondition condition) -> PointIterable override;
 
     std::vector<std::tuple<VertexAccessor, double, double>> VectorIndexSearch(
         const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector) override;

--- a/src/storage/v2/inmemory/unique_constraints.cpp
+++ b/src/storage/v2/inmemory/unique_constraints.cpp
@@ -504,7 +504,7 @@ std::vector<std::pair<LabelId, std::set<PropertyId>>> InMemoryUniqueConstraints:
 }
 
 void InMemoryUniqueConstraints::RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token) {
-  auto maybe_stop = utils::ResettableCounter<2048>();
+  auto maybe_stop = utils::ResettableCounter(2048);
 
   for (auto &[label_props, storage] : constraints_) {
     // before starting constraint, check if stop_requested

--- a/src/storage/v2/replication/replication_storage_state.hpp
+++ b/src/storage/v2/replication/replication_storage_state.hpp
@@ -35,6 +35,8 @@ class ReplicationStorageClient;
 class ReplicaStream;
 class TransactionReplication;
 
+using EpochHistory = std::deque<std::pair<std::string, uint64_t>>;
+
 struct ReplicationStorageState {
   // Only MAIN can send
   auto InitializeTransaction(uint64_t seq_num, Storage *storage, DatabaseAccessProtector db_acc)
@@ -69,7 +71,7 @@ struct ReplicationStorageState {
   // History of the previous epoch ids.
   // Each value consists of the epoch id along the last commit belonging to that
   // epoch.
-  std::deque<std::pair<std::string, uint64_t>> history;
+  EpochHistory history;
   std::atomic<uint64_t> last_durable_timestamp_{kTimestampInitialId};
 
   // We create ReplicationClient using unique_ptr so we can move

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -708,8 +708,8 @@ class Storage {
   utils::Synchronized<std::map<LabelId, uint32_t>, utils::SpinLock> labels_to_auto_index_;
   utils::Synchronized<std::map<EdgeTypeId, uint32_t>, utils::SpinLock> edge_types_to_auto_index_;
 
-  std::atomic<uint64_t> vertex_id_{0};
-  std::atomic<uint64_t> edge_id_{0};
+  std::atomic<uint64_t> vertex_id_{0};  // contains Vertex Gid that has not been used yet
+  std::atomic<uint64_t> edge_id_{0};    // contains Edge Gid that has not been used yet
 
   // Mutable methods only safe if we have UniqueAccess to this storage
   EnumStore enum_store_;

--- a/src/utils/counter.hpp
+++ b/src/utils/counter.hpp
@@ -17,15 +17,20 @@
 namespace memgraph::utils {
 
 /// A resettable counter, every Nth call returns true
-template <std::size_t N>
-auto ResettableCounter() {
-  return [counter = N]() mutable {
-    --counter;
-    if (counter != 0) return false;
-    counter = N;
+
+struct ResettableCounter {
+  ResettableCounter(std::size_t N) : counter_{N}, orig_{N} {}
+  bool operator()() const {
+    --counter_;
+    if (counter_ != 0) return false;
+    counter_ = orig_;
     return true;
-  };
-}
+  }
+
+ private:
+  mutable std::size_t counter_;
+  std::size_t orig_;
+};
 
 struct ResettableAtomicCounter {
   explicit ResettableAtomicCounter(uint64_t const original_size) : original_size_(original_size) {

--- a/src/utils/file.cpp
+++ b/src/utils/file.cpp
@@ -350,6 +350,7 @@ const std::filesystem::path &OutputFile::path() const { return path_; }
 
 void OutputFile::Write(const uint8_t *data, size_t size) {
   std::unique_lock flush_guard(flush_lock_);
+  MG_ASSERT(IsOpen(), "Trying to write to an unopened file!");
   auto const buffer_start = buffer_position_.load(std::memory_order_acquire);
 
   auto write_ptr = buffer_ + buffer_start;

--- a/src/utils/file.hpp
+++ b/src/utils/file.hpp
@@ -262,7 +262,7 @@ class OutputFile {
  private:
   void FlushBuffer();
   void FlushBufferInternal();
-  void FlushBufferInternal(unsigned long to_write);
+  void FlushBufferInternal(size_t to_write);
 
   size_t SeekFile(Position position, ssize_t offset);
 
@@ -356,7 +356,7 @@ class NonConcurrentOutputFile {
  private:
   void FlushBuffer();
   void FlushBufferInternal();
-  void FlushBufferInternal(unsigned long to_write);
+  void FlushBufferInternal(size_t to_write);
 
   size_t SeekFile(Position position, ssize_t offset);
 

--- a/src/utils/file.hpp
+++ b/src/utils/file.hpp
@@ -240,12 +240,12 @@ class OutputFile {
   void Close() noexcept;
 
   /// Disable flushing of the internal buffer.
-  void DisableFlushing();
+  void DisableFlushing();  // This is over the top for snapshot file...no concurrent flush protection needed
 
   /// Enable flushing of the internal buffer.
   /// Before the flushing is enabled, the internal buffer
   /// is flushed.
-  void EnableFlushing();
+  void EnableFlushing();  // This is over the top for snapshot file...no concurrent flush protection needed
 
   /// Try flushing the internal buffer.
   void TryFlushing();
@@ -271,7 +271,7 @@ class OutputFile {
   std::atomic<size_t> buffer_position_{0};
 
   // Flushing buffer should be a higher priority
-  utils::RWLock flush_lock_{RWLock::Priority::WRITE};
+  utils::RWLock flush_lock_{RWLock::Priority::WRITE}; // This is over the top for snapshot file...no concurrent flush protection needed
 };
 
 }  // namespace memgraph::utils

--- a/src/utils/file.hpp
+++ b/src/utils/file.hpp
@@ -240,12 +240,12 @@ class OutputFile {
   void Close() noexcept;
 
   /// Disable flushing of the internal buffer.
-  void DisableFlushing();  // This is over the top for snapshot file...no concurrent flush protection needed
+  void DisableFlushing();
 
   /// Enable flushing of the internal buffer.
   /// Before the flushing is enabled, the internal buffer
   /// is flushed.
-  void EnableFlushing();  // This is over the top for snapshot file...no concurrent flush protection needed
+  void EnableFlushing();
 
   /// Try flushing the internal buffer.
   void TryFlushing();
@@ -266,8 +266,7 @@ class OutputFile {
   size_t SeekFile(Position position, ssize_t offset);
 
   // put flush lock on its own cacheline
-  alignas(64) utils::RWSpinLock
-      flush_lock_{};  // This is over the top for snapshot file...no concurrent flush protection needed
+  alignas(64) utils::RWSpinLock flush_lock_{};
 
   // ensure the rest start on a new cacheline
   alignas(64) int fd_{-1};

--- a/src/utils/file.hpp
+++ b/src/utils/file.hpp
@@ -256,6 +256,7 @@ class OutputFile {
   /// Get the size of the file.
   size_t GetSize();
 
+  /// Get the POSIX file handle
   auto fd() const { return fd_; }
 
  private:
@@ -265,11 +266,101 @@ class OutputFile {
   size_t SeekFile(Position position, ssize_t offset);
 
   // put flush lock on its own cacheline
-  alignas(64) utils::RWSpinLock flush_lock_{}; // This is over the top for snapshot file...no concurrent flush protection needed
+  alignas(64) utils::RWSpinLock
+      flush_lock_{};  // This is over the top for snapshot file...no concurrent flush protection needed
 
   // ensure the rest start on a new cacheline
   alignas(64) int fd_{-1};
   std::atomic<size_t> buffer_position_{0};
+  size_t written_since_last_sync_{0};
+  uint8_t buffer_[kFileBufferSize];
+
+  // Path should be cold data
+  std::filesystem::path path_;
+};
+
+// Like OutputFile but without concurrent access to its buffer
+class NonConcurrentOutputFile {
+ public:
+  enum class Mode {
+    OVERWRITE_EXISTING,
+    APPEND_TO_EXISTING,
+  };
+
+  enum class Position {
+    SET,
+    RELATIVE_TO_CURRENT,
+    RELATIVE_TO_END,
+  };
+
+  NonConcurrentOutputFile() = default;
+  ~NonConcurrentOutputFile();
+
+  NonConcurrentOutputFile(const NonConcurrentOutputFile &) = delete;
+  NonConcurrentOutputFile &operator=(const NonConcurrentOutputFile &) = delete;
+
+  /// This method opens a new file used for writing. If the file doesn't exist
+  /// it is created. The `mode` flags controls whether data is appended to the
+  /// file or the file is wiped on first write. Files are created with a
+  /// restrictive permission mask (0640). On failure and misuse it crashes the
+  /// program.
+  void Open(const std::filesystem::path &path, Mode mode);
+
+  /// Returns a boolean indicating whether a file is opened.
+  bool IsOpen() const;
+
+  /// Returns the path to the currently opened file. If a file isn't opened the
+  /// path is empty.
+  const std::filesystem::path &path() const;
+
+  /// Writes data to the currently opened file. On failure and misuse it crashes
+  /// the program.
+  void Write(const uint8_t *data, size_t size);
+  void Write(const char *data, size_t size);
+  void Write(std::string_view data);
+
+  /// This method gets the current absolute position in the file. On failure and
+  /// misuse it crashes the program.
+  size_t GetPosition();
+
+  /// This method sets the current position in the file and returns the absolute
+  /// set position in the file. The position is set to `offset` with the
+  /// starting point taken from `position`. On failure and misuse it crashes the
+  /// program.
+  size_t SetPosition(Position position, ssize_t offset);
+
+  /// This function tries to acquire a POSIX write lock on the file. The
+  /// acquired lock is valid during the whole lifetime of the process and can't
+  /// be acquired again. The function returns `true` if the lock was required
+  /// successfully, `false` is returned otherwise. On misuse it crashes the
+  /// program.
+  bool AcquireLock();
+
+  /// Syncs currently pending data to the currently opened file. On failure
+  /// and misuse it crashes the program.
+  void Sync();
+
+  /// Closes the currently opened file. It doesn't perform a `Sync` on the
+  /// file. On failure and misuse it crashes the program.
+  void Close() noexcept;
+
+  /// Get the internal buffer with its current size.
+  std::pair<const uint8_t *, size_t> CurrentBuffer() const;
+
+  /// Get the size of the file.
+  size_t GetSize();
+
+  /// Get the POSIX file handle
+  auto fd() const { return fd_; }
+
+ private:
+  void FlushBuffer();
+  void FlushBufferInternal();
+
+  size_t SeekFile(Position position, ssize_t offset);
+
+  int fd_{-1};
+  size_t buffer_position_{0};
   size_t written_since_last_sync_{0};
   uint8_t buffer_[kFileBufferSize];
 

--- a/src/utils/file.hpp
+++ b/src/utils/file.hpp
@@ -262,6 +262,7 @@ class OutputFile {
  private:
   void FlushBuffer();
   void FlushBufferInternal();
+  void FlushBufferInternal(unsigned long to_write);
 
   size_t SeekFile(Position position, ssize_t offset);
 
@@ -355,6 +356,7 @@ class NonConcurrentOutputFile {
  private:
   void FlushBuffer();
   void FlushBufferInternal();
+  void FlushBufferInternal(unsigned long to_write);
 
   size_t SeekFile(Position position, ssize_t offset);
 

--- a/src/utils/memory_tracker.cpp
+++ b/src/utils/memory_tracker.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -33,14 +33,7 @@ bool MemoryTrackerCanThrow() {
 }  // namespace
 
 thread_local uint64_t MemoryTracker::OutOfMemoryExceptionEnabler::counter_ = 0;
-MemoryTracker::OutOfMemoryExceptionEnabler::OutOfMemoryExceptionEnabler() { ++counter_; }
-MemoryTracker::OutOfMemoryExceptionEnabler::~OutOfMemoryExceptionEnabler() { --counter_; }
-bool MemoryTracker::OutOfMemoryExceptionEnabler::CanThrow() { return counter_ > 0; }
-
 thread_local uint64_t MemoryTracker::OutOfMemoryExceptionBlocker::counter_ = 0;
-MemoryTracker::OutOfMemoryExceptionBlocker::OutOfMemoryExceptionBlocker() { ++counter_; }
-MemoryTracker::OutOfMemoryExceptionBlocker::~OutOfMemoryExceptionBlocker() { --counter_; }
-bool MemoryTracker::OutOfMemoryExceptionBlocker::IsBlocked() { return counter_ > 0; }
 
 MemoryTracker total_memory_tracker;
 

--- a/src/utils/memory_tracker.hpp
+++ b/src/utils/memory_tracker.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -94,10 +94,10 @@ class MemoryTracker final {
     OutOfMemoryExceptionEnabler(OutOfMemoryExceptionEnabler &&) = delete;
     OutOfMemoryExceptionEnabler &operator=(OutOfMemoryExceptionEnabler &&) = delete;
 
-    OutOfMemoryExceptionEnabler();
-    ~OutOfMemoryExceptionEnabler();
+    OutOfMemoryExceptionEnabler() { ++counter_; }
+    ~OutOfMemoryExceptionEnabler() { --counter_; }
 
-    static bool CanThrow();
+    static bool CanThrow() { return counter_ > 0; };
 
    private:
     static thread_local uint64_t counter_;
@@ -113,10 +113,10 @@ class MemoryTracker final {
     OutOfMemoryExceptionBlocker(OutOfMemoryExceptionBlocker &&) = delete;
     OutOfMemoryExceptionBlocker &operator=(OutOfMemoryExceptionBlocker &&) = delete;
 
-    OutOfMemoryExceptionBlocker();
-    ~OutOfMemoryExceptionBlocker();
+    OutOfMemoryExceptionBlocker() { ++counter_; }
+    ~OutOfMemoryExceptionBlocker() { --counter_; }
 
-    static bool IsBlocked();
+    static bool IsBlocked() { return counter_ > 0; };
 
    private:
     static thread_local uint64_t counter_;

--- a/src/utils/skip_list.hpp
+++ b/src/utils/skip_list.hpp
@@ -754,7 +754,7 @@ class SkipList final : detail::SkipListNode_base {
     ~Accessor() {
       if (skiplist_ != nullptr) {
         skiplist_->gc_.ReleaseId(id_);
-        thread_local auto gc_run_interval = utils::ResettableCounter<1024>();
+        thread_local auto gc_run_interval = utils::ResettableCounter(1024);
         if (gc_run_interval()) {
           skiplist_->run_gc();
         }

--- a/src/utils/skip_list.hpp
+++ b/src/utils/skip_list.hpp
@@ -619,11 +619,13 @@ class SkipList final : detail::SkipListNode_base {
     friend bool operator==(Iterator const &lhs, Iterator const &rhs) { return lhs.node_ == rhs.node_; }
 
     Iterator &operator++() {
+      auto current = node_;
       while (true) {
-        node_ = node_->nexts[0].load(std::memory_order_acquire);
-        if (node_ != nullptr && node_->marked.load(std::memory_order_acquire)) [[unlikely]] {
+        current = current->nexts[0].load(std::memory_order_acquire);
+        if (current != nullptr && current->marked.load(std::memory_order_acquire)) [[unlikely]] {
           continue;
         } else {
+          node_ = current;
           return *this;
         }
       }

--- a/tests/e2e/replication/switching_roles.py
+++ b/tests/e2e/replication/switching_roles.py
@@ -106,8 +106,6 @@ def test_switch_main_after_local_snapshot(connection, test_name):
 
     # 2/
     execute_and_fetch_all(cursor1, "CREATE SNAPSHOT;")
-    execute_and_fetch_all(cursor1, "CREATE SNAPSHOT;")
-    execute_and_fetch_all(cursor1, "CREATE SNAPSHOT;")
 
     # 3/
     execute_and_fetch_all(cursor1, f"SET REPLICATION ROLE TO REPLICA WITH PORT {REPLICATION_PORTS['instance1']};")

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -102,7 +102,9 @@ def run(args):
                     conn = mg_instance.get_connection()
                     for validation in validation_queries:
                         data = mg_instance.query(validation["query"], conn)[0][0]
-                        assert data == validation["expected"]
+                        assert (
+                            data == validation["expected"]
+                        ), f"Assertion failed: got {data}, expected {validation['expected']} from query `{validation['query']}`"
                     conn.close()
 
             log.info("%s PASSED.", workload_name)

--- a/tests/unit/counter.cpp
+++ b/tests/unit/counter.cpp
@@ -46,7 +46,7 @@ TEST(Counter, RuntimeCounterLarge3) {
 }
 
 TEST(Counter, CompiletimeCounter) {
-  auto cnt = ResettableCounter<2>();
+  auto cnt = ResettableCounter(2);
   ASSERT_FALSE(cnt());
   ASSERT_TRUE(cnt());
   ASSERT_FALSE(cnt());

--- a/tests/unit/storage_v2_decoder_encoder.cpp
+++ b/tests/unit/storage_v2_decoder_encoder.cpp
@@ -190,40 +190,8 @@ GENERATE_READ_TEST(
     }                                                                    \
   }
 
-// // NOLINTNEXTLINE(hicpp-special-member-functions)
-// GENERATE_SKIP_TEST(String, std::string, "hello", "world", "nandare", "haihaihai", std::string(500000, 'a'));
-
-TYPED_TEST(DecoderEncoderTest, SkipString) {
-  std::vector<std::string> dataset{"hello", "world", "nandare", "haihaihai", std::string(500000, 'a')};
-
-  {
-    memgraph::storage::durability::Encoder<TypeParam> encoder;
-    encoder.Initialize(this->storage_file, kTestMagic, kTestVersion);
-    for (const auto &item : dataset) {
-      encoder.WriteString(item);
-    }
-    {
-      uint8_t invalid = 1;
-      encoder.Write(&invalid, sizeof(invalid));
-    }
-    encoder.Finalize();
-  }
-
-  {
-    memgraph::storage::durability::Decoder decoder;
-    auto version = decoder.Initialize(this->storage_file, kTestMagic);
-    ASSERT_TRUE(version);
-    ASSERT_EQ(*version, kTestVersion);
-    for (auto it = dataset.begin(); it != dataset.end(); ++it) {
-      ASSERT_TRUE(decoder.SkipString());
-    }
-    ASSERT_FALSE(decoder.SkipString());
-    ASSERT_FALSE(decoder.SkipString());
-    auto pos = decoder.GetPosition();
-    ASSERT_TRUE(pos);
-    ASSERT_EQ(pos, decoder.GetSize());
-  }
-}
+// NOLINTNEXTLINE(hicpp-special-member-functions)
+GENERATE_SKIP_TEST(String, std::string, "hello", "world", "nandare", "haihaihai", std::string(500000, 'a'));
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 GENERATE_SKIP_TEST(

--- a/tests/unit/storage_v2_decoder_encoder.cpp
+++ b/tests/unit/storage_v2_decoder_encoder.cpp
@@ -19,11 +19,13 @@
 #include "storage/v2/point.hpp"
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/temporal.hpp"
+#include "utils/file.hpp"
 #include "utils/temporal.hpp"
 
 static const std::string kTestMagic{"MGtest"};
 static const uint64_t kTestVersion{1};
 
+template <typename T>
 class DecoderEncoderTest : public ::testing::Test {
  public:
   void SetUp() override { Clear(); }
@@ -38,8 +40,8 @@ class DecoderEncoderTest : public ::testing::Test {
 
  private:
   void Clear() {
-    if (std::filesystem::exists(storage_file)) {
-      std::filesystem::remove(storage_file);
+    if (std::filesystem::exists(this->storage_file)) {
+      std::filesystem::remove(this->storage_file);
     }
     if (std::filesystem::exists(alternate_file)) {
       std::filesystem::remove(alternate_file);
@@ -47,11 +49,14 @@ class DecoderEncoderTest : public ::testing::Test {
   }
 };
 
+using FileTypes = testing::Types<memgraph::utils::OutputFile, memgraph::utils::NonConcurrentOutputFile>;
+TYPED_TEST_SUITE(DecoderEncoderTest, FileTypes);
+
 // NOLINTNEXTLINE(hicpp-special-member-functions)
-TEST_F(DecoderEncoderTest, ReadMarker) {
+TYPED_TEST(DecoderEncoderTest, ReadMarker) {
   {
-    memgraph::storage::durability::Encoder encoder;
-    encoder.Initialize(storage_file, kTestMagic, kTestVersion);
+    memgraph::storage::durability::Encoder<TypeParam> encoder;
+    encoder.Initialize(this->storage_file, kTestMagic, kTestVersion);
     for (const auto &item : memgraph::storage::durability::kMarkersAll) {
       encoder.WriteMarker(item);
     }
@@ -63,7 +68,7 @@ TEST_F(DecoderEncoderTest, ReadMarker) {
   }
   {
     memgraph::storage::durability::Decoder decoder;
-    auto version = decoder.Initialize(storage_file, kTestMagic);
+    auto version = decoder.Initialize(this->storage_file, kTestMagic);
     ASSERT_TRUE(version);
     ASSERT_EQ(*version, kTestVersion);
     for (const auto &item : memgraph::storage::durability::kMarkersAll) {
@@ -80,37 +85,37 @@ TEST_F(DecoderEncoderTest, ReadMarker) {
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define GENERATE_READ_TEST(name, type, ...)                        \
-  TEST_F(DecoderEncoderTest, Read##name) {                         \
-    std::vector<type> dataset{__VA_ARGS__};                        \
-    {                                                              \
-      memgraph::storage::durability::Encoder encoder;              \
-      encoder.Initialize(storage_file, kTestMagic, kTestVersion);  \
-      for (const auto &item : dataset) {                           \
-        encoder.Write##name(item);                                 \
-      }                                                            \
-      {                                                            \
-        uint8_t invalid = 1;                                       \
-        encoder.Write(&invalid, sizeof(invalid));                  \
-      }                                                            \
-      encoder.Finalize();                                          \
-    }                                                              \
-    {                                                              \
-      memgraph::storage::durability::Decoder decoder;              \
-      auto version = decoder.Initialize(storage_file, kTestMagic); \
-      ASSERT_TRUE(version);                                        \
-      ASSERT_EQ(*version, kTestVersion);                           \
-      for (const auto &item : dataset) {                           \
-        auto decoded = decoder.Read##name();                       \
-        ASSERT_TRUE(decoded);                                      \
-        ASSERT_EQ(*decoded, item);                                 \
-      }                                                            \
-      ASSERT_FALSE(decoder.Read##name());                          \
-      ASSERT_FALSE(decoder.Read##name());                          \
-      auto pos = decoder.GetPosition();                            \
-      ASSERT_TRUE(pos);                                            \
-      ASSERT_EQ(pos, decoder.GetSize());                           \
-    }                                                              \
+#define GENERATE_READ_TEST(name, type, ...)                              \
+  TYPED_TEST(DecoderEncoderTest, Read##name) {                           \
+    std::vector<type> dataset{__VA_ARGS__};                              \
+    {                                                                    \
+      memgraph::storage::durability::Encoder<TypeParam> encoder;         \
+      encoder.Initialize(this->storage_file, kTestMagic, kTestVersion);  \
+      for (const auto &item : dataset) {                                 \
+        encoder.Write##name(item);                                       \
+      }                                                                  \
+      {                                                                  \
+        uint8_t invalid = 1;                                             \
+        encoder.Write(&invalid, sizeof(invalid));                        \
+      }                                                                  \
+      encoder.Finalize();                                                \
+    }                                                                    \
+    {                                                                    \
+      memgraph::storage::durability::Decoder decoder;                    \
+      auto version = decoder.Initialize(this->storage_file, kTestMagic); \
+      ASSERT_TRUE(version);                                              \
+      ASSERT_EQ(*version, kTestVersion);                                 \
+      for (const auto &item : dataset) {                                 \
+        auto decoded = decoder.Read##name();                             \
+        ASSERT_TRUE(decoded);                                            \
+        ASSERT_EQ(*decoded, item);                                       \
+      }                                                                  \
+      ASSERT_FALSE(decoder.Read##name());                                \
+      ASSERT_FALSE(decoder.Read##name());                                \
+      auto pos = decoder.GetPosition();                                  \
+      ASSERT_TRUE(pos);                                                  \
+      ASSERT_EQ(pos, decoder.GetSize());                                 \
+    }                                                                    \
   }
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
@@ -154,39 +159,71 @@ GENERATE_READ_TEST(
         memgraph::storage::CoordinateReferenceSystem::Cartesian_3d, 1.0, 2.0, 3.0}));
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define GENERATE_SKIP_TEST(name, type, ...)                        \
-  TEST_F(DecoderEncoderTest, Skip##name) {                         \
-    std::vector<type> dataset{__VA_ARGS__};                        \
-    {                                                              \
-      memgraph::storage::durability::Encoder encoder;              \
-      encoder.Initialize(storage_file, kTestMagic, kTestVersion);  \
-      for (const auto &item : dataset) {                           \
-        encoder.Write##name(item);                                 \
-      }                                                            \
-      {                                                            \
-        uint8_t invalid = 1;                                       \
-        encoder.Write(&invalid, sizeof(invalid));                  \
-      }                                                            \
-      encoder.Finalize();                                          \
-    }                                                              \
-    {                                                              \
-      memgraph::storage::durability::Decoder decoder;              \
-      auto version = decoder.Initialize(storage_file, kTestMagic); \
-      ASSERT_TRUE(version);                                        \
-      ASSERT_EQ(*version, kTestVersion);                           \
-      for (auto it = dataset.begin(); it != dataset.end(); ++it) { \
-        ASSERT_TRUE(decoder.Skip##name());                         \
-      }                                                            \
-      ASSERT_FALSE(decoder.Skip##name());                          \
-      ASSERT_FALSE(decoder.Skip##name());                          \
-      auto pos = decoder.GetPosition();                            \
-      ASSERT_TRUE(pos);                                            \
-      ASSERT_EQ(pos, decoder.GetSize());                           \
-    }                                                              \
+#define GENERATE_SKIP_TEST(name, type, ...)                              \
+  TYPED_TEST(DecoderEncoderTest, Skip##name) {                           \
+    std::vector<type> dataset{__VA_ARGS__};                              \
+    {                                                                    \
+      memgraph::storage::durability::Encoder<TypeParam> encoder;         \
+      encoder.Initialize(this->storage_file, kTestMagic, kTestVersion);  \
+      for (const auto &item : dataset) {                                 \
+        encoder.Write##name(item);                                       \
+      }                                                                  \
+      {                                                                  \
+        uint8_t invalid = 1;                                             \
+        encoder.Write(&invalid, sizeof(invalid));                        \
+      }                                                                  \
+      encoder.Finalize();                                                \
+    }                                                                    \
+    {                                                                    \
+      memgraph::storage::durability::Decoder decoder;                    \
+      auto version = decoder.Initialize(this->storage_file, kTestMagic); \
+      ASSERT_TRUE(version);                                              \
+      ASSERT_EQ(*version, kTestVersion);                                 \
+      for (auto it = dataset.begin(); it != dataset.end(); ++it) {       \
+        ASSERT_TRUE(decoder.Skip##name());                               \
+      }                                                                  \
+      ASSERT_FALSE(decoder.Skip##name());                                \
+      ASSERT_FALSE(decoder.Skip##name());                                \
+      auto pos = decoder.GetPosition();                                  \
+      ASSERT_TRUE(pos);                                                  \
+      ASSERT_EQ(pos, decoder.GetSize());                                 \
+    }                                                                    \
   }
 
-// NOLINTNEXTLINE(hicpp-special-member-functions)
-GENERATE_SKIP_TEST(String, std::string, "hello", "world", "nandare", "haihaihai", std::string(500000, 'a'));
+// // NOLINTNEXTLINE(hicpp-special-member-functions)
+// GENERATE_SKIP_TEST(String, std::string, "hello", "world", "nandare", "haihaihai", std::string(500000, 'a'));
+
+TYPED_TEST(DecoderEncoderTest, SkipString) {
+  std::vector<std::string> dataset{"hello", "world", "nandare", "haihaihai", std::string(500000, 'a')};
+
+  {
+    memgraph::storage::durability::Encoder<TypeParam> encoder;
+    encoder.Initialize(this->storage_file, kTestMagic, kTestVersion);
+    for (const auto &item : dataset) {
+      encoder.WriteString(item);
+    }
+    {
+      uint8_t invalid = 1;
+      encoder.Write(&invalid, sizeof(invalid));
+    }
+    encoder.Finalize();
+  }
+
+  {
+    memgraph::storage::durability::Decoder decoder;
+    auto version = decoder.Initialize(this->storage_file, kTestMagic);
+    ASSERT_TRUE(version);
+    ASSERT_EQ(*version, kTestVersion);
+    for (auto it = dataset.begin(); it != dataset.end(); ++it) {
+      ASSERT_TRUE(decoder.SkipString());
+    }
+    ASSERT_FALSE(decoder.SkipString());
+    ASSERT_FALSE(decoder.SkipString());
+    auto pos = decoder.GetPosition();
+    ASSERT_TRUE(pos);
+    ASSERT_EQ(pos, decoder.GetSize());
+  }
+}
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 GENERATE_SKIP_TEST(
@@ -215,44 +252,44 @@ GENERATE_SKIP_TEST(
         memgraph::storage::CoordinateReferenceSystem::Cartesian_3d, 1.0, 2.0, 3.0}));
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define GENERATE_PARTIAL_READ_TEST(name, value)                                          \
-  TEST_F(DecoderEncoderTest, PartialRead##name) {                                        \
-    {                                                                                    \
-      memgraph::storage::durability::Encoder encoder;                                    \
-      encoder.Initialize(storage_file, kTestMagic, kTestVersion);                        \
-      encoder.Write##name(value);                                                        \
-      encoder.Finalize();                                                                \
-    }                                                                                    \
-    {                                                                                    \
-      memgraph::utils::InputFile ifile;                                                  \
-      memgraph::utils::OutputFile ofile;                                                 \
-      ASSERT_TRUE(ifile.Open(storage_file));                                             \
-      ofile.Open(alternate_file, memgraph::utils::OutputFile::Mode::OVERWRITE_EXISTING); \
-      auto size = ifile.GetSize();                                                       \
-      for (size_t i = 0; i <= size; ++i) {                                               \
-        if (i != 0) {                                                                    \
-          uint8_t byte;                                                                  \
-          ASSERT_TRUE(ifile.Read(&byte, sizeof(byte)));                                  \
-          ofile.Write(&byte, sizeof(byte));                                              \
-          ofile.Sync();                                                                  \
-        }                                                                                \
-        memgraph::storage::durability::Decoder decoder;                                  \
-        auto version = decoder.Initialize(alternate_file, kTestMagic);                   \
-        if (i < kTestMagic.size() + sizeof(kTestVersion)) {                              \
-          ASSERT_FALSE(version);                                                         \
-        } else {                                                                         \
-          ASSERT_TRUE(version);                                                          \
-          ASSERT_EQ(*version, kTestVersion);                                             \
-        }                                                                                \
-        if (i != size) {                                                                 \
-          ASSERT_FALSE(decoder.Read##name());                                            \
-        } else {                                                                         \
-          auto decoded = decoder.Read##name();                                           \
-          ASSERT_TRUE(decoded);                                                          \
-          ASSERT_EQ(*decoded, value);                                                    \
-        }                                                                                \
-      }                                                                                  \
-    }                                                                                    \
+#define GENERATE_PARTIAL_READ_TEST(name, value)                                                \
+  TYPED_TEST(DecoderEncoderTest, PartialRead##name) {                                          \
+    {                                                                                          \
+      memgraph::storage::durability::Encoder<TypeParam> encoder;                               \
+      encoder.Initialize(this->storage_file, kTestMagic, kTestVersion);                        \
+      encoder.Write##name(value);                                                              \
+      encoder.Finalize();                                                                      \
+    }                                                                                          \
+    {                                                                                          \
+      memgraph::utils::InputFile ifile;                                                        \
+      memgraph::utils::OutputFile ofile;                                                       \
+      ASSERT_TRUE(ifile.Open(this->storage_file));                                             \
+      ofile.Open(this->alternate_file, memgraph::utils::OutputFile::Mode::OVERWRITE_EXISTING); \
+      auto size = ifile.GetSize();                                                             \
+      for (size_t i = 0; i <= size; ++i) {                                                     \
+        if (i != 0) {                                                                          \
+          uint8_t byte;                                                                        \
+          ASSERT_TRUE(ifile.Read(&byte, sizeof(byte)));                                        \
+          ofile.Write(&byte, sizeof(byte));                                                    \
+          ofile.Sync();                                                                        \
+        }                                                                                      \
+        memgraph::storage::durability::Decoder decoder;                                        \
+        auto version = decoder.Initialize(this->alternate_file, kTestMagic);                   \
+        if (i < kTestMagic.size() + sizeof(kTestVersion)) {                                    \
+          ASSERT_FALSE(version);                                                               \
+        } else {                                                                               \
+          ASSERT_TRUE(version);                                                                \
+          ASSERT_EQ(*version, kTestVersion);                                                   \
+        }                                                                                      \
+        if (i != size) {                                                                       \
+          ASSERT_FALSE(decoder.Read##name());                                                  \
+        } else {                                                                               \
+          auto decoded = decoder.Read##name();                                                 \
+          ASSERT_TRUE(decoded);                                                                \
+          ASSERT_EQ(*decoded, value);                                                          \
+        }                                                                                      \
+      }                                                                                        \
+    }                                                                                          \
   }
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
@@ -296,42 +333,42 @@ GENERATE_PARTIAL_READ_TEST(
             memgraph::storage::CoordinateReferenceSystem::Cartesian_3d, 1.0, 2.0, 3.0})}));
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define GENERATE_PARTIAL_SKIP_TEST(name, value)                                          \
-  TEST_F(DecoderEncoderTest, PartialSkip##name) {                                        \
-    {                                                                                    \
-      memgraph::storage::durability::Encoder encoder;                                    \
-      encoder.Initialize(storage_file, kTestMagic, kTestVersion);                        \
-      encoder.Write##name(value);                                                        \
-      encoder.Finalize();                                                                \
-    }                                                                                    \
-    {                                                                                    \
-      memgraph::utils::InputFile ifile;                                                  \
-      memgraph::utils::OutputFile ofile;                                                 \
-      ASSERT_TRUE(ifile.Open(storage_file));                                             \
-      ofile.Open(alternate_file, memgraph::utils::OutputFile::Mode::OVERWRITE_EXISTING); \
-      auto size = ifile.GetSize();                                                       \
-      for (size_t i = 0; i <= size; ++i) {                                               \
-        if (i != 0) {                                                                    \
-          uint8_t byte;                                                                  \
-          ASSERT_TRUE(ifile.Read(&byte, sizeof(byte)));                                  \
-          ofile.Write(&byte, sizeof(byte));                                              \
-          ofile.Sync();                                                                  \
-        }                                                                                \
-        memgraph::storage::durability::Decoder decoder;                                  \
-        auto version = decoder.Initialize(alternate_file, kTestMagic);                   \
-        if (i < kTestMagic.size() + sizeof(kTestVersion)) {                              \
-          ASSERT_FALSE(version);                                                         \
-        } else {                                                                         \
-          ASSERT_TRUE(version);                                                          \
-          ASSERT_EQ(*version, kTestVersion);                                             \
-        }                                                                                \
-        if (i != size) {                                                                 \
-          ASSERT_FALSE(decoder.Skip##name());                                            \
-        } else {                                                                         \
-          ASSERT_TRUE(decoder.Skip##name());                                             \
-        }                                                                                \
-      }                                                                                  \
-    }                                                                                    \
+#define GENERATE_PARTIAL_SKIP_TEST(name, value)                                                \
+  TYPED_TEST(DecoderEncoderTest, PartialSkip##name) {                                          \
+    {                                                                                          \
+      memgraph::storage::durability::Encoder<TypeParam> encoder;                               \
+      encoder.Initialize(this->storage_file, kTestMagic, kTestVersion);                        \
+      encoder.Write##name(value);                                                              \
+      encoder.Finalize();                                                                      \
+    }                                                                                          \
+    {                                                                                          \
+      memgraph::utils::InputFile ifile;                                                        \
+      memgraph::utils::OutputFile ofile;                                                       \
+      ASSERT_TRUE(ifile.Open(this->storage_file));                                             \
+      ofile.Open(this->alternate_file, memgraph::utils::OutputFile::Mode::OVERWRITE_EXISTING); \
+      auto size = ifile.GetSize();                                                             \
+      for (size_t i = 0; i <= size; ++i) {                                                     \
+        if (i != 0) {                                                                          \
+          uint8_t byte;                                                                        \
+          ASSERT_TRUE(ifile.Read(&byte, sizeof(byte)));                                        \
+          ofile.Write(&byte, sizeof(byte));                                                    \
+          ofile.Sync();                                                                        \
+        }                                                                                      \
+        memgraph::storage::durability::Decoder decoder;                                        \
+        auto version = decoder.Initialize(this->alternate_file, kTestMagic);                   \
+        if (i < kTestMagic.size() + sizeof(kTestVersion)) {                                    \
+          ASSERT_FALSE(version);                                                               \
+        } else {                                                                               \
+          ASSERT_TRUE(version);                                                                \
+          ASSERT_EQ(*version, kTestVersion);                                                   \
+        }                                                                                      \
+        if (i != size) {                                                                       \
+          ASSERT_FALSE(decoder.Skip##name());                                                  \
+        } else {                                                                               \
+          ASSERT_TRUE(decoder.Skip##name());                                                   \
+        }                                                                                      \
+      }                                                                                        \
+    }                                                                                          \
   }
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
@@ -363,16 +400,16 @@ GENERATE_PARTIAL_SKIP_TEST(
             memgraph::storage::CoordinateReferenceSystem::Cartesian_3d, 1.0, 2.0, 3.0})}));
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
-TEST_F(DecoderEncoderTest, PropertyValueInvalidMarker) {
+TYPED_TEST(DecoderEncoderTest, PropertyValueInvalidMarker) {
   {
-    memgraph::storage::durability::Encoder encoder;
-    encoder.Initialize(storage_file, kTestMagic, kTestVersion);
+    memgraph::storage::durability::Encoder<TypeParam> encoder;
+    encoder.Initialize(this->storage_file, kTestMagic, kTestVersion);
     encoder.WritePropertyValue(memgraph::storage::PropertyValue(123L));
     encoder.Finalize();
   }
   {
     memgraph::utils::OutputFile file;
-    file.Open(storage_file, memgraph::utils::OutputFile::Mode::OVERWRITE_EXISTING);
+    file.Open(this->storage_file, memgraph::utils::OutputFile::Mode::OVERWRITE_EXISTING);
     for (auto marker : memgraph::storage::durability::kMarkersAll) {
       bool valid_marker;
       switch (marker) {
@@ -457,14 +494,14 @@ TEST_F(DecoderEncoderTest, PropertyValueInvalidMarker) {
       }
       {
         memgraph::storage::durability::Decoder decoder;
-        auto version = decoder.Initialize(storage_file, kTestMagic);
+        auto version = decoder.Initialize(this->storage_file, kTestMagic);
         ASSERT_TRUE(version);
         ASSERT_EQ(*version, kTestVersion);
         ASSERT_FALSE(decoder.SkipPropertyValue());
       }
       {
         memgraph::storage::durability::Decoder decoder;
-        auto version = decoder.Initialize(storage_file, kTestMagic);
+        auto version = decoder.Initialize(this->storage_file, kTestMagic);
         ASSERT_TRUE(version);
         ASSERT_EQ(*version, kTestVersion);
         ASSERT_FALSE(decoder.ReadPropertyValue());
@@ -480,14 +517,14 @@ TEST_F(DecoderEncoderTest, PropertyValueInvalidMarker) {
       }
       {
         memgraph::storage::durability::Decoder decoder;
-        auto version = decoder.Initialize(storage_file, kTestMagic);
+        auto version = decoder.Initialize(this->storage_file, kTestMagic);
         ASSERT_TRUE(version);
         ASSERT_EQ(*version, kTestVersion);
         ASSERT_FALSE(decoder.SkipPropertyValue());
       }
       {
         memgraph::storage::durability::Decoder decoder;
-        auto version = decoder.Initialize(storage_file, kTestMagic);
+        auto version = decoder.Initialize(this->storage_file, kTestMagic);
         ASSERT_TRUE(version);
         ASSERT_EQ(*version, kTestVersion);
         ASSERT_FALSE(decoder.ReadPropertyValue());
@@ -497,16 +534,16 @@ TEST_F(DecoderEncoderTest, PropertyValueInvalidMarker) {
 }
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
-TEST_F(DecoderEncoderTest, DecoderPosition) {
+TYPED_TEST(DecoderEncoderTest, DecoderPosition) {
   {
-    memgraph::storage::durability::Encoder encoder;
-    encoder.Initialize(storage_file, kTestMagic, kTestVersion);
+    memgraph::storage::durability::Encoder<TypeParam> encoder;
+    encoder.Initialize(this->storage_file, kTestMagic, kTestVersion);
     encoder.WriteBool(true);
     encoder.Finalize();
   }
   {
     memgraph::storage::durability::Decoder decoder;
-    auto version = decoder.Initialize(storage_file, kTestMagic);
+    auto version = decoder.Initialize(this->storage_file, kTestMagic);
     ASSERT_TRUE(version);
     ASSERT_EQ(*version, kTestVersion);
     for (int i = 0; i < 10; ++i) {
@@ -522,10 +559,10 @@ TEST_F(DecoderEncoderTest, DecoderPosition) {
 }
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
-TEST_F(DecoderEncoderTest, EncoderPosition) {
+TYPED_TEST(DecoderEncoderTest, EncoderPosition) {
   {
-    memgraph::storage::durability::Encoder encoder;
-    encoder.Initialize(storage_file, kTestMagic, kTestVersion);
+    memgraph::storage::durability::Encoder<TypeParam> encoder;
+    encoder.Initialize(this->storage_file, kTestMagic, kTestVersion);
     encoder.WriteBool(false);
     encoder.SetPosition(kTestMagic.size() + sizeof(kTestVersion));
     ASSERT_EQ(encoder.GetPosition(), kTestMagic.size() + sizeof(kTestVersion));
@@ -534,7 +571,7 @@ TEST_F(DecoderEncoderTest, EncoderPosition) {
   }
   {
     memgraph::storage::durability::Decoder decoder;
-    auto version = decoder.Initialize(storage_file, kTestMagic);
+    auto version = decoder.Initialize(this->storage_file, kTestMagic);
     ASSERT_TRUE(version);
     ASSERT_EQ(*version, kTestVersion);
     auto decoded = decoder.ReadBool();

--- a/tests/unit/storage_v2_durability_inmemory.cpp
+++ b/tests/unit/storage_v2_durability_inmemory.cpp
@@ -1482,7 +1482,7 @@ TEST_P(DurabilityTest, SnapshotRetention) {
       acc->CreateVertex();
     }
     ASSERT_FALSE(acc->Commit().HasError());
-  }
+  }  // Snapshot made on exit
 
   ASSERT_GE(GetSnapshotsList().size(), 1);
   ASSERT_EQ(GetBackupSnapshotsList().size(), 0);
@@ -1508,7 +1508,7 @@ TEST_P(DurabilityTest, SnapshotRetention) {
     CreateBaseDataset(db.storage(), GetParam());
     // Allow approximately 3 snapshots to be created.
     std::this_thread::sleep_for(std::chrono::milliseconds(6000));
-  }
+  }  // Periodic snapshot was made ~3 times, retention we only kept 1
 
   ASSERT_EQ(GetSnapshotsList().size(), 1 + 1);
   ASSERT_EQ(GetBackupSnapshotsList().size(), 0);

--- a/tests/unit/storage_v2_replication.cpp
+++ b/tests/unit/storage_v2_replication.cpp
@@ -1238,7 +1238,7 @@ TEST_F(ReplicationTest, RecoverySteps) {
     create_vertex_and_commit();
     ASSERT_FALSE(in_mem->CreateSnapshot(memgraph::replication_coordination_glue::ReplicationRole::MAIN).HasError());
     const auto recovery_steps = GetRecoverySteps(0, &file_locker, in_mem).value();
-    ASSERT_EQ(recovery_steps.size(), 2);  // TODO: Gareth/Andreja/Andi is this fine?
+    ASSERT_EQ(recovery_steps.size(), 1);
     ASSERT_TRUE(std::holds_alternative<memgraph::storage::RecoverySnapshot>(recovery_steps[0]));
   }
 


### PR DESCRIPTION
Main work was to optimise the snapshot processing

Results:
10 million nodes + 10 million edges + 1 label property index
running `CREATE SNAPSHOT` in release mode
master:  avg 5.50 seconds
this PR:  avg 3.57 seconds

- Feature: Already running 
  - Don't block is a snapshot is already in progress 
- Feature: Snapshot unnecessary
  - If digest is identical to previous snapshot, avoid work  
- Optimise Snapshot
  - Early exit for vertices+edges processing, if object is new after the start of creating the snapshot
  - Hot code, sample snapshot_aborted less often, avoid cost of checking the current time
  - NonConcurrentOutputFile: No need for concurrent access to internal buffer, hence cheaper version of OutputFile without need for locks

Extra optimisations:
- Optimise AllVerticesIterable::Iterator
  - Common case: everything is visible
  - Avoid unnecessary writes to memory  
- Optimise ScopedProfile
  - Common case: not profiling, use optional to make it cheaper to ctr/dtr
- Optimise MemoryTracker
  - Inline the ++/-- of counter 
- Optimise OutputFile (impact WALs)
  - Fewer memory writes (use local variables) 
  - Better atomic load/store memory orders
  - Fewer lock+unlock
  - Cheaper lock, RWSpinLock
  - Better memory alignment, avoid false sharing
- Optimise In/OutEdges
  - Early exit if no edges
  - [[unlikely]] branch annotations 