### PR TITLE
Improve read-write benchmark test

### DIFF
--- a/tests/e2e/replication/read_write_benchmark.cpp
+++ b/tests/e2e/replication/read_write_benchmark.cpp
@@ -11,7 +11,6 @@
 
 #include <chrono>
 #include <fstream>
-#include <random>
 #include <thread>
 
 #include <fmt/format.h>
@@ -19,7 +18,6 @@
 #include <nlohmann/json.hpp>
 
 #include "common.hpp"
-#include "io/network/fmt.hpp"
 #include "utils/logging.hpp"
 #include "utils/thread.hpp"
 #include "utils/timer.hpp"
@@ -78,6 +76,48 @@ int main(int argc, char **argv) {
       client->DiscardAll();
     }
     output["edge_write_time"] = node_write_timer.Elapsed().count();
+  }
+
+  {
+    // Wait for the writes to be replicated.
+    auto constexpr TIMEOUT = std::chrono::seconds(10);
+    auto constexpr SLEEP_TIME = std::chrono::milliseconds(500);
+    auto start = std::chrono::steady_clock::now();
+
+    for (const auto &database_endpoint : database_endpoints) {
+      auto now = std::chrono::steady_clock::now();
+      while (now - start < TIMEOUT) {
+        auto client = mg::e2e::replication::Connect(database_endpoint);
+        client->Execute("SHOW STORAGE INFO;");
+        auto maybe_rows = client->FetchAll();
+        if (!maybe_rows) {
+          LOG_FATAL("Failed to fetch storage info from {}", database_endpoint.SocketAddress());
+        }
+
+        auto find_value = [&](std::string_view key) -> std::optional<int64_t> {
+          auto it = std::ranges::find_if(*maybe_rows, [&](const auto &row) { return row[0].ValueString() == key; });
+          if (it != maybe_rows->end()) {
+            return (*it)[1].ValueInt();
+          }
+          return std::nullopt;
+        };
+
+        auto maybe_vertex_count = find_value("vertex_count");
+        auto maybe_edge_count = find_value("edge_count");
+
+        if (!maybe_vertex_count || !maybe_edge_count) {
+          LOG_FATAL("Failed to fetch vertex or edge count from {}", database_endpoint.SocketAddress());
+        }
+
+        if (*maybe_vertex_count == FLAGS_nodes && *maybe_edge_count == FLAGS_edges) {
+          break;
+        }
+
+        std::this_thread::sleep_for(SLEEP_TIME);
+        now = std::chrono::steady_clock::now();
+      }
+    }
+    spdlog::info("All nodes and edges were replicated.");
   }
 
   {  // Benchmark read queries.

--- a/tests/e2e/replication/workloads.yaml
+++ b/tests/e2e/replication/workloads.yaml
@@ -62,7 +62,8 @@ workloads:
 
   - name: "Read-write benchmark"
     binary: "tests/e2e/replication/memgraph__e2e__replication__read_write_benchmark"
-    args: []
+    args:
+      - "--database_endpoints=127.0.0.1:7687,127.0.0.1:7688,127.0.0.1:7689,127.0.0.1:7690"
     <<: *template_cluster
 
   - name: "Show"

--- a/tests/e2e/replication/workloads.yaml
+++ b/tests/e2e/replication/workloads.yaml
@@ -57,7 +57,8 @@ template_cluster: &template_cluster
 workloads:
   - name: "Constraints"
     binary: "tests/e2e/replication/memgraph__e2e__replication__constraints"
-    args: []
+    args:
+     - "--database_endpoints=127.0.0.1:7687,127.0.0.1:7688,127.0.0.1:7689,127.0.0.1:7690"
     <<: *template_cluster
 
   - name: "Read-write benchmark"


### PR DESCRIPTION
Added checks for the correct `vertex_count` and `edge_count` in the storage info response before proceeding with the test, ensuring that data is correctly replicated. This allows the test to fail early if the expected replication data is missing.

Additionally, the endpoints flag was previously hardcoded in `common.hpp`, but the number of database instances being tested has changed. Instead of relying on the default value, the correct value is now explicitly passed.