### PR TITLE
Remove package update to stop CentOS 10 build getting stuck

### DIFF
--- a/environment/os/centos-10.sh
+++ b/environment/os/centos-10.sh
@@ -136,9 +136,6 @@ install() {
     # enable EPEL repo for rpmlint
     sudo dnf install -y epel-release
 
-    # --nobest is used because of libipt because we install custom versions
-    # because libipt-devel is not available on CentOS 9 Stream
-    dnf update -y --nobest
     dnf install -y wget git python3 python3-pip
     # CRB repo is required for, e.g. texinfo, ninja-build
     dnf config-manager --set-enabled crb

--- a/release/package/centos-10/Dockerfile
+++ b/release/package/centos-10/Dockerfile
@@ -2,8 +2,7 @@ FROM dokken/centos-stream-10
 
 ARG TOOLCHAIN_VERSION
 
-RUN dnf -y update \
-    && dnf install -y wget git
+RUN dnf install -y wget git
 # Do NOT be smart here and clean the cache because the container is used in the
 # stateful context.
 

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -430,19 +430,17 @@ package_memgraph() {
   local ACTIVATE_TOOLCHAIN="source /opt/toolchain-${toolchain_version}/activate"
   local container_output_dir="$MGBUILD_ROOT_DIR/build/output"
   local package_command=""
-  # TODO (matt): tidy this
-  if [[ "$os" =~ ^"centos".* ]] || [[ "$os" =~ ^"fedora".* ]] || [[ "$os" =~ ^"amzn".* ]] || [[ "$os" =~ ^"rocky".* ]]; then
+
+  if [[ "$os" == "centos-10" ]]; then
+      package_command=" cpack -G RPM --config ../CPackConfig.cmake && rpmlint --file='../../release/rpm/rpmlintrc_centos10' memgraph*.rpm "
+  elif [[ "$os" =~ ^"fedora".* ]]; then
+      docker exec -u root "$build_container" bash -c "yum -y update"
+      package_command=" cpack -G RPM --config ../CPackConfig.cmake && rpmlint --file='../../release/rpm/rpmlintrc_fedora' memgraph*.rpm "
+  elif [[ "$os" =~ ^"centos".* ]] || [[ "$os" =~ ^"amzn".* ]] || [[ "$os" =~ ^"rocky".* ]]; then
       docker exec -u root "$build_container" bash -c "yum -y update"
       package_command=" cpack -G RPM --config ../CPackConfig.cmake && rpmlint --file='../../release/rpm/rpmlintrc' memgraph*.rpm "
   fi
-  if [[ "$os" =~ ^"centos-10".* ]]; then
-    docker exec -u root "$build_container" bash -c "yum -y update"
-    package_command=" cpack -G RPM --config ../CPackConfig.cmake && rpmlint --file='../../release/rpm/rpmlintrc_centos10' memgraph*.rpm "
-  fi
-  if [[ "$os" =~ ^"fedora".* ]]; then
-      docker exec -u root "$build_container" bash -c "yum -y update"
-      package_command=" cpack -G RPM --config ../CPackConfig.cmake && rpmlint --file='../../release/rpm/rpmlintrc_fedora' memgraph*.rpm "
-  fi
+
   if [[ "$os" =~ ^"debian".* ]]; then
       docker exec -u root "$build_container" bash -c "apt --allow-releaseinfo-change -y update"
       package_command=" cpack -G DEB --config ../CPackConfig.cmake "


### PR DESCRIPTION
Package update using `dnf update -y --nobest` was getting stuck at the stage where where it would attempt to install `nvidia-gpu-firmware`; this fix stops the update happening and should allow the build to continue.
