### PR TITLE
Fix workflow used by daily and RC builds

### DIFF
--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -479,7 +479,7 @@ jobs:
     name: "Release build"
     runs-on: [self-hosted, DockerMgBuild, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
     timeout-minutes: 60
-    if: ${{ inputs.run_stress_large == 'false' }}
+    if: ${{ inputs.run_release_tests == 'true' }}
     steps:
       - name: Set up repository
         uses: actions/checkout@v4


### PR DESCRIPTION
A bug in the `release_build_tests` workflow introduced by #3213 to fix an accidental duplicate run of the "Release Build" job means that this jobs does not run at all on the daily build. This should address that problem.
