### PR TITLE
Fix packaging-only build

### DIFF
--- a/src/planner/CMakeLists.txt
+++ b/src/planner/CMakeLists.txt
@@ -12,5 +12,7 @@ target_sources(mg-planner
     src/core/union_find.cpp
 )
 
-add_subdirectory(test)
-add_subdirectory(bench)
+if(MG_ENABLE_TESTING)
+  add_subdirectory(test)
+  add_subdirectory(bench)
+endif()


### PR DESCRIPTION
Fix packaging build which tries to include unit tests within `src/` while `MG_ENABLE_TESTING=OFF`
