### PR TITLE
Speed up building by using `ccache` in CI

### DIFF
--- a/.github/workflows/diff_coverage.yaml
+++ b/.github/workflows/diff_coverage.yaml
@@ -60,6 +60,7 @@ jobs:
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
+          --no-ccache \
           run
 
       # This is also needed if we want do to comparison against other branches
@@ -137,6 +138,7 @@ jobs:
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
+          --no-ccache \
           stop --remove
 
   clang-tidy-community:
@@ -162,6 +164,7 @@ jobs:
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
+          --no-ccache \
           run
 
       - name: Set base branch
@@ -198,6 +201,7 @@ jobs:
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
+          --no-ccache \
           stop --remove
 
   clang-tidy-enterprise:
@@ -223,6 +227,7 @@ jobs:
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
+          --no-ccache \
           run
 
       - name: Set base branch
@@ -259,4 +264,5 @@ jobs:
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
+          --no-ccache \
           stop --remove

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -1134,7 +1134,7 @@ case $command in
       done
 
       # Create ccache override file if ccache is enabled (same logic as run command)
-      local compose_files=$(setup_ccache_override)
+      compose_files=$(setup_ccache_override)
 
       if [[ "$os" == "all" ]]; then
         $docker_compose_cmd $compose_files down
@@ -1152,7 +1152,7 @@ case $command in
       cd $SCRIPT_DIR
 
       # Create ccache override file if ccache is enabled (same logic as run command)
-      local compose_files=$(setup_ccache_override)
+      compose_files=$(setup_ccache_override)
 
       if [[ "$os" == "all" ]]; then
         $docker_compose_cmd $compose_files pull --ignore-pull-failures

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -300,6 +300,34 @@ cleanup_ccache_override() {
   fi
 }
 
+setup_host_ccache_permissions() {
+  if [[ "$ccache_enabled" == "true" ]]; then
+    echo "Setting up host ccache directory permissions..."
+    mkdir -p ~/.cache/ccache
+
+    # Check if we can determine the mg user UID from the container
+    if docker image inspect memgraph/mgbuild:${toolchain_version}_${os} > /dev/null 2>&1; then
+      # Try to get the mg user UID from the container image
+      container_uid=$(docker run --rm memgraph/mgbuild:${toolchain_version}_${os} id -u mg 2>/dev/null || echo "1000")
+      echo "Container mg user UID: $container_uid"
+
+      # If the host user UID matches the container UID, we can use normal permissions
+      if [[ "$(id -u)" == "$container_uid" ]]; then
+        chmod 755 ~/.cache/ccache
+        echo "Host ccache directory permissions set to 755 (UID match)"
+      else
+        # Otherwise, make it world-writable to avoid permission issues
+        chmod 777 ~/.cache/ccache
+        echo "Host ccache directory permissions set to 777 (UID mismatch)"
+      fi
+    else
+      # Fallback: make it world-writable
+      chmod 777 ~/.cache/ccache
+      echo "Host ccache directory permissions set to 777 (fallback)"
+    fi
+  fi
+}
+
 copy_project_files() {
   echo "Copying project files..."
   project_files=$(ls -A1 "$PROJECT_ROOT")
@@ -1003,6 +1031,9 @@ case $command in
       # Create ccache override file if ccache is enabled
       compose_files=$(setup_ccache_override)
 
+      # Set up host ccache permissions
+      setup_host_ccache_permissions
+
       if [[ "$os" == "all" ]]; then
         if [[ "$pull" == "true" ]]; then
           $docker_compose_cmd $compose_files pull --ignore-pull-failures
@@ -1064,6 +1095,22 @@ case $command in
         else
           echo "Warning: Unknown OS $os - not installing ccache"
         fi
+
+        # Set up ccache directory permissions
+        echo "Setting up ccache directory permissions..."
+        docker exec -u root $build_container bash -c "
+          mkdir -p /home/mg/.cache/ccache
+          chown -R mg:mg /home/mg/.cache/ccache
+          chmod -R 755 /home/mg/.cache/ccache
+        "
+
+        # Verify ccache installation and permissions
+        echo "Verifying ccache installation..."
+        docker exec -u mg $build_container bash -c "
+          ccache --version
+          ccache -s
+          echo 'Ccache is ready for use'
+        "
       fi
 
       # Clean up override file if it was created

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -270,9 +270,7 @@ setup_ccache_override() {
   local compose_files="-f ${arch}-builders-${toolchain_version}.yml"
 
   if [[ "$ccache_enabled" == "true" ]]; then
-    echo "Enabling ccache volume mounting..."
     cat > ccache-override.yml << EOF
-version: "3"
 services:
 EOF
     # Add ccache volumes for all services in the compose file
@@ -1003,7 +1001,7 @@ case $command in
       done
 
       # Create ccache override file if ccache is enabled
-      local compose_files=$(setup_ccache_override)
+      compose_files=$(setup_ccache_override)
 
       if [[ "$os" == "all" ]]; then
         if [[ "$pull" == "true" ]]; then


### PR DESCRIPTION
The CI machines will all have a local `ccache` directory `~/.cache/ccache` which will be mounted as a volume in the `mgbuild` container. When the container is started, `ccache` should be installed (using `apt` or `yum`). This should speed up building once the cache is built up for the first time on each machine. The flag `--no-ccache` can be used to build without it, as will be done in the coverage workflow.

