### PR TITLE
Return snapshot path

### DIFF
--- a/src/dbms/inmemory/storage_helper.hpp
+++ b/src/dbms/inmemory/storage_helper.hpp
@@ -32,7 +32,11 @@ inline std::unique_ptr<storage::Storage> CreateInMemoryStorage(
         // Holding on to the lock for the duration of CreateSnapshot will cause a deadlock
         // Not holding the lock might allow a replica to create the snapshot if the role switch is happening
         const auto role = repl_state.ReadLock()->GetRole();
-        return storage->CreateSnapshot(role);
+        auto result = storage->CreateSnapshot(role);
+        if (result.HasError()) {
+          return result.GetError();
+        }
+        return utils::BasicResult<storage::InMemoryStorage::CreateSnapshotError>{};
       });
 
   return std::move(storage);

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -4755,31 +4755,43 @@ PreparedQuery PrepareCreateSnapshotQuery(ParsedQuery parsed_query, bool in_expli
     throw CreateSnapshotDisabledOnDiskStorage();
   }
 
-  return PreparedQuery{
-      {},
-      std::move(parsed_query.required_privileges),
-      [storage, replication_role](AnyStream * /*stream*/,
-                                  std::optional<int> /*n*/) -> std::optional<QueryHandlerResult> {
-        auto *mem_storage = static_cast<storage::InMemoryStorage *>(storage);
-        if (auto maybe_error = mem_storage->CreateSnapshot(replication_role); maybe_error.HasError()) {
-          switch (maybe_error.GetError()) {
-            case storage::InMemoryStorage::CreateSnapshotError::DisabledForReplica:
-              throw utils::BasicException(
-                  "Failed to create a snapshot. Replica instances are not allowed to create them.");
-            case storage::InMemoryStorage::CreateSnapshotError::ReachedMaxNumTries:
-              spdlog::warn("Failed to create snapshot. Reached max number of tries. Please contact support");
-              break;
-            case storage::InMemoryStorage::CreateSnapshotError::AbortSnapshot:
-              throw utils::BasicException("Failed to create snapshot. The current snapshot needs to be aborted.");
-            case storage::InMemoryStorage::CreateSnapshotError::AlreadyRunning:
-              throw utils::BasicException("Another snapshot creation is already in progress.");
-            case storage::InMemoryStorage::CreateSnapshotError::NothingNewToWrite:
-              throw utils::BasicException("Nothing has been written since the last snapshot.");
-          }
-        }
-        return QueryHandlerResult::COMMIT;
-      },
-      RWType::NONE};
+  Callback callback;
+  callback.header = {"path"};
+  callback.fn = [storage, replication_role]() mutable -> std::vector<std::vector<TypedValue>> {
+    auto *mem_storage = static_cast<storage::InMemoryStorage *>(storage);
+    const auto maybe_path = mem_storage->CreateSnapshot(replication_role);
+    if (maybe_path.HasError()) {
+      switch (maybe_path.GetError()) {
+        case storage::InMemoryStorage::CreateSnapshotError::DisabledForReplica:
+          throw utils::BasicException("Failed to create a snapshot. Replica instances are not allowed to create them.");
+        case storage::InMemoryStorage::CreateSnapshotError::ReachedMaxNumTries:
+          spdlog::warn("Failed to create snapshot. Reached max number of tries. Please contact support");
+          break;
+        case storage::InMemoryStorage::CreateSnapshotError::AbortSnapshot:
+          throw utils::BasicException("Failed to create snapshot. The current snapshot needs to be aborted.");
+        case storage::InMemoryStorage::CreateSnapshotError::AlreadyRunning:
+          throw utils::BasicException("Another snapshot creation is already in progress.");
+        case storage::InMemoryStorage::CreateSnapshotError::NothingNewToWrite:
+          throw utils::BasicException("Nothing has been written since the last snapshot.");
+      }
+    }
+    return std::vector<std::vector<TypedValue>>{{TypedValue{maybe_path.GetValue()}}};
+  };
+
+  return PreparedQuery{std::move(callback.header), std::move(parsed_query.required_privileges),
+                       [handler = std::move(callback.fn), pull_plan = std::shared_ptr<PullPlanVector>(nullptr)](
+                           AnyStream *stream, std::optional<int> n) mutable -> std::optional<QueryHandlerResult> {
+                         if (!pull_plan) {
+                           auto results = handler();
+                           pull_plan = std::make_shared<PullPlanVector>(std::move(results));
+                         }
+
+                         if (pull_plan->Pull(stream, n)) {
+                           return QueryHandlerResult::COMMIT;
+                         }
+                         return std::nullopt;
+                       },
+                       RWType::NONE};
 }
 
 PreparedQuery PrepareRecoverSnapshotQuery(ParsedQuery parsed_query, bool in_explicit_transaction, CurrentDB &current_db,

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -4759,7 +4759,8 @@ PreparedQuery PrepareCreateSnapshotQuery(ParsedQuery parsed_query, bool in_expli
   callback.header = {"path"};
   callback.fn = [storage, replication_role]() mutable -> std::vector<std::vector<TypedValue>> {
     auto *mem_storage = static_cast<storage::InMemoryStorage *>(storage);
-    const auto maybe_path = mem_storage->CreateSnapshot(replication_role);
+    constexpr bool kForce = true;
+    const auto maybe_path = mem_storage->CreateSnapshot(replication_role, kForce);
     if (maybe_path.HasError()) {
       switch (maybe_path.GetError()) {
         case storage::InMemoryStorage::CreateSnapshotError::DisabledForReplica:

--- a/src/storage/v2/durability/snapshot.hpp
+++ b/src/storage/v2/durability/snapshot.hpp
@@ -77,11 +77,11 @@ RecoveredSnapshot LoadSnapshot(std::filesystem::path const &path, utils::SkipLis
                                memgraph::storage::SharedSchemaTracking *schema_info,
                                std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
-bool CreateSnapshot(Storage *storage, Transaction *transaction, const std::filesystem::path &snapshot_directory,
-                    const std::filesystem::path &wal_directory, utils::SkipList<Vertex> *vertices,
-                    utils::SkipList<Edge> *edges, utils::UUID const &uuid,
-                    const memgraph::replication::ReplicationEpoch &epoch,
-                    const std::deque<std::pair<std::string, uint64_t>> &epoch_history,
-                    utils::FileRetainer *file_retainer, std::atomic_bool *abort_snapshot = nullptr);
+std::optional<std::filesystem::path> CreateSnapshot(
+    Storage *storage, Transaction *transaction, const std::filesystem::path &snapshot_directory,
+    const std::filesystem::path &wal_directory, utils::SkipList<Vertex> *vertices, utils::SkipList<Edge> *edges,
+    utils::UUID const &uuid, const memgraph::replication::ReplicationEpoch &epoch,
+    const std::deque<std::pair<std::string, uint64_t>> &epoch_history, utils::FileRetainer *file_retainer,
+    std::atomic_bool *abort_snapshot = nullptr);
 
 }  // namespace memgraph::storage::durability

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2809,7 +2809,7 @@ bool InMemoryStorage::InMemoryAccessor::HandleDurabilityAndReplicate(uint64_t du
 }
 
 utils::BasicResult<InMemoryStorage::CreateSnapshotError, std::filesystem::path> InMemoryStorage::CreateSnapshot(
-    memgraph::replication_coordination_glue::ReplicationRole replication_role) {
+    memgraph::replication_coordination_glue::ReplicationRole replication_role, bool force) {
   using memgraph::replication_coordination_glue::ReplicationRole;
   if (replication_role == ReplicationRole::REPLICA) {
     return CreateSnapshotError::DisabledForReplica;
@@ -2856,7 +2856,7 @@ utils::BasicResult<InMemoryStorage::CreateSnapshotError, std::filesystem::path> 
   // In memory analytical doesn't update last_durable_ts so digest isn't valid
   if (transaction->storage_mode == StorageMode::IN_MEMORY_TRANSACTIONAL) {
     auto current_digest = SnapshotDigest{epoch, epochHistory, storage_uuid, *transaction->last_durable_ts_};
-    if (last_snapshot_digest_ == current_digest) return CreateSnapshotError::NothingNewToWrite;
+    if (!force && last_snapshot_digest_ == current_digest) return CreateSnapshotError::NothingNewToWrite;
     last_snapshot_digest_ = std::move(current_digest);
   }
 

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -564,7 +564,7 @@ class InMemoryStorage final : public Storage {
   utils::FileRetainer::FileLockerAccessor::ret_type LockPath();
   utils::FileRetainer::FileLockerAccessor::ret_type UnlockPath();
 
-  utils::BasicResult<InMemoryStorage::CreateSnapshotError> CreateSnapshot(
+  utils::BasicResult<InMemoryStorage::CreateSnapshotError, std::filesystem::path> CreateSnapshot(
       memgraph::replication_coordination_glue::ReplicationRole replication_role);
 
   utils::BasicResult<InMemoryStorage::RecoverSnapshotError> RecoverSnapshot(

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -565,7 +565,7 @@ class InMemoryStorage final : public Storage {
   utils::FileRetainer::FileLockerAccessor::ret_type UnlockPath();
 
   utils::BasicResult<InMemoryStorage::CreateSnapshotError, std::filesystem::path> CreateSnapshot(
-      memgraph::replication_coordination_glue::ReplicationRole replication_role);
+      memgraph::replication_coordination_glue::ReplicationRole replication_role, bool force = false);
 
   utils::BasicResult<InMemoryStorage::RecoverSnapshotError> RecoverSnapshot(
       std::filesystem::path path, bool force,

--- a/tests/e2e/durability/snapshot_recovery.py
+++ b/tests/e2e/durability/snapshot_recovery.py
@@ -413,7 +413,17 @@ def test_local_snapshot(global_snapshot, database):
     cursor = mt_cursor(connection, database)
     execute_and_fetch_all(cursor, "CREATE (:L{p:'random data'});")
     execute_and_fetch_all(cursor, "CREATE (:L{p:'random data'});")
-    execute_and_fetch_all(cursor, "CREATE SNAPSHOT;")
+    result = execute_and_fetch_all(cursor, "CREATE SNAPSHOT;")
+    # Verify that CREATE SNAPSHOT returned a path and it exists as a file
+    assert len(result) == 1, "CREATE SNAPSHOT should return exactly one row"
+    assert len(result[0]) == 1, "CREATE SNAPSHOT should return exactly one column (path)"
+    snapshot_path = result[0][0]
+    assert snapshot_path is not None, "CREATE SNAPSHOT should return a non-null path"
+    assert isinstance(snapshot_path, str), "CREATE SNAPSHOT should return a string path"
+    # Verify the path exists and is a file
+    path_obj = Path(snapshot_path)
+    assert path_obj.exists(), f"Snapshot file should exist at {snapshot_path}"
+    assert path_obj.is_file(), f"Snapshot should be a file at {snapshot_path}"
     main_test(mt_data_dir(data_directory.name, database), global_snapshot, database, False)
     interactive_mg_runner.kill_all()
     interactive_mg_runner.start(memgraph_instances(data_directory.name), "recover_on_startup")
@@ -431,7 +441,17 @@ def test_local_snapshot_and_current_wal(global_snapshot, database):
     cursor = mt_cursor(connection, database)
     execute_and_fetch_all(cursor, "CREATE (:L{p:'random data'});")
     execute_and_fetch_all(cursor, "CREATE (:L{p:'random data'});")
-    execute_and_fetch_all(cursor, "CREATE SNAPSHOT;")
+    result = execute_and_fetch_all(cursor, "CREATE SNAPSHOT;")
+    # Verify that CREATE SNAPSHOT returned a path and it exists as a file
+    assert len(result) == 1, "CREATE SNAPSHOT should return exactly one row"
+    assert len(result[0]) == 1, "CREATE SNAPSHOT should return exactly one column (path)"
+    snapshot_path = result[0][0]
+    assert snapshot_path is not None, "CREATE SNAPSHOT should return a non-null path"
+    assert isinstance(snapshot_path, str), "CREATE SNAPSHOT should return a string path"
+    # Verify the path exists and is a file
+    path_obj = Path(snapshot_path)
+    assert path_obj.exists(), f"Snapshot file should exist at {snapshot_path}"
+    assert path_obj.is_file(), f"Snapshot should be a file at {snapshot_path}"
     execute_and_fetch_all(cursor, "CREATE (:L{p:'random data'});")
     main_test(mt_data_dir(data_directory.name, database), global_snapshot, database, False)
     interactive_mg_runner.kill_all()
@@ -459,7 +479,17 @@ def test_marked_commits_after_snapshot():
     execute_and_fetch_all(cursor, "CREATE ()")
     execute_and_fetch_all(cursor, "CREATE ()")
     # 2
-    execute_and_fetch_all(cursor, "CREATE SNAPSHOT")
+    result = execute_and_fetch_all(cursor, "CREATE SNAPSHOT")
+    # Verify that CREATE SNAPSHOT returned a path and it exists as a file
+    assert len(result) == 1, "CREATE SNAPSHOT should return exactly one row"
+    assert len(result[0]) == 1, "CREATE SNAPSHOT should return exactly one column (path)"
+    snapshot_path = result[0][0]
+    assert snapshot_path is not None, "CREATE SNAPSHOT should return a non-null path"
+    assert isinstance(snapshot_path, str), "CREATE SNAPSHOT should return a string path"
+    # Verify the path exists and is a file
+    path_obj = Path(snapshot_path)
+    assert path_obj.exists(), f"Snapshot file should exist at {snapshot_path}"
+    assert path_obj.is_file(), f"Snapshot should be a file at {snapshot_path}"
     # 3
     execute_and_fetch_all(cursor, "MATCH (n) RETURN count(*)")
     execute_and_fetch_all(cursor, "MATCH (n) RETURN count(*)")

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -359,6 +359,9 @@ target_link_libraries(${test_prefix}storage_v2_decoder_encoder mg::storage)
 add_unit_test(storage_v2_durability_inmemory.cpp)
 target_link_libraries(${test_prefix}storage_v2_durability_inmemory mg::storage mg-dbms)
 
+add_unit_test(storage_v2_create_snapshot.cpp)
+target_link_libraries(${test_prefix}storage_v2_create_snapshot mg::storage mg-dbms)
+
 add_unit_test(storage_rocks.cpp)
 target_link_libraries(${test_prefix}storage_rocks mg::storage)
 

--- a/tests/unit/storage_v2_create_snapshot.cpp
+++ b/tests/unit/storage_v2_create_snapshot.cpp
@@ -1,0 +1,247 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <string>
+
+#include "dbms/database.hpp"
+#include "replication/state.hpp"
+#include "storage/v2/config.hpp"
+#include "storage/v2/durability/paths.hpp"
+#include "storage/v2/inmemory/storage.hpp"
+#include "storage_test_utils.hpp"
+
+using memgraph::replication_coordination_glue::ReplicationRole;
+
+class CreateSnapshotTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    // Create a temporary directory for testing
+    storage_directory = std::filesystem::temp_directory_path() / "create_snapshot_test";
+    std::filesystem::create_directories(storage_directory);
+  }
+
+  void TearDown() override {
+    // Clean up the test directory
+    std::filesystem::remove_all(storage_directory);
+  }
+
+  memgraph::storage::Config CreateConfig() {
+    return memgraph::storage::Config{
+        .durability = {.storage_directory = storage_directory,
+                       .recover_on_startup = false,
+                       .snapshot_on_exit = false,
+                       .items_per_batch = 13,
+                       .allow_parallel_schema_creation = true},
+        .salient = {.items = {.properties_on_edges = false, .enable_schema_info = true}},
+    };
+  }
+
+  std::filesystem::path storage_directory;
+};
+
+TEST_F(CreateSnapshotTest, CreateSnapshotReturnsPathOnSuccess) {
+  auto config = CreateConfig();
+  memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock> repl_state{
+      memgraph::storage::ReplicationStateRootPath(config)};
+  memgraph::dbms::Database db{config, repl_state};
+
+  auto *mem_storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
+
+  // Create some data to ensure snapshot has content
+  {
+    auto acc = mem_storage->Access();
+    auto vertex = acc->CreateVertex();
+    ASSERT_FALSE(acc->PrepareForCommitPhase().HasError());
+  }
+
+  // Test CreateSnapshot returns path on success
+  auto result = mem_storage->CreateSnapshot(ReplicationRole::MAIN);
+
+  ASSERT_FALSE(result.HasError()) << "CreateSnapshot should succeed with some data";
+
+  auto snapshot_path = result.GetValue();
+  ASSERT_TRUE(std::filesystem::exists(snapshot_path)) << "Snapshot file should exist at returned path";
+  ASSERT_TRUE(std::filesystem::is_regular_file(snapshot_path)) << "Snapshot should be a regular file";
+
+  // Verify the path is in the expected directory
+  auto expected_dir = config.durability.storage_directory / memgraph::storage::durability::kSnapshotDirectory;
+  ASSERT_EQ(snapshot_path.parent_path(), expected_dir) << "Snapshot should be in the snapshots directory";
+
+  // Verify the filename format (should contain timestamp)
+  auto filename = snapshot_path.filename().string();
+  ASSERT_TRUE(filename.find("timestamp_") != std::string::npos) << "Snapshot filename should contain timestamp";
+}
+
+TEST_F(CreateSnapshotTest, CreateSnapshotReturnsErrorForReplica) {
+  auto config = CreateConfig();
+  memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock> repl_state{
+      memgraph::storage::ReplicationStateRootPath(config)};
+  memgraph::dbms::Database db{config, repl_state};
+
+  auto *mem_storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
+
+  // Test CreateSnapshot returns error for replica role
+  auto result = mem_storage->CreateSnapshot(ReplicationRole::REPLICA);
+
+  ASSERT_TRUE(result.HasError()) << "CreateSnapshot should fail for replica role";
+  ASSERT_EQ(result.GetError(), memgraph::storage::InMemoryStorage::CreateSnapshotError::DisabledForReplica)
+      << "Should return DisabledForReplica error";
+}
+
+TEST_F(CreateSnapshotTest, CreateSnapshotReturnsErrorWhenNothingNewToWrite) {
+  auto config = CreateConfig();
+  memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock> repl_state{
+      memgraph::storage::ReplicationStateRootPath(config)};
+  memgraph::dbms::Database db{config, repl_state};
+
+  auto *mem_storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
+
+  // Create some data and take a snapshot
+  {
+    auto acc = mem_storage->Access();
+    auto vertex = acc->CreateVertex();
+    ASSERT_FALSE(acc->PrepareForCommitPhase().HasError());
+  }
+
+  auto result1 = mem_storage->CreateSnapshot(ReplicationRole::MAIN);
+  ASSERT_FALSE(result1.HasError()) << "First CreateSnapshot should succeed";
+
+  // Try to create another snapshot immediately - should fail with NothingNewToWrite
+  auto result2 = mem_storage->CreateSnapshot(ReplicationRole::MAIN);
+  ASSERT_TRUE(result2.HasError()) << "Second CreateSnapshot should fail";
+  ASSERT_EQ(result2.GetError(), memgraph::storage::InMemoryStorage::CreateSnapshotError::NothingNewToWrite)
+      << "Should return NothingNewToWrite error";
+}
+
+TEST_F(CreateSnapshotTest, CreateSnapshotReturnsErrorWhenAlreadyRunning) {
+  auto config = CreateConfig();
+  memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock> repl_state{
+      memgraph::storage::ReplicationStateRootPath(config)};
+  memgraph::dbms::Database db{config, repl_state};
+
+  auto *mem_storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
+
+  // Create some data
+  {
+    auto acc = mem_storage->Access();
+    auto vertex = acc->CreateVertex();
+    ASSERT_FALSE(acc->PrepareForCommitPhase().HasError());
+  }
+
+  // Start a snapshot creation in a separate thread
+  std::thread snapshot_thread([mem_storage]() {
+    auto result = mem_storage->CreateSnapshot(ReplicationRole::MAIN);
+    // This should succeed, but we don't check the result here
+  });
+
+  // Try to create another snapshot while the first one is running
+  auto result = mem_storage->CreateSnapshot(ReplicationRole::MAIN);
+
+  // Wait for the first snapshot to complete
+  snapshot_thread.join();
+
+  // The second call should fail with AlreadyRunning
+  ASSERT_TRUE(result.HasError()) << "Concurrent CreateSnapshot should fail";
+  ASSERT_EQ(result.GetError(), memgraph::storage::InMemoryStorage::CreateSnapshotError::AlreadyRunning)
+      << "Should return AlreadyRunning error";
+}
+
+TEST_F(CreateSnapshotTest, CreateSnapshotPathFormat) {
+  auto config = CreateConfig();
+  memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock> repl_state{
+      memgraph::storage::ReplicationStateRootPath(config)};
+  memgraph::dbms::Database db{config, repl_state};
+
+  auto *mem_storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
+
+  // Create some data
+  {
+    auto acc = mem_storage->Access();
+    auto vertex = acc->CreateVertex();
+    ASSERT_FALSE(acc->PrepareForCommitPhase().HasError());
+  }
+
+  // Create snapshot and verify path format
+  auto result = mem_storage->CreateSnapshot(ReplicationRole::MAIN);
+  ASSERT_FALSE(result.HasError()) << "CreateSnapshot should succeed";
+
+  auto snapshot_path = result.GetValue();
+  auto filename = snapshot_path.filename().string();
+
+  // Verify the filename follows the expected format: YYYYmmddHHMMSSffffff_timestamp_<timestamp>
+  // The format should contain exactly one underscore before "timestamp_"
+  auto timestamp_pos = filename.find("_timestamp_");
+  ASSERT_NE(timestamp_pos, std::string::npos) << "Filename should contain '_timestamp_'";
+
+  // Verify there's only one underscore before "timestamp_"
+  auto first_underscore = filename.find('_');
+  ASSERT_EQ(first_underscore, timestamp_pos) << "Should have only one underscore before 'timestamp_'";
+
+  // Verify the timestamp part is numeric
+  auto timestamp_str = filename.substr(timestamp_pos + 11);  // Skip "_timestamp_"
+  ASSERT_FALSE(timestamp_str.empty()) << "Timestamp should not be empty";
+  ASSERT_TRUE(std::all_of(timestamp_str.begin(), timestamp_str.end(), ::isdigit)) << "Timestamp should be numeric";
+}
+
+TEST_F(CreateSnapshotTest, BackwardCompatibilityWithErrorHandling) {
+  auto config = CreateConfig();
+  memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock> repl_state{
+      memgraph::storage::ReplicationStateRootPath(config)};
+  memgraph::dbms::Database db{config, repl_state};
+
+  auto *mem_storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
+
+  // Test that existing error handling code still works
+  auto result = mem_storage->CreateSnapshot(ReplicationRole::REPLICA);
+
+  // This should work exactly as before - checking for errors
+  if (result.HasError()) {
+    auto error = result.GetError();
+    ASSERT_EQ(error, memgraph::storage::InMemoryStorage::CreateSnapshotError::DisabledForReplica);
+  } else {
+    FAIL() << "Should have returned an error for replica role";
+  }
+}
+
+TEST_F(CreateSnapshotTest, SuccessCaseWithPathRetrieval) {
+  auto config = CreateConfig();
+  memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock> repl_state{
+      memgraph::storage::ReplicationStateRootPath(config)};
+  memgraph::dbms::Database db{config, repl_state};
+
+  auto *mem_storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
+
+  // Create some data
+  {
+    auto acc = mem_storage->Access();
+    auto vertex = acc->CreateVertex();
+    ASSERT_FALSE(acc->PrepareForCommitPhase().HasError());
+  }
+
+  // Test the new functionality - getting the path on success
+  auto result = mem_storage->CreateSnapshot(ReplicationRole::MAIN);
+
+  if (result.HasError()) {
+    FAIL() << "CreateSnapshot should succeed with data present";
+  } else {
+    // New functionality: get the path
+    auto snapshot_path = result.GetValue();
+    ASSERT_TRUE(std::filesystem::exists(snapshot_path));
+
+    // Verify the path is reasonable
+    ASSERT_EQ(snapshot_path.extension(), "");
+    ASSERT_TRUE(snapshot_path.filename().string().find("timestamp_") != std::string::npos);
+  }
+}


### PR DESCRIPTION
`CREATE SNAPSHOT` now returns the path of the created snapshot.
User query also cannot fail because there is no change (snapshot is forced)