### PR TITLE
Bugfix: Fix deadlock when using ASYNC replicas by skipping recovery tasks if lock cannot be obtained

### DIFF
--- a/src/rpc/client.hpp
+++ b/src/rpc/client.hpp
@@ -102,7 +102,7 @@ class Client {
         timeout_ms_ = other.timeout_ms_;
         defunct_ = std::exchange(other.defunct_, true);
         guard_ = std::move(other.guard_);
-        req_builder_ = slk::Builder(std::move(other.req_builder_, GenBuilderCallback(self_, this, timeout_ms_)));
+        req_builder_ = slk::Builder(std::move(other.req_builder_), GenBuilderCallback(self_, this, timeout_ms_));
         res_load_ = std::move(other.res_load_);
       }
       return *this;

--- a/src/rpc/exceptions.hpp
+++ b/src/rpc/exceptions.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -8,6 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
+
+#pragma once
 
 #include "io/network/endpoint.hpp"
 #include "utils/exceptions.hpp"
@@ -21,11 +23,11 @@ namespace memgraph::rpc {
 /// This exception always requires explicit handling.
 class RpcFailedException : public utils::BasicException {
  public:
-  explicit RpcFailedException(std::string_view msg) : utils::BasicException(msg) {}
+  explicit RpcFailedException(std::string_view const msg) : utils::BasicException(msg) {}
   SPECIALIZE_GET_EXCEPTION_NAME(RpcFailedException);
 };
 
-class VersionMismatchRpcFailedException : public RpcFailedException {
+class VersionMismatchRpcFailedException final : public RpcFailedException {
  public:
   VersionMismatchRpcFailedException()
       : RpcFailedException(
@@ -35,7 +37,7 @@ class VersionMismatchRpcFailedException : public RpcFailedException {
   SPECIALIZE_GET_EXCEPTION_NAME(VersionMismatchRpcFailedException);
 };
 
-class GenericRpcFailedException : public RpcFailedException {
+class GenericRpcFailedException final : public RpcFailedException {
  public:
   GenericRpcFailedException()
       : RpcFailedException(
@@ -45,12 +47,20 @@ class GenericRpcFailedException : public RpcFailedException {
   SPECIALIZE_GET_EXCEPTION_NAME(GenericRpcFailedException);
 };
 
-class SlkRpcFailedException : public RpcFailedException {
+class SlkRpcFailedException final : public RpcFailedException {
  public:
   SlkRpcFailedException()
-      : RpcFailedException("Received malformed message from cluster. Please raise an issue on Memgraph GitHub issues.") {}
+      : RpcFailedException(
+            "Received malformed message from cluster. Please raise an issue on Memgraph GitHub issues.") {}
 
   SPECIALIZE_GET_EXCEPTION_NAME(SlkRpcFailedException);
+};
+
+class FailedToGetRpcStreamException final : public RpcFailedException {
+ public:
+  FailedToGetRpcStreamException() : RpcFailedException("Failed to get RPC stream by try-locking.") {}
+
+  SPECIALIZE_GET_EXCEPTION_NAME(FailedToGetRpcStreamException);
 };
 
 }  // namespace memgraph::rpc

--- a/src/storage/v2/inmemory/replication/recovery.hpp
+++ b/src/storage/v2/inmemory/replication/recovery.hpp
@@ -56,13 +56,32 @@ std::enable_if_t<std::is_same_v<T, std::vector<std::filesystem::path>>, bool> Wr
 }
 
 template <rpc::IsRpc T, typename R, typename... Args>
-std::optional<typename T::Response> TransferDurabilityFiles(const R &files, rpc::Client &client, Args &&...args) {
+std::optional<typename T::Response> TransferDurabilityFiles(const R &files, rpc::Client &client,
+                                                            replication_coordination_glue::ReplicationMode mode,
+                                                            Args &&...args) {
   utils::MetricsTimer const timer{RpcInfo<T>::timerLabel};
-  auto stream = client.Stream<T>(std::forward<Args>(args)...);
-  if (replication::Encoder encoder(stream.GetBuilder()); !WriteFiles(files, encoder)) {
+  std::optional<rpc::Client::StreamHandler<T>> maybe_stream_result;
+
+  // if ASYNC mode, we shouldn't block on transferring durability files because there could be a commit task which holds
+  // rpc stream and which needs to be executed
+  if (mode == replication_coordination_glue::ReplicationMode::ASYNC) {
+    maybe_stream_result = client.TryStream<T>(std::forward<Args>(args)...);
+  } else {
+    // in SYNC mode, we block until we obtain RPC lock
+    maybe_stream_result.emplace(client.Stream<T>(std::forward<Args>(args)...));
+  }
+
+  // If dealing with ASYNC replica and couldn't obtain the lock
+  if (!maybe_stream_result.has_value()) {
     return std::nullopt;
   }
-  return stream.SendAndWaitProgress();
+
+  // If writing files failed, fail the task by return std::nullopt
+  if (replication::Encoder encoder(maybe_stream_result->GetBuilder()); !WriteFiles(files, encoder)) {
+    return std::nullopt;
+  }
+
+  return maybe_stream_result->SendAndWaitProgress();
 }
 
 auto GetRecoverySteps(uint64_t replica_commit, utils::FileRetainer::FileLocker *file_locker,

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -444,13 +444,13 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_last_commit_ts, S
       std::visit(
           utils::Overloaded{
               [this, &replica_last_commit_ts, main_mem_storage, &rpcClient, &recovery_failed, main_uuid = main_uuid_,
-               &main_db_name](RecoverySnapshot const &snapshot) {
+               &main_db_name, repl_mode = client_.mode_](RecoverySnapshot const &snapshot) {
                 spdlog::debug("Sending the latest snapshot file {} to {} for db {}", snapshot, client_.name_,
                               main_db_name);
                 // Loading snapshot on the replica side either passes cleanly or it doesn't pass at all. If it doesn't
                 // pass, we won't update commit timestamp. Heartbeat should trigger recovering replica again.
                 auto const maybe_response = TransferDurabilityFiles<replication::SnapshotRpc>(
-                    snapshot, rpcClient, main_uuid, main_mem_storage->uuid());
+                    snapshot, rpcClient, repl_mode, main_uuid, main_mem_storage->uuid());
                 // Error happened on our side when trying to load snapshot file
                 if (!maybe_response.has_value()) {
                   recovery_failed = true;
@@ -472,8 +472,8 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_last_commit_ts, S
                 }
               },
               [this, &replica_last_commit_ts, main_mem_storage, &rpcClient, &recovery_failed,
-               do_reset = reset_needed && step_index == 0, main_uuid = main_uuid_,
-               &main_db_name](RecoveryWals const &wals) {
+               do_reset = reset_needed && step_index == 0, main_uuid = main_uuid_, &main_db_name,
+               repl_mode = client_.mode_](RecoveryWals const &wals) {
                 spdlog::debug("Sending the latest wal files to {} for db {}.", client_.name_, main_db_name);
 
                 if (wals.empty()) {
@@ -485,7 +485,7 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_last_commit_ts, S
                 // passed so that possibly next step of recovering current wal can be executed
 
                 auto const maybe_response = TransferDurabilityFiles<replication::WalFilesRpc>(
-                    wals, rpcClient, wals.size(), main_uuid, main_mem_storage->uuid(), do_reset);
+                    wals, rpcClient, repl_mode, wals.size(), main_uuid, main_mem_storage->uuid(), do_reset);
                 if (!maybe_response.has_value()) {
                   recovery_failed = true;
                   return;
@@ -504,8 +504,8 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_last_commit_ts, S
                 }
               },
               [this, &replica_last_commit_ts, main_mem_storage, &rpcClient, &recovery_failed,
-               do_reset = reset_needed && step_index == 0, main_uuid = main_uuid_,
-               &main_db_name](RecoveryCurrentWal const &current_wal) {
+               do_reset = reset_needed && step_index == 0, main_uuid = main_uuid_, &main_db_name,
+               repl_mode = client_.mode_](RecoveryCurrentWal const &current_wal) {
                 std::unique_lock transaction_guard(main_mem_storage->engine_lock_);
                 if (main_mem_storage->wal_file_ &&
                     main_mem_storage->wal_file_->SequenceNumber() == current_wal.current_wal_seq_num) {
@@ -516,7 +516,8 @@ void ReplicationStorageClient::RecoverReplica(uint64_t replica_last_commit_ts, S
                   spdlog::debug("Sending current wal file to {} for db {}.", client_.name_, main_db_name);
 
                   auto const maybe_response = TransferDurabilityFiles<replication::CurrentWalRpc>(
-                      main_mem_storage->wal_file_->Path(), rpcClient, main_uuid, main_mem_storage->uuid(), do_reset);
+                      main_mem_storage->wal_file_->Path(), rpcClient, repl_mode, main_uuid, main_mem_storage->uuid(),
+                      do_reset);
                   // Error happened on our side when trying to load current WAL file
                   if (!maybe_response.has_value()) {
                     recovery_failed = true;


### PR DESCRIPTION
When using ASYNC replicas, MAIN could deadlock because in its thread pool there would be a commit task holding RPC lock. Commit task would wait for other tasks to finish but these tasks wouldn't not be able to get executed because RPC lock couldn't be acquired. The current fix is to try lock on RPC lock and if this is not possible, skip the task. This shouldn't be a problem because replica will stay in RECOVERY state,