### PR TITLE
feat: Speed up demote process upon failover

### DIFF
--- a/src/coordination/coordinator_rpc.cpp
+++ b/src/coordination/coordinator_rpc.cpp
@@ -188,11 +188,11 @@ void Load(memgraph::coordination::PromoteToMainReq *self, memgraph::slk::Reader 
 
 // DemoteMainToReplicaRpc
 void Save(const memgraph::coordination::DemoteMainToReplicaReq &self, memgraph::slk::Builder *builder) {
-  memgraph::slk::Save(self.replication_client_info, builder);
+  memgraph::slk::Save(self.replication_client_info_, builder);
 }
 
 void Load(memgraph::coordination::DemoteMainToReplicaReq *self, memgraph::slk::Reader *reader) {
-  memgraph::slk::Load(&self->replication_client_info, reader);
+  memgraph::slk::Load(&self->replication_client_info_, reader);
 }
 
 void Save(const memgraph::coordination::DemoteMainToReplicaRes &self, memgraph::slk::Builder *builder) {

--- a/src/coordination/data_instance_management_server_handlers.cpp
+++ b/src/coordination/data_instance_management_server_handlers.cpp
@@ -214,9 +214,9 @@ void DataInstanceManagementServerHandlers::DemoteMainToReplicaHandler(
 
   // Use localhost as ip for creating ReplicationServer
   const replication::ReplicationServerConfig clients_config{
-      .repl_server = io::network::Endpoint("0.0.0.0", req.replication_client_info.replication_server.GetPort())};
+      .repl_server = io::network::Endpoint("0.0.0.0", req.replication_client_info_.replication_server.GetPort())};
 
-  if (!replication_handler.SetReplicationRoleReplica(clients_config)) {
+  if (!replication_handler.SetReplicationRoleReplica(clients_config, req.main_uuid_)) {
     spdlog::error("Demoting main to replica failed.");
     coordination::DemoteMainToReplicaRes const rpc_res{false};
     rpc::SendFinalResponse(rpc_res, request_version, res_builder);

--- a/src/coordination/include/coordination/coordinator_rpc.hpp
+++ b/src/coordination/include/coordination/coordinator_rpc.hpp
@@ -96,12 +96,16 @@ struct DemoteMainToReplicaReq {
   static void Load(DemoteMainToReplicaReq *self, memgraph::slk::Reader *reader);
   static void Save(const DemoteMainToReplicaReq &self, memgraph::slk::Builder *builder);
 
-  explicit DemoteMainToReplicaReq(ReplicationClientInfo replication_client_info)
-      : replication_client_info(std::move(replication_client_info)) {}
+  // main uuid is provided when Demote is called from InstanceSuccessCallback because at that point we already know
+  // what's next main uuid since the failover has already been done
+  explicit DemoteMainToReplicaReq(ReplicationClientInfo replication_client_info,
+                                  std::optional<utils::UUID> const &main_uuid = std::nullopt)
+      : replication_client_info_(std::move(replication_client_info)), main_uuid_(main_uuid) {}
 
   DemoteMainToReplicaReq() = default;
 
-  ReplicationClientInfo replication_client_info;
+  ReplicationClientInfo replication_client_info_;
+  std::optional<utils::UUID> main_uuid_;
 };
 
 struct DemoteMainToReplicaRes {

--- a/src/coordination/include/coordination/replication_instance_client.hpp
+++ b/src/coordination/include/coordination/replication_instance_client.hpp
@@ -88,6 +88,9 @@ class ReplicationInstanceClient {
   auto SendRpc(Args &&...args) const -> bool {
     utils::MetricsTimer const timer{RpcInfo<T>::timerLabel};
     try {
+      // Instead of retrieving config_.replication_client_info and sending it again into this function, we have this
+      // compile-time switch which decides specifically to ship config_.replication_client_info for
+      // DemoteMainToReplicaRpc
       auto stream = std::invoke([&]() {
         if constexpr (std::same_as<T, DemoteMainToReplicaRpc>) {
           return rpc_client_.Stream<T>(config_.replication_client_info, std::forward<Args>(args)...);

--- a/src/query/replication_query_handler.hpp
+++ b/src/query/replication_query_handler.hpp
@@ -94,7 +94,8 @@ struct ReplicationQueryHandler {
   virtual bool SetReplicationRoleMain() = 0;
 
   // as MAIN, become REPLICA
-  virtual bool SetReplicationRoleReplica(const replication::ReplicationServerConfig &config) = 0;
+  virtual bool SetReplicationRoleReplica(const replication::ReplicationServerConfig &config,
+                                         std::optional<utils::UUID> const &maybe_main_uuid) = 0;
 
   virtual bool TrySetReplicationRoleReplica(const replication::ReplicationServerConfig &config) = 0;
 

--- a/src/replication/include/replication/state.hpp
+++ b/src/replication/include/replication/state.hpp
@@ -131,7 +131,8 @@ struct ReplicationState {
   utils::BasicResult<RegisterReplicaStatus, ReplicationClient *> RegisterReplica(const ReplicationClientConfig &config);
 
   bool SetReplicationRoleMain(const utils::UUID &main_uuid);
-  bool SetReplicationRoleReplica(const ReplicationServerConfig &config);
+  bool SetReplicationRoleReplica(const ReplicationServerConfig &config,
+                                 std::optional<utils::UUID> const &maybe_main_uuid);
 
  private:
   bool HandleVersionMigration(durability::ReplicationRoleEntry &data) const;

--- a/src/replication/state.cpp
+++ b/src/replication/state.cpp
@@ -284,10 +284,16 @@ bool ReplicationState::SetReplicationRoleMain(const utils::UUID &main_uuid) {
   return true;
 }
 
-bool ReplicationState::SetReplicationRoleReplica(const ReplicationServerConfig &config) {
+bool ReplicationState::SetReplicationRoleReplica(const ReplicationServerConfig &config,
+                                                 std::optional<utils::UUID> const &maybe_main_uuid) {
   // False positive report for the std::make_unique
-  // Random UUID when first setting replica rol
-  auto const main_uuid = utils::UUID{};
+  // Random UUID when first setting replica role if main_uuid not provided already
+  auto const main_uuid = std::invoke([&maybe_main_uuid]() -> utils::UUID {
+    if (maybe_main_uuid.has_value()) {
+      return *maybe_main_uuid;
+    }
+    return utils::UUID{};
+  });
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
   if (!TryPersistRoleReplica(config, main_uuid)) {
     return false;

--- a/src/replication_handler/include/replication_handler/replication_handler.hpp
+++ b/src/replication_handler/include/replication_handler/replication_handler.hpp
@@ -130,7 +130,8 @@ struct ReplicationHandler : public query::ReplicationQueryHandler {
   bool SetReplicationRoleMain() override;
 
   // as MAIN, become REPLICA, can be called on MAIN and REPLICA
-  bool SetReplicationRoleReplica(const ReplicationServerConfig &config) override;
+  bool SetReplicationRoleReplica(const ReplicationServerConfig &config,
+                                 std::optional<utils::UUID> const &maybe_main_uuid) override;
 
   // as MAIN, become REPLICA, can be called only on MAIN
   bool TrySetReplicationRoleReplica(const ReplicationServerConfig &config) override;
@@ -298,7 +299,8 @@ struct ReplicationHandler : public query::ReplicationQueryHandler {
   }
 
   template <bool AllowIdempotency>
-  bool SetReplicationRoleReplica_(auto &locked_repl_state, const ReplicationServerConfig &config) {
+  bool SetReplicationRoleReplica_(auto &locked_repl_state, const ReplicationServerConfig &config,
+                                  std::optional<utils::UUID> const &maybe_main_uuid = std::nullopt) {
     if (locked_repl_state->IsReplica()) {
       if (!AllowIdempotency) {
         return false;
@@ -308,7 +310,7 @@ struct ReplicationHandler : public query::ReplicationQueryHandler {
       if (replica_data.config == config) {
         return true;
       }
-      locked_repl_state->SetReplicationRoleReplica(config);
+      locked_repl_state->SetReplicationRoleReplica(config, maybe_main_uuid);
 #ifdef MG_ENTERPRISE
       return StartRpcServer(dbms_handler_, replica_data, auth_, system_);
 #else
@@ -319,7 +321,7 @@ struct ReplicationHandler : public query::ReplicationQueryHandler {
     // Shutdown any clients we might have had
     ClientsShutdown(locked_repl_state);
     // Creates the server
-    locked_repl_state->SetReplicationRoleReplica(config);
+    locked_repl_state->SetReplicationRoleReplica(config, maybe_main_uuid);
     spdlog::trace("Role set to replica, instance-level clients destroyed.");
 
     // Start

--- a/src/replication_handler/replication_handler.cpp
+++ b/src/replication_handler/replication_handler.cpp
@@ -196,7 +196,8 @@ ReplicationHandler::ReplicationHandler(utils::Synchronized<ReplicationState, uti
 
 bool ReplicationHandler::SetReplicationRoleMain() { return DoToMainPromotion({}, false); }
 
-bool ReplicationHandler::SetReplicationRoleReplica(const ReplicationServerConfig &config) {
+bool ReplicationHandler::SetReplicationRoleReplica(const ReplicationServerConfig &config,
+                                                   std::optional<utils::UUID> const &maybe_main_uuid) {
   try {
     auto locked_repl_state = repl_state_.TryLock();
 
@@ -233,7 +234,7 @@ bool ReplicationHandler::SetReplicationRoleReplica(const ReplicationServerConfig
       });
     }
 
-    return SetReplicationRoleReplica_<true>(locked_repl_state, config);
+    return SetReplicationRoleReplica_<true>(locked_repl_state, config, maybe_main_uuid);
   } catch (const utils::TryLockException & /* unused */) {
     return false;
   }


### PR DESCRIPTION
Instead of waiting for swap main uuid, old main can start listening new main faster with a single RPC call. 