### PR TITLE
Use std::pmr::memory_resource

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,7 @@ add_compile_options(
         -Werror=switch-bool
         -Werror=return-type
         -Werror=return-stack-address
+        -Werror=non-power-of-two-alignment
         -Wno-missing-field-initializers # C++20 designated init, unspecified fields are zero-initialized
         -Wno-c99-designator
         -Werror=implicit-fallthrough

--- a/src/query/graph.cpp
+++ b/src/query/graph.cpp
@@ -19,20 +19,18 @@ namespace memgraph::query {
 namespace r = std::ranges;
 namespace rv = r::views;
 
-Graph::Graph(utils::MemoryResource *memory) : vertices_(memory), edges_(memory) {}
+Graph::Graph(allocator_type alloc) : vertices_(alloc), edges_(alloc) {}
 
-Graph::Graph(const Graph &other, utils::MemoryResource *memory)
-    : vertices_(other.vertices_, memory), edges_(other.edges_, memory) {}
+Graph::Graph(const Graph &other, allocator_type alloc)
+    : vertices_(other.vertices_, alloc), edges_(other.edges_, alloc) {}
 
-Graph::Graph(Graph &&other) noexcept : Graph(std::move(other), other.GetMemoryResource()) {}
+Graph::Graph(Graph &&other) noexcept : Graph(std::move(other), other.get_allocator()) {}
 
 Graph::Graph(const Graph &other)
-    : Graph(other,
-            std::allocator_traits<allocator_type>::select_on_container_copy_construction(other.GetMemoryResource())
-                .GetMemoryResource()) {}
+    : Graph(other, alloc_traits::select_on_container_copy_construction(other.get_allocator())) {}
 
-Graph::Graph(Graph &&other, utils::MemoryResource *memory)
-    : vertices_(std::move(other.vertices_), memory), edges_(std::move(other.edges_), memory) {}
+Graph::Graph(Graph &&other, allocator_type alloc)
+    : vertices_(std::move(other.vertices_), alloc), edges_(std::move(other.edges_), alloc) {}
 
 void Graph::Expand(const Path &path) {
   const auto &path_vertices_ = path.vertices();
@@ -92,6 +90,6 @@ utils::pmr::unordered_set<EdgeAccessor> &Graph::edges() { return edges_; }
 const utils::pmr::unordered_set<VertexAccessor> &Graph::vertices() const { return vertices_; }
 const utils::pmr::unordered_set<EdgeAccessor> &Graph::edges() const { return edges_; }
 
-utils::MemoryResource *Graph::GetMemoryResource() const { return vertices_.get_allocator().GetMemoryResource(); }
+auto Graph::get_allocator() const -> allocator_type { return vertices_.get_allocator(); }
 
 }  // namespace memgraph::query

--- a/src/query/graph.hpp
+++ b/src/query/graph.hpp
@@ -32,25 +32,26 @@ class Graph final {
  public:
   /** Allocator type so that STL containers are aware that we need one */
   using allocator_type = utils::Allocator<Graph>;
+  using alloc_traits = std::allocator_traits<allocator_type>;
 
   /**
    * Create the graph with no elements
    * Allocations are done using the given MemoryResource.
    */
-  explicit Graph(utils::MemoryResource *memory);
+  explicit Graph(allocator_type alloc);
 
   /**
    * Construct a copy of other.
    * utils::MemoryResource is obtained by calling
    * std::allocator_traits<>::
-   *     select_on_container_copy_construction(other.GetMemoryResource()).
+   *     select_on_container_copy_construction(other.get_allocator()).
    * Since we use utils::Allocator, which does not propagate, this means that we
    * will default to utils::NewDeleteResource().
    */
   Graph(const Graph &other);
 
   /** Construct a copy using the given utils::MemoryResource */
-  Graph(const Graph &other, utils::MemoryResource *memory);
+  Graph(const Graph &other, allocator_type alloc);
 
   /**
    * Construct with the value of other.
@@ -62,10 +63,10 @@ class Graph final {
   /**
    * Construct with the value of other, but use the given utils::MemoryResource.
    * After the move, other may not be empty if `*memory !=
-   * *other.GetMemoryResource()`, because an element-wise move will be
+   * *other.get_allocator()`, because an element-wise move will be
    * performed.
    */
-  Graph(Graph &&other, utils::MemoryResource *memory);
+  Graph(Graph &&other, allocator_type alloc);
 
   /** Expands the graph with the given path. */
   void Expand(const Path &path);
@@ -108,7 +109,7 @@ class Graph final {
   const utils::pmr::unordered_set<VertexAccessor> &vertices() const;
   const utils::pmr::unordered_set<EdgeAccessor> &edges() const;
 
-  utils::MemoryResource *GetMemoryResource() const;
+  auto get_allocator() const -> allocator_type;
 
  private:
   // Contains all the vertices in the Graph.

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -1465,7 +1465,7 @@ TypedValue LocalDateTime(const TypedValue *args, int64_t nargs, const FunctionCo
   }
 
   if (args[0].IsString()) {
-    const auto &[date_parameters, local_time_parameters] = ParseLocalDateTimeParameters(args[0].ValueString());
+    const auto &[date_parameters, local_time_parameters] = utils::ParseLocalDateTimeParameters(args[0].ValueString());
     return TypedValue(utils::LocalDateTime(date_parameters, local_time_parameters), ctx.memory);
   }
 
@@ -1491,7 +1491,7 @@ TypedValue Duration(const TypedValue *args, int64_t nargs, const FunctionContext
   FType<Or<String, Map>>("duration", args, nargs);
 
   if (args[0].IsString()) {
-    return TypedValue(utils::Duration(ParseDurationParameters(args[0].ValueString())), ctx.memory);
+    return TypedValue(utils::Duration(utils::ParseDurationParameters(args[0].ValueString())), ctx.memory);
   }
 
   utils::DurationParameters duration_parameters;
@@ -1534,7 +1534,7 @@ TypedValue DateTime(const TypedValue *args, int64_t nargs, const FunctionContext
   }
 
   if (args[0].IsString()) {
-    const auto &zoned_date_time_parameters = ParseZonedDateTimeParameters(args[0].ValueString());
+    const auto &zoned_date_time_parameters = utils::ParseZonedDateTimeParameters(args[0].ValueString());
     return TypedValue(utils::ZonedDateTime(zoned_date_time_parameters), ctx.memory);
   }
 
@@ -1584,7 +1584,7 @@ TypedValue Point(const TypedValue *args, int64_t nargs, const FunctionContext &c
 
   for (auto const &[k, v] : input) {
     if (v.IsNull()) {
-      return TypedValue{ctx.memory};
+      return TypedValue(ctx.memory);
     }
   }
 

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -676,7 +676,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
       }
       res = function.function_(arguments.data(), arguments.size(), function_ctx);
     }
-    MG_ASSERT(res.GetMemoryResource() == ctx_->memory);
+    MG_ASSERT(res.get_allocator().resource() == ctx_->memory);
     if (!is_transactional && res.ContainsDeleted()) [[unlikely]] {
       return TypedValue(ctx_->memory);
     }
@@ -777,7 +777,7 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
           "Unexpected behavior: Exists expected a function, got {}. Please report the problem on GitHub issues",
           frame_exists_value.type());
     }
-    TypedValue result{ctx_->memory};
+    TypedValue result(ctx_->memory);
     frame_exists_value.ValueFunction()(&result);
     return result;
   }

--- a/src/query/interpret/frame.hpp
+++ b/src/query/interpret/frame.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -23,10 +23,12 @@ namespace memgraph::query {
 
 class Frame {
  public:
+  using allocator_type = utils::Allocator<TypedValue>;
+
   /// Create a Frame of given size backed by a utils::NewDeleteResource()
   explicit Frame(int64_t size) : elems_(size, utils::NewDeleteResource()) { MG_ASSERT(size >= 0); }
 
-  Frame(int64_t size, utils::MemoryResource *memory) : elems_(size, memory) { MG_ASSERT(size >= 0); }
+  Frame(int64_t size, allocator_type alloc) : elems_(size, alloc) { MG_ASSERT(size >= 0); }
 
   TypedValue &operator[](const Symbol &symbol) { return elems_[symbol.position()]; }
   const TypedValue &operator[](const Symbol &symbol) const { return elems_[symbol.position()]; }
@@ -36,7 +38,7 @@ class Frame {
 
   auto &elems() { return elems_; }
 
-  utils::MemoryResource *GetMemoryResource() const { return elems_.get_allocator().GetMemoryResource(); }
+  auto get_allocator() const -> allocator_type { return elems_.get_allocator(); }
 
  private:
   utils::pmr::vector<TypedValue> elems_;

--- a/src/query/path.hpp
+++ b/src/query/path.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -31,19 +31,19 @@ class Path {
  public:
   /** Allocator type so that STL containers are aware that we need one */
   using allocator_type = utils::Allocator<char>;
+  using alloc_traits = std::allocator_traits<allocator_type>;
 
   /**
    * Create the path with no elements
    * Allocations are done using the given MemoryResource.
    */
-  explicit Path(utils::MemoryResource *memory) : vertices_(memory), edges_(memory) {}
+  explicit Path(allocator_type alloc) : vertices_(alloc), edges_(alloc) {}
 
   /**
    * Create the path starting with the given vertex.
    * Allocations are done using the given MemoryResource.
    */
-  explicit Path(const VertexAccessor &vertex, utils::MemoryResource *memory = utils::NewDeleteResource())
-      : vertices_(memory), edges_(memory) {
+  explicit Path(const VertexAccessor &vertex, allocator_type alloc = {}) : vertices_(alloc), edges_(alloc) {
     Expand(vertex);
   }
 
@@ -53,10 +53,11 @@ class Path {
    * Allocations are done using the default utils::NewDeleteResource().
    */
   template <typename... TOthers>
-  explicit Path(const VertexAccessor &vertex, const TOthers &...others)
+  requires(!std::is_convertible_v<std::remove_cvref_t<TOthers>, allocator_type> &&
+           ...) explicit Path(const VertexAccessor &vertex, TOthers &&...others)
       : vertices_(utils::NewDeleteResource()), edges_(utils::NewDeleteResource()) {
     Expand(vertex);
-    Expand(others...);
+    Expand(std::forward<TOthers>(others)...);
   }
 
   /**
@@ -65,44 +66,40 @@ class Path {
    * Allocations are done using the given MemoryResource.
    */
   template <typename... TOthers>
-  Path(std::allocator_arg_t, utils::MemoryResource *memory, const VertexAccessor &vertex, const TOthers &...others)
-      : vertices_(memory), edges_(memory) {
+  Path(std::allocator_arg_t, allocator_type alloc, const VertexAccessor &vertex, TOthers &&...others)
+      : vertices_(alloc), edges_(alloc) {
     Expand(vertex);
-    Expand(others...);
+    Expand(std::forward<TOthers>(others)...);
   }
 
   /**
    * Construct a copy of other.
    * utils::MemoryResource is obtained by calling
    * std::allocator_traits<>::
-   *     select_on_container_copy_construction(other.GetMemoryResource()).
+   *     select_on_container_copy_construction(other.get_allocator()).
    * Since we use utils::Allocator, which does not propagate, this means that we
    * will default to utils::NewDeleteResource().
    */
-  Path(const Path &other)
-      : Path(other,
-             std::allocator_traits<allocator_type>::select_on_container_copy_construction(other.GetMemoryResource())
-                 .GetMemoryResource()) {}
+  Path(const Path &other) : Path(other, alloc_traits::select_on_container_copy_construction(other.get_allocator())) {}
 
   /** Construct a copy using the given utils::MemoryResource */
-  Path(const Path &other, utils::MemoryResource *memory)
-      : vertices_(other.vertices_, memory), edges_(other.edges_, memory) {}
+  Path(const Path &other, allocator_type alloc) : vertices_(other.vertices_, alloc), edges_(other.edges_, alloc) {}
 
   /**
    * Construct with the value of other.
    * utils::MemoryResource is obtained from other. After the move, other will be
    * empty.
    */
-  Path(Path &&other) noexcept : Path(std::move(other), other.GetMemoryResource()) {}
+  Path(Path &&other) noexcept : Path(std::move(other), other.get_allocator()) {}
 
   /**
    * Construct with the value of other, but use the given utils::MemoryResource.
    * After the move, other may not be empty if `*memory !=
-   * *other.GetMemoryResource()`, because an element-wise move will be
+   * *other.get_allocator()`, because an element-wise move will be
    * performed.
    */
-  Path(Path &&other, utils::MemoryResource *memory)
-      : vertices_(std::move(other.vertices_), memory), edges_(std::move(other.edges_), memory) {}
+  Path(Path &&other, allocator_type alloc)
+      : vertices_(std::move(other.vertices_), alloc), edges_(std::move(other.edges_), alloc) {}
 
   /** Copy assign other, utils::MemoryResource of `this` is used */
   Path &operator=(const Path &) = default;
@@ -113,27 +110,27 @@ class Path {
   ~Path() = default;
 
   /** Expands the path with the given vertex. */
-  void Expand(const VertexAccessor &vertex) {
+  void Expand(VertexAccessor vertex) {
     DMG_ASSERT(vertices_.size() == edges_.size(), "Illegal path construction order");
     DMG_ASSERT(edges_.empty() || (!edges_.empty() && (edges_.back().To().Gid() == vertex.Gid() ||
                                                       edges_.back().From().Gid() == vertex.Gid())),
                "Illegal path construction order");
-    vertices_.emplace_back(vertex);
+    vertices_.emplace_back(std::move(vertex));
   }
 
   /** Expands the path with the given edge. */
-  void Expand(const EdgeAccessor &edge) {
+  void Expand(EdgeAccessor edge) {
     DMG_ASSERT(vertices_.size() - 1 == edges_.size(), "Illegal path construction order");
     DMG_ASSERT(vertices_.back().Gid() == edge.From().Gid() || vertices_.back().Gid() == edge.To().Gid(),
                "Illegal path construction order");
-    edges_.emplace_back(edge);
+    edges_.emplace_back(std::move(edge));
   }
 
   /** Expands the path with the given elements. */
   template <typename TFirst, typename... TOthers>
-  void Expand(const TFirst &first, const TOthers &...others) {
-    Expand(first);
-    Expand(others...);
+  void Expand(TFirst &&first, TOthers &&...others) {
+    Expand(std::forward<TFirst>(first));
+    Expand(std::forward<TOthers>(others)...);
   }
 
   void Shrink() {
@@ -152,7 +149,7 @@ class Path {
   const auto &vertices() const { return vertices_; }
   const auto &edges() const { return edges_; }
 
-  utils::MemoryResource *GetMemoryResource() const { return vertices_.get_allocator().GetMemoryResource(); }
+  auto get_allocator() const -> allocator_type { return vertices_.get_allocator(); }
 
   bool operator==(const Path &other) const { return vertices_ == other.vertices_ && edges_ == other.edges_; }
 

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1176,8 +1176,8 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
 
       if (int cmp_res = compare_indices(found, new_stats, vertex_count);
           cmp_res == -1 ||
-          cmp_res == 0 && (vertex_count < found->vertex_count ||
-                           vertex_count == found->vertex_count && is_better_type(candidate.filters_, *found))) {
+          (cmp_res == 0 && (vertex_count < found->vertex_count ||
+                            (vertex_count == found->vertex_count && is_better_type(candidate.filters_, *found))))) {
         found = make_label_property_index();
       }
     }

--- a/src/query/procedure/mg_procedure_impl.cpp
+++ b/src/query/procedure/mg_procedure_impl.cpp
@@ -81,7 +81,7 @@ void *MgpAlignedAllocImpl(memgraph::utils::MemoryResource &memory, const size_t 
   const size_t alloc_size = bytes_for_header + size_in_bytes;
   if (alloc_size < size_in_bytes) return nullptr;
 
-  void *ptr = memory.Allocate(alloc_size, alloc_align);
+  void *ptr = memory.allocate(alloc_size, alloc_align);
   char *data = reinterpret_cast<char *>(ptr) + bytes_for_header;
   std::memcpy(data - sizeof(size_in_bytes), &size_in_bytes, sizeof(size_in_bytes));
   std::memcpy(data - sizeof(size_in_bytes) - sizeof(alloc_align), &alloc_align, sizeof(alloc_align));
@@ -105,7 +105,7 @@ void MgpFreeImpl(memgraph::utils::MemoryResource &memory, void *const p) noexcep
     const size_t alloc_size = bytes_for_header + size_in_bytes;
     // Get the original ptr we allocated.
     void *const original_ptr = data - bytes_for_header;
-    memory.Deallocate(original_ptr, alloc_size, alloc_align);
+    memory.deallocate(original_ptr, alloc_size, alloc_align);
   } catch (const memgraph::utils::BasicException &be) {
     spdlog::error("BasicException during the release of memory for query modules: {}", be.what());
   } catch (const std::exception &e) {
@@ -269,6 +269,11 @@ void mgp_global_free(void *const p) {
 namespace {
 
 template <class U, class... TArgs>
+U *NewRawMgpObject(memgraph::utils::Allocator<U> allocator, TArgs &&...args) {
+  return allocator.template new_object<U>(std::forward<TArgs>(args)...);
+}
+
+template <class U, class... TArgs>
 U *NewRawMgpObject(memgraph::utils::MemoryResource *memory, TArgs &&...args) {
   memgraph::utils::Allocator<U> allocator(memory);
   return allocator.template new_object<U>(std::forward<TArgs>(args)...);
@@ -390,44 +395,44 @@ bool ContainsDeleted(const mgp_value *val) {
   return false;
 }
 
-memgraph::query::TypedValue ToTypedValue(const mgp_value &val, memgraph::utils::MemoryResource *memory) {
+memgraph::query::TypedValue ToTypedValue(const mgp_value &val, memgraph::utils::Allocator<mgp_value> alloc) {
   switch (val.type) {
     case MGP_VALUE_TYPE_NULL:
-      return memgraph::query::TypedValue(memory);
+      return memgraph::query::TypedValue(alloc);
     case MGP_VALUE_TYPE_BOOL:
-      return memgraph::query::TypedValue(val.bool_v, memory);
+      return memgraph::query::TypedValue(val.bool_v, alloc);
     case MGP_VALUE_TYPE_INT:
-      return memgraph::query::TypedValue(val.int_v, memory);
+      return memgraph::query::TypedValue(val.int_v, alloc);
     case MGP_VALUE_TYPE_DOUBLE:
-      return memgraph::query::TypedValue(val.double_v, memory);
+      return memgraph::query::TypedValue(val.double_v, alloc);
     case MGP_VALUE_TYPE_STRING:
-      return {val.string_v, memory};
+      return {val.string_v, alloc};
     case MGP_VALUE_TYPE_LIST: {
       const auto *list = val.list_v;
-      memgraph::query::TypedValue::TVector tv_list(memory);
+      memgraph::query::TypedValue::TVector tv_list(alloc);
       tv_list.reserve(list->elems.size());
       for (const auto &elem : list->elems) {
-        tv_list.emplace_back(ToTypedValue(elem, memory));
+        tv_list.emplace_back(ToTypedValue(elem, alloc));
       }
       return memgraph::query::TypedValue(std::move(tv_list));
     }
     case MGP_VALUE_TYPE_MAP: {
       const auto *map = val.map_v;
-      memgraph::query::TypedValue::TMap tv_map(memory);
+      memgraph::query::TypedValue::TMap tv_map(alloc);
       for (const auto &item : map->items) {
-        tv_map.emplace(item.first, ToTypedValue(item.second, memory));
+        tv_map.emplace(item.first, ToTypedValue(item.second, alloc));
       }
       return memgraph::query::TypedValue(std::move(tv_map));
     }
     case MGP_VALUE_TYPE_VERTEX:
-      return memgraph::query::TypedValue(val.vertex_v->getImpl(), memory);
+      return memgraph::query::TypedValue(val.vertex_v->getImpl(), alloc);
     case MGP_VALUE_TYPE_EDGE:
-      return memgraph::query::TypedValue(val.edge_v->impl, memory);
+      return memgraph::query::TypedValue(val.edge_v->impl, alloc);
     case MGP_VALUE_TYPE_PATH: {
       const auto *path = val.path_v;
       MG_ASSERT(!path->vertices.empty());
       MG_ASSERT(path->vertices.size() == path->edges.size() + 1);
-      memgraph::query::Path tv_path(path->vertices[0].getImpl(), memory);
+      memgraph::query::Path tv_path(path->vertices[0].getImpl(), alloc);
       for (size_t i = 0; i < path->edges.size(); ++i) {
         tv_path.Expand(path->edges[i].impl);
         tv_path.Expand(path->vertices[i + 1].getImpl());
@@ -435,77 +440,83 @@ memgraph::query::TypedValue ToTypedValue(const mgp_value &val, memgraph::utils::
       return memgraph::query::TypedValue(std::move(tv_path));
     }
     case MGP_VALUE_TYPE_DATE:
-      return memgraph::query::TypedValue(val.date_v->date, memory);
+      return memgraph::query::TypedValue(val.date_v->date, alloc);
     case MGP_VALUE_TYPE_LOCAL_TIME:
-      return memgraph::query::TypedValue(val.local_time_v->local_time, memory);
+      return memgraph::query::TypedValue(val.local_time_v->local_time, alloc);
     case MGP_VALUE_TYPE_LOCAL_DATE_TIME:
-      return memgraph::query::TypedValue(val.local_date_time_v->local_date_time, memory);
+      return memgraph::query::TypedValue(val.local_date_time_v->local_date_time, alloc);
     case MGP_VALUE_TYPE_DURATION:
-      return memgraph::query::TypedValue(val.duration_v->duration, memory);
+      return memgraph::query::TypedValue(val.duration_v->duration, alloc);
   }
 }
 
-mgp_value::mgp_value(memgraph::utils::MemoryResource *m) noexcept : type(MGP_VALUE_TYPE_NULL), memory(m) {}
+mgp_value::mgp_value(allocator_type alloc) noexcept : type(MGP_VALUE_TYPE_NULL), alloc(alloc) {}
 
-mgp_value::mgp_value(bool val, memgraph::utils::MemoryResource *m) noexcept
-    : type(MGP_VALUE_TYPE_BOOL), memory(m), bool_v(val) {}
+mgp_value::mgp_value(bool val, allocator_type alloc) noexcept : type(MGP_VALUE_TYPE_BOOL), alloc(alloc), bool_v(val) {}
 
-mgp_value::mgp_value(int64_t val, memgraph::utils::MemoryResource *m) noexcept
-    : type(MGP_VALUE_TYPE_INT), memory(m), int_v(val) {}
+mgp_value::mgp_value(int64_t val, allocator_type alloc) noexcept : type(MGP_VALUE_TYPE_INT), alloc(alloc), int_v(val) {}
 
-mgp_value::mgp_value(double val, memgraph::utils::MemoryResource *m) noexcept
-    : type(MGP_VALUE_TYPE_DOUBLE), memory(m), double_v(val) {}
+mgp_value::mgp_value(double val, allocator_type alloc) noexcept
+    : type(MGP_VALUE_TYPE_DOUBLE), alloc(alloc), double_v(val) {}
 
-mgp_value::mgp_value(const char *val, memgraph::utils::MemoryResource *m)
-    : type(MGP_VALUE_TYPE_STRING), memory(m), string_v(val, m) {}
+mgp_value::mgp_value(const char *val, allocator_type alloc)
+    : type(MGP_VALUE_TYPE_STRING), alloc(alloc), string_v(val, alloc) {}
 
-mgp_value::mgp_value(mgp_list *val, memgraph::utils::MemoryResource *m) noexcept
-    : type(MGP_VALUE_TYPE_LIST), memory(m), list_v(val) {
-  MG_ASSERT(val->GetMemoryResource() == m, "Unable to take ownership of a pointer with different allocator.");
+mgp_value::mgp_value(mgp_list *val, allocator_type alloc) noexcept
+    : type(MGP_VALUE_TYPE_LIST), alloc(alloc), list_v(val) {
+  MG_ASSERT(val->GetMemoryResource() == alloc.resource(),
+            "Unable to take ownership of a pointer with different allocator.");
 }
 
-mgp_value::mgp_value(mgp_map *val, memgraph::utils::MemoryResource *m) noexcept
-    : type(MGP_VALUE_TYPE_MAP), memory(m), map_v(val) {
-  MG_ASSERT(val->GetMemoryResource() == m, "Unable to take ownership of a pointer with different allocator.");
+mgp_value::mgp_value(mgp_map *val, allocator_type alloc) noexcept : type(MGP_VALUE_TYPE_MAP), alloc(alloc), map_v(val) {
+  MG_ASSERT(val->GetMemoryResource() == alloc.resource(),
+            "Unable to take ownership of a pointer with different allocator.");
 }
 
-mgp_value::mgp_value(mgp_vertex *val, memgraph::utils::MemoryResource *m) noexcept
-    : type(MGP_VALUE_TYPE_VERTEX), memory(m), vertex_v(val) {
-  MG_ASSERT(val->GetMemoryResource() == m, "Unable to take ownership of a pointer with different allocator.");
+mgp_value::mgp_value(mgp_vertex *val, allocator_type alloc) noexcept
+    : type(MGP_VALUE_TYPE_VERTEX), alloc(alloc), vertex_v(val) {
+  MG_ASSERT(val->GetMemoryResource() == alloc.resource(),
+            "Unable to take ownership of a pointer with different allocator.");
 }
 
-mgp_value::mgp_value(mgp_edge *val, memgraph::utils::MemoryResource *m) noexcept
-    : type(MGP_VALUE_TYPE_EDGE), memory(m), edge_v(val) {
-  MG_ASSERT(val->GetMemoryResource() == m, "Unable to take ownership of a pointer with different allocator.");
+mgp_value::mgp_value(mgp_edge *val, allocator_type alloc) noexcept
+    : type(MGP_VALUE_TYPE_EDGE), alloc(alloc), edge_v(val) {
+  MG_ASSERT(val->GetMemoryResource() == alloc.resource(),
+            "Unable to take ownership of a pointer with different allocator.");
 }
 
-mgp_value::mgp_value(mgp_path *val, memgraph::utils::MemoryResource *m) noexcept
-    : type(MGP_VALUE_TYPE_PATH), memory(m), path_v(val) {
-  MG_ASSERT(val->GetMemoryResource() == m, "Unable to take ownership of a pointer with different allocator.");
+mgp_value::mgp_value(mgp_path *val, allocator_type alloc) noexcept
+    : type(MGP_VALUE_TYPE_PATH), alloc(alloc), path_v(val) {
+  MG_ASSERT(val->GetMemoryResource() == alloc.resource(),
+            "Unable to take ownership of a pointer with different allocator.");
 }
 
-mgp_value::mgp_value(mgp_date *val, memgraph::utils::MemoryResource *m) noexcept
-    : type(MGP_VALUE_TYPE_DATE), memory(m), date_v(val) {
-  MG_ASSERT(val->GetMemoryResource() == m, "Unable to take ownership of a pointer with different allocator.");
+mgp_value::mgp_value(mgp_date *val, allocator_type alloc) noexcept
+    : type(MGP_VALUE_TYPE_DATE), alloc(alloc), date_v(val) {
+  MG_ASSERT(val->GetMemoryResource() == alloc.resource(),
+            "Unable to take ownership of a pointer with different allocator.");
 }
 
-mgp_value::mgp_value(mgp_local_time *val, memgraph::utils::MemoryResource *m) noexcept
-    : type(MGP_VALUE_TYPE_LOCAL_TIME), memory(m), local_time_v(val) {
-  MG_ASSERT(val->GetMemoryResource() == m, "Unable to take ownership of a pointer with different allocator.");
+mgp_value::mgp_value(mgp_local_time *val, allocator_type alloc) noexcept
+    : type(MGP_VALUE_TYPE_LOCAL_TIME), alloc(alloc), local_time_v(val) {
+  MG_ASSERT(val->GetMemoryResource() == alloc.resource(),
+            "Unable to take ownership of a pointer with different allocator.");
 }
 
-mgp_value::mgp_value(mgp_local_date_time *val, memgraph::utils::MemoryResource *m) noexcept
-    : type(MGP_VALUE_TYPE_LOCAL_DATE_TIME), memory(m), local_date_time_v(val) {
-  MG_ASSERT(val->GetMemoryResource() == m, "Unable to take ownership of a pointer with different allocator.");
+mgp_value::mgp_value(mgp_local_date_time *val, allocator_type alloc) noexcept
+    : type(MGP_VALUE_TYPE_LOCAL_DATE_TIME), alloc(alloc), local_date_time_v(val) {
+  MG_ASSERT(val->GetMemoryResource() == alloc.resource(),
+            "Unable to take ownership of a pointer with different allocator.");
 }
 
-mgp_value::mgp_value(mgp_duration *val, memgraph::utils::MemoryResource *m) noexcept
-    : type(MGP_VALUE_TYPE_DURATION), memory(m), duration_v(val) {
-  MG_ASSERT(val->GetMemoryResource() == m, "Unable to take ownership of a pointer with different allocator.");
+mgp_value::mgp_value(mgp_duration *val, allocator_type alloc) noexcept
+    : type(MGP_VALUE_TYPE_DURATION), alloc(alloc), duration_v(val) {
+  MG_ASSERT(val->GetMemoryResource() == alloc.resource(),
+            "Unable to take ownership of a pointer with different allocator.");
 }
 
-mgp_value::mgp_value(const memgraph::query::TypedValue &tv, mgp_graph *graph, memgraph::utils::MemoryResource *m)
-    : type(FromTypedValueType(tv.type())), memory(m) {
+mgp_value::mgp_value(const memgraph::query::TypedValue &tv, mgp_graph *graph, allocator_type alloc)
+    : type(FromTypedValueType(tv.type())), alloc(alloc) {
   switch (type) {
     case MGP_VALUE_TYPE_NULL:
       break;
@@ -519,19 +530,19 @@ mgp_value::mgp_value(const memgraph::query::TypedValue &tv, mgp_graph *graph, me
       double_v = tv.ValueDouble();
       break;
     case MGP_VALUE_TYPE_STRING:
-      new (&string_v) memgraph::utils::pmr::string(tv.ValueString(), m);
+      new (&string_v) memgraph::utils::pmr::string(tv.ValueString(), alloc);
       break;
     case MGP_VALUE_TYPE_LIST: {
       // Fill the stack allocated container and then construct the actual member
       // value. This handles the case when filling the container throws
       // something and our destructor doesn't get called so member value isn't
       // released.
-      memgraph::utils::pmr::vector<mgp_value> elems(m);
+      memgraph::utils::pmr::vector<mgp_value> elems(alloc);
       elems.reserve(tv.ValueList().size());
       for (const auto &elem : tv.ValueList()) {
         elems.emplace_back(elem, graph);
       }
-      memgraph::utils::Allocator<mgp_list> allocator(m);
+      memgraph::utils::Allocator<mgp_list> allocator(alloc);
       list_v = allocator.new_object<mgp_list>(std::move(elems));
       break;
     }
@@ -540,16 +551,16 @@ mgp_value::mgp_value(const memgraph::query::TypedValue &tv, mgp_graph *graph, me
       // value. This handles the case when filling the container throws
       // something and our destructor doesn't get called so member value isn't
       // released.
-      memgraph::utils::pmr::map<memgraph::utils::pmr::string, mgp_value> items(m);
+      memgraph::utils::pmr::map<memgraph::utils::pmr::string, mgp_value> items(alloc);
       for (const auto &item : tv.ValueMap()) {
-        items.emplace(item.first, mgp_value(item.second, graph, m));
+        items.emplace(item.first, mgp_value(item.second, graph, alloc));
       }
-      memgraph::utils::Allocator<mgp_map> allocator(m);
+      memgraph::utils::Allocator<mgp_map> allocator(alloc);
       map_v = allocator.new_object<mgp_map>(std::move(items));
       break;
     }
     case MGP_VALUE_TYPE_VERTEX: {
-      memgraph::utils::Allocator<mgp_vertex> allocator(m);
+      memgraph::utils::Allocator<mgp_vertex> allocator(alloc);
       vertex_v = std::visit(
           memgraph::utils::Overloaded{
               [&](memgraph::query::DbAccessor *) { return allocator.new_object<mgp_vertex>(tv.ValueVertex(), graph); },
@@ -562,7 +573,7 @@ mgp_value::mgp_value(const memgraph::query::TypedValue &tv, mgp_graph *graph, me
       break;
     }
     case MGP_VALUE_TYPE_EDGE: {
-      memgraph::utils::Allocator<mgp_edge> allocator(m);
+      memgraph::utils::Allocator<mgp_edge> allocator(alloc);
 
       edge_v = std::visit(
           memgraph::utils::Overloaded{
@@ -586,7 +597,7 @@ mgp_value::mgp_value(const memgraph::query::TypedValue &tv, mgp_graph *graph, me
       // value. This handles the case when filling the container throws
       // something and our destructor doesn't get called so member value isn't
       // released.
-      mgp_path tmp_path(m);
+      mgp_path tmp_path(alloc);
       tmp_path.vertices.reserve(tv.ValuePath().vertices().size());
       for (const auto &v : tv.ValuePath().vertices()) {
         std::visit(
@@ -608,34 +619,34 @@ mgp_value::mgp_value(const memgraph::query::TypedValue &tv, mgp_graph *graph, me
                        }},
                    graph->impl);
       }
-      memgraph::utils::Allocator<mgp_path> allocator(m);
+      memgraph::utils::Allocator<mgp_path> allocator(alloc);
       path_v = allocator.new_object<mgp_path>(std::move(tmp_path));
       break;
     }
     case MGP_VALUE_TYPE_DATE: {
-      memgraph::utils::Allocator<mgp_date> allocator(m);
+      memgraph::utils::Allocator<mgp_date> allocator(alloc);
       date_v = allocator.new_object<mgp_date>(tv.ValueDate());
       break;
     }
     case MGP_VALUE_TYPE_LOCAL_TIME: {
-      memgraph::utils::Allocator<mgp_local_time> allocator(m);
+      memgraph::utils::Allocator<mgp_local_time> allocator(alloc);
       local_time_v = allocator.new_object<mgp_local_time>(tv.ValueLocalTime());
       break;
     }
     case MGP_VALUE_TYPE_LOCAL_DATE_TIME: {
-      memgraph::utils::Allocator<mgp_local_date_time> allocator(m);
+      memgraph::utils::Allocator<mgp_local_date_time> allocator(alloc);
       local_date_time_v = allocator.new_object<mgp_local_date_time>(tv.ValueLocalDateTime());
       break;
     }
     case MGP_VALUE_TYPE_DURATION: {
-      memgraph::utils::Allocator<mgp_duration> allocator(m);
+      memgraph::utils::Allocator<mgp_duration> allocator(alloc);
       duration_v = allocator.new_object<mgp_duration>(tv.ValueDuration());
       break;
     }
   }
 }
 
-mgp_value::mgp_value(const memgraph::storage::PropertyValue &pv, memgraph::utils::MemoryResource *m) : memory(m) {
+mgp_value::mgp_value(const memgraph::storage::PropertyValue &pv, allocator_type alloc) : alloc(alloc) {
   switch (pv.type()) {
     case memgraph::storage::PropertyValue::Type::Null:
       type = MGP_VALUE_TYPE_NULL;
@@ -654,7 +665,7 @@ mgp_value::mgp_value(const memgraph::storage::PropertyValue &pv, memgraph::utils
       break;
     case memgraph::storage::PropertyValue::Type::String:
       type = MGP_VALUE_TYPE_STRING;
-      new (&string_v) memgraph::utils::pmr::string(pv.ValueString(), m);
+      new (&string_v) memgraph::utils::pmr::string(pv.ValueString(), alloc);
       break;
     case memgraph::storage::PropertyValue::Type::List: {
       // Fill the stack allocated container and then construct the actual member
@@ -662,12 +673,12 @@ mgp_value::mgp_value(const memgraph::storage::PropertyValue &pv, memgraph::utils
       // something and our destructor doesn't get called so member value isn't
       // released.
       type = MGP_VALUE_TYPE_LIST;
-      memgraph::utils::pmr::vector<mgp_value> elems(m);
+      memgraph::utils::pmr::vector<mgp_value> elems(alloc);
       elems.reserve(pv.ValueList().size());
       for (const auto &elem : pv.ValueList()) {
         elems.emplace_back(elem);
       }
-      memgraph::utils::Allocator<mgp_list> allocator(m);
+      memgraph::utils::Allocator<mgp_list> allocator(alloc);
       list_v = allocator.new_object<mgp_list>(std::move(elems));
       break;
     }
@@ -677,11 +688,11 @@ mgp_value::mgp_value(const memgraph::storage::PropertyValue &pv, memgraph::utils
       // something and our destructor doesn't get called so member value isn't
       // released.
       type = MGP_VALUE_TYPE_MAP;
-      memgraph::utils::pmr::map<memgraph::utils::pmr::string, mgp_value> items(m);
+      memgraph::utils::pmr::map<memgraph::utils::pmr::string, mgp_value> items(alloc);
       for (const auto &item : pv.ValueMap()) {
         items.emplace(item.first, item.second);
       }
-      memgraph::utils::Allocator<mgp_map> allocator(m);
+      memgraph::utils::Allocator<mgp_map> allocator(alloc);
       map_v = allocator.new_object<mgp_map>(std::move(items));
       break;
     }
@@ -690,22 +701,22 @@ mgp_value::mgp_value(const memgraph::storage::PropertyValue &pv, memgraph::utils
       switch (temporal_data.type) {
         case memgraph::storage::TemporalType::Date: {
           type = MGP_VALUE_TYPE_DATE;
-          date_v = NewRawMgpObject<mgp_date>(m, temporal_data.microseconds);
+          date_v = NewRawMgpObject<mgp_date>(alloc.resource(), temporal_data.microseconds);
           break;
         }
         case memgraph::storage::TemporalType::LocalTime: {
           type = MGP_VALUE_TYPE_LOCAL_TIME;
-          local_time_v = NewRawMgpObject<mgp_local_time>(m, temporal_data.microseconds);
+          local_time_v = NewRawMgpObject<mgp_local_time>(alloc.resource(), temporal_data.microseconds);
           break;
         }
         case memgraph::storage::TemporalType::LocalDateTime: {
           type = MGP_VALUE_TYPE_LOCAL_DATE_TIME;
-          local_date_time_v = NewRawMgpObject<mgp_local_date_time>(m, temporal_data.microseconds);
+          local_date_time_v = NewRawMgpObject<mgp_local_date_time>(alloc.resource(), temporal_data.microseconds);
           break;
         }
         case memgraph::storage::TemporalType::Duration: {
           type = MGP_VALUE_TYPE_DURATION;
-          duration_v = NewRawMgpObject<mgp_duration>(m, temporal_data.microseconds);
+          duration_v = NewRawMgpObject<mgp_duration>(alloc.resource(), temporal_data.microseconds);
           break;
         }
       }
@@ -736,7 +747,7 @@ mgp_value::mgp_value(const memgraph::storage::PropertyValue &pv, memgraph::utils
   }
 }
 
-mgp_value::mgp_value(const mgp_value &other, memgraph::utils::MemoryResource *m) : type(other.type), memory(m) {
+mgp_value::mgp_value(const mgp_value &other, allocator_type alloc) : type(other.type), alloc(alloc) {
   switch (other.type) {
     case MGP_VALUE_TYPE_NULL:
       break;
@@ -750,47 +761,42 @@ mgp_value::mgp_value(const mgp_value &other, memgraph::utils::MemoryResource *m)
       double_v = other.double_v;
       break;
     case MGP_VALUE_TYPE_STRING:
-      new (&string_v) memgraph::utils::pmr::string(other.string_v, m);
+      new (&string_v) memgraph::utils::pmr::string(other.string_v, alloc);
       break;
     case MGP_VALUE_TYPE_LIST: {
-      memgraph::utils::Allocator<mgp_list> allocator(m);
-      list_v = allocator.new_object<mgp_list>(*other.list_v);
+      list_v = NewRawMgpObject<mgp_list>(alloc, *other.list_v);
       break;
     }
     case MGP_VALUE_TYPE_MAP: {
-      memgraph::utils::Allocator<mgp_map> allocator(m);
-      map_v = allocator.new_object<mgp_map>(*other.map_v);
+      map_v = NewRawMgpObject<mgp_map>(alloc, *other.map_v);
       break;
     }
     case MGP_VALUE_TYPE_VERTEX: {
-      memgraph::utils::Allocator<mgp_vertex> allocator(m);
-      vertex_v = allocator.new_object<mgp_vertex>(*other.vertex_v);
+      vertex_v = NewRawMgpObject<mgp_vertex>(alloc, *other.vertex_v);
       break;
     }
     case MGP_VALUE_TYPE_EDGE: {
-      memgraph::utils::Allocator<mgp_edge> allocator(m);
-      edge_v = allocator.new_object<mgp_edge>(*other.edge_v);
+      edge_v = NewRawMgpObject<mgp_edge>(alloc, *other.edge_v);
       break;
     }
     case MGP_VALUE_TYPE_PATH: {
-      memgraph::utils::Allocator<mgp_path> allocator(m);
-      path_v = allocator.new_object<mgp_path>(*other.path_v);
+      path_v = NewRawMgpObject<mgp_path>(alloc, *other.path_v);
       break;
     }
     case MGP_VALUE_TYPE_DATE: {
-      date_v = NewRawMgpObject<mgp_date>(m, *other.date_v);
+      date_v = NewRawMgpObject<mgp_date>(alloc, *other.date_v);
       break;
     }
     case MGP_VALUE_TYPE_LOCAL_TIME: {
-      local_time_v = NewRawMgpObject<mgp_local_time>(m, *other.local_time_v);
+      local_time_v = NewRawMgpObject<mgp_local_time>(alloc, *other.local_time_v);
       break;
     }
     case MGP_VALUE_TYPE_LOCAL_DATE_TIME: {
-      local_date_time_v = NewRawMgpObject<mgp_local_date_time>(m, *other.local_date_time_v);
+      local_date_time_v = NewRawMgpObject<mgp_local_date_time>(alloc, *other.local_date_time_v);
       break;
     }
     case MGP_VALUE_TYPE_DURATION: {
-      duration_v = NewRawMgpObject<mgp_duration>(m, *other.duration_v);
+      duration_v = NewRawMgpObject<mgp_duration>(alloc, *other.duration_v);
       break;
     }
   }
@@ -843,7 +849,7 @@ void DeleteValueMember(mgp_value *value) noexcept {
 
 }  // namespace
 
-mgp_value::mgp_value(mgp_value &&other, memgraph::utils::MemoryResource *m) : type(other.type), memory(m) {
+mgp_value::mgp_value(mgp_value &&other, allocator_type alloc) : type(other.type), alloc(alloc) {
   switch (other.type) {
     case MGP_VALUE_TYPE_NULL:
       break;
@@ -857,93 +863,93 @@ mgp_value::mgp_value(mgp_value &&other, memgraph::utils::MemoryResource *m) : ty
       double_v = other.double_v;
       break;
     case MGP_VALUE_TYPE_STRING:
-      new (&string_v) memgraph::utils::pmr::string(std::move(other.string_v), m);
+      new (&string_v) memgraph::utils::pmr::string(std::move(other.string_v), alloc);
       break;
     case MGP_VALUE_TYPE_LIST:
       static_assert(std::is_pointer_v<decltype(list_v)>, "Expected to move list_v by copying pointers.");
-      if (*other.GetMemoryResource() == *m) {
+      if (other.alloc == alloc) {
         list_v = other.list_v;
         other.type = MGP_VALUE_TYPE_NULL;
       } else {
-        memgraph::utils::Allocator<mgp_list> allocator(m);
+        memgraph::utils::Allocator<mgp_list> allocator(alloc);
         list_v = allocator.new_object<mgp_list>(std::move(*other.list_v));
       }
       break;
     case MGP_VALUE_TYPE_MAP:
       static_assert(std::is_pointer_v<decltype(map_v)>, "Expected to move map_v by copying pointers.");
-      if (*other.GetMemoryResource() == *m) {
+      if (*other.GetMemoryResource() == *alloc.resource()) {
         map_v = other.map_v;
         other.type = MGP_VALUE_TYPE_NULL;
       } else {
-        memgraph::utils::Allocator<mgp_map> allocator(m);
+        memgraph::utils::Allocator<mgp_map> allocator(alloc);
         map_v = allocator.new_object<mgp_map>(std::move(*other.map_v));
       }
       break;
     case MGP_VALUE_TYPE_VERTEX:
       static_assert(std::is_pointer_v<decltype(vertex_v)>, "Expected to move vertex_v by copying pointers.");
-      if (*other.GetMemoryResource() == *m) {
+      if (*other.GetMemoryResource() == *alloc.resource()) {
         vertex_v = other.vertex_v;
         other.type = MGP_VALUE_TYPE_NULL;
       } else {
-        memgraph::utils::Allocator<mgp_vertex> allocator(m);
+        memgraph::utils::Allocator<mgp_vertex> allocator(alloc);
         vertex_v = allocator.new_object<mgp_vertex>(std::move(*other.vertex_v));
       }
       break;
     case MGP_VALUE_TYPE_EDGE:
       static_assert(std::is_pointer_v<decltype(edge_v)>, "Expected to move edge_v by copying pointers.");
-      if (*other.GetMemoryResource() == *m) {
+      if (*other.GetMemoryResource() == *alloc.resource()) {
         edge_v = other.edge_v;
         other.type = MGP_VALUE_TYPE_NULL;
       } else {
-        memgraph::utils::Allocator<mgp_edge> allocator(m);
+        memgraph::utils::Allocator<mgp_edge> allocator(alloc);
         edge_v = allocator.new_object<mgp_edge>(std::move(*other.edge_v));
       }
       break;
     case MGP_VALUE_TYPE_PATH:
       static_assert(std::is_pointer_v<decltype(path_v)>, "Expected to move path_v by copying pointers.");
-      if (*other.GetMemoryResource() == *m) {
+      if (*other.GetMemoryResource() == *alloc.resource()) {
         path_v = other.path_v;
         other.type = MGP_VALUE_TYPE_NULL;
       } else {
-        memgraph::utils::Allocator<mgp_path> allocator(m);
+        memgraph::utils::Allocator<mgp_path> allocator(alloc);
         path_v = allocator.new_object<mgp_path>(std::move(*other.path_v));
       }
       break;
     case MGP_VALUE_TYPE_DATE:
       static_assert(std::is_pointer_v<decltype(date_v)>, "Expected to move date_v by copying pointers.");
-      if (*other.GetMemoryResource() == *m) {
+      if (*other.GetMemoryResource() == *alloc.resource()) {
         date_v = other.date_v;
         other.type = MGP_VALUE_TYPE_NULL;
       } else {
-        date_v = NewRawMgpObject<mgp_date>(m, *other.date_v);
+        date_v = NewRawMgpObject<mgp_date>(alloc.resource(), *other.date_v);
       }
       break;
     case MGP_VALUE_TYPE_LOCAL_TIME:
       static_assert(std::is_pointer_v<decltype(local_time_v)>, "Expected to move local_time_v by copying pointers.");
-      if (*other.GetMemoryResource() == *m) {
+      if (*other.GetMemoryResource() == *alloc.resource()) {
         local_time_v = other.local_time_v;
         other.type = MGP_VALUE_TYPE_NULL;
       } else {
-        local_time_v = NewRawMgpObject<mgp_local_time>(m, *other.local_time_v);
+        local_time_v = NewRawMgpObject<mgp_local_time>(alloc.resource(), *other.local_time_v);
       }
       break;
     case MGP_VALUE_TYPE_LOCAL_DATE_TIME:
       static_assert(std::is_pointer_v<decltype(local_date_time_v)>,
                     "Expected to move local_date_time_v by copying pointers.");
-      if (*other.GetMemoryResource() == *m) {
+      if (*other.GetMemoryResource() == *alloc.resource()) {
         local_date_time_v = other.local_date_time_v;
         other.type = MGP_VALUE_TYPE_NULL;
       } else {
-        local_date_time_v = NewRawMgpObject<mgp_local_date_time>(m, *other.local_date_time_v);
+        local_date_time_v = NewRawMgpObject<mgp_local_date_time>(alloc.resource(), *other.local_date_time_v);
       }
       break;
     case MGP_VALUE_TYPE_DURATION:
       static_assert(std::is_pointer_v<decltype(duration_v)>, "Expected to move duration_v by copying pointers.");
-      if (*other.GetMemoryResource() == *m) {
+      if (*other.GetMemoryResource() == *alloc.resource()) {
         duration_v = other.duration_v;
         other.type = MGP_VALUE_TYPE_NULL;
       } else {
-        duration_v = NewRawMgpObject<mgp_duration>(m, *other.duration_v);
+        duration_v = NewRawMgpObject<mgp_duration>(alloc.resource(), *other.duration_v);
       }
       break;
   }
@@ -1654,20 +1660,19 @@ mgp_error mgp_duration_sub(mgp_duration *first, mgp_duration *second, mgp_memory
 mgp_error mgp_result_set_error_msg(mgp_result *res, const char *msg) {
   return WrapExceptions([=] {
     memgraph::utils::MemoryTracker::OutOfMemoryExceptionBlocker blocker{};
-    auto *memory = res->rows.get_allocator().GetMemoryResource();
-    res->error_msg.emplace(msg, memory);
+    res->error_msg.emplace(msg, res->rows.get_allocator());
   });
 }
 
 mgp_error mgp_result_new_record(mgp_result *res, mgp_result_record **result) {
   return WrapExceptions(
       [res] {
-        auto *memory = res->rows.get_allocator().GetMemoryResource();
+        auto allocator = res->rows.get_allocator();
         res->rows.push_back(
             mgp_result_record{.signature = &res->signature,
                               .values =
                                   memgraph::utils::pmr::vector<memgraph::query::TypedValue>{
-                                      res->signature.size(), memgraph::query::TypedValue(memory), memory},
+                                      res->signature.size(), memgraph::query::TypedValue(allocator), allocator},
                               .ignore_deleted_values = !res->is_transactional});
         return &res->rows.back();
       },
@@ -1680,7 +1685,7 @@ mgp_error mgp_result_reserve(mgp_result *res, size_t n) {
 
 mgp_error mgp_result_record_insert(mgp_result_record *record, const char *field_name, mgp_value *val) {
   return WrapExceptions([=] {
-    auto *memory = record->values.get_allocator().GetMemoryResource();
+    auto allocator = record->values.get_allocator();
     // Validate field_name & val satisfy the procedure's result signature.
     MG_ASSERT(record->signature, "Expected to have a valid signature");
     auto find_it = record->signature->find(field_name);
@@ -1698,7 +1703,7 @@ mgp_error mgp_result_record_insert(mgp_result_record *record, const char *field_
           fmt::format("The type of value doesn't satisfy the type '{}'!", field_type->GetPresentableName())};
     }
 
-    record->values[field_id] = ToTypedValue(*val, memory);
+    record->values[field_id] = ToTypedValue(*val, allocator);
   });
 }
 
@@ -1929,7 +1934,7 @@ mgp_error mgp_vertex_set_property(struct mgp_vertex *v, const char *property_nam
       trigger_ctx_collector->RegisterRemovedObjectProperty(v->getImpl(), prop_key, old_value);
       return;
     }
-    const auto new_value = ToTypedValue(*property_value, property_value->memory);
+    const auto new_value = ToTypedValue(*property_value, property_value->alloc);
     trigger_ctx_collector->RegisterSetObjectProperty(v->getImpl(), prop_key, old_value, new_value);
   });
 }
@@ -2564,7 +2569,7 @@ mgp_error mgp_edge_set_property(struct mgp_edge *e, const char *property_name, m
       e->from.graph->ctx->trigger_context_collector->RegisterRemovedObjectProperty(e->impl, prop_key, old_value);
       return;
     }
-    const auto new_value = ToTypedValue(*property_value, property_value->memory);
+    const auto new_value = ToTypedValue(*property_value, property_value->alloc);
     e->from.graph->ctx->trigger_context_collector->RegisterSetObjectProperty(e->impl, prop_key, old_value, new_value);
   });
 }
@@ -3729,8 +3734,8 @@ void NextPermitted(mgp_vertices_iterator &it) {
 #endif
 
 /// @throw anything VerticesIterable may throw
-mgp_vertices_iterator::mgp_vertices_iterator(mgp_graph *graph, memgraph::utils::MemoryResource *memory)
-    : memory(memory),
+mgp_vertices_iterator::mgp_vertices_iterator(mgp_graph *graph, allocator_type alloc)
+    : alloc(alloc),
       graph(graph),
       vertices(std::visit([graph](auto *impl) { return impl->Vertices(graph->view); }, graph->impl)),
       current_it(vertices.begin()) {
@@ -3743,9 +3748,9 @@ mgp_vertices_iterator::mgp_vertices_iterator(mgp_graph *graph, memgraph::utils::
   if (current_it != vertices.end()) {
     std::visit(
         memgraph::utils::Overloaded{
-            [this, graph, memory](memgraph::query::DbAccessor *) { current_v.emplace(*current_it, graph, memory); },
-            [this, graph, memory](memgraph::query::SubgraphDbAccessor *impl) {
-              current_v.emplace(memgraph::query::SubgraphVertexAccessor(*current_it, impl->getGraph()), graph, memory);
+            [this, graph, alloc](memgraph::query::DbAccessor *) { current_v.emplace(*current_it, graph, alloc); },
+            [this, graph, alloc](memgraph::query::SubgraphDbAccessor *impl) {
+              current_v.emplace(memgraph::query::SubgraphVertexAccessor(*current_it, impl->getGraph()), graph, alloc);
             }},
         graph->impl);
   }
@@ -3870,7 +3875,7 @@ mgp_error mgp_type_list(mgp_type *type, mgp_type **result) {
         CypherTypePtr impl(
             alloc.new_object<ListType>(
                 // Just obtain the pointer to original impl, don't own it.
-                CypherTypePtr(type->impl.get(), NoOpCypherTypeDeleter), alloc.GetMemoryResource()),
+                CypherTypePtr(type->impl.get(), NoOpCypherTypeDeleter), alloc.resource()),
             [alloc](CypherType *base_ptr) mutable { alloc.delete_object(static_cast<ListType *>(base_ptr)); });
         return &gListTypes.emplace(type, mgp_type{std::move(impl)}).first->second;
       },
@@ -3888,8 +3893,7 @@ mgp_error mgp_type_nullable(mgp_type *type, mgp_type **result) {
         if (found_it != gNullableTypes.end()) return &found_it->second;
 
         auto alloc = gNullableTypes.get_allocator();
-        auto impl =
-            NullableType::Create(CypherTypePtr(type->impl.get(), NoOpCypherTypeDeleter), alloc.GetMemoryResource());
+        auto impl = NullableType::Create(CypherTypePtr(type->impl.get(), NoOpCypherTypeDeleter), alloc.resource());
         return &gNullableTypes.emplace(type, mgp_type{std::move(impl)}).first->second;
       },
       result);
@@ -3906,7 +3910,7 @@ mgp_proc *mgp_module_add_procedure(mgp_module *module, const char *name, mgp_pro
     throw std::logic_error{fmt::format("Procedure already exists with name '{}'", name)};
   };
 
-  auto *memory = module->procedures.get_allocator().GetMemoryResource();
+  auto *memory = module->procedures.get_allocator().resource();
   return &module->procedures.emplace(name, mgp_proc(name, cb, memory, procedure_info)).first->second;
 }
 
@@ -3920,7 +3924,7 @@ mgp_proc *mgp_module_add_batch_procedure(mgp_module *module, const char *name, m
   if (module->procedures.find(name) != module->procedures.end()) {
     throw std::logic_error{fmt::format("Procedure already exists with name '{}'", name)};
   };
-  auto *memory = module->procedures.get_allocator().GetMemoryResource();
+  auto *memory = module->procedures.get_allocator().resource();
   return &module->procedures.emplace(name, mgp_proc(name, cb_batch, initializer, cleanup, memory, procedure_info))
               .first->second;
 }
@@ -4022,7 +4026,7 @@ mgp_error MgpAddOptArg(TCall &callable, const std::string name, mgp_type &type, 
       throw std::logic_error{fmt::format("The default value of argument '{}' for {} '{}' doesn't satisfy type '{}'",
                                          name, type_name, callable.name, type.impl->GetPresentableName())};
     }
-    auto *memory = callable.opt_args.get_allocator().GetMemoryResource();
+    auto *memory = callable.opt_args.get_allocator().resource();
     callable.opt_args.emplace_back(memgraph::utils::pmr::string(name, memory), type.impl.get(),
                                    ToTypedValue(default_value, memory));
   });
@@ -4059,7 +4063,7 @@ mgp_error AddResultToProp(T *prop, const char *name, mgp_type *type, bool is_dep
     if (prop->results.find(name) != prop->results.end()) {
       throw std::logic_error{fmt::format("Result already exists with name '{}' for procedure '{}'", name, prop->name)};
     };
-    auto *memory = prop->results.get_allocator().GetMemoryResource();
+    auto *memory = prop->results.get_allocator().resource();
     prop->results.emplace(memgraph::utils::pmr::string(name, memory), std::make_pair(type->impl.get(), is_deprecated));
   });
 }
@@ -4363,7 +4367,7 @@ mgp_error mgp_module_add_transformation(mgp_module *module, const char *name, mg
     if (module->transformations.find(name) != module->transformations.end()) {
       throw std::logic_error{fmt::format("Transformation already exists with name '{}'", name)};
     };
-    auto *memory = module->transformations.get_allocator().GetMemoryResource();
+    auto *memory = module->transformations.get_allocator().resource();
     module->transformations.emplace(name, mgp_trans(name, cb, memory));
   });
 }
@@ -4377,7 +4381,7 @@ mgp_error mgp_module_add_function(mgp_module *module, const char *name, mgp_func
         if (module->functions.find(name) != module->functions.end()) {
           throw std::logic_error{fmt::format("Function with similar name already exists '{}'", name)};
         };
-        auto *memory = module->functions.get_allocator().GetMemoryResource();
+        auto *memory = module->functions.get_allocator().resource();
 
         return &module->functions.emplace(name, mgp_func(name, cb, memory)).first->second;
       },
@@ -4483,8 +4487,8 @@ struct mgp_execution_result::pImplMgpExecutionResult {
   std::unique_ptr<mgp_execution_headers> headers;
 };
 
-mgp_execution_result::mgp_execution_result(mgp_graph *graph, memgraph::utils::MemoryResource *memory)
-    : pImpl(std::make_unique<pImplMgpExecutionResult>()), memory(memory) {
+mgp_execution_result::mgp_execution_result(mgp_graph *graph, allocator_type alloc)
+    : pImpl(std::make_unique<pImplMgpExecutionResult>()), alloc(alloc) {
   auto &instance = memgraph::query::InterpreterContextHolder::GetInstance();
   pImpl->interpreter = std::make_unique<memgraph::query::Interpreter>(&instance, instance.dbms_handler->Get(
 #ifdef MG_ENTERPRISE
@@ -4508,7 +4512,7 @@ mgp_error mgp_execute_query(mgp_graph *graph, mgp_memory *memory, const char *qu
         auto query_string = std::string(query);
         auto &instance = memgraph::query::InterpreterContextHolder::GetInstance();
 
-        auto *result = NewRawMgpObject<mgp_execution_result>(memory->impl, graph, memory->impl);
+        auto *result = NewRawMgpObject<mgp_execution_result>(memory->impl, graph);
         result->pImpl->interpreter->SetUser(graph->ctx->user_or_role);
 
         instance.interpreters.WithLock(

--- a/src/query/procedure/mg_procedure_impl.hpp
+++ b/src/query/procedure/mg_procedure_impl.hpp
@@ -51,51 +51,51 @@ struct mgp_value {
   using allocator_type = memgraph::utils::Allocator<mgp_value>;
 
   // Construct MGP_VALUE_TYPE_NULL.
-  explicit mgp_value(memgraph::utils::MemoryResource *) noexcept;
+  explicit mgp_value(allocator_type) noexcept;
 
-  mgp_value(bool, memgraph::utils::MemoryResource *) noexcept;
-  mgp_value(int64_t, memgraph::utils::MemoryResource *) noexcept;
-  mgp_value(double, memgraph::utils::MemoryResource *) noexcept;
+  mgp_value(bool, allocator_type) noexcept;
+  mgp_value(int64_t, allocator_type) noexcept;
+  mgp_value(double, allocator_type) noexcept;
   /// @throw std::bad_alloc
-  mgp_value(const char *, memgraph::utils::MemoryResource *);
+  mgp_value(const char *, allocator_type);
   /// Take ownership of the mgp_list, MemoryResource must match.
-  mgp_value(mgp_list *, memgraph::utils::MemoryResource *) noexcept;
+  mgp_value(mgp_list *, allocator_type) noexcept;
   /// Take ownership of the mgp_map, MemoryResource must match.
-  mgp_value(mgp_map *, memgraph::utils::MemoryResource *) noexcept;
+  mgp_value(mgp_map *, allocator_type) noexcept;
   /// Take ownership of the mgp_vertex, MemoryResource must match.
-  mgp_value(mgp_vertex *, memgraph::utils::MemoryResource *) noexcept;
+  mgp_value(mgp_vertex *, allocator_type) noexcept;
   /// Take ownership of the mgp_edge, MemoryResource must match.
-  mgp_value(mgp_edge *, memgraph::utils::MemoryResource *) noexcept;
+  mgp_value(mgp_edge *, allocator_type) noexcept;
   /// Take ownership of the mgp_path, MemoryResource must match.
-  mgp_value(mgp_path *, memgraph::utils::MemoryResource *) noexcept;
+  mgp_value(mgp_path *, allocator_type) noexcept;
 
-  mgp_value(mgp_date *, memgraph::utils::MemoryResource *) noexcept;
-  mgp_value(mgp_local_time *, memgraph::utils::MemoryResource *) noexcept;
-  mgp_value(mgp_local_date_time *, memgraph::utils::MemoryResource *) noexcept;
-  mgp_value(mgp_duration *, memgraph::utils::MemoryResource *) noexcept;
+  mgp_value(mgp_date *, allocator_type) noexcept;
+  mgp_value(mgp_local_time *, allocator_type) noexcept;
+  mgp_value(mgp_local_date_time *, allocator_type) noexcept;
+  mgp_value(mgp_duration *, allocator_type) noexcept;
 
   /// Construct by copying memgraph::query::TypedValue using memgraph::utils::MemoryResource.
   /// mgp_graph is needed to construct mgp_vertex and mgp_edge.
   /// @throw std::bad_alloc
-  mgp_value(const memgraph::query::TypedValue &, mgp_graph *, memgraph::utils::MemoryResource *);
+  mgp_value(const memgraph::query::TypedValue &, mgp_graph *, allocator_type);
 
   /// Construct by copying memgraph::storage::PropertyValue using memgraph::utils::MemoryResource.
   /// @throw std::bad_alloc
-  mgp_value(const memgraph::storage::PropertyValue &, memgraph::utils::MemoryResource *);
+  mgp_value(const memgraph::storage::PropertyValue &, allocator_type);
 
   /// Copy construction without memgraph::utils::MemoryResource is not allowed.
   mgp_value(const mgp_value &) = delete;
 
   /// Copy construct using given memgraph::utils::MemoryResource.
   /// @throw std::bad_alloc
-  mgp_value(const mgp_value &, memgraph::utils::MemoryResource *);
+  mgp_value(const mgp_value &, allocator_type);
 
   /// Move construct using given memgraph::utils::MemoryResource.
   /// @throw std::bad_alloc if MemoryResource is different, so we cannot move.
-  mgp_value(mgp_value &&, memgraph::utils::MemoryResource *);
+  mgp_value(mgp_value &&, allocator_type);
 
   /// Move construct, memgraph::utils::MemoryResource is inherited.
-  mgp_value(mgp_value &&other) noexcept : mgp_value(other, other.memory) {}
+  mgp_value(mgp_value &&other) noexcept : mgp_value(other, other.alloc) {}
 
   /// Copy-assignment is not allowed to preserve immutability.
   mgp_value &operator=(const mgp_value &) = delete;
@@ -105,10 +105,10 @@ struct mgp_value {
 
   ~mgp_value() noexcept;
 
-  memgraph::utils::MemoryResource *GetMemoryResource() const noexcept { return memory; }
+  memgraph::utils::MemoryResource *GetMemoryResource() const noexcept { return alloc.resource(); }
 
   mgp_value_type type;
-  memgraph::utils::MemoryResource *memory;
+  allocator_type alloc;
 
   union {
     bool bool_v;
@@ -144,24 +144,21 @@ struct mgp_date {
   // have everything noexcept here.
   static_assert(std::is_nothrow_copy_constructible_v<memgraph::utils::Date>);
 
-  mgp_date(const memgraph::utils::Date &date, memgraph::utils::MemoryResource *memory) noexcept
-      : memory(memory), date(date) {}
+  mgp_date(const memgraph::utils::Date &date, allocator_type alloc) noexcept : alloc(alloc), date(date) {}
 
-  mgp_date(const std::string_view string, memgraph::utils::MemoryResource *memory)
-      : memory(memory), date(memgraph::utils::ParseDateParameters(string).first) {}
+  mgp_date(const std::string_view string, allocator_type alloc)
+      : alloc(alloc), date(memgraph::utils::ParseDateParameters(string).first) {}
 
-  mgp_date(const mgp_date_parameters *parameters, memgraph::utils::MemoryResource *memory)
-      : memory(memory), date(MapDateParameters(parameters)) {}
+  mgp_date(const mgp_date_parameters *parameters, allocator_type alloc)
+      : alloc(alloc), date(MapDateParameters(parameters)) {}
 
-  mgp_date(const int64_t microseconds, memgraph::utils::MemoryResource *memory) noexcept
-      : memory(memory), date(microseconds) {}
+  mgp_date(const int64_t microseconds, allocator_type alloc) noexcept : alloc(alloc), date(microseconds) {}
 
-  mgp_date(const mgp_date &other, memgraph::utils::MemoryResource *memory) noexcept
-      : memory(memory), date(other.date) {}
+  mgp_date(const mgp_date &other, allocator_type alloc) noexcept : alloc(alloc), date(other.date) {}
 
-  mgp_date(mgp_date &&other, memgraph::utils::MemoryResource *memory) noexcept : memory(memory), date(other.date) {}
+  mgp_date(mgp_date &&other, allocator_type alloc) noexcept : alloc(alloc), date(other.date) {}
 
-  mgp_date(mgp_date &&other) noexcept : memory(other.memory), date(other.date) {}
+  mgp_date(mgp_date &&other) noexcept : alloc(other.alloc), date(other.date) {}
 
   /// Copy construction without memgraph::utils::MemoryResource is not allowed.
   mgp_date(const mgp_date &) = delete;
@@ -171,9 +168,9 @@ struct mgp_date {
 
   ~mgp_date() = default;
 
-  memgraph::utils::MemoryResource *GetMemoryResource() const noexcept { return memory; }
+  memgraph::utils::MemoryResource *GetMemoryResource() const noexcept { return alloc.resource(); }
 
-  memgraph::utils::MemoryResource *memory;
+  allocator_type alloc;
   memgraph::utils::Date date;
 };
 
@@ -195,25 +192,23 @@ struct mgp_local_time {
   // have everything noexcept here.
   static_assert(std::is_nothrow_copy_constructible_v<memgraph::utils::LocalTime>);
 
-  mgp_local_time(const std::string_view string, memgraph::utils::MemoryResource *memory)
-      : memory(memory), local_time(memgraph::utils::ParseLocalTimeParameters(string).first) {}
+  mgp_local_time(const std::string_view string, allocator_type alloc)
+      : alloc(alloc), local_time(memgraph::utils::ParseLocalTimeParameters(string).first) {}
 
-  mgp_local_time(const mgp_local_time_parameters *parameters, memgraph::utils::MemoryResource *memory)
-      : memory(memory), local_time(MapLocalTimeParameters(parameters)) {}
+  mgp_local_time(const mgp_local_time_parameters *parameters, allocator_type alloc)
+      : alloc(alloc), local_time(MapLocalTimeParameters(parameters)) {}
 
-  mgp_local_time(const memgraph::utils::LocalTime &local_time, memgraph::utils::MemoryResource *memory) noexcept
-      : memory(memory), local_time(local_time) {}
+  mgp_local_time(const memgraph::utils::LocalTime &local_time, allocator_type alloc) noexcept
+      : alloc(alloc), local_time(local_time) {}
 
-  mgp_local_time(const int64_t microseconds, memgraph::utils::MemoryResource *memory) noexcept
-      : memory(memory), local_time(microseconds) {}
+  mgp_local_time(const int64_t microseconds, allocator_type alloc) noexcept : alloc(alloc), local_time(microseconds) {}
 
-  mgp_local_time(const mgp_local_time &other, memgraph::utils::MemoryResource *memory) noexcept
-      : memory(memory), local_time(other.local_time) {}
+  mgp_local_time(const mgp_local_time &other, allocator_type alloc) noexcept
+      : alloc(alloc), local_time(other.local_time) {}
 
-  mgp_local_time(mgp_local_time &&other, memgraph::utils::MemoryResource *memory) noexcept
-      : memory(memory), local_time(other.local_time) {}
+  mgp_local_time(mgp_local_time &&other, allocator_type alloc) noexcept : alloc(alloc), local_time(other.local_time) {}
 
-  mgp_local_time(mgp_local_time &&other) noexcept : memory(other.memory), local_time(other.local_time) {}
+  mgp_local_time(mgp_local_time &&other) noexcept : alloc(other.alloc), local_time(other.local_time) {}
 
   /// Copy construction without memgraph::utils::MemoryResource is not allowed.
   mgp_local_time(const mgp_local_time &) = delete;
@@ -223,9 +218,9 @@ struct mgp_local_time {
 
   ~mgp_local_time() = default;
 
-  memgraph::utils::MemoryResource *GetMemoryResource() const noexcept { return memory; }
+  memgraph::utils::MemoryResource *GetMemoryResource() const noexcept { return alloc.resource(); }
 
-  memgraph::utils::MemoryResource *memory;
+  allocator_type alloc;
   memgraph::utils::LocalTime local_time;
 };
 
@@ -244,29 +239,28 @@ struct mgp_local_date_time {
   // have everything noexcept here.
   static_assert(std::is_nothrow_copy_constructible_v<memgraph::utils::LocalDateTime>);
 
-  mgp_local_date_time(const memgraph::utils::LocalDateTime &local_date_time,
-                      memgraph::utils::MemoryResource *memory) noexcept
-      : memory(memory), local_date_time(local_date_time) {}
+  mgp_local_date_time(const memgraph::utils::LocalDateTime &local_date_time, allocator_type alloc) noexcept
+      : alloc(alloc), local_date_time(local_date_time) {}
 
-  mgp_local_date_time(const std::string_view string, memgraph::utils::MemoryResource *memory) noexcept
-      : memory(memory), local_date_time(CreateLocalDateTimeFromString(string)) {}
+  mgp_local_date_time(const std::string_view string, allocator_type alloc) noexcept
+      : alloc(alloc), local_date_time(CreateLocalDateTimeFromString(string)) {}
 
-  mgp_local_date_time(const mgp_local_date_time_parameters *parameters, memgraph::utils::MemoryResource *memory)
-      : memory(memory),
+  mgp_local_date_time(const mgp_local_date_time_parameters *parameters, allocator_type alloc)
+      : alloc(alloc),
         local_date_time(MapDateParameters(parameters->date_parameters),
                         MapLocalTimeParameters(parameters->local_time_parameters)) {}
 
-  mgp_local_date_time(const int64_t microseconds, memgraph::utils::MemoryResource *memory) noexcept
-      : memory(memory), local_date_time(microseconds) {}
+  mgp_local_date_time(const int64_t microseconds, allocator_type alloc) noexcept
+      : alloc(alloc), local_date_time(microseconds) {}
 
-  mgp_local_date_time(const mgp_local_date_time &other, memgraph::utils::MemoryResource *memory) noexcept
-      : memory(memory), local_date_time(other.local_date_time) {}
+  mgp_local_date_time(const mgp_local_date_time &other, allocator_type alloc) noexcept
+      : alloc(alloc), local_date_time(other.local_date_time) {}
 
-  mgp_local_date_time(mgp_local_date_time &&other, memgraph::utils::MemoryResource *memory) noexcept
-      : memory(memory), local_date_time(other.local_date_time) {}
+  mgp_local_date_time(mgp_local_date_time &&other, allocator_type alloc) noexcept
+      : alloc(alloc), local_date_time(other.local_date_time) {}
 
   mgp_local_date_time(mgp_local_date_time &&other) noexcept
-      : memory(other.memory), local_date_time(other.local_date_time) {}
+      : alloc(other.alloc), local_date_time(other.local_date_time) {}
 
   /// Copy construction without memgraph::utils::MemoryResource is not allowed.
   mgp_local_date_time(const mgp_local_date_time &) = delete;
@@ -276,9 +270,9 @@ struct mgp_local_date_time {
 
   ~mgp_local_date_time() = default;
 
-  memgraph::utils::MemoryResource *GetMemoryResource() const noexcept { return memory; }
+  memgraph::utils::MemoryResource *GetMemoryResource() const noexcept { return alloc.resource(); }
 
-  memgraph::utils::MemoryResource *memory;
+  allocator_type alloc;
   memgraph::utils::LocalDateTime local_date_time;
 };
 
@@ -301,25 +295,22 @@ struct mgp_duration {
   // have everything noexcept here.
   static_assert(std::is_nothrow_copy_constructible_v<memgraph::utils::Duration>);
 
-  mgp_duration(const std::string_view string, memgraph::utils::MemoryResource *memory)
-      : memory(memory), duration(memgraph::utils::ParseDurationParameters(string)) {}
+  mgp_duration(const std::string_view string, allocator_type alloc)
+      : alloc(alloc), duration(memgraph::utils::ParseDurationParameters(string)) {}
 
-  mgp_duration(const mgp_duration_parameters *parameters, memgraph::utils::MemoryResource *memory) noexcept
-      : memory(memory), duration(MapDurationParameters(parameters)) {}
+  mgp_duration(const mgp_duration_parameters *parameters, allocator_type alloc) noexcept
+      : alloc(alloc), duration(MapDurationParameters(parameters)) {}
 
-  mgp_duration(const memgraph::utils::Duration &duration, memgraph::utils::MemoryResource *memory) noexcept
-      : memory(memory), duration(duration) {}
+  mgp_duration(const memgraph::utils::Duration &duration, allocator_type alloc) noexcept
+      : alloc(alloc), duration(duration) {}
 
-  mgp_duration(const int64_t microseconds, memgraph::utils::MemoryResource *memory) noexcept
-      : memory(memory), duration(microseconds) {}
+  mgp_duration(const int64_t microseconds, allocator_type alloc) noexcept : alloc(alloc), duration(microseconds) {}
 
-  mgp_duration(const mgp_duration &other, memgraph::utils::MemoryResource *memory) noexcept
-      : memory(memory), duration(other.duration) {}
+  mgp_duration(const mgp_duration &other, allocator_type alloc) noexcept : alloc(alloc), duration(other.duration) {}
 
-  mgp_duration(mgp_duration &&other, memgraph::utils::MemoryResource *memory) noexcept
-      : memory(memory), duration(other.duration) {}
+  mgp_duration(mgp_duration &&other, allocator_type alloc) noexcept : alloc(alloc), duration(other.duration) {}
 
-  mgp_duration(mgp_duration &&other) noexcept : memory(other.memory), duration(other.duration) {}
+  mgp_duration(mgp_duration &&other) noexcept : alloc(other.alloc), duration(other.duration) {}
 
   /// Copy construction without memgraph::utils::MemoryResource is not allowed.
   mgp_duration(const mgp_duration &) = delete;
@@ -329,9 +320,9 @@ struct mgp_duration {
 
   ~mgp_duration() = default;
 
-  memgraph::utils::MemoryResource *GetMemoryResource() const noexcept { return memory; }
+  memgraph::utils::MemoryResource *GetMemoryResource() const noexcept { return alloc.resource(); }
 
-  memgraph::utils::MemoryResource *memory;
+  allocator_type alloc;
   memgraph::utils::Duration duration;
 };
 
@@ -339,14 +330,13 @@ struct mgp_list {
   /// Allocator type so that STL containers are aware that we need one.
   using allocator_type = memgraph::utils::Allocator<mgp_list>;
 
-  explicit mgp_list(memgraph::utils::MemoryResource *memory) : elems(memory) {}
+  explicit mgp_list(allocator_type alloc) : elems(alloc) {}
 
-  mgp_list(memgraph::utils::pmr::vector<mgp_value> &&elems, memgraph::utils::MemoryResource *memory)
-      : elems(std::move(elems), memory) {}
+  mgp_list(memgraph::utils::pmr::vector<mgp_value> &&elems, allocator_type alloc) : elems(std::move(elems), alloc) {}
 
-  mgp_list(const mgp_list &other, memgraph::utils::MemoryResource *memory) : elems(other.elems, memory) {}
+  mgp_list(const mgp_list &other, allocator_type alloc) : elems(other.elems, alloc) {}
 
-  mgp_list(mgp_list &&other, memgraph::utils::MemoryResource *memory) : elems(std::move(other.elems), memory) {}
+  mgp_list(mgp_list &&other, allocator_type alloc) : elems(std::move(other.elems), alloc) {}
 
   mgp_list(mgp_list &&other) noexcept : elems(std::move(other.elems)) {}
 
@@ -358,9 +348,7 @@ struct mgp_list {
 
   ~mgp_list() = default;
 
-  memgraph::utils::MemoryResource *GetMemoryResource() const noexcept {
-    return elems.get_allocator().GetMemoryResource();
-  }
+  memgraph::utils::MemoryResource *GetMemoryResource() const noexcept { return elems.get_allocator().resource(); }
 
   // C++17 vector can work with incomplete type.
   memgraph::utils::pmr::vector<mgp_value> elems;
@@ -370,15 +358,14 @@ struct mgp_map {
   /// Allocator type so that STL containers are aware that we need one.
   using allocator_type = memgraph::utils::Allocator<mgp_map>;
 
-  explicit mgp_map(memgraph::utils::MemoryResource *memory) : items(memory) {}
+  explicit mgp_map(allocator_type alloc) : items(alloc) {}
 
-  mgp_map(memgraph::utils::pmr::map<memgraph::utils::pmr::string, mgp_value> &&items,
-          memgraph::utils::MemoryResource *memory)
-      : items(std::move(items), memory) {}
+  mgp_map(memgraph::utils::pmr::map<memgraph::utils::pmr::string, mgp_value> &&items, allocator_type alloc)
+      : items(std::move(items), alloc) {}
 
-  mgp_map(const mgp_map &other, memgraph::utils::MemoryResource *memory) : items(other.items, memory) {}
+  mgp_map(const mgp_map &other, allocator_type alloc) : items(other.items, alloc) {}
 
-  mgp_map(mgp_map &&other, memgraph::utils::MemoryResource *memory) : items(std::move(other.items), memory) {}
+  mgp_map(mgp_map &&other, allocator_type alloc) : items(std::move(other.items), alloc) {}
 
   mgp_map(mgp_map &&other) noexcept : items(std::move(other.items)) {}
 
@@ -390,9 +377,7 @@ struct mgp_map {
 
   ~mgp_map() = default;
 
-  memgraph::utils::MemoryResource *GetMemoryResource() const noexcept {
-    return items.get_allocator().GetMemoryResource();
-  }
+  memgraph::utils::MemoryResource *GetMemoryResource() const noexcept { return items.get_allocator().resource(); }
 
   // Unfortunately using incomplete type with map is undefined, so mgp_map
   // needs to be defined after mgp_value.
@@ -407,8 +392,7 @@ struct mgp_map_item {
 struct mgp_map_items_iterator {
   using allocator_type = memgraph::utils::Allocator<mgp_map_items_iterator>;
 
-  mgp_map_items_iterator(mgp_map *map, memgraph::utils::MemoryResource *memory)
-      : memory(memory), map(map), current_it(map->items.begin()) {
+  mgp_map_items_iterator(mgp_map *map, allocator_type alloc) : alloc(alloc), map(map), current_it(map->items.begin()) {
     if (current_it != map->items.end()) {
       current.key = current_it->first.c_str();
       current.value = &current_it->second;
@@ -422,9 +406,9 @@ struct mgp_map_items_iterator {
 
   ~mgp_map_items_iterator() = default;
 
-  memgraph::utils::MemoryResource *GetMemoryResource() const { return memory; }
+  memgraph::utils::MemoryResource *GetMemoryResource() const { return alloc.resource(); }
 
-  memgraph::utils::MemoryResource *memory;
+  allocator_type alloc;
   mgp_map *map;
   decltype(map->items.begin()) current_it;
   mgp_map_item current;
@@ -436,20 +420,18 @@ struct mgp_vertex {
   /// the allocator which was used to allocate `this`.
   using allocator_type = memgraph::utils::Allocator<mgp_vertex>;
 
-  mgp_vertex(memgraph::query::VertexAccessor v, mgp_graph *graph, memgraph::utils::MemoryResource *memory)
-      : memory(memory), impl(v), graph(graph) {}
+  mgp_vertex(memgraph::query::VertexAccessor v, mgp_graph *graph, allocator_type alloc)
+      : alloc(alloc), impl(v), graph(graph) {}
 
-  mgp_vertex(memgraph::query::SubgraphVertexAccessor v, mgp_graph *graph, memgraph::utils::MemoryResource *memory)
-      : memory(memory), impl(v), graph(graph) {}
+  mgp_vertex(memgraph::query::SubgraphVertexAccessor v, mgp_graph *graph, allocator_type alloc)
+      : alloc(alloc), impl(v), graph(graph) {}
 
-  mgp_vertex(const mgp_vertex &other, memgraph::utils::MemoryResource *memory)
-      : memory(memory), impl(other.impl), graph(other.graph) {}
+  mgp_vertex(const mgp_vertex &other, allocator_type alloc) : alloc(alloc), impl(other.impl), graph(other.graph) {}
 
-  mgp_vertex(mgp_vertex &&other, memgraph::utils::MemoryResource *memory)
-      : memory(memory), impl(other.impl), graph(other.graph) {}
+  mgp_vertex(mgp_vertex &&other, allocator_type alloc) : alloc(alloc), impl(other.impl), graph(other.graph) {}
 
   // NOLINTNEXTLINE(hicpp-noexcept-move, performance-noexcept-move-constructor)
-  mgp_vertex(mgp_vertex &&other) : memory(other.memory), impl(other.impl), graph(other.graph) {}
+  mgp_vertex(mgp_vertex &&other) : alloc(other.alloc), impl(other.impl), graph(other.graph) {}
 
   memgraph::query::VertexAccessor getImpl() const {
     return std::visit(
@@ -470,9 +452,9 @@ struct mgp_vertex {
 
   ~mgp_vertex() = default;
 
-  memgraph::utils::MemoryResource *GetMemoryResource() const noexcept { return memory; }
+  memgraph::utils::MemoryResource *GetMemoryResource() const noexcept { return alloc.resource(); }
 
-  memgraph::utils::MemoryResource *memory;
+  allocator_type alloc;
   std::variant<memgraph::query::VertexAccessor, memgraph::query::SubgraphVertexAccessor> impl;
   mgp_graph *graph;
 };
@@ -485,27 +467,26 @@ struct mgp_edge {
 
   static mgp_edge *Copy(const mgp_edge &edge, mgp_memory &memory);
 
-  mgp_edge(const memgraph::query::EdgeAccessor &impl, mgp_graph *graph, memgraph::utils::MemoryResource *memory)
-      : memory(memory), impl(impl), from(impl.From(), graph, memory), to(impl.To(), graph, memory) {}
+  mgp_edge(const memgraph::query::EdgeAccessor &impl, mgp_graph *graph, allocator_type alloc)
+      : alloc(alloc), impl(impl), from(impl.From(), graph, alloc), to(impl.To(), graph, alloc) {}
 
   mgp_edge(const memgraph::query::EdgeAccessor &impl, const memgraph::query::VertexAccessor &from_v,
-           const memgraph::query::VertexAccessor &to_v, mgp_graph *graph, memgraph::utils::MemoryResource *memory)
-      : memory(memory), impl(impl), from(from_v, graph, memory), to(to_v, graph, memory) {}
+           const memgraph::query::VertexAccessor &to_v, mgp_graph *graph, allocator_type alloc)
+      : alloc(alloc), impl(impl), from(from_v, graph, alloc), to(to_v, graph, alloc) {}
 
   mgp_edge(const memgraph::query::EdgeAccessor &impl, const memgraph::query::SubgraphVertexAccessor &from_v,
-           const memgraph::query::SubgraphVertexAccessor &to_v, mgp_graph *graph,
-           memgraph::utils::MemoryResource *memory)
-      : memory(memory), impl(impl), from(from_v, graph, memory), to(to_v, graph, memory) {}
+           const memgraph::query::SubgraphVertexAccessor &to_v, mgp_graph *graph, allocator_type alloc)
+      : alloc(alloc), impl(impl), from(from_v, graph, alloc), to(to_v, graph, alloc) {}
 
-  mgp_edge(const mgp_edge &other, memgraph::utils::MemoryResource *memory)
-      : memory(memory), impl(other.impl), from(other.from, memory), to(other.to, memory) {}
+  mgp_edge(const mgp_edge &other, allocator_type alloc)
+      : alloc(alloc), impl(other.impl), from(other.from, alloc), to(other.to, alloc) {}
 
-  mgp_edge(mgp_edge &&other, memgraph::utils::MemoryResource *memory)
-      : memory(other.memory), impl(other.impl), from(std::move(other.from), memory), to(std::move(other.to), memory) {}
+  mgp_edge(mgp_edge &&other, allocator_type alloc)
+      : alloc(other.alloc), impl(other.impl), from(std::move(other.from), alloc), to(std::move(other.to), alloc) {}
 
   // NOLINTNEXTLINE(hicpp-noexcept-move, performance-noexcept-move-constructor)
   mgp_edge(mgp_edge &&other)
-      : memory(other.memory), impl(other.impl), from(std::move(other.from)), to(std::move(other.to)) {}
+      : alloc(other.alloc), impl(other.impl), from(std::move(other.from)), to(std::move(other.to)) {}
 
   /// Copy construction without memgraph::utils::MemoryResource is not allowed.
   mgp_edge(const mgp_edge &) = delete;
@@ -517,9 +498,9 @@ struct mgp_edge {
   bool operator==(const mgp_edge &other) const noexcept { return this->impl == other.impl; }
   bool operator!=(const mgp_edge &other) const noexcept { return !(*this == other); };
 
-  memgraph::utils::MemoryResource *GetMemoryResource() const noexcept { return memory; }
+  memgraph::utils::MemoryResource *GetMemoryResource() const noexcept { return alloc.resource(); }
 
-  memgraph::utils::MemoryResource *memory;
+  allocator_type alloc;
   memgraph::query::EdgeAccessor impl;
   mgp_vertex from;
   mgp_vertex to;
@@ -529,13 +510,12 @@ struct mgp_path {
   /// Allocator type so that STL containers are aware that we need one.
   using allocator_type = memgraph::utils::Allocator<mgp_path>;
 
-  explicit mgp_path(memgraph::utils::MemoryResource *memory) : vertices(memory), edges(memory) {}
+  explicit mgp_path(allocator_type alloc) : vertices(alloc), edges(alloc) {}
 
-  mgp_path(const mgp_path &other, memgraph::utils::MemoryResource *memory)
-      : vertices(other.vertices, memory), edges(other.edges, memory) {}
+  mgp_path(const mgp_path &other, allocator_type alloc) : vertices(other.vertices, alloc), edges(other.edges, alloc) {}
 
-  mgp_path(mgp_path &&other, memgraph::utils::MemoryResource *memory)
-      : vertices(std::move(other.vertices), memory), edges(std::move(other.edges), memory) {}
+  mgp_path(mgp_path &&other, allocator_type alloc)
+      : vertices(std::move(other.vertices), alloc), edges(std::move(other.edges), alloc) {}
 
   mgp_path(mgp_path &&other) noexcept : vertices(std::move(other.vertices)), edges(std::move(other.edges)) {}
 
@@ -547,9 +527,7 @@ struct mgp_path {
 
   ~mgp_path() = default;
 
-  memgraph::utils::MemoryResource *GetMemoryResource() const noexcept {
-    return vertices.get_allocator().GetMemoryResource();
-  }
+  memgraph::utils::MemoryResource *GetMemoryResource() const noexcept { return vertices.get_allocator().resource(); }
 
   memgraph::utils::pmr::vector<mgp_vertex> vertices;
   memgraph::utils::pmr::vector<mgp_edge> edges;
@@ -632,7 +610,7 @@ struct mgp_properties_iterator {
   // Define members at the start because we use decltype a lot here, so members
   // need to be visible in method definitions.
 
-  memgraph::utils::MemoryResource *memory;
+  allocator_type alloc;
   mgp_graph *graph;
   std::remove_reference_t<decltype(*std::declval<memgraph::query::VertexAccessor>().Properties(graph->view))> pvs;
   decltype(pvs.begin()) current_it;
@@ -640,22 +618,22 @@ struct mgp_properties_iterator {
   mgp_property property{nullptr, nullptr};
 
   // Construct with no properties.
-  explicit mgp_properties_iterator(mgp_graph *graph, memgraph::utils::MemoryResource *memory)
-      : memory(memory), graph(graph), current_it(pvs.begin()) {}
+  explicit mgp_properties_iterator(mgp_graph *graph, allocator_type alloc)
+      : alloc(alloc), graph(graph), current_it(pvs.begin()) {}
 
   // May throw who the #$@! knows what because PropertyValueStore doesn't
   // document what it throws, and it may surely throw some piece of !@#$
   // exception because it's built on top of STL and other libraries.
-  mgp_properties_iterator(mgp_graph *graph, decltype(pvs) pvs, memgraph::utils::MemoryResource *memory)
-      : memory(memory), graph(graph), pvs(std::move(pvs)), current_it(this->pvs.begin()) {
+  mgp_properties_iterator(mgp_graph *graph, decltype(pvs) pvs, allocator_type alloc)
+      : alloc(alloc), graph(graph), pvs(std::move(pvs)), current_it(this->pvs.begin()) {
     if (current_it != this->pvs.end()) {
       auto value = std::visit(
-          [this, memory](const auto *impl) {
-            return memgraph::utils::pmr::string(impl->PropertyToName(current_it->first), memory);
+          [this, alloc](const auto *impl) {
+            return memgraph::utils::pmr::string(impl->PropertyToName(current_it->first), alloc);
           },
           graph->impl);
 
-      current.emplace(value, mgp_value(current_it->second, memory));
+      current.emplace(value, mgp_value(current_it->second, alloc));
       property.name = current->first.c_str();
       property.value = &current->second;
     }
@@ -669,18 +647,17 @@ struct mgp_properties_iterator {
 
   ~mgp_properties_iterator() = default;
 
-  memgraph::utils::MemoryResource *GetMemoryResource() const { return memory; }
+  memgraph::utils::MemoryResource *GetMemoryResource() const { return alloc.resource(); }
 };
 
 struct mgp_edges_iterator {
   using allocator_type = memgraph::utils::Allocator<mgp_edges_iterator>;
 
-  mgp_edges_iterator(const mgp_vertex &v, memgraph::utils::MemoryResource *memory)
-      : memory(memory), source_vertex(v, memory) {}
+  mgp_edges_iterator(const mgp_vertex &v, allocator_type alloc) : alloc(alloc), source_vertex(v, alloc) {}
 
   // NOLINTNEXTLINE(hicpp-noexcept-move, performance-noexcept-move-constructor)
   mgp_edges_iterator(mgp_edges_iterator &&other)
-      : memory(other.memory),
+      : alloc(other.alloc),
         source_vertex(std::move(other.source_vertex)),
         in(std::move(other.in)),
         in_it(std::move(other.in_it)),
@@ -694,9 +671,9 @@ struct mgp_edges_iterator {
 
   ~mgp_edges_iterator() = default;
 
-  memgraph::utils::MemoryResource *GetMemoryResource() const { return memory; }
+  memgraph::utils::MemoryResource *GetMemoryResource() const { return alloc.resource(); }
 
-  memgraph::utils::MemoryResource *memory;
+  allocator_type alloc;
   mgp_vertex source_vertex;
 
   std::optional<std::remove_reference_t<decltype(std::get<memgraph::query::VertexAccessor>(source_vertex.impl)
@@ -716,11 +693,11 @@ struct mgp_vertices_iterator {
   using allocator_type = memgraph::utils::Allocator<mgp_vertices_iterator>;
 
   /// @throw anything VerticesIterable may throw
-  mgp_vertices_iterator(mgp_graph *graph, memgraph::utils::MemoryResource *memory);
+  mgp_vertices_iterator(mgp_graph *graph, allocator_type alloc);
 
-  memgraph::utils::MemoryResource *GetMemoryResource() const { return memory; }
+  memgraph::utils::MemoryResource *GetMemoryResource() const { return alloc.resource(); }
 
-  memgraph::utils::MemoryResource *memory;
+  allocator_type alloc;
   mgp_graph *graph;
   memgraph::query::VerticesIterable vertices;
   decltype(vertices.begin()) current_it;
@@ -743,68 +720,68 @@ struct mgp_proc {
 
   /// @throw std::bad_alloc
   /// @throw std::length_error
-  mgp_proc(const char *name, mgp_proc_cb cb, memgraph::utils::MemoryResource *memory, const ProcedureInfo &info = {})
-      : name(name, memory), cb(cb), args(memory), opt_args(memory), results(memory), info(info) {}
+  mgp_proc(const char *name, mgp_proc_cb cb, allocator_type alloc, const ProcedureInfo &info = {})
+      : name(name, alloc), cb(cb), args(alloc), opt_args(alloc), results(alloc), info(info) {}
 
   /// @throw std::bad_alloc
   /// @throw std::length_error
   mgp_proc(const char *name, mgp_proc_cb cb, mgp_proc_initializer initializer, mgp_proc_cleanup cleanup,
-           memgraph::utils::MemoryResource *memory, const ProcedureInfo &info = {})
-      : name(name, memory),
+           allocator_type alloc, const ProcedureInfo &info = {})
+      : name(name, alloc),
         cb(cb),
         initializer(initializer),
         cleanup(cleanup),
-        args(memory),
-        opt_args(memory),
-        results(memory),
+        args(alloc),
+        opt_args(alloc),
+        results(alloc),
         info(info) {}
 
   /// @throw std::bad_alloc
   /// @throw std::length_error
   mgp_proc(const char *name, std::function<void(mgp_list *, mgp_graph *, mgp_result *, mgp_memory *)> cb,
            std::function<void(mgp_list *, mgp_graph *, mgp_memory *)> initializer, std::function<void()> cleanup,
-           memgraph::utils::MemoryResource *memory, const ProcedureInfo &info = {})
-      : name(name, memory),
+           allocator_type alloc, const ProcedureInfo &info = {})
+      : name(name, alloc),
         cb(cb),
         initializer(initializer),
         cleanup(cleanup),
-        args(memory),
-        opt_args(memory),
-        results(memory),
+        args(alloc),
+        opt_args(alloc),
+        results(alloc),
         info(info) {}
 
   /// @throw std::bad_alloc
   /// @throw std::length_error
   mgp_proc(const char *name, std::function<void(mgp_list *, mgp_graph *, mgp_result *, mgp_memory *)> cb,
-           memgraph::utils::MemoryResource *memory, const ProcedureInfo &info = {})
-      : name(name, memory), cb(cb), args(memory), opt_args(memory), results(memory), info(info) {}
+           allocator_type alloc, const ProcedureInfo &info = {})
+      : name(name, alloc), cb(cb), args(alloc), opt_args(alloc), results(alloc), info(info) {}
 
   /// @throw std::bad_alloc
   /// @throw std::length_error
   mgp_proc(const std::string_view name, std::function<void(mgp_list *, mgp_graph *, mgp_result *, mgp_memory *)> cb,
-           memgraph::utils::MemoryResource *memory, const ProcedureInfo &info = {})
-      : name(name, memory), cb(cb), args(memory), opt_args(memory), results(memory), info(info) {}
+           allocator_type alloc, const ProcedureInfo &info = {})
+      : name(name, alloc), cb(cb), args(alloc), opt_args(alloc), results(alloc), info(info) {}
 
   /// @throw std::bad_alloc
   /// @throw std::length_error
-  mgp_proc(const mgp_proc &other, memgraph::utils::MemoryResource *memory)
-      : name(other.name, memory),
+  mgp_proc(const mgp_proc &other, allocator_type alloc)
+      : name(other.name, alloc),
         cb(other.cb),
         initializer(other.initializer),
         cleanup(other.cleanup),
-        args(other.args, memory),
-        opt_args(other.opt_args, memory),
-        results(other.results, memory),
+        args(other.args, alloc),
+        opt_args(other.opt_args, alloc),
+        results(other.results, alloc),
         info(other.info) {}
 
-  mgp_proc(mgp_proc &&other, memgraph::utils::MemoryResource *memory)
-      : name(std::move(other.name), memory),
+  mgp_proc(mgp_proc &&other, allocator_type alloc)
+      : name(std::move(other.name), alloc),
         cb(std::move(other.cb)),
         initializer(other.initializer),
         cleanup(other.cleanup),
-        args(std::move(other.args), memory),
-        opt_args(std::move(other.opt_args), memory),
-        results(std::move(other.results), memory),
+        args(std::move(other.args), alloc),
+        opt_args(std::move(other.opt_args), alloc),
+        results(std::move(other.results), alloc),
         info(other.info) {}
 
   mgp_proc(const mgp_proc &other) = default;
@@ -843,22 +820,21 @@ struct mgp_trans {
 
   /// @throw std::bad_alloc
   /// @throw std::length_error
-  mgp_trans(const char *name, mgp_trans_cb cb, memgraph::utils::MemoryResource *memory)
-      : name(name, memory), cb(cb), results(memory) {}
+  mgp_trans(const char *name, mgp_trans_cb cb, allocator_type alloc) : name(name, alloc), cb(cb), results(alloc) {}
 
   /// @throw std::bad_alloc
   /// @throw std::length_error
   mgp_trans(const char *name, std::function<void(mgp_messages *, mgp_graph *, mgp_result *, mgp_memory *)> cb,
-            memgraph::utils::MemoryResource *memory)
-      : name(name, memory), cb(cb), results(memory) {}
+            allocator_type alloc)
+      : name(name, alloc), cb(cb), results(alloc) {}
 
   /// @throw std::bad_alloc
   /// @throw std::length_error
-  mgp_trans(const mgp_trans &other, memgraph::utils::MemoryResource *memory)
-      : name(other.name, memory), cb(other.cb), results(other.results) {}
+  mgp_trans(const mgp_trans &other, allocator_type alloc)
+      : name(other.name, alloc), cb(other.cb), results(other.results) {}
 
-  mgp_trans(mgp_trans &&other, memgraph::utils::MemoryResource *memory)
-      : name(std::move(other.name), memory), cb(std::move(other.cb)), results(std::move(other.results)) {}
+  mgp_trans(mgp_trans &&other, allocator_type alloc)
+      : name(std::move(other.name), alloc), cb(std::move(other.cb)), results(std::move(other.results)) {}
 
   mgp_trans(const mgp_trans &other) = default;
   mgp_trans(mgp_trans &&other) = default;
@@ -881,25 +857,25 @@ struct mgp_func {
 
   /// @throw std::bad_alloc
   /// @throw std::length_error
-  mgp_func(const char *name, mgp_func_cb cb, memgraph::utils::MemoryResource *memory)
-      : name(name, memory), cb(cb), args(memory), opt_args(memory) {}
+  mgp_func(const char *name, mgp_func_cb cb, allocator_type alloc)
+      : name(name, alloc), cb(cb), args(alloc), opt_args(alloc) {}
 
   /// @throw std::bad_alloc
   /// @throw std::length_error
   mgp_func(const char *name, std::function<void(mgp_list *, mgp_func_context *, mgp_func_result *, mgp_memory *)> cb,
-           memgraph::utils::MemoryResource *memory)
-      : name(name, memory), cb(cb), args(memory), opt_args(memory) {}
+           allocator_type alloc)
+      : name(name, alloc), cb(cb), args(alloc), opt_args(alloc) {}
 
   /// @throw std::bad_alloc
   /// @throw std::length_error
-  mgp_func(const mgp_func &other, memgraph::utils::MemoryResource *memory)
-      : name(other.name, memory), cb(other.cb), args(other.args, memory), opt_args(other.opt_args, memory) {}
+  mgp_func(const mgp_func &other, allocator_type alloc)
+      : name(other.name, alloc), cb(other.cb), args(other.args, alloc), opt_args(other.opt_args, alloc) {}
 
-  mgp_func(mgp_func &&other, memgraph::utils::MemoryResource *memory)
-      : name(std::move(other.name), memory),
+  mgp_func(mgp_func &&other, allocator_type alloc)
+      : name(std::move(other.name), alloc),
         cb(std::move(other.cb)),
-        args(std::move(other.args), memory),
-        opt_args(std::move(other.opt_args), memory) {}
+        args(std::move(other.args), alloc),
+        opt_args(std::move(other.opt_args), alloc) {}
 
   mgp_func(const mgp_func &other) = default;
   mgp_func(mgp_func &&other) = default;
@@ -927,18 +903,17 @@ mgp_error MgpTransAddFixedResult(mgp_trans *trans) noexcept;
 struct mgp_module {
   using allocator_type = memgraph::utils::Allocator<mgp_module>;
 
-  explicit mgp_module(memgraph::utils::MemoryResource *memory)
-      : procedures(memory), transformations(memory), functions(memory) {}
+  explicit mgp_module(allocator_type alloc) : procedures(alloc), transformations(alloc), functions(alloc) {}
 
-  mgp_module(const mgp_module &other, memgraph::utils::MemoryResource *memory)
-      : procedures(other.procedures, memory),
-        transformations(other.transformations, memory),
-        functions(other.functions, memory) {}
+  mgp_module(const mgp_module &other, allocator_type alloc)
+      : procedures(other.procedures, alloc),
+        transformations(other.transformations, alloc),
+        functions(other.functions, alloc) {}
 
-  mgp_module(mgp_module &&other, memgraph::utils::MemoryResource *memory)
-      : procedures(std::move(other.procedures), memory),
-        transformations(std::move(other.transformations), memory),
-        functions(std::move(other.functions), memory) {}
+  mgp_module(mgp_module &&other, allocator_type alloc)
+      : procedures(std::move(other.procedures), alloc),
+        transformations(std::move(other.transformations), alloc),
+        functions(std::move(other.functions), alloc) {}
 
   mgp_module(const mgp_module &) = default;
   mgp_module(mgp_module &&) = default;
@@ -996,7 +971,7 @@ struct mgp_messages {
 
 bool ContainsDeleted(const mgp_value *val);
 
-memgraph::query::TypedValue ToTypedValue(const mgp_value &val, memgraph::utils::MemoryResource *memory);
+memgraph::query::TypedValue ToTypedValue(const mgp_value &val, memgraph::utils::Allocator<mgp_value> alloc);
 
 struct mgp_execution_headers {
   using allocator_type = memgraph::utils::Allocator<mgp_execution_headers>;
@@ -1017,12 +992,13 @@ struct mgp_execution_rows {
 };
 
 struct mgp_execution_result {
-  explicit mgp_execution_result(mgp_graph *graph, memgraph::utils::MemoryResource *memory);
+  using allocator_type = memgraph::utils::Allocator<mgp_execution_result>;
+  explicit mgp_execution_result(mgp_graph *graph, allocator_type alloc);
   ~mgp_execution_result();
 
-  memgraph::utils::MemoryResource *GetMemoryResource() const noexcept { return memory; }
+  memgraph::utils::MemoryResource *GetMemoryResource() const noexcept { return alloc.resource(); }
 
   struct pImplMgpExecutionResult;
   std::unique_ptr<pImplMgpExecutionResult> pImpl;
-  memgraph::utils::MemoryResource *memory;
+  allocator_type alloc;
 };

--- a/src/query/procedure/py_module.cpp
+++ b/src/query/procedure/py_module.cpp
@@ -507,7 +507,7 @@ PyObject *PyCallableAddOptArg(TCall *self, PyObject *args) {
   PyObject *py_value = nullptr;
   if (!PyArg_ParseTuple(args, "sO!O", &name, &PyCypherTypeType, &py_type, &py_value)) return nullptr;
   auto *type = py_type->type;
-  mgp_memory memory{self->callable->opt_args.get_allocator().GetMemoryResource()};
+  mgp_memory memory{self->callable->opt_args.get_allocator().resource()};
   mgp_value *value = PyObjectToMgpValueWithPythonExceptions(py_value, &memory);
   if (value == nullptr) {
     return nullptr;
@@ -1300,7 +1300,7 @@ PyObject *PyQueryModuleAddProcedure(PyQueryModule *self, PyObject *cb, bool is_w
     PyErr_SetString(PyExc_ValueError, "Procedure name is not a valid identifier");
     return nullptr;
   }
-  auto *memory = self->module->procedures.get_allocator().GetMemoryResource();
+  auto *memory = self->module->procedures.get_allocator().resource();
   mgp_proc proc(name,
                 [py_cb](mgp_list *args, mgp_graph *graph, mgp_result *result, mgp_memory *memory) {
                   CallPythonProcedure(py_cb, args, graph, result, memory, false);
@@ -1341,7 +1341,7 @@ PyObject *PyQueryModuleAddBatchProcedure(PyQueryModule *self, PyObject *args, bo
     PyErr_SetString(PyExc_ValueError, "Procedure name is not a valid identifier");
     return nullptr;
   }
-  auto *memory = self->module->procedures.get_allocator().GetMemoryResource();
+  auto *memory = self->module->procedures.get_allocator().resource();
   mgp_proc proc(
       name,
       [py_cb](mgp_list *args, mgp_graph *graph, mgp_result *result, mgp_memory *memory) {
@@ -1394,7 +1394,7 @@ PyObject *PyQueryModuleAddTransformation(PyQueryModule *self, PyObject *cb) {
     PyErr_SetString(PyExc_ValueError, "Transformation name is not a valid identifier");
     return nullptr;
   }
-  auto *memory = self->module->transformations.get_allocator().GetMemoryResource();
+  auto *memory = self->module->transformations.get_allocator().resource();
   mgp_trans trans(
       name,
       [py_cb](mgp_messages *msgs, mgp_graph *graph, mgp_result *result, mgp_memory *memory) {
@@ -1423,7 +1423,7 @@ PyObject *PyQueryModuleAddFunction(PyQueryModule *self, PyObject *cb) {
     PyErr_SetString(PyExc_ValueError, "Function name is not a valid identifier");
     return nullptr;
   }
-  auto *memory = self->module->functions.get_allocator().GetMemoryResource();
+  auto *memory = self->module->functions.get_allocator().resource();
   mgp_func func(
       name,
       [py_cb](mgp_list *args, mgp_func_context *func_ctx, mgp_func_result *result, mgp_memory *memory) {

--- a/src/query/typed_value.cpp
+++ b/src/query/typed_value.cpp
@@ -30,29 +30,29 @@
 
 namespace memgraph::query {
 
-TypedValue::TypedValue(TMap &&other) : TypedValue(std::move(other), other.get_allocator().GetMemoryResource()) {}
+TypedValue::TypedValue(TMap &&other) : TypedValue(std::move(other), other.get_allocator()) {}
 
-TypedValue::TypedValue(std::map<std::string, TypedValue> &&other, utils::MemoryResource *memory)
-    : memory_(memory), type_(Type::Map) {
-  std::construct_at(&map_v, memory_);
-  for (auto &kv : other) map_v.emplace(TString(kv.first, memory_), std::move(kv.second));
+TypedValue::TypedValue(std::map<std::string, TypedValue> &&other, allocator_type alloc)
+    : alloc_{alloc}, type_(Type::Map) {
+  std::construct_at(&map_v, alloc_);
+  for (auto &kv : other) map_v.emplace(TString(kv.first, alloc_), std::move(kv.second));
 }
 
-TypedValue::TypedValue(TMap &&other, utils::MemoryResource *memory) : memory_(memory), type_(Type::Map) {
-  std::construct_at(&map_v, std::move(other), memory_);
+TypedValue::TypedValue(TMap &&other, allocator_type alloc) : alloc_{alloc}, type_(Type::Map) {
+  std::construct_at(&map_v, std::move(other), alloc_);
 }
 
-TypedValue::TypedValue(Path &&path) : TypedValue(std::move(path), path.GetMemoryResource()) {}
+TypedValue::TypedValue(Path &&path) : TypedValue(std::move(path), path.get_allocator()) {}
 
-TypedValue::TypedValue(Path &&path, utils::MemoryResource *memory) : memory_(memory), type_(Type::Path) {
-  auto *path_ptr = utils::Allocator<Path>(memory_).new_object<Path>(std::move(path));
+TypedValue::TypedValue(Path &&path, allocator_type alloc) : alloc_{alloc}, type_(Type::Path) {
+  auto *path_ptr = utils::Allocator<Path>(alloc_).new_object<Path>(std::move(path));
   std::construct_at(&path_v, path_ptr);
 }
 
-TypedValue::TypedValue(Graph &&graph) : TypedValue(std::move(graph), graph.GetMemoryResource()) {}
+TypedValue::TypedValue(Graph &&graph) : TypedValue(std::move(graph), graph.get_allocator()) {}
 
-TypedValue::TypedValue(Graph &&graph, utils::MemoryResource *memory) : memory_(memory), type_(Type::Graph) {
-  auto *graph_ptr = utils::Allocator<Graph>(memory_).new_object<Graph>(std::move(graph));
+TypedValue::TypedValue(Graph &&graph, allocator_type alloc) : alloc_{alloc}, type_(Type::Graph) {
+  auto *graph_ptr = utils::Allocator<Graph>(alloc_).new_object<Graph>(std::move(graph));
   std::construct_at(&graph_v, graph_ptr);
 }
 
@@ -60,7 +60,7 @@ TypedValue::TypedValue(const storage::PropertyValue &value)
     // TODO: MemoryResource in storage::PropertyValue
     : TypedValue(value, utils::NewDeleteResource()) {}
 
-TypedValue::TypedValue(const storage::PropertyValue &value, utils::MemoryResource *memory) : memory_(memory) {
+TypedValue::TypedValue(const storage::PropertyValue &value, allocator_type alloc) : alloc_{alloc} {
   switch (value.type()) {
     case storage::PropertyValue::Type::Null:
       type_ = Type::Null;
@@ -79,12 +79,12 @@ TypedValue::TypedValue(const storage::PropertyValue &value, utils::MemoryResourc
       return;
     case storage::PropertyValue::Type::String:
       type_ = Type::String;
-      new (&string_v) TString(value.ValueString(), memory_);
+      new (&string_v) TString(value.ValueString(), alloc_);
       return;
     case storage::PropertyValue::Type::List: {
       type_ = Type::List;
       const auto &vec = value.ValueList();
-      new (&list_v) TVector(memory_);
+      new (&list_v) TVector(alloc_);
       list_v.reserve(vec.size());
       for (const auto &v : vec) list_v.emplace_back(v);
       return;
@@ -92,8 +92,8 @@ TypedValue::TypedValue(const storage::PropertyValue &value, utils::MemoryResourc
     case storage::PropertyValue::Type::Map: {
       type_ = Type::Map;
       const auto &map = value.ValueMap();
-      std::construct_at(&map_v, memory_);
-      for (const auto &kv : map) map_v.emplace(TString(kv.first, memory_), kv.second);
+      std::construct_at(&map_v, alloc_);
+      for (const auto &kv : map) map_v.emplace(TString(kv.first, alloc_), kv.second);
       return;
     }
     case storage::PropertyValue::Type::TemporalData: {
@@ -156,7 +156,7 @@ TypedValue::TypedValue(storage::PropertyValue &&other) /* noexcept */
     // TODO: MemoryResource in storage::PropertyValue, so this can be noexcept
     : TypedValue(std::move(other), utils::NewDeleteResource()) {}
 
-TypedValue::TypedValue(storage::PropertyValue &&other, utils::MemoryResource *memory) : memory_(memory) {
+TypedValue::TypedValue(storage::PropertyValue &&other, allocator_type alloc) : alloc_{alloc} {
   switch (other.type()) {
     case storage::PropertyValue::Type::Null:
       type_ = Type::Null;
@@ -175,19 +175,19 @@ TypedValue::TypedValue(storage::PropertyValue &&other, utils::MemoryResource *me
       break;
     case storage::PropertyValue::Type::String:
       type_ = Type::String;
-      new (&string_v) TString(other.ValueString(), memory_);
+      new (&string_v) TString(other.ValueString(), alloc_);
       break;
     case storage::PropertyValue::Type::List: {
       type_ = Type::List;
       auto &vec = other.ValueList();
-      new (&list_v) TVector(std::make_move_iterator(vec.begin()), std::make_move_iterator(vec.end()), memory_);
+      new (&list_v) TVector(std::make_move_iterator(vec.begin()), std::make_move_iterator(vec.end()), alloc_);
       break;
     }
     case storage::PropertyValue::Type::Map: {
       type_ = Type::Map;
       auto &map = other.ValueMap();
-      std::construct_at(&map_v, memory_);
-      for (auto &kv : map) map_v.emplace(TString(kv.first, memory_), std::move(kv.second));
+      std::construct_at(&map_v, alloc_);
+      for (auto &kv : map) map_v.emplace(TString(kv.first, alloc_), std::move(kv.second));
       break;
     }
     case storage::PropertyValue::Type::TemporalData: {
@@ -247,12 +247,7 @@ TypedValue::TypedValue(storage::PropertyValue &&other, utils::MemoryResource *me
   other = storage::PropertyValue();
 }
 
-TypedValue::TypedValue(const TypedValue &other)
-    : TypedValue(other, std::allocator_traits<utils::Allocator<TypedValue>>::select_on_container_copy_construction(
-                            other.memory_)
-                            .GetMemoryResource()) {}
-
-TypedValue::TypedValue(const TypedValue &other, utils::MemoryResource *memory) : memory_(memory), type_(other.type_) {
+TypedValue::TypedValue(const TypedValue &other, allocator_type alloc) : alloc_{alloc}, type_(other.type_) {
   switch (other.type_) {
     case TypedValue::Type::Null:
       return;
@@ -266,13 +261,13 @@ TypedValue::TypedValue(const TypedValue &other, utils::MemoryResource *memory) :
       this->double_v = other.double_v;
       return;
     case TypedValue::Type::String:
-      new (&string_v) TString(other.string_v, memory_);
+      new (&string_v) TString(other.string_v, alloc_);
       return;
     case Type::List:
-      new (&list_v) TVector(other.list_v, memory_);
+      new (&list_v) TVector(other.list_v, alloc_);
       return;
     case Type::Map: {
-      std::construct_at(&map_v, other.map_v, memory_);
+      std::construct_at(&map_v, other.map_v, alloc_);
       return;
     }
     case Type::Vertex:
@@ -282,7 +277,7 @@ TypedValue::TypedValue(const TypedValue &other, utils::MemoryResource *memory) :
       new (&edge_v) EdgeAccessor(other.edge_v);
       return;
     case Type::Path: {
-      auto *path_ptr = utils::Allocator<Path>(memory_).new_object<Path>(*other.path_v);
+      auto *path_ptr = utils::Allocator<Path>(alloc_).new_object<Path>(*other.path_v);
       std::construct_at(&path_v, path_ptr);
       return;
     }
@@ -314,16 +309,16 @@ TypedValue::TypedValue(const TypedValue &other, utils::MemoryResource *memory) :
       new (&function_v) std::function<void(TypedValue *)>(other.function_v);
       return;
     case Type::Graph:
-      auto *graph_ptr = utils::Allocator<Graph>(memory_).new_object<Graph>(*other.graph_v);
+      auto *graph_ptr = utils::Allocator<Graph>(alloc_).new_object<Graph>(*other.graph_v);
       new (&graph_v) std::unique_ptr<Graph>(graph_ptr);
       return;
   }
   LOG_FATAL("Unsupported TypedValue::Type");
 }
 
-TypedValue::TypedValue(TypedValue &&other) noexcept : TypedValue(std::move(other), other.memory_) {}
+TypedValue::TypedValue(TypedValue &&other) noexcept : TypedValue(std::move(other), other.alloc_) {}
 
-TypedValue::TypedValue(TypedValue &&other, utils::MemoryResource *memory) : memory_(memory), type_(other.type_) {
+TypedValue::TypedValue(TypedValue &&other, allocator_type alloc) : alloc_{alloc}, type_(other.type_) {
   switch (other.type_) {
     case TypedValue::Type::Null:
       break;
@@ -337,13 +332,13 @@ TypedValue::TypedValue(TypedValue &&other, utils::MemoryResource *memory) : memo
       std::construct_at(&double_v, other.double_v);
       break;
     case TypedValue::Type::String:
-      std::construct_at(&string_v, std::move(other.string_v), memory_);
+      std::construct_at(&string_v, std::move(other.string_v), alloc_);
       break;
     case Type::List:
-      std::construct_at(&list_v, std::move(other.list_v), memory_);
+      std::construct_at(&list_v, std::move(other.list_v), alloc_);
       break;
     case Type::Map: {
-      std::construct_at(&map_v, std::move(other.map_v), memory_);
+      std::construct_at(&map_v, std::move(other.map_v), alloc_);
       break;
     }
     case Type::Vertex:
@@ -353,10 +348,10 @@ TypedValue::TypedValue(TypedValue &&other, utils::MemoryResource *memory) : memo
       std::construct_at(&edge_v, other.edge_v);
       break;
     case Type::Path: {
-      if (other.GetMemoryResource() == memory_) {
+      if (other.alloc_ == alloc_) {
         std::construct_at(&path_v, std::move(other.path_v));
       } else {
-        auto *path_ptr = utils::Allocator<Path>(memory_).new_object<Path>(std::move(*other.path_v));
+        auto *path_ptr = utils::Allocator<Path>(alloc_).new_object<Path>(std::move(*other.path_v));
         std::construct_at(&path_v, path_ptr);
       }
       break;
@@ -389,10 +384,10 @@ TypedValue::TypedValue(TypedValue &&other, utils::MemoryResource *memory) : memo
       std::construct_at(&function_v, std::move(other.function_v));
       break;
     case Type::Graph:
-      if (other.GetMemoryResource() == memory_) {
+      if (other.alloc_ == alloc_) {
         std::construct_at(&graph_v, std::move(other.graph_v));
       } else {
-        auto *graph_ptr = utils::Allocator<Graph>(memory_).new_object<Graph>(std::move(*other.graph_v));
+        auto *graph_ptr = utils::Allocator<Graph>(alloc_).new_object<Graph>(std::move(*other.graph_v));
         std::construct_at(&graph_v, graph_ptr);
       }
   }
@@ -614,7 +609,7 @@ std::ostream &operator<<(std::ostream &os, const TypedValue::Type &type) {
     if (this->type_ == TypedValue::Type::typed_value_type) {                     \
       this->member = other;                                                      \
     } else {                                                                     \
-      *this = TypedValue(other, memory_);                                        \
+      *this = TypedValue(other, alloc_);                                         \
     }                                                                            \
                                                                                  \
     return *this;                                                                \
@@ -633,7 +628,7 @@ TypedValue &TypedValue::operator=(const std::vector<TypedValue> &other) {
     list_v.reserve(other.size());
     list_v.assign(other.begin(), other.end());
   } else {
-    *this = TypedValue(other, memory_);
+    *this = TypedValue(other, alloc_);
   }
   return *this;
 }
@@ -643,9 +638,9 @@ DEFINE_TYPED_VALUE_COPY_ASSIGNMENT(const TypedValue::TMap &, Map, map_v)
 TypedValue &TypedValue::operator=(const std::map<std::string, TypedValue> &other) {
   if (type_ == Type::Map) {
     map_v.clear();
-    for (const auto &kv : other) map_v.emplace(TString(kv.first, memory_), kv.second);
+    for (const auto &kv : other) map_v.emplace(TString(kv.first, alloc_), kv.second);
   } else {
-    *this = TypedValue(other, memory_);
+    *this = TypedValue(other, alloc_);
   }
   return *this;
 }
@@ -663,12 +658,12 @@ TypedValue &TypedValue::operator=(const Path &other) {
   if (type_ == Type::Path) {
     auto path = path_v.release();
     if (path) {
-      utils::Allocator<Path>(memory_).delete_object(path);
+      utils::Allocator<Path>(alloc_).delete_object(path);
     }
-    auto *path_ptr = utils::Allocator<Path>(memory_).new_object<Path>(other);
+    auto *path_ptr = utils::Allocator<Path>(alloc_).new_object<Path>(other);
     path_v = std::unique_ptr<Path>(path_ptr);
   } else {
-    *this = TypedValue(other, memory_);
+    *this = TypedValue(other, alloc_);
   }
   return *this;
 }
@@ -680,7 +675,7 @@ TypedValue &TypedValue::operator=(const Path &other) {
     if (this->type_ == TypedValue::Type::typed_value_type) {                     \
       this->member = std::move(other);                                           \
     } else {                                                                     \
-      *this = TypedValue(std::move(other), memory_);                             \
+      *this = TypedValue(std::move(other), alloc_);                              \
     }                                                                            \
     return *this;                                                                \
   }
@@ -693,7 +688,7 @@ TypedValue &TypedValue::operator=(std::vector<TypedValue> &&other) {
     list_v.reserve(other.size());
     list_v.assign(std::make_move_iterator(other.begin()), std::make_move_iterator(other.end()));
   } else {
-    *this = TypedValue(std::move(other), memory_);
+    *this = TypedValue(std::move(other), alloc_);
   }
   return *this;
 }
@@ -703,9 +698,9 @@ DEFINE_TYPED_VALUE_MOVE_ASSIGNMENT(TMap, Map, map_v)
 TypedValue &TypedValue::operator=(std::map<std::string, TypedValue> &&other) {
   if (type_ == Type::Map) {
     map_v.clear();
-    for (auto &kv : other) map_v.emplace(TString(kv.first, memory_), std::move(kv.second));
+    for (auto &kv : other) map_v.emplace(TString(kv.first, alloc_), std::move(kv.second));
   } else {
-    *this = TypedValue(std::move(other), memory_);
+    *this = TypedValue(std::move(other), alloc_);
   }
   return *this;
 }
@@ -714,11 +709,11 @@ TypedValue &TypedValue::operator=(Path &&other) {
   if (type_ == Type::Path) {
     auto path = path_v.release();
     if (path) {
-      utils::Allocator<Path>(memory_).delete_object(path);
+      utils::Allocator<Path>(alloc_).delete_object(path);
     }
     path_v = std::make_unique<Path>(std::move(other));
   } else {
-    *this = TypedValue(std::move(other), memory_);
+    *this = TypedValue(std::move(other), alloc_);
   }
   return *this;
 }
@@ -726,10 +721,9 @@ TypedValue &TypedValue::operator=(Path &&other) {
 #undef DEFINE_TYPED_VALUE_MOVE_ASSIGNMENT
 
 TypedValue &TypedValue::operator=(const TypedValue &other) {
-  static_assert(!std::allocator_traits<utils::Allocator<TypedValue>>::propagate_on_container_copy_assignment::value,
-                "Allocator propagation not implemented");
+  static_assert(!alloc_trait::propagate_on_container_copy_assignment::value, "Allocator propagation not implemented");
   if (this != &other) {
-    if (type_ == other.type_ && memory_ == other.memory_) {
+    if (type_ == other.type_ && alloc_ == other.alloc_) {
       // same type, copy assign value
       switch (type_) {
         case Type::Null:
@@ -762,10 +756,10 @@ TypedValue &TypedValue::operator=(const TypedValue &other) {
         case Type::Path: {
           auto *path = path_v.release();
           if (path) {
-            utils::Allocator<Path>(memory_).delete_object(path);
+            utils::Allocator<Path>(alloc_).delete_object(path);
           }
           if (other.path_v) {
-            auto *path_ptr = utils::Allocator<Path>(memory_).new_object<Path>(*other.path_v);
+            auto *path_ptr = utils::Allocator<Path>(alloc_).new_object<Path>(*other.path_v);
             path_v = std::unique_ptr<Path>(path_ptr);
           }
           break;
@@ -788,10 +782,10 @@ TypedValue &TypedValue::operator=(const TypedValue &other) {
         case Type::Graph: {
           auto *graph = graph_v.release();
           if (graph) {
-            utils::Allocator<Graph>(memory_).delete_object(graph);
+            utils::Allocator<Graph>(alloc_).delete_object(graph);
           }
           if (other.graph_v) {
-            auto *graph_ptr = utils::Allocator<Graph>(memory_).new_object<Graph>(*other.graph_v);
+            auto *graph_ptr = utils::Allocator<Graph>(alloc_).new_object<Graph>(*other.graph_v);
             graph_v = std::unique_ptr<Graph>(graph_ptr);
           }
           break;
@@ -812,10 +806,11 @@ TypedValue &TypedValue::operator=(const TypedValue &other) {
       return *this;
     }
     // destroy + construct
-    auto *orig_mem = memory_;
-    std::destroy_at(this);
+    auto alloc = alloc_;
+    alloc_trait::destroy(alloc, this);
+    alloc_trait::construct(alloc, std::launder(this), other);
     // NOLINTNEXTLINE(cppcoreguidelines-c-copy-assignment-signature,misc-unconventional-assign-operator)
-    return *std::construct_at(std::launder(this), other, orig_mem);
+    return *std::launder(this);
   }
   return *this;
 }
@@ -824,7 +819,7 @@ TypedValue &TypedValue::operator=(TypedValue &&other) noexcept(false) {
   static_assert(!std::allocator_traits<utils::Allocator<TypedValue>>::propagate_on_container_move_assignment::value,
                 "Allocator propagation not implemented");
   if (this != &other) {
-    if (type_ == other.type_ && memory_ == other.memory_) {
+    if (type_ == other.type_ && alloc_ == other.alloc_) {
       // same type, move assign value
       switch (type_) {
         case Type::Null:
@@ -857,7 +852,7 @@ TypedValue &TypedValue::operator=(TypedValue &&other) noexcept(false) {
         case Type::Path: {
           auto *path = path_v.release();
           if (path) {
-            utils::Allocator<Path>(memory_).delete_object(path);
+            utils::Allocator<Path>(alloc_).delete_object(path);
           }
           path_v = std::move(other.path_v);
           break;
@@ -880,7 +875,7 @@ TypedValue &TypedValue::operator=(TypedValue &&other) noexcept(false) {
         case Type::Graph: {
           auto *graph = graph_v.release();
           if (graph) {
-            utils::Allocator<Graph>(memory_).delete_object(graph);
+            utils::Allocator<Graph>(alloc_).delete_object(graph);
           }
           graph_v = std::move(other.graph_v);
           break;
@@ -902,7 +897,7 @@ TypedValue &TypedValue::operator=(TypedValue &&other) noexcept(false) {
       return *this;
     }
     // destroy + construct
-    auto *orig_mem = memory_;
+    auto orig_mem = alloc_;
     std::destroy_at(this);
     // NOLINTNEXTLINE(cppcoreguidelines-c-copy-assignment-signature,misc-unconventional-assign-operator)
     return *std::construct_at(std::launder(this), std::move(other), orig_mem);
@@ -941,7 +936,7 @@ TypedValue::~TypedValue() {
       auto *path = path_v.release();
       std::destroy_at(&path_v);
       if (path) {
-        utils::Allocator<Path>(memory_).delete_object(path);
+        utils::Allocator<Path>(alloc_).delete_object(path);
       }
       break;
     }
@@ -962,7 +957,7 @@ TypedValue::~TypedValue() {
       auto *graph = graph_v.release();
       std::destroy_at(&graph_v);
       if (graph) {
-        utils::Allocator<Graph>(memory_).delete_object(graph);
+        utils::Allocator<Graph>(alloc_).delete_object(graph);
       }
       break;
     }
@@ -1030,14 +1025,14 @@ TypedValue operator<(const TypedValue &a, const TypedValue &b) {
   }
 
   if (a.IsNull() || b.IsNull()) {
-    return TypedValue(a.GetMemoryResource());
+    return TypedValue(a.alloc_);
   }
 
   if (a.IsString() || b.IsString()) {
     if (a.type() != b.type()) {
       throw TypedValueException("Invalid 'less' operand types({} + {})", a.type(), b.type());
     } else {
-      return TypedValue(a.ValueString() < b.ValueString(), a.GetMemoryResource());
+      return TypedValue(a.ValueString() < b.ValueString(), a.alloc_);
     }
   }
 
@@ -1049,19 +1044,19 @@ TypedValue operator<(const TypedValue &a, const TypedValue &b) {
     switch (a.type()) {
       case TypedValue::Type::Date:
         // NOLINTNEXTLINE(modernize-use-nullptr)
-        return TypedValue(a.ValueDate() < b.ValueDate(), a.GetMemoryResource());
+        return TypedValue(a.ValueDate() < b.ValueDate(), a.alloc_);
       case TypedValue::Type::LocalTime:
         // NOLINTNEXTLINE(modernize-use-nullptr)
-        return TypedValue(a.ValueLocalTime() < b.ValueLocalTime(), a.GetMemoryResource());
+        return TypedValue(a.ValueLocalTime() < b.ValueLocalTime(), a.alloc_);
       case TypedValue::Type::LocalDateTime:
         // NOLINTNEXTLINE(modernize-use-nullptr)
-        return TypedValue(a.ValueLocalDateTime() < b.ValueLocalDateTime(), a.GetMemoryResource());
+        return TypedValue(a.ValueLocalDateTime() < b.ValueLocalDateTime(), a.alloc_);
       case TypedValue::Type::ZonedDateTime:
         // NOLINTNEXTLINE(modernize-use-nullptr)
-        return TypedValue(a.ValueZonedDateTime() < b.ValueZonedDateTime(), a.GetMemoryResource());
+        return TypedValue(a.ValueZonedDateTime() < b.ValueZonedDateTime(), a.alloc_);
       case TypedValue::Type::Duration:
         // NOLINTNEXTLINE(modernize-use-nullptr)
-        return TypedValue(a.ValueDuration() < b.ValueDuration(), a.GetMemoryResource());
+        return TypedValue(a.ValueDuration() < b.ValueDuration(), a.alloc_);
       default:
         LOG_FATAL("Invalid temporal type");
     }
@@ -1069,35 +1064,35 @@ TypedValue operator<(const TypedValue &a, const TypedValue &b) {
 
   // at this point we only have int and double
   if (a.IsDouble() || b.IsDouble()) {
-    return TypedValue(ToDouble(a) < ToDouble(b), a.GetMemoryResource());
+    return TypedValue(ToDouble(a) < ToDouble(b), a.alloc_);
   } else {
-    return TypedValue(a.ValueInt() < b.ValueInt(), a.GetMemoryResource());
+    return TypedValue(a.ValueInt() < b.ValueInt(), a.alloc_);
   }
 }
 
 TypedValue operator==(const TypedValue &a, const TypedValue &b) {
-  if (a.IsNull() || b.IsNull()) return TypedValue(a.GetMemoryResource());
+  if (a.IsNull() || b.IsNull()) return TypedValue(a.alloc_);
 
   // check we have values that can be compared
   // this means that either they're the same type, or (int, double) combo
-  if ((a.type() != b.type() && !(a.IsNumeric() && b.IsNumeric()))) return TypedValue(false, a.GetMemoryResource());
+  if ((a.type() != b.type() && !(a.IsNumeric() && b.IsNumeric()))) return TypedValue(false, a.alloc_);
 
   switch (a.type()) {
     case TypedValue::Type::Bool:
-      return TypedValue(a.ValueBool() == b.ValueBool(), a.GetMemoryResource());
+      return TypedValue(a.ValueBool() == b.ValueBool(), a.alloc_);
     case TypedValue::Type::Int:
       if (b.IsDouble())
-        return TypedValue(ToDouble(a) == ToDouble(b), a.GetMemoryResource());
+        return TypedValue(ToDouble(a) == ToDouble(b), a.alloc_);
       else
-        return TypedValue(a.ValueInt() == b.ValueInt(), a.GetMemoryResource());
+        return TypedValue(a.ValueInt() == b.ValueInt(), a.alloc_);
     case TypedValue::Type::Double:
-      return TypedValue(ToDouble(a) == ToDouble(b), a.GetMemoryResource());
+      return TypedValue(ToDouble(a) == ToDouble(b), a.alloc_);
     case TypedValue::Type::String:
-      return TypedValue(a.ValueString() == b.ValueString(), a.GetMemoryResource());
+      return TypedValue(a.ValueString() == b.ValueString(), a.alloc_);
     case TypedValue::Type::Vertex:
-      return TypedValue(a.ValueVertex() == b.ValueVertex(), a.GetMemoryResource());
+      return TypedValue(a.ValueVertex() == b.ValueVertex(), a.alloc_);
     case TypedValue::Type::Edge:
-      return TypedValue(a.ValueEdge() == b.ValueEdge(), a.GetMemoryResource());
+      return TypedValue(a.ValueEdge() == b.ValueEdge(), a.alloc_);
     case TypedValue::Type::List: {
       // We are not compatible with neo4j at this point. In neo4j 2 = [2]
       // compares
@@ -1109,45 +1104,44 @@ TypedValue operator==(const TypedValue &a, const TypedValue &b) {
       // 2 = [2] compares to false.
       const auto &list_a = a.ValueList();
       const auto &list_b = b.ValueList();
-      if (list_a.size() != list_b.size()) return TypedValue(false, a.GetMemoryResource());
+      if (list_a.size() != list_b.size()) return TypedValue(false, a.alloc_);
       // two arrays are considered equal (by neo) if all their
       // elements are bool-equal. this means that:
       //    [1] == [null] -> false
       //    [null] == [null] -> true
       // in that sense array-comparison never results in Null
-      return TypedValue(std::equal(list_a.begin(), list_a.end(), list_b.begin(), TypedValue::BoolEqual{}),
-                        a.GetMemoryResource());
+      return TypedValue(std::equal(list_a.begin(), list_a.end(), list_b.begin(), TypedValue::BoolEqual{}), a.alloc_);
     }
     case TypedValue::Type::Map: {
       const auto &map_a = a.ValueMap();
       const auto &map_b = b.ValueMap();
-      if (map_a.size() != map_b.size()) return TypedValue(false, a.GetMemoryResource());
+      if (map_a.size() != map_b.size()) return TypedValue(false, a.alloc_);
       for (const auto &kv_a : map_a) {
         auto found_b_it = map_b.find(kv_a.first);
-        if (found_b_it == map_b.end()) return TypedValue(false, a.GetMemoryResource());
+        if (found_b_it == map_b.end()) return TypedValue(false, a.alloc_);
         TypedValue comparison = kv_a.second == found_b_it->second;
-        if (comparison.IsNull() || !comparison.ValueBool()) return TypedValue(false, a.GetMemoryResource());
+        if (comparison.IsNull() || !comparison.ValueBool()) return TypedValue(false, a.alloc_);
       }
-      return TypedValue(true, a.GetMemoryResource());
+      return TypedValue(true, a.alloc_);
     }
     case TypedValue::Type::Path:
-      return TypedValue(a.ValuePath() == b.ValuePath(), a.GetMemoryResource());
+      return TypedValue(a.ValuePath() == b.ValuePath(), a.alloc_);
     case TypedValue::Type::Date:
-      return TypedValue(a.ValueDate() == b.ValueDate(), a.GetMemoryResource());
+      return TypedValue(a.ValueDate() == b.ValueDate(), a.alloc_);
     case TypedValue::Type::LocalTime:
-      return TypedValue(a.ValueLocalTime() == b.ValueLocalTime(), a.GetMemoryResource());
+      return TypedValue(a.ValueLocalTime() == b.ValueLocalTime(), a.alloc_);
     case TypedValue::Type::LocalDateTime:
-      return TypedValue(a.ValueLocalDateTime() == b.ValueLocalDateTime(), a.GetMemoryResource());
+      return TypedValue(a.ValueLocalDateTime() == b.ValueLocalDateTime(), a.alloc_);
     case TypedValue::Type::ZonedDateTime:
-      return TypedValue(a.ValueZonedDateTime() == b.ValueZonedDateTime(), a.GetMemoryResource());
+      return TypedValue(a.ValueZonedDateTime() == b.ValueZonedDateTime(), a.alloc_);
     case TypedValue::Type::Duration:
-      return TypedValue(a.ValueDuration() == b.ValueDuration(), a.GetMemoryResource());
+      return TypedValue(a.ValueDuration() == b.ValueDuration(), a.alloc_);
     case TypedValue::Type::Enum:
-      return TypedValue(a.ValueEnum() == b.ValueEnum(), a.GetMemoryResource());
+      return TypedValue(a.ValueEnum() == b.ValueEnum(), a.alloc_);
     case TypedValue::Type::Point2d:
-      return TypedValue(a.ValuePoint2d() == b.ValuePoint2d(), a.GetMemoryResource());
+      return TypedValue(a.ValuePoint2d() == b.ValuePoint2d(), a.alloc_);
     case TypedValue::Type::Point3d:
-      return TypedValue(a.ValuePoint3d() == b.ValuePoint3d(), a.GetMemoryResource());
+      return TypedValue(a.ValuePoint3d() == b.ValuePoint3d(), a.alloc_);
     case TypedValue::Type::Graph:
       throw TypedValueException("Unsupported comparison operator");
     case TypedValue::Type::Function:
@@ -1157,8 +1151,8 @@ TypedValue operator==(const TypedValue &a, const TypedValue &b) {
 }
 
 TypedValue operator!(const TypedValue &a) {
-  if (a.IsNull()) return TypedValue(a.GetMemoryResource());
-  if (a.IsBool()) return TypedValue(!a.ValueBool(), a.GetMemoryResource());
+  if (a.IsNull()) return TypedValue(a.alloc_);
+  if (a.IsBool()) return TypedValue(!a.ValueBool(), a.alloc_);
   throw TypedValueException("Invalid logical not operand type (!{})", a.type());
 }
 
@@ -1169,7 +1163,7 @@ TypedValue operator!(const TypedValue &a) {
  * @return A string.
  */
 std::string ValueToString(const TypedValue &value) {
-  // TODO: Should this allocate a string through value.GetMemoryResource()?
+  // TODO: Should this allocate a string through value.alloc_?
   if (value.IsString()) return std::string(value.ValueString());
   if (value.IsInt()) return std::to_string(value.ValueInt());
   if (value.IsDouble()) return fmt::format("{}", value.ValueDouble());
@@ -1178,17 +1172,17 @@ std::string ValueToString(const TypedValue &value) {
 }
 
 TypedValue operator-(const TypedValue &a) {
-  if (a.IsNull()) return TypedValue(a.GetMemoryResource());
-  if (a.IsInt()) return TypedValue(-a.ValueInt(), a.GetMemoryResource());
-  if (a.IsDouble()) return TypedValue(-a.ValueDouble(), a.GetMemoryResource());
-  if (a.IsDuration()) return TypedValue(-a.ValueDuration(), a.GetMemoryResource());
+  if (a.IsNull()) return TypedValue(a.alloc_);
+  if (a.IsInt()) return TypedValue(-a.ValueInt(), a.alloc_);
+  if (a.IsDouble()) return TypedValue(-a.ValueDouble(), a.alloc_);
+  if (a.IsDuration()) return TypedValue(-a.ValueDuration(), a.alloc_);
   throw TypedValueException("Invalid unary minus operand type (-{})", a.type());
 }
 
 TypedValue operator+(const TypedValue &a) {
-  if (a.IsNull()) return TypedValue(a.GetMemoryResource());
-  if (a.IsInt()) return TypedValue(+a.ValueInt(), a.GetMemoryResource());
-  if (a.IsDouble()) return TypedValue(+a.ValueDouble(), a.GetMemoryResource());
+  if (a.IsNull()) return TypedValue(a.alloc_);
+  if (a.IsInt()) return TypedValue(+a.ValueInt(), a.alloc_);
+  if (a.IsDouble()) return TypedValue(+a.ValueDouble(), a.alloc_);
   throw TypedValueException("Invalid unary plus operand type (+{})", a.type());
 }
 
@@ -1294,10 +1288,10 @@ std::optional<TypedValue> MaybeDoTemporalTypeSubtraction(const TypedValue &a, co
 }  // namespace
 
 TypedValue operator+(const TypedValue &a, const TypedValue &b) {
-  if (a.IsNull() || b.IsNull()) return TypedValue(a.GetMemoryResource());
+  if (a.IsNull() || b.IsNull()) return TypedValue(a.alloc_);
 
   if (a.IsList() || b.IsList()) {
-    TypedValue::TVector list(a.GetMemoryResource());
+    TypedValue::TVector list(a.alloc_);
 
     size_t const new_list_size{(a.IsList() ? a.ValueList().size() : 1) + (b.IsList() ? b.ValueList().size() : 1)};
     list.reserve(new_list_size);
@@ -1312,7 +1306,7 @@ TypedValue operator+(const TypedValue &a, const TypedValue &b) {
     };
     append_list(a);
     append_list(b);
-    return TypedValue(std::move(list), a.GetMemoryResource());
+    return TypedValue(std::move(list), a.alloc_);
   }
 
   if (const auto maybe_add = MaybeDoTemporalTypeAddition(a, b); maybe_add) {
@@ -1322,71 +1316,71 @@ TypedValue operator+(const TypedValue &a, const TypedValue &b) {
   EnsureArithmeticallyOk(a, b, true, "addition");
   // no more Bool nor Null, summing works on anything from here onward
 
-  if (a.IsString() || b.IsString()) return TypedValue(ValueToString(a) + ValueToString(b), a.GetMemoryResource());
+  if (a.IsString() || b.IsString()) return TypedValue(ValueToString(a) + ValueToString(b), a.alloc_);
 
   // at this point we only have int and double
   if (a.IsDouble() || b.IsDouble()) {
-    return TypedValue(ToDouble(a) + ToDouble(b), a.GetMemoryResource());
+    return TypedValue(ToDouble(a) + ToDouble(b), a.alloc_);
   }
-  return TypedValue(a.ValueInt() + b.ValueInt(), a.GetMemoryResource());
+  return TypedValue(a.ValueInt() + b.ValueInt(), a.alloc_);
 }
 
 TypedValue operator-(const TypedValue &a, const TypedValue &b) {
-  if (a.IsNull() || b.IsNull()) return TypedValue(a.GetMemoryResource());
+  if (a.IsNull() || b.IsNull()) return TypedValue(a.alloc_);
   if (const auto maybe_sub = MaybeDoTemporalTypeSubtraction(a, b); maybe_sub) {
     return *maybe_sub;
   }
   EnsureArithmeticallyOk(a, b, true, "subraction");
   // at this point we only have int and double
   if (a.IsDouble() || b.IsDouble()) {
-    return TypedValue(ToDouble(a) - ToDouble(b), a.GetMemoryResource());
+    return TypedValue(ToDouble(a) - ToDouble(b), a.alloc_);
   }
-  return TypedValue(a.ValueInt() - b.ValueInt(), a.GetMemoryResource());
+  return TypedValue(a.ValueInt() - b.ValueInt(), a.alloc_);
 }
 
 TypedValue operator/(const TypedValue &a, const TypedValue &b) {
-  if (a.IsNull() || b.IsNull()) return TypedValue(a.GetMemoryResource());
+  if (a.IsNull() || b.IsNull()) return TypedValue(a.alloc_);
   EnsureArithmeticallyOk(a, b, false, "division");
 
   // at this point we only have int and double
   if (a.IsDouble() || b.IsDouble()) {
-    return TypedValue(ToDouble(a) / ToDouble(b), a.GetMemoryResource());
+    return TypedValue(ToDouble(a) / ToDouble(b), a.alloc_);
   } else {
     if (b.ValueInt() == 0LL) throw TypedValueException("Division by zero");
-    return TypedValue(a.ValueInt() / b.ValueInt(), a.GetMemoryResource());
+    return TypedValue(a.ValueInt() / b.ValueInt(), a.alloc_);
   }
 }
 
 TypedValue operator*(const TypedValue &a, const TypedValue &b) {
-  if (a.IsNull() || b.IsNull()) return TypedValue(a.GetMemoryResource());
+  if (a.IsNull() || b.IsNull()) return TypedValue(a.alloc_);
   EnsureArithmeticallyOk(a, b, false, "multiplication");
 
   // at this point we only have int and double
   if (a.IsDouble() || b.IsDouble()) {
-    return TypedValue(ToDouble(a) * ToDouble(b), a.GetMemoryResource());
+    return TypedValue(ToDouble(a) * ToDouble(b), a.alloc_);
   } else {
-    return TypedValue(a.ValueInt() * b.ValueInt(), a.GetMemoryResource());
+    return TypedValue(a.ValueInt() * b.ValueInt(), a.alloc_);
   }
 }
 
 TypedValue operator%(const TypedValue &a, const TypedValue &b) {
-  if (a.IsNull() || b.IsNull()) return TypedValue(a.GetMemoryResource());
+  if (a.IsNull() || b.IsNull()) return TypedValue(a.alloc_);
   EnsureArithmeticallyOk(a, b, false, "modulo");
 
   // at this point we only have int and double
   if (a.IsDouble() || b.IsDouble()) {
-    return TypedValue(static_cast<double>(fmod(ToDouble(a), ToDouble(b))), a.GetMemoryResource());
+    return TypedValue(static_cast<double>(fmod(ToDouble(a), ToDouble(b))), a.alloc_);
   } else {
     if (b.ValueInt() == 0LL) throw TypedValueException("Mod with zero");
-    return TypedValue(a.ValueInt() % b.ValueInt(), a.GetMemoryResource());
+    return TypedValue(a.ValueInt() % b.ValueInt(), a.alloc_);
   }
 }
 
 TypedValue pow(const TypedValue &a, const TypedValue &b) {
-  if (a.IsNull() || b.IsNull()) return TypedValue(a.GetMemoryResource());
+  if (a.IsNull() || b.IsNull()) return TypedValue(a.alloc_);
   EnsureArithmeticallyOk(a, b, false, "^");
 
-  return TypedValue(std::pow(ToDouble(a), ToDouble(b)), a.GetMemoryResource());
+  return TypedValue(std::pow(ToDouble(a), ToDouble(b)), a.alloc_);
 }
 
 inline void EnsureLogicallyOk(const TypedValue &a, const TypedValue &b, const std::string &op_name) {
@@ -1399,31 +1393,31 @@ TypedValue operator&&(const TypedValue &a, const TypedValue &b) {
   EnsureLogicallyOk(a, b, "logical AND");
   // at this point we only have null and bool
   // if either operand is false, the result is false
-  if (a.IsBool() && !a.ValueBool()) return TypedValue(false, a.GetMemoryResource());
-  if (b.IsBool() && !b.ValueBool()) return TypedValue(false, a.GetMemoryResource());
-  if (a.IsNull() || b.IsNull()) return TypedValue(a.GetMemoryResource());
+  if (a.IsBool() && !a.ValueBool()) return TypedValue(false, a.alloc_);
+  if (b.IsBool() && !b.ValueBool()) return TypedValue(false, a.alloc_);
+  if (a.IsNull() || b.IsNull()) return TypedValue(a.alloc_);
   // neither is false, neither is null, thus both are true
-  return TypedValue(true, a.GetMemoryResource());
+  return TypedValue(true, a.alloc_);
 }
 
 TypedValue operator||(const TypedValue &a, const TypedValue &b) {
   EnsureLogicallyOk(a, b, "logical OR");
   // at this point we only have null and bool
   // if either operand is true, the result is true
-  if (a.IsBool() && a.ValueBool()) return TypedValue(true, a.GetMemoryResource());
-  if (b.IsBool() && b.ValueBool()) return TypedValue(true, a.GetMemoryResource());
-  if (a.IsNull() || b.IsNull()) return TypedValue(a.GetMemoryResource());
+  if (a.IsBool() && a.ValueBool()) return TypedValue(true, a.alloc_);
+  if (b.IsBool() && b.ValueBool()) return TypedValue(true, a.alloc_);
+  if (a.IsNull() || b.IsNull()) return TypedValue(a.alloc_);
   // neither is true, neither is null, thus both are false
-  return TypedValue(false, a.GetMemoryResource());
+  return TypedValue(false, a.alloc_);
 }
 
 TypedValue operator^(const TypedValue &a, const TypedValue &b) {
   EnsureLogicallyOk(a, b, "logical XOR");
   // at this point we only have null and bool
   if (a.IsNull() || b.IsNull())
-    return TypedValue(a.GetMemoryResource());
+    return TypedValue(a.alloc_);
   else
-    return TypedValue(static_cast<bool>(a.ValueBool() ^ b.ValueBool()), a.GetMemoryResource());
+    return TypedValue(static_cast<bool>(a.ValueBool() ^ b.ValueBool()), a.alloc_);
 }
 
 bool TypedValue::BoolEqual::operator()(const TypedValue &lhs, const TypedValue &rhs) const {
@@ -1499,6 +1493,21 @@ size_t TypedValue::Hash::operator()(const TypedValue &value) const {
       throw TypedValueException("Unsupported hash function for Graph");
   }
   LOG_FATAL("Unhandled TypedValue.type() in hash function");
+}
+
+auto GetCRS(TypedValue const &tv) -> std::optional<storage::CoordinateReferenceSystem> {
+  switch (tv.type()) {
+    using enum TypedValue::Type;
+    case Point2d: {
+      return tv.point_2d_v.crs();
+    }
+    case Point3d: {
+      return tv.point_3d_v.crs();
+    }
+    default: {
+      return std::nullopt;
+    }
+  }
 }
 
 }  // namespace memgraph::query

--- a/src/query/typed_value.hpp
+++ b/src/query/typed_value.hpp
@@ -113,13 +113,16 @@ class TypedValue {
 
   using TString = utils::pmr::string;
   using TVector = utils::pmr::vector<TypedValue>;
-  using TMap = utils::pmr::flat_map<TString, TypedValue>;
+  using TMap = std::pmr::map<TString, TypedValue, std::less<>>;
+  // TODO: use boost flat_map when boost has been updated
+  // using TMap = utils::pmr::flat_map<TString, TypedValue>;
 
   /** Construct a Null value with default utils::NewDeleteResource(). */
   TypedValue() : type_(Type::Null) {}
 
   /** Construct a Null value with given utils::MemoryResource. */
-  explicit TypedValue(utils::MemoryResource *memory) : memory_(memory), type_(Type::Null) {}
+  explicit TypedValue(utils::MemoryResource *res) : alloc_(res), type_(Type::Null) {}
+  explicit TypedValue(allocator_type alloc) : alloc_(alloc), type_(Type::Null) {}
 
   /**
    * Construct a copy of other.
@@ -128,10 +131,11 @@ class TypedValue {
    * Since we use utils::Allocator, which does not propagate, this means that
    * memory_ will be the default utils::NewDeleteResource().
    */
-  TypedValue(const TypedValue &other);
+  TypedValue(const TypedValue &other)
+      : TypedValue(other, alloc_trait::select_on_container_copy_construction(other.alloc_)) {}
 
   /** Construct a copy using the given utils::MemoryResource */
-  TypedValue(const TypedValue &other, utils::MemoryResource *memory);
+  TypedValue(const TypedValue &other, allocator_type alloc);
 
   /**
    * Construct with the value of other.
@@ -143,68 +147,53 @@ class TypedValue {
   /**
    * Construct with the value of other, but use the given utils::MemoryResource.
    * After the move, other will be set to Null.
-   * If `*memory != *other.GetMemoryResource()`, then a copy is made instead of
+   * If `*memory != *other.get_allocator()`, then a copy is made instead of
    * a move.
    */
-  TypedValue(TypedValue &&other, utils::MemoryResource *memory);
+  TypedValue(TypedValue &&other, allocator_type alloc);
 
-  explicit TypedValue(bool value, utils::MemoryResource *memory = utils::NewDeleteResource())
-      : memory_(memory), type_(Type::Bool) {
-    bool_v = value;
-  }
+  explicit TypedValue(bool value, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::Bool) { bool_v = value; }
 
-  explicit TypedValue(int value, utils::MemoryResource *memory = utils::NewDeleteResource())
-      : memory_(memory), type_(Type::Int) {
-    int_v = value;
-  }
+  explicit TypedValue(int value, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::Int) { int_v = value; }
 
-  explicit TypedValue(int64_t value, utils::MemoryResource *memory = utils::NewDeleteResource())
-      : memory_(memory), type_(Type::Int) {
-    int_v = value;
-  }
+  explicit TypedValue(int64_t value, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::Int) { int_v = value; }
 
-  explicit TypedValue(double value, utils::MemoryResource *memory = utils::NewDeleteResource())
-      : memory_(memory), type_(Type::Double) {
+  explicit TypedValue(double value, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::Double) {
     double_v = value;
   }
 
-  explicit TypedValue(storage::Enum value, utils::MemoryResource *memory = utils::NewDeleteResource())
-      : memory_(memory), type_(Type::Enum) {
+  explicit TypedValue(storage::Enum value, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::Enum) {
     enum_v = value;
   }
 
-  explicit TypedValue(const utils::Date &value, utils::MemoryResource *memory = utils::NewDeleteResource())
-      : memory_(memory), type_(Type::Date) {
+  explicit TypedValue(const utils::Date &value, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::Date) {
     date_v = value;
   }
 
-  explicit TypedValue(const utils::LocalTime &value, utils::MemoryResource *memory = utils::NewDeleteResource())
-      : memory_(memory), type_(Type::LocalTime) {
+  explicit TypedValue(const utils::LocalTime &value, allocator_type alloc = {})
+      : alloc_{alloc}, type_(Type::LocalTime) {
     local_time_v = value;
   }
 
-  explicit TypedValue(const utils::LocalDateTime &value, utils::MemoryResource *memory = utils::NewDeleteResource())
-      : memory_(memory), type_(Type::LocalDateTime) {
+  explicit TypedValue(const utils::LocalDateTime &value, allocator_type alloc = {})
+      : alloc_{alloc}, type_(Type::LocalDateTime) {
     local_date_time_v = value;
   }
 
-  explicit TypedValue(const utils::ZonedDateTime &value, utils::MemoryResource *memory = utils::NewDeleteResource())
-      : memory_(memory), type_(Type::ZonedDateTime) {
+  explicit TypedValue(const utils::ZonedDateTime &value, allocator_type alloc = {})
+      : alloc_{alloc}, type_(Type::ZonedDateTime) {
     zoned_date_time_v = value;
   }
 
-  explicit TypedValue(const utils::Duration &value, utils::MemoryResource *memory = utils::NewDeleteResource())
-      : memory_(memory), type_(Type::Duration) {
+  explicit TypedValue(const utils::Duration &value, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::Duration) {
     duration_v = value;
   }
 
-  explicit TypedValue(const storage::Point2d &value, utils::MemoryResource *memory = utils::NewDeleteResource())
-      : memory_(memory), type_(Type::Point2d) {
+  explicit TypedValue(const storage::Point2d &value, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::Point2d) {
     point_2d_v = value;
   }
 
-  explicit TypedValue(const storage::Point3d &value, utils::MemoryResource *memory = utils::NewDeleteResource())
-      : memory_(memory), type_(Type::Point3d) {
+  explicit TypedValue(const storage::Point3d &value, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::Point3d) {
     point_3d_v = value;
   }
 
@@ -212,19 +201,16 @@ class TypedValue {
   explicit operator storage::PropertyValue() const;
 
   // copy constructors for non-primitive types
-  explicit TypedValue(const std::string &value, utils::MemoryResource *memory = utils::NewDeleteResource())
-      : memory_(memory), type_(Type::String) {
-    new (&string_v) TString(value, memory_);
+  explicit TypedValue(const std::string &value, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::String) {
+    std::construct_at(&string_v, value, alloc_);
   }
 
-  explicit TypedValue(const char *value, utils::MemoryResource *memory = utils::NewDeleteResource())
-      : memory_(memory), type_(Type::String) {
-    new (&string_v) TString(value, memory_);
+  explicit TypedValue(const char *value, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::String) {
+    std::construct_at(&string_v, value, alloc_);
   }
 
-  explicit TypedValue(const std::string_view value, utils::MemoryResource *memory = utils::NewDeleteResource())
-      : memory_(memory), type_(Type::String) {
-    new (&string_v) TString(value, memory_);
+  explicit TypedValue(const std::string_view value, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::String) {
+    std::construct_at(&string_v, value, alloc_);
   }
 
   /**
@@ -236,26 +222,23 @@ class TypedValue {
    * memory_ will be the default utils::NewDeleteResource().
    */
   explicit TypedValue(const TString &other)
-      : TypedValue(other, std::allocator_traits<utils::Allocator<TypedValue>>::select_on_container_copy_construction(
-                              other.get_allocator())
-                              .GetMemoryResource()) {}
+      : TypedValue(other, alloc_trait::select_on_container_copy_construction(other.get_allocator())) {}
 
   /** Construct a copy using the given utils::MemoryResource */
-  TypedValue(const TString &other, utils::MemoryResource *memory) : memory_(memory), type_(Type::String) {
-    new (&string_v) TString(other, memory_);
+  TypedValue(const TString &other, allocator_type alloc) : alloc_{alloc}, type_(Type::String) {
+    std::construct_at(&string_v, other, alloc_);
   }
 
   /** Construct a copy using the given utils::MemoryResource */
-  explicit TypedValue(const std::vector<TypedValue> &value, utils::MemoryResource *memory = utils::NewDeleteResource())
-      : memory_(memory), type_(Type::List) {
-    new (&list_v) TVector(value.begin(), value.end(), memory_);
+  explicit TypedValue(const std::vector<TypedValue> &value, allocator_type alloc = {})
+      : alloc_{alloc}, type_(Type::List) {
+    std::construct_at(&list_v, value.begin(), value.end(), alloc_);
   }
 
   template <class T>
   requires TypedValueValidPrimativeType<T>
-  explicit TypedValue(const std::vector<T> &value, utils::MemoryResource *memory = utils::NewDeleteResource())
-      : memory_(memory), type_(Type::List) {
-    new (&list_v) TVector(value.begin(), value.end(), memory_);
+  explicit TypedValue(const std::vector<T> &value, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::List) {
+    std::construct_at(&list_v, value.begin(), value.end(), alloc_);
   }
 
   /**
@@ -267,21 +250,17 @@ class TypedValue {
    * memory_ will be the default utils::NewDeleteResource().
    */
   explicit TypedValue(const TVector &other)
-      : TypedValue(other, std::allocator_traits<utils::Allocator<TypedValue>>::select_on_container_copy_construction(
-                              other.get_allocator())
-                              .GetMemoryResource()) {}
+      : TypedValue(other, alloc_trait::select_on_container_copy_construction(other.get_allocator())) {}
 
   /** Construct a copy using the given utils::MemoryResource */
-  TypedValue(const TVector &value, utils::MemoryResource *memory) : memory_(memory), type_(Type::List) {
-    new (&list_v) TVector(value, memory_);
+  TypedValue(const TVector &value, allocator_type alloc) : alloc_{alloc}, type_(Type::List) {
+    std::construct_at(&list_v, value, alloc_);
   }
 
   /** Construct a copy using the given utils::MemoryResource */
-  explicit TypedValue(const std::map<std::string, TypedValue> &value,
-                      utils::MemoryResource *memory = utils::NewDeleteResource())
-      : memory_(memory), type_(Type::Map) {
-    std::construct_at(&map_v, memory_);
-    for (const auto &kv : value) map_v.emplace(TString(kv.first, memory_), kv.second);
+  explicit TypedValue(const std::map<std::string, TypedValue> &value, allocator_type alloc = {})
+      : alloc_{alloc}, type_(Type::Map) {
+    std::construct_at(&map_v, value.begin(), value.end(), alloc_);
   }
 
   /**
@@ -293,28 +272,23 @@ class TypedValue {
    * memory_ will be the default utils::NewDeleteResource().
    */
   explicit TypedValue(const TMap &other)
-      : TypedValue(other, std::allocator_traits<utils::Allocator<TypedValue>>::select_on_container_copy_construction(
-                              other.get_allocator())
-                              .GetMemoryResource()) {}
+      : TypedValue(other, alloc_trait::select_on_container_copy_construction(other.get_allocator())) {}
 
   /** Construct a copy using the given utils::MemoryResource */
-  TypedValue(const TMap &value, utils::MemoryResource *memory) : memory_(memory), type_(Type::Map) {
-    std::construct_at(&map_v, value, memory_);
+  TypedValue(const TMap &value, allocator_type alloc) : alloc_{alloc}, type_(Type::Map) {
+    std::construct_at(&map_v, value, alloc_);
   }
 
-  explicit TypedValue(const VertexAccessor &vertex, utils::MemoryResource *memory = utils::NewDeleteResource())
-      : memory_(memory), type_(Type::Vertex) {
-    new (&vertex_v) VertexAccessor(vertex);
+  explicit TypedValue(const VertexAccessor &vertex, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::Vertex) {
+    std::construct_at(&vertex_v, vertex);
   }
 
-  explicit TypedValue(const EdgeAccessor &edge, utils::MemoryResource *memory = utils::NewDeleteResource())
-      : memory_(memory), type_(Type::Edge) {
-    new (&edge_v) EdgeAccessor(edge);
+  explicit TypedValue(const EdgeAccessor &edge, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::Edge) {
+    std::construct_at(&edge_v, edge);
   }
 
-  explicit TypedValue(const Path &path, utils::MemoryResource *memory = utils::NewDeleteResource())
-      : memory_(memory), type_(Type::Path) {
-    auto *path_ptr = utils::Allocator<Path>(memory_).new_object<Path>(path);
+  explicit TypedValue(const Path &path, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::Path) {
+    auto *path_ptr = utils::Allocator<Path>(alloc_).new_object<Path>(path);
     std::construct_at(&path_v, path_ptr);
   }
 
@@ -322,7 +296,7 @@ class TypedValue {
   explicit TypedValue(const storage::PropertyValue &value);
 
   /** Construct a copy using the given utils::MemoryResource */
-  TypedValue(const storage::PropertyValue &value, utils::MemoryResource *memory);
+  TypedValue(const storage::PropertyValue &value, allocator_type alloc);
 
   // move constructors for non-primitive types
 
@@ -331,15 +305,14 @@ class TypedValue {
    * utils::MemoryResource is obtained from other. After the move, other will be
    * left in unspecified state.
    */
-  explicit TypedValue(TString &&other) noexcept
-      : TypedValue(std::move(other), other.get_allocator().GetMemoryResource()) {}
+  explicit TypedValue(TString &&other) noexcept : TypedValue(std::move(other), other.get_allocator()) {}
 
   /**
    * Construct with the value of other and use the given MemoryResource
    * After the move, other will be left in unspecified state.
    */
-  TypedValue(TString &&other, utils::MemoryResource *memory) : memory_(memory), type_(Type::String) {
-    new (&string_v) TString(std::move(other), memory_);
+  TypedValue(TString &&other, allocator_type alloc) : alloc_{alloc}, type_(Type::String) {
+    std::construct_at(&string_v, std::move(other), alloc_);
   }
 
   /**
@@ -352,16 +325,8 @@ class TypedValue {
    * Perform an element-wise move of the other and use the given MemoryResource.
    * Other will be not be left empty, though elements may be Null.
    */
-  TypedValue(std::vector<TypedValue> &&other, utils::MemoryResource *memory) : memory_(memory), type_(Type::List) {
-    new (&list_v) TVector(memory_);
-    list_v.reserve(other.size());
-    // std::vector<TypedValue> has std::allocator and there's no move
-    // constructor for std::vector using different allocator types. Since
-    // std::allocator is not propagated to elements, it is possible that some
-    // TypedValue elements have a MemoryResource that is the same as the one we
-    // are given. In such a case we would like to move those TypedValue
-    // instances, so we use move_iterator.
-    list_v.assign(std::make_move_iterator(other.begin()), std::make_move_iterator(other.end()));
+  TypedValue(std::vector<TypedValue> &&other, allocator_type alloc) : alloc_{alloc}, type_(Type::List) {
+    std::construct_at(&list_v, std::make_move_iterator(other.begin()), std::make_move_iterator(other.end()), alloc_);
   }
 
   /**
@@ -369,16 +334,15 @@ class TypedValue {
    * utils::MemoryResource is obtained from other. After the move, other will be
    * left empty.
    */
-  explicit TypedValue(TVector &&other) noexcept
-      : TypedValue(std::move(other), other.get_allocator().GetMemoryResource()) {}
+  explicit TypedValue(TVector &&other) noexcept : TypedValue(std::move(other), other.get_allocator()) {}
 
   /**
    * Construct with the value of other and use the given MemoryResource.
    * If `other.get_allocator() != *memory`, this call will perform an
    * element-wise move and other is not guaranteed to be empty.
    */
-  TypedValue(TVector &&other, utils::MemoryResource *memory) : memory_(memory), type_(Type::List) {
-    new (&list_v) TVector(std::move(other), memory_);
+  TypedValue(TVector &&other, allocator_type alloc) : alloc_{alloc}, type_(Type::List) {
+    std::construct_at(&list_v, std::move(other), alloc_);
   }
 
   /**
@@ -394,7 +358,7 @@ class TypedValue {
    * Other will not be left empty, i.e. keys will exist but their values may
    * be Null.
    */
-  TypedValue(std::map<std::string, TypedValue> &&other, utils::MemoryResource *memory);
+  TypedValue(std::map<std::string, TypedValue> &&other, allocator_type alloc);
   /**
    * Construct with the value of other.
    * utils::MemoryResource is obtained from other. After the move, other will be
@@ -407,16 +371,14 @@ class TypedValue {
    * element-wise move and other is not guaranteed to be empty, i.e. keys may
    * exist but their values may be Null.
    */
-  TypedValue(TMap &&other, utils::MemoryResource *memory);
+  TypedValue(TMap &&other, allocator_type alloc);
 
-  explicit TypedValue(VertexAccessor &&vertex, utils::MemoryResource *memory = utils::NewDeleteResource()) noexcept
-      : memory_(memory), type_(Type::Vertex) {
-    new (&vertex_v) VertexAccessor(std::move(vertex));
+  explicit TypedValue(VertexAccessor &&vertex, allocator_type alloc) noexcept : alloc_{alloc}, type_(Type::Vertex) {
+    std::construct_at(&vertex_v, std::move(vertex));
   }
 
-  explicit TypedValue(EdgeAccessor &&edge, utils::MemoryResource *memory = utils::NewDeleteResource()) noexcept
-      : memory_(memory), type_(Type::Edge) {
-    new (&edge_v) EdgeAccessor(std::move(edge));
+  explicit TypedValue(EdgeAccessor &&edge, allocator_type alloc) noexcept : alloc_{alloc}, type_(Type::Edge) {
+    std::construct_at(&edge_v, std::move(edge));
   }
 
   /**
@@ -428,10 +390,10 @@ class TypedValue {
 
   /**
    * Construct with the value of path and use the given MemoryResource.
-   * If `*path.GetMemoryResource() != *memory`, this call will perform an
+   * If `*path.get_allocator() != *memory`, this call will perform an
    * element-wise move and path is not guaranteed to be empty.
    */
-  explicit TypedValue(Path &&path, utils::MemoryResource *memory);
+  explicit TypedValue(Path &&path, allocator_type alloc);
 
   /**
    * Construct with the value of graph.
@@ -442,10 +404,10 @@ class TypedValue {
 
   /**
    * Construct with the value of graph and use the given MemoryResource.
-   * If `*graph.GetMemoryResource() != *memory`, this call will perform an
+   * If `*graph.get_allocator() != *memory`, this call will perform an
    * element-wise move and graph is not guaranteed to be empty.
    */
-  TypedValue(Graph &&graph, utils::MemoryResource *memory);
+  TypedValue(Graph &&graph, allocator_type alloc);
 
   explicit TypedValue(std::function<void(TypedValue *)> &&other)
       : function_v(std::move(other)), type_(Type::Function) {}
@@ -461,7 +423,7 @@ class TypedValue {
    * Construct with the value of other, but use the given utils::MemoryResource.
    * After the move, other will be set to Null.
    */
-  TypedValue(storage::PropertyValue &&other, utils::MemoryResource *memory);
+  TypedValue(storage::PropertyValue &&other, allocator_type alloc);
 
   // copy assignment operators
   TypedValue &operator=(const char *);
@@ -561,11 +523,216 @@ class TypedValue {
    * storage::PropertyValue */
   bool IsPropertyValue() const;
 
-  utils::MemoryResource *GetMemoryResource() const { return memory_; }
+  auto get_allocator() const -> allocator_type { return alloc_; }
+
+  // binary bool operators
+
+  /**
+   * Perform logical 'and' on TypedValues.
+   *
+   * If any of the values is false, return false. Otherwise checks if any value is
+   * Null and return Null. All other cases return true. The resulting value uses
+   * the same MemoryResource as the left hand side arguments.
+   *
+   * @throw TypedValueException if arguments are not boolean or Null.
+   */
+  friend TypedValue operator&&(const TypedValue &a, const TypedValue &b);
+
+  /**
+   * Perform logical 'or' on TypedValues.
+   *
+   * If any of the values is true, return true. Otherwise checks if any value is
+   * Null and return Null. All other cases return false. The resulting value uses
+   * the same MemoryResource as the left hand side arguments.
+   *
+   * @throw TypedValueException if arguments are not boolean or Null.
+   */
+  friend TypedValue operator||(const TypedValue &a, const TypedValue &b);
+
+  /**
+   * Logically negate a TypedValue.
+   *
+   * Negating Null value returns Null. Values other than null raise an exception.
+   * The resulting value uses the same MemoryResource as the argument.
+   *
+   * @throw TypedValueException if TypedValue is not a boolean or Null.
+   */
+  friend TypedValue operator!(const TypedValue &a);
+
+  // binary bool xor, not power operator
+  // Be careful: since ^ is binary operator and || and && are logical operators
+  // they have different priority in c++.
+  friend TypedValue operator^(const TypedValue &a, const TypedValue &b);
+
+  // comparison operators
+
+  /**
+   * Compare TypedValues and return true, false or Null.
+   *
+   * Null is returned if either of the two values is Null.
+   * Since each TypedValue may have a different MemoryResource for allocations,
+   * the results is allocated using MemoryResource obtained from the left hand
+   * side.
+   */
+  friend TypedValue operator==(const TypedValue &a, const TypedValue &b);
+
+  /**
+   * Compare TypedValues and return true, false or Null.
+   *
+   * Null is returned if either of the two values is Null.
+   * Since each TypedValue may have a different MemoryResource for allocations,
+   * the results is allocated using MemoryResource obtained from the left hand
+   * side.
+   */
+  friend TypedValue operator!=(const TypedValue &a, const TypedValue &b) { return !(a == b); }
+
+  /**
+   * Compare TypedValues and return true, false or Null.
+   *
+   * Null is returned if either of the two values is Null.
+   * The resulting value uses the same MemoryResource as the left hand side
+   * argument.
+   *
+   * @throw TypedValueException if the values cannot be compared, i.e. they are
+   *        not either Null, numeric or a character string type.
+   */
+  friend TypedValue operator<(const TypedValue &a, const TypedValue &b);
+
+  /**
+   * Compare TypedValues and return true, false or Null.
+   *
+   * Null is returned if either of the two values is Null.
+   * The resulting value uses the same MemoryResource as the left hand side
+   * argument.
+   *
+   * @throw TypedValueException if the values cannot be compared, i.e. they are
+   *        not either Null, numeric or a character string type.
+   */
+  // TODO: why not `!(b < a)` or C++20 auto generated
+  friend TypedValue operator<=(const TypedValue &a, const TypedValue &b) { return a < b || a == b; }
+
+  /**
+   * Compare TypedValues and return true, false or Null.
+   *
+   * Null is returned if either of the two values is Null.
+   * The resulting value uses the same MemoryResource as the left hand side
+   * argument.
+   *
+   * @throw TypedValueException if the values cannot be compared, i.e. they are
+   *        not either Null, numeric or a character string type.
+   */
+  friend TypedValue operator>(const TypedValue &a, const TypedValue &b) { return !(a <= b); }
+
+  /**
+   * Compare TypedValues and return true, false or Null.
+   *
+   * Null is returned if either of the two values is Null.
+   * The resulting value uses the same MemoryResource as the left hand side
+   * argument.
+   *
+   * @throw TypedValueException if the values cannot be compared, i.e. they are
+   *        not either Null, numeric or a character string type.
+   */
+  friend TypedValue operator>=(const TypedValue &a, const TypedValue &b) { return !(a < b); }
+
+  // arithmetic operators
+
+  /**
+   * Arithmetically negate a value.
+   *
+   * If the value is Null, then Null is returned.
+   * The resulting value uses the same MemoryResource as the argument.
+   *
+   * @throw TypedValueException if the value is not numeric or Null.
+   */
+  friend TypedValue operator-(const TypedValue &a);
+
+  /**
+   * Apply the unary plus operator to a value.
+   *
+   * If the value is Null, then Null is returned.
+   * The resulting value uses the same MemoryResource as the argument.
+   *
+   * @throw TypedValueException if the value is not numeric or Null.
+   */
+  friend TypedValue operator+(const TypedValue &a);
+
+  /**
+   * Perform addition or concatenation on two values.
+   *
+   * Numeric values are summed, while lists and character strings are
+   * concatenated. If either value is Null, then Null is returned. The resulting
+   * value uses the same MemoryResource as the left hand side argument.
+   *
+   * @throw TypedValueException if values cannot be summed or concatenated.
+   */
+  friend TypedValue operator+(const TypedValue &a, const TypedValue &b);
+
+  /**
+   * Subtract two values.
+   *
+   * If any of the values is Null, then Null is returned.
+   * The resulting value uses the same MemoryResource as the left hand side
+   * argument.
+   *
+   * @throw TypedValueException if the values are not numeric or Null.
+   */
+  friend TypedValue operator-(const TypedValue &a, const TypedValue &b);
+
+  /**
+   * Divide two values.
+   *
+   * If any of the values is Null, then Null is returned.
+   * The resulting value uses the same MemoryResource as the left hand side
+   * argument.
+   *
+   * @throw TypedValueException if the values are not numeric or Null, or if
+   *        dividing two integer values by zero.
+   */
+  friend TypedValue operator/(const TypedValue &a, const TypedValue &b);
+
+  /**
+   * Multiply two values.
+   *
+   * If any of the values is Null, then Null is returned.
+   * The resulting value uses the same MemoryResource as the left hand side
+   * argument.
+   *
+   * @throw TypedValueException if the values are not numeric or Null.
+   */
+  friend TypedValue operator*(const TypedValue &a, const TypedValue &b);
+
+  /**
+   * Perform modulo operation on two values.
+   *
+   * If any of the values is Null, then Null is returned.
+   * The resulting value uses the same MemoryResource as the left hand side
+   * argument.
+   *
+   * @throw TypedValueException if the values are not numeric or Null.
+   */
+  friend TypedValue operator%(const TypedValue &a, const TypedValue &b);
+
+  /**
+   * Perform an exponentation operation on two values.
+   *
+   * If any of the values is Null, then Null is returned. The return value
+   * is always a floating-point value, even when called with integers.
+   * The resulting value uses the same MemoryResource as the left hand side
+   * argument.
+   *
+   * @throw TypedValueException if the values are not numeric or Null.
+   */
+  friend TypedValue pow(const TypedValue &a, const TypedValue &b);
+
+  /** Output the TypedValue::Type value as a string */
+  friend std::ostream &operator<<(std::ostream &os, const TypedValue::Type &type);
+
+  /** Helper method for extract CRS from possible point types */
+  friend auto GetCRS(TypedValue const &tv) -> std::optional<storage::CoordinateReferenceSystem>;
 
  private:
-  // Memory resource for allocations of non primitive values
-  utils::MemoryResource *memory_{utils::NewDeleteResource()};
+  [[no_unique_address]] allocator_type alloc_{};
 
   // storage for the value of the property
   union {
@@ -612,223 +779,5 @@ class TypedValueException : public utils::BasicException {
   using utils::BasicException::BasicException;
   SPECIALIZE_GET_EXCEPTION_NAME(TypedValueException)
 };
-
-// binary bool operators
-
-/**
- * Perform logical 'and' on TypedValues.
- *
- * If any of the values is false, return false. Otherwise checks if any value is
- * Null and return Null. All other cases return true. The resulting value uses
- * the same MemoryResource as the left hand side arguments.
- *
- * @throw TypedValueException if arguments are not boolean or Null.
- */
-TypedValue operator&&(const TypedValue &a, const TypedValue &b);
-
-/**
- * Perform logical 'or' on TypedValues.
- *
- * If any of the values is true, return true. Otherwise checks if any value is
- * Null and return Null. All other cases return false. The resulting value uses
- * the same MemoryResource as the left hand side arguments.
- *
- * @throw TypedValueException if arguments are not boolean or Null.
- */
-TypedValue operator||(const TypedValue &a, const TypedValue &b);
-
-/**
- * Logically negate a TypedValue.
- *
- * Negating Null value returns Null. Values other than null raise an exception.
- * The resulting value uses the same MemoryResource as the argument.
- *
- * @throw TypedValueException if TypedValue is not a boolean or Null.
- */
-TypedValue operator!(const TypedValue &a);
-
-// binary bool xor, not power operator
-// Be careful: since ^ is binary operator and || and && are logical operators
-// they have different priority in c++.
-TypedValue operator^(const TypedValue &a, const TypedValue &b);
-
-// comparison operators
-
-/**
- * Compare TypedValues and return true, false or Null.
- *
- * Null is returned if either of the two values is Null.
- * Since each TypedValue may have a different MemoryResource for allocations,
- * the results is allocated using MemoryResource obtained from the left hand
- * side.
- */
-TypedValue operator==(const TypedValue &a, const TypedValue &b);
-
-/**
- * Compare TypedValues and return true, false or Null.
- *
- * Null is returned if either of the two values is Null.
- * Since each TypedValue may have a different MemoryResource for allocations,
- * the results is allocated using MemoryResource obtained from the left hand
- * side.
- */
-inline TypedValue operator!=(const TypedValue &a, const TypedValue &b) { return !(a == b); }
-
-/**
- * Compare TypedValues and return true, false or Null.
- *
- * Null is returned if either of the two values is Null.
- * The resulting value uses the same MemoryResource as the left hand side
- * argument.
- *
- * @throw TypedValueException if the values cannot be compared, i.e. they are
- *        not either Null, numeric or a character string type.
- */
-TypedValue operator<(const TypedValue &a, const TypedValue &b);
-
-/**
- * Compare TypedValues and return true, false or Null.
- *
- * Null is returned if either of the two values is Null.
- * The resulting value uses the same MemoryResource as the left hand side
- * argument.
- *
- * @throw TypedValueException if the values cannot be compared, i.e. they are
- *        not either Null, numeric or a character string type.
- */
-inline TypedValue operator<=(const TypedValue &a, const TypedValue &b) { return a < b || a == b; }
-
-/**
- * Compare TypedValues and return true, false or Null.
- *
- * Null is returned if either of the two values is Null.
- * The resulting value uses the same MemoryResource as the left hand side
- * argument.
- *
- * @throw TypedValueException if the values cannot be compared, i.e. they are
- *        not either Null, numeric or a character string type.
- */
-inline TypedValue operator>(const TypedValue &a, const TypedValue &b) { return !(a <= b); }
-
-/**
- * Compare TypedValues and return true, false or Null.
- *
- * Null is returned if either of the two values is Null.
- * The resulting value uses the same MemoryResource as the left hand side
- * argument.
- *
- * @throw TypedValueException if the values cannot be compared, i.e. they are
- *        not either Null, numeric or a character string type.
- */
-inline TypedValue operator>=(const TypedValue &a, const TypedValue &b) { return !(a < b); }
-
-// arithmetic operators
-
-/**
- * Arithmetically negate a value.
- *
- * If the value is Null, then Null is returned.
- * The resulting value uses the same MemoryResource as the argument.
- *
- * @throw TypedValueException if the value is not numeric or Null.
- */
-TypedValue operator-(const TypedValue &a);
-
-/**
- * Apply the unary plus operator to a value.
- *
- * If the value is Null, then Null is returned.
- * The resulting value uses the same MemoryResource as the argument.
- *
- * @throw TypedValueException if the value is not numeric or Null.
- */
-TypedValue operator+(const TypedValue &a);
-
-/**
- * Perform addition or concatenation on two values.
- *
- * Numeric values are summed, while lists and character strings are
- * concatenated. If either value is Null, then Null is returned. The resulting
- * value uses the same MemoryResource as the left hand side argument.
- *
- * @throw TypedValueException if values cannot be summed or concatenated.
- */
-TypedValue operator+(const TypedValue &a, const TypedValue &b);
-
-/**
- * Subtract two values.
- *
- * If any of the values is Null, then Null is returned.
- * The resulting value uses the same MemoryResource as the left hand side
- * argument.
- *
- * @throw TypedValueException if the values are not numeric or Null.
- */
-TypedValue operator-(const TypedValue &a, const TypedValue &b);
-
-/**
- * Divide two values.
- *
- * If any of the values is Null, then Null is returned.
- * The resulting value uses the same MemoryResource as the left hand side
- * argument.
- *
- * @throw TypedValueException if the values are not numeric or Null, or if
- *        dividing two integer values by zero.
- */
-TypedValue operator/(const TypedValue &a, const TypedValue &b);
-
-/**
- * Multiply two values.
- *
- * If any of the values is Null, then Null is returned.
- * The resulting value uses the same MemoryResource as the left hand side
- * argument.
- *
- * @throw TypedValueException if the values are not numeric or Null.
- */
-TypedValue operator*(const TypedValue &a, const TypedValue &b);
-
-/**
- * Perform modulo operation on two values.
- *
- * If any of the values is Null, then Null is returned.
- * The resulting value uses the same MemoryResource as the left hand side
- * argument.
- *
- * @throw TypedValueException if the values are not numeric or Null.
- */
-TypedValue operator%(const TypedValue &a, const TypedValue &b);
-
-/**
- * Perform an exponentation operation on two values.
- *
- * If any of the values is Null, then Null is returned. The return value
- * is always a floating-point value, even when called with integers.
- * The resulting value uses the same MemoryResource as the left hand side
- * argument.
- *
- * @throw TypedValueException if the values are not numeric or Null.
- */
-TypedValue pow(const TypedValue &a, const TypedValue &b);
-
-/** Output the TypedValue::Type value as a string */
-std::ostream &operator<<(std::ostream &os, const TypedValue::Type &type);
-
-/** Helper method for extract CRS from possible point types */
-inline auto GetCRS(TypedValue const &tv) -> std::optional<storage::CoordinateReferenceSystem> {
-  switch (tv.type()) {
-    using enum TypedValue::Type;
-    case Point2d: {
-      return tv.ValuePoint2d().crs();
-    }
-    case Point3d: {
-      return tv.ValuePoint3d().crs();
-    }
-    default: {
-      return std::nullopt;
-    }
-  }
-}
 
 }  // namespace memgraph::query

--- a/src/query/typed_value.hpp
+++ b/src/query/typed_value.hpp
@@ -126,7 +126,7 @@ class TypedValue {
 
   /**
    * Construct a copy of other.
-   * utils::MemoryResource is obtained by calling
+   * allocator_type is obtained by calling
    * std::allocator_traits<>::select_on_container_copy_construction(other.memory_).
    * Since we use utils::Allocator, which does not propagate, this means that
    * memory_ will be the default utils::NewDeleteResource().
@@ -134,18 +134,18 @@ class TypedValue {
   TypedValue(const TypedValue &other)
       : TypedValue(other, alloc_trait::select_on_container_copy_construction(other.alloc_)) {}
 
-  /** Construct a copy using the given utils::MemoryResource */
+  /** Construct a copy given allocator_type */
   TypedValue(const TypedValue &other, allocator_type alloc);
 
   /**
    * Construct with the value of other.
-   * utils::MemoryResource is obtained from other. After the move, other will be
+   * allocator_type is obtained from other. After the move, other will be
    * set to Null.
    */
   TypedValue(TypedValue &&other) noexcept;
 
   /**
-   * Construct with the value of other, but use the given utils::MemoryResource.
+   * Construct with the value of other, but use the given allocator_type.
    * After the move, other will be set to Null.
    * If `*memory != *other.get_allocator()`, then a copy is made instead of
    * a move.
@@ -212,7 +212,7 @@ class TypedValue {
 
   /**
    * Construct a copy of other.
-   * utils::MemoryResource is obtained by calling
+   * allocator_type is obtained by calling
    * std::allocator_traits<>::
    *     select_on_container_copy_construction(other.get_allocator()).
    * Since we use utils::Allocator, which does not propagate, this means that
@@ -221,11 +221,11 @@ class TypedValue {
   explicit TypedValue(const TString &other)
       : TypedValue(other, alloc_trait::select_on_container_copy_construction(other.get_allocator())) {}
 
-  /** Construct a copy using the given utils::MemoryResource */
+  /** Construct a copy given allocator_type */
   TypedValue(const TString &other, allocator_type alloc)
       : alloc_{alloc}, string_v{other, alloc_}, type_(Type::String) {}
 
-  /** Construct a copy using the given utils::MemoryResource */
+  /** Construct a copy given allocator_type */
   explicit TypedValue(const std::vector<TypedValue> &value, allocator_type alloc = {})
       : alloc_{alloc}, list_v{value.begin(), value.end(), alloc_}, type_(Type::List) {}
 
@@ -236,7 +236,7 @@ class TypedValue {
 
   /**
    * Construct a copy of other.
-   * utils::MemoryResource is obtained by calling
+   * allocator_type is obtained by calling
    * std::allocator_traits<>::
    *     select_on_container_copy_construction(other.get_allocator()).
    * Since we use utils::Allocator, which does not propagate, this means that
@@ -245,16 +245,16 @@ class TypedValue {
   explicit TypedValue(const TVector &other)
       : TypedValue(other, alloc_trait::select_on_container_copy_construction(other.get_allocator())) {}
 
-  /** Construct a copy using the given utils::MemoryResource */
+  /** Construct a copy given allocator_type */
   TypedValue(const TVector &value, allocator_type alloc) : alloc_{alloc}, list_v{value, alloc_}, type_(Type::List) {}
 
-  /** Construct a copy using the given utils::MemoryResource */
+  /** Construct a copy given allocator_type */
   explicit TypedValue(const std::map<std::string, TypedValue> &value, allocator_type alloc = {})
       : alloc_{alloc}, map_v{value.begin(), value.end(), alloc_}, type_(Type::Map) {}
 
   /**
    * Construct a copy of other.
-   * utils::MemoryResource is obtained by calling
+   * allocator_type is obtained by calling
    * std::allocator_traits<>::
    *     select_on_container_copy_construction(other.get_allocator()).
    * Since we use utils::Allocator, which does not propagate, this means that
@@ -263,7 +263,7 @@ class TypedValue {
   explicit TypedValue(const TMap &other)
       : TypedValue(other, alloc_trait::select_on_container_copy_construction(other.get_allocator())) {}
 
-  /** Construct a copy using the given utils::MemoryResource */
+  /** Construct a copy given allocator_type */
   TypedValue(const TMap &value, allocator_type alloc) : alloc_{alloc}, map_v{value, alloc_}, type_(Type::Map) {}
 
   explicit TypedValue(const VertexAccessor &vertex, allocator_type alloc = {})
@@ -280,14 +280,14 @@ class TypedValue {
   /** Construct a copy using default utils::NewDeleteResource() */
   explicit TypedValue(const storage::PropertyValue &value);
 
-  /** Construct a copy using the given utils::MemoryResource */
+  /** Construct a copy given allocator_type */
   TypedValue(const storage::PropertyValue &value, allocator_type alloc);
 
   // move constructors for non-primitive types
 
   /**
    * Construct with the value of other.
-   * utils::MemoryResource is obtained from other. After the move, other will be
+   * allocator_type is obtained from other. After the move, other will be
    * left in unspecified state.
    */
   explicit TypedValue(TString &&other) noexcept : TypedValue(std::move(other), other.get_allocator()) {}
@@ -313,7 +313,7 @@ class TypedValue {
 
   /**
    * Construct with the value of other.
-   * utils::MemoryResource is obtained from other. After the move, other will be
+   * allocator_type is obtained from other. After the move, other will be
    * left empty.
    */
   explicit TypedValue(TVector &&other) noexcept : TypedValue(std::move(other), other.get_allocator()) {}
@@ -342,7 +342,7 @@ class TypedValue {
   TypedValue(std::map<std::string, TypedValue> &&other, allocator_type alloc);
   /**
    * Construct with the value of other.
-   * utils::MemoryResource is obtained from other. After the move, other will be
+   * allocator_type is obtained from other. After the move, other will be
    * left empty.
    */
   explicit TypedValue(TMap &&other);
@@ -362,7 +362,7 @@ class TypedValue {
 
   /**
    * Construct with the value of path.
-   * utils::MemoryResource is obtained from path. After the move, path will be
+   * allocator_type is obtained from path. After the move, path will be
    * left empty.
    */
   explicit TypedValue(Path &&path);
@@ -376,7 +376,7 @@ class TypedValue {
 
   /**
    * Construct with the value of graph.
-   * utils::MemoryResource is obtained from graph. After the move, graph will be
+   * allocator_type is obtained from graph. After the move, graph will be
    * left empty.
    */
   explicit TypedValue(Graph &&graph);
@@ -399,7 +399,7 @@ class TypedValue {
   explicit TypedValue(storage::PropertyValue &&other);
 
   /**
-   * Construct with the value of other, but use the given utils::MemoryResource.
+   * Construct with the value of other, but use the given allocator_type.
    * After the move, other will be set to Null.
    */
   TypedValue(storage::PropertyValue &&other, allocator_type alloc);
@@ -426,10 +426,10 @@ class TypedValue {
   TypedValue &operator=(const storage::Enum &);
   TypedValue &operator=(const std::function<void(TypedValue *)> &);
 
-  /** Copy assign other, utils::MemoryResource of `this` is used */
+  /** Copy assign other, allocator_type of `this` is used */
   TypedValue &operator=(const TypedValue &other);
 
-  /** Move assign other, utils::MemoryResource of `this` is used. */
+  /** Move assign other, allocator_type of `this` is used. */
   TypedValue &operator=(TypedValue &&other) noexcept(false);
 
   // move assignment operators

--- a/src/query/typed_value.hpp
+++ b/src/query/typed_value.hpp
@@ -201,17 +201,14 @@ class TypedValue {
   explicit operator storage::PropertyValue() const;
 
   // copy constructors for non-primitive types
-  explicit TypedValue(const std::string &value, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::String) {
-    std::construct_at(&string_v, value, alloc_);
-  }
+  explicit TypedValue(const std::string &value, allocator_type alloc = {})
+      : alloc_{alloc}, string_v{value, alloc_}, type_(Type::String) {}
 
-  explicit TypedValue(const char *value, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::String) {
-    std::construct_at(&string_v, value, alloc_);
-  }
+  explicit TypedValue(const char *value, allocator_type alloc = {})
+      : alloc_{alloc}, string_v{value, alloc_}, type_(Type::String) {}
 
-  explicit TypedValue(const std::string_view value, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::String) {
-    std::construct_at(&string_v, value, alloc_);
-  }
+  explicit TypedValue(const std::string_view value, allocator_type alloc = {})
+      : alloc_{alloc}, string_v{value, alloc_}, type_(Type::String) {}
 
   /**
    * Construct a copy of other.
@@ -225,21 +222,17 @@ class TypedValue {
       : TypedValue(other, alloc_trait::select_on_container_copy_construction(other.get_allocator())) {}
 
   /** Construct a copy using the given utils::MemoryResource */
-  TypedValue(const TString &other, allocator_type alloc) : alloc_{alloc}, type_(Type::String) {
-    std::construct_at(&string_v, other, alloc_);
-  }
+  TypedValue(const TString &other, allocator_type alloc)
+      : alloc_{alloc}, string_v{other, alloc_}, type_(Type::String) {}
 
   /** Construct a copy using the given utils::MemoryResource */
   explicit TypedValue(const std::vector<TypedValue> &value, allocator_type alloc = {})
-      : alloc_{alloc}, type_(Type::List) {
-    std::construct_at(&list_v, value.begin(), value.end(), alloc_);
-  }
+      : alloc_{alloc}, list_v{value.begin(), value.end(), alloc_}, type_(Type::List) {}
 
   template <class T>
   requires TypedValueValidPrimativeType<T>
-  explicit TypedValue(const std::vector<T> &value, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::List) {
-    std::construct_at(&list_v, value.begin(), value.end(), alloc_);
-  }
+  explicit TypedValue(const std::vector<T> &value, allocator_type alloc = {})
+      : alloc_{alloc}, list_v{value.begin(), value.end(), alloc_}, type_(Type::List) {}
 
   /**
    * Construct a copy of other.
@@ -253,15 +246,11 @@ class TypedValue {
       : TypedValue(other, alloc_trait::select_on_container_copy_construction(other.get_allocator())) {}
 
   /** Construct a copy using the given utils::MemoryResource */
-  TypedValue(const TVector &value, allocator_type alloc) : alloc_{alloc}, type_(Type::List) {
-    std::construct_at(&list_v, value, alloc_);
-  }
+  TypedValue(const TVector &value, allocator_type alloc) : alloc_{alloc}, list_v{value, alloc_}, type_(Type::List) {}
 
   /** Construct a copy using the given utils::MemoryResource */
   explicit TypedValue(const std::map<std::string, TypedValue> &value, allocator_type alloc = {})
-      : alloc_{alloc}, type_(Type::Map) {
-    std::construct_at(&map_v, value.begin(), value.end(), alloc_);
-  }
+      : alloc_{alloc}, map_v{value.begin(), value.end(), alloc_}, type_(Type::Map) {}
 
   /**
    * Construct a copy of other.
@@ -275,21 +264,17 @@ class TypedValue {
       : TypedValue(other, alloc_trait::select_on_container_copy_construction(other.get_allocator())) {}
 
   /** Construct a copy using the given utils::MemoryResource */
-  TypedValue(const TMap &value, allocator_type alloc) : alloc_{alloc}, type_(Type::Map) {
-    std::construct_at(&map_v, value, alloc_);
-  }
+  TypedValue(const TMap &value, allocator_type alloc) : alloc_{alloc}, map_v{value, alloc_}, type_(Type::Map) {}
 
-  explicit TypedValue(const VertexAccessor &vertex, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::Vertex) {
-    std::construct_at(&vertex_v, vertex);
-  }
+  explicit TypedValue(const VertexAccessor &vertex, allocator_type alloc = {})
+      : alloc_{alloc}, vertex_v{vertex}, type_(Type::Vertex) {}
 
-  explicit TypedValue(const EdgeAccessor &edge, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::Edge) {
-    std::construct_at(&edge_v, edge);
-  }
+  explicit TypedValue(const EdgeAccessor &edge, allocator_type alloc = {})
+      : alloc_{alloc}, edge_v{edge}, type_(Type::Edge) {}
 
   explicit TypedValue(const Path &path, allocator_type alloc = {}) : alloc_{alloc}, type_(Type::Path) {
     auto *path_ptr = utils::Allocator<Path>(alloc_).new_object<Path>(path);
-    std::construct_at(&path_v, path_ptr);
+    alloc_trait::construct(alloc_, &path_v, path_ptr);
   }
 
   /** Construct a copy using default utils::NewDeleteResource() */
@@ -311,9 +296,8 @@ class TypedValue {
    * Construct with the value of other and use the given MemoryResource
    * After the move, other will be left in unspecified state.
    */
-  TypedValue(TString &&other, allocator_type alloc) : alloc_{alloc}, type_(Type::String) {
-    std::construct_at(&string_v, std::move(other), alloc_);
-  }
+  TypedValue(TString &&other, allocator_type alloc)
+      : alloc_{alloc}, string_v{std::move(other), alloc_}, type_(Type::String) {}
 
   /**
    * Perform an element-wise move using default utils::NewDeleteResource().
@@ -325,9 +309,7 @@ class TypedValue {
    * Perform an element-wise move of the other and use the given MemoryResource.
    * Other will be not be left empty, though elements may be Null.
    */
-  TypedValue(std::vector<TypedValue> &&other, allocator_type alloc) : alloc_{alloc}, type_(Type::List) {
-    std::construct_at(&list_v, std::make_move_iterator(other.begin()), std::make_move_iterator(other.end()), alloc_);
-  }
+  TypedValue(std::vector<TypedValue> &&other, allocator_type alloc);
 
   /**
    * Construct with the value of other.
@@ -341,9 +323,8 @@ class TypedValue {
    * If `other.get_allocator() != *memory`, this call will perform an
    * element-wise move and other is not guaranteed to be empty.
    */
-  TypedValue(TVector &&other, allocator_type alloc) : alloc_{alloc}, type_(Type::List) {
-    std::construct_at(&list_v, std::move(other), alloc_);
-  }
+  TypedValue(TVector &&other, allocator_type alloc)
+      : alloc_{alloc}, list_v{std::move(other), alloc_}, type_(Type::List) {}
 
   /**
    * Perform an element-wise move using default utils::NewDeleteResource().
@@ -373,13 +354,11 @@ class TypedValue {
    */
   TypedValue(TMap &&other, allocator_type alloc);
 
-  explicit TypedValue(VertexAccessor &&vertex, allocator_type alloc) noexcept : alloc_{alloc}, type_(Type::Vertex) {
-    std::construct_at(&vertex_v, std::move(vertex));
-  }
+  explicit TypedValue(VertexAccessor &&vertex, allocator_type alloc) noexcept
+      : alloc_{alloc}, vertex_v{std::move(vertex)}, type_(Type::Vertex) {}
 
-  explicit TypedValue(EdgeAccessor &&edge, allocator_type alloc) noexcept : alloc_{alloc}, type_(Type::Edge) {
-    std::construct_at(&edge_v, std::move(edge));
-  }
+  explicit TypedValue(EdgeAccessor &&edge, allocator_type alloc) noexcept
+      : alloc_{alloc}, edge_v{std::move(edge)}, type_(Type::Edge) {}
 
   /**
    * Construct with the value of path.

--- a/src/utils/memory.cpp
+++ b/src/utils/memory.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -77,7 +77,7 @@ void MonotonicBufferResource::Release() {
     auto alloc_size = b->size();
     auto alignment = b->alignment;
     b->~Buffer();
-    memory_->Deallocate(b, alloc_size, alignment);
+    memory_->deallocate(b, alloc_size, alignment);
     b = next;
   }
   current_buffer_ = nullptr;
@@ -85,7 +85,7 @@ void MonotonicBufferResource::Release() {
   allocated_ = 0U;
 }
 
-void *MonotonicBufferResource::DoAllocate(size_t bytes, size_t alignment) {
+void *MonotonicBufferResource::do_allocate(size_t bytes, size_t alignment) {
   static_assert(std::is_same_v<size_t, uintptr_t>);
   static_assert(std::is_same_v<size_t, uint64_t>);
   auto push_current_buffer = [this, bytes, alignment](size_t next_size) {
@@ -108,7 +108,7 @@ void *MonotonicBufferResource::DoAllocate(size_t bytes, size_t alignment) {
     // TODO : use better function than RoundUint64ToMultiple because we know alloc_align is a power of 2
     const auto alloc_size = RoundUint64ToMultiple(bytes_for_buffer + size, alloc_align);
     if (!alloc_size) throw BadAlloc("Allocation size overflow");
-    void *ptr = memory_->Allocate(*alloc_size, alloc_align);
+    void *ptr = memory_->allocate(*alloc_size, alloc_align);
     // Instantiate the Buffer at the start of the allocated block.
     current_buffer_ = new (ptr) Buffer{current_buffer_, *alloc_size - bytes_for_buffer, alloc_align};
     allocated_ = 0;
@@ -167,7 +167,7 @@ Pool::~Pool() {
     auto const dataSize = blocks_per_chunk_ * block_size_;
     auto const alignment = Ceil2(block_size_);
     for (auto &chunk : chunks_) {
-      resource->Deallocate(chunk.raw_data, dataSize, alignment);
+      resource->deallocate(chunk.raw_data, dataSize, alignment);
     }
     chunks_.clear();
   }
@@ -180,12 +180,12 @@ void *Pool::Allocate() {
     auto const data_size = blocks_per_chunk_ * block_size_;
     auto const alignment = Ceil2(block_size_);
     auto *resource = GetUpstreamResource();
-    auto *data = reinterpret_cast<std::byte *>(resource->Allocate(data_size, alignment));
+    auto *data = reinterpret_cast<std::byte *>(resource->allocate(data_size, alignment));
     try {
       auto &new_chunk = chunks_.emplace_front(data);
       free_list_ = new_chunk.build_freelist(block_size_, blocks_per_chunk_);
     } catch (...) {
-      resource->Deallocate(data, data_size, alignment);
+      resource->deallocate(data, data_size, alignment);
       throw;
     }
   }
@@ -207,13 +207,13 @@ struct NullMemoryResourceImpl final : public MemoryResource {
   ~NullMemoryResourceImpl() override = default;
 
  private:
-  void *DoAllocate(size_t /*bytes*/, size_t /*alignment*/) override {
+  void *do_allocate(size_t /*bytes*/, size_t /*alignment*/) override {
     throw BadAlloc{"NullMemoryResource doesn't allocate"};
   }
-  void DoDeallocate(void * /*p*/, size_t /*bytes*/, size_t /*alignment*/) override {
+  void do_deallocate(void * /*p*/, size_t /*bytes*/, size_t /*alignment*/) override {
     throw BadAlloc{"NullMemoryResource doesn't deallocate"};
   }
-  bool DoIsEqual(MemoryResource const &other) const noexcept override {
+  bool do_is_equal(MemoryResource const &other) const noexcept override {
     return dynamic_cast<NullMemoryResourceImpl const *>(&other) != nullptr;
   }
 };
@@ -275,7 +275,7 @@ static_assert(bin_index<2>(24U) == 2);
 
 }  // namespace impl
 
-void *PoolResource::DoAllocate(size_t bytes, size_t alignment) {
+void *PoolResource::do_allocate(size_t bytes, size_t alignment) {
   // Take the max of `bytes` and `alignment` so that we simplify handling
   // alignment requests.
   size_t block_size = std::max({bytes, alignment, 1UL});
@@ -299,9 +299,9 @@ void *PoolResource::DoAllocate(size_t bytes, size_t alignment) {
   if (block_size <= 1024) {
     return pools_5bit_.allocate(block_size);
   }
-  return unpooled_memory_->Allocate(bytes, alignment);
+  return unpooled_memory_->allocate(bytes, alignment);
 }
-void PoolResource::DoDeallocate(void *p, size_t bytes, size_t alignment) {
+void PoolResource::do_deallocate(void *p, size_t bytes, size_t alignment) {
   size_t block_size = std::max({bytes, alignment, 1UL});
   DMG_ASSERT(block_size % alignment == 0);
 
@@ -314,8 +314,8 @@ void PoolResource::DoDeallocate(void *p, size_t bytes, size_t alignment) {
   } else if (block_size <= 1024) {
     pools_5bit_.deallocate(p, block_size);
   } else {
-    unpooled_memory_->Deallocate(p, bytes, alignment);
+    unpooled_memory_->deallocate(p, bytes, alignment);
   }
 }
-bool PoolResource::DoIsEqual(MemoryResource const &other) const noexcept { return this == &other; }
+bool PoolResource::do_is_equal(const std::pmr::memory_resource &other) const noexcept { return this == &other; }
 }  // namespace memgraph::utils

--- a/src/utils/memory.hpp
+++ b/src/utils/memory.hpp
@@ -49,42 +49,9 @@ class BadAlloc final : public std::bad_alloc {
 };
 
 /// Abstract class for writing custom memory management, i.e. allocators.
-class MemoryResource {
- public:
-  virtual ~MemoryResource() = default;
+using MemoryResource = std::pmr::memory_resource;
 
-  /// Allocate storage with a size of at least `bytes` bytes.
-  ///
-  /// `bytes` must be greater than 0, while `alignment` must be a power of 2, if
-  /// they are not, `std::bad_alloc` is thrown.
-  ///
-  /// Some concrete implementations may have stricter requirements on `bytes`
-  /// and `alignment` values.
-  ///
-  /// @throw std::bad_alloc if the requested storage and alignment combination
-  ///     cannot be obtained.
-  void *Allocate(size_t bytes, size_t alignment = alignof(std::max_align_t)) {
-    if (bytes == 0U || !IsPow2(alignment)) throw BadAlloc("Invalid allocation request");
-    return DoAllocate(bytes, alignment);
-  }
-
-  void Deallocate(void *p, size_t bytes, size_t alignment = alignof(std::max_align_t)) {
-    return DoDeallocate(p, bytes, alignment);
-  }
-
-  bool IsEqual(const MemoryResource &other) const noexcept { return DoIsEqual(other); }
-
- private:
-  virtual void *DoAllocate(size_t bytes, size_t alignment) = 0;
-  virtual void DoDeallocate(void *p, size_t bytes, size_t alignment) = 0;
-  virtual bool DoIsEqual(const MemoryResource &other) const noexcept = 0;
-};
-
-inline bool operator==(const MemoryResource &a, const MemoryResource &b) noexcept { return &a == &b || a.IsEqual(b); }
-
-inline bool operator!=(const MemoryResource &a, const MemoryResource &b) noexcept { return !(a == b); }
-
-MemoryResource *NewDeleteResource() noexcept;
+std::pmr::memory_resource *NewDeleteResource() noexcept;
 
 /// Allocator for a concrete type T using the underlying MemoryResource
 ///
@@ -103,241 +70,20 @@ MemoryResource *NewDeleteResource() noexcept;
 /// implementations of MemoryResource.
 ///
 /// Classes which have a member allocator_type typedef to this allocator will
-/// receive an instance of `this->GetMemoryResource()` upon construction if the
+/// receive an instance of `this->get_allocator()` upon construction if the
 /// outer container also uses this allocator. For concrete behaviour on how this
 /// is done refer to `std::uses_allocator` in C++ reference.
 template <class T>
-class Allocator {
- public:
-  using value_type = T;
-  using propagate_on_container_copy_assignment = std::false_type;
-  using propagate_on_container_move_assignment = std::false_type;
-  using propagate_on_container_swap = std::false_type;
-
-  /// Implicit conversion from MemoryResource.
-  /// This makes working with STL containers much easier.
-  Allocator(MemoryResource *memory) : memory_(memory) {}
-
-  template <class U>
-  Allocator(const Allocator<U> &other) noexcept : memory_(other.GetMemoryResource()) {}
-
-  template <class U>
-  Allocator &operator=(const Allocator<U> &) = delete;
-
-  MemoryResource *GetMemoryResource() const { return memory_; }
-
-  T *allocate(size_t count_elements) {
-    return static_cast<T *>(memory_->Allocate(count_elements * sizeof(T), alignof(T)));
-  }
-
-  void deallocate(T *p, size_t count_elements) { memory_->Deallocate(p, count_elements * sizeof(T), alignof(T)); }
-
-  /// Return default NewDeleteResource() allocator.
-  Allocator select_on_container_copy_construction() const { return utils::NewDeleteResource(); }
-
-  template <class U, class... TArgs>
-  void construct(U *ptr, TArgs &&...args) {
-    if constexpr (std::uses_allocator_v<U, Allocator>) {
-      if constexpr (std::is_constructible_v<U, std::allocator_arg_t, MemoryResource *, TArgs...>) {
-        std::construct_at(ptr, std::allocator_arg, memory_, std::forward<TArgs>(args)...);
-      } else if constexpr (std::is_constructible_v<U, TArgs..., MemoryResource *>) {
-        std::construct_at(ptr, std::forward<TArgs>(args)..., memory_);
-      } else {
-        static_assert(!std::uses_allocator_v<U, Allocator>,
-                      "Class declares std::uses_allocator but has no valid "
-                      "constructor overload. Refer to 'Uses-allocator "
-                      "construction' rules in C++ reference.");
-      }
-    } else {
-      std::construct_at(ptr, std::forward<TArgs>(args)...);
-    }
-  }
-
-  // Overloads for constructing a std::pair. Needed until C++20, when allocator
-  // propagation to std::pair in std::map is resolved. These are all modeled
-  // after std::pmr::polymorphic_allocator<>::construct, documentation
-  // referenced here:
-  // https://en.cppreference.com/w/cpp/memory/polymorphic_allocator/construct
-
-  template <class T1, class T2, class... Args1, class... Args2>
-  void construct(std::pair<T1, T2> *p, std::piecewise_construct_t, std::tuple<Args1...> x, std::tuple<Args2...> y) {
-    auto xprime = MakePairElementArguments<T1>(&x);
-    auto yprime = MakePairElementArguments<T2>(&y);
-    ::new (p) std::pair<T1, T2>(std::piecewise_construct, std::move(xprime), std::move(yprime));
-  }
-
-  template <class T1, class T2>
-  void construct(std::pair<T1, T2> *p) {
-    construct(p, std::piecewise_construct, std::tuple<>(), std::tuple<>());
-  }
-
-  template <class T1, class T2, class U, class V>
-  void construct(std::pair<T1, T2> *p, U &&x, V &&y) {
-    construct(p, std::piecewise_construct, std::forward_as_tuple(std::forward<U>(x)),
-              std::forward_as_tuple(std::forward<V>(y)));
-  }
-
-  template <class T1, class T2, class U, class V>
-  void construct(std::pair<T1, T2> *p, const std::pair<U, V> &xy) {
-    construct(p, std::piecewise_construct, std::forward_as_tuple(xy.first), std::forward_as_tuple(xy.second));
-  }
-
-  template <class T1, class T2, class U, class V>
-  void construct(std::pair<T1, T2> *p, std::pair<U, V> &&xy) {
-    construct(p, std::piecewise_construct, std::forward_as_tuple(std::forward<U>(xy.first)),
-              std::forward_as_tuple(std::forward<V>(xy.second)));
-  }
-
-  // To ensure pair & doesn't use the generic overload, here is explicitly a non-const ref overload
-  template <class T1, class T2, class U, class V>
-  void construct(std::pair<T1, T2> *p, std::pair<U, V> &xy) {
-    construct(p, std::piecewise_construct, std::forward_as_tuple(xy.first), std::forward_as_tuple(xy.second));
-  }
-
-  template <class T1, class T2, class... Args1, class... Args2>
-  void construct(boost::container::dtl::pair<T1, T2> *p, std::piecewise_construct_t, std::tuple<Args1...> x,
-                 std::tuple<Args2...> y) {
-    auto xprime = MakePairElementArguments<T1>(&x);
-    auto yprime = MakePairElementArguments<T2>(&y);
-    std::construct_at(p, std::piecewise_construct, std::move(xprime), std::move(yprime));
-  }
-
-  template <class T1, class T2>
-  void construct(boost::container::dtl::pair<T1, T2> *p) {
-    construct(p, std::piecewise_construct, std::tuple<>(), std::tuple<>());
-  }
-
-  template <class T1, class T2, class U, class V>
-  void construct(boost::container::dtl::pair<T1, T2> *p, U &&x, V &&y) {
-    construct(p, std::piecewise_construct, std::forward_as_tuple(std::forward<U>(x)),
-              std::forward_as_tuple(std::forward<V>(y)));
-  }
-
-  template <class T1, class T2, class U, class V>
-  void construct(boost::container::dtl::pair<T1, T2> *p, const boost::container::dtl::pair<U, V> &xy) {
-    construct(p, std::piecewise_construct, std::forward_as_tuple(xy.first), std::forward_as_tuple(xy.second));
-  }
-
-  template <class T1, class T2, class U, class V>
-  void construct(boost::container::dtl::pair<T1, T2> *p, boost::container::dtl::pair<U, V> &&xy) {
-    construct(p, std::piecewise_construct, std::forward_as_tuple(std::forward<U>(xy.first)),
-              std::forward_as_tuple(std::forward<V>(xy.second)));
-  }
-
-  // To ensure pair & doesn't use the generic overload, here is explicitly a non-const ref overload
-  template <class T1, class T2, class U, class V>
-  void construct(boost::container::dtl::pair<T1, T2> *p, boost::container::dtl::pair<U, V> &xy) {
-    construct(p, std::piecewise_construct, std::forward_as_tuple(xy.first), std::forward_as_tuple(xy.second));
-  }
-
-  template <class U>
-  void destroy(U *p) {
-    p->~U();
-  }
-
-  template <class U, class... TArgs>
-  U *new_object(TArgs &&...args) {
-    U *p = static_cast<U *>(memory_->Allocate(sizeof(U), alignof(U)));
-    try {
-      construct(p, std::forward<TArgs>(args)...);
-    } catch (...) {
-      memory_->Deallocate(p, sizeof(U), alignof(U));
-      throw;
-    }
-    return p;
-  }
-
-  template <class U>
-  void delete_object(U *p) {
-    destroy(p);
-    memory_->Deallocate(p, sizeof(U), alignof(U));
-  }
-
- private:
-  MemoryResource *memory_;
-
-  template <class TElem, class... TArgs>
-  auto MakePairElementArguments(std::tuple<TArgs...> *args) {
-    if constexpr (std::uses_allocator_v<TElem, Allocator>) {
-      if constexpr (std::is_constructible_v<TElem, std::allocator_arg_t, MemoryResource *, TArgs...>) {
-        return std::tuple_cat(std::make_tuple(std::allocator_arg, memory_), std::move(*args));
-      } else if constexpr (std::is_constructible_v<TElem, TArgs..., MemoryResource *>) {
-        return std::tuple_cat(std::move(*args), std::make_tuple(memory_));
-      } else {
-        static_assert(!std::uses_allocator_v<TElem, Allocator>,
-                      "Class declares std::uses_allocator but has no valid "
-                      "constructor overload. Refer to 'Uses-allocator "
-                      "construction' rules in C++ reference.");
-      }
-    } else {
-      // Explicitly do a move as we don't want a needless copy of `*args`.
-      // Previous return statements return a temporary, so the compiler should
-      // optimize that.
-      return std::move(*args);
-    }
-  }
-};
-
-template <class T, class U>
-bool operator==(const Allocator<T> &a, const Allocator<U> &b) {
-  return *a.GetMemoryResource() == *b.GetMemoryResource();
-}
-
-template <class T, class U>
-bool operator!=(const Allocator<T> &a, const Allocator<U> &b) {
-  return !(a == b);
-}
+using Allocator = std::pmr::polymorphic_allocator<T>;
 
 auto NullMemoryResource() noexcept -> MemoryResource *;
 
-/// Wraps std::pmr::memory_resource for use with out MemoryResource
-class StdMemoryResource final : public MemoryResource {
- public:
-#if _GLIBCXX_RELEASE < 9
-  StdMemoryResource(std::experimental::pmr::memory_resource *memory) : memory_(memory) {}
-#else
-  /// Implicitly convert std::pmr::memory_resource to StdMemoryResource
-  StdMemoryResource(std::pmr::memory_resource *memory) : memory_(memory) {}
-#endif
-
- private:
-  void *DoAllocate(size_t bytes, size_t alignment) override {
-    // In the current implementation of libstdc++-8.3, standard memory_resource
-    // implementations don't check alignment overflows. Below is the copied
-    // implementation of _S_aligned_size, but we throw if it overflows.
-    // Currently, this only concerns new_delete_resource as there are no other
-    // memory_resource implementations available. This issue appears to persist
-    // in newer implementations, additionally pool_resource does no alignment of
-    // allocated pointers whatsoever.
-    size_t aligned_size = ((bytes - 1) | (alignment - 1)) + 1;
-    if (aligned_size < bytes) throw BadAlloc("Allocation alignment overflow");
-    return memory_->allocate(bytes, alignment);
-  }
-
-  void DoDeallocate(void *p, size_t bytes, size_t alignment) override {
-    return memory_->deallocate(p, bytes, alignment);
-  }
-
-  bool DoIsEqual(const MemoryResource &other) const noexcept override {
-    const auto *other_std = dynamic_cast<const StdMemoryResource *>(&other);
-    if (!other_std) return false;
-    return *memory_ == *other_std->memory_;
-  }
-
-#if _GLIBCXX_RELEASE < 9
-  std::experimental::pmr::memory_resource *memory_;
-#else
-  std::pmr::memory_resource *memory_;
-#endif
-};
-
 inline MemoryResource *NewDeleteResource() noexcept {
 #if _GLIBCXX_RELEASE < 9
-  static StdMemoryResource memory(std::experimental::pmr::new_delete_resource());
+  return std::experimental::pmr::new_delete_resource();
 #else
-  static StdMemoryResource memory(std::pmr::new_delete_resource());
+  return std::pmr::new_delete_resource();
 #endif
-  return &memory;
 }
 
 /// MemoryResource which releases the memory only when the resource is
@@ -413,11 +159,11 @@ class MonotonicBufferResource final : public MemoryResource {
   size_t next_buffer_size_{initial_size_};
   size_t allocated_{0U};
 
-  void *DoAllocate(size_t bytes, size_t alignment) override;
+  void *do_allocate(size_t bytes, size_t alignment) override;
 
-  void DoDeallocate(void *, size_t, size_t) override {}
+  void do_deallocate(void *, size_t, size_t) override {}
 
-  bool DoIsEqual(const MemoryResource &other) const noexcept override { return this == &other; }
+  bool do_is_equal(const MemoryResource &other) const noexcept override { return this == &other; }
 };
 
 namespace impl {
@@ -470,7 +216,7 @@ class Pool final {
   /// Destructor does not free blocks, you have to call `Release` before.
   ~Pool();
 
-  MemoryResource *GetUpstreamResource() const { return chunks_.get_allocator().GetMemoryResource(); }
+  auto GetUpstreamResource() const -> std::pmr::memory_resource * { return chunks_.get_allocator().resource(); }
 
   auto GetBlockSize() const { return block_size_; }
 
@@ -575,14 +321,14 @@ struct MultiPool {
 
   static constexpr auto n_bins = bin_index<Bits, LB>(UB) + 1U;
 
-  MultiPool(uint8_t blocks_per_chunk, MemoryResource *memory, MemoryResource *internal_memory)
+  MultiPool(uint8_t blocks_per_chunk, std::pmr::memory_resource *memory, std::pmr::memory_resource *internal_memory)
       : blocks_per_chunk_{blocks_per_chunk}, memory_{memory}, internal_memory_{internal_memory} {}
 
   ~MultiPool() {
     if (pools_) {
       auto pool_alloc = Allocator<Pool>(internal_memory_);
       for (auto i = 0U; i != n_bins; ++i) {
-        pool_alloc.destroy(&pools_[i]);
+        std::allocator_traits<Allocator<Pool>>::destroy(pool_alloc, &pools_[i]);
       }
       pool_alloc.deallocate(pools_, n_bins);
     }
@@ -619,8 +365,8 @@ struct MultiPool {
 
   Pool *pools_{};
   uint8_t blocks_per_chunk_{};
-  MemoryResource *memory_{};
-  MemoryResource *internal_memory_{};
+  std::pmr::memory_resource *memory_{};
+  std::pmr::memory_resource *internal_memory_{};
 };
 
 }  // namespace impl
@@ -648,10 +394,10 @@ struct MultiPool {
 ///   * Maximum number of blocks per chunk can be tuned by passing the
 ///     arguments to the constructor.
 
-class PoolResource final : public MemoryResource {
+class PoolResource final : public std::pmr::memory_resource {
  public:
-  PoolResource(uint8_t blocks_per_chunk, MemoryResource *memory = NewDeleteResource(),
-                MemoryResource *internal_memory = NewDeleteResource())
+  PoolResource(uint8_t blocks_per_chunk, std::pmr::memory_resource *memory = NewDeleteResource(),
+                std::pmr::memory_resource *internal_memory = NewDeleteResource())
       : mini_pools_{
             impl::Pool{8, blocks_per_chunk, memory},
             impl::Pool{16, blocks_per_chunk, memory},
@@ -669,61 +415,63 @@ class PoolResource final : public MemoryResource {
   ~PoolResource() override = default;
 
  private:
-  void *DoAllocate(size_t bytes, size_t alignment) override;
-  void DoDeallocate(void *p, size_t bytes, size_t alignment) override;
-  bool DoIsEqual(MemoryResource const &other) const noexcept override;
+  void *do_allocate(size_t bytes, size_t alignment) override;
+  void do_deallocate(void *p, size_t bytes, size_t alignment) override;
+  bool do_is_equal(std::pmr::memory_resource const &other) const noexcept override;
 
  private:
   std::array<impl::Pool, 8> mini_pools_;
   impl::MultiPool<3, 64, 128> pools_3bit_;
   impl::MultiPool<4, 128, 512> pools_4bit_;
   impl::MultiPool<5, 512, 1024> pools_5bit_;
-  MemoryResource *unpooled_memory_;
+  std::pmr::memory_resource *unpooled_memory_;
 };
 
-class MemoryTrackingResource final : public utils::MemoryResource {
+class MemoryTrackingResource final : public std::pmr::memory_resource {
  public:
-  explicit MemoryTrackingResource(utils::MemoryResource *memory, size_t max_allocated_bytes)
+  explicit MemoryTrackingResource(std::pmr::memory_resource *memory, size_t max_allocated_bytes)
       : memory_(memory), max_allocated_bytes_(max_allocated_bytes) {}
 
   size_t GetAllocatedBytes() const noexcept { return max_allocated_bytes_ - available_bytes_; }
 
  private:
-  utils::MemoryResource *memory_;
+  std::pmr::memory_resource *memory_;
   size_t max_allocated_bytes_;
   size_t available_bytes_{max_allocated_bytes_};
 
-  void *DoAllocate(size_t bytes, size_t alignment) override {
+  void *do_allocate(size_t bytes, size_t alignment) override {
     available_bytes_ -= bytes;
-    return memory_->Allocate(bytes, alignment);
+    return memory_->allocate(bytes, alignment);
   }
 
-  void DoDeallocate(void *p, size_t bytes, size_t alignment) override {
+  void do_deallocate(void *p, size_t bytes, size_t alignment) override {
     available_bytes_ += bytes;
-    return memory_->Deallocate(p, bytes, alignment);
+    return memory_->deallocate(p, bytes, alignment);
   }
 
-  bool DoIsEqual(const MemoryResource &other) const noexcept override { return this == &other; }
+  bool do_is_equal(const MemoryResource &other) const noexcept override { return this == &other; }
 };
 
 // Allocate memory with the OutOfMemoryException enabled if the requested size
 // puts total allocated amount over the limit.
 class ResourceWithOutOfMemoryException : public MemoryResource {
  public:
-  explicit ResourceWithOutOfMemoryException(utils::MemoryResource *upstream = utils::NewDeleteResource())
+  explicit ResourceWithOutOfMemoryException(std::pmr::memory_resource *upstream = utils::NewDeleteResource())
       : upstream_{upstream} {}
 
-  utils::MemoryResource *GetUpstream() noexcept { return upstream_; }
+  auto GetUpstream() noexcept -> std::pmr::memory_resource * { return upstream_; }
 
  private:
-  void *DoAllocate(size_t bytes, size_t alignment) override {
+  void *do_allocate(size_t bytes, size_t alignment) override {
     utils::MemoryTracker::OutOfMemoryExceptionEnabler exception_enabler;
-    return upstream_->Allocate(bytes, alignment);
+    return upstream_->allocate(bytes, alignment);
   }
 
-  void DoDeallocate(void *p, size_t bytes, size_t alignment) override { upstream_->Deallocate(p, bytes, alignment); }
+  void do_deallocate(void *p, size_t bytes, size_t alignment) override { upstream_->deallocate(p, bytes, alignment); }
 
-  bool DoIsEqual(const utils::MemoryResource &other) const noexcept override { return upstream_->IsEqual(other); }
+  bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override {
+    return upstream_->is_equal(other);
+  }
 
   MemoryResource *upstream_{utils::NewDeleteResource()};
 };

--- a/src/utils/skip_list.hpp
+++ b/src/utils/skip_list.hpp
@@ -356,7 +356,7 @@ class SkipListGc final {
       if (item->first < last_dead) {
         size_t bytes = SkipListNodeSize(*item->second);
         item->second->~TNode();
-        memory_->Deallocate(item->second, bytes, SkipListNodeAlign<TObj>());
+        memory_->deallocate(item->second, bytes, SkipListNodeAlign<TObj>());
       } else {
         leftover.Push(*item);
       }
@@ -384,7 +384,7 @@ class SkipListGc final {
       while ((item = deleted_.Pop())) {
         size_t bytes = SkipListNodeSize(*item->second);
         item->second->~TNode();
-        memory_->Deallocate(item->second, bytes, SkipListNodeAlign<TObj>());
+        memory_->deallocate(item->second, bytes, SkipListNodeAlign<TObj>());
       }
     }
 
@@ -982,7 +982,7 @@ class SkipList final : detail::SkipListNode_base {
 
   explicit SkipList(MemoryResource *memory) : gc_(memory) {
     static_assert(kSkipListMaxHeight <= 32, "The SkipList height must be less or equal to 32!");
-    void *ptr = memory->Allocate(MaxSkipListNodeSize<TObj>(), SkipListNodeAlign<TObj>());
+    void *ptr = memory->allocate(MaxSkipListNodeSize<TObj>(), SkipListNodeAlign<TObj>());
     // `calloc` would be faster, but the API has no such call.
     memset(ptr, 0, MaxSkipListNodeSize<TObj>());
     // Here we don't call the `SkipListNode` constructor so that the `TObj`
@@ -1008,7 +1008,7 @@ class SkipList final : detail::SkipListNode_base {
       TNode *succ = head->nexts[0].load(std::memory_order_acquire);
       size_t bytes = SkipListNodeSize(*head);
       head->~TNode();
-      GetMemoryResource()->Deallocate(head, bytes, SkipListNodeAlign<TObj>());
+      GetMemoryResource()->deallocate(head, bytes, SkipListNodeAlign<TObj>());
       head = succ;
     }
     head_ = other.head_;
@@ -1029,7 +1029,7 @@ class SkipList final : detail::SkipListNode_base {
       // constructor (see the note in the `SkipList` constructor). We mustn't
       // call the `TObj` destructor because we didn't call its constructor.
       head_->lock.~SpinLock();
-      GetMemoryResource()->Deallocate(head_, SkipListNodeSize(*head_), SkipListNodeAlign<TObj>());
+      GetMemoryResource()->deallocate(head_, SkipListNodeSize(*head_), SkipListNodeAlign<TObj>());
     }
   }
 
@@ -1053,7 +1053,7 @@ class SkipList final : detail::SkipListNode_base {
       TNode *succ = curr->nexts[0].load(std::memory_order_acquire);
       size_t bytes = SkipListNodeSize(*curr);
       curr->~TNode();
-      GetMemoryResource()->Deallocate(curr, bytes, SkipListNodeAlign<TObj>());
+      GetMemoryResource()->deallocate(curr, bytes, SkipListNodeAlign<TObj>());
       curr = succ;
     }
     for (int layer = 0; layer < kSkipListMaxHeight; ++layer) {
@@ -1161,7 +1161,7 @@ class SkipList final : detail::SkipListNode_base {
         size_t node_bytes = sizeof(TNode) + top_layer * sizeof(std::atomic<TNode *>);
 
         MemoryResource *memoryResource = GetMemoryResource();
-        void *ptr = memoryResource->Allocate(node_bytes, SkipListNodeAlign<TObj>());
+        void *ptr = memoryResource->allocate(node_bytes, SkipListNodeAlign<TObj>());
         new_node = static_cast<TNode *>(ptr);
 
         // Construct through allocator so it propagates if needed.

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -99,8 +99,8 @@ class ExpressionEvaluatorTest : public ::testing::Test {
     ctx.properties = NamesToProperties(storage.properties_, &dba);
     ctx.labels = NamesToLabels(storage.labels_, &dba);
     auto value = expr->Accept(eval);
-    EXPECT_EQ(value.GetMemoryResource(), &mem) << "ExpressionEvaluator must use the MemoryResource from "
-                                                  "EvaluationContext for allocations!";
+    EXPECT_EQ(value.get_allocator().resource(), &mem) << "ExpressionEvaluator must use the MemoryResource from "
+                                                         "EvaluationContext for allocations!";
     return value;
   }
 };


### PR DESCRIPTION
Remove our own `utils::MemoryResource` in favour of std::pmr::memory_resource. Also change to `std::pmr::polymorphic_allocator`.

The main reasons to do this:
- reduce code maintenance
- better tested, updated and, correct version in libstdc++
- handles pair like types better

Also changed TypedValue's map to `std::pmr::map<TString, TypedValue, std::less<>>` until we update boost to make flat_map correct.