### PR TITLE
Use deltas' timestamp instead of wal.to_timestamp

### DIFF
--- a/src/replication_handler/replication_handler.cpp
+++ b/src/replication_handler/replication_handler.cpp
@@ -284,6 +284,7 @@ bool ReplicationHandler::DoToMainPromotion(const utils::UUID &main_uuid, bool fo
 
     // STEP 3) We are now MAIN, update storage local epoch
     const auto &epoch = std::get<replication::RoleMainData>(locked_repl_state->ReplicationData()).epoch_;
+    spdlog::trace("New epoch is {}", epoch.id());
     dbms_handler_.ForEach([&](dbms::DatabaseAccess db_acc) {
       auto *storage = db_acc->storage();
       storage->repl_storage_state_.epoch_ = epoch;

--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -582,19 +582,12 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
         spdlog::trace("1st wal file {} has sequence number {} which is != 0.", first_wal.path, first_wal.seq_num);
         // We don't have all WAL files. We need to see whether we need them all.
         if (!snapshot_timestamp) {
-          // We didn't recover from a snapshot and we must have all WAL files
+          // We didn't recover from a snapshot, and we must have all WAL files
           // starting from the first one (seq_num == 0) to be able to recover
           // data from them.
           LOG_FATAL(
               "There are missing prefix WAL files and data can't be "
               "recovered without them!");
-        } else if (first_wal.from_timestamp > *snapshot_timestamp) {
-          // We recovered from a snapshot and we must have at least one WAL file
-          // that has at least one delta that was created before the snapshot in order to
-          // verify that nothing is missing from the beginning of the WAL chain.
-          LOG_FATAL(
-              "You must have at least one WAL file that contains at least one "
-              "delta that was created before the snapshot file!");
         }
       }
     }

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -162,6 +162,7 @@ void ReplicationStorageClient::UpdateReplicaState(Storage *main_storage, Databas
           client_.name_, main_db_name, epoch_info_iter->first, epoch_info_iter->second);
     }
   }
+
   if (branching_point) {
     auto log_error = [replica_name = client_.name_]() {
       spdlog::error(
@@ -204,6 +205,7 @@ void ReplicationStorageClient::UpdateReplicaState(Storage *main_storage, Databas
 #endif
     return;
   }
+
   // No branching point
   // Lock engine lock in order to read main_storage timestamp and synchronize with any active commits
   auto engine_lock = std::unique_lock{main_storage->engine_lock_};

--- a/tests/jepsen/src/memgraph/high_availability/create/test.clj
+++ b/tests/jepsen/src/memgraph/high_availability/create/test.clj
@@ -611,7 +611,7 @@
                (gen/mix [show-instances-reads add-nodes])))))
 
 (defn workload
-  "Basic HA workload."
+  "The basic HA workload."
   [opts]
   (let [nodes-config (:nodes-config opts)
         db (:db opts)

--- a/tests/jepsen/src/memgraph/high_availability/create/test.clj
+++ b/tests/jepsen/src/memgraph/high_availability/create/test.clj
@@ -606,7 +606,7 @@
    (gen/phases
     (gen/once setup-cluster)
     (gen/sleep 5)
-    ; (gen/once create-unique-constraint)
+    (gen/once create-unique-constraint)
     (gen/delay delay-requests-sec
                (gen/mix [show-instances-reads add-nodes])))))
 


### PR DESCRIPTION
When WAL file is used during the restart, instead of setting ldt to wal.to_timestamp, we track which deltas were applied. 
The LOG_FATAL is removed since that property doesn't hold anymore for STRICT_SYNC replicas.