### PR TITLE
Support `OR` label filters alongside label `MATCH`

### DIFF
--- a/src/query/plan/preprocess.cpp
+++ b/src/query/plan/preprocess.cpp
@@ -308,7 +308,7 @@ void Filters::EraseLabelFilter(const Symbol &symbol, const LabelIx &label, std::
     }
     filter_it->labels.erase(label_it);
     DMG_ASSERT(!utils::Contains(filter_it->labels, label), "Didn't expect duplicated labels");
-    if (filter_it->labels.empty()) {
+    if (filter_it->labels.empty() && filter_it->or_labels.empty()) {
       // If there are no labels to filter, then erase the whole FilterInfo.
       if (removed_filters) {
         removed_filters->push_back(filter_it->expression);
@@ -339,7 +339,7 @@ void Filters::EraseOrLabelFilter(const Symbol &symbol, const std::vector<LabelIx
     }
     filter_it->or_labels.erase(label_vec_it);
     DMG_ASSERT(!utils::Contains(filter_it->or_labels, labels), "Didn't expect duplicated labels");
-    if (filter_it->or_labels.empty()) {
+    if (filter_it->or_labels.empty() && filter_it->labels.empty()) {
       // If there are no labels to filter, then erase the whole FilterInfo.
       if (removed_filters) {
         removed_filters->push_back(filter_it->expression);

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1467,7 +1467,7 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
                                                         std::move(found_index->properties), std::move(expr_ranges),
                                                         view);
     }
-    if (!labels.empty()) {
+    if (!labels.empty() && or_labels.empty()) {
       auto maybe_label = FindBestLabelIndex(labels);
       if (maybe_label) {
         const auto &label = *maybe_label;

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1478,7 +1478,8 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
           return std::make_unique<ScanAllByLabel>(input, node_symbol, GetLabel(label), view);
         }
       }
-    } else if (!or_labels.empty()) {
+    }
+    if (!or_labels.empty()) {
       auto best_group = FindBestIndexGroup(node_symbol, bound_symbols, or_labels);
       // If we satisfy max_vertex_count and if there is a group for which we can find an index let's use it and chain it
       // in unions

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1467,7 +1467,7 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
                                                         std::move(found_index->properties), std::move(expr_ranges),
                                                         view);
     }
-    if (!labels.empty() && or_labels.empty()) {
+    if (!labels.empty()) {
       auto maybe_label = FindBestLabelIndex(labels);
       if (maybe_label) {
         const auto &label = *maybe_label;
@@ -1478,8 +1478,7 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
           return std::make_unique<ScanAllByLabel>(input, node_symbol, GetLabel(label), view);
         }
       }
-    }
-    if (!or_labels.empty()) {
+    } else if (!or_labels.empty()) {
       auto best_group = FindBestIndexGroup(node_symbol, bound_symbols, or_labels);
       // If we satisfy max_vertex_count and if there is a group for which we can find an index let's use it and chain it
       // in unions

--- a/tests/gql_behave/tests/memgraph_V1/features/match.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/match.feature
@@ -925,3 +925,56 @@ Feature: Match
             MERGE (n:Label1|Label2) RETURN n;
             """
         Then an error should be raised
+
+    Scenario: Using OR expression with label index MATCH
+        Given an empty graph
+        And with new index :A
+        And with new index :B
+        And with new index :C
+        And having executed
+            """
+            CREATE (:A:B), (:A:C), (:A), (:D);
+            """
+        When executing query:
+            """
+            MATCH (n:A) WHERE (n:B OR n:C) RETURN n;
+            """
+        Then the result should be:
+            | n      |
+            | (:A:C) |
+            | (:A:B) |
+
+    Scenario: Using OR expression with mixed indexed and non-indexed labels
+        Given an empty graph
+        And with new index :A
+        And with new index :B
+        And having executed
+            """
+            CREATE (:A:B), (:A:Z), (:A), (:C);
+            """
+        When executing query:
+            """
+            MATCH (n:A) WHERE (n:B OR n:Z) RETURN n;
+            """
+        Then the result should be:
+            | n      |
+            | (:A:B) |
+            | (:A:Z) |
+
+    Scenario: Using OR expression with label index and prop filter
+        Given an empty graph
+        And with new index :A
+        And with new index :B
+        And with new index :C
+        And having executed
+            """
+            CREATE (:A:B {prop: 1}), (:A:C {prop: 2}), (:A:B {prop: 3}), (:A), (:D);
+            """
+        When executing query:
+            """
+            MATCH (n:A) WHERE (n:B OR n:C) AND n.prop > 1 RETURN n;
+            """
+        Then the result should be:
+            | n                |
+            | (:A:C {prop: 2}) |
+            | (:A:B {prop: 3}) |


### PR DESCRIPTION
This fixes an issue where OR label filter expressions would produce incorrect results when we have both `MATCH (:L1)` and `WHERE (:L2 OR :L3)` in the same query. For example:

```cypher
CREATE INDEX ON :A;
CREATE INDEX ON :B;
CREATE INDEX ON :C
CREATE (:A:B);
CREATE (:A:C);
CREATE (:A)

MATCH (n:A)
WHERE (n:B OR n:C)
RETURN n;
```

Would return:
```
+--------+
| n      |
+--------+
| (:A:C) |
| (:A:B) |
| (:A)   |
+--------+
```

instead of the expected:
```
+--------+
| n      |
+--------+
| (:A:C) |
| (:A:B) |
+--------+
```

Also adds some additional tests for edges cases with OR expressions.

Closes #3236
