### PR TITLE
User-configurable option to failover only to SYNC replica

### DIFF
--- a/src/coordination/coordinator_state_machine.cpp
+++ b/src/coordination/coordinator_state_machine.cpp
@@ -161,6 +161,7 @@ auto CoordinatorStateMachine::SerializeUpdateClusterState(CoordinatorClusterStat
   add_if_set(kCoordinatorInstances, delta_state.coordinator_instances_);
   add_if_set(kUuid, delta_state.current_main_uuid_);
   add_if_set(kEnabledReadsOnMain, delta_state.enabled_reads_on_main_);
+  add_if_set(kSyncFailoverOnly, delta_state.sync_failover_only_);
 
   return CreateLog(delta_state_json);
 }
@@ -190,6 +191,12 @@ auto CoordinatorStateMachine::DecodeLog(buffer &data) -> CoordinatorClusterState
       // enabled_reads_on_main policy is added later, read it optionally, otherwise default it to false
       auto const enabled_reads_on_main = json.value(kEnabledReadsOnMain.data(), false);
       delta_state.enabled_reads_on_main_ = enabled_reads_on_main;
+    }
+
+    if (json.contains(kSyncFailoverOnly.data())) {
+      // sync_failover_only policy is added later, read it optionally, otherwise default it to true
+      auto const sync_failover_only = json.value(kSyncFailoverOnly.data(), true);
+      delta_state.sync_failover_only_ = sync_failover_only;
     }
 
     return delta_state;
@@ -372,6 +379,8 @@ auto CoordinatorStateMachine::TryGetCurrentMainName() const -> std::optional<std
 }
 
 auto CoordinatorStateMachine::GetEnabledReadsOnMain() const -> bool { return cluster_state_.GetEnabledReadsOnMain(); }
+
+auto CoordinatorStateMachine::GetSyncFailoverOnly() const -> bool { return cluster_state_.GetSyncFailoverOnly(); }
 
 }  // namespace memgraph::coordination
 #endif

--- a/src/coordination/include/coordination/constants.hpp
+++ b/src/coordination/include/coordination/constants.hpp
@@ -50,6 +50,7 @@ const std::string kLogEntryValTypeKey = "val_type";
 
 // routing policies
 constexpr auto kEnabledReadsOnMain = "enabled_reads_on_main"sv;
+constexpr auto kSyncFailoverOnly = "sync_failover_only"sv;
 
 // cluster state
 constexpr int MAX_SNAPSHOTS = 3;

--- a/src/coordination/include/coordination/coordinator_cluster_state.hpp
+++ b/src/coordination/include/coordination/coordinator_cluster_state.hpp
@@ -37,7 +37,8 @@ struct CoordinatorClusterStateDelta {
   std::optional<std::vector<DataInstanceContext>> data_instances_;
   std::optional<std::vector<CoordinatorInstanceContext>> coordinator_instances_;
   std::optional<utils::UUID> current_main_uuid_;
-  std::optional<bool> enabled_reads_on_main_{false};
+  std::optional<bool> enabled_reads_on_main_;
+  std::optional<bool> sync_failover_only_;
 
   bool operator==(const CoordinatorClusterStateDelta &other) const = default;
 };
@@ -77,6 +78,8 @@ class CoordinatorClusterState {
 
   auto GetEnabledReadsOnMain() const -> bool;
 
+  auto GetSyncFailoverOnly() const -> bool;
+
   auto TryGetCurrentMainName() const -> std::optional<std::string>;
 
   // Setter function used on parsing data from json
@@ -91,15 +94,18 @@ class CoordinatorClusterState {
   // Setter function used on parsing data from json
   void SetEnabledReadsOnMain(bool enabled_reads_on_main);
 
+  void SetSyncFailoverOnly(bool sync_failover_only);
+
   friend bool operator==(const CoordinatorClusterState &lhs, const CoordinatorClusterState &rhs) {
     if (&lhs == &rhs) {
       return true;
     }
     std::scoped_lock lock(lhs.app_lock_, rhs.app_lock_);
 
-    return std::tie(lhs.data_instances_, lhs.coordinator_instances_, lhs.current_main_uuid_,
-                    lhs.enabled_reads_on_main_) == std::tie(rhs.data_instances_, rhs.coordinator_instances_,
-                                                            rhs.current_main_uuid_, rhs.enabled_reads_on_main_);
+    return std::tie(lhs.data_instances_, lhs.coordinator_instances_, lhs.current_main_uuid_, lhs.enabled_reads_on_main_,
+                    lhs.sync_failover_only_) == std::tie(rhs.data_instances_, rhs.coordinator_instances_,
+                                                         rhs.current_main_uuid_, rhs.enabled_reads_on_main_,
+                                                         rhs.sync_failover_only_);
   }
 
  private:
@@ -107,6 +113,7 @@ class CoordinatorClusterState {
   std::vector<CoordinatorInstanceContext> coordinator_instances_;
   utils::UUID current_main_uuid_;
   bool enabled_reads_on_main_{false};
+  bool sync_failover_only_{true};
   mutable utils::ResourceLock app_lock_;
 };
 

--- a/src/coordination/include/coordination/coordinator_communication_config.hpp
+++ b/src/coordination/include/coordination/coordinator_communication_config.hpp
@@ -66,8 +66,8 @@ struct CoordinatorStateManagerConfig {
 // NOTE: We need to be careful about durability versioning when changing the config which is persisted on disk.
 
 struct ReplicationClientInfo {
-  std::string instance_name{};
-  replication_coordination_glue::ReplicationMode replication_mode{};
+  std::string instance_name;
+  replication_coordination_glue::ReplicationMode replication_mode;
   io::network::Endpoint replication_server;
 
   friend bool operator==(ReplicationClientInfo const &, ReplicationClientInfo const &) = default;
@@ -80,7 +80,7 @@ struct DataInstanceConfig {
     return replication_client_info.replication_server.SocketAddress();
   }
 
-  std::string instance_name{};
+  std::string instance_name;
   io::network::Endpoint mgt_server;
   io::network::Endpoint bolt_server;
   ReplicationClientInfo replication_client_info;

--- a/src/coordination/include/coordination/coordinator_state_machine.hpp
+++ b/src/coordination/include/coordination/coordinator_state_machine.hpp
@@ -101,6 +101,7 @@ class CoordinatorStateMachine final : public state_machine {
   auto TryGetCurrentMainName() const -> std::optional<std::string>;
 
   auto GetEnabledReadsOnMain() const -> bool;
+  auto GetSyncFailoverOnly() const -> bool;
 
  private:
   bool HandleMigration(LogStoreVersion stored_version);

--- a/src/coordination/include/coordination/raft_state.hpp
+++ b/src/coordination/include/coordination/raft_state.hpp
@@ -97,6 +97,7 @@ class RaftState {
   auto GetMyBoltServer() const -> std::optional<std::string>;
 
   auto GetEnabledReadsOnMain() const -> bool;
+  auto GetSyncFailoverOnly() const -> bool;
 
  private:
   uint16_t coordinator_port_;

--- a/src/coordination/raft_state.cpp
+++ b/src/coordination/raft_state.cpp
@@ -483,6 +483,9 @@ auto RaftState::GetRoutingTable() const -> RoutingTable {
 auto RaftState::GetLeaderId() const -> int32_t { return raft_server_->get_leader(); }
 
 auto RaftState::GetEnabledReadsOnMain() const -> bool { return state_machine_->GetEnabledReadsOnMain(); }
+
+auto RaftState::GetSyncFailoverOnly() const -> bool { return state_machine_->GetSyncFailoverOnly(); }
+
 }  // namespace memgraph::coordination
 
 // namespace memgraph::coordination

--- a/src/replication_coordination_glue/role.hpp
+++ b/src/replication_coordination_glue/role.hpp
@@ -17,7 +17,6 @@
 
 namespace memgraph::replication_coordination_glue {
 
-// TODO: figure out a way of ensuring that usage of this type is never uninitialized/defaulted incorrectly to MAIN
 enum class ReplicationRole : uint8_t { MAIN, REPLICA };
 
 NLOHMANN_JSON_SERIALIZE_ENUM(ReplicationRole, {{ReplicationRole::MAIN, "main"}, {ReplicationRole::REPLICA, "replica"}})

--- a/tests/unit/coordinator_log_store.cpp
+++ b/tests/unit/coordinator_log_store.cpp
@@ -109,7 +109,7 @@ TEST_F(CoordinatorLogStoreTests, TestBasicSerialization) {
 
     auto entry = log_store.entry_at(1);
 
-    auto const [ds, cs, uuid, enabled_reads_on_main] = CoordinatorStateMachine::DecodeLog(entry->get_buf());
+    CoordinatorStateMachine::DecodeLog(entry->get_buf());
 
     ASSERT_EQ(log_store.next_slot(), 2);
     ASSERT_EQ(log_store.start_index(), 1);
@@ -272,8 +272,8 @@ TEST_F(CoordinatorLogStoreTests, TestPackAndApplyPack) {
       auto entry1 = log_store1.entry_at(i);
       auto entry2 = log_store2.entry_at(i);
 
-      auto const [ds1, cs1, uuid1, enabled_reads_on_main1] = CoordinatorStateMachine::DecodeLog(entry1->get_buf());
-      auto const [ds2, cs2, uuid2, enabled_reads_on_main2] = CoordinatorStateMachine::DecodeLog(entry2->get_buf());
+      CoordinatorStateMachine::DecodeLog(entry1->get_buf());
+      CoordinatorStateMachine::DecodeLog(entry2->get_buf());
 
       ASSERT_EQ(entry1->get_term(), entry2->get_term());
       ASSERT_EQ(entry1->get_val_type(), entry2->get_val_type());
@@ -293,8 +293,8 @@ TEST_F(CoordinatorLogStoreTests, TestPackAndApplyPack) {
       auto entry1 = log_store1.entry_at(i);
       auto entry2 = log_store2.entry_at(i);
 
-      auto const [ds1, cs1, uuid1, enabled_reads_on_main1] = CoordinatorStateMachine::DecodeLog(entry1->get_buf());
-      auto const [ds2, cs2, uuid2, enabled_reads_on_main2] = CoordinatorStateMachine::DecodeLog(entry2->get_buf());
+      CoordinatorStateMachine::DecodeLog(entry1->get_buf());
+      CoordinatorStateMachine::DecodeLog(entry2->get_buf());
 
       ASSERT_EQ(entry1->get_term(), entry2->get_term());
       ASSERT_EQ(entry1->get_val_type(), entry2->get_val_type());
@@ -340,7 +340,7 @@ TEST_F(CoordinatorLogStoreTests, TestCompact) {
   for (int i = 4; i <= 5; ++i) {
     auto entry = log_store.entry_at(i);
     ASSERT_TRUE(entry != nullptr);
-    auto const [ds, cs, uuid, enabled_reads_on_main] = CoordinatorStateMachine::DecodeLog(entry->get_buf());
+    CoordinatorStateMachine::DecodeLog(entry->get_buf());
   }
 
   // Check that logs from 1 to 3 do not exist


### PR DESCRIPTION
Using the query `set coordinator setting 'sync_failover_only' to 'true'/'false'` users can modify the failover logic when deciding on which instance to perform a failover. When the option is set to true, only sync replicas will be considered. The option is by default set to true to minimize the chances of experiencing a data loss upon failover.