### PR TITLE
Non blocking edge type property and global property index

### DIFF
--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -314,8 +314,8 @@ class DbAccessor final {
                      plan::PointDistanceCondition condition) -> PointIterable;
 
   auto PointVertices(storage::LabelId label, storage::PropertyId property, storage::CoordinateReferenceSystem crs,
-                     TypedValue const &bottom_left, TypedValue const &top_right, plan::WithinBBoxCondition condition)
-      -> PointIterable;
+                     TypedValue const &bottom_left, TypedValue const &top_right,
+                     plan::WithinBBoxCondition condition) -> PointIterable;
 
   EdgesIterable Edges(storage::View view, storage::EdgeTypeId edge_type) {
     return EdgesIterable(accessor_->Edges(edge_type, view));
@@ -503,8 +503,8 @@ class DbAccessor final {
 
   bool EdgeTypeIndexReady(storage::EdgeTypeId edge_type) const { return accessor_->EdgeTypeIndexReady(edge_type); }
 
-  bool EdgeTypePropertyIndexExists(storage::EdgeTypeId edge_type, storage::PropertyId property) const {
-    return accessor_->EdgeTypePropertyIndexExists(edge_type, property);
+  bool EdgeTypePropertyIndexReady(storage::EdgeTypeId edge_type, storage::PropertyId property) const {
+    return accessor_->EdgeTypePropertyIndexReady(edge_type, property);
   }
 
   bool EdgePropertyIndexExists(storage::PropertyId property) const {
@@ -664,8 +664,9 @@ class DbAccessor final {
 
   utils::BasicResult<storage::StorageIndexDefinitionError, void> CreateIndex(
       storage::EdgeTypeId edge_type, storage::PropertyId property,
+      storage::CheckCancelFunction cancel_check = storage::neverCancel,
       storage::PublishIndexWrapper wrapper = storage::publish_no_wrap) {
-    return accessor_->CreateIndex(edge_type, property, std::move(wrapper));
+    return accessor_->CreateIndex(edge_type, property, std::move(cancel_check), std::move(wrapper));
   }
 
   utils::BasicResult<storage::StorageIndexDefinitionError, void> CreateGlobalEdgeIndex(
@@ -768,8 +769,8 @@ class DbAccessor final {
 
   auto ShowEnums() { return accessor_->ShowEnums(); }
 
-  auto GetEnumValue(std::string_view name, std::string_view value) const
-      -> utils::BasicResult<storage::EnumStorageError, storage::Enum> {
+  auto GetEnumValue(std::string_view name,
+                    std::string_view value) const -> utils::BasicResult<storage::EnumStorageError, storage::Enum> {
     return accessor_->GetEnumValue(name, value);
   }
   auto GetEnumValue(std::string_view enum_str) -> utils::BasicResult<storage::EnumStorageError, storage::Enum> {
@@ -780,13 +781,13 @@ class DbAccessor final {
     return accessor_->GetEnumStoreShared().ToString(value);
   }
 
-  auto EnumAlterAdd(std::string_view name, std::string_view value)
-      -> utils::BasicResult<storage::EnumStorageError, storage::Enum> {
+  auto EnumAlterAdd(std::string_view name,
+                    std::string_view value) -> utils::BasicResult<storage::EnumStorageError, storage::Enum> {
     return accessor_->EnumAlterAdd(name, value);
   }
 
-  auto EnumAlterUpdate(std::string_view name, std::string_view old_value, std::string_view new_value)
-      -> utils::BasicResult<storage::EnumStorageError, storage::Enum> {
+  auto EnumAlterUpdate(std::string_view name, std::string_view old_value,
+                       std::string_view new_value) -> utils::BasicResult<storage::EnumStorageError, storage::Enum> {
     return accessor_->EnumAlterUpdate(name, old_value, new_value);
   }
 

--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -507,8 +507,8 @@ class DbAccessor final {
     return accessor_->EdgeTypePropertyIndexReady(edge_type, property);
   }
 
-  bool EdgePropertyIndexExists(storage::PropertyId property) const {
-    return accessor_->EdgePropertyIndexExists(property);
+  bool EdgePropertyIndexReady(storage::PropertyId property) const {
+    return accessor_->EdgePropertyIndexReady(property);
   }
 
   bool TextIndexExists(const std::string &index_name) const { return accessor_->TextIndexExists(index_name); }

--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -670,8 +670,9 @@ class DbAccessor final {
   }
 
   utils::BasicResult<storage::StorageIndexDefinitionError, void> CreateGlobalEdgeIndex(
-      storage::PropertyId property, storage::PublishIndexWrapper wrapper = storage::publish_no_wrap) {
-    return accessor_->CreateGlobalEdgeIndex(property, std::move(wrapper));
+      storage::PropertyId property, storage::CheckCancelFunction cancel_check = storage::neverCancel,
+      storage::PublishIndexWrapper wrapper = storage::publish_no_wrap) {
+    return accessor_->CreateGlobalEdgeIndex(property, std::move(cancel_check), std::move(wrapper));
   }
 
   utils::BasicResult<storage::StorageIndexDefinitionError, void> DropIndex(

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3460,7 +3460,7 @@ PreparedQuery PrepareEdgeIndexQuery(ParsedQuery parsed_query, bool in_explicit_t
           } else if (properties.empty()) {
             return dba->CreateIndex(edge_type, std::move(cancel_check), std::move(plan_invalidator_builder));
           }
-          return dba->CreateIndex(edge_type, properties[0], make_create_index_cancel_callback(stopping_context),
+          return dba->CreateIndex(edge_type, properties[0], std::move(cancel_check),
                                   std::move(plan_invalidator_builder));
         });
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -885,14 +885,21 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
         // If the license is not valid we create users with admin access
         if (!valid_enterprise_license) {
           spdlog::warn("Granting all the privileges to {}.", username);
-          auth->GrantPrivilege(username, kPrivilegesAll
+          auth->GrantPrivilege(
+              username, kPrivilegesAll
 #ifdef MG_ENTERPRISE
-                               ,
-                               {{{AuthQuery::FineGrainedPrivilege::CREATE_DELETE, {query::kAsterisk}}}},
-                               {{{AuthQuery::FineGrainedPrivilege::CREATE_DELETE, {query::kAsterisk}}}}
+              ,
+              {{{AuthQuery::FineGrainedPrivilege::CREATE_DELETE, {query::kAsterisk}}}},
+              {
+                {
+                  {
+                    AuthQuery::FineGrainedPrivilege::CREATE_DELETE, { query::kAsterisk }
+                  }
+                }
+              }
 #endif
-                               ,
-                               &*interpreter->system_transaction_);
+              ,
+              &*interpreter->system_transaction_);
         }
 
         return std::vector<std::vector<TypedValue>>();
@@ -2467,8 +2474,8 @@ auto DetermineTxTimeout(std::optional<int64_t> tx_timeout_ms, InterpreterConfig 
   return TxTimeout{};
 }
 
-auto CreateTimeoutTimer(QueryExtras const &extras,
-                        InterpreterConfig const &config) -> std::shared_ptr<utils::AsyncTimer> {
+auto CreateTimeoutTimer(QueryExtras const &extras, InterpreterConfig const &config)
+    -> std::shared_ptr<utils::AsyncTimer> {
   if (auto const timeout = DetermineTxTimeout(extras.tx_timeout, config)) {
     return std::make_shared<utils::AsyncTimer>(timeout.ValueUnsafe().count());
   }
@@ -3135,11 +3142,11 @@ std::vector<std::vector<TypedValue>> AnalyzeGraphQueryHandler::AnalyzeGraphDelet
   std::vector<std::vector<TypedValue>> results;
   results.reserve(label_results.size() + label_prop_results.size());
 
-  std::transform(label_results.begin(), label_results.end(), std::back_inserter(results),
-                 [execution_db_accessor](const auto &label_index) {
-                   return std::vector<TypedValue>{TypedValue(execution_db_accessor->LabelToName(label_index)),
-                                                  TypedValue("")};
-                 });
+  std::transform(
+      label_results.begin(), label_results.end(), std::back_inserter(results),
+      [execution_db_accessor](const auto &label_index) {
+        return std::vector<TypedValue>{TypedValue(execution_db_accessor->LabelToName(label_index)), TypedValue("")};
+      });
 
   auto const prop_path_to_name = [&](storage::PropertyPath const &property_path) {
     return TypedValue{PropertyPathToName(execution_db_accessor, property_path)};
@@ -3231,7 +3238,7 @@ struct DoNothing {
 // We need to atomically invalidate the plan when publishing new index
 auto make_create_index_plan_invalidator_builder(memgraph::dbms::DatabaseAccess db_acc) {
   // capture DatabaseAccess in builder
-  return [db_acc = std::move(db_acc)]<InvocableWithUInt64 Func = DoNothing>(Func &&publish_func = Func{}) {
+  return [db_acc = std::move(db_acc)]<InvocableWithUInt64 Func = DoNothing>(Func && publish_func = Func{}) {
     // build plan invalidator wrapper
     return [db_acc = std::move(db_acc),
             publish_func = std::forward<Func>(publish_func)](uint64_t commit_timestamp) mutable {
@@ -3246,7 +3253,7 @@ auto make_create_index_plan_invalidator_builder(memgraph::dbms::DatabaseAccess d
 
 auto make_drop_index_plan_invalidator_builder(memgraph::dbms::DatabaseAccess db_acc) {
   // capture DatabaseAccess in builder
-  return [db_acc = std::move(db_acc)]<std::invocable Func = DoNothing>(Func &&publish_func = Func{}) {
+  return [db_acc = std::move(db_acc)]<std::invocable Func = DoNothing>(Func && publish_func = Func{}) {
     // build plan invalidator wrapper
     return [db_acc = std::move(db_acc), publish_func = std::forward<Func>(publish_func)]() mutable {
       return db_acc->plan_cache()->WithLock([&](auto &cache) {
@@ -3418,7 +3425,7 @@ PreparedQuery PrepareEdgeIndexQuery(ParsedQuery parsed_query, bool in_explicit_t
   }
 
   if (properties.size() > 1) {
-    // TODO(composite_index): extend to also apply for edge type indicies
+    // TODO(composite_index): extend to also apply for edge type indices
     throw utils::NotYetImplemented("composite indices");
   }
 
@@ -6340,11 +6347,14 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
   void Visit(IsolationLevelQuery &) override {}
   void Visit(StorageModeQuery &) override {}
   void Visit(CreateSnapshotQuery &)
-      override { /*CreateSnapshot is also used in a periodic way so internally will arrange its own access*/ }
+      override { /*CreateSnapshot is also used in a periodic way so internally will arrange its own access*/
+  }
   void Visit(ShowSnapshotsQuery &) override {}
   void Visit(EdgeImportModeQuery &) override {}
-  void Visit(AlterEnumRemoveValueQuery &) override { /* Not implemented yet */ }
-  void Visit(DropEnumQuery &) override { /* Not implemented yet */ }
+  void Visit(AlterEnumRemoveValueQuery &) override { /* Not implemented yet */
+  }
+  void Visit(DropEnumQuery &) override { /* Not implemented yet */
+  }
   void Visit(SessionTraceQuery &) override {}
 
   // Some queries require an active transaction in order to be prepared.

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -885,21 +885,14 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
         // If the license is not valid we create users with admin access
         if (!valid_enterprise_license) {
           spdlog::warn("Granting all the privileges to {}.", username);
-          auth->GrantPrivilege(
-              username, kPrivilegesAll
+          auth->GrantPrivilege(username, kPrivilegesAll
 #ifdef MG_ENTERPRISE
-              ,
-              {{{AuthQuery::FineGrainedPrivilege::CREATE_DELETE, {query::kAsterisk}}}},
-              {
-                {
-                  {
-                    AuthQuery::FineGrainedPrivilege::CREATE_DELETE, { query::kAsterisk }
-                  }
-                }
-              }
+                               ,
+                               {{{AuthQuery::FineGrainedPrivilege::CREATE_DELETE, {query::kAsterisk}}}},
+                               {{{AuthQuery::FineGrainedPrivilege::CREATE_DELETE, {query::kAsterisk}}}}
 #endif
-              ,
-              &*interpreter->system_transaction_);
+                               ,
+                               &*interpreter->system_transaction_);
         }
 
         return std::vector<std::vector<TypedValue>>();
@@ -2474,8 +2467,8 @@ auto DetermineTxTimeout(std::optional<int64_t> tx_timeout_ms, InterpreterConfig 
   return TxTimeout{};
 }
 
-auto CreateTimeoutTimer(QueryExtras const &extras, InterpreterConfig const &config)
-    -> std::shared_ptr<utils::AsyncTimer> {
+auto CreateTimeoutTimer(QueryExtras const &extras,
+                        InterpreterConfig const &config) -> std::shared_ptr<utils::AsyncTimer> {
   if (auto const timeout = DetermineTxTimeout(extras.tx_timeout, config)) {
     return std::make_shared<utils::AsyncTimer>(timeout.ValueUnsafe().count());
   }
@@ -3142,11 +3135,11 @@ std::vector<std::vector<TypedValue>> AnalyzeGraphQueryHandler::AnalyzeGraphDelet
   std::vector<std::vector<TypedValue>> results;
   results.reserve(label_results.size() + label_prop_results.size());
 
-  std::transform(
-      label_results.begin(), label_results.end(), std::back_inserter(results),
-      [execution_db_accessor](const auto &label_index) {
-        return std::vector<TypedValue>{TypedValue(execution_db_accessor->LabelToName(label_index)), TypedValue("")};
-      });
+  std::transform(label_results.begin(), label_results.end(), std::back_inserter(results),
+                 [execution_db_accessor](const auto &label_index) {
+                   return std::vector<TypedValue>{TypedValue(execution_db_accessor->LabelToName(label_index)),
+                                                  TypedValue("")};
+                 });
 
   auto const prop_path_to_name = [&](storage::PropertyPath const &property_path) {
     return TypedValue{PropertyPathToName(execution_db_accessor, property_path)};
@@ -3238,7 +3231,7 @@ struct DoNothing {
 // We need to atomically invalidate the plan when publishing new index
 auto make_create_index_plan_invalidator_builder(memgraph::dbms::DatabaseAccess db_acc) {
   // capture DatabaseAccess in builder
-  return [db_acc = std::move(db_acc)]<InvocableWithUInt64 Func = DoNothing>(Func && publish_func = Func{}) {
+  return [db_acc = std::move(db_acc)]<InvocableWithUInt64 Func = DoNothing>(Func &&publish_func = Func{}) {
     // build plan invalidator wrapper
     return [db_acc = std::move(db_acc),
             publish_func = std::forward<Func>(publish_func)](uint64_t commit_timestamp) mutable {
@@ -3253,7 +3246,7 @@ auto make_create_index_plan_invalidator_builder(memgraph::dbms::DatabaseAccess d
 
 auto make_drop_index_plan_invalidator_builder(memgraph::dbms::DatabaseAccess db_acc) {
   // capture DatabaseAccess in builder
-  return [db_acc = std::move(db_acc)]<std::invocable Func = DoNothing>(Func && publish_func = Func{}) {
+  return [db_acc = std::move(db_acc)]<std::invocable Func = DoNothing>(Func &&publish_func = Func{}) {
     // build plan invalidator wrapper
     return [db_acc = std::move(db_acc), publish_func = std::forward<Func>(publish_func)]() mutable {
       return db_acc->plan_cache()->WithLock([&](auto &cache) {
@@ -3459,7 +3452,8 @@ PreparedQuery PrepareEdgeIndexQuery(ParsedQuery parsed_query, bool in_explicit_t
             return dba->CreateIndex(edge_type, make_create_index_cancel_callback(stopping_context),
                                     std::move(plan_invalidator_builder));
           }
-          return dba->CreateIndex(edge_type, properties[0], std::move(plan_invalidator_builder));
+          return dba->CreateIndex(edge_type, properties[0], make_create_index_cancel_callback(stopping_context),
+                                  std::move(plan_invalidator_builder));
         });
 
         if (maybe_index_error.HasError()) {
@@ -6346,14 +6340,11 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
   void Visit(IsolationLevelQuery &) override {}
   void Visit(StorageModeQuery &) override {}
   void Visit(CreateSnapshotQuery &)
-      override { /*CreateSnapshot is also used in a periodic way so internally will arrange its own access*/
-  }
+      override { /*CreateSnapshot is also used in a periodic way so internally will arrange its own access*/ }
   void Visit(ShowSnapshotsQuery &) override {}
   void Visit(EdgeImportModeQuery &) override {}
-  void Visit(AlterEnumRemoveValueQuery &) override { /* Not implemented yet */
-  }
-  void Visit(DropEnumQuery &) override { /* Not implemented yet */
-  }
+  void Visit(AlterEnumRemoveValueQuery &) override { /* Not implemented yet */ }
+  void Visit(DropEnumQuery &) override { /* Not implemented yet */ }
   void Visit(SessionTraceQuery &) override {}
 
   // Some queries require an active transaction in order to be prepared.
@@ -6406,8 +6397,8 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
     if (is_in_memory_transactional_) {
       // Concurrent population of index requires snapshot isolation
       isolation_level_override_ = storage::IsolationLevel::SNAPSHOT_ISOLATION;
-      if (edge_index_query.properties_.empty()) {
-        // edge type index
+      if (!edge_index_query.global_) {
+        // edge type index & edge type property index
         if (edge_index_query.action_ == EdgeIndexQuery::Action::CREATE) {
           // Need writers to leave so we can make populate a consistent index
           accessor_type_ = storage::Storage::Accessor::Type::READ_ONLY;
@@ -6415,7 +6406,6 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
           accessor_type_ = storage::Storage::Accessor::Type::READ;
         }
       } else {
-        // edge type + properties
         // edge global property
         accessor_type_ = storage::Storage::Accessor::Type::UNIQUE;  // TODO: READ_ONLY
       }

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -6408,17 +6408,11 @@ struct QueryTransactionRequirements : QueryVisitor<void> {
     if (is_in_memory_transactional_) {
       // Concurrent population of index requires snapshot isolation
       isolation_level_override_ = storage::IsolationLevel::SNAPSHOT_ISOLATION;
-      if (!edge_index_query.global_) {
-        // edge type index & edge type property index
-        if (edge_index_query.action_ == EdgeIndexQuery::Action::CREATE) {
-          // Need writers to leave so we can make populate a consistent index
-          accessor_type_ = storage::Storage::Accessor::Type::READ_ONLY;
-        } else {
-          accessor_type_ = storage::Storage::Accessor::Type::READ;
-        }
+      if (edge_index_query.action_ == EdgeIndexQuery::Action::CREATE) {
+        // Need writers to leave so we can make populate a consistent index
+        accessor_type_ = storage::Storage::Accessor::Type::READ_ONLY;
       } else {
-        // edge global property
-        accessor_type_ = storage::Storage::Accessor::Type::UNIQUE;  // TODO: READ_ONLY
+        accessor_type_ = storage::Storage::Accessor::Type::READ;
       }
     } else {
       // IN_MEMORY_ANALYTICAL and ON_DISK_TRANSACTIONAL require unique access

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3452,12 +3452,13 @@ PreparedQuery PrepareEdgeIndexQuery(ParsedQuery parsed_query, bool in_explicit_t
         MG_ASSERT(properties.size() <= 1U);
 
         const utils::BasicResult<storage::StorageIndexDefinitionError, void> maybe_index_error = std::invoke([&] {
+          auto cancel_check = make_create_index_cancel_callback(stopping_context);
           if (global_index) {
             if (properties.empty()) throw utils::BasicException("Missing property for global edge index.");
-            return dba->CreateGlobalEdgeIndex(properties[0], std::move(plan_invalidator_builder));
+            return dba->CreateGlobalEdgeIndex(properties[0], std::move(cancel_check),
+                                              std::move(plan_invalidator_builder));
           } else if (properties.empty()) {
-            return dba->CreateIndex(edge_type, make_create_index_cancel_callback(stopping_context),
-                                    std::move(plan_invalidator_builder));
+            return dba->CreateIndex(edge_type, std::move(cancel_check), std::move(plan_invalidator_builder));
           }
           return dba->CreateIndex(edge_type, properties[0], make_create_index_cancel_callback(stopping_context),
                                   std::move(plan_invalidator_builder));

--- a/src/query/plan/rewrite/edge_index_lookup.hpp
+++ b/src/query/plan/rewrite/edge_index_lookup.hpp
@@ -726,7 +726,7 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
       }
 
       const auto &property = filter.property_filter->property_ids_.path[0];
-      if (!db_->EdgePropertyIndexExists(GetProperty(property))) {
+      if (!db_->EdgePropertyIndexReady(GetProperty(property))) {
         continue;
       }
       candidate_indices.push_back({.property = property, .filter = filter});

--- a/src/query/plan/rewrite/edge_index_lookup.hpp
+++ b/src/query/plan/rewrite/edge_index_lookup.hpp
@@ -704,7 +704,7 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
         }
 
         const auto &property = filter.property_filter->property_ids_.path[0];
-        if (!db_->EdgeTypePropertyIndexExists(GetEdgeType(edge_type), GetProperty(property))) {
+        if (!db_->EdgeTypePropertyIndexReady(GetEdgeType(edge_type), GetProperty(property))) {
           continue;
         }
         candidate_indices.push_back({.edge_type_from_filter = edge_type, .property = property, .filter = filter});
@@ -748,7 +748,7 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
       }
 
       const auto &property = filter.property_filter->property_ids_.path[0];
-      if (!db_->EdgeTypePropertyIndexExists(edge_type_from_relationship.value(), GetProperty(property))) {
+      if (!db_->EdgeTypePropertyIndexReady(edge_type_from_relationship.value(), GetProperty(property))) {
         continue;
       }
       candidate_indices.push_back(

--- a/src/query/plan/used_index_checker.cpp
+++ b/src/query/plan/used_index_checker.cpp
@@ -58,12 +58,23 @@ bool UsedIndexChecker::PreVisit(ScanAllByEdgePropertyRange &op) {
   return true;
 }
 
+bool UsedIndexChecker::PreVisit(ScanAllByEdgeTypeProperty &op) {
+  required_indices_.edge_type_properties_.emplace_back(op.common_.edge_types[0], op.property_);
+  return true;
+}
+
+bool UsedIndexChecker::PreVisit(ScanAllByEdgeTypePropertyValue &op) {
+  required_indices_.edge_type_properties_.emplace_back(op.common_.edge_types[0], op.property_);
+  return true;
+}
+
+bool UsedIndexChecker::PreVisit(ScanAllByEdgeTypePropertyRange &op) {
+  required_indices_.edge_type_properties_.emplace_back(op.common_.edge_types[0], op.property_);
+  return true;
+}
+
 PRE_VISIT(ScanAllById)
 PRE_VISIT(ScanAllByEdge)
-
-PRE_VISIT(ScanAllByEdgeTypeProperty)       // TODO: gather for concurrent index check
-PRE_VISIT(ScanAllByEdgeTypePropertyValue)  // TODO: gather for concurrent index check
-PRE_VISIT(ScanAllByEdgeTypePropertyRange)  // TODO: gather for concurrent index check
 
 PRE_VISIT(ScanAllByEdgeId)
 

--- a/src/query/plan/used_index_checker.cpp
+++ b/src/query/plan/used_index_checker.cpp
@@ -43,15 +43,28 @@ bool UsedIndexChecker::PreVisit(ScanAllByEdgeType &op) {
   return true;
 }
 
+bool UsedIndexChecker::PreVisit(ScanAllByEdgeProperty &op) {
+  required_indices_.edge_property_.emplace_back(op.property_);
+  return true;
+}
+
+bool UsedIndexChecker::PreVisit(ScanAllByEdgePropertyValue &op) {
+  required_indices_.edge_property_.emplace_back(op.property_);
+  return true;
+}
+
+bool UsedIndexChecker::PreVisit(ScanAllByEdgePropertyRange &op) {
+  required_indices_.edge_property_.emplace_back(op.property_);
+  return true;
+}
+
 PRE_VISIT(ScanAllById)
 PRE_VISIT(ScanAllByEdge)
 
 PRE_VISIT(ScanAllByEdgeTypeProperty)       // TODO: gather for concurrent index check
 PRE_VISIT(ScanAllByEdgeTypePropertyValue)  // TODO: gather for concurrent index check
 PRE_VISIT(ScanAllByEdgeTypePropertyRange)  // TODO: gather for concurrent index check
-PRE_VISIT(ScanAllByEdgeProperty)           // TODO: gather for concurrent index check
-PRE_VISIT(ScanAllByEdgePropertyValue)      // TODO: gather for concurrent index check
-PRE_VISIT(ScanAllByEdgePropertyRange)      // TODO: gather for concurrent index check
+
 PRE_VISIT(ScanAllByEdgeId)
 
 PRE_VISIT(Expand)

--- a/src/query/plan/vertex_count_cache.hpp
+++ b/src/query/plan/vertex_count_cache.hpp
@@ -33,8 +33,8 @@ class VertexCountCache {
   auto NameToLabel(const std::string &name) { return db_->NameToLabel(name); }
   auto NameToProperty(const std::string &name) { return db_->NameToProperty(name); }
   auto NameToEdgeType(const std::string &name) { return db_->NameToEdgeType(name); }
-  auto GetEnumValue(std::string_view name,
-                    std::string_view value) -> utils::BasicResult<storage::EnumStorageError, storage::Enum> {
+  auto GetEnumValue(std::string_view name, std::string_view value)
+      -> utils::BasicResult<storage::EnumStorageError, storage::Enum> {
     return db_->GetEnumValue(name, value);
   }
 
@@ -153,7 +153,7 @@ class VertexCountCache {
     return db_->EdgeTypePropertyIndexReady(edge_type, property);
   }
 
-  bool EdgePropertyIndexExists(storage::PropertyId property) { return db_->EdgePropertyIndexExists(property); }
+  bool EdgePropertyIndexReady(storage::PropertyId property) { return db_->EdgePropertyIndexReady(property); }
 
   bool PointIndexExists(storage::LabelId label, storage::PropertyId prop) const {
     return db_->PointIndexExists(label, prop);

--- a/src/query/plan/vertex_count_cache.hpp
+++ b/src/query/plan/vertex_count_cache.hpp
@@ -149,8 +149,8 @@ class VertexCountCache {
 
   bool EdgeTypeIndexReady(storage::EdgeTypeId edge_type) { return db_->EdgeTypeIndexReady(edge_type); }
 
-  bool EdgeTypePropertyIndexExists(storage::EdgeTypeId edge_type, storage::PropertyId property) {
-    return db_->EdgeTypePropertyIndexExists(edge_type, property);
+  bool EdgeTypePropertyIndexReady(storage::EdgeTypeId edge_type, storage::PropertyId property) {
+    return db_->EdgeTypePropertyIndexReady(edge_type, property);
   }
 
   bool EdgePropertyIndexExists(storage::PropertyId property) { return db_->EdgePropertyIndexExists(property); }

--- a/src/storage/v2/CMakeLists.txt
+++ b/src/storage/v2/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(mg-storage-v2
         edge_accessor.cpp
         edges_iterable.cpp
         indices/edge_type_index.cpp
+        indices/edge_type_property_index.cpp
         indices/indices.cpp
         indices/indices_utils.hpp
         indices/label_index_stats.cpp

--- a/src/storage/v2/CMakeLists.txt
+++ b/src/storage/v2/CMakeLists.txt
@@ -12,9 +12,9 @@ target_sources(mg-storage-v2
         constraints/type_constraints_validator.cpp
         disk/durable_metadata.cpp
         disk/edge_import_mode_cache.cpp
+        disk/edge_property_index.cpp
         disk/edge_type_index.cpp
         disk/edge_type_property_index.cpp
-        disk/edge_property_index.cpp
         disk/label_index.cpp
         disk/label_property_index.cpp
         disk/rocksdb_storage.cpp
@@ -26,6 +26,7 @@ target_sources(mg-storage-v2
         durability/wal.cpp
         edge_accessor.cpp
         edges_iterable.cpp
+        indices/edge_property_index.cpp
         indices/edge_type_index.cpp
         indices/edge_type_property_index.cpp
         indices/indices.cpp
@@ -53,13 +54,13 @@ target_sources(mg-storage-v2
         replication/rpc.cpp
         replication/serialization.cpp
         replication/slk.cpp
+        schema_info.cpp
         storage.cpp
         storage_mode.cpp
         temporal.cpp
         vertex_accessor.cpp
         vertex_info_cache.cpp
         vertices_iterable.cpp
-        schema_info.cpp
         edge_ref.cpp
         indices/point_iterator.cpp
         property_value_utils.cpp

--- a/src/storage/v2/disk/edge_property_index.cpp
+++ b/src/storage/v2/disk/edge_property_index.cpp
@@ -20,48 +20,55 @@ bool DiskEdgePropertyIndex::DropIndex(PropertyId /*property*/) {
   return true;
 }
 
-bool DiskEdgePropertyIndex::IndexExists(PropertyId /*property*/) const {
+bool DiskEdgePropertyIndex::ActiveIndices::IndexReady(PropertyId property) const {
   spdlog::warn("Edge index related operations are not yet supported using on-disk storage mode.");
   return false;
 }
 
-std::vector<PropertyId> DiskEdgePropertyIndex::ListIndices() const {
+std::vector<PropertyId> DiskEdgePropertyIndex::ActiveIndices::ListIndices(uint64_t start_timestamp) const {
   spdlog::warn("Edge index related operations are not yet supported using on-disk storage mode.");
   return {};
 }
 
-void DiskEdgePropertyIndex::UpdateOnSetProperty(Vertex * /*from_vertex*/, Vertex * /*to_vertex*/, Edge * /*edge*/,
-                                                EdgeTypeId /*edge_type*/, PropertyId /*property*/,
-                                                PropertyValue /*value*/, uint64_t /*timestamp*/) {
+void DiskEdgePropertyIndex::ActiveIndices::UpdateOnSetProperty(Vertex * /*from_vertex*/, Vertex * /*to_vertex*/,
+                                                               Edge * /*edge*/, EdgeTypeId /*edge_type*/,
+                                                               PropertyId /*property*/, PropertyValue /*value*/,
+                                                               uint64_t /*timestamp*/) {
   spdlog::warn("Edge index related operations are not yet supported using on-disk storage mode.");
 }
 
-uint64_t DiskEdgePropertyIndex::ApproximateEdgeCount(PropertyId /*property*/) const {
+uint64_t DiskEdgePropertyIndex::ActiveIndices::ApproximateEdgeCount(PropertyId /*property*/) const {
   spdlog::warn("Edge index related operations are not yet supported using on-disk storage mode.");
   return 0U;
 }
 
-uint64_t DiskEdgePropertyIndex::ApproximateEdgeCount(PropertyId /*property*/, const PropertyValue & /*value*/) const {
+uint64_t DiskEdgePropertyIndex::ActiveIndices::ApproximateEdgeCount(PropertyId /*property*/,
+                                                                    const PropertyValue & /*value*/) const {
   spdlog::warn("Edge index related operations are not yet supported using on-disk storage mode.");
   return 0U;
 };
 
-uint64_t DiskEdgePropertyIndex::ApproximateEdgeCount(
+uint64_t DiskEdgePropertyIndex::ActiveIndices::ApproximateEdgeCount(
     PropertyId /*property*/, const std::optional<utils::Bound<PropertyValue>> & /*lower*/,
     const std::optional<utils::Bound<PropertyValue>> & /*upper*/) const {
   spdlog::warn("Edge index related operations are not yet supported using on-disk storage mode.");
   return 0U;
-};
-
-void DiskEdgePropertyIndex::UpdateOnEdgeModification(Vertex * /*old_from*/, Vertex * /*old_to*/, Vertex * /*new_from*/,
-                                                     Vertex * /*new_to*/, EdgeRef /*edge_ref*/,
-                                                     EdgeTypeId /*edge_type*/, PropertyId /*property*/,
-                                                     const PropertyValue & /*value*/, const Transaction & /*tx*/) {
-  spdlog::warn("Edge index related operations are not yet supported using on-disk storage mode.");
 }
+
+EdgePropertyIndex::AbortProcessor DiskEdgePropertyIndex::ActiveIndices::GetAbortProcessor() const {
+  return AbortProcessor({});
+}
+
+void DiskEdgePropertyIndex::ActiveIndices::AbortEntries(EdgePropertyIndex::AbortableInfo const &info,
+                                                        uint64_t start_timestamp){
+
+};
 
 void DiskEdgePropertyIndex::DropGraphClearIndices() {
   spdlog::warn("Edge index related operations are not yet supported using on-disk storage mode.");
+}
+std::unique_ptr<EdgePropertyIndex::ActiveIndices> DiskEdgePropertyIndex::GetActiveIndices() const {
+  return std::make_unique<ActiveIndices>();
 }
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/disk/edge_type_index.cpp
+++ b/src/storage/v2/disk/edge_type_index.cpp
@@ -47,13 +47,6 @@ void DiskEdgeTypeIndex::ActiveIndices::UpdateOnEdgeCreation(Vertex * /*from*/, V
   spdlog::warn("Edge-type index related operations are not yet supported using on-disk storage mode.");
 }
 
-void DiskEdgeTypeIndex::ActiveIndices::UpdateOnEdgeModification(Vertex * /*old_from*/, Vertex * /*old_to*/,
-                                                                Vertex * /*new_from*/, Vertex * /*new_to*/,
-                                                                EdgeRef /*edge_ref*/, EdgeTypeId /*edge_type*/,
-                                                                const Transaction & /*tx*/) {
-  spdlog::warn("Edge-type index related operations are not yet supported using on-disk storage mode.");
-}
-
 EdgeTypeIndex::AbortProcessor DiskEdgeTypeIndex::ActiveIndices::GetAbortProcessor() const { return AbortProcessor({}); }
 
 void DiskEdgeTypeIndex::DropGraphClearIndices() {

--- a/src/storage/v2/disk/edge_type_index.hpp
+++ b/src/storage/v2/disk/edge_type_index.hpp
@@ -29,8 +29,6 @@ class DiskEdgeTypeIndex : public EdgeTypeIndex {
     void UpdateOnEdgeCreation(Vertex *from, Vertex *to, EdgeRef edge_ref, EdgeTypeId edge_type,
                               const Transaction &tx) override;
 
-    void UpdateOnEdgeModification(Vertex *old_from, Vertex *old_to, Vertex *new_from, Vertex *new_to, EdgeRef edge_ref,
-                                  EdgeTypeId edge_type, const Transaction &tx) override;
     void AbortEntries(AbortableInfo const &info, uint64_t exact_start_timestamp) override {}
 
     auto GetAbortProcessor() const -> AbortProcessor override;

--- a/src/storage/v2/disk/edge_type_property_index.cpp
+++ b/src/storage/v2/disk/edge_type_property_index.cpp
@@ -10,6 +10,7 @@
 // licenses/APL.txt.
 
 #include "edge_type_property_index.hpp"
+#include <cstdint>
 
 #include "utils/exceptions.hpp"
 
@@ -20,45 +21,47 @@ bool DiskEdgeTypePropertyIndex::DropIndex(EdgeTypeId /*edge_type*/, PropertyId /
   return true;
 }
 
-bool DiskEdgeTypePropertyIndex::IndexExists(EdgeTypeId /*edge_type*/, PropertyId /*property*/) const {
+bool DiskEdgeTypePropertyIndex::ActiveIndices::IndexReady(EdgeTypeId /*edge_type*/, PropertyId /*property*/) const {
   spdlog::warn("Edge-type index related operations are not yet supported using on-disk storage mode.");
   return false;
 }
 
-std::vector<std::pair<EdgeTypeId, PropertyId>> DiskEdgeTypePropertyIndex::ListIndices() const {
+std::vector<std::pair<EdgeTypeId, PropertyId>> DiskEdgeTypePropertyIndex::ActiveIndices::ListIndices(
+    uint64_t start_timestamp) const {
   spdlog::warn("Edge-type index related operations are not yet supported using on-disk storage mode.");
   return {};
 }
 
-void DiskEdgeTypePropertyIndex::UpdateOnSetProperty(Vertex * /*from_vertex*/, Vertex * /*to_vertex*/, Edge * /*edge*/,
-                                                    EdgeTypeId /*edge_type*/, PropertyId /*property*/,
-                                                    PropertyValue /*value*/, uint64_t /*timestamp*/) {
+void DiskEdgeTypePropertyIndex::ActiveIndices::UpdateOnSetProperty(Vertex * /*from_vertex*/, Vertex * /*to_vertex*/,
+                                                                   Edge * /*edge*/, EdgeTypeId /*edge_type*/,
+                                                                   PropertyId /*property*/, PropertyValue /*value*/,
+                                                                   uint64_t /*timestamp*/) {
   spdlog::warn("Edge-type index related operations are not yet supported using on-disk storage mode.");
 }
 
-uint64_t DiskEdgeTypePropertyIndex::ApproximateEdgeCount(EdgeTypeId /*edge_type*/, PropertyId /*property*/) const {
+uint64_t DiskEdgeTypePropertyIndex::ActiveIndices::ApproximateEdgeCount(EdgeTypeId /*edge_type*/,
+                                                                        PropertyId /*property*/) const {
   spdlog::warn("Edge-type index related operations are not yet supported using on-disk storage mode.");
   return 0U;
 }
 
-uint64_t DiskEdgeTypePropertyIndex::ApproximateEdgeCount(EdgeTypeId /*edge_type*/, PropertyId /*property*/,
-                                                         const PropertyValue & /*value*/) const {
+uint64_t DiskEdgeTypePropertyIndex::ActiveIndices::ApproximateEdgeCount(EdgeTypeId /*edge_type*/,
+                                                                        PropertyId /*property*/,
+                                                                        const PropertyValue & /*value*/) const {
   spdlog::warn("Edge-type index related operations are not yet supported using on-disk storage mode.");
   return 0U;
 };
 
-uint64_t DiskEdgeTypePropertyIndex::ApproximateEdgeCount(
+uint64_t DiskEdgeTypePropertyIndex::ActiveIndices::ApproximateEdgeCount(
     EdgeTypeId /*edge_type*/, PropertyId /*property*/, const std::optional<utils::Bound<PropertyValue>> & /*lower*/,
     const std::optional<utils::Bound<PropertyValue>> & /*upper*/) const {
   spdlog::warn("Edge-type index related operations are not yet supported using on-disk storage mode.");
   return 0U;
 };
 
-void DiskEdgeTypePropertyIndex::UpdateOnEdgeModification(Vertex * /*old_from*/, Vertex * /*old_to*/,
-                                                         Vertex * /*new_from*/, Vertex * /*new_to*/,
-                                                         EdgeRef /*edge_ref*/, EdgeTypeId /*edge_type*/,
-                                                         PropertyId /*property*/, const PropertyValue & /*value*/,
-                                                         const Transaction & /*tx*/) {
+void DiskEdgeTypePropertyIndex::ActiveIndices::UpdateOnEdgeModification(
+    Vertex * /*old_from*/, Vertex * /*old_to*/, Vertex * /*new_from*/, Vertex * /*new_to*/, EdgeRef /*edge_ref*/,
+    EdgeTypeId /*edge_type*/, PropertyId /*property*/, const PropertyValue & /*value*/, const Transaction & /*tx*/) {
   spdlog::warn("Edge-type index related operations are not yet supported using on-disk storage mode.");
 }
 

--- a/src/storage/v2/disk/edge_type_property_index.cpp
+++ b/src/storage/v2/disk/edge_type_property_index.cpp
@@ -57,6 +57,15 @@ uint64_t DiskEdgeTypePropertyIndex::ActiveIndices::ApproximateEdgeCount(
     const std::optional<utils::Bound<PropertyValue>> & /*upper*/) const {
   spdlog::warn("Edge-type index related operations are not yet supported using on-disk storage mode.");
   return 0U;
+}
+
+EdgeTypePropertyIndex::AbortProcessor DiskEdgeTypePropertyIndex::ActiveIndices::GetAbortProcessor() const {
+  return AbortProcessor({});
+}
+
+void DiskEdgeTypePropertyIndex::ActiveIndices::AbortEntries(EdgeTypePropertyIndex::AbortableInfo const &info,
+                                                            uint64_t start_timestamp) {
+  spdlog::warn("Edge-type index related operations are not yet supported using on-disk storage mode.");
 };
 
 void DiskEdgeTypePropertyIndex::DropGraphClearIndices() {

--- a/src/storage/v2/disk/edge_type_property_index.cpp
+++ b/src/storage/v2/disk/edge_type_property_index.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -58,12 +58,6 @@ uint64_t DiskEdgeTypePropertyIndex::ActiveIndices::ApproximateEdgeCount(
   spdlog::warn("Edge-type index related operations are not yet supported using on-disk storage mode.");
   return 0U;
 };
-
-void DiskEdgeTypePropertyIndex::ActiveIndices::UpdateOnEdgeModification(
-    Vertex * /*old_from*/, Vertex * /*old_to*/, Vertex * /*new_from*/, Vertex * /*new_to*/, EdgeRef /*edge_ref*/,
-    EdgeTypeId /*edge_type*/, PropertyId /*property*/, const PropertyValue & /*value*/, const Transaction & /*tx*/) {
-  spdlog::warn("Edge-type index related operations are not yet supported using on-disk storage mode.");
-}
 
 void DiskEdgeTypePropertyIndex::DropGraphClearIndices() {
   spdlog::warn("Edge-type index related operations are not yet supported using on-disk storage mode.");

--- a/src/storage/v2/disk/edge_type_property_index.hpp
+++ b/src/storage/v2/disk/edge_type_property_index.hpp
@@ -32,6 +32,9 @@ class DiskEdgeTypePropertyIndex : public EdgeTypePropertyIndex {
     bool IndexReady(EdgeTypeId edge_type, PropertyId property) const override;
 
     auto ListIndices(uint64_t start_timestamp) const -> std::vector<std::pair<EdgeTypeId, PropertyId>> override;
+
+    auto GetAbortProcessor() const -> AbortProcessor override;
+    void AbortEntries(AbortableInfo const &info, uint64_t start_timestamp) override;
   };
 
   bool DropIndex(EdgeTypeId edge_type, PropertyId property) override;

--- a/src/storage/v2/disk/edge_type_property_index.hpp
+++ b/src/storage/v2/disk/edge_type_property_index.hpp
@@ -15,30 +15,36 @@
 
 namespace memgraph::storage {
 
-class DiskEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
+class DiskEdgeTypePropertyIndex : public EdgeTypePropertyIndex {
  public:
+  struct ActiveIndices : storage::EdgeTypePropertyIndex::ActiveIndices {
+    void UpdateOnSetProperty(Vertex *from_vertex, Vertex *to_vertex, Edge *edge, EdgeTypeId edge_type,
+                             PropertyId property, PropertyValue value, uint64_t timestamp) override;
+
+    void UpdateOnEdgeModification(Vertex *old_from, Vertex *old_to, Vertex *new_from, Vertex *new_to, EdgeRef edge_ref,
+                                  EdgeTypeId edge_type, PropertyId property, const PropertyValue &value,
+                                  const Transaction &tx) override;
+
+    uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property) const override;
+
+    uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property, const PropertyValue &value) const override;
+
+    uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property,
+                                  const std::optional<utils::Bound<PropertyValue>> &lower,
+                                  const std::optional<utils::Bound<PropertyValue>> &upper) const override;
+
+    bool IndexReady(EdgeTypeId edge_type, PropertyId property) const override;
+
+    auto ListIndices(uint64_t start_timestamp) const -> std::vector<std::pair<EdgeTypeId, PropertyId>> override;
+  };
+
   bool DropIndex(EdgeTypeId edge_type, PropertyId property) override;
 
-  bool IndexExists(EdgeTypeId edge_type, PropertyId property) const override;
-
-  std::vector<std::pair<EdgeTypeId, PropertyId>> ListIndices() const override;
-
-  void UpdateOnSetProperty(Vertex *from_vertex, Vertex *to_vertex, Edge *edge, EdgeTypeId edge_type,
-                           PropertyId property, PropertyValue value, uint64_t timestamp) override;
-
-  uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property) const override;
-
-  uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property, const PropertyValue &value) const override;
-
-  uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property,
-                                const std::optional<utils::Bound<PropertyValue>> &lower,
-                                const std::optional<utils::Bound<PropertyValue>> &upper) const override;
-
-  void UpdateOnEdgeModification(Vertex *old_from, Vertex *old_to, Vertex *new_from, Vertex *new_to, EdgeRef edge_ref,
-                                EdgeTypeId edge_type, PropertyId property, const PropertyValue &value,
-                                const Transaction &tx) override;
-
   void DropGraphClearIndices() override;
+
+  auto GetActiveIndices() const -> std::unique_ptr<EdgeTypePropertyIndex::ActiveIndices> override {
+    return std::make_unique<ActiveIndices>();
+  }
 };
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/disk/edge_type_property_index.hpp
+++ b/src/storage/v2/disk/edge_type_property_index.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -20,10 +20,6 @@ class DiskEdgeTypePropertyIndex : public EdgeTypePropertyIndex {
   struct ActiveIndices : storage::EdgeTypePropertyIndex::ActiveIndices {
     void UpdateOnSetProperty(Vertex *from_vertex, Vertex *to_vertex, Edge *edge, EdgeTypeId edge_type,
                              PropertyId property, PropertyValue value, uint64_t timestamp) override;
-
-    void UpdateOnEdgeModification(Vertex *old_from, Vertex *old_to, Vertex *new_from, Vertex *new_to, EdgeRef edge_ref,
-                                  EdgeTypeId edge_type, PropertyId property, const PropertyValue &value,
-                                  const Transaction &tx) override;
 
     uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property) const override;
 

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -72,8 +72,8 @@ namespace memgraph::storage {
 
 namespace {
 
-auto FindEdges(const View view, EdgeTypeId edge_type, const VertexAccessor *from_vertex, VertexAccessor *to_vertex)
-    -> Result<EdgesVertexAccessorResult> {
+auto FindEdges(const View view, EdgeTypeId edge_type, const VertexAccessor *from_vertex,
+               VertexAccessor *to_vertex) -> Result<EdgesVertexAccessorResult> {
   auto use_out_edges = [](Vertex const *from_vertex, Vertex const *to_vertex) {
     // Obtain the locks by `gid` order to avoid lock cycles.
     auto guard_from = std::unique_lock{from_vertex->lock, std::defer_lock};
@@ -2100,7 +2100,8 @@ utils::BasicResult<StorageIndexDefinitionError, void> DiskStorage::DiskAccessor:
 }
 
 utils::BasicResult<StorageIndexDefinitionError, void> DiskStorage::DiskAccessor::CreateIndex(
-    EdgeTypeId /*edge_type*/, PropertyId /*property*/, PublishIndexWrapper /*wrapper*/) {
+    EdgeTypeId /*edge_type*/, PropertyId /*property*/, CheckCancelFunction /*cancel_check*/,
+    PublishIndexWrapper /*wrapper*/) {
   throw utils::NotYetImplemented(
       "Edge-type index related operations are not yet supported using on-disk storage mode. {}", kErrorMessage);
 }
@@ -2311,8 +2312,8 @@ std::vector<VectorEdgeIndexInfo> DiskStorage::DiskAccessor::ListAllVectorEdgeInd
 
 auto DiskStorage::DiskAccessor::PointVertices(LabelId /*label*/, PropertyId /*property*/,
                                               CoordinateReferenceSystem /*crs*/, PropertyValue const & /*bottom_left*/,
-                                              PropertyValue const & /*top_right*/, WithinBBoxCondition /*condition*/)
-    -> PointIterable {
+                                              PropertyValue const & /*top_right*/,
+                                              WithinBBoxCondition /*condition*/) -> PointIterable {
   throw utils::NotYetImplemented("Point Vertices is not yet implemented for on-disk storage. {}", kErrorMessage);
 };
 
@@ -2383,7 +2384,7 @@ bool DiskStorage::DiskAccessor::EdgeTypeIndexReady(EdgeTypeId /*edge_type*/) con
   return false;
 }
 
-bool DiskStorage::DiskAccessor::EdgeTypePropertyIndexExists(EdgeTypeId /*edge_type*/, PropertyId /*property*/) const {
+bool DiskStorage::DiskAccessor::EdgeTypePropertyIndexReady(EdgeTypeId /*edge_type*/, PropertyId /*property*/) const {
   spdlog::info("Edge-type index related operations are not yet supported using on-disk storage mode. {}",
                kErrorMessage);
   return false;

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -2390,7 +2390,7 @@ bool DiskStorage::DiskAccessor::EdgeTypePropertyIndexReady(EdgeTypeId /*edge_typ
   return false;
 }
 
-bool DiskStorage::DiskAccessor::EdgePropertyIndexExists(PropertyId /*property*/) const {
+bool DiskStorage::DiskAccessor::EdgePropertyIndexReady(PropertyId /*property*/) const {
   spdlog::info("Edge index related operations are not yet supported using on-disk storage mode. {}", kErrorMessage);
   return false;
 }

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -2107,7 +2107,7 @@ utils::BasicResult<StorageIndexDefinitionError, void> DiskStorage::DiskAccessor:
 }
 
 utils::BasicResult<StorageIndexDefinitionError, void> DiskStorage::DiskAccessor::CreateGlobalEdgeIndex(
-    PropertyId /*property*/, PublishIndexWrapper /*wrapper*/) {
+    PropertyId /*property*/, CheckCancelFunction /*cancel_check*/, PublishIndexWrapper /*wrapper*/) {
   throw utils::NotYetImplemented(
       "Edge-type index related operations are not yet supported using on-disk storage mode. {}", kErrorMessage);
 }

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "kvstore/kvstore.hpp"
+#include "storage/v2/common_function_signatures.hpp"
 #include "storage/v2/constraints/constraint_violation.hpp"
 #include "storage/v2/disk/durable_metadata.hpp"
 #include "storage/v2/disk/edge_import_mode_cache.hpp"
@@ -201,7 +202,7 @@ class DiskStorage final : public Storage {
 
     bool EdgeTypeIndexReady(EdgeTypeId edge_type) const override;
 
-    bool EdgeTypePropertyIndexExists(EdgeTypeId edge_type, PropertyId proeprty) const override;
+    bool EdgeTypePropertyIndexReady(EdgeTypeId edge_type, PropertyId proeprty) const override;
 
     bool EdgePropertyIndexExists(PropertyId proeprty) const override;
 
@@ -238,7 +239,8 @@ class DiskStorage final : public Storage {
         PublishIndexWrapper wrapper = publish_no_wrap) override;
 
     utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
-        EdgeTypeId edge_type, PropertyId property, PublishIndexWrapper wrapper = publish_no_wrap) override;
+        EdgeTypeId edge_type, PropertyId property, CheckCancelFunction cancel_check = neverCancel,
+        PublishIndexWrapper wrapper = publish_no_wrap) override;
 
     utils::BasicResult<StorageIndexDefinitionError, void> CreateGlobalEdgeIndex(
         PropertyId property, PublishIndexWrapper wrapper = publish_no_wrap) override;
@@ -298,8 +300,8 @@ class DiskStorage final : public Storage {
                        PointDistanceCondition condition) -> PointIterable override;
 
     auto PointVertices(LabelId label, PropertyId property, CoordinateReferenceSystem crs,
-                       PropertyValue const &bottom_left, PropertyValue const &top_right, WithinBBoxCondition condition)
-        -> PointIterable override;
+                       PropertyValue const &bottom_left, PropertyValue const &top_right,
+                       WithinBBoxCondition condition) -> PointIterable override;
 
     std::vector<std::tuple<VertexAccessor, double, double>> VectorIndexSearchOnNodes(
         const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector) override;

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -204,7 +204,7 @@ class DiskStorage final : public Storage {
 
     bool EdgeTypePropertyIndexReady(EdgeTypeId edge_type, PropertyId proeprty) const override;
 
-    bool EdgePropertyIndexExists(PropertyId proeprty) const override;
+    bool EdgePropertyIndexReady(PropertyId proeprty) const override;
 
     bool PointIndexExists(LabelId label, PropertyId property) const override;
 

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -243,7 +243,8 @@ class DiskStorage final : public Storage {
         PublishIndexWrapper wrapper = publish_no_wrap) override;
 
     utils::BasicResult<StorageIndexDefinitionError, void> CreateGlobalEdgeIndex(
-        PropertyId property, PublishIndexWrapper wrapper = publish_no_wrap) override;
+        PropertyId property, CheckCancelFunction cancel_check = neverCancel,
+        PublishIndexWrapper wrapper = publish_no_wrap) override;
 
     utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(LabelId label,
                                                                     DropIndexWrapper wrapper = drop_no_wrap) override;

--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -301,7 +301,7 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
   auto *mem_edge_property_index = static_cast<InMemoryEdgePropertyIndex *>(indices->edge_property_index_.get());
   for (const auto &property : indices_metadata.edge_property) {
     // TODO: parallel execution
-    if (!mem_edge_property_index->CreateIndex(property, vertices->access(), snapshot_info)) {
+    if (!mem_edge_property_index->CreateIndexOnePass(property, vertices->access(), snapshot_info)) {
       throw RecoveryFailure("The global edge property index must be created here!");
     }
     spdlog::info("Edge index on property {} is recreated from metadata", name_id_mapper->IdToName(property.AsUint()));

--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -286,7 +286,7 @@ void RecoverIndicesAndStats(const RecoveredIndicesAndConstraints::IndicesMetadat
       static_cast<InMemoryEdgeTypePropertyIndex *>(indices->edge_type_property_index_.get());
   for (const auto &item : indices_metadata.edge_type_property) {
     // TODO: parallel execution
-    if (!mem_edge_type_property_index->CreateIndex(item.first, item.second, vertices->access(), snapshot_info)) {
+    if (!mem_edge_type_property_index->CreateIndexOnePass(item.first, item.second, vertices->access(), snapshot_info)) {
       throw RecoveryFailure("The edge-type property index must be created here!");
     }
     spdlog::info("Index on :{} + {} is recreated from metadata", name_id_mapper->IdToName(item.first.AsUint()),

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -6451,8 +6451,8 @@ void EnsureNecessaryWalFilesExist(const std::filesystem::path &wal_directory, co
 }
 
 auto EnsureRetentionCountSnapshotsExist(const std::filesystem::path &snapshot_directory, const std::string &path,
-                                        const std::string &uuid, utils::FileRetainer *file_retainer, Storage *storage)
-    -> OldSnapshotFiles {
+                                        const std::string &uuid, utils::FileRetainer *file_retainer,
+                                        Storage *storage) -> OldSnapshotFiles {
   OldSnapshotFiles old_snapshot_files;
   std::error_code error_code;
   for (const auto &item : std::filesystem::directory_iterator(snapshot_directory, error_code)) {
@@ -6937,7 +6937,7 @@ bool CreateSnapshot(Storage *storage, Transaction *transaction, const std::files
 
     // Write edge-type + property indices.
     {
-      auto edge_type = storage->indices_.edge_type_property_index_->ListIndices();
+      auto edge_type = transaction->active_indices_.edge_type_properties_->ListIndices(transaction->start_timestamp);
       snapshot.WriteUint(edge_type.size());
       for (const auto &item : edge_type) {
         write_mapping(item.first);

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -6950,7 +6950,7 @@ bool CreateSnapshot(Storage *storage, Transaction *transaction, const std::files
 
     // Write global edge property indices.
     {
-      auto indices = storage->indices_.edge_property_index_->ListIndices();
+      auto indices = transaction->active_indices_.edge_property_->ListIndices(transaction->start_timestamp);
       snapshot.WriteUint(indices.size());
       for (const auto &property : indices) {
         write_mapping(property);

--- a/src/storage/v2/indices/active_indices.hpp
+++ b/src/storage/v2/indices/active_indices.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "storage/v2/indices/edge_property_index.hpp"
 #include "storage/v2/indices/edge_type_index.hpp"
 #include "storage/v2/indices/edge_type_property_index.hpp"
 #include "storage/v2/indices/label_index.hpp"
@@ -34,11 +35,13 @@ struct ActiveIndices {
   explicit ActiveIndices(std::unique_ptr<LabelIndex::ActiveIndices> label,
                          std::unique_ptr<LabelPropertyIndex::ActiveIndices> label_properties,
                          std::unique_ptr<EdgeTypeIndex::ActiveIndices> edge_type,
-                         std::unique_ptr<EdgeTypePropertyIndex::ActiveIndices> edge_type_properties)
+                         std::unique_ptr<EdgeTypePropertyIndex::ActiveIndices> edge_type_properties,
+                         std::unique_ptr<EdgePropertyIndex::ActiveIndices> edge_property)
       : label_{std::move(label)},
         label_properties_{std::move(label_properties)},
         edge_type_{std::move(edge_type)},
-        edge_type_properties_(std::move(edge_type_properties)) {}
+        edge_type_properties_(std::move(edge_type_properties)),
+        edge_property_(std::move(edge_property) {}
 
   bool CheckIndicesAreReady(IndicesCollection const &required_indices) const {
     // label
@@ -61,6 +64,11 @@ struct ActiveIndices {
       if (!edge_type_properties_->IndexReady(edge_type, property)) return false;
     }
 
+    // edge property
+    for (auto const property : required_indices.edge_property_) {
+      if (!edge_property_->IndexReady(property)) return false;
+    }
+
     return true;
   }
 
@@ -68,5 +76,6 @@ struct ActiveIndices {
   std::unique_ptr<LabelPropertyIndex::ActiveIndices> label_properties_;
   std::unique_ptr<EdgeTypeIndex::ActiveIndices> edge_type_;
   std::unique_ptr<EdgeTypePropertyIndex::ActiveIndices> edge_type_properties_;
+  std::unique_ptr<EdgePropertyIndex::ActiveIndices> edge_property_;
 };
 }  // namespace memgraph::storage

--- a/src/storage/v2/indices/active_indices.hpp
+++ b/src/storage/v2/indices/active_indices.hpp
@@ -41,7 +41,7 @@ struct ActiveIndices {
         label_properties_{std::move(label_properties)},
         edge_type_{std::move(edge_type)},
         edge_type_properties_(std::move(edge_type_properties)),
-        edge_property_(std::move(edge_property) {}
+        edge_property_(std::move(edge_property)) {}
 
   bool CheckIndicesAreReady(IndicesCollection const &required_indices) const {
     // label

--- a/src/storage/v2/indices/active_indices.hpp
+++ b/src/storage/v2/indices/active_indices.hpp
@@ -11,11 +11,13 @@
 
 #pragma once
 
-#include "storage/v2/indices/label_index.hpp"
 #include "storage/v2/indices/edge_type_index.hpp"
+#include "storage/v2/indices/edge_type_property_index.hpp"
+#include "storage/v2/indices/label_index.hpp"
 #include "storage/v2/indices/label_property_index.hpp"
 
 #include <memory>
+#include <vector>
 
 namespace memgraph::storage {
 
@@ -23,7 +25,7 @@ struct IndicesCollection {
   std::vector<storage::LabelId> label_;
   std::vector<std::pair<storage::LabelId, std::vector<storage::PropertyPath>>> label_properties_;
   std::vector<storage::EdgeTypeId> edge_type_;
-  // TODO: edge_type + properties
+  std::vector<std::pair<storage::EdgeTypeId, storage::PropertyId>> edge_type_properties_;
   // TODO: edge properties
 };
 
@@ -31,8 +33,12 @@ struct ActiveIndices {
   ActiveIndices() = delete;  // to avoid nullptr
   explicit ActiveIndices(std::unique_ptr<LabelIndex::ActiveIndices> label,
                          std::unique_ptr<LabelPropertyIndex::ActiveIndices> label_properties,
-                         std::unique_ptr<EdgeTypeIndex::ActiveIndices> edge_type)
-      : label_{std::move(label)}, label_properties_{std::move(label_properties)}, edge_type_{std::move(edge_type)} {}
+                         std::unique_ptr<EdgeTypeIndex::ActiveIndices> edge_type,
+                         std::unique_ptr<EdgeTypePropertyIndex::ActiveIndices> edge_type_properties)
+      : label_{std::move(label)},
+        label_properties_{std::move(label_properties)},
+        edge_type_{std::move(edge_type)},
+        edge_type_properties_(std::move(edge_type_properties)) {}
 
   bool CheckIndicesAreReady(IndicesCollection const &required_indices) const {
     // label
@@ -50,11 +56,17 @@ struct ActiveIndices {
       if (!edge_type_->IndexReady(edge_type)) return false;
     }
 
+    // edge type + property
+    for (auto const &[edge_type, property] : required_indices.edge_type_properties_) {
+      if (!edge_type_properties_->IndexReady(edge_type, property)) return false;
+    }
+
     return true;
   }
 
   std::unique_ptr<LabelIndex::ActiveIndices> label_;
   std::unique_ptr<LabelPropertyIndex::ActiveIndices> label_properties_;
   std::unique_ptr<EdgeTypeIndex::ActiveIndices> edge_type_;
+  std::unique_ptr<EdgeTypePropertyIndex::ActiveIndices> edge_type_properties_;
 };
 }  // namespace memgraph::storage

--- a/src/storage/v2/indices/active_indices.hpp
+++ b/src/storage/v2/indices/active_indices.hpp
@@ -26,7 +26,7 @@ struct IndicesCollection {
   std::vector<std::pair<storage::LabelId, std::vector<storage::PropertyPath>>> label_properties_;
   std::vector<storage::EdgeTypeId> edge_type_;
   std::vector<std::pair<storage::EdgeTypeId, storage::PropertyId>> edge_type_properties_;
-  // TODO: edge properties
+  std::vector<storage::PropertyId> edge_property_;
 };
 
 struct ActiveIndices {

--- a/src/storage/v2/indices/edge_property_index.cpp
+++ b/src/storage/v2/indices/edge_property_index.cpp
@@ -1,0 +1,31 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "storage/v2/indices/edge_property_index.hpp"
+#include "storage/v2/edge.hpp"
+
+namespace memgraph::storage {
+
+void EdgePropertyIndex::AbortProcessor::CollectOnPropertyChange(PropertyId property, Vertex *from_vertex,
+                                                                Vertex *to_vertex, Edge *edge, EdgeTypeId edge_type) {
+  auto it = cleanup_collection_.find(property);
+  if (it == cleanup_collection_.end()) return;
+  auto old_value = edge->properties.GetProperty(property);
+  if (old_value.IsNull()) return;
+  it->second.emplace_back(std::move(old_value), from_vertex, to_vertex, edge, edge_type);
+}
+
+EdgePropertyIndex::AbortProcessor::AbortProcessor(std::span<PropertyId const> properties) {
+  for (auto edge_type : properties) {
+    cleanup_collection_.insert({edge_type, {}});
+  }
+}
+}  // namespace memgraph::storage

--- a/src/storage/v2/indices/edge_property_index.hpp
+++ b/src/storage/v2/indices/edge_property_index.hpp
@@ -32,10 +32,11 @@ class EdgePropertyIndex {
   struct AbortProcessor {
     explicit AbortProcessor(std::span<PropertyId const> properties);
 
-    void CollectOnPropertyChange(PropertyId property, Vertex *from_vertex, Vertex *to_vertex, Edge *edge,
-                                 EdgeTypeId edge_type);
+    void CollectOnPropertyChange(EdgeTypeId edge_type, PropertyId property, Vertex *from_vertex, Vertex *to_vertex,
+                                 Edge *edge, PropertyValue value);
 
     AbortableInfo cleanup_collection_;
+    bool IsInteresting(PropertyId property);
   };
 
   struct ActiveIndices {

--- a/src/storage/v2/indices/edge_property_index.hpp
+++ b/src/storage/v2/indices/edge_property_index.hpp
@@ -26,6 +26,40 @@ struct Edge;
 
 class EdgePropertyIndex {
  public:
+  using AbortableInfo =
+      std::map<PropertyId, std::vector<std::tuple<PropertyValue, Vertex *, Vertex *, Edge *, EdgeTypeId>>>;
+
+  struct AbortProcessor {
+    explicit AbortProcessor(std::span<PropertyId const> properties);
+
+    void CollectOnPropertyChange(PropertyId property, Vertex *from_vertex, Vertex *to_vertex, Edge *edge,
+                                 EdgeTypeId edge_type);
+
+    AbortableInfo cleanup_collection_;
+  };
+
+  struct ActiveIndices {
+    virtual ~ActiveIndices() = default;
+
+    virtual void UpdateOnSetProperty(Vertex *from_vertex, Vertex *to_vertex, Edge *edge, EdgeTypeId edge_type,
+                                     PropertyId property, PropertyValue value, uint64_t timestamp) = 0;
+
+    virtual uint64_t ApproximateEdgeCount(PropertyId property) const = 0;
+
+    virtual uint64_t ApproximateEdgeCount(PropertyId property, const PropertyValue &value) const = 0;
+
+    virtual uint64_t ApproximateEdgeCount(PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower,
+                                          const std::optional<utils::Bound<PropertyValue>> &upper) const = 0;
+
+    virtual bool IndexReady(PropertyId property) const = 0;
+
+    virtual std::vector<PropertyId> ListIndices(uint64_t start_timestamp) const = 0;
+
+    virtual auto GetAbortProcessor() const -> AbortProcessor = 0;
+
+    virtual void AbortEntries(AbortableInfo const &info, uint64_t start_timestamp) = 0;
+  };
+
   struct IndexStats {
     std::vector<PropertyId> ep;
   };
@@ -41,25 +75,9 @@ class EdgePropertyIndex {
 
   virtual bool DropIndex(PropertyId property) = 0;
 
-  virtual bool IndexExists(PropertyId property) const = 0;
-
-  virtual std::vector<PropertyId> ListIndices() const = 0;
-
-  virtual void UpdateOnSetProperty(Vertex *from_vertex, Vertex *to_vertex, Edge *edge, EdgeTypeId edge_type,
-                                   PropertyId property, PropertyValue value, uint64_t timestamp) = 0;
-
-  virtual uint64_t ApproximateEdgeCount(PropertyId property) const = 0;
-
-  virtual uint64_t ApproximateEdgeCount(PropertyId property, const PropertyValue &value) const = 0;
-
-  virtual uint64_t ApproximateEdgeCount(PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower,
-                                        const std::optional<utils::Bound<PropertyValue>> &upper) const = 0;
-
-  virtual void UpdateOnEdgeModification(Vertex *old_from, Vertex *old_to, Vertex *new_from, Vertex *new_to,
-                                        EdgeRef edge_ref, EdgeTypeId edge_type, PropertyId property,
-                                        const PropertyValue &value, const Transaction &tx) = 0;
-
   virtual void DropGraphClearIndices() = 0;
+
+  virtual auto GetActiveIndices() const -> std::unique_ptr<ActiveIndices> = 0;
 };
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/indices/edge_type_index.hpp
+++ b/src/storage/v2/indices/edge_type_index.hpp
@@ -42,9 +42,6 @@ class EdgeTypeIndex {
     virtual void UpdateOnEdgeCreation(Vertex *from, Vertex *to, EdgeRef edge_ref, EdgeTypeId edge_type,
                                       const Transaction &tx) = 0;
 
-    virtual void UpdateOnEdgeModification(Vertex *old_from, Vertex *old_to, Vertex *new_from, Vertex *new_to,
-                                          EdgeRef edge_ref, EdgeTypeId edge_type, const Transaction &tx) = 0;
-
     virtual auto ApproximateEdgeCount(EdgeTypeId edge_type) const -> uint64_t = 0;
 
     virtual bool IndexReady(EdgeTypeId edge_type) const = 0;

--- a/src/storage/v2/indices/edge_type_index.hpp
+++ b/src/storage/v2/indices/edge_type_index.hpp
@@ -28,8 +28,6 @@ class EdgeTypeIndex {
  public:
   using AbortableInfo = std::map<EdgeTypeId, std::vector<std::tuple<Vertex *, Vertex *, Edge *>>>;
 
-  struct ActiveIndices;
-
   struct AbortProcessor {
     explicit AbortProcessor(std::span<EdgeTypeId const> edge_types);
 

--- a/src/storage/v2/indices/edge_type_property_index.cpp
+++ b/src/storage/v2/indices/edge_type_property_index.cpp
@@ -1,0 +1,33 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "storage/v2/indices/edge_type_property_index.hpp"
+
+#include "storage/v2/edge.hpp"
+
+namespace memgraph::storage {
+void EdgeTypePropertyIndex::AbortProcessor::CollectOnPropertyChange(EdgeTypeId edge_type, PropertyId property,
+                                                                    Vertex *from_vertex, Vertex *to_vertex,
+                                                                    Edge *edge) {
+  auto it = cleanup_collection_.find({edge_type, property});
+  if (it == cleanup_collection_.end()) return;
+  auto value = edge->properties.GetProperty(property);
+  if (value.IsNull()) return;
+  it->second.emplace_back(from_vertex, to_vertex, edge, std::move(value));
+}
+
+EdgeTypePropertyIndex::AbortProcessor::AbortProcessor(std::span<std::pair<EdgeTypeId, PropertyId> const> keys) {
+  for (auto const &key : keys) {
+    cleanup_collection_.insert({key, {}});
+    interesting_properties_.insert(key.second);
+  }
+}
+}  // namespace memgraph::storage

--- a/src/storage/v2/indices/edge_type_property_index.hpp
+++ b/src/storage/v2/indices/edge_type_property_index.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -37,13 +37,6 @@ class EdgeTypePropertyIndex {
 
     virtual void UpdateOnSetProperty(Vertex *from_vertex, Vertex *to_vertex, Edge *edge, EdgeTypeId edge_type,
                                      PropertyId property, PropertyValue value, uint64_t timestamp) = 0;
-    // TODO (ivan): why is this missing?
-    // virtual void UpdateOnEdgeCreation(Vertex *from, Vertex *to, EdgeRef edge_ref, EdgeTypeId edge_type,
-    //                                   const Transaction &tx) = 0;
-
-    virtual void UpdateOnEdgeModification(Vertex *old_from, Vertex *old_to, Vertex *new_from, Vertex *new_to,
-                                          EdgeRef edge_ref, EdgeTypeId edge_type, PropertyId property,
-                                          const PropertyValue &value, const Transaction &tx) = 0;
 
     virtual uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property) const = 0;
 

--- a/src/storage/v2/indices/edge_type_property_index.hpp
+++ b/src/storage/v2/indices/edge_type_property_index.hpp
@@ -37,10 +37,12 @@ class EdgeTypePropertyIndex {
     void CollectOnPropertyChange(EdgeTypeId edge_type, PropertyId property, Vertex *from_vertex, Vertex *to_vertex,
                                  Edge *edge, PropertyValue value);
 
+    bool IsInteresting(PropertyId id);
+
+    bool IsInteresting(EdgeTypeId edge_type, PropertyId property);
+
     std::set<PropertyId> interesting_properties_;
     AbortableInfo cleanup_collection_;
-    bool IsInteresting(PropertyId id);
-    bool IsInteresting(EdgeTypeId edge_type, PropertyId property);
   };
 
   struct IndexStats {
@@ -73,8 +75,6 @@ class EdgeTypePropertyIndex {
   };
 
   virtual auto GetActiveIndices() const -> std::unique_ptr<ActiveIndices> = 0;
-
-  // TODO (ivan): why no AbortProcessor here?
 
   EdgeTypePropertyIndex() = default;
 

--- a/src/storage/v2/indices/edge_type_property_index.hpp
+++ b/src/storage/v2/indices/edge_type_property_index.hpp
@@ -32,6 +32,37 @@ class EdgeTypePropertyIndex {
     std::map<PropertyId, std::vector<EdgeTypeId>> p2et;
   };
 
+  struct ActiveIndices {
+    virtual ~ActiveIndices() = default;
+
+    virtual void UpdateOnSetProperty(Vertex *from_vertex, Vertex *to_vertex, Edge *edge, EdgeTypeId edge_type,
+                                     PropertyId property, PropertyValue value, uint64_t timestamp) = 0;
+    // TODO (ivan): why is this missing?
+    // virtual void UpdateOnEdgeCreation(Vertex *from, Vertex *to, EdgeRef edge_ref, EdgeTypeId edge_type,
+    //                                   const Transaction &tx) = 0;
+
+    virtual void UpdateOnEdgeModification(Vertex *old_from, Vertex *old_to, Vertex *new_from, Vertex *new_to,
+                                          EdgeRef edge_ref, EdgeTypeId edge_type, PropertyId property,
+                                          const PropertyValue &value, const Transaction &tx) = 0;
+
+    virtual uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property) const = 0;
+
+    virtual uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property,
+                                          const PropertyValue &value) const = 0;
+
+    virtual uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property,
+                                          const std::optional<utils::Bound<PropertyValue>> &lower,
+                                          const std::optional<utils::Bound<PropertyValue>> &upper) const = 0;
+
+    virtual bool IndexReady(EdgeTypeId edge_type, PropertyId property) const = 0;
+
+    virtual auto ListIndices(uint64_t start_timestamp) const -> std::vector<std::pair<EdgeTypeId, PropertyId>> = 0;
+  };
+
+  virtual auto GetActiveIndices() const -> std::unique_ptr<ActiveIndices> = 0;
+
+  // TODO (ivan): why no AbortProcessor here?
+
   EdgeTypePropertyIndex() = default;
 
   EdgeTypePropertyIndex(const EdgeTypePropertyIndex &) = delete;
@@ -42,26 +73,6 @@ class EdgeTypePropertyIndex {
   virtual ~EdgeTypePropertyIndex() = default;
 
   virtual bool DropIndex(EdgeTypeId edge_type, PropertyId property) = 0;
-
-  virtual bool IndexExists(EdgeTypeId edge_type, PropertyId property) const = 0;
-
-  virtual std::vector<std::pair<EdgeTypeId, PropertyId>> ListIndices() const = 0;
-
-  virtual void UpdateOnSetProperty(Vertex *from_vertex, Vertex *to_vertex, Edge *edge, EdgeTypeId edge_type,
-                                   PropertyId property, PropertyValue value, uint64_t timestamp) = 0;
-
-  virtual uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property) const = 0;
-
-  virtual uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property,
-                                        const PropertyValue &value) const = 0;
-
-  virtual uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property,
-                                        const std::optional<utils::Bound<PropertyValue>> &lower,
-                                        const std::optional<utils::Bound<PropertyValue>> &upper) const = 0;
-
-  virtual void UpdateOnEdgeModification(Vertex *old_from, Vertex *old_to, Vertex *new_from, Vertex *new_to,
-                                        EdgeRef edge_ref, EdgeTypeId edge_type, PropertyId property,
-                                        const PropertyValue &value, const Transaction &tx) = 0;
 
   virtual void DropGraphClearIndices() = 0;
 };

--- a/src/storage/v2/indices/edge_type_property_index.hpp
+++ b/src/storage/v2/indices/edge_type_property_index.hpp
@@ -35,10 +35,12 @@ class EdgeTypePropertyIndex {
     explicit AbortProcessor(std::span<std::pair<EdgeTypeId, PropertyId> const> keys);
 
     void CollectOnPropertyChange(EdgeTypeId edge_type, PropertyId property, Vertex *from_vertex, Vertex *to_vertex,
-                                 Edge *edge);
+                                 Edge *edge, PropertyValue value);
 
     std::set<PropertyId> interesting_properties_;
     AbortableInfo cleanup_collection_;
+    bool IsInteresting(PropertyId id);
+    bool IsInteresting(EdgeTypeId edge_type, PropertyId property);
   };
 
   struct IndexStats {

--- a/src/storage/v2/indices/indices.hpp
+++ b/src/storage/v2/indices/indices.hpp
@@ -47,20 +47,14 @@ struct Indices {
   /// TODO: unused in disk indices
   void RemoveObsoleteEdgeEntries(uint64_t oldest_active_start_timestamp, std::stop_token token) const;
 
-  /// Surgical removal of entries that were inserted in this transaction
-  /// TODO: unused in disk indices
-  void AbortEntries(std::pair<EdgeTypeId, PropertyId> edge_type_property,
-                    std::span<std::tuple<Vertex *const, Vertex *const, Edge *const, PropertyValue> const> edges,
-                    uint64_t exact_start_timestamp, Transaction *tx) const;
-
   void DropGraphClearIndices();
 
   struct AbortProcessor {
     LabelIndex::AbortProcessor label_;
     LabelPropertyIndex::AbortProcessor label_properties_;
     EdgeTypeIndex::AbortProcessor edge_type_;
+    EdgeTypePropertyIndex::AbortProcessor edge_type_property_;
 
-    EdgeTypePropertyIndex::IndexStats property_edge_type_;
     EdgePropertyIndex::IndexStats property_edge_;
     // TODO: point? Nothing to abort, it gets build in Commit
     // TODO: text?
@@ -70,6 +64,10 @@ struct Indices {
     void CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex *from_vertex, Vertex *to_vertex, Edge *edge);
     void CollectOnLabelRemoval(LabelId labelId, Vertex *vertex);
     void CollectOnPropertyChange(PropertyId propId, Vertex *vertex);
+    void CollectOnPropertyChange(EdgeTypeId edge_type, PropertyId property, Vertex *from_vertex, Vertex *to_vertex,
+                                 Edge *edge);
+    bool IsInterestingEdgeProperty(PropertyId property);
+
     void Process(Indices &indices, ActiveIndices &active_indices, uint64_t start_timestamp);
   };
 

--- a/src/storage/v2/indices/indices.hpp
+++ b/src/storage/v2/indices/indices.hpp
@@ -54,8 +54,7 @@ struct Indices {
     LabelPropertyIndex::AbortProcessor label_properties_;
     EdgeTypeIndex::AbortProcessor edge_type_;
     EdgeTypePropertyIndex::AbortProcessor edge_type_property_;
-
-    EdgePropertyIndex::IndexStats property_edge_;
+    EdgePropertyIndex::AbortProcessor edge_property_;
     // TODO: point? Nothing to abort, it gets build in Commit
     // TODO: text?
     VectorIndex::IndexStats vector_;

--- a/src/storage/v2/indices/indices.hpp
+++ b/src/storage/v2/indices/indices.hpp
@@ -51,7 +51,7 @@ struct Indices {
   /// TODO: unused in disk indices
   void AbortEntries(std::pair<EdgeTypeId, PropertyId> edge_type_property,
                     std::span<std::tuple<Vertex *const, Vertex *const, Edge *const, PropertyValue> const> edges,
-                    uint64_t exact_start_timestamp) const;
+                    uint64_t exact_start_timestamp, Transaction *tx) const;
 
   void DropGraphClearIndices();
 

--- a/src/storage/v2/inmemory/edge_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_property_index.cpp
@@ -213,8 +213,10 @@ InMemoryEdgePropertyIndex::IndividualIndex::~IndividualIndex() {
 
 bool InMemoryEdgePropertyIndex::DropIndex(PropertyId property) {
   auto const result = index_.WithLock([&](std::shared_ptr<IndicesContainer const> &indices_container) {
-    auto const it = indices_container->indices_.find(property);
-    if (it == indices_container->indices_.cend()) return false;
+    {
+      auto const it = indices_container->indices_.find(property);
+      if (it == indices_container->indices_.cend()) return false;
+    }
 
     auto new_container = std::make_shared<IndicesContainer>();
     for (auto const &[existing_property, index] : indices_container->indices_) {

--- a/src/storage/v2/inmemory/edge_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_property_index.cpp
@@ -20,6 +20,9 @@
 #include "storage/v2/property_value_utils.hpp"
 #include "utils/counter.hpp"
 
+namespace r = ranges;
+namespace rv = r::views;
+
 namespace {
 
 using Delta = memgraph::storage::Delta;
@@ -36,56 +39,149 @@ using View = memgraph::storage::View;
 
 namespace memgraph::storage {
 
-bool InMemoryEdgePropertyIndex::Entry::operator<(const PropertyValue &rhs) const { return value < rhs; }
+namespace {
+inline void TryInsertEdgePropertyIndex(Vertex &from_vertex, PropertyId property, auto &&index_accessor,
+                                       std::optional<SnapshotObserverInfo> const &snapshot_info) {
+  if (from_vertex.deleted) {
+    return;
+  }
+  for (auto const &[edge_type, to_vertex, edge_ref] : from_vertex.out_edges) {
+    if (to_vertex->deleted) {
+      continue;
+    }
+    index_accessor.insert(
+        {edge_ref.ptr->properties.GetProperty(property), &from_vertex, to_vertex, edge_ref.ptr, edge_type, 0});
+    if (snapshot_info) {
+      snapshot_info->Update(UpdateType::EDGES);
+    }
+  }
+}
 
-bool InMemoryEdgePropertyIndex::Entry::operator==(const PropertyValue &rhs) const { return value == rhs; }
+inline void TryInsertEdgePropertyIndex(Vertex &from_vertex, PropertyId property, auto &&index_accessor,
+                                       std::optional<SnapshotObserverInfo> const &snapshot_info,
+                                       Transaction const &tx) {
+  // TODO
+  TryInsertEdgePropertyIndex(from_vertex, property, std::move(index_accessor), snapshot_info);
+}
+}  // namespace
 
-bool InMemoryEdgePropertyIndex::CreateIndex(PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
-                                            std::optional<SnapshotObserverInfo> const &snapshot_info) {
-  auto [it, emplaced] = index_.try_emplace(property);
-  if (!emplaced) {
-    return false;
+bool InMemoryEdgePropertyIndex::CreateIndexOnePass(PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
+                                                   std::optional<SnapshotObserverInfo> const &snapshot_info) {
+  auto res = RegisterIndex(property);
+  if (!res) return false;
+  auto res2 = PopulateIndex(property, std::move(vertices), snapshot_info);
+  if (res2.HasError()) {
+    MG_ASSERT(false, "Index population can't fail, there was no cancellation callback.");
+  }
+  return PublishIndex(property, 0);
+}
+
+bool InMemoryEdgePropertyIndex::RegisterIndex(PropertyId property) {
+  return index_.WithLock([&](std::shared_ptr<IndicesContainer const> &indices_container) {
+    auto const &indices = indices_container->indices_;
+    auto it = indices.find(property);
+    if (it != indices.end()) return false;  // already exists
+
+    utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
+    // Register
+    auto new_container = std::make_shared<IndicesContainer>(*indices_container);
+    auto [new_it, _] = new_container->indices_.emplace(property, std::make_shared<IndividualIndex>());
+    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
+    all_indexes_.WithLock([&](auto &all_indexes) {
+      // TODO: shared_ptr, build a new one
+      all_indexes.emplace(property, new_it->second);
+    });
+    indices_container = new_container;
+    return true;
+  });
+}
+
+auto InMemoryEdgePropertyIndex::PopulateIndex(PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
+                                              std::optional<SnapshotObserverInfo> const &snapshot_info,
+                                              Transaction const *tx, CheckCancelFunction cancel_check)
+    -> utils::BasicResult<IndexPopulateError> {
+  auto index = GetIndividualIndex(property);
+  if (!index) {
+    MG_ASSERT(false, "It should not be possible to remove the index before populating it.");
   }
 
-  const utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
   try {
-    auto edge_acc = it->second.access();
-    for (auto &from_vertex : vertices) {
-      if (from_vertex.deleted) {
-        continue;
-      }
-
-      for (auto &edge : from_vertex.out_edges) {
-        const auto type = std::get<EdgeTypeId>(edge);
-        auto *to_vertex = std::get<Vertex *>(edge);
-        if (to_vertex->deleted) {
-          continue;
-        }
-        auto *edge_ptr = std::get<EdgeRef>(edge).ptr;
-        edge_acc.insert({edge_ptr->properties.GetProperty(property), &from_vertex, to_vertex, edge_ptr, type, 0});
-        if (snapshot_info) {
-          snapshot_info->Update(UpdateType::EDGES);
-        }
-      }
+    auto const accessor_factory = [&] { return index->skip_list_.access(); };
+    if (tx) {
+      // If we are in a transaction, we need to read the object with the correct MVCC snapshot isolation
+      auto const insert_function = [&](Vertex &from_vertex, auto &index_accessor) {
+        TryInsertEdgePropertyIndex(from_vertex, property, index_accessor, snapshot_info, *tx);
+      };
+      PopulateIndexDispatch(vertices, accessor_factory, insert_function, std::move(cancel_check),
+                            {} /*TODO: parallel*/);
+    } else {
+      // If we are not in a transaction, we need to read the object as it is. (post recovery)
+      auto const insert_function = [&](Vertex &from_vertex, auto &index_accessor) {
+        TryInsertEdgePropertyIndex(from_vertex, property, index_accessor, snapshot_info);
+      };
+      PopulateIndexDispatch(vertices, accessor_factory, insert_function, std::move(cancel_check),
+                            {} /*TODO: parallel*/);
     }
+  } catch (const PopulateCancel &) {
+    DropIndex(property);
+    return IndexPopulateError::Cancellation;
   } catch (const utils::OutOfMemoryException &) {
-    const utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_exception_blocker;
-    index_.erase(it);
+    DropIndex(property);
     throw;
   }
+  return {};
+}
 
+bool InMemoryEdgePropertyIndex::PublishIndex(PropertyId property, uint64_t commit_timestamp) {
+  auto index = GetIndividualIndex(property);
+  if (!index) return false;
+  index->Publish(commit_timestamp);
   return true;
 }
 
-bool InMemoryEdgePropertyIndex::DropIndex(PropertyId property) { return index_.erase(property) > 0; }
+void InMemoryEdgePropertyIndex::IndividualIndex::Publish(uint64_t commit_timestamp) {
+  status_.Commit(commit_timestamp);
+  memgraph::metrics::IncrementCounter(memgraph::metrics::ActiveEdgePropertyIndices);
+}
 
-bool InMemoryEdgePropertyIndex::IndexExists(PropertyId property) const { return index_.find(property) != index_.end(); }
+InMemoryEdgePropertyIndex::IndividualIndex::~IndividualIndex() {
+  if (status_.IsReady()) {
+    memgraph::metrics::DecrementCounter(memgraph::metrics::ActiveEdgePropertyIndices);
+  }
+}
 
-std::vector<PropertyId> InMemoryEdgePropertyIndex::ListIndices() const {
-  std::vector<PropertyId> ret;
-  ret.reserve(index_.size());
-  for (const auto &item : index_) {
-    ret.emplace_back(item.first);
+bool InMemoryEdgePropertyIndex::DropIndex(PropertyId property) {
+  auto const result = index_.WithLock([&](std::shared_ptr<IndicesContainer const> &indices_container) {
+    auto const it = indices_container->indices_.find(property);
+    if (it == indices_container->indices_.cend()) return false;
+
+    auto new_container = std::make_shared<IndicesContainer>();
+    for (auto const &[existing_property, index] : indices_container->indices_) {
+      if (existing_property != property) {
+        new_container->indices_.emplace(existing_property, index);
+      }
+    }
+    indices_container = new_container;
+    return true;
+  });
+  CleanupAllIndicies();
+  return result;
+}
+
+bool InMemoryEdgePropertyIndex::ActiveIndices::IndexReady(PropertyId property) const {
+  auto const &indices = ptr_->indices_;
+  auto it = indices.find(property);
+  if (it == indices.end()) return false;
+  return it->second->status_.IsReady();
+}
+
+std::vector<PropertyId> InMemoryEdgePropertyIndex::ActiveIndices::ListIndices(uint64_t start_timestamp) const {
+  auto ret = std::vector<PropertyId>{};
+  ret.reserve(ptr_->indices_.size());
+  for (auto const &[property, index] : ptr_->indices_) {
+    if (index->status_.IsVisible(start_timestamp)) {
+      ret.emplace_back(property);
+    }
   }
   return ret;
 }
@@ -93,10 +189,14 @@ std::vector<PropertyId> InMemoryEdgePropertyIndex::ListIndices() const {
 void InMemoryEdgePropertyIndex::RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token) {
   auto maybe_stop = utils::ResettableCounter(2048);
 
-  for (auto &[property_id, index] : index_) {
+  CleanupAllIndicies();
+
+  auto cpy = all_indexes_.WithReadLock(std::identity{});
+
+  for (auto &[property_id, index] : cpy) {
     if (token.stop_requested()) return;
 
-    auto edges_acc = index.access();
+    auto edges_acc = index->skip_list_.access();
     for (auto it = edges_acc.begin(); it != edges_acc.end();) {
       if (maybe_stop() && token.stop_requested()) return;
 
@@ -129,47 +229,33 @@ void InMemoryEdgePropertyIndex::RemoveObsoleteEntries(uint64_t oldest_active_sta
   }
 }
 
-void InMemoryEdgePropertyIndex::AbortEntries(
-    std::pair<EdgeTypeId, PropertyId> edge_property,
-    std::span<std::tuple<Vertex *const, Vertex *const, Edge *const, PropertyValue> const> edges,
-    uint64_t exact_start_timestamp) {
-  auto it = index_.find(edge_property.second);
-  if (it == index_.end()) {
-    return;
-  }
-
-  auto acc = it->second.access();
-  for (const auto &[from_vertex, to_vertex, edge, value] : edges) {
-    acc.remove(Entry{value, from_vertex, to_vertex, edge, edge_property.first, exact_start_timestamp});
-  }
-}
-
-void InMemoryEdgePropertyIndex::UpdateOnSetProperty(Vertex *from_vertex, Vertex *to_vertex, Edge *edge,
-                                                    EdgeTypeId edge_type, PropertyId property, PropertyValue value,
-                                                    uint64_t timestamp) {
+void InMemoryEdgePropertyIndex::ActiveIndices::UpdateOnSetProperty(Vertex *from_vertex, Vertex *to_vertex, Edge *edge,
+                                                                   EdgeTypeId edge_type, PropertyId property,
+                                                                   PropertyValue value, uint64_t timestamp) {
   if (value.IsNull()) {
     return;
   }
 
-  auto it = index_.find(property);
-  if (it == index_.end()) return;
+  auto it = ptr_->indices_.find(property);
+  if (it == ptr_->indices_.end()) return;
 
-  auto acc = it->second.access();
+  auto acc = it->second->skip_list_.access();
   acc.insert({value, from_vertex, to_vertex, edge, edge_type, timestamp});
 }
 
-uint64_t InMemoryEdgePropertyIndex::ApproximateEdgeCount(PropertyId property) const {
-  if (auto it = index_.find(property); it != index_.end()) {
-    return it->second.size();
+uint64_t InMemoryEdgePropertyIndex::ActiveIndices::ApproximateEdgeCount(PropertyId property) const {
+  if (auto it = ptr_->indices_.find(property); it != ptr_->indices_.end()) {
+    return it->second->skip_list_.size();
   }
 
   return 0U;
 }
 
-uint64_t InMemoryEdgePropertyIndex::ApproximateEdgeCount(PropertyId property, const PropertyValue &value) const {
-  auto it = index_.find(property);
-  MG_ASSERT(it != index_.end(), "Index for edge property {} doesn't exist", property.AsUint());
-  auto acc = it->second.access();
+uint64_t InMemoryEdgePropertyIndex::ActiveIndices::ApproximateEdgeCount(PropertyId property,
+                                                                        const PropertyValue &value) const {
+  auto it = ptr_->indices_.find(property);
+  MG_ASSERT(it != ptr_->indices_.end(), "Index for edge property {} doesn't exist", property.AsUint());
+  auto acc = it->second->skip_list_.access();
   if (!value.IsNull()) {
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     return acc.estimate_count(value, utils::SkipListLayerForCountEstimation(acc.size()));
@@ -184,30 +270,20 @@ uint64_t InMemoryEdgePropertyIndex::ApproximateEdgeCount(PropertyId property, co
       utils::SkipListLayerForAverageEqualsEstimation(acc.size()));
 }
 
-uint64_t InMemoryEdgePropertyIndex::ApproximateEdgeCount(
+uint64_t InMemoryEdgePropertyIndex::ActiveIndices::ApproximateEdgeCount(
     PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower,
     const std::optional<utils::Bound<PropertyValue>> &upper) const {
-  auto it = index_.find(property);
-  MG_ASSERT(it != index_.end(), "Index for edge property {} doesn't exist", property.AsUint());
-  auto acc = it->second.access();
+  auto it = ptr_->indices_.find(property);
+  MG_ASSERT(it != ptr_->indices_.end(), "Index for edge property {} doesn't exist", property.AsUint());
+  auto acc = it->second->skip_list_.access();
   // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
   return acc.estimate_range_count(lower, upper, utils::SkipListLayerForCountEstimation(acc.size()));
 }
 
-void InMemoryEdgePropertyIndex::UpdateOnEdgeModification(Vertex * /*old_from*/, Vertex * /*old_to*/, Vertex *new_from,
-                                                         Vertex *new_to, EdgeRef edge_ref, EdgeTypeId edge_type,
-                                                         PropertyId property, const PropertyValue &value,
-                                                         const Transaction &tx) {
-  auto it = index_.find(property);
-  if (it == index_.end()) {
-    return;
-  }
-
-  auto acc = it->second.access();
-  acc.insert(Entry{value, new_from, new_to, edge_ref.ptr, edge_type, tx.start_timestamp});
+void InMemoryEdgePropertyIndex::DropGraphClearIndices() {
+  index_.WithLock([](std::shared_ptr<IndicesContainer const> &index) { index = std::make_shared<IndicesContainer>(); });
+  CleanupAllIndicies();
 }
-
-void InMemoryEdgePropertyIndex::DropGraphClearIndices() { index_.clear(); }
 
 InMemoryEdgePropertyIndex::Iterable::Iterable(utils::SkipList<Entry>::Accessor index_accessor,
                                               utils::SkipList<Vertex>::ConstAccessor vertex_accessor,
@@ -306,20 +382,25 @@ void InMemoryEdgePropertyIndex::Iterable::Iterator::AdvanceUntilValid() {
 }
 
 void InMemoryEdgePropertyIndex::RunGC() {
-  for (auto &index_entry : index_) {
-    index_entry.second.run_gc();
+  // Remove indicies that are not used by any txn
+  CleanupAllIndicies();
+
+  // For each skip_list remaining, run GC
+  auto cpy = all_indexes_.WithReadLock(std::identity{});
+  for (auto &[_, index] : cpy) {
+    index->skip_list_.run_gc();
   }
 }
 
-InMemoryEdgePropertyIndex::Iterable InMemoryEdgePropertyIndex::Edges(
+InMemoryEdgePropertyIndex::Iterable InMemoryEdgePropertyIndex::ActiveIndices::Edges(
     PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
     Transaction *transaction) {
-  auto it = index_.find(property);
-  MG_ASSERT(it != index_.end(), "Index for edge property {} doesn't exist", property.AsUint());
+  auto it = ptr_->indices_.find(property);
+  MG_ASSERT(it != ptr_->indices_.end(), "Index for edge property {} doesn't exist", property.AsUint());
   auto vertex_acc = static_cast<InMemoryStorage const *>(storage)->vertices_.access();
   auto edge_acc = static_cast<InMemoryStorage const *>(storage)->edges_.access();
-  return {it->second.access(),
+  return {it->second->skip_list_.access(),
           std::move(vertex_acc),
           std::move(edge_acc),
           property,
@@ -328,6 +409,48 @@ InMemoryEdgePropertyIndex::Iterable InMemoryEdgePropertyIndex::Edges(
           view,
           storage,
           transaction};
+}
+
+EdgePropertyIndex::AbortProcessor InMemoryEdgePropertyIndex::ActiveIndices::GetAbortProcessor() const {
+  auto property_ids_filter = ptr_->indices_ | std::views::keys | ranges::to_vector;
+  return AbortProcessor{property_ids_filter};
+}
+
+void InMemoryEdgePropertyIndex::ActiveIndices::AbortEntries(EdgePropertyIndex::AbortableInfo const &info,
+                                                            uint64_t start_timestamp) {
+  for (auto const &[property, edges] : info) {
+    auto const it = ptr_->indices_.find(property);
+    DMG_ASSERT(it != ptr_->indices_.end());
+
+    auto &index_storage = it->second;
+    auto acc = index_storage->skip_list_.access();
+    for (const auto &[value, from_vertex, to_vertex, edge, type] : edges) {
+      acc.remove(Entry{value, from_vertex, to_vertex, edge, type, start_timestamp});
+    }
+  }
+}
+
+std::unique_ptr<EdgePropertyIndex::ActiveIndices> InMemoryEdgePropertyIndex::GetActiveIndices() const {
+  return std::make_unique<ActiveIndices>(index_.WithReadLock(std::identity{}));
+}
+
+auto InMemoryEdgePropertyIndex::GetIndividualIndex(PropertyId property) const -> std::shared_ptr<IndividualIndex> {
+  return index_.WithReadLock(
+      [&](std::shared_ptr<IndicesContainer const> const &index) -> std::shared_ptr<IndividualIndex> {
+        auto it = index->indices_.find(property);
+        if (it == index->indices_.cend()) [[unlikely]]
+          return {};
+        return it->second;
+      });
+}
+
+void InMemoryEdgePropertyIndex::CleanupAllIndicies() {
+  all_indexes_.WithLock([](std::map<PropertyId, std::shared_ptr<IndividualIndex>> &indices) {
+    // TODO:
+    //    std::erase_if(indices, [](std::shared_ptr<IndividualIndex> const &individualIndex) {
+    //      return individualIndex.use_count() == 1;
+    //    });
+  });
 }
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/inmemory/edge_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_property_index.cpp
@@ -49,8 +49,11 @@ inline void TryInsertEdgePropertyIndex(Vertex &from_vertex, PropertyId property,
     if (to_vertex->deleted) {
       continue;
     }
-    index_accessor.insert(
-        {edge_ref.ptr->properties.GetProperty(property), &from_vertex, to_vertex, edge_ref.ptr, edge_type, 0});
+    auto value = edge_ref.ptr->properties.GetProperty(property);
+    if (value.IsNull()) {
+      continue;
+    }
+    index_accessor.insert({std::move(value), &from_vertex, to_vertex, edge_ref.ptr, edge_type, 0});
     if (snapshot_info) {
       snapshot_info->Update(UpdateType::EDGES);
     }

--- a/src/storage/v2/inmemory/edge_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_property_index.hpp
@@ -15,17 +15,21 @@
 #include <map>
 #include <utility>
 
+#include "storage/v2/common_function_signatures.hpp"
 #include "storage/v2/edge_accessor.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indices/edge_property_index.hpp"
+#include "storage/v2/indices/errors.hpp"
+#include "storage/v2/inmemory/indices_mvcc.hpp"
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/snapshot_observer_info.hpp"
 #include "storage/v2/vertex_accessor.hpp"
+#include "utils/rw_lock.hpp"
 #include "utils/skip_list.hpp"
 
 namespace memgraph::storage {
 
-class InMemoryEdgePropertyIndex : public storage::EdgePropertyIndex {
+class InMemoryEdgePropertyIndex : public EdgePropertyIndex {
  private:
   struct Entry {
     PropertyValue value;
@@ -46,54 +50,29 @@ class InMemoryEdgePropertyIndex : public storage::EdgePropertyIndex {
              std::tie(rhs.value, rhs.edge, rhs.from_vertex, rhs.to_vertex, rhs.edge_type, rhs.timestamp);
     }
 
-    bool operator<(const PropertyValue &rhs) const;
-    bool operator==(const PropertyValue &rhs) const;
+    bool operator<(const PropertyValue &rhs) const { return value < rhs; }
+    bool operator==(const PropertyValue &rhs) const { return value == rhs; }
   };
 
  public:
-  InMemoryEdgePropertyIndex() = default;
+  struct IndividualIndex {
+    ~IndividualIndex();
+    void Publish(uint64_t commit_timestamp);
 
-  /// @throw std::bad_alloc
-  bool CreateIndex(PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
-                   std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
+    utils::SkipList<Entry> skip_list_;
+    IndexStatus status_{};
+  };
 
-  /// Returns false if there was no index to drop
-  bool DropIndex(PropertyId property) override;
+  struct IndicesContainer {
+    IndicesContainer(IndicesContainer const &other) : indices_(other.indices_) {}
+    IndicesContainer(IndicesContainer &&) = default;
+    IndicesContainer &operator=(IndicesContainer const &) = default;
+    IndicesContainer &operator=(IndicesContainer &&) = default;
+    IndicesContainer() = default;
+    ~IndicesContainer() = default;
 
-  bool IndexExists(PropertyId property) const override;
-
-  std::vector<PropertyId> ListIndices() const override;
-
-  void RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token);
-
-  void AbortEntries(std::pair<EdgeTypeId, PropertyId> edge_property,
-                    std::span<std::tuple<Vertex *const, Vertex *const, Edge *const, PropertyValue> const> edges,
-                    uint64_t exact_start_timestamp);
-
-  uint64_t ApproximateEdgeCount(PropertyId property) const override;
-
-  uint64_t ApproximateEdgeCount(PropertyId property, const PropertyValue &value) const override;
-
-  uint64_t ApproximateEdgeCount(PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower,
-                                const std::optional<utils::Bound<PropertyValue>> &upper) const override;
-
-  // Functions that update the index
-  void UpdateOnSetProperty(Vertex *from_vertex, Vertex *to_vertex, Edge *edge, EdgeTypeId edge_type,
-                           PropertyId property, PropertyValue value, uint64_t timestamp) override;
-
-  void UpdateOnEdgeModification(Vertex *old_from, Vertex *old_to, Vertex *new_from, Vertex *new_to, EdgeRef edge_ref,
-                                EdgeTypeId edge_type, PropertyId property, const PropertyValue &value,
-                                const Transaction &tx) override;
-
-  void DropGraphClearIndices() override;
-
-  IndexStats Analysis() const {
-    IndexStats stats;
-    for (const auto &[key, _] : index_) {
-      stats.ep.push_back(key);
-    }
-    return stats;
-  }
+    std::map<PropertyId, std::shared_ptr<IndividualIndex>> indices_;
+  };
 
   class Iterable {
    public:
@@ -140,14 +119,70 @@ class InMemoryEdgePropertyIndex : public storage::EdgePropertyIndex {
     Transaction *transaction_;
   };
 
+  struct ActiveIndices : EdgePropertyIndex::ActiveIndices {
+    explicit ActiveIndices(std::shared_ptr<IndicesContainer const> indices = std::make_shared<IndicesContainer>())
+        : ptr_{std::move(indices)} {}
+
+    void UpdateOnSetProperty(Vertex *from_vertex, Vertex *to_vertex, Edge *edge, EdgeTypeId edge_type,
+                             PropertyId property, PropertyValue value, uint64_t timestamp) override;
+
+    uint64_t ApproximateEdgeCount(PropertyId property) const override;
+
+    uint64_t ApproximateEdgeCount(PropertyId property, const PropertyValue &value) const override;
+
+    uint64_t ApproximateEdgeCount(PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower,
+                                  const std::optional<utils::Bound<PropertyValue>> &upper) const override;
+
+    bool IndexReady(PropertyId property) const override;
+
+    std::vector<PropertyId> ListIndices(uint64_t start_timestamp) const override;
+
+    Iterable Edges(PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+                   const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
+                   Transaction *transaction);
+
+    auto GetAbortProcessor() const -> AbortProcessor override;
+    void AbortEntries(AbortableInfo const &info, uint64_t start_timestamp) override;
+
+   private:
+    std::shared_ptr<IndicesContainer const> ptr_;
+  };
+
+  InMemoryEdgePropertyIndex() = default;
+
+  /// @throw std::bad_alloc
+  bool CreateIndexOnePass(PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
+                          std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
+
+  bool RegisterIndex(PropertyId property);
+  auto PopulateIndex(PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
+                     std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt,
+                     Transaction const *tx = nullptr, CheckCancelFunction cancel_check = neverCancel)
+      -> utils::BasicResult<IndexPopulateError>;
+  bool PublishIndex(PropertyId property, uint64_t commit_timestamp);
+
+  /// Returns false if there was no index to drop
+  bool DropIndex(PropertyId property) override;
+
+  void RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token);
+
+  void DropGraphClearIndices() override;
+
   void RunGC();
 
-  Iterable Edges(PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
-                 const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
-                 Transaction *transaction);
+  auto GetActiveIndices() const -> std::unique_ptr<EdgePropertyIndex::ActiveIndices> override;
 
  private:
-  std::map<PropertyId, utils::SkipList<Entry>> index_;
+  auto GetIndividualIndex(PropertyId property) const -> std::shared_ptr<IndividualIndex>;
+  void CleanupAllIndicies();
+
+  utils::Synchronized<std::shared_ptr<IndicesContainer const>, utils::WritePrioritizedRWLock> index_{
+      std::make_shared<IndicesContainer>()};
+
+  // For correct GC we need a copy of all indexes, even if dropped, this is so we can ensure dangling ptr are removed
+  // even for dropped indices
+  utils::Synchronized<std::map<PropertyId, std::shared_ptr<IndividualIndex>>, utils::WritePrioritizedRWLock>
+      all_indexes_{};
 };
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -93,8 +93,8 @@ bool InMemoryEdgeTypeIndex::CreateIndexOnePass(EdgeTypeId edge_type, utils::Skip
 
 auto InMemoryEdgeTypeIndex::PopulateIndex(EdgeTypeId edge_type, utils::SkipList<Vertex>::Accessor vertices,
                                           std::optional<SnapshotObserverInfo> const &snapshot_info,
-                                          Transaction const *tx, CheckCancelFunction cancel_check)
-    -> utils::BasicResult<IndexPopulateError> {
+                                          Transaction const *tx,
+                                          CheckCancelFunction cancel_check) -> utils::BasicResult<IndexPopulateError> {
   auto index = GetIndividualIndex(edge_type);
   if (!index) {
     MG_ASSERT(false, "It should not be possible to remove the index before populating it.");

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -172,8 +172,10 @@ InMemoryEdgeTypeIndex::IndividualIndex::~IndividualIndex() {
 
 bool InMemoryEdgeTypeIndex::DropIndex(EdgeTypeId edge_type) {
   auto const result = index_.WithLock([&](std::shared_ptr<IndicesContainer const> &indices_container) {
-    auto const it = indices_container->indices_.find(edge_type);
-    if (it == indices_container->indices_.cend()) return false;
+    {
+      auto const it = indices_container->indices_.find(edge_type);
+      if (it == indices_container->indices_.cend()) return false;
+    }
 
     auto new_container = std::make_shared<IndicesContainer>();
     for (auto const &[existing_edge_type, index] : indices_container->indices_) {

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -145,8 +145,8 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
   bool RegisterIndex(EdgeTypeId edge_type);
   auto PopulateIndex(EdgeTypeId insert_function, utils::SkipList<Vertex>::Accessor vertices,
                      std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt,
-                     Transaction const *tx = nullptr, CheckCancelFunction cancel_check = neverCancel)
-      -> utils::BasicResult<IndexPopulateError>;
+                     Transaction const *tx = nullptr,
+                     CheckCancelFunction cancel_check = neverCancel) -> utils::BasicResult<IndexPopulateError>;
 
   bool PublishIndex(EdgeTypeId edge_type, uint64_t commit_timestamp);
 

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -125,8 +125,6 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
     void UpdateOnEdgeCreation(Vertex *from, Vertex *to, EdgeRef edge_ref, EdgeTypeId edge_type,
                               const Transaction &tx) override;
 
-    void UpdateOnEdgeModification(Vertex *old_from, Vertex *old_to, Vertex *new_from, Vertex *new_to, EdgeRef edge_ref,
-                                  EdgeTypeId edge_type, const Transaction &tx) override;
     void AbortEntries(AbortableInfo const &info, uint64_t exact_start_timestamp) override;
     auto GetAbortProcessor() const -> AbortProcessor override;
 

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -145,8 +145,8 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
   bool RegisterIndex(EdgeTypeId edge_type);
   auto PopulateIndex(EdgeTypeId insert_function, utils::SkipList<Vertex>::Accessor vertices,
                      std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt,
-                     Transaction const *tx = nullptr,
-                     CheckCancelFunction cancel_check = neverCancel) -> utils::BasicResult<IndexPopulateError>;
+                     Transaction const *tx = nullptr, CheckCancelFunction cancel_check = neverCancel)
+      -> utils::BasicResult<IndexPopulateError>;
 
   bool PublishIndex(EdgeTypeId edge_type, uint64_t commit_timestamp);
 
@@ -162,7 +162,7 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
   auto GetActiveIndices() const -> std::unique_ptr<EdgeTypeIndex::ActiveIndices> override;
 
  private:
-  void CleanupAllIndicies();
+  void CleanupAllIndices();
   auto GetIndividualIndex(EdgeTypeId edge_type) const -> std::shared_ptr<IndividualIndex>;
 
   utils::Synchronized<std::shared_ptr<IndicesContainer const>, utils::WritePrioritizedRWLock> index_{
@@ -170,7 +170,9 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
 
   // For correct GC we need a copy of all indexes, even if dropped, this is so we can ensure dangling ptr are removed
   // even for dropped indices
-  utils::Synchronized<std::vector<std::shared_ptr<IndividualIndex>>, utils::WritePrioritizedRWLock> all_indexes_{};
+  using AllIndicesEntry = std::shared_ptr<IndividualIndex>;
+  utils::Synchronized<std::shared_ptr<std::vector<AllIndicesEntry> const>, utils::WritePrioritizedRWLock>
+      all_indexes_{};
 };
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -164,13 +164,13 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
   auto GetIndividualIndex(EdgeTypeId edge_type) const -> std::shared_ptr<IndividualIndex>;
 
   utils::Synchronized<std::shared_ptr<IndicesContainer const>, utils::WritePrioritizedRWLock> index_{
-      std::make_shared<IndicesContainer>()};
+      std::make_shared<IndicesContainer const>()};
 
   // For correct GC we need a copy of all indexes, even if dropped, this is so we can ensure dangling ptr are removed
   // even for dropped indices
   using AllIndicesEntry = std::shared_ptr<IndividualIndex>;
-  utils::Synchronized<std::shared_ptr<std::vector<AllIndicesEntry> const>, utils::WritePrioritizedRWLock>
-      all_indexes_{};
+  utils::Synchronized<std::shared_ptr<std::vector<AllIndicesEntry> const>, utils::WritePrioritizedRWLock> all_indices_{
+      std::make_shared<std::vector<AllIndicesEntry> const>()};
 };
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -112,7 +112,7 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
  public:
   struct ActiveIndices : storage::EdgeTypeIndex::ActiveIndices {
     explicit ActiveIndices(std::shared_ptr<IndicesContainer const> indices = std::make_shared<IndicesContainer>())
-        : ptr_{std::move(indices)} {}
+        : index_container_{std::move(indices)} {}
 
     bool IndexReady(EdgeTypeId edge_type) const override;
 
@@ -133,7 +133,7 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
     Iterable Edges(EdgeTypeId edge_type, View view, Storage *storage, Transaction *transaction);
 
    private:
-    std::shared_ptr<IndicesContainer const> ptr_;
+    std::shared_ptr<IndicesContainer const> index_container_;
   };
 
   InMemoryEdgeTypeIndex() = default;

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -174,9 +174,11 @@ bool InMemoryEdgeTypePropertyIndex::CreateIndexOnePass(EdgeTypeId edge_type, Pro
 
 bool InMemoryEdgeTypePropertyIndex::DropIndex(EdgeTypeId edge_type, PropertyId property) {
   auto result = index_.WithLock([&](std::shared_ptr<IndexContainer const> &index_container) {
-    auto it = index_container->find({edge_type, property});
-    if (it == index_container->end()) [[unlikely]] {
-      return false;
+    {
+      auto it = index_container->find({edge_type, property});
+      if (it == index_container->end()) [[unlikely]] {
+        return false;
+      }
     }
 
     auto new_container = std::make_shared<IndexContainer>(*index_container);

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -101,7 +101,6 @@ inline void TryInsertEdgeTypePropertyIndex(Vertex &from_vertex, EdgeTypeId edge_
   }
 }
 
-// TODO (ivan): Is this function correct?
 inline void TryInsertEdgeTypePropertyIndex(Vertex &from_vertex, EdgeTypeId edge_type, PropertyId property,
                                            auto &&index_accessor,
                                            std::optional<SnapshotObserverInfo> const &snapshot_info,
@@ -148,11 +147,11 @@ inline void TryInsertEdgeTypePropertyIndex(Vertex &from_vertex, EdgeTypeId edge_
       // Edge type is immutable so we don't need to check it
       ApplyDeltasForRead(&tx, delta, View::OLD, [&](const Delta &delta) {
         // clang-format off
-      DeltaDispatch(delta, utils::ChainedOverloaded{
-        Exists_ActionMethod(exists),
-        Deleted_ActionMethod(deleted),
-        PropertyValue_ActionMethod(property_value, property),
-      });
+        DeltaDispatch(delta, utils::ChainedOverloaded{
+          Exists_ActionMethod(exists),
+          Deleted_ActionMethod(deleted),
+          PropertyValue_ActionMethod(property_value, property),
+        });
         // clang-format on
       });
     }

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -21,66 +21,209 @@
 #include "storage/v2/property_value_utils.hpp"
 #include "utils/counter.hpp"
 
+namespace r = ranges;
+namespace rv = r::views;
 namespace memgraph::storage {
 
 bool InMemoryEdgeTypePropertyIndex::Entry::operator<(const PropertyValue &rhs) const { return value < rhs; }
 
 bool InMemoryEdgeTypePropertyIndex::Entry::operator==(const PropertyValue &rhs) const { return value == rhs; }
 
-bool InMemoryEdgeTypePropertyIndex::CreateIndex(EdgeTypeId edge_type, PropertyId property,
-                                                utils::SkipList<Vertex>::Accessor vertices,
-                                                std::optional<SnapshotObserverInfo> const &snapshot_info) {
-  auto [it, emplaced] = index_.try_emplace({edge_type, property});
-  if (!emplaced) {
-    return false;
-  }
+bool InMemoryEdgeTypePropertyIndex::RegisterIndex(EdgeTypeId edge_type, PropertyId property) {
+  return index_.WithLock([&](std::shared_ptr<IndexContainer const> &index_container) {
+    auto it = index_container->find({edge_type, property});
+    if (it != index_container->end()) return false;
 
-  const utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
-  try {
-    auto edge_acc = it->second.access();
-    for (auto &from_vertex : vertices) {
-      if (from_vertex.deleted) {
-        continue;
-      }
+    auto new_container = std::make_shared<IndexContainer>(*index_container);
+    auto [new_it, _] = new_container->emplace(std::make_pair(edge_type, property), std::make_shared<IndividualIndex>());
 
-      for (auto &edge : from_vertex.out_edges) {
-        const auto type = std::get<EdgeTypeId>(edge);
-        if (type != edge_type) {
-          continue;
-        }
-        auto *to_vertex = std::get<Vertex *>(edge);
-        if (to_vertex->deleted) {
-          continue;
-        }
-        auto *edge_ptr = std::get<EdgeRef>(edge).ptr;
-        edge_acc.insert({edge_ptr->properties.GetProperty(property), &from_vertex, to_vertex, edge_ptr, 0});
-        if (snapshot_info) {
-          snapshot_info->Update(UpdateType::EDGES);
-        }
-      }
-    }
-  } catch (const utils::OutOfMemoryException &) {
-    const utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_exception_blocker;
-    index_.erase(it);
-    throw;
-  }
+    utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_blocker;
+    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
+    all_indices_.WithLock([&](auto &all_indices) { all_indices->emplace_back(new_it->second, property); });
+    index_container = std::move(new_container);
+    return true;
+  });
+}
 
+bool InMemoryEdgeTypePropertyIndex::PublishIndex(EdgeTypeId edge_type, PropertyId property, uint64_t commit_timestamp) {
+  auto index = GetIndividualIndex(edge_type, property);
+  if (!index) return false;
+  index->Publish(commit_timestamp);
   return true;
 }
 
+void InMemoryEdgeTypePropertyIndex::IndividualIndex::Publish(uint64_t commit_timestamp) {
+  status.Commit(commit_timestamp);
+  memgraph::metrics::IncrementCounter(memgraph::metrics::ActiveEdgeTypePropertyIndices);
+}
+
+InMemoryEdgeTypePropertyIndex::IndividualIndex::~IndividualIndex() {
+  if (status.IsReady()) {
+    memgraph::metrics::DecrementCounter(memgraph::metrics::ActiveEdgeTypePropertyIndices);
+  }
+}
+
+bool InMemoryEdgeTypePropertyIndex::CreateIndexOnePass(EdgeTypeId edge_type, PropertyId property,
+                                                       utils::SkipList<Vertex>::Accessor vertices,
+                                                       std::optional<SnapshotObserverInfo> const &snapshot_info) {
+  auto res = RegisterIndex(edge_type, property);
+  if (!res) return false;
+  auto res2 = PopulateIndex(edge_type, property, std::move(vertices), snapshot_info);
+  if (res2.HasError()) {
+    MG_ASSERT(false, "Index population can't fail, there was no cancellation callback.");
+  }
+  return PublishIndex(edge_type, property, 0);
+}
+
 bool InMemoryEdgeTypePropertyIndex::DropIndex(EdgeTypeId edge_type, PropertyId property) {
-  return index_.erase({edge_type, property}) > 0;
+  return RemoveIndividualIndex(edge_type, property);
 }
 
-bool InMemoryEdgeTypePropertyIndex::IndexExists(EdgeTypeId edge_type, PropertyId property) const {
-  return index_.find({edge_type, property}) != index_.end();
+namespace {
+inline void TryInsertEdgeTypePropertyIndex(Vertex &from_vertex, EdgeTypeId edge_type, PropertyId property,
+                                           auto &&index_accessor,
+                                           std::optional<SnapshotObserverInfo> const &snapshot_info) {
+  if (from_vertex.deleted) {
+    return;
+  }
+
+  for (auto const &[type, to_vertex, edge_ref] : from_vertex.out_edges) {
+    if (type != edge_type || to_vertex->deleted) continue;
+    auto property_value = edge_ref.ptr->properties.GetProperty(property);
+    if (property_value.IsNull()) {
+      continue;
+    }
+
+    index_accessor.insert({property_value, &from_vertex, to_vertex, edge_ref.ptr, 0});
+    if (snapshot_info) {
+      snapshot_info->Update(UpdateType::EDGES);
+    }
+  }
 }
 
-std::vector<std::pair<EdgeTypeId, PropertyId>> InMemoryEdgeTypePropertyIndex::ListIndices() const {
+// TODO (ivan): Is this function correct?
+inline void TryInsertEdgeTypePropertyIndex(Vertex &from_vertex, EdgeTypeId edge_type, PropertyId property,
+                                           auto &&index_accessor,
+                                           std::optional<SnapshotObserverInfo> const &snapshot_info,
+                                           Transaction const &tx) {
+  bool exists = true;
+  bool deleted = false;
+  Delta *delta = nullptr;
+  utils::small_vector<Vertex::EdgeTriple> edges;
+
+  auto matches_edge_type = [edge_type](auto const &each) { return std::get<EdgeTypeId>(each) == edge_type; };
+  {
+    auto guard = std::shared_lock{from_vertex.lock};
+    deleted = from_vertex.deleted;
+    delta = from_vertex.delta;
+    edges = from_vertex.out_edges | rv::filter(matches_edge_type) | r::to<utils::small_vector<Vertex::EdgeTriple>>;
+  }
+
+  // Create and drop index will always use snapshot isolation
+  if (delta) {
+    ApplyDeltasForRead(&tx, delta, View::OLD, [&](const Delta &delta) {
+      // clang-format off
+      DeltaDispatch(delta, utils::ChainedOverloaded{
+        Exists_ActionMethod(exists),
+        Deleted_ActionMethod(deleted),
+        Edges_ActionMethod<EdgeDirection::OUT>(edges, edge_type),
+      });
+      // clang-format on
+    });
+  }
+  if (!exists || deleted || edges.empty()) {
+    return;
+  }
+
+  for (auto const &[type, to_vertex, edge_ref] : edges) {
+    PropertyValue property_value;
+    {
+      auto guard = std::shared_lock{edge_ref.ptr->lock};
+      exists = true;
+      deleted = false;
+      delta = edge_ref.ptr->delta;
+      PropertyValue property_value = edge_ref.ptr->properties.GetProperty(property);
+    }
+    if (delta) {
+      // Edge type is immutable so we don't need to check it
+      ApplyDeltasForRead(&tx, delta, View::OLD, [&](const Delta &delta) {
+        // clang-format off
+      DeltaDispatch(delta, utils::ChainedOverloaded{
+        Exists_ActionMethod(exists),
+        Deleted_ActionMethod(deleted),
+        PropertyValue_ActionMethod(property_value, property),
+      });
+        // clang-format on
+      });
+    }
+
+    if (!exists || deleted || property_value.IsNull()) {
+      continue;
+    }
+
+    index_accessor.insert({property_value, &from_vertex, to_vertex, edge_ref.ptr, tx.start_timestamp});
+    if (snapshot_info) {
+      snapshot_info->Update(UpdateType::EDGES);
+    }
+  }
+}
+
+}  // namespace
+
+auto InMemoryEdgeTypePropertyIndex::GetActiveIndices() const -> std::unique_ptr<EdgeTypePropertyIndex::ActiveIndices> {
+  return std::make_unique<ActiveIndices>(index_.WithReadLock(std::identity{}));
+}
+
+auto InMemoryEdgeTypePropertyIndex::PopulateIndex(
+    EdgeTypeId edge_type, PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
+    std::optional<SnapshotObserverInfo> const &snapshot_info, Transaction const *tx,
+    CheckCancelFunction cancel_check) -> utils::BasicResult<IndexPopulateError> {
+  auto index = GetIndividualIndex(edge_type, property);
+  if (!index) {
+    MG_ASSERT(false, "It should not be possible to remove the index before populating it.");
+  }
+
+  try {
+    auto const accessor_factory = [&] { return index->skiplist.access(); };
+    if (tx) {
+      // If we are in a transaction, we need to read the object with the correct MVCC snapshot isolation
+      auto const insert_function = [&](Vertex &from_vertex, auto &index_accessor) {
+        TryInsertEdgeTypePropertyIndex(from_vertex, edge_type, property, index_accessor, snapshot_info, *tx);
+      };
+      PopulateIndexDispatch(vertices, accessor_factory, insert_function, std::move(cancel_check),
+                            {} /*TODO: parallel*/);
+    } else {
+      // If we are not in a transaction, we need to read the object as it is. (post recovery)
+      auto const insert_function = [&](Vertex &from_vertex, auto &index_accessor) {
+        TryInsertEdgeTypePropertyIndex(from_vertex, edge_type, property, index_accessor, snapshot_info);
+      };
+      PopulateIndexDispatch(vertices, accessor_factory, insert_function, std::move(cancel_check),
+                            {} /*TODO: parallel*/);
+    }
+  } catch (const PopulateCancel &) {
+    RemoveIndividualIndex(edge_type, property);
+    return IndexPopulateError::Cancellation;
+  } catch (const utils::OutOfMemoryException &) {
+    RemoveIndividualIndex(edge_type, property);
+    throw;
+  }
+  return {};
+}
+
+bool InMemoryEdgeTypePropertyIndex::ActiveIndices::IndexReady(EdgeTypeId edge_type, PropertyId property) const {
+  auto it = index_container_->find(std::make_pair(edge_type, property));
+  if (it == index_container_->cend()) [[unlikely]] {
+    return false;
+  }
+  return it->second->status.IsReady();
+}
+
+std::vector<std::pair<EdgeTypeId, PropertyId>> InMemoryEdgeTypePropertyIndex::ActiveIndices::ListIndices(
+    uint64_t start_timestamp) const {
   std::vector<std::pair<EdgeTypeId, PropertyId>> ret;
-  ret.reserve(index_.size());
-  for (const auto &item : index_) {
-    ret.emplace_back(item.first.first, item.first.second);
+  ret.reserve(index_container_->size());
+  for (const auto &item : *index_container_) {
+    ret.emplace_back(item.first);
   }
   return ret;
 }
@@ -88,11 +231,13 @@ std::vector<std::pair<EdgeTypeId, PropertyId>> InMemoryEdgeTypePropertyIndex::Li
 void InMemoryEdgeTypePropertyIndex::RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp,
                                                           std::stop_token token) {
   auto maybe_stop = utils::ResettableCounter(2048);
+  CleanupAllIndices();
+  auto all_indices = all_indices_.WithReadLock(std::identity{});
 
-  for (auto &[key, index] : index_) {
+  for (auto &[index, property] : *all_indices) {
     if (token.stop_requested()) return;
 
-    auto edges_acc = index.access();
+    auto edges_acc = index->skiplist.access();
     for (auto it = edges_acc.begin(); it != edges_acc.end();) {
       if (maybe_stop() && token.stop_requested()) return;
 
@@ -115,7 +260,6 @@ void InMemoryEdgeTypePropertyIndex::RemoveObsoleteEntries(uint64_t oldest_active
       const bool redundant_duplicate = has_next && it->value == next_it->value &&
                                        it->from_vertex == next_it->from_vertex && it->to_vertex == next_it->to_vertex &&
                                        it->edge == next_it->edge;
-      auto const &[_, property] = key;
       if (redundant_duplicate || vertices_deleted || edge_deleted ||
           !AnyVersionHasProperty(*it->edge, property, it->value, oldest_active_start_timestamp)) {
         edges_acc.remove(*it);
@@ -126,49 +270,51 @@ void InMemoryEdgeTypePropertyIndex::RemoveObsoleteEntries(uint64_t oldest_active
   }
 }
 
-void InMemoryEdgeTypePropertyIndex::AbortEntries(
+void InMemoryEdgeTypePropertyIndex::ActiveIndices::AbortEntries(
     std::pair<EdgeTypeId, PropertyId> edge_type_property,
     std::span<std::tuple<Vertex *const, Vertex *const, Edge *const, PropertyValue> const> edges,
     uint64_t exact_start_timestamp) {
-  auto it = index_.find(edge_type_property);
-  if (it == index_.end()) {
+  auto it = index_container_->find(edge_type_property);
+  if (it == index_container_->end()) [[unlikely]] {
     return;
   }
 
-  auto acc = it->second.access();
+  auto acc = it->second->skiplist.access();
   for (const auto &[from_vertex, to_vertex, edge, value] : edges) {
     acc.remove(Entry{value, from_vertex, to_vertex, edge, exact_start_timestamp});
   }
 }
 
-void InMemoryEdgeTypePropertyIndex::UpdateOnSetProperty(Vertex *from_vertex, Vertex *to_vertex, Edge *edge,
-                                                        EdgeTypeId edge_type, PropertyId property, PropertyValue value,
-                                                        uint64_t timestamp) {
+void InMemoryEdgeTypePropertyIndex::ActiveIndices::UpdateOnSetProperty(Vertex *from_vertex, Vertex *to_vertex,
+                                                                       Edge *edge, EdgeTypeId edge_type,
+                                                                       PropertyId property, PropertyValue value,
+                                                                       uint64_t timestamp) {
   if (value.IsNull()) {
     return;
   }
 
-  auto it = index_.find({edge_type, property});
-  if (it == index_.end()) return;
+  auto it = index_container_->find({edge_type, property});
+  if (it == index_container_->end()) [[unlikely]]
+    return;
 
-  auto acc = it->second.access();
+  auto acc = it->second->skiplist.access();
   acc.insert({value, from_vertex, to_vertex, edge, timestamp});
 }
 
-uint64_t InMemoryEdgeTypePropertyIndex::ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property) const {
-  if (auto it = index_.find({edge_type, property}); it != index_.end()) {
-    return it->second.size();
+uint64_t InMemoryEdgeTypePropertyIndex::ActiveIndices::ApproximateEdgeCount(EdgeTypeId edge_type,
+                                                                            PropertyId property) const {
+  if (auto it = index_container_->find({edge_type, property}); it != index_container_->end()) [[likely]] {
+    return it->second->skiplist.size();
   }
-
   return 0U;
 }
 
-uint64_t InMemoryEdgeTypePropertyIndex::ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property,
-                                                             const PropertyValue &value) const {
-  auto it = index_.find({edge_type, property});
-  MG_ASSERT(it != index_.end(), "Index for edge type {} and property {} doesn't exist", edge_type.AsUint(),
+uint64_t InMemoryEdgeTypePropertyIndex::ActiveIndices::ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property,
+                                                                            const PropertyValue &value) const {
+  auto it = index_container_->find({edge_type, property});
+  MG_ASSERT(it != index_container_->end(), "Index for edge type {} and property {} doesn't exist", edge_type.AsUint(),
             property.AsUint());
-  auto acc = it->second.access();
+  auto acc = it->second->skiplist.access();
   if (!value.IsNull()) {
     // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     return acc.estimate_count(value, utils::SkipListLayerForCountEstimation(acc.size()));
@@ -183,31 +329,33 @@ uint64_t InMemoryEdgeTypePropertyIndex::ApproximateEdgeCount(EdgeTypeId edge_typ
       utils::SkipListLayerForAverageEqualsEstimation(acc.size()));
 }
 
-uint64_t InMemoryEdgeTypePropertyIndex::ApproximateEdgeCount(
+uint64_t InMemoryEdgeTypePropertyIndex::ActiveIndices::ApproximateEdgeCount(
     EdgeTypeId edge_type, PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower,
     const std::optional<utils::Bound<PropertyValue>> &upper) const {
-  auto it = index_.find({edge_type, property});
-  MG_ASSERT(it != index_.end(), "Index for edge type {} and property {} doesn't exist", edge_type.AsUint(),
+  auto it = index_container_->find({edge_type, property});
+  MG_ASSERT(it != index_container_->end(), "Index for edge type {} and property {} doesn't exist", edge_type.AsUint(),
             property.AsUint());
-  auto acc = it->second.access();
+  auto acc = it->second->skiplist.access();
   // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
   return acc.estimate_range_count(lower, upper, utils::SkipListLayerForCountEstimation(acc.size()));
 }
 
-void InMemoryEdgeTypePropertyIndex::UpdateOnEdgeModification(Vertex *old_from, Vertex *old_to, Vertex *new_from,
-                                                             Vertex *new_to, EdgeRef edge_ref, EdgeTypeId edge_type,
-                                                             PropertyId property, const PropertyValue &value,
-                                                             const Transaction &tx) {
-  auto it = index_.find({edge_type, property});
-  if (it == index_.end()) {
+void InMemoryEdgeTypePropertyIndex::ActiveIndices::UpdateOnEdgeModification(
+    Vertex *old_from, Vertex *old_to, Vertex *new_from, Vertex *new_to, EdgeRef edge_ref, EdgeTypeId edge_type,
+    PropertyId property, const PropertyValue &value, const Transaction &tx) {
+  auto it = index_container_->find({edge_type, property});
+  if (it == index_container_->end()) [[unlikely]] {
     return;
   }
 
-  auto acc = it->second.access();
+  auto acc = it->second->skiplist.access();
   acc.insert(Entry{value, new_from, new_to, edge_ref.ptr, tx.start_timestamp});
 }
 
-void InMemoryEdgeTypePropertyIndex::DropGraphClearIndices() { index_.clear(); }
+void InMemoryEdgeTypePropertyIndex::DropGraphClearIndices() {
+  index_.WithLock([](std::shared_ptr<IndexContainer const> &index) { index = std::make_shared<IndexContainer>(); });
+  CleanupAllIndices();
+}
 
 InMemoryEdgeTypePropertyIndex::Iterable::Iterable(utils::SkipList<Entry>::Accessor index_accessor,
                                                   utils::SkipList<Vertex>::ConstAccessor vertex_accessor,
@@ -314,21 +462,26 @@ void InMemoryEdgeTypePropertyIndex::Iterable::Iterator::AdvanceUntilValid() {
 }
 
 void InMemoryEdgeTypePropertyIndex::RunGC() {
-  for (auto &index_entry : index_) {
-    index_entry.second.run_gc();
+  // Remove indicies that are not used by any txn
+  CleanupAllIndices();
+
+  // For each skip_list remaining, run GC
+  auto cpy = all_indices_.WithReadLock(std::identity{});
+  for (auto &entry : *cpy) {
+    entry.index_->skiplist.run_gc();
   }
 }
 
-InMemoryEdgeTypePropertyIndex::Iterable InMemoryEdgeTypePropertyIndex::Edges(
+InMemoryEdgeTypePropertyIndex::Iterable InMemoryEdgeTypePropertyIndex::ActiveIndices::Edges(
     EdgeTypeId edge_type, PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
     Transaction *transaction) {
-  auto it = index_.find({edge_type, property});
-  MG_ASSERT(it != index_.end(), "Index for edge type {} and property {} doesn't exist", edge_type.AsUint(),
+  auto it = index_container_->find({edge_type, property});
+  MG_ASSERT(it != index_container_->end(), "Index for edge type {} and property {} doesn't exist", edge_type.AsUint(),
             property.AsUint());
   auto vertex_acc = static_cast<InMemoryStorage const *>(storage)->vertices_.access();
   auto edge_acc = static_cast<InMemoryStorage const *>(storage)->edges_.access();
-  return {it->second.access(),
+  return {it->second->skiplist.access(),
           std::move(vertex_acc),
           std::move(edge_acc),
           edge_type,
@@ -338,6 +491,40 @@ InMemoryEdgeTypePropertyIndex::Iterable InMemoryEdgeTypePropertyIndex::Edges(
           view,
           storage,
           transaction};
+}
+
+auto InMemoryEdgeTypePropertyIndex::RemoveIndividualIndex(EdgeTypeId edge_type, PropertyId property) -> bool {
+  auto result = index_.WithLock([&](std::shared_ptr<IndexContainer const> &index_container) {
+    auto it = index_container->find({edge_type, property});
+    if (it == index_container->end()) [[unlikely]] {
+      return false;
+    }
+
+    auto new_container = std::make_shared<IndexContainer>(*index_container);
+    new_container->erase(it);
+    index_container = std::move(new_container);
+    return true;
+  });
+  CleanupAllIndices();
+  return result;
+}
+
+auto InMemoryEdgeTypePropertyIndex::GetIndividualIndex(EdgeTypeId edge_type,
+                                                       PropertyId property) const -> std::shared_ptr<IndividualIndex> {
+  return index_.WithReadLock(
+      [&](std::shared_ptr<IndexContainer const> const &index) -> std::shared_ptr<IndividualIndex> {
+        auto it = index->find({edge_type, property});
+        if (it == index->cend()) [[unlikely]]
+          return {};
+        return it->second;
+      });
+}
+
+void InMemoryEdgeTypePropertyIndex::CleanupAllIndices() {
+  all_indices_.WithLock([](std::shared_ptr<std::vector<AllIndicesEntry>> &indices) {
+    std::erase_if(*indices,
+                  [](AllIndicesEntry const &individual_index) { return individual_index.index_.use_count() == 1; });
+  });
 }
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -174,10 +174,11 @@ auto InMemoryEdgeTypePropertyIndex::GetActiveIndices() const -> std::unique_ptr<
   return std::make_unique<ActiveIndices>(index_.WithReadLock(std::identity{}));
 }
 
-auto InMemoryEdgeTypePropertyIndex::PopulateIndex(
-    EdgeTypeId edge_type, PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
-    std::optional<SnapshotObserverInfo> const &snapshot_info, Transaction const *tx,
-    CheckCancelFunction cancel_check) -> utils::BasicResult<IndexPopulateError> {
+auto InMemoryEdgeTypePropertyIndex::PopulateIndex(EdgeTypeId edge_type, PropertyId property,
+                                                  utils::SkipList<Vertex>::Accessor vertices,
+                                                  std::optional<SnapshotObserverInfo> const &snapshot_info,
+                                                  Transaction const *tx, CheckCancelFunction cancel_check)
+    -> utils::BasicResult<IndexPopulateError> {
   auto index = GetIndividualIndex(edge_type, property);
   if (!index) {
     MG_ASSERT(false, "It should not be possible to remove the index before populating it.");
@@ -501,7 +502,7 @@ auto InMemoryEdgeTypePropertyIndex::RemoveIndividualIndex(EdgeTypeId edge_type, 
     }
 
     auto new_container = std::make_shared<IndexContainer>(*index_container);
-    new_container->erase(it);
+    new_container->erase({edge_type, property});
     index_container = std::move(new_container);
     return true;
   });
@@ -509,8 +510,8 @@ auto InMemoryEdgeTypePropertyIndex::RemoveIndividualIndex(EdgeTypeId edge_type, 
   return result;
 }
 
-auto InMemoryEdgeTypePropertyIndex::GetIndividualIndex(EdgeTypeId edge_type,
-                                                       PropertyId property) const -> std::shared_ptr<IndividualIndex> {
+auto InMemoryEdgeTypePropertyIndex::GetIndividualIndex(EdgeTypeId edge_type, PropertyId property) const
+    -> std::shared_ptr<IndividualIndex> {
   return index_.WithReadLock(
       [&](std::shared_ptr<IndexContainer const> const &index) -> std::shared_ptr<IndividualIndex> {
         auto it = index->find({edge_type, property});

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -40,7 +40,7 @@ inline void TryInsertEdgeTypePropertyIndex(Vertex &from_vertex, EdgeTypeId edge_
       continue;
     }
 
-    index_accessor.insert({property_value, &from_vertex, to_vertex, edge_ref.ptr, 0});
+    index_accessor.insert({std::move(property_value), &from_vertex, to_vertex, edge_ref.ptr, 0});
     if (snapshot_info) {
       snapshot_info->Update(UpdateType::EDGES);
     }
@@ -106,7 +106,7 @@ inline void TryInsertEdgeTypePropertyIndex(Vertex &from_vertex, EdgeTypeId edge_
       continue;
     }
 
-    index_accessor.insert({property_value, &from_vertex, to_vertex, edge_ref.ptr, tx.start_timestamp});
+    index_accessor.insert({std::move(property_value), &from_vertex, to_vertex, edge_ref.ptr, tx.start_timestamp});
     if (snapshot_info) {
       snapshot_info->Update(UpdateType::EDGES);
     }

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -142,7 +142,7 @@ inline void TryInsertEdgeTypePropertyIndex(Vertex &from_vertex, EdgeTypeId edge_
       exists = true;
       deleted = false;
       delta = edge_ref.ptr->delta;
-      PropertyValue property_value = edge_ref.ptr->properties.GetProperty(property);
+      property_value = edge_ref.ptr->properties.GetProperty(property);
     }
     if (delta) {
       // Edge type is immutable so we don't need to check it

--- a/src/storage/v2/inmemory/edge_type_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.hpp
@@ -100,9 +100,9 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
   };
 
   struct IndividualIndex {
-    IndividualIndex() {}
     ~IndividualIndex();
     void Publish(uint64_t commit_timestamp);
+
     utils::SkipList<Entry> skiplist{};
     IndexStatus status{};
   };
@@ -143,6 +143,8 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
     void AbortEntries(std::pair<EdgeTypeId, PropertyId> edge_type_property,
                       std::span<std::tuple<Vertex *const, Vertex *const, Edge *const, PropertyValue> const> edges,
                       uint64_t exact_start_timestamp);
+    auto GetAbortProcessor() const -> AbortProcessor override;
+    void AbortEntries(AbortableInfo const &info, uint64_t start_timestamp) override;
 
    private:
     std::shared_ptr<IndexContainer const> index_container_;

--- a/src/storage/v2/inmemory/edge_type_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.hpp
@@ -15,14 +15,17 @@
 #include <map>
 #include <utility>
 
+#include "storage/v2/common_function_signatures.hpp"
 #include "storage/v2/constraints/constraints.hpp"
 #include "storage/v2/edge_accessor.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indices/edge_type_property_index.hpp"
-#include "storage/v2/indices/label_index_stats.hpp"
+#include "storage/v2/indices/errors.hpp"
+#include "storage/v2/inmemory/indices_mvcc.hpp"
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/snapshot_observer_info.hpp"
 #include "storage/v2/vertex_accessor.hpp"
+#include "utils/rw_lock.hpp"
 
 namespace memgraph::storage {
 
@@ -51,52 +54,6 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
   };
 
  public:
-  InMemoryEdgeTypePropertyIndex() = default;
-
-  /// @throw std::bad_alloc
-  bool CreateIndex(EdgeTypeId edge_type, PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
-                   std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
-
-  /// Returns false if there was no index to drop
-  bool DropIndex(EdgeTypeId edge_type, PropertyId property) override;
-
-  bool IndexExists(EdgeTypeId edge_type, PropertyId property) const override;
-
-  std::vector<std::pair<EdgeTypeId, PropertyId>> ListIndices() const override;
-
-  void RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token);
-
-  void AbortEntries(std::pair<EdgeTypeId, PropertyId> edge_type_property,
-                    std::span<std::tuple<Vertex *const, Vertex *const, Edge *const, PropertyValue> const> edges,
-                    uint64_t exact_start_timestamp);
-
-  uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property) const override;
-
-  uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property, const PropertyValue &value) const override;
-
-  uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property,
-                                const std::optional<utils::Bound<PropertyValue>> &lower,
-                                const std::optional<utils::Bound<PropertyValue>> &upper) const override;
-
-  // Functions that update the index
-  void UpdateOnSetProperty(Vertex *from_vertex, Vertex *to_vertex, Edge *edge, EdgeTypeId edge_type,
-                           PropertyId property, PropertyValue value, uint64_t timestamp) override;
-
-  void UpdateOnEdgeModification(Vertex *old_from, Vertex *old_to, Vertex *new_from, Vertex *new_to, EdgeRef edge_ref,
-                                EdgeTypeId edge_type, PropertyId property, const PropertyValue &value,
-                                const Transaction &tx) override;
-
-  void DropGraphClearIndices() override;
-
-  IndexStats Analysis() const {
-    IndexStats stats;
-    for (const auto &[key, _] : index_) {
-      stats.et2p[key.first].push_back(key.second);
-      stats.p2et[key.second].push_back(key.first);
-    }
-    return stats;
-  }
-
   class Iterable {
    public:
     Iterable(utils::SkipList<Entry>::Accessor index_accessor, utils::SkipList<Vertex>::ConstAccessor vertex_accessor,
@@ -142,15 +99,103 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
     Transaction *transaction_;
   };
 
+  struct IndividualIndex {
+    IndividualIndex() {}
+    ~IndividualIndex();
+    void Publish(uint64_t commit_timestamp);
+    utils::SkipList<Entry> skiplist{};
+    IndexStatus status{};
+  };
+
+  // TODO: change to map of maps as in label property index
+  using IndexContainer = std::map<std::pair<EdgeTypeId, PropertyId>, std::shared_ptr<IndividualIndex>>;
+
+  struct AllIndicesEntry {
+    std::shared_ptr<IndividualIndex> index_;
+    PropertyId property_;
+    // edge type can't be changed so not needed here
+  };
+  struct ActiveIndices : storage::EdgeTypePropertyIndex::ActiveIndices {
+    explicit ActiveIndices(std::shared_ptr<IndexContainer const> indices = std::make_shared<IndexContainer>())
+        : index_container_{std::move(indices)} {}
+
+    void UpdateOnSetProperty(Vertex *from_vertex, Vertex *to_vertex, Edge *edge, EdgeTypeId edge_type,
+                             PropertyId property, PropertyValue value, uint64_t timestamp) override;
+
+    void UpdateOnEdgeModification(Vertex *old_from, Vertex *old_to, Vertex *new_from, Vertex *new_to, EdgeRef edge_ref,
+                                  EdgeTypeId edge_type, PropertyId property, const PropertyValue &value,
+                                  const Transaction &tx) override;
+
+    uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property) const override;
+
+    uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property, const PropertyValue &value) const override;
+
+    uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property,
+                                  const std::optional<utils::Bound<PropertyValue>> &lower,
+                                  const std::optional<utils::Bound<PropertyValue>> &upper) const override;
+
+    bool IndexReady(EdgeTypeId edge_type, PropertyId property) const override;
+
+    auto ListIndices(uint64_t start_timestamp) const -> std::vector<std::pair<EdgeTypeId, PropertyId>> override;
+
+    Iterable Edges(EdgeTypeId edge_type, PropertyId property,
+                   const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+                   const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
+                   Transaction *transaction);
+
+    void AbortEntries(std::pair<EdgeTypeId, PropertyId> edge_type_property,
+                      std::span<std::tuple<Vertex *const, Vertex *const, Edge *const, PropertyValue> const> edges,
+                      uint64_t exact_start_timestamp);
+
+   private:
+    std::shared_ptr<IndexContainer const> index_container_;
+  };
+
+  InMemoryEdgeTypePropertyIndex() = default;
+
+  /// @throw std::bad_alloc
+  bool CreateIndexOnePass(EdgeTypeId edge_type, PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
+                          std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
+
+  /// Returns false if there was no index to drop
+  bool DropIndex(EdgeTypeId edge_type, PropertyId property) override;
+
+  void RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token);
+
+  void DropGraphClearIndices() override;
+
+  // TODO (ivan): what is this used for
+  IndexStats Analysis() const {
+    IndexStats stats;
+    index_.WithReadLock([&](auto const &index_accessor) {
+      for (const auto &[key, index] : *index_accessor) {
+        stats.et2p[key.first].push_back(key.second);
+        stats.p2et[key.second].push_back(key.first);
+      }
+    });
+    return stats;
+  }
+
+  auto GetActiveIndices() const -> std::unique_ptr<EdgeTypePropertyIndex::ActiveIndices> override;
+
+  auto RegisterIndex(EdgeTypeId edge_type, PropertyId property) -> bool;
+  auto PopulateIndex(EdgeTypeId edge_type, PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
+                     std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt,
+                     Transaction const *tx = nullptr,
+                     CheckCancelFunction cancel_check = neverCancel) -> utils::BasicResult<IndexPopulateError>;
+  bool PublishIndex(EdgeTypeId edge_type, PropertyId property, uint64_t commit_timestamp);
+
   void RunGC();
 
-  Iterable Edges(EdgeTypeId edge_type, PropertyId property,
-                 const std::optional<utils::Bound<PropertyValue>> &lower_bound,
-                 const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
-                 Transaction *transaction);
-
  private:
-  std::map<std::pair<EdgeTypeId, PropertyId>, utils::SkipList<Entry>> index_;
+  auto CleanupAllIndices() -> void;
+  auto GetIndividualIndex(EdgeTypeId edge_type, PropertyId property) const -> std::shared_ptr<IndividualIndex>;
+  auto RemoveIndividualIndex(EdgeTypeId edge_type, PropertyId property) -> bool;
+
+  utils::Synchronized<std::shared_ptr<IndexContainer const>, utils::WritePrioritizedRWLock> index_{
+      std::make_shared<IndexContainer>()};
+  utils::Synchronized<std::shared_ptr<std::vector<AllIndicesEntry>>, utils::WritePrioritizedRWLock> all_indices_{
+      std::make_shared<std::vector<AllIndicesEntry>>()};
 };
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/inmemory/edge_type_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.hpp
@@ -163,18 +163,6 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
 
   void DropGraphClearIndices() override;
 
-  // TODO (ivan): what is this used for
-  IndexStats Analysis() const {
-    IndexStats stats;
-    index_.WithReadLock([&](auto const &index_accessor) {
-      for (const auto &[key, index] : *index_accessor) {
-        stats.et2p[key.first].push_back(key.second);
-        stats.p2et[key.second].push_back(key.first);
-      }
-    });
-    return stats;
-  }
-
   auto GetActiveIndices() const -> std::unique_ptr<EdgeTypePropertyIndex::ActiveIndices> override;
 
   auto RegisterIndex(EdgeTypeId edge_type, PropertyId property) -> bool;
@@ -191,9 +179,9 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
   auto GetIndividualIndex(EdgeTypeId edge_type, PropertyId property) const -> std::shared_ptr<IndividualIndex>;
 
   utils::Synchronized<std::shared_ptr<IndexContainer const>, utils::WritePrioritizedRWLock> index_{
-      std::make_shared<IndexContainer>()};
+      std::make_shared<IndexContainer const>()};
   utils::Synchronized<std::shared_ptr<std::vector<AllIndicesEntry> const>, utils::WritePrioritizedRWLock> all_indices_{
-      std::make_shared<std::vector<AllIndicesEntry>>()};
+      std::make_shared<std::vector<AllIndicesEntry> const>()};
 };
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/inmemory/edge_type_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.hpp
@@ -115,16 +115,13 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
     PropertyId property_;
     // edge type can't be changed so not needed here
   };
+
   struct ActiveIndices : storage::EdgeTypePropertyIndex::ActiveIndices {
     explicit ActiveIndices(std::shared_ptr<IndexContainer const> indices = std::make_shared<IndexContainer>())
         : index_container_{std::move(indices)} {}
 
     void UpdateOnSetProperty(Vertex *from_vertex, Vertex *to_vertex, Edge *edge, EdgeTypeId edge_type,
                              PropertyId property, PropertyValue value, uint64_t timestamp) override;
-
-    void UpdateOnEdgeModification(Vertex *old_from, Vertex *old_to, Vertex *new_from, Vertex *new_to, EdgeRef edge_ref,
-                                  EdgeTypeId edge_type, PropertyId property, const PropertyValue &value,
-                                  const Transaction &tx) override;
 
     uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property) const override;
 
@@ -181,8 +178,8 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
   auto RegisterIndex(EdgeTypeId edge_type, PropertyId property) -> bool;
   auto PopulateIndex(EdgeTypeId edge_type, PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
                      std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt,
-                     Transaction const *tx = nullptr,
-                     CheckCancelFunction cancel_check = neverCancel) -> utils::BasicResult<IndexPopulateError>;
+                     Transaction const *tx = nullptr, CheckCancelFunction cancel_check = neverCancel)
+      -> utils::BasicResult<IndexPopulateError>;
   bool PublishIndex(EdgeTypeId edge_type, PropertyId property, uint64_t commit_timestamp);
 
   void RunGC();
@@ -190,11 +187,10 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
  private:
   auto CleanupAllIndices() -> void;
   auto GetIndividualIndex(EdgeTypeId edge_type, PropertyId property) const -> std::shared_ptr<IndividualIndex>;
-  auto RemoveIndividualIndex(EdgeTypeId edge_type, PropertyId property) -> bool;
 
   utils::Synchronized<std::shared_ptr<IndexContainer const>, utils::WritePrioritizedRWLock> index_{
       std::make_shared<IndexContainer>()};
-  utils::Synchronized<std::shared_ptr<std::vector<AllIndicesEntry>>, utils::WritePrioritizedRWLock> all_indices_{
+  utils::Synchronized<std::shared_ptr<std::vector<AllIndicesEntry> const>, utils::WritePrioritizedRWLock> all_indices_{
       std::make_shared<std::vector<AllIndicesEntry>>()};
 };
 

--- a/src/storage/v2/inmemory/label_index.cpp
+++ b/src/storage/v2/inmemory/label_index.cpp
@@ -138,8 +138,8 @@ inline void TryInsertLabelIndex(Vertex &vertex, LabelId label, auto &&index_acce
 auto InMemoryLabelIndex::PopulateIndex(
     LabelId label, utils::SkipList<Vertex>::Accessor vertices,
     const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info,
-    std::optional<SnapshotObserverInfo> const &snapshot_info, Transaction const *tx, CheckCancelFunction cancel_check)
-    -> utils::BasicResult<IndexPopulateError> {
+    std::optional<SnapshotObserverInfo> const &snapshot_info, Transaction const *tx,
+    CheckCancelFunction cancel_check) -> utils::BasicResult<IndexPopulateError> {
   auto index = GetIndividualIndex(label);
   if (!index) {
     MG_ASSERT(false, "It should not be possible to remove the index before populating it.");

--- a/src/storage/v2/inmemory/label_index.cpp
+++ b/src/storage/v2/inmemory/label_index.cpp
@@ -192,9 +192,11 @@ void InMemoryLabelIndex::ActiveIndices::UpdateOnAddLabel(LabelId added_label, Ve
 
 bool InMemoryLabelIndex::DropIndex(LabelId label) {
   auto result = index_.WithLock([&](std::shared_ptr<IndexContainer const> &index) -> bool {
-    auto it = index->find(label);
-    if (it == index->end()) [[unlikely]] {
-      return false;
+    {
+      auto it = index->find(label);
+      if (it == index->end()) [[unlikely]] {
+        return false;
+      }
     }
     auto new_index = std::make_shared<IndexContainer>(*index);
     new_index->erase(label);

--- a/src/storage/v2/inmemory/label_index.hpp
+++ b/src/storage/v2/inmemory/label_index.hpp
@@ -112,7 +112,7 @@ class InMemoryLabelIndex : public LabelIndex {
     void UpdateOnAddLabel(LabelId added_label, Vertex *vertex_after_update, const Transaction &tx) override;
 
     // Not used for in-memory
-    void UpdateOnRemoveLabel(LabelId removed_label, Vertex *vertex_after_update, const Transaction &tx) override{};
+    void UpdateOnRemoveLabel(LabelId removed_label, Vertex *vertex_after_update, const Transaction &tx) override {};
 
     bool IndexRegistered(LabelId label) const override;
 
@@ -142,8 +142,8 @@ class InMemoryLabelIndex : public LabelIndex {
   auto PopulateIndex(LabelId label, utils::SkipList<Vertex>::Accessor vertices,
                      const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info,
                      std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt,
-                     Transaction const *tx = nullptr, CheckCancelFunction cancel_check = neverCancel)
-      -> utils::BasicResult<IndexPopulateError>;
+                     Transaction const *tx = nullptr,
+                     CheckCancelFunction cancel_check = neverCancel) -> utils::BasicResult<IndexPopulateError>;
   bool PublishIndex(LabelId label, uint64_t commit_timestamp);
 
   void RunGC();

--- a/src/storage/v2/inmemory/label_index.hpp
+++ b/src/storage/v2/inmemory/label_index.hpp
@@ -55,9 +55,6 @@ class InMemoryLabelIndex : public LabelIndex {
 
   using IndexContainer = std::map<LabelId, std::shared_ptr<IndividualIndex>>;
 
-  InMemoryLabelIndex()
-      : index_(std::make_shared<IndexContainer>()), all_indices_(std::make_shared<std::vector<AllIndicesEntry>>()) {}
-
   /// @throw std::bad_alloc
   bool CreateIndexOnePass(LabelId label, utils::SkipList<Vertex>::Accessor vertices,
                           const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info,
@@ -162,8 +159,10 @@ class InMemoryLabelIndex : public LabelIndex {
   auto CleanupAllIndices() -> void;
   auto GetIndividualIndex(LabelId label) const -> std::shared_ptr<IndividualIndex>;
 
-  utils::Synchronized<std::shared_ptr<IndexContainer const>, utils::WritePrioritizedRWLock> index_;
-  utils::Synchronized<std::shared_ptr<std::vector<AllIndicesEntry> const>, utils::WritePrioritizedRWLock> all_indices_;
+  utils::Synchronized<std::shared_ptr<IndexContainer const>, utils::WritePrioritizedRWLock> index_{
+      std::make_shared<IndexContainer const>()};
+  utils::Synchronized<std::shared_ptr<std::vector<AllIndicesEntry> const>, utils::WritePrioritizedRWLock> all_indices_{
+      std::make_shared<std::vector<AllIndicesEntry> const>()};
   utils::Synchronized<std::map<LabelId, storage::LabelIndexStats>, utils::ReadPrioritizedRWLock> stats_;
 };
 

--- a/src/storage/v2/inmemory/label_index.hpp
+++ b/src/storage/v2/inmemory/label_index.hpp
@@ -112,7 +112,7 @@ class InMemoryLabelIndex : public LabelIndex {
     void UpdateOnAddLabel(LabelId added_label, Vertex *vertex_after_update, const Transaction &tx) override;
 
     // Not used for in-memory
-    void UpdateOnRemoveLabel(LabelId removed_label, Vertex *vertex_after_update, const Transaction &tx) override {};
+    void UpdateOnRemoveLabel(LabelId removed_label, Vertex *vertex_after_update, const Transaction &tx) override{};
 
     bool IndexRegistered(LabelId label) const override;
 
@@ -142,8 +142,8 @@ class InMemoryLabelIndex : public LabelIndex {
   auto PopulateIndex(LabelId label, utils::SkipList<Vertex>::Accessor vertices,
                      const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info,
                      std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt,
-                     Transaction const *tx = nullptr,
-                     CheckCancelFunction cancel_check = neverCancel) -> utils::BasicResult<IndexPopulateError>;
+                     Transaction const *tx = nullptr, CheckCancelFunction cancel_check = neverCancel)
+      -> utils::BasicResult<IndexPopulateError>;
   bool PublishIndex(LabelId label, uint64_t commit_timestamp);
 
   void RunGC();
@@ -161,10 +161,9 @@ class InMemoryLabelIndex : public LabelIndex {
  private:
   auto CleanupAllIndices() -> void;
   auto GetIndividualIndex(LabelId label) const -> std::shared_ptr<IndividualIndex>;
-  auto RemoveIndividualIndex(LabelId label) -> bool;
 
   utils::Synchronized<std::shared_ptr<IndexContainer const>, utils::WritePrioritizedRWLock> index_;
-  utils::Synchronized<std::shared_ptr<std::vector<AllIndicesEntry>>, utils::WritePrioritizedRWLock> all_indices_;
+  utils::Synchronized<std::shared_ptr<std::vector<AllIndicesEntry> const>, utils::WritePrioritizedRWLock> all_indices_;
   utils::Synchronized<std::map<LabelId, storage::LabelIndexStats>, utils::ReadPrioritizedRWLock> stats_;
 };
 

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -312,8 +312,8 @@ bool InMemoryLabelPropertyIndex::RegisterIndex(LabelId label, PropertiesPaths co
 auto InMemoryLabelPropertyIndex::PopulateIndex(
     LabelId label, PropertiesPaths const &properties, utils::SkipList<Vertex>::Accessor vertices,
     const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info,
-    std::optional<SnapshotObserverInfo> const &snapshot_info, Transaction const *tx,
-    CheckCancelFunction cancel_check) -> utils::BasicResult<IndexPopulateError> {
+    std::optional<SnapshotObserverInfo> const &snapshot_info, Transaction const *tx, CheckCancelFunction cancel_check)
+    -> utils::BasicResult<IndexPopulateError> {
   auto index = GetIndividualIndex(label, properties);
   if (!index) {
     MG_ASSERT(false, "It should not be possible to remove the index before populating it.");
@@ -338,10 +338,10 @@ auto InMemoryLabelPropertyIndex::PopulateIndex(
       PopulateIndexDispatch(vertices, accessor_factory, insert_function, std::move(cancel_check), parallel_exec_info);
     }
   } catch (const PopulateCancel &) {
-    RemoveIndividualIndex(label, properties);
+    DropIndex(label, properties);
     return IndexPopulateError::Cancellation;
   } catch (const utils::OutOfMemoryException &) {
-    RemoveIndividualIndex(label, properties);
+    DropIndex(label, properties);
     throw;
   }
 
@@ -382,7 +382,57 @@ auto InMemoryLabelPropertyIndex::GetIndividualIndex(LabelId const &label, Proper
       });
 }
 
-bool InMemoryLabelPropertyIndex::RemoveIndividualIndex(LabelId const &label, PropertiesPaths const &properties) {
+void InMemoryLabelPropertyIndex::ActiveIndices::UpdateOnAddLabel(LabelId added_label, Vertex *vertex_after_update,
+                                                                 const Transaction &tx) {
+  auto const it = index_container_->indices_.find(added_label);
+  if (it == index_container_->indices_.cend()) {
+    return;
+  }
+
+  auto const prop_ids = vertex_after_update->properties.ExtractPropertyIds();
+
+  auto const relevant_index = [&](auto &&each) {
+    auto &[index_props, _] = each;
+    auto vector_has_property = [&](auto &&index_prop) { return r::binary_search(prop_ids, index_prop); };
+    return r::any_of(index_props[0], vector_has_property);
+  };
+
+  for (auto &[props, index] : it->second | rv::filter(relevant_index)) {
+    auto &[permutations_helper, skiplist, status] = *index;
+    auto values = permutations_helper.Extract(vertex_after_update->properties);
+    if (r::any_of(values, [](auto &&val) { return !val.IsNull(); })) {
+      auto acc = skiplist.access();
+      acc.insert({permutations_helper.ApplyPermutation(std::move(values)), vertex_after_update, tx.start_timestamp});
+    }
+  }
+}
+
+void InMemoryLabelPropertyIndex::ActiveIndices::UpdateOnSetProperty(PropertyId property, const PropertyValue &value,
+                                                                    Vertex *vertex, const Transaction &tx) {
+  auto const it = index_container_->reverse_lookup_.find(property);
+  if (it == index_container_->reverse_lookup_.end()) {
+    return;
+  }
+
+  auto const has_label = [&](auto &&each) { return r::find(vertex->labels, each.first) != vertex->labels.cend(); };
+  auto const has_property = [&](auto &&each) {
+    auto &ids = *std::get<PropertiesPaths const *>(each.second);
+    return r::find_if(ids, [&](auto &&path) { return path[0] == property; }) != ids.cend();
+  };
+  auto const relevant_index = [&](auto &&each) { return has_label(each) && has_property(each); };
+
+  for (auto &lookup : it->second | rv::filter(relevant_index)) {
+    auto &[property_ids, index] = lookup.second;
+
+    auto values = index->permutations_helper.Extract(vertex->properties);
+    if (r::any_of(values, [](auto &&value) { return !value.IsNull(); })) {
+      auto acc = index->skiplist.access();
+      acc.insert({index->permutations_helper.ApplyPermutation(std::move(values)), vertex, tx.start_timestamp});
+    }
+  }
+}
+
+bool InMemoryLabelPropertyIndex::DropIndex(LabelId label, std::vector<PropertyPath> const &properties) {
   auto result = index_.WithLock([&](std::shared_ptr<IndexContainer const> &index) {
     {
       auto it = index->indices_.find(label);
@@ -481,62 +531,8 @@ bool InMemoryLabelPropertyIndex::RemoveIndividualIndex(LabelId const &label, Pro
     index = std::move(new_index);
     return true;
   });
-  CleanupAllIndicies();
+  CleanupAllIndices();
   return result;
-}
-
-void InMemoryLabelPropertyIndex::ActiveIndices::UpdateOnAddLabel(LabelId added_label, Vertex *vertex_after_update,
-                                                                 const Transaction &tx) {
-  auto const it = index_container_->indices_.find(added_label);
-  if (it == index_container_->indices_.cend()) {
-    return;
-  }
-
-  auto const prop_ids = vertex_after_update->properties.ExtractPropertyIds();
-
-  auto const relevant_index = [&](auto &&each) {
-    auto &[index_props, _] = each;
-    auto vector_has_property = [&](auto &&index_prop) { return r::binary_search(prop_ids, index_prop); };
-    return r::any_of(index_props[0], vector_has_property);
-  };
-
-  for (auto &[props, index] : it->second | rv::filter(relevant_index)) {
-    auto &[permutations_helper, skiplist, status] = *index;
-    auto values = permutations_helper.Extract(vertex_after_update->properties);
-    if (r::any_of(values, [](auto &&val) { return !val.IsNull(); })) {
-      auto acc = skiplist.access();
-      acc.insert({permutations_helper.ApplyPermutation(std::move(values)), vertex_after_update, tx.start_timestamp});
-    }
-  }
-}
-
-void InMemoryLabelPropertyIndex::ActiveIndices::UpdateOnSetProperty(PropertyId property, const PropertyValue &value,
-                                                                    Vertex *vertex, const Transaction &tx) {
-  auto const it = index_container_->reverse_lookup_.find(property);
-  if (it == index_container_->reverse_lookup_.end()) {
-    return;
-  }
-
-  auto const has_label = [&](auto &&each) { return r::find(vertex->labels, each.first) != vertex->labels.cend(); };
-  auto const has_property = [&](auto &&each) {
-    auto &ids = *std::get<PropertiesPaths const *>(each.second);
-    return r::find_if(ids, [&](auto &&path) { return path[0] == property; }) != ids.cend();
-  };
-  auto const relevant_index = [&](auto &&each) { return has_label(each) && has_property(each); };
-
-  for (auto &lookup : it->second | rv::filter(relevant_index)) {
-    auto &[property_ids, index] = lookup.second;
-
-    auto values = index->permutations_helper.Extract(vertex->properties);
-    if (r::any_of(values, [](auto &&value) { return !value.IsNull(); })) {
-      auto acc = index->skiplist.access();
-      acc.insert({index->permutations_helper.ApplyPermutation(std::move(values)), vertex, tx.start_timestamp});
-    }
-  }
-}
-
-bool InMemoryLabelPropertyIndex::DropIndex(LabelId label, std::vector<PropertyPath> const &properties) {
-  return RemoveIndividualIndex(label, properties);
 }
 
 bool InMemoryLabelPropertyIndex::ActiveIndices::IndexReady(LabelId label,
@@ -553,8 +549,8 @@ bool InMemoryLabelPropertyIndex::ActiveIndices::IndexReady(LabelId label,
 }
 
 auto InMemoryLabelPropertyIndex::ActiveIndices::RelevantLabelPropertiesIndicesInfo(
-    std::span<LabelId const> labels,
-    std::span<PropertyPath const> properties) const -> std::vector<LabelPropertiesIndicesInfo> {
+    std::span<LabelId const> labels, std::span<PropertyPath const> properties) const
+    -> std::vector<LabelPropertiesIndicesInfo> {
   auto res = std::vector<LabelPropertiesIndicesInfo>{};
   auto ppos_indices = rv::iota(size_t{}, properties.size()) | r::to_vector;
   auto properties_vec = properties | ranges::to_vector;
@@ -635,7 +631,7 @@ auto InMemoryLabelPropertyIndex::ActiveIndices::ListIndices(uint64_t start_times
 void InMemoryLabelPropertyIndex::RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token) {
   auto maybe_stop = utils::ResettableCounter(2048);
 
-  CleanupAllIndicies();
+  CleanupAllIndices();
 
   auto cpy = all_indexes_.WithReadLock(std::identity{});
 
@@ -1048,8 +1044,8 @@ std::optional<storage::LabelPropertyIndexStats> InMemoryLabelPropertyIndex::GetI
 }
 
 void InMemoryLabelPropertyIndex::RunGC() {
-  // Remove indicies that are not used by any txn
-  CleanupAllIndicies();
+  // Remove indices that are not used by any txn
+  CleanupAllIndices();
 
   auto cpy = all_indexes_.WithReadLock(std::identity{});
   for (auto &[index, _1, _2] : *cpy) {
@@ -1103,7 +1099,7 @@ InMemoryLabelPropertyIndex::Iterable InMemoryLabelPropertyIndex::ActiveIndices::
 void InMemoryLabelPropertyIndex::DropGraphClearIndices() {
   index_.WithLock([](auto &idx) { idx = std::make_shared<IndexContainer>(); });
   stats_->clear();
-  CleanupAllIndicies();
+  CleanupAllIndices();
 }
 
 auto InMemoryLabelPropertyIndex::ActiveIndices::GetAbortProcessor() const -> LabelPropertyIndex::AbortProcessor {
@@ -1149,7 +1145,7 @@ void InMemoryLabelPropertyIndex::ActiveIndices::AbortEntries(AbortableInfo const
   }
 }
 
-void InMemoryLabelPropertyIndex::CleanupAllIndicies() {
+void InMemoryLabelPropertyIndex::CleanupAllIndices() {
   // By cleanup, we mean just cleanup of the all_indexes_
   // If all_indexes_ is the only thing holding onto an IndividualIndex, we remove it
   all_indexes_.WithLock([](std::shared_ptr<std::vector<AllIndicesEntry> const> &indices) {

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -97,9 +97,6 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
   };
   using PropertiesIndicesStats = std::map<PropertiesPaths, storage::LabelPropertyIndexStats, Compare>;
 
-  InMemoryLabelPropertyIndex()
-      : index_(std::make_shared<IndexContainer>()), all_indexes_(std::make_shared<std::vector<AllIndicesEntry>>()) {}
-
   // Convience function that does Register + Populate + direct Publish
   // TODO: direct Publish...should it be for a particular timestamp?
   bool CreateIndexOnePass(LabelId label, PropertiesPaths const &properties, utils::SkipList<Vertex>::Accessor vertices,
@@ -235,9 +232,10 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
   auto GetIndividualIndex(LabelId const &label, PropertiesPaths const &properties) const
       -> std::shared_ptr<IndividualIndex>;
 
-  utils::Synchronized<std::shared_ptr<IndexContainer const>, utils::WritePrioritizedRWLock> index_;
-  utils::Synchronized<std::shared_ptr<std::vector<AllIndicesEntry> const>, utils::WritePrioritizedRWLock>
-      all_indexes_{};
+  utils::Synchronized<std::shared_ptr<IndexContainer const>, utils::WritePrioritizedRWLock> index_{
+      std::make_shared<IndexContainer const>()};
+  utils::Synchronized<std::shared_ptr<std::vector<AllIndicesEntry> const>, utils::WritePrioritizedRWLock> all_indices_{
+      std::make_shared<std::vector<AllIndicesEntry> const>()};
   utils::Synchronized<std::map<LabelId, PropertiesIndicesStats>, utils::ReadPrioritizedRWLock> stats_;
 };
 

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -16,8 +16,8 @@
 #include "storage/v2/common_function_signatures.hpp"
 #include "storage/v2/durability/recovery_type.hpp"
 #include "storage/v2/id_types.hpp"
-#include "storage/v2/indices/indices_utils.hpp"
 #include "storage/v2/indices/errors.hpp"
+#include "storage/v2/indices/indices_utils.hpp"
 #include "storage/v2/indices/label_property_index.hpp"
 #include "storage/v2/indices/label_property_index_stats.hpp"
 #include "storage/v2/inmemory/indices_mvcc.hpp"
@@ -111,8 +111,8 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
   auto PopulateIndex(LabelId label, PropertiesPaths const &properties, utils::SkipList<Vertex>::Accessor vertices,
                      const std::optional<durability::ParallelizedSchemaCreationInfo> &parallel_exec_info,
                      std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt,
-                     Transaction const *tx = nullptr,
-                     CheckCancelFunction cancel_check = neverCancel) -> utils::BasicResult<IndexPopulateError>;
+                     Transaction const *tx = nullptr, CheckCancelFunction cancel_check = neverCancel)
+      -> utils::BasicResult<IndexPopulateError>;
 
   bool PublishIndex(LabelId label, PropertiesPaths const &properties, uint64_t commit_timestamp);
 
@@ -176,8 +176,9 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
 
     bool IndexReady(LabelId label, std::span<PropertyPath const> properties) const override;
 
-    auto RelevantLabelPropertiesIndicesInfo(std::span<LabelId const> labels, std::span<PropertyPath const> properties)
-        const -> std::vector<LabelPropertiesIndicesInfo> override;
+    auto RelevantLabelPropertiesIndicesInfo(std::span<LabelId const> labels,
+                                            std::span<PropertyPath const> properties) const
+        -> std::vector<LabelPropertiesIndicesInfo> override;
 
     auto ListIndices(uint64_t start_timestamp) const
         -> std::vector<std::pair<LabelId, std::vector<PropertyPath>>> override;
@@ -230,10 +231,9 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
   void DropGraphClearIndices() override;
 
  private:
-  void CleanupAllIndicies();
-  auto GetIndividualIndex(LabelId const &label,
-                          PropertiesPaths const &properties) const -> std::shared_ptr<IndividualIndex>;
-  bool RemoveIndividualIndex(LabelId const &label, PropertiesPaths const &properties);
+  void CleanupAllIndices();
+  auto GetIndividualIndex(LabelId const &label, PropertiesPaths const &properties) const
+      -> std::shared_ptr<IndividualIndex>;
 
   utils::Synchronized<std::shared_ptr<IndexContainer const>, utils::WritePrioritizedRWLock> index_;
   utils::Synchronized<std::shared_ptr<std::vector<AllIndicesEntry> const>, utils::WritePrioritizedRWLock>

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1611,7 +1611,7 @@ utils::BasicResult<StorageIndexDefinitionError, void> InMemoryStorage::InMemoryA
 
 utils::BasicResult<StorageIndexDefinitionError, void> InMemoryStorage::InMemoryAccessor::DropGlobalEdgeIndex(
     PropertyId property, DropIndexWrapper wrapper) {
-  MG_ASSERT(type() == UNIQUE || type() == READ_ONLY, "Drop index requires a unique access to the storage!");
+  MG_ASSERT(type() == UNIQUE || type() == READ, "Drop index requires a unique access to the storage!");
   auto *in_memory = static_cast<InMemoryStorage *>(storage_);
   if (!in_memory->config_.salient.items.properties_on_edges) {
     // Not possible to create the index, no properties on edges

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1517,7 +1517,7 @@ utils::BasicResult<StorageIndexDefinitionError, void> InMemoryStorage::InMemoryA
 }
 
 utils::BasicResult<StorageIndexDefinitionError, void> InMemoryStorage::InMemoryAccessor::CreateGlobalEdgeIndex(
-    PropertyId property, PublishIndexWrapper wrapper) {
+    PropertyId property, CheckCancelFunction cancel_check, PublishIndexWrapper wrapper) {
   MG_ASSERT(unique_guard_.owns_lock(), "Create index requires a unique access to the storage!");
   auto *in_memory = static_cast<InMemoryStorage *>(storage_);
   if (!in_memory->config_.salient.items.properties_on_edges) {

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -231,18 +231,19 @@ class InMemoryStorage final : public Storage {
     }
 
     uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property) const override {
-      return storage_->indices_.edge_type_property_index_->ApproximateEdgeCount(edge_type, property);
+      return transaction_.active_indices_.edge_type_properties_->ApproximateEdgeCount(edge_type, property);
     }
 
     uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property,
                                   const PropertyValue &value) const override {
-      return storage_->indices_.edge_type_property_index_->ApproximateEdgeCount(edge_type, property, value);
+      return transaction_.active_indices_.edge_type_properties_->ApproximateEdgeCount(edge_type, property, value);
     }
 
     uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property,
                                   const std::optional<utils::Bound<PropertyValue>> &lower,
                                   const std::optional<utils::Bound<PropertyValue>> &upper) const override {
-      return storage_->indices_.edge_type_property_index_->ApproximateEdgeCount(edge_type, property, lower, upper);
+      return transaction_.active_indices_.edge_type_properties_->ApproximateEdgeCount(edge_type, property, lower,
+                                                                                      upper);
     }
 
     uint64_t ApproximateEdgeCount(PropertyId property) const override {
@@ -313,8 +314,8 @@ class InMemoryStorage final : public Storage {
       return transaction_.active_indices_.edge_type_->IndexReady(edge_type);
     }
 
-    bool EdgeTypePropertyIndexExists(EdgeTypeId edge_type, PropertyId property) const override {
-      return storage_->indices_.edge_type_property_index_->IndexExists(edge_type, property);
+    bool EdgeTypePropertyIndexReady(EdgeTypeId edge_type, PropertyId property) const override {
+      return transaction_.active_indices_.edge_type_properties_->IndexReady(edge_type, property);
     }
 
     bool EdgePropertyIndexExists(PropertyId property) const override {
@@ -382,7 +383,8 @@ class InMemoryStorage final : public Storage {
     /// * `IndexDefinitionError`: the index already exists.
     /// @throw std::bad_alloc
     utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
-        EdgeTypeId edge_type, PropertyId property, PublishIndexWrapper wrapper = publish_no_wrap) override;
+        EdgeTypeId edge_type, PropertyId property, CheckCancelFunction cancel_check = neverCancel,
+        PublishIndexWrapper wrapper = publish_no_wrap) override;
 
     /// Create an index.
     /// Returns void if the index has been created.
@@ -509,8 +511,8 @@ class InMemoryStorage final : public Storage {
     /// View is not needed because a new rtree gets created for each transaction and it is always
     /// using the latest version
     auto PointVertices(LabelId label, PropertyId property, CoordinateReferenceSystem crs,
-                       PropertyValue const &bottom_left, PropertyValue const &top_right, WithinBBoxCondition condition)
-        -> PointIterable override;
+                       PropertyValue const &bottom_left, PropertyValue const &top_right,
+                       WithinBBoxCondition condition) -> PointIterable override;
 
     std::vector<std::tuple<VertexAccessor, double, double>> VectorIndexSearchOnNodes(
         const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector) override;

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -393,7 +393,8 @@ class InMemoryStorage final : public Storage {
     /// * `IndexDefinitionError`: the index already exists.
     /// @throw std::bad_alloc
     utils::BasicResult<StorageIndexDefinitionError, void> CreateGlobalEdgeIndex(
-        PropertyId property, PublishIndexWrapper wrapper = publish_no_wrap) override;
+        PropertyId property, CheckCancelFunction cancel_check = neverCancel,
+        PublishIndexWrapper wrapper = publish_no_wrap) override;
 
     /// Drop an existing index.
     /// Returns void if the index has been dropped.

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -318,7 +318,7 @@ class InMemoryStorage final : public Storage {
       return transaction_.active_indices_.edge_type_properties_->IndexReady(edge_type, property);
     }
 
-    bool EdgePropertyIndexExists(PropertyId property) const override {
+    bool EdgePropertyIndexReady(PropertyId property) const override {
       return static_cast<InMemoryStorage *>(storage_)->indices_.edge_property_index_->IndexExists(property);
     }
 

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -247,18 +247,16 @@ class InMemoryStorage final : public Storage {
     }
 
     uint64_t ApproximateEdgeCount(PropertyId property) const override {
-      return static_cast<InMemoryStorage *>(storage_)->indices_.edge_property_index_->ApproximateEdgeCount(property);
+      return transaction_.active_indices_.edge_property_->ApproximateEdgeCount(property);
     }
 
     uint64_t ApproximateEdgeCount(PropertyId property, const PropertyValue &value) const override {
-      return static_cast<InMemoryStorage *>(storage_)->indices_.edge_property_index_->ApproximateEdgeCount(property,
-                                                                                                           value);
+      return transaction_.active_indices_.edge_property_->ApproximateEdgeCount(property, value);
     }
 
     uint64_t ApproximateEdgeCount(PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower,
                                   const std::optional<utils::Bound<PropertyValue>> &upper) const override {
-      return static_cast<InMemoryStorage *>(storage_)->indices_.edge_property_index_->ApproximateEdgeCount(
-          property, lower, upper);
+      return transaction_.active_indices_.edge_property_->ApproximateEdgeCount(property, lower, upper);
     }
 
     std::optional<uint64_t> ApproximateVerticesPointCount(LabelId label, PropertyId property) const override {
@@ -319,7 +317,7 @@ class InMemoryStorage final : public Storage {
     }
 
     bool EdgePropertyIndexReady(PropertyId property) const override {
-      return static_cast<InMemoryStorage *>(storage_)->indices_.edge_property_index_->IndexExists(property);
+      return transaction_.active_indices_.edge_property_->IndexReady(property);
     }
 
     bool PointIndexExists(LabelId label, PropertyId property) const override;

--- a/src/storage/v2/property_value.hpp
+++ b/src/storage/v2/property_value.hpp
@@ -175,9 +175,9 @@ class PropertyValueImpl {
 
   /// Copy accross allocators
   template <typename AllocOther, typename KeyTypeOther>
-  requires(!std::same_as<allocator_type, AllocOther> && std::same_as<KeyType, KeyTypeOther>)
-      PropertyValueImpl(PropertyValueImpl<AllocOther, KeyTypeOther> const &other,
-                        allocator_type const &alloc = allocator_type{})
+    requires(!std::same_as<allocator_type, AllocOther> && std::same_as<KeyType, KeyTypeOther>)
+  PropertyValueImpl(PropertyValueImpl<AllocOther, KeyTypeOther> const &other,
+                    allocator_type const &alloc = allocator_type{})
       : alloc_{alloc}, type_{other.type_} {
     switch (other.type_) {
       case Type::Null:
@@ -682,8 +682,8 @@ inline auto PropertyValueImpl<Alloc, KeyType>::operator=(PropertyValueImpl const
 
 template <typename Alloc, typename KeyType>
 inline auto PropertyValueImpl<Alloc, KeyType>::operator=(PropertyValueImpl &&other) noexcept(
-    alloc_trait::is_always_equal::value || alloc_trait::propagate_on_container_move_assignment::value)
-    -> PropertyValueImpl<Alloc, KeyType> & {
+    alloc_trait::is_always_equal::value ||
+    alloc_trait::propagate_on_container_move_assignment::value) -> PropertyValueImpl<Alloc, KeyType> & {
   auto do_move = [&]() -> PropertyValueImpl<Alloc, KeyType> & {
     if (type_ == other.type_) {
       // maybe the same object, check if no work is required
@@ -963,8 +963,8 @@ static_assert(sizeof(pmr::PropertyValue) == 72 /*56*/);
  * is valid, returns a positional pointer to the `PropertyValue` within the
  * top-most value. Otherwise, return `nullptr`.
  */
-inline auto ReadNestedPropertyValue(PropertyValue const &value, std::span<PropertyId const> path_to_property)
-    -> PropertyValue const * {
+inline auto ReadNestedPropertyValue(PropertyValue const &value,
+                                    std::span<PropertyId const> path_to_property) -> PropertyValue const * {
   auto const *current = &value;
   // Follow the path down into the nested maps
   for (auto &&property_id : path_to_property) {

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -348,7 +348,7 @@ class Storage {
 
     virtual bool EdgeTypePropertyIndexReady(EdgeTypeId edge_type, PropertyId property) const = 0;
 
-    virtual bool EdgePropertyIndexExists(PropertyId property) const = 0;
+    virtual bool EdgePropertyIndexReady(PropertyId property) const = 0;
 
     bool TextIndexExists(const std::string &index_name) const {
       return storage_->indices_.text_index_.IndexExists(index_name);

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -37,6 +37,7 @@ extern const Event ActiveLabelIndices;
 extern const Event ActiveLabelPropertyIndices;
 extern const Event ActiveEdgeTypeIndices;
 extern const Event ActiveEdgeTypePropertyIndices;
+extern const Event ActiveEdgePropertyIndices;
 extern const Event ActivePointIndices;
 extern const Event ActiveTextIndices;
 extern const Event ActiveVectorIndices;
@@ -677,6 +678,7 @@ class Storage {
         indices_.label_property_index_->GetActiveIndices(),
         indices_.edge_type_index_->GetActiveIndices(),
         indices_.edge_type_property_index_->GetActiveIndices(),
+        indices_.edge_property_index_->GetActiveIndices(),
     };
   }
 

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -437,7 +437,8 @@ class Storage {
         PublishIndexWrapper wrapper = publish_no_wrap) = 0;
 
     virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateGlobalEdgeIndex(
-        PropertyId property, PublishIndexWrapper wrapper = publish_no_wrap) = 0;
+        PropertyId property, CheckCancelFunction cancel_check = neverCancel,
+        PublishIndexWrapper wrapper = publish_no_wrap) = 0;
 
     virtual utils::BasicResult<StorageIndexDefinitionError, void> DropIndex(
         LabelId label, DropIndexWrapper wrapper = drop_no_wrap) = 0;

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -36,6 +36,7 @@ extern const Event SnapshotCreationLatency_us;
 extern const Event ActiveLabelIndices;
 extern const Event ActiveLabelPropertyIndices;
 extern const Event ActiveEdgeTypeIndices;
+extern const Event ActiveEdgeTypePropertyIndices;
 extern const Event ActivePointIndices;
 extern const Event ActiveTextIndices;
 extern const Event ActiveVectorIndices;
@@ -338,15 +339,14 @@ class Storage {
 
     virtual bool LabelPropertyIndexReady(LabelId label, std::span<PropertyPath const> properties) const = 0;
 
-    auto RelevantLabelPropertiesIndicesInfo(std::span<LabelId const> labels,
-                                            std::span<PropertyPath const> properties) const
-        -> std::vector<LabelPropertiesIndicesInfo> {
+    auto RelevantLabelPropertiesIndicesInfo(std::span<LabelId const> labels, std::span<PropertyPath const> properties)
+        const -> std::vector<LabelPropertiesIndicesInfo> {
       return transaction_.active_indices_.label_properties_->RelevantLabelPropertiesIndicesInfo(labels, properties);
     };
 
     virtual bool EdgeTypeIndexReady(EdgeTypeId edge_type) const = 0;
 
-    virtual bool EdgeTypePropertyIndexExists(EdgeTypeId edge_type, PropertyId property) const = 0;
+    virtual bool EdgeTypePropertyIndexReady(EdgeTypeId edge_type, PropertyId property) const = 0;
 
     virtual bool EdgePropertyIndexExists(PropertyId property) const = 0;
 
@@ -433,7 +433,8 @@ class Storage {
         PublishIndexWrapper wrapper = publish_no_wrap) = 0;
 
     virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateIndex(
-        EdgeTypeId edge_type, PropertyId property, PublishIndexWrapper wrapper = publish_no_wrap) = 0;
+        EdgeTypeId edge_type, PropertyId property, CheckCancelFunction cancel_check = neverCancel,
+        PublishIndexWrapper wrapper = publish_no_wrap) = 0;
 
     virtual utils::BasicResult<StorageIndexDefinitionError, void> CreateGlobalEdgeIndex(
         PropertyId property, PublishIndexWrapper wrapper = publish_no_wrap) = 0;
@@ -499,8 +500,8 @@ class Storage {
     }
     auto GetEnumStoreShared() const -> EnumStore const & { return storage_->enum_store_; }
 
-    auto CreateEnum(std::string_view name, std::span<std::string const> values)
-        -> memgraph::utils::BasicResult<EnumStorageError, EnumTypeId> {
+    auto CreateEnum(std::string_view name,
+                    std::span<std::string const> values) -> memgraph::utils::BasicResult<EnumStorageError, EnumTypeId> {
       auto res = storage_->enum_store_.RegisterEnum(name, values);
       if (res.HasValue()) {
         transaction_.md_deltas.emplace_back(MetadataDelta::enum_create, res.GetValue());
@@ -508,8 +509,8 @@ class Storage {
       return res;
     }
 
-    auto EnumAlterAdd(std::string_view name, std::string_view value)
-        -> utils::BasicResult<storage::EnumStorageError, storage::Enum> {
+    auto EnumAlterAdd(std::string_view name,
+                      std::string_view value) -> utils::BasicResult<storage::EnumStorageError, storage::Enum> {
       auto res = storage_->enum_store_.AddValue(name, value);
       if (res.HasValue()) {
         transaction_.md_deltas.emplace_back(MetadataDelta::enum_alter_add, res.GetValue());
@@ -517,8 +518,8 @@ class Storage {
       return res;
     }
 
-    auto EnumAlterUpdate(std::string_view name, std::string_view old_value, std::string_view new_value)
-        -> utils::BasicResult<storage::EnumStorageError, storage::Enum> {
+    auto EnumAlterUpdate(std::string_view name, std::string_view old_value,
+                         std::string_view new_value) -> utils::BasicResult<storage::EnumStorageError, storage::Enum> {
       auto res = storage_->enum_store_.UpdateValue(name, old_value, new_value);
       if (res.HasValue()) {
         transaction_.md_deltas.emplace_back(MetadataDelta::enum_alter_update, res.GetValue(), std::string{old_value});
@@ -528,8 +529,8 @@ class Storage {
 
     auto ShowEnums() { return storage_->enum_store_.AllRegistered(); }
 
-    auto GetEnumValue(std::string_view name, std::string_view value) const
-        -> utils::BasicResult<EnumStorageError, Enum> {
+    auto GetEnumValue(std::string_view name,
+                      std::string_view value) const -> utils::BasicResult<EnumStorageError, Enum> {
       return storage_->enum_store_.ToEnum(name, value);
     }
 
@@ -674,6 +675,7 @@ class Storage {
         indices_.label_index_->GetActiveIndices(),
         indices_.label_property_index_->GetActiveIndices(),
         indices_.edge_type_index_->GetActiveIndices(),
+        indices_.edge_type_property_index_->GetActiveIndices(),
     };
   }
 

--- a/src/utils/event_counter.cpp
+++ b/src/utils/event_counter.cpp
@@ -83,6 +83,7 @@
   M(ActiveLabelIndices, Index, "Number of active label indices in the system.")                                        \
   M(ActiveLabelPropertyIndices, Index, "Number of active label property indices in the system.")                       \
   M(ActiveEdgeTypeIndices, Index, "Number of active edge type indices in the system.")                                 \
+  M(ActiveEdgeTypePropertyIndices, Index, "Number of active edge type property indices in the system.")                \
   M(ActivePointIndices, Index, "Number of active point indices in the system.")                                        \
   M(ActiveTextIndices, Index, "Number of active text indices in the system.")                                          \
   M(ActiveVectorIndices, Index, "Number of active vector indices in the system.")                                      \

--- a/src/utils/event_counter.cpp
+++ b/src/utils/event_counter.cpp
@@ -84,6 +84,7 @@
   M(ActiveLabelPropertyIndices, Index, "Number of active label property indices in the system.")                       \
   M(ActiveEdgeTypeIndices, Index, "Number of active edge type indices in the system.")                                 \
   M(ActiveEdgeTypePropertyIndices, Index, "Number of active edge type property indices in the system.")                \
+  M(ActiveEdgePropertyIndices, Index, "Number of active edge property indices in the system.")                         \
   M(ActivePointIndices, Index, "Number of active point indices in the system.")                                        \
   M(ActiveTextIndices, Index, "Number of active text indices in the system.")                                          \
   M(ActiveVectorIndices, Index, "Number of active vector indices in the system.")                                      \

--- a/tests/e2e/schema_info/schema_info.py
+++ b/tests/e2e/schema_info/schema_info.py
@@ -107,7 +107,7 @@ def test_spec(connect):
         else:
             assert index["edge_type"] == ["IS_FAMILY"]
             assert index["properties"] == ["since"]
-            assert index["count"] == 5
+            assert index["count"] == 4
     enums = schema_json["enums"]
     assert len(enums) == 1
     assert enums[0]["name"] == "Status"

--- a/tests/e2e/show_metrics/show_metrics.py
+++ b/tests/e2e/show_metrics/show_metrics.py
@@ -119,6 +119,7 @@ def test_all_show_metrics_info_values_are_present(memgraph):
         {"name": "WalFilesRpc_us_90p", "type": "HighAvailability", "metric type": "Histogram"},
         {"name": "WalFilesRpc_us_99p", "type": "HighAvailability", "metric type": "Histogram"},
         {"name": "ActiveEdgeTypeIndices", "type": "Index", "metric type": "Counter"},
+        {"name": "ActiveEdgeTypePropertyIndices", "type": "Index", "metric type": "Counter"},
         {"name": "ActiveLabelIndices", "type": "Index", "metric type": "Counter"},
         {"name": "ActiveLabelPropertyIndices", "type": "Index", "metric type": "Counter"},
         {"name": "ActivePointIndices", "type": "Index", "metric type": "Counter"},

--- a/tests/e2e/show_metrics/show_metrics.py
+++ b/tests/e2e/show_metrics/show_metrics.py
@@ -118,6 +118,7 @@ def test_all_show_metrics_info_values_are_present(memgraph):
         {"name": "WalFilesRpc_us_50p", "type": "HighAvailability", "metric type": "Histogram"},
         {"name": "WalFilesRpc_us_90p", "type": "HighAvailability", "metric type": "Histogram"},
         {"name": "WalFilesRpc_us_99p", "type": "HighAvailability", "metric type": "Histogram"},
+        {"name": "ActiveEdgePropertyIndices", "type": "Index", "metric type": "Counter"},
         {"name": "ActiveEdgeTypeIndices", "type": "Index", "metric type": "Counter"},
         {"name": "ActiveEdgeTypePropertyIndices", "type": "Index", "metric type": "Counter"},
         {"name": "ActiveLabelIndices", "type": "Index", "metric type": "Counter"},

--- a/tests/manual/interactive_planning.cpp
+++ b/tests/manual/interactive_planning.cpp
@@ -369,7 +369,7 @@ class InteractiveDbAccessor {
     return edge_type_property_index_.at(key);
   }
 
-  bool EdgePropertyIndexExists(memgraph::storage::PropertyId property_id) { return false; }
+  bool EdgePropertyIndexReady(memgraph::storage::PropertyId property_id) { return false; }
 
   std::optional<memgraph::storage::LabelIndexStats> GetIndexStats(const memgraph::storage::LabelId label) const {
     return dba_->GetIndexStats(label);

--- a/tests/manual/interactive_planning.cpp
+++ b/tests/manual/interactive_planning.cpp
@@ -356,8 +356,9 @@ class InteractiveDbAccessor {
 
   bool EdgeTypeIndexReady(memgraph::storage::EdgeTypeId edge_type_id) { return true; }
 
-  bool EdgeTypePropertyIndexExists(memgraph::storage::EdgeTypeId edge_type_id,
-                                   memgraph::storage::PropertyId property_id) {
+  bool EdgeTypePropertyIndexReady(memgraph::storage::EdgeTypeId edge_type_id,
+                                  memgraph::storage::PropertyId property_id) {
+    // TODO (ivan): what is this
     auto edge_type = dba_->EdgeTypeToName(edge_type_id);
     auto property = dba_->PropertyToName(property_id);
     auto key = std::make_pair(edge_type, property);

--- a/tests/manual/interactive_planning.cpp
+++ b/tests/manual/interactive_planning.cpp
@@ -358,7 +358,6 @@ class InteractiveDbAccessor {
 
   bool EdgeTypePropertyIndexReady(memgraph::storage::EdgeTypeId edge_type_id,
                                   memgraph::storage::PropertyId property_id) {
-    // TODO (ivan): what is this
     auto edge_type = dba_->EdgeTypeToName(edge_type_id);
     auto property = dba_->PropertyToName(property_id);
     auto key = std::make_pair(edge_type, property);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -8,6 +8,9 @@ add_custom_target(memgraph__unit)
 
 add_library(memgraph_unit_main OBJECT main.cpp)
 target_link_libraries(memgraph_unit_main mg-memory mg-utils gtest gmock Threads::Threads dl)
+target_precompile_headers(memgraph_unit_main PRIVATE
+    <gtest/gtest.h>
+)
 
 function(add_unit_test test_cpp)
   _add_unit_test(${test_cpp} FALSE ${ARGN})

--- a/tests/unit/query_dump.cpp
+++ b/tests/unit/query_dump.cpp
@@ -256,7 +256,7 @@ DatabaseState GetState(memgraph::storage::Storage *db) {
   std::set<DatabaseState::OrderedLabelPropertiesItem> label_properties_indices;
   std::set<DatabaseState::TextItem> text_indices;
   std::set<DatabaseState::PointItem> point_indices;
-  // TODO: where are the edge types indicies?
+  // TODO: where are the edge types indices?
 
   {
     auto info = dba->ListAllIndices();

--- a/tests/unit/query_plan_checker.hpp
+++ b/tests/unit/query_plan_checker.hpp
@@ -768,7 +768,7 @@ class FakeDbAccessor {
     return false;
   }
 
-  bool EdgePropertyIndexExists(memgraph::storage::PropertyId property) const { return false; }
+  bool EdgePropertyIndexReady(memgraph::storage::PropertyId property) const { return false; }
 
   std::optional<memgraph::storage::LabelPropertyIndexStats> GetIndexStats(
       const memgraph::storage::LabelId label, std::span<memgraph::storage::PropertyPath const> properties) const {
@@ -850,8 +850,8 @@ class FakeDbAccessor {
 
   std::string PropertyName(memgraph::storage::PropertyId property) const { return PropertyToName(property); }
 
-  auto GetEnumValue(std::string_view name,
-                    std::string_view value) -> utils::BasicResult<storage::EnumStorageError, storage::Enum> {
+  auto GetEnumValue(std::string_view name, std::string_view value)
+      -> utils::BasicResult<storage::EnumStorageError, storage::Enum> {
     // Does this need to be less fake?
     return memgraph::storage::Enum{memgraph::storage::EnumTypeId{0}, memgraph::storage::EnumValueId{0}};
   }

--- a/tests/unit/query_plan_checker.hpp
+++ b/tests/unit/query_plan_checker.hpp
@@ -758,8 +758,8 @@ class FakeDbAccessor {
     return edge_type_index_.find(edge_type) != edge_type_index_.end();
   }
 
-  bool EdgeTypePropertyIndexExists(memgraph::storage::EdgeTypeId edge_type,
-                                   memgraph::storage::PropertyId property) const {
+  bool EdgeTypePropertyIndexReady(memgraph::storage::EdgeTypeId edge_type,
+                                  memgraph::storage::PropertyId property) const {
     for (const auto &index : edge_type_property_index_) {
       if (std::get<0>(index) == edge_type && std::get<1>(index) == property) {
         return true;

--- a/tests/unit/snapshot_rpc_progress.cpp
+++ b/tests/unit/snapshot_rpc_progress.cpp
@@ -437,7 +437,7 @@ TEST_F(SnapshotRpcProgressTest, TestEdgeTypePropertyIndexSingleThreadedNoVertice
   snapshot_info.emplace(mocked_observer, 3);
 
   EXPECT_CALL(*mocked_observer, Update()).Times(0);
-  ASSERT_TRUE(etype_idx.CreateIndex(etype, prop, vertices.access(), snapshot_info));
+  ASSERT_TRUE(etype_idx.CreateIndexOnePass(etype, prop, vertices.access(), snapshot_info));
 }
 
 TEST_F(SnapshotRpcProgressTest, TestEdgeTypePropertyIndexSingleThreadedVerticesEdges) {
@@ -465,7 +465,7 @@ TEST_F(SnapshotRpcProgressTest, TestEdgeTypePropertyIndexSingleThreadedVerticesE
   snapshot_info.emplace(mocked_observer, 3);
 
   EXPECT_CALL(*mocked_observer, Update()).Times(2);
-  ASSERT_TRUE(etype_idx.CreateIndex(etype, prop, vertices.access(), snapshot_info));
+  ASSERT_TRUE(etype_idx.CreateIndexOnePass(etype, prop, vertices.access(), snapshot_info));
 }
 
 TEST_F(SnapshotRpcProgressTest, TestPointIndexSingleThreadedNoVertices) {

--- a/tests/unit/snapshot_rpc_progress.cpp
+++ b/tests/unit/snapshot_rpc_progress.cpp
@@ -458,6 +458,7 @@ TEST_F(SnapshotRpcProgressTest, TestEdgeTypePropertyIndexSingleThreadedVerticesE
       auto [it, ver_inserted] = acc.insert(std::move(vertex));
       ASSERT_TRUE(ver_inserted);
       it->out_edges.emplace_back(etype, &*it, edge_ref);
+      edge->properties.SetProperty(prop, PropertyValue{1});
     }
   }
   auto mocked_observer = std::make_shared<MockedSnapshotObserver>();

--- a/tests/unit/storage_v2_durability_inmemory.cpp
+++ b/tests/unit/storage_v2_durability_inmemory.cpp
@@ -149,9 +149,9 @@ class DurabilityTest : public ::testing::TestWithParam<bool> {
     }
     {
       // Create label index.
-      auto unique_acc = store->UniqueAccess();
-      ASSERT_FALSE(unique_acc->CreateIndex(label_unindexed).HasError());
-      ASSERT_FALSE(unique_acc->Commit().HasError());
+      auto acc = store->ReadOnlyAccess();
+      ASSERT_FALSE(acc->CreateIndex(label_unindexed).HasError());
+      ASSERT_FALSE(acc->Commit().HasError());
     }
     {
       // Create label index statistics.
@@ -455,9 +455,9 @@ class DurabilityTest : public ::testing::TestWithParam<bool> {
                                memgraph::storage::PropertyId prop) {
     {
       // Create edge-type index.
-      auto unique_acc = store->UniqueAccess();
-      ASSERT_FALSE(unique_acc->CreateIndex(edge_type, prop).HasError());
-      ASSERT_FALSE(unique_acc->Commit().HasError());
+      auto acc = store->ReadOnlyAccess();
+      ASSERT_FALSE(acc->CreateIndex(edge_type, prop).HasError());
+      ASSERT_FALSE(acc->Commit().HasError());
     }
   }
 

--- a/tests/unit/storage_v2_indices.cpp
+++ b/tests/unit/storage_v2_indices.cpp
@@ -2959,9 +2959,9 @@ TYPED_TEST(IndexTest, EdgePropertyIndexCreate) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateGlobalEdgeIndex(this->edge_prop_id1).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateGlobalEdgeIndex(this->edge_prop_id1).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   {
@@ -3121,9 +3121,9 @@ TYPED_TEST(IndexTest, EdgePropertyIndexDrop) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateGlobalEdgeIndex(this->edge_prop_id1).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateGlobalEdgeIndex(this->edge_prop_id1).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   {
@@ -3135,9 +3135,9 @@ TYPED_TEST(IndexTest, EdgePropertyIndexDrop) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->DropGlobalEdgeIndex(this->edge_prop_id1).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->DropIndexAccessor();
+    EXPECT_FALSE(acc->DropGlobalEdgeIndex(this->edge_prop_id1).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
   {
     auto acc = this->storage->Access();
@@ -3146,9 +3146,9 @@ TYPED_TEST(IndexTest, EdgePropertyIndexDrop) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_TRUE(unique_acc->DropGlobalEdgeIndex(this->edge_prop_id1).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->DropIndexAccessor();
+    EXPECT_TRUE(acc->DropGlobalEdgeIndex(this->edge_prop_id1).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
   {
     auto acc = this->storage->Access();
@@ -3169,9 +3169,9 @@ TYPED_TEST(IndexTest, EdgePropertyIndexDrop) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateGlobalEdgeIndex(this->edge_prop_id1).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateGlobalEdgeIndex(this->edge_prop_id1).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
   {
     auto acc = this->storage->Access();
@@ -3207,14 +3207,14 @@ TYPED_TEST(IndexTest, EdgePropertyIndexBasic) {
     return;
   }
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateGlobalEdgeIndex(this->edge_prop_id1).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateGlobalEdgeIndex(this->edge_prop_id1).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateGlobalEdgeIndex(this->edge_prop_id2).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateGlobalEdgeIndex(this->edge_prop_id2).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   auto acc = this->storage->Access();
@@ -3277,14 +3277,14 @@ TYPED_TEST(IndexTest, EdgePropertyIndexTransactionalIsolation) {
   }
   // Check that transactions only see entries they are supposed to see.
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateGlobalEdgeIndex(this->edge_prop_id1).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateGlobalEdgeIndex(this->edge_prop_id1).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateGlobalEdgeIndex(this->edge_prop_id2).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateGlobalEdgeIndex(this->edge_prop_id2).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   auto acc_before = this->storage->Access();
@@ -3322,14 +3322,14 @@ TYPED_TEST(IndexTest, EdgePropertyIndexCountEstimate) {
     return;
   }
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateGlobalEdgeIndex(this->edge_prop_id1).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateGlobalEdgeIndex(this->edge_prop_id1).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateGlobalEdgeIndex(this->edge_prop_id2).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateGlobalEdgeIndex(this->edge_prop_id2).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   auto acc = this->storage->Access();
@@ -3355,9 +3355,9 @@ TYPED_TEST(IndexTest, EdgePropertyIndexRepeatingEdgeTypesBetweenSameVertices) {
     return;
   }
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateGlobalEdgeIndex(this->edge_prop_id1).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateGlobalEdgeIndex(this->edge_prop_id1).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   auto acc = this->storage->Access();

--- a/tests/unit/storage_v2_indices.cpp
+++ b/tests/unit/storage_v2_indices.cpp
@@ -62,9 +62,7 @@ using KVPair = std::tuple<PropertyId, PropertyValue>;
 /** Creates a map from a (possibly nested) list of `KVPair`s.
  */
 template <typename... Ts>
-auto MakeMap(Ts &&...values) -> PropertyValue
-  requires(std::is_same_v<std::decay_t<Ts>, KVPair> && ...)
-{
+auto MakeMap(Ts &&...values) -> PropertyValue requires(std::is_same_v<std::decay_t<Ts>, KVPair> &&...) {
   return PropertyValue{PropertyValue::map_t{
       {std::get<0>(values),
        std::forward<std::tuple_element_t<1, std::decay_t<Ts>>>(std::get<1>(std::forward<Ts>(values)))}...}};
@@ -2494,11 +2492,11 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexCreate) {
     auto acc = this->CreateIndexAccessor();
     EXPECT_FALSE(acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
     ASSERT_NO_ERROR(acc->Commit());
-    EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_type_id1, this->edge_prop_id1), 5);
   }
 
   {
     auto acc = this->storage->Access();
+    EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_type_id1, this->edge_prop_id1), 5);
     EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, this->edge_prop_id1, View::OLD), View::OLD),
                 UnorderedElementsAre(1, 3, 5, 7, 9));
     EXPECT_THAT(this->GetIds(acc->Edges(this->edge_type_id1, this->edge_prop_id1, View::NEW), View::NEW),

--- a/tests/unit/storage_v2_indices.cpp
+++ b/tests/unit/storage_v2_indices.cpp
@@ -2940,7 +2940,7 @@ TYPED_TEST(IndexTest, EdgePropertyIndexCreate) {
   }
   {
     auto acc = this->storage->Access();
-    EXPECT_FALSE(acc->EdgePropertyIndexExists(this->edge_prop_id1));
+    EXPECT_FALSE(acc->EdgePropertyIndexReady(this->edge_prop_id1));
     EXPECT_EQ(acc->ListAllIndices().edge_type_property.size(), 0);
     EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_prop_id1), 0);
   }
@@ -3104,7 +3104,7 @@ TYPED_TEST(IndexTest, EdgePropertyIndexDrop) {
   }
   {
     auto acc = this->storage->Access();
-    EXPECT_FALSE(acc->EdgePropertyIndexExists(this->edge_prop_id1));
+    EXPECT_FALSE(acc->EdgePropertyIndexReady(this->edge_prop_id1));
     EXPECT_EQ(acc->ListAllIndices().edge_property.size(), 0);
   }
 
@@ -3141,7 +3141,7 @@ TYPED_TEST(IndexTest, EdgePropertyIndexDrop) {
   }
   {
     auto acc = this->storage->Access();
-    EXPECT_FALSE(acc->EdgePropertyIndexExists(this->edge_prop_id1));
+    EXPECT_FALSE(acc->EdgePropertyIndexReady(this->edge_prop_id1));
     EXPECT_EQ(acc->ListAllIndices().edge_property.size(), 0);
   }
 
@@ -3152,7 +3152,7 @@ TYPED_TEST(IndexTest, EdgePropertyIndexDrop) {
   }
   {
     auto acc = this->storage->Access();
-    EXPECT_FALSE(acc->EdgePropertyIndexExists(this->edge_prop_id1));
+    EXPECT_FALSE(acc->EdgePropertyIndexReady(this->edge_prop_id1));
     EXPECT_EQ(acc->ListAllIndices().edge_property.size(), 0);
   }
 
@@ -3175,7 +3175,7 @@ TYPED_TEST(IndexTest, EdgePropertyIndexDrop) {
   }
   {
     auto acc = this->storage->Access();
-    EXPECT_TRUE(acc->EdgePropertyIndexExists(this->edge_prop_id1));
+    EXPECT_TRUE(acc->EdgePropertyIndexReady(this->edge_prop_id1));
     EXPECT_THAT(acc->ListAllIndices().edge_property, UnorderedElementsAre(this->edge_prop_id1));
   }
 

--- a/tests/unit/storage_v2_indices.cpp
+++ b/tests/unit/storage_v2_indices.cpp
@@ -2962,11 +2962,11 @@ TYPED_TEST(IndexTest, EdgePropertyIndexCreate) {
     auto unique_acc = this->storage->UniqueAccess();
     EXPECT_FALSE(unique_acc->CreateGlobalEdgeIndex(this->edge_prop_id1).HasError());
     ASSERT_NO_ERROR(unique_acc->Commit());
-    EXPECT_EQ(unique_acc->ApproximateEdgeCount(this->edge_prop_id1), 10);
   }
 
   {
     auto acc = this->storage->Access();
+    EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_prop_id1), 10);
     EXPECT_THAT(this->GetIds(acc->Edges(this->edge_prop_id1, View::OLD), View::OLD),
                 UnorderedElementsAre(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
     EXPECT_THAT(this->GetIds(acc->Edges(this->edge_prop_id1, View::NEW), View::NEW),

--- a/tests/unit/storage_v2_indices.cpp
+++ b/tests/unit/storage_v2_indices.cpp
@@ -62,7 +62,9 @@ using KVPair = std::tuple<PropertyId, PropertyValue>;
 /** Creates a map from a (possibly nested) list of `KVPair`s.
  */
 template <typename... Ts>
-auto MakeMap(Ts &&...values) -> PropertyValue requires(std::is_same_v<std::decay_t<Ts>, KVPair> &&...) {
+auto MakeMap(Ts &&...values) -> PropertyValue
+  requires(std::is_same_v<std::decay_t<Ts>, KVPair> && ...)
+{
   return PropertyValue{PropertyValue::map_t{
       {std::get<0>(values),
        std::forward<std::tuple_element_t<1, std::decay_t<Ts>>>(std::get<1>(std::forward<Ts>(values)))}...}};
@@ -2470,7 +2472,7 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexCreate) {
   }
   {
     auto acc = this->storage->Access();
-    EXPECT_FALSE(acc->EdgeTypePropertyIndexExists(this->edge_type_id1, this->edge_prop_id1));
+    EXPECT_FALSE(acc->EdgeTypePropertyIndexReady(this->edge_type_id1, this->edge_prop_id1));
     EXPECT_EQ(acc->ListAllIndices().edge_type_property.size(), 0);
     EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_type_id1, this->edge_prop_id1), 0);
   }
@@ -2489,10 +2491,10 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexCreate) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
-    EXPECT_EQ(unique_acc->ApproximateEdgeCount(this->edge_type_id1, this->edge_prop_id1), 5);
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
+    EXPECT_EQ(acc->ApproximateEdgeCount(this->edge_type_id1, this->edge_prop_id1), 5);
   }
 
   {
@@ -2634,7 +2636,7 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexDrop) {
   }
   {
     auto acc = this->storage->Access();
-    EXPECT_FALSE(acc->EdgeTypePropertyIndexExists(this->edge_type_id1, this->edge_prop_id1));
+    EXPECT_FALSE(acc->EdgeTypePropertyIndexReady(this->edge_type_id1, this->edge_prop_id1));
     EXPECT_EQ(acc->ListAllIndices().edge_type_property.size(), 0);
   }
 
@@ -2651,9 +2653,9 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexDrop) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   {
@@ -2665,24 +2667,24 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexDrop) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->DropIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->DropIndexAccessor();
+    EXPECT_FALSE(acc->DropIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
   {
     auto acc = this->storage->Access();
-    EXPECT_FALSE(acc->EdgeTypePropertyIndexExists(this->edge_type_id1, this->edge_prop_id1));
+    EXPECT_FALSE(acc->EdgeTypePropertyIndexReady(this->edge_type_id1, this->edge_prop_id1));
     EXPECT_EQ(acc->ListAllIndices().edge_type_property.size(), 0);
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_TRUE(unique_acc->DropIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->DropIndexAccessor();
+    EXPECT_TRUE(acc->DropIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
   {
     auto acc = this->storage->Access();
-    EXPECT_FALSE(acc->EdgeTypePropertyIndexExists(this->edge_type_id1, this->edge_prop_id1));
+    EXPECT_FALSE(acc->EdgeTypePropertyIndexReady(this->edge_type_id1, this->edge_prop_id1));
     EXPECT_EQ(acc->ListAllIndices().edge_type_property.size(), 0);
   }
 
@@ -2699,13 +2701,13 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexDrop) {
   }
 
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
   {
     auto acc = this->storage->Access();
-    EXPECT_TRUE(acc->EdgeTypePropertyIndexExists(this->edge_type_id1, this->edge_prop_id1));
+    EXPECT_TRUE(acc->EdgeTypePropertyIndexReady(this->edge_type_id1, this->edge_prop_id1));
     EXPECT_THAT(acc->ListAllIndices().edge_type_property,
                 UnorderedElementsAre(std::make_pair(this->edge_type_id1, this->edge_prop_id1)));
   }
@@ -2738,14 +2740,14 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexBasic) {
     return;
   }
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id2, this->edge_prop_id2).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->edge_type_id2, this->edge_prop_id2).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   auto acc = this->storage->Access();
@@ -2821,14 +2823,14 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexTransactionalIsolation) {
   }
   // Check that transactions only see entries they are supposed to see.
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id2, this->edge_prop_id2).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->edge_type_id2, this->edge_prop_id2).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   auto acc_before = this->storage->Access();
@@ -2871,14 +2873,14 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexCountEstimate) {
     return;
   }
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id2, this->edge_prop_id2).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->edge_type_id2, this->edge_prop_id2).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   auto acc = this->storage->Access();
@@ -2904,9 +2906,9 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexRepeatingEdgeTypesBetweenSameVertices
     return;
   }
   {
-    auto unique_acc = this->storage->UniqueAccess();
-    EXPECT_FALSE(unique_acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
-    ASSERT_NO_ERROR(unique_acc->Commit());
+    auto acc = this->CreateIndexAccessor();
+    EXPECT_FALSE(acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1).HasError());
+    ASSERT_NO_ERROR(acc->Commit());
   }
 
   auto acc = this->storage->Access();

--- a/tests/unit/storage_v2_wal_file.cpp
+++ b/tests/unit/storage_v2_wal_file.cpp
@@ -51,6 +51,7 @@ class DeltaGenerator final {
                            std::make_unique<memgraph::storage::InMemoryLabelIndex::ActiveIndices>(),
                            std::make_unique<memgraph::storage::InMemoryLabelPropertyIndex::ActiveIndices>(),
                            std::make_unique<memgraph::storage::InMemoryEdgeTypeIndex::ActiveIndices>(),
+                           std::make_unique<memgraph::storage::InMemoryEdgeTypePropertyIndex::ActiveIndices>(),
                        }) {}
 
    public:

--- a/tests/unit/storage_v2_wal_file.cpp
+++ b/tests/unit/storage_v2_wal_file.cpp
@@ -52,6 +52,7 @@ class DeltaGenerator final {
                            std::make_unique<memgraph::storage::InMemoryLabelPropertyIndex::ActiveIndices>(),
                            std::make_unique<memgraph::storage::InMemoryEdgeTypeIndex::ActiveIndices>(),
                            std::make_unique<memgraph::storage::InMemoryEdgeTypePropertyIndex::ActiveIndices>(),
+                           std::make_unique<memgraph::storage::InMemoryEdgePropertyIndex::ActiveIndices>(),
                        }) {}
 
    public:


### PR DESCRIPTION
More indexes (edge type property, edge property)

Split index creation into phases
- Register (requires read-only access)
- Populate (drop down to read access)
- Publish (can be used for planning)

This allows for concurrent index queries, allowing for index population to happen while also allowing read/write queries to happen at the same time.

Extra capability:
- Plan cache invalidation only when index has been populated
- Can now terminate index creation