### PR TITLE
Non blocking edge type index creation

### DIFF
--- a/ADRs/004_concurrent_index_creation.md
+++ b/ADRs/004_concurrent_index_creation.md
@@ -1,7 +1,7 @@
-# Concurrent index creation ADR
+# Concurrent Index Creation ADR
 
 **Author**
-Gareth Lloyd (https://github.com/Ignition)
+Gareth Lloyd (https://github.com/Ignition), Ivan Milinović
 
 **Status**
 ACCEPTED
@@ -11,33 +11,189 @@ April 23, 2025
 
 **Problem**
 
-Currently, index creation is a unique access operation, meaning that:
-- Queries can not run concurrently while the index is being made
-- Allowing for a consistent index to be made
-- Once complete other queries can run again using the new index in the plan
+Previously, index creation was a unique access operation, meaning that:
+- Queries cannot run concurrently while the index is being made
+- This blocks all operations until index creation completes
+- Poor user experience during large dataset index creation
 
 **Criteria**
 
-- Allow index population (most expensive part), to happen concurrent with other queries
-- Allow read only queries to be uninterupted
-- Planning can only use indexes once populated
+- Allow index population (most expensive part) to happen concurrent with other queries
+- Allow read-only queries to be uninterrupted during index creation
+- Planning can only use indexes once they are fully populated and ready
+- Maintain ACID guarantees and consistency during concurrent operations
+- Support cancellation of long-running index creation operations
 
 **Decision**
 
-We will leverage new storage access locking mode of READ_ONLY. This will allow readers to continue
-uninterupted. Once the index is registered we downgrade the access to READ, allowing new writers.
-The skip list based indexes are concurrently safe datastructures where propable entries are
-inserted, MVCC is still required on scan to validated the index entry is correct to any given
-transcation. The idea is that new writers can insert new entries, while the index creation is
-populating for all entries consistent with its snapshot isolation. Once the index is populated,
-it can be made availible for the planner to use.
+## Three-Phase Index Creation
 
-Considerations:
-- Replica, would also be able to use READ_ONLY downgrade to READ. But replica has no writers
-  so this would be a perf win.
-- TTL, enable + disable modified multiple internal indices. Can only downgrade once, need to
-  take that into consideration.
-- Auto indexing, ATM done during commit. Hence data and metadata update within same txn. This
-  currently means that the replica changes the order and using UNIQUE access to make this work.
-  We will need to initially keep replica as UNIQUE, but full fix is to do auto-indexing in
-  separate txn.
+We implemented a three-phase approach to index creation that allows concurrent operations:
+
+### Phase 1: Register (READ_ONLY access)
+- Create index metadata and reserve the index structure
+- Requires READ_ONLY access to prevent writers being unaware of the index to write enries into
+- Quick operation that sets up the IndexStatus with `kTransactionInitialId` (populating state)
+- Index is not yet available for query planning
+
+### Phase 2: Populate (downgrade to READ access)
+- Downgrade access level from READ_ONLY to READ to allow concurrent writers
+- Iterate through all existing vertices and populate the index
+- New transactions can continue inserting vertices while population is in progress
+- Uses MVCC timestamp isolation to ensure consistent population
+- Population can be cancelled via `CheckCancelFunction`
+- Concurrent insertions by other transactions are handled via skip list thread-safety
+
+### Phase 3: Publish (atomic commit)
+- Atomically update the IndexStatus with the commit timestamp
+- Index becomes visible to query planner once `IsVisible(timestamp)` returns true
+- Plan cache invalidation is triggered only when index is ready for use
+- Index is now available for query optimization
+
+## Key Implementation Components
+
+### IndexStatus (`src/storage/v2/inmemory/indices_mvcc.hpp:20`)
+```cpp
+struct IndexStatus {
+  bool IsPopulating() const; // commit_timestamp == kTransactionInitialId
+  bool IsReady() const;      // !IsPopulating()
+  bool IsVisible(uint64_t timestamp) const; // commit_timestamp <= timestamp
+  void Commit(uint64_t timestamp);  // atomic publish
+}
+```
+
+### ActiveIndices System (`src/storage/v2/indices/active_indices.hpp:29`)
+- Tracks which indices are ready for query planning
+- `CheckIndicesAreReady()` prevents using unpopulated indices
+- Integrates with query planner to ensure only ready indices are used
+
+### Used Index Checker (`src/query/plan/used_index_checker.hpp:19`)
+- Validates that all required indices for a query plan are ready
+- Integrated into query planning pipeline
+- Prevents execution of plans that depend on still-populating indices
+
+### Concurrent Skip List Architecture
+- Skip lists are inherently thread-safe for concurrent reads/writes
+- MVCC validation ensures transaction isolation during index scans
+- Population uses snapshot isolation for consistency
+- New entries from concurrent transactions are automatically included
+
+## Benefits Achieved
+
+1. **Non-blocking Reads**: Read-only queries continue uninterrupted during index creation
+2. **Concurrent Writes**: Write transactions can proceed during population phase
+3. **Cancellable Operations**: Long-running index creation can be terminated
+4. **Plan Cache Efficiency**: Cache invalidation only occurs when index is ready
+5. **MVCC Consistency**: Full transaction isolation maintained throughout process
+
+## Storage Interface Changes
+
+Enhanced the Storage interface with new parameters:
+- `CheckCancelFunction` for cancellation support
+- `PublishIndexWrapper` for custom publication logic
+- `DropIndexWrapper` for symmetric drop operations
+
+Example signature change:
+```cpp
+// Before
+virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
+    LabelId label, std::vector<storage::PropertyPath> properties) = 0;
+
+// After
+virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
+    LabelId label, PropertiesPaths properties,
+    CheckCancelFunction cancel_check = neverCancel,
+    PublishIndexWrapper wrapper = publish_no_wrap) = 0;
+```
+
+## Error Handling
+
+New error types in `storage_error.hpp:25`:
+- `IndexDefinitionCancelationError` for cancelled operations
+- Proper error propagation through all three phases
+
+## Testing
+
+Comprehensive testing added in:
+- `tests/e2e/concurrency/` - End-to-end concurrent operation tests
+- `tests/unit/storage_v2_indices.cpp` - Unit tests for concurrent index operations
+- Integration with existing index test suites
+
+## Implementation Details
+
+### Query Context Updates (`src/query/context.hpp:67`)
+- Introduced `StoppingContext` to replace individual transaction status tracking
+- Consolidated cancellation logic across query execution and index operations
+
+### Plan Validation
+- Query plans are validated against active indices before execution
+- Plan cache invalidation occurs only when indices transition to ready state
+- Prevents using indices that are still populating
+
+### MVCC Integration (`src/storage/v2/inmemory/indices_mvcc.hpp`)
+- Population respects transaction timestamp boundaries
+- Concurrent updates are properly isolated using MVCC
+- Index visibility tied to transaction commit timestamps
+
+## Current Implementation Status
+
+### ✅ **Implemented**
+- **Main Database**: Full three-phase concurrent index creation for label+property indices
+- **Single Transaction**: Register/Populate/Publish all occur within one transaction
+- **Plan Integration**: Query planner correctly ignores unpopulated indices
+- **Cancellation**: Robust cleanup of partially populated indices
+- **MVCC Isolation**: Proper snapshot isolation during population
+
+### 🚧 **Limitations & Future Work**
+
+#### **Replica Replication** (src/dbms/inmemory/replication_handlers.cpp:777-1336)
+```cpp
+// TODO: add when concurrent index creation can actually replicate using READ_ONLY
+// constexpr auto kReadOnlyAccess = storage::Storage::Accessor::Type::READ_ONLY;
+
+// Multiple TODO comments throughout:
+// TODO: For now kUniqueAccess, when everything is ready kReadOnlyAccess
+auto *transaction = get_replication_accessor(delta_timestamp, kUniqueAccess);
+```
+- **Current**: All replica operations use `kUniqueAccess` (blocking)
+- **Reason**: Replication delta ordering needs to be resolved first
+- **Impact**: Replicas don't benefit from concurrent index creation yet
+
+#### **TTL Multi-Index Operations**
+- **Current**: TTL operations don't use Register/Populate/Publish pattern yet
+- **Issue**: Can only downgrade access once per transaction
+- **Workaround**: TTL uses `kUniqueAccess` to avoid multiple downgrades
+- **Future**: Split TTL into separate Register→(downgrade)→Populate/Publish phases
+
+#### **Auto-indexing**
+- **Current**: Concurrent creation for auto indexing not implemented yet
+- **Planned**: Auto-indexing happens during it own txn
+- **Replica Issue**: ATM requires special delta ordering to work with writes that have happened
+- **Solution**: Move auto-indexing to separate async transactions
+
+## Architecture Decisions Made
+
+### **ActiveIndices Snapshot**
+- **Decision**: Transactions capture `ActiveIndices` at start, newer transactions see updates via `UpdateOnX` methods
+- **Rationale**: Ensures no writes are missed during population while allowing concurrent access
+- **Implementation**: `transaction.active_indices_` provides transaction-local view
+
+### **Access Level Progression**
+- **Decision**: READ_ONLY → READ rather than UNIQUE throughout
+- **Rationale**: Allows concurrent writes during expensive population phase
+- **Constraint**: Only one downgrade per transaction (affects TTL)
+
+## Future Improvements
+
+1. **Replica READ_ONLY Support**: Resolve delta ordering to enable `kReadOnlyAccess` in replication
+2. **TTL Register/Populate/Publish Split**: Enable TTL to register multiple indices then downgrade once
+3. **Auto-indexing**: Build async transaction capability for auto-indexing
+4. **Other Index Types**: Extend concurrent creation to label-only and edge-type indices
+
+## Impact
+
+This implementation significantly improves the user experience for large datasets by:
+- Reduce blocking operations and their impact during index creation
+- Maintaining query performance during index population
+- Providing graceful cancellation of long-running operations
+- Ensuring consistency through proper MVCC integration

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -1133,6 +1133,7 @@ std::pair<uint64_t, uint32_t> InMemoryReplicationHandlers::ReadAndApplyDeltasSin
           transaction->DeleteLabelPropertyIndexStats(storage->NameToLabel(data.label));
         },
         [&](WalEdgeTypeIndexCreate const &data) {
+          // TODO: For now kUniqueAccess, when everything is ready kReadOnlyAccess
           spdlog::trace("   Delta {}. Create edge index on :{}", current_delta_idx, data.edge_type);
           auto *transaction = get_replication_accessor(delta_timestamp, kUniqueAccess);
           if (transaction->CreateIndex(storage->NameToEdgeType(data.edge_type)).HasError()) {
@@ -1147,6 +1148,7 @@ std::pair<uint64_t, uint32_t> InMemoryReplicationHandlers::ReadAndApplyDeltasSin
           }
         },
         [&](WalEdgeTypePropertyIndexCreate const &data) {
+          // TODO: For now kUniqueAccess, when everything is ready kReadOnlyAccess
           spdlog::trace("   Delta {}. Create edge index on :{}({})", current_delta_idx, data.edge_type, data.property);
           auto *transaction = get_replication_accessor(delta_timestamp, kUniqueAccess);
           if (transaction->CreateIndex(storage->NameToEdgeType(data.edge_type), storage->NameToProperty(data.property))
@@ -1165,6 +1167,7 @@ std::pair<uint64_t, uint32_t> InMemoryReplicationHandlers::ReadAndApplyDeltasSin
           }
         },
         [&](WalEdgePropertyIndexCreate const &data) {
+          // TODO: For now kUniqueAccess, when everything is ready kReadOnlyAccess
           spdlog::trace("       Create global edge index on ({})", data.property);
           auto *transaction = get_replication_accessor(delta_timestamp, kUniqueAccess);
           if (transaction->CreateGlobalEdgeIndex(storage->NameToProperty(data.property)).HasError()) {

--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -647,8 +647,9 @@ class DbAccessor final {
   }
 
   utils::BasicResult<storage::StorageIndexDefinitionError, void> CreateIndex(
-      storage::EdgeTypeId edge_type, storage::PublishIndexWrapper wrapper = storage::publish_no_wrap) {
-    return accessor_->CreateIndex(edge_type, true, storage::neverCancel /*TODO*/, std::move(wrapper));
+      storage::EdgeTypeId edge_type, storage::CheckCancelFunction cancel_check = storage::neverCancel,
+      storage::PublishIndexWrapper wrapper = storage::publish_no_wrap) {
+    return accessor_->CreateIndex(edge_type, true, std::move(cancel_check), std::move(wrapper));
   }
 
   utils::BasicResult<storage::StorageIndexDefinitionError, void> CreateIndex(

--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -646,17 +646,20 @@ class DbAccessor final {
     return accessor_->CreateIndex(label, std::move(properties), std::move(cancel_check), std::move(wrapper));
   }
 
-  utils::BasicResult<storage::StorageIndexDefinitionError, void> CreateIndex(storage::EdgeTypeId edge_type) {
-    return accessor_->CreateIndex(edge_type);
+  utils::BasicResult<storage::StorageIndexDefinitionError, void> CreateIndex(
+      storage::EdgeTypeId edge_type, storage::PublishIndexWrapper wrapper = storage::publish_no_wrap) {
+    return accessor_->CreateIndex(edge_type, true, storage::neverCancel /*TODO*/, std::move(wrapper));
   }
 
-  utils::BasicResult<storage::StorageIndexDefinitionError, void> CreateIndex(storage::EdgeTypeId edge_type,
-                                                                             storage::PropertyId property) {
-    return accessor_->CreateIndex(edge_type, property);
+  utils::BasicResult<storage::StorageIndexDefinitionError, void> CreateIndex(
+      storage::EdgeTypeId edge_type, storage::PropertyId property,
+      storage::PublishIndexWrapper wrapper = storage::publish_no_wrap) {
+    return accessor_->CreateIndex(edge_type, property, std::move(wrapper));
   }
 
-  utils::BasicResult<storage::StorageIndexDefinitionError, void> CreateGlobalEdgeIndex(storage::PropertyId property) {
-    return accessor_->CreateGlobalEdgeIndex(property);
+  utils::BasicResult<storage::StorageIndexDefinitionError, void> CreateGlobalEdgeIndex(
+      storage::PropertyId property, storage::PublishIndexWrapper wrapper = storage::publish_no_wrap) {
+    return accessor_->CreateGlobalEdgeIndex(property, std::move(wrapper));
   }
 
   utils::BasicResult<storage::StorageIndexDefinitionError, void> DropIndex(
@@ -670,17 +673,20 @@ class DbAccessor final {
     return accessor_->DropIndex(label, std::move(properties), std::move(wrapper));
   }
 
-  utils::BasicResult<storage::StorageIndexDefinitionError, void> DropIndex(storage::EdgeTypeId edge_type) {
-    return accessor_->DropIndex(edge_type);
+  utils::BasicResult<storage::StorageIndexDefinitionError, void> DropIndex(
+      storage::EdgeTypeId edge_type, storage::DropIndexWrapper wrapper = storage::drop_no_wrap) {
+    return accessor_->DropIndex(edge_type, std::move(wrapper));
   }
 
-  utils::BasicResult<storage::StorageIndexDefinitionError, void> DropIndex(storage::EdgeTypeId edge_type,
-                                                                           storage::PropertyId property) {
-    return accessor_->DropIndex(edge_type, property);
+  utils::BasicResult<storage::StorageIndexDefinitionError, void> DropIndex(
+      storage::EdgeTypeId edge_type, storage::PropertyId property,
+      storage::DropIndexWrapper wrapper = storage::drop_no_wrap) {
+    return accessor_->DropIndex(edge_type, property, std::move(wrapper));
   }
 
-  utils::BasicResult<storage::StorageIndexDefinitionError, void> DropGlobalEdgeIndex(storage::PropertyId property) {
-    return accessor_->DropGlobalEdgeIndex(property);
+  utils::BasicResult<storage::StorageIndexDefinitionError, void> DropGlobalEdgeIndex(
+      storage::PropertyId property, storage::DropIndexWrapper wrapper = storage::drop_no_wrap) {
+    return accessor_->DropGlobalEdgeIndex(property, std::move(wrapper));
   }
 
   utils::BasicResult<storage::StorageIndexDefinitionError, void> CreatePointIndex(storage::LabelId label,

--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -500,7 +500,7 @@ class DbAccessor final {
     return accessor_->RelevantLabelPropertiesIndicesInfo(labels, properties);
   }
 
-  bool EdgeTypeIndexExists(storage::EdgeTypeId edge_type) const { return accessor_->EdgeTypeIndexExists(edge_type); }
+  bool EdgeTypeIndexReady(storage::EdgeTypeId edge_type) const { return accessor_->EdgeTypeIndexReady(edge_type); }
 
   bool EdgeTypePropertyIndexExists(storage::EdgeTypeId edge_type, storage::PropertyId property) const {
     return accessor_->EdgeTypePropertyIndexExists(edge_type, property);

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -6324,6 +6324,7 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
         }
       } else {
         // edge type + properties
+        // edge global property
         accessor_type_ = storage::Storage::Accessor::Type::UNIQUE;  // TODO: READ_ONLY
       }
     } else {

--- a/src/query/metadata.cpp
+++ b/src/query/metadata.cpp
@@ -33,7 +33,7 @@ constexpr std::string_view GetCodeString(const NotificationCode code) {
     case NotificationCode::CREATE_CONSTRAINT:
       return "CreateConstraint"sv;
     case NotificationCode::CREATE_INDEX:
-      return "CreateIndex"sv;
+      return "CreateIndexOnePass"sv;
     case NotificationCode::CREATE_STREAM:
       return "CreateStream"sv;
     case NotificationCode::CHECK_STREAM:

--- a/src/query/metadata.cpp
+++ b/src/query/metadata.cpp
@@ -33,7 +33,7 @@ constexpr std::string_view GetCodeString(const NotificationCode code) {
     case NotificationCode::CREATE_CONSTRAINT:
       return "CreateConstraint"sv;
     case NotificationCode::CREATE_INDEX:
-      return "CreateIndexOnePass"sv;
+      return "CreateIndex"sv;
     case NotificationCode::CREATE_STREAM:
       return "CreateStream"sv;
     case NotificationCode::CHECK_STREAM:

--- a/src/query/plan/rewrite/edge_index_lookup.hpp
+++ b/src/query/plan/rewrite/edge_index_lookup.hpp
@@ -776,7 +776,7 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
 
     std::optional<LabelIx> best_edge_type;
     for (const auto &edge_type : edge_types) {
-      if (!db_->EdgeTypeIndexExists(GetEdgeType(edge_type))) continue;
+      if (!db_->EdgeTypeIndexReady(GetEdgeType(edge_type))) continue;
       if (!best_edge_type) {
         best_edge_type = edge_type;
         continue;
@@ -912,7 +912,7 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
     }
 
     // if no edge type property index found, we try to see if we can add an index from the relationship
-    if (edge_type_from_relationship.has_value() && db_->EdgeTypeIndexExists(edge_type_from_relationship.value())) {
+    if (edge_type_from_relationship.has_value() && db_->EdgeTypeIndexReady(edge_type_from_relationship.value())) {
       return std::make_unique<ScanAllByEdgeType>(input, common.edge_symbol, common.node1_symbol, common.node2_symbol,
                                                  common.direction, edge_type_from_relationship.value(), view);
     }

--- a/src/query/plan/used_index_checker.cpp
+++ b/src/query/plan/used_index_checker.cpp
@@ -44,8 +44,8 @@ bool UsedIndexChecker::PreVisit(ScanAllByEdgeType &op) {
 }
 
 PRE_VISIT(ScanAllById)
+PRE_VISIT(ScanAllByEdge)
 
-PRE_VISIT(ScanAllByEdge)                   // TODO: gather for concurrent index check
 PRE_VISIT(ScanAllByEdgeTypeProperty)       // TODO: gather for concurrent index check
 PRE_VISIT(ScanAllByEdgeTypePropertyValue)  // TODO: gather for concurrent index check
 PRE_VISIT(ScanAllByEdgeTypePropertyRange)  // TODO: gather for concurrent index check

--- a/src/query/plan/used_index_checker.cpp
+++ b/src/query/plan/used_index_checker.cpp
@@ -37,10 +37,15 @@ bool UsedIndexChecker::PreVisit(ScanAllByLabelProperties &op) {
   required_indices_.label_properties_.emplace_back(op.label_, op.properties_);
   return true;
 }
+
+bool UsedIndexChecker::PreVisit(ScanAllByEdgeType &op) {
+  required_indices_.edge_type_.emplace_back(op.common_.edge_types[0]);
+  return true;
+}
+
 PRE_VISIT(ScanAllById)
 
 PRE_VISIT(ScanAllByEdge)                   // TODO: gather for concurrent index check
-PRE_VISIT(ScanAllByEdgeType)               // TODO: gather for concurrent index check
 PRE_VISIT(ScanAllByEdgeTypeProperty)       // TODO: gather for concurrent index check
 PRE_VISIT(ScanAllByEdgeTypePropertyValue)  // TODO: gather for concurrent index check
 PRE_VISIT(ScanAllByEdgeTypePropertyRange)  // TODO: gather for concurrent index check

--- a/src/query/plan/vertex_count_cache.hpp
+++ b/src/query/plan/vertex_count_cache.hpp
@@ -147,7 +147,7 @@ class VertexCountCache {
     return db_->RelevantLabelPropertiesIndicesInfo(labels, properties);
   }
 
-  bool EdgeTypeIndexExists(storage::EdgeTypeId edge_type) { return db_->EdgeTypeIndexExists(edge_type); }
+  bool EdgeTypeIndexReady(storage::EdgeTypeId edge_type) { return db_->EdgeTypeIndexReady(edge_type); }
 
   bool EdgeTypePropertyIndexExists(storage::EdgeTypeId edge_type, storage::PropertyId property) {
     return db_->EdgeTypePropertyIndexExists(edge_type, property);

--- a/src/storage/v2/CMakeLists.txt
+++ b/src/storage/v2/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(mg-storage-v2
         durability/wal.cpp
         edge_accessor.cpp
         edges_iterable.cpp
+        indices/edge_type_index.cpp
         indices/indices.cpp
         indices/label_index_stats.cpp
         indices/label_property_index.cpp
@@ -34,9 +35,9 @@ target_sources(mg-storage-v2
         indices/point_index_change_collector.cpp
         indices/text_index.cpp
         indices/vector_index.cpp
+        inmemory/edge_property_index.cpp
         inmemory/edge_type_index.cpp
         inmemory/edge_type_property_index.cpp
-        inmemory/edge_property_index.cpp
         inmemory/label_index.cpp
         inmemory/label_property_index.cpp
         inmemory/replication/recovery.cpp

--- a/src/storage/v2/common_function_signatures.hpp
+++ b/src/storage/v2/common_function_signatures.hpp
@@ -29,10 +29,8 @@ using PublishIndexWrapper = std::function<PublishIndexFunction(PublishIndexFunct
 using DropIndexWrapper = std::function<DropIndexFunction(DropIndexFunction)>;
 
 // default for when callback not provided
-constexpr auto publish_no_wrap = [](PublishIndexFunction func) {
-  return [func = std::move(func)](uint64_t timestamp) { return func(timestamp); };
-};
-constexpr auto drop_no_wrap = [](DropIndexFunction func) { return [func = std::move(func)] { return func(); }; };
+constexpr auto publish_no_wrap = std::identity{};
+constexpr auto drop_no_wrap = std::identity{};
 constexpr auto always_invalidate_plan_cache = []<typename... Args>(Args && ...) { return true; };
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/disk/edge_type_index.cpp
+++ b/src/storage/v2/disk/edge_type_index.cpp
@@ -64,16 +64,4 @@ auto DiskEdgeTypeIndex::GetActiveIndices() const -> std::unique_ptr<EdgeTypeInde
   return std::make_unique<DiskEdgeTypeIndex::ActiveIndices>();
 }
 
-void EdgeTypeIndex::AbortProcessor::CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex *from_vertex, Vertex *to_vertex,
-                                                         Edge *edge) {
-  auto it = cleanup_collection_.find(edge_type);
-  if (it == cleanup_collection_.end()) return;
-  it->second.emplace_back(from_vertex, to_vertex, edge);
-}
-
-EdgeTypeIndex::AbortProcessor::AbortProcessor(std::span<EdgeTypeId const> edge_types) {
-  for (auto edge_type : edge_types) {
-    cleanup_collection_.insert({edge_type, {}});
-  }
-}
 }  // namespace memgraph::storage

--- a/src/storage/v2/disk/edge_type_index.cpp
+++ b/src/storage/v2/disk/edge_type_index.cpp
@@ -66,9 +66,14 @@ auto DiskEdgeTypeIndex::GetActiveIndices() const -> std::unique_ptr<EdgeTypeInde
 
 void EdgeTypeIndex::AbortProcessor::CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex *from_vertex, Vertex *to_vertex,
                                                          Edge *edge) {
-  // TODO: this is a filter for only relevant edge_types? If so it should be based off the ActiveIndices
-  if (std::binary_search(edge_type_.begin(), edge_type_.end(), edge_type)) {
-    cleanup_collection_[edge_type].emplace_back(from_vertex, to_vertex, edge);
+  auto it = cleanup_collection_.find(edge_type);
+  if (it == cleanup_collection_.end()) return;
+  it->second.emplace_back(from_vertex, to_vertex, edge);
+}
+
+EdgeTypeIndex::AbortProcessor::AbortProcessor(std::span<EdgeTypeId const> edge_types) {
+  for (auto edge_type : edge_types) {
+    cleanup_collection_.insert({edge_type, {}});
   }
 }
 }  // namespace memgraph::storage

--- a/src/storage/v2/disk/edge_type_index.hpp
+++ b/src/storage/v2/disk/edge_type_index.hpp
@@ -15,25 +15,32 @@
 
 namespace memgraph::storage {
 
-class DiskEdgeTypeIndex : public storage::EdgeTypeIndex {
+class DiskEdgeTypeIndex : public EdgeTypeIndex {
  public:
+  struct ActiveIndices : EdgeTypeIndex::ActiveIndices {
+    bool IndexReady(EdgeTypeId edge_type) const override;
+
+    bool IndexRegistered(EdgeTypeId edge_type) const override;
+
+    auto ListIndices(uint64_t start_timestamp) const -> std::vector<EdgeTypeId> override;
+
+    auto ApproximateEdgeCount(EdgeTypeId edge_type) const -> uint64_t override;
+
+    void UpdateOnEdgeCreation(Vertex *from, Vertex *to, EdgeRef edge_ref, EdgeTypeId edge_type,
+                              const Transaction &tx) override;
+
+    void UpdateOnEdgeModification(Vertex *old_from, Vertex *old_to, Vertex *new_from, Vertex *new_to, EdgeRef edge_ref,
+                                  EdgeTypeId edge_type, const Transaction &tx) override;
+    void AbortEntries(AbortableInfo const &info, uint64_t exact_start_timestamp) override {}
+
+    auto GetAbortProcessor() const -> AbortProcessor override;
+  };
+
   bool DropIndex(EdgeTypeId edge_type) override;
-
-  bool IndexExists(EdgeTypeId edge_type) const override;
-
-  std::vector<EdgeTypeId> ListIndices() const override;
-
-  uint64_t ApproximateEdgeCount(EdgeTypeId edge_type) const override;
-
-  void UpdateOnEdgeCreation(Vertex *from, Vertex *to, EdgeRef edge_ref, EdgeTypeId edge_type,
-                            const Transaction &tx) override;
-
-  void UpdateOnEdgeModification(Vertex *old_from, Vertex *old_to, Vertex *new_from, Vertex *new_to, EdgeRef edge_ref,
-                                EdgeTypeId edge_type, const Transaction &tx) override;
 
   void DropGraphClearIndices() override;
 
-  void AbortEntries(AbortableInfo const &info, uint64_t exact_start_timestamp) override {}
+  auto GetActiveIndices() const -> std::unique_ptr<EdgeTypeIndex::ActiveIndices> override;
 };
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -2095,14 +2095,14 @@ utils::BasicResult<StorageIndexDefinitionError, void> DiskStorage::DiskAccessor:
       "Edge-type index related operations are not yet supported using on-disk storage mode. {}", kErrorMessage);
 }
 
-utils::BasicResult<StorageIndexDefinitionError, void> DiskStorage::DiskAccessor::CreateIndex(EdgeTypeId /*edge_type*/,
-                                                                                             PropertyId /*property*/) {
+utils::BasicResult<StorageIndexDefinitionError, void> DiskStorage::DiskAccessor::CreateIndex(
+    EdgeTypeId /*edge_type*/, PropertyId /*property*/, PublishIndexWrapper /*wrapper*/) {
   throw utils::NotYetImplemented(
       "Edge-type index related operations are not yet supported using on-disk storage mode. {}", kErrorMessage);
 }
 
 utils::BasicResult<StorageIndexDefinitionError, void> DiskStorage::DiskAccessor::CreateGlobalEdgeIndex(
-    PropertyId /*property*/) {
+    PropertyId /*property*/, PublishIndexWrapper /*wrapper*/) {
   throw utils::NotYetImplemented(
       "Edge-type index related operations are not yet supported using on-disk storage mode. {}", kErrorMessage);
 }
@@ -2156,19 +2156,20 @@ utils::BasicResult<StorageIndexDefinitionError, void> DiskStorage::DiskAccessor:
   return {};
 }
 
-utils::BasicResult<StorageIndexDefinitionError, void> DiskStorage::DiskAccessor::DropIndex(EdgeTypeId /*edge_type*/) {
+utils::BasicResult<StorageIndexDefinitionError, void> DiskStorage::DiskAccessor::DropIndex(
+    EdgeTypeId /*edge_type*/, DropIndexWrapper /*wrapper*/) {
   throw utils::NotYetImplemented(
       "Edge-type index related operations are not yet supported using on-disk storage mode. {}", kErrorMessage);
 }
 
-utils::BasicResult<StorageIndexDefinitionError, void> DiskStorage::DiskAccessor::DropIndex(EdgeTypeId /*edge_type*/,
-                                                                                           PropertyId /*property*/) {
+utils::BasicResult<StorageIndexDefinitionError, void> DiskStorage::DiskAccessor::DropIndex(
+    EdgeTypeId /*edge_type*/, PropertyId /*property*/, DropIndexWrapper /*wrapper*/) {
   throw utils::NotYetImplemented(
       "Edge-type index related operations are not yet supported using on-disk storage mode. {}", kErrorMessage);
 }
 
 utils::BasicResult<StorageIndexDefinitionError, void> DiskStorage::DiskAccessor::DropGlobalEdgeIndex(
-    PropertyId /*property*/) {
+    PropertyId /*property*/, DropIndexWrapper /*wrapper*/) {
   throw utils::NotYetImplemented(
       "Edge-type index related operations are not yet supported using on-disk storage mode. {}", kErrorMessage);
 }

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -2089,7 +2089,8 @@ utils::BasicResult<StorageIndexDefinitionError, void> DiskStorage::DiskAccessor:
 }
 
 utils::BasicResult<StorageIndexDefinitionError, void> DiskStorage::DiskAccessor::CreateIndex(
-    EdgeTypeId /*edge_type*/, bool /*unique_access_needed*/) {
+    EdgeTypeId /*edge_type*/, bool /*unique_access_needed*/, CheckCancelFunction /*cancel_check*/,
+    PublishIndexWrapper /*wrapper*/) {
   throw utils::NotYetImplemented(
       "Edge-type index related operations are not yet supported using on-disk storage mode. {}", kErrorMessage);
 }
@@ -2356,7 +2357,7 @@ std::unique_ptr<Storage::Accessor> DiskStorage::ReadOnlyAccess(std::optional<Iso
       new DiskAccessor{Storage::Accessor::read_only_access, this, isolation_level, storage_mode_});
 }
 
-bool DiskStorage::DiskAccessor::EdgeTypeIndexExists(EdgeTypeId /*edge_type*/) const {
+bool DiskStorage::DiskAccessor::EdgeTypeIndexReady(EdgeTypeId /*edge_type*/) const {
   spdlog::info("Edge-type index related operations are not yet supported using on-disk storage mode. {}",
                kErrorMessage);
   return false;

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -232,10 +232,11 @@ class DiskStorage final : public Storage {
         EdgeTypeId edge_type, bool unique_access_needed = true, CheckCancelFunction cancel_check = neverCancel,
         PublishIndexWrapper wrapper = publish_no_wrap) override;
 
-    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(EdgeTypeId edge_type,
-                                                                      PropertyId property) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
+        EdgeTypeId edge_type, PropertyId property, PublishIndexWrapper wrapper = publish_no_wrap) override;
 
-    utils::BasicResult<StorageIndexDefinitionError, void> CreateGlobalEdgeIndex(PropertyId property) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> CreateGlobalEdgeIndex(
+        PropertyId property, PublishIndexWrapper wrapper = publish_no_wrap) override;
 
     utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(LabelId label,
                                                                     DropIndexWrapper wrapper = drop_no_wrap) override;
@@ -244,11 +245,14 @@ class DiskStorage final : public Storage {
                                                                     std::vector<storage::PropertyPath> &&properties,
                                                                     DropIndexWrapper wrapper = drop_no_wrap) override;
 
-    utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(EdgeTypeId edge_type) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(EdgeTypeId edge_type,
+                                                                    DropIndexWrapper wrapper = drop_no_wrap) override;
 
-    utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(EdgeTypeId edge_type, PropertyId property) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(EdgeTypeId edge_type, PropertyId property,
+                                                                    DropIndexWrapper wrapper = drop_no_wrap) override;
 
-    utils::BasicResult<StorageIndexDefinitionError, void> DropGlobalEdgeIndex(PropertyId property) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> DropGlobalEdgeIndex(
+        PropertyId property, DropIndexWrapper wrapper = drop_no_wrap) override;
 
     utils::BasicResult<storage::StorageIndexDefinitionError, void> CreatePointIndex(
         storage::LabelId label, storage::PropertyId property) override;

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -195,7 +195,7 @@ class DiskStorage final : public Storage {
       return transaction_.active_indices_.label_properties_->IndexReady(label, properties);
     }
 
-    bool EdgeTypeIndexExists(EdgeTypeId edge_type) const override;
+    bool EdgeTypeIndexReady(EdgeTypeId edge_type) const override;
 
     bool EdgeTypePropertyIndexExists(EdgeTypeId edge_type, PropertyId proeprty) const override;
 
@@ -228,8 +228,9 @@ class DiskStorage final : public Storage {
         LabelId label, PropertiesPaths, CheckCancelFunction cancel_check = neverCancel,
         PublishIndexWrapper wrapper = publish_no_wrap) override;
 
-    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(EdgeTypeId edge_type,
-                                                                      bool unique_access_needed = true) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
+        EdgeTypeId edge_type, bool unique_access_needed = true, CheckCancelFunction cancel_check = neverCancel,
+        PublishIndexWrapper wrapper = publish_no_wrap) override;
 
     utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(EdgeTypeId edge_type,
                                                                       PropertyId property) override;

--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -270,7 +270,7 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
 
     for (const auto &item : indices_metadata.edge) {
       // TODO: parallel execution
-      if (!mem_edge_type_index->CreateIndex(item, vertices->access(), snapshot_info)) {
+      if (!mem_edge_type_index->CreateIndexOnePass(item, vertices->access(), snapshot_info)) {
         throw RecoveryFailure("The edge-type index must be created here!");
       }
       spdlog::info("Index on :{} is recreated from metadata", name_id_mapper->IdToName(item.AsUint()));

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -6303,7 +6303,7 @@ bool CreateSnapshot(Storage *storage, Transaction *transaction, const std::files
     offset_edge_indices = snapshot.GetPosition();
     snapshot.WriteMarker(Marker::SECTION_EDGE_INDICES);
     {
-      auto edge_type = storage->indices_.edge_type_index_->ListIndices();
+      auto edge_type = transaction->active_indices_.edge_type_->ListIndices(transaction->start_timestamp);
       snapshot.WriteUint(edge_type.size());
       for (const auto &item : edge_type) {
         write_mapping(item);

--- a/src/storage/v2/indices/active_indices.hpp
+++ b/src/storage/v2/indices/active_indices.hpp
@@ -28,8 +28,9 @@ struct IndicesCollection {
 
 struct ActiveIndices {
   ActiveIndices() = delete;  // to avoid nullptr
-  explicit ActiveIndices(std::unique_ptr<LabelPropertyIndex::ActiveIndices> label_properties)
-      : label_properties_{std::move(label_properties)} {}
+  explicit ActiveIndices(std::unique_ptr<LabelPropertyIndex::ActiveIndices> label_properties,
+                         std::unique_ptr<EdgeTypeIndex::ActiveIndices> edge_type)
+      : label_properties_{std::move(label_properties)}, edge_type_{std::move(edge_type)} {}
 
   bool CheckIndicesAreReady(IndicesCollection const &required_indices) const {
     // label

--- a/src/storage/v2/indices/active_indices.hpp
+++ b/src/storage/v2/indices/active_indices.hpp
@@ -22,6 +22,8 @@ struct IndicesCollection {
   std::vector<storage::LabelId> label_;
   std::vector<std::pair<storage::LabelId, std::vector<storage::PropertyPath>>> label_properties_;
   std::vector<storage::EdgeTypeId> edge_type_;
+  // TODO: edge_type + properties
+  // TODO: edge properties
 };
 
 struct ActiveIndices {

--- a/src/storage/v2/indices/active_indices.hpp
+++ b/src/storage/v2/indices/active_indices.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "storage/v2/indices/edge_type_index.hpp"
 #include "storage/v2/indices/label_property_index.hpp"
 
 #include <memory>
@@ -20,6 +21,7 @@ namespace memgraph::storage {
 struct IndicesCollection {
   std::vector<storage::LabelId> label_;
   std::vector<std::pair<storage::LabelId, std::vector<storage::PropertyPath>>> label_properties_;
+  std::vector<storage::EdgeTypeId> edge_type_;
 };
 
 struct ActiveIndices {
@@ -38,9 +40,15 @@ struct ActiveIndices {
       if (!label_properties_->IndexReady(label, properties)) return false;
     }
 
+    // edge type
+    for (auto const edge_type : required_indices.edge_type_) {
+      if (!edge_type_->IndexReady(edge_type)) return false;
+    }
+
     return true;
   }
 
   std::unique_ptr<LabelPropertyIndex::ActiveIndices> label_properties_;
+  std::unique_ptr<EdgeTypeIndex::ActiveIndices> edge_type_;
 };
 }  // namespace memgraph::storage

--- a/src/storage/v2/indices/edge_type_index.cpp
+++ b/src/storage/v2/indices/edge_type_index.cpp
@@ -1,0 +1,27 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "storage/v2/indices/edge_type_index.hpp"
+
+namespace memgraph::storage {
+void EdgeTypeIndex::AbortProcessor::CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex *from_vertex, Vertex *to_vertex,
+                                                         Edge *edge) {
+  auto it = cleanup_collection_.find(edge_type);
+  if (it == cleanup_collection_.end()) return;
+  it->second.emplace_back(from_vertex, to_vertex, edge);
+}
+
+EdgeTypeIndex::AbortProcessor::AbortProcessor(std::span<EdgeTypeId const> edge_types) {
+  for (auto edge_type : edge_types) {
+    cleanup_collection_.insert({edge_type, {}});
+  }
+}
+}  // namespace memgraph::storage

--- a/src/storage/v2/indices/edge_type_index.hpp
+++ b/src/storage/v2/indices/edge_type_index.hpp
@@ -35,7 +35,7 @@ class EdgeTypeIndex {
 
     void CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex *from_vertex, Vertex *to_vertex, Edge *edge);
 
-    void process(ActiveIndices &active_indices, uint64_t start_timestamp) {
+    void Process(ActiveIndices &active_indices, uint64_t start_timestamp) {
       active_indices.AbortEntries(cleanup_collection_, start_timestamp);
     }
 

--- a/src/storage/v2/indices/edge_type_index.hpp
+++ b/src/storage/v2/indices/edge_type_index.hpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <map>
+#include <span>
 #include <vector>
 
 namespace memgraph::storage {
@@ -30,8 +31,7 @@ class EdgeTypeIndex {
   struct ActiveIndices;
 
   struct AbortProcessor {
-    // TODO: why constructed with vector?
-    explicit AbortProcessor(std::vector<EdgeTypeId> edge_type) : edge_type_(std::move(edge_type)) {}
+    explicit AbortProcessor(std::span<EdgeTypeId const> edge_types);
 
     void CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex *from_vertex, Vertex *to_vertex, Edge *edge);
 
@@ -40,7 +40,6 @@ class EdgeTypeIndex {
     }
 
    private:
-    std::vector<EdgeTypeId> edge_type_;
     AbortableInfo cleanup_collection_;
   };
 

--- a/src/storage/v2/indices/edge_type_index.hpp
+++ b/src/storage/v2/indices/edge_type_index.hpp
@@ -25,6 +25,46 @@ struct Vertex;
 
 class EdgeTypeIndex {
  public:
+  using AbortableInfo = std::map<EdgeTypeId, std::vector<std::tuple<Vertex *, Vertex *, Edge *>>>;
+
+  struct ActiveIndices;
+
+  struct AbortProcessor {
+    // TODO: why constructed with vector?
+    explicit AbortProcessor(std::vector<EdgeTypeId> edge_type) : edge_type_(std::move(edge_type)) {}
+
+    void CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex *from_vertex, Vertex *to_vertex, Edge *edge);
+
+    void process(ActiveIndices &active_indices, uint64_t start_timestamp) {
+      active_indices.AbortEntries(cleanup_collection_, start_timestamp);
+    }
+
+   private:
+    std::vector<EdgeTypeId> edge_type_;
+    AbortableInfo cleanup_collection_;
+  };
+
+  struct ActiveIndices {
+    virtual ~ActiveIndices() = default;
+
+    virtual void UpdateOnEdgeCreation(Vertex *from, Vertex *to, EdgeRef edge_ref, EdgeTypeId edge_type,
+                                      const Transaction &tx) = 0;
+
+    virtual void UpdateOnEdgeModification(Vertex *old_from, Vertex *old_to, Vertex *new_from, Vertex *new_to,
+                                          EdgeRef edge_ref, EdgeTypeId edge_type, const Transaction &tx) = 0;
+
+    virtual auto ApproximateEdgeCount(EdgeTypeId edge_type) const -> uint64_t = 0;
+
+    virtual bool IndexReady(EdgeTypeId edge_type) const = 0;
+    virtual bool IndexRegistered(EdgeTypeId edge_type) const = 0;
+
+    virtual auto ListIndices(uint64_t start_timestamp) const -> std::vector<EdgeTypeId> = 0;
+
+    virtual auto GetAbortProcessor() const -> AbortProcessor = 0;
+
+    virtual void AbortEntries(AbortableInfo const &info, uint64_t start_timestamp) = 0;
+  };
+
   EdgeTypeIndex() = default;
 
   EdgeTypeIndex(const EdgeTypeIndex &) = delete;
@@ -36,41 +76,9 @@ class EdgeTypeIndex {
 
   virtual bool DropIndex(EdgeTypeId edge_type) = 0;
 
-  virtual bool IndexExists(EdgeTypeId edge_type) const = 0;
-
-  virtual std::vector<EdgeTypeId> ListIndices() const = 0;
-
-  virtual uint64_t ApproximateEdgeCount(EdgeTypeId edge_type) const = 0;
-
-  virtual void UpdateOnEdgeCreation(Vertex *from, Vertex *to, EdgeRef edge_ref, EdgeTypeId edge_type,
-                                    const Transaction &tx) = 0;
-
-  virtual void UpdateOnEdgeModification(Vertex *old_from, Vertex *old_to, Vertex *new_from, Vertex *new_to,
-                                        EdgeRef edge_ref, EdgeTypeId edge_type, const Transaction &tx) = 0;
-
   virtual void DropGraphClearIndices() = 0;
 
-  using AbortableInfo = std::map<EdgeTypeId, std::vector<std::tuple<Vertex *, Vertex *, Edge *>>>;
-
-  struct AbortProcessor {
-    explicit AbortProcessor(std::vector<EdgeTypeId> edge_type) : edge_type_(std::move(edge_type)) {}
-
-    void CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex *from_vertex, Vertex *to_vertex, Edge *edge) {
-      if (std::binary_search(edge_type_.begin(), edge_type_.end(), edge_type)) {
-        cleanup_collection_[edge_type].emplace_back(from_vertex, to_vertex, edge);
-      }
-    }
-
-    void Process(EdgeTypeIndex &index, uint64_t start_timestamp) {
-      index.AbortEntries(cleanup_collection_, start_timestamp);
-    }
-
-   private:
-    std::vector<EdgeTypeId> edge_type_;
-    AbortableInfo cleanup_collection_;
-  };
-
-  virtual void AbortEntries(AbortableInfo const &, uint64_t start_timestamp) = 0;
+  virtual auto GetActiveIndices() const -> std::unique_ptr<ActiveIndices> = 0;
 };
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/indices/errors.hpp
+++ b/src/storage/v2/indices/errors.hpp
@@ -1,0 +1,18 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+namespace memgraph::storage {
+enum class IndexPopulateError {
+  Cancellation,
+};
+}

--- a/src/storage/v2/indices/indices.cpp
+++ b/src/storage/v2/indices/indices.cpp
@@ -129,16 +129,16 @@ void Indices::AbortProcessor::CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex 
 
 void Indices::AbortProcessor::CollectOnLabelRemoval(LabelId labelId, Vertex *vertex) {
   label_.CollectOnLabelRemoval(labelId, vertex);
-  property_label_.CollectOnLabelRemoval(labelId, vertex);
+  label_properties_.CollectOnLabelRemoval(labelId, vertex);
 }
 
 void Indices::AbortProcessor::CollectOnPropertyChange(PropertyId propId, Vertex *vertex) {
-  property_label_.CollectOnPropertyChange(propId, vertex);
+  label_properties_.CollectOnPropertyChange(propId, vertex);
 }
 
 void Indices::AbortProcessor::Process(Indices &indices, ActiveIndices &active_indices, uint64_t start_timestamp) {
   label_.Process(*indices.label_index_, start_timestamp);
-  property_label_.Process(*active_indices.label_properties_, start_timestamp);
+  label_properties_.Process(*active_indices.label_properties_, start_timestamp);
   edge_type_.Process(*active_indices.edge_type_, start_timestamp);
   // TODO: edge type properties
 }

--- a/src/storage/v2/indices/indices.hpp
+++ b/src/storage/v2/indices/indices.hpp
@@ -56,7 +56,7 @@ struct Indices {
 
   struct AbortProcessor {
     LabelIndex::AbortProcessor label_;
-    LabelPropertyIndex::AbortProcessor property_label_;
+    LabelPropertyIndex::AbortProcessor label_properties_;
     EdgeTypeIndex::AbortProcessor edge_type_;
 
     EdgeTypePropertyIndex::IndexStats property_edge_type_;

--- a/src/storage/v2/indices/indices_utils.hpp
+++ b/src/storage/v2/indices/indices_utils.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "storage/v2/common_function_signatures.hpp"
 #include "storage/v2/delta.hpp"
 #include "storage/v2/durability/recovery_type.hpp"
 #include "storage/v2/mvcc.hpp"
@@ -198,19 +199,22 @@ inline bool CurrentEdgeVersionHasProperty(const Edge &edge, PropertyId key, cons
 }
 
 template <typename TIndexAccessor>
-inline void TryInsertLabelIndex(Vertex &vertex, LabelId label, TIndexAccessor &index_accessor) {
+inline void TryInsertLabelIndex(Vertex &vertex, LabelId label, TIndexAccessor &index_accessor,
+                                std::optional<SnapshotObserverInfo> const &snapshot_info) {
   if (vertex.deleted || !utils::Contains(vertex.labels, label)) {
     return;
   }
 
   index_accessor.insert({&vertex, 0});
+  if (snapshot_info) {
+    snapshot_info->Update(UpdateType::VERTICES);
+  }
 }
 
 template <typename TSkipListAccessorFactory, typename TFunc>
 inline void PopulateIndexOnMultipleThreads(utils::SkipList<Vertex>::Accessor &vertices,
                                            TSkipListAccessorFactory &&accessor_factory, const TFunc &func,
-                                           durability::ParallelizedSchemaCreationInfo const &parallel_exec_info,
-                                           std::optional<SnapshotObserverInfo> const &snapshot_info) {
+                                           durability::ParallelizedSchemaCreationInfo const &parallel_exec_info) {
   utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
 
   const auto &vertex_batches = parallel_exec_info.vertex_recovery_info;
@@ -229,7 +233,7 @@ inline void PopulateIndexOnMultipleThreads(utils::SkipList<Vertex>::Accessor &ve
     threads.reserve(thread_count);
 
     for (auto i{0U}; i < thread_count; ++i) {
-      threads.emplace_back([&]() mutable {
+      threads.emplace_back([&, func /*local copy incase there is local state*/]() {
         auto acc = accessor_factory();
         while (!maybe_error.Lock()->has_value()) {
           const auto batch_index = batch_counter++;
@@ -242,9 +246,6 @@ inline void PopulateIndexOnMultipleThreads(utils::SkipList<Vertex>::Accessor &ve
           try {
             for (auto i{0U}; i < batch.second; ++i, ++it) {
               func(*it, acc);
-              if (snapshot_info) {
-                snapshot_info->Update(UpdateType::VERTICES);
-              }
             }
 
           } catch (utils::OutOfMemoryException &failure) {
@@ -263,47 +264,50 @@ inline void PopulateIndexOnMultipleThreads(utils::SkipList<Vertex>::Accessor &ve
 
 template <typename TSkipListAccessorFactory, typename TFunc>
 inline void PopulateIndexOnSingleThread(utils::SkipList<Vertex>::Accessor &vertices,
-                                        TSkipListAccessorFactory &&accessor_factory, const TFunc &func,
-                                        std::optional<SnapshotObserverInfo> const &snapshot_info) {
+                                        TSkipListAccessorFactory &&accessor_factory, const TFunc &func) {
   utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
 
   auto acc = accessor_factory();
   for (Vertex &vertex : vertices) {
     func(vertex, acc);
-    if (snapshot_info) {
-      snapshot_info->Update(UpdateType::VERTICES);
-    }
   }
 }
 
+struct PopulateCancel : std::exception {};
+
 template <typename TSkipListAccessorFactory, typename TFunc>
 inline void PopulateIndexDispatch(utils::SkipList<Vertex>::Accessor &vertices,
-                                  TSkipListAccessorFactory &&accessor_factory, const TFunc &func,
-                                  std::optional<durability::ParallelizedSchemaCreationInfo> const &parallel_exec_info,
-                                  std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt) {
+                                  TSkipListAccessorFactory &&accessor_factory, const TFunc &insert_function,
+                                  CheckCancelFunction &&cancel_check,
+                                  std::optional<durability::ParallelizedSchemaCreationInfo> const &parallel_exec_info) {
+  auto checked_insert_function =
+      [&, cancel_check = std::move(cancel_check) /*need to be owned, if parallel these will be copied per thread*/](
+          Vertex &vertex, auto &index_accessor) {
+        if (cancel_check()) {
+          throw PopulateCancel{};
+        }
+        insert_function(vertex, index_accessor);
+      };
+
   if (parallel_exec_info && parallel_exec_info->thread_count > 1) {
-    PopulateIndexOnMultipleThreads(vertices, std::forward<TSkipListAccessorFactory>(accessor_factory), func,
-                                   *parallel_exec_info, snapshot_info);
+    PopulateIndexOnMultipleThreads(vertices, std::forward<TSkipListAccessorFactory>(accessor_factory),
+                                   checked_insert_function, *parallel_exec_info);
   } else {
-    PopulateIndexOnSingleThread(vertices, std::forward<TSkipListAccessorFactory>(accessor_factory), func,
-                                snapshot_info);
+    PopulateIndexOnSingleThread(vertices, std::forward<TSkipListAccessorFactory>(accessor_factory),
+                                checked_insert_function);
   }
 }
 
 // @TODO Is `Create` the correct term here? Should this be `PopulateIndexOnSingleThread`?
 template <typename TSkiplistIter, typename TIndex, typename TFunc>
 inline void CreateIndexOnSingleThread(utils::SkipList<Vertex>::Accessor &vertices, TSkiplistIter it, TIndex &index,
-                                      const TFunc &func,
-                                      std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt) {
+                                      const TFunc &func) {
   utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
 
   try {
     auto acc = it->second.access();
     for (Vertex &vertex : vertices) {
       func(vertex, acc);
-      if (snapshot_info) {
-        snapshot_info->Update(UpdateType::VERTICES);
-      }
     }
   } catch (const utils::OutOfMemoryException &) {
     utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_exception_blocker;
@@ -316,8 +320,7 @@ template <typename TIndex, typename TSKiplistIter, typename TFunc>
 inline void CreateIndexOnMultipleThreads(utils::SkipList<Vertex>::Accessor &vertices, TSKiplistIter skiplist_iter,
                                          TIndex &index,
                                          const durability::ParallelizedSchemaCreationInfo &parallel_exec_info,
-                                         const TFunc &func,
-                                         std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt) {
+                                         const TFunc &func) {
   utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
 
   const auto &vertex_batches = parallel_exec_info.vertex_recovery_info;
@@ -349,9 +352,6 @@ inline void CreateIndexOnMultipleThreads(utils::SkipList<Vertex>::Accessor &vert
           try {
             for (auto i{0U}; i < batch.second; ++i, ++it) {
               func(*it, index_accessor);
-              if (snapshot_info) {
-                snapshot_info->Update(UpdateType::VERTICES);
-              }
             }
 
           } catch (utils::OutOfMemoryException &failure) {

--- a/src/storage/v2/indices/indices_utils.hpp
+++ b/src/storage/v2/indices/indices_utils.hpp
@@ -201,14 +201,16 @@ inline bool CurrentEdgeVersionHasProperty(const Edge &edge, PropertyId key, cons
 template <typename TIndexAccessor>
 inline void TryInsertLabelIndex(Vertex &vertex, LabelId label, TIndexAccessor &index_accessor,
                                 std::optional<SnapshotObserverInfo> const &snapshot_info) {
+  // observe regardless
+  if (snapshot_info) {
+    snapshot_info->Update(UpdateType::VERTICES);
+  }
+
   if (vertex.deleted || !utils::Contains(vertex.labels, label)) {
     return;
   }
 
   index_accessor.insert({&vertex, 0});
-  if (snapshot_info) {
-    snapshot_info->Update(UpdateType::VERTICES);
-  }
 }
 
 template <typename TSkipListAccessorFactory, typename TFunc>

--- a/src/storage/v2/indices/label_property_index.hpp
+++ b/src/storage/v2/indices/label_property_index.hpp
@@ -184,6 +184,8 @@ class LabelPropertyIndex {
   struct ActiveIndices;
 
   struct AbortProcessor {
+    // TODO: this is a filter for only relevant indicies? If so it should be based off the ActiveIndices
+    //       + via constructor
     std::map<LabelId, std::map<PropertyId, std::vector<IndexInfo>>> l2p;
     std::map<PropertyId, std::map<LabelId, std::vector<IndexInfo>>> p2l;
 

--- a/src/storage/v2/inmemory/edge_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_property_index.cpp
@@ -56,12 +56,12 @@ bool InMemoryEdgePropertyIndex::CreateIndex(PropertyId property, utils::SkipList
       }
 
       for (auto &edge : from_vertex.out_edges) {
-        const auto type = std::get<kEdgeTypeIdPos>(edge);
-        auto *to_vertex = std::get<kVertexPos>(edge);
+        const auto type = std::get<EdgeTypeId>(edge);
+        auto *to_vertex = std::get<Vertex *>(edge);
         if (to_vertex->deleted) {
           continue;
         }
-        auto *edge_ptr = std::get<kEdgeRefPos>(edge).ptr;
+        auto *edge_ptr = std::get<EdgeRef>(edge).ptr;
         edge_acc.insert({edge_ptr->properties.GetProperty(property), &from_vertex, to_vertex, edge_ptr, type, 0});
         if (snapshot_info) {
           snapshot_info->Update(UpdateType::EDGES);

--- a/src/storage/v2/inmemory/edge_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_property_index.hpp
@@ -95,10 +95,6 @@ class InMemoryEdgePropertyIndex : public storage::EdgePropertyIndex {
     return stats;
   }
 
-  static constexpr std::size_t kEdgeTypeIdPos = 0U;
-  static constexpr std::size_t kVertexPos = 1U;
-  static constexpr std::size_t kEdgeRefPos = 2U;
-
   class Iterable {
    public:
     Iterable(utils::SkipList<Entry>::Accessor index_accessor, utils::SkipList<Vertex>::ConstAccessor vertex_accessor,

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -151,12 +151,12 @@ bool InMemoryEdgeTypeIndex::PublishIndex(EdgeTypeId edge_type, uint64_t commit_t
 }
 
 void InMemoryEdgeTypeIndex::IndividualIndex::Publish(uint64_t commit_timestamp) {
-  status_.commit(commit_timestamp);
+  status_.Commit(commit_timestamp);
   memgraph::metrics::IncrementCounter(memgraph::metrics::ActiveEdgeTypeIndices);
 }
 
 InMemoryEdgeTypeIndex::IndividualIndex::~IndividualIndex() {
-  if (status_.is_ready()) {
+  if (status_.IsReady()) {
     memgraph::metrics::DecrementCounter(memgraph::metrics::ActiveEdgeTypeIndices);
   }
 }
@@ -183,7 +183,7 @@ bool InMemoryEdgeTypeIndex::ActiveIndices::IndexReady(memgraph::storage::EdgeTyp
   auto const &indices = ptr_->indices_;
   auto it = indices.find(edge_type);
   if (it == indices.end()) return false;
-  return it->second->status_.is_ready();
+  return it->second->status_.IsReady();
 }
 
 bool InMemoryEdgeTypeIndex::ActiveIndices::IndexRegistered(EdgeTypeId edge_type) const {
@@ -194,7 +194,7 @@ std::vector<EdgeTypeId> InMemoryEdgeTypeIndex::ActiveIndices::ListIndices(uint64
   auto ret = std::vector<EdgeTypeId>{};
   ret.reserve(ptr_->indices_.size());
   for (auto const &[edge_type, index] : ptr_->indices_) {
-    if (index->status_.is_visible(start_timestamp)) {
+    if (index->status_.IsVisible(start_timestamp)) {
       ret.emplace_back(edge_type);
     }
   }

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -17,55 +17,119 @@
 #include "storage/v2/inmemory/storage.hpp"
 #include "utils/counter.hpp"
 
+namespace r = ranges;
+namespace rv = r::views;
+
 namespace memgraph::storage {
 
-bool InMemoryEdgeTypeIndex::CreateIndex(EdgeTypeId edge_type, utils::SkipList<Vertex>::Accessor vertices,
-                                        std::optional<SnapshotObserverInfo> const &snapshot_info) {
-  auto [it, emplaced] = index_.try_emplace(edge_type);
-  if (!emplaced) {
-    return false;
+bool InMemoryEdgeTypeIndex::CreateIndexOnePass(EdgeTypeId edge_type, utils::SkipList<Vertex>::Accessor vertices,
+                                               std::optional<SnapshotObserverInfo> const &snapshot_info) {
+  auto res = RegisterIndex(edge_type);
+  if (!res) return false;
+  auto res2 = PopulateIndex(edge_type, std::move(vertices), snapshot_info);
+  if (res2.HasError()) {
+    MG_ASSERT(false, "Index population can't fail, there was no cancellation callback.");
+  }
+  return PublishIndex(edge_type, 0);
+}
+
+auto InMemoryEdgeTypeIndex::PopulateIndex(EdgeTypeId edge_type, utils::SkipList<Vertex>::Accessor vertices,
+                                          std::optional<SnapshotObserverInfo> const &snapshot_info,
+                                          Transaction const *tx, CheckCancelFunction cancel_check) const
+    -> utils::BasicResult<IndexPopulateError> {
+  auto index = GetIndividualIndex(edge_type);
+  if (!index) {
+    MG_ASSERT(false, "It should not be possible to remove the index before populating it.");
   }
 
-  utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
-  try {
-    auto edge_acc = it->second.access();
-    for (auto &from_vertex : vertices) {
-      if (from_vertex.deleted) {
-        continue;
-      }
+  auto const accessor_factory = [&] { return index->skip_list_.access(); };
 
-      for (auto &edge : from_vertex.out_edges) {
-        const auto type = std::get<kEdgeTypeIdPos>(edge);
-        if (type == edge_type) {
-          auto *to_vertex = std::get<kVertexPos>(edge);
-          if (to_vertex->deleted) {
-            continue;
-          }
-          edge_acc.insert({&from_vertex, to_vertex, std::get<kEdgeRefPos>(edge).ptr, 0});
-          if (snapshot_info) {
-            snapshot_info->Update(UpdateType::EDGES);
-          }
+  // TODO: ATM this is not MVCC
+  auto edge_acc = accessor_factory();
+  for (auto &from_vertex : vertices) {
+    if (from_vertex.deleted) {
+      continue;
+    }
+
+    for (auto &edge : from_vertex.out_edges) {
+      const auto type = std::get<kEdgeTypeIdPos>(edge);
+      if (type == edge_type) {
+        auto *to_vertex = std::get<kVertexPos>(edge);
+        if (to_vertex->deleted) {
+          continue;
+        }
+        edge_acc.insert({&from_vertex, to_vertex, std::get<kEdgeRefPos>(edge).ptr, 0});
+        if (snapshot_info) {
+          snapshot_info->Update(UpdateType::EDGES);
         }
       }
     }
-  } catch (const utils::OutOfMemoryException &) {
-    utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_exception_blocker;
-    index_.erase(it);
-    throw;
   }
+  return {};
+}
 
+bool InMemoryEdgeTypeIndex::RegisterIndex(EdgeTypeId edge_type) {
+  return index_.WithLock([&](std::shared_ptr<IndicesContainer const> &indices_container) {
+    auto const &indices = indices_container->indices_;
+    auto it = indices.find(edge_type);
+    if (it != indices.end()) return false;  // already exists
+
+    utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
+    // Register
+    auto new_container = std::make_shared<IndicesContainer>(*indices_container);
+    new_container->indices_.emplace(edge_type, std::make_shared<IndividualIndex>());
+    indices_container = new_container;
+    return true;
+  });
+}
+
+bool InMemoryEdgeTypeIndex::PublishIndex(EdgeTypeId edge_type, uint64_t commit_timestamp) {
+  auto index = GetIndividualIndex(edge_type);
+  if (!index) return false;
+  index->Publish(commit_timestamp);
   return true;
 }
 
-bool InMemoryEdgeTypeIndex::DropIndex(EdgeTypeId edge_type) { return index_.erase(edge_type) > 0; }
+void InMemoryEdgeTypeIndex::IndividualIndex::Publish(uint64_t commit_timestamp) {
+  status_.commit(commit_timestamp);
+  memgraph::metrics::IncrementCounter(memgraph::metrics::ActiveEdgeTypeIndices);
+}
 
-bool InMemoryEdgeTypeIndex::IndexExists(EdgeTypeId edge_type) const { return index_.find(edge_type) != index_.end(); }
+InMemoryEdgeTypeIndex::IndividualIndex::~IndividualIndex() {
+  if (status_.is_ready()) {
+    memgraph::metrics::IncrementCounter(memgraph::metrics::ActiveEdgeTypeIndices);
+  }
+}
 
-std::vector<EdgeTypeId> InMemoryEdgeTypeIndex::ListIndices() const {
-  std::vector<EdgeTypeId> ret;
-  ret.reserve(index_.size());
-  for (const auto &item : index_) {
-    ret.push_back(item.first);
+bool InMemoryEdgeTypeIndex::DropIndex(EdgeTypeId edge_type) {
+  return index_.WithLock([&](std::shared_ptr<IndicesContainer const> &indices_container) {
+    auto const it = indices_container->indices_.find(edge_type);
+    if (it == indices_container->indices_.cend()) return false;
+
+    auto new_container = std::make_shared<IndicesContainer>(*indices_container);
+    new_container->indices_.erase(edge_type);
+    indices_container = new_container;
+    return true;
+  });
+}
+
+bool InMemoryEdgeTypeIndex::ActiveIndices::IndexReady(memgraph::storage::EdgeTypeId edge_type) const {
+  auto const &indices = ptr_->indices_;
+  auto it = indices.find(edge_type);
+  if (it == indices.end()) return false;
+  return it->second->status_.is_ready();
+}
+bool InMemoryEdgeTypeIndex::ActiveIndices::IndexRegistered(EdgeTypeId edge_type) const {
+  return ptr_->indices_.find(edge_type) != ptr_->indices_.end();
+}
+
+std::vector<EdgeTypeId> InMemoryEdgeTypeIndex::ActiveIndices::ListIndices(uint64_t start_timestamp) const {
+  auto ret = std::vector<EdgeTypeId>{};
+  ret.reserve(ptr_->indices_.size());
+  for (auto const &[edge_type, index] : ptr_->indices_) {
+    if (index->status_.is_visible(start_timestamp)) {
+      ret.emplace_back(edge_type);
+    }
   }
   return ret;
 }
@@ -73,10 +137,11 @@ std::vector<EdgeTypeId> InMemoryEdgeTypeIndex::ListIndices() const {
 void InMemoryEdgeTypeIndex::RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token) {
   auto maybe_stop = utils::ResettableCounter(2048);
 
-  for (auto &[_, et_index] : index_) {
+  auto cpy = index_.WithReadLock(std::identity{});
+  for (auto &[_, et_index] : cpy->indices_) {
     if (token.stop_requested()) return;
 
-    auto edges_acc = et_index.access();
+    auto edges_acc = et_index->skip_list_.access();
     for (auto it = edges_acc.begin(); it != edges_acc.end();) {
       if (maybe_stop() && token.stop_requested()) return;
 
@@ -107,48 +172,52 @@ void InMemoryEdgeTypeIndex::RemoveObsoleteEntries(uint64_t oldest_active_start_t
   }
 }
 
-uint64_t InMemoryEdgeTypeIndex::ApproximateEdgeCount(EdgeTypeId edge_type) const {
-  if (auto it = index_.find(edge_type); it != index_.end()) {
-    return it->second.size();
+uint64_t InMemoryEdgeTypeIndex::ActiveIndices::ApproximateEdgeCount(EdgeTypeId edge_type) const {
+  if (auto it = ptr_->indices_.find(edge_type); it != ptr_->indices_.end()) {
+    return it->second->skip_list_.size();
   }
   return 0;
 }
 
-void InMemoryEdgeTypeIndex::AbortEntries(EdgeTypeIndex::AbortableInfo const &info, uint64_t exact_start_timestamp) {
+void InMemoryEdgeTypeIndex::ActiveIndices::AbortEntries(EdgeTypeIndex::AbortableInfo const &info,
+                                                        uint64_t exact_start_timestamp) {
   for (auto const &[edge_type, edges] : info) {
-    auto const it = index_.find(edge_type);
-    DMG_ASSERT(it != index_.end());
+    auto const it = ptr_->indices_.find(edge_type);
+    DMG_ASSERT(it != ptr_->indices_.end());
 
     auto &index_storage = it->second;
-    auto acc = index_storage.access();
+    auto acc = index_storage->skip_list_.access();
     for (const auto &[from_vertex, to_vertex, edge] : edges) {
       acc.remove(Entry{from_vertex, to_vertex, edge, exact_start_timestamp});
     }
   }
 }
 
-void InMemoryEdgeTypeIndex::UpdateOnEdgeCreation(Vertex *from, Vertex *to, EdgeRef edge_ref, EdgeTypeId edge_type,
-                                                 const Transaction &tx) {
-  auto it = index_.find(edge_type);
-  if (it == index_.end()) {
+void InMemoryEdgeTypeIndex::ActiveIndices::UpdateOnEdgeCreation(Vertex *from, Vertex *to, EdgeRef edge_ref,
+                                                                EdgeTypeId edge_type, const Transaction &tx) {
+  auto it = ptr_->indices_.find(edge_type);
+  if (it == ptr_->indices_.end()) {
     return;
   }
-  auto acc = it->second.access();
+  auto acc = it->second->skip_list_.access();
   acc.insert(Entry{from, to, edge_ref.ptr, tx.start_timestamp});
 }
 
-void InMemoryEdgeTypeIndex::UpdateOnEdgeModification(Vertex *old_from, Vertex *old_to, Vertex *new_from, Vertex *new_to,
-                                                     EdgeRef edge_ref, EdgeTypeId edge_type, const Transaction &tx) {
-  auto it = index_.find(edge_type);
-  if (it == index_.end()) {
+void InMemoryEdgeTypeIndex::ActiveIndices::UpdateOnEdgeModification(Vertex *old_from, Vertex *old_to, Vertex *new_from,
+                                                                    Vertex *new_to, EdgeRef edge_ref,
+                                                                    EdgeTypeId edge_type, const Transaction &tx) {
+  auto it = ptr_->indices_.find(edge_type);
+  if (it == ptr_->indices_.end()) {
     return;
   }
 
-  auto acc = it->second.access();
+  auto acc = it->second->skip_list_.access();
   acc.insert(Entry{new_from, new_to, edge_ref.ptr, tx.start_timestamp});
 }
 
-void InMemoryEdgeTypeIndex::DropGraphClearIndices() { index_.clear(); }
+void InMemoryEdgeTypeIndex::DropGraphClearIndices() {
+  index_.WithLock([](std::shared_ptr<IndicesContainer const> &index) { index = std::make_shared<IndicesContainer>(); });
+}
 
 InMemoryEdgeTypeIndex::Iterable::Iterable(utils::SkipList<Entry>::Accessor index_accessor,
                                           utils::SkipList<Vertex>::ConstAccessor vertex_accessor,
@@ -203,27 +272,45 @@ void InMemoryEdgeTypeIndex::Iterable::Iterator::AdvanceUntilValid() {
 }
 
 void InMemoryEdgeTypeIndex::RunGC() {
-  for (auto &index_entry : index_) {
-    index_entry.second.run_gc();
+  auto cpy = index_.WithReadLock(std::identity{});
+  for (auto &[edge_type, index] : cpy->indices_) {
+    index->skip_list_.run_gc();
   }
 }
 
-InMemoryEdgeTypeIndex::Iterable InMemoryEdgeTypeIndex::Edges(EdgeTypeId edge_type, View view, Storage *storage,
-                                                             Transaction *transaction) {
-  const auto it = index_.find(edge_type);
-  MG_ASSERT(it != index_.end(), "Index for edge-type {} doesn't exist", edge_type.AsUint());
+InMemoryEdgeTypeIndex::Iterable InMemoryEdgeTypeIndex::ActiveIndices::Edges(EdgeTypeId edge_type, View view,
+                                                                            Storage *storage,
+                                                                            Transaction *transaction) {
+  const auto it = ptr_->indices_.find(edge_type);
+  MG_ASSERT(it != ptr_->indices_.end(), "Index for edge-type {} doesn't exist", edge_type.AsUint());
   auto vertex_acc = static_cast<InMemoryStorage const *>(storage)->vertices_.access();
   auto edge_acc = static_cast<InMemoryStorage const *>(storage)->edges_.access();
-  return {it->second.access(), std::move(vertex_acc), std::move(edge_acc), edge_type, view, storage, transaction};
+  return {it->second->skip_list_.access(),
+          std::move(vertex_acc),
+          std::move(edge_acc),
+          edge_type,
+          view,
+          storage,
+          transaction};
 }
 
-EdgeTypeIndex::AbortProcessor InMemoryEdgeTypeIndex::GetAbortProcessor() const {
-  std::vector<EdgeTypeId> res;
-  res.reserve(index_.size());
-  for (const auto &[edge_type, _] : index_) {
-    res.emplace_back(edge_type);
-  }
-  return AbortProcessor{res};
+EdgeTypeIndex::AbortProcessor InMemoryEdgeTypeIndex::ActiveIndices::GetAbortProcessor() const {
+  auto edge_type_filter = ptr_->indices_ | std::views::keys | ranges::to_vector;
+  return AbortProcessor{std::move(edge_type_filter)};
+}
+
+auto InMemoryEdgeTypeIndex::GetActiveIndices() const -> std::unique_ptr<EdgeTypeIndex::ActiveIndices> {
+  return std::make_unique<ActiveIndices>(index_.WithReadLock(std::identity{}));
+}
+
+auto InMemoryEdgeTypeIndex::GetIndividualIndex(EdgeTypeId edge_type) const -> std::shared_ptr<IndividualIndex> {
+  return index_.WithReadLock(
+      [&](std::shared_ptr<IndicesContainer const> const &index) -> std::shared_ptr<IndividualIndex> {
+        auto it = index->indices_.find(edge_type);
+        if (it == index->indices_.cend()) [[unlikely]]
+          return {};
+        return it->second;
+      });
 }
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -44,7 +44,7 @@ auto InMemoryEdgeTypeIndex::PopulateIndex(EdgeTypeId edge_type, utils::SkipList<
 
   auto const accessor_factory = [&] { return index->skip_list_.access(); };
 
-  // TODO: ATM this is not MVCC
+  // TODO: ATM this is not MVCC or parallel
   auto edge_acc = accessor_factory();
   for (auto &from_vertex : vertices) {
     if (from_vertex.deleted) {

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -56,7 +56,7 @@ inline void TryInsertEdgeTypeIndex(Vertex &from_vertex, EdgeTypeId edge_type, au
   }
   // Create and drop index will always use snapshot isolation
   if (delta) {
-    ApplyDeltasForRead(&tx, delta, View::OLD, [&](const Delta &delta) {
+    ApplyDeltasForRead(&tx, delta, View::NEW /*NEW becasue of auto indexing*/, [&](const Delta &delta) {
       // clang-format off
       DeltaDispatch(delta, utils::ChainedOverloaded{
         Exists_ActionMethod(exists),

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -137,6 +137,7 @@ bool InMemoryEdgeTypeIndex::RegisterIndex(EdgeTypeId edge_type) {
     // Register
     auto new_container = std::make_shared<IndicesContainer>(*indices_container);
     auto [new_it, _] = new_container->indices_.emplace(edge_type, std::make_shared<IndividualIndex>());
+    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
     all_indexes_.WithLock([&](auto &all_indexes) { all_indexes.emplace_back(new_it->second); });
     indices_container = new_container;
     return true;

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -144,7 +144,7 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
   bool RegisterIndex(EdgeTypeId edge_type);
   auto PopulateIndex(EdgeTypeId edge_type, utils::SkipList<Vertex>::Accessor vertices,
                      std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt,
-                     Transaction const *tx = nullptr, CheckCancelFunction cancel_check = neverCancel) const
+                     Transaction const *tx = nullptr, CheckCancelFunction cancel_check = neverCancel)
       -> utils::BasicResult<IndexPopulateError>;
 
   bool PublishIndex(EdgeTypeId edge_type, uint64_t commit_timestamp);

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -111,7 +111,8 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
 
  public:
   struct ActiveIndices : storage::EdgeTypeIndex::ActiveIndices {
-    explicit ActiveIndices(std::shared_ptr<IndicesContainer const> indices) : ptr_{std::move(indices)} {}
+    explicit ActiveIndices(std::shared_ptr<IndicesContainer const> indices = std::make_shared<IndicesContainer>())
+        : ptr_{std::move(indices)} {}
 
     bool IndexReady(EdgeTypeId edge_type) const override;
 

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -157,11 +157,6 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
 
   void DropGraphClearIndices() override;
 
-  // TODO: move?
-  static constexpr std::size_t kEdgeTypeIdPos = 0U;
-  static constexpr std::size_t kVertexPos = 1U;
-  static constexpr std::size_t kEdgeRefPos = 2U;
-
   void RunGC();
 
   auto GetActiveIndices() const -> std::unique_ptr<EdgeTypeIndex::ActiveIndices> override;

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -44,15 +44,15 @@ bool InMemoryEdgeTypePropertyIndex::CreateIndex(EdgeTypeId edge_type, PropertyId
       }
 
       for (auto &edge : from_vertex.out_edges) {
-        const auto type = std::get<kEdgeTypeIdPos>(edge);
+        const auto type = std::get<EdgeTypeId>(edge);
         if (type != edge_type) {
           continue;
         }
-        auto *to_vertex = std::get<kVertexPos>(edge);
+        auto *to_vertex = std::get<Vertex *>(edge);
         if (to_vertex->deleted) {
           continue;
         }
-        auto *edge_ptr = std::get<kEdgeRefPos>(edge).ptr;
+        auto *edge_ptr = std::get<EdgeRef>(edge).ptr;
         edge_acc.insert({edge_ptr->properties.GetProperty(property), &from_vertex, to_vertex, edge_ptr, 0});
         if (snapshot_info) {
           snapshot_info->Update(UpdateType::EDGES);

--- a/src/storage/v2/inmemory/edge_type_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.hpp
@@ -97,10 +97,6 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
     return stats;
   }
 
-  static constexpr std::size_t kEdgeTypeIdPos = 0U;
-  static constexpr std::size_t kVertexPos = 1U;
-  static constexpr std::size_t kEdgeRefPos = 2U;
-
   class Iterable {
    public:
     Iterable(utils::SkipList<Entry>::Accessor index_accessor, utils::SkipList<Vertex>::ConstAccessor vertex_accessor,

--- a/src/storage/v2/inmemory/label_index.cpp
+++ b/src/storage/v2/inmemory/label_index.cpp
@@ -36,12 +36,14 @@ bool InMemoryLabelIndex::CreateIndex(
     return false;
   }
 
-  auto const func = [&](Vertex &vertex, auto &index_accessor) { TryInsertLabelIndex(vertex, label, index_accessor); };
+  auto const func = [&](Vertex &vertex, auto &index_accessor) {
+    TryInsertLabelIndex(vertex, label, index_accessor, snapshot_info);
+  };
 
   if (parallel_exec_info) {
-    CreateIndexOnMultipleThreads(vertices, it, index_, *parallel_exec_info, func, snapshot_info);
+    CreateIndexOnMultipleThreads(vertices, it, index_, *parallel_exec_info, func);
   } else {
-    CreateIndexOnSingleThread(vertices, it, index_, func, snapshot_info);
+    CreateIndexOnSingleThread(vertices, it, index_, func);
   }
 
   return true;

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -265,7 +265,6 @@ bool InMemoryLabelPropertyIndex::CreateIndexOnePass(
   if (res2.HasError()) {
     MG_ASSERT(false, "Index population can't fail, there was no cancellation callback.");
   }
-  // Invalidate plans?
   return PublishIndex(label, properties, 0);
 }
 

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -203,6 +203,11 @@ bool InMemoryLabelPropertyIndex::Entry::operator==(std::vector<PropertyValue> co
 inline void TryInsertLabelPropertiesIndex(Vertex &vertex, LabelId label, PropertiesPermutationHelper const &props,
                                           auto &&index_accessor,
                                           std::optional<SnapshotObserverInfo> const &snapshot_info) {
+  // observe regardless
+  if (snapshot_info) {
+    snapshot_info->Update(UpdateType::VERTICES);
+  }
+
   if (vertex.deleted || !utils::Contains(vertex.labels, label)) {
     return;
   }
@@ -215,16 +220,17 @@ inline void TryInsertLabelPropertiesIndex(Vertex &vertex, LabelId label, Propert
   // Using 0 as a timestamp is fine because the index is created at timestamp x
   // and any query using the index will be > x.
   index_accessor.insert({props.ApplyPermutation(std::move(values)), &vertex, 0});
-
-  if (snapshot_info) {
-    snapshot_info->Update(UpdateType::VERTICES);
-  }
 }
 
 inline void TryInsertLabelPropertiesIndex(Vertex &vertex, LabelId label, PropertiesPermutationHelper const &props,
                                           auto &&index_accessor,
                                           std::optional<SnapshotObserverInfo> const &snapshot_info,
                                           Transaction const &tx) {
+  // observe regardless
+  if (snapshot_info) {
+    snapshot_info->Update(UpdateType::VERTICES);
+  }
+
   bool exists = true;
   bool deleted = false;
   Delta *delta = nullptr;
@@ -260,10 +266,6 @@ inline void TryInsertLabelPropertiesIndex(Vertex &vertex, LabelId label, Propert
   }
 
   index_accessor.insert({props.ApplyPermutation(std::move(properties)), &vertex, tx.start_timestamp});
-
-  if (snapshot_info) {
-    snapshot_info->Update(UpdateType::VERTICES);
-  }
 }
 
 bool InMemoryLabelPropertyIndex::CreateIndexOnePass(

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -16,6 +16,7 @@
 #include "storage/v2/common_function_signatures.hpp"
 #include "storage/v2/durability/recovery_type.hpp"
 #include "storage/v2/id_types.hpp"
+#include "storage/v2/indices/errors.hpp"
 #include "storage/v2/indices/label_property_index.hpp"
 #include "storage/v2/indices/label_property_index_stats.hpp"
 #include "storage/v2/inmemory/indices_mvcc.hpp"
@@ -25,10 +26,6 @@
 #include "utils/synchronized.hpp"
 
 namespace memgraph::storage {
-
-enum class IndexPopulateError {
-  Cancellation,
-};
 
 class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
  private:

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1540,7 +1540,9 @@ utils::BasicResult<StorageIndexDefinitionError, void> InMemoryStorage::InMemoryA
 
 utils::BasicResult<StorageIndexDefinitionError, void> InMemoryStorage::InMemoryAccessor::DropIndex(
     EdgeTypeId edge_type, DropIndexWrapper wrapper) {
-  MG_ASSERT(type() == UNIQUE, "Drop index requires a unique access to the storage!");
+  // Because of replication we still use UNIQUE ATM
+  MG_ASSERT(type() == UNIQUE || type() == READ,
+            "Dropping edge-type index requires a unique or read access to the storage!");
   auto *in_memory = static_cast<InMemoryStorage *>(storage_);
   auto *mem_edge_type_index = static_cast<InMemoryEdgeTypeIndex *>(in_memory->indices_.edge_type_index_.get());
   // Done inside the wrapper to ensure plan cache invalidation is safe

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1318,9 +1318,11 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
     if (flags::AreExperimentsEnabled(flags::Experiments::TEXT_SEARCH)) {
       storage_->indices_.text_index_.Rollback();
     }
+    // TODO: abort processor
     for (auto const &[edge_type_property, edge] : edge_type_property_cleanup) {
       storage_->indices_.AbortEntries(edge_type_property, edge, transaction_.start_timestamp);
     }
+    // TODO: missing Global edge property aborts
     for (auto const &[label_prop, vertices] : vector_label_property_cleanup) {
       storage_->indices_.vector_index_.AbortEntries(label_prop, vertices);
     }

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -373,8 +373,8 @@ class InMemoryStorage final : public Storage {
     /// * `ReplicationError`:  there is at least one SYNC replica that has not confirmed receiving the transaction.
     /// * `IndexDefinitionError`: the index already exists.
     /// @throw std::bad_alloc
-    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(EdgeTypeId edge_type,
-                                                                      PropertyId property) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
+        EdgeTypeId edge_type, PropertyId property, PublishIndexWrapper wrapper = publish_no_wrap) override;
 
     /// Create an index.
     /// Returns void if the index has been created.
@@ -382,7 +382,8 @@ class InMemoryStorage final : public Storage {
     /// * `ReplicationError`:  there is at least one SYNC replica that has not confirmed receiving the transaction.
     /// * `IndexDefinitionError`: the index already exists.
     /// @throw std::bad_alloc
-    utils::BasicResult<StorageIndexDefinitionError, void> CreateGlobalEdgeIndex(PropertyId property) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> CreateGlobalEdgeIndex(
+        PropertyId property, PublishIndexWrapper wrapper = publish_no_wrap) override;
 
     /// Drop an existing index.
     /// Returns void if the index has been dropped.
@@ -406,21 +407,24 @@ class InMemoryStorage final : public Storage {
     /// Returns `StorageIndexDefinitionError` if an error occures. Error can be:
     /// * `ReplicationError`:  there is at least one SYNC replica that has not confirmed receiving the transaction.
     /// * `IndexDefinitionError`: the index does not exist.
-    utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(EdgeTypeId edge_type) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(EdgeTypeId edge_type,
+                                                                    DropIndexWrapper wrapper = drop_no_wrap) override;
 
     /// Drop an existing index.
     /// Returns void if the index has been dropped.
     /// Returns `StorageIndexDefinitionError` if an error occures. Error can be:
     /// * `ReplicationError`:  there is at least one SYNC replica that has not confirmed receiving the transaction.
     /// * `IndexDefinitionError`: the index does not exist.
-    utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(EdgeTypeId edge_type, PropertyId property) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(EdgeTypeId edge_type, PropertyId property,
+                                                                    DropIndexWrapper wrapper = drop_no_wrap) override;
 
     /// Drop an existing index.
     /// Returns void if the index has been dropped.
     /// Returns `StorageIndexDefinitionError` if an error occures. Error can be:
     /// * `ReplicationError`:  there is at least one SYNC replica that has not confirmed receiving the transaction.
     /// * `IndexDefinitionError`: the index does not exist.
-    utils::BasicResult<StorageIndexDefinitionError, void> DropGlobalEdgeIndex(PropertyId property) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> DropGlobalEdgeIndex(
+        PropertyId property, DropIndexWrapper wrapper = drop_no_wrap) override;
 
     utils::BasicResult<StorageIndexDefinitionError, void> CreatePointIndex(storage::LabelId label,
                                                                            storage::PropertyId property) override;

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -226,7 +226,7 @@ class InMemoryStorage final : public Storage {
     uint64_t ApproximateEdgeCount() const override { return storage_->edge_count_.load(std::memory_order_acquire); }
 
     uint64_t ApproximateEdgeCount(EdgeTypeId edge_type) const override {
-      return storage_->indices_.edge_type_index_->ApproximateEdgeCount(edge_type);
+      return transaction_.active_indices_.edge_type_->ApproximateEdgeCount(edge_type);
     }
 
     uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property) const override {
@@ -302,8 +302,8 @@ class InMemoryStorage final : public Storage {
       return transaction_.active_indices_.label_properties_->IndexReady(label, properties);
     }
 
-    bool EdgeTypeIndexExists(EdgeTypeId edge_type) const override {
-      return storage_->indices_.edge_type_index_->IndexExists(edge_type);
+    bool EdgeTypeIndexReady(EdgeTypeId edge_type) const override {
+      return transaction_.active_indices_.edge_type_->IndexReady(edge_type);
     }
 
     bool EdgeTypePropertyIndexExists(EdgeTypeId edge_type, PropertyId property) const override {
@@ -363,8 +363,9 @@ class InMemoryStorage final : public Storage {
     /// * `ReplicationError`:  there is at least one SYNC replica that has not confirmed receiving the transaction.
     /// * `IndexDefinitionError`: the index already exists.
     /// @throw std::bad_alloc
-    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(EdgeTypeId edge_type,
-                                                                      bool unique_access_needed = true) override;
+    utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
+        EdgeTypeId edge_type, bool unique_access_needed = true, CheckCancelFunction cancel_check = neverCancel,
+        PublishIndexWrapper wrapper = publish_no_wrap) override;
 
     /// Create an index.
     /// Returns void if the index has been created.

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -427,10 +427,11 @@ class Storage {
         EdgeTypeId edge_type, bool unique_access_needed = true, CheckCancelFunction cancel_check = neverCancel,
         PublishIndexWrapper wrapper = publish_no_wrap) = 0;
 
-    virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(EdgeTypeId edge_type,
-                                                                              PropertyId property) = 0;
+    virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
+        EdgeTypeId edge_type, PropertyId property, PublishIndexWrapper wrapper = publish_no_wrap) = 0;
 
-    virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateGlobalEdgeIndex(PropertyId property) = 0;
+    virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateGlobalEdgeIndex(
+        PropertyId property, PublishIndexWrapper wrapper = publish_no_wrap) = 0;
 
     virtual utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(
         LabelId label, DropIndexWrapper wrapper = drop_no_wrap) = 0;
@@ -438,12 +439,14 @@ class Storage {
     virtual utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(
         LabelId label, std::vector<storage::PropertyPath> &&properties, DropIndexWrapper wrapper = drop_no_wrap) = 0;
 
-    virtual utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(EdgeTypeId edge_type) = 0;
+    virtual utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(
+        EdgeTypeId edge_type, DropIndexWrapper wrapper = drop_no_wrap) = 0;
 
-    virtual utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(EdgeTypeId edge_type,
-                                                                            PropertyId property) = 0;
+    virtual utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(
+        EdgeTypeId edge_type, PropertyId property, DropIndexWrapper wrapper = drop_no_wrap) = 0;
 
-    virtual utils::BasicResult<StorageIndexDefinitionError, void> DropGlobalEdgeIndex(PropertyId property) = 0;
+    virtual utils::BasicResult<StorageIndexDefinitionError, void> DropGlobalEdgeIndex(
+        PropertyId property, DropIndexWrapper wrapper = drop_no_wrap) = 0;
 
     virtual utils::BasicResult<storage::StorageIndexDefinitionError, void> CreatePointIndex(
         storage::LabelId label, storage::PropertyId property) = 0;

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -37,6 +37,7 @@ extern const Event SnapshotCreationLatency_us;
 
 extern const Event ActiveLabelIndices;
 extern const Event ActiveLabelPropertyIndices;
+extern const Event ActiveEdgeTypeIndices;
 extern const Event ActivePointIndices;
 extern const Event ActiveTextIndices;
 extern const Event ActiveVectorIndices;
@@ -339,7 +340,7 @@ class Storage {
       return transaction_.active_indices_.label_properties_->RelevantLabelPropertiesIndicesInfo(labels, properties);
     };
 
-    virtual bool EdgeTypeIndexExists(EdgeTypeId edge_type) const = 0;
+    virtual bool EdgeTypeIndexReady(EdgeTypeId edge_type) const = 0;
 
     virtual bool EdgeTypePropertyIndexExists(EdgeTypeId edge_type, PropertyId property) const = 0;
 
@@ -422,8 +423,9 @@ class Storage {
         LabelId label, PropertiesPaths properties, CheckCancelFunction cancel_check = neverCancel,
         PublishIndexWrapper wrapper = publish_no_wrap) = 0;
 
-    virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(EdgeTypeId edge_type,
-                                                                              bool unique_access_needed = true) = 0;
+    virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
+        EdgeTypeId edge_type, bool unique_access_needed = true, CheckCancelFunction cancel_check = neverCancel,
+        PublishIndexWrapper wrapper = publish_no_wrap) = 0;
 
     virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(EdgeTypeId edge_type,
                                                                               PropertyId property) = 0;
@@ -654,7 +656,10 @@ class Storage {
   }
 
   auto GetActiveIndices() const -> ActiveIndices {
-    return ActiveIndices{indices_.label_property_index_->GetActiveIndices()};
+    return ActiveIndices{
+        indices_.label_property_index_->GetActiveIndices(),
+        indices_.edge_type_index_->GetActiveIndices(),
+    };
   }
 
   // TODO: make non-public

--- a/src/storage/v2/vertex.hpp
+++ b/src/storage/v2/vertex.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -38,8 +38,10 @@ struct Vertex {
 
   utils::small_vector<LabelId> labels;
 
-  utils::small_vector<std::tuple<EdgeTypeId, Vertex *, EdgeRef>> in_edges;
-  utils::small_vector<std::tuple<EdgeTypeId, Vertex *, EdgeRef>> out_edges;
+  using EdgeTriple = std::tuple<EdgeTypeId, Vertex *, EdgeRef>;
+
+  utils::small_vector<EdgeTriple> in_edges;
+  utils::small_vector<EdgeTriple> out_edges;
 
   PropertyStore properties;
   mutable utils::RWSpinLock lock;

--- a/src/storage/v2/vertex_info_helpers.hpp
+++ b/src/storage/v2/vertex_info_helpers.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -156,6 +156,43 @@ inline auto Edges_ActionMethod(utils::small_vector<std::tuple<EdgeTypeId, Vertex
       return false;
     return true;
   };
+
+  // clang-format off
+  using enum Delta::Action;
+  return utils::Overloaded{
+      ActionMethod <(dir == EdgeDirection::IN) ? ADD_IN_EDGE : ADD_OUT_EDGE> (
+          [&, predicate](Delta const &delta) {
+              if (!predicate(delta)) return;
+              // Add the edge because we don't see the removal.
+              auto link = std::tuple{delta.vertex_edge.edge_type, delta.vertex_edge.vertex, delta.vertex_edge.edge};
+              /// NOTE: For in_memory_storage, link should never exist but for on_disk storage it is possible that
+              /// after edge deletion, in the same txn, user requests loading from disk. Then edge will already exist
+              /// in out_edges struct.
+              auto link_exists = std::find(edges.begin(), edges.end(), link) != edges.end();
+              if (!link_exists) {
+                edges.push_back(link);
+              }
+          }
+      ),
+      ActionMethod <(dir == EdgeDirection::IN) ? REMOVE_IN_EDGE : REMOVE_OUT_EDGE> (
+          [&, predicate](Delta const &delta) {
+              if (!predicate(delta)) return;
+              // Remove the label because we don't see the addition.
+              auto it = std::find(edges.begin(), edges.end(),
+                            std::tuple{delta.vertex_edge.edge_type, delta.vertex_edge.vertex, delta.vertex_edge.edge});
+              DMG_ASSERT(it != edges.end(), "Invalid database state!");
+              *it = edges.back();
+              edges.pop_back();
+          }
+      )
+  };
+  // clang-format on
+}
+
+template <EdgeDirection dir>
+inline auto Edges_ActionMethod(utils::small_vector<std::tuple<EdgeTypeId, Vertex *, EdgeRef>> &edges,
+                               EdgeTypeId edge_type) {
+  auto const predicate = [&](Delta const &delta) { return delta.vertex_edge.edge_type == edge_type; };
 
   // clang-format off
   using enum Delta::Action;

--- a/src/utils/event_counter.cpp
+++ b/src/utils/event_counter.cpp
@@ -82,6 +82,7 @@
                                                                                                                        \
   M(ActiveLabelIndices, Index, "Number of active label indices in the system.")                                        \
   M(ActiveLabelPropertyIndices, Index, "Number of active label property indices in the system.")                       \
+  M(ActiveEdgeTypeIndices, Index, "Number of active edge type indices in the system.")                                 \
   M(ActivePointIndices, Index, "Number of active point indices in the system.")                                        \
   M(ActiveTextIndices, Index, "Number of active text indices in the system.")                                          \
   M(ActiveVectorIndices, Index, "Number of active vector indices in the system.")                                      \

--- a/tests/e2e/show_metrics/show_metrics.py
+++ b/tests/e2e/show_metrics/show_metrics.py
@@ -118,6 +118,7 @@ def test_all_show_metrics_info_values_are_present(memgraph):
         {"name": "WalFilesRpc_us_50p", "type": "HighAvailability", "metric type": "Histogram"},
         {"name": "WalFilesRpc_us_90p", "type": "HighAvailability", "metric type": "Histogram"},
         {"name": "WalFilesRpc_us_99p", "type": "HighAvailability", "metric type": "Histogram"},
+        {"name": "ActiveEdgeTypeIndices", "type": "Index", "metric type": "Counter"},
         {"name": "ActiveLabelIndices", "type": "Index", "metric type": "Counter"},
         {"name": "ActiveLabelPropertyIndices", "type": "Index", "metric type": "Counter"},
         {"name": "ActivePointIndices", "type": "Index", "metric type": "Counter"},

--- a/tests/manual/interactive_planning.cpp
+++ b/tests/manual/interactive_planning.cpp
@@ -354,7 +354,7 @@ class InteractiveDbAccessor {
     return label_property_index_.at(key);
   }
 
-  bool EdgeTypeIndexExists(memgraph::storage::EdgeTypeId edge_type_id) { return true; }
+  bool EdgeTypeIndexReady(memgraph::storage::EdgeTypeId edge_type_id) { return true; }
 
   bool EdgeTypePropertyIndexExists(memgraph::storage::EdgeTypeId edge_type_id,
                                    memgraph::storage::PropertyId property_id) {

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -1364,7 +1364,7 @@ TYPED_TEST(InterpreterTest, IndexInfoNotifications) {
 
     auto notification = notifications[0].ValueMap();
     ASSERT_EQ(notification["severity"].ValueString(), "INFO");
-    ASSERT_EQ(notification["code"].ValueString(), "CreateIndex");
+    ASSERT_EQ(notification["code"].ValueString(), "CreateIndexOnePass");
     ASSERT_EQ(notification["title"].ValueString(), "Created index on label Person on properties .");
     ASSERT_EQ(notification["description"].ValueString(), "");
   }
@@ -1377,7 +1377,7 @@ TYPED_TEST(InterpreterTest, IndexInfoNotifications) {
 
     auto notification = notifications[0].ValueMap();
     ASSERT_EQ(notification["severity"].ValueString(), "INFO");
-    ASSERT_EQ(notification["code"].ValueString(), "CreateIndex");
+    ASSERT_EQ(notification["code"].ValueString(), "CreateIndexOnePass");
     ASSERT_EQ(notification["title"].ValueString(), "Created index on label Person on properties id.");
     ASSERT_EQ(notification["description"].ValueString(), "");
   }

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -1364,7 +1364,7 @@ TYPED_TEST(InterpreterTest, IndexInfoNotifications) {
 
     auto notification = notifications[0].ValueMap();
     ASSERT_EQ(notification["severity"].ValueString(), "INFO");
-    ASSERT_EQ(notification["code"].ValueString(), "CreateIndexOnePass");
+    ASSERT_EQ(notification["code"].ValueString(), "CreateIndex");
     ASSERT_EQ(notification["title"].ValueString(), "Created index on label Person on properties .");
     ASSERT_EQ(notification["description"].ValueString(), "");
   }
@@ -1377,7 +1377,7 @@ TYPED_TEST(InterpreterTest, IndexInfoNotifications) {
 
     auto notification = notifications[0].ValueMap();
     ASSERT_EQ(notification["severity"].ValueString(), "INFO");
-    ASSERT_EQ(notification["code"].ValueString(), "CreateIndexOnePass");
+    ASSERT_EQ(notification["code"].ValueString(), "CreateIndex");
     ASSERT_EQ(notification["title"].ValueString(), "Created index on label Person on properties id.");
     ASSERT_EQ(notification["description"].ValueString(), "");
   }

--- a/tests/unit/query_plan_checker.hpp
+++ b/tests/unit/query_plan_checker.hpp
@@ -754,7 +754,7 @@ class FakeDbAccessor {
     return res;
   }
 
-  bool EdgeTypeIndexExists(memgraph::storage::EdgeTypeId edge_type) const {
+  bool EdgeTypeIndexReady(memgraph::storage::EdgeTypeId edge_type) const {
     return edge_type_index_.find(edge_type) != edge_type_index_.end();
   }
 

--- a/tests/unit/snapshot_rpc_progress.cpp
+++ b/tests/unit/snapshot_rpc_progress.cpp
@@ -401,7 +401,7 @@ TEST_F(SnapshotRpcProgressTest, TestEdgeTypeIndexSingleThreadedNoVertices) {
   snapshot_info.emplace(mocked_observer, 3);
 
   EXPECT_CALL(*mocked_observer, Update()).Times(0);
-  ASSERT_TRUE(etype_idx.CreateIndex(etype, vertices.access(), snapshot_info));
+  ASSERT_TRUE(etype_idx.CreateIndexOnePass(etype, vertices.access(), snapshot_info));
 }
 
 TEST_F(SnapshotRpcProgressTest, TestEdgeTypeIndexSingleThreadedVerticesEdges) {
@@ -424,7 +424,7 @@ TEST_F(SnapshotRpcProgressTest, TestEdgeTypeIndexSingleThreadedVerticesEdges) {
   snapshot_info.emplace(mocked_observer, 3);
 
   EXPECT_CALL(*mocked_observer, Update()).Times(3);
-  ASSERT_TRUE(etype_idx.CreateIndex(etype, vertices.access(), snapshot_info));
+  ASSERT_TRUE(etype_idx.CreateIndexOnePass(etype, vertices.access(), snapshot_info));
 }
 
 TEST_F(SnapshotRpcProgressTest, TestEdgeTypePropertyIndexSingleThreadedNoVertices) {

--- a/tests/unit/storage_v2_durability_inmemory.cpp
+++ b/tests/unit/storage_v2_durability_inmemory.cpp
@@ -438,9 +438,9 @@ class DurabilityTest : public ::testing::TestWithParam<bool> {
   void CreateEdgeIndex(memgraph::storage::Storage *store, memgraph::storage::EdgeTypeId edge_type) {
     {
       // Create edge-type index.
-      auto unique_acc = store->UniqueAccess();
-      ASSERT_FALSE(unique_acc->CreateIndex(edge_type).HasError());
-      ASSERT_FALSE(unique_acc->Commit().HasError());
+      auto read_only_acc = store->ReadOnlyAccess();
+      ASSERT_FALSE(read_only_acc->CreateIndex(edge_type).HasError());
+      ASSERT_FALSE(read_only_acc->Commit().HasError());
     }
   }
 

--- a/tests/unit/storage_v2_indices.cpp
+++ b/tests/unit/storage_v2_indices.cpp
@@ -2052,7 +2052,7 @@ TYPED_TEST(IndexTest, EdgeTypeIndexCreate) {
   if constexpr ((std::is_same_v<TypeParam, memgraph::storage::InMemoryStorage>)) {
     {
       auto acc = this->storage->Access();
-      EXPECT_FALSE(acc->EdgeTypeIndexExists(this->edge_type_id1));
+      EXPECT_FALSE(acc->EdgeTypeIndexReady(this->edge_type_id1));
       EXPECT_EQ(acc->ListAllIndices().edge_type.size(), 0);
       EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_type_id1), 0);
     }
@@ -2065,18 +2065,18 @@ TYPED_TEST(IndexTest, EdgeTypeIndexCreate) {
         this->CreateEdge(&vertex_from, &vertex_to, i % 2 ? this->edge_type_id1 : this->edge_type_id2, acc.get());
       }
       ASSERT_NO_ERROR(acc->Commit());
-      EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_type_id1), 0);
     }
 
     {
       auto unique_acc = this->storage->UniqueAccess();
+      EXPECT_EQ(unique_acc->ApproximateEdgeCount(this->edge_type_id1), 0);
       EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
-      EXPECT_EQ(unique_acc->ApproximateEdgeCount(this->edge_type_id1), 5);
     }
 
     {
       auto acc = this->storage->Access();
+      EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_type_id1), 5);
       EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, View::OLD), View::OLD),
                   UnorderedElementsAre(1, 3, 5, 7, 9));
       EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, View::NEW), View::NEW),
@@ -2209,7 +2209,7 @@ TYPED_TEST(IndexTest, EdgeTypeIndexDrop) {
   if constexpr ((std::is_same_v<TypeParam, memgraph::storage::InMemoryStorage>)) {
     {
       auto acc = this->storage->Access();
-      EXPECT_FALSE(acc->EdgeTypeIndexExists(this->edge_type_id1));
+      EXPECT_FALSE(acc->EdgeTypeIndexReady(this->edge_type_id1));
       EXPECT_EQ(acc->ListAllIndices().edge_type.size(), 0);
     }
 
@@ -2242,11 +2242,11 @@ TYPED_TEST(IndexTest, EdgeTypeIndexDrop) {
       auto unique_acc = this->storage->UniqueAccess();
       EXPECT_FALSE(unique_acc->DropIndex(this->edge_type_id1).HasError());
       ASSERT_NO_ERROR(unique_acc->Commit());
-      EXPECT_EQ(unique_acc->ApproximateEdgeCount(this->edge_type_id1), 0);
     }
     {
       auto acc = this->storage->Access();
-      EXPECT_FALSE(acc->EdgeTypeIndexExists(this->edge_type_id1));
+      EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_type_id1), 0);
+      EXPECT_FALSE(acc->EdgeTypeIndexReady(this->edge_type_id1));
       EXPECT_EQ(acc->ListAllIndices().edge_type.size(), 0);
       EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_type_id1), 0);
     }
@@ -2268,7 +2268,7 @@ TYPED_TEST(IndexTest, EdgeTypeIndexDrop) {
     }
     {
       auto acc = this->storage->Access();
-      EXPECT_TRUE(acc->EdgeTypeIndexExists(this->edge_type_id1));
+      EXPECT_TRUE(acc->EdgeTypeIndexReady(this->edge_type_id1));
       EXPECT_THAT(acc->ListAllIndices().edge_type, UnorderedElementsAre(this->edge_type_id1));
     }
 

--- a/tests/unit/storage_v2_indices.cpp
+++ b/tests/unit/storage_v2_indices.cpp
@@ -2068,10 +2068,10 @@ TYPED_TEST(IndexTest, EdgeTypeIndexCreate) {
     }
 
     {
-      auto unique_acc = this->storage->UniqueAccess();
-      EXPECT_EQ(unique_acc->ApproximateEdgeCount(this->edge_type_id1), 0);
-      EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1).HasError());
-      ASSERT_NO_ERROR(unique_acc->Commit());
+      auto read_only_acc = this->storage->ReadOnlyAccess();
+      EXPECT_EQ(read_only_acc->ApproximateEdgeCount(this->edge_type_id1), 0);
+      EXPECT_FALSE(read_only_acc->CreateIndex(this->edge_type_id1).HasError());
+      ASSERT_NO_ERROR(read_only_acc->Commit());
     }
 
     {
@@ -2224,9 +2224,9 @@ TYPED_TEST(IndexTest, EdgeTypeIndexDrop) {
     }
 
     {
-      auto unique_acc = this->storage->UniqueAccess();
-      EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1).HasError());
-      ASSERT_NO_ERROR(unique_acc->Commit());
+      auto read_only_acc = this->storage->ReadOnlyAccess();
+      EXPECT_FALSE(read_only_acc->CreateIndex(this->edge_type_id1).HasError());
+      ASSERT_NO_ERROR(read_only_acc->Commit());
     }
 
     {
@@ -2239,9 +2239,9 @@ TYPED_TEST(IndexTest, EdgeTypeIndexDrop) {
     }
 
     {
-      auto unique_acc = this->storage->UniqueAccess();
-      EXPECT_FALSE(unique_acc->DropIndex(this->edge_type_id1).HasError());
-      ASSERT_NO_ERROR(unique_acc->Commit());
+      auto drop_acc = this->DropIndexAccessor();
+      EXPECT_FALSE(drop_acc->DropIndex(this->edge_type_id1).HasError());
+      ASSERT_NO_ERROR(drop_acc->Commit());
     }
     {
       auto acc = this->storage->Access();
@@ -2262,9 +2262,9 @@ TYPED_TEST(IndexTest, EdgeTypeIndexDrop) {
     }
 
     {
-      auto unique_acc = this->storage->UniqueAccess();
-      EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1).HasError());
-      ASSERT_NO_ERROR(unique_acc->Commit());
+      auto read_only_acc = this->storage->ReadOnlyAccess();
+      EXPECT_FALSE(read_only_acc->CreateIndex(this->edge_type_id1).HasError());
+      ASSERT_NO_ERROR(read_only_acc->Commit());
     }
     {
       auto acc = this->storage->Access();
@@ -2299,14 +2299,14 @@ TYPED_TEST(IndexTest, EdgeTypeIndexBasic) {
   // 3. Delete even numbered edges.
   if constexpr ((std::is_same_v<TypeParam, memgraph::storage::InMemoryStorage>)) {
     {
-      auto unique_acc = this->storage->UniqueAccess();
-      EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1).HasError());
-      ASSERT_NO_ERROR(unique_acc->Commit());
+      auto read_only_acc = this->storage->ReadOnlyAccess();
+      EXPECT_FALSE(read_only_acc->CreateIndex(this->edge_type_id1).HasError());
+      ASSERT_NO_ERROR(read_only_acc->Commit());
     }
     {
-      auto unique_acc = this->storage->UniqueAccess();
-      EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id2).HasError());
-      ASSERT_NO_ERROR(unique_acc->Commit());
+      auto read_only_acc = this->storage->ReadOnlyAccess();
+      EXPECT_FALSE(read_only_acc->CreateIndex(this->edge_type_id2).HasError());
+      ASSERT_NO_ERROR(read_only_acc->Commit());
     }
 
     auto acc = this->storage->Access();
@@ -2373,14 +2373,14 @@ TYPED_TEST(IndexTest, EdgeTypeIndexTransactionalIsolation) {
   if constexpr ((std::is_same_v<TypeParam, memgraph::storage::InMemoryStorage>)) {
     // Check that transactions only see entries they are supposed to see.
     {
-      auto unique_acc = this->storage->UniqueAccess();
-      EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1).HasError());
-      ASSERT_NO_ERROR(unique_acc->Commit());
+      auto read_only_acc = this->storage->ReadOnlyAccess();
+      EXPECT_FALSE(read_only_acc->CreateIndex(this->edge_type_id1).HasError());
+      ASSERT_NO_ERROR(read_only_acc->Commit());
     }
     {
-      auto unique_acc = this->storage->UniqueAccess();
-      EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id2).HasError());
-      ASSERT_NO_ERROR(unique_acc->Commit());
+      auto read_only_acc = this->storage->ReadOnlyAccess();
+      EXPECT_FALSE(read_only_acc->CreateIndex(this->edge_type_id2).HasError());
+      ASSERT_NO_ERROR(read_only_acc->Commit());
     }
 
     auto acc_before = this->storage->Access();
@@ -2417,14 +2417,14 @@ TYPED_TEST(IndexTest, EdgeTypeIndexTransactionalIsolation) {
 TYPED_TEST(IndexTest, EdgeTypeIndexCountEstimate) {
   if constexpr ((std::is_same_v<TypeParam, memgraph::storage::InMemoryStorage>)) {
     {
-      auto unique_acc = this->storage->UniqueAccess();
-      EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1).HasError());
-      ASSERT_NO_ERROR(unique_acc->Commit());
+      auto read_only_acc = this->storage->ReadOnlyAccess();
+      EXPECT_FALSE(read_only_acc->CreateIndex(this->edge_type_id1).HasError());
+      ASSERT_NO_ERROR(read_only_acc->Commit());
     }
     {
-      auto unique_acc = this->storage->UniqueAccess();
-      EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id2).HasError());
-      ASSERT_NO_ERROR(unique_acc->Commit());
+      auto read_only_acc = this->storage->ReadOnlyAccess();
+      EXPECT_FALSE(read_only_acc->CreateIndex(this->edge_type_id2).HasError());
+      ASSERT_NO_ERROR(read_only_acc->Commit());
     }
 
     auto acc = this->storage->Access();
@@ -2443,9 +2443,9 @@ TYPED_TEST(IndexTest, EdgeTypeIndexCountEstimate) {
 TYPED_TEST(IndexTest, EdgeTypeIndexRepeatingEdgeTypesBetweenSameVertices) {
   if constexpr ((std::is_same_v<TypeParam, memgraph::storage::InMemoryStorage>)) {
     {
-      auto unique_acc = this->storage->UniqueAccess();
-      EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1).HasError());
-      ASSERT_NO_ERROR(unique_acc->Commit());
+      auto read_only_acc = this->storage->ReadOnlyAccess();
+      EXPECT_FALSE(read_only_acc->CreateIndex(this->edge_type_id1).HasError());
+      ASSERT_NO_ERROR(read_only_acc->Commit());
     }
 
     auto acc = this->storage->Access();

--- a/tests/unit/storage_v2_wal_file.cpp
+++ b/tests/unit/storage_v2_wal_file.cpp
@@ -47,7 +47,9 @@ class DeltaGenerator final {
                        gen->storage_mode_, false, false,
                        memgraph::storage::PointIndexStorage{}.CreatePointIndexContext(),
                        memgraph::storage::ActiveIndices{
-                           std::make_unique<memgraph::storage::InMemoryLabelPropertyIndex::ActiveIndices>()}) {}
+                           std::make_unique<memgraph::storage::InMemoryLabelPropertyIndex::ActiveIndices>(),
+                           std::make_unique<memgraph::storage::InMemoryEdgeTypeIndex::ActiveIndices>(),
+                       }) {}
 
    public:
     memgraph::storage::Vertex *CreateVertex() {


### PR DESCRIPTION
Split edge type index creation into phases
- Register (requires read-only access)
- Populate (drop down to read access)
- Publish (can be used for planning)

This allows for concurrent index queries, allowing for index population to happen while also allowing read/write queries to happen at the same time.

Extra capability:
- Plan cache invalidation only when index has been populated
- Can now terminate index creation