### PR TITLE
Allow Jepsen stress tests to run on machines with less RAM

### DIFF
--- a/.github/workflows/reusable_stress_jepsen.yaml
+++ b/.github/workflows/reusable_stress_jepsen.yaml
@@ -34,7 +34,7 @@ env:
 jobs:
   ha-test:
     name: "Run Jepsen HA Tests"
-    runs-on: [self-hosted, Linux, X64, DockerMgBuild, JepsenControl]
+    runs-on: [self-hosted, Linux, X64, DockerMgBuild, x86-64-v3]
     timeout-minutes: 720
     steps:
       - name: Set up repository

--- a/.github/workflows/reusable_stress_jepsen.yaml
+++ b/.github/workflows/reusable_stress_jepsen.yaml
@@ -34,7 +34,7 @@ env:
 jobs:
   ha-test:
     name: "Run Jepsen HA Tests"
-    runs-on: [self-hosted, Linux, X64, DockerMgBuild, x86-64-v3]
+    runs-on: [self-hosted, Linux, X64, DockerMgBuild]
     timeout-minutes: 720
     steps:
       - name: Set up repository

--- a/.github/workflows/stress_jepsen_ha.yaml
+++ b/.github/workflows/stress_jepsen_ha.yaml
@@ -1,6 +1,6 @@
 name: "Jepsen HA Stress Tests"
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ inputs.mode }}-${{ inputs.run-mt }}-${{ inputs.run-non-mt }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
Remove requirement for Jepsen jobs to run on machines with the `JepsenControl` tag, allowing the Jepsen stress tests to run on smaller CI machines. For future reference: MT jobs used about 4.5 GiB ram, and non-MT used around 3.2 GiB.

Additionally, modified concurrency to allow runs with different input parameters on the same git ref.