### PR TITLE
Remove duplicate nodes in `to_tree` result

### DIFF
--- a/query_modules/convert.c
+++ b/query_modules/convert.c
@@ -620,6 +620,9 @@ static inline merge_identity_t extract_identity(struct mgp_map *map) {
         type_hash ^= (unsigned char)*p;
         type_hash *= 1099511628211ULL;
       }
+
+      // Concatenate strings using `:` as a delimiter, as we know that can't
+      // appear in the labels.
       if (i < list_size - 1) {
         type_hash ^= ':';
         type_hash *= 1099511628211ULL;

--- a/query_modules/convert.c
+++ b/query_modules/convert.c
@@ -305,9 +305,8 @@ static const property_filter_t *get_node_property_filter(const node_property_fil
     }
   }
 
-  // Return default wildcard filter if not found
-  static property_filter_t default_wildcard = {FILTER_MODE_WILDCARD, {{0}}, 0};
-  return &default_wildcard;
+  // Return NULL if no filter found for this label
+  return NULL;
 }
 
 // Check if node property should be included
@@ -535,9 +534,8 @@ static const property_filter_t *get_rel_property_filter(const rel_property_filte
     }
   }
 
-  // Return default wildcard filter if not found
-  static property_filter_t default_wildcard = {FILTER_MODE_WILDCARD, {{0}}, 0};
-  return &default_wildcard;
+  // Return NULL if no filter found for this relationship type
+  return NULL;
 }
 
 // Check if relationship property should be included

--- a/tests/query_modules/to_tree_test/test_merge_duplicate_nodes/input.cyp
+++ b/tests/query_modules/to_tree_test/test_merge_duplicate_nodes/input.cyp
@@ -1,0 +1,7 @@
+CREATE (sw:SWRelease {uid: "Release_1.0", name: "MyRelease"});
+CREATE (comp:Component {uid: "Component_A", name: "ComponentA"});
+CREATE (sub1:Component {uid: "SubComponent_1", name: "SubComponent1"});
+CREATE (sub2:Component {uid: "SubComponent_2", name: "SubComponent2"});
+CREATE (comp)-[:PACKAGED]->(sw);
+CREATE (sub1)-[:HAS_PARENT]->(comp);
+CREATE (sub2)-[:HAS_PARENT]->(comp);

--- a/tests/query_modules/to_tree_test/test_merge_duplicate_nodes/input.cyp
+++ b/tests/query_modules/to_tree_test/test_merge_duplicate_nodes/input.cyp
@@ -1,1 +1,4 @@
-CREATE (alice:Person:Employee {name: "Alice", age: 30}), (bob:Person:Employee {name: "Bob", age: 25}), (techcorp:Company:Organization {name: "TechCorp", industry: "Technology"}), (alice)-[:WORKS_FOR {since: 2020}]->(techcorp), (bob)-[:WORKS_FOR {since: 2021}]->(techcorp);
+CREATE (alice:Person:Employee {name: "Alice", age: 30});
+CREATE (bob:Person:Employee {name: "Bob", age: 25});
+CREATE (techcorp:Company:Organization {name: "TechCorp", industry: "Technology"});
+MATCH (alice:Person {name: 'Alice'}), (bob:Person {name: 'Bob'}), (techcorp:Company {name: 'TechCorp'}) CREATE (alice)-[:WORKS_FOR {since: 2020}]->(techcorp), (bob)-[:WORKS_FOR {since: 2021}]->(techcorp);

--- a/tests/query_modules/to_tree_test/test_merge_duplicate_nodes/input.cyp
+++ b/tests/query_modules/to_tree_test/test_merge_duplicate_nodes/input.cyp
@@ -1,7 +1,1 @@
-CREATE (sw:SWRelease {uid: "Release_1.0", name: "MyRelease"});
-CREATE (comp:Component {uid: "Component_A", name: "ComponentA"});
-CREATE (sub1:Component {uid: "SubComponent_1", name: "SubComponent1"});
-CREATE (sub2:Component {uid: "SubComponent_2", name: "SubComponent2"});
-CREATE (comp)-[:PACKAGED]->(sw);
-CREATE (sub1)-[:HAS_PARENT]->(comp);
-CREATE (sub2)-[:HAS_PARENT]->(comp);
+CREATE (alice:Person:Employee {name: "Alice", age: 30}), (bob:Person:Employee {name: "Bob", age: 25}), (techcorp:Company:Organization {name: "TechCorp", industry: "Technology"}), (alice)-[:WORKS_FOR {since: 2020}]->(techcorp), (bob)-[:WORKS_FOR {since: 2021}]->(techcorp);

--- a/tests/query_modules/to_tree_test/test_merge_duplicate_nodes/test.yml
+++ b/tests/query_modules/to_tree_test/test_merge_duplicate_nodes/test.yml
@@ -1,19 +1,20 @@
 query: >
-  MATCH path=(sw:SWRelease{uid: 'Release_1.0'})<-[:PACKAGED|HAS_PARENT*]-(c:Component)
-  WITH collect(path) AS paths
-  CALL convert_c.to_tree(paths, false, {}) YIELD value
-  RETURN
-    value.name AS root_name,
-    value._type AS root_type,
-    size(value.PACKAGED) AS packaged_count,
-    value.PACKAGED[0].name AS component_name,
-    size(value.PACKAGED[0].HAS_PARENT) AS child_count,
-    [child IN value.PACKAGED[0].HAS_PARENT | child.name] AS child_names
+  MATCH p = (company:Company)<-[:WORKS_FOR]-(person:Person)
+  WITH collect(p) AS paths
+  CALL convert_c.to_tree(paths, true, {}) YIELD value
+  RETURN value.name AS company_name,
+         value._type AS company_type,
+         value.industry AS industry,
+         size(value.works_for) AS employee_count,
+         [emp IN value.works_for | emp.name] AS employee_names,
+         [emp IN value.works_for | emp._type] AS employee_types,
+         [emp IN value.works_for | emp.age] AS employee_ages
 
 output:
-  - root_name: MyRelease
-    root_type: SWRelease
-    packaged_count: 1
-    component_name: ComponentA
-    child_count: 2
-    child_names: ["SubComponent1", "SubComponent2"]
+  - company_name: "TechCorp"
+    company_type: ["Company", "Organization"]
+    industry: "Technology"
+    employee_count: 2
+    employee_names: ["Alice", "Bob"]
+    employee_types: [["Person", "Employee"], ["Person", "Employee"]]
+    employee_ages: [30, 25]

--- a/tests/query_modules/to_tree_test/test_merge_duplicate_nodes/test.yml
+++ b/tests/query_modules/to_tree_test/test_merge_duplicate_nodes/test.yml
@@ -1,0 +1,19 @@
+query: >
+  MATCH path=(sw:SWRelease{uid: 'Release_1.0'})<-[:PACKAGED|HAS_PARENT*]-(c:Component)
+  WITH collect(path) AS paths
+  CALL convert_c.to_tree(paths, false, {}) YIELD value
+  RETURN
+    value.name AS root_name,
+    value._type AS root_type,
+    size(value.PACKAGED) AS packaged_count,
+    value.PACKAGED[0].name AS component_name,
+    size(value.PACKAGED[0].HAS_PARENT) AS child_count,
+    [child IN value.PACKAGED[0].HAS_PARENT | child.name] AS child_names
+
+output:
+  - root_name: MyRelease
+    root_type: SWRelease
+    packaged_count: 1
+    component_name: ComponentA
+    child_count: 2
+    child_names: ["SubComponent1", "SubComponent2"]

--- a/tests/query_modules/to_tree_test/test_multi_label_distinct/input.cyp
+++ b/tests/query_modules/to_tree_test/test_multi_label_distinct/input.cyp
@@ -1,0 +1,1 @@
+CREATE (alice:Person:Employee {name: "Alice"}), (bob:Person:Manager {name: "Bob"}), (company:Company {name: "TechCorp"}), (alice)-[:WORKS_FOR]->(company), (bob)-[:WORKS_FOR]->(company);

--- a/tests/query_modules/to_tree_test/test_multi_label_distinct/input.cyp
+++ b/tests/query_modules/to_tree_test/test_multi_label_distinct/input.cyp
@@ -1,1 +1,4 @@
-CREATE (alice:Person:Employee {name: "Alice"}), (bob:Person:Manager {name: "Bob"}), (company:Company {name: "TechCorp"}), (alice)-[:WORKS_FOR]->(company), (bob)-[:WORKS_FOR]->(company);
+CREATE (alice:Person:Employee {name: "Alice"});
+CREATE (bob:Person:Manager {name: "Bob"});
+CREATE (company:Company {name: "TechCorp"});
+MATCH (alice:Person {name: "Alice"}), (bob:Person {name: "Bob"}), (company:Company {name: "TechCorp"}) CREATE (alice)-[:WORKS_FOR]->(company), (bob)-[:WORKS_FOR]->(company);

--- a/tests/query_modules/to_tree_test/test_multi_label_distinct/test.yml
+++ b/tests/query_modules/to_tree_test/test_multi_label_distinct/test.yml
@@ -1,0 +1,15 @@
+query: >
+  MATCH p = (company:Company)<-[:WORKS_FOR]-(person:Person)
+  WITH collect(p) AS paths
+  CALL convert_c.to_tree(paths, true, {}) YIELD value
+  RETURN value.name AS company_name,
+         size(value.works_for) AS employee_count,
+         [emp IN value.works_for | emp.name] AS employee_names,
+         [emp IN value.works_for | emp._type] AS employee_types
+  ORDER BY company_name
+
+output:
+  - company_name: "TechCorp"
+    employee_count: 2
+    employee_names: ["Alice", "Bob"]
+    employee_types: [["Person", "Employee"], ["Person", "Manager"]]

--- a/tests/query_modules/to_tree_test/test_multiple_label_property_filtering/input.cyp
+++ b/tests/query_modules/to_tree_test/test_multiple_label_property_filtering/input.cyp
@@ -1,0 +1,4 @@
+CREATE (company:Company {name: 'Acme Corp'});
+CREATE (alice:Person:Employee { name: 'Alice', age: 30, start_date: '2020-01-15', salary: 75000 });
+CREATE (bob:Person:Employee { name: 'Bob', age: 45, start_date: '2018-05-20', salary: 90000 });
+MATCH (alice:Person {name: 'Alice'}), (bob:Person {name: 'Bob'}), (company:Company {name: 'Acme Corp'}) CREATE (alice)-[:WORKS_FOR]->(company), (bob)-[:WORKS_FOR]->(company);

--- a/tests/query_modules/to_tree_test/test_multiple_label_property_filtering/test.yml
+++ b/tests/query_modules/to_tree_test/test_multiple_label_property_filtering/test.yml
@@ -1,0 +1,22 @@
+query: >
+  MATCH path = (company:Company)<-[:WORKS_FOR]-(person:Person)
+  WITH collect(path) AS paths
+  CALL convert_c.to_tree(paths, true, {nodes: {Person:['name'], Employee:['start_date']}}) YIELD value
+  RETURN value;
+
+output:
+  - value:
+      _id: 9
+      _type: "Company"
+      name: "Acme Corp"
+      works_for:
+        - _id: 10
+          _type: ["Person", "Employee"]
+          name: "Alice"
+          start_date: '2020-01-15'
+          works_for._id: 7
+        - _id: 11
+          _type: ["Person", "Employee"]
+          name: "Bob"
+          start_date: '2018-05-20'
+          works_for._id: 8

--- a/tests/query_modules/to_tree_test/test_multiple_label_property_filtering/test.yml
+++ b/tests/query_modules/to_tree_test/test_multiple_label_property_filtering/test.yml
@@ -2,21 +2,21 @@ query: >
   MATCH path = (company:Company)<-[:WORKS_FOR]-(person:Person)
   WITH collect(path) AS paths
   CALL convert_c.to_tree(paths, true, {nodes: {Person:['name'], Employee:['start_date']}}) YIELD value
-  RETURN value;
+  RETURN value.name AS company_name,
+         value._type AS company_type,
+         keys(value) AS company_keys,
+         size(value.works_for) AS employee_count,
+         [emp IN value.works_for | emp.name] AS employee_names,
+         [emp IN value.works_for | emp._type] AS employee_types,
+         [emp IN value.works_for | emp.start_date] AS employee_start_dates,
+         keys(value.works_for[0]) AS first_employee_keys
 
 output:
-  - value:
-      _id: 9
-      _type: "Company"
-      name: "Acme Corp"
-      works_for:
-        - _id: 10
-          _type: ["Person", "Employee"]
-          name: "Alice"
-          start_date: '2020-01-15'
-          works_for._id: 7
-        - _id: 11
-          _type: ["Person", "Employee"]
-          name: "Bob"
-          start_date: '2018-05-20'
-          works_for._id: 8
+  - company_name: "Acme Corp"
+    company_type: "Company"
+    company_keys: ["_id", "_type", "name", "works_for"]
+    employee_count: 2
+    employee_names: ["Alice", "Bob"]
+    employee_types: [["Person", "Employee"], ["Person", "Employee"]]
+    employee_start_dates: ["2020-01-15", "2018-05-20"]
+    first_employee_keys: ["_id", "_type", "name", "start_date", "works_for._id"]


### PR DESCRIPTION
Fixes node identification when nodes have more than one label. Previously, the identity function wasn't working for these nodes, meaning that they would appear multiple times in the tree output if they were also duplicated in the input paths.

We now use a hash-based comparison on all labels, and nodes are deduplicated.