### PR TITLE
Remove networking overhead from the flaky Raft state test

### DIFF
--- a/src/coordination/include/coordination/raft_state.hpp
+++ b/src/coordination/include/coordination/raft_state.hpp
@@ -18,6 +18,7 @@
 #include "coordination/coordinator_communication_config.hpp"
 #include "coordination/coordinator_state_machine.hpp"
 #include "coordination/coordinator_state_manager.hpp"
+#include "coordination/utils.hpp"
 #include "coordination_observer.hpp"
 
 #include <libnuraft/logger.hxx>
@@ -30,7 +31,6 @@ struct DataInstanceConfig;
 
 using BecomeLeaderCb = std::function<void()>;
 using BecomeFollowerCb = std::function<void()>;
-using RoutingTable = std::vector<std::pair<std::vector<std::string>, std::string>>;
 
 using nuraft::asio_service;
 using nuraft::buffer;

--- a/src/coordination/include/coordination/utils.hpp
+++ b/src/coordination/include/coordination/utils.hpp
@@ -11,14 +11,74 @@
 
 #pragma once
 
+#include "coordination/coordinator_instance_context.hpp"
+#include "coordination/data_instance_context.hpp"
 #include "coordination/logger_wrapper.hpp"
 #include "kvstore/kvstore.hpp"
+#include "utils/logging.hpp"
+
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/view/filter.hpp>
+#include <range/v3/view/transform.hpp>
 
 #ifdef MG_ENTERPRISE
 
 namespace memgraph::coordination {
 auto GetOrSetDefaultVersion(kvstore::KVStore &durability, std::string_view key, int default_value, LoggerWrapper logger)
     -> int;
+
+using RoutingTable = std::vector<std::pair<std::vector<std::string>, std::string>>;
+
+auto CreateRoutingTable(std::vector<DataInstanceContext> const &raft_log_data_instances,
+                        std::vector<CoordinatorInstanceContext> const &coord_servers, auto const &is_instance_main_func,
+                        bool const enabled_reads_on_main) {
+  auto res = RoutingTable{};
+
+  auto const repl_instance_to_bolt = [](auto const &instance) {
+    return instance.config.BoltSocketAddress();  // non-resolved IP
+  };
+
+  auto writers = raft_log_data_instances | ranges::views::filter(is_instance_main_func) |
+                 ranges::views::transform(repl_instance_to_bolt) | ranges::to_vector;
+  MG_ASSERT(writers.size() <= 1, "There can be at most one main instance active!");
+
+  spdlog::trace("WRITERS");
+  for (auto const &writer : writers) {
+    spdlog::trace("  {}", writer);
+  }
+
+  auto readers = raft_log_data_instances | ranges::views::filter(std::not_fn(is_instance_main_func)) |
+                 ranges::views::transform(repl_instance_to_bolt) | ranges::to_vector;
+
+  if (enabled_reads_on_main && writers.size() == 1) {
+    readers.emplace_back(writers[0]);
+  }
+
+  spdlog::trace("READERS:");
+  for (auto const &reader : readers) {
+    spdlog::trace("  {}", reader);
+  }
+
+  if (!std::ranges::empty(writers)) {
+    res.emplace_back(std::move(writers), "WRITE");
+  }
+
+  if (!std::ranges::empty(readers)) {
+    res.emplace_back(std::move(readers), "READ");
+  }
+
+  auto const get_bolt_server = [](CoordinatorInstanceContext const &context) { return context.bolt_server; };
+
+  auto routers = coord_servers | ranges::views::transform(get_bolt_server) | ranges::to_vector;
+  spdlog::trace("ROUTERS:");
+  for (auto const &server : routers) {
+    spdlog::trace("  {}", server);
+  }
+
+  res.emplace_back(std::move(routers), "ROUTE");
+
+  return res;
+}
 
 }  // namespace memgraph::coordination
 

--- a/src/coordination/raft_state.cpp
+++ b/src/coordination/raft_state.cpp
@@ -23,7 +23,6 @@
 #include "coordination/coordinator_exceptions.hpp"
 #include "coordination/logger_wrapper.hpp"
 #include "coordination/raft_state.hpp"
-#include "coordination/utils.hpp"
 #include "utils/counter.hpp"
 #include "utils/file.hpp"
 #include "utils/logging.hpp"
@@ -412,7 +411,7 @@ auto RaftState::GetMyCoordinatorInstanceAux() const -> CoordinatorInstanceAux {
 
 auto RaftState::GetCurrentMainUUID() const -> utils::UUID { return state_machine_->GetCurrentMainUUID(); }
 
-auto RaftState::IsCurrentMain(std::string_view instance_name) const -> bool {
+auto RaftState::IsCurrentMain(std::string_view const instance_name) const -> bool {
   return state_machine_->IsCurrentMain(instance_name);
 }
 
@@ -421,60 +420,12 @@ auto RaftState::TryGetCurrentMainName() const -> std::optional<std::string> {
 }
 
 auto RaftState::GetRoutingTable() const -> RoutingTable {
-  auto res = RoutingTable{};
-
-  auto const repl_instance_to_bolt = [](auto const &instance) {
-    return instance.config.BoltSocketAddress();  // non-resolved IP
-  };
-
   auto const is_instance_main = [&](auto const &instance) { return IsCurrentMain(instance.config.instance_name); };
-
-  auto const is_instance_replica = [&](auto const &instance) { return !IsCurrentMain(instance.config.instance_name); };
-
   // Fetch data instances from raft log
   auto const raft_log_data_instances = GetDataInstancesContext();
-
-  auto writers = raft_log_data_instances | ranges::views::filter(is_instance_main) |
-                 ranges::views::transform(repl_instance_to_bolt) | ranges::to_vector;
-  MG_ASSERT(writers.size() <= 1, "There can be at most one main instance active!");
-
-  spdlog::trace("WRITERS");
-  for (auto const &writer : writers) {
-    spdlog::trace("  {}", writer);
-  }
-
-  auto readers = raft_log_data_instances | ranges::views::filter(is_instance_replica) |
-                 ranges::views::transform(repl_instance_to_bolt) | ranges::to_vector;
-
-  if (GetEnabledReadsOnMain() && writers.size() == 1) {
-    readers.emplace_back(writers[0]);
-  }
-
-  spdlog::trace("READERS:");
-  for (auto const &reader : readers) {
-    spdlog::trace("  {}", reader);
-  }
-
-  if (!std::ranges::empty(writers)) {
-    res.emplace_back(std::move(writers), "WRITE");
-  }
-
-  if (!std::ranges::empty(readers)) {
-    res.emplace_back(std::move(readers), "READ");
-  }
-
-  auto const get_bolt_server = [](CoordinatorInstanceContext const &context) { return context.bolt_server; };
-
   auto const coord_servers = GetCoordinatorInstancesContext();
-  auto routers = coord_servers | ranges::views::transform(get_bolt_server) | ranges::to_vector;
-  spdlog::trace("ROUTERS:");
-  for (auto const &server : routers) {
-    spdlog::trace("  {}", server);
-  }
 
-  res.emplace_back(std::move(routers), "ROUTE");
-
-  return res;
+  return CreateRoutingTable(raft_log_data_instances, coord_servers, is_instance_main, GetEnabledReadsOnMain());
 }
 
 auto RaftState::GetLeaderId() const -> int32_t { return raft_server_->get_leader(); }

--- a/src/coordination/utils.cpp
+++ b/src/coordination/utils.cpp
@@ -13,6 +13,7 @@
 
 #include <string_view>
 
+#include "coordination/data_instance_context.hpp"
 #include "coordination/logger_wrapper.hpp"
 #include "kvstore/kvstore.hpp"
 #include "utils/logging.hpp"
@@ -31,6 +32,5 @@ auto GetOrSetDefaultVersion(kvstore::KVStore &durability, std::string_view key, 
   MG_ASSERT(durability.Put(key, std::to_string(default_value)), "Failed to store durability version.");
   return default_value;
 }
-
 }  // namespace memgraph::coordination
 #endif


### PR DESCRIPTION
The important part of testing is preserved by isolating routing table creation into utils method.
