### PR TITLE
Flaky test fixes

### DIFF
--- a/tests/e2e/memory/memory_control.cpp
+++ b/tests/e2e/memory/memory_control.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2025 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -32,15 +32,29 @@ int main(int argc, char **argv) {
     LOG_FATAL("Failed to connect!");
   }
 
+  client->Execute("FREE MEMORY;");
+  client->DiscardAll();
+  client->Execute("STORAGE MODE IN_MEMORY_ANALYTICAL;");
+  client->DiscardAll();
+  client->Execute("DROP GRAPH;");
+  client->DiscardAll();
+  client->Execute("STORAGE MODE IN_MEMORY_TRANSACTIONAL;");
+  client->DiscardAll();
   client->Execute("MATCH (n) DETACH DELETE n;");
+  client->DiscardAll();
+  client->Execute("FREE MEMORY;");
   client->DiscardAll();
 
   if (FLAGS_multi_db) {
+    try {
+      client->Execute("DROP DATABASE clean;");
+      client->DiscardAll();
+    } catch (const std::exception & /*unused*/) {
+      // Ignore
+    }
     client->Execute("CREATE DATABASE clean;");
     client->DiscardAll();
     client->Execute("USE DATABASE clean;");
-    client->DiscardAll();
-    client->Execute("MATCH (n) DETACH DELETE n;");
     client->DiscardAll();
   }
 

--- a/tests/e2e/memory/workloads.yaml
+++ b/tests/e2e/memory/workloads.yaml
@@ -12,6 +12,7 @@ args_100_MiB_limit: &args_100_MiB_limit
   - "--memory-limit=100"
   - "--storage-gc-cycle-sec=180"
   - "--log-level=TRACE"
+  - "--data-recovery-on-startup=false"
 
 in_memory_100_MiB_limit_cluster: &in_memory_100_MiB_limit_cluster
   cluster:

--- a/tests/unit/multi_tenancy.cpp
+++ b/tests/unit/multi_tenancy.cpp
@@ -319,9 +319,14 @@ TEST_F(MultiTenantTest, DbmsNewDelete) {
                memgraph::query::DatabaseContextRequiredException);
 
   // 5
-  using namespace std::chrono_literals;
-  std::this_thread::sleep_for(100ms);                          // Wait for the filesystem to be updated
-  ASSERT_EQ(GetDirs(data_directory / "databases").size(), 1);  // Databases deleted from disk
+  int tries = 0;
+  constexpr int max_tries = 50;
+  for (; tries < max_tries; tries++) {
+    if (GetDirs(data_directory / "databases").size() == 1) break;
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));  // Wait for the filesystem to be updated
+  }
+  ASSERT_LT(tries, max_tries) << "Failed to delete databases. Remaining databases "
+                              << GetDirs(data_directory / "databases").size();
   ASSERT_THROW(RunQuery(interpreter1, "MATCH(n) RETURN n"), memgraph::query::DatabaseContextRequiredException);
   ASSERT_THROW(RunQuery(interpreter2, "MATCH(n) RETURN n"), memgraph::query::DatabaseContextRequiredException);
 }
@@ -377,8 +382,14 @@ TEST_F(MultiTenantTest, DbmsNewDeleteWTx) {
   RunQuery(interpreter2, "COMMIT");
 
   // 5
-  using namespace std::chrono_literals;
-  std::this_thread::sleep_for(100ms);                          // Wait for the filesystem to be updated
+  int tries = 0;
+  constexpr int max_tries = 50;
+  for (; tries < max_tries; tries++) {
+    if (GetDirs(data_directory / "databases").size() == 1) break;
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));  // Wait for the filesystem to be updated
+  }
+  ASSERT_LT(tries, max_tries) << "Failed to delete databases. Remaining databases "
+                              << GetDirs(data_directory / "databases").size();
   ASSERT_EQ(GetDirs(data_directory / "databases").size(), 1);  // Only the active databases remain
   ASSERT_THROW(RunQuery(interpreter1, "MATCH(n) RETURN n"), memgraph::query::DatabaseContextRequiredException);
   ASSERT_THROW(RunQuery(interpreter2, "MATCH(n) RETURN n"), memgraph::query::DatabaseContextRequiredException);


### PR DESCRIPTION
unit/utils_resource_lock: timing closer to the locking mechanism and larger threshold
integration/audit: memgraph closing not synced which would lead to partial file reads
e2e/triggers/triggers_properties_false: general robustness and better checks
e2e/memory/memory_control: general robustness and better checks
unit/multi_tenancy: longer timeouts