### PR TITLE
Set the UID of memgraph user in Docker container to match that of MAGE

### DIFF
--- a/release/docker/v6_deb.dockerfile
+++ b/release/docker/v6_deb.dockerfile
@@ -19,6 +19,10 @@ RUN pip3 install --break-system-packages  numpy==1.26.4 scipy==1.13.0 networkx==
 
 COPY "${BINARY_NAME}${TARGETARCH}.${EXTENSION}" /
 
+# fix `memgraph` UID and GID for compatibility with previous Debian releases
+RUN groupadd -g 103 memgraph && \
+    useradd -u 101 -g memgraph -m -d /home/memgraph -s /bin/bash memgraph
+
 # Install memgraph package
 RUN dpkg -i "${BINARY_NAME}${TARGETARCH}.deb"
 

--- a/release/docker/v6_deb_relwithdebinfo.dockerfile
+++ b/release/docker/v6_deb_relwithdebinfo.dockerfile
@@ -25,6 +25,10 @@ RUN pip3 install --break-system-packages  numpy==1.26.4 scipy==1.13.0 networkx==
 COPY "${BINARY_NAME}${TARGETARCH}.${EXTENSION}" /
 COPY "${SOURCE_CODE}" /home/mg/memgraph/src
 
+# fix `memgraph` UID and GID for compatibility with previous Debian releases
+RUN groupadd -g 103 memgraph && \
+    useradd -u 101 -g memgraph -m -d /home/memgraph -s /bin/bash memgraph
+
 # Install memgraph package
 RUN dpkg -i "${BINARY_NAME}${TARGETARCH}.deb"
 


### PR DESCRIPTION
For compatibility with MAGE containers we need to match the UID and GID of the `memgraph` user. This fix has already been applied to MAGE in [#568](https://github.com/memgraph/mage/pull/568).
