### PR TITLE
Bugfix: Improve the usage of RMW pattern in HA coordinators

### DIFF
--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -365,7 +365,8 @@ auto CoordinatorInstance::ReconcileClusterState() -> ReconcileClusterStateStatus
     switch (auto const result = ReconcileClusterState_()) {
       case (ReconcileClusterStateStatus::SUCCESS): {
         auto expected = CoordinatorStatus::LEADER_NOT_READY;
-        if (!status.compare_exchange_strong(expected, CoordinatorStatus::LEADER_READY, std::memory_order_acq_rel)) {
+        if (!status.compare_exchange_strong(expected, CoordinatorStatus::LEADER_READY, std::memory_order_acq_rel,
+                                            std::memory_order_acquire)) {
           if (expected == CoordinatorStatus::FOLLOWER) {
             spdlog::trace(
                 "Reconcile cluster state finished successfully but coordinator in the meantime became follower.");
@@ -490,7 +491,8 @@ auto CoordinatorInstance::TryVerifyOrCorrectClusterState() -> ReconcileClusterSt
   // Follows nomenclature from replication handler where Try<> means doing action from the
   // user query.
   auto expected = CoordinatorStatus::LEADER_READY;
-  if (!status.compare_exchange_strong(expected, CoordinatorStatus::LEADER_NOT_READY, std::memory_order_acq_rel)) {
+  if (!status.compare_exchange_strong(expected, CoordinatorStatus::LEADER_NOT_READY, std::memory_order_acq_rel,
+                                      std::memory_order_acquire)) {
     return ReconcileClusterStateStatus::NOT_LEADER_ANYMORE;
   }
   return ReconcileClusterState();

--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -365,7 +365,7 @@ auto CoordinatorInstance::ReconcileClusterState() -> ReconcileClusterStateStatus
     switch (auto const result = ReconcileClusterState_()) {
       case (ReconcileClusterStateStatus::SUCCESS): {
         auto expected = CoordinatorStatus::LEADER_NOT_READY;
-        if (!status.compare_exchange_strong(expected, CoordinatorStatus::LEADER_READY)) {
+        if (!status.compare_exchange_strong(expected, CoordinatorStatus::LEADER_READY, std::memory_order_acq_rel)) {
           if (expected == CoordinatorStatus::FOLLOWER) {
             spdlog::trace(
                 "Reconcile cluster state finished successfully but coordinator in the meantime became follower.");
@@ -490,7 +490,7 @@ auto CoordinatorInstance::TryVerifyOrCorrectClusterState() -> ReconcileClusterSt
   // Follows nomenclature from replication handler where Try<> means doing action from the
   // user query.
   auto expected = CoordinatorStatus::LEADER_READY;
-  if (!status.compare_exchange_strong(expected, CoordinatorStatus::LEADER_NOT_READY)) {
+  if (!status.compare_exchange_strong(expected, CoordinatorStatus::LEADER_NOT_READY, std::memory_order_acq_rel)) {
     return ReconcileClusterStateStatus::NOT_LEADER_ANYMORE;
   }
   return ReconcileClusterState();

--- a/src/coordination/coordinator_log_store.cpp
+++ b/src/coordination/coordinator_log_store.cpp
@@ -308,10 +308,6 @@ bool CoordinatorLogStore::compact(uint64_t last_log_index) {
     }
   }
 
-  if (old_start_idx > last_log_index) {
-    return true;
-  }
-
   auto lock = std::lock_guard{logs_lock_};
   for (uint64_t ii = old_start_idx; ii <= last_log_index; ++ii) {
     auto const entry = logs_.find(ii);

--- a/src/coordination/coordinator_log_store.cpp
+++ b/src/coordination/coordinator_log_store.cpp
@@ -57,22 +57,22 @@ bool CoordinatorLogStore::HandleVersionMigration(LogStoreVersion const stored_ve
         is_first_start = true;
       }
       if (is_first_start) {
-        start_idx_ = 1;
+        start_idx_.store(1, std::memory_order_release);
         durability_->Put(kStartIdx, "1");
         durability_->Put(kLastLogEntry, "0");
         return true;
       }
 
       uint64_t const last_log_entry = std::stoull(maybe_last_log_entry.value());
-      start_idx_ = std::stoull(maybe_start_idx.value());
+      start_idx_.store(std::stoull(maybe_start_idx.value(), std::memory_order_release);
 
       // Compaction might have happened so we might be missing some logs.
-      for (auto const id : std::ranges::iota_view{start_idx_.load(), last_log_entry + 1}) {
+      for (auto const id : std::ranges::iota_view{start_idx_.load(std::memory_order_acquire), last_log_entry + 1}) {
         auto const entry = durability_->Get(fmt::format("{}{}", kLogEntryPrefix, id));
 
         if (!entry.has_value()) {
-          logger_.Log(nuraft_log_level::TRACE,
-                      fmt::format("Missing entry with id {} in range [{}:{}]", id, start_idx_.load(), last_log_entry));
+          logger_.Log(nuraft_log_level::TRACE, fmt::format("Missing entry with id {} in range [{}:{}]", id,
+                                                           start_idx_.load(std::memory_order_acquire), last_log_entry));
           continue;
         }
 
@@ -126,9 +126,11 @@ uint64_t CoordinatorLogStore::next_slot() const {
   return GetNextSlot();
 }
 
-auto CoordinatorLogStore::GetNextSlot() const -> uint64_t { return start_idx_ + logs_.size(); }
+auto CoordinatorLogStore::GetNextSlot() const -> uint64_t {
+  return start_idx_.load(std::memory_order_acquire) + logs_.size();
+}
 
-uint64_t CoordinatorLogStore::start_index() const { return start_idx_; }
+uint64_t CoordinatorLogStore::start_index() const { return start_idx_.load(std::memory_order_acquire); }
 
 std::shared_ptr<log_entry> CoordinatorLogStore::last_entry() const {
   auto lock = std::lock_guard{logs_lock_};
@@ -280,10 +282,10 @@ void CoordinatorLogStore::apply_pack(uint64_t index, buffer &pack) {
   {
     auto lock = std::lock_guard{logs_lock_};
     if (auto const entry = logs_.upper_bound(0); entry != logs_.end()) {
-      start_idx_ = entry->first;
-      durability_->Put(kStartIdx, std::to_string(start_idx_.load()));
+      start_idx_.store(entry->first, std::memory_order_release);
+      durability_->Put(kStartIdx, std::to_string(start_idx_.load(std::memory_order_acquire)));
     } else {
-      start_idx_ = 1;
+      start_idx_.store(1, std::memory_order_release);
     }
   }
 }
@@ -292,7 +294,7 @@ void CoordinatorLogStore::apply_pack(uint64_t index, buffer &pack) {
 bool CoordinatorLogStore::compact(uint64_t last_log_index) {
   logger_.Log(nuraft_log_level::TRACE, fmt::format("Compacting logs up to {}", last_log_index));
   auto lock = std::lock_guard{logs_lock_};
-  for (uint64_t ii = start_idx_; ii <= last_log_index; ++ii) {
+  for (uint64_t ii = start_idx_.load(std::memory_order_acquire); ii <= last_log_index; ++ii) {
     auto const entry = logs_.find(ii);
     if (entry == logs_.end()) {
       continue;
@@ -301,9 +303,9 @@ bool CoordinatorLogStore::compact(uint64_t last_log_index) {
     durability_->Delete(fmt::format("{}{}", kLogEntryPrefix, ii));
   }
 
-  if (start_idx_ <= last_log_index) {
-    start_idx_ = last_log_index + 1;
-    durability_->Put(kStartIdx, std::to_string(start_idx_.load()));
+  if (start_idx_.load(std::memory_order_acquire) <= last_log_index) {
+    start_idx_.store(last_log_index + 1, std::memory_order_release);
+    durability_->Put(kStartIdx, std::to_string(start_idx_.load(std::memory_order_acquire)));
   }
   return true;
 }

--- a/src/coordination/coordinator_log_store.cpp
+++ b/src/coordination/coordinator_log_store.cpp
@@ -64,7 +64,7 @@ bool CoordinatorLogStore::HandleVersionMigration(LogStoreVersion const stored_ve
       }
 
       uint64_t const last_log_entry = std::stoull(maybe_last_log_entry.value());
-      auto const durable_start_idx_value = std::stoull(maybe_start_idx.value();
+      auto const durable_start_idx_value = std::stoull(maybe_start_idx.value());
       start_idx_.store(durable_start_idx_value, std::memory_order_release);
 
       // Compaction might have happened so we might be missing some logs.
@@ -307,7 +307,7 @@ bool CoordinatorLogStore::compact(uint64_t last_log_index) {
   }
 
   auto lock = std::lock_guard{logs_lock_};
-  for (uint64_t ii = ; ii <= last_log_index; ++ii) {
+  for (uint64_t ii = old_start_idx; ii <= last_log_index; ++ii) {
     auto const entry = logs_.find(ii);
     if (entry == logs_.end()) {
       continue;

--- a/src/coordination/include/coordination/coordinator_log_store.hpp
+++ b/src/coordination/include/coordination/coordinator_log_store.hpp
@@ -92,12 +92,15 @@ class CoordinatorLogStore final : public log_store {
    */
   auto GetNextSlot() const -> ulong;
 
+  // Must be called under the logs_lock_
   auto FindOrDefault_(ulong index) const -> std::shared_ptr<log_entry>;
 
   bool HandleVersionMigration(LogStoreVersion stored_version);
 
   std::map<ulong, std::shared_ptr<log_entry>> logs_;
   mutable std::mutex logs_lock_;
+  // Atomic as suggested by NuRaft. Changes in HandleVersionMigration shouldn't be a concurrent issue because they
+  // happen in the constructor
   std::atomic<ulong> start_idx_{0};
   std::shared_ptr<kvstore::KVStore> durability_;
   LoggerWrapper logger_;

--- a/src/coordination/include/coordination/coordinator_log_store.hpp
+++ b/src/coordination/include/coordination/coordinator_log_store.hpp
@@ -99,7 +99,6 @@ class CoordinatorLogStore final : public log_store {
   std::map<ulong, std::shared_ptr<log_entry>> logs_;
   mutable std::mutex logs_lock_;
   std::atomic<ulong> start_idx_{0};
-  std::atomic<ulong> next_idx_{0};
   std::shared_ptr<kvstore::KVStore> durability_;
   LoggerWrapper logger_;
 };

--- a/src/coordination/include/coordination/coordinator_state_machine.hpp
+++ b/src/coordination/include/coordination/coordinator_state_machine.hpp
@@ -116,7 +116,6 @@ class CoordinatorStateMachine final : public state_machine {
 
   LoggerWrapper logger_;
   ptr<snapshot> last_snapshot_;
-  std::mutex last_snapshot_lock_;
 
   std::shared_ptr<kvstore::KVStore> durability_;
 };


### PR DESCRIPTION
Removes unused atomic variables and fixes some of the concurrency bugs noticed in HA stack. The operation`compare_exchange_strong` in coordinator_instance.cpp now uses acquire-release memory order semantics on success and failure operations. The variable `start_idx` now uses also acquire-release semantics instead of sequentially consistent operations. The lock `last_snapshot_lock` wasn't used and atomic variable `next_idx` from coordinator_log_store.