### PR TITLE
Enabling replication in case of RECOVER SNAPSHOT

### DIFF
--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -130,6 +130,8 @@ std::vector<SnapshotDurabilityInfo> GetSnapshotFiles(const std::filesystem::path
         auto info = ReadSnapshotInfo(item.path());
         if (uuid.empty() || info.uuid == uuid) {
           snapshot_files.emplace_back(item.path(), std::move(info.uuid), info.start_timestamp);
+        } else {
+          spdlog::warn("Skipping snapshot file '{}' because UUID does not match!", item.path());
         }
       } catch (const RecoveryFailure &) {
         continue;

--- a/src/storage/v2/durability/snapshot.hpp
+++ b/src/storage/v2/durability/snapshot.hpp
@@ -65,6 +65,8 @@ struct RecoveredSnapshot {
 /// @throw RecoveryFailure
 SnapshotInfo ReadSnapshotInfo(const std::filesystem::path &path);
 
+void OverwriteSnapshotUUID(std::filesystem::path const &path, utils::UUID const &uuid);
+
 /// Function used to load the snapshot data into the storage.
 /// @throw RecoveryFailure
 RecoveredSnapshot LoadSnapshot(std::filesystem::path const &path, utils::SkipList<Vertex> *vertices,

--- a/src/storage/v2/inmemory/replication/recovery.cpp
+++ b/src/storage/v2/inmemory/replication/recovery.cpp
@@ -117,8 +117,6 @@ std::optional<std::vector<RecoveryStep>> GetRecoverySteps(uint64_t replica_commi
       spdlog::error("Tried to lock a non-existent snapshot path while obtaining recovery steps.");
       return false;
     }
-    spdlog::trace("Found snapshot at path {} with timestamp {}.", latest_snapshot->path,
-                  latest_snapshot->start_timestamp);
     recovery_steps.emplace_back(std::in_place_type_t<RecoverySnapshot>{}, std::move(latest_snapshot->path));
     last_durable_timestamp = std::max(last_durable_timestamp, latest_snapshot->start_timestamp);
     return true;
@@ -190,7 +188,6 @@ std::optional<std::vector<RecoveryStep>> GetRecoverySteps(uint64_t replica_commi
         }
         rw.emplace_back(std::move(wal.path));
       }
-      spdlog::trace("Found {} WAL files to recover from.", rw.size());
       recovery_steps.emplace_back(std::in_place_type_t<RecoveryWals>{}, std::move(rw));
     }
 
@@ -207,12 +204,9 @@ std::optional<std::vector<RecoveryStep>> GetRecoverySteps(uint64_t replica_commi
   // If we have a current wal file we need to use it
   if (last_durable_timestamp < current_wal_timestamp && current_wal_seq_num) {
     // NOTE: File not handled directly, so no need to lock it
-    spdlog::trace("Found current WAL file with seq_num {} and timestamp {}.", *current_wal_seq_num,
-                  *current_wal_timestamp);
     recovery_steps.emplace_back(RecoveryCurrentWal{*current_wal_seq_num});
   }
 
-  spdlog::trace("Found {} recovery steps.", recovery_steps.size());
   return recovery_steps;
 }
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2660,10 +2660,6 @@ utils::BasicResult<InMemoryStorage::RecoverSnapshotError> InMemoryStorage::Recov
   if (replication_role == ReplicationRole::REPLICA) {
     return InMemoryStorage::RecoverSnapshotError::DisabledForReplica;
   }
-  if (!repl_storage_state_.replication_storage_clients_->empty()) {
-    // MAIN would need to reset its storage handler and force update the replicas to this snapshot. ATM not supported!
-    return InMemoryStorage::RecoverSnapshotError::DisabledForMainWithReplicas;
-  }
   if (!std::filesystem::exists(path) || std::filesystem::is_directory(path)) {
     return InMemoryStorage::RecoverSnapshotError::MissingFile;
   }

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -115,7 +115,6 @@ class InMemoryStorage final : public Storage {
   };
   enum class RecoverSnapshotError : uint8_t {
     DisabledForReplica,
-    DisabledForMainWithReplicas,
     NonEmptyStorage,
     MissingFile,
     CopyFailure,

--- a/src/storage/v2/replication/replication_client.hpp
+++ b/src/storage/v2/replication/replication_client.hpp
@@ -186,6 +186,13 @@ class ReplicationStorageClient {
    */
   void TryCheckReplicaStateAsync(Storage *main_storage, DatabaseAccessProtector db_acc);
 
+  /**
+   * @brief Force reset a replica.
+   * @param main_storage pointer to the storage associated with the client
+   * @param db_acc gatekeeper access that protects the database; std::any to have separation between dbms and storage
+   */
+  void ForceRecoverReplica(Storage *storage, DatabaseAccessProtector db_acc) const;
+
  private:
   /**
    * @brief Get necessary recovery steps and execute them.

--- a/src/utils/uuid.hpp
+++ b/src/utils/uuid.hpp
@@ -62,6 +62,7 @@ struct UUID {
   explicit operator arr_t() const { return uuid; }
 
   friend bool operator==(UUID const &, UUID const &) = default;
+  friend bool operator==(UUID const &lhs, std::string_view rhs) { return std::string(lhs) == rhs; };
 
  private:
   friend void to_json(nlohmann::json &j, const UUID &uuid);


### PR DESCRIPTION
RECOVER SNAPSHOT did not work with replication.
Bugfix: Snapshot's UUID would override the storage one would cause the DBMS on REPLICAS to search for the wrong database. Now in case of user recovery, the local snapshot's UUID is overwritten.
Bugfix: Replication would not work in all cases due to the timestamp change. Now user recovery forces a reset of the replicas.

