### PR TITLE
Add support for replication benchmark

### DIFF
--- a/tests/e2e/interactive_mg_runner.py
+++ b/tests/e2e/interactive_mg_runner.py
@@ -42,10 +42,10 @@ from inspect import signature
 import yaml
 
 from memgraph import (
-    MemgraphInstanceRunner,
-    connectable_port,
-    extract_bolt_port,
-    extract_management_port,
+  MemgraphInstanceRunner,
+  connectable_port,
+  extract_bolt_port,
+  extract_management_port,
 )
 
 log = logging.getLogger("memgraph.tests.e2e")
@@ -81,7 +81,7 @@ MEMGRAPH_INSTANCES = {}
 ACTIONS = {
     "info": lambda context: info(context),
     "stop": lambda context, name: stop(context, name),
-    "start": lambda context, name: start(context, name),
+    "start": lambda context, name: start_wrapper(context, name),
     "sleep": lambda _, delta: time.sleep(float(delta)),
     "exit": lambda _: sys.exit(1),
     "quit": lambda _: sys.exit(1),
@@ -203,6 +203,13 @@ def kill(context, name, keep_directories=True):
             continue
         MEMGRAPH_INSTANCES[name].kill(keep_directories)
         MEMGRAPH_INSTANCES.pop(name)
+
+
+def start_wrapper(context, name, procdir=""):
+    if name == "all":
+        start_all(context, procdir)
+    else:
+        start(context, name, procdir)
 
 
 def start(context, name, procdir=""):

--- a/tests/mgbench/benchmark.py
+++ b/tests/mgbench/benchmark.py
@@ -30,7 +30,6 @@ from benchmark_context import BenchmarkContext
 from benchmark_results import BenchmarkResults
 from constants import *
 from workload_mode import BENCHMARK_MODE_MIXED, BENCHMARK_MODE_REALISTIC
-from workloads import *
 
 WARMUP_TO_HOT_QUERIES = [
     ("CREATE ();", {}),
@@ -232,17 +231,27 @@ def parse_args():
         help="Input vendor name to run in docker (memgraph-docker, neo4j-docker)",
     )
 
+    parser_vendor_external = subparsers.add_parser(
+        "external-vendor", help="Database/cluster is run separately from the test", parents=[benchmark_parser]
+    )
+
+    parser_vendor_external.add_argument(
+        "--client-binary",
+        default=helpers.get_binary_path("tests/mgbench/client"),
+        help="Client binary used for benchmarking",
+    )
+
     return parser.parse_args()
 
 
 def sanitize_args(args):
-    assert args.benchmarks != None, helpers.list_available_workloads()
+    assert args.benchmarks is not None, helpers.list_available_workloads()
     assert args.num_workers_for_import > 0
     assert args.num_workers_for_benchmark > 0
-    assert args.export_results != None, "Pass where will results be saved"
+    assert args.export_results is not None, "Pass where will results be saved"
     assert args.single_threaded_runtime_sec >= 1, "Low runtime value, consider extending time for more accurate results"
     assert (
-        args.workload_realistic == None or args.workload_mixed == None
+        args.workload_realistic is None or args.workload_mixed is None
     ), "Cannot run both realistic and mixed workload, only one mode run at the time"
 
 
@@ -435,7 +444,7 @@ def mixed_workload(
         results.set_value(*results_key, value=ret)
 
 
-def warmup(condition: str, client: runners.BaseRunner, queries: list = None):
+def warmup(condition: str, client, queries: list = None):
     if condition == DATABASE_CONDITION_HOT:
         log.log("Execute warm-up to match condition: {} ".format(condition))
         client.execute(
@@ -682,6 +691,8 @@ def save_memory_usage_of_empty_db(vendor_runner, workload, results):
     rss_db = workload.NAME + workload.get_variant() + "_" + EMPTY_DB
     vendor_runner.start_db(rss_db)
     usage = vendor_runner.stop_db(rss_db)
+    if usage is None:
+        return {"memory": 0, "cpu": 0}
     key = [workload.NAME, workload.get_variant(), EMPTY_DB]
     results.set_value(*key, value={DATABASE: usage})
     return usage[MEMORY]
@@ -747,7 +758,6 @@ def run_target_workload(benchmark_context, workload, bench_queries, vendor_runne
             )
 
 
-# TODO: (andi) Reorder functions in top-down notion in order to improve readibility
 def run_target_workloads(benchmark_context, target_workloads, bench_results):
     for workload, bench_queries in target_workloads:
         log.info(f"Started running {str(workload.NAME)} workload")
@@ -770,7 +780,13 @@ def run_target_workloads(benchmark_context, target_workloads, bench_results):
 
 def run_on_disk_transactional_benchmark(benchmark_context, workload, bench_queries, disk_results):
     log.info(f"Running benchmarks for {ON_DISK_TRANSACTIONAL} storage mode.")
-    disk_vendor_runner, disk_client = client_runner_factory(benchmark_context)
+    disk_vendor_runner = client_runner_factory(benchmark_context)
+    disk_client = (
+        runners.BoltClient(benchmark_context=benchmark_context)
+        if benchmark_context.vendor_name is None or DOCKER not in benchmark_context.vendor_name
+        else runners.BoltClientDocker(benchmark_context=benchmark_context)
+    )
+
     disk_vendor_runner.start_db(DISK_PREPARATION_RSS)
     disk_client.execute(queries=SETUP_DISK_STORAGE)
     disk_vendor_runner.stop_db(DISK_PREPARATION_RSS)
@@ -782,7 +798,13 @@ def run_on_disk_transactional_benchmark(benchmark_context, workload, bench_queri
 
 def run_in_memory_analytical_benchmark(benchmark_context, workload, bench_queries, in_memory_analytical_results):
     log.info(f"Running benchmarks for {IN_MEMORY_ANALYTICAL} storage mode.")
-    in_memory_analytical_vendor_runner, in_memory_analytical_client = client_runner_factory(benchmark_context)
+    in_memory_analytical_vendor_runner = client_runner_factory(benchmark_context)
+    in_memory_analytical_client = (
+        runners.BoltClient(benchmark_context=benchmark_context)
+        if benchmark_context.vendor_name is None or DOCKER not in benchmark_context.vendor_name
+        else runners.BoltClientDocker(benchmark_context=benchmark_context)
+    )
+
     in_memory_analytical_vendor_runner.start_db(IN_MEMORY_ANALYTICAL_RSS)
     in_memory_analytical_client.execute(queries=SETUP_IN_MEMORY_ANALYTICAL_STORAGE_MODE)
     in_memory_analytical_vendor_runner.stop_db(IN_MEMORY_ANALYTICAL_RSS)
@@ -800,7 +822,13 @@ def run_in_memory_analytical_benchmark(benchmark_context, workload, bench_querie
 
 def run_in_memory_transactional_benchmark(benchmark_context, workload, bench_queries, in_memory_txn_results):
     log.info(f"Running benchmarks for {IN_MEMORY_TRANSACTIONAL} storage mode.")
-    in_memory_txn_vendor_runner, in_memory_txn_client = client_runner_factory(benchmark_context)
+    in_memory_txn_vendor_runner = client_runner_factory(benchmark_context)
+    in_memory_txn_client = (
+        runners.BoltClient(benchmark_context=benchmark_context)
+        if benchmark_context.vendor_name is None or DOCKER not in benchmark_context.vendor_name
+        else runners.BoltClientDocker(benchmark_context=benchmark_context)
+    )
+
     run_target_workload(
         benchmark_context,
         workload,
@@ -817,8 +845,7 @@ def client_runner_factory(benchmark_context):
     vendor_runner = runners.BaseRunner.create(benchmark_context=benchmark_context)
     vendor_runner.clean_db()
     log.log("Database cleaned from any previous data")
-    client = vendor_runner.fetch_client()
-    return vendor_runner, client
+    return vendor_runner
 
 
 def validate_target_workloads(benchmark_context, target_workloads):
@@ -900,11 +927,16 @@ if __name__ == "__main__":
     temp_dir = pathlib.Path.cwd() / ".temp"
     temp_dir.mkdir(parents=True, exist_ok=True)
 
+    vendor_name = getattr(args, "vendor_name", None)
+    if vendor_name is not None:
+        vendor_name = vendor_name.replace("-", "")
+
     benchmark_context = BenchmarkContext(
         benchmark_target_workload=args.benchmarks,
+        external_vendor=args.run_option == "external-vendor",
         vendor_binary=args.vendor_binary if args.run_option == "vendor-native" else None,
-        vendor_name=args.vendor_name.replace("-", ""),
-        client_binary=args.client_binary if args.run_option == "vendor-native" else None,
+        vendor_name=vendor_name,
+        client_binary=getattr(args, "client_binary", None),
         num_workers_for_import=args.num_workers_for_import,
         num_workers_for_benchmark=args.num_workers_for_benchmark,
         single_threaded_runtime_sec=args.single_threaded_runtime_sec,

--- a/tests/mgbench/benchmark.py
+++ b/tests/mgbench/benchmark.py
@@ -84,6 +84,14 @@ def parse_args():
         default=multiprocessing.cpu_count() // 2,
         help="number of workers used to import the dataset",
     )
+
+    benchmark_parser.add_argument(
+        "--client-bolt-address",
+        type=str,
+        default="127.0.0.1",
+        help="On which IP is instance available for a client to connect to",
+    )
+
     benchmark_parser.add_argument(
         "--num-workers-for-benchmark",
         type=int,
@@ -933,6 +941,7 @@ if __name__ == "__main__":
 
     benchmark_context = BenchmarkContext(
         benchmark_target_workload=args.benchmarks,
+        client_bolt_address=args.client_bolt_address,
         external_vendor=args.run_option == "external-vendor",
         vendor_binary=args.vendor_binary if args.run_option == "vendor-native" else None,
         vendor_name=vendor_name,

--- a/tests/mgbench/benchmark_context.py
+++ b/tests/mgbench/benchmark_context.py
@@ -10,9 +10,9 @@
 # licenses/APL.txt.
 
 from workload_mode import (
-    BENCHMARK_MODE_ISOLATED,
-    BENCHMARK_MODE_MIXED,
-    BENCHMARK_MODE_REALISTIC,
+  BENCHMARK_MODE_ISOLATED,
+  BENCHMARK_MODE_MIXED,
+  BENCHMARK_MODE_REALISTIC,
 )
 
 
@@ -24,6 +24,7 @@ class BenchmarkContext:
     def __init__(
         self,
         benchmark_target_workload: str = None,  # Workload that needs to be executed (dataset/variant/group/query)
+        external_vendor: bool = False,
         vendor_binary: str = None,
         vendor_name: str = None,
         client_binary: str = None,
@@ -60,15 +61,16 @@ class BenchmarkContext:
         self.export_results_in_memory_analytical = export_results_in_memory_analytical
         self.export_results_on_disk_txn = export_results_on_disk_txn
         self.temporary_directory = temporary_directory
+        self.external_vendor = external_vendor
 
         assert (
             workload_mixed is None or workload_realistic is None
         ), "Cannot run both mixed and realistic workload, please select one!"
 
-        if workload_mixed != None:
+        if workload_mixed is not None:
             self.mode = BENCHMARK_MODE_MIXED
             self.mode_config = workload_mixed
-        elif workload_realistic != None:
+        elif workload_realistic is not None:
             self.mode = BENCHMARK_MODE_REALISTIC
             self.mode_config = workload_realistic
         else:

--- a/tests/mgbench/benchmark_context.py
+++ b/tests/mgbench/benchmark_context.py
@@ -24,6 +24,7 @@ class BenchmarkContext:
     def __init__(
         self,
         benchmark_target_workload: str = None,  # Workload that needs to be executed (dataset/variant/group/query)
+        client_bolt_address: str = "127.0.0.1",
         external_vendor: bool = False,
         vendor_binary: str = None,
         vendor_name: str = None,
@@ -48,6 +49,8 @@ class BenchmarkContext:
         vendor_args: dict = {},
     ) -> None:
         self.benchmark_target_workload = benchmark_target_workload
+        self.external_vendor = external_vendor
+        self.client_bolt_address = client_bolt_address
         self.vendor_binary = vendor_binary
         self.vendor_name = vendor_name
         self.client_binary = client_binary
@@ -61,7 +64,6 @@ class BenchmarkContext:
         self.export_results_in_memory_analytical = export_results_in_memory_analytical
         self.export_results_on_disk_txn = export_results_on_disk_txn
         self.temporary_directory = temporary_directory
-        self.external_vendor = external_vendor
 
         assert (
             workload_mixed is None or workload_realistic is None

--- a/tests/mgbench/runners.py
+++ b/tests/mgbench/runners.py
@@ -109,6 +109,7 @@ class BoltClient(BaseClient):
         self._bolt_port = (
             benchmark_context.vendor_args["bolt-port"] if "bolt-port" in benchmark_context.vendor_args.keys() else 7687
         )
+        self._bolt_address = benchmark_context.client_bolt_address
 
     def _get_args(self, **kwargs):
         return _convert_args_to_flags(self._client_binary, **kwargs)
@@ -140,6 +141,7 @@ class BoltClient(BaseClient):
             username=self._username,
             password=self._password,
             port=self._bolt_port,
+            address=self._bolt_address,
             validation=False,
             time_dependent_execution=time_dependent_execution,
         )

--- a/tests/mgbench/runners.py
+++ b/tests/mgbench/runners.py
@@ -132,7 +132,7 @@ class BoltClient(BaseClient):
             json.dump(query, f)
             f.write("\n")
 
-        check_db_args = self._get_args(
+        client_args = self._get_args(
             input=check_db_query,
             num_workers=1,
             max_retries=max_retries,
@@ -144,9 +144,11 @@ class BoltClient(BaseClient):
             time_dependent_execution=time_dependent_execution,
         )
 
+        log.info("Client args: {}".format(client_args))
+
         while True:
             try:
-                subprocess.run(check_db_args, capture_output=True, text=True, check=True)
+                subprocess.run(client_args, capture_output=True, text=True, check=True)
                 break
             except subprocess.CalledProcessError as e:
                 log.log("Checking if database is up and running failed...")
@@ -196,7 +198,6 @@ class BoltClient(BaseClient):
 
 class BoltClientDocker(BaseClient):
     def __init__(self, benchmark_context: BenchmarkContext):
-        self._client_binary = benchmark_context.client_binary
         self._directory = tempfile.TemporaryDirectory(dir=benchmark_context.temporary_directory)
         self._username = ""
         self._password = ""
@@ -376,6 +377,9 @@ class BaseRunner(ABC):
 
     @classmethod
     def create(cls, benchmark_context: BenchmarkContext):
+        if benchmark_context.external_vendor:
+            return ExternalVendor(benchmark_context=benchmark_context)
+
         if benchmark_context.vendor_name not in cls.subclasses:
             raise ValueError("Missing runner with name: {}".format(benchmark_context.vendor_name))
 
@@ -388,27 +392,43 @@ class BaseRunner(ABC):
         self.benchmark_context = benchmark_context
 
     @abstractmethod
-    def start_db_init(self):
+    def start_db_init(self, arg):
         pass
 
     @abstractmethod
-    def stop_db_init(self):
+    def stop_db_init(self, arg):
         pass
 
     @abstractmethod
-    def start_db(self):
+    def start_db(self, arg):
         pass
 
     @abstractmethod
-    def stop_db(self):
+    def stop_db(self, arg):
         pass
 
     @abstractmethod
     def clean_db(self):
         pass
 
-    @abstractmethod
-    def fetch_client(self) -> BaseClient:
+
+class ExternalVendor(BaseRunner):
+    def __init__(self, benchmark_context: BenchmarkContext):
+        super().__init__(benchmark_context=benchmark_context)
+
+    def start_db_init(self, arg):
+        pass
+
+    def stop_db_init(self, arg):
+        pass
+
+    def start_db(self, arg):
+        pass
+
+    def stop_db(self, arg):
+        pass
+
+    def clean_db(self):
         pass
 
 
@@ -528,9 +548,6 @@ class Memgraph(BaseRunner):
                 f.write(str(rss))
                 f.write("\n")
             f.close()
-
-    def fetch_client(self) -> BoltClient:
-        return BoltClient(benchmark_context=self.benchmark_context)
 
 
 class Neo4j(BaseRunner):
@@ -781,9 +798,6 @@ class Neo4j(BaseRunner):
                 f.write(memory_usage.stdout)
                 f.close()
 
-    def fetch_client(self) -> BoltClient:
-        return BoltClient(benchmark_context=self.benchmark_context)
-
 
 class MemgraphDocker(BaseRunner):
     def __init__(self, benchmark_context: BenchmarkContext):
@@ -878,9 +892,6 @@ class MemgraphDocker(BaseRunner):
 
     def clean_db(self):
         self.remove_container(self._container_name)
-
-    def fetch_client(self) -> BaseClient:
-        return BoltClientDocker(benchmark_context=self.benchmark_context)
 
     def remove_container(self, containerName):
         command = ["docker", "rm", "-f", containerName]
@@ -1025,9 +1036,6 @@ class Neo4jDocker(BaseRunner):
 
     def clean_db(self):
         self.remove_container(self._container_name)
-
-    def fetch_client(self) -> BaseClient:
-        return BoltClientDocker(benchmark_context=self.benchmark_context)
 
     def remove_container(self, containerName):
         command = ["docker", "rm", "-f", containerName]

--- a/tests/mgbench/setup.py
+++ b/tests/mgbench/setup.py
@@ -18,6 +18,8 @@ from benchmark_context import BenchmarkContext
 
 
 def check_requirements(benchmark_context: BenchmarkContext):
+    if benchmark_context.vendor_name is None:
+        return True
     if "docker" in benchmark_context.vendor_name:
         log.info("Checking requirements ... ")
         command = ["docker", "info"]


### PR DESCRIPTION
Benchmark can now be started without necessarily starting instances during test time. Instead, by specifying configuration parameters `external-vendor` and `--client-bolt-address` client can get attached to any instance or even cluster.