### PR TITLE
[Temporary] Try to isolate headers in v6 toolchain builds

### DIFF
--- a/environment/toolchain/v6/build.sh
+++ b/environment/toolchain/v6/build.sh
@@ -687,7 +687,12 @@ export ORIG_CFLAGS=\$CFLAGS
 export PATH=\$PREFIX:\$PREFIX/bin:\$PATH
 export PS1="($NAME) \$PS1"
 export LD_LIBRARY_PATH=\$PREFIX/lib:\$PREFIX/lib64
-export CXXFLAGS="-isystem \$PREFIX/include  \$CXXFLAGS"
+case "\$(uname -m)" in
+    x86_64) TARGET_TRIPLET="x86_64-linux-gnu" ;;
+    aarch64) TARGET_TRIPLET="aarch64-linux-gnu" ;;
+    *) TARGET_TRIPLET="\$(uname -m)-linux-gnu" ;;
+esac
+export CXXFLAGS="-nostdinc -nostdinc++ -isystem \$PREFIX/include/c++/14.2.0 -isystem \$PREFIX/include/c++/14.2.0/\$TARGET_TRIPLET -isystem \$PREFIX/include \$CXXFLAGS"
 export CFLAGS="-isystem \$PREFIX/include \$CFLAGS"
 export MG_TOOLCHAIN_ROOT=\$PREFIX
 export MG_TOOLCHAIN_VERSION=$TOOLCHAIN_VERSION


### PR DESCRIPTION
Investigation into fixing header isolation with mgcxx rust lib.

---
__*Leave above in PR description, copy the below into a comment*__
___

### Tracking
- [ ] **[Link to Epic/Issue]**

### Standard development
- [ ] Update unit/E2E tests
- [ ] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch this branch

### CI Testing Labels
- [ ] Select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_

### Documentation checklist
- [ ] Add the documentation label
- [ ] Add the bug / feature label
- [ ] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - What has changed? What does it mean for a user? What should a user do with it? [#{{PR_number}}]({{link to the PR}})
- [ ] **[ Documentation PR link memgraph/documentation#XXXX ]**
    - [ ] Is back linked to this development PR
