### PR TITLE
Bugfix: Impersonate user misalignment between interpreter and session

### DIFF
--- a/src/communication/bolt/client.cpp
+++ b/src/communication/bolt/client.cpp
@@ -83,7 +83,7 @@ void Client::Connect(const io::network::Endpoint &endpoint, const std::string &u
   spdlog::debug("Metadata of init message response: {}", metadata);
 }
 
-QueryData Client::Execute(const std::string &query, const map_t &parameters) {
+QueryData Client::Execute(const std::string &query, const map_t &parameters, const map_t &extra) {
   if (!client_.IsConnected()) {
     throw ClientFatalException("You must first connect to the server before using the client!");
   }
@@ -92,7 +92,7 @@ QueryData Client::Execute(const std::string &query, const map_t &parameters) {
 
   // It is super critical from performance point of view to send the pull message right after the run message. Otherwise
   // the performance will degrade multiple magnitudes.
-  encoder_.MessageRun(query, parameters, {});
+  encoder_.MessageRun(query, parameters, extra);
   encoder_.MessagePull({{"n", Value(-1)}});
 
   spdlog::debug("Reading run message response");

--- a/src/communication/bolt/client.hpp
+++ b/src/communication/bolt/client.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -113,7 +113,7 @@ class Client final {
   ///                              executing the query (eg. mistyped query,
   ///                              etc.)
   /// @throws ClientFatalException when we couldn't communicate with the server
-  QueryData Execute(const std::string &query, const map_t &parameters);
+  QueryData Execute(const std::string &query, const map_t &parameters, const map_t &extra = {});
 
   /// Close the active client connection.
   void Close();

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -128,7 +128,7 @@ void ImpersonateUserAuth(memgraph::query::QueryUserOrRole *user_or_role, const s
   }
   if (!user_or_role) {
     throw memgraph::communication::bolt::ClientError(
-        "No session userYou must be logged-in in order to use the impersonate-user feature.");
+        "No session user. You must be logged-in in order to use the impersonate-user feature.");
   }
   if (!user_or_role->CanImpersonate(impersonated_user, &memgraph::query::session_long_policy)) {
     throw memgraph::communication::bolt::ClientError(
@@ -143,9 +143,9 @@ namespace memgraph::glue {
 
 #ifdef MG_ENTERPRISE
 std::optional<std::string> SessionHL::GetDefaultDB() const {
-  if (user_or_role_) {
+  if (interpreter_.user_or_role_) {
     try {
-      return user_or_role_->GetDefaultDB();
+      return interpreter_.user_or_role_->GetDefaultDB();
     } catch (auth::AuthException &) {
       // Support non-db connection
       return {};
@@ -204,8 +204,8 @@ bool SessionHL::Authenticate(const std::string &username, const std::string &pas
     if (locked_auth->AccessControlled()) {
       const auto user_or_role = locked_auth->Authenticate(username, password);
       if (user_or_role.has_value()) {
-        user_or_role_ = AuthChecker::GenQueryUser(auth_, *user_or_role);
-        interpreter_.SetUser(user_or_role_);
+        session_user_or_role_ = AuthChecker::GenQueryUser(auth_, *user_or_role);
+        interpreter_.SetUser(session_user_or_role_);
         interpreter_.SetSessionInfo(
             UUID(),
             interpreter_.user_or_role_->username().has_value() ? interpreter_.user_or_role_->username().value() : "",
@@ -215,8 +215,8 @@ bool SessionHL::Authenticate(const std::string &username, const std::string &pas
       }
     } else {
       // No access control -> give empty user
-      user_or_role_ = AuthChecker::GenQueryUser(auth_, std::nullopt);
-      interpreter_.SetUser(user_or_role_);
+      session_user_or_role_ = AuthChecker::GenQueryUser(auth_, std::nullopt);
+      interpreter_.SetUser(session_user_or_role_);
       interpreter_.SetSessionInfo(UUID(), "", GetLoginTimestamp());
     }
   }
@@ -235,8 +235,8 @@ bool SessionHL::SSOAuthenticate(const std::string &scheme, const std::string &id
     return false;
   }
 
-  user_or_role_ = AuthChecker::GenQueryUser(auth_, *user_or_role);
-  interpreter_.SetUser(user_or_role_);
+  session_user_or_role_ = AuthChecker::GenQueryUser(auth_, *user_or_role);
+  interpreter_.SetUser(session_user_or_role_);
 
   TryDefaultDB();
   return true;
@@ -291,27 +291,16 @@ std::pair<std::vector<std::string>, std::optional<int>> SessionHL::Interpret(con
 #ifdef MG_ENTERPRISE
   if (memgraph::license::global_license_checker.IsEnterpriseValidFast()) {
     auto &db = interpreter_.current_db_.db_acc_;
-    const auto username = user_or_role_ ? (user_or_role_->username() ? *user_or_role_->username() : "") : "";
+    const auto &user_or_role = interpreter_.user_or_role_;
+    const auto username = user_or_role ? (user_or_role->username() ? *user_or_role->username() : "") : "";
     audit_log_->Record(fmt::format("{}:{}", endpoint_.address().to_string(), std::to_string(endpoint_.port())),
                        username, query, params, db ? db->get()->name() : "");
   }
 #endif
   try {
     auto result = interpreter_.Prepare(query, get_params_pv, ToQueryExtras(extra));
-    const std::string db_name = result.db ? *result.db : "";
-    if (user_or_role_ && !user_or_role_->IsAuthorized(result.privileges, db_name, &query::session_long_policy)) {
-      interpreter_.Abort();
-      if (db_name.empty()) {
-        throw memgraph::communication::bolt::ClientError(
-            "You are not authorized to execute this query! Please contact your database administrator.");
-      }
-      throw memgraph::communication::bolt::ClientError(
-          "You are not authorized to execute this query on database \"{}\"! Please contact your database "
-          "administrator.",
-          db_name);
-    }
+    interpreter_.CheckAuthorized(result.privileges, result.db);
     return {std::move(result.headers), result.qid};
-
   } catch (const memgraph::query::QueryException &e) {
     // Count the number of specific exceptions thrown
     metrics::IncrementCounter(GetExceptionName(e));
@@ -407,6 +396,8 @@ void SessionHL::BeginTransaction(const bolt_map_t &extra) {
 
 void SessionHL::Configure(const bolt_map_t &run_time_info) {
 #ifdef MG_ENTERPRISE
+  // NOTE: Order is important, runtime_user_ must be configured before runtime_db_
+  // because runtime_db_ uses runtime_user_ to check if the user is authorized
   runtime_user_.Configure(run_time_info, interpreter_.in_explicit_transaction_);
   runtime_db_.Configure(run_time_info, interpreter_.in_explicit_transaction_);
 #else
@@ -431,7 +422,7 @@ SessionHL::SessionHL(memgraph::query::InterpreterContext *interpreter_context,
       runtime_db_{"db", [this]() { return GetCurrentDB(); }, [this]() { return GetDefaultDB(); },
                   [this](std::optional<std::string> defined_db, bool user_defined) {
                     if (defined_db) {  // Db connection
-                      MultiDatabaseAuth(user_or_role_.get(), *defined_db);
+                      MultiDatabaseAuth(interpreter_.user_or_role_.get(), *defined_db);
                       interpreter_.SetCurrentDB(*defined_db, user_defined);
                     } else {  // Non-db connection
                       interpreter_.ResetDB();
@@ -444,13 +435,20 @@ SessionHL::SessionHL(memgraph::query::InterpreterContext *interpreter_context,
                     },
                     [this](std::optional<std::string> defined_user, bool impersonate_user) {
                       if (impersonate_user) {
-                        ImpersonateUserAuth(user_or_role_.get(), *defined_user);
+                        if (!defined_user) {
+                          throw memgraph::communication::bolt::ClientError("Trying to impersonate an undefined user.");
+                        }
+                        spdlog::trace("Trying to impersonate user '{}'...", *defined_user);
+                        ImpersonateUserAuth(session_user_or_role_.get(), *defined_user);
                         const auto &imp_usr = auth_->ReadLock()->GetUser(*defined_user);
                         if (!imp_usr) throw auth::AuthException("Trying to impersonate a user that doesn't exist.");
                         interpreter_.SetUser(AuthChecker::GenQueryUser(auth_, imp_usr));
+                        TryDefaultDB();
                       } else {
+                        spdlog::trace("Done impersonating users.");
                         // Set our default user/role
-                        interpreter_.SetUser(user_or_role_);
+                        interpreter_.SetUser(session_user_or_role_);
+                        TryDefaultDB();
                       }
                     }},
 #endif
@@ -459,7 +457,10 @@ SessionHL::SessionHL(memgraph::query::InterpreterContext *interpreter_context,
   // Metrics update
   memgraph::metrics::IncrementCounter(memgraph::metrics::ActiveBoltSessions);
 #ifdef MG_ENTERPRISE
-  interpreter_.OnChangeCB([&](std::string_view db_name) { MultiDatabaseAuth(user_or_role_.get(), db_name); });
+  interpreter_.OnChangeCB([&](std::string_view db_name) {
+    auto &user_or_role = interpreter_.user_or_role_;
+    MultiDatabaseAuth(user_or_role.get(), db_name);
+  });
 #endif
   interpreter_context_->interpreters.WithLock([this](auto &interpreters) { interpreters.insert(&interpreter_); });
 }

--- a/src/glue/SessionHL.hpp
+++ b/src/glue/SessionHL.hpp
@@ -114,7 +114,7 @@ class SessionHL final : public memgraph::communication::bolt::Session<memgraph::
 
   memgraph::query::InterpreterContext *interpreter_context_;
   memgraph::query::Interpreter interpreter_;
-  std::shared_ptr<query::QueryUserOrRole> user_or_role_;
+  std::shared_ptr<query::QueryUserOrRole> session_user_or_role_;
 #ifdef MG_ENTERPRISE
   memgraph::audit::Log *audit_log_;
   RunTimeConfig runtime_db_;

--- a/src/query/frontend/semantic/required_privileges.cpp
+++ b/src/query/frontend/semantic/required_privileges.cpp
@@ -13,7 +13,6 @@
 #include "query/frontend/ast/ast_visitor.hpp"
 #include "query/procedure/mg_procedure_impl.hpp"
 #include "query/procedure/module.hpp"
-#include "utils/memory.hpp"
 
 namespace memgraph::query {
 
@@ -38,7 +37,12 @@ class PrivilegeExtractor : public QueryVisitor<void>, public HierarchicalTreeVis
 
   void Visit(AnalyzeGraphQuery & /*unused*/) override { AddPrivilege(AuthQuery::Privilege::INDEX); }
 
-  void Visit(AuthQuery & /*unused*/) override { AddPrivilege(AuthQuery::Privilege::AUTH); }
+  void Visit(AuthQuery &query) override {
+    // Special cases
+    if (query.action_ == AuthQuery::Action::SHOW_CURRENT_USER) return;
+    // Default to AUTH
+    AddPrivilege(AuthQuery::Privilege::AUTH);
+  }
 
   void Visit(ExplainQuery &query) override { query.cypher_query_->Accept(dynamic_cast<QueryVisitor &>(*this)); }
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -6425,6 +6425,20 @@ Interpreter::PrepareResult Interpreter::Prepare(const std::string &query_string,
   }
 }
 
+void Interpreter::CheckAuthorized(std::vector<AuthQuery::Privilege> const &privileges, std::optional<std::string> db) {
+  const std::string db_name = db ? *db : "";
+  if (user_or_role_ && !user_or_role_->IsAuthorized(privileges, db_name, &query::session_long_policy)) {
+    Abort();
+    if (db_name.empty()) {
+      throw QueryException("You are not authorized to execute this query! Please contact your database administrator.");
+    }
+    throw QueryException(
+        "You are not authorized to execute this query on database \"{}\"! Please contact your database "
+        "administrator.",
+        db_name);
+  }
+}
+
 void Interpreter::SetupDatabaseTransaction(bool couldCommit, storage::Storage::Accessor::Type acc_type) {
   current_db_.SetupDatabaseTransaction(GetIsolationLevelOverride(), couldCommit, acc_type);
 }

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -287,6 +287,13 @@ class Interpreter final {
   Interpreter::PrepareResult Prepare(const std::string &query, UserParameters_fn params_getter,
                                      QueryExtras const &extras);
 
+  /**
+   * Checks if the user has the required privileges to execute the query.
+   *
+   * @throw query::QueryException
+   */
+  void CheckAuthorized(std::vector<AuthQuery::Privilege> const &privileges, std::optional<std::string> db = {});
+
 #ifdef MG_ENTERPRISE
   auto Route(std::map<std::string, std::string> const &routing) -> RouteResult;
 #endif

--- a/tests/integration/audit/tester.cpp
+++ b/tests/integration/audit/tester.cpp
@@ -14,6 +14,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "bolt/v1/value.hpp"
 #include "communication/bolt/client.hpp"
 #include "io/network/endpoint.hpp"
 #include "io/network/utils.hpp"
@@ -27,6 +28,7 @@ DEFINE_bool(use_ssl, false, "Set to true to connect with SSL to the server.");
 DEFINE_string(query, "", "Query to execute");
 DEFINE_string(params_json, "{}", "Params for the query");
 DEFINE_string(use_db, "memgraph", "Database to run the query against");
+DEFINE_string(imp_user, "", "User to impersonate. Empty to disable");
 
 memgraph::communication::bolt::Value JsonToValue(const nlohmann::json &jv) {
   memgraph::communication::bolt::Value ret;
@@ -91,8 +93,10 @@ int main(int argc, char **argv) {
   memgraph::communication::bolt::Client client(context);
 
   client.Connect(endpoint, FLAGS_username, FLAGS_password);
+  memgraph::communication::bolt::map_t extra;
+  if (!FLAGS_imp_user.empty()) extra.emplace("imp_user", FLAGS_imp_user);
   client.Execute(fmt::format("USE DATABASE {}", FLAGS_use_db), {});
-  client.Execute(FLAGS_query, JsonToValue(nlohmann::json::parse(FLAGS_params_json)).ValueMap());
+  client.Execute(FLAGS_query, JsonToValue(nlohmann::json::parse(FLAGS_params_json)).ValueMap(), extra);
 
   return 0;
 }


### PR DESCRIPTION
SessionHL would update the interpreter with the imp_user, but the logic was split between the two
Parts of the logic inside SessionHL:
	- query authorization
	- audit logs
	- MT authoriztaion 
Query authorization has been moved to the interpreter.
Other parts remain in the SessionHL, but use the interpreter's user.