### PR TITLE
Add timeout on socket connect

### DIFF
--- a/src/io/network/socket.cpp
+++ b/src/io/network/socket.cpp
@@ -25,7 +25,7 @@
 #include "utils/metrics_timer.hpp"
 
 namespace {
-constexpr int timeout_ms = 5000;
+constexpr uint32_t timeout_ms = 5000;
 }  // namespace
 
 namespace memgraph::metrics {

--- a/src/io/network/socket.cpp
+++ b/src/io/network/socket.cpp
@@ -24,6 +24,10 @@
 #include "utils/logging.hpp"
 #include "utils/metrics_timer.hpp"
 
+namespace {
+constexpr int timeout_ms = 5000;
+}  // namespace
+
 namespace memgraph::metrics {
 extern const Event SocketConnect_us;
 }  // namespace memgraph::metrics
@@ -75,7 +79,6 @@ bool Socket::Connect(const Endpoint &endpoint) {
   }
 
   auto const socket_addr = endpoint.SocketAddress();
-  constexpr int timeout_ms = 10000;
 
   try {
     for (const auto &it : AddrInfo{endpoint}) {

--- a/src/io/network/socket.hpp
+++ b/src/io/network/socket.hpp
@@ -11,8 +11,6 @@
 
 #pragma once
 
-#include <functional>
-#include <iosfwd>
 #include <optional>
 #include <utility>
 
@@ -210,6 +208,8 @@ class Socket {
 
  private:
   Socket(int fd, Endpoint endpoint) : socket_(fd), endpoint_(std::move(endpoint)) {}
+
+  static void Close(int sfd, std::string_view socket_addr);
 
   int socket_ = -1;
   Endpoint endpoint_;

--- a/src/rpc/client.hpp
+++ b/src/rpc/client.hpp
@@ -44,9 +44,9 @@ class Client {
       {"UnregisterReplicaReq"sv, 10000},      // coordinator sending to main
       {"EnableWritingOnMainReq"sv, 10000},    // coordinator to main
       {"GetDatabaseHistoriesReq"sv, 10000},   // coordinator to data instances
-      {"StateCheckReq"sv, 10000},             // coordinator to data instances
+      {"StateCheckReq"sv, 5000},              // coordinator to data instances
       {"SwapMainUUIDReq"sv, 10000},           // coord to data instances
-      {"FrequentHeartbeatReq"sv, 10000},      // coord to data instances
+      {"FrequentHeartbeatReq"sv, 5000},       // coord to data instances
       {"HeartbeatReq"sv, 10000},              // main to replica
       {"SystemRecoveryReq"sv, 30000},  // main to replica when MT is used. Recovering 1000DBs should take around 25''
       {"AppendDeltasReq"sv, 30000},    // Waiting 30'' on a progress/final response

--- a/tests/jepsen/src/memgraph/core.clj
+++ b/tests/jepsen/src/memgraph/core.clj
@@ -93,7 +93,7 @@
             :checker         (checker/compose
                               {:stats      (checker/stats)
                                :exceptions (unhandled-exceptions)
-                               :log-checker (checker/log-file-pattern #"[Aa]ssert*|Segmentation fault|core dumped|critical|NullPointerException|json.exception.parse_error|Message response was of unexpected type|Received malformed message from cluster|There is still leftover data in the SLK stream|Failed to close fd for" "memgraph.log")
+                               :log-checker (checker/log-file-pattern #"[Aa]ssert*|Segmentation fault|core dumped|critical|NullPointerException|json.exception.parse_error|Message response was of unexpected type|Received malformed message from cluster|There is still leftover data in the SLK stream|Failed to close fd" "memgraph.log")
                                :workload   (:checker workload)})
             :nodes           (keys (:nodes-config opts))
             :nemesis         (:nemesis nemesis-config)


### PR DESCRIPTION
The PR adds the functionality of socket connect with timeout. The only portable way of doing this is creating a socket in a non-blocking mode, timeout check using `poll` and switching it back to a blocking mode since we all our sockets are used in blocking mode. UNIX doesn't have an API which would allow that from the start. The primary motivation for such a change is the fact that socket connect timeout can be quite high (~130s) and that it depends on the platform and on the number of SYN packets sent during connect. Two properties need to be satisfied for a system to be considered synchronous:
1. There is a known upper bound on processing delays. This includes the time needed to receive a message, perform a local computation and replying
2. There is a known upper bound on message transmission delays.

We already had timeouts on read and write message, the only thing left was a timeout on connect.

The timeout for StateCheckRpc and FrequentHeartbeatRpc is reduced to 5s.

