### PR TITLE
[experiment] investigate stress test flakiness

### DIFF
--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -843,6 +843,10 @@ test_memgraph() {
       docker cp $build_container:$test_output_path $test_output_host_dest
     ;;
     stress-plain)
+      echo "Packages installed in ve3: $(hostname)"
+      echo "-------------------------"
+      docker exec -u mg $build_container bash -c "cd $MGBUILD_ROOT_DIR/tests/stress && source ve3/bin/activate && uv pip list"
+      echo "-------------------------"
       docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && cd $MGBUILD_ROOT_DIR/tests/stress && source ve3/bin/activate "'&& ./continuous_integration'
       # TODO: Add when mgconsole is available on CI
       # docker exec -u mg $build_container bash -c "$EXPORT_LICENSE && $EXPORT_ORG_NAME && cd $MGBUILD_ROOT_DIR/tests/stress && source ve3/bin/activate "'&& ./continuous_integration --config-file=configurations/templates/config_ha.yaml'


### PR DESCRIPTION
Some recent failures:

- release stress https://github.com/memgraph/memgraph/actions/runs/17725545620/job/50365354244
- release stress https://github.com/memgraph/memgraph/actions/runs/17661842271/job/50200574660
- daily build release durability and stress https://github.com/memgraph/memgraph/actions/runs/17658478904/job/50186905357

### Tracking
- [ ] **[Link to Epic/Issue]**

### Standard development
- [ ] Update unit/E2E tests
- [ ] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch this branch

### CI Testing Labels
- [ ] Select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_

### Documentation checklist
- [ ] Add the documentation label
- [ ] Add the bug / feature label
- [ ] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - What has changed? What does it mean for a user? What should a user do with it? [#{{PR_number}}]({{link to the PR}})
- [ ] **[ Documentation PR link memgraph/documentation#XXXX ]**
    - [ ] Is back linked to this development PR
