### PR TITLE
fix: Finalize WAL before updating epoch on replica

### DIFF
--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -338,10 +338,6 @@ void InMemoryReplicationHandlers::PrepareCommitHandler(dbms::DbmsHandler *dbms_h
   auto *storage = static_cast<storage::InMemoryStorage *>(db_acc->get()->storage());
   auto &repl_storage_state = storage->repl_storage_state_;
 
-  // We do not care about incoming sequence numbers, after a snapshot recovery, the sequence number is 0
-  // This is because the snapshots completely wipes the storage and durability
-  // It is also the first recovery step, so the WAL chain needs to restart from 0, otherwise the instance won't be
-  // able to recover from durable data
   if (*maybe_epoch_id != repl_storage_state.epoch_.id()) {
     // We should first finalize WAL file and then update the epoch
     if (storage->wal_file_) {

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -337,20 +337,20 @@ void InMemoryReplicationHandlers::PrepareCommitHandler(dbms::DbmsHandler *dbms_h
 
   auto *storage = static_cast<storage::InMemoryStorage *>(db_acc->get()->storage());
   auto &repl_storage_state = storage->repl_storage_state_;
-  if (*maybe_epoch_id != repl_storage_state.epoch_.id()) {
-    repl_storage_state.SaveLatestHistory();
-    repl_storage_state.epoch_.SetEpoch(*maybe_epoch_id);
-  }
 
   // We do not care about incoming sequence numbers, after a snapshot recovery, the sequence number is 0
   // This is because the snapshots completely wipes the storage and durability
   // It is also the first recovery step, so the WAL chain needs to restart from 0, otherwise the instance won't be
   // able to recover from durable data
-  if (storage->wal_file_) {
-    if (*maybe_epoch_id != repl_storage_state.epoch_.id()) {
+  if (*maybe_epoch_id != repl_storage_state.epoch_.id()) {
+    // We should first finalize WAL file and then update the epoch
+    if (storage->wal_file_) {
       storage->wal_file_->FinalizeWal();
       storage->wal_file_.reset();
     }
+
+    repl_storage_state.SaveLatestHistory();
+    repl_storage_state.epoch_.SetEpoch(*maybe_epoch_id);
   }
 
   // last_durable_timestamp could be set by snapshot; so we cannot guarantee exactly what's the previous timestamp


### PR DESCRIPTION
When new epoch is detected, the replica should finalise its WAL file and start creating a new one. That wasn't the case before, we first updated the epoch and then compared them so the check was always true.