### PR TITLE
Clean coord statuses and unify handling of epochs under one method

### DIFF
--- a/src/coordination/include/coordination/coordinator_ops_status.hpp
+++ b/src/coordination/include/coordination/coordinator_ops_status.hpp
@@ -28,8 +28,6 @@ enum class RegisterInstanceCoordinatorStatus : uint8_t {
   RAFT_LOG_ERROR,
   SUCCESS,
   LOCK_OPENED,
-  FAILED_TO_OPEN_LOCK,
-  FAILED_TO_CLOSE_LOCK,
   STRICT_SYNC_AND_SYNC_FORBIDDEN,
 };
 
@@ -43,8 +41,6 @@ enum class UnregisterInstanceCoordinatorStatus : uint8_t {
   RAFT_LOG_ERROR,
   SUCCESS,
   LOCK_OPENED,
-  FAILED_TO_OPEN_LOCK,
-  FAILED_TO_CLOSE_LOCK
 };
 
 enum class SetInstanceToMainCoordinatorStatus : uint8_t {
@@ -55,10 +51,7 @@ enum class SetInstanceToMainCoordinatorStatus : uint8_t {
   RAFT_LOG_ERROR,
   COULD_NOT_PROMOTE_TO_MAIN,
   SUCCESS,
-  LOCK_OPENED,
-  FAILED_TO_OPEN_LOCK,
   ENABLE_WRITING_FAILED,
-  FAILED_TO_CLOSE_LOCK
 };
 
 enum class AddCoordinatorInstanceStatus : uint8_t {
@@ -79,9 +72,6 @@ enum class DemoteInstanceCoordinatorStatus : uint8_t {
   RPC_FAILED,
   RAFT_LOG_ERROR,
   SUCCESS,
-  LOCK_OPENED,
-  FAILED_TO_OPEN_LOCK,
-  FAILED_TO_CLOSE_LOCK,
   NOT_COORDINATOR
 };
 

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -326,8 +326,8 @@ void InMemoryReplicationHandlers::PrepareCommitHandler(dbms::DbmsHandler *dbms_h
   auto *storage = static_cast<storage::InMemoryStorage *>(db_acc->get()->storage());
   auto &repl_storage_state = storage->repl_storage_state_;
   if (*maybe_epoch_id != repl_storage_state.epoch_.id()) {
-    auto prev_epoch = repl_storage_state.epoch_.SetEpoch(*maybe_epoch_id);
-    repl_storage_state.AddEpochToHistoryForce(prev_epoch);
+    repl_storage_state.SaveLatestHistory();
+    repl_storage_state.epoch_.SetEpoch(*maybe_epoch_id);
   }
 
   // We do not care about incoming sequence numbers, after a snapshot recovery, the sequence number is 0
@@ -809,10 +809,10 @@ std::pair<bool, uint32_t> InMemoryReplicationHandlers::LoadWal(storage::InMemory
   }
 
   // We trust only WAL files which contain changes we are interested in (newer changes)
-  if (auto &replica_epoch = storage->repl_storage_state_.epoch_; wal_info.epoch_id != replica_epoch.id()) {
+  if (auto &repl_epoch = storage->repl_storage_state_.epoch_; wal_info.epoch_id != repl_epoch.id()) {
     spdlog::trace("Set epoch to {} for db {}", wal_info.epoch_id, storage->name());
-    auto prev_epoch = replica_epoch.SetEpoch(wal_info.epoch_id);
-    storage->repl_storage_state_.AddEpochToHistoryForce(prev_epoch);
+    storage->repl_storage_state_.SaveLatestHistory();
+    repl_epoch.SetEpoch(wal_info.epoch_id);
   }
 
   // We do not care about incoming sequence numbers, after a snapshot recovery, the sequence number is 0

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -509,13 +509,6 @@ class CoordQueryHandler final : public query::CoordinatorQueryHandler {
       case RPC_FAILED:
         throw QueryRuntimeException(
             "Couldn't unregister replica instance because current main instance couldn't unregister replica!");
-      case LOCK_OPENED:
-        throw QueryRuntimeException("Couldn't unregister replica because the last action didn't finish successfully!");
-      case FAILED_TO_OPEN_LOCK:
-        throw QueryRuntimeException("Couldn't unregister instance as cluster didn't accept start of action!");
-      case FAILED_TO_CLOSE_LOCK:
-        throw QueryRuntimeException(
-            "Couldn't unregister instance as cluster didn't accept successful finish of action!");
       case SUCCESS:
         break;
     }
@@ -550,15 +543,6 @@ class CoordQueryHandler final : public query::CoordinatorQueryHandler {
       case RPC_FAILED:
         throw QueryRuntimeException(
             "Couldn't demote instance to replica because current main instance couldn't unregister replica!");
-      case LOCK_OPENED:
-        throw QueryRuntimeException(
-            "Couldn't successfully finish action demote instance to replica because the last action didn't finish "
-            "successfully!");
-      case FAILED_TO_OPEN_LOCK:
-        throw QueryRuntimeException("Couldn't demote instance to replica as cluster didn't accept start of action!");
-      case FAILED_TO_CLOSE_LOCK:
-        throw QueryRuntimeException(
-            "Couldn't demote  instance to replica as cluster didn't accept successful finish of action!");
       case SUCCESS:
         break;
     }
@@ -677,13 +661,6 @@ class CoordQueryHandler final : public query::CoordinatorQueryHandler {
         throw QueryRuntimeException(
             "Couldn't register replica instance because setting instance to replica failed! Check logs on replica to "
             "find out more info!");
-      case LOCK_OPENED:
-        throw QueryRuntimeException(
-            "Couldn't register replica instance because because the last action didn't finish successfully!");
-      case FAILED_TO_OPEN_LOCK:
-        throw QueryRuntimeException("Couldn't register instance as cluster didn't accept start of action!");
-      case FAILED_TO_CLOSE_LOCK:
-        throw QueryRuntimeException("Couldn't register instance as cluster didn't accept successful finish of action!");
       case SUCCESS:
         break;
     }
@@ -770,16 +747,8 @@ class CoordQueryHandler final : public query::CoordinatorQueryHandler {
       case COULD_NOT_PROMOTE_TO_MAIN:
         throw QueryRuntimeException(
             "Couldn't set replica instance to main! Check coordinator and replica for more logs");
-      case FAILED_TO_OPEN_LOCK:
-        throw QueryRuntimeException("Couldn't set instance to main as cluster didn't accept start of action!");
-      case LOCK_OPENED:
-        throw QueryRuntimeException(
-            "Couldn't set instance to main instance because because the last action didn't finish successfully!");
       case ENABLE_WRITING_FAILED:
         throw QueryRuntimeException("Instance promoted to MAIN, but couldn't enable writing to instance.");
-      case FAILED_TO_CLOSE_LOCK:
-        throw QueryRuntimeException(
-            "Couldn't set instance to main as cluster didn't accept successful finish of action!");
       case SUCCESS:
         break;
     }

--- a/src/replication/include/replication/epoch.hpp
+++ b/src/replication/include/replication/epoch.hpp
@@ -15,8 +15,6 @@
 
 #include "utils/uuid.hpp"
 
-#include <spdlog/spdlog.h>
-
 namespace memgraph::replication {
 
 struct ReplicationEpoch {

--- a/src/replication_handler/replication_handler.cpp
+++ b/src/replication_handler/replication_handler.cpp
@@ -283,7 +283,7 @@ bool ReplicationHandler::DoToMainPromotion(const utils::UUID &main_uuid, bool fo
     }
 
     // STEP 3) We are now MAIN, update storage local epoch
-    const auto &epoch = std::get<replication::RoleMainData>(locked_repl_state->ReplicationData()).epoch_;
+    const auto &epoch = std::get<RoleMainData>(locked_repl_state->ReplicationData()).epoch_;
     dbms_handler_.ForEach([&](dbms::DatabaseAccess db_acc) {
       auto *storage = db_acc->storage();
       storage->repl_storage_state_.epoch_ = epoch;

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -3060,7 +3060,7 @@ void InMemoryStorage::PrepareForNewEpoch() {
     wal_file_->FinalizeWal();
     wal_file_.reset();
   }
-  repl_storage_state_.TrackLatestHistory();
+  repl_storage_state_.SaveLatestHistory();
 }
 
 utils::FileRetainer::FileLockerAccessor::ret_type InMemoryStorage::IsPathLocked() {

--- a/src/storage/v2/replication/replication_storage_state.cpp
+++ b/src/storage/v2/replication/replication_storage_state.cpp
@@ -39,7 +39,7 @@ void ReplicationStorageState::Reset() {
 }
 
 // Don't save epochs in history for which ldt wasn't changed
-void ReplicationStorageState::TrackLatestHistory() {
+void ReplicationStorageState::SaveLatestHistory() {
   auto const new_ldt = last_durable_timestamp_.load(std::memory_order_acquire);
   if (!history.empty() && history.back().second == new_ldt) {
     return;
@@ -49,18 +49,8 @@ void ReplicationStorageState::TrackLatestHistory() {
   if (constexpr uint16_t kEpochHistoryRetention = 1000; history.size() == kEpochHistoryRetention) {
     history.pop_front();
   }
+
   history.emplace_back(epoch_.id(), new_ldt);
-}
-
-// TODO: (andi) Can this method be the same as TrackLatestHistory
-// Called when Deltas are obtained and when loading WAL
-void ReplicationStorageState::AddEpochToHistoryForce(std::string prev_epoch) {
-  auto const new_ldt = last_durable_timestamp_.load(std::memory_order_acquire);
-  if (!history.empty() && history.back().second == new_ldt) {
-    return;
-  }
-
-  history.emplace_back(std::move(prev_epoch), new_ldt);
 }
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/replication/replication_storage_state.hpp
+++ b/src/storage/v2/replication/replication_storage_state.hpp
@@ -46,8 +46,7 @@ struct ReplicationStorageState {
   auto GetReplicaState(std::string_view name) const -> std::optional<replication::ReplicaState>;
 
   // History
-  void TrackLatestHistory();
-  void AddEpochToHistoryForce(std::string prev_epoch);
+  void SaveLatestHistory();
 
   void Reset();
 


### PR DESCRIPTION
There were some unused enum values from the past. 
Epochs are now handled with the single method to simplify the reasoning.
