### PR TITLE
Non blocking label property index creation

### DIFF
--- a/ADRs/004_concurrent_index_creation.md
+++ b/ADRs/004_concurrent_index_creation.md
@@ -1,0 +1,43 @@
+# Concurrent index creation ADR
+
+**Author**
+Gareth Lloyd (https://github.com/Ignition)
+
+**Status**
+ACCEPTED
+
+**Date**
+April 23, 2025
+
+**Problem**
+
+Currently, index creation is a unique access operation, meaning that:
+- Queries can not run concurrently while the index is being made
+- Allowing for a consistent index to be made
+- One complete other queries can run again using the new index in the plan
+
+**Criteria**
+
+- Allow index population (most expensive part), to happen concurrent with other queries
+- Allow read only queries to be uninterupted
+- Planning can only use indexes once populated
+
+**Decision**
+
+We will leverage new storage access locking mode of READ_ONLY. This will allow readers to continue
+uninterupted. Once the index is registered we downgrade the access to READ, allowing new writers.
+The skip list based indexes are concurrently safe datastructures where propable entries are
+inserted, MVCC is still required on scan to validated the index entry is correct to any given
+transcation. The idea is that new writers can insert new entries, while the index creation is
+populating for all entries consistent with its snapshot isolation. Once the index is populated,
+it can be made availible for the planner to use.
+
+Considerations:
+- Replica, would also be able to use READ_ONLY downgrade to READ. But replica has no writters
+  so this would be a perf win.
+- TTL, enable + disable modified multiple internal indices. Can only downgrade once, need to
+  take that into consideration.
+- Auto indexing, ATM done during commit. Hence data and metadata update within same txn. This
+  currently means that the replica changes the order and using UNIQUE access to make this work.
+  We will need to initially keep replica as UNIQUE, but full fix is to do auto-indexing in
+  separate txn.

--- a/ADRs/004_concurrent_index_creation.md
+++ b/ADRs/004_concurrent_index_creation.md
@@ -14,7 +14,7 @@ April 23, 2025
 Currently, index creation is a unique access operation, meaning that:
 - Queries can not run concurrently while the index is being made
 - Allowing for a consistent index to be made
-- One complete other queries can run again using the new index in the plan
+- Once complete other queries can run again using the new index in the plan
 
 **Criteria**
 
@@ -33,7 +33,7 @@ populating for all entries consistent with its snapshot isolation. Once the inde
 it can be made availible for the planner to use.
 
 Considerations:
-- Replica, would also be able to use READ_ONLY downgrade to READ. But replica has no writters
+- Replica, would also be able to use READ_ONLY downgrade to READ. But replica has no writers
   so this would be a perf win.
 - TTL, enable + disable modified multiple internal indices. Can only downgrade once, need to
   take that into consideration.

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -775,6 +775,8 @@ std::pair<uint64_t, uint32_t> InMemoryReplicationHandlers::ReadAndApplyDeltasSin
 
   constexpr auto kSharedAccess = storage::Storage::Accessor::Type::WRITE;
   constexpr auto kUniqueAccess = storage::Storage::Accessor::Type::UNIQUE;
+  // TODO: add when concurrent index creation can actually replicate using READ_ONLY
+  // constexpr auto kReadOnlyAccess = storage::Storage::Accessor::Type::READ_ONLY;
 
   std::optional<std::pair<uint64_t, storage::InMemoryStorage::ReplicationAccessor>> commit_timestamp_and_accessor;
   auto const get_replication_accessor = [storage, &commit_timestamp_and_accessor](
@@ -1058,6 +1060,7 @@ std::pair<uint64_t, uint32_t> InMemoryReplicationHandlers::ReadAndApplyDeltasSin
         [&](WalLabelIndexCreate const &data) {
           spdlog::trace("   Delta {}. Create label index on :{}", current_delta_idx, data.label);
           // Need to send the timestamp
+          // TODO: For now kUniqueAccess, when everything is ready kReadOnlyAccess
           auto *transaction = get_replication_accessor(delta_timestamp, kUniqueAccess);
           if (transaction->CreateIndex(storage->NameToLabel(data.label)).HasError())
             throw utils::BasicException("Failed to create label index on :{}.", data.label);
@@ -1065,6 +1068,7 @@ std::pair<uint64_t, uint32_t> InMemoryReplicationHandlers::ReadAndApplyDeltasSin
         [&](WalLabelIndexDrop const &data) {
           spdlog::trace("   Delta {}. Drop label index on :{}", current_delta_idx, data.label);
           auto *transaction = get_replication_accessor(delta_timestamp, kUniqueAccess);
+          // TODO: For now kUniqueAccess, when everything is ready kReadOnlyAccess
           if (transaction->DropIndex(storage->NameToLabel(data.label)).HasError())
             throw utils::BasicException("Failed to drop label index on :{}.", data.label);
         },
@@ -1090,6 +1094,7 @@ std::pair<uint64_t, uint32_t> InMemoryReplicationHandlers::ReadAndApplyDeltasSin
         [&](WalLabelPropertyIndexCreate const &data) {
           spdlog::trace("   Delta {}. Create label+property index on :{} ({})", current_delta_idx, data.label,
                         data.composite_property_paths);
+          // TODO: For now kUniqueAccess, when everything is ready kReadOnlyAccess
           auto *transaction = get_replication_accessor(delta_timestamp, kUniqueAccess);
           auto property_paths = data.composite_property_paths.convert(mapper);
           if (transaction->CreateIndex(storage->NameToLabel(data.label), std::move(property_paths)).HasError())
@@ -1100,6 +1105,7 @@ std::pair<uint64_t, uint32_t> InMemoryReplicationHandlers::ReadAndApplyDeltasSin
         [&](WalLabelPropertyIndexDrop const &data) {
           spdlog::trace("   Delta {}. Drop label+property index on :{} ({})", current_delta_idx, data.label,
                         data.composite_property_paths);
+          // TODO: For now kUniqueAccess, when everything is ready kReadOnlyAccess
           auto *transaction = get_replication_accessor(delta_timestamp, kUniqueAccess);
           auto property_paths = data.composite_property_paths.convert(mapper);
 

--- a/src/glue/query_user.cpp
+++ b/src/glue/query_user.cpp
@@ -56,4 +56,21 @@ std::string QueryUserOrRole::GetDefaultDB() const {
 }
 #endif
 
+QueryUserOrRole::QueryUserOrRole(auth::SynchedAuth *auth, auth::UserOrRole user_or_role)
+    : query::QueryUserOrRole{std::visit(
+                                 utils::Overloaded{[](const auto &user_or_role) { return user_or_role.username(); }},
+                                 user_or_role),
+                             std::visit(utils::Overloaded{[&](const auth::User &) -> std::optional<std::string> {
+                                                            return std::nullopt;
+                                                          },
+                                                          [&](const auth::Role &role) -> std::optional<std::string> {
+                                                            return role.rolename();
+                                                          }},
+                                        user_or_role)},
+      auth_{auth} {
+  std::visit(utils::Overloaded{[&](auth::User &&user) { user_.emplace(std::move(user)); },
+                               [&](auth::Role &&role) { role_.emplace(std::move(role)); }},
+             std::move(user_or_role));
+}
+
 }  // namespace memgraph::glue

--- a/src/glue/query_user.hpp
+++ b/src/glue/query_user.hpp
@@ -30,22 +30,7 @@ struct QueryUserOrRole : public query::QueryUserOrRole {
 
   explicit QueryUserOrRole(auth::SynchedAuth *auth) : query::QueryUserOrRole{std::nullopt, std::nullopt}, auth_{auth} {}
 
-  QueryUserOrRole(auth::SynchedAuth *auth, auth::UserOrRole user_or_role)
-      : query::QueryUserOrRole{std::visit(
-                                   utils::Overloaded{[](const auto &user_or_role) { return user_or_role.username(); }},
-                                   user_or_role),
-                               std::visit(utils::Overloaded{[&](const auth::User &) -> std::optional<std::string> {
-                                                              return std::nullopt;
-                                                            },
-                                                            [&](const auth::Role &role) -> std::optional<std::string> {
-                                                              return role.rolename();
-                                                            }},
-                                          user_or_role)},
-        auth_{auth} {
-    std::visit(utils::Overloaded{[&](auth::User &&user) { user_.emplace(std::move(user)); },
-                                 [&](auth::Role &&role) { role_.emplace(std::move(role)); }},
-               std::move(user_or_role));
-  }
+  QueryUserOrRole(auth::SynchedAuth *auth, auth::UserOrRole user_or_role);
 
   std::optional<auth::UserOrRole> GenAuthUserOrRole() const {
     if (user_) return {*user_};

--- a/src/query/CMakeLists.txt
+++ b/src/query/CMakeLists.txt
@@ -48,6 +48,7 @@ target_sources(mg-query
     plan/pretty_print.cpp
     plan/profile.cpp
     plan/read_write_type_checker.cpp
+    plan/used_index_checker.cpp
     plan/rewrite/index_lookup.cpp
     plan/rewrite/general.cpp
     plan/rewrite/range.cpp
@@ -98,6 +99,8 @@ target_sources(mg-query
     frontend/ast/query/pattern.hpp
     frontend/ast/query/pattern_comprehension.hpp
     frontend/ast/query/query.hpp
+    plan/used_index_checker.hpp
+    plan/read_write_type_checker.hpp
 )
 
 

--- a/src/query/cypher_query_interpreter.cpp
+++ b/src/query/cypher_query_interpreter.cpp
@@ -174,11 +174,12 @@ std::shared_ptr<PlanWrapper> CypherQueryToPlan(frontend::StrippedQuery const &st
       auto &plan = ptr->plan();
 
       auto checker = plan::UsedIndexChecker{};
-      // TODO: this const_cast is BAD
+      // G_Lloyd: I am so SORRY, const_cast is BAD, but I'm not fixing Visitable and HierarchicalLogicalOperatorVisitor
+      //          ATM to work with a const visitor. This maybe addressed when the planner is redone.
       const_cast<plan::LogicalOperator &>(plan).Accept(checker);
 
       // TODO: when we are not eagerly collecting all indexes at CreateTransaction we want to Gather rather than Check
-      auto all_satisfied = db_accessor->CheckActiveIndices(checker.required_indices_);
+      auto all_satisfied = db_accessor->CheckIndicesAreReady(checker.required_indices_);
       if (all_satisfied) {
         return ptr;
       } else {

--- a/src/query/cypher_query_interpreter.hpp
+++ b/src/query/cypher_query_interpreter.hpp
@@ -66,7 +66,7 @@ class PlanWrapper {
  public:
   explicit PlanWrapper(std::unique_ptr<LogicalPlan> plan);
 
-  const auto &plan() const { return plan_->GetRoot(); }
+  auto plan() const -> plan::LogicalOperator const & { return plan_->GetRoot(); }
   double cost() const { return plan_->GetCost(); }
   const auto &symbol_table() const { return plan_->GetSymbolTable(); }
   const auto &ast_storage() const { return plan_->GetAstStorage(); }

--- a/src/query/cypher_query_interpreter.hpp
+++ b/src/query/cypher_query_interpreter.hpp
@@ -76,14 +76,6 @@ class PlanWrapper {
   std::unique_ptr<LogicalPlan> plan_;
 };
 
-struct CachedPlanWrapper : PlanWrapper {
-  explicit CachedPlanWrapper(std::unique_ptr<LogicalPlan> plan, std::string stripped_query);
-  auto stripped_query() const -> std::string_view { return stripped_query_; }
-
- private:
-  std::string stripped_query_;  // used so we can identify hash collision
-};
-
 struct CachedQuery {
   AstStorage ast_storage;
   Query *query;
@@ -140,8 +132,8 @@ class SingleNodeLogicalPlan final : public LogicalPlan {
   plan::ReadWriteTypeChecker::RWType rw_type_;
 };
 
-using PlanCacheLRU = utils::Synchronized<utils::LRUCache<uint64_t, std::shared_ptr<query::CachedPlanWrapper>>,
-                                         utils::RWSpinLock>;  // TODO: check RW
+using PlanCacheLRU = utils::Synchronized<utils::LRUCache<frontend::HashedString, std::shared_ptr<query::PlanWrapper>>,
+                                         utils::RWSpinLock>;
 
 std::unique_ptr<LogicalPlan> MakeLogicalPlan(AstStorage ast_storage, CypherQuery *query, const Parameters &parameters,
                                              DbAccessor *db_accessor,

--- a/src/query/cypher_query_interpreter.hpp
+++ b/src/query/cypher_query_interpreter.hpp
@@ -132,8 +132,8 @@ class SingleNodeLogicalPlan final : public LogicalPlan {
   plan::ReadWriteTypeChecker::RWType rw_type_;
 };
 
-using PlanCacheLRU =
-    utils::Synchronized<utils::LRUCache<uint64_t, std::shared_ptr<query::PlanWrapper>>, utils::RWSpinLock>;
+using PlanCacheLRU = utils::Synchronized<utils::LRUCache<uint64_t, std::shared_ptr<query::PlanWrapper>>,
+                                         utils::RWSpinLock>;  // TODO: check RW
 
 std::unique_ptr<LogicalPlan> MakeLogicalPlan(AstStorage ast_storage, CypherQuery *query, const Parameters &parameters,
                                              DbAccessor *db_accessor,

--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -631,14 +631,14 @@ class DbAccessor final {
   const std::string &id() const { return accessor_->id(); }
 
   utils::BasicResult<storage::StorageIndexDefinitionError, void> CreateIndex(
-      storage::LabelId label, storage::PublishIndexWrapper wraper = storage::no_wrap) {
-    return accessor_->CreateIndex(label, true, std::move(wraper));
+      storage::LabelId label, storage::PublishIndexWrapper wrapper = storage::publish_no_wrap) {
+    return accessor_->CreateIndex(label, true, std::move(wrapper));
   }
 
   utils::BasicResult<storage::StorageIndexDefinitionError, void> CreateIndex(
       storage::LabelId label, std::vector<storage::PropertyPath> &&properties,
-      storage::PublishIndexWrapper wraper = storage::no_wrap) {
-    return accessor_->CreateIndex(label, std::move(properties), std::move(wraper));
+      storage::PublishIndexWrapper wrapper = storage::publish_no_wrap) {
+    return accessor_->CreateIndex(label, std::move(properties), std::move(wrapper));
   }
 
   utils::BasicResult<storage::StorageIndexDefinitionError, void> CreateIndex(storage::EdgeTypeId edge_type) {
@@ -654,13 +654,15 @@ class DbAccessor final {
     return accessor_->CreateGlobalEdgeIndex(property);
   }
 
-  utils::BasicResult<storage::StorageIndexDefinitionError, void> DropIndex(storage::LabelId label) {
-    return accessor_->DropIndex(label);
+  utils::BasicResult<storage::StorageIndexDefinitionError, void> DropIndex(
+      storage::LabelId label, storage::DropIndexWrapper wrapper = storage::drop_no_wrap) {
+    return accessor_->DropIndex(label, std::move(wrapper));
   }
 
   utils::BasicResult<storage::StorageIndexDefinitionError, void> DropIndex(
-      storage::LabelId label, std::vector<storage::PropertyPath> &&properties) {
-    return accessor_->DropIndex(label, std::move(properties));
+      storage::LabelId label, std::vector<storage::PropertyPath> &&properties,
+      storage::DropIndexWrapper wrapper = storage::drop_no_wrap) {
+    return accessor_->DropIndex(label, std::move(properties), std::move(wrapper));
   }
 
   utils::BasicResult<storage::StorageIndexDefinitionError, void> DropIndex(storage::EdgeTypeId edge_type) {

--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -18,6 +18,7 @@
 #include "query/hops_limit.hpp"
 #include "query/typed_value.hpp"
 #include "query/vertex_accessor.hpp"
+#include "storage/v2/common_function_signatures.hpp"
 #include "storage/v2/constraints/type_constraints.hpp"
 #include "storage/v2/edge_accessor.hpp"
 #include "storage/v2/id_types.hpp"
@@ -629,13 +630,15 @@ class DbAccessor final {
 
   const std::string &id() const { return accessor_->id(); }
 
-  utils::BasicResult<storage::StorageIndexDefinitionError, void> CreateIndex(storage::LabelId label) {
-    return accessor_->CreateIndex(label);
+  utils::BasicResult<storage::StorageIndexDefinitionError, void> CreateIndex(
+      storage::LabelId label, storage::PublishIndexWrapper wraper = storage::no_wrap) {
+    return accessor_->CreateIndex(label, true, std::move(wraper));
   }
 
   utils::BasicResult<storage::StorageIndexDefinitionError, void> CreateIndex(
-      storage::LabelId label, std::vector<storage::PropertyPath> &&properties) {
-    return accessor_->CreateIndex(label, std::move(properties));
+      storage::LabelId label, std::vector<storage::PropertyPath> &&properties,
+      storage::PublishIndexWrapper wraper = storage::no_wrap) {
+    return accessor_->CreateIndex(label, std::move(properties), std::move(wraper));
   }
 
   utils::BasicResult<storage::StorageIndexDefinitionError, void> CreateIndex(storage::EdgeTypeId edge_type) {

--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -266,7 +266,7 @@ class DbAccessor final {
  public:
   explicit DbAccessor(storage::Storage::Accessor *accessor) : accessor_(accessor) {}
 
-  bool CheckIndicesAreReady(storage::IndicesCollection const &required_indices) {
+  bool CheckIndicesAreReady(storage::IndicesCollection const &required_indices) const {
     return accessor_->CheckIndicesAreReady(required_indices);
   }
 

--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -266,6 +266,10 @@ class DbAccessor final {
  public:
   explicit DbAccessor(storage::Storage::Accessor *accessor) : accessor_(accessor) {}
 
+  bool CheckActiveIndices(storage::IndicesCollection const &required_indices) {
+    return accessor_->CheckActiveIndices(required_indices);
+  }
+
   auto type() const { return accessor_->type(); }
 
   std::optional<VertexAccessor> FindVertex(storage::Gid gid, storage::View view) {

--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -266,8 +266,8 @@ class DbAccessor final {
  public:
   explicit DbAccessor(storage::Storage::Accessor *accessor) : accessor_(accessor) {}
 
-  bool CheckActiveIndices(storage::IndicesCollection const &required_indices) {
-    return accessor_->CheckActiveIndices(required_indices);
+  bool CheckIndicesAreReady(storage::IndicesCollection const &required_indices) {
+    return accessor_->CheckIndicesAreReady(required_indices);
   }
 
   auto type() const { return accessor_->type(); }
@@ -490,8 +490,8 @@ class DbAccessor final {
 
   bool LabelIndexExists(storage::LabelId label) const { return accessor_->LabelIndexExists(label); }
 
-  bool LabelPropertyIndexExists(storage::LabelId label, std::span<storage::PropertyPath const> properties) const {
-    return accessor_->LabelPropertyIndexExists(label, properties);
+  bool LabelPropertyIndexReady(storage::LabelId label, std::span<storage::PropertyPath const> properties) const {
+    return accessor_->LabelPropertyIndexReady(label, properties);
   }
 
   auto RelevantLabelPropertiesIndicesInfo(std::span<storage::LabelId const> labels,

--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -637,8 +637,9 @@ class DbAccessor final {
 
   utils::BasicResult<storage::StorageIndexDefinitionError, void> CreateIndex(
       storage::LabelId label, std::vector<storage::PropertyPath> &&properties,
+      storage::CheckCancelFunction cancel_check = storage::neverCancel,
       storage::PublishIndexWrapper wrapper = storage::publish_no_wrap) {
-    return accessor_->CreateIndex(label, std::move(properties), std::move(wrapper));
+    return accessor_->CreateIndex(label, std::move(properties), std::move(cancel_check), std::move(wrapper));
   }
 
   utils::BasicResult<storage::StorageIndexDefinitionError, void> CreateIndex(storage::EdgeTypeId edge_type) {

--- a/src/query/frontend/stripped.cpp
+++ b/src/query/frontend/stripped.cpp
@@ -168,8 +168,7 @@ StrippedQuery::StrippedQuery(std::string query) : original_(std::move(query)) {
     token_strings.push_back(std::move(unstripped_chunk));
   }
 
-  query_ = utils::Join(token_strings, " ");
-  hash_ = utils::Fnv(query_);
+  stripped_query_ = HashedString{utils::Join(token_strings, " ")};
 
   auto it = tokens.begin();
   while (it != tokens.end()) {

--- a/src/query/frontend/stripped.hpp
+++ b/src/query/frontend/stripped.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -56,7 +56,7 @@ class StrippedQuery {
   StrippedQuery(StrippedQuery &&other) = default;
   StrippedQuery &operator=(StrippedQuery &&other) = default;
 
-  const std::string &query() const { return query_; }
+  auto query() const -> std::string const & { return query_; }
   const auto &original_query() const { return original_; }
   const auto &literals() const { return literals_; }
   const auto &named_expressions() const { return named_exprs_; }

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3231,7 +3231,7 @@ struct DoNothing {
 };
 
 // Creating an index influences computed plan costs.
-// We need to atomically invcalidate the plan when publishing new index
+// We need to atomically invalidate the plan when publishing new index
 auto make_create_index_plan_invalidator_builder(memgraph::dbms::DatabaseAccess db_acc) {
   // capture DatabaseAccess in builder
   return [db_acc = std::move(db_acc)]<InvocableWithUInt64 Func = DoNothing>(Func && publish_func = Func{}) {

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -2610,7 +2610,7 @@ PreparedQuery PrepareCypherQuery(ParsedQuery parsed_query, std::map<std::string,
   const auto is_cacheable = parsed_query.is_cacheable;
   auto *plan_cache = is_cacheable ? current_db.db_acc_->get()->plan_cache() : nullptr;
 
-  auto plan = CypherQueryToPlan(parsed_query.stripped_query.hash(), std::move(parsed_query.ast_storage), cypher_query,
+  auto plan = CypherQueryToPlan(parsed_query.stripped_query, std::move(parsed_query.ast_storage), cypher_query,
                                 parsed_query.parameters, plan_cache, dba);
 
   auto hints = plan::ProvidePlanHints(&plan->plan(), plan->symbol_table());
@@ -2693,8 +2693,8 @@ PreparedQuery PrepareExplainQuery(ParsedQuery parsed_query, std::map<std::string
   auto *plan_cache = parsed_inner_query.is_cacheable ? current_db.db_acc_->get()->plan_cache() : nullptr;
 
   auto cypher_query_plan =
-      CypherQueryToPlan(parsed_inner_query.stripped_query.hash(), std::move(parsed_inner_query.ast_storage),
-                        cypher_query, parsed_inner_query.parameters, plan_cache, dba);
+      CypherQueryToPlan(parsed_inner_query.stripped_query, std::move(parsed_inner_query.ast_storage), cypher_query,
+                        parsed_inner_query.parameters, plan_cache, dba);
 
   auto hints = plan::ProvidePlanHints(&cypher_query_plan->plan(), cypher_query_plan->symbol_table());
   for (const auto &hint : hints) {
@@ -2780,8 +2780,8 @@ PreparedQuery PrepareProfileQuery(ParsedQuery parsed_query, bool in_explicit_tra
 
   auto *plan_cache = parsed_inner_query.is_cacheable ? current_db.db_acc_->get()->plan_cache() : nullptr;
   auto cypher_query_plan =
-      CypherQueryToPlan(parsed_inner_query.stripped_query.hash(), std::move(parsed_inner_query.ast_storage),
-                        cypher_query, parsed_inner_query.parameters, plan_cache, dba);
+      CypherQueryToPlan(parsed_inner_query.stripped_query, std::move(parsed_inner_query.ast_storage), cypher_query,
+                        parsed_inner_query.parameters, plan_cache, dba);
   TryCaching(cypher_query_plan->ast_storage(), frame_change_collector);
 
   auto hints = plan::ProvidePlanHints(&cypher_query_plan->plan(), cypher_query_plan->symbol_table());

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -2671,8 +2671,9 @@ PreparedQuery PrepareExplainQuery(ParsedQuery parsed_query, std::map<std::string
                                   std::vector<Notification> *notifications, InterpreterContext *interpreter_context,
                                   Interpreter &interpreter, CurrentDB &current_db) {
   const std::string kExplainQueryStart = "explain ";
-  MG_ASSERT(utils::StartsWith(utils::ToLowerCase(parsed_query.stripped_query.query()), kExplainQueryStart),
-            "Expected stripped query to start with '{}'", kExplainQueryStart);
+  MG_ASSERT(
+      utils::StartsWith(utils::ToLowerCase(parsed_query.stripped_query.stripped_query().str()), kExplainQueryStart),
+      "Expected stripped query to start with '{}'", kExplainQueryStart);
 
   // Parse and cache the inner query separately (as if it was a standalone
   // query), producing a fresh AST. Note that currently we cannot just reuse
@@ -2731,8 +2732,9 @@ PreparedQuery PrepareProfileQuery(ParsedQuery parsed_query, bool in_explicit_tra
                                   FrameChangeCollector *frame_change_collector) {
   const std::string kProfileQueryStart = "profile ";
 
-  MG_ASSERT(utils::StartsWith(utils::ToLowerCase(parsed_query.stripped_query.query()), kProfileQueryStart),
-            "Expected stripped query to start with '{}'", kProfileQueryStart);
+  MG_ASSERT(
+      utils::StartsWith(utils::ToLowerCase(parsed_query.stripped_query.stripped_query().str()), kProfileQueryStart),
+      "Expected stripped query to start with '{}'", kProfileQueryStart);
 
   // PROFILE isn't allowed inside multi-command (explicit) transactions. This is
   // because PROFILE executes each PROFILE'd query and collects additional

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -357,9 +357,16 @@ uint64_t ComputeProfilingKey(const T *obj) {
   return reinterpret_cast<uint64_t>(obj);
 }
 
+// Checking abort is a cheap check but is still doing atomic
+// reads. Reducing the frequency of those reads will reduce their
+// impact on performance for the expected (non-abort) case.
+thread_local auto maybe_check_abort = utils::ResettableCounter{20};
+
 inline void AbortCheck(ExecutionContext const &context) {
-  if (!context.maybe_check_abort_()) return;
-  if (auto const reason = MustAbort(context); reason != AbortReason::NO_ABORT) throw HintedAbortError(reason);
+  if (!maybe_check_abort()) return;
+
+  if (auto const reason = context.stopping_context.MustAbort(); reason != AbortReason::NO_ABORT)
+    throw HintedAbortError(reason);
 }
 
 std::vector<storage::LabelId> EvaluateLabels(const std::vector<StorageLabelType> &labels,

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -72,7 +72,7 @@ struct IndexHints {
             index_hint.property_ixs_ | ranges::views::transform(property_path_converter(db)) | ranges::to_vector;
 
         // Fetching the corresponding index to the hint
-        if (!db->LabelPropertyIndexExists(db->NameToLabel(label_name), properties)) {
+        if (!db->LabelPropertyIndexReady(db->NameToLabel(label_name), properties)) {
           auto property_names = index_hint.property_ixs_ |
                                 ranges::views::transform([&](auto &&path) { return fmt::format("{}", path); }) |
                                 ranges::views::join(", ") | ranges::to<std::string>;

--- a/src/query/plan/used_index_checker.cpp
+++ b/src/query/plan/used_index_checker.cpp
@@ -1,0 +1,130 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "query/plan/used_index_checker.hpp"
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define PRE_VISIT(TOp) \
+  bool UsedIndexChecker::PreVisit(TOp &) { return true; }
+
+namespace memgraph::query::plan {
+
+PRE_VISIT(CreateNode)
+PRE_VISIT(CreateExpand)
+PRE_VISIT(Delete)
+
+PRE_VISIT(SetProperty)
+PRE_VISIT(SetProperties)
+PRE_VISIT(SetLabels)
+
+PRE_VISIT(RemoveProperty)
+PRE_VISIT(RemoveLabels)
+
+PRE_VISIT(ScanAll)
+bool UsedIndexChecker::PreVisit(ScanAllByLabel &op) {
+  required_indices_.label_.emplace_back(op.label_);
+  return true;
+}
+bool UsedIndexChecker::PreVisit(ScanAllByLabelProperties &op) {
+  required_indices_.label_properties_.emplace_back(op.label_, op.properties_);
+  return true;
+}
+PRE_VISIT(ScanAllById)
+
+PRE_VISIT(ScanAllByEdge)                   // TODO: gather for concurrent index check
+PRE_VISIT(ScanAllByEdgeType)               // TODO: gather for concurrent index check
+PRE_VISIT(ScanAllByEdgeTypeProperty)       // TODO: gather for concurrent index check
+PRE_VISIT(ScanAllByEdgeTypePropertyValue)  // TODO: gather for concurrent index check
+PRE_VISIT(ScanAllByEdgeTypePropertyRange)  // TODO: gather for concurrent index check
+PRE_VISIT(ScanAllByEdgeProperty)           // TODO: gather for concurrent index check
+PRE_VISIT(ScanAllByEdgePropertyValue)      // TODO: gather for concurrent index check
+PRE_VISIT(ScanAllByEdgePropertyRange)      // TODO: gather for concurrent index check
+PRE_VISIT(ScanAllByEdgeId)
+
+PRE_VISIT(Expand)
+PRE_VISIT(ExpandVariable)
+
+PRE_VISIT(ConstructNamedPath)
+
+PRE_VISIT(Filter)
+PRE_VISIT(EdgeUniquenessFilter)
+
+PRE_VISIT(Merge)
+PRE_VISIT(Optional)
+
+bool UsedIndexChecker::PreVisit(Cartesian &op) {
+  op.left_op_->Accept(*this);
+  op.right_op_->Accept(*this);
+  return true;
+}
+
+PRE_VISIT(EmptyResult)
+PRE_VISIT(Produce)
+PRE_VISIT(Accumulate)
+PRE_VISIT(Aggregate)
+PRE_VISIT(Skip)
+PRE_VISIT(Limit)
+PRE_VISIT(OrderBy)
+PRE_VISIT(Distinct)
+PRE_VISIT(PeriodicCommit)
+
+bool UsedIndexChecker::PreVisit(Union &op) {
+  op.left_op_->Accept(*this);
+  op.right_op_->Accept(*this);
+  return true;
+}
+
+PRE_VISIT(Unwind)
+
+bool UsedIndexChecker::PreVisit(CallProcedure &op) {
+  if (op.is_write_) {
+    return true;
+  }
+  return true;
+}
+
+bool UsedIndexChecker::PreVisit([[maybe_unused]] Foreach &op) { return true; }
+
+bool UsedIndexChecker::PreVisit(Apply &op) {
+  op.input_->Accept(*this);
+  op.subquery_->Accept(*this);
+  return true;
+}
+
+bool UsedIndexChecker::PreVisit(IndexedJoin &op) {
+  op.main_branch_->Accept(*this);
+  op.sub_branch_->Accept(*this);
+  return true;
+}
+
+bool UsedIndexChecker::PreVisit(HashJoin &op) {
+  op.left_op_->Accept(*this);
+  op.right_op_->Accept(*this);
+  return true;
+}
+
+bool UsedIndexChecker::PreVisit(PeriodicSubquery &op) {
+  op.input_->Accept(*this);
+  op.subquery_->Accept(*this);
+  return true;
+}
+
+bool UsedIndexChecker::PreVisit(RollUpApply &op) {
+  op.input_->Accept(*this);
+  op.list_collection_branch_->Accept(*this);
+  return true;
+}
+
+#undef PRE_VISIT
+
+bool UsedIndexChecker::Visit(Once &) { return true; }  // NOLINT(hicpp-named-parameter)
+
+}  // namespace memgraph::query::plan

--- a/src/query/plan/used_index_checker.hpp
+++ b/src/query/plan/used_index_checker.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "query/plan/operator.hpp"
+#include "storage/v2/indices/active_indices.hpp"
 
 namespace memgraph::query::plan {
 

--- a/src/query/plan/used_index_checker.hpp
+++ b/src/query/plan/used_index_checker.hpp
@@ -1,0 +1,94 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include "query/plan/operator.hpp"
+
+namespace memgraph::query::plan {
+
+struct UsedIndexChecker : public virtual HierarchicalLogicalOperatorVisitor {
+  UsedIndexChecker() = default;
+
+  UsedIndexChecker(const UsedIndexChecker &) = delete;
+  UsedIndexChecker(UsedIndexChecker &&) = delete;
+
+  UsedIndexChecker &operator=(const UsedIndexChecker &) = delete;
+  UsedIndexChecker &operator=(UsedIndexChecker &&) = delete;
+
+  using HierarchicalLogicalOperatorVisitor::PostVisit;
+  using HierarchicalLogicalOperatorVisitor::PreVisit;
+  using HierarchicalLogicalOperatorVisitor::Visit;
+
+  bool PreVisit(CreateNode &) override;
+  bool PreVisit(CreateExpand &) override;
+  bool PreVisit(Delete &) override;
+
+  bool PreVisit(SetProperty &) override;
+  bool PreVisit(SetProperties &) override;
+  bool PreVisit(SetLabels &) override;
+
+  bool PreVisit(RemoveProperty &) override;
+  bool PreVisit(RemoveLabels &) override;
+
+  bool PreVisit(ScanAll &) override;
+  bool PreVisit(ScanAllByLabel &) override;
+  bool PreVisit(ScanAllByLabelProperties &) override;
+  bool PreVisit(ScanAllById &) override;
+
+  bool PreVisit(ScanAllByEdge &) override;
+  bool PreVisit(ScanAllByEdgeType &) override;
+  bool PreVisit(ScanAllByEdgeTypeProperty &) override;
+  bool PreVisit(ScanAllByEdgeTypePropertyValue &) override;
+  bool PreVisit(ScanAllByEdgeTypePropertyRange &) override;
+  bool PreVisit(ScanAllByEdgeProperty &) override;
+  bool PreVisit(ScanAllByEdgePropertyValue &) override;
+  bool PreVisit(ScanAllByEdgePropertyRange &) override;
+  bool PreVisit(ScanAllByEdgeId &) override;
+
+  bool PreVisit(Expand &) override;
+  bool PreVisit(ExpandVariable &) override;
+
+  bool PreVisit(ConstructNamedPath &) override;
+
+  bool PreVisit(Filter &) override;
+  bool PreVisit(EdgeUniquenessFilter &) override;
+
+  bool PreVisit(Merge &) override;
+  bool PreVisit(Optional &) override;
+  bool PreVisit(Cartesian &) override;
+
+  bool PreVisit(EmptyResult &) override;
+  bool PreVisit(Produce &) override;
+  bool PreVisit(Accumulate &) override;
+  bool PreVisit(Aggregate &) override;
+  bool PreVisit(Skip &) override;
+  bool PreVisit(Limit &) override;
+  bool PreVisit(OrderBy &) override;
+  bool PreVisit(Distinct &) override;
+  bool PreVisit(Union &) override;
+
+  bool PreVisit(Unwind &) override;
+  bool PreVisit(CallProcedure &) override;
+  bool PreVisit(Foreach &) override;
+
+  bool PreVisit(Apply &) override;
+  bool PreVisit(IndexedJoin &) override;
+  bool PreVisit(HashJoin &) override;
+  bool PreVisit(RollUpApply &) override;
+  bool PreVisit(PeriodicSubquery &) override;
+  bool PreVisit(PeriodicCommit &) override;
+
+  bool Visit(Once &) override;
+
+  storage::IndicesCollection required_indices_;
+};
+}  // namespace memgraph::query::plan

--- a/src/query/plan/vertex_count_cache.hpp
+++ b/src/query/plan/vertex_count_cache.hpp
@@ -137,8 +137,8 @@ class VertexCountCache {
 
   bool LabelIndexExists(storage::LabelId label) { return db_->LabelIndexExists(label); }
 
-  bool LabelPropertyIndexExists(storage::LabelId label, std::span<storage::PropertyPath const> properties) {
-    return db_->LabelPropertyIndexExists(label, properties);
+  bool LabelPropertyIndexReady(storage::LabelId label, std::span<storage::PropertyPath const> properties) {
+    return db_->LabelPropertyIndexReady(label, properties);
   }
 
   auto RelevantLabelPropertiesIndicesInfo(std::span<storage::LabelId const> labels,

--- a/src/query/procedure/mg_procedure_impl.cpp
+++ b/src/query/procedure/mg_procedure_impl.cpp
@@ -4208,8 +4208,8 @@ mgp_error mgp_proc_add_deprecated_result(mgp_proc *proc, const char *name, mgp_t
 
 int mgp_must_abort(mgp_graph *graph) {
   MG_ASSERT(graph->ctx);
-  static_assert(noexcept(memgraph::query::MustAbort(*graph->ctx)));
-  auto const reason = memgraph::query::MustAbort(*graph->ctx);
+  static_assert(noexcept(graph->ctx->stopping_context.MustAbort()));
+  auto const reason = graph->ctx->stopping_context.MustAbort();
   // NOTE: deliberately decoupled to avoid accidental ABI breaks
   switch (reason) {
     case memgraph::query::AbortReason::TERMINATED:

--- a/src/query/trigger.cpp
+++ b/src/query/trigger.cpp
@@ -210,9 +210,11 @@ void Trigger::Execute(DbAccessor *dba, DatabaseAccessProtector db_acc, utils::Me
   ctx.evaluation_context.parameters = parsed_statements_.parameters;
   ctx.evaluation_context.properties = NamesToProperties(plan.ast_storage().properties_, dba);
   ctx.evaluation_context.labels = NamesToLabels(plan.ast_storage().labels_, dba);
-  ctx.timer = (max_execution_time_sec > 0.0) ? std::make_shared<utils::AsyncTimer>(max_execution_time_sec) : nullptr;
-  ctx.is_shutting_down = is_shutting_down;
-  ctx.transaction_status = transaction_status;
+  ctx.stopping_context = {
+      .transaction_status = transaction_status,
+      .is_shutting_down = is_shutting_down,
+      .timer = (max_execution_time_sec > 0.0) ? std::make_shared<utils::AsyncTimer>(max_execution_time_sec) : nullptr,
+  };
   ctx.is_profile_query = false;
   ctx.evaluation_context.memory = execution_memory;
   ctx.db_acc = std::move(db_acc);

--- a/src/storage/v2/CMakeLists.txt
+++ b/src/storage/v2/CMakeLists.txt
@@ -27,7 +27,9 @@ target_sources(mg-storage-v2
         edge_accessor.cpp
         edges_iterable.cpp
         indices/indices.cpp
+        indices/label_index_stats.cpp
         indices/label_property_index.cpp
+        indices/label_property_index_stats.cpp
         indices/point_index.cpp
         indices/point_index_change_collector.cpp
         indices/text_index.cpp

--- a/src/storage/v2/CMakeLists.txt
+++ b/src/storage/v2/CMakeLists.txt
@@ -72,6 +72,7 @@ target_sources(mg-storage-v2
         indices/point_iterator.hpp
         indices/point_index_expensive_header.hpp
         indices/vector_index.hpp
+        indices/active_indices.hpp
         mvcc.hpp
         point.hpp
         point_functions.hpp

--- a/src/storage/v2/CMakeLists.txt
+++ b/src/storage/v2/CMakeLists.txt
@@ -64,35 +64,37 @@ target_sources(mg-storage-v2
         FILE_SET HEADERS
         BASE_DIRS ../../
         FILES
+        config.hpp
+        constraints/type_constraints.hpp
+        constraints/type_constraints_kind.hpp
+        constraints/type_constraints_validator.hpp
         delta_container.hpp
+        disk/storage.hpp
+        edge_ref.hpp
         enum.hpp
         enum_store.hpp
+        id_types.hpp
+        indices/active_indices.hpp
         indices/point_index.hpp
         indices/point_index_change_collector.hpp
-        indices/point_iterator.hpp
         indices/point_index_expensive_header.hpp
+        indices/point_iterator.hpp
         indices/vector_index.hpp
-        indices/active_indices.hpp
+        inmemory/indices_mvcc.hpp
+        inmemory/storage.hpp
         mvcc.hpp
         point.hpp
         point_functions.hpp
+        property_constants.hpp
         property_store.hpp
         property_value.hpp
+        property_value_utils.hpp
+        schema_info.hpp
+        storage.hpp
         transaction.hpp
-        constraints/type_constraints_kind.hpp
-        constraints/type_constraints.hpp
-        constraints/type_constraints_validator.hpp
+        transaction_constants.hpp
         vertex_info_cache.hpp
         vertex_info_cache_fwd.hpp
-        schema_info.hpp
-        edge_ref.hpp
-        id_types.hpp
-        property_value_utils.hpp
-        property_constants.hpp
-        storage.hpp
-        inmemory/storage.hpp
-        disk/storage.hpp
-        config.hpp
 )
 
 find_package(gflags REQUIRED)

--- a/src/storage/v2/common_function_signatures.hpp
+++ b/src/storage/v2/common_function_signatures.hpp
@@ -16,6 +16,9 @@
 
 namespace memgraph::storage {
 
+using CheckCancelFunction = std::function<bool()>;
+constexpr auto neverCancel = []() { return false; };
+
 using PublishIndexFunction = std::function<bool(uint64_t)>;
 using DropIndexFunction = std::function<bool()>;
 

--- a/src/storage/v2/common_function_signatures.hpp
+++ b/src/storage/v2/common_function_signatures.hpp
@@ -29,10 +29,10 @@ using PublishIndexWrapper = std::function<PublishIndexFunction(PublishIndexFunct
 using DropIndexWrapper = std::function<DropIndexFunction(DropIndexFunction)>;
 
 // default for when callback not provided
-constexpr auto publish_no_wrap = [](PublishIndexFunction &&func) {
-  return [=](uint64_t timestamp) { return func(timestamp); };
+constexpr auto publish_no_wrap = [](PublishIndexFunction func) {
+  return [func = std::move(func)](uint64_t timestamp) { return func(timestamp); };
 };
-constexpr auto drop_no_wrap = [](DropIndexFunction &&func) { return [=] { return func(); }; };
+constexpr auto drop_no_wrap = [](DropIndexFunction func) { return [func = std::move(func)] { return func(); }; };
 constexpr auto always_invalidate_plan_cache = []<typename... Args>(Args && ...) { return true; };
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/common_function_signatures.hpp
+++ b/src/storage/v2/common_function_signatures.hpp
@@ -1,0 +1,28 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+
+namespace memgraph::storage {
+
+using PublishIndexFunction = std::function<void(uint64_t)>;
+
+// Main purpose is the we need to invalidate plans at query level
+// the wrapper allows that to happen in storage level via a callback
+// which executed the index publish function while the plan cache is locked
+using PublishIndexWrapper = std::function<PublishIndexFunction(PublishIndexFunction)>;
+
+// default for when callback not provided
+constexpr auto no_wrap = [](auto &&func) { return [=](uint64_t timestamp) { return func(timestamp); }; };
+}  // namespace memgraph::storage

--- a/src/storage/v2/disk/edge_import_mode_cache.cpp
+++ b/src/storage/v2/disk/edge_import_mode_cache.cpp
@@ -50,11 +50,11 @@ bool EdgeImportModeCache::CreateIndex(
     const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info) {
   auto *mem_label_property_index =
       static_cast<InMemoryLabelPropertyIndex *>(in_memory_indices_.label_property_index_.get());
-  bool const res = mem_label_property_index->CreateIndex(label, {{property}}, vertices_.access(), parallel_exec_info);
-  if (res) {
-    scanned_label_properties_.insert({label, property});
-  }
-  return res;
+  bool const res =
+      mem_label_property_index->CreateIndexOnePass(label, {{property}}, vertices_.access(), parallel_exec_info);
+  if (!res) return false;
+  scanned_label_properties_.insert({label, property});
+  return true;
 }
 
 bool EdgeImportModeCache::CreateIndex(

--- a/src/storage/v2/disk/edge_import_mode_cache.cpp
+++ b/src/storage/v2/disk/edge_import_mode_cache.cpp
@@ -38,11 +38,11 @@ InMemoryLabelPropertyIndex::Iterable EdgeImportModeCache::Vertices(
     LabelId label, PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
     Transaction *transaction) const {
-  auto *mem_label_property_index =
-      static_cast<InMemoryLabelPropertyIndex *>(in_memory_indices_.label_property_index_.get());
-  return mem_label_property_index->Vertices(label, std::array{PropertyPath{property}},
-                                            std::array{PropertyValueRange::Bounded(lower_bound, upper_bound)},
-                                            vertices_.access(), view, storage, transaction);
+  auto index = in_memory_indices_.label_property_index_->GetActiveIndices();
+  return static_cast<InMemoryLabelPropertyIndex::ActiveIndices *>(index.get())
+      ->Vertices(label, std::array{PropertyPath{property}},
+                 std::array{PropertyValueRange::Bounded(lower_bound, upper_bound)}, vertices_.access(), view, storage,
+                 transaction);
 }
 
 bool EdgeImportModeCache::CreateIndex(

--- a/src/storage/v2/disk/label_property_index.cpp
+++ b/src/storage/v2/disk/label_property_index.cpp
@@ -175,7 +175,7 @@ bool DiskLabelPropertyIndex::ActiveIndices::IndexExists(LabelId label, std::span
   return utils::Contains(index_, LabelProperty{label, properties[0][0]});
 }
 
-auto DiskLabelPropertyIndex::ActiveIndices::ListIndices() const
+auto DiskLabelPropertyIndex::ActiveIndices::ListIndices(uint64_t start_timestamp) const
     -> std::vector<std::pair<LabelId, std::vector<PropertyPath>>> {
   auto const convert = [](auto &&index) -> std::pair<LabelId, std::vector<PropertyPath>> {
     auto [label, property] = index;

--- a/src/storage/v2/disk/label_property_index.cpp
+++ b/src/storage/v2/disk/label_property_index.cpp
@@ -171,7 +171,7 @@ bool DiskLabelPropertyIndex::DropIndex(LabelId label, std::vector<PropertyPath> 
   return index_.erase({label, properties[0][0]}) > 0U;
 }
 
-bool DiskLabelPropertyIndex::ActiveIndices::IndexExists(LabelId label, std::span<PropertyPath const> properties) const {
+bool DiskLabelPropertyIndex::ActiveIndices::IndexReady(LabelId label, std::span<PropertyPath const> properties) const {
   return utils::Contains(index_, LabelProperty{label, properties[0][0]});
 }
 
@@ -227,7 +227,7 @@ auto DiskLabelPropertyIndex::ActiveIndices::RelevantLabelPropertiesIndicesInfo(
   // NOTE: only looking for singular property index, as disk does not support composite indices
   for (auto &&[l_pos, label] : ranges::views::enumerate(labels)) {
     for (auto [p_pos, property] : ranges::views::enumerate(properties)) {
-      if (IndexExists(label, std::array{property})) {
+      if (IndexReady(label, std::array{property})) {
         // NOLINTNEXTLINE(google-runtime-int)
         res.emplace_back(l_pos, std::vector{static_cast<long>(p_pos)}, label, std::vector{property});
       }

--- a/src/storage/v2/disk/label_property_index.cpp
+++ b/src/storage/v2/disk/label_property_index.cpp
@@ -16,6 +16,7 @@
 #include "utils/disk_utils.hpp"
 #include "utils/exceptions.hpp"
 #include "utils/file.hpp"
+#include "utils/logging.hpp"
 #include "utils/rocksdb_serialization.hpp"
 
 namespace memgraph::storage {
@@ -27,8 +28,7 @@ bool IsVertexIndexedByLabelProperty(const Vertex &vertex, LabelId label, Propert
 }
 
 [[nodiscard]] bool ClearTransactionEntriesWithRemovedIndexingLabel(
-    rocksdb::Transaction &disk_transaction,
-    const std::map<Gid, std::vector<std::pair<LabelId, PropertyId>>> &transaction_entries) {
+    rocksdb::Transaction &disk_transaction, const DiskLabelPropertyIndex::EntriesForDeletion &transaction_entries) {
   for (const auto &[vertex_gid, index] : transaction_entries) {
     for (const auto &[indexing_label, indexing_property] : index) {
       if (auto status = disk_transaction.Delete(
@@ -127,8 +127,9 @@ bool DiskLabelPropertyIndex::ClearDeletedVertex(std::string_view gid, uint64_t t
 }
 
 bool DiskLabelPropertyIndex::DeleteVerticesWithRemovedIndexingLabel(uint64_t transaction_start_timestamp,
-                                                                    uint64_t transaction_commit_timestamp) {
-  if (entries_for_deletion->empty()) {
+                                                                    uint64_t transaction_commit_timestamp,
+                                                                    EntriesForDeletion const &entries_for_deletion) {
+  if (entries_for_deletion.empty()) {
     return true;
   }
   auto disk_transaction = CreateAllReadingRocksDBTransaction();
@@ -137,52 +138,32 @@ bool DiskLabelPropertyIndex::DeleteVerticesWithRemovedIndexingLabel(uint64_t tra
   std::string strTs = utils::StringTimestamp(std::numeric_limits<uint64_t>::max());
   rocksdb::Slice ts(strTs);
   ro.timestamp = &ts;
-  bool deletion_success = entries_for_deletion.WithLock(
-      [transaction_start_timestamp, disk_transaction_ptr = disk_transaction.get()](auto &tx_to_entries_for_deletion) {
-        if (auto tx_it = tx_to_entries_for_deletion.find(transaction_start_timestamp);
-            tx_it != tx_to_entries_for_deletion.end()) {
-          bool res = ClearTransactionEntriesWithRemovedIndexingLabel(*disk_transaction_ptr, tx_it->second);
-          tx_to_entries_for_deletion.erase(tx_it);
-          return res;
-        }
-        return true;
-      });
+  bool deletion_success = ClearTransactionEntriesWithRemovedIndexingLabel(*disk_transaction, entries_for_deletion);
   if (deletion_success) {
     return CommitWithTimestamp(disk_transaction.get(), transaction_commit_timestamp);
   }
   return false;
 }
 
-void DiskLabelPropertyIndex::UpdateOnAddLabel(LabelId added_label, Vertex *vertex_after_update, const Transaction &tx) {
-  entries_for_deletion.WithLock([added_label, vertex_after_update, &tx](auto &tx_to_entries_for_deletion) {
-    auto tx_it = tx_to_entries_for_deletion.find(tx.start_timestamp);
-    if (tx_it == tx_to_entries_for_deletion.end()) {
-      return;
-    }
-    auto vertex_label_index_it = tx_it->second.find(vertex_after_update->gid);
-    if (vertex_label_index_it == tx_it->second.end()) {
-      return;
-    }
-    std::erase_if(vertex_label_index_it->second,
-                  [added_label](const std::pair<LabelId, PropertyId> &index) { return index.first == added_label; });
-  });
+void DiskLabelPropertyIndex::ActiveIndices::UpdateOnAddLabel(LabelId added_label, Vertex *vertex_after_update,
+                                                             const Transaction &tx) {
+  auto vertex_label_index_it = entries_for_deletion_.find(vertex_after_update->gid);
+  if (vertex_label_index_it == entries_for_deletion_.end()) {
+    return;
+  }
+  std::erase_if(vertex_label_index_it->second,
+                [added_label](const LabelProperty &index) { return index.label == added_label; });
 }
 
-void DiskLabelPropertyIndex::UpdateOnRemoveLabel(LabelId removed_label, Vertex *vertex_after_update,
-                                                 const Transaction &tx) {
-  for (const auto &index_entry : index_) {
-    if (index_entry.first != removed_label) {
+void DiskLabelPropertyIndex::ActiveIndices::UpdateOnRemoveLabel(LabelId removed_label, Vertex *vertex_after_update,
+                                                                const Transaction &tx) {
+  for (const auto &entry : index_) {
+    if (entry.label != removed_label) {
       continue;
     }
-    entries_for_deletion.WithLock([&index_entry, &tx, vertex_after_update](auto &tx_to_entries_for_deletion) {
-      const auto &[indexing_label, indexing_property] = index_entry;
-      auto [it, _] = tx_to_entries_for_deletion.emplace(
-          std::piecewise_construct, std::forward_as_tuple(tx.start_timestamp), std::forward_as_tuple());
-      auto &vertex_map_store = it->second;
-      auto [it_vertex_map_store, emplaced] = vertex_map_store.emplace(
-          std::piecewise_construct, std::forward_as_tuple(vertex_after_update->gid), std::forward_as_tuple());
-      it_vertex_map_store->second.emplace_back(indexing_label, indexing_property);
-    });
+    auto [it_vertex_map_store, emplaced] = entries_for_deletion_.emplace(
+        std::piecewise_construct, std::forward_as_tuple(vertex_after_update->gid), std::forward_as_tuple());
+    it_vertex_map_store->second.emplace_back(entry);
   }
 }
 
@@ -190,11 +171,12 @@ bool DiskLabelPropertyIndex::DropIndex(LabelId label, std::vector<PropertyPath> 
   return index_.erase({label, properties[0][0]}) > 0U;
 }
 
-bool DiskLabelPropertyIndex::IndexExists(LabelId label, std::span<PropertyPath const> properties) const {
-  return utils::Contains(index_, std::make_pair(label, properties[0][0]));
+bool DiskLabelPropertyIndex::ActiveIndices::IndexExists(LabelId label, std::span<PropertyPath const> properties) const {
+  return utils::Contains(index_, LabelProperty{label, properties[0][0]});
 }
 
-std::vector<std::pair<LabelId, std::vector<PropertyPath>>> DiskLabelPropertyIndex::ListIndices() const {
+auto DiskLabelPropertyIndex::ActiveIndices::ListIndices() const
+    -> std::vector<std::pair<LabelId, std::vector<PropertyPath>>> {
   auto const convert = [](auto &&index) -> std::pair<LabelId, std::vector<PropertyPath>> {
     auto [label, property] = index;
     return {label, {PropertyPath{property}}};
@@ -203,18 +185,23 @@ std::vector<std::pair<LabelId, std::vector<PropertyPath>>> DiskLabelPropertyInde
   return index_ | ranges::views::transform(convert) | ranges::to_vector;
 }
 
-uint64_t DiskLabelPropertyIndex::ApproximateVertexCount(LabelId /*label*/,
-                                                        std::span<PropertyPath const> /*properties*/) const {
+auto DiskLabelPropertyIndex::ActiveIndices::ApproximateVertexCount(LabelId /*label*/,
+                                                                   std::span<PropertyPath const> /*properties*/) const
+    -> uint64_t {
   return 10;
 }
 
-uint64_t DiskLabelPropertyIndex::ApproximateVertexCount(LabelId /*label*/, std::span<PropertyPath const> /*properties*/,
-                                                        std::span<PropertyValue const> /*values*/) const {
+auto DiskLabelPropertyIndex::ActiveIndices::ApproximateVertexCount(LabelId /*label*/,
+                                                                   std::span<PropertyPath const> /*properties*/,
+                                                                   std::span<PropertyValue const> /*values*/) const
+    -> uint64_t {
   return 10;
 }
 
-uint64_t DiskLabelPropertyIndex::ApproximateVertexCount(LabelId label, std::span<PropertyPath const> /*properties*/,
-                                                        std::span<PropertyValueRange const> /*bounds*/) const {
+auto DiskLabelPropertyIndex::ActiveIndices::ApproximateVertexCount(LabelId label,
+                                                                   std::span<PropertyPath const> /*properties*/,
+                                                                   std::span<PropertyValueRange const> /*bounds*/) const
+    -> uint64_t {
   return 10;
 }
 
@@ -227,10 +214,15 @@ void DiskLabelPropertyIndex::LoadIndexInfo(const std::vector<std::string> &keys)
 
 RocksDBStorage *DiskLabelPropertyIndex::GetRocksDBStorage() const { return kvstore_.get(); }
 
-std::set<std::pair<LabelId, PropertyId>> DiskLabelPropertyIndex::GetInfo() const { return index_; }
+auto DiskLabelPropertyIndex::GetInfo() const -> std::set<DiskLabelPropertyIndex::LabelProperty> { return index_; }
 
-std::vector<LabelPropertiesIndicesInfo> DiskLabelPropertyIndex::RelevantLabelPropertiesIndicesInfo(
-    std::span<LabelId const> labels, std::span<PropertyPath const> properties) const {
+auto DiskLabelPropertyIndex::GetActiveIndices() const -> std::unique_ptr<LabelPropertyIndex::ActiveIndices> {
+  return std::make_unique<DiskLabelPropertyIndex::ActiveIndices>(index_);
+}
+
+auto DiskLabelPropertyIndex::ActiveIndices::RelevantLabelPropertiesIndicesInfo(
+    std::span<LabelId const> labels, std::span<PropertyPath const> properties) const
+    -> std::vector<LabelPropertiesIndicesInfo> {
   auto res = std::vector<LabelPropertiesIndicesInfo>{};
   // NOTE: only looking for singular property index, as disk does not support composite indices
   for (auto &&[l_pos, label] : ranges::views::enumerate(labels)) {
@@ -244,6 +236,9 @@ std::vector<LabelPropertiesIndicesInfo> DiskLabelPropertyIndex::RelevantLabelPro
   return res;
 }
 
-void DiskLabelPropertyIndex::AbortEntries(AbortableInfo const &info, uint64_t start_timestamp) {}
+void DiskLabelPropertyIndex::ActiveIndices::AbortEntries(AbortableInfo const &info, uint64_t start_timestamp) {}
+LabelPropertyIndex::AbortProcessor DiskLabelPropertyIndex::ActiveIndices::GetAbortProcessor() const {
+  return AbortProcessor();
+}
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/disk/label_property_index.hpp
+++ b/src/storage/v2/disk/label_property_index.hpp
@@ -39,7 +39,7 @@ class DiskLabelPropertyIndex : public storage::LabelPropertyIndex {
     void UpdateOnSetProperty(PropertyId property, const PropertyValue &value, Vertex *vertex,
                              const Transaction &tx) override{};
 
-    bool IndexExists(LabelId label, std::span<PropertyPath const> properties) const override;
+    bool IndexReady(LabelId label, std::span<PropertyPath const> properties) const override;
 
     auto RelevantLabelPropertiesIndicesInfo(std::span<LabelId const> labels,
                                             std::span<PropertyPath const> properties) const

--- a/src/storage/v2/disk/label_property_index.hpp
+++ b/src/storage/v2/disk/label_property_index.hpp
@@ -19,6 +19,50 @@ namespace memgraph::storage {
 
 class DiskLabelPropertyIndex : public storage::LabelPropertyIndex {
  public:
+  struct LabelProperty {
+    LabelId label;
+    PropertyId property;
+
+    LabelProperty(LabelId label, PropertyId property) : label(label), property(property) {}
+    friend auto operator<=>(LabelProperty const &, LabelProperty const &) = default;
+  };
+
+  using EntriesForDeletion = std::map<Gid, std::vector<LabelProperty>>;
+
+  struct ActiveIndices : LabelPropertyIndex::ActiveIndices {
+    explicit ActiveIndices(std::set<LabelProperty> index) : index_(std::move(index)) {}
+
+    void UpdateOnAddLabel(LabelId added_label, Vertex *vertex_after_update, const Transaction &tx) override;
+
+    void UpdateOnRemoveLabel(LabelId removed_label, Vertex *vertex_after_update, const Transaction &tx) override;
+
+    void UpdateOnSetProperty(PropertyId property, const PropertyValue &value, Vertex *vertex,
+                             const Transaction &tx) override{};
+
+    bool IndexExists(LabelId label, std::span<PropertyPath const> properties) const override;
+
+    auto RelevantLabelPropertiesIndicesInfo(std::span<LabelId const> labels,
+                                            std::span<PropertyPath const> properties) const
+        -> std::vector<LabelPropertiesIndicesInfo> override;
+
+    auto ListIndices() const -> std::vector<std::pair<LabelId, std::vector<PropertyPath>>> override;
+
+    auto ApproximateVertexCount(LabelId label, std::span<PropertyPath const> properties) const -> uint64_t override;
+
+    auto ApproximateVertexCount(LabelId label, std::span<PropertyPath const> properties,
+                                std::span<PropertyValue const> values) const -> uint64_t override;
+
+    auto ApproximateVertexCount(LabelId label, std::span<PropertyPath const> properties,
+                                std::span<PropertyValueRange const> bounds) const -> uint64_t override;
+
+    void AbortEntries(AbortableInfo const &info, uint64_t start_timestamp) override;
+
+    auto GetAbortProcessor() const -> AbortProcessor override;
+
+    std::set<LabelProperty> index_;
+    EntriesForDeletion entries_for_deletion_;
+  };
+
   explicit DiskLabelPropertyIndex(const Config &config);
 
   bool CreateIndex(LabelId label, PropertyId property,
@@ -33,47 +77,23 @@ class DiskLabelPropertyIndex : public storage::LabelPropertyIndex {
   [[nodiscard]] bool ClearDeletedVertex(std::string_view gid, uint64_t transaction_commit_timestamp) const;
 
   [[nodiscard]] bool DeleteVerticesWithRemovedIndexingLabel(uint64_t transaction_start_timestamp,
-                                                            uint64_t transaction_commit_timestamp);
-
-  void UpdateOnAddLabel(LabelId added_label, Vertex *vertex_after_update, const Transaction &tx) override;
-
-  void UpdateOnRemoveLabel(LabelId removed_label, Vertex *vertex_after_update, const Transaction &tx) override;
-
-  void UpdateOnSetProperty(PropertyId property, const PropertyValue &value, Vertex *vertex,
-                           const Transaction &tx) override{};
+                                                            uint64_t transaction_commit_timestamp,
+                                                            EntriesForDeletion const &entries_for_deletion);
 
   bool DropIndex(LabelId label, std::vector<PropertyPath> const &properties) override;
-
-  bool IndexExists(LabelId label, std::span<PropertyPath const> properties) const override;
-
-  auto RelevantLabelPropertiesIndicesInfo(std::span<LabelId const> labels,
-                                          std::span<PropertyPath const> properties) const
-      -> std::vector<LabelPropertiesIndicesInfo> override;
-
-  std::vector<std::pair<LabelId, std::vector<PropertyPath>>> ListIndices() const override;
-
-  uint64_t ApproximateVertexCount(LabelId label, std::span<PropertyPath const> properties) const override;
-
-  uint64_t ApproximateVertexCount(LabelId label, std::span<PropertyPath const> properties,
-                                  std::span<PropertyValue const> values) const override;
-
-  uint64_t ApproximateVertexCount(LabelId label, std::span<PropertyPath const> properties,
-                                  std::span<PropertyValueRange const> bounds) const override;
 
   RocksDBStorage *GetRocksDBStorage() const;
 
   void LoadIndexInfo(const std::vector<std::string> &keys);
 
-  std::set<std::pair<LabelId, PropertyId>> GetInfo() const;
+  auto GetInfo() const -> std::set<LabelProperty>;
 
   void DropGraphClearIndices() override{};
 
-  void AbortEntries(AbortableInfo const &info, uint64_t start_timestamp) override;
+  auto GetActiveIndices() const -> std::unique_ptr<LabelPropertyIndex::ActiveIndices> override;
 
  private:
-  utils::Synchronized<std::map<uint64_t, std::map<Gid, std::vector<std::pair<LabelId, PropertyId>>>>>
-      entries_for_deletion;
-  std::set<std::pair<LabelId, PropertyId>> index_;
+  std::set<LabelProperty> index_;
   std::unique_ptr<RocksDBStorage> kvstore_;
 };
 

--- a/src/storage/v2/disk/label_property_index.hpp
+++ b/src/storage/v2/disk/label_property_index.hpp
@@ -45,7 +45,8 @@ class DiskLabelPropertyIndex : public storage::LabelPropertyIndex {
                                             std::span<PropertyPath const> properties) const
         -> std::vector<LabelPropertiesIndicesInfo> override;
 
-    auto ListIndices() const -> std::vector<std::pair<LabelId, std::vector<PropertyPath>>> override;
+    auto ListIndices(uint64_t start_timestamp) const
+        -> std::vector<std::pair<LabelId, std::vector<PropertyPath>>> override;
 
     auto ApproximateVertexCount(LabelId label, std::span<PropertyPath const> properties) const -> uint64_t override;
 

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -2359,7 +2359,7 @@ IndicesInfo DiskStorage::DiskAccessor::ListAllIndices() const {
   auto *disk_label_index = static_cast<DiskLabelIndex *>(on_disk->indices_.label_index_.get());
   auto &text_index = storage_->indices_.text_index_;
   return {disk_label_index->ListIndices(),
-          transaction_.active_indices_.label_properties_->ListIndices(),
+          transaction_.active_indices_.label_properties_->ListIndices(transaction_.start_timestamp),
           {/* edge type indices */},
           {/* edge_type_property */},
           {/*edge property*/},

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -2053,7 +2053,7 @@ utils::BasicResult<StorageIndexDefinitionError, void> DiskStorage::DiskAccessor:
 }
 
 utils::BasicResult<StorageIndexDefinitionError, void> DiskStorage::DiskAccessor::CreateIndex(
-    LabelId label, std::vector<storage::PropertyPath> properties) {
+    LabelId label, PropertiesPaths properties) {
   MG_ASSERT(type() == UNIQUE, "Create index requires a unique access to the storage!");
 
   if (properties.size() != 1) {

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -2059,7 +2059,7 @@ utils::BasicResult<StorageIndexDefinitionError, void> DiskStorage::DiskAccessor:
 }
 
 utils::BasicResult<StorageIndexDefinitionError, void> DiskStorage::DiskAccessor::CreateIndex(
-    LabelId label, PropertiesPaths properties, PublishIndexWrapper wrapper) {
+    LabelId label, PropertiesPaths properties, CheckCancelFunction cancel_check, PublishIndexWrapper wrapper) {
   MG_ASSERT(type() == UNIQUE, "Create index requires a unique access to the storage!");
 
   if (properties.size() != 1) {

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -192,8 +192,7 @@ class DiskStorage final : public Storage {
     }
 
     bool LabelPropertyIndexExists(LabelId label, std::span<PropertyPath const> properties) const override {
-      auto *disk_storage = static_cast<DiskStorage *>(storage_);
-      return disk_storage->indices_.label_property_index_->IndexExists(label, properties);
+      return transaction_.active_indices_.label_properties_->IndexExists(label, properties);
     }
 
     bool EdgeTypeIndexExists(EdgeTypeId edge_type) const override;

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -191,8 +191,8 @@ class DiskStorage final : public Storage {
       return disk_storage->indices_.label_index_->IndexExists(label);
     }
 
-    bool LabelPropertyIndexExists(LabelId label, std::span<PropertyPath const> properties) const override {
-      return transaction_.active_indices_.label_properties_->IndexExists(label, properties);
+    bool LabelPropertyIndexReady(LabelId label, std::span<PropertyPath const> properties) const override {
+      return transaction_.active_indices_.label_properties_->IndexReady(label, properties);
     }
 
     bool EdgeTypeIndexExists(EdgeTypeId edge_type) const override;

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -221,11 +221,11 @@ class DiskStorage final : public Storage {
 
     void FinalizeTransaction() override;
 
-    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(LabelId label, bool unique_access_needed = true,
-                                                                      PublishIndexWrapper wrapper = no_wrap) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
+        LabelId label, bool unique_access_needed = true, PublishIndexWrapper wrapper = publish_no_wrap) override;
 
-    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(LabelId label, PropertiesPaths,
-                                                                      PublishIndexWrapper wrapper = no_wrap) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
+        LabelId label, PropertiesPaths, PublishIndexWrapper wrapper = publish_no_wrap) override;
 
     utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(EdgeTypeId edge_type,
                                                                       bool unique_access_needed = true) override;
@@ -235,10 +235,12 @@ class DiskStorage final : public Storage {
 
     utils::BasicResult<StorageIndexDefinitionError, void> CreateGlobalEdgeIndex(PropertyId property) override;
 
-    utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(LabelId label) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(LabelId label,
+                                                                    DropIndexWrapper wrapper = drop_no_wrap) override;
 
-    utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(
-        LabelId label, std::vector<storage::PropertyPath> &&properties) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(LabelId label,
+                                                                    std::vector<storage::PropertyPath> &&properties,
+                                                                    DropIndexWrapper wrapper = drop_no_wrap) override;
 
     utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(EdgeTypeId edge_type) override;
 

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -224,8 +224,8 @@ class DiskStorage final : public Storage {
     utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(LabelId label,
                                                                       bool unique_access_needed = true) override;
 
-    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
-        LabelId label, std::vector<storage::PropertyPath> properties) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(LabelId label,
+                                                                      PropertiesPaths properties) override;
 
     utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(EdgeTypeId edge_type,
                                                                       bool unique_access_needed = true) override;

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -225,7 +225,8 @@ class DiskStorage final : public Storage {
         LabelId label, bool unique_access_needed = true, PublishIndexWrapper wrapper = publish_no_wrap) override;
 
     utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
-        LabelId label, PropertiesPaths, PublishIndexWrapper wrapper = publish_no_wrap) override;
+        LabelId label, PropertiesPaths, CheckCancelFunction cancel_check = neverCancel,
+        PublishIndexWrapper wrapper = publish_no_wrap) override;
 
     utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(EdgeTypeId edge_type,
                                                                       bool unique_access_needed = true) override;

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -221,11 +221,11 @@ class DiskStorage final : public Storage {
 
     void FinalizeTransaction() override;
 
-    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(LabelId label,
-                                                                      bool unique_access_needed = true) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(LabelId label, bool unique_access_needed = true,
+                                                                      PublishIndexWrapper wrapper = no_wrap) override;
 
-    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(LabelId label,
-                                                                      PropertiesPaths properties) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(LabelId label, PropertiesPaths,
+                                                                      PublishIndexWrapper wrapper = no_wrap) override;
 
     utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(EdgeTypeId edge_type,
                                                                       bool unique_access_needed = true) override;

--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -239,8 +239,8 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
   {
     spdlog::info("Recreating {} label+property indices from metadata.", indices_metadata.label_properties.size());
     for (auto const &[label, properties] : indices_metadata.label_properties) {
-      if (!mem_label_property_index->CreateIndex(label, properties, vertices->access(), parallel_exec_info,
-                                                 snapshot_info))
+      if (!mem_label_property_index->CreateIndexOnePass(label, properties, vertices->access(), parallel_exec_info,
+                                                        snapshot_info))
         throw RecoveryFailure("The label+property index must be created here!");
       spdlog::info("Index on :{}({}) is recreated from metadata", name_id_mapper->IdToName(label.AsUint()),
                    PropertyPathFormatter{properties, name_id_mapper});

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -6243,8 +6243,7 @@ bool CreateSnapshot(Storage *storage, Transaction *transaction, const std::files
 
     // Write label+properties indices.
     {
-      // TODO: filter by committed
-      auto label_property = transaction->active_indices_.label_properties_->ListIndices();
+      auto label_property = transaction->active_indices_.label_properties_->ListIndices(transaction->start_timestamp);
       snapshot.WriteUint(label_property.size());
       for (const auto &[label, property_paths] : label_property) {
         write_mapping(label);
@@ -6265,8 +6264,8 @@ bool CreateSnapshot(Storage *storage, Transaction *transaction, const std::files
     {
       // NOTE: On-disk does not support snapshots
       auto *inmem_index = static_cast<InMemoryLabelPropertyIndex *>(storage->indices_.label_property_index_.get());
-      // TODO: filter by committed
-      auto label_property_path_pair = transaction->active_indices_.label_properties_->ListIndices();
+      auto label_property_path_pair =
+          transaction->active_indices_.label_properties_->ListIndices(transaction->start_timestamp);
       const auto size_pos = snapshot.GetPosition();
       snapshot.WriteUint(0);  // Just a place holder
       unsigned i = 0;

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -6243,7 +6243,8 @@ bool CreateSnapshot(Storage *storage, Transaction *transaction, const std::files
 
     // Write label+properties indices.
     {
-      auto label_property = storage->indices_.label_property_index_->ListIndices();
+      // TODO: filter by committed
+      auto label_property = transaction->active_indices_.label_properties_->ListIndices();
       snapshot.WriteUint(label_property.size());
       for (const auto &[label, property_paths] : label_property) {
         write_mapping(label);
@@ -6264,7 +6265,8 @@ bool CreateSnapshot(Storage *storage, Transaction *transaction, const std::files
     {
       // NOTE: On-disk does not support snapshots
       auto *inmem_index = static_cast<InMemoryLabelPropertyIndex *>(storage->indices_.label_property_index_.get());
-      auto label_property_path_pair = inmem_index->ListIndices();
+      // TODO: filter by committed
+      auto label_property_path_pair = transaction->active_indices_.label_properties_->ListIndices();
       const auto size_pos = snapshot.GetPosition();
       snapshot.WriteUint(0);  // Just a place holder
       unsigned i = 0;

--- a/src/storage/v2/indices/active_indices.hpp
+++ b/src/storage/v2/indices/active_indices.hpp
@@ -16,7 +16,27 @@
 #include <memory>
 
 namespace memgraph::storage {
+
+struct IndicesCollection {
+  std::vector<storage::LabelId> label_;
+  std::vector<std::pair<storage::LabelId, std::vector<storage::PropertyPath>>> label_properties_;
+};
+
 struct ActiveIndices {
+  bool CheckActiveIndices(IndicesCollection const &required_indices) {
+    // label
+    for ([[maybe_unused]] auto const &label : required_indices.label_) {
+      // TODO: when we have concurrent index creation for labels
+    }
+
+    // label + properties
+    for (auto const &[label, properties] : required_indices.label_properties_) {
+      if (!label_properties_->IndexExists(label, properties)) return false;
+    }
+
+    return true;
+  }
+
   std::unique_ptr<LabelPropertyIndex::ActiveIndices> label_properties_;
 };
 }  // namespace memgraph::storage

--- a/src/storage/v2/indices/active_indices.hpp
+++ b/src/storage/v2/indices/active_indices.hpp
@@ -1,0 +1,22 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include "storage/v2/indices/label_property_index.hpp"
+
+#include <memory>
+
+namespace memgraph::storage {
+struct ActiveIndices {
+  std::unique_ptr<LabelPropertyIndex::ActiveIndices> label_properties_;
+};
+}  // namespace memgraph::storage

--- a/src/storage/v2/indices/active_indices.hpp
+++ b/src/storage/v2/indices/active_indices.hpp
@@ -23,7 +23,7 @@ struct IndicesCollection {
 };
 
 struct ActiveIndices {
-  bool CheckActiveIndices(IndicesCollection const &required_indices) {
+  bool CheckIndicesAreReady(IndicesCollection const &required_indices) {
     // label
     for ([[maybe_unused]] auto const &label : required_indices.label_) {
       // TODO: when we have concurrent index creation for labels
@@ -31,7 +31,7 @@ struct ActiveIndices {
 
     // label + properties
     for (auto const &[label, properties] : required_indices.label_properties_) {
-      if (!label_properties_->IndexExists(label, properties)) return false;
+      if (!label_properties_->IndexReady(label, properties)) return false;
     }
 
     return true;

--- a/src/storage/v2/indices/active_indices.hpp
+++ b/src/storage/v2/indices/active_indices.hpp
@@ -23,7 +23,11 @@ struct IndicesCollection {
 };
 
 struct ActiveIndices {
-  bool CheckIndicesAreReady(IndicesCollection const &required_indices) {
+  ActiveIndices() = delete;  // to avoid nullptr
+  explicit ActiveIndices(std::unique_ptr<LabelPropertyIndex::ActiveIndices> label_properties)
+      : label_properties_{std::move(label_properties)} {}
+
+  bool CheckIndicesAreReady(IndicesCollection const &required_indices) const {
     // label
     for ([[maybe_unused]] auto const &label : required_indices.label_) {
       // TODO: when we have concurrent index creation for labels

--- a/src/storage/v2/indices/indices.cpp
+++ b/src/storage/v2/indices/indices.cpp
@@ -116,10 +116,10 @@ Indices::Indices(const Config &config, StorageMode storage_mode) : text_index_(c
 Indices::AbortProcessor Indices::GetAbortProcessor(ActiveIndices const &active_indices) const {
   return {static_cast<InMemoryLabelIndex *>(label_index_.get())->GetAbortProcessor(),
           active_indices.label_properties_->GetAbortProcessor(),
-          //          static_cast<InMemoryLabelPropertyIndex *>(label_property_index_.get())->GetAbortProcessor(),
           static_cast<InMemoryEdgeTypeIndex *>(edge_type_index_.get())->GetAbortProcessor(),
           static_cast<InMemoryEdgeTypePropertyIndex *>(edge_type_property_index_.get())->Analysis(),
-          static_cast<InMemoryEdgePropertyIndex *>(edge_property_index_.get())->Analysis(), vector_index_.Analysis()};
+          static_cast<InMemoryEdgePropertyIndex *>(edge_property_index_.get())->Analysis(),
+          vector_index_.Analysis()};
 }
 
 void Indices::AbortProcessor::CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex *from_vertex, Vertex *to_vertex,
@@ -128,18 +128,18 @@ void Indices::AbortProcessor::CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex 
 }
 
 void Indices::AbortProcessor::CollectOnLabelRemoval(LabelId labelId, Vertex *vertex) {
-  label_.collect_on_label_removal(labelId, vertex);
-  property_label_.collect_on_label_removal(labelId, vertex);
+  label_.CollectOnLabelRemoval(labelId, vertex);
+  property_label_.CollectOnLabelRemoval(labelId, vertex);
 }
 
 void Indices::AbortProcessor::CollectOnPropertyChange(PropertyId propId, Vertex *vertex) {
-  property_label_.collect_on_property_change(propId, vertex);
+  property_label_.CollectOnPropertyChange(propId, vertex);
 }
 
 void Indices::AbortProcessor::Process(Indices &indices, ActiveIndices &active_indices, uint64_t start_timestamp) {
-  label_.process(*indices.label_index_, start_timestamp);
+  label_.Process(*indices.label_index_, start_timestamp);
   active_indices.label_properties_->AbortEntries(property_label_.cleanup_collection, start_timestamp);
-  property_label_.process(*active_indices.label_properties_, start_timestamp);
+  property_label_.Process(*active_indices.label_properties_, start_timestamp);
   edge_type_.Process(*indices.edge_type_index_, start_timestamp);
 }
 }  // namespace memgraph::storage

--- a/src/storage/v2/indices/indices.hpp
+++ b/src/storage/v2/indices/indices.hpp
@@ -14,6 +14,7 @@
 #include <memory>
 #include <span>
 
+#include "storage/v2/indices/active_indices.hpp"
 #include "storage/v2/indices/edge_property_index.hpp"
 #include "storage/v2/indices/edge_type_index.hpp"
 #include "storage/v2/indices/edge_type_property_index.hpp"
@@ -67,10 +68,10 @@ struct Indices {
     void CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex *from_vertex, Vertex *to_vertex, Edge *edge);
     void CollectOnLabelRemoval(LabelId labelId, Vertex *vertex);
     void CollectOnPropertyChange(PropertyId propId, Vertex *vertex);
-    void Process(Indices &indices, uint64_t start_timestamp);
+    void Process(Indices &indices, ActiveIndices &active_indices, uint64_t start_timestamp);
   };
 
-  auto GetAbortProcessor() const -> AbortProcessor;
+  auto GetAbortProcessor(ActiveIndices const &active_indices) const -> AbortProcessor;
 
   // Indices are updated whenever an update occurs, instead of only on commit or
   // advance command. This is necessary because we want indices to support `NEW`

--- a/src/storage/v2/indices/indices_utils.hpp
+++ b/src/storage/v2/indices/indices_utils.hpp
@@ -277,10 +277,10 @@ inline void PopulateIndexOnSingleThread(utils::SkipList<Vertex>::Accessor &verti
 }
 
 template <typename TSkipListAccessorFactory, typename TFunc>
-inline void PopulateIndex(utils::SkipList<Vertex>::Accessor &vertices, TSkipListAccessorFactory &&accessor_factory,
-                          const TFunc &func,
-                          std::optional<durability::ParallelizedSchemaCreationInfo> const &parallel_exec_info,
-                          std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt) {
+inline void PopulateIndexDispatch(utils::SkipList<Vertex>::Accessor &vertices,
+                                  TSkipListAccessorFactory &&accessor_factory, const TFunc &func,
+                                  std::optional<durability::ParallelizedSchemaCreationInfo> const &parallel_exec_info,
+                                  std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt) {
   if (parallel_exec_info && parallel_exec_info->thread_count > 1) {
     PopulateIndexOnMultipleThreads(vertices, std::forward<TSkipListAccessorFactory>(accessor_factory), func,
                                    *parallel_exec_info, snapshot_info);

--- a/src/storage/v2/indices/label_index.hpp
+++ b/src/storage/v2/indices/label_index.hpp
@@ -48,12 +48,12 @@ class LabelIndex {
   struct AbortProcessor {
     explicit AbortProcessor(std::vector<LabelId> label) : label_(std::move(label)) {}
 
-    void collect_on_label_removal(LabelId label, Vertex *vertex) {
+    void CollectOnLabelRemoval(LabelId label, Vertex *vertex) {
       if (std::binary_search(label_.begin(), label_.end(), label)) {
         cleanup_collection_[label].emplace_back(vertex);
       }
     }
-    void process(LabelIndex &index, uint64_t start_timestamp) {
+    void Process(LabelIndex &index, uint64_t start_timestamp) {
       index.AbortEntries(cleanup_collection_, start_timestamp);
     }
 

--- a/src/storage/v2/indices/label_index_stats.cpp
+++ b/src/storage/v2/indices/label_index_stats.cpp
@@ -9,22 +9,20 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-#pragma once
+#include "storage/v2/indices/label_index_stats.hpp"
 
-#include <cstdint>
-#include <string>
+#include <fmt/core.h>
+#include "utils/simple_json.hpp"
 
 namespace memgraph::storage {
 
-struct LabelIndexStats {
-  uint64_t count;
-  double avg_degree;
-
-  auto operator<=>(const LabelIndexStats &) const = default;
-};
-
-std::string ToJson(const LabelIndexStats &in);
-
-bool FromJson(const std::string &json, LabelIndexStats &out);
-
+std::string ToJson(LabelIndexStats const &in) {
+  return fmt::format(R"({{"count":{}, "avg_degree":{}}})", in.count, in.avg_degree);
+}
+bool FromJson(std::string const &json, LabelIndexStats &out) {
+  bool res = true;
+  res &= utils::GetJsonValue(json, "count", out.count);
+  res &= utils::GetJsonValue(json, "avg_degree", out.avg_degree);
+  return res;
+}
 }  // namespace memgraph::storage

--- a/src/storage/v2/indices/label_property_index.cpp
+++ b/src/storage/v2/indices/label_property_index.cpp
@@ -113,4 +113,45 @@ size_t PropertyValueRange::hash() const noexcept {
   return seed;
 }
 
+void LabelPropertyIndex::AbortProcessor::process(LabelPropertyIndex::ActiveIndices &active_indices,
+                                                 uint64_t start_timestamp) {
+  active_indices.AbortEntries(cleanup_collection, start_timestamp);
+}
+
+void LabelPropertyIndex::AbortProcessor::collect_on_property_change(PropertyId propId, Vertex *vertex) {
+  const auto &it = p2l.find(propId);
+  if (it == p2l.end()) return;
+
+  for (auto const &[label, index_info] : it->second) {
+    if (!utils::Contains(vertex->labels, label)) continue;
+    for (auto const &[properties, helper] : index_info) {
+      auto current_values = helper->Extract(vertex->properties);
+      // Only if current_values has at least one non-null value do we need to cleanup its index entry
+      if (ranges::any_of(current_values, [](PropertyValue const &val) { return !val.IsNull(); })) {
+        cleanup_collection[label][properties].emplace_back(helper->ApplyPermutation(std::move(current_values)).values_,
+                                                           vertex);
+      }
+    }
+  }
+}
+
+void LabelPropertyIndex::AbortProcessor::collect_on_label_removal(LabelId label, Vertex *vertex) {
+  const auto &it = l2p.find(label);
+  if (it == l2p.end()) return;
+
+  auto dedup = std::set<IndexInfo>{};
+  for (const auto &[property, index_info] : it->second) {
+    for (auto const &info : index_info) {
+      dedup.insert(info);
+    }
+  }
+  for (auto const &[properties, helper] : dedup) {
+    auto current_values = helper->Extract(vertex->properties);
+    // Only if current_values has at least one non-null value do we need to cleanup its index entry
+    if (ranges::any_of(current_values, [](PropertyValue const &val) { return !val.IsNull(); })) {
+      cleanup_collection[label][properties].emplace_back(helper->ApplyPermutation(std::move(current_values)).values_,
+                                                         vertex);
+    }
+  }
+}
 }  // namespace memgraph::storage

--- a/src/storage/v2/indices/label_property_index.cpp
+++ b/src/storage/v2/indices/label_property_index.cpp
@@ -59,10 +59,25 @@ PropertiesPermutationHelper::PropertiesPermutationHelper(std::span<PropertyPath 
           [](auto const &value) -> decltype(auto) { return std::get<1>(value); });
   position_lookup_ = std::move(inverse_permutation);
   cycles_ = build_permutation_cycles(position_lookup_);
+  for (auto const &[pos, path] : ranges::views::enumerate(sorted_properties_)) {
+    auto const outer_prop_id = path[0];
+    grouped_by_outer_prop_id_[outer_prop_id].emplace_back(pos);
+  }
 }
 
 auto PropertiesPermutationHelper::Extract(PropertyStore const &properties) const -> std::vector<PropertyValue> {
   return properties.ExtractPropertyValuesMissingAsNull(sorted_properties_);
+}
+
+void PropertiesPermutationHelper::Update(PropertyId outer_prop_id, PropertyValue const &value,
+                                         std::vector<PropertyValue> &extracted_values) const {
+  auto it = grouped_by_outer_prop_id_.find(outer_prop_id);
+  if (it == grouped_by_outer_prop_id_.cend()) return;  // outer_prop_id is irrelevant to this index
+  auto const &sorted_positions = it->second;
+  for (auto const &pos : sorted_positions) {
+    auto const *nested_value = ReadNestedPropertyValue(value, sorted_properties_[pos] | rv::drop(1));
+    extracted_values[pos] = *nested_value;
+  }
 }
 
 auto PropertiesPermutationHelper::ApplyPermutation(std::vector<PropertyValue> values) const
@@ -79,7 +94,7 @@ auto PropertiesPermutationHelper::ApplyPermutation(std::vector<PropertyValue> va
 }
 
 auto PropertiesPermutationHelper::MatchesValue(PropertyId outer_prop_id, PropertyValue const &value,
-                                               IndexOrderedPropertyValues const &values) const
+                                               IndexOrderedPropertyValues const &cmp_values) const
     -> std::vector<std::pair<std::ptrdiff_t, bool>> {
   auto enum_properties = rv::enumerate(sorted_properties_);
   auto relevant_paths =
@@ -87,7 +102,7 @@ auto PropertiesPermutationHelper::MatchesValue(PropertyId outer_prop_id, Propert
 
   auto is_match = [&](auto &&el) -> std::pair<std::ptrdiff_t, bool> {
     auto &&[index, path] = el;
-    auto const &cmp_value = values.values_[position_lookup_[index]];
+    auto const &cmp_value = cmp_values.values_[position_lookup_[index]];
     // Outer property was already read to get `value`, strip that off of the path
     DMG_ASSERT(!path.empty(), "PropertyPath should be at least 1");
     auto const *nested_value = ReadNestedPropertyValue(value, path | rv::drop(1));

--- a/src/storage/v2/indices/label_property_index.cpp
+++ b/src/storage/v2/indices/label_property_index.cpp
@@ -128,12 +128,12 @@ size_t PropertyValueRange::hash() const noexcept {
   return seed;
 }
 
-void LabelPropertyIndex::AbortProcessor::process(LabelPropertyIndex::ActiveIndices &active_indices,
+void LabelPropertyIndex::AbortProcessor::Process(LabelPropertyIndex::ActiveIndices &active_indices,
                                                  uint64_t start_timestamp) {
   active_indices.AbortEntries(cleanup_collection, start_timestamp);
 }
 
-void LabelPropertyIndex::AbortProcessor::collect_on_property_change(PropertyId propId, Vertex *vertex) {
+void LabelPropertyIndex::AbortProcessor::CollectOnPropertyChange(PropertyId propId, Vertex *vertex) {
   const auto &it = p2l.find(propId);
   if (it == p2l.end()) return;
 
@@ -150,7 +150,7 @@ void LabelPropertyIndex::AbortProcessor::collect_on_property_change(PropertyId p
   }
 }
 
-void LabelPropertyIndex::AbortProcessor::collect_on_label_removal(LabelId label, Vertex *vertex) {
+void LabelPropertyIndex::AbortProcessor::CollectOnLabelRemoval(LabelId label, Vertex *vertex) {
   const auto &it = l2p.find(label);
   if (it == l2p.end()) return;
 

--- a/src/storage/v2/indices/label_property_index.hpp
+++ b/src/storage/v2/indices/label_property_index.hpp
@@ -211,7 +211,8 @@ class LabelPropertyIndex {
                                                     std::span<PropertyPath const> properties) const
         -> std::vector<LabelPropertiesIndicesInfo> = 0;
 
-    virtual auto ListIndices() const -> std::vector<std::pair<LabelId, std::vector<PropertyPath>>> = 0;
+    virtual auto ListIndices(uint64_t start_timestamp) const
+        -> std::vector<std::pair<LabelId, std::vector<PropertyPath>>> = 0;
 
     virtual auto ApproximateVertexCount(LabelId label, std::span<PropertyPath const> properties) const -> uint64_t = 0;
 

--- a/src/storage/v2/indices/label_property_index.hpp
+++ b/src/storage/v2/indices/label_property_index.hpp
@@ -205,7 +205,7 @@ class LabelPropertyIndex {
     virtual void UpdateOnSetProperty(PropertyId property, const PropertyValue &value, Vertex *vertex,
                                      const Transaction &tx) = 0;
 
-    virtual bool IndexExists(LabelId label, std::span<PropertyPath const> properties) const = 0;
+    virtual bool IndexReady(LabelId label, std::span<PropertyPath const> properties) const = 0;
 
     virtual auto RelevantLabelPropertiesIndicesInfo(std::span<LabelId const> labels,
                                                     std::span<PropertyPath const> properties) const

--- a/src/storage/v2/indices/label_property_index.hpp
+++ b/src/storage/v2/indices/label_property_index.hpp
@@ -187,9 +187,9 @@ class LabelPropertyIndex {
     std::map<LabelId, std::map<PropertyId, std::vector<IndexInfo>>> l2p;
     std::map<PropertyId, std::map<LabelId, std::vector<IndexInfo>>> p2l;
 
-    void collect_on_label_removal(LabelId label, Vertex *vertex);
-    void collect_on_property_change(PropertyId propId, Vertex *vertex);
-    void process(ActiveIndices &active_indices, uint64_t start_timestamp);
+    void CollectOnLabelRemoval(LabelId label, Vertex *vertex);
+    void CollectOnPropertyChange(PropertyId propId, Vertex *vertex);
+    void Process(ActiveIndices &active_indices, uint64_t start_timestamp);
 
     // collection
     AbortableInfo cleanup_collection;

--- a/src/storage/v2/indices/label_property_index.hpp
+++ b/src/storage/v2/indices/label_property_index.hpp
@@ -127,6 +127,13 @@ struct PropertiesPermutationHelper {
    */
   auto Extract(PropertyStore const &properties) const -> std::vector<PropertyValue>;
 
+  /**
+   * Inplace update the `extracted_values` with the current value if relevant
+   * - if outer_prop_id is relevant
+   * - updates all positions in `values` with the correctly extracted nested values from `extracted_values`
+   */
+  void Update(PropertyId outer_prop_id, PropertyValue const &value, std::vector<PropertyValue> &extracted_values) const;
+
   /** Compares the property with id `property_id` and value `value` against the
    * same property values in the `values` array. For every id in the index,
    * (which may occur multiple times for composite nested indices, such as `a.b`
@@ -135,7 +142,7 @@ struct PropertiesPermutationHelper {
    * property matches.
    */
   auto MatchesValue(PropertyId outer_prop_id, PropertyValue const &value,
-                    IndexOrderedPropertyValues const &values) const -> std::vector<std::pair<std::ptrdiff_t, bool>>;
+                    IndexOrderedPropertyValues const &cmp_values) const -> std::vector<std::pair<std::ptrdiff_t, bool>>;
 
   /** Efficiently compares multiple values in the property store with the given
    * values. This returns a vector of boolean flags indicating per-element
@@ -157,6 +164,7 @@ struct PropertiesPermutationHelper {
   std::vector<PropertyPath> sorted_properties_;
   std::vector<std::size_t> position_lookup_;
   permutation_cycles cycles_;
+  std::map<PropertyId, std::vector<std::size_t>> grouped_by_outer_prop_id_;
 };
 
 class LabelPropertyIndex {

--- a/src/storage/v2/indices/label_property_index_stats.cpp
+++ b/src/storage/v2/indices/label_property_index_stats.cpp
@@ -1,0 +1,35 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "storage/v2/indices/label_property_index_stats.hpp"
+
+#include <fmt/core.h>
+#include "utils/simple_json.hpp"
+
+namespace memgraph::storage {
+
+bool FromJson(std::string const &json, LabelPropertyIndexStats &out) {
+  bool res = true;
+  res &= utils::GetJsonValue(json, "count", out.count);
+  res &= utils::GetJsonValue(json, "distinct_values_count", out.distinct_values_count);
+  res &= utils::GetJsonValue(json, "statistic", out.statistic);
+  res &= utils::GetJsonValue(json, "avg_group_size", out.avg_group_size);
+  res &= utils::GetJsonValue(json, "avg_degree", out.avg_degree);
+  return res;
+}
+
+std::string ToJson(LabelPropertyIndexStats const &in) {
+  return fmt::format(
+      R"({{"count":{}, "distinct_values_count":{}, "statistic":{}, "avg_group_size":{} "avg_degree":{}}})", in.count,
+      in.distinct_values_count, in.statistic, in.avg_group_size, in.avg_degree);
+}
+
+}  // namespace memgraph::storage

--- a/src/storage/v2/indices/label_property_index_stats.hpp
+++ b/src/storage/v2/indices/label_property_index_stats.hpp
@@ -11,8 +11,8 @@
 
 #pragma once
 
-#include <fmt/core.h>
-#include "utils/simple_json.hpp"
+#include <cstdint>
+#include <string>
 
 namespace memgraph::storage {
 
@@ -23,20 +23,8 @@ struct LabelPropertyIndexStats {
   auto operator<=>(const LabelPropertyIndexStats &) const = default;
 };
 
-static inline std::string ToJson(const LabelPropertyIndexStats &in) {
-  return fmt::format(
-      R"({{"count":{}, "distinct_values_count":{}, "statistic":{}, "avg_group_size":{} "avg_degree":{}}})", in.count,
-      in.distinct_values_count, in.statistic, in.avg_group_size, in.avg_degree);
-}
+std::string ToJson(const LabelPropertyIndexStats &in);
 
-static inline bool FromJson(const std::string &json, LabelPropertyIndexStats &out) {
-  bool res = true;
-  res &= utils::GetJsonValue(json, "count", out.count);
-  res &= utils::GetJsonValue(json, "distinct_values_count", out.distinct_values_count);
-  res &= utils::GetJsonValue(json, "statistic", out.statistic);
-  res &= utils::GetJsonValue(json, "avg_group_size", out.avg_group_size);
-  res &= utils::GetJsonValue(json, "avg_degree", out.avg_degree);
-  return res;
-}
+bool FromJson(const std::string &json, LabelPropertyIndexStats &out);
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/inmemory/indices_mvcc.hpp
+++ b/src/storage/v2/inmemory/indices_mvcc.hpp
@@ -18,13 +18,11 @@
 namespace memgraph::storage {
 
 struct IndexStatus {
-  IndexStatus() = default;
+  bool IsPopulating() const { return commit_timestamp.load(std::memory_order_acquire) == kTransactionInitialId; }
+  bool IsReady() const { return !IsPopulating(); }
+  bool IsVisible(uint64_t timestamp) const { return commit_timestamp.load(std::memory_order_acquire) <= timestamp; }
 
-  bool is_populating() const { return commit_timestamp.load(std::memory_order_acquire) == kTransactionInitialId; }
-  bool is_ready() const { return !is_populating(); }
-  bool is_visible(uint64_t timestamp) const { return commit_timestamp.load(std::memory_order_acquire) <= timestamp; }
-
-  void commit(uint64_t timestamp) { commit_timestamp.store(timestamp, std::memory_order_release); }
+  void Commit(uint64_t timestamp) { commit_timestamp.store(timestamp, std::memory_order_release); }
 
  private:
   // kTransactionInitialId means popuating

--- a/src/storage/v2/inmemory/indices_mvcc.hpp
+++ b/src/storage/v2/inmemory/indices_mvcc.hpp
@@ -1,0 +1,33 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include "storage/v2/transaction_constants.hpp"
+
+#include <atomic>
+
+namespace memgraph::storage {
+
+struct IndexStatus {
+  IndexStatus() = default;
+
+  bool is_populating() const { return commit_timestamp.load(std::memory_order_acquire) == kTransactionInitialId; }
+  bool is_ready() const { return !is_populating(); }
+
+  void commit(uint64_t timestamp) { commit_timestamp.store(timestamp, std::memory_order_release); }
+
+ private:
+  // kTransactionInitialId means popuating
+  std::atomic<uint64_t> commit_timestamp{kTransactionInitialId};
+};
+
+}  // namespace memgraph::storage

--- a/src/storage/v2/inmemory/indices_mvcc.hpp
+++ b/src/storage/v2/inmemory/indices_mvcc.hpp
@@ -22,6 +22,7 @@ struct IndexStatus {
 
   bool is_populating() const { return commit_timestamp.load(std::memory_order_acquire) == kTransactionInitialId; }
   bool is_ready() const { return !is_populating(); }
+  bool is_visible(uint64_t timestamp) const { return commit_timestamp.load(std::memory_order_acquire) <= timestamp; }
 
   void commit(uint64_t timestamp) { commit_timestamp.store(timestamp, std::memory_order_release); }
 

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -1048,7 +1048,7 @@ void InMemoryLabelPropertyIndex::RunGC() {
   CleanupAllIndicies();
 
   auto cpy = all_indexes_.WithReadLock(std::identity{});
-  for (auto &[index, _, _] : *cpy) {
+  for (auto &[index, _1, _2] : *cpy) {
     index->skiplist.run_gc();
   }
 }

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -561,7 +561,7 @@ auto InMemoryLabelPropertyIndex::ActiveIndices::RelevantLabelPropertiesIndicesIn
   return res;
 }
 
-auto InMemoryLabelPropertyIndex::ActiveIndices::ListIndices() const
+auto InMemoryLabelPropertyIndex::ActiveIndices::ListIndices(uint64_t start_timestamp) const
     -> std::vector<std::pair<LabelId, std::vector<PropertyPath>>> {
   std::vector<std::pair<LabelId, std::vector<PropertyPath>>> ret;
 
@@ -570,8 +570,10 @@ auto InMemoryLabelPropertyIndex::ActiveIndices::ListIndices() const
 
   ret.reserve(num_indexes);
   for (auto const &[label, indices] : index_container_) {
-    for (auto const &props : indices | std::views::keys) {
-      ret.emplace_back(label, props);
+    for (auto const &[props, index] : indices) {
+      if (index->status.is_visible(start_timestamp)) {
+        ret.emplace_back(label, props);
+      }
     }
   }
   return ret;

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -354,7 +354,7 @@ void InMemoryLabelPropertyIndex::IndividualIndex::Publish(uint64_t commit_timest
 
 InMemoryLabelPropertyIndex::IndividualIndex::~IndividualIndex() {
   if (status.is_ready()) {
-    memgraph::metrics::IncrementCounter(memgraph::metrics::ActiveLabelPropertyIndices);
+    memgraph::metrics::DecrementCounter(memgraph::metrics::ActiveLabelPropertyIndices);
   }
 }
 

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -323,8 +323,19 @@ bool InMemoryLabelPropertyIndex::PublishIndex(LabelId label, PropertiesPaths con
                                               uint64_t commit_timestamp) {
   auto index = GetIndividualIndex(label, properties);
   if (!index) return false;
-  index->status.commit(commit_timestamp);
+  index->Publish(commit_timestamp);
   return true;
+}
+
+void InMemoryLabelPropertyIndex::IndividualIndex::Publish(uint64_t commit_timestamp) {
+  status.commit(commit_timestamp);
+  memgraph::metrics::IncrementCounter(memgraph::metrics::ActiveLabelPropertyIndices);
+}
+
+InMemoryLabelPropertyIndex::IndividualIndex::~IndividualIndex() {
+  if (status.is_ready()) {
+    memgraph::metrics::IncrementCounter(memgraph::metrics::ActiveLabelPropertyIndices);
+  }
 }
 
 auto InMemoryLabelPropertyIndex::GetIndividualIndex(LabelId const &label, PropertiesPaths const &properties) const

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -348,12 +348,12 @@ bool InMemoryLabelPropertyIndex::PublishIndex(LabelId label, PropertiesPaths con
 }
 
 void InMemoryLabelPropertyIndex::IndividualIndex::Publish(uint64_t commit_timestamp) {
-  status.commit(commit_timestamp);
+  status.Commit(commit_timestamp);
   memgraph::metrics::IncrementCounter(memgraph::metrics::ActiveLabelPropertyIndices);
 }
 
 InMemoryLabelPropertyIndex::IndividualIndex::~IndividualIndex() {
-  if (status.is_ready()) {
+  if (status.IsReady()) {
     memgraph::metrics::DecrementCounter(memgraph::metrics::ActiveLabelPropertyIndices);
   }
 }
@@ -534,7 +534,7 @@ bool InMemoryLabelPropertyIndex::ActiveIndices::IndexReady(LabelId label,
   if (it != index_container_->indices_.end()) {
     auto it2 = it->second.find(properties);
     if (it2 != it->second.end()) {
-      return it2->second->status.is_ready();
+      return it2->second->status.IsReady();
     }
   }
 
@@ -580,7 +580,7 @@ auto InMemoryLabelPropertyIndex::ActiveIndices::RelevantLabelPropertiesIndicesIn
 
     for (const auto &[nested_props, index] : it->second) {
       // Skip indexes which are not ready, they are never relevant for planning
-      if (!index->status.is_ready()) continue;
+      if (!index->status.IsReady()) continue;
 
       bool has_matching_property = false;
       auto positions = std::vector<int64_t>();
@@ -613,7 +613,7 @@ auto InMemoryLabelPropertyIndex::ActiveIndices::ListIndices(uint64_t start_times
   ret.reserve(num_indexes);
   for (auto const &[label, indices] : index_container_->indices_) {
     for (auto const &[props, index] : indices) {
-      if (index->status.is_visible(start_timestamp)) {
+      if (index->status.IsVisible(start_timestamp)) {
         ret.emplace_back(label, props);
       }
     }

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -299,8 +299,7 @@ auto InMemoryLabelPropertyIndex::PopulateIndex(
   spdlog::trace("Vertices size when creating index: {}", vertices.size());
 
   try {
-    auto &[helper, skip_list, status] = *index;
-    auto const accessor_factory = [&] { return skip_list.access(); };
+    auto const accessor_factory = [&] { return index->skiplist.access(); };
 
     if (tx) {
       // If we are in a transaction, we need to read the object with the correct MVCC snapshot isolation
@@ -308,7 +307,7 @@ auto InMemoryLabelPropertyIndex::PopulateIndex(
         if (cancel_check()) {
           throw PopulateCancel{};
         }
-        TryInsertLabelPropertiesIndex(vertex, label, helper, index_accessor, *tx);
+        TryInsertLabelPropertiesIndex(vertex, label, index->permutations_helper, index_accessor, *tx);
       };
       PopulateIndexDispatch(vertices, accessor_factory, try_insert_into_index, parallel_exec_info, snapshot_info);
     } else {
@@ -317,7 +316,7 @@ auto InMemoryLabelPropertyIndex::PopulateIndex(
         if (cancel_check()) {
           throw PopulateCancel{};
         }
-        TryInsertLabelPropertiesIndex(vertex, label, helper, index_accessor);
+        TryInsertLabelPropertiesIndex(vertex, label, index->permutations_helper, index_accessor);
       };
       PopulateIndexDispatch(vertices, accessor_factory, try_insert_into_index, parallel_exec_info, snapshot_info);
     }

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -297,8 +297,8 @@ struct PopulateCancel : std::exception {};
 auto InMemoryLabelPropertyIndex::PopulateIndex(
     LabelId label, PropertiesPaths const &properties, utils::SkipList<Vertex>::Accessor vertices,
     const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info,
-    std::optional<SnapshotObserverInfo> const &snapshot_info, Transaction const *tx, CheckCancelFunction cancel_check)
-    -> utils::BasicResult<IndexPopulateError> {
+    std::optional<SnapshotObserverInfo> const &snapshot_info, Transaction const *tx,
+    CheckCancelFunction cancel_check) -> utils::BasicResult<IndexPopulateError> {
   auto index = GetIndividualIndex(label, properties);
   if (!index) {
     MG_ASSERT(false, "It should not be possible to remove the index before populating it.");
@@ -395,7 +395,7 @@ bool InMemoryLabelPropertyIndex::RemoveIndividualIndex(LabelId const &label, Pro
     // Erase the reverse lookup before removing the index entry
     for (auto const &prop_selector : properties) {
       auto it3 = new_index->reverse_lookup_.find(prop_selector[0]);
-      DMG_ASSERT(it3 != new_index->reverse_lookup_.cend(), "Reverse lookup should exist");
+      if (it3 == new_index->reverse_lookup_.cend()) continue;
       auto &label_map = it3->second;
       auto [b, e] = label_map.equal_range(label);
       // TODO(composite_index): replace linear search with logn
@@ -542,8 +542,8 @@ bool InMemoryLabelPropertyIndex::ActiveIndices::IndexReady(LabelId label,
 }
 
 auto InMemoryLabelPropertyIndex::ActiveIndices::RelevantLabelPropertiesIndicesInfo(
-    std::span<LabelId const> labels, std::span<PropertyPath const> properties) const
-    -> std::vector<LabelPropertiesIndicesInfo> {
+    std::span<LabelId const> labels,
+    std::span<PropertyPath const> properties) const -> std::vector<LabelPropertiesIndicesInfo> {
   auto res = std::vector<LabelPropertiesIndicesInfo>{};
   auto ppos_indices = rv::iota(size_t{}, properties.size()) | r::to_vector;
   auto properties_vec = properties | ranges::to_vector;

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -920,7 +920,7 @@ InMemoryLabelPropertyIndex::Iterable::Iterator InMemoryLabelPropertyIndex::Itera
 uint64_t InMemoryLabelPropertyIndex::ActiveIndices::ApproximateVertexCount(
     LabelId label, std::span<PropertyPath const> properties) const {
   auto it = index_container_->find(label);
-  DMG_ASSERT(it != index_container_.end(), "Index for label {} and properties {} doesn't exist", label.AsUint(),
+  DMG_ASSERT(it != index_container_->end(), "Index for label {} and properties {} doesn't exist", label.AsUint(),
              JoinPropertiesAsString(properties));
   auto it2 = it->second.find(properties);
   DMG_ASSERT(it2 != it->second.end(), "Index for label {} and properties {} doesn't exist", label.AsUint(),
@@ -931,7 +931,7 @@ uint64_t InMemoryLabelPropertyIndex::ActiveIndices::ApproximateVertexCount(
 uint64_t InMemoryLabelPropertyIndex::ActiveIndices::ApproximateVertexCount(
     LabelId label, std::span<PropertyPath const> properties, std::span<PropertyValue const> values) const {
   auto const it = index_container_->find(label);
-  DMG_ASSERT(it != index_container_.end(), "Index for label {} and properties {} doesn't exist", label.AsUint(),
+  DMG_ASSERT(it != index_container_->end(), "Index for label {} and properties {} doesn't exist", label.AsUint(),
              JoinPropertiesAsString(properties));
 
   auto const it2 = it->second.find(properties);
@@ -958,7 +958,7 @@ uint64_t InMemoryLabelPropertyIndex::ActiveIndices::ApproximateVertexCount(
 uint64_t InMemoryLabelPropertyIndex::ActiveIndices::ApproximateVertexCount(
     LabelId label, std::span<PropertyPath const> properties, std::span<PropertyValueRange const> bounds) const {
   auto const it = index_container_->find(label);
-  DMG_ASSERT(it != index_container_.end(), "Index for label {} and properties {} doesn't exist", label.AsUint(),
+  DMG_ASSERT(it != index_container_->end(), "Index for label {} and properties {} doesn't exist", label.AsUint(),
              JoinPropertiesAsString(properties));
 
   auto const it2 = it->second.find(properties);
@@ -1054,7 +1054,7 @@ InMemoryLabelPropertyIndex::Iterable InMemoryLabelPropertyIndex::ActiveIndices::
     Storage *storage, Transaction *transaction) {
   auto vertices_acc = static_cast<InMemoryStorage const *>(storage)->vertices_.access();
   auto it = index_container_->find(label);
-  DMG_ASSERT(it != index_container_.end(), "Index for label {} and properties {} doesn't exist", label.AsUint(),
+  DMG_ASSERT(it != index_container_->end(), "Index for label {} and properties {} doesn't exist", label.AsUint(),
              JoinPropertiesAsString(properties));
   auto it2 = it->second.find(properties);
   DMG_ASSERT(it2 != it->second.end(), "Index for label {} and properties {} doesn't exist", label.AsUint(),
@@ -1075,7 +1075,7 @@ InMemoryLabelPropertyIndex::Iterable InMemoryLabelPropertyIndex::ActiveIndices::
     memgraph::utils::SkipList<memgraph::storage::Vertex>::ConstAccessor vertices_acc, View view, Storage *storage,
     Transaction *transaction) {
   auto it = index_container_->find(label);
-  DMG_ASSERT(it != index_container_.end(), "Index for label {} and properties {} doesn't exist", label.AsUint(),
+  DMG_ASSERT(it != index_container_->end(), "Index for label {} and properties {} doesn't exist", label.AsUint(),
              JoinPropertiesAsString(properties));
   auto it2 = it->second.find(properties);
   DMG_ASSERT(it2 != it->second.end(), "Index for label {} and properties {} doesn't exist", label.AsUint(),
@@ -1128,7 +1128,7 @@ auto InMemoryLabelPropertyIndex::GetActiveIndices() const -> std::unique_ptr<Lab
 void InMemoryLabelPropertyIndex::ActiveIndices::AbortEntries(AbortableInfo const &info, uint64_t start_timestamp) {
   for (auto const &[label, by_properties] : info) {
     auto it = index_container_->find(label);
-    DMG_ASSERT(it != index_container_.end());
+    DMG_ASSERT(it != index_container_->end());
     for (auto const &[prop, to_remove] : by_properties) {
       auto it2 = it->second.find(*prop);
       DMG_ASSERT(it2 != it->second.end());

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -289,8 +289,8 @@ struct PopulateCancel : std::exception {};
 auto InMemoryLabelPropertyIndex::PopulateIndex(
     LabelId label, PropertiesPaths const &properties, utils::SkipList<Vertex>::Accessor vertices,
     const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info,
-    std::optional<SnapshotObserverInfo> const &snapshot_info, Transaction const *tx, CheckCancelFunction cancel_check)
-    -> utils::BasicResult<IndexPopulateError> {
+    std::optional<SnapshotObserverInfo> const &snapshot_info, Transaction const *tx,
+    CheckCancelFunction cancel_check) -> utils::BasicResult<IndexPopulateError> {
   auto index = GetIndividualIndex(label, properties);
   if (!index) {
     MG_ASSERT(false, "It should not be possible to remove the index before populating it.");
@@ -507,7 +507,6 @@ bool InMemoryLabelPropertyIndex::DropIndex(LabelId label, std::vector<PropertyPa
       index.erase(it1);
     }
 
-    // TODO: invalidate plan cache?
     return true;
   });
 }
@@ -523,8 +522,8 @@ bool InMemoryLabelPropertyIndex::ActiveIndices::IndexExists(LabelId label,
 }
 
 auto InMemoryLabelPropertyIndex::ActiveIndices::RelevantLabelPropertiesIndicesInfo(
-    std::span<LabelId const> labels, std::span<PropertyPath const> properties) const
-    -> std::vector<LabelPropertiesIndicesInfo> {
+    std::span<LabelId const> labels,
+    std::span<PropertyPath const> properties) const -> std::vector<LabelPropertiesIndicesInfo> {
   auto res = std::vector<LabelPropertiesIndicesInfo>{};
   auto ppos_indices = rv::iota(size_t{}, properties.size()) | r::to_vector;
   auto properties_vec = properties | ranges::to_vector;

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -155,7 +155,7 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
     void UpdateOnSetProperty(PropertyId property, const PropertyValue &value, Vertex *vertex,
                              const Transaction &tx) override;
 
-    bool IndexExists(LabelId label, std::span<PropertyPath const> properties) const override;
+    bool IndexReady(LabelId label, std::span<PropertyPath const> properties) const override;
 
     auto RelevantLabelPropertiesIndicesInfo(std::span<LabelId const> labels,
                                             std::span<PropertyPath const> properties) const
@@ -165,6 +165,8 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
         -> std::vector<std::pair<LabelId, std::vector<PropertyPath>>> override;
 
     void AbortEntries(AbortableInfo const &info, uint64_t start_timestamp) override;
+
+    auto GetAbortProcessor() const -> AbortProcessor override;
 
     auto ApproximateVertexCount(LabelId label, std::span<PropertyPath const> properties) const -> uint64_t override;
 
@@ -177,8 +179,6 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
 
     auto ApproximateVertexCount(LabelId label, std::span<PropertyPath const> properties,
                                 std::span<PropertyValueRange const> bounds) const -> uint64_t override;
-
-    auto GetAbortProcessor() const -> AbortProcessor override;
 
     auto Vertices(LabelId label, std::span<PropertyPath const> properties, std::span<PropertyValueRange const> range,
                   View view, Storage *storage, Transaction *transaction) -> Iterable;

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -25,10 +25,6 @@
 
 namespace memgraph::storage {
 
-enum class Status : uint8_t {
-  POPULATING = 0,
-};
-
 class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
  private:
   struct Entry {
@@ -78,7 +74,8 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
 
   bool PopulateIndex(LabelId label, PropertiesPaths const &properties, utils::SkipList<Vertex>::Accessor vertices,
                      const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info,
-                     std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
+                     std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt,
+                     Transaction const *tx = nullptr);
 
   bool PublishIndex(LabelId label, PropertiesPaths const &properties, uint64_t commit_timestamp);
 

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -92,6 +92,11 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
     // Used to make UpdateOnSetProperty faster
     ReverseLabelPropertiesIndices reverse_lookup_;
   };
+  struct AllIndicesEntry {
+    std::shared_ptr<IndividualIndex> index_;
+    LabelId label_;
+    PropertiesPaths properties_;
+  };
   using PropertiesIndicesStats = std::map<PropertiesPaths, storage::LabelPropertyIndexStats, Compare>;
 
   InMemoryLabelPropertyIndex() : index_(std::make_shared<IndexContainer>()) {}
@@ -227,11 +232,14 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
   void DropGraphClearIndices() override;
 
  private:
+  void CleanupAllIndicies();
   auto GetIndividualIndex(LabelId const &label, PropertiesPaths const &properties) const
       -> std::shared_ptr<IndividualIndex>;
   bool RemoveIndividualIndex(LabelId const &label, PropertiesPaths const &properties);
 
   utils::Synchronized<std::shared_ptr<IndexContainer const>, utils::WritePrioritizedRWLock> index_;
+  utils::Synchronized<std::shared_ptr<std::vector<AllIndicesEntry> const>, utils::WritePrioritizedRWLock>
+      all_indexes_{};
   utils::Synchronized<std::map<LabelId, PropertiesIndicesStats>, utils::ReadPrioritizedRWLock> stats_;
 };
 

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -220,7 +220,7 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
       -> std::shared_ptr<IndividualIndex>;
   void RemoveIndividualIndex(LabelId const &label, PropertiesPaths const &properties);
 
-  utils::Synchronized<IndexContainer, utils::WritePrioritizedRWLock> index_;
+  utils::Synchronized<std::shared_ptr<IndexContainer const>, utils::WritePrioritizedRWLock> index_;
   utils::Synchronized<std::map<LabelId, PropertiesIndicesStats>, utils::ReadPrioritizedRWLock> stats_;
 };
 

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -17,6 +17,7 @@
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indices/label_property_index.hpp"
 #include "storage/v2/indices/label_property_index_stats.hpp"
+#include "storage/v2/inmemory/indices_mvcc.hpp"
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/snapshot_observer_info.hpp"
 #include "utils/rw_lock.hpp"
@@ -48,7 +49,7 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
         : permutations_helper(std::move(permutations_helper)) {}
     PropertiesPermutationHelper const permutations_helper;
     utils::SkipList<Entry> skiplist{};
-    std::atomic<Status> status = Status::POPULATING;
+    IndexStatus status{};
   };
   struct Compare {
     template <std::ranges::forward_range T, std::ranges::forward_range U>

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -70,7 +70,7 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
   using ReverseIndexContainer = std::unordered_map<PropertyId, std::multimap<LabelId, EntryDetail>>;
   using PropertiesIndicesStats = std::map<PropertiesPaths, storage::LabelPropertyIndexStats, Compare>;
 
-  InMemoryLabelPropertyIndex() = default;
+  InMemoryLabelPropertyIndex() : index_(std::make_shared<IndexContainer>()) {}
 
   // Convience function that does Register + Populate + direct Publish
   // TODO: direct Publish...should it be for a particular timestamp?
@@ -136,7 +136,7 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
   };
 
   struct ActiveIndices : LabelPropertyIndex::ActiveIndices {
-    ActiveIndices(std::shared_ptr<const IndexContainer> index_container = {})
+    ActiveIndices(std::shared_ptr<const IndexContainer> index_container = std::make_shared<IndexContainer>())
         : index_container_{std::move(index_container)} {
       // TODO: build this earlier instead of rebuilding each time
       for (auto const &[label, by_label] : *index_container_) {

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -13,6 +13,7 @@
 
 #include <span>
 
+#include "storage/v2/common_function_signatures.hpp"
 #include "storage/v2/durability/recovery_type.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indices/label_property_index.hpp"
@@ -24,6 +25,10 @@
 #include "utils/synchronized.hpp"
 
 namespace memgraph::storage {
+
+enum class IndexPopulateError {
+  Cancellation,
+};
 
 class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
  private:
@@ -75,10 +80,11 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
 
   bool RegisterIndex(LabelId label, PropertiesPaths const &properties);
 
-  bool PopulateIndex(LabelId label, PropertiesPaths const &properties, utils::SkipList<Vertex>::Accessor vertices,
+  auto PopulateIndex(LabelId label, PropertiesPaths const &properties, utils::SkipList<Vertex>::Accessor vertices,
                      const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info,
                      std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt,
-                     Transaction const *tx = nullptr);
+                     Transaction const *tx = nullptr, CheckCancelFunction cancel_check = neverCancel)
+      -> utils::BasicResult<IndexPopulateError>;
 
   bool PublishIndex(LabelId label, PropertiesPaths const &properties, uint64_t commit_timestamp);
 

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -99,7 +99,8 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
   };
   using PropertiesIndicesStats = std::map<PropertiesPaths, storage::LabelPropertyIndexStats, Compare>;
 
-  InMemoryLabelPropertyIndex() : index_(std::make_shared<IndexContainer>()) {}
+  InMemoryLabelPropertyIndex()
+      : index_(std::make_shared<IndexContainer>()), all_indexes_(std::make_shared<std::vector<AllIndicesEntry>>()) {}
 
   // Convience function that does Register + Populate + direct Publish
   // TODO: direct Publish...should it be for a particular timestamp?

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -43,6 +43,9 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
   struct IndividualIndex {
     IndividualIndex(PropertiesPermutationHelper permutations_helper)
         : permutations_helper(std::move(permutations_helper)) {}
+    ~IndividualIndex();
+    void Publish(uint64_t commit_timestamp);
+
     PropertiesPermutationHelper const permutations_helper;
     utils::SkipList<Entry> skiplist{};
     IndexStatus status{};

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -80,6 +80,8 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
                      const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info,
                      std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
+  bool PublishIndex(LabelId label, PropertiesPaths const &properties, uint64_t commit_timestamp);
+
   class Iterable {
    public:
     Iterable(utils::SkipList<Entry>::Accessor index_accessor, utils::SkipList<Vertex>::ConstAccessor vertices_accessor,
@@ -212,8 +214,6 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
   void RemoveIndividualIndex(LabelId const &label, PropertiesPaths const &properties);
 
   utils::Synchronized<IndexContainer, utils::WritePrioritizedRWLock> index_;
-
-  //  ReverseIndexContainer indices_by_property_;
   utils::Synchronized<std::map<LabelId, PropertiesIndicesStats>, utils::ReadPrioritizedRWLock> stats_;
 };
 

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -155,7 +155,8 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
                                             std::span<PropertyPath const> properties) const
         -> std::vector<LabelPropertiesIndicesInfo> override;
 
-    auto ListIndices() const -> std::vector<std::pair<LabelId, std::vector<PropertyPath>>> override;
+    auto ListIndices(uint64_t start_timestamp) const
+        -> std::vector<std::pair<LabelId, std::vector<PropertyPath>>> override;
 
     void AbortEntries(AbortableInfo const &info, uint64_t start_timestamp) override;
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -3060,7 +3060,7 @@ IndicesInfo InMemoryStorage::InMemoryAccessor::ListAllIndices() const {
 
   // TODO: add status populating/ready?
   return {mem_label_index->ListIndices(),
-          transaction_.active_indices_.label_properties_->ListIndices(),
+          transaction_.active_indices_.label_properties_->ListIndices(transaction_.start_timestamp),
           mem_edge_type_index->ListIndices(),
           mem_edge_type_property_index->ListIndices(),
           mem_edge_property_index->ListIndices(),

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -106,8 +106,8 @@ constexpr auto ActionToStorageOperation(MetadataDelta::Action action) -> durabil
 #undef add_case
 }
 
-auto FindEdges(const View view, EdgeTypeId edge_type, const VertexAccessor *from_vertex, VertexAccessor *to_vertex)
-    -> Result<EdgesVertexAccessorResult> {
+auto FindEdges(const View view, EdgeTypeId edge_type, const VertexAccessor *from_vertex,
+               VertexAccessor *to_vertex) -> Result<EdgesVertexAccessorResult> {
   auto use_out_edges = [](Vertex const *from_vertex, Vertex const *to_vertex) {
     // Obtain the locks by `gid` order to avoid lock cycles.
     auto guard_from = std::unique_lock{from_vertex->lock, std::defer_lock};

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -708,6 +708,7 @@ utils::BasicResult<StorageManipulationError, void> InMemoryStorage::InMemoryAcce
             // when the last one commits.
             if (count == 0) {
               // TODO: (andi) Handle auto-creation issue
+              // NOLINTNEXTLINE(clang-diagnostic-unused-result)
               CreateIndex(label, false);
               label_indices.erase(it);
             }
@@ -727,6 +728,7 @@ utils::BasicResult<StorageManipulationError, void> InMemoryStorage::InMemoryAcce
             // when the last one commits.
             if (count == 0) {
               // TODO: (andi) Handle silent failure
+              // NOLINTNEXTLINE(clang-diagnostic-unused-result)
               CreateIndex(edge_type, false);
               edge_type_indices.erase(it);
             }

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -456,18 +456,10 @@ Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdge(VertexAccesso
 
   if (storage_->config_.salient.items.enable_edge_type_index_auto_creation &&
       !storage_->indices_.edge_type_index_->IndexExists(edge_type)) {
-    storage_->edge_types_to_auto_index_.WithLock([&](auto &edge_type_indices) {
-      if (auto it = edge_type_indices.find(edge_type); it != edge_type_indices.end()) {
-        const bool this_txn_already_encountered_edge_type =
-            transaction_.introduced_new_edge_type_index_.contains(edge_type);
-        if (!this_txn_already_encountered_edge_type) {
-          ++(it->second);
-        }
-        return;
-      }
-      edge_type_indices.insert({edge_type, 1});
-    });
-    transaction_.introduced_new_edge_type_index_.insert(edge_type);
+    auto [_, inserted] = transaction_.introduced_new_edge_type_index_.insert(edge_type);
+    if (inserted) {
+      storage_->edge_types_to_auto_index_.WithLock([&](auto &edge_type_indices) { ++edge_type_indices[edge_type]; });
+    }
   }
 
   if (!PrepareForWrite(&transaction_, from_vertex)) return Error::SERIALIZATION_ERROR;
@@ -705,34 +697,38 @@ utils::BasicResult<StorageManipulationError, void> InMemoryStorage::InMemoryAcce
       auto engine_guard = std::unique_lock{storage_->engine_lock_};
 
       // LabelIndex auto-creation block.
-      if (storage_->config_.salient.items.enable_label_index_auto_creation) {
+      if (!transaction_.introduced_new_label_index_.empty()) {
         storage_->labels_to_auto_index_.WithLock([&](auto &label_indices) {
-          for (auto &label : label_indices) {
-            --label.second;
+          for (auto label : transaction_.introduced_new_label_index_) {
+            auto it = label_indices.find(label);
+            auto &[_, count] = *it;
+            --count;
             // If there are multiple transactions that would like to create an
             // auto-created index on a specific label, we only build the index
             // when the last one commits.
-            if (label.second == 0) {
+            if (count == 0) {
               // TODO: (andi) Handle auto-creation issue
-              CreateIndex(label.first, false);
-              label_indices.erase(label.first);
+              CreateIndex(label, false);
+              label_indices.erase(it);
             }
           }
         });
       }
 
       // EdgeIndex auto-creation block.
-      if (storage_->config_.salient.items.enable_edge_type_index_auto_creation) {
+      if (!transaction_.introduced_new_edge_type_index_.empty()) {
         storage_->edge_types_to_auto_index_.WithLock([&](auto &edge_type_indices) {
-          for (auto &edge_type : edge_type_indices) {
-            --edge_type.second;
+          for (auto edge_type : transaction_.introduced_new_edge_type_index_) {
+            auto it = edge_type_indices.find(edge_type);
+            auto &[_, count] = *it;
+            --count;
             // If there are multiple transactions that would like to create an
             // auto-created index on a specific edge-type, we only build the index
             // when the last one commits.
-            if (edge_type.second == 0) {
+            if (count == 0) {
               // TODO: (andi) Handle silent failure
-              CreateIndex(edge_type.first, false);
-              edge_type_indices.erase(edge_type.first);
+              CreateIndex(edge_type, false);
+              edge_type_indices.erase(it);
             }
           }
         });
@@ -1288,7 +1284,12 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
         !transaction_.introduced_new_label_index_.empty()) {
       storage_->labels_to_auto_index_.WithLock([&](auto &label_indices) {
         for (const auto label : transaction_.introduced_new_label_index_) {
-          --label_indices.at(label);
+          auto it = label_indices.find(label);
+          auto &[_, count] = *it;
+          --count;
+          if (count == 0) {
+            label_indices.erase(it);
+          }
         }
       });
     }
@@ -1297,7 +1298,12 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
         !transaction_.introduced_new_edge_type_index_.empty()) {
       storage_->edge_types_to_auto_index_.WithLock([&](auto &edge_type_indices) {
         for (const auto edge_type : transaction_.introduced_new_edge_type_index_) {
-          --edge_type_indices.at(edge_type);
+          auto it = edge_type_indices.find(edge_type);
+          auto &[_, count] = *it;
+          --count;
+          if (count == 0) {
+            edge_type_indices.erase(it);
+          }
         }
       });
     }

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1392,9 +1392,14 @@ utils::BasicResult<StorageIndexDefinitionError, void> InMemoryStorage::InMemoryA
   auto *in_memory = static_cast<InMemoryStorage *>(storage_);
   auto *mem_label_property_index =
       static_cast<InMemoryLabelPropertyIndex *>(in_memory->indices_.label_property_index_.get());
-  if (!mem_label_property_index->CreateIndex(label, properties, in_memory->vertices_.access(), std::nullopt)) {
+  if (!mem_label_property_index->RegisterIndex(label, properties)) {
     return StorageIndexDefinitionError{IndexDefinitionError{}};
   }
+  if (!mem_label_property_index->PopulateIndex(label, properties, in_memory->vertices_.access(), std::nullopt)) {
+    return StorageIndexDefinitionError{IndexDefinitionError{}};
+  }
+  // TODO: Publish?
+
   transaction_.md_deltas.emplace_back(MetadataDelta::label_property_index_create, label, std::move(properties));
   // We don't care if there is a replication error because on main node the change will go through
   memgraph::metrics::IncrementCounter(memgraph::metrics::ActiveLabelPropertyIndices);

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -354,7 +354,8 @@ class InMemoryStorage final : public Storage {
     /// * `IndexDefinitionError`: the index already exists.
     /// @throw std::bad_alloc
     utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
-        LabelId label, PropertiesPaths properties, PublishIndexWrapper wrapper = publish_no_wrap) override;
+        LabelId label, PropertiesPaths properties, CheckCancelFunction cancel_check = neverCancel,
+        PublishIndexWrapper wrapper = publish_no_wrap) override;
 
     /// Create an index.
     /// Returns void if the index has been created.

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -298,8 +298,8 @@ class InMemoryStorage final : public Storage {
 
     bool LabelIndexExists(LabelId label) const override { return storage_->indices_.label_index_->IndexExists(label); }
 
-    bool LabelPropertyIndexExists(LabelId label, std::span<PropertyPath const> properties) const override {
-      return transaction_.active_indices_.label_properties_->IndexExists(label, properties);
+    bool LabelPropertyIndexReady(LabelId label, std::span<PropertyPath const> properties) const override {
+      return transaction_.active_indices_.label_properties_->IndexReady(label, properties);
     }
 
     bool EdgeTypeIndexExists(EdgeTypeId edge_type) const override {

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -499,6 +499,8 @@ class InMemoryStorage final : public Storage {
 
     std::vector<VectorIndexInfo> ListAllVectorIndices() const override;
 
+    void DowngradeToReadIfValid();
+
    protected:
     // TODO Better naming
     /// @throw std::bad_alloc

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -353,8 +353,8 @@ class InMemoryStorage final : public Storage {
     /// * `ReplicationError`:  there is at least one SYNC replica that has not confirmed receiving the transaction.
     /// * `IndexDefinitionError`: the index already exists.
     /// @throw std::bad_alloc
-    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
-        LabelId label, std::vector<storage::PropertyPath> properties) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(LabelId label,
+                                                                      PropertiesPaths properties) override;
 
     /// Create an index.
     /// Returns void if the index has been created.

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -204,7 +204,7 @@ class InMemoryStorage final : public Storage {
     /// Return approximate number of vertices with the given label and property.
     /// Note that this is always an over-estimate and never an under-estimate.
     uint64_t ApproximateVertexCount(LabelId label, std::span<PropertyPath const> properties) const override {
-      return storage_->indices_.label_property_index_->ApproximateVertexCount(label, properties);
+      return transaction_.active_indices_.label_properties_->ApproximateVertexCount(label, properties);
     }
 
     /// Return approximate number of vertices with the given label and the given
@@ -212,7 +212,7 @@ class InMemoryStorage final : public Storage {
     /// and never an under-estimate.
     uint64_t ApproximateVertexCount(LabelId label, std::span<PropertyPath const> properties,
                                     std::span<PropertyValue const> values) const override {
-      return storage_->indices_.label_property_index_->ApproximateVertexCount(label, properties, values);
+      return transaction_.active_indices_.label_properties_->ApproximateVertexCount(label, properties, values);
     }
 
     /// Return approximate number of vertices with the given label and value for
@@ -220,7 +220,7 @@ class InMemoryStorage final : public Storage {
     /// bounds.
     uint64_t ApproximateVertexCount(LabelId label, std::span<PropertyPath const> properties,
                                     std::span<PropertyValueRange const> bounds) const override {
-      return storage_->indices_.label_property_index_->ApproximateVertexCount(label, properties, bounds);
+      return transaction_.active_indices_.label_properties_->ApproximateVertexCount(label, properties, bounds);
     }
 
     uint64_t ApproximateEdgeCount() const override { return storage_->edge_count_.load(std::memory_order_acquire); }
@@ -299,7 +299,7 @@ class InMemoryStorage final : public Storage {
     bool LabelIndexExists(LabelId label) const override { return storage_->indices_.label_index_->IndexExists(label); }
 
     bool LabelPropertyIndexExists(LabelId label, std::span<PropertyPath const> properties) const override {
-      return storage_->indices_.label_property_index_->IndexExists(label, properties);
+      return transaction_.active_indices_.label_properties_->IndexExists(label, properties);
     }
 
     bool EdgeTypeIndexExists(EdgeTypeId edge_type) const override {

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -344,8 +344,8 @@ class InMemoryStorage final : public Storage {
     /// * `IndexDefinitionError`: the index already exists.
     /// * `ReplicationError`:  there is at least one SYNC replica that has not confirmed receiving the transaction.
     /// @throw std::bad_alloc
-    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(LabelId label,
-                                                                      bool unique_access_needed = true) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(LabelId label, bool unique_access_needed = true,
+                                                                      PublishIndexWrapper wrapper = no_wrap) override;
 
     /// Create an index.
     /// Returns void if the index has been created.
@@ -353,8 +353,8 @@ class InMemoryStorage final : public Storage {
     /// * `ReplicationError`:  there is at least one SYNC replica that has not confirmed receiving the transaction.
     /// * `IndexDefinitionError`: the index already exists.
     /// @throw std::bad_alloc
-    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(LabelId label,
-                                                                      PropertiesPaths properties) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(LabelId label, PropertiesPaths properties,
+                                                                      PublishIndexWrapper wrapper = no_wrap) override;
 
     /// Create an index.
     /// Returns void if the index has been created.

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -344,8 +344,8 @@ class InMemoryStorage final : public Storage {
     /// * `IndexDefinitionError`: the index already exists.
     /// * `ReplicationError`:  there is at least one SYNC replica that has not confirmed receiving the transaction.
     /// @throw std::bad_alloc
-    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(LabelId label, bool unique_access_needed = true,
-                                                                      PublishIndexWrapper wrapper = no_wrap) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
+        LabelId label, bool unique_access_needed = true, PublishIndexWrapper wrapper = publish_no_wrap) override;
 
     /// Create an index.
     /// Returns void if the index has been created.
@@ -353,8 +353,8 @@ class InMemoryStorage final : public Storage {
     /// * `ReplicationError`:  there is at least one SYNC replica that has not confirmed receiving the transaction.
     /// * `IndexDefinitionError`: the index already exists.
     /// @throw std::bad_alloc
-    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(LabelId label, PropertiesPaths properties,
-                                                                      PublishIndexWrapper wrapper = no_wrap) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
+        LabelId label, PropertiesPaths properties, PublishIndexWrapper wrapper = publish_no_wrap) override;
 
     /// Create an index.
     /// Returns void if the index has been created.
@@ -387,15 +387,17 @@ class InMemoryStorage final : public Storage {
     /// Returns `StorageIndexDefinitionError` if an error occures. Error can be:
     /// * `ReplicationError`:  there is at least one SYNC replica that has not confirmed receiving the transaction.
     /// * `IndexDefinitionError`: the index does not exist.
-    utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(LabelId label) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(LabelId label,
+                                                                    DropIndexWrapper wrapper = drop_no_wrap) override;
 
     /// Drop an existing index.
     /// Returns void if the index has been dropped.
     /// Returns `StorageIndexDefinitionError` if an error occures. Error can be:
     /// * `ReplicationError`:  there is at least one SYNC replica that has not confirmed receiving the transaction.
     /// * `IndexDefinitionError`: the index does not exist.
-    utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(
-        LabelId label, std::vector<storage::PropertyPath> &&properties) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(LabelId label,
+                                                                    std::vector<storage::PropertyPath> &&properties,
+                                                                    DropIndexWrapper wrapper = drop_no_wrap) override;
 
     /// Drop an existing index.
     /// Returns void if the index has been dropped.

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -27,11 +27,9 @@
 
 #include <algorithm>
 #include <atomic>
+#include "utils/compile_time.hpp"
 
 namespace {
-template <typename>
-[[maybe_unused]] inline constexpr bool always_false_v = false;
-
 constexpr auto kHeartbeatRpcTimeout = std::chrono::milliseconds(5000);
 constexpr auto kCommitRpcTimeout = std::chrono::milliseconds(50);
 
@@ -580,7 +578,7 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_last_commit_ts, S
                   spdlog::debug("Cannot recover using current wal file {} for db {}.", client_.name_, main_db_name);
                 }
               },
-              []<typename T>(T const &) { static_assert(always_false_v<T>, "Missing type from variant visitor"); },
+              []<typename T>(T const &) { static_assert(utils::always_false<T>, "Missing type from variant visitor"); },
           },
           recovery_step);
     } catch (const rpc::RpcFailedException &) {

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -70,6 +70,7 @@ class ReadOnlyAccessTimeout : public utils::BasicException {
 struct Transaction;
 class EdgeAccessor;
 
+// TODO: list status Populating/Ready
 struct IndicesInfo {
   std::vector<LabelId> label;
   std::vector<std::pair<LabelId, std::vector<PropertyPath>>> label_properties;
@@ -328,7 +329,7 @@ class Storage {
     auto RelevantLabelPropertiesIndicesInfo(std::span<LabelId const> labels,
                                             std::span<PropertyPath const> properties) const
         -> std::vector<LabelPropertiesIndicesInfo> {
-      return storage_->indices_.label_property_index_->RelevantLabelPropertiesIndicesInfo(labels, properties);
+      return transaction_.active_indices_.label_properties_->RelevantLabelPropertiesIndicesInfo(labels, properties);
     };
 
     virtual bool EdgeTypeIndexExists(EdgeTypeId edge_type) const = 0;
@@ -637,6 +638,12 @@ class Storage {
 
   auto GetReplicaState(std::string_view name) const -> std::optional<replication::ReplicaState> {
     return repl_storage_state_.GetReplicaState(name);
+  }
+
+  auto GetActiveIndices() -> ActiveIndices {
+    return {
+        indices_.label_property_index_->GetActiveIndices(),
+    };
   }
 
   // TODO: make non-public

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -411,8 +411,8 @@ class Storage {
     virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(LabelId label,
                                                                               bool unique_access_needed = true) = 0;
 
-    virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
-        LabelId label, std::vector<storage::PropertyPath> properties) = 0;
+    virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(LabelId label,
+                                                                              PropertiesPaths properties) = 0;
 
     virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(EdgeTypeId edge_type,
                                                                               bool unique_access_needed = true) = 0;

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -541,6 +541,10 @@ class Storage {
 
     auto GetNameIdMapper() const -> NameIdMapper * { return storage_->name_id_mapper_.get(); }
 
+    bool CheckActiveIndices(IndicesCollection const &required_indices) {
+      return transaction_.active_indices_.CheckActiveIndices(required_indices);
+    }
+
    protected:
     Storage *storage_;
     utils::SharedResourceLockGuard storage_guard_;

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -189,7 +189,13 @@ class Storage {
     static constexpr struct ReadOnlyAccess {
     } read_only_access;
 
-    enum Type { NO_ACCESS, UNIQUE, WRITE, READ, READ_ONLY };
+    enum Type {
+      NO_ACCESS,  // Modifies nothing in the storage
+      UNIQUE,     // An operation that requires mutral exclusive access to the storage
+      WRITE,      // Writes to the data of storage
+      READ,       // Either reads the data of storage, or a metadata operation that doesn't require unique access
+      READ_ONLY,  // Ensures writers have gone
+    };
 
     Accessor(SharedAccess /* tag */, Storage *storage, IsolationLevel isolation_level, StorageMode storage_mode,
              Type rw_type = Type::WRITE, std::optional<std::chrono::milliseconds> timeout = std::nullopt);
@@ -413,7 +419,8 @@ class Storage {
         LabelId label, bool unique_access_needed = true, PublishIndexWrapper wrapper = publish_no_wrap) = 0;
 
     virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
-        LabelId label, PropertiesPaths properties, PublishIndexWrapper wrapper = publish_no_wrap) = 0;
+        LabelId label, PropertiesPaths properties, CheckCancelFunction cancel_check = neverCancel,
+        PublishIndexWrapper wrapper = publish_no_wrap) = 0;
 
     virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(EdgeTypeId edge_type,
                                                                               bool unique_access_needed = true) = 0;

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -410,10 +410,10 @@ class Storage {
     std::vector<EdgeTypeId> ListAllPossiblyPresentEdgeTypes() const;
 
     virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
-        LabelId label, bool unique_access_needed = true, PublishIndexWrapper wrapper = no_wrap) = 0;
+        LabelId label, bool unique_access_needed = true, PublishIndexWrapper wrapper = publish_no_wrap) = 0;
 
     virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
-        LabelId label, PropertiesPaths properties, PublishIndexWrapper wrapper = no_wrap) = 0;
+        LabelId label, PropertiesPaths properties, PublishIndexWrapper wrapper = publish_no_wrap) = 0;
 
     virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(EdgeTypeId edge_type,
                                                                               bool unique_access_needed = true) = 0;
@@ -423,10 +423,11 @@ class Storage {
 
     virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateGlobalEdgeIndex(PropertyId property) = 0;
 
-    virtual utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(LabelId label) = 0;
+    virtual utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(
+        LabelId label, DropIndexWrapper wrapper = drop_no_wrap) = 0;
 
     virtual utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(
-        LabelId label, std::vector<storage::PropertyPath> &&properties) = 0;
+        LabelId label, std::vector<storage::PropertyPath> &&properties, DropIndexWrapper wrapper = drop_no_wrap) = 0;
 
     virtual utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(EdgeTypeId edge_type) = 0;
 

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -333,9 +333,8 @@ class Storage {
 
     virtual bool LabelPropertyIndexReady(LabelId label, std::span<PropertyPath const> properties) const = 0;
 
-    auto RelevantLabelPropertiesIndicesInfo(std::span<LabelId const> labels,
-                                            std::span<PropertyPath const> properties) const
-        -> std::vector<LabelPropertiesIndicesInfo> {
+    auto RelevantLabelPropertiesIndicesInfo(std::span<LabelId const> labels, std::span<PropertyPath const> properties)
+        const -> std::vector<LabelPropertiesIndicesInfo> {
       return transaction_.active_indices_.label_properties_->RelevantLabelPropertiesIndicesInfo(labels, properties);
     };
 
@@ -488,8 +487,8 @@ class Storage {
     }
     auto GetEnumStoreShared() const -> EnumStore const & { return storage_->enum_store_; }
 
-    auto CreateEnum(std::string_view name, std::span<std::string const> values)
-        -> memgraph::utils::BasicResult<EnumStorageError, EnumTypeId> {
+    auto CreateEnum(std::string_view name,
+                    std::span<std::string const> values) -> memgraph::utils::BasicResult<EnumStorageError, EnumTypeId> {
       auto res = storage_->enum_store_.RegisterEnum(name, values);
       if (res.HasValue()) {
         transaction_.md_deltas.emplace_back(MetadataDelta::enum_create, res.GetValue());
@@ -497,8 +496,8 @@ class Storage {
       return res;
     }
 
-    auto EnumAlterAdd(std::string_view name, std::string_view value)
-        -> utils::BasicResult<storage::EnumStorageError, storage::Enum> {
+    auto EnumAlterAdd(std::string_view name,
+                      std::string_view value) -> utils::BasicResult<storage::EnumStorageError, storage::Enum> {
       auto res = storage_->enum_store_.AddValue(name, value);
       if (res.HasValue()) {
         transaction_.md_deltas.emplace_back(MetadataDelta::enum_alter_add, res.GetValue());
@@ -506,8 +505,8 @@ class Storage {
       return res;
     }
 
-    auto EnumAlterUpdate(std::string_view name, std::string_view old_value, std::string_view new_value)
-        -> utils::BasicResult<storage::EnumStorageError, storage::Enum> {
+    auto EnumAlterUpdate(std::string_view name, std::string_view old_value,
+                         std::string_view new_value) -> utils::BasicResult<storage::EnumStorageError, storage::Enum> {
       auto res = storage_->enum_store_.UpdateValue(name, old_value, new_value);
       if (res.HasValue()) {
         transaction_.md_deltas.emplace_back(MetadataDelta::enum_alter_update, res.GetValue(), std::string{old_value});
@@ -517,8 +516,8 @@ class Storage {
 
     auto ShowEnums() { return storage_->enum_store_.AllRegistered(); }
 
-    auto GetEnumValue(std::string_view name, std::string_view value) const
-        -> utils::BasicResult<EnumStorageError, Enum> {
+    auto GetEnumValue(std::string_view name,
+                      std::string_view value) const -> utils::BasicResult<EnumStorageError, Enum> {
       return storage_->enum_store_.ToEnum(name, value);
     }
 

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -333,8 +333,9 @@ class Storage {
 
     virtual bool LabelPropertyIndexReady(LabelId label, std::span<PropertyPath const> properties) const = 0;
 
-    auto RelevantLabelPropertiesIndicesInfo(std::span<LabelId const> labels, std::span<PropertyPath const> properties)
-        const -> std::vector<LabelPropertiesIndicesInfo> {
+    auto RelevantLabelPropertiesIndicesInfo(std::span<LabelId const> labels,
+                                            std::span<PropertyPath const> properties) const
+        -> std::vector<LabelPropertiesIndicesInfo> {
       return transaction_.active_indices_.label_properties_->RelevantLabelPropertiesIndicesInfo(labels, properties);
     };
 
@@ -487,8 +488,8 @@ class Storage {
     }
     auto GetEnumStoreShared() const -> EnumStore const & { return storage_->enum_store_; }
 
-    auto CreateEnum(std::string_view name,
-                    std::span<std::string const> values) -> memgraph::utils::BasicResult<EnumStorageError, EnumTypeId> {
+    auto CreateEnum(std::string_view name, std::span<std::string const> values)
+        -> memgraph::utils::BasicResult<EnumStorageError, EnumTypeId> {
       auto res = storage_->enum_store_.RegisterEnum(name, values);
       if (res.HasValue()) {
         transaction_.md_deltas.emplace_back(MetadataDelta::enum_create, res.GetValue());
@@ -496,8 +497,8 @@ class Storage {
       return res;
     }
 
-    auto EnumAlterAdd(std::string_view name,
-                      std::string_view value) -> utils::BasicResult<storage::EnumStorageError, storage::Enum> {
+    auto EnumAlterAdd(std::string_view name, std::string_view value)
+        -> utils::BasicResult<storage::EnumStorageError, storage::Enum> {
       auto res = storage_->enum_store_.AddValue(name, value);
       if (res.HasValue()) {
         transaction_.md_deltas.emplace_back(MetadataDelta::enum_alter_add, res.GetValue());
@@ -505,8 +506,8 @@ class Storage {
       return res;
     }
 
-    auto EnumAlterUpdate(std::string_view name, std::string_view old_value,
-                         std::string_view new_value) -> utils::BasicResult<storage::EnumStorageError, storage::Enum> {
+    auto EnumAlterUpdate(std::string_view name, std::string_view old_value, std::string_view new_value)
+        -> utils::BasicResult<storage::EnumStorageError, storage::Enum> {
       auto res = storage_->enum_store_.UpdateValue(name, old_value, new_value);
       if (res.HasValue()) {
         transaction_.md_deltas.emplace_back(MetadataDelta::enum_alter_update, res.GetValue(), std::string{old_value});
@@ -516,8 +517,8 @@ class Storage {
 
     auto ShowEnums() { return storage_->enum_store_.AllRegistered(); }
 
-    auto GetEnumValue(std::string_view name,
-                      std::string_view value) const -> utils::BasicResult<EnumStorageError, Enum> {
+    auto GetEnumValue(std::string_view name, std::string_view value) const
+        -> utils::BasicResult<EnumStorageError, Enum> {
       return storage_->enum_store_.ToEnum(name, value);
     }
 
@@ -540,7 +541,7 @@ class Storage {
 
     auto GetNameIdMapper() const -> NameIdMapper * { return storage_->name_id_mapper_.get(); }
 
-    bool CheckIndicesAreReady(IndicesCollection const &required_indices) {
+    bool CheckIndicesAreReady(IndicesCollection const &required_indices) const {
       return transaction_.active_indices_.CheckIndicesAreReady(required_indices);
     }
 
@@ -652,10 +653,8 @@ class Storage {
     return repl_storage_state_.GetReplicaState(name);
   }
 
-  auto GetActiveIndices() -> ActiveIndices {
-    return {
-        indices_.label_property_index_->GetActiveIndices(),
-    };
+  auto GetActiveIndices() const -> ActiveIndices {
+    return ActiveIndices{indices_.label_property_index_->GetActiveIndices()};
   }
 
   // TODO: make non-public

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "common_function_signatures.hpp"
 #include "mg_procedure.h"
 #include "storage/v2/commit_log.hpp"
 #include "storage/v2/config.hpp"
@@ -408,11 +409,11 @@ class Storage {
 
     std::vector<EdgeTypeId> ListAllPossiblyPresentEdgeTypes() const;
 
-    virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(LabelId label,
-                                                                              bool unique_access_needed = true) = 0;
+    virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
+        LabelId label, bool unique_access_needed = true, PublishIndexWrapper wrapper = no_wrap) = 0;
 
-    virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(LabelId label,
-                                                                              PropertiesPaths properties) = 0;
+    virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
+        LabelId label, PropertiesPaths properties, PublishIndexWrapper wrapper = no_wrap) = 0;
 
     virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(EdgeTypeId edge_type,
                                                                               bool unique_access_needed = true) = 0;

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -331,7 +331,7 @@ class Storage {
 
     virtual bool LabelIndexExists(LabelId label) const = 0;
 
-    virtual bool LabelPropertyIndexExists(LabelId label, std::span<PropertyPath const> properties) const = 0;
+    virtual bool LabelPropertyIndexReady(LabelId label, std::span<PropertyPath const> properties) const = 0;
 
     auto RelevantLabelPropertiesIndicesInfo(std::span<LabelId const> labels,
                                             std::span<PropertyPath const> properties) const
@@ -541,8 +541,8 @@ class Storage {
 
     auto GetNameIdMapper() const -> NameIdMapper * { return storage_->name_id_mapper_.get(); }
 
-    bool CheckActiveIndices(IndicesCollection const &required_indices) {
-      return transaction_.active_indices_.CheckActiveIndices(required_indices);
+    bool CheckIndicesAreReady(IndicesCollection const &required_indices) {
+      return transaction_.active_indices_.CheckIndicesAreReady(required_indices);
     }
 
    protected:

--- a/src/storage/v2/storage_error.hpp
+++ b/src/storage/v2/storage_error.hpp
@@ -22,6 +22,7 @@ struct PersistenceError {};  // TODO: Generalize and add to InMemory durability 
                              // asserts and terminated if failed)
 
 struct IndexDefinitionError {};
+struct IndexDefinitionAlreadyExistsError {};
 struct IndexDefinitionConfigError {};
 
 struct ConstraintsPersistenceError {};
@@ -32,7 +33,8 @@ inline bool operator==(const SerializationError & /*err1*/, const SerializationE
 using StorageManipulationError =
     std::variant<ConstraintViolation, ReplicationError, SerializationError, PersistenceError>;
 
-using StorageIndexDefinitionError = std::variant<IndexDefinitionError, IndexDefinitionConfigError>;
+using StorageIndexDefinitionError =
+    std::variant<IndexDefinitionError, IndexDefinitionAlreadyExistsError, IndexDefinitionConfigError>;
 
 struct ConstraintDefinitionError {};
 

--- a/src/storage/v2/storage_error.hpp
+++ b/src/storage/v2/storage_error.hpp
@@ -22,6 +22,7 @@ struct PersistenceError {};  // TODO: Generalize and add to InMemory durability 
                              // asserts and terminated if failed)
 
 struct IndexDefinitionError {};
+struct IndexDefinitionCancelationError {};
 struct IndexDefinitionAlreadyExistsError {};
 struct IndexDefinitionConfigError {};
 
@@ -33,8 +34,8 @@ inline bool operator==(const SerializationError & /*err1*/, const SerializationE
 using StorageManipulationError =
     std::variant<ConstraintViolation, ReplicationError, SerializationError, PersistenceError>;
 
-using StorageIndexDefinitionError =
-    std::variant<IndexDefinitionError, IndexDefinitionAlreadyExistsError, IndexDefinitionConfigError>;
+using StorageIndexDefinitionError = std::variant<IndexDefinitionError, IndexDefinitionAlreadyExistsError,
+                                                 IndexDefinitionConfigError, IndexDefinitionCancelationError>;
 
 struct ConstraintDefinitionError {};
 

--- a/src/storage/v2/transaction.hpp
+++ b/src/storage/v2/transaction.hpp
@@ -34,6 +34,7 @@
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/schema_info_types.hpp"
 #include "storage/v2/storage_mode.hpp"
+#include "storage/v2/transaction_constants.hpp"
 #include "storage/v2/vertex.hpp"
 #include "storage/v2/vertex_info_cache.hpp"
 #include "utils/pmr/list.hpp"
@@ -41,9 +42,6 @@
 #include <rocksdb/utilities/transaction.h>
 
 namespace memgraph::storage {
-
-const uint64_t kTimestampInitialId = 0;
-const uint64_t kTransactionInitialId = 1ULL << 63U;
 
 struct Transaction {
   Transaction(uint64_t transaction_id, uint64_t start_timestamp, IsolationLevel isolation_level,

--- a/src/storage/v2/transaction_constants.hpp
+++ b/src/storage/v2/transaction_constants.hpp
@@ -1,0 +1,21 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <cstdint>
+
+namespace memgraph::storage {
+
+const uint64_t kTimestampInitialId = 0;
+const uint64_t kTransactionInitialId = 1ULL << 63U;
+
+}  // namespace memgraph::storage

--- a/src/storage/v2/vertex_accessor.cpp
+++ b/src/storage/v2/vertex_accessor.cpp
@@ -168,17 +168,10 @@ Result<bool> VertexAccessor::AddLabel(LabelId label) {
 
   if (storage_->config_.salient.items.enable_label_index_auto_creation &&
       !storage_->indices_.label_index_->IndexExists(label)) {
-    storage_->labels_to_auto_index_.WithLock([&](auto &label_indices) {
-      if (auto it = label_indices.find(label); it != label_indices.end()) {
-        const bool this_txn_already_encountered_label = transaction_->introduced_new_label_index_.contains(label);
-        if (!this_txn_already_encountered_label) {
-          ++(it->second);
-        }
-        return;
-      }
-      label_indices.insert({label, 1});
-    });
-    transaction_->introduced_new_label_index_.insert(label);
+    auto [_, inserted] = transaction_->introduced_new_label_index_.insert(label);
+    if (inserted) {
+      storage_->labels_to_auto_index_.WithLock([&](auto &label_indices) { ++label_indices[label]; });
+    }
   }
 
   /// TODO: some by pointers, some by reference => not good, make it better

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -45,6 +45,7 @@ target_sources(mg-utils
     priority_thread_pool.hpp
     barrier.hpp
     transparent_compare.hpp
+    compile_time.hpp
 )
 
 find_package(Boost REQUIRED CONFIG)

--- a/src/utils/compile_time.hpp
+++ b/src/utils/compile_time.hpp
@@ -1,0 +1,17 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+namespace memgraph::utils {
+template <typename>
+[[maybe_unused]] inline constexpr bool always_false = false;
+}

--- a/src/utils/lru_cache.hpp
+++ b/src/utils/lru_cache.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -36,6 +36,7 @@ class LRUCache {
     item_map.insert(std::make_pair(key, item_list.begin()));
     try_clean();
   };
+
   std::optional<TVal> get(const TKey &key) {
     if (!exists(key)) {
       return std::nullopt;
@@ -44,10 +45,20 @@ class LRUCache {
     item_list.splice(item_list.begin(), item_list, it->second);
     return it->second->second;
   }
+
+  void invalidate(const TKey &key) {
+    auto it = item_map.find(key);
+    if (it != item_map.end()) {
+      item_list.erase(it->second);
+      item_map.erase(it);
+    }
+  }
+
   void reset() {
     item_list.clear();
     item_map.clear();
   };
+
   std::size_t size() { return item_map.size(); };
 
  private:

--- a/src/utils/lru_cache.hpp
+++ b/src/utils/lru_cache.hpp
@@ -32,22 +32,22 @@ class LRUCache {
       item_list.erase(it->second);
       item_map.erase(it);
     }
-    item_list.push_front(std::make_pair(key, val));
+    item_list.emplace_front(key, val);
     item_map.insert(std::make_pair(key, item_list.begin()));
     try_clean();
   };
 
   std::optional<TVal> get(const TKey &key) {
-    if (!exists(key)) {
+    auto const it = item_map.find(key);
+    if (it == item_map.end()) {
       return std::nullopt;
     }
-    auto it = item_map.find(key);
     item_list.splice(item_list.begin(), item_list, it->second);
     return it->second->second;
   }
 
   void invalidate(const TKey &key) {
-    auto it = item_map.find(key);
+    auto const it = item_map.find(key);
     if (it != item_map.end()) {
       item_list.erase(it->second);
       item_map.erase(it);
@@ -59,18 +59,16 @@ class LRUCache {
     item_map.clear();
   };
 
-  std::size_t size() { return item_map.size(); };
+  std::size_t size() const { return item_map.size(); }
 
  private:
   void try_clean() {
     while (item_map.size() > cache_size) {
-      auto last_it_elem_it = item_list.end();
-      last_it_elem_it--;
-      item_map.erase(last_it_elem_it->first);
+      auto last = std::prev(item_list.end());
+      item_map.erase(last->first);
       item_list.pop_back();
     }
   };
-  bool exists(const TKey &key) { return (item_map.count(key) > 0); };
 
   std::list<std::pair<TKey, TVal>> item_list;
   std::unordered_map<TKey, decltype(item_list.begin())> item_map;

--- a/src/utils/scheduler.cpp
+++ b/src/utils/scheduler.cpp
@@ -126,6 +126,13 @@ SchedulerInterval::SchedulerInterval(std::string str) {
   LOG_FATAL("Scheduler setup not an interval or cron expression");
 }
 
+SchedulerInterval::operator bool() const {
+  return std::visit(
+      utils::Overloaded{[](const PeriodStartTime &pst) { return pst.period != std::chrono::milliseconds(0); },
+                        [](const std::string &cron) { return !cron.empty(); }},
+      period_or_cron);
+}
+
 // Checking stop_possible() is necessary because otherwise calling IsRunning
 // on a non-started Scheduler would return true.
 bool Scheduler::IsRunning() {

--- a/src/utils/scheduler.hpp
+++ b/src/utils/scheduler.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -47,12 +47,7 @@ struct SchedulerInterval {
 
   std::variant<PeriodStartTime, std::string> period_or_cron{};
 
-  explicit operator bool() const {
-    return std::visit(
-        utils::Overloaded{[](const PeriodStartTime &pst) { return pst.period != std::chrono::milliseconds(0); },
-                          [](const std::string &cron) { return !cron.empty(); }},
-        period_or_cron);
-  }
+  explicit operator bool() const;
 
   void Execute(auto &&overloaded) const {
     std::visit(utils::Overloaded([&overloaded](PeriodStartTime pst) { overloaded(pst.period, pst.start_time); },

--- a/tests/e2e/CMakeLists.txt
+++ b/tests/e2e/CMakeLists.txt
@@ -5,12 +5,16 @@ function(add_query_module target_name src)
         target_include_directories(${target_name} PRIVATE ${CMAKE_SOURCE_DIR}/include)
 endfunction()
 
+add_custom_target(memgraph__e2e)
+add_dependencies(memgraph__e2e memgraph)
+
 function(copy_e2e_python_files TARGET_PREFIX FILE_NAME)
         add_custom_target(memgraph__e2e__${TARGET_PREFIX}__${FILE_NAME} ALL
                 COMMAND ${CMAKE_COMMAND} -E copy
                 ${CMAKE_CURRENT_SOURCE_DIR}/${FILE_NAME}
                 ${CMAKE_CURRENT_BINARY_DIR}/${FILE_NAME}
                 DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${FILE_NAME})
+        add_dependencies(memgraph__e2e memgraph__e2e__${TARGET_PREFIX}__${FILE_NAME})
 endfunction()
 
 function(copy_e2e_python_files_from_parent_folder TARGET_PREFIX EXTRA_PATH FILE_NAME)
@@ -19,6 +23,7 @@ function(copy_e2e_python_files_from_parent_folder TARGET_PREFIX EXTRA_PATH FILE_
                 ${CMAKE_CURRENT_SOURCE_DIR}/${EXTRA_PATH}/${FILE_NAME}
                 ${CMAKE_CURRENT_BINARY_DIR}/${FILE_NAME}
                 DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${EXTRA_PATH}/${FILE_NAME})
+        add_dependencies(memgraph__e2e memgraph__e2e__${TARGET_PREFIX}__${FILE_NAME})
 endfunction()
 
 function(copy_e2e_cpp_files TARGET_PREFIX FILE_NAME)
@@ -27,6 +32,7 @@ function(copy_e2e_cpp_files TARGET_PREFIX FILE_NAME)
                 ${CMAKE_CURRENT_SOURCE_DIR}/${FILE_NAME}
                 ${CMAKE_CURRENT_BINARY_DIR}/${FILE_NAME}
                 DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${FILE_NAME})
+        add_dependencies(memgraph__e2e memgraph__e2e__${TARGET_PREFIX}__${FILE_NAME})
 endfunction()
 
 function(copy_e2e_files TARGET_PREFIX FILE_NAME)
@@ -35,6 +41,7 @@ function(copy_e2e_files TARGET_PREFIX FILE_NAME)
                 ${CMAKE_CURRENT_SOURCE_DIR}/${FILE_NAME}
                 ${CMAKE_CURRENT_BINARY_DIR}/${FILE_NAME}
                 DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${FILE_NAME})
+        add_dependencies(memgraph__e2e memgraph__e2e__${TARGET_PREFIX}__${FILE_NAME})
 endfunction()
 
 add_subdirectory(fine_grained_access)

--- a/tests/manual/query_hash.cpp
+++ b/tests/manual/query_hash.cpp
@@ -33,8 +33,8 @@ int main(int argc, char **argv) {
 
   // print query, stripped query, hash and variable values (propertie values)
   std::cout << fmt::format("Query: {}\n", query);
-  std::cout << fmt::format("Stripped query: {}\n", preprocessed.query());
-  std::cout << fmt::format("Query hash: {}\n", preprocessed.hash());
+  std::cout << fmt::format("Stripped query: {}\n", preprocessed.stripped_query().str());
+  std::cout << fmt::format("Query hash: {}\n", preprocessed.stripped_query().hash());
   std::cout << fmt::format("Property values:\n");
   for (int i = 0; i < preprocessed.literals().size(); ++i) {
     std::cout << " " << preprocessed.literals().At(1).second;

--- a/tests/unit/cpp_api.cpp
+++ b/tests/unit/cpp_api.cpp
@@ -764,42 +764,73 @@ TYPED_TEST(CppApiTestFixture, TestLabelIndex) {
 }
 
 TYPED_TEST(CppApiTestFixture, TestLabelPropertyIndex) {
-  auto storage_acc = this->storage->UniqueAccess();
-  auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
-  mgp_graph raw_graph = this->CreateGraph(db_acc.get());
+  {
+    auto storage_acc = this->storage->UniqueAccess();
+    auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
+    mgp_graph raw_graph = this->CreateGraph(db_acc.get());
+    ASSERT_TRUE(mgp::CreateLabelPropertyIndex(&raw_graph, "User", "name"));
+  }
+  {
+    auto storage_acc = this->storage->UniqueAccess();
+    auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
+    mgp_graph raw_graph = this->CreateGraph(db_acc.get());
 
-  ASSERT_TRUE(mgp::CreateLabelPropertyIndex(&raw_graph, "User", "name"));
+    auto indices = mgp::ListAllLabelPropertyIndices(&raw_graph);
+    ASSERT_EQ(indices.Size(), 1);
+    auto index_info = indices[0].ValueString();
+    ASSERT_EQ(index_info, "User:name");
+  }
+  {
+    auto storage_acc = this->storage->UniqueAccess();
+    auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
+    mgp_graph raw_graph = this->CreateGraph(db_acc.get());
+    ASSERT_TRUE(mgp::DropLabelPropertyIndex(&raw_graph, "User", "name"));
+  }
+  {
+    auto storage_acc = this->storage->UniqueAccess();
+    auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
+    mgp_graph raw_graph = this->CreateGraph(db_acc.get());
+    auto updated_indices = mgp::ListAllLabelPropertyIndices(&raw_graph);
+    ASSERT_EQ(updated_indices.Size(), 0);
 
-  auto indices = mgp::ListAllLabelPropertyIndices(&raw_graph);
-  ASSERT_EQ(indices.Size(), 1);
-  auto index_info = indices[0].ValueString();
-  ASSERT_EQ(index_info, "User:name");
-
-  ASSERT_TRUE(mgp::DropLabelPropertyIndex(&raw_graph, "User", "name"));
-  auto updated_indices = mgp::ListAllLabelPropertyIndices(&raw_graph);
-  ASSERT_EQ(updated_indices.Size(), 0);
-
-  ASSERT_FALSE(mgp::DropLabelPropertyIndex(&raw_graph, "User", "nonexistent"));
+    ASSERT_FALSE(mgp::DropLabelPropertyIndex(&raw_graph, "User", "nonexistent"));
+  }
 }
 
 TYPED_TEST(CppApiTestFixture, TestNestedIndex) {
   if constexpr (!std::is_same<TypeParam, memgraph::storage::InMemoryStorage>::value) {
     GTEST_SKIP() << "TestNestedIndex runs only on InMemoryStorage.";
   }
-  auto storage_acc = this->storage->UniqueAccess();
-  auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
-  mgp_graph raw_graph = this->CreateGraph(db_acc.get());
+  {
+    auto storage_acc = this->storage->UniqueAccess();
+    auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
+    mgp_graph raw_graph = this->CreateGraph(db_acc.get());
 
-  ASSERT_TRUE(mgp::CreateLabelPropertyIndex(&raw_graph, "Label", "nested1.nested2.nested3"));
+    ASSERT_TRUE(mgp::CreateLabelPropertyIndex(&raw_graph, "Label", "nested1.nested2.nested3"));
+  }
+  {
+    auto storage_acc = this->storage->UniqueAccess();
+    auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
+    mgp_graph raw_graph = this->CreateGraph(db_acc.get());
+    auto indices = mgp::ListAllLabelPropertyIndices(&raw_graph);
+    ASSERT_EQ(indices.Size(), 1);
+    auto index_info = indices[0].ValueString();
+    ASSERT_EQ(index_info, "Label:nested1.nested2.nested3");
+  }
+  {
+    auto storage_acc = this->storage->UniqueAccess();
+    auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
+    mgp_graph raw_graph = this->CreateGraph(db_acc.get());
+    ASSERT_TRUE(mgp::DropLabelPropertyIndex(&raw_graph, "Label", "nested1.nested2.nested3"));
+  }
+  {
+    auto storage_acc = this->storage->UniqueAccess();
+    auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
+    mgp_graph raw_graph = this->CreateGraph(db_acc.get());
 
-  auto indices = mgp::ListAllLabelPropertyIndices(&raw_graph);
-  ASSERT_EQ(indices.Size(), 1);
-  auto index_info = indices[0].ValueString();
-  ASSERT_EQ(index_info, "Label:nested1.nested2.nested3");
-
-  ASSERT_TRUE(mgp::DropLabelPropertyIndex(&raw_graph, "Label", "nested1.nested2.nested3"));
-  auto updated_indices = mgp::ListAllLabelPropertyIndices(&raw_graph);
-  ASSERT_EQ(updated_indices.Size(), 0);
+    auto updated_indices = mgp::ListAllLabelPropertyIndices(&raw_graph);
+    ASSERT_EQ(updated_indices.Size(), 0);
+  }
 }
 
 TYPED_TEST(CppApiTestFixture, TestExistenceConstraint) {

--- a/tests/unit/cpp_api.cpp
+++ b/tests/unit/cpp_api.cpp
@@ -40,7 +40,7 @@ struct CppApiTestFixture : public ::testing::Test {
   }
 
   auto CreateIndexAccessor() -> std::unique_ptr<memgraph::storage::Storage::Accessor> {
-    if constexpr ((std::is_same_v<StorageType, memgraph::storage::InMemoryStorage>)) {
+    if constexpr (std::is_same_v<StorageType, memgraph::storage::InMemoryStorage>) {
       return this->storage->ReadOnlyAccess();
     } else {
       return this->storage->UniqueAccess();
@@ -48,7 +48,7 @@ struct CppApiTestFixture : public ::testing::Test {
   }
 
   auto DropIndexAccessor() -> std::unique_ptr<memgraph::storage::Storage::Accessor> {
-    if constexpr ((std::is_same_v<StorageType, memgraph::storage::InMemoryStorage>)) {
+    if constexpr (std::is_same_v<StorageType, memgraph::storage::InMemoryStorage>) {
       return this->storage->Access(memgraph::storage::Storage::Accessor::Type::READ);
     } else {
       return this->storage->UniqueAccess();

--- a/tests/unit/cpp_api.cpp
+++ b/tests/unit/cpp_api.cpp
@@ -785,6 +785,7 @@ TYPED_TEST(CppApiTestFixture, TestLabelPropertyIndex) {
     auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
     mgp_graph raw_graph = this->CreateGraph(db_acc.get());
     ASSERT_TRUE(mgp::CreateLabelPropertyIndex(&raw_graph, "User", "name"));
+    ASSERT_FALSE(db_acc->Commit().HasError());
   }
   {
     auto storage_acc = this->storage->UniqueAccess();
@@ -801,6 +802,7 @@ TYPED_TEST(CppApiTestFixture, TestLabelPropertyIndex) {
     auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
     mgp_graph raw_graph = this->CreateGraph(db_acc.get());
     ASSERT_TRUE(mgp::DropLabelPropertyIndex(&raw_graph, "User", "name"));
+    ASSERT_FALSE(db_acc->Commit().HasError());
   }
   {
     auto storage_acc = this->storage->UniqueAccess();
@@ -814,6 +816,7 @@ TYPED_TEST(CppApiTestFixture, TestLabelPropertyIndex) {
     auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
     mgp_graph raw_graph = this->CreateGraph(db_acc.get());
     ASSERT_FALSE(mgp::DropLabelPropertyIndex(&raw_graph, "User", "nonexistent"));
+    ASSERT_FALSE(db_acc->Commit().HasError());
   }
 }
 
@@ -827,6 +830,7 @@ TYPED_TEST(CppApiTestFixture, TestNestedIndex) {
     mgp_graph raw_graph = this->CreateGraph(db_acc.get());
 
     ASSERT_TRUE(mgp::CreateLabelPropertyIndex(&raw_graph, "Label", "nested1.nested2.nested3"));
+    ASSERT_FALSE(db_acc->Commit().HasError());
   }
   {
     auto storage_acc = this->storage->UniqueAccess();
@@ -842,6 +846,7 @@ TYPED_TEST(CppApiTestFixture, TestNestedIndex) {
     auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
     mgp_graph raw_graph = this->CreateGraph(db_acc.get());
     ASSERT_TRUE(mgp::DropLabelPropertyIndex(&raw_graph, "Label", "nested1.nested2.nested3"));
+    ASSERT_FALSE(db_acc->Commit().HasError());
   }
   {
     auto storage_acc = this->storage->UniqueAccess();

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -199,7 +199,7 @@ class CachedAstGenerator : public Base {
     context_.is_query_cached = true;
     StrippedQuery stripped(query_string);
     parameters_ = stripped.literals();
-    ::frontend::opencypher::Parser parser(stripped.query());
+    ::frontend::opencypher::Parser parser(stripped.stripped_query().str());
     Parameters parameters;
     AstStorage tmp_storage;
     CypherMainVisitor visitor(context_, &tmp_storage, &parameters);
@@ -259,9 +259,9 @@ class MockModule : public procedure::Module {
   std::map<std::string, mgp_func, std::less<>> functions{};
 };
 
-void DummyProcCallback(mgp_list * /*args*/, mgp_graph * /*graph*/, mgp_result * /*result*/, mgp_memory * /*memory*/){};
+void DummyProcCallback(mgp_list * /*args*/, mgp_graph * /*graph*/, mgp_result * /*result*/, mgp_memory * /*memory*/) {};
 void DummyFuncCallback(mgp_list * /*args*/, mgp_func_context * /*func_ctx*/, mgp_func_result * /*result*/,
-                       mgp_memory * /*memory*/){};
+                       mgp_memory * /*memory*/) {};
 
 enum class ProcedureType { WRITE, READ };
 

--- a/tests/unit/lru_cache.cpp
+++ b/tests/unit/lru_cache.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -108,4 +108,37 @@ TEST(LRUCacheTest, LargeCacheTest) {
     EXPECT_TRUE(value.has_value());
     EXPECT_EQ(value.value(), i);
   }
+}
+
+TEST(LRUCacheTest, InvalidateTest) {
+  memgraph::utils::LRUCache<int, int> cache(3);
+  cache.put(1, 100);
+  cache.put(2, 200);
+  cache.put(3, 300);
+
+  // Ensure all elements are present
+  EXPECT_TRUE(cache.get(1).has_value());
+  EXPECT_TRUE(cache.get(2).has_value());
+  EXPECT_TRUE(cache.get(3).has_value());
+
+  // Invalidate one key
+  cache.invalidate(2);
+
+  // Key 2 should be removed
+  std::optional<int> value = cache.get(2);
+  EXPECT_FALSE(value.has_value());
+
+  // Other keys should still be present
+  EXPECT_TRUE(cache.get(1).has_value());
+  EXPECT_EQ(cache.get(1).value(), 100);
+
+  EXPECT_TRUE(cache.get(3).has_value());
+  EXPECT_EQ(cache.get(3).value(), 300);
+
+  // Cache size should be 2 now
+  EXPECT_EQ(cache.size(), 2);
+
+  // Invalidate a non-existent key (should not crash or change state)
+  cache.invalidate(42);
+  EXPECT_EQ(cache.size(), 2);
 }

--- a/tests/unit/query_plan_checker.hpp
+++ b/tests/unit/query_plan_checker.hpp
@@ -712,19 +712,8 @@ class FakeDbAccessor {
     return label_index_.find(label) != label_index_.end();
   }
 
-  bool LabelPropertyIndexExists(memgraph::storage::LabelId label,
-                                memgraph::storage::PropertyPath const &property) const {
-    std::vector const properties{property};
-    for (const auto &index : label_properties_index_) {
-      if (std::get<0>(index) == label && std::get<1>(index) == properties) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  bool LabelPropertyIndexExists(memgraph::storage::LabelId label,
-                                std::span<memgraph::storage::PropertyPath const> properties) const {
+  bool LabelPropertyIndexReady(memgraph::storage::LabelId label,
+                               std::span<memgraph::storage::PropertyPath const> properties) const {
     return std::ranges::find_if(label_properties_index_, [&](auto const &each) {
              return std::get<0>(each) == label && std::ranges::equal(std::get<1>(each), properties);
            }) != label_properties_index_.end();

--- a/tests/unit/snapshot_rpc_progress.cpp
+++ b/tests/unit/snapshot_rpc_progress.cpp
@@ -189,8 +189,8 @@ TEST_F(SnapshotRpcProgressTest, TestLabelPropertyIndexSingleThreadedNoVertices) 
   snapshot_info.emplace(mocked_observer, 3);
 
   EXPECT_CALL(*mocked_observer, Update()).Times(0);
-  ASSERT_TRUE(label_prop_idx.CreateIndex(label, std::vector{PropertyPath{prop}}, vertices.access(), par_schema_info,
-                                         snapshot_info));
+  ASSERT_TRUE(label_prop_idx.CreateIndexOnePass(label, std::vector{PropertyPath{prop}}, vertices.access(),
+                                                par_schema_info, snapshot_info));
 }
 
 TEST_F(SnapshotRpcProgressTest, TestLabelPropertyIndexSingleThreadedVertices) {
@@ -213,8 +213,8 @@ TEST_F(SnapshotRpcProgressTest, TestLabelPropertyIndexSingleThreadedVertices) {
   std::optional<SnapshotObserverInfo> snapshot_info;
   snapshot_info.emplace(mocked_observer, 2);
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
-  ASSERT_TRUE(label_prop_idx.CreateIndex(label, std::vector{PropertyPath{prop}}, vertices.access(), par_schema_info,
-                                         snapshot_info));
+  ASSERT_TRUE(label_prop_idx.CreateIndexOnePass(label, std::vector{PropertyPath{prop}}, vertices.access(),
+                                                par_schema_info, snapshot_info));
 }
 
 TEST_F(SnapshotRpcProgressTest, TestLabelPropertiesIndexSingleThreadedVertices) {
@@ -239,9 +239,9 @@ TEST_F(SnapshotRpcProgressTest, TestLabelPropertiesIndexSingleThreadedVertices) 
   std::optional<SnapshotObserverInfo> snapshot_info;
   snapshot_info.emplace(mocked_observer, 2);
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
-  ASSERT_TRUE(label_prop_idx.CreateIndex(label,
-                                         std::vector{PropertyPath{prop_c}, PropertyPath{prop_a}, PropertyPath{prop_b}},
-                                         vertices.access(), par_schema_info, snapshot_info));
+  ASSERT_TRUE(label_prop_idx.CreateIndexOnePass(
+      label, std::vector{PropertyPath{prop_c}, PropertyPath{prop_a}, PropertyPath{prop_b}}, vertices.access(),
+      par_schema_info, snapshot_info));
 }
 
 TEST_F(SnapshotRpcProgressTest, TestLabelPropertyIndexMultiThreadedVertices) {
@@ -266,8 +266,8 @@ TEST_F(SnapshotRpcProgressTest, TestLabelPropertyIndexMultiThreadedVertices) {
   std::optional<SnapshotObserverInfo> snapshot_info;
   snapshot_info.emplace(mocked_observer, 2);
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
-  ASSERT_TRUE(label_prop_idx.CreateIndex(label, std::vector{PropertyPath{prop}}, vertices.access(), par_schema_info,
-                                         snapshot_info));
+  ASSERT_TRUE(label_prop_idx.CreateIndexOnePass(label, std::vector{PropertyPath{prop}}, vertices.access(),
+                                                par_schema_info, snapshot_info));
 }
 
 TEST_F(SnapshotRpcProgressTest, TestLabelPropertiesIndexMultiThreadedVertices) {
@@ -294,9 +294,9 @@ TEST_F(SnapshotRpcProgressTest, TestLabelPropertiesIndexMultiThreadedVertices) {
   std::optional<SnapshotObserverInfo> snapshot_info;
   snapshot_info.emplace(mocked_observer, 2);
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
-  ASSERT_TRUE(label_prop_idx.CreateIndex(label,
-                                         std::vector{PropertyPath{prop_c}, PropertyPath{prop_a}, PropertyPath{prop_b}},
-                                         vertices.access(), par_schema_info, snapshot_info));
+  ASSERT_TRUE(label_prop_idx.CreateIndexOnePass(
+      label, std::vector{PropertyPath{prop_c}, PropertyPath{prop_a}, PropertyPath{prop_b}}, vertices.access(),
+      par_schema_info, snapshot_info));
 }
 
 TEST_F(SnapshotRpcProgressTest, SnapshotRpcNoTimeout) {

--- a/tests/unit/storage_v2_durability_inmemory.cpp
+++ b/tests/unit/storage_v2_durability_inmemory.cpp
@@ -161,9 +161,9 @@ class DurabilityTest : public ::testing::TestWithParam<bool> {
     }
     {
       // Create label+property index.
-      auto unique_acc = store->UniqueAccess();
-      ASSERT_FALSE(unique_acc->CreateIndex(label_indexed, {property_id}).HasError());
-      ASSERT_FALSE(unique_acc->Commit().HasError());
+      auto acc = store->ReadOnlyAccess();
+      ASSERT_FALSE(acc->CreateIndex(label_indexed, {property_id}).HasError());
+      ASSERT_FALSE(acc->Commit().HasError());
     }
     {
       // Create label+property index statistics.
@@ -175,9 +175,9 @@ class DurabilityTest : public ::testing::TestWithParam<bool> {
     }
     {
       // Create label+properties index.
-      auto unique_acc = store->UniqueAccess();
-      ASSERT_FALSE(unique_acc->CreateIndex(label_indexed, {property_b, property_a, property_c}).HasError());
-      ASSERT_FALSE(unique_acc->Commit().HasError());
+      auto acc = store->ReadOnlyAccess();
+      ASSERT_FALSE(acc->CreateIndex(label_indexed, {property_b, property_a, property_c}).HasError());
+      ASSERT_FALSE(acc->Commit().HasError());
     }
     {
       // Create label+properties index statistics.
@@ -194,10 +194,10 @@ class DurabilityTest : public ::testing::TestWithParam<bool> {
     }
     {
       // Create nested index.
-      auto unique_acc = store->UniqueAccess();
+      auto acc = store->ReadOnlyAccess();
       ASSERT_FALSE(
-          unique_acc->CreateIndex(label_indexed, {{nested1_property, nested2_property, nested3_property}}).HasError());
-      ASSERT_FALSE(unique_acc->Commit().HasError());
+          acc->CreateIndex(label_indexed, {{nested1_property, nested2_property, nested3_property}}).HasError());
+      ASSERT_FALSE(acc->Commit().HasError());
     }
     {
       // Create nested index statistics.
@@ -365,9 +365,9 @@ class DurabilityTest : public ::testing::TestWithParam<bool> {
     }
     {
       // Create label+property index.
-      auto unique_acc = store->UniqueAccess();
-      ASSERT_FALSE(unique_acc->CreateIndex(label_indexed, {property_count}).HasError());
-      ASSERT_FALSE(unique_acc->Commit().HasError());
+      auto acc = store->ReadOnlyAccess();
+      ASSERT_FALSE(acc->CreateIndex(label_indexed, {property_count}).HasError());
+      ASSERT_FALSE(acc->Commit().HasError());
     }
     {
       // Create label+property index statistics.
@@ -2244,9 +2244,9 @@ TEST_P(DurabilityTest, WalCreateAndRemoveEverything) {
       ASSERT_FALSE(unique_acc->Commit().HasError());
     }
     for (const auto &[label, properties] : indices.label_properties) {
-      auto unique_acc = db.UniqueAccess();
-      ASSERT_FALSE(unique_acc->DropIndex(label, std::vector(properties)).HasError());
-      ASSERT_FALSE(unique_acc->Commit().HasError());
+      auto acc = db.Access(memgraph::storage::Storage::Accessor::Type::READ);
+      ASSERT_FALSE(acc->DropIndex(label, std::vector(properties)).HasError());
+      ASSERT_FALSE(acc->Commit().HasError());
     }
     auto constraints = [&] {
       auto acc = db.Access();

--- a/tests/unit/storage_v2_get_info.cpp
+++ b/tests/unit/storage_v2_get_info.cpp
@@ -49,6 +49,22 @@ class InfoTest : public testing::Test {
     this->storage.reset(nullptr);
   }
 
+  auto CreateIndexAccessor() -> std::unique_ptr<memgraph::storage::Storage::Accessor> {
+    if constexpr ((std::is_same_v<StorageType, memgraph::storage::InMemoryStorage>)) {
+      return this->storage->ReadOnlyAccess();
+    } else {
+      return this->storage->UniqueAccess();
+    }
+  }
+
+  auto DropIndexAccessor() -> std::unique_ptr<memgraph::storage::Storage::Accessor> {
+    if constexpr ((std::is_same_v<StorageType, memgraph::storage::InMemoryStorage>)) {
+      return this->storage->Access(memgraph::storage::Storage::Accessor::Type::READ);
+    } else {
+      return this->storage->UniqueAccess();
+    }
+  }
+
   memgraph::storage::Config config_;
   memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock> repl_state_{
       storage_directory};
@@ -109,36 +125,36 @@ TYPED_TEST(InfoTest, InfoCheck) {
     ASSERT_FALSE(unique_acc->Commit().HasError());
   }
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    ASSERT_FALSE(unique_acc->CreateIndex(lbl, {prop}).HasError());
-    ASSERT_FALSE(unique_acc->Commit().HasError());
+    auto acc = this->CreateIndexAccessor();
+    ASSERT_FALSE(acc->CreateIndex(lbl, {prop}).HasError());
+    ASSERT_FALSE(acc->Commit().HasError());
   }
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    ASSERT_FALSE(unique_acc->CreateIndex(lbl, {prop2}).HasError());
-    ASSERT_FALSE(unique_acc->Commit().HasError());
+    auto acc = this->CreateIndexAccessor();
+    ASSERT_FALSE(acc->CreateIndex(lbl, {prop2}).HasError());
+    ASSERT_FALSE(acc->Commit().HasError());
   }
   if constexpr (!is_using_disk_storage) {
     {
-      auto unique_acc = this->storage->UniqueAccess();
-      ASSERT_FALSE(unique_acc->CreateIndex(lbl, {prop, prop2}).HasError());
-      ASSERT_FALSE(unique_acc->Commit().HasError());
+      auto acc = this->CreateIndexAccessor();
+      ASSERT_FALSE(acc->CreateIndex(lbl, {prop, prop2}).HasError());
+      ASSERT_FALSE(acc->Commit().HasError());
     }
     {
-      auto unique_acc = this->storage->UniqueAccess();
-      ASSERT_FALSE(unique_acc->CreateIndex(lbl, {prop2, prop}).HasError());
-      ASSERT_FALSE(unique_acc->Commit().HasError());
+      auto acc = this->CreateIndexAccessor();
+      ASSERT_FALSE(acc->CreateIndex(lbl, {prop2, prop}).HasError());
+      ASSERT_FALSE(acc->Commit().HasError());
     }
   }
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    ASSERT_FALSE(unique_acc->DropIndex(lbl, {prop}).HasError());
-    ASSERT_FALSE(unique_acc->Commit().HasError());
+    auto acc = this->DropIndexAccessor();
+    ASSERT_FALSE(acc->DropIndex(lbl, {prop}).HasError());
+    ASSERT_FALSE(acc->Commit().HasError());
   }
   if constexpr (!is_using_disk_storage) {
-    auto unique_acc = this->storage->UniqueAccess();
-    ASSERT_FALSE(unique_acc->DropIndex(lbl, {prop, prop2}).HasError());
-    ASSERT_FALSE(unique_acc->Commit().HasError());
+    auto acc = this->DropIndexAccessor();
+    ASSERT_FALSE(acc->DropIndex(lbl, {prop, prop2}).HasError());
+    ASSERT_FALSE(acc->Commit().HasError());
   }
 
   {

--- a/tests/unit/storage_v2_get_info.cpp
+++ b/tests/unit/storage_v2_get_info.cpp
@@ -50,7 +50,7 @@ class InfoTest : public testing::Test {
   }
 
   auto CreateIndexAccessor() -> std::unique_ptr<memgraph::storage::Storage::Accessor> {
-    if constexpr ((std::is_same_v<StorageType, memgraph::storage::InMemoryStorage>)) {
+    if constexpr (std::is_same_v<StorageType, memgraph::storage::InMemoryStorage>) {
       return this->storage->ReadOnlyAccess();
     } else {
       return this->storage->UniqueAccess();
@@ -58,7 +58,7 @@ class InfoTest : public testing::Test {
   }
 
   auto DropIndexAccessor() -> std::unique_ptr<memgraph::storage::Storage::Accessor> {
-    if constexpr ((std::is_same_v<StorageType, memgraph::storage::InMemoryStorage>)) {
+    if constexpr (std::is_same_v<StorageType, memgraph::storage::InMemoryStorage>) {
       return this->storage->Access(memgraph::storage::Storage::Accessor::Type::READ);
     } else {
       return this->storage->UniqueAccess();

--- a/tests/unit/storage_v2_indices.cpp
+++ b/tests/unit/storage_v2_indices.cpp
@@ -100,7 +100,7 @@ class IndexTest : public testing::Test {
   }
 
   auto CreateIndexAccessor() -> std::unique_ptr<memgraph::storage::Storage::Accessor> {
-    if constexpr ((std::is_same_v<StorageType, memgraph::storage::InMemoryStorage>)) {
+    if constexpr (std::is_same_v<StorageType, memgraph::storage::InMemoryStorage>) {
       return this->storage->ReadOnlyAccess();
     } else {
       return this->storage->UniqueAccess();
@@ -108,7 +108,7 @@ class IndexTest : public testing::Test {
   }
 
   auto DropIndexAccessor() -> std::unique_ptr<memgraph::storage::Storage::Accessor> {
-    if constexpr ((std::is_same_v<StorageType, memgraph::storage::InMemoryStorage>)) {
+    if constexpr (std::is_same_v<StorageType, memgraph::storage::InMemoryStorage>) {
       return this->storage->Access(memgraph::storage::Storage::Accessor::Type::READ);
     } else {
       return this->storage->UniqueAccess();

--- a/tests/unit/storage_v2_indices.cpp
+++ b/tests/unit/storage_v2_indices.cpp
@@ -660,7 +660,7 @@ TYPED_TEST(IndexTest, LabelPropertyIndexCreateAndDrop) {
   }
   {
     auto acc = this->storage->Access();
-    EXPECT_TRUE(acc->LabelPropertyIndexExists(this->label1, std::array{PropertyPath{this->prop_id}}));
+    EXPECT_TRUE(acc->LabelPropertyIndexReady(this->label1, std::array{PropertyPath{this->prop_id}}));
   }
   {
     auto acc = this->storage->Access();
@@ -670,7 +670,7 @@ TYPED_TEST(IndexTest, LabelPropertyIndexCreateAndDrop) {
   }
   {
     auto acc = this->storage->Access();
-    EXPECT_FALSE(acc->LabelPropertyIndexExists(this->label2, std::array{PropertyPath{this->prop_id}}));
+    EXPECT_FALSE(acc->LabelPropertyIndexReady(this->label2, std::array{PropertyPath{this->prop_id}}));
   }
 
   {
@@ -694,7 +694,7 @@ TYPED_TEST(IndexTest, LabelPropertyIndexCreateAndDrop) {
 
   {
     auto acc = this->storage->Access();
-    EXPECT_TRUE(acc->LabelPropertyIndexExists(this->label2, std::array{PropertyPath{this->prop_id}}));
+    EXPECT_TRUE(acc->LabelPropertyIndexReady(this->label2, std::array{PropertyPath{this->prop_id}}));
   }
 
   {
@@ -712,7 +712,7 @@ TYPED_TEST(IndexTest, LabelPropertyIndexCreateAndDrop) {
   }
   {
     auto acc = this->storage->Access();
-    EXPECT_FALSE(acc->LabelPropertyIndexExists(this->label1, std::array{PropertyPath{this->prop_id}}));
+    EXPECT_FALSE(acc->LabelPropertyIndexReady(this->label1, std::array{PropertyPath{this->prop_id}}));
   }
 
   {
@@ -735,7 +735,7 @@ TYPED_TEST(IndexTest, LabelPropertyIndexCreateAndDrop) {
   }
   {
     auto acc = this->storage->Access();
-    EXPECT_FALSE(acc->LabelPropertyIndexExists(this->label2, std::array{PropertyPath{this->prop_id}}));
+    EXPECT_FALSE(acc->LabelPropertyIndexReady(this->label2, std::array{PropertyPath{this->prop_id}}));
   }
 
   {
@@ -762,7 +762,7 @@ TYPED_TEST(IndexTest, LabelPropertyCompositeIndexCreateAndDrop) {
   }
   {
     auto acc = this->storage->Access();
-    EXPECT_TRUE(acc->LabelPropertyIndexExists(
+    EXPECT_TRUE(acc->LabelPropertyIndexReady(
         this->label1, std::array{PropertyPath{this->prop_a}, PropertyPath{this->prop_b}, PropertyPath{this->prop_c}}));
   }
   {
@@ -774,7 +774,7 @@ TYPED_TEST(IndexTest, LabelPropertyCompositeIndexCreateAndDrop) {
   }
   {
     auto acc = this->storage->Access();
-    EXPECT_FALSE(acc->LabelPropertyIndexExists(
+    EXPECT_FALSE(acc->LabelPropertyIndexReady(
         this->label2, std::array{PropertyPath{this->prop_a}, PropertyPath{this->prop_b}, PropertyPath{this->prop_c}}));
   }
 
@@ -804,7 +804,7 @@ TYPED_TEST(IndexTest, LabelPropertyCompositeIndexCreateAndDrop) {
 
   {
     auto acc = this->storage->Access();
-    EXPECT_TRUE(acc->LabelPropertyIndexExists(
+    EXPECT_TRUE(acc->LabelPropertyIndexReady(
         this->label2, std::array{PropertyPath{this->prop_a}, PropertyPath{this->prop_b}, PropertyPath{this->prop_c}}));
   }
 
@@ -827,7 +827,7 @@ TYPED_TEST(IndexTest, LabelPropertyCompositeIndexCreateAndDrop) {
   }
   {
     auto acc = this->storage->Access();
-    EXPECT_FALSE(acc->LabelPropertyIndexExists(
+    EXPECT_FALSE(acc->LabelPropertyIndexReady(
         this->label1, std::array{PropertyPath{this->prop_a}, PropertyPath{this->prop_b}, PropertyPath{this->prop_c}}));
   }
 
@@ -856,7 +856,7 @@ TYPED_TEST(IndexTest, LabelPropertyCompositeIndexCreateAndDrop) {
   }
   {
     auto acc = this->storage->Access();
-    EXPECT_FALSE(acc->LabelPropertyIndexExists(
+    EXPECT_FALSE(acc->LabelPropertyIndexReady(
         this->label2, std::array{PropertyPath{this->prop_a}, PropertyPath{this->prop_b}, PropertyPath{this->prop_c}}));
   }
 

--- a/tests/unit/storage_v2_indices.cpp
+++ b/tests/unit/storage_v2_indices.cpp
@@ -99,6 +99,22 @@ class IndexTest : public testing::Test {
     this->storage.reset(nullptr);
   }
 
+  auto CreateIndexAccessor() -> std::unique_ptr<memgraph::storage::Storage::Accessor> {
+    if constexpr ((std::is_same_v<StorageType, memgraph::storage::InMemoryStorage>)) {
+      return this->storage->ReadOnlyAccess();
+    } else {
+      return this->storage->UniqueAccess();
+    }
+  }
+
+  auto DropIndexAccessor() -> std::unique_ptr<memgraph::storage::Storage::Accessor> {
+    if constexpr ((std::is_same_v<StorageType, memgraph::storage::InMemoryStorage>)) {
+      return this->storage->Access(memgraph::storage::Storage::Accessor::Type::READ);
+    } else {
+      return this->storage->UniqueAccess();
+    }
+  }
+
   const std::string testSuite = "storage_v2_indices";
   memgraph::storage::Config config_;
   std::unique_ptr<memgraph::storage::Storage> storage;
@@ -638,9 +654,9 @@ TYPED_TEST(IndexTest, LabelPropertyIndexCreateAndDrop) {
     EXPECT_EQ(acc->ListAllIndices().label_properties.size(), 0);
   }
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateIndex(this->label1, {PropertyPath{this->prop_id}}).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->label1, {PropertyPath{this->prop_id}}).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
   {
     auto acc = this->storage->Access();
@@ -658,9 +674,9 @@ TYPED_TEST(IndexTest, LabelPropertyIndexCreateAndDrop) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_TRUE(unique_acc->CreateIndex(this->label1, {PropertyPath{this->prop_id}}).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_TRUE(acc->CreateIndex(this->label1, {PropertyPath{this->prop_id}}).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   {
@@ -671,9 +687,9 @@ TYPED_TEST(IndexTest, LabelPropertyIndexCreateAndDrop) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateIndex(this->label2, {PropertyPath{this->prop_id}}).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->label2, {PropertyPath{this->prop_id}}).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   {
@@ -690,9 +706,9 @@ TYPED_TEST(IndexTest, LabelPropertyIndexCreateAndDrop) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->DropIndex(this->label1, {PropertyPath{this->prop_id}}).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->DropIndexAccessor();
+    EXPECT_FALSE(acc->DropIndex(this->label1, {PropertyPath{this->prop_id}}).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
   {
     auto acc = this->storage->Access();
@@ -707,15 +723,15 @@ TYPED_TEST(IndexTest, LabelPropertyIndexCreateAndDrop) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_TRUE(unique_acc->DropIndex(this->label1, {PropertyPath{this->prop_id}}).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->DropIndexAccessor();
+    EXPECT_TRUE(acc->DropIndex(this->label1, {PropertyPath{this->prop_id}}).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->DropIndex(this->label2, {PropertyPath{this->prop_id}}).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->DropIndexAccessor();
+    EXPECT_FALSE(acc->DropIndex(this->label2, {PropertyPath{this->prop_id}}).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
   {
     auto acc = this->storage->Access();
@@ -738,12 +754,11 @@ TYPED_TEST(IndexTest, LabelPropertyCompositeIndexCreateAndDrop) {
     EXPECT_EQ(acc->ListAllIndices().label_properties.size(), 0);
   }
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc
-                     ->CreateIndex(this->label1,
-                                   {PropertyPath{this->prop_a}, PropertyPath{this->prop_b}, PropertyPath{this->prop_c}})
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->label1,
+                                  {PropertyPath{this->prop_a}, PropertyPath{this->prop_b}, PropertyPath{this->prop_c}})
                      .HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    ASSERT_NO_ERROR(acc->Commit());
   }
   {
     auto acc = this->storage->Access();
@@ -764,12 +779,11 @@ TYPED_TEST(IndexTest, LabelPropertyCompositeIndexCreateAndDrop) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_TRUE(unique_acc
-                    ->CreateIndex(this->label1,
-                                  {PropertyPath{this->prop_a}, PropertyPath{this->prop_b}, PropertyPath{this->prop_c}})
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_TRUE(acc->CreateIndex(this->label1,
+                                 {PropertyPath{this->prop_a}, PropertyPath{this->prop_b}, PropertyPath{this->prop_c}})
                     .HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   {
@@ -781,12 +795,11 @@ TYPED_TEST(IndexTest, LabelPropertyCompositeIndexCreateAndDrop) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc
-                     ->CreateIndex(this->label2,
-                                   {PropertyPath{this->prop_a}, PropertyPath{this->prop_b}, PropertyPath{this->prop_c}})
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->label2,
+                                  {PropertyPath{this->prop_a}, PropertyPath{this->prop_b}, PropertyPath{this->prop_c}})
                      .HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   {
@@ -806,12 +819,11 @@ TYPED_TEST(IndexTest, LabelPropertyCompositeIndexCreateAndDrop) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc
-                     ->DropIndex(this->label1,
-                                 {PropertyPath{this->prop_a}, PropertyPath{this->prop_b}, PropertyPath{this->prop_c}})
+    auto acc = this->DropIndexAccessor();
+    EXPECT_FALSE(acc->DropIndex(this->label1,
+                                {PropertyPath{this->prop_a}, PropertyPath{this->prop_b}, PropertyPath{this->prop_c}})
                      .HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    ASSERT_NO_ERROR(acc->Commit());
   }
   {
     auto acc = this->storage->Access();
@@ -828,21 +840,19 @@ TYPED_TEST(IndexTest, LabelPropertyCompositeIndexCreateAndDrop) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_TRUE(unique_acc
-                    ->DropIndex(this->label1,
-                                {PropertyPath{this->prop_a}, PropertyPath{this->prop_b}, PropertyPath{this->prop_c}})
+    auto acc = this->DropIndexAccessor();
+    EXPECT_TRUE(acc->DropIndex(this->label1,
+                               {PropertyPath{this->prop_a}, PropertyPath{this->prop_b}, PropertyPath{this->prop_c}})
                     .HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc
-                     ->DropIndex(this->label2,
-                                 {PropertyPath{this->prop_a}, PropertyPath{this->prop_b}, PropertyPath{this->prop_c}})
+    auto acc = this->DropIndexAccessor();
+    EXPECT_FALSE(acc->DropIndex(this->label2,
+                                {PropertyPath{this->prop_a}, PropertyPath{this->prop_b}, PropertyPath{this->prop_c}})
                      .HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    ASSERT_NO_ERROR(acc->Commit());
   }
   {
     auto acc = this->storage->Access();
@@ -864,14 +874,14 @@ TYPED_TEST(IndexTest, LabelPropertyCompositeIndexCreateAndDrop) {
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TYPED_TEST(IndexTest, LabelPropertyIndexBasic) {
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateIndex(this->label1, {PropertyPath{this->prop_val}}).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->label1, {PropertyPath{this->prop_val}}).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateIndex(this->label2, {PropertyPath{this->prop_val}}).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->label2, {PropertyPath{this->prop_val}}).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   auto acc = this->storage->Access();
@@ -1013,18 +1023,16 @@ TYPED_TEST(IndexTest, LabelPropertyCompositeIndexBasic) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc
-                     ->CreateIndex(this->label1,
-                                   {PropertyPath{this->prop_b}, PropertyPath{this->prop_a}, PropertyPath{this->prop_c}})
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->label1,
+                                  {PropertyPath{this->prop_b}, PropertyPath{this->prop_a}, PropertyPath{this->prop_c}})
                      .HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    ASSERT_NO_ERROR(acc->Commit());
   }
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(
-        unique_acc->CreateIndex(this->label2, {PropertyPath{this->prop_c}, PropertyPath{this->prop_b}}).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->label2, {PropertyPath{this->prop_c}, PropertyPath{this->prop_b}}).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   auto acc = this->storage->Access();
@@ -1209,9 +1217,9 @@ TYPED_TEST(IndexTest, LabelPropertyCompositeIndexBasic) {
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TYPED_TEST(IndexTest, LabelPropertyIndexDuplicateVersions) {
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateIndex(this->label1, {PropertyPath{this->prop_val}}).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->label1, {PropertyPath{this->prop_val}}).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   {
@@ -1273,9 +1281,9 @@ TYPED_TEST(IndexTest, LabelPropertyIndexStrictInsert) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    ASSERT_FALSE(unique_acc->CreateIndex(this->label1, {PropertyPath{this->prop_val}}).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    ASSERT_FALSE(acc->CreateIndex(this->label1, {PropertyPath{this->prop_val}}).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   auto acc = this->storage->Access();
@@ -1300,9 +1308,9 @@ TYPED_TEST(IndexTest, LabelPropertyIndexStrictInsert) {
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TYPED_TEST(IndexTest, LabelPropertyIndexTransactionalIsolation) {
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateIndex(this->label1, {PropertyPath{this->prop_val}}).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->label1, {PropertyPath{this->prop_val}}).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   auto acc_before = this->storage->Access();
@@ -1359,9 +1367,9 @@ TYPED_TEST(IndexTest, LabelPropertyIndexFiltering) {
   // properly.
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateIndex(this->label1, {PropertyPath{this->prop_val}}).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->label1, {PropertyPath{this->prop_val}}).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   {
@@ -1451,9 +1459,9 @@ TYPED_TEST(IndexTest, LabelPropertyIndexCountEstimate) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateIndex(this->label1, {PropertyPath{this->prop_val}}).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->label1, {PropertyPath{this->prop_val}}).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   auto acc = this->storage->Access();
@@ -1485,10 +1493,9 @@ TYPED_TEST(IndexTest, LabelPropertyCompositeIndexCountEstimate) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(
-        unique_acc->CreateIndex(this->label1, {PropertyPath{this->prop_a}, PropertyPath{this->prop_b}}).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->label1, {PropertyPath{this->prop_a}, PropertyPath{this->prop_b}}).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   auto acc = this->storage->Access();
@@ -1531,9 +1538,9 @@ TYPED_TEST(IndexTest, LabelPropertyNestedIndexCountEstimate) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateIndex(this->label1, {PropertyPath{this->prop_a, this->prop_b}}).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->label1, {PropertyPath{this->prop_a, this->prop_b}}).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   auto acc = this->storage->Access();
@@ -1562,9 +1569,9 @@ TYPED_TEST(IndexTest, LabelPropertyNestedIndexCountEstimate) {
 
 TYPED_TEST(IndexTest, LabelPropertyIndexMixedIteration) {
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateIndex(this->label1, {PropertyPath{this->prop_val}}).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->label1, {PropertyPath{this->prop_val}}).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   const std::array temporals{TemporalData{TemporalType::Date, 23}, TemporalData{TemporalType::Date, 28},
@@ -1817,9 +1824,9 @@ TYPED_TEST(IndexTest, LabelPropertyCompositeIndexMixedIteration) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateIndex(this->label1, {PropertyPath{prop_a}, PropertyPath{prop_b}}).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->label1, {PropertyPath{prop_a}, PropertyPath{prop_b}}).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   auto a_values = ranges::views::iota(0, 5) | ranges::views::transform([](int val) { return PropertyValue(val); }) |
@@ -1909,9 +1916,9 @@ TYPED_TEST(IndexTest, LabelPropertyCompositeIndexMixedIteration) {
 TYPED_TEST(IndexTest, LabelPropertyIndexDeletedVertex) {
   if constexpr ((std::is_same_v<TypeParam, memgraph::storage::DiskStorage>)) {
     {
-      auto unique_acc = this->storage->UniqueAccess();
-      EXPECT_FALSE(unique_acc->CreateIndex(this->label1, {PropertyPath{this->prop_val}}).HasError());
-      ASSERT_NO_ERROR(unique_acc->Commit());
+      auto acc = this->CreateIndexAccessor();
+      EXPECT_FALSE(acc->CreateIndex(this->label1, {PropertyPath{this->prop_val}}).HasError());
+      ASSERT_NO_ERROR(acc->Commit());
     }
     auto acc1 = this->storage->Access();
 
@@ -1944,9 +1951,9 @@ TYPED_TEST(IndexTest, LabelPropertyIndexDeletedVertex) {
 TYPED_TEST(IndexTest, LabelPropertyIndexRemoveIndexedLabel) {
   if constexpr ((std::is_same_v<TypeParam, memgraph::storage::DiskStorage>)) {
     {
-      auto unique_acc = this->storage->UniqueAccess();
-      EXPECT_FALSE(unique_acc->CreateIndex(this->label1, {PropertyPath{this->prop_val}}).HasError());
-      ASSERT_NO_ERROR(unique_acc->Commit());
+      auto acc = this->CreateIndexAccessor();
+      EXPECT_FALSE(acc->CreateIndex(this->label1, {PropertyPath{this->prop_val}}).HasError());
+      ASSERT_NO_ERROR(acc->Commit());
     }
     auto acc1 = this->storage->Access();
 
@@ -1978,9 +1985,9 @@ TYPED_TEST(IndexTest, LabelPropertyIndexRemoveIndexedLabel) {
 TYPED_TEST(IndexTest, LabelPropertyIndexRemoveAndAddIndexedLabel) {
   if constexpr ((std::is_same_v<TypeParam, memgraph::storage::DiskStorage>)) {
     {
-      auto unique_acc = this->storage->UniqueAccess();
-      EXPECT_FALSE(unique_acc->CreateIndex(this->label1, {PropertyPath{this->prop_val}}).HasError());
-      ASSERT_NO_ERROR(unique_acc->Commit());
+      auto acc = this->CreateIndexAccessor();
+      EXPECT_FALSE(acc->CreateIndex(this->label1, {PropertyPath{this->prop_val}}).HasError());
+      ASSERT_NO_ERROR(acc->Commit());
     }
     auto acc1 = this->storage->Access();
 
@@ -2011,9 +2018,9 @@ TYPED_TEST(IndexTest, LabelPropertyIndexClearOldDataFromDisk) {
         static_cast<memgraph::storage::DiskLabelPropertyIndex *>(this->storage->indices_.label_property_index_.get());
 
     {
-      auto unique_acc = this->storage->UniqueAccess();
-      EXPECT_FALSE(unique_acc->CreateIndex(this->label1, {PropertyPath{this->prop_val}}).HasError());
-      ASSERT_NO_ERROR(unique_acc->Commit());
+      auto acc = this->CreateIndexAccessor();
+      EXPECT_FALSE(acc->CreateIndex(this->label1, {PropertyPath{this->prop_val}}).HasError());
+      ASSERT_NO_ERROR(acc->Commit());
     }
     auto acc1 = this->storage->Access();
     auto vertex = this->CreateVertex(acc1.get());

--- a/tests/unit/storage_v2_replication.cpp
+++ b/tests/unit/storage_v2_replication.cpp
@@ -133,6 +133,13 @@ struct MinMemgraph {
 #endif
         ) {
   }
+
+  auto CreateIndexAccessor() -> std::unique_ptr<memgraph::storage::Storage::Accessor> { return db.ReadOnlyAccess(); }
+
+  auto DropIndexAccessor() -> std::unique_ptr<memgraph::storage::Storage::Accessor> {
+    return db.Access(memgraph::storage::Storage::Accessor::Type::READ);
+  }
+
   memgraph::auth::SynchedAuth auth;
   memgraph::system::System system_;
   memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock> repl_state;
@@ -317,14 +324,14 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
     ASSERT_FALSE(unique_acc->Commit({}, main.db_acc).HasError());
   }
   {
-    auto unique_acc = main.db.UniqueAccess();
+    auto unique_acc = main.CreateIndexAccessor();
     ASSERT_FALSE(
         unique_acc->CreateIndex(main.db.storage()->NameToLabel(label), {main.db.storage()->NameToProperty(property)})
             .HasError());
     ASSERT_FALSE(unique_acc->Commit({}, main.db_acc).HasError());
   }
   {
-    auto unique_acc = main.db.UniqueAccess();
+    auto unique_acc = main.CreateIndexAccessor();
     ASSERT_FALSE(
         unique_acc
             ->CreateIndex(main.db.storage()->NameToLabel(label), {main.db.storage()->NameToProperty(property),
@@ -350,7 +357,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
   }
   {
     // Create nested index
-    auto unique_acc = main.db.UniqueAccess();
+    auto unique_acc = main.CreateIndexAccessor();
     memgraph::storage::PropertyPath property_path{main.db.storage()->NameToProperty(nested_property1),
                                                   main.db.storage()->NameToProperty(nested_property2),
                                                   main.db.storage()->NameToProperty(nested_property3)};
@@ -471,7 +478,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
     ASSERT_FALSE(unique_acc->Commit({}, main.db_acc).HasError());
   }
   {
-    auto unique_acc = main.db.UniqueAccess();
+    auto unique_acc = main.DropIndexAccessor();
     ASSERT_FALSE(
         unique_acc->DropIndex(main.db.storage()->NameToLabel(label), {main.db.storage()->NameToProperty(property)})
             .HasError());
@@ -479,7 +486,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
   }
   {
     // Drop nested index
-    auto unique_acc = main.db.UniqueAccess();
+    auto unique_acc = main.DropIndexAccessor();
     memgraph::storage::PropertyPath property_path{main.db.storage()->NameToProperty(nested_property1),
                                                   main.db.storage()->NameToProperty(nested_property2),
                                                   main.db.storage()->NameToProperty(nested_property3)};
@@ -493,7 +500,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
     ASSERT_FALSE(unique_acc->Commit({}, main.db_acc).HasError());
   }
   {
-    auto unique_acc = main.db.UniqueAccess();
+    auto unique_acc = main.DropIndexAccessor();
     ASSERT_FALSE(
         unique_acc
             ->DropIndex(main.db.storage()->NameToLabel(label), {main.db.storage()->NameToProperty(property),

--- a/tests/unit/storage_v2_wal_file.cpp
+++ b/tests/unit/storage_v2_wal_file.cpp
@@ -43,14 +43,13 @@ class DeltaGenerator final {
 
     explicit Transaction(DeltaGenerator *gen)
         : gen_(gen),
-          transaction_(
-              gen->transaction_id_++, gen->timestamp_++, memgraph::storage::IsolationLevel::SNAPSHOT_ISOLATION,
-              gen->storage_mode_, false, false, memgraph::storage::PointIndexStorage{}.CreatePointIndexContext(),
-              memgraph::storage::ActiveIndices{
-                  // TODO: fake?
-                  .label_properties_ = std::make_unique<memgraph::storage::InMemoryLabelPropertyIndex::ActiveIndices>()}
-
-          ) {}
+          transaction_(gen->transaction_id_++, gen->timestamp_++, memgraph::storage::IsolationLevel::SNAPSHOT_ISOLATION,
+                       gen->storage_mode_, false, false,
+                       memgraph::storage::PointIndexStorage{}.CreatePointIndexContext(),
+                       memgraph::storage::ActiveIndices{
+                           // TODO: fake?
+                           .label_properties_ =
+                               std::make_unique<memgraph::storage::InMemoryLabelPropertyIndex::ActiveIndices>()}) {}
 
    public:
     memgraph::storage::Vertex *CreateVertex() {

--- a/tests/unit/storage_v2_wal_file.cpp
+++ b/tests/unit/storage_v2_wal_file.cpp
@@ -47,9 +47,7 @@ class DeltaGenerator final {
                        gen->storage_mode_, false, false,
                        memgraph::storage::PointIndexStorage{}.CreatePointIndexContext(),
                        memgraph::storage::ActiveIndices{
-                           // TODO: fake?
-                           .label_properties_ =
-                               std::make_unique<memgraph::storage::InMemoryLabelPropertyIndex::ActiveIndices>()}) {}
+                           std::make_unique<memgraph::storage::InMemoryLabelPropertyIndex::ActiveIndices>()}) {}
 
    public:
     memgraph::storage::Vertex *CreateVertex() {

--- a/tests/unit/storage_v2_wal_file.cpp
+++ b/tests/unit/storage_v2_wal_file.cpp
@@ -43,9 +43,14 @@ class DeltaGenerator final {
 
     explicit Transaction(DeltaGenerator *gen)
         : gen_(gen),
-          transaction_(gen->transaction_id_++, gen->timestamp_++, memgraph::storage::IsolationLevel::SNAPSHOT_ISOLATION,
-                       gen->storage_mode_, false, false,
-                       memgraph::storage::PointIndexStorage{}.CreatePointIndexContext()) {}
+          transaction_(
+              gen->transaction_id_++, gen->timestamp_++, memgraph::storage::IsolationLevel::SNAPSHOT_ISOLATION,
+              gen->storage_mode_, false, false, memgraph::storage::PointIndexStorage{}.CreatePointIndexContext(),
+              memgraph::storage::ActiveIndices{
+                  // TODO: fake?
+                  .label_properties_ = std::make_unique<memgraph::storage::InMemoryLabelPropertyIndex::ActiveIndices>()}
+
+          ) {}
 
    public:
     memgraph::storage::Vertex *CreateVertex() {
@@ -389,11 +394,11 @@ class DeltaGenerator final {
           case LABEL_INDEX_STATS_SET:
             return {WalLabelIndexStatsSet{label, stats}};
           case LABEL_PROPERTIES_INDEX_CREATE:
-            return {WalLabelPropertyIndexCreate{label, property_paths_as_str}};
+            return {WalLabelPropertyIndexCreate{label, {property_paths_as_str}}};
           case LABEL_PROPERTIES_INDEX_DROP:
-            return {WalLabelPropertyIndexDrop{label, property_paths_as_str}};
+            return {WalLabelPropertyIndexDrop{label, {property_paths_as_str}}};
           case LABEL_PROPERTIES_INDEX_STATS_SET:
-            return {WalLabelPropertyIndexStatsSet{label, property_paths_as_str, stats}};
+            return {WalLabelPropertyIndexStatsSet{label, {property_paths_as_str}, stats}};
           case LABEL_PROPERTIES_INDEX_STATS_CLEAR:
             return {WalLabelPropertyIndexStatsClear{label}};
           case EDGE_INDEX_CREATE:

--- a/tests/unit/stripped.cpp
+++ b/tests/unit/stripped.cpp
@@ -40,7 +40,7 @@ void EXPECT_PROP_EQ(const memgraph::storage::ExternalPropertyValue &a, const Typ
 TEST(QueryStripper, NoLiterals) {
   StrippedQuery stripped("CREATE (n)");
   EXPECT_EQ(stripped.literals().size(), 0);
-  EXPECT_EQ(stripped.query(), "CREATE ( n )");
+  EXPECT_EQ(stripped.stripped_query().str(), "CREATE ( n )");
 }
 
 TEST(QueryStripper, ZeroInteger) {
@@ -49,7 +49,7 @@ TEST(QueryStripper, ZeroInteger) {
   EXPECT_EQ(stripped.literals().At(0).first, 1);
   EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 0);
   EXPECT_EQ(stripped.literals().AtTokenPosition(1).ValueInt(), 0);
-  EXPECT_EQ(stripped.query(), "RETURN " + kStrippedIntToken);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedIntToken);
 }
 
 TEST(QueryStripper, DecimalInteger) {
@@ -58,83 +58,83 @@ TEST(QueryStripper, DecimalInteger) {
   EXPECT_EQ(stripped.literals().At(0).first, 1);
   EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 42);
   EXPECT_EQ(stripped.literals().AtTokenPosition(1).ValueInt(), 42);
-  EXPECT_EQ(stripped.query(), "RETURN " + kStrippedIntToken);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedIntToken);
 }
 
 TEST(QueryStripper, OctalInteger) {
   StrippedQuery stripped("RETURN 010");
   EXPECT_EQ(stripped.literals().size(), 1);
   EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 8);
-  EXPECT_EQ(stripped.query(), "RETURN " + kStrippedIntToken);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedIntToken);
 }
 
 TEST(QueryStripper, HexInteger) {
   StrippedQuery stripped("RETURN 0xa");
   EXPECT_EQ(stripped.literals().size(), 1);
   EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 10);
-  EXPECT_EQ(stripped.query(), "RETURN " + kStrippedIntToken);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedIntToken);
 }
 
 TEST(QueryStripper, RegularDecimal) {
   StrippedQuery stripped("RETURN 42.3");
   EXPECT_EQ(stripped.literals().size(), 1);
   EXPECT_FLOAT_EQ(stripped.literals().At(0).second.ValueDouble(), 42.3);
-  EXPECT_EQ(stripped.query(), "RETURN " + kStrippedDoubleToken);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedDoubleToken);
 }
 
 TEST(QueryStripper, ExponentDecimal) {
   StrippedQuery stripped("RETURN 4e2");
   EXPECT_EQ(stripped.literals().size(), 1);
   EXPECT_FLOAT_EQ(stripped.literals().At(0).second.ValueDouble(), 4e2);
-  EXPECT_EQ(stripped.query(), "RETURN " + kStrippedDoubleToken);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedDoubleToken);
 }
 
 TEST(QueryStripper, ExponentDecimal2) {
   StrippedQuery stripped("RETURN 4e-2");
   EXPECT_EQ(stripped.literals().size(), 1);
   EXPECT_FLOAT_EQ(stripped.literals().At(0).second.ValueDouble(), 4e-2);
-  EXPECT_EQ(stripped.query(), "RETURN " + kStrippedDoubleToken);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedDoubleToken);
 }
 
 TEST(QueryStripper, ExponentDecimal3) {
   StrippedQuery stripped("RETURN 0.1e-2");
   EXPECT_EQ(stripped.literals().size(), 1);
   EXPECT_FLOAT_EQ(stripped.literals().At(0).second.ValueDouble(), 0.1e-2);
-  EXPECT_EQ(stripped.query(), "RETURN " + kStrippedDoubleToken);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedDoubleToken);
 }
 
 TEST(QueryStripper, ExponentDecimal4) {
   StrippedQuery stripped("RETURN .1e-2");
   EXPECT_EQ(stripped.literals().size(), 1);
   EXPECT_FLOAT_EQ(stripped.literals().At(0).second.ValueDouble(), .1e-2);
-  EXPECT_EQ(stripped.query(), "RETURN " + kStrippedDoubleToken);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedDoubleToken);
 }
 
 TEST(QueryStripper, SymbolicNameStartingWithE) {
   StrippedQuery stripped("RETURN e1");
   EXPECT_EQ(stripped.literals().size(), 0);
-  EXPECT_EQ(stripped.query(), "RETURN e1");
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN e1");
 }
 
 TEST(QueryStripper, StringLiteral) {
   StrippedQuery stripped("RETURN 'something'");
   EXPECT_EQ(stripped.literals().size(), 1);
   EXPECT_EQ(stripped.literals().At(0).second.ValueString(), "something");
-  EXPECT_EQ(stripped.query(), "RETURN " + kStrippedStringToken);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
 
 TEST(QueryStripper, StringLiteral2) {
   StrippedQuery stripped("RETURN 'so\\'me'");
   EXPECT_EQ(stripped.literals().size(), 1);
   EXPECT_EQ(stripped.literals().At(0).second.ValueString(), "so'me");
-  EXPECT_EQ(stripped.query(), "RETURN " + kStrippedStringToken);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
 
 TEST(QueryStripper, StringLiteral3) {
   StrippedQuery stripped("RETURN \"so\\\"me'\"");
   EXPECT_EQ(stripped.literals().size(), 1);
   EXPECT_EQ(stripped.literals().At(0).second.ValueString(), "so\"me'");
-  EXPECT_EQ(stripped.query(), "RETURN " + kStrippedStringToken);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
 
 TEST(QueryStripper, StringLiteral4) {
@@ -142,7 +142,7 @@ TEST(QueryStripper, StringLiteral4) {
   EXPECT_EQ(stripped.literals().size(), 1);
   EXPECT_EQ(stripped.literals().At(0).second.ValueString(),
             "\xE1\xAA\xA4");  // "u8"\u1Aa4
-  EXPECT_EQ(stripped.query(), "RETURN " + kStrippedStringToken);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
 
 TEST(QueryStripper, HighSurrogateAlone) { ASSERT_THROW(StrippedQuery("RETURN '\\udeeb'"), SemanticException); }
@@ -154,7 +154,7 @@ TEST(QueryStripper, Surrogates) {
   EXPECT_EQ(stripped.literals().size(), 1);
   EXPECT_EQ(stripped.literals().At(0).second.ValueString(),
             "\xF0\x9F\x9B\xAB");  // u8"\U0001f6eb"
-  EXPECT_EQ(stripped.query(), "RETURN " + kStrippedStringToken);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedStringToken);
 }
 
 TEST(QueryStripper, StringLiteralIllegalEscapedSequence) {
@@ -166,38 +166,38 @@ TEST(QueryStripper, TrueLiteral) {
   StrippedQuery stripped("RETURN trUE");
   EXPECT_EQ(stripped.literals().size(), 1);
   EXPECT_PROP_EQ(stripped.literals().At(0).second, TypedValue(true));
-  EXPECT_EQ(stripped.query(), "RETURN " + kStrippedBooleanToken);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedBooleanToken);
 }
 
 TEST(QueryStripper, FalseLiteral) {
   StrippedQuery stripped("RETURN fAlse");
   EXPECT_EQ(stripped.literals().size(), 1);
   EXPECT_PROP_EQ(stripped.literals().At(0).second, TypedValue(false));
-  EXPECT_EQ(stripped.query(), "RETURN " + kStrippedBooleanToken);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedBooleanToken);
 }
 
 TEST(QueryStripper, NullLiteral) {
   StrippedQuery stripped("RETURN NuLl");
   EXPECT_EQ(stripped.literals().size(), 0);
-  EXPECT_EQ(stripped.query(), "RETURN NuLl");
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN NuLl");
 }
 
 TEST(QueryStripper, ListLiteral) {
   StrippedQuery stripped("MATCH (n) RETURN [n, n.prop]");
   EXPECT_EQ(stripped.literals().size(), 0);
-  EXPECT_EQ(stripped.query(), "MATCH ( n ) RETURN [ n , n . prop ]");
+  EXPECT_EQ(stripped.stripped_query().str(), "MATCH ( n ) RETURN [ n , n . prop ]");
 }
 
 TEST(QueryStripper, MapLiteral) {
   StrippedQuery stripped("MATCH (n) RETURN {val: n}");
   EXPECT_EQ(stripped.literals().size(), 0);
-  EXPECT_EQ(stripped.query(), "MATCH ( n ) RETURN { val : n }");
+  EXPECT_EQ(stripped.stripped_query().str(), "MATCH ( n ) RETURN { val : n }");
 }
 
 TEST(QueryStripper, MapProjectionLiteral) {
   StrippedQuery stripped("WITH 0 as var MATCH (n) RETURN n {.x, var, key: 'a'}");
   EXPECT_EQ(stripped.literals().size(), 2);
-  EXPECT_EQ(stripped.query(), "WITH 0 as var MATCH ( n ) RETURN n { . x , var , key : \"a\" }");
+  EXPECT_EQ(stripped.stripped_query().str(), "WITH 0 as var MATCH ( n ) RETURN n { . x , var , key : \"a\" }");
 }
 
 TEST(QueryStripper, RangeLiteral) {
@@ -205,76 +205,76 @@ TEST(QueryStripper, RangeLiteral) {
   EXPECT_EQ(stripped.literals().size(), 2);
   EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 2);
   EXPECT_EQ(stripped.literals().At(1).second.ValueInt(), 3);
-  EXPECT_EQ(stripped.query(),
+  EXPECT_EQ(stripped.stripped_query().str(),
             "MATCH ( n ) - [ * " + kStrippedIntToken + " .. " + kStrippedIntToken + " ] - ( ) RETURN n");
 }
 
 TEST(QueryStripper, EscapedName) {
   StrippedQuery stripped("MATCH (n:`mirko``slavko`)");
   EXPECT_EQ(stripped.literals().size(), 0);
-  EXPECT_EQ(stripped.query(), "MATCH ( n : `mirko``slavko` )");
+  EXPECT_EQ(stripped.stripped_query().str(), "MATCH ( n : `mirko``slavko` )");
 }
 
 TEST(QueryStripper, UnescapedName) {
   StrippedQuery stripped("MATCH (n:peropero)");
   EXPECT_EQ(stripped.literals().size(), 0);
-  EXPECT_EQ(stripped.query(), "MATCH ( n : peropero )");
+  EXPECT_EQ(stripped.stripped_query().str(), "MATCH ( n : peropero )");
 }
 
 TEST(QueryStripper, UnescapedName2) {
   // using u8string this string is u8"\uffd5\u04c2\u04c2pero\u0078pe"
   StrippedQuery stripped("MATCH (n:\xEF\xBF\x95\xD3\x82\xD3\x82pero\x78pe)");
   EXPECT_EQ(stripped.literals().size(), 0);
-  EXPECT_EQ(stripped.query(), "MATCH ( n : \xEF\xBF\x95\xD3\x82\xD3\x82pero\x78pe )");
+  EXPECT_EQ(stripped.stripped_query().str(), "MATCH ( n : \xEF\xBF\x95\xD3\x82\xD3\x82pero\x78pe )");
 }
 
 TEST(QueryStripper, MixedCaseKeyword) {
   StrippedQuery stripped("MaTch (n:peropero)");
   EXPECT_EQ(stripped.literals().size(), 0);
-  EXPECT_EQ(stripped.query(), "MaTch ( n : peropero )");
+  EXPECT_EQ(stripped.stripped_query().str(), "MaTch ( n : peropero )");
 }
 
 TEST(QueryStripper, BlockComment) {
   StrippedQuery stripped("MaTch (n:/**fhf/gf\n\r\n//fjhf*/peropero)");
   EXPECT_EQ(stripped.literals().size(), 0);
-  EXPECT_EQ(stripped.query(), "MaTch ( n : peropero )");
+  EXPECT_EQ(stripped.stripped_query().str(), "MaTch ( n : peropero )");
 }
 
 TEST(QueryStripper, LineComment1) {
   StrippedQuery stripped("MaTch (n:peropero) // komentar\nreturn n");
   EXPECT_EQ(stripped.literals().size(), 0);
-  EXPECT_EQ(stripped.query(), "MaTch ( n : peropero ) return n");
+  EXPECT_EQ(stripped.stripped_query().str(), "MaTch ( n : peropero ) return n");
 }
 
 TEST(QueryStripper, LineComment2) {
   StrippedQuery stripped("MaTch (n:peropero) // komentar\r\nreturn n");
   EXPECT_EQ(stripped.literals().size(), 0);
-  EXPECT_EQ(stripped.query(), "MaTch ( n : peropero ) return n");
+  EXPECT_EQ(stripped.stripped_query().str(), "MaTch ( n : peropero ) return n");
 }
 
 TEST(QueryStripper, LineComment3) {
   StrippedQuery stripped("MaTch (n:peropero) return n // komentar");
   EXPECT_EQ(stripped.literals().size(), 0);
-  EXPECT_EQ(stripped.query(), "MaTch ( n : peropero ) return n");
+  EXPECT_EQ(stripped.stripped_query().str(), "MaTch ( n : peropero ) return n");
 }
 
 TEST(QueryStripper, LineComment4) {
   StrippedQuery stripped("MaTch (n:peropero) return n // komentar\r");
   EXPECT_EQ(stripped.literals().size(), 0);
   // Didn't manage to parse comment because it ends with \r.
-  EXPECT_EQ(stripped.query(), "MaTch ( n : peropero ) return n / / komentar");
+  EXPECT_EQ(stripped.stripped_query().str(), "MaTch ( n : peropero ) return n / / komentar");
 }
 
 TEST(QueryStripper, LineComment5) {
   {
     StrippedQuery stripped("MaTch (n:peropero) return n//");
     EXPECT_EQ(stripped.literals().size(), 0);
-    EXPECT_EQ(stripped.query(), "MaTch ( n : peropero ) return n");
+    EXPECT_EQ(stripped.stripped_query().str(), "MaTch ( n : peropero ) return n");
   }
   {
     StrippedQuery stripped("MATCH (n) MATCH (n)-[*bfs]->(m) RETURN n;\n//");
     EXPECT_EQ(stripped.literals().size(), 0);
-    EXPECT_EQ(stripped.query(), "MATCH ( n ) MATCH ( n ) - [ * bfs ] - > ( m ) RETURN n ;");
+    EXPECT_EQ(stripped.stripped_query().str(), "MATCH ( n ) MATCH ( n ) - [ * bfs ] - > ( m ) RETURN n ;");
   }
 }
 
@@ -282,13 +282,13 @@ TEST(QueryStripper, Spaces) {
   // using u8string this string is u8"\u202f"
   StrippedQuery stripped("RETURN \r\n\xE2\x80\xAF\t\xE2\x80\x87  NuLl");
   EXPECT_EQ(stripped.literals().size(), 0);
-  EXPECT_EQ(stripped.query(), "RETURN NuLl");
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN NuLl");
 }
 
 TEST(QueryStripper, OtherTokens) {
   StrippedQuery stripped("++=...");
   EXPECT_EQ(stripped.literals().size(), 0);
-  EXPECT_EQ(stripped.query(), "+ += .. .");
+  EXPECT_EQ(stripped.stripped_query().str(), "+ += .. .");
 }
 
 TEST(QueryStripper, NamedExpression) {
@@ -330,7 +330,7 @@ TEST(QueryStripper, ReturnListsAndFunctionCalls) {
 TEST(QueryStripper, Parameters) {
   StrippedQuery stripped("RETURN $123, $pero, $`mirko ``slavko`");
   EXPECT_EQ(stripped.literals().size(), 0);
-  EXPECT_EQ(stripped.query(), "RETURN $123 , $pero , $`mirko ``slavko`");
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN $123 , $pero , $`mirko ``slavko`");
   EXPECT_THAT(stripped.parameters(), UnorderedElementsAre(Pair(1, "123"), Pair(4, "pero"), Pair(7, "mirko `slavko")));
   EXPECT_THAT(stripped.named_expressions(),
               UnorderedElementsAre(Pair(1, "$123"), Pair(4, "$pero"), Pair(7, "$`mirko ``slavko`")));
@@ -339,7 +339,7 @@ TEST(QueryStripper, Parameters) {
 TEST(QueryStripper, KeywordInNamedExpression) {
   StrippedQuery stripped("RETURN CoUnT(n)");
   EXPECT_EQ(stripped.literals().size(), 0);
-  EXPECT_EQ(stripped.query(), "RETURN CoUnT ( n )");
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN CoUnT ( n )");
   EXPECT_THAT(stripped.named_expressions(), UnorderedElementsAre(Pair(1, "CoUnT(n)")));
 }
 
@@ -388,7 +388,7 @@ TEST(QueryStripper, CreateTriggerQuery) {
       SCOPED_TRACE("Query starting with CREATE keyword");
       StrippedQuery stripped(
           fmt::format("CREATE TRIGGER execute  /*test*/ ON CREATE BEFORE COMMIT EXECUTE{}", execute_query));
-      EXPECT_EQ(stripped.query(),
+      EXPECT_EQ(stripped.stripped_query().str(),
                 fmt::format("CREATE TRIGGER execute ON CREATE BEFORE COMMIT EXECUTE {}", execute_query));
     }
 
@@ -396,7 +396,8 @@ TEST(QueryStripper, CreateTriggerQuery) {
       SCOPED_TRACE("Query starting with comments and spaces");
       StrippedQuery stripped(fmt::format(
           "/*comment*/    \n\n //other comment\nCREATE TRIGGER execute AFTER COMMIT EXECUTE{}", execute_query));
-      EXPECT_EQ(stripped.query(), fmt::format("CREATE TRIGGER execute AFTER COMMIT EXECUTE {}", execute_query));
+      EXPECT_EQ(stripped.stripped_query().str(),
+                fmt::format("CREATE TRIGGER execute AFTER COMMIT EXECUTE {}", execute_query));
     }
 
     {
@@ -404,13 +405,14 @@ TEST(QueryStripper, CreateTriggerQuery) {
       StrippedQuery stripped(fmt::format(
           "/*comment*/    \n\n //other comment\nCREATE //some comment \n   TRIGGER execute AFTER COMMIT EXECUTE{}",
           execute_query));
-      EXPECT_EQ(stripped.query(), fmt::format("CREATE TRIGGER execute AFTER COMMIT EXECUTE {}", execute_query));
+      EXPECT_EQ(stripped.stripped_query().str(),
+                fmt::format("CREATE TRIGGER execute AFTER COMMIT EXECUTE {}", execute_query));
     }
   }
   {
     SCOPED_TRACE("Execute keyword should still be allowed in other queries");
     StrippedQuery stripped("MATCH (execute:Node)   //comment \n  RETURN  /* test comment */  execute");
-    EXPECT_EQ(stripped.query(), "MATCH ( execute : Node ) RETURN execute");
+    EXPECT_EQ(stripped.stripped_query().str(), "MATCH ( execute : Node ) RETURN execute");
     EXPECT_THAT(stripped.named_expressions(), UnorderedElementsAre(Pair(7, "execute")));
   }
 }


### PR DESCRIPTION
Split index creation into phases
- Register (requires read-only access)
- Populate (drop down to read access)
- Publish (can be used for planning)

This allows for concurrent index queries, allowing for index population to happen while also allowing read/write queries to happen at the same time.

Extra capability:
- Plan cache invalidation only when index has been populated
- Can now terminate index creation