### PR TITLE
Fix Jepsen release tests

### DIFF
--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -773,6 +773,11 @@ jobs:
       - name: Set Jepsen OS
         run: echo "OS=debian-12" >> $GITHUB_ENV
 
+      - name: Refresh Jepsen Cluster
+        run: |
+          cd tests/jepsen
+          ./run.sh cluster-refresh --nodes-no 6
+
       - name: Spin up mgbuild container
         run: |
           ./release/package/mgbuild.sh \
@@ -797,17 +802,59 @@ jobs:
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
-          copy --binary
+          copy --binary --dest-dir build
+  
+      - name: Copy libmemgraph_module_support.so
+        run: |
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN \
+          --os $OS \
+          --arch $ARCH \
+          copy --libs --dest-dir build/src/query
 
-      - name: Refresh Jepsen Cluster
+      - name: Run unit tests for Jepsen code
         run: |
           cd tests/jepsen
-          ./run.sh cluster-refresh
+          ./run.sh unit-tests --binary ../../build/memgraph
 
-      - name: Run Jepsen tests
+      - name: Run replication bank test
         run: |
           cd tests/jepsen
-          ./run.sh test-all-individually --binary ../../build/memgraph --ignore-run-stdout-logs --ignore-run-stderr-logs
+          ./run.sh test \
+          --binary ../../build/memgraph \
+          --run-args "--workload bank --nodes-config resources/replication-config.edn --time-limit 120 --concurrency 5" \
+          --ignore-run-stdout-logs \
+          --ignore-run-stderr-logs \
+          --nodes-no 5
+
+      - name: Run replication large test
+        run: |
+          cd tests/jepsen
+          ./run.sh test \
+          --binary ../../build/memgraph \
+          --run-args "--workload large --nodes-config resources/replication-config.edn --time-limit 60 --concurrency 5" \
+          --ignore-run-stdout-logs \
+          --ignore-run-stderr-logs \
+          --nodes-no 5
+
+      - name: Run HA bank test
+        run: |
+          cd tests/jepsen
+          ./run.sh test \
+          --binary ../../build/memgraph \
+          --run-args "--workload habank --nodes-config resources/sync_cluster.edn --time-limit 120 --concurrency 6" \
+          --ignore-run-stdout-logs \
+          --ignore-run-stderr-logs \
+          --nodes-no 6 \
+          --enterprise-license $MEMGRAPH_ENTERPRISE_LICENSE \
+          --organization-name $MEMGRAPH_ORGANIZATION_NAME
+
+      - name: Process Jepsen results
+        continue-on-error: true
+        if: always()
+        run: |
+          cd tests/jepsen
+          ./run.sh process-results
 
       - name: Save Jepsen report
         uses: actions/upload-artifact@v4

--- a/tests/jepsen/run.sh
+++ b/tests/jepsen/run.sh
@@ -31,7 +31,7 @@ PRINT_CONTEXT() {
 
 HELP_EXIT() {
     echo ""
-    echo "HELP: $0 help|cluster-up|cluster-refresh|cluster-nodes-cleanup|cluster-dealloc|test|test-all-individually|unit-tests|process-results [args]"
+    echo "HELP: $0 help|cluster-up|cluster-refresh|cluster-nodes-cleanup|cluster-dealloc|test|unit-tests|process-results [args]"
     echo ""
     echo "    test args --binary                 MEMGRAPH_BINARY_PATH"
     echo "              --ignore-run-stdout-logs Ignore lein run stdout logs."


### PR DESCRIPTION
Fixes missing test option by running the same tests used in the `diff_jepsen` workflow.



