### PR TITLE
Previous commit timestamp should be unnecessary for AppendDeltasRpc

### DIFF
--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -307,14 +307,10 @@ auto ReplicationStorageClient::StartTransactionReplication(const uint64_t curren
 
         if (client_.mode_ == replication_coordination_glue::ReplicationMode::ASYNC) {
           maybe_stream_handler = client_.rpc_client_.TryStream<replication::AppendDeltasRpc>(
-              std::optional<std::chrono::milliseconds>{kCommitRpcTimeout}, main_uuid_, storage->uuid(),
-              storage->repl_storage_state_.last_durable_timestamp_.load(std::memory_order_acquire),
-              current_wal_seq_num);
+              std::optional{kCommitRpcTimeout}, main_uuid_, storage->uuid(), current_wal_seq_num);
         } else {
           maybe_stream_handler.emplace(client_.rpc_client_.Stream<replication::AppendDeltasRpc>(
-              main_uuid_, storage->uuid(),
-              storage->repl_storage_state_.last_durable_timestamp_.load(std::memory_order_acquire),
-              current_wal_seq_num));
+              main_uuid_, storage->uuid(), current_wal_seq_num));
         }
 
         if (!maybe_stream_handler.has_value()) {

--- a/src/storage/v2/replication/rpc.cpp
+++ b/src/storage/v2/replication/rpc.cpp
@@ -211,14 +211,12 @@ void Load(memgraph::storage::replication::AppendDeltasRes *self, memgraph::slk::
 void Save(const memgraph::storage::replication::AppendDeltasReq &self, memgraph::slk::Builder *builder) {
   memgraph::slk::Save(self.main_uuid, builder);
   memgraph::slk::Save(self.uuid, builder);
-  memgraph::slk::Save(self.previous_commit_timestamp, builder);
   memgraph::slk::Save(self.seq_num, builder);
 }
 
 void Load(memgraph::storage::replication::AppendDeltasReq *self, memgraph::slk::Reader *reader) {
   memgraph::slk::Load(&self->main_uuid, reader);
   memgraph::slk::Load(&self->uuid, reader);
-  memgraph::slk::Load(&self->previous_commit_timestamp, reader);
   memgraph::slk::Load(&self->seq_num, reader);
 }
 

--- a/src/storage/v2/replication/rpc.hpp
+++ b/src/storage/v2/replication/rpc.hpp
@@ -30,13 +30,11 @@ struct AppendDeltasReq {
   static void Load(AppendDeltasReq *self, memgraph::slk::Reader *reader);
   static void Save(const AppendDeltasReq &self, memgraph::slk::Builder *builder);
   AppendDeltasReq() = default;
-  AppendDeltasReq(const utils::UUID &main_uuid, const utils::UUID &uuid, uint64_t previous_commit_timestamp,
-                  uint64_t seq_num)
-      : main_uuid{main_uuid}, uuid{uuid}, previous_commit_timestamp(previous_commit_timestamp), seq_num(seq_num) {}
+  AppendDeltasReq(const utils::UUID &main_uuid, const utils::UUID &uuid, uint64_t const seq_num)
+      : main_uuid{main_uuid}, uuid{uuid}, seq_num(seq_num) {}
 
   utils::UUID main_uuid;
   utils::UUID uuid;
-  uint64_t previous_commit_timestamp;
   uint64_t seq_num;
 };
 

--- a/tests/unit/replication_rpc_progress.cpp
+++ b/tests/unit/replication_rpc_progress.cpp
@@ -103,9 +103,7 @@ TEST_F(ReplicationRpcProgressTest, AppendDeltasNoTimeout) {
   ClientContext client_context;
   Client client{endpoint, &client_context, rpc_timeouts};
 
-  auto stream_handler = client.Stream<AppendDeltasRpc>(
-      UUID{}, main_storage.uuid(),
-      main_storage.repl_storage_state_.last_durable_timestamp_.load(std::memory_order_acquire), 1);
+  auto stream_handler = client.Stream<AppendDeltasRpc>(UUID{}, main_storage.uuid(), 1);
 
   ReplicaStream stream{&main_storage, std::move(stream_handler)};
   EXPECT_NO_THROW(stream.Finalize());
@@ -141,9 +139,7 @@ TEST_F(ReplicationRpcProgressTest, AppendDeltasTimeout) {
   ClientContext client_context;
   Client client{endpoint, &client_context, rpc_timeouts};
 
-  auto stream_handler = client.Stream<AppendDeltasRpc>(
-      UUID{}, main_storage.uuid(),
-      main_storage.repl_storage_state_.last_durable_timestamp_.load(std::memory_order_acquire), 1);
+  auto stream_handler = client.Stream<AppendDeltasRpc>(UUID{}, main_storage.uuid(), 1);
 
   ReplicaStream stream{&main_storage, std::move(stream_handler)};
   EXPECT_THROW(stream.Finalize(), GenericRpcFailedException);
@@ -182,9 +178,7 @@ TEST_F(ReplicationRpcProgressTest, AppendDeltasProgressTimeout) {
   ClientContext client_context;
   Client client{endpoint, &client_context, rpc_timeouts};
 
-  auto stream_handler = client.Stream<AppendDeltasRpc>(
-      UUID{}, main_storage.uuid(),
-      main_storage.repl_storage_state_.last_durable_timestamp_.load(std::memory_order_acquire), 1);
+  auto stream_handler = client.Stream<AppendDeltasRpc>(UUID{}, main_storage.uuid(), 1);
 
   ReplicaStream stream{&main_storage, std::move(stream_handler)};
 


### PR DESCRIPTION
Emptying the replica stream is unnecessary. It should be impossible to get into a state where deltas are sent with the global timestamp smaller than replica's current ldt.