### PR TITLE
Bugfix: Fix replication state machine when recovery and commit tasks are interleaved

### DIFF
--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -180,7 +180,7 @@ void ReplicationStorageClient::UpdateReplicaState(Storage *main_storage, Databas
   spdlog::trace("Current timestamp on replica {} for db {} is {}.", client_.name_, main_db_name,
                 heartbeat_res.current_commit_timestamp);
   spdlog::trace("Current durable timestamp on main for db {} is {}", main_db_name,
-                replStorageState.last_durable_timestamp_.load());
+                replStorageState.last_durable_timestamp_.load(std::memory_order_acquire));
 
   replica_state_.WithLock([&](auto &state) {
     // Recovered state didn't change in the meantime
@@ -201,7 +201,7 @@ void ReplicationStorageClient::UpdateReplicaState(Storage *main_storage, Databas
 
 TimestampInfo ReplicationStorageClient::GetTimestampInfo(Storage const *storage) const {
   TimestampInfo info;
-  auto const main_timestamp = storage->repl_storage_state_.last_durable_timestamp_.load();
+  auto const main_timestamp = storage->repl_storage_state_.last_durable_timestamp_.load(std::memory_order_acquire);
   info.current_timestamp_of_replica = last_known_ts_.load(std::memory_order::acquire);
   info.current_number_of_timestamp_behind_main = info.current_timestamp_of_replica - main_timestamp;
   return info;
@@ -537,7 +537,8 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_last_commit_ts, S
   // replica state to ready. When the next txn starts, we are in state ready without
   // actually sending data to replica
   auto lock = std::lock_guard{main_storage->engine_lock_};
-  const auto last_durable_timestamp = main_storage->repl_storage_state_.last_durable_timestamp_.load();
+  const auto last_durable_timestamp =
+      main_storage->repl_storage_state_.last_durable_timestamp_.load(std::memory_order_acquire);
   spdlog::info("Replica: {} DB: {} Timestamp: {}, Last main durable commit: {}", client_.name_, main_db_name,
                replica_last_commit_ts, last_durable_timestamp);
   last_known_ts_.store(replica_last_commit_ts, std::memory_order_release);
@@ -562,8 +563,8 @@ ReplicaStream::ReplicaStream(Storage *storage, rpc::Client &rpc_client, const ui
                              utils::UUID main_uuid)
     : storage_{storage},
       stream_(rpc_client.Stream<replication::AppendDeltasRpc>(
-          main_uuid, storage->uuid(), storage->repl_storage_state_.last_durable_timestamp_.load(),
-          current_wal_seq_num)),
+          main_uuid, storage->uuid(),
+          storage->repl_storage_state_.last_durable_timestamp_.load(std::memory_order_acquire), current_wal_seq_num)),
       main_uuid_(main_uuid) {
   replication::Encoder encoder{stream_.GetBuilder()};
   encoder.WriteString(storage->repl_storage_state_.epoch_.id());

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -298,10 +298,22 @@ bool ReplicationStorageClient::FinalizeTransactionReplication(DatabaseAccessProt
   // that this and other transaction replication functions can only be
   // called from a one thread stands)
   utils::MetricsTimer const timer{metrics::FinalizeTxnReplication_us};
-  spdlog::trace("Finalizing transaction on replica {} in state {}", client_.name_,
-                StateToString(*replica_state_.Lock()));
-  if (State() != ReplicaState::REPLICATING) {
-    spdlog::trace("Skipping finalizing transaction on replica {} because it's not replicating", client_.name_);
+  auto const continue_finalize = replica_state_.WithLock([this, &replica_stream](auto &state) mutable {
+    spdlog::trace("Finalizing transaction on replica {} in state {}", client_.name_, StateToString(state));
+
+    if (state != ReplicaState::REPLICATING) {
+      // Recovery finished between the txn start and txn finish.
+      // Set the state to maybe behind and rely on heartbeat to check asynchronously the state
+      if (state == ReplicaState::READY) {
+        replica_stream.reset();
+        state = ReplicaState::MAYBE_BEHIND;
+      }
+      return false;
+    }
+    return true;
+  });
+
+  if (!continue_finalize) {
     return false;
   }
 
@@ -520,10 +532,16 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_last_commit_ts, S
     }
   }
 
+  // Protect the exit from the recovery. Otherwise, FinalizeTransactionReplication()
+  // could check that the replica state isn't replicating, this recovery sets the
+  // replica state to ready. When the next txn starts, we are in state ready without
+  // actually sending data to replica
+  auto lock = std::lock_guard{main_storage->engine_lock_};
   const auto last_durable_timestamp = main_storage->repl_storage_state_.last_durable_timestamp_.load();
   spdlog::info("Replica: {} DB: {} Timestamp: {}, Last main durable commit: {}", client_.name_, main_db_name,
                replica_last_commit_ts, last_durable_timestamp);
   last_known_ts_.store(replica_last_commit_ts, std::memory_order_release);
+
   // ldt can be larger on replica due to a snapshot
   if (last_durable_timestamp <= replica_last_commit_ts) {
     replica_state_.WithLock([name = client_.name_, &main_db_name](auto &val) {


### PR DESCRIPTION
The PR fixes the bug with asynchronous replication. If the recovery would've finished between starting and finishing txn, it would set the replica state to ready and then a txn wouldn't ever be replicated. This is fixed by protecting the exit from FinalizeTransactionReplication using engine lock.

The replication performance is improved by reducing the memory order level required from sequentially consistent to acquire.