### PR TITLE
Extra logging while waiting for server in GQL behave tests

### DIFF
--- a/tests/gql_behave/continuous_integration
+++ b/tests/gql_behave/continuous_integration
@@ -37,20 +37,22 @@ def wait_for_server(port, process, delay=0.01):
     while subprocess.call(cmd) != 0:
         time.sleep(0.01)
         if count > 20 / 0.01:
-            print("Could not wait for server on port", port, "to startup!")
+            print("Could not wait for server on port", port, "to startup!", flush=True)
             
             # Check if the process is still running
-            print("Memgraph PID: ", process.pid)
+            print("Memgraph PID: ", process.pid, flush=True)
             exit_code = process.poll()
             if exit_code is None:
-                print("Process is still running but server is not responding")
+                print("Process is still running but server is not responding", flush=True)
             else:
-                print(f"Process has exited with code: {exit_code}")
+                print(f"Process has exited with code: {exit_code}", flush=True)
             
+            sys.stdout.flush()
+            sys.stderr.flush()
             sys.exit(1)
         count += 1
 
-    print(f"Memgraph started in {count*0.01} seconds")
+    print(f"Memgraph started in {count*0.01} seconds", flush=True)
     time.sleep(delay)
 
 

--- a/tests/gql_behave/continuous_integration
+++ b/tests/gql_behave/continuous_integration
@@ -31,13 +31,22 @@ BUILD_DIR = os.path.join(BASE_DIR, "build")
 LOG_LEVEL = "TRACE"
 
 
-def wait_for_server(port, delay=0.01):
+def wait_for_server(port, process, delay=0.01):
     cmd = ["nc", "-z", "-w", "1", "127.0.0.1", str(port)]
     count = 0
     while subprocess.call(cmd) != 0:
         time.sleep(0.01)
         if count > 20 / 0.01:
             print("Could not wait for server on port", port, "to startup!")
+            
+            # Check if the process is still running
+            print("Memgraph PID: ", process.pid)
+            exit_code = process.poll()
+            if exit_code is None:
+                print("Process is still running but server is not responding")
+            else:
+                print(f"Process has exited with code: {exit_code}")
+            
             sys.exit(1)
         count += 1
     time.sleep(delay)
@@ -119,7 +128,7 @@ class MemgraphRunner:
             "--experimental-enabled=text-search",
         ]
         self.proc_mg = subprocess.Popen(args_mg + self.args)
-        wait_for_server(7687, 1)
+        wait_for_server(7687, self.proc_mg, 1)
         assert self.is_running(), "The Memgraph process died!"
 
     def is_running(self):

--- a/tests/gql_behave/continuous_integration
+++ b/tests/gql_behave/continuous_integration
@@ -49,6 +49,8 @@ def wait_for_server(port, process, delay=0.01):
             
             sys.exit(1)
         count += 1
+
+    print(f"Memgraph started in {count*0.01} seconds")
     time.sleep(delay)
 
 


### PR DESCRIPTION
Added some extra debugging info in the `wait_for_server` function:
- show time taken for server to be ready
- show exit status if server is not running
- display message if server is running but not responding
