### PR TITLE
Add more accurate way to get number of logical CPU cores

### DIFF
--- a/src/communication/server.hpp
+++ b/src/communication/server.hpp
@@ -26,6 +26,7 @@
 #include "io/network/socket.hpp"
 #include "utils/logging.hpp"
 #include "utils/message.hpp"
+#include "utils/sysinfo/cpuinfo.hpp"
 #include "utils/thread.hpp"
 
 namespace memgraph::communication {
@@ -61,7 +62,7 @@ class Server final {
    */
   Server(io::network::Endpoint endpoint, TSessionContext *session_context, ServerContext *context,
          int inactivity_timeout_sec, const std::string &service_name,
-         size_t workers_count = std::thread::hardware_concurrency())
+         size_t workers_count = memgraph::utils::sysinfo::LogicalCPUCores().value_or(1U))
       : alive_(false),
         endpoint_(std::move(endpoint)),
         listener_(session_context, context, inactivity_timeout_sec, service_name, workers_count),

--- a/src/flags/bolt.cpp
+++ b/src/flags/bolt.cpp
@@ -16,6 +16,7 @@
 
 #include "spdlog/spdlog.h"
 #include "utils/flag_validation.hpp"
+#include "utils/sysinfo/cpuinfo.hpp"
 
 // Bolt server flags.
 DEFINE_string(bolt_address, "0.0.0.0", "IP address on which the Bolt server should listen.");
@@ -24,7 +25,7 @@ DEFINE_VALIDATED_int32(bolt_port, 7687, "Port on which the Bolt server should li
                        FLAG_IN_RANGE(0, std::numeric_limits<uint16_t>::max()));
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_VALIDATED_int32(bolt_num_workers, std::max(std::thread::hardware_concurrency(), 1U),
+DEFINE_VALIDATED_int32(bolt_num_workers, memgraph::utils::sysinfo::LogicalCPUCores().value_or(1U),
                        "Number of workers used by the Bolt server. By default, this will be the "
                        "number of processing units available on the machine.",
                        FLAG_IN_RANGE(1, INT32_MAX));

--- a/src/flags/general.cpp
+++ b/src/flags/general.cpp
@@ -15,6 +15,7 @@
 #include "utils/file.hpp"
 #include "utils/flag_validation.hpp"
 #include "utils/string.hpp"
+#include "utils/sysinfo/cpuinfo.hpp"
 
 #include <iostream>
 #include <thread>
@@ -118,13 +119,13 @@ DEFINE_bool(storage_parallel_snapshot_creation, false,
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_uint64(storage_snapshot_thread_count,
-              std::max(static_cast<uint64_t>(std::thread::hardware_concurrency()),
+              std::max(memgraph::utils::sysinfo::LogicalCPUCores().value_or(1),
                        memgraph::storage::Config::Durability().snapshot_thread_count),
               "The number of threads used to create snapshots.");
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_uint64(storage_recovery_thread_count,
-              std::max(static_cast<uint64_t>(std::thread::hardware_concurrency()),
+              std::max(memgraph::utils::sysinfo::LogicalCPUCores().value_or(1),
                        memgraph::storage::Config::Durability().recovery_thread_count),
               "The number of threads used to recover persisted data from disk.");
 

--- a/src/rpc/server.hpp
+++ b/src/rpc/server.hpp
@@ -20,6 +20,7 @@
 #include "rpc/messages.hpp"
 #include "rpc/protocol.hpp"
 #include "slk/streams.hpp"
+#include "utils/sysinfo/cpuinfo.hpp"
 #include "utils/typeinfo.hpp"
 
 namespace memgraph::rpc {
@@ -27,7 +28,7 @@ namespace memgraph::rpc {
 class Server {
  public:
   Server(io::network::Endpoint endpoint, communication::ServerContext *context,
-         size_t workers_count = std::thread::hardware_concurrency());
+         size_t workers_count = memgraph::utils::sysinfo::LogicalCPUCores().value_or(1U));
   Server(const Server &) = delete;
   Server(Server &&) = delete;
   Server &operator=(const Server &) = delete;

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(mg-utils
     memory_tracker.cpp
     readable_size.cpp
     signals.cpp
+    sysinfo/cpuinfo.cpp
     sysinfo/memory.cpp
     temporal.cpp
     thread.cpp

--- a/src/utils/priority_thread_pool.cpp
+++ b/src/utils/priority_thread_pool.cpp
@@ -25,6 +25,7 @@
 #include "utils/logging.hpp"
 #include "utils/on_scope_exit.hpp"
 #include "utils/priorities.hpp"
+#include "utils/sysinfo/cpuinfo.hpp"
 #include "utils/thread.hpp"
 #include "utils/yielder.hpp"
 
@@ -177,7 +178,7 @@ void PriorityThreadPool::ScheduledAddTask(TaskSignature new_task, const Priority
     // Limit the number of directly used threads when there are more workers than hw threads.
     // Gives better overall performance.
     static const auto max_wakeup_thread =
-        std::min(static_cast<TaskID>(std::thread::hardware_concurrency()), workers_.size());
+        std::min(static_cast<TaskID>(memgraph::utils::sysinfo::LogicalCPUCores().value_or(1U)), workers_.size());
     // If no hot thread found, give it to the next thread
     tid = last_wid_++ % max_wakeup_thread;
   }

--- a/src/utils/sysinfo/cpuinfo.cpp
+++ b/src/utils/sysinfo/cpuinfo.cpp
@@ -1,0 +1,42 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "utils/sysinfo/cpuinfo.hpp"
+
+#include <fstream>
+#include <string>
+#include <thread>
+
+namespace memgraph::utils::sysinfo {
+
+std::optional<uint64_t> LogicalCPUCores() {
+  const auto logical_cores = static_cast<uint64_t>(std::thread::hardware_concurrency());
+  if (logical_cores != 0) {
+    return logical_cores;
+  }
+
+  std::ifstream cpuinfo("/proc/cpuinfo");
+  if (cpuinfo.is_open()) {
+    uint64_t count = 0;
+    std::string line;
+    while (std::getline(cpuinfo, line)) {
+      if (line.rfind("processor", 0) == 0) {  // starts with "processor"
+        ++count;
+      }
+    }
+    if (count > 0) {
+      return count;
+    }
+  }
+  return std::nullopt;
+}
+
+}  // namespace memgraph::utils::sysinfo

--- a/src/utils/sysinfo/cpuinfo.hpp
+++ b/src/utils/sysinfo/cpuinfo.hpp
@@ -1,0 +1,26 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+namespace memgraph::utils::sysinfo {
+
+/**
+ * Gets the amount of logical CPU cores. If the information is
+ * unavailable an empty value is returned.
+ */
+
+std::optional<uint64_t> LogicalCPUCores();
+
+}  // namespace memgraph::utils::sysinfo


### PR DESCRIPTION
Add a function to detect number of logical CPU cores reading from `/proc/cpuinfo` when `std::thread::hardware_concurrency` returns 0.
