### PR TITLE
Do not update existing RPM packages in mgbuild container

### DIFF
--- a/environment/os/centos-9.sh
+++ b/environment/os/centos-9.sh
@@ -156,7 +156,6 @@ install() {
 
     # --nobest is used because of libipt because we install custom versions
     # because libipt-devel is not available on CentOS 9 Stream
-    dnf update -y --nobest
     dnf install -y wget git python3 python3-pip
     dnf config-manager --set-enabled crb
 

--- a/environment/os/fedora-41.sh
+++ b/environment/os/fedora-41.sh
@@ -151,9 +151,6 @@ install() {
         echo "NOTE: export LANG=en_US.utf8"
     fi
 
-    # Update package lists first
-    dnf update -y
-
     # Separate standard and custom packages
     local standard_packages=()
     local custom_packages=()

--- a/environment/os/fedora-42.sh
+++ b/environment/os/fedora-42.sh
@@ -155,7 +155,6 @@ install() {
         echo "NOTE: export LANG=en_US.utf8"
     fi
 
-    dnf update -y
     dnf install -y wget git python3 python3-pip
 
     # Separate standard and custom packages

--- a/environment/os/rocky-10.sh
+++ b/environment/os/rocky-10.sh
@@ -171,8 +171,6 @@ install() {
     dnf config-manager --set-enabled crb
     dnf config-manager --set-enabled devel
     sudo dnf install -y epel-release
-
-    dnf update -y
     dnf install -y wget git python3 python3-pip
 
     # Separate standard and custom packages

--- a/environment/os/rocky-9.sh
+++ b/environment/os/rocky-9.sh
@@ -175,12 +175,6 @@ install() {
     dnf config-manager --set-enabled crb
     dnf config-manager --set-enabled devel
     sudo dnf install -y epel-release
-
-
-    # Try to install SBCL from standard repositories first
-    # If not available, we'll handle it in the custom package logic
-
-    dnf update -y
     dnf install -y wget git python3 python3-pip
 
     # Separate standard and custom packages


### PR DESCRIPTION
Do not update existing RPM packages in mgbuild container as some updates to system packages can cause CI to fail unexpectedly.

