### PR TITLE
Add force unique lock on a query

### DIFF
--- a/src/query/frontend/ast/ast.hpp
+++ b/src/query/frontend/ast/ast.hpp
@@ -1878,6 +1878,8 @@ struct PreQueryDirectives {
   /// Commit frequency
   memgraph::query::Expression *commit_frequency_{nullptr};
 
+  bool use_unique_lock_{false};
+
   PreQueryDirectives Clone(AstStorage *storage) const {
     PreQueryDirectives object;
     object.index_hints_.resize(index_hints_.size());
@@ -1886,6 +1888,7 @@ struct PreQueryDirectives {
     }
     object.hops_limit_ = hops_limit_ ? hops_limit_->Clone(storage) : nullptr;
     object.commit_frequency_ = commit_frequency_ ? commit_frequency_->Clone(storage) : nullptr;
+    object.use_unique_lock_ = use_unique_lock_;
     return object;
   }
 };

--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -349,6 +349,8 @@ antlrcpp::Any CypherMainVisitor::visitPreQueryDirectives(MemgraphCypher::PreQuer
         throw SyntaxException("Hops limit can be set only once in the USING statement.");
       }
       pre_query_directives.hops_limit_ = std::any_cast<Expression *>(pre_query_directive->hopsLimit()->accept(this));
+    } else if (pre_query_directive->useUniqueLock()) {
+      pre_query_directives.use_unique_lock_ = true;
     } else {
       throw SyntaxException("Unknown pre query directive!");
     }

--- a/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
+++ b/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
@@ -331,7 +331,7 @@ foreach :  FOREACH '(' variable IN expression '|' updateClause+  ')' ;
 
 preQueryDirectives: USING preQueryDirective ( ',' preQueryDirective )* ;
 
-preQueryDirective: hopsLimit | indexHints  | periodicCommit ;
+preQueryDirective: hopsLimit | indexHints  | periodicCommit | useUniqueLock ;
 
 hopsLimit: HOPS LIMIT literal ;
 
@@ -340,6 +340,8 @@ indexHints: INDEX indexHint ( ',' indexHint )* ;
 indexHint: ':' labelName ( '(' nestedPropertyKeyNames ( ',' nestedPropertyKeyNames )*  ')' )? ;
 
 periodicCommit : PERIODIC COMMIT periodicCommitNumber=literal ;
+
+useUniqueLock : UNIQUE LOCK ;
 
 periodicSubquery : IN TRANSACTIONS OF_TOKEN periodicCommitNumber=literal ROWS ;
 

--- a/tests/e2e/CMakeLists.txt
+++ b/tests/e2e/CMakeLists.txt
@@ -108,6 +108,7 @@ add_subdirectory(enterprise_query_modules)
 add_subdirectory(dynamic_variable_creation)
 add_subdirectory(graphql)
 add_subdirectory(show_privileges)
+add_subdirectory(using_unique_lock)
 
 copy_e2e_python_files(pytest_runner pytest_runner.sh "")
 copy_e2e_python_files(x x.sh "")

--- a/tests/e2e/using_unique_lock/CMakeLists.txt
+++ b/tests/e2e/using_unique_lock/CMakeLists.txt
@@ -1,0 +1,8 @@
+function(copy_using_unique_lock_e2e_python_files FILE_NAME)
+    copy_e2e_python_files(using_unique_lock ${FILE_NAME})
+endfunction()
+
+copy_using_unique_lock_e2e_python_files(common.py)
+copy_using_unique_lock_e2e_python_files(using_unique_lock.py)
+
+copy_e2e_files(using_unique_lock workloads.yaml)

--- a/tests/e2e/using_unique_lock/common.py
+++ b/tests/e2e/using_unique_lock/common.py
@@ -1,0 +1,22 @@
+# Copyright 2023 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+import pytest
+from gqlalchemy import Memgraph
+
+
+@pytest.fixture
+def memgraph(**kwargs) -> Memgraph:
+    memgraph = Memgraph()
+
+    yield memgraph
+
+    memgraph.drop_database()

--- a/tests/e2e/using_unique_lock/using_unique_lock.py
+++ b/tests/e2e/using_unique_lock/using_unique_lock.py
@@ -1,0 +1,34 @@
+import sys
+import threading
+
+import pytest
+from common import memgraph
+from gqlalchemy import Memgraph
+
+
+def execute_concurrent_write():
+    mg = Memgraph()
+
+    mg.execute("USING UNIQUE LOCK MATCH (n) MATCH (m) CREATE (n)-[:EDGE]->(m)")
+
+
+def test_concurrent_write(memgraph):
+    memgraph.execute("MATCH (n) DETACH DELETE n")
+    memgraph.execute("UNWIND range(1, 1000) as x CREATE ()")
+
+    t1 = threading.Thread(target=execute_concurrent_write)
+    t2 = threading.Thread(target=execute_concurrent_write)
+
+    t1.start()
+    t2.start()
+
+    t1.join()
+    t2.join()
+
+    assert [
+        x["value"] for x in list(memgraph.execute_and_fetch("SHOW STORAGE INFO;")) if x["storage info"] == "edge_count"
+    ][0] == 2000000
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/using_unique_lock/workloads.yaml
+++ b/tests/e2e/using_unique_lock/workloads.yaml
@@ -1,0 +1,14 @@
+using_unique_lock_cluster: &using_unique_lock_cluster
+  cluster:
+    main:
+      args: ["--bolt-port", "7687", "--log-level=TRACE", "--storage-access-timeout-sec=60"]
+      log_file: "using_unique_lock.log"
+      setup_queries: []
+      validation_queries: []
+
+
+workloads:
+  - name: "Using unique lock"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["using_unique_lock/using_unique_lock.py"]
+    <<: *using_unique_lock_cluster

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -6016,3 +6016,20 @@ TEST_P(CypherMainVisitorTest, ExistsSubqueries) {
     ASSERT_EQ(union_single_query->clauses_.size(), 1);
   }
 }
+
+TEST_P(CypherMainVisitorTest, UseUniqueLock) {
+  auto &ast_generator = *GetParam();
+  {
+    const auto *query =
+        dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("MATCH (n) MATCH (m) CREATE (n)-[:TYPE]->(m);"));
+    ASSERT_NE(query, nullptr);
+    ASSERT_FALSE(query->pre_query_directives_.use_unique_lock_);
+  }
+
+  {
+    const auto *query = dynamic_cast<CypherQuery *>(
+        ast_generator.ParseQuery("USING UNIQUE LOCK MATCH (n) MATCH (m) CREATE (n)-[:TYPE]->(m);"));
+    ASSERT_NE(query, nullptr);
+    ASSERT_TRUE(query->pre_query_directives_.use_unique_lock_);
+  }
+}


### PR DESCRIPTION
Add `USING UNIQUE LOCK` syntax to create a unique lock on a query. Possible usage would be to protect deletes in analytical mode

