### PR TITLE
Fix diff setup

### DIFF
--- a/.github/workflows/check_flakiness.yaml
+++ b/.github/workflows/check_flakiness.yaml
@@ -82,8 +82,6 @@ jobs:
             sequence+="${i},"
           done
           echo "runs=[${sequence::-1}]" >> $GITHUB_OUTPUT
-      - name: Print output
-        run: |
           cat "$GITHUB_OUTPUT"
 
   Community:

--- a/.github/workflows/check_flakiness.yaml
+++ b/.github/workflows/check_flakiness.yaml
@@ -30,7 +30,7 @@ on:
         description: ""
       release:
         description: 'Comma-separated list of release tests to run (e.g. core,benchmark,e2e,stress,query_modules)'
-        default: 'core,benchmark,e2e,stress,query_modules'
+        default: 'core,e2e,stress,query_modules'
       malloc_build:
         type: boolean
         default: true
@@ -159,7 +159,7 @@ jobs:
       os: 'ubuntu-24.04'
       toolchain: 'v6'
       run_core: ${{ needs.DiffSetup.outputs.run_release_core }}
-      run_benchmark: 'false'
+      run_benchmark: ${{ needs.DiffSetup.outputs.run_release_core && github.event_name == 'workflow_dispatch' }}
       run_e2e: ${{ needs.DiffSetup.outputs.run_release_e2e }}
       run_stress: ${{ needs.DiffSetup.outputs.run_release_stress }}
       run_query_modules: ${{ needs.DiffSetup.outputs.run_release_query_modules }}

--- a/.github/workflows/check_flakiness.yaml
+++ b/.github/workflows/check_flakiness.yaml
@@ -69,7 +69,9 @@ jobs:
         run: echo "$GH_CONTEXT" >> "$GH_CONTEXT_FILE_NAME"
       - name: Set up diff execution
         id: setup
-        run: ./tools/diff_setup.py --gh-context-path "$GH_CONTEXT_FILE_NAME" --base-branch "origin/master"
+        run: |
+          ./tools/diff_setup.py --gh-context-path "$GH_CONTEXT_FILE_NAME" --base-branch "origin/master"
+          cat "$GITHUB_OUTPUT"
       - name: Set up flakiness runs
         id: setup_flakiness
         run: |
@@ -82,7 +84,7 @@ jobs:
             sequence+="${i},"
           done
           echo "runs=[${sequence::-1}]" >> $GITHUB_OUTPUT
-          cat "$GITHUB_OUTPUT"
+
 
   Community:
     needs: DiffSetup

--- a/.github/workflows/check_flakiness.yaml
+++ b/.github/workflows/check_flakiness.yaml
@@ -82,6 +82,9 @@ jobs:
             sequence+="${i},"
           done
           echo "runs=[${sequence::-1}]" >> $GITHUB_OUTPUT
+      - name: Print output
+        run: |
+          echo "$GITHUB_OUTPUT"
 
   Community:
     needs: DiffSetup

--- a/.github/workflows/check_flakiness.yaml
+++ b/.github/workflows/check_flakiness.yaml
@@ -28,22 +28,12 @@ on:
         type: boolean
         default: true
         description: ""
-      release_core:
+      release:
+        description: 'Comma-separated list of release tests to run (e.g. core,benchmark,e2e,stress,query_modules)'
+        default: 'core,benchmark,e2e,stress,query_modules'
+      malloc_build:
         type: boolean
         default: true
-        description: ""
-      release_e2e:
-        type: boolean
-        default: true
-        description: ""
-      release_stress:
-        type: boolean
-        default: true
-        description: ""
-      release_query_modules:
-        type: boolean
-        default: true
-        description: ""
       flakiness_runs:
         type: number
         default: 3
@@ -64,6 +54,7 @@ jobs:
       run_release_e2e: ${{ steps.setup.outputs.run_release_e2e }}
       run_release_stress: ${{ steps.setup.outputs.run_release_stress }}
       run_release_query_modules: ${{ steps.setup.outputs.run_release_query_modules }}
+      run_malloc_build: ${{ steps.setup.outputs.run_malloc_build }}
       runs: ${{ steps.setup_flakiness.outputs.runs }}
     env:
       GH_CONTEXT: ${{ toJson(github) }}
@@ -172,5 +163,21 @@ jobs:
       run_e2e: ${{ needs.DiffSetup.outputs.run_release_e2e }}
       run_stress: ${{ needs.DiffSetup.outputs.run_release_stress }}
       run_query_modules: ${{ needs.DiffSetup.outputs.run_release_query_modules }}
+      run_id: "${{ matrix.run_no }}"
+    secrets: inherit
+
+  Malloc:
+    needs: DiffSetup
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        run_no: ${{ fromJSON(needs.DiffSetup.outputs.runs) }}
+    uses: ./.github/workflows/diff_malloc.yaml
+    with:
+      arch: 'amd'
+      os: 'ubuntu-24.04'
+      toolchain: 'v6'
+      run_build: ${{ needs.DiffSetup.outputs.run_malloc_build }}
       run_id: "${{ matrix.run_no }}"
     secrets: inherit

--- a/.github/workflows/check_flakiness.yaml
+++ b/.github/workflows/check_flakiness.yaml
@@ -159,7 +159,7 @@ jobs:
       os: 'ubuntu-24.04'
       toolchain: 'v6'
       run_core: ${{ needs.DiffSetup.outputs.run_release_core }}
-      run_benchmark: ${{ needs.DiffSetup.outputs.run_release_core && github.event_name == 'workflow_dispatch' }}
+      run_benchmark: ${{ needs.DiffSetup.outputs.run_release_core =='true' && github.event_name == 'workflow_dispatch' }}
       run_e2e: ${{ needs.DiffSetup.outputs.run_release_e2e }}
       run_stress: ${{ needs.DiffSetup.outputs.run_release_stress }}
       run_query_modules: ${{ needs.DiffSetup.outputs.run_release_query_modules }}

--- a/.github/workflows/check_flakiness.yaml
+++ b/.github/workflows/check_flakiness.yaml
@@ -162,7 +162,7 @@ jobs:
       os: 'ubuntu-24.04'
       toolchain: 'v6'
       run_core: ${{ needs.DiffSetup.outputs.run_release_core }}
-      run_benchmark: ${{ needs.DiffSetup.outputs.run_release_core =='true' && github.event_name == 'workflow_dispatch' }}
+      run_benchmark: ${{ needs.DiffSetup.outputs.run_release_benchmark =='true' && github.event_name == 'workflow_dispatch' }}
       run_e2e: ${{ needs.DiffSetup.outputs.run_release_e2e }}
       run_stress: ${{ needs.DiffSetup.outputs.run_release_stress }}
       run_query_modules: ${{ needs.DiffSetup.outputs.run_release_query_modules }}

--- a/.github/workflows/check_flakiness.yaml
+++ b/.github/workflows/check_flakiness.yaml
@@ -84,7 +84,7 @@ jobs:
           echo "runs=[${sequence::-1}]" >> $GITHUB_OUTPUT
       - name: Print output
         run: |
-          echo "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
 
   Community:
     needs: DiffSetup

--- a/tools/diff_setup.py
+++ b/tools/diff_setup.py
@@ -18,12 +18,13 @@ class DiffSetup:
                 self._gh_context = json.load(gh_context_file)
                 if not self._get_event_name():
                     raise KeyError
-                
+
                 # reformat release key
                 inputs = self._get_workflow_dispatch_inputs()
+                print(f"inputs: {inputs}")
                 if inputs:
-                    release = inputs.pop("release","")
-                    for test in ["core","benchmark","e2e","stress","query_modules"]:
+                    release = inputs.pop("release", "")
+                    for test in ["core", "benchmark", "e2e", "stress", "query_modules"]:
                         self._gh_context["event"]["inputs"][f"release_{test}"] = test in release
 
         except FileNotFoundError:

--- a/tools/diff_setup.py
+++ b/tools/diff_setup.py
@@ -25,7 +25,7 @@ class DiffSetup:
                 if inputs:
                     release = inputs.pop("release", "")
                     for test in ["core", "benchmark", "e2e", "stress", "query_modules"]:
-                        self._gh_context["event"]["inputs"][f"release_{test}"] = test in release
+                        self._gh_context["event"]["inputs"][f"release_{test}"] = "true" if test in release else "false"
                     print(f"context: {self._gh_context}")
 
         except FileNotFoundError:

--- a/tools/diff_setup.py
+++ b/tools/diff_setup.py
@@ -21,12 +21,10 @@ class DiffSetup:
 
                 # reformat release key
                 inputs = self._get_workflow_dispatch_inputs()
-                print(f"inputs: {inputs}")
                 if inputs:
                     release = inputs.pop("release", "")
                     for test in ["core", "benchmark", "e2e", "stress", "query_modules"]:
                         self._gh_context["event"]["inputs"][f"release_{test}"] = "true" if test in release else "false"
-                    print(f"context: {self._gh_context}")
 
         except FileNotFoundError:
             print(f"Error: file not found {self._gh_context_path}")
@@ -100,7 +98,6 @@ class DiffSetup:
         for build, tests in self._test_suite.items():
             for test in tests.keys():
                 self._test_suite[build][test] = self._check_workflow_input(build, test, workflow_dispatch_inputs)
-                print(f"build: {build}, test: {test}, input: {self._test_suite[build][test]}")
 
     def setup_diff_workflow(self) -> None:
         event_name = self._get_event_name()

--- a/tools/diff_setup.py
+++ b/tools/diff_setup.py
@@ -26,6 +26,7 @@ class DiffSetup:
                     release = inputs.pop("release", "")
                     for test in ["core", "benchmark", "e2e", "stress", "query_modules"]:
                         self._gh_context["event"]["inputs"][f"release_{test}"] = test in release
+                    print(f"context: {self._gh_context}")
 
         except FileNotFoundError:
             print(f"Error: file not found {self._gh_context_path}")
@@ -99,6 +100,7 @@ class DiffSetup:
         for build, tests in self._test_suite.items():
             for test in tests.keys():
                 self._test_suite[build][test] = self._check_workflow_input(build, test, workflow_dispatch_inputs)
+                print(f"build: {build}, test: {test}, input: {self._test_suite[build][test]}")
 
     def setup_diff_workflow(self) -> None:
         event_name = self._get_event_name()

--- a/tools/diff_setup.py
+++ b/tools/diff_setup.py
@@ -88,6 +88,7 @@ class DiffSetup:
                 self._test_suite[build][test] = self._check_pr_label(build, test, pr_labels)
 
     def _check_workflow_input(self, build: str, test: str, workflow_dispatch_inputs: dict) -> bool:
+        print(f"DEBUG: {build} {test} {workflow_dispatch_inputs.get(f'{build}_{test}')}")
         if workflow_dispatch_inputs.get(f"{build}_{test}") == "true":
             return True
         return False


### PR DESCRIPTION
- Diff setup script was not setting up the release tests correctly due to using a Boolean `True` rather than string `true`
- Check flakiness inputs updated to be in line with standard diff inputs
- Benchmark test is now an option for checking flakiness via workflow dispatch, but is still off by default
