### PR TITLE
Re-enable tests using npm

### DIFF
--- a/tests/drivers/run.sh
+++ b/tests/drivers/run.sh
@@ -41,13 +41,6 @@ wait_for_server 7687
 code_test=0
 for i in *; do
     if [ ! -d $i ]; then continue; fi
-    
-    # Skip Node.js driver tests in CI
-    if [ "$i" = "node" ] || [ "$i" = "javascript" ]; then
-        echo "Skipping Node.js driver tests in CI"
-        continue
-    fi
-    
     pushd $i
     echo "Running: $i"
     # run all versions

--- a/tests/drivers/run_cluster.sh
+++ b/tests/drivers/run_cluster.sh
@@ -239,13 +239,6 @@ echo "All instances registered successfully."
 code_test=0
 for lang in *; do
     if [ ! -d $lang ]; then continue; fi
-    
-    # Skip Node.js driver tests in CI
-    if [ "${CI:-}" = "true" ] && [ "$lang" = "node" ]; then
-        echo "Skipping Node.js driver cluster tests in CI"
-        continue
-    fi
-    
     pushd $lang
     echo "Running tests for language: $lang"
     for version in *; do

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -60,9 +60,6 @@ def load_workloads(root_directory):
         # 8.03.2024. - Skip streams e2e tests
         if str(file).endswith("/streams/workloads.yaml"):
             continue
-        # Skip GraphQL e2e tests in CI
-        if str(file).endswith("/graphql/workloads.yaml"):
-            continue
         with open(file, "r") as f:
             workloads.extend(yaml.load(f, Loader=yaml.FullLoader)["workloads"])
     return workloads

--- a/tests/util.sh
+++ b/tests/util.sh
@@ -2,11 +2,6 @@
 
 NODE_VERSION="20"
 setup_node() {
-  # Temporarily disabled npm usage in CI
-  echo "NPM usage temporarily disabled in CI"
-  return 0
-  
-  
   if [ -f "$HOME/.nvm/nvm.sh" ]; then
     . "$HOME/.nvm/nvm.sh"
     nvm install $NODE_VERSION


### PR DESCRIPTION
Re-enable tests using `npm` which were disabled in [3273](https://github.com/memgraph/memgraph/pull/3273).

