### PR TITLE
Fix unwind checking symbols in all scopes to checking in current scope

### DIFF
--- a/src/query/frontend/semantic/symbol_generator.cpp
+++ b/src/query/frontend/semantic/symbol_generator.cpp
@@ -328,8 +328,9 @@ bool SymbolGenerator::PostVisit(Merge &) {
 }
 
 bool SymbolGenerator::PostVisit(Unwind &unwind) {
+  auto &scope = scopes_.back();
   const auto &name = unwind.named_expression_->name_;
-  if (HasSymbol(name)) {
+  if (FindSymbolInScope(name, scope, Symbol::Type::ANY).has_value()) {
     throw RedeclareVariableError(name);
   }
   unwind.named_expression_->MapTo(CreateSymbol(name, true));

--- a/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/subqueries.feature
@@ -467,3 +467,24 @@ Scenario: Advance command on subquery should not affect outer query vertex visib
         Then the result should be:
             | n0 |
             | 0  |
+
+    Scenario: Unwind in subquery passes correctly with same named symbol
+        Given an empty graph
+        When executing query:
+            """
+            CREATE (this0 {id: 1})
+            WITH this0
+            CALL {
+                WITH this0
+                WITH collect(this0) as parentNodes
+                CALL {
+                    WITH parentNodes
+                    UNWIND parentNodes as this0
+                    create ()
+                }
+            }
+            RETURN this0.id AS id
+            """
+        Then the result should be:
+            | id |
+            | 1  |


### PR DESCRIPTION
Fix unwind checking symbols in all scopes to checking in current scope

