### PR TITLE
Added mappings for new apoc functions

### DIFF
--- a/config/mappings.json
+++ b/config/mappings.json
@@ -40,5 +40,9 @@
     "apoc.text.format": "text.format",
     "apoc.text.regexGroups": "text.regexGroups",
     "apoc.text.replace": "text.replace",
-    "apoc.text.regReplace": "text.regreplace"
+    "apoc.text.regReplace": "text.regreplace",
+    "apoc.convert.toJson": "convert.to_json",
+    "apoc.convert.fromJsonList": "convert.from_json_list",
+    "apoc.convert.toTree": "convert.to_tree",
+    "apoc.coll.flatten": "collections.flatten"
 }

--- a/config/mappings.json
+++ b/config/mappings.json
@@ -44,5 +44,6 @@
     "apoc.convert.toJson": "convert.to_json",
     "apoc.convert.fromJsonList": "convert.from_json_list",
     "apoc.convert.toTree": "convert.to_tree",
-    "apoc.coll.flatten": "collections.flatten"
+    "apoc.coll.flatten": "collections.flatten",
+    "apoc.text.indexOf": "text.indexOf"
 }


### PR DESCRIPTION
Added mappings for following apoc functions:
apoc.convert.toJson()
apoc.convert.fromJsonList()
apoc.convert.toTree()
apoc.coll.flatten()