### PR TITLE
feat: Add HA telemetry collectors

### DIFF
--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -1382,5 +1382,13 @@ auto CoordinatorInstance::ShowReplicationLag() const -> std::map<std::string, st
   return {};
 }
 
+auto CoordinatorInstance::GetTelemetryJson() const -> nlohmann::json {
+  return nlohmann::json({{"cluster_size", raft_state_->GetCoordinatorInstancesContext().size()},
+                         {"enabled_reads_on_main", raft_state_->GetEnabledReadsOnMain()},
+                         {"sync_failover_only", raft_state_->GetSyncFailoverOnly()},
+                         {"instance_down_timeout_sec", instance_down_timeout_sec_.count()},
+                         {"instance_health_check_frequency_sec", instance_health_check_frequency_sec_.count()}});
+}
+
 }  // namespace memgraph::coordination
 #endif

--- a/src/coordination/coordinator_state.cpp
+++ b/src/coordination/coordinator_state.cpp
@@ -183,6 +183,12 @@ auto CoordinatorState::YieldLeadership() const -> YieldLeadershipStatus {
   return std::get<CoordinatorInstance>(data_).YieldLeadership();
 }
 
+auto CoordinatorState::GetTelemetryJson() const -> nlohmann::json {
+  MG_ASSERT(std::holds_alternative<CoordinatorInstance>(data_),
+            "Coordinator cannot return telemetry json data since variant holds wrong alternative");
+  return std::get<CoordinatorInstance>(data_).GetTelemetryJson();
+}
+
 auto CoordinatorState::IsCoordinator() const -> bool { return std::holds_alternative<CoordinatorInstance>(data_); }
 
 auto CoordinatorState::IsDataInstance() const -> bool {

--- a/src/coordination/data_instance_management_server_handlers.cpp
+++ b/src/coordination/data_instance_management_server_handlers.cpp
@@ -133,6 +133,7 @@ void DataInstanceManagementServerHandlers::GetDatabaseHistoriesHandler(
   if (request_version == coordination::GetDatabaseHistoriesReqV1::kVersion) {
     rpc::SendFinalResponse(std::get<coordination::GetDatabaseHistoriesResV1>(rpc_res_var), request_version,
                            res_builder);
+    `
   } else {
     rpc::SendFinalResponse(std::get<coordination::GetDatabaseHistoriesRes>(rpc_res_var), request_version, res_builder);
   }

--- a/src/coordination/data_instance_management_server_handlers.cpp
+++ b/src/coordination/data_instance_management_server_handlers.cpp
@@ -133,7 +133,6 @@ void DataInstanceManagementServerHandlers::GetDatabaseHistoriesHandler(
   if (request_version == coordination::GetDatabaseHistoriesReqV1::kVersion) {
     rpc::SendFinalResponse(std::get<coordination::GetDatabaseHistoriesResV1>(rpc_res_var), request_version,
                            res_builder);
-    `
   } else {
     rpc::SendFinalResponse(std::get<coordination::GetDatabaseHistoriesRes>(rpc_res_var), request_version, res_builder);
   }

--- a/src/coordination/include/coordination/coordinator_instance.hpp
+++ b/src/coordination/include/coordination/coordinator_instance.hpp
@@ -124,6 +124,8 @@ class CoordinatorInstance {
   auto ShowCoordinatorSettings() const -> std::vector<std::pair<std::string, std::string>>;
   auto ShowReplicationLag() const -> std::map<std::string, std::map<std::string, ReplicaDBLagData>>;
 
+  auto GetTelemetryJson() const -> nlohmann::json;
+
  private:
   auto FindReplicationInstance(std::string_view replication_instance_name)
       -> std::optional<std::reference_wrapper<ReplicationInstanceConnector>>;

--- a/src/coordination/include/coordination/coordinator_state.hpp
+++ b/src/coordination/include/coordination/coordinator_state.hpp
@@ -15,6 +15,7 @@
 
 #include <optional>
 #include <string_view>
+#include <variant>
 
 #include "coordination/coordinator_communication_config.hpp"
 #include "coordination/coordinator_instance.hpp"
@@ -22,7 +23,7 @@
 #include "coordination/data_instance_management_server.hpp"
 #include "coordination/instance_status.hpp"
 
-#include <variant>
+#include "nlohmann/json_fwd.hpp"
 
 namespace memgraph::coordination {
 
@@ -71,6 +72,8 @@ class CoordinatorState {
   auto GetDataInstanceManagementServer() const -> DataInstanceManagementServer &;
 
   auto GetRoutingTable(std::string_view db_name) const -> RoutingTable;
+
+  auto GetTelemetryJson() const -> nlohmann::json;
 
   [[nodiscard]] auto IsCoordinator() const -> bool;
   [[nodiscard]] auto IsDataInstance() const -> bool;

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -712,6 +712,7 @@ int main(int argc, char **argv) {
     telemetry->AddStorageCollector(dbms_handler, *auth_);
 #ifdef MG_ENTERPRISE
     telemetry->AddDatabaseCollector(dbms_handler);
+    telemetry->AddCoordinatorCollector(coordinator_state);
 #else
     telemetry->AddDatabaseCollector();
 #endif

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -719,7 +719,7 @@ int main(int argc, char **argv) {
     telemetry->AddEventsCollector();
     telemetry->AddQueryModuleCollector();
     telemetry->AddExceptionCollector();
-    telemetry->AddReplicationCollector();
+    telemetry->AddReplicationCollector(repl_state);
     telemetry->Start();
   }
   memgraph::license::LicenseInfoSender license_info_sender(telemetry_server, memgraph::glue::run_id_, machine_id,

--- a/src/replication/include/replication/state.hpp
+++ b/src/replication/include/replication/state.hpp
@@ -11,7 +11,6 @@
 
 #pragma once
 
-#include "flags/coordination.hpp"
 #include "kvstore/kvstore.hpp"
 #include "replication/config.hpp"
 #include "replication/replication_client.hpp"
@@ -26,6 +25,8 @@
 #include <list>
 #include <optional>
 #include <variant>
+
+#include "nlohmann/json_fwd.hpp"
 
 namespace memgraph::replication {
 
@@ -133,6 +134,8 @@ struct ReplicationState {
   bool SetReplicationRoleMain(const utils::UUID &main_uuid);
   bool SetReplicationRoleReplica(const ReplicationServerConfig &config,
                                  std::optional<utils::UUID> const &maybe_main_uuid);
+
+  std::optional<nlohmann::json> GetTelemetryJson() const;
 
  private:
   bool HandleVersionMigration(durability::ReplicationRoleEntry &data) const;

--- a/src/telemetry/telemetry.hpp
+++ b/src/telemetry/telemetry.hpp
@@ -22,7 +22,7 @@
 
 namespace memgraph::telemetry {
 
-using FuncSig = const std::function<std::optional<nlohmann::json>()>;
+using FuncSig = std::function<std::optional<nlohmann::json>()>;
 
 /**
  * This class implements the telemetry collector service. It periodically scrapes
@@ -41,7 +41,7 @@ class Telemetry final {
             std::chrono::duration<int64_t> refresh_interval = std::chrono::minutes(10), uint64_t send_every_n = 10);
 
   // Generic/user-defined collector
-  void AddCollector(const std::string &name, FuncSig &func);
+  void AddCollector(std::string name, FuncSig func);
 
   // Specialized collectors
   void AddStorageCollector(dbms::DbmsHandler &dbms_handler, memgraph::auth::SynchedAuth &auth);

--- a/src/telemetry/telemetry.hpp
+++ b/src/telemetry/telemetry.hpp
@@ -48,6 +48,7 @@ class Telemetry final {
 
 #ifdef MG_ENTERPRISE
   void AddDatabaseCollector(dbms::DbmsHandler &dbms_handler);
+  void AddCoordinatorCollector(std::optional<coordination::CoordinatorState> const &coordinator_state);
 #else
   void AddDatabaseCollector() {
     AddCollector("database", []() -> nlohmann::json { return nlohmann::json::array(); });

--- a/src/utils/event_map.cpp
+++ b/src/utils/event_map.cpp
@@ -27,7 +27,7 @@ int NameToId(T &names, const K &name, uint64_t &free) {
   if (id != -1) return id;
   // Add new name
   if (free < 1) return -1;  // No more space
-  int idx = names.size() - free;
+  int const idx = names.size() - free;
   names[idx] = name;
   --free;
   return idx;
@@ -60,7 +60,7 @@ bool EventMap::Decrement(const std::string_view event, Count const amount) {
   return false;
 }
 
-nlohmann::json EventMap::ToJson() {
+nlohmann::json EventMap::ToJson() const {
   auto res = nlohmann::json::array();
   auto const num_counters = kMaxCounters - num_free_counters_;
   for (size_t i = 0; i < num_counters; ++i) {

--- a/src/utils/event_map.cpp
+++ b/src/utils/event_map.cpp
@@ -73,6 +73,7 @@ nlohmann::json EventMap::ToJson() const {
 bool IncrementCounter(const std::string_view event, Count const amount) {
   return global_counters_map.Increment(event, amount);
 }
+
 bool DecrementCounter(const std::string_view event, Count const amount) {
   return global_counters_map.Decrement(event, amount);
 }

--- a/src/utils/event_map.hpp
+++ b/src/utils/event_map.hpp
@@ -13,7 +13,6 @@
 
 #include <array>
 #include <atomic>
-#include <cstdlib>
 #include <memory>
 #include <string>
 
@@ -29,22 +28,17 @@ class EventMap {
 
   explicit EventMap(Counter *allocated_counters) noexcept : counters_(allocated_counters) {}
 
-  auto &operator[](std::string_view event);
-
-  const auto &operator[](std::string_view event) const;
-
   bool Increment(std::string_view event, Count amount = 1);
 
   bool Decrement(std::string_view event, Count amount = 1);
 
-  nlohmann::json ToJson();
+  nlohmann::json ToJson() const;
 
   uint64_t num_free_counters_{kMaxCounters};
   std::array<std::string, kMaxCounters> name_to_id_;
 
  private:
   Counter *counters_;
-  const auto &operator[](int event) const;
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/src/utils/system_info.cpp
+++ b/src/utils/system_info.cpp
@@ -211,4 +211,12 @@ nlohmann::json GetSystemInfo() {
           {"microarch_level", cpu_info.microarch_level}};
 }
 
+RuntimeEnv DetectRuntimeEnv() {
+  // These are always added when the app is run in K8s
+  if (std::getenv("KUBERNETES_SERVICE_HOST") || std::getenv("KUBERNETES_PORT")) {
+    return RuntimeEnv::KUBERNETES;
+  }
+  return RuntimeEnv::NO_KUBERNETES;
+}
+
 }  // namespace memgraph::utils

--- a/src/utils/system_info.hpp
+++ b/src/utils/system_info.hpp
@@ -20,6 +20,11 @@
 
 namespace memgraph::utils {
 
+// This is a bit imprecise but it is important that we can be certain about whether we are running in K8s or not
+// For Docker, .dockerenv file apparently doesn't exist always so it could lead us into wrong direction that people
+// aren't actually using that much Docker while in fact they do
+enum class RuntimeEnv : uint8_t { KUBERNETES, NO_KUBERNETES };
+
 struct MemoryInfo {
   uint64_t memory;
   uint64_t swap;
@@ -46,6 +51,8 @@ bool HasCPUFlag(const std::unordered_set<std::string> &flags, const std::string 
 std::unordered_set<std::string> ExtractCPUFlags(const std::vector<std::string> &cpu_data);
 
 std::string ExtractArmCPUVariant(const std::vector<std::string> &cpu_data);
+
+RuntimeEnv DetectRuntimeEnv();
 
 /**
  * This function return a dictionary containing some basic system information

--- a/tests/integration/telemetry/client.cpp
+++ b/tests/integration/telemetry/client.cpp
@@ -27,6 +27,9 @@ DEFINE_int64(duration, 10, "Duration of the test in seconds.");
 DEFINE_string(storage_directory, "", "Path to the storage directory where to save telemetry data.");
 DEFINE_string(root_directory, "", "Path to the database durability root dir.");
 
+using memgraph::coordination::CoordinatorInstanceInitConfig;
+using memgraph::coordination::CoordinatorState;
+
 int main(int argc, char **argv) {
   gflags::SetVersionString("telemetry");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
@@ -59,6 +62,19 @@ int main(int argc, char **argv) {
                                                            ,
                                                            &auth_handler, &auth_checker);
 
+#ifdef MG_ENTERPRISE
+  std::optional<CoordinatorState> coord_state;
+  coord_state.emplace(CoordinatorInstanceInitConfig{.coordinator_id = 1,
+                                                    .coordinator_port = 20000,
+                                                    .bolt_port = 7689,
+                                                    .management_port = 10000,
+                                                    .durability_dir = "coord_state_dir",
+                                                    .coordinator_hostname = "localhost",
+                                                    .nuraft_log_file = "test.log",
+                                                    .instance_down_timeout_sec = std::chrono::seconds(5),
+                                                    .instance_health_check_frequency_sec = std::chrono::seconds(1)});
+#endif
+
   memgraph::requests::Init();
   memgraph::telemetry::Telemetry telemetry(FLAGS_endpoint, FLAGS_storage_directory, memgraph::utils::GenerateUUID(),
                                            memgraph::utils::GetMachineId(), false, FLAGS_root_directory,
@@ -75,6 +91,7 @@ int main(int argc, char **argv) {
   telemetry.AddStorageCollector(dbms_handler, auth_);
 #ifdef MG_ENTERPRISE
   telemetry.AddDatabaseCollector(dbms_handler);
+  telemetry.AddCoordinatorCollector(coord_state);
 #else
   telemetry.AddDatabaseCollector();
 #endif
@@ -82,7 +99,7 @@ int main(int argc, char **argv) {
   telemetry.AddEventsCollector();
   telemetry.AddQueryModuleCollector();
   telemetry.AddExceptionCollector();
-  telemetry.AddReplicationCollector();
+  telemetry.AddReplicationCollector(repl_state);
   telemetry.Start();
 
   std::this_thread::sleep_for(std::chrono::seconds(FLAGS_duration));

--- a/tests/integration/telemetry/client.cpp
+++ b/tests/integration/telemetry/client.cpp
@@ -27,8 +27,10 @@ DEFINE_int64(duration, 10, "Duration of the test in seconds.");
 DEFINE_string(storage_directory, "", "Path to the storage directory where to save telemetry data.");
 DEFINE_string(root_directory, "", "Path to the database durability root dir.");
 
+#ifdef MG_ENTERPRISE
 using memgraph::coordination::CoordinatorInstanceInitConfig;
 using memgraph::coordination::CoordinatorState;
+#endif
 
 int main(int argc, char **argv) {
   gflags::SetVersionString("telemetry");

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -59,6 +59,12 @@ add_unit_test(cypher_main_visitor
     LINK_TARGETS mg-query
 )
 
+add_unit_test(event_map
+        SOURCES event_map.cpp
+        LINK_TARGETS mg-events mg-utils
+)
+
+
 add_unit_test(interpreter
     SOURCES interpreter.cpp ${CMAKE_SOURCE_DIR}/src/glue/communication.cpp
     LINK_TARGETS mg-communication mg-query mg-glue

--- a/tests/unit/event_map.cpp
+++ b/tests/unit/event_map.cpp
@@ -1,0 +1,33 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "utils/event_map.hpp"
+#include "gtest/gtest.h"
+#include "nlohmann/json.hpp"
+
+using memgraph::metrics::DecrementCounter;
+using memgraph::metrics::EventMap;
+using memgraph::metrics::global_counters_map;
+using memgraph::metrics::IncrementCounter;
+
+TEST(EventMapTest, SimpleTest) {
+  IncrementCounter("ReplicationException1");
+  IncrementCounter("ReplicationException1");
+  IncrementCounter("ReplicationException2");
+  ASSERT_EQ(global_counters_map.num_free_counters_, EventMap::kMaxCounters - 2);
+  ASSERT_EQ(global_counters_map.name_to_id_[0], "ReplicationException1");
+  ASSERT_EQ(global_counters_map.name_to_id_[1], "ReplicationException2");
+
+  auto const expected_json = nlohmann::json::array({nlohmann::json{{"name", "ReplicationException1"}, {"count", 2}},
+                                                    nlohmann::json{{"name", "ReplicationException2"}, {"count", 1}}});
+
+  ASSERT_EQ(global_counters_map.ToJson(), expected_json);
+}


### PR DESCRIPTION
The PR adds a support for exposing replication and coordination data to the telemetry server:
- the number of strict_sync, sync and asynchronous replicas
- coordinator's configuration: cluster size and its runtime configuration options


Problems with detecting Docker env:
- https://github.com/moby/moby/issues/47420

