### PR TITLE
Bugfix: fails to create empty user while using auth modules

### DIFF
--- a/src/glue/auth_checker.cpp
+++ b/src/glue/auth_checker.cpp
@@ -115,6 +115,10 @@ std::unique_ptr<query::QueryUserOrRole> AuthChecker::GenQueryUser(auth::SynchedA
   return std::make_unique<QueryUserOrRole>(auth);
 }
 
+std::shared_ptr<query::QueryUserOrRole> AuthChecker::GenEmptyUser() const {
+  return std::make_shared<QueryUserOrRole>(auth_);
+}
+
 #ifdef MG_ENTERPRISE
 std::unique_ptr<memgraph::query::FineGrainedAuthChecker> AuthChecker::GetFineGrainedAuthChecker(
     std::shared_ptr<query::QueryUserOrRole> user_or_role, const memgraph::query::DbAccessor *dba) const {

--- a/src/glue/auth_checker.hpp
+++ b/src/glue/auth_checker.hpp
@@ -28,6 +28,8 @@ class AuthChecker : public query::AuthChecker {
   static std::unique_ptr<query::QueryUserOrRole> GenQueryUser(auth::SynchedAuth *auth,
                                                               const std::optional<auth::UserOrRole> &user_or_role);
 
+  std::shared_ptr<query::QueryUserOrRole> GenEmptyUser() const override;
+
 #ifdef MG_ENTERPRISE
   std::unique_ptr<query::FineGrainedAuthChecker> GetFineGrainedAuthChecker(std::shared_ptr<query::QueryUserOrRole> user,
                                                                            const query::DbAccessor *dba) const override;

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -95,7 +95,7 @@ void InitFromCypherlFile(memgraph::query::InterpreterContext &ctx, memgraph::dbm
   // Temporary empty user
   // TODO: Double check with buda
   memgraph::query::AllowEverythingAuthChecker tmp_auth_checker;
-  auto tmp_user = tmp_auth_checker.GenQueryUser(std::nullopt, std::nullopt);
+  auto tmp_user = tmp_auth_checker.GenEmptyUser();
   interpreter.SetUser(tmp_user);
 
   std::ifstream file(cypherl_file_path);

--- a/src/query/auth_checker.hpp
+++ b/src/query/auth_checker.hpp
@@ -35,6 +35,8 @@ class AuthChecker {
   virtual std::shared_ptr<QueryUserOrRole> GenQueryUser(const std::optional<std::string> &username,
                                                         const std::optional<std::string> &rolename) const = 0;
 
+  virtual std::shared_ptr<QueryUserOrRole> GenEmptyUser() const = 0;
+
 #ifdef MG_ENTERPRISE
   [[nodiscard]] virtual std::unique_ptr<FineGrainedAuthChecker> GetFineGrainedAuthChecker(
       std::shared_ptr<QueryUserOrRole> user, const DbAccessor *db_accessor) const = 0;
@@ -113,9 +115,11 @@ class AllowEverythingAuthChecker final : public AuthChecker {
 
   std::shared_ptr<query::QueryUserOrRole> GenQueryUser(const std::optional<std::string> &name,
                                                        const std::optional<std::string> & /*role*/) const override {
-    if (name) return std::make_shared<User>(std::move(*name));
+    if (name) return std::make_shared<User>(*name);
     return std::make_shared<User>();
   }
+
+  std::shared_ptr<QueryUserOrRole> GenEmptyUser() const override { return std::make_shared<User>(); }
 
 #ifdef MG_ENTERPRISE
   std::unique_ptr<FineGrainedAuthChecker> GetFineGrainedAuthChecker(std::shared_ptr<QueryUserOrRole> /*user*/,

--- a/src/query/stream/streams.cpp
+++ b/src/query/stream/streams.cpp
@@ -518,7 +518,7 @@ Streams::StreamsMap::iterator Streams::CreateConsumer(StreamsMap &map, const std
     // NOTE: We generate an empty user to avoid generating interpreter's fine grained access control and rely only on
     // the global auth_checker used in the stream itself
     // TODO: Fix auth inconsistency
-    interpreter->SetUser(interpreter_context->auth_checker->GenQueryUser(std::nullopt, std::nullopt));
+    interpreter->SetUser(interpreter_context->auth_checker->GenEmptyUser());
 #ifdef MG_ENTERPRISE
     interpreter->OnChangeCB([](auto) { return false; });  // Disable database change
 #endif

--- a/src/query/time_to_live/time_to_live.cpp
+++ b/src/query/time_to_live/time_to_live.cpp
@@ -62,7 +62,8 @@ void TTL::Setup_(TDbAccess db_acc, InterpreterContext *interpreter_context, cons
 
   // NOTE: We generate an empty user to avoid generating interpreter's fine grained access control.
   // The TTL query already protects who is configuring it, so no need to auth here
-  interpreter->SetUser(interpreter_context->auth_checker->GenQueryUser(std::nullopt, std::nullopt));
+  // TODO: Fix auth inconsistency
+  interpreter->SetUser(interpreter_context->auth_checker->GenEmptyUser());
   interpreter->OnChangeCB([](auto) { return false; });  // Disable database change
                                                         // register new interpreter into interpreter_context
   interpreter_context->interpreters->insert(interpreter.get());

--- a/tests/unit/query_trigger.cpp
+++ b/tests/unit/query_trigger.cpp
@@ -46,6 +46,9 @@ class MockAuthChecker : public memgraph::query::AuthChecker {
   MOCK_CONST_METHOD2(GenQueryUser,
                      std::shared_ptr<memgraph::query::QueryUserOrRole>(const std::optional<std::string> &username,
                                                                        const std::optional<std::string> &rolename));
+
+  MOCK_CONST_METHOD0(GenEmptyUser, std::shared_ptr<memgraph::query::QueryUserOrRole>());
+
 #ifdef MG_ENTERPRISE
   MOCK_CONST_METHOD2(GetFineGrainedAuthChecker, std::unique_ptr<memgraph::query::FineGrainedAuthChecker>(
                                                     std::shared_ptr<memgraph::query::QueryUserOrRole> user,


### PR DESCRIPTION
Explicitly creating empty users, instead of reusing generic auth logic 
This is because when using auth modules we force user/role 
It is only in these specific cases where we don't want to force it: init from cypher file, streams and TTL