### PR TITLE
BUG-2395: Instead of crashing with SIGABRT when a type-constrained…

### DIFF
--- a/src/storage/v2/constraints/type_constraints.cpp
+++ b/src/storage/v2/constraints/type_constraints.cpp
@@ -86,6 +86,7 @@ TypeConstraintKind PropertyValueToTypeConstraintKind(const PropertyValue &proper
 
 [[nodiscard]] std::optional<ConstraintViolation> TypeConstraints::Validate(const Vertex &vertex, PropertyId property_id,
                                                                            const PropertyValue &property_value) const {
+  if (property_value.type() == PropertyValueType::Null) return std::nullopt;
   for (auto const label : vertex.labels) {
     auto constraint_type_it = constraints_.find({label, property_id});
     if (constraint_type_it == constraints_.end()) continue;

--- a/tests/unit/storage_v2_constraints.cpp
+++ b/tests/unit/storage_v2_constraints.cpp
@@ -1521,6 +1521,86 @@ TYPED_TEST(ConstraintsTest, TypeConstraintsSubtypeCheckForTemporalDataAddLabelLa
   }
 }
 
+TYPED_TEST(ConstraintsTest, TypeConstraintsTypedPropertyNullNotAnError) {
+  if (std::is_same_v<TypeParam, memgraph::storage::DiskStorage>) {
+    GTEST_SKIP() << "Type constraints not implemented for on-disk";
+  }
+
+  {
+    auto unique_acc = this->db_acc_->get()->UniqueAccess();
+    auto res = unique_acc->CreateTypeConstraint(this->label1, this->prop1, TypeConstraintKind::STRING);
+    ASSERT_NO_ERROR(res);
+    ASSERT_NO_ERROR(unique_acc->Commit());
+  }
+
+  // (label1)  Constrain prop1 TYPED STRING (see above), insert vertexA with prop1=Null.
+  {
+    auto acc = this->storage->Access();
+    auto vertexA = acc->CreateVertex();
+    ASSERT_NO_ERROR(vertexA.AddLabel(this->label1));
+    ASSERT_NO_ERROR(vertexA.SetProperty(this->prop1, PropertyValue()));
+    ASSERT_NO_ERROR(vertexA.SetProperty(this->prop2, PropertyValue(TemporalData{TemporalType::Date, 0})));
+    ASSERT_NO_ERROR(acc->Commit());
+  }
+
+  // (label1)  Constrain prop1 TYPED STRING (see above), insert vertexB with prop1=non-Null, update prop1=Null.
+  std::optional<VertexAccessor> holder_vertexB;
+  {
+    auto acc = this->storage->Access();
+    holder_vertexB = acc->CreateVertex();
+    auto &vertexB = *holder_vertexB;
+    ASSERT_NO_ERROR(vertexB.AddLabel(this->label1));
+    ASSERT_NO_ERROR(vertexB.SetProperty(this->prop1, PropertyValue("This is only a test.")));
+    ASSERT_NO_ERROR(vertexB.SetProperty(this->prop2, PropertyValue(-42)));
+    ASSERT_NO_ERROR(acc->Commit());
+  }
+  {
+    auto acc = this->storage->Access();
+    auto &vertexB = *holder_vertexB;
+    ASSERT_NO_ERROR(vertexB.SetProperty(this->prop1, PropertyValue()));
+    ASSERT_NO_ERROR(acc->Commit());
+  }
+
+  // (label2)  Insert vertexC with prop2=Null, constrain prop2 TYPED STRING (see below).
+  std::optional<VertexAccessor> holder_vertexC;
+  {
+    auto acc = this->storage->Access();
+    holder_vertexC = acc->CreateVertex();
+    auto &vertexC = *holder_vertexC;
+    ASSERT_NO_ERROR(vertexC.AddLabel(this->label2));
+    ASSERT_NO_ERROR(vertexC.SetProperty(this->prop1, PropertyValue(TemporalData{TemporalType::Date, 0})));
+    ASSERT_NO_ERROR(vertexC.SetProperty(this->prop2, PropertyValue()));
+    ASSERT_NO_ERROR(acc->Commit());
+  }
+
+  // (label2)  Insert vertexD with prop2=non-Null, constrain prop2 TYPED STRING (see below), update prop2=Null.
+  std::optional<VertexAccessor> holder_vertexD;
+  {
+    auto acc = this->storage->Access();
+    holder_vertexD = acc->CreateVertex();
+    auto &vertexD = *holder_vertexD;
+    ASSERT_NO_ERROR(vertexD.AddLabel(this->label2));
+    ASSERT_NO_ERROR(vertexD.SetProperty(this->prop1, PropertyValue(-42)));
+    ASSERT_NO_ERROR(vertexD.SetProperty(this->prop2, PropertyValue("This is only a test.")));
+    ASSERT_NO_ERROR(acc->Commit());
+  }
+
+  {
+    auto unique_acc = this->db_acc_->get()->UniqueAccess();
+    auto res = unique_acc->CreateTypeConstraint(this->label2, this->prop2, TypeConstraintKind::STRING);
+    ASSERT_NO_ERROR(res);
+    ASSERT_NO_ERROR(unique_acc->Commit());
+  }
+
+  // Finish dealing with vertexD.
+  {
+    auto acc = this->storage->Access();
+    auto &vertexD = *holder_vertexD;
+    ASSERT_NO_ERROR(vertexD.SetProperty(this->prop2, PropertyValue()));
+    ASSERT_NO_ERROR(acc->Commit());
+  }
+}
+
 TYPED_TEST(ConstraintsTest, TypeConstraintsDrop) {
   if (std::is_same_v<TypeParam, memgraph::storage::DiskStorage>) {
     GTEST_SKIP() << "Type constraints not implemented for on-disk";


### PR DESCRIPTION
…property is set to Null on insert or update, allow such behavior.

### Explanation of Changes
After analyzing code, decided (https://github.com/memgraph/memgraph/issues/2935#issuecomment-2885332276) that the workflow which had triggered crash in question (setting a type-constrained property to Null on insert or update) should be allowed.  Therefore, prepended to logic of `std::optional<ConstraintViolation> TypeConstraints::Validate(const Vertex &vertex, PropertyId property_id, const PropertyValue &property_value) const` a check for `(property_value.type() == PropertyValueType::Null)`; if that condition holds, `Validate()` returns an empty `std::optional<ConstraintViolation>`, signifying no violation.

Apart from that, added a `TypeConstraintsTypedPropertyNullNotAnError` test to the `ConstraintsTest` suite.  Here we check that making a type-constrained property Null is allowed, both when inserting a vertex and when updating it. Further, we check that it is possible to create such a constraint on a label which already encompasses such a vertex.


---
__*Leave above in PR description, copy the below into a comment*__
___
