### PR TITLE
Added workflow to trigger MAGE build upon PR merge

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -1,0 +1,85 @@
+name: "Build and Upload Packages"
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - master
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        type: string
+        description: "PR number to use for the build (e.g., 1234)"
+        required: true
+
+jobs:
+  get-pr-number:
+    if: (github.event.pull_request.merged == true && github.ref == 'refs/heads/master') || github.event_name == 'workflow_dispatch'
+    name: "Get PR Number"
+    runs-on: [self-hosted, Linux, X64, DockerMgBuild]
+    outputs:
+      pr_number: ${{ steps.get_pr.outputs.pr_number }}
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get PR Number
+        id: get_pr
+        run: |
+          # Get the PR number from the event or manual input
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            PR_NUMBER=${{ github.event.inputs.pr_number }}
+            echo "Using manually provided PR number: $PR_NUMBER"
+          else
+            PR_NUMBER=${{ github.event.pull_request.number }}
+            echo "Using PR number from merged PR: $PR_NUMBER"
+          fi
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "PR Number: $PR_NUMBER"
+
+  build-packages:
+    if: (github.event.pull_request.merged == true && github.ref == 'refs/heads/master') || github.event_name == 'workflow_dispatch'
+    name: "Build ${{ matrix.arch }} Package"
+    needs: get-pr-number
+    uses: ./.github/workflows/reusable_package.yaml
+    secrets: inherit
+    strategy:
+      matrix:
+        arch: [amd, arm]
+    with:
+      os: ubuntu-24.04
+      arch: ${{ matrix.arch }}
+      toolchain: v6
+      build_type: RelWithDebInfo
+      push_to_s3: true
+      s3_bucket: deps.memgraph.io
+      s3_dest_dir: pr-build/memgraph/pr${{ needs.get-pr-number.outputs.pr_number }}
+      ref: refs/heads/master
+
+  trigger-repository-dispatch:
+    if: (github.event.pull_request.merged == true && github.ref == 'refs/heads/master') || github.event_name == 'workflow_dispatch'
+    name: "Trigger Repository Dispatch"
+    needs: [get-pr-number, build-packages]
+    runs-on: [self-hosted, Linux, X64, DockerMgBuild]
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Send Repository Dispatch
+        env:
+          GITHUB_TOKEN: ${{ secrets.REPO_PAT }}
+        run: |
+          # Create the payload with the PR number
+          payload="{\"event_type\": \"trigger_pr_build\", \"client_payload\": {\"pr\": \"pr${{ needs.get-pr-number.outputs.pr_number }}\"}}"
+          echo "Payload: $payload"
+
+          # Send the dispatch request to the mage repository
+          curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            https://api.github.com/repos/memgraph/mage/dispatches \
+            -d "$payload"


### PR DESCRIPTION
A new workflow which should build Memgraph (`RelWithDebInfo`: `arm64` and `amd64`), then trigger MAGE to build using those DEB packages.


