### PR TITLE
Replace `PropertyValue` map internals

### DIFF
--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -314,7 +314,7 @@ void SessionHL::InterpretParse(const std::string &query, bolt_map_t params, cons
   auto get_params_pv =
       [params = std::move(params)](storage::Storage const *storage) -> memgraph::storage::ExternalPropertyValue::map_t {
     auto params_pv = memgraph::storage::ExternalPropertyValue::map_t{};
-    params_pv.reserve(params.size());
+    do_reserve(params_pv, params.size());
     for (const auto &[key, bolt_param] : params) {
       params_pv.try_emplace(key, ToExternalPropertyValue(bolt_param, storage));
     }

--- a/src/glue/communication.cpp
+++ b/src/glue/communication.cpp
@@ -325,7 +325,7 @@ storage::ExternalPropertyValue ToExternalPropertyValue(communication::bolt::Valu
       if (mg_type) return *mg_type;
 
       auto map = storage::ExternalPropertyValue::map_t{};
-      map.reserve(valueMap.size());
+      do_reserve(map, valueMap.size());
       for (const auto &[k, v] : valueMap) {
         map.try_emplace(k, ToExternalPropertyValue(v, storage));
       }

--- a/src/query/frontend/ast/pretty_print.cpp
+++ b/src/query/frontend/ast/pretty_print.cpp
@@ -119,7 +119,7 @@ template <typename K, typename V>
 void PrintObject(std::ostream *out, const DbAccessor *dba, const std::map<K, V> &map);
 
 template <typename K, typename V, typename C, typename A>
-void PrintObject(std::ostream *out, const DbAccessor *dba, const boost::container::flat_map<K, V, C, A> &map);
+void PrintObject(std::ostream *out, const DbAccessor *dba, const std::map<K, V, C, A> &map);
 
 void PrintObject(std::ostream *out, EnumValueAccess op);
 
@@ -296,7 +296,7 @@ void PrintObject(std::ostream *out, const DbAccessor *dba, const std::map<K, V> 
 }
 
 template <typename K, typename V, typename C, typename A>
-void PrintObject(std::ostream *out, const DbAccessor *dba, const boost::container::flat_map<K, V, C, A> &map) {
+void PrintObject(std::ostream *out, const DbAccessor *dba, const std::map<K, V, C, A> &map) {
   *out << "{";
   utils::PrintIterable(*out, map, ", ", [&dba](auto &stream, const auto &item) {
     PrintObject(&stream, dba, item.first);

--- a/src/query/procedure/mg_procedure_impl.cpp
+++ b/src/query/procedure/mg_procedure_impl.cpp
@@ -1847,7 +1847,7 @@ memgraph::storage::PropertyValue ToPropertyValue(const mgp_list &list,
 
 memgraph::storage::PropertyValue ToPropertyValue(const mgp_map &map, memgraph::storage::NameIdMapper *name_id_mapper) {
   auto result_map = memgraph::storage::PropertyValue::map_t{};
-  result_map.reserve(map.items.size());
+  do_reserve(result_map, map.items.size());
   for (const auto &[key, value] : map.items) {
     auto property_id = memgraph::storage::PropertyId::FromUint(name_id_mapper->NameToId(key));
     result_map.insert_or_assign(property_id, ToPropertyValue(value, name_id_mapper));
@@ -1908,7 +1908,7 @@ memgraph::storage::ExternalPropertyValue ToExternalPropertyValue(const mgp_list 
 
 memgraph::storage::ExternalPropertyValue ToExternalPropertyValue(const mgp_map &map) {
   auto result_map = memgraph::storage::ExternalPropertyValue::map_t{};
-  result_map.reserve(map.items.size());
+  do_reserve(result_map, map.items.size());
   for (const auto &[key, value] : map.items) {
     result_map.insert_or_assign(std::string{key}, ToExternalPropertyValue(value));
   }
@@ -4581,7 +4581,7 @@ struct MgProcedureResultStream final {
 
 memgraph::storage::ExternalPropertyValue::map_t CreateQueryParams(mgp_map *params) {
   auto query_params = memgraph::storage::ExternalPropertyValue::map_t{};
-  query_params.reserve(params->items.size());
+  do_reserve(query_params, params->items.size());
   for (auto &[k, v] : params->items) {
     query_params.emplace(k, ToExternalPropertyValue(v));
   }

--- a/src/query/serialization/property_value.cpp
+++ b/src/query/serialization/property_value.cpp
@@ -211,7 +211,7 @@ storage::ExternalPropertyValue::map_t DeserializeExternalPropertyValueMap(nlohma
   const nlohmann::json::object_t &values = data.at("value");
 
   auto property_values = storage::ExternalPropertyValue::map_t{};
-  property_values.reserve(values.size());
+  do_reserve(property_values, values.size());
   for (const auto &[key, value] : values) {
     property_values.emplace(key, DeserializeExternalPropertyValue(value, storage_acc));
   }

--- a/src/storage/v2/delta.hpp
+++ b/src/storage/v2/delta.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -207,14 +207,13 @@ struct Delta {
   Delta(RemoveLabelTag /*tag*/, LabelId label, std::atomic<uint64_t> *timestamp, uint64_t command_id)
       : timestamp(timestamp), command_id(command_id), label{.action = Action::REMOVE_LABEL, .value = label} {}
 
-  Delta(SetPropertyTag /*tag*/, PropertyId key, PropertyValue value, std::atomic<uint64_t> *timestamp,
+  Delta(SetPropertyTag /*tag*/, PropertyId key, PropertyValue const &value, std::atomic<uint64_t> *timestamp,
         uint64_t command_id, utils::PageSlabMemoryResource *res)
       : timestamp(timestamp),
         command_id(command_id),
-        property{
-            .action = Action::SET_PROPERTY,
-            .key = key,
-            .value = std::pmr::polymorphic_allocator<Delta>{res}.new_object<pmr::PropertyValue>(std::move(value))} {}
+        property{.action = Action::SET_PROPERTY,
+                 .key = key,
+                 .value = std::pmr::polymorphic_allocator<Delta>{res}.new_object<pmr::PropertyValue>(value)} {}
 
   Delta(SetPropertyTag /*tag*/, Vertex *out_vertex, PropertyId key, PropertyValue value,
         std::atomic<uint64_t> *timestamp, uint64_t command_id, utils::PageSlabMemoryResource *res)

--- a/src/storage/v2/durability/serialization.cpp
+++ b/src/storage/v2/durability/serialization.cpp
@@ -507,7 +507,7 @@ std::optional<ExternalPropertyValue> Decoder::ReadExternalPropertyValue() {
       auto size = ReadSize(this);
       if (!size) return std::nullopt;
       auto value = ExternalPropertyValue::map_t{};
-      value.reserve(*size);
+      do_reserve(value, *size);
       for (uint64_t i = 0; i < *size; ++i) {
         auto key = ReadString();
         if (!key) return std::nullopt;

--- a/src/storage/v2/property_store.cpp
+++ b/src/storage/v2/property_store.cpp
@@ -841,7 +841,7 @@ std::optional<uint64_t> DecodeZonedTemporalDataSize(Reader &reader) {
       auto size = reader->ReadUint(payload_size);
       if (!size) return false;
       auto map = PropertyValue::map_t{};
-      map.reserve(*size);
+      do_reserve(map, *size);
       for (uint32_t i = 0; i < *size; ++i) {
         auto metadata = reader->ReadMetadata();
         if (!metadata) return false;
@@ -942,7 +942,7 @@ std::optional<uint64_t> DecodeZonedTemporalDataSize(Reader &reader) {
       auto size = reader->ReadUint(payload_size);
       if (!size) return std::nullopt;
       auto map = PropertyValue::map_t{};
-      map.reserve(*size);
+      do_reserve(map, *size);
       for (uint32_t i = 0; i < *size; ++i) {
         auto metadata = reader->ReadMetadata();
         if (!metadata) return std::nullopt;

--- a/src/storage/v2/property_value.hpp
+++ b/src/storage/v2/property_value.hpp
@@ -29,6 +29,21 @@
 
 namespace memgraph::storage {
 
+template <typename T>
+concept Reservable = requires(T &t, std::size_t n) {
+  { t.reserve(n) } -> std::same_as<void>;
+};
+
+// While we are temporarily using std::map, we need to disable the reserve
+// This code is here to do nothing right now, but to ensure we put back in
+// reserves when we go back to flat_map
+template <typename T>
+void do_reserve(T &v, std::size_t n) {
+  if constexpr (Reservable<T>) {
+    v.reserve(n);
+  }
+}
+
 /// An exception raised by the PropertyValue. Typically when trying to perform
 /// operations (such as addition) on PropertyValues of incompatible Types.
 class PropertyValueException : public utils::BasicException {
@@ -73,9 +88,9 @@ class PropertyValueImpl {
   using Type = PropertyValueType;
 
   using string_t = std::basic_string<char, std::char_traits<char>, typename alloc_trait::template rebind_alloc<char>>;
-  using map_t = boost::container::flat_map<
-      KeyType, PropertyValueImpl, std::less<>,
-      typename alloc_trait::template rebind_alloc<std::pair<KeyType const, PropertyValueImpl>>>;
+  // TODO: go back to boost::container::flat_map when it works for "IndexTest, DeltaDoesNotLeak"
+  using map_t = std::map<KeyType, PropertyValueImpl, std::less<>,
+                         typename alloc_trait::template rebind_alloc<std::pair<KeyType const, PropertyValueImpl>>>;
 
   using list_t = std::vector<PropertyValueImpl, typename alloc_trait::template rebind_alloc<PropertyValueImpl>>;
 
@@ -937,8 +952,11 @@ struct ExtendedPropertyType {
   }
 };
 
-static_assert(sizeof(PropertyValue) == 40);
-static_assert(sizeof(pmr::PropertyValue) == 56);
+// TODO: go back down in size ASAP
+//       v3.3.0 we used std::map to fix bug
+//       ASAP go back to boost::container::flat_map
+static_assert(sizeof(PropertyValue) == 56 /*40*/);
+static_assert(sizeof(pmr::PropertyValue) == 72 /*56*/);
 
 /**
  * Helper to read a nested value from within a PropertyValue map. If the path

--- a/src/storage/v2/replication/slk.cpp
+++ b/src/storage/v2/replication/slk.cpp
@@ -242,7 +242,7 @@ void Load(storage::ExternalPropertyValue *value, slk::Reader *reader) {
       size_t size;
       slk::Load(&size, reader);
       auto map = storage::ExternalPropertyValue::map_t{};
-      map.reserve(size);
+      do_reserve(map, size);
       for (size_t i = 0; i < size; ++i) {
         std::pair<std::string, storage::ExternalPropertyValue> kv;
         slk::Load(&kv, reader);


### PR DESCRIPTION
Replace `PropertyValue` `map_t` with `std::map` rather than `boost::container::flat_map`. 

boost's `flat_map` does not correctly propogate allocators in nested containers. This means that nested `PropertyValue`s created for `Delta`s are created using the incorrect allocator, and leak memory which is never reclaimed.

This temporary fix replaces the internal `map_t` with `std::map`, which *does* propogate allocators. Once we have established if a more recent `boost` version fixes the issue, we can revert this fix.