### PR TITLE
Improve handling of epochs during data recovery

### DIFF
--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -1074,7 +1074,7 @@ void CoordinatorInstance::InstanceFailCallback(std::string_view instance_name,
     spdlog::trace("Cluster without main instance, trying failover.");
     switch (TryFailover()) {
       case FailoverStatus::SUCCESS: {
-        spdlog::trace("Failover successful after failing to promote main instance.");
+        spdlog::trace("Failover successful in the InstanceFailCallback");
         break;
       };
       case FailoverStatus::NO_INSTANCE_ALIVE: {

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -284,7 +284,7 @@ void InMemoryReplicationHandlers::HeartbeatHandler(dbms::DbmsHandler *dbms_handl
   auto const ldt = storage->repl_storage_state_.last_durable_timestamp_.load(std::memory_order_acquire);
 
   auto const last_epoch_with_commit = std::invoke([storage, ldt]() -> std::string {
-    if (auto &history = storage->repl_storage_state_.history; !history.empty()) {
+    if (auto const &history = storage->repl_storage_state_.history; !history.empty()) {
       auto [history_epoch, history_ldt] = history.back();
       return history_ldt != ldt ? std::string{storage->repl_storage_state_.epoch_.id()} : history_epoch;
     }

--- a/src/replication/include/replication/state.hpp
+++ b/src/replication/include/replication/state.hpp
@@ -43,7 +43,7 @@ struct RoleMainData {
   RoleMainData(RoleMainData &&) = default;
   RoleMainData &operator=(RoleMainData &&) = default;
 
-  std::list<ReplicationClient> registered_replicas_{};
+  std::list<ReplicationClient> registered_replicas_;
   utils::UUID uuid_;  // also used in ReplicationStorageClient but important thing is that at both places, the value is
   // immutable.
   bool writing_enabled_{false};

--- a/src/replication_handler/replication_handler.cpp
+++ b/src/replication_handler/replication_handler.cpp
@@ -285,6 +285,7 @@ bool ReplicationHandler::DoToMainPromotion(const utils::UUID &main_uuid, bool co
 
     // All DBs should have the same epoch
     auto const new_epoch = ReplicationEpoch();
+    spdlog::trace("Generated new epoch {}", new_epoch.id());
 
     // STEP 3) We are now MAIN, update storage local epoch
     dbms_handler_.ForEach([&](dbms::DatabaseAccess db_acc) {

--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -601,10 +601,6 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
     auto last_loaded_timestamp = snapshot_durable_timestamp;
     spdlog::info("Trying to load WAL files.");
 
-    if (last_loaded_timestamp) {
-      epoch_history->emplace_back(repl_storage_state.epoch_.id(), *last_loaded_timestamp);
-    }
-
     for (const auto &wal_file : wal_files) {
       if (previous_seq_num && (wal_file.seq_num - *previous_seq_num) > 1) {
         LOG_FATAL("You are missing a WAL file with the sequence number {}!", *previous_seq_num + 1);

--- a/src/storage/v2/replication/rpc.hpp
+++ b/src/storage/v2/replication/rpc.hpp
@@ -128,7 +128,7 @@ struct HeartbeatRes {
   static void Load(HeartbeatRes *self, memgraph::slk::Reader *reader);
   static void Save(const HeartbeatRes &self, memgraph::slk::Builder *builder);
   HeartbeatRes() = default;
-  HeartbeatRes(bool success, uint64_t current_commit_timestamp, std::string epoch_id)
+  HeartbeatRes(bool const success, uint64_t const current_commit_timestamp, std::string epoch_id)
       : success(success), current_commit_timestamp(current_commit_timestamp), epoch_id(std::move(epoch_id)) {}
 
   bool success;


### PR DESCRIPTION
When recovering from snapshot, there is no need to modify epoch history with the epoch from snapshot since this will modify history's state compared to the moment when snapshot is being taken.
There was a bug in one of the previous PR's in which epochs and ldt from wal would update the state even if there was no change made in that WAL (all txns were aborted). 