### PR TITLE
Remove packages that pull in linux-libc-dev and libtiff6

### DIFF
--- a/release/docker/v5_deb.dockerfile
+++ b/release/docker/v5_deb.dockerfile
@@ -6,7 +6,7 @@ ARG EXTENSION
 ARG TARGETARCH
 
 RUN apt-get update && apt-get install -y \
-  openssl libcurl4 libssl3 libseccomp2 python3 libpython3.11 python3-pip libxmlsec1-dev xmlsec1 \
+  openssl libcurl4 libssl3 libseccomp2 python3 libpython3.11 python3-pip libxmlsec1 \
   --no-install-recommends && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/release/docker/v5_deb_relwithdebinfo.dockerfile
+++ b/release/docker/v5_deb_relwithdebinfo.dockerfile
@@ -7,7 +7,7 @@ ARG TARGETARCH
 ARG SOURCE_CODE
 
 RUN apt-get update && apt-get install -y \
-  openssl libcurl4 libssl3 libseccomp2 python3 libpython3.11 python3-pip gdb procps linux-perf libc6-dbg libxmlsec1-dev xmlsec1 \
+  openssl libcurl4 libssl3 libseccomp2 python3 libpython3.11 python3-pip gdb procps linux-perf libc6-dbg libxmlsec1 \
   --no-install-recommends && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/release/docker/v6_deb.dockerfile
+++ b/release/docker/v6_deb.dockerfile
@@ -18,7 +18,7 @@ RUN if [ -n "$CUSTOM_MIRROR" ]; then \
 RUN apt-get update && apt-get install -y \
   openssl libcurl4 libssl3 libseccomp2 python3 libpython3.12 python3-pip python3.12-venv libatomic1 adduser \
   --no-install-recommends && \
-  apt install -y libxmlsec1-dev xmlsec1 && \
+  apt install -y libxmlsec1 && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # NOTE: The following are required to run built-in Python modules. For the full

--- a/release/docker/v6_deb_relwithdebinfo.dockerfile
+++ b/release/docker/v6_deb_relwithdebinfo.dockerfile
@@ -20,7 +20,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
   openssl libcurl4 libssl3 libseccomp2 python3 libpython3.12 python3-pip python3.12-venv libatomic1 adduser \
   gdb procps linux-tools-common linux-tools-generic linux-tools-generic libc6-dbg \
   --no-install-recommends && \
-  apt install -y libxmlsec1-dev xmlsec1 && \
+  apt install -y libxmlsec1 && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 


### PR DESCRIPTION
Remove packages that pull in linux-libc-dev and libtiff6 as dependencies in order to address the following vulnerabilities:
- CVE-2025-9900
- CVE-2025-38352
- CVE-2025-40300 

