### PR TITLE
Unpin tzdata

### DIFF
--- a/environment/os/debian-11.sh
+++ b/environment/os/debian-11.sh
@@ -39,7 +39,6 @@ TOOLCHAIN_RUN_DEPS=(
     libreadline8 # for cmake and llvm
     libffi7 libxml2 # for llvm
     libssl-dev # for libevent
-    tzdata # for timezone bugfix
 )
 
 MEMGRAPH_BUILD_DEPS=(
@@ -165,10 +164,6 @@ EOF
                 apt-get update
                 apt-get install -y apt-transport-https dotnet-sdk-3.1
             fi
-            continue
-        fi
-        if [ "$pkg" == tzdata ]; then
-            apt install -y tzdata=2024a-0+deb11u1 --allow-downgrades # specific version for timezone bug
             continue
         fi
         apt install -y "$pkg"

--- a/environment/os/ubuntu-22.04.sh
+++ b/environment/os/ubuntu-22.04.sh
@@ -38,7 +38,6 @@ TOOLCHAIN_RUN_DEPS=(
     libreadline8 # for cmake and llvm
     libffi7 libxml2 # for llvm
     libssl-dev # for libevent
-    tzdata # for timezone bug
 )
 
 MEMGRAPH_BUILD_DEPS=(
@@ -156,15 +155,9 @@ install() {
             install_node "20"
             continue
         fi
-        if [ "$pkg" == tzdata ]; then
-            apt install -y tzdata=2022a-0ubuntu1 --allow-downgrades # specific version for timezone bug
-            continue
-        fi
         apt install -y "$pkg"
     done
 }
 
 deps=$2"[*]"
 "$1" "${!deps}"
-
-

--- a/environment/os/ubuntu-24.04.sh
+++ b/environment/os/ubuntu-24.04.sh
@@ -38,7 +38,6 @@ TOOLCHAIN_RUN_DEPS=(
     libreadline8t64 # for cmake and llvm
     libffi8 libxml2 # for llvm
     libssl-dev # for libevent
-    tzdata # timezone bug fix
 )
 
 MEMGRAPH_BUILD_DEPS=(
@@ -154,10 +153,6 @@ install() {
         fi
         if [ "$pkg" == custom-node ]; then
             install_node "20"
-            continue
-        fi
-        if [ "$pkg" == tzdata ]; then
-            apt install -y tzdata=2024a-2ubuntu1 --allow-downgrades # specific version for timezone bug
             continue
         fi
         apt install -y "$pkg"

--- a/release/docker/v5_deb.dockerfile
+++ b/release/docker/v5_deb.dockerfile
@@ -8,12 +8,6 @@ ARG TARGETARCH
 RUN apt-get update && apt-get install -y \
   openssl libcurl4 libssl3 libseccomp2 python3 libpython3.11 python3-pip libxmlsec1-dev xmlsec1 \
   --no-install-recommends && \
-  apt install wget && \
-  TEMP_DEB="$(mktemp)" && \
-  wget -O "$TEMP_DEB" 'https://snapshot.debian.org/archive/debian/20240204T221334Z/pool/main/t/tzdata/tzdata_2024a-0+deb12u1_all.deb' && \
-  dpkg -i "$TEMP_DEB" && \
-  apt-mark hold tzdata && \
-  rm -f "$TEMP_DEB" && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN pip3 install --break-system-packages  numpy==1.26.4 scipy==1.12.0 networkx==3.2.1 gensim==4.3.3

--- a/release/docker/v5_deb_relwithdebinfo.dockerfile
+++ b/release/docker/v5_deb_relwithdebinfo.dockerfile
@@ -9,12 +9,6 @@ ARG SOURCE_CODE
 RUN apt-get update && apt-get install -y \
   openssl libcurl4 libssl3 libseccomp2 python3 libpython3.11 python3-pip gdb procps linux-perf libc6-dbg libxmlsec1-dev xmlsec1 \
   --no-install-recommends && \
-  apt install wget && \
-  TEMP_DEB="$(mktemp)" && \
-  wget -O "$TEMP_DEB" 'https://snapshot.debian.org/archive/debian/20240204T221334Z/pool/main/t/tzdata/tzdata_2024a-0+deb12u1_all.deb' && \
-  dpkg -i "$TEMP_DEB" && \
-  apt-mark hold tzdata && \
-  rm -f "$TEMP_DEB" && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN pip3 install --break-system-packages  numpy==1.26.4 scipy==1.12.0 networkx==3.2.1 gensim==4.3.3

--- a/release/docker/v6_deb.dockerfile
+++ b/release/docker/v6_deb.dockerfile
@@ -9,8 +9,6 @@ RUN apt-get update && apt-get install -y \
   openssl libcurl4 libssl3 libseccomp2 python3 libpython3.12 python3-pip libatomic1 adduser \
   --no-install-recommends && \
   apt install -y libxmlsec1-dev xmlsec1 && \
-  apt install -y tzdata=2024a-2ubuntu1 --allow-downgrades && \
-  apt-mark hold tzdata && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # NOTE: The following are required to run built-in Python modules. For the full

--- a/release/docker/v6_deb_relwithdebinfo.dockerfile
+++ b/release/docker/v6_deb_relwithdebinfo.dockerfile
@@ -6,10 +6,6 @@ ARG EXTENSION
 ARG TARGETARCH
 ARG SOURCE_CODE
 
-# Bugfix for timezone issues - pin the package
-RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -y tzdata=2024a-2ubuntu1 --allow-downgrades
-RUN apt-mark hold tzdata
-
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
   openssl libcurl4 libssl3 libseccomp2 python3 libpython3.12 python3-pip libatomic1 adduser \
   gdb procps linux-tools-common linux-tools-generic linux-tools-generic libc6-dbg \


### PR DESCRIPTION
[Bug](https://bugs.launchpad.net/ubuntu/+source/tzdata/+bug/2096974) in `tzdata` has been [fixed](https://bugs.launchpad.net/ubuntu/noble/+source/tzdata/+bug/2107950),  so we can unpin the package version.


