### PR TITLE
Bugfix: utils::Scheduler start_time drift

### DIFF
--- a/tests/unit/utils_scheduler.cpp
+++ b/tests/unit/utils_scheduler.cpp
@@ -14,6 +14,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <thread>
 #include "tests/unit/timezone_handler.hpp"
 #include "utils/scheduler.hpp"
 #include "utils/temporal.hpp"
@@ -441,6 +442,41 @@ TEST(Scheduler, SkipSlowExecutions) {
     ASSERT_LE(x.load(), 3);
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
+
+  scheduler.Stop();
+}
+
+TEST(Scheduler, TimeDrift) {
+  std::atomic<int> x{0};
+  const auto start_time = std::chrono::system_clock::now();
+  const auto period = std::chrono::milliseconds(500);
+
+  std::function<void()> func{[&x, first_now = std::chrono::system_clock::time_point{}, start_time, period]() mutable {
+    ++x;
+    const auto now = std::chrono::system_clock::now();
+    if (x == 1) {
+      // First - cause a time drift
+      std::this_thread::sleep_for(std::chrono::seconds(2));
+      first_now = std::chrono::system_clock::now();
+    } else if (x == 2) {
+      // Second - next execution, execute right away
+      EXPECT_NEAR(
+          first_now.time_since_epoch().count(), now.time_since_epoch().count(),
+          std::chrono::duration_cast<std::chrono::system_clock::duration>(std::chrono::milliseconds(100)).count());
+    } else {
+      // From 3. should go back to the original time offset
+      const auto delta = now - start_time;
+      EXPECT_NEAR(delta / period, x.load() + 3.0 /* skipped executions */, 0.1);
+    }
+  }};
+
+  memgraph::utils::Scheduler scheduler;
+  scheduler.SetInterval(period, start_time);
+  scheduler.Run("Test", func);
+
+  // Wait for a few executions and check
+  std::this_thread::sleep_for(std::chrono::seconds(5));
+  ASSERT_GE(x.load(), 3);
 
   scheduler.Stop();
 }


### PR DESCRIPTION
After v3.2 the scheduler start time could drift in cases where tasks take longer to complete than the period
This is now fixed by using the period as the time increment instead of resetting the next iteration to be now
This issue could cause ttl to drift.