### PR TITLE
Add support for c++26 atomix_fetch_max_explicit

### DIFF
--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -51,6 +51,7 @@
 #include "storage/v2/storage.hpp"
 #include "storage/v2/vertex.hpp"
 #include "storage/v2/vertex_accessor.hpp"
+#include "utils/atomic_max.hpp"
 #include "utils/file.hpp"
 #include "utils/file_locker.hpp"
 #include "utils/logging.hpp"
@@ -1586,10 +1587,7 @@ RecoveredSnapshot LoadSnapshotVersion15(Decoder &snapshot, const std::filesystem
               LoadPartialConnectivity(path, *vertices, *edges, *edges_metadata, schema_info, batch.offset, batch.count,
                                       items, snapshot_has_edges, get_edge_type_from_id, name_id_mapper);
           edge_count->fetch_add(result.edge_count);
-          auto known_highest_edge_gid = highest_edge_gid.load();
-          while (known_highest_edge_gid < result.highest_edge_id) {
-            highest_edge_gid.compare_exchange_weak(known_highest_edge_gid, result.highest_edge_id);
-          }
+          atomic_fetch_max_explicit(&highest_edge_gid, result.highest_edge_id, std::memory_order_acq_rel);
           recovery_info.vertex_batches[batch_index].first = result.first_vertex_gid;
         },
         vertex_batches);
@@ -1874,10 +1872,7 @@ RecoveredSnapshot LoadSnapshotVersion16(Decoder &snapshot, const std::filesystem
               LoadPartialConnectivity(path, *vertices, *edges, *edges_metadata, schema_info, batch.offset, batch.count,
                                       items, snapshot_has_edges, get_edge_type_from_id, name_id_mapper);
           edge_count->fetch_add(result.edge_count);
-          auto known_highest_edge_gid = highest_edge_gid.load();
-          while (known_highest_edge_gid < result.highest_edge_id) {
-            highest_edge_gid.compare_exchange_weak(known_highest_edge_gid, result.highest_edge_id);
-          }
+          atomic_fetch_max_explicit(&highest_edge_gid, result.highest_edge_id, std::memory_order_acq_rel);
           recovery_info.vertex_batches[batch_index].first = result.first_vertex_gid;
         },
         vertex_batches);
@@ -2216,10 +2211,7 @@ RecoveredSnapshot LoadSnapshotVersion17(Decoder &snapshot, const std::filesystem
               LoadPartialConnectivity(path, *vertices, *edges, *edges_metadata, schema_info, batch.offset, batch.count,
                                       items, snapshot_has_edges, get_edge_type_from_id, name_id_mapper);
           edge_count->fetch_add(result.edge_count);
-          auto known_highest_edge_gid = highest_edge_gid.load();
-          while (known_highest_edge_gid < result.highest_edge_id) {
-            highest_edge_gid.compare_exchange_weak(known_highest_edge_gid, result.highest_edge_id);
-          }
+          atomic_fetch_max_explicit(&highest_edge_gid, result.highest_edge_id, std::memory_order_acq_rel);
           recovery_info.vertex_batches[batch_index].first = result.first_vertex_gid;
         },
         vertex_batches);
@@ -2641,10 +2633,7 @@ RecoveredSnapshot LoadSnapshotVersion18or19(Decoder &snapshot, const std::filesy
               LoadPartialConnectivity(path, *vertices, *edges, *edges_metadata, schema_info, batch.offset, batch.count,
                                       items, snapshot_has_edges, get_edge_type_from_id, name_id_mapper);
           edge_count->fetch_add(result.edge_count);
-          auto known_highest_edge_gid = highest_edge_gid.load();
-          while (known_highest_edge_gid < result.highest_edge_id) {
-            highest_edge_gid.compare_exchange_weak(known_highest_edge_gid, result.highest_edge_id);
-          }
+          atomic_fetch_max_explicit(&highest_edge_gid, result.highest_edge_id, std::memory_order_acq_rel);
           recovery_info.vertex_batches[batch_index].first = result.first_vertex_gid;
         },
         vertex_batches);
@@ -3083,10 +3072,7 @@ RecoveredSnapshot LoadSnapshotVersion20or21(Decoder &snapshot, const std::filesy
               LoadPartialConnectivity(path, *vertices, *edges, *edges_metadata, schema_info, batch.offset, batch.count,
                                       items, snapshot_has_edges, get_edge_type_from_id, name_id_mapper);
           edge_count->fetch_add(result.edge_count);
-          auto known_highest_edge_gid = highest_edge_gid.load();
-          while (known_highest_edge_gid < result.highest_edge_id) {
-            highest_edge_gid.compare_exchange_weak(known_highest_edge_gid, result.highest_edge_id);
-          }
+          atomic_fetch_max_explicit(&highest_edge_gid, result.highest_edge_id, std::memory_order_acq_rel);
           recovery_info.vertex_batches[batch_index].first = result.first_vertex_gid;
         },
         vertex_batches);
@@ -3578,10 +3564,7 @@ RecoveredSnapshot LoadSnapshotVersion22or23(Decoder &snapshot, const std::filesy
               LoadPartialConnectivity(path, *vertices, *edges, *edges_metadata, schema_info, batch.offset, batch.count,
                                       items, snapshot_has_edges, get_edge_type_from_id, name_id_mapper, snapshot_info);
           edge_count->fetch_add(result.edge_count);
-          auto known_highest_edge_gid = highest_edge_gid.load();
-          while (known_highest_edge_gid < result.highest_edge_id) {
-            highest_edge_gid.compare_exchange_weak(known_highest_edge_gid, result.highest_edge_id);
-          }
+          atomic_fetch_max_explicit(&highest_edge_gid, result.highest_edge_id, std::memory_order_acq_rel);
           recovery_info.vertex_batches[batch_index].first = result.first_vertex_gid;
         },
         vertex_batches);
@@ -4120,10 +4103,7 @@ RecoveredSnapshot LoadCurrentVersionSnapshot(Decoder &snapshot, std::filesystem:
                                                         batch.offset, batch.count, items, snapshot_has_edges,
                                                         get_edge_type_from_id, name_id_mapper, snapshot_info);
             edge_count->fetch_add(result.edge_count);
-            auto known_highest_edge_gid = highest_edge_gid.load();
-            while (known_highest_edge_gid < result.highest_edge_id) {
-              highest_edge_gid.compare_exchange_weak(known_highest_edge_gid, result.highest_edge_id);
-            }
+            atomic_fetch_max_explicit(&highest_edge_gid, result.highest_edge_id, std::memory_order_acq_rel);
             recovery_info.vertex_batches[batch_index].first = result.first_vertex_gid;
           },
           vertex_batches);

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -49,6 +49,7 @@
 #include "storage/v2/schema_info.hpp"
 #include "storage/v2/storage.hpp"
 #include "storage/v2/storage_mode.hpp"
+#include "utils/atomic_max.hpp"
 #include "utils/atomic_memory_block.hpp"
 #include "utils/event_gauge.hpp"
 #include "utils/exceptions.hpp"
@@ -196,7 +197,7 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
       edge_id_ = info->next_edge_id;
       timestamp_ = std::max(timestamp_, info->next_timestamp);
       if (info->last_durable_timestamp) {
-        repl_storage_state_.last_durable_timestamp_ = *info->last_durable_timestamp;
+        repl_storage_state_.last_durable_timestamp_.store(*info->last_durable_timestamp, std::memory_order_release);
         spdlog::trace("Recovering last durable timestamp {}. Timestamp recovered to {}", *info->last_durable_timestamp,
                       timestamp_);
       }
@@ -348,14 +349,7 @@ std::optional<VertexAccessor> InMemoryStorage::InMemoryAccessor::CreateVertexEx(
   // threads (it is the replica), it is guaranteed that no other writes are
   // possible.
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
-  auto current_vertex_id = mem_storage->vertex_id_.load(std::memory_order_acquire);
-  bool updated = false;
-  auto next_vertex_id = gid.AsUint() + 1;
-  // Only update if larger
-  while (!updated && current_vertex_id < next_vertex_id) {
-    updated =
-        mem_storage->vertex_id_.compare_exchange_weak(current_vertex_id, next_vertex_id, std::memory_order_acq_rel);
-  }
+  atomic_fetch_max_explicit(&mem_storage->vertex_id_, gid.AsUint() + 1, std::memory_order_acq_rel);
   auto acc = mem_storage->vertices_.access();
 
   auto *delta = CreateDeleteObjectDelta(&transaction_);
@@ -602,12 +596,7 @@ Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdgeEx(VertexAcces
   // possible.
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
 
-  auto const next_edge_id = gid.AsUint() + 1;
-  auto current_edge_id = mem_storage->edge_id_.load(std::memory_order_acquire);
-  bool updated = false;
-  while (!updated && current_edge_id < next_edge_id) {
-    updated = mem_storage->edge_id_.compare_exchange_weak(current_edge_id, next_edge_id, std::memory_order_acq_rel);
-  }
+  atomic_fetch_max_explicit(&mem_storage->edge_id_, gid.AsUint() + 1, std::memory_order_acq_rel);
 
   EdgeRef edge(gid);
   if (config_.properties_on_edges) {
@@ -2572,9 +2561,9 @@ bool InMemoryStorage::AppendToWal(const Transaction &transaction, uint64_t durab
 
   // Handle MVCC deltas
   if (!transaction.deltas.empty()) {
-    append_deltas([&](const Delta &delta, const auto &parent, uint64_t durability_commit_timestamp) {
-      wal_file_->AppendDelta(delta, parent, durability_commit_timestamp);
-      tx_replication.AppendDelta(delta, parent, durability_commit_timestamp);
+    append_deltas([&](const Delta &delta, const auto &parent, uint64_t durability_commit_timestamp_arg) {
+      wal_file_->AppendDelta(delta, parent, durability_commit_timestamp_arg);
+      tx_replication.AppendDelta(delta, parent, durability_commit_timestamp_arg);
     });
   }
 
@@ -2689,7 +2678,7 @@ utils::BasicResult<InMemoryStorage::RecoverSnapshotError> InMemoryStorage::Recov
   if (force) {
     Clear();
   } else {
-    if (repl_storage_state_.last_durable_timestamp_ != storage::kTimestampInitialId) {
+    if (repl_storage_state_.last_durable_timestamp_.load(std::memory_order_acquire) != kTimestampInitialId) {
       handler_error();
       return InMemoryStorage::RecoverSnapshotError::NonEmptyStorage;
     }
@@ -3003,7 +2992,7 @@ void InMemoryStorage::Clear() {
 
   // Replication epoch and timestamp reset
   repl_storage_state_.epoch_.SetEpoch(std::string(utils::UUID{}));
-  repl_storage_state_.last_durable_timestamp_ = 0;
+  repl_storage_state_.last_durable_timestamp_.store(0, std::memory_order_release);
   repl_storage_state_.history.clear();
 
   last_snapshot_digest_ = std::nullopt;

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library(mg-utils STATIC)
+add_library(mg-utils STATIC
+        atomic_max.hpp)
 add_library(mg::utils ALIAS mg-utils)
 
 target_sources(mg-utils

--- a/src/utils/atomic_max.hpp
+++ b/src/utils/atomic_max.hpp
@@ -17,8 +17,8 @@
 // Replace with C++26 code when available
 template <class T>
 T atomic_fetch_max_explicit(std::atomic<T> *current, typename std::atomic<T>::value_type const value,
-                            std::memory_order m_order) noexcept {
-  auto old = current->load(m_order);
+                            std::memory_order m_order = std::memory_order_acq_rel) noexcept {
+  auto old = current->load(std::memory_order_acquire);
   while (std::max(old, value) != old) {
     if (current->compare_exchange_weak(old, value, m_order, m_order)) {
       return old;

--- a/src/utils/atomic_max.hpp
+++ b/src/utils/atomic_max.hpp
@@ -14,7 +14,7 @@
 #include <algorithm>
 #include <atomic>
 
-// Replace with C++26 version
+// Replace with C++26 code when available
 template <class T>
 T atomic_fetch_max_explicit(std::atomic<T> *current, typename std::atomic<T>::value_type const value,
                             std::memory_order m_order) noexcept {

--- a/src/utils/atomic_max.hpp
+++ b/src/utils/atomic_max.hpp
@@ -18,7 +18,7 @@
 template <class T>
 T atomic_fetch_max_explicit(std::atomic<T> *current, typename std::atomic<T>::value_type const value,
                             std::memory_order m_order) noexcept {
-  auto old = current.load(m_order);
+  auto old = current->load(m_order);
   while (std::max(old, value) != old) {
     if (current->compare_exchange_weak(old, value, m_order, m_order)) {
       return old;

--- a/src/utils/atomic_max.hpp
+++ b/src/utils/atomic_max.hpp
@@ -1,0 +1,33 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+
+// Replace with C++26 version
+template <class T>
+T atomic_fetch_max_explicit(std::atomic<T> *current, typename std::atomic<T>::value_type const value,
+                            std::memory_order m_order) noexcept {
+  auto old = current.load(m_order);
+  while (std::max(old, value) != old) {
+    if (current->compare_exchange_weak(old, value, m_order, m_order)) {
+      return old;
+    }
+  }
+  // dummy write if release operation
+  if (m_order == std::memory_order::release || m_order == std::memory_order::acq_rel ||
+      m_order == std::memory_order::seq_cst) {
+    current->fetch_add(0, m_order);
+  }
+  return old;
+}

--- a/src/utils/atomic_max.hpp
+++ b/src/utils/atomic_max.hpp
@@ -20,7 +20,7 @@ T atomic_fetch_max_explicit(std::atomic<T> *current, typename std::atomic<T>::va
                             std::memory_order m_order = std::memory_order_acq_rel) noexcept {
   auto old = current->load(std::memory_order_acquire);
   while (std::max(old, value) != old) {
-    if (current->compare_exchange_weak(old, value, m_order, m_order)) {
+    if (current->compare_exchange_weak(old, value, m_order, std::memory_order_acquire)) {
       return old;
     }
   }

--- a/src/utils/memory_tracker.cpp
+++ b/src/utils/memory_tracker.cpp
@@ -13,11 +13,9 @@
 
 #include <atomic>
 #include <exception>
-#include <stdexcept>
 
-#include "utils/likely.hpp"
+#include "utils/atomic_max.hpp"
 #include "utils/logging.hpp"
-#include "utils/on_scope_exit.hpp"
 #include "utils/readable_size.hpp"
 
 namespace memgraph::utils {
@@ -77,9 +75,7 @@ void MemoryTracker::SetHardLimit(const int64_t limit) {
 }
 
 void MemoryTracker::TryRaiseHardLimit(const int64_t limit) {
-  int64_t old_limit = hard_limit_.load(std::memory_order_relaxed);
-  while (old_limit < limit && !hard_limit_.compare_exchange_weak(old_limit, limit))
-    ;
+  atomic_fetch_max_explicit(&hard_limit_, limit, std::memory_order_acq_rel);
 }
 
 void MemoryTracker::ResetTrackings() {


### PR DESCRIPTION
Simplifies lock-free max impl.

https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0493r3.pdf