### PR TITLE
Add support for MT benchmark

### DIFF
--- a/tests/mgbench/benchmark.py
+++ b/tests/mgbench/benchmark.py
@@ -204,6 +204,12 @@ def parse_args():
         help="Vendor specific arguments that can be applied to each vendor, format: [key=value, key=value ...]",
     )
 
+    benchmark_parser.add_argument(
+        "--databases",
+        default="memgraph",
+        help="Comma-separated list of databases",
+    )
+
     subparsers = parser.add_subparsers(help="Subparsers", dest="run_option")
 
     parser_vendor_native = subparsers.add_parser(
@@ -950,6 +956,7 @@ if __name__ == "__main__":
 
     benchmark_context = BenchmarkContext(
         benchmark_target_workload=args.benchmarks,
+        databases=args.databases,
         client_bolt_address=args.client_bolt_address,
         external_vendor=args.run_option == "external-vendor",
         vendor_binary=args.vendor_binary if args.run_option == "vendor-native" else helpers.get_binary_path("memgraph"),

--- a/tests/mgbench/benchmark_context.py
+++ b/tests/mgbench/benchmark_context.py
@@ -24,6 +24,7 @@ class BenchmarkContext:
     def __init__(
         self,
         benchmark_target_workload: str = None,  # Workload that needs to be executed (dataset/variant/group/query)
+        databases: str = "memgraph",
         client_bolt_address: str = "127.0.0.1",
         external_vendor: bool = False,
         vendor_binary: str = None,
@@ -49,6 +50,7 @@ class BenchmarkContext:
         vendor_args: dict = {},
     ) -> None:
         self.benchmark_target_workload = benchmark_target_workload
+        self.databases = databases
         self.external_vendor = external_vendor
         self.client_bolt_address = client_bolt_address
         self.vendor_binary = vendor_binary

--- a/tests/mgbench/client.cpp
+++ b/tests/mgbench/client.cpp
@@ -18,6 +18,7 @@
 #include <map>
 #include <numeric>
 #include <ostream>
+#include <random>
 #include <string>
 #include <thread>
 #include <vector>
@@ -53,6 +54,7 @@ DEFINE_bool(queries_json, false,
             "that should be executed and the second element should be a dictionary of "
             "query parameters for that query.");
 
+DEFINE_string(databases, "memgraph", "Comma-separated list of databases");
 DEFINE_string(input, "", "Input file. By default stdin is used.");
 DEFINE_string(output, "", "Output file. By default stdout is used.");
 DEFINE_bool(validation, false,
@@ -66,12 +68,22 @@ DEFINE_int64(time_dependent_execution, 0,
 
 using bolt_map_t = memgraph::communication::bolt::map_t;
 
+std::random_device rd;
+std::mt19937 gen(rd());  // Mersenne Twister RNG
+
+std::string GetRandomDB(std::vector<std::string> const &dbs) {
+  std::uniform_int_distribution<> dis(0, dbs.size() - 1);
+  auto const rnd_index = dis(gen);
+  return dbs[rnd_index];
+}
+
 std::pair<bolt_map_t, uint64_t> ExecuteNTimesTillSuccess(memgraph::communication::bolt::Client *client,
                                                          const std::string &query, const bolt_map_t &params,
-                                                         int max_attempts) {
+                                                         int max_attempts, std::string const &db) {
+  bolt_map_t const extras{{"db", db}};
   for (uint64_t i = 0; i < max_attempts; ++i) {
     try {
-      auto ret = client->Execute(query, params);
+      auto ret = client->Execute(query, params, extras);
 
       return {std::move(ret.metadata), i};
     } catch (const memgraph::utils::BasicException &e) {
@@ -88,10 +100,12 @@ std::pair<bolt_map_t, uint64_t> ExecuteNTimesTillSuccess(memgraph::communication
 // Validation returns results and metadata
 std::pair<bolt_map_t, std::vector<std::vector<memgraph::communication::bolt::Value>>>
 ExecuteValidationNTimesTillSuccess(memgraph::communication::bolt::Client *client, const std::string &query,
-                                   const bolt_map_t &params, int max_attempts) {
+                                   const bolt_map_t &params, int max_attempts, std::string const &db) {
+  bolt_map_t const extras{{"db", db}};
+
   for (uint64_t i = 0; i < max_attempts; ++i) {
     try {
-      auto ret = client->Execute(query, params);
+      auto ret = client->Execute(query, params, extras);
       return {std::move(ret.metadata), std::move(ret.records)};
     } catch (const memgraph::utils::BasicException &e) {
       if (i == max_attempts - 1) {
@@ -224,8 +238,8 @@ nlohmann::json LatencyStatistics(std::vector<std::vector<double>> &worker_query_
   return statistics;
 }
 
-void ExecuteTimeDependentWorkload(const std::vector<std::pair<std::string, bolt_map_t>> &queries,
-                                  std::ostream *stream) {
+void ExecuteTimeDependentWorkload(const std::vector<std::pair<std::string, bolt_map_t>> &queries, std::ostream *stream,
+                                  std::vector<std::string> const &dbs) {
   std::vector<std::thread> threads;
   threads.reserve(FLAGS_num_workers);
 
@@ -273,8 +287,9 @@ void ExecuteTimeDependentWorkload(const std::vector<std::pair<std::string, bolt_
           pos = position.fetch_add(1, std::memory_order_acq_rel);
         }
         const auto &query = queries[pos];
+        auto const random_db = GetRandomDB(dbs);
         memgraph::utils::Timer query_timer;
-        auto ret = ExecuteNTimesTillSuccess(&client, query.first, query.second, FLAGS_max_retries);
+        auto ret = ExecuteNTimesTillSuccess(&client, query.first, query.second, FLAGS_max_retries, random_db);
         query_duration.emplace_back(query_timer.Elapsed().count());
         retries += ret.second;
         metadata.Append(ret.first);
@@ -328,7 +343,8 @@ void ExecuteTimeDependentWorkload(const std::vector<std::pair<std::string, bolt_
   (*stream) << summary.dump() << '\n';
 }
 
-void ExecuteWorkload(const std::vector<std::pair<std::string, bolt_map_t>> &queries, std::ostream *stream) {
+void ExecuteWorkload(const std::vector<std::pair<std::string, bolt_map_t>> &queries, std::ostream *stream,
+                     std::vector<std::string> const &dbs) {
   std::vector<std::thread> threads;
   threads.reserve(FLAGS_num_workers);
 
@@ -364,8 +380,9 @@ void ExecuteWorkload(const std::vector<std::pair<std::string, bolt_map_t>> &quer
         auto pos = position.fetch_add(1, std::memory_order_acq_rel);
         if (pos >= size) break;
         const auto &query = queries[pos];
+        auto const random_db = GetRandomDB(dbs);
         memgraph::utils::Timer query_timer;
-        auto ret = ExecuteNTimesTillSuccess(&client, query.first, query.second, FLAGS_max_retries);
+        auto ret = ExecuteNTimesTillSuccess(&client, query.first, query.second, FLAGS_max_retries, random_db);
         query_duration.emplace_back(query_timer.Elapsed().count());
         retries += ret.second;
         metadata.Append(ret.first);
@@ -421,7 +438,8 @@ nlohmann::json BoltRecordsToJSONStrings(std::vector<std::vector<memgraph::commun
 }
 
 /// Validation mode works on single thread with 1 query.
-void ExecuteValidation(const std::vector<std::pair<std::string, bolt_map_t>> &queries, std::ostream *stream) {
+void ExecuteValidation(const std::vector<std::pair<std::string, bolt_map_t>> &queries, std::ostream *stream,
+                       std::vector<std::string> const &dbs) {
   spdlog::info("Running validation mode, number of workers forced to 1");
   FLAGS_num_workers = 1;
 
@@ -436,10 +454,11 @@ void ExecuteValidation(const std::vector<std::pair<std::string, bolt_map_t>> &qu
   memgraph::communication::bolt::Client client(context);
   client.Connect(endpoint, FLAGS_username, FLAGS_password);
 
-  memgraph::utils::Timer timer;
+  auto const random_db = GetRandomDB(dbs);
   if (size == 1) {
     const auto &query = queries[0];
-    auto ret = ExecuteValidationNTimesTillSuccess(&client, query.first, query.second, FLAGS_max_retries);
+    memgraph::utils::Timer timer;
+    auto ret = ExecuteValidationNTimesTillSuccess(&client, query.first, query.second, FLAGS_max_retries, random_db);
     metadata.Append(ret.first);
     results = ret.second;
     duration = timer.Elapsed().count();
@@ -458,6 +477,20 @@ void ExecuteValidation(const std::vector<std::pair<std::string, bolt_map_t>> &qu
   (*stream) << summary.dump() << '\n';
 }
 
+void CreateDatabases(std::vector<std::string> const &dbs) {
+  memgraph::io::network::Endpoint endpoint(FLAGS_address, FLAGS_port);
+  memgraph::communication::ClientContext context(FLAGS_use_ssl);
+  memgraph::communication::bolt::Client client(context);
+  client.Connect(endpoint, FLAGS_username, FLAGS_password);
+  for (auto const &db : dbs) {
+    if (db == "memgraph") {
+      continue;
+    }
+    auto const create_db_query = fmt::format("CREATE DATABASE {}", db);
+    client.Execute(create_db_query, {});
+  }
+}
+
 int main(int argc, char **argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
@@ -473,7 +506,7 @@ int main(int argc, char **argv) {
   spdlog::info("Input: {}", FLAGS_input);
   spdlog::info("Output: {}", FLAGS_output);
   spdlog::info("Validation: {}", FLAGS_validation);
-  spdlog::info("Time dependend execution: {}", FLAGS_time_dependent_execution);
+  spdlog::info("Time dependent execution: {}", FLAGS_time_dependent_execution);
 
   memgraph::communication::SSLInit sslInit;
 
@@ -494,6 +527,9 @@ int main(int argc, char **argv) {
     ostream = &ofile;
   }
 
+  auto const dbs = memgraph::utils::Split(FLAGS_databases, ",");
+  CreateDatabases(dbs);
+
   std::vector<std::pair<std::string, bolt_map_t>> queries;
   if (!FLAGS_queries_json) {
     // Load simple queries.
@@ -501,7 +537,7 @@ int main(int argc, char **argv) {
     while (std::getline(*istream, query)) {
       auto trimmed = memgraph::utils::Trim(query);
       if (trimmed == "" || trimmed == ";") {
-        ExecuteWorkload(queries, ostream);
+        ExecuteWorkload(queries, ostream, dbs);
         queries.clear();
         continue;
       }
@@ -517,7 +553,7 @@ int main(int argc, char **argv) {
                 "array!");
       MG_ASSERT(data.is_array() && data.size() == 2, "Each item of the loaded JSON queries must be an array!");
       if (data.size() == 0) {
-        ExecuteWorkload(queries, ostream);
+        ExecuteWorkload(queries, ostream, dbs);
         queries.clear();
         continue;
       }
@@ -536,11 +572,11 @@ int main(int argc, char **argv) {
   }
 
   if (FLAGS_validation) {
-    ExecuteValidation(queries, ostream);
+    ExecuteValidation(queries, ostream, dbs);
   } else if (FLAGS_time_dependent_execution > 0) {
-    ExecuteTimeDependentWorkload(queries, ostream);
+    ExecuteTimeDependentWorkload(queries, ostream, dbs);
   } else {
-    ExecuteWorkload(queries, ostream);
+    ExecuteWorkload(queries, ostream, dbs);
   }
 
   return 0;

--- a/tests/mgbench/client.cpp
+++ b/tests/mgbench/client.cpp
@@ -489,6 +489,7 @@ void CreateDatabases(std::vector<std::string> const &dbs) {
     auto const create_db_query = fmt::format("CREATE DATABASE {}", db);
     client.Execute(create_db_query, {});
   }
+  client.Close();
 }
 
 int main(int argc, char **argv) {

--- a/tests/mgbench/runners.py
+++ b/tests/mgbench/runners.py
@@ -110,6 +110,7 @@ class BoltClient(BaseClient):
             benchmark_context.vendor_args["bolt-port"] if "bolt-port" in benchmark_context.vendor_args.keys() else 7687
         )
         self._bolt_address = benchmark_context.client_bolt_address
+        self._databases = benchmark_context.databases
 
     def _get_args(self, **kwargs):
         return _convert_args_to_flags(self._client_binary, **kwargs)
@@ -144,6 +145,7 @@ class BoltClient(BaseClient):
             address=self._bolt_address,
             validation=False,
             time_dependent_execution=time_dependent_execution,
+            databases=self._databases,
         )
 
         log.info("Client args: {}".format(client_args))
@@ -181,6 +183,7 @@ class BoltClient(BaseClient):
             port=self._bolt_port,
             validation=validation,
             time_dependent_execution=time_dependent_execution,
+            databases=self._databases,
         )
 
         ret = None

--- a/tests/mgbench/runners.py
+++ b/tests/mgbench/runners.py
@@ -186,6 +186,8 @@ class BoltClient(BaseClient):
             databases=self._databases,
         )
 
+        log.info("Client args: {}".format(args))
+
         ret = None
         try:
             ret = subprocess.run(args, capture_output=True)

--- a/tests/mgbench/workloads/pokec.py
+++ b/tests/mgbench/workloads/pokec.py
@@ -71,6 +71,14 @@ class Pokec(Workload):
     def benchmark__arango__single_vertex_read(self):
         return ("MATCH (n:User {id : $id}) RETURN n", {"id": self._get_random_vertex()})
 
+    def benchmark__arango__unwind_range_vertex_write(self):
+        return (
+            "UNWIND range(1, 100) as x CREATE (:L1:L2:L3:L4:L5:L6:L7 {p1: true, p2: 42, "
+            'p3: "Here is some text that is not extremely short", '
+            'p4:"Short text", p5: 234.434, p6: 11.11, p7: false})',
+            {},
+        )
+
     def benchmark__arango__single_vertex_write(self):
         return (
             "CREATE (n:UserTemp {id : $id}) RETURN n",


### PR DESCRIPTION
Databases can be specified when external-vendor is used.

```bash
./benchmark.py external-vendor --num-workers-for-benchmark 4 --export-results benchmark_result_external.json --client-bolt-address localhost --no-authorization --databases memgraph,db1,db2,db3 pokec/small/arango/single_vertex_read
```

When multiple threads are used, each thread uses a separate set of databases so that commit is as parallel as possible on the Memgraph level.
