### PR TITLE
Update workflows to re-tag mgbench images

### DIFF
--- a/.github/workflows/release_mgbench_client.yaml
+++ b/.github/workflows/release_mgbench_client.yaml
@@ -33,6 +33,7 @@ jobs:
       arch:           ${{ matrix.arch }}
       version:        ${{ inputs.version }}
       push_to_dockerhub: ${{ inputs.push_to_dockerhub }}
+      test_docker_push: ${{ inputs.test_docker_push }}
       force_release:  ${{ inputs.force_release }}
       image_type:     ${{ matrix.image_type }}
     secrets: inherit

--- a/.github/workflows/release_mgbench_client.yaml
+++ b/.github/workflows/release_mgbench_client.yaml
@@ -101,8 +101,8 @@ jobs:
 
           curl -X DELETE \
             -u "${{ secrets.DOCKERHUB_USERNAME }}:${{ secrets.DOCKERHUB_TOKEN }}" \
-            "https://hub.docker.com/v2/repositories/${{ env.DOCKER_ORGANIZATION_NAME }}/${{ env.DOCKER_REPOSITORY_NAME }}/tags/${{ env.REPO_TAG_ARM }}"
+            "https://hub.docker.com/v2/repositories/${{ env.DOCKER_ORGANIZATION_NAME }}/${{ env.DOCKER_REPOSITORY_NAME }}/tags/${REPO_TAG_ARM#*:}"
 
           curl -X DELETE \
             -u "${{ secrets.DOCKERHUB_USERNAME }}:${{ secrets.DOCKERHUB_TOKEN }}" \
-            "https://hub.docker.com/v2/repositories/${{ env.DOCKER_ORGANIZATION_NAME }}/${{ env.DOCKER_REPOSITORY_NAME }}/tags/${{ env.REPO_TAG_AMD }}"
+            "https://hub.docker.com/v2/repositories/${{ env.DOCKER_ORGANIZATION_NAME }}/${{ env.DOCKER_REPOSITORY_NAME }}/tags/${REPO_TAG_AMD#*:}"

--- a/.github/workflows/release_mgbench_client.yaml
+++ b/.github/workflows/release_mgbench_client.yaml
@@ -16,17 +16,15 @@ on:
       test_docker_push:
         type: boolean
         default: false
+        description: "Push to test repository on Dockerhub"
       force_release:
         type: boolean
         required: false
         default: false
-      cleanup_docker:
-        type: boolean
-        default: false
+        description: "Overwrite existing images with the same tags"
 
 jobs:
   build_images:
-    if: ${{ inputs.cleanup_docker == false }}
     strategy:
       fail-fast: false
       matrix:
@@ -44,9 +42,9 @@ jobs:
 
   cleanup_docker:
     runs-on: ubuntu-latest
-    if: ${{ inputs.push_to_dockerhub || inputs.cleanup_docker }}
+    if: ${{ inputs.push_to_dockerhub }}
     name: "Clean up Docker tags"
-    #needs: build_images
+    needs: build_images
     env:
       DOCKER_ORGANIZATION_NAME: memgraph
       DOCKER_REPOSITORY_NAME: mgbench-client${{ inputs.test_docker_push && '-test' || '' }}

--- a/.github/workflows/release_mgbench_client.yaml
+++ b/.github/workflows/release_mgbench_client.yaml
@@ -98,11 +98,9 @@ jobs:
 
       - name: Delete single-arch tags
         run: |
-
-          curl -X DELETE \
-            -u "${{ secrets.DOCKERHUB_USERNAME }}:${{ secrets.DOCKERHUB_TOKEN }}" \
-            "https://hub.docker.com/v2/repositories/${{ env.DOCKER_ORGANIZATION_NAME }}/${{ env.DOCKER_REPOSITORY_NAME }}/tags/${REPO_TAG_ARM#*:}"
-
-          curl -X DELETE \
-            -u "${{ secrets.DOCKERHUB_USERNAME }}:${{ secrets.DOCKERHUB_TOKEN }}" \
-            "https://hub.docker.com/v2/repositories/${{ env.DOCKER_ORGANIZATION_NAME }}/${{ env.DOCKER_REPOSITORY_NAME }}/tags/${REPO_TAG_AMD#*:}"
+          for t in "${REPO_TAG_ARM#*:}" "${REPO_TAG_AMD#*:}"; do
+            echo "Deleting tag → $t"
+            curl -s -X DELETE \
+              -u "${{ secrets.DOCKERHUB_USERNAME }}:${{ secrets.DOCKERHUB_TOKEN }}" \
+              "https://hub.docker.com/v2/repositories/${DOCKER_ORGANIZATION_NAME}/${DOCKER_REPOSITORY_NAME}/tags/$t/"
+          done

--- a/.github/workflows/release_mgbench_client.yaml
+++ b/.github/workflows/release_mgbench_client.yaml
@@ -13,6 +13,9 @@ on:
         type: boolean
         default: false
         description: "Push images to dockerhub"
+      test_docker_push:
+        type: boolean
+        default: false
       force_release:
         type: boolean
         required: false
@@ -33,3 +36,71 @@ jobs:
       force_release:  ${{ inputs.force_release }}
       image_type:     ${{ matrix.image_type }}
     secrets: inherit
+
+  cleanup_docker:
+    runs-on: ubuntu-latest
+    if: ${{ inputs.push_to_dockerhub }}
+    name: "Clean up Docker tags"
+    needs: build_images
+    env:
+      DOCKER_ORGANIZATION_NAME: memgraph
+      DOCKER_REPOSITORY_NAME: mgbench-client${{ inputs.test_docker_push && '-test' || '' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        image_type: [client, full]
+    steps:
+      - name: Log in to Docker Hub
+        if: ${{ inputs.push_to_dockerhub }}
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest for version
+        run: |
+
+          if [[ "${{ matrix.image_type }}" == "client" ]]; then
+            repo_tag="$DOCKER_ORGANIZATION_NAME/$DOCKER_REPOSITORY_NAME:${{ inputs.version }}"
+          else
+            repo_tag="$DOCKER_ORGANIZATION_NAME/$DOCKER_REPOSITORY_NAME:${{ inputs.version }}-full"
+          fi
+
+          repo_tag_arm="${repo_tag}-arm64"
+          repo_tag_amd="${repo_tag}-amd64"
+
+          echo "REPO_TAG=${repo_tag}" >> $GITHUB_ENV
+          echo "REPO_TAG_ARM=${repo_tag_arm}" >> $GITHUB_ENV
+          echo "REPO_TAG_AMD=${repo_tag_amd}" >> $GITHUB_ENV
+
+      - name: Create and push multi-arch manifest for version
+        run: |
+          # pull them
+          docker pull $REPO_TAG_ARM
+          docker pull $REPO_TAG_AMD
+
+          # create version manifest
+          docker manifest create $REPO_TAG \
+            $REPO_TAG_ARM $REPO_TAG_AMD
+          docker manifest annotate $REPO_TAG $REPO_TAG_ARM --os linux --arch arm64
+          docker manifest annotate $REPO_TAG $REPO_TAG_AMD --os linux --arch amd64
+          docker manifest push $REPO_TAG
+
+      - name: Tag latest client image
+        if: ${{ matrix.image_type == 'client' }}
+        run: |
+          docker manifest create $REPO_TAG:latest $REPO_TAG_AMD $REPO_TAG_ARM
+          docker manifest annotate $REPO_TAG:latest $REPO_TAG_ARM --os linux --arch arm64
+          docker manifest annotate $REPO_TAG:latest $REPO_TAG_AMD --os linux --arch amd64
+          docker manifest push $REPO_TAG:latest
+
+      - name: Delete single-arch tags
+        run: |
+
+          curl -X DELETE \
+            -u "${{ secrets.DOCKERHUB_USERNAME }}:${{ secrets.DOCKERHUB_TOKEN }}" \
+            "https://hub.docker.com/v2/repositories/${{ env.DOCKER_ORGANIZATION_NAME }}/${{ env.DOCKER_REPOSITORY_NAME }}/tags/${{ env.REPO_TAG_ARM }}"
+
+          curl -X DELETE \
+            -u "${{ secrets.DOCKERHUB_USERNAME }}:${{ secrets.DOCKERHUB_TOKEN }}" \
+            "https://hub.docker.com/v2/repositories/${{ env.DOCKER_ORGANIZATION_NAME }}/${{ env.DOCKER_REPOSITORY_NAME }}/tags/${{ env.REPO_TAG_AMD }}"

--- a/.github/workflows/release_mgbench_client.yaml
+++ b/.github/workflows/release_mgbench_client.yaml
@@ -20,9 +20,13 @@ on:
         type: boolean
         required: false
         default: false
+      cleanup_docker:
+        type: boolean
+        default: false
 
 jobs:
   build_images:
+    if: ${{ inputs.cleanup_docker == false }}
     strategy:
       fail-fast: false
       matrix:
@@ -40,9 +44,9 @@ jobs:
 
   cleanup_docker:
     runs-on: ubuntu-latest
-    if: ${{ inputs.push_to_dockerhub }}
+    if: ${{ inputs.push_to_dockerhub || inputs.cleanup_docker }}
     name: "Clean up Docker tags"
-    needs: build_images
+    #needs: build_images
     env:
       DOCKER_ORGANIZATION_NAME: memgraph
       DOCKER_REPOSITORY_NAME: mgbench-client${{ inputs.test_docker_push && '-test' || '' }}
@@ -96,11 +100,16 @@ jobs:
           docker manifest annotate $LATEST_TAG $REPO_TAG_AMD --os linux --arch amd64
           docker manifest push $LATEST_TAG
 
+      - name: Get dockerhub token
+        run: |
+          dockerhub_token=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "${{ secrets.DOCKERHUB_USERNAME }}", "password": "${{ secrets.DOCKERHUB_TOKEN }}"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
+          echo "dockerhub_token=${dockerhub_token}" >> $GITHUB_ENV
+
       - name: Delete single-arch tags
         run: |
           for t in "${REPO_TAG_ARM#*:}" "${REPO_TAG_AMD#*:}"; do
-            echo "Deleting tag → $t"
-            curl -s -X DELETE \
-              -u "${{ secrets.DOCKERHUB_USERNAME }}:${{ secrets.DOCKERHUB_TOKEN }}" \
+            url="https://hub.docker.com/v2/repositories/${DOCKER_ORGANIZATION_NAME}/${DOCKER_REPOSITORY_NAME}/tags/$t/"
+            echo "Deleting tag → $t from $url"
+            curl -i -n -X DELETE -H "Authorization: JWT ${dockerhub_token}" \
               "https://hub.docker.com/v2/repositories/${DOCKER_ORGANIZATION_NAME}/${DOCKER_REPOSITORY_NAME}/tags/$t/"
           done

--- a/.github/workflows/release_mgbench_client.yaml
+++ b/.github/workflows/release_mgbench_client.yaml
@@ -90,10 +90,11 @@ jobs:
       - name: Tag latest client image
         if: ${{ matrix.image_type == 'client' }}
         run: |
-          docker manifest create $REPO_TAG:latest $REPO_TAG_AMD $REPO_TAG_ARM
-          docker manifest annotate $REPO_TAG:latest $REPO_TAG_ARM --os linux --arch arm64
-          docker manifest annotate $REPO_TAG:latest $REPO_TAG_AMD --os linux --arch amd64
-          docker manifest push $REPO_TAG:latest
+          LATEST_TAG="$DOCKER_ORGANIZATION_NAME/$DOCKER_REPOSITORY_NAME:latest"
+          docker manifest create $LATEST_TAG $REPO_TAG_AMD $REPO_TAG_ARM
+          docker manifest annotate $LATEST_TAG $REPO_TAG_ARM --os linux --arch arm64
+          docker manifest annotate $LATEST_TAG $REPO_TAG_AMD --os linux --arch amd64
+          docker manifest push $LATEST_TAG
 
       - name: Delete single-arch tags
         run: |

--- a/.github/workflows/reusable_build_mgbench_client.yml
+++ b/.github/workflows/reusable_build_mgbench_client.yml
@@ -15,6 +15,10 @@ on:
         type: boolean
         default: false
         description: "Push images to dockerhub"
+      test_docker_push:
+        type: boolean
+        default: false
+        description: "Push images to dockerhub-test"
       force_release:
         type: boolean
         required: false
@@ -30,7 +34,7 @@ jobs:
     runs-on: ${{ (inputs.arch == 'arm') && fromJSON('["self-hosted", "DockerMgBuild", "ARM64", "Linux"]') || fromJSON('["self-hosted", "DockerMgBuild", "X64", "Linux"]') }}
     env:
       DOCKER_ORGANIZATION_NAME: memgraph
-      DOCKER_REPOSITORY_NAME: mgbench-client
+      DOCKER_REPOSITORY_NAME: mgbench-client${{ inputs.test_docker_push && '-test' || '' }}
 
     steps:
       - name: Verify image type
@@ -47,6 +51,9 @@ jobs:
             repo_tag="$DOCKER_ORGANIZATION_NAME/$DOCKER_REPOSITORY_NAME:${{ inputs.version }}-full"
             dockerfile="tests/mgbench/Dockerfile.mgbench_full"
           fi
+
+          repo_tag="${repo_tag}-${{ inputs.arch }}64"
+
           echo "Building image: ${repo_tag}"
           echo "REPO_TAG=${repo_tag}" >> $GITHUB_ENV
           echo "DOCKERFILE=${dockerfile}" >> $GITHUB_ENV
@@ -104,7 +111,3 @@ jobs:
         if: ${{ inputs.push_to_dockerhub }}
         run: |
           docker push ${{ env.REPO_TAG }}
-          if [[ "${{ inputs.image_type }}" == "client" ]]; then
-            docker tag ${{ env.REPO_TAG }} $DOCKER_ORGANIZATION_NAME/$DOCKER_REPOSITORY_NAME:latest
-            docker push $DOCKER_ORGANIZATION_NAME/$DOCKER_REPOSITORY_NAME:latest
-          fi


### PR DESCRIPTION
Additional job to re-tag `mgbench` images after pushing individual `amd64` and `arm64` tags.

