### PR TITLE
Remove cost of vector in label+property index for non-composite indices [prototype]

### DIFF
--- a/src/storage/v2/indices/label_property_index.cpp
+++ b/src/storage/v2/indices/label_property_index.cpp
@@ -64,7 +64,7 @@ auto PropertiesPermutationHelper::Extract(PropertyStore const &properties) const
 }
 
 auto PropertiesPermutationHelper::ApplyPermutation(std::vector<PropertyValue> values) const
-    -> IndexOrderedPropertyValues {
+    -> std::vector<PropertyValue> {
   for (const auto &cycle : cycles_) {
     auto tmp = std::move(values[cycle.front()]);
     for (auto pos : std::span{cycle}.subspan<1>()) {
@@ -73,22 +73,23 @@ auto PropertiesPermutationHelper::ApplyPermutation(std::vector<PropertyValue> va
     values[cycle.front()] = std::move(tmp);
   }
 
-  return {std::move(values)};
+  return values;
 }
 
 auto PropertiesPermutationHelper::MatchesValue(PropertyId property_id, PropertyValue const &value,
-                                               IndexOrderedPropertyValues const &values) const
+                                               std::span<PropertyValue const> index_ordered_values) const
     -> std::optional<std::pair<std::ptrdiff_t, bool>> {
   auto it = std::ranges::find(sorted_properties_, property_id);
   if (it == sorted_properties_.end()) return std::nullopt;
 
   auto pos = std::distance(sorted_properties_.begin(), it);
-  return std::pair{pos, values.values_[position_lookup_[pos]] == value};
+  return std::pair{pos, index_ordered_values[position_lookup_[pos]] == value};
 }
 
 auto PropertiesPermutationHelper::MatchesValues(PropertyStore const &properties,
-                                                IndexOrderedPropertyValues const &values) const -> std::vector<bool> {
-  return properties.ArePropertiesEqual(sorted_properties_, values.values_, position_lookup_);
+                                                std::span<PropertyValue const> index_ordered_values) const
+    -> std::vector<bool> {
+  return properties.ArePropertiesEqual(sorted_properties_, index_ordered_values, position_lookup_);
 }
 
 size_t PropertyValueRange::hash() const noexcept {

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -28,15 +28,16 @@ namespace memgraph::storage {
 class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
  private:
   struct Entry {
-    IndexOrderedPropertyValues values;
+    using Values = std::variant<PropertyValue, std::vector<PropertyValue>>;
+    Values values;
     Vertex *vertex;
     uint64_t timestamp;
 
     friend auto operator<=>(Entry const &, Entry const &) = default;
     friend bool operator==(Entry const &, Entry const &) = default;
 
-    bool operator<(std::vector<PropertyValue> const &rhs) const;
-    bool operator==(std::vector<PropertyValue> const &rhs) const;
+    bool operator<(Entry::Values const &rhs) const;
+    bool operator==(Entry::Values const &rhs) const;
   };
 
  public:


### PR DESCRIPTION
This is a prototype for optimising in-memory label property indices. Since replacing the single `PropertyId` for a `vector<PropertyId>`, every index - even on a single ("non-composite") index - pays the cost of the vector. This vector adds the burden of an additional allocation and deallocation.

This is the first stage in replacing the index skiplist with a variant, which will (eventually) have alternatives for various fixed-sized arrays, as well as a catch-all `vector` implementations for any indexes which have
more than n properties (for some value of n).