### PR TITLE
Fix daily coverage build test

### DIFF
--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -148,7 +148,8 @@ jobs:
           --arch $ARCH \
           --build-type $BUILD_TYPE \
           --threads $THREADS \
-          build-memgraph --coverage --no-ccache
+          --no-ccache \
+          build-memgraph --coverage
 
       - name: Run unit tests
         run: |


### PR DESCRIPTION
The flag `--no-ccache` was put in the wrong place and broke the daily coverage build, now it should work again!

