### PR TITLE
Optimize usage of std::atomic for x86 platform around replication code

### DIFF
--- a/src/dbms/dbms_handler.hpp
+++ b/src/dbms/dbms_handler.hpp
@@ -169,9 +169,10 @@ class DbmsHandler {
     // TODO: Fix this hack
     if (config.name == kDefaultDB) {
       spdlog::debug("Last commit timestamp for DB {} is {}", kDefaultDB,
-                    db->storage()->repl_storage_state_.last_durable_timestamp_);
+                    db->storage()->repl_storage_state_.last_durable_timestamp_.load(std::memory_order_acquire));
       // This seems correct, if database made progress
-      if (db->storage()->repl_storage_state_.last_durable_timestamp_ != storage::kTimestampInitialId) {
+      if (db->storage()->repl_storage_state_.last_durable_timestamp_.load(std::memory_order_acquire) !=
+          storage::kTimestampInitialId) {
         spdlog::debug("Default storage is not clean, cannot update UUID...");
         return NewError::GENERIC;  // Update error
       }

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -273,8 +273,9 @@ void InMemoryReplicationHandlers::HeartbeatHandler(dbms::DbmsHandler *dbms_handl
   }
   // Move db acc
   auto const *storage = db_acc->get()->storage();
-  const storage::replication::HeartbeatRes res{true, storage->repl_storage_state_.last_durable_timestamp_.load(),
-                                               std::string{storage->repl_storage_state_.epoch_.id()}};
+  const storage::replication::HeartbeatRes res{
+      true, storage->repl_storage_state_.last_durable_timestamp_.load(std::memory_order_acquire),
+      std::string{storage->repl_storage_state_.epoch_.id()}};
   rpc::SendFinalResponse(res, res_builder, fmt::format("db: {}", storage->name()));
 }
 
@@ -330,7 +331,7 @@ void InMemoryReplicationHandlers::AppendDeltasHandler(dbms::DbmsHandler *dbms_ha
 
   // last_durable_timestamp could be set by snapshot; so we cannot guarantee exactly what's the previous timestamp
   // TODO: (andi) Not sure if emptying the stream is needed?
-  if (req.previous_commit_timestamp > repl_storage_state.last_durable_timestamp_.load()) {
+  if (req.previous_commit_timestamp > repl_storage_state.last_durable_timestamp_.load(std::memory_order_acquire)) {
     // Empty the stream
     bool transaction_complete = false;
     while (!transaction_complete) {
@@ -810,7 +811,7 @@ std::pair<uint64_t, uint32_t> InMemoryReplicationHandlers::ReadAndApplyDeltasSin
   uint64_t current_delta_idx = 0;  // tracks over how many deltas we iterated, includes also skipped deltas.
   uint64_t applied_deltas = 0;     // Non-skipped deltas
   uint32_t current_batch_counter = start_batch_counter;
-  auto max_delta_timestamp = storage->repl_storage_state_.last_durable_timestamp_.load();
+  auto max_delta_timestamp = storage->repl_storage_state_.last_durable_timestamp_.load(std::memory_order_acquire);
 
   auto current_durable_commit_timestamp = max_delta_timestamp;
   spdlog::trace("Current durable commit timestamp: {}", current_durable_commit_timestamp);
@@ -1337,7 +1338,7 @@ std::pair<uint64_t, uint32_t> InMemoryReplicationHandlers::ReadAndApplyDeltasSin
 
   if (commit_timestamp_and_accessor) throw utils::BasicException("Did not finish the transaction!");
 
-  storage->repl_storage_state_.last_durable_timestamp_ = max_delta_timestamp;
+  storage->repl_storage_state_.last_durable_timestamp_.store(max_delta_timestamp, std::memory_order_release);
 
   spdlog::debug("Applied {} deltas", applied_deltas);
   return {current_delta_idx, current_batch_counter};

--- a/src/replication/state.cpp
+++ b/src/replication/state.cpp
@@ -257,7 +257,7 @@ bool ReplicationState::TryPersistRegisteredReplica(const ReplicationClientConfig
   if (!HasDurability()) return true;
 
   // If any replicas are persisted then Role must be persisted
-  if (role_persisted.load(std::memory_order_acquire) == RolePersisted::YES) {
+  if (role_persisted.load(std::memory_order_acquire) != RolePersisted::YES) {
     DMG_ASSERT(IsMain(), "MAIN is expected");
     auto epoch_str = std::string(std::get<RoleMainData>(replication_data_).epoch_.id());
     if (!TryPersistRoleMain(std::move(epoch_str), main_uuid)) return false;

--- a/src/replication/state.cpp
+++ b/src/replication/state.cpp
@@ -84,7 +84,7 @@ bool ReplicationState::TryPersistRoleReplica(const ReplicationServerConfig &conf
     spdlog::error("Error when saving REPLICA replication role in settings.");
     return false;
   }
-  role_persisted = RolePersisted::YES;
+  role_persisted.store(RolePersisted::YES, std::memory_order_release);
 
   // Cleanup remove registered replicas (assume successful delete)
   // NOTE: we could do the alternative which would be on REPLICA -> MAIN we recover these registered replicas
@@ -104,7 +104,7 @@ bool ReplicationState::TryPersistRoleMain(std::string new_epoch, utils::UUID mai
       .role = durability::MainRole{.epoch = ReplicationEpoch{std::move(new_epoch)}, .main_uuid = main_uuid}};
 
   if (durability_->Put(durability::kReplicationRoleName, nlohmann::json(data).dump())) {
-    role_persisted = RolePersisted::YES;
+    role_persisted.store(RolePersisted::YES, std::memory_order_release);
     return true;
   }
   spdlog::error("Error when saving MAIN replication role in settings.");
@@ -142,7 +142,7 @@ auto ReplicationState::FetchReplicationData() -> FetchReplicationResult_t {
     }
 
     // To get here this must be the case
-    role_persisted = memgraph::replication::RolePersisted::YES;
+    role_persisted.store(RolePersisted::YES, std::memory_order_release);
 
     return std::visit(
         utils::Overloaded{
@@ -257,7 +257,7 @@ bool ReplicationState::TryPersistRegisteredReplica(const ReplicationClientConfig
   if (!HasDurability()) return true;
 
   // If any replicas are persisted then Role must be persisted
-  if (role_persisted != RolePersisted::YES) {
+  if (role_persisted.load(std::memory_order_acquire) == RolePersisted::YES) {
     DMG_ASSERT(IsMain(), "MAIN is expected");
     auto epoch_str = std::string(std::get<RoleMainData>(replication_data_).epoch_.id());
     if (!TryPersistRoleMain(std::move(epoch_str), main_uuid)) return false;

--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -646,7 +646,7 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
   memgraph::metrics::Measure(memgraph::metrics::SnapshotRecoveryLatency_us,
                              std::chrono::duration_cast<std::chrono::microseconds>(timer.Elapsed()).count());
   spdlog::trace("Epoch id: {}. Last durable commit timestamp: {}.", std::string(repl_storage_state.epoch_.id()),
-                repl_storage_state.last_durable_timestamp_);
+                repl_storage_state.last_durable_timestamp_.load(std::memory_order_acquire));
 
   spdlog::trace("History with its epochs and attached commit timestamps.");
   r::for_each(repl_storage_state.history, [](auto &&history) {

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -81,7 +81,8 @@ void ReplicationStorageClient::UpdateReplicaState(Storage *main_storage, Databas
         // If SYNC replica, block while waiting for RPC lock
         if (client_.mode_ == replication_coordination_glue::ReplicationMode::SYNC) {
           auto hb_stream = client_.rpc_client_.Stream<replication::HeartbeatRpc>(
-              main_uuid_, main_storage->uuid(), replStorageState.last_durable_timestamp_,
+              main_uuid_, main_storage->uuid(),
+              replStorageState.last_durable_timestamp_.load(std::memory_order_acquire),
               std::string{replStorageState.epoch_.id()});
           return hb_stream.SendAndWait();
         }
@@ -92,7 +93,8 @@ void ReplicationStorageClient::UpdateReplicaState(Storage *main_storage, Databas
         // get scheduled since UpdateReplicaState tasks cannot finish due to impossibility to get RPC lock
         auto hb_stream = client_.rpc_client_.TryStream<replication::HeartbeatRpc>(
             std::optional{kHeartbeatRpcTimeout}, main_uuid_, main_storage->uuid(),
-            replStorageState.last_durable_timestamp_, std::string{replStorageState.epoch_.id()});
+            replStorageState.last_durable_timestamp_.load(std::memory_order_acquire),
+            std::string{replStorageState.epoch_.id()});
 
         std::optional<replication::HeartbeatRes> res;
         if (hb_stream.has_value()) {
@@ -131,7 +133,8 @@ void ReplicationStorageClient::UpdateReplicaState(Storage *main_storage, Databas
     spdlog::trace(
         "DB: {} Replica {}: Epoch id: {}, last_durable_timestamp: {}; Main: Epoch id: {}, last_durable_timestamp: {}",
         main_db_name, client_.name_, std::string(heartbeat_res.epoch_id), heartbeat_res.current_commit_timestamp,
-        std::string(replStorageState.epoch_.id()), replStorageState.last_durable_timestamp_);
+        std::string(replStorageState.epoch_.id()),
+        replStorageState.last_durable_timestamp_.load(std::memory_order_acquire));
 
     auto const &history = replStorageState.history;
     const auto epoch_info_iter = std::find_if(history.crbegin(), history.crend(), [&](const auto &main_epoch_info) {

--- a/src/storage/v2/replication/replication_storage_state.cpp
+++ b/src/storage/v2/replication/replication_storage_state.cpp
@@ -47,11 +47,11 @@ void ReplicationStorageState::TrackLatestHistory() {
   if (history.size() == kEpochHistoryRetention) {
     history.pop_front();
   }
-  history.emplace_back(epoch_.id(), last_durable_timestamp_);
+  history.emplace_back(epoch_.id(), last_durable_timestamp_.load(std::memory_order_acquire));
 }
 
 void ReplicationStorageState::AddEpochToHistoryForce(std::string prev_epoch) {
-  history.emplace_back(std::move(prev_epoch), last_durable_timestamp_);
+  history.emplace_back(std::move(prev_epoch), last_durable_timestamp_.load(std::memory_order_acquire));
 }
 
 }  // namespace memgraph::storage

--- a/src/system/include/system/transaction.hpp
+++ b/src/system/include/system/transaction.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -81,7 +81,9 @@ struct Transaction {
     actions_.clear();
   }
 
-  auto last_committed_system_timestamp() const -> uint64_t { return state_->last_committed_system_timestamp_.load(); }
+  auto last_committed_system_timestamp() const -> uint64_t {
+    return state_->last_committed_system_timestamp_.load(std::memory_order_acquire);
+  }
   auto timestamp() const -> uint64_t { return timestamp_; }
 
  private:

--- a/src/utils/barrier.hpp
+++ b/src/utils/barrier.hpp
@@ -36,7 +36,7 @@ class SimpleBarrier {
       phase1_done_.wait(false);
     }
     // Phase2 decrement and return
-    // This guards against the barrier's desctruction while threads are waiting
+    // This guards against the barrier's destruction while threads are waiting
     if (--phase2_ == 0) {
       phase2_done_ = true;
       phase2_done_.notify_all();


### PR DESCRIPTION
We use seq_cst on multiple places which is unnecessarily slow.
For x86 platforms, stores with seq_cst use one of the alternatives:

(LOCK) XCHG // alternative: MOV (into memory),MFENCE

https://www.cl.cam.ac.uk/~pes20/cpp/cpp0xmappings.html


Changing it to release will reduce the need of generating MFENCE
