### PR TITLE
Increase runner timeouts

### DIFF
--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -182,7 +182,7 @@ jobs:
     if: ${{ inputs.run_release_tests == 'true' }}
     name: "Debug build"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
-    timeout-minutes: 70
+    timeout-minutes: 80
     env:
       BUILD_TYPE: Debug
 
@@ -522,7 +522,7 @@ jobs:
     if: ${{ inputs.run_release_tests == 'true' }}
     name: "Release Benchmark Tests"
     runs-on: [self-hosted, DockerMgBuild, Gen7, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
-    timeout-minutes: 60
+    timeout-minutes: 70
 
     steps:
       - name: Set up repository
@@ -597,7 +597,7 @@ jobs:
     if: ${{ inputs.run_release_tests == 'true' }}
     name: "Release End-to-end Test"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
-    timeout-minutes: 70
+    timeout-minutes: 80
 
     steps:
       - name: Set up repository
@@ -803,7 +803,7 @@ jobs:
           --os $OS \
           --arch $ARCH \
           copy --binary --dest-dir build
-  
+
       - name: Copy libmemgraph_module_support.so
         run: |
           ./release/package/mgbuild.sh \


### PR DESCRIPTION
Some tests are timing out in slightly slower runners, this PR increases those timeouts by a small amount to reduce the number of failing daily builds.
