### PR TITLE
Bugfix: Wrong logic for determining how far behind is replica behind main

### DIFF
--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -233,11 +233,10 @@ void ReplicationStorageClient::UpdateReplicaState(Storage *main_storage, Databas
 }
 
 TimestampInfo ReplicationStorageClient::GetTimestampInfo(Storage const *storage) const {
-  TimestampInfo info;
   auto const main_timestamp = storage->repl_storage_state_.last_durable_timestamp_.load(std::memory_order_acquire);
-  info.current_timestamp_of_replica = last_known_ts_.load(std::memory_order::acquire);
-  info.current_number_of_timestamp_behind_main = info.current_timestamp_of_replica - main_timestamp;
-  return info;
+  auto const repl_timestamp = last_known_ts_.load(std::memory_order_acquire);
+  return {.current_timestamp_of_replica = repl_timestamp,
+          .current_number_of_timestamp_behind_main = main_timestamp - repl_timestamp};
 }
 
 void ReplicationStorageClient::LogRpcFailure() const {

--- a/tests/e2e/replication/show_while_creating_invalid_state.py
+++ b/tests/e2e/replication/show_while_creating_invalid_state.py
@@ -833,7 +833,7 @@ def test_basic_recovery(recover_data_on_startup, connection, test_name):
             "127.0.0.1:10001",
             "sync",
             {"ts": 0, "behind": None, "status": "invalid"},
-            {"memgraph": {"ts": 6, "behind": -3, "status": "invalid"}},
+            {"memgraph": {"ts": 6, "behind": 3, "status": "invalid"}},
         ),
         (
             "replica_2",
@@ -1560,7 +1560,7 @@ def test_attempt_to_write_data_on_main_when_sync_replica_is_down(connection, tes
             "127.0.0.1:10001",
             "sync",
             {"ts": 0, "behind": None, "status": "invalid"},
-            {"memgraph": {"ts": 2, "behind": -3, "status": "invalid"}},
+            {"memgraph": {"ts": 2, "behind": 3, "status": "invalid"}},
         ),
         (
             "sync_replica2",
@@ -1807,7 +1807,7 @@ def test_attempt_to_create_indexes_on_main_when_sync_replica_is_down(connection,
             "127.0.0.1:10001",
             "sync",
             {"ts": 0, "behind": None, "status": "invalid"},
-            {"memgraph": {"ts": 2, "behind": -4, "status": "invalid"}},
+            {"memgraph": {"ts": 2, "behind": 4, "status": "invalid"}},
         ),
         (
             "sync_replica2",


### PR DESCRIPTION
Wrong order of args, was relying on static_cast for correctness. This should be safer version.