### PR TITLE
Bugfix: Don't abort rpc client for async replica which doesn't own the stream

### DIFF
--- a/src/storage/v2/replication/replication_transaction.cpp
+++ b/src/storage/v2/replication/replication_transaction.cpp
@@ -75,8 +75,9 @@ auto TransactionReplication::FinalizeTransaction(bool const decision, utils::UUI
     } else if (client->Mode() == replication_coordination_glue::ReplicationMode::ASYNC) {
       if (decision) {
         client->FinalizeTransactionReplication(db_acc, std::move(replica_stream), durability_commit_timestamp);
-      } else {
-        // Reconnect needed because we optimistically prepared PrepareCommitReq message already
+      } else if (replica_stream.has_value()) {
+        // Reconnect needed because we optimistically prepared PrepareCommitReq message already.
+        // We should only do this if we own the RPC lock.
         client->AbortRpcClient();
       }
     }


### PR DESCRIPTION
Fixes the following scenario:
Main tries to commit while STRICT_SYNC and ASYNC replica are behind. For ASYNC replica we don't take the RPC lock. When aborting we were calling `client->AbortRpcClient()` although we didn't own the stream, hence we would destroy on-going FrequentHeartbeatRpc.
