### PR TITLE
Bugfix: Unreleased deltas when using HA

### DIFF
--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -456,12 +456,12 @@ void InMemoryReplicationHandlers::SnapshotHandler(DbmsHandler *dbms_handler,
       storage->vertex_id_ = recovery_info.next_vertex_id;
       storage->edge_id_ = recovery_info.next_edge_id;
       storage->timestamp_ = std::max(storage->timestamp_, recovery_info.next_timestamp);
-      storage->repl_storage_state_.last_durable_timestamp_ = snapshot_info.durable_timestamp;
+      storage->repl_storage_state_.last_durable_timestamp_.store(snapshot_info.durable_timestamp,
+                                                                 std::memory_order_release);
 
-      storage::durability::RecoverIndicesStatsAndConstraints(
-          &storage->vertices_, storage->name_id_mapper_.get(), &storage->indices_, &storage->constraints_,
-          storage->config_, recovery_info, indices_constraints, storage->config_.salient.items.properties_on_edges,
-          snapshot_observer_info);
+      RecoverIndicesStatsAndConstraints(&storage->vertices_, storage->name_id_mapper_.get(), &storage->indices_,
+                                        &storage->constraints_, storage->config_, recovery_info, indices_constraints,
+                                        storage->config_.salient.items.properties_on_edges, snapshot_observer_info);
     } catch (const storage::durability::RecoveryFailure &e) {
       spdlog::error(
           "Couldn't load the snapshot from {} because of: {}. Storage will be cleared. Snapshot and WAL files are "
@@ -475,7 +475,8 @@ void InMemoryReplicationHandlers::SnapshotHandler(DbmsHandler *dbms_handler,
   }
   spdlog::debug("Snapshot from {} loaded successfully.", *maybe_recovery_snapshot_path);
 
-  const storage::replication::SnapshotRes res{storage->repl_storage_state_.last_durable_timestamp_.load()};
+  const storage::replication::SnapshotRes res{
+      storage->repl_storage_state_.last_durable_timestamp_.load(std::memory_order_acquire)};
   rpc::SendFinalResponse(res, res_builder, fmt::format("db: {}", storage->name()));
 
   auto const not_recovery_snapshot = [&recovery_snapshot_path](auto const &snapshot_info) {

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -458,6 +458,7 @@ void InMemoryReplicationHandlers::SnapshotHandler(DbmsHandler *dbms_handler,
       storage->timestamp_ = std::max(storage->timestamp_, recovery_info.next_timestamp);
       storage->repl_storage_state_.last_durable_timestamp_.store(snapshot_info.durable_timestamp,
                                                                  std::memory_order_release);
+      storage->commit_log_->MarkFinishedInRange(0, snapshot_info.durable_timestamp);
 
       RecoverIndicesStatsAndConstraints(&storage->vertices_, storage->name_id_mapper_.get(), &storage->indices_,
                                         &storage->constraints_, storage->config_, recovery_info, indices_constraints,

--- a/src/replication_handler/replication_handler.cpp
+++ b/src/replication_handler/replication_handler.cpp
@@ -294,6 +294,9 @@ bool ReplicationHandler::DoToMainPromotion(const utils::UUID &main_uuid, bool fo
       storage->timestamp_ =
           std::max(storage->timestamp_, storage->repl_storage_state_.last_durable_timestamp_.load() + 1);
       spdlog::trace("New timestamp on the MAIN is {} for the database {}.", storage->timestamp_, db_acc->name());
+
+      // Mark all up to timestamp + timestamp
+      static_cast<storage::InMemoryStorage *>(storage)->commit_log_->MarkFinishedUpToId(storage->timestamp_);
     });
 
     // STEP 4) Resume TTL

--- a/src/replication_handler/replication_handler.cpp
+++ b/src/replication_handler/replication_handler.cpp
@@ -297,6 +297,7 @@ bool ReplicationHandler::DoToMainPromotion(const utils::UUID &main_uuid, bool fo
 
       // Mark all up to timestamp + timestamp
       static_cast<storage::InMemoryStorage *>(storage)->commit_log_->MarkFinishedUpToId(storage->timestamp_);
+      spdlog::trace("Commit log marked finished up to id: {}", storage->timestamp_);
     });
 
     // STEP 4) Resume TTL

--- a/src/replication_handler/replication_handler.cpp
+++ b/src/replication_handler/replication_handler.cpp
@@ -288,7 +288,8 @@ bool ReplicationHandler::DoToMainPromotion(const utils::UUID &main_uuid, bool fo
       auto *storage = db_acc->storage();
       storage->repl_storage_state_.epoch_ = epoch;
 
-      // Modifying storage->timestamp_ needs to be done under the lock
+      // Modifying storage->timestamp_ needs to be done under the engine lock.
+      // Engine lock needs to be acquired after the repl state lock
       auto lock = std::lock_guard{storage->engine_lock_};
 
       // Durability is tracking last durable timestamp from MAIN, whereas timestamp_ is dependent on MVCC

--- a/src/storage/v2/commit_log.cpp
+++ b/src/storage/v2/commit_log.cpp
@@ -59,6 +59,12 @@ void CommitLog::MarkFinished(uint64_t const id) {
 
 void CommitLog::MarkFinishedUpToId(uint64_t const id) {
   auto guard = std::lock_guard{lock_};
+
+  // Just starting, nothing to mark
+  if (head_ == nullptr) {
+    return;
+  }
+
   // 1. Mark finished all blocks with smaller IDs than the id
   Block *current = head_;
   uint64_t current_start = head_start_;
@@ -82,8 +88,7 @@ void CommitLog::MarkFinishedUpToId(uint64_t const id) {
   current->field[field_idx] = std::numeric_limits<uint64_t>::max();
   current->field[field_idx] >>= kIdsInField - (idx_in_field + 1);
 
-  // Shouldn't be but just in case
-  if (id == oldest_active_) {
+  if (id >= oldest_active_) {
     UpdateOldestActive();
   }
 }

--- a/src/storage/v2/commit_log.hpp
+++ b/src/storage/v2/commit_log.hpp
@@ -50,14 +50,21 @@ class CommitLog final {
   void MarkFinished(uint64_t id);
 
   /**
-   * Marks a transaction finished including all timestamps up to the current id.
-   * @param id Timestamp
-   * @param id_included Whether to mark finished id
+   * Marks transactions that are in range [start_id, end_id] as finished.
+   * @param start_id Start txn timestamp
+   * @param end_id End txn timestamp
    */
-  void MarkFinishedUpToId(uint64_t id);
+  void MarkFinishedInRange(uint64_t start_id, uint64_t end_id);
 
   /// Retrieve the oldest transaction still not marked as finished.
   uint64_t OldestActive();
+
+  /**
+   * Checks if txn is finished.
+   * @param id Check if txn with id is finished
+   * @return bool true if finished, false otherwise
+   */
+  bool IsFinished(uint64_t id) const;
 
  private:
   static constexpr uint64_t kBlockSize = 8192;

--- a/src/storage/v2/commit_log.hpp
+++ b/src/storage/v2/commit_log.hpp
@@ -49,11 +49,19 @@ class CommitLog final {
   /// @throw std::bad_alloc
   void MarkFinished(uint64_t id);
 
+  /**
+   * Marks a transaction finished including all timestamps up to the current id.
+   * @param id Timestamp
+   * @param id_included Whether to mark finished id
+   */
+  void MarkFinishedUpToId(uint64_t id);
+
   /// Retrieve the oldest transaction still not marked as finished.
   uint64_t OldestActive();
 
  private:
   static constexpr uint64_t kBlockSize = 8192;
+  // 64 bits
   static constexpr uint64_t kIdsInField = sizeof(uint64_t) * 8;
   static constexpr uint64_t kIdsInBlock = kBlockSize * kIdsInField;
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2712,7 +2712,9 @@ utils::BasicResult<InMemoryStorage::RecoverSnapshotError> InMemoryStorage::Recov
     vertex_id_ = recovery_info.next_vertex_id;
     edge_id_ = recovery_info.next_edge_id;
     timestamp_ = std::max(timestamp_, recovery_info.next_timestamp);
-    repl_storage_state_.last_durable_timestamp_ = recovered_snapshot.snapshot_info.durable_timestamp;
+    repl_storage_state_.last_durable_timestamp_.store(recovered_snapshot.snapshot_info.durable_timestamp,
+                                                      std::memory_order_release);
+    commit_log_->MarkFinishedInRange(0, recovered_snapshot.snapshot_info.durable_timestamp);
 
     spdlog::trace("Recovering indices and constraints from snapshot.");
     storage::durability::RecoverIndicesStatsAndConstraints(

--- a/tests/unit/commit_log_v2.cpp
+++ b/tests/unit/commit_log_v2.cpp
@@ -17,6 +17,8 @@ namespace {
 inline constexpr size_t ids_per_block = 8192 * 64;
 }  // namespace
 
+using memgraph::storage::CommitLog;
+
 TEST(CommitLog, Simple) {
   memgraph::storage::CommitLog log;
   EXPECT_EQ(log.OldestActive(), 0);
@@ -75,9 +77,75 @@ TEST(CommitLog, TrackAfterInitialId) {
   }
 }
 
-TEST(CommitLog, MarkUpToId) {
-  memgraph::storage::CommitLog commit_log{25};
-  ASSERT_EQ(commit_log.OldestActive(), 25);
-  commit_log.MarkFinishedUpToId(28);
-  ASSERT_EQ(commit_log.OldestActive(), 29);
+TEST(CommitLog, MarkAsFinishedTxn) {
+  CommitLog log;
+  log.MarkFinished(1);
+  EXPECT_FALSE(log.IsFinished(0));
+  EXPECT_TRUE(log.IsFinished(1));
+  EXPECT_FALSE(log.IsFinished(2));
+}
+
+TEST(CommitLog, MarkSingleTransaction) {
+  CommitLog log;
+  log.MarkFinishedInRange(100, 100);
+  EXPECT_TRUE(log.IsFinished(100));
+  EXPECT_FALSE(log.IsFinished(99));
+  EXPECT_FALSE(log.IsFinished(101));
+}
+
+TEST(CommitLog, MarkRangeWithinSameField) {
+  CommitLog log;
+  log.MarkFinishedInRange(200, 203);
+  for (uint64_t id = 200; id <= 203; ++id) {
+    EXPECT_TRUE(log.IsFinished(id));
+  }
+  EXPECT_FALSE(log.IsFinished(199));
+  EXPECT_FALSE(log.IsFinished(204));
+}
+
+TEST(CommitLog, MarkRangeAcrossFieldsInSameBlock) {
+  constexpr uint64_t start = 60;  // Field 0
+  constexpr uint64_t end = 70;    // Field 1
+  CommitLog log;
+  log.MarkFinishedInRange(start, end);
+  for (uint64_t id = start; id <= end; ++id) {
+    EXPECT_TRUE(log.IsFinished(id));
+  }
+  EXPECT_FALSE(log.IsFinished(59));
+  EXPECT_FALSE(log.IsFinished(71));
+}
+
+TEST(CommitLog, MarkRangeAcrossBlocks) {
+  // Assuming block size = 8192 * 64 = 524288 IDs per block
+  constexpr uint64_t block_size = 8192 * 64;
+  constexpr uint64_t start = block_size - 2;
+  constexpr uint64_t end = block_size + 2;
+
+  CommitLog log;
+
+  log.MarkFinishedInRange(start, end);
+  for (uint64_t id = start; id <= end; ++id) {
+    EXPECT_TRUE(log.IsFinished(id));
+  }
+  EXPECT_FALSE(log.IsFinished(start - 1));
+  EXPECT_FALSE(log.IsFinished(end + 1));
+}
+
+TEST(CommitLog, MarkRangeWithEndBeforeStartIsNoOp) {
+  CommitLog log;
+  log.MarkFinishedInRange(1000, 999);  // Invalid range
+  EXPECT_FALSE(log.IsFinished(999));
+  EXPECT_FALSE(log.IsFinished(1000));
+}
+
+TEST(CommitLog, MarkZeroToMaxIntRangeIsSafe) {
+  constexpr uint64_t start = 0;
+  constexpr uint64_t end = start + 10000;
+  CommitLog log;
+  log.MarkFinishedInRange(start, end);
+
+  for (uint64_t id = start; id <= end; ++id) {
+    EXPECT_TRUE(log.IsFinished(id));
+  }
+  EXPECT_FALSE(log.IsFinished(end + 1));
 }

--- a/tests/unit/commit_log_v2.cpp
+++ b/tests/unit/commit_log_v2.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -59,11 +59,6 @@ TEST(CommitLog, Blocks) {
     log.MarkFinished(i);
     EXPECT_EQ(log.OldestActive(), ids_per_block);
   }
-
-  for (uint64_t i = ids_per_block; i < ids_per_block; ++i) {
-    log.MarkFinished(i);
-    EXPECT_EQ(log.OldestActive(), i < ids_per_block - 1 ? i + 1 : ids_per_block * 3);
-  }
 }
 
 TEST(CommitLog, TrackAfterInitialId) {
@@ -78,4 +73,11 @@ TEST(CommitLog, TrackAfterInitialId) {
     memgraph::storage::CommitLog log{i};
     check_marking_ids(&log, i);
   }
+}
+
+TEST(CommitLog, MarkUpToId) {
+  memgraph::storage::CommitLog commit_log{25};
+  ASSERT_EQ(commit_log.OldestActive(), 25);
+  commit_log.MarkFinishedUpToId(28);
+  ASSERT_EQ(commit_log.OldestActive(), 29);
 }


### PR DESCRIPTION
When an instance becomes MAIN, `RECOVER SNAPSHOT` query is used or `SnapshotRpc` is received, IDs in range [old_storage_timestamp, ldt] are marked as finished in the commit log.