### PR TITLE
Use std::source_location for MG_ASSERT

### DIFF
--- a/src/utils/logging.cpp
+++ b/src/utils/logging.cpp
@@ -95,13 +95,12 @@ std::string memgraph::logging::MaskSensitiveInformation(std::string_view input) 
   return result;
 }
 
-void memgraph::logging::AssertFailed(char const *file_name, int line_num, char const *expr,
-                                     std::string const &message) {
+void memgraph::logging::AssertFailed(std::source_location const loc, char const *expr, std::string const &message) {
   spdlog::critical(
       "\nAssertion failed in file {} at line {}."
       "\n\tExpression: '{}'"
       "{}",
-      file_name, line_num, expr, !message.empty() ? fmt::format("\n\tMessage: '{}'", message) : "");
+      loc.file_name(), loc.line(), expr, !message.empty() ? fmt::format("\n\tMessage: '{}'", message) : "");
   std::terminate();
 }
 

--- a/src/utils/logging.hpp
+++ b/src/utils/logging.hpp
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <optional>
+#include <source_location>
 #include <string>
 
 #include <fmt/format.h>
@@ -38,21 +39,19 @@
 
 namespace memgraph::logging {
 
-// TODO (antonio2368): Replace with std::source_location when it's supported by
-// compilers
-[[noreturn]] void AssertFailed(const char *file_name, int line_num, const char *expr, const std::string &message);
+[[noreturn]] void AssertFailed(std::source_location loc, const char *expr, const std::string &message);
 
 #define GET_MESSAGE(...) \
   BOOST_PP_IF(BOOST_PP_EQUAL(BOOST_PP_VARIADIC_SIZE(__VA_ARGS__), 0), "", fmt::format(__VA_ARGS__))
 
-#define MG_ASSERT(expr, ...)                                                                    \
-  do {                                                                                          \
-    if (!(expr)) [[unlikely]] {                                                                 \
-      [&]() __attribute__((noinline, cold, noreturn)) {                                         \
-        ::memgraph::logging::AssertFailed(__FILE__, __LINE__, #expr, GET_MESSAGE(__VA_ARGS__)); \
-      }                                                                                         \
-      ();                                                                                       \
-    }                                                                                           \
+#define MG_ASSERT(expr, ...)                                                                                 \
+  do {                                                                                                       \
+    if (!(expr)) [[unlikely]] {                                                                              \
+      [&]() __attribute__((noinline, cold, noreturn)) {                                                      \
+        ::memgraph::logging::AssertFailed(std::source_location::current(), #expr, GET_MESSAGE(__VA_ARGS__)); \
+      }                                                                                                      \
+      ();                                                                                                    \
+    }                                                                                                        \
   } while (false)
 
 #ifndef NDEBUG

--- a/src/utils/thread_pool.hpp
+++ b/src/utils/thread_pool.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -10,16 +10,13 @@
 // licenses/APL.txt.
 
 #pragma once
+
 #include <atomic>
 #include <condition_variable>
 #include <functional>
 #include <mutex>
 #include <queue>
 #include <thread>
-
-#include "utils/spin_lock.hpp"
-#include "utils/synchronized.hpp"
-#include "utils/thread.hpp"
 
 namespace memgraph::utils {
 


### PR DESCRIPTION
Use std::source_location instead of relying on __FILE and __LINE
