### PR TITLE
Support regex queries with label+property indices

### DIFF
--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -700,9 +700,20 @@ InMemoryLabelPropertyIndex::Iterable::Iterable(utils::SkipList<Entry>::Accessor 
         upper_bound = std::nullopt;
       }
 
+      auto const are_comparable_ranges = [](auto const &lower_bound, auto const &upper_bound) {
+        if (AreComparableTypes(lower_bound.value().type(), upper_bound.value().type())) {
+          return true;
+        } else if (upper_bound.IsInclusive()) {
+          return false;
+        } else {
+          auto const upper_bound_for_lower_bound_type = storage::UpperBoundForType(lower_bound.value().type());
+          return upper_bound_for_lower_bound_type && upper_bound.value() == upper_bound_for_lower_bound_type->value();
+        };
+      };
+
       // If both bounds are set, but are incomparable types, then this is an
       // invalid range and will yield an empty result set.
-      if (lower_bound && upper_bound && !AreComparableTypes(lower_bound->value().type(), upper_bound->value().type())) {
+      if (lower_bound && upper_bound && !are_comparable_ranges(*lower_bound, *upper_bound)) {
         return {std::nullopt, std::nullopt, false};
       }
 


### PR DESCRIPTION
Queries using a label+property index now correctly return matching results when comparing properties against regular expressions. 

The problem was caused by index code rejecting ranges across different `PropertyType`s as being invalid. This is true in most cases, (e.g. `WHERE node.a > 'hello' AND node.a < 42`) but not in the case where the upper-bound is an exclusive (`<`) bound on the next (from an ordering standpoint) `PropertyType`. As the exclusive upper bound exclusive sentinel is not compared against, it means that the range is still across a single `PropertyType`.

Regexes uses a range that is inclusively lower bounded on the empty string, and exclusively upper bounded on the minimum value of whatever `PropertyType` happens to follow string.

(This bug was a regression introduced by composite indices.)

#Fixes 3010