### PR TITLE
Bugfix: RWChecker gives wrong result for read proc

### DIFF
--- a/src/query/frontend/semantic/rw_checker.cpp
+++ b/src/query/frontend/semantic/rw_checker.cpp
@@ -34,7 +34,7 @@ bool RWChecker::PreVisit(Create & /*unused*/) {
 }
 
 bool RWChecker::PreVisit(CallProcedure &call_proc) {
-  is_write_ = call_proc.is_write_;
+  is_write_ |= call_proc.is_write_;
   return !is_write_;
 }
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -63,6 +63,7 @@
 #include "query/interpreter_context.hpp"
 #include "query/metadata.hpp"
 #include "query/parameters.hpp"
+#include "query/plan/fmt.hpp"
 #include "query/plan/hint_provider.hpp"
 #include "query/plan/planner.hpp"
 #include "query/plan/profile.hpp"
@@ -83,6 +84,7 @@
 #include "storage/v2/constraints/type_constraints_kind.hpp"
 #include "storage/v2/disk/storage.hpp"
 #include "storage/v2/edge_import_mode.hpp"
+#include "storage/v2/fmt.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indices/vector_index.hpp"
 #include "storage/v2/inmemory/storage.hpp"
@@ -2423,8 +2425,7 @@ void AccessorCompliance(PlanWrapper &plan, DbAccessor &dba) {
   const auto rw_type = plan.rw_type();
   if (rw_type == RWType::W || rw_type == RWType::RW) {
     if (dba.type() != storage::Storage::Accessor::Type::WRITE) {
-      throw QueryRuntimeException("Accessor type {} and query type {} are misaligned!", static_cast<int>(dba.type()),
-                                  static_cast<int>(rw_type));
+      throw QueryRuntimeException("Accessor type {} and query type {} are misaligned!", dba.type(), rw_type);
     }
   }
 }

--- a/src/query/plan/fmt.hpp
+++ b/src/query/plan/fmt.hpp
@@ -14,13 +14,8 @@
 #if FMT_VERSION > 90000
 #include <fmt/ostream.h>
 
-#include "storage/v2/property_value.hpp"
-#include "storage/v2/storage.hpp"
+#include "query/plan/read_write_type_checker.hpp"
 
 template <>
-class fmt::formatter<memgraph::storage::PropertyValue> : public fmt::ostream_formatter {};
-template <>
-class fmt::formatter<memgraph::storage::PropertyValue::Type> : public fmt::ostream_formatter {};
-template <>
-class fmt::formatter<memgraph::storage::Storage::Accessor::Type> : public fmt::ostream_formatter {};
+class fmt::formatter<memgraph::query::plan::ReadWriteTypeChecker::RWType> : public fmt::ostream_formatter {};
 #endif

--- a/src/query/plan/read_write_type_checker.hpp
+++ b/src/query/plan/read_write_type_checker.hpp
@@ -107,4 +107,19 @@ struct ReadWriteTypeChecker : public virtual HierarchicalLogicalOperatorVisitor 
   void UpdateType(RWType op_type);
 };
 
+inline std::ostream &operator<<(std::ostream &os, ReadWriteTypeChecker::RWType type) {
+  switch (type) {
+    using enum ReadWriteTypeChecker::RWType;
+    case NONE:
+      return os << "NONE";
+    case R:
+      return os << "READ";
+    case W:
+      return os << "WRITE";
+    case RW:
+      return os << "READ-WRITE";
+  }
+  return os;
+}
+
 }  // namespace memgraph::query::plan

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -698,4 +698,21 @@ class Storage {
   SchemaInfo schema_info_;
 };
 
+inline std::ostream &operator<<(std::ostream &os, Storage::Accessor::Type type) {
+  switch (type) {
+    using enum Storage::Accessor::Type;
+    case NO_ACCESS:
+      return os << "NO_ACCESS";
+    case UNIQUE:
+      return os << "UNIQUE";
+    case WRITE:
+      return os << "WRITE";
+    case READ:
+      return os << "READ";
+    case READ_ONLY:
+      return os << "READ_ONLY";
+  }
+  return os;
+}
+
 }  // namespace memgraph::storage


### PR DESCRIPTION
RWChecker would overwrite status based on procedure rw status
This would break if a write query was calling a read procedure
Nicer error message in case of accessor misalignment