### PR TITLE
Rename `date.py` so it can co-exist with MAGE `date.py`

### DIFF
--- a/config/mappings.json
+++ b/config/mappings.json
@@ -24,5 +24,5 @@
     "apoc.refactor.cloneSubgraph": "refactor.clone_subgraph",
     "apoc.refactor.cloneSubgraphFromPath": "refactor.clone_subgraph_from_path",
     "apoc.label.exists": "label.exists",
-    "apoc.date.convertFormat": "date.convert_format"
+    "apoc.date.convertFormat": "chrono.convert_format"
 }

--- a/query_modules/CMakeLists.txt
+++ b/query_modules/CMakeLists.txt
@@ -97,7 +97,7 @@ set(PYTHON_QUERY_MODULES_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/nxalg.py
     ${CMAKE_CURRENT_SOURCE_DIR}/wcc.py
     ${CMAKE_CURRENT_SOURCE_DIR}/mgps.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/date.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/chrono.py
 )
 add_custom_target(copy_python_query_modules ALL
     COMMAND ${CMAKE_COMMAND} -E copy ${PYTHON_QUERY_MODULES_FILES} ${QUERY_MODULES_BUILD_DIR}
@@ -117,6 +117,6 @@ install(FILES mgp_networkx.py DESTINATION lib/memgraph/query_modules)
 install(FILES nxalg.py DESTINATION lib/memgraph/query_modules)
 install(FILES wcc.py DESTINATION lib/memgraph/query_modules)
 install(FILES mgps.py DESTINATION lib/memgraph/query_modules)
-install(FILES date.py DESTINATION lib/memgraph/query_modules)
+install(FILES chrono.py DESTINATION lib/memgraph/query_modules)
 
 # IMPORTANT: when adding enterprise module add its name to kEnterpriseModuleList in src/query/procedure/module.cpp

--- a/query_modules/chrono.py
+++ b/query_modules/chrono.py
@@ -4,6 +4,13 @@ from zoneinfo import ZoneInfo
 
 import mgp
 
+# TODO(colinbarry) This file has been renamed to `chrono.py` from `date.py`
+# because we already have `date.py` in the MAGE query modules repo. Having
+# matching names means that installing all the query modules in one place gives
+# us either the Memgraph `date.py` or the MAGE `date.py`, depending on copy
+# order. Once we have a monorepo, this code can be combined with the existing
+# `date.py`.
+
 
 class FormatLength(IntEnum):
     """Enum for various date/time format lengths to replace magic numbers"""

--- a/tests/e2e/graphql/callable_alias_mapping.json
+++ b/tests/e2e/graphql/callable_alias_mapping.json
@@ -1,6 +1,6 @@
 {
     "dbms.components": "mgps.components",
     "apoc.util.validate": "mgps.validate",
-    "apoc.date.convertFormat": "date.convert_format",
+    "apoc.date.convertFormat": "chrono.convert_format",
     "apoc.util.validatePredicate": "mgps.validate_predicate"
 }

--- a/tests/query_modules/date_test/convert_format/test.yml
+++ b/tests/query_modules/date_test/convert_format/test.yml
@@ -1,109 +1,109 @@
 - query: >-
-    RETURN date.convert_format('2011-12-03T10:15:30+01:00[Europe/Paris]', 'iso_zoned_date_time', 'iso_offset_date_time') AS output;
+    RETURN chrono.convert_format('2011-12-03T10:15:30+01:00[Europe/Paris]', 'iso_zoned_date_time', 'iso_offset_date_time') AS output;
   output:
     - output: "2011-12-03T10:15:30+01:00"
 
 - query: >-
-    RETURN date.convert_format('2011-12-03T10:15:30+01:00', 'iso_offset_date_time', 'iso_zoned_date_time') AS output;
+    RETURN chrono.convert_format('2011-12-03T10:15:30+01:00', 'iso_offset_date_time', 'iso_zoned_date_time') AS output;
   output:
     - output: "2011-12-03T10:15:30+01:00"
 
 - query: >-
-    RETURN date.convert_format('20111203', 'basic_iso_date', 'iso_local_date') AS output;
+    RETURN chrono.convert_format('20111203', 'basic_iso_date', 'iso_local_date') AS output;
   output:
     - output: "2011-12-03"
 
 - query: >-
-    RETURN date.convert_format('2011-12-03', 'iso_local_date', 'basic_iso_date') AS output;
+    RETURN chrono.convert_format('2011-12-03', 'iso_local_date', 'basic_iso_date') AS output;
   output:
     - output: "20111203"
 
 - query: >-
-    RETURN date.convert_format('2011-12-03+01:00', 'iso_offset_date', 'iso_local_date') AS output;
+    RETURN chrono.convert_format('2011-12-03+01:00', 'iso_offset_date', 'iso_local_date') AS output;
   output:
     - output: "2011-12-03"
 
 - query: >-
-    RETURN date.convert_format('2011-12-03+01:00', 'iso_offset_date', 'basic_iso_date') AS output;
+    RETURN chrono.convert_format('2011-12-03+01:00', 'iso_offset_date', 'basic_iso_date') AS output;
   output:
     - output: "20111203"
 
 - query: >-
-    RETURN date.convert_format('10:15:30', 'iso_local_time', 'iso_offset_time') AS output;
+    RETURN chrono.convert_format('10:15:30', 'iso_local_time', 'iso_offset_time') AS output;
   output:
     - output: "10:15:30+00:00"
 
 - query: >-
-    RETURN date.convert_format('10:15:30+01:00', 'iso_offset_time', 'iso_local_time') AS output;
+    RETURN chrono.convert_format('10:15:30+01:00', 'iso_offset_time', 'iso_local_time') AS output;
   output:
     - output: "10:15:30"
 
 - query: >-
-    RETURN date.convert_format('2011-12-03T10:15:30', 'iso_local_date_time', 'iso_local_date') AS output;
+    RETURN chrono.convert_format('2011-12-03T10:15:30', 'iso_local_date_time', 'iso_local_date') AS output;
   output:
     - output: "2011-12-03"
 
 - query: >-
-    RETURN date.convert_format('2011-12-03T10:15:30', 'iso_local_date_time', 'iso_local_time') AS output;
+    RETURN chrono.convert_format('2011-12-03T10:15:30', 'iso_local_date_time', 'iso_local_time') AS output;
   output:
     - output: "10:15:30"
 
 - query: >-
-    RETURN date.convert_format('2011-12-03T10:15:30', 'iso_local_date_time', 'basic_iso_date') AS output;
+    RETURN chrono.convert_format('2011-12-03T10:15:30', 'iso_local_date_time', 'basic_iso_date') AS output;
   output:
     - output: "20111203"
 
 - query: >-
-    RETURN date.convert_format('2011-12-03T10:15:30+01:00', 'iso_offset_date_time', 'iso_local_date_time') AS output;
+    RETURN chrono.convert_format('2011-12-03T10:15:30+01:00', 'iso_offset_date_time', 'iso_local_date_time') AS output;
   output:
     - output: "2011-12-03T10:15:30"
 
 - query: >-
-    RETURN date.convert_format('2011-12-03T10:15:30+01:00', 'iso_offset_date_time', 'iso_offset_date') AS output;
+    RETURN chrono.convert_format('2011-12-03T10:15:30+01:00', 'iso_offset_date_time', 'iso_offset_date') AS output;
   output:
     - output: "2011-12-03+01:00"
 
 - query: >-
-    RETURN date.convert_format('2011-12-03T10:15:30+01:00', 'iso_offset_date_time', 'iso_offset_time') AS output;
+    RETURN chrono.convert_format('2011-12-03T10:15:30+01:00', 'iso_offset_date_time', 'iso_offset_time') AS output;
   output:
     - output: "10:15:30+01:00"
 
 - query: >-
-    RETURN date.convert_format('2011-12-03T10:15:30+01:00[Europe/Paris]', 'iso_zoned_date_time', 'iso_local_date') AS output;
+    RETURN chrono.convert_format('2011-12-03T10:15:30+01:00[Europe/Paris]', 'iso_zoned_date_time', 'iso_local_date') AS output;
   output:
     - output: "2011-12-03"
 
 - query: >-
-    RETURN date.convert_format('2011-12-03T10:15:30+01:00[Europe/Paris]', 'iso_zoned_date_time', 'iso_local_date_time') AS output;
+    RETURN chrono.convert_format('2011-12-03T10:15:30+01:00[Europe/Paris]', 'iso_zoned_date_time', 'iso_local_date_time') AS output;
   output:
     - output: "2011-12-03T10:15:30"
 
 - query: >-
-    RETURN date.convert_format('2011-12-03T10:15:30+01:00[Europe/Paris]', 'iso_zoned_date_time', 'basic_iso_date') AS output;
+    RETURN chrono.convert_format('2011-12-03T10:15:30+01:00[Europe/Paris]', 'iso_zoned_date_time', 'basic_iso_date') AS output;
   output:
     - output: "20111203"
 
 - query: >-
-    RETURN date.convert_format('2011-12-03', 'iso_date', 'basic_iso_date') AS output;
+    RETURN chrono.convert_format('2011-12-03', 'iso_date', 'basic_iso_date') AS output;
   output:
     - output: "20111203"
 
 - query: >-
-    RETURN date.convert_format('2011-12-03+01:00', 'iso_date', 'iso_local_date') AS output;
+    RETURN chrono.convert_format('2011-12-03+01:00', 'iso_date', 'iso_local_date') AS output;
   output:
     - output: "2011-12-03"
 
 - query: >-
-    RETURN date.convert_format('10:15:30+01:00', 'iso_time', 'iso_offset_time') AS output;
+    RETURN chrono.convert_format('10:15:30+01:00', 'iso_time', 'iso_offset_time') AS output;
   output:
     - output: "10:15:30+01:00"
 
 - query: >-
-    RETURN date.convert_format('20111203', 'basic_iso_date', 'iso_offset_date') AS output;
+    RETURN chrono.convert_format('20111203', 'basic_iso_date', 'iso_offset_date') AS output;
   output:
     - output: "2011-12-03+00:00"
 
 - query: >-
-    RETURN date.convert_format('2011-12-03T10:15:30', 'iso_local_date_time', 'iso_offset_date_time') AS output;
+    RETURN chrono.convert_format('2011-12-03T10:15:30', 'iso_local_date_time', 'iso_offset_date_time') AS output;
   output:
     - output: "2011-12-03T10:15:30+00:00"


### PR DESCRIPTION
Rename Memgraph's `date.py` query module to `mg_date.py` to avoid a name collision with the MAGE module with the same name. (Once we have a monorepo, these two files can be combined into a single `date.py`.)