### PR TITLE
Fix Jepsen txn timeout handling

### DIFF
--- a/tests/jepsen/src/memgraph/high_availability/create/test.clj
+++ b/tests/jepsen/src/memgraph/high_availability/create/test.clj
@@ -278,6 +278,9 @@
                                  (catch Exception e
                                    (dbclient/disconnect bolt-routing-conn)
                                    (cond
+                                     (utils/txn-timeout? e)
+                                     (assoc op :type :info :value {:str "Txn timeout occurred."})
+
                                      (utils/server-no-longer-available e)
                                      (assoc op :type :info :value {:str "Server no longer available."})
 

--- a/tests/jepsen/src/memgraph/utils.clj
+++ b/tests/jepsen/src/memgraph/utils.clj
@@ -98,6 +98,12 @@
   [e]
   (string/includes? (str e) "Unable to commit due to unique constraint violation"))
 
+(defn txn-timeout?
+  "Txn timeout has occurred."
+  [e]
+  (string/includes? (str e) "Transaction was asked to abort because of transaction timeout."
+ )
+
 (defn server-no-longer-available
   "Accepts exception e as argument."
   [e]

--- a/tests/jepsen/src/memgraph/utils.clj
+++ b/tests/jepsen/src/memgraph/utils.clj
@@ -102,7 +102,7 @@
   "Txn timeout has occurred."
   [e]
   (string/includes? (str e) "Transaction was asked to abort because of transaction timeout."
- )
+ ))
 
 (defn server-no-longer-available
   "Accepts exception e as argument."


### PR DESCRIPTION
The test won't fail anymore if the following exception gets thrown: Transaction was asked to abort due to transaction timeout.
