### PR TITLE
Release 3.5 fixes

### DIFF
--- a/.github/actions/docker-login/action.yml
+++ b/.github/actions/docker-login/action.yml
@@ -2,6 +2,12 @@ name: 'Docker Login with Retry'
 description: 'Login to Docker Hub with retry logic for network resilience'
 
 inputs:
+  username:
+    description: 'Docker Hub username'
+    required: true
+  password:
+    description: 'Docker Hub password'
+    required: true
   max-retries:
     description: 'Maximum number of retry attempts'
     required: false
@@ -16,19 +22,33 @@ runs:
   steps:
     - name: Log in to Docker Hub with retry
       shell: bash
+      env:
+        DOCKER_USERNAME: ${{ inputs.username }}
+        DOCKER_PASSWORD: ${{ inputs.password }}
+        MAX_RETRIES: ${{ inputs.max-retries }}
+        RETRY_DELAY: ${{ inputs.retry-delay }}
       run: |
-        for i in $(seq 1 ${{ inputs.max-retries }}); do
-          echo "Attempt $i of ${{ inputs.max-retries }}: Logging in to Docker Hub..."
-          if echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin; then
+        set -euo pipefail
+
+        # Ensure masking even if password wasn’t passed from secrets.*
+        echo "::add-mask::${DOCKER_PASSWORD}"
+
+        # Basic validation (numbers only)
+        [[ "${MAX_RETRIES}" =~ ^[0-9]+$ ]] || { echo "max-retries must be an integer"; exit 2; }
+        [[ "${RETRY_DELAY}" =~ ^[0-9]+$ ]] || { echo "retry-delay must be an integer"; exit 2; }
+
+        for i in $(seq 1 "${MAX_RETRIES}"); do
+          echo "Attempt ${i} of ${MAX_RETRIES}: Logging in to Docker Hub..."
+          if printf '%s' "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin; then
             echo "Successfully logged in to Docker Hub"
             break
           else
-            echo "Failed to log in to Docker Hub (attempt $i)"
-            if [ $i -eq ${{ inputs.max-retries }} ]; then
+            echo "Failed to log in to Docker Hub (attempt ${i})"
+            if [ "${i}" -eq "${MAX_RETRIES}" ]; then
               echo "All attempts failed"
               exit 1
             fi
-            echo "Waiting ${{ inputs.retry-delay }} seconds before retry..."
-            sleep ${{ inputs.retry-delay }}
+            echo "Waiting ${RETRY_DELAY} seconds before retry..."
+            sleep "${RETRY_DELAY}"
           fi
-        done 
+        done

--- a/.github/actions/docker-login/action.yml
+++ b/.github/actions/docker-login/action.yml
@@ -1,0 +1,34 @@
+name: 'Docker Login with Retry'
+description: 'Login to Docker Hub with retry logic for network resilience'
+
+inputs:
+  max-retries:
+    description: 'Maximum number of retry attempts'
+    required: false
+    default: '3'
+  retry-delay:
+    description: 'Delay between retries in seconds'
+    required: false
+    default: '10'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Log in to Docker Hub with retry
+      shell: bash
+      run: |
+        for i in $(seq 1 ${{ inputs.max-retries }}); do
+          echo "Attempt $i of ${{ inputs.max-retries }}: Logging in to Docker Hub..."
+          if echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin; then
+            echo "Successfully logged in to Docker Hub"
+            break
+          else
+            echo "Failed to log in to Docker Hub (attempt $i)"
+            if [ $i -eq ${{ inputs.max-retries }} ]; then
+              echo "All attempts failed"
+              exit 1
+            fi
+            echo "Waiting ${{ inputs.retry-delay }} seconds before retry..."
+            sleep ${{ inputs.retry-delay }}
+          fi
+        done 

--- a/.github/workflows/benchmark_on_pokec_large.yaml
+++ b/.github/workflows/benchmark_on_pokec_large.yaml
@@ -26,10 +26,8 @@ jobs:
             fetch-depth: 0
 
         - name: Log in to Docker Hub
-          uses: docker/login-action@v3
+          uses: ./.github/actions/docker-login
           with:
-            username: ${{ secrets.DOCKERHUB_USERNAME }}
-            password: ${{ secrets.DOCKERHUB_TOKEN }}
 
         - name: Spin up mgbuild container
           run: |

--- a/.github/workflows/benchmark_on_pokec_large.yaml
+++ b/.github/workflows/benchmark_on_pokec_large.yaml
@@ -27,7 +27,6 @@ jobs:
 
         - name: Log in to Docker Hub
           uses: ./.github/actions/docker-login
-          with:
 
         - name: Spin up mgbuild container
           run: |

--- a/.github/workflows/benchmark_on_pokec_large.yaml
+++ b/.github/workflows/benchmark_on_pokec_large.yaml
@@ -27,6 +27,9 @@ jobs:
 
         - name: Log in to Docker Hub
           uses: ./.github/actions/docker-login
+          with:
+            username: ${{ secrets.DOCKERHUB_USERNAME }}
+            password: ${{ secrets.DOCKERHUB_TOKEN }}
 
         - name: Spin up mgbuild container
           run: |

--- a/.github/workflows/build_rc.yml
+++ b/.github/workflows/build_rc.yml
@@ -104,7 +104,7 @@ jobs:
       arch: amd
       threads: 24
       build_type: Release
-      ref: ${{ needs.PrepareReleaseBranch.outputs.branch_name }}
+      ref: ${{ needs.PrepareReleaseBranch.outputs.tag_name }}
     secrets: inherit
 
   StressTestLarge:
@@ -119,6 +119,7 @@ jobs:
       build_type: Release
       run_stress_large: 'true'
       run_release_tests: 'false'
+      ref: ${{ needs.PrepareReleaseBranch.outputs.tag_name }}
     secrets: inherit
 
   PackageArtifact:
@@ -166,9 +167,9 @@ jobs:
       push_to_s3: 'true'
       s3_bucket: deps.memgraph.io
       s3_region: eu-west-1
-      s3_dest_dir: "memgraph/${{ github.ref_name }}"
+      s3_dest_dir: "memgraph/${{ needs.PrepareReleaseBranch.outputs.tag_name }}"
       additional_build_args: ${{ matrix.additional_build_args }}
-      ref: ${{ needs.PrepareReleaseBranch.outputs.branch_name }}
+      ref: ${{ needs.PrepareReleaseBranch.outputs.tag_name }}
     secrets: inherit
 
   DockerArtifact:
@@ -191,8 +192,8 @@ jobs:
       push_to_s3: 'true'
       s3_bucket: deps.memgraph.io
       s3_region: eu-west-1
-      s3_dest_dir: "memgraph/${{ github.ref_name }}"
-      ref: ${{ needs.PrepareReleaseBranch.outputs.branch_name }}
+      s3_dest_dir: "memgraph/${{ needs.PrepareReleaseBranch.outputs.tag_name }}"
+      ref: ${{ needs.PrepareReleaseBranch.outputs.tag_name }}
     secrets: inherit
 
   TriggerMAGEBuild:
@@ -205,7 +206,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ needs.PrepareReleaseBranch.outputs.branch_name }}
+          ref: ${{ needs.PrepareReleaseBranch.outputs.tag_name }}
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/build_rc.yml
+++ b/.github/workflows/build_rc.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Set Memgraph Override Version
         run: |
-          sed -i "s/set(MEMGRAPH_OVERRIDE_VERSION \"\")/set(MEMGRAPH_OVERRIDE_VERSION \"${{ inputs.release_version }}\")/" CMakeLists.txt
+          sed -i "s/set(MEMGRAPH_OVERRIDE_VERSION \"\")/set(MEMGRAPH_OVERRIDE_VERSION \"${{ inputs.version }}\")/" CMakeLists.txt
           git add CMakeLists.txt
           # this will fail if there are no changes, but we don't care
           git commit -m "Update CMakeLists.txt with new memgraph override version [skip tests] [skip build]" || true

--- a/.github/workflows/build_rc.yml
+++ b/.github/workflows/build_rc.yml
@@ -199,7 +199,7 @@ jobs:
   TriggerMAGEBuild:
     name: Trigger MAGE Build
     needs: [PrepareReleaseBranch, PackageArtifact]
-    if: ${{ inputs.build_mage }}
+    if: ${{ inputs.build_mage && always() }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code

--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -25,10 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |

--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -26,6 +26,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |

--- a/.github/workflows/diff_community.yaml
+++ b/.github/workflows/diff_community.yaml
@@ -45,10 +45,7 @@ jobs:
           fetch-depth: 0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |

--- a/.github/workflows/diff_community.yaml
+++ b/.github/workflows/diff_community.yaml
@@ -46,6 +46,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |

--- a/.github/workflows/diff_coverage.yaml
+++ b/.github/workflows/diff_coverage.yaml
@@ -49,10 +49,7 @@ jobs:
           fetch-depth: 0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |
@@ -155,10 +152,7 @@ jobs:
           fetch-depth: 0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |
@@ -219,10 +213,7 @@ jobs:
           fetch-depth: 0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |

--- a/.github/workflows/diff_coverage.yaml
+++ b/.github/workflows/diff_coverage.yaml
@@ -50,6 +50,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |
@@ -153,6 +156,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |
@@ -214,6 +220,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |

--- a/.github/workflows/diff_debug.yaml
+++ b/.github/workflows/diff_debug.yaml
@@ -50,6 +50,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |
@@ -145,6 +148,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |

--- a/.github/workflows/diff_debug.yaml
+++ b/.github/workflows/diff_debug.yaml
@@ -49,10 +49,7 @@ jobs:
           fetch-depth: 0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |
@@ -147,10 +144,7 @@ jobs:
           fetch-depth: 0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |

--- a/.github/workflows/diff_jepsen.yaml
+++ b/.github/workflows/diff_jepsen.yaml
@@ -34,6 +34,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Refresh Jepsen Cluster
         run: |

--- a/.github/workflows/diff_jepsen.yaml
+++ b/.github/workflows/diff_jepsen.yaml
@@ -33,10 +33,7 @@ jobs:
           fetch-depth: 0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Refresh Jepsen Cluster
         run: |

--- a/.github/workflows/diff_malloc.yaml
+++ b/.github/workflows/diff_malloc.yaml
@@ -44,10 +44,7 @@ jobs:
           fetch-depth: 0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |

--- a/.github/workflows/diff_malloc.yaml
+++ b/.github/workflows/diff_malloc.yaml
@@ -45,6 +45,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -60,10 +60,7 @@ jobs:
           fetch-depth: 0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |
@@ -172,10 +169,7 @@ jobs:
           fetch-depth: 0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |
@@ -274,10 +268,7 @@ jobs:
           fetch-depth: 0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |
@@ -363,10 +354,7 @@ jobs:
           fetch-depth: 0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |
@@ -446,10 +434,7 @@ jobs:
           fetch-depth: 0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -61,6 +61,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |
@@ -170,6 +173,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |
@@ -269,6 +275,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |
@@ -355,6 +364,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |
@@ -435,6 +447,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |

--- a/.github/workflows/release_mgbench_client.yaml
+++ b/.github/workflows/release_mgbench_client.yaml
@@ -88,6 +88,9 @@ jobs:
       - name: Log in to Docker Hub
         if: ${{ inputs.push_to_dockerhub }}
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Create and push multi-arch manifest for version
         run: |

--- a/.github/workflows/release_mgbench_client.yaml
+++ b/.github/workflows/release_mgbench_client.yaml
@@ -87,10 +87,7 @@ jobs:
     steps:
       - name: Log in to Docker Hub
         if: ${{ inputs.push_to_dockerhub }}
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Create and push multi-arch manifest for version
         run: |

--- a/.github/workflows/reusable_package.yaml
+++ b/.github/workflows/reusable_package.yaml
@@ -80,10 +80,7 @@ jobs:
         run: security -v unlock-keychain -p ${{ secrets.SELF_HOSTED_RUNNER_PASSWORD }} ~/Library/Keychains/login.keychain-db
 
       - name: "Log in to Docker Hub"
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: "Set artifact name and dir"
         run: |

--- a/.github/workflows/reusable_package.yaml
+++ b/.github/workflows/reusable_package.yaml
@@ -81,6 +81,9 @@ jobs:
 
       - name: "Log in to Docker Hub"
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: "Set artifact name and dir"
         run: |

--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -67,10 +67,7 @@ jobs:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |
@@ -126,10 +123,7 @@ jobs:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |
@@ -203,10 +197,7 @@ jobs:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |
@@ -301,10 +292,7 @@ jobs:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |
@@ -359,10 +347,7 @@ jobs:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |
@@ -448,10 +433,7 @@ jobs:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |
@@ -545,10 +527,7 @@ jobs:
           ref:  ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |
@@ -621,10 +600,7 @@ jobs:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |
@@ -696,10 +672,7 @@ jobs:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |
@@ -782,10 +755,7 @@ jobs:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Set Jepsen OS
         run: echo "OS=debian-12" >> $GITHUB_ENV
@@ -895,10 +865,7 @@ jobs:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |
@@ -951,10 +918,7 @@ jobs:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Spin up mgbuild container
         run: |

--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -439,7 +439,7 @@ jobs:
     name: "Release build"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
     timeout-minutes: 60
-
+    if: ${{ inputs.run_stress_large == 'false' }}
     steps:
       - name: Set up repository
         uses: actions/checkout@v4

--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -68,6 +68,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |
@@ -124,6 +127,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |
@@ -198,6 +204,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |
@@ -293,6 +302,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |
@@ -348,6 +360,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |
@@ -434,6 +449,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |
@@ -528,6 +546,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |
@@ -601,6 +622,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |
@@ -673,6 +697,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |
@@ -756,6 +783,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set Jepsen OS
         run: echo "OS=debian-12" >> $GITHUB_ENV
@@ -866,6 +896,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |
@@ -919,6 +952,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Spin up mgbuild container
         run: |

--- a/.github/workflows/reusable_stress_jepsen.yaml
+++ b/.github/workflows/reusable_stress_jepsen.yaml
@@ -44,6 +44,9 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set Cluster File
         run: |

--- a/.github/workflows/reusable_stress_jepsen.yaml
+++ b/.github/workflows/reusable_stress_jepsen.yaml
@@ -43,10 +43,7 @@ jobs:
           fetch-depth: 0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/docker-login
 
       - name: Set Cluster File
         run: |

--- a/src/py/py.hpp
+++ b/src/py/py.hpp
@@ -27,6 +27,11 @@
 #error "Minimum supported Python API is 3.5"
 #endif
 
+// Python 3.9 compatibility macro
+#ifndef Py_Is
+#define Py_Is(x, y) ((x) == (y))
+#endif
+
 #include "utils/logging.hpp"
 
 namespace memgraph::py {


### PR DESCRIPTION
Fixes for the `3.5.0` release of Memgraph:
- Added action to login to Dockerhub in workflows with a retry mechanism
- Some minor fixes to the build RC workflow
- `Py_Is` macro for builds which use Python `<3.10` (CentOS 9 and Debian 11, currently)
