### PR TITLE
Remove optional UUID from replica's role

### DIFF
--- a/src/coordination/data_instance_management_server_handlers.cpp
+++ b/src/coordination/data_instance_management_server_handlers.cpp
@@ -184,7 +184,7 @@ void DataInstanceManagementServerHandlers::DemoteMainToReplicaHandler(
   const replication::ReplicationServerConfig clients_config{
       .repl_server = io::network::Endpoint("0.0.0.0", req.replication_client_info.replication_server.GetPort())};
 
-  if (!replication_handler.SetReplicationRoleReplica(clients_config, std::nullopt)) {
+  if (!replication_handler.SetReplicationRoleReplica(clients_config)) {
     spdlog::error("Demoting main to replica failed.");
     coordination::DemoteMainToReplicaRes const rpc_res{false};
     rpc::SendFinalResponse(rpc_res, res_builder);

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -381,7 +381,7 @@ class ReplQueryHandler {
           .repl_server = memgraph::io::network::Endpoint(memgraph::replication::kDefaultReplicationServerIp,
                                                          static_cast<uint16_t>(*port))};
 
-      if (!handler_->TrySetReplicationRoleReplica(config, std::nullopt)) {
+      if (!handler_->TrySetReplicationRoleReplica(config)) {
         throw QueryRuntimeException("Couldn't set role to replica!");
       }
     }

--- a/src/query/replication_query_handler.hpp
+++ b/src/query/replication_query_handler.hpp
@@ -94,11 +94,9 @@ struct ReplicationQueryHandler {
   virtual bool SetReplicationRoleMain() = 0;
 
   // as MAIN, become REPLICA
-  virtual bool SetReplicationRoleReplica(const memgraph::replication::ReplicationServerConfig &config,
-                                         const std::optional<utils::UUID> &main_uuid) = 0;
+  virtual bool SetReplicationRoleReplica(const replication::ReplicationServerConfig &config) = 0;
 
-  virtual bool TrySetReplicationRoleReplica(const memgraph::replication::ReplicationServerConfig &config,
-                                            const std::optional<utils::UUID> &main_uuid) = 0;
+  virtual bool TrySetReplicationRoleReplica(const replication::ReplicationServerConfig &config) = 0;
 
   // as MAIN, define and connect to REPLICAs
   virtual auto TryRegisterReplica(const memgraph::replication::ReplicationClientConfig &config)

--- a/src/replication/include/replication/state.hpp
+++ b/src/replication/include/replication/state.hpp
@@ -53,7 +53,7 @@ struct RoleReplicaData {
   ReplicationServerConfig config;
   std::unique_ptr<ReplicationServer> server;
   // uuid of main instance that replica is listening to
-  std::optional<utils::UUID> uuid_;
+  utils::UUID uuid_;
 };
 
 // Global (instance) level object
@@ -121,7 +121,7 @@ struct ReplicationState {
   bool HasDurability() const { return nullptr != durability_; }
 
   bool TryPersistRoleMain(utils::UUID main_uuid);
-  bool TryPersistRoleReplica(const ReplicationServerConfig &config, const std::optional<utils::UUID> &main_uuid);
+  bool TryPersistRoleReplica(const ReplicationServerConfig &config, utils::UUID const &main_uuid);
   bool TryPersistUnregisterReplica(std::string_view name);
   bool TryPersistRegisteredReplica(const ReplicationClientConfig &config, utils::UUID main_uuid);
 
@@ -130,8 +130,7 @@ struct ReplicationState {
   utils::BasicResult<RegisterReplicaStatus, ReplicationClient *> RegisterReplica(const ReplicationClientConfig &config);
 
   bool SetReplicationRoleMain(const utils::UUID &main_uuid);
-  bool SetReplicationRoleReplica(const ReplicationServerConfig &config,
-                                 const std::optional<utils::UUID> &main_uuid = std::nullopt);
+  bool SetReplicationRoleReplica(const ReplicationServerConfig &config);
 
  private:
   bool HandleVersionMigration(durability::ReplicationRoleEntry &data) const;

--- a/src/replication/include/replication/status.hpp
+++ b/src/replication/include/replication/status.hpp
@@ -41,8 +41,8 @@ struct MainRole {
 
 // fragment of key: "__replication_role"
 struct ReplicaRole {
-  ReplicationServerConfig config{};
-  std::optional<utils::UUID> main_uuid{};
+  ReplicationServerConfig config;
+  utils::UUID main_uuid;
   friend bool operator==(ReplicaRole const &, ReplicaRole const &) = default;
 };
 

--- a/src/replication/state.cpp
+++ b/src/replication/state.cpp
@@ -59,7 +59,6 @@ ReplicationState::ReplicationState(std::optional<std::filesystem::path> durabili
 #ifdef MG_ENTERPRISE
   if (flags::CoordinationSetupInstance().IsDataInstanceManagedByCoordinator() &&
       std::holds_alternative<RoleReplicaData>(replication_data)) {
-    // TODO: (andi) Do we still need that and if yes why?
     std::get<RoleReplicaData>(replication_data).uuid_ = utils::UUID{};
     spdlog::trace("Replica's replication uuid for replica has been reset");
   }

--- a/src/replication_handler/replication_handler.cpp
+++ b/src/replication_handler/replication_handler.cpp
@@ -196,8 +196,7 @@ ReplicationHandler::ReplicationHandler(utils::Synchronized<ReplicationState, uti
 
 bool ReplicationHandler::SetReplicationRoleMain() { return DoToMainPromotion({}, false); }
 
-bool ReplicationHandler::SetReplicationRoleReplica(const ReplicationServerConfig &config,
-                                                   const std::optional<utils::UUID> &main_uuid) {
+bool ReplicationHandler::SetReplicationRoleReplica(const ReplicationServerConfig &config) {
   try {
     auto locked_repl_state = repl_state_.TryLock();
 
@@ -231,17 +230,16 @@ bool ReplicationHandler::SetReplicationRoleReplica(const ReplicationServerConfig
       });
     }
 
-    return SetReplicationRoleReplica_<true>(locked_repl_state, config, main_uuid);
+    return SetReplicationRoleReplica_<true>(locked_repl_state, config);
   } catch (const utils::TryLockException & /* unused */) {
     return false;
   }
 }
 
-bool ReplicationHandler::TrySetReplicationRoleReplica(const ReplicationServerConfig &config,
-                                                      const std::optional<utils::UUID> &main_uuid) {
+bool ReplicationHandler::TrySetReplicationRoleReplica(const ReplicationServerConfig &config) {
   try {
     auto locked_repl_state = repl_state_.TryLock();
-    return SetReplicationRoleReplica_<false>(locked_repl_state, config, main_uuid);
+    return SetReplicationRoleReplica_<false>(locked_repl_state, config);
   } catch (const utils::TryLockException & /* unused */) {
     return false;
   }

--- a/tests/unit/replication_persistence_helper.cpp
+++ b/tests/unit/replication_persistence_helper.cpp
@@ -35,11 +35,10 @@ TEST(ReplicationDurability, V3Main) {
 }
 
 TEST(ReplicationDurability, V1Replica) {
-  auto const role_entry =
-      ReplicationRoleEntry{.version = DurabilityVersion::V1,
-                           .role = ReplicaRole{
-                               .config = ReplicationServerConfig{.repl_server = Endpoint("000.123.456.789", 2023)},
-                           }};
+  auto const role_entry = ReplicationRoleEntry{
+      .version = DurabilityVersion::V1,
+      .role = ReplicaRole{.config = ReplicationServerConfig{.repl_server = Endpoint("000.123.456.789", 2023)},
+                          .main_uuid = UUID{}}};
   nlohmann::json j;
   to_json(j, role_entry);
   ReplicationRoleEntry deser;
@@ -48,11 +47,12 @@ TEST(ReplicationDurability, V1Replica) {
 }
 
 TEST(ReplicationDurability, V2Replica) {
-  auto const role_entry =
-      ReplicationRoleEntry{.version = DurabilityVersion::V2,
-                           .role = ReplicaRole{
-                               .config = ReplicationServerConfig{.repl_server = Endpoint("000.123.456.789", 2023)},
-                           }};
+  auto const role_entry = ReplicationRoleEntry{
+      .version = DurabilityVersion::V2,
+      .role = ReplicaRole{
+          .config = ReplicationServerConfig{.repl_server = Endpoint("000.123.456.789", 2023)}, .main_uuid = UUID{}
+
+      }};
   nlohmann::json j;
   to_json(j, role_entry);
   ReplicationRoleEntry deser;
@@ -61,11 +61,12 @@ TEST(ReplicationDurability, V2Replica) {
 }
 
 TEST(ReplicationDurability, V3ReplicaNoMain) {
-  auto const role_entry =
-      ReplicationRoleEntry{.version = DurabilityVersion::V3,
-                           .role = ReplicaRole{
-                               .config = ReplicationServerConfig{.repl_server = Endpoint("000.123.456.789", 2023)},
-                           }};
+  auto const role_entry = ReplicationRoleEntry{
+      .version = DurabilityVersion::V3,
+      .role = ReplicaRole{
+          .config = ReplicationServerConfig{.repl_server = Endpoint("000.123.456.789", 2023)}, .main_uuid = UUID{}
+
+      }};
   nlohmann::json j;
   to_json(j, role_entry);
   ReplicationRoleEntry deser;
@@ -78,7 +79,7 @@ TEST(ReplicationDurability, V3ReplicaMain) {
       ReplicationRoleEntry{.version = DurabilityVersion::V3,
                            .role = ReplicaRole{
                                .config = ReplicationServerConfig{.repl_server = Endpoint("000.123.456.789", 2023)},
-                               .main_uuid = memgraph::utils::UUID{},
+                               .main_uuid = UUID{},
                            }};
   nlohmann::json j;
   to_json(j, role_entry);
@@ -92,7 +93,7 @@ TEST(ReplicationDurability, V4Replica) {
       ReplicationRoleEntry{.version = DurabilityVersion::V4,
                            .role = ReplicaRole{
                                .config = ReplicationServerConfig{.repl_server = Endpoint("memgraph.dns.example", 2023)},
-                               .main_uuid = memgraph::utils::UUID{},
+                               .main_uuid = UUID{},
                            }};
   nlohmann::json j;
   to_json(j, role_entry);

--- a/tests/unit/storage_v2_replication.cpp
+++ b/tests/unit/storage_v2_replication.cpp
@@ -155,7 +155,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
 
   auto replica_store_handler = replica.repl_handler;
   replica_store_handler.TrySetReplicationRoleReplica(
-      ReplicationServerConfig{.repl_server = Endpoint(local_host, ports[0])}, std::nullopt);
+      ReplicationServerConfig{.repl_server = Endpoint(local_host, ports[0])});
 
   const auto &reg = main.repl_handler.TryRegisterReplica(ReplicationClientConfig{
       .name = "REPLICA",
@@ -548,16 +548,12 @@ TEST_F(ReplicationTest, MultipleSynchronousReplicationTest) {
   MinMemgraph replica1(repl_conf);
   MinMemgraph replica2(repl2_conf);
 
-  replica1.repl_handler.TrySetReplicationRoleReplica(
-      ReplicationServerConfig{
-          .repl_server = Endpoint(local_host, ports[0]),
-      },
-      std::nullopt);
-  replica2.repl_handler.TrySetReplicationRoleReplica(
-      ReplicationServerConfig{
-          .repl_server = Endpoint(local_host, ports[1]),
-      },
-      std::nullopt);
+  replica1.repl_handler.TrySetReplicationRoleReplica(ReplicationServerConfig{
+      .repl_server = Endpoint(local_host, ports[0]),
+  });
+  replica2.repl_handler.TrySetReplicationRoleReplica(ReplicationServerConfig{
+      .repl_server = Endpoint(local_host, ports[1]),
+  });
 
   ASSERT_FALSE(main.repl_handler
                    .TryRegisterReplica(ReplicationClientConfig{
@@ -698,11 +694,9 @@ TEST_F(ReplicationTest, RecoveryProcess) {
     MinMemgraph replica(repl_conf);
     auto replica_store_handler = replica.repl_handler;
 
-    replica_store_handler.TrySetReplicationRoleReplica(
-        ReplicationServerConfig{
-            .repl_server = Endpoint(local_host, ports[0]),
-        },
-        std::nullopt);
+    replica_store_handler.TrySetReplicationRoleReplica(ReplicationServerConfig{
+        .repl_server = Endpoint(local_host, ports[0]),
+    });
     ASSERT_FALSE(main.repl_handler
                      .TryRegisterReplica(ReplicationClientConfig{
                          .name = replicas[0],
@@ -773,11 +767,9 @@ TEST_F(ReplicationTest, BasicAsynchronousReplicationTest) {
   MinMemgraph replica_async(repl_conf);
 
   auto replica_store_handler = replica_async.repl_handler;
-  replica_store_handler.TrySetReplicationRoleReplica(
-      ReplicationServerConfig{
-          .repl_server = Endpoint(local_host, ports[1]),
-      },
-      std::nullopt);
+  replica_store_handler.TrySetReplicationRoleReplica(ReplicationServerConfig{
+      .repl_server = Endpoint(local_host, ports[1]),
+  });
 
   ASSERT_FALSE(main.repl_handler
                    .TryRegisterReplica(ReplicationClientConfig{
@@ -820,18 +812,14 @@ TEST_F(ReplicationTest, EpochTest) {
   MinMemgraph main(main_conf);
   MinMemgraph replica1(repl_conf);
 
-  replica1.repl_handler.TrySetReplicationRoleReplica(
-      ReplicationServerConfig{
-          .repl_server = Endpoint(local_host, ports[0]),
-      },
-      std::nullopt);
+  replica1.repl_handler.TrySetReplicationRoleReplica(ReplicationServerConfig{
+      .repl_server = Endpoint(local_host, ports[0]),
+  });
 
   MinMemgraph replica2(repl2_conf);
-  replica2.repl_handler.TrySetReplicationRoleReplica(
-      ReplicationServerConfig{
-          .repl_server = Endpoint(local_host, 10001),
-      },
-      std::nullopt);
+  replica2.repl_handler.TrySetReplicationRoleReplica(ReplicationServerConfig{
+      .repl_server = Endpoint(local_host, 10001),
+  });
 
   ASSERT_FALSE(main.repl_handler
                    .TryRegisterReplica(ReplicationClientConfig{
@@ -901,11 +889,9 @@ TEST_F(ReplicationTest, EpochTest) {
     ASSERT_FALSE(acc->PrepareForCommitPhase().HasError());
   }
 
-  replica1.repl_handler.TrySetReplicationRoleReplica(
-      ReplicationServerConfig{
-          .repl_server = Endpoint(local_host, ports[0]),
-      },
-      std::nullopt);
+  replica1.repl_handler.TrySetReplicationRoleReplica(ReplicationServerConfig{
+      .repl_server = Endpoint(local_host, ports[0]),
+  });
   ASSERT_TRUE(main.repl_handler
                   .TryRegisterReplica(ReplicationClientConfig{
                       .name = replicas[0],
@@ -935,19 +921,15 @@ TEST_F(ReplicationTest, ReplicationInformation) {
   MinMemgraph replica1(repl_conf);
 
   uint16_t replica1_port = 10001;
-  replica1.repl_handler.TrySetReplicationRoleReplica(
-      ReplicationServerConfig{
-          .repl_server = Endpoint(local_host, replica1_port),
-      },
-      std::nullopt);
+  replica1.repl_handler.TrySetReplicationRoleReplica(ReplicationServerConfig{
+      .repl_server = Endpoint(local_host, replica1_port),
+  });
 
   uint16_t replica2_port = 10002;
   MinMemgraph replica2(repl2_conf);
-  replica2.repl_handler.TrySetReplicationRoleReplica(
-      ReplicationServerConfig{
-          .repl_server = Endpoint(local_host, replica2_port),
-      },
-      std::nullopt);
+  replica2.repl_handler.TrySetReplicationRoleReplica(ReplicationServerConfig{
+      .repl_server = Endpoint(local_host, replica2_port),
+  });
 
   ASSERT_FALSE(main.repl_handler
                    .TryRegisterReplica(ReplicationClientConfig{
@@ -990,19 +972,15 @@ TEST_F(ReplicationTest, ReplicationReplicaWithExistingName) {
   MinMemgraph replica1(repl_conf);
 
   uint16_t replica1_port = 10001;
-  replica1.repl_handler.TrySetReplicationRoleReplica(
-      ReplicationServerConfig{
-          .repl_server = Endpoint(local_host, replica1_port),
-      },
-      std::nullopt);
+  replica1.repl_handler.TrySetReplicationRoleReplica(ReplicationServerConfig{
+      .repl_server = Endpoint(local_host, replica1_port),
+  });
 
   uint16_t replica2_port = 10002;
   MinMemgraph replica2(repl2_conf);
-  replica2.repl_handler.TrySetReplicationRoleReplica(
-      ReplicationServerConfig{
-          .repl_server = Endpoint(local_host, replica2_port),
-      },
-      std::nullopt);
+  replica2.repl_handler.TrySetReplicationRoleReplica(ReplicationServerConfig{
+      .repl_server = Endpoint(local_host, replica2_port),
+  });
   ASSERT_FALSE(main.repl_handler
                    .TryRegisterReplica(ReplicationClientConfig{
                        .name = replicas[0],
@@ -1025,18 +1003,14 @@ TEST_F(ReplicationTest, ReplicationReplicaWithExistingEndPoint) {
 
   MinMemgraph main(main_conf);
   MinMemgraph replica1(repl_conf);
-  replica1.repl_handler.TrySetReplicationRoleReplica(
-      ReplicationServerConfig{
-          .repl_server = Endpoint(local_host, common_port),
-      },
-      std::nullopt);
+  replica1.repl_handler.TrySetReplicationRoleReplica(ReplicationServerConfig{
+      .repl_server = Endpoint(local_host, common_port),
+  });
 
   MinMemgraph replica2(repl2_conf);
-  replica2.repl_handler.TrySetReplicationRoleReplica(
-      ReplicationServerConfig{
-          .repl_server = Endpoint(local_host, common_port),
-      },
-      std::nullopt);
+  replica2.repl_handler.TrySetReplicationRoleReplica(ReplicationServerConfig{
+      .repl_server = Endpoint(local_host, common_port),
+  });
 
   ASSERT_FALSE(main.repl_handler
                    .TryRegisterReplica(ReplicationClientConfig{
@@ -1074,18 +1048,14 @@ TEST_F(ReplicationTest, RestoringReplicationAtStartupAfterDroppingReplica) {
   std::optional<MinMemgraph> main(main_config);
   MinMemgraph replica1(replica1_config);
 
-  replica1.repl_handler.TrySetReplicationRoleReplica(
-      ReplicationServerConfig{
-          .repl_server = Endpoint(local_host, ports[0]),
-      },
-      std::nullopt);
+  replica1.repl_handler.TrySetReplicationRoleReplica(ReplicationServerConfig{
+      .repl_server = Endpoint(local_host, ports[0]),
+  });
 
   MinMemgraph replica2(replica2_config);
-  replica2.repl_handler.TrySetReplicationRoleReplica(
-      ReplicationServerConfig{
-          .repl_server = Endpoint(local_host, ports[1]),
-      },
-      std::nullopt);
+  replica2.repl_handler.TrySetReplicationRoleReplica(ReplicationServerConfig{
+      .repl_server = Endpoint(local_host, ports[1]),
+  });
 
   auto res = main->repl_handler.TryRegisterReplica(ReplicationClientConfig{
       .name = replicas[0],
@@ -1135,19 +1105,15 @@ TEST_F(ReplicationTest, RestoringReplicationAtStartup) {
   std::optional<MinMemgraph> main(main_config);
   MinMemgraph replica1(repl_conf);
 
-  replica1.repl_handler.TrySetReplicationRoleReplica(
-      ReplicationServerConfig{
-          .repl_server = Endpoint(local_host, ports[0]),
-      },
-      std::nullopt);
+  replica1.repl_handler.TrySetReplicationRoleReplica(ReplicationServerConfig{
+      .repl_server = Endpoint(local_host, ports[0]),
+  });
 
   MinMemgraph replica2(repl2_conf);
 
-  replica2.repl_handler.TrySetReplicationRoleReplica(
-      ReplicationServerConfig{
-          .repl_server = Endpoint(local_host, ports[1]),
-      },
-      std::nullopt);
+  replica2.repl_handler.TrySetReplicationRoleReplica(ReplicationServerConfig{
+      .repl_server = Endpoint(local_host, ports[1]),
+  });
   auto res = main->repl_handler.TryRegisterReplica(ReplicationClientConfig{
       .name = replicas[0],
       .mode = ReplicationMode::SYNC,
@@ -1488,7 +1454,7 @@ TEST_F(ReplicationTest, SchemaReplication) {
   std::optional<MinMemgraph> replica(repl_conf);
 
   replica->repl_handler.TrySetReplicationRoleReplica(
-      ReplicationServerConfig{.repl_server = Endpoint(local_host, ports[0])}, std::nullopt);
+      ReplicationServerConfig{.repl_server = Endpoint(local_host, ports[0])});
 
   const auto &reg = main->repl_handler.TryRegisterReplica(ReplicationClientConfig{
       .name = "REPLICA",
@@ -1627,7 +1593,7 @@ TEST_F(ReplicationTest, SchemaReplication) {
   auto start_replica = [&]() {
     replica.emplace(repl_conf);
     replica->repl_handler.TrySetReplicationRoleReplica(
-        ReplicationServerConfig{.repl_server = Endpoint(local_host, ports[0])}, std::nullopt);
+        ReplicationServerConfig{.repl_server = Endpoint(local_host, ports[0])});
     {
       int tries = 0;
       while (main->repl_handler.ShowReplicas().GetValue().entries_[0].data_info_.at("memgraph").state_ !=


### PR DESCRIPTION
The goal of this PR is to simplify the code by removing unneeded optionalness. 