### PR TITLE
Update to latest xmlsec package to address CVEs in libxml2

### DIFF
--- a/release/docker/v6_deb.dockerfile
+++ b/release/docker/v6_deb.dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y \
 
 # NOTE: The following are required to run built-in Python modules. For the full
 # list, please visit query_modules/CMakeLists.txt.
-RUN pip3 install --break-system-packages  numpy==1.26.4 scipy==1.13.0 networkx==3.4.2 gensim==4.3.3 xmlsec==1.3.14
+RUN pip3 install --break-system-packages  numpy==1.26.4 scipy==1.13.0 networkx==3.4.2 gensim==4.3.3 xmlsec==1.3.16
 
 COPY "${BINARY_NAME}${TARGETARCH}.${EXTENSION}" /
 

--- a/release/docker/v6_deb_relwithdebinfo.dockerfile
+++ b/release/docker/v6_deb_relwithdebinfo.dockerfile
@@ -26,7 +26,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
 
 # NOTE: The following are required to run built-in Python modules. For the full
 # list, please visit query_modules/CMakeLists.txt.
-RUN pip3 install --break-system-packages  numpy==1.26.4 scipy==1.13.0 networkx==3.4.2 gensim==4.3.3 xmlsec==1.3.14
+RUN pip3 install --break-system-packages  numpy==1.26.4 scipy==1.13.0 networkx==3.4.2 gensim==4.3.3 xmlsec==1.3.16
 
 COPY "${BINARY_NAME}${TARGETARCH}.${EXTENSION}" /
 COPY "${SOURCE_CODE}" /home/mg/memgraph/src

--- a/src/auth/reference_modules/requirements.txt
+++ b/src/auth/reference_modules/requirements.txt
@@ -6,4 +6,4 @@ pyyaml==6.0.1
 python3-saml==1.16.0
 lxml==5.2.1
 setuptools==80.9.0
-xmlsec==1.3.14
+xmlsec==1.3.16

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -33,7 +33,7 @@ set -u
 # https://docs.python.org/3/library/sys.html#sys.version_info
 PYTHON_MINOR=$(python3 -c 'import sys; print(sys.version_info[:][1])')
 # install xmlsec
-pip --timeout 1000 install xmlsec==1.3.14
+pip --timeout 1000 install xmlsec==1.3.16
 # install pulsar-client
 pip --timeout 1000 install "pulsar-client==3.5.0"
 for pkg in "${PIP_DEPS[@]}"; do


### PR DESCRIPTION
Updates the Python package used for `xmlsec` to address the following vulnerabilities:
```
Product | Version | Severity | CVE          
--------+---------+----------+--------------
libxml2 | 2.9.1   | CRITICAL | CVE-2017-7375
libxml2 | 2.9.1   | CRITICAL | CVE-2017-7376
```


