### PR TITLE
Move container hosts

### DIFF
--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -85,11 +85,19 @@ jobs:
         run: |
           echo "Testing mgdeps cache connection..."
           docker exec mgbuild_${TOOLCHAIN}_${OS} bash -c "
+            echo 'Installing network tools...'
+            apt update && apt install -y dnsutils iputils-ping curl
+            
             echo 'Testing hostname resolution:'
             nslookup mgdeps-cache || echo 'nslookup failed, trying ping...'
             ping -c 1 mgdeps-cache || echo 'ping failed'
+            
             echo 'Testing HTTP connection to mgdeps-cache:8000:'
-            curl -f http://mgdeps-cache:8000/health || echo 'HTTP connection failed'
+            curl -f http://mgdeps-cache:8000/health || echo 'HTTP connection failed (404 is expected if no health endpoint)'
+            
+            echo 'Testing basic connectivity with telnet-style test:'
+            timeout 5 bash -c '</dev/tcp/mgdeps-cache/8000' && echo 'Port 8000 is reachable' || echo 'Port 8000 is not reachable'
+            
             echo 'mgdeps cache connection test completed'
           "
 

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -81,28 +81,6 @@ jobs:
           --arch $ARCH \
           run
 
-      - name: Test mgdeps cache connection
-        run: |
-          echo "Testing mgdeps cache connection..."
-          
-          echo "Installing network tools..."
-          docker exec -u root mgbuild_${TOOLCHAIN}_${OS} bash -c "apt update && apt install -y dnsutils iputils-ping curl"
-          
-          echo "Running connectivity tests..."
-          docker exec mgbuild_${TOOLCHAIN}_${OS} bash -c "
-            echo 'Testing hostname resolution:'
-            nslookup mgdeps-cache || echo 'nslookup failed, trying ping...'
-            ping -c 1 mgdeps-cache || echo 'ping failed'
-            
-            echo 'Testing HTTP connection to mgdeps-cache:8000:'
-            curl -f http://mgdeps-cache:8000/health || echo 'HTTP connection failed (404 is expected if no health endpoint)'
-            
-            echo 'Testing basic connectivity with telnet-style test:'
-            timeout 5 bash -c '</dev/tcp/mgdeps-cache/8000' && echo 'Port 8000 is reachable' || echo 'Port 8000 is not reachable'
-            
-            echo 'mgdeps cache connection test completed'
-          "
-
       - name: Build release binary
         run: |
           ./release/package/mgbuild.sh \

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -81,6 +81,18 @@ jobs:
           --arch $ARCH \
           run
 
+      - name: Test mgdeps cache connection
+        run: |
+          echo "Testing mgdeps cache connection..."
+          docker exec mgbuild_${TOOLCHAIN}_${OS} bash -c "
+            echo 'Testing hostname resolution:'
+            nslookup mgdeps-cache || echo 'nslookup failed, trying ping...'
+            ping -c 1 mgdeps-cache || echo 'ping failed'
+            echo 'Testing HTTP connection to mgdeps-cache:8000:'
+            curl -f http://mgdeps-cache:8000/health || echo 'HTTP connection failed'
+            echo 'mgdeps cache connection test completed'
+          "
+
       - name: Build release binary
         run: |
           ./release/package/mgbuild.sh \

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -84,10 +84,12 @@ jobs:
       - name: Test mgdeps cache connection
         run: |
           echo "Testing mgdeps cache connection..."
+          
+          echo "Installing network tools..."
+          docker exec -u root mgbuild_${TOOLCHAIN}_${OS} bash -c "apt update && apt install -y dnsutils iputils-ping curl"
+          
+          echo "Running connectivity tests..."
           docker exec mgbuild_${TOOLCHAIN}_${OS} bash -c "
-            echo 'Installing network tools...'
-            apt update && apt install -y dnsutils iputils-ping curl
-            
             echo 'Testing hostname resolution:'
             nslookup mgdeps-cache || echo 'nslookup failed, trying ping...'
             ping -c 1 mgdeps-cache || echo 'ping failed'

--- a/release/package/amd-builders-v5.yml
+++ b/release/package/amd-builders-v5.yml
@@ -7,8 +7,8 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:10.42.16.10"
-      - "bench-graph-api:10.42.16.10"
+      - "mgdeps-cache:host.docker.internal"
+      - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_centos-9"
 
   mgbuild_v5_debian-11:
@@ -18,8 +18,8 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:10.42.16.10"
-      - "bench-graph-api:10.42.16.10"
+      - "mgdeps-cache:host.docker.internal"
+      - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_debian-11"
 
   mgbuild_v5_debian-12:
@@ -29,8 +29,8 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:10.42.16.10"
-      - "bench-graph-api:10.42.16.10"
+      - "mgdeps-cache:host.docker.internal"
+      - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_debian-12"
 
   mgbuild_v5_fedora-38:
@@ -40,8 +40,8 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:10.42.16.10"
-      - "bench-graph-api:10.42.16.10"
+      - "mgdeps-cache:host.docker.internal"
+      - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_fedora-38"
 
   mgbuild_v5_fedora-39:
@@ -51,8 +51,8 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:10.42.16.10"
-      - "bench-graph-api:10.42.16.10"
+      - "mgdeps-cache:host.docker.internal"
+      - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_fedora-39"
 
   mgbuild_v5_rocky-9.3:
@@ -62,8 +62,8 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:10.42.16.10"
-      - "bench-graph-api:10.42.16.10"
+      - "mgdeps-cache:host.docker.internal"
+      - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_rocky-9.3"
 
   mgbuild_v5_ubuntu-20.04:
@@ -73,8 +73,8 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:10.42.16.10"
-      - "bench-graph-api:10.42.16.10"
+      - "mgdeps-cache:host.docker.internal"
+      - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_ubuntu-20.04"
 
   mgbuild_v5_ubuntu-22.04:
@@ -84,8 +84,8 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:10.42.16.10"
-      - "bench-graph-api:10.42.16.10"
+      - "mgdeps-cache:host.docker.internal"
+      - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_ubuntu-22.04"
 
   mgbuild_v5_ubuntu-24.04:
@@ -95,6 +95,6 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:10.42.16.10"
-      - "bench-graph-api:10.42.16.10"
+      - "mgdeps-cache:host.docker.internal"
+      - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_ubuntu-24.04"

--- a/release/package/amd-builders-v5.yml
+++ b/release/package/amd-builders-v5.yml
@@ -7,7 +7,7 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:host.docker.internal"
+      - "mgdeps-cache:host-gateway"
       - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_centos-9"
 
@@ -18,7 +18,7 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:host.docker.internal"
+      - "mgdeps-cache:host-gateway"
       - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_debian-11"
 
@@ -29,7 +29,7 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:host.docker.internal"
+      - "mgdeps-cache:host-gateway"
       - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_debian-12"
 
@@ -40,7 +40,7 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:host.docker.internal"
+      - "mgdeps-cache:host-gateway"
       - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_fedora-38"
 
@@ -51,7 +51,7 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:host.docker.internal"
+      - "mgdeps-cache:host-gateway"
       - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_fedora-39"
 
@@ -62,7 +62,7 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:host.docker.internal"
+      - "mgdeps-cache:host-gateway"
       - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_rocky-9.3"
 
@@ -73,7 +73,7 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:host.docker.internal"
+      - "mgdeps-cache:host-gateway"
       - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_ubuntu-20.04"
 
@@ -84,7 +84,7 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:host.docker.internal"
+      - "mgdeps-cache:host-gateway"
       - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_ubuntu-22.04"
 
@@ -95,6 +95,6 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:host.docker.internal"
+      - "mgdeps-cache:host-gateway"
       - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_ubuntu-24.04"

--- a/release/package/amd-builders-v6.yml
+++ b/release/package/amd-builders-v6.yml
@@ -9,7 +9,7 @@ services:
       args:
         TOOLCHAIN_VERSION: "v6"
     extra_hosts:
-      - "mgdeps-cache:host.docker.internal"
+      - "mgdeps-cache:host-gateway"
       - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v6_centos-9"
 
@@ -20,7 +20,7 @@ services:
       args:
         TOOLCHAIN_VERSION: "v6"
     extra_hosts:
-      - "mgdeps-cache:host.docker.internal"
+      - "mgdeps-cache:host-gateway"
       - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v6_centos-10"
 
@@ -31,7 +31,7 @@ services:
       args:
         TOOLCHAIN_VERSION: "v6"
     extra_hosts:
-      - "mgdeps-cache:host.docker.internal"
+      - "mgdeps-cache:host-gateway"
       - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v6_debian-11"
 
@@ -42,7 +42,7 @@ services:
       args:
         TOOLCHAIN_VERSION: "v6"
     extra_hosts:
-      - "mgdeps-cache:host.docker.internal"
+      - "mgdeps-cache:host-gateway"
       - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v6_debian-12"
 
@@ -53,7 +53,7 @@ services:
       args:
         TOOLCHAIN_VERSION: "v6"
     extra_hosts:
-      - "mgdeps-cache:host.docker.internal"
+      - "mgdeps-cache:host-gateway"
       - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v6_fedora-41"
 
@@ -64,7 +64,7 @@ services:
       args:
         TOOLCHAIN_VERSION: "v6"
     extra_hosts:
-      - "mgdeps-cache:host.docker.internal"
+      - "mgdeps-cache:host-gateway"
       - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v6_ubuntu-22.04"
 
@@ -75,6 +75,6 @@ services:
       args:
         TOOLCHAIN_VERSION: "v6"
     extra_hosts:
-      - "mgdeps-cache:host.docker.internal"
+      - "mgdeps-cache:host-gateway"
       - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v6_ubuntu-24.04"

--- a/release/package/amd-builders-v6.yml
+++ b/release/package/amd-builders-v6.yml
@@ -9,8 +9,8 @@ services:
       args:
         TOOLCHAIN_VERSION: "v6"
     extra_hosts:
-      - "mgdeps-cache:10.42.16.10"
-      - "bench-graph-api:10.42.16.10"
+      - "mgdeps-cache:host.docker.internal"
+      - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v6_centos-9"
 
   mgbuild_v6_centos-10:
@@ -20,8 +20,8 @@ services:
       args:
         TOOLCHAIN_VERSION: "v6"
     extra_hosts:
-      - "mgdeps-cache:10.42.16.10"
-      - "bench-graph-api:10.42.16.10"
+      - "mgdeps-cache:host.docker.internal"
+      - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v6_centos-10"
 
   mgbuild_v6_debian-11:
@@ -31,8 +31,8 @@ services:
       args:
         TOOLCHAIN_VERSION: "v6"
     extra_hosts:
-      - "mgdeps-cache:10.42.16.10"
-      - "bench-graph-api:10.42.16.10"
+      - "mgdeps-cache:host.docker.internal"
+      - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v6_debian-11"
 
   mgbuild_v6_debian-12:
@@ -42,8 +42,8 @@ services:
       args:
         TOOLCHAIN_VERSION: "v6"
     extra_hosts:
-      - "mgdeps-cache:10.42.16.10"
-      - "bench-graph-api:10.42.16.10"
+      - "mgdeps-cache:host.docker.internal"
+      - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v6_debian-12"
 
   mgbuild_v6_fedora-41:
@@ -53,8 +53,8 @@ services:
       args:
         TOOLCHAIN_VERSION: "v6"
     extra_hosts:
-      - "mgdeps-cache:10.42.16.10"
-      - "bench-graph-api:10.42.16.10"
+      - "mgdeps-cache:host.docker.internal"
+      - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v6_fedora-41"
 
   mgbuild_v6_ubuntu-22.04:
@@ -64,8 +64,8 @@ services:
       args:
         TOOLCHAIN_VERSION: "v6"
     extra_hosts:
-      - "mgdeps-cache:10.42.16.10"
-      - "bench-graph-api:10.42.16.10"
+      - "mgdeps-cache:host.docker.internal"
+      - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v6_ubuntu-22.04"
 
   mgbuild_v6_ubuntu-24.04:
@@ -75,6 +75,6 @@ services:
       args:
         TOOLCHAIN_VERSION: "v6"
     extra_hosts:
-      - "mgdeps-cache:10.42.16.10"
-      - "bench-graph-api:10.42.16.10"
+      - "mgdeps-cache:host.docker.internal"
+      - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v6_ubuntu-24.04"

--- a/release/package/arm-builders-v5.yml
+++ b/release/package/arm-builders-v5.yml
@@ -8,8 +8,8 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:10.42.16.10"
-      - "bench-graph-api:10.42.16.10"
+      - "mgdeps-cache:host.docker.internal"
+      - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_debian-11-arm"
 
   mgbuild_v5_debian-12-arm:
@@ -19,8 +19,8 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:10.42.16.10"
-      - "bench-graph-api:10.42.16.10"
+      - "mgdeps-cache:host.docker.internal"
+      - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_debian-12-arm"
 
   mgbuild_v5_ubuntu-22.04-arm:
@@ -30,8 +30,8 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:10.42.16.10"
-      - "bench-graph-api:10.42.16.10"
+      - "mgdeps-cache:host.docker.internal"
+      - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_ubuntu-22.04-arm"
 
   mgbuild_v5_ubuntu-24.04-arm:
@@ -41,6 +41,6 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:10.42.16.10"
-      - "bench-graph-api:10.42.16.10"
+      - "mgdeps-cache:host.docker.internal"
+      - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_ubuntu-24.04-arm"

--- a/release/package/arm-builders-v5.yml
+++ b/release/package/arm-builders-v5.yml
@@ -8,7 +8,7 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:host.docker.internal"
+      - "mgdeps-cache:host-gateway"
       - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_debian-11-arm"
 
@@ -19,7 +19,7 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:host.docker.internal"
+      - "mgdeps-cache:host-gateway"
       - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_debian-12-arm"
 
@@ -30,7 +30,7 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:host.docker.internal"
+      - "mgdeps-cache:host-gateway"
       - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_ubuntu-22.04-arm"
 
@@ -41,6 +41,6 @@ services:
       args:
         TOOLCHAIN_VERSION: "v5"
     extra_hosts:
-      - "mgdeps-cache:host.docker.internal"
+      - "mgdeps-cache:host-gateway"
       - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v5_ubuntu-24.04-arm"

--- a/release/package/arm-builders-v6.yml
+++ b/release/package/arm-builders-v6.yml
@@ -9,8 +9,8 @@ services:
       args:
         TOOLCHAIN_VERSION: "v6"
     extra_hosts:
-      - "mgdeps-cache:10.42.16.10"
-      - "bench-graph-api:10.42.16.10"
+      - "mgdeps-cache:host.docker.internal"
+      - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v6_debian-11-arm"
 
   mgbuild_v6_debian-12-arm:
@@ -20,8 +20,8 @@ services:
       args:
         TOOLCHAIN_VERSION: "v6"
     extra_hosts:
-      - "mgdeps-cache:10.42.16.10"
-      - "bench-graph-api:10.42.16.10"
+      - "mgdeps-cache:host.docker.internal"
+      - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v6_debian-12-arm"
 
   mgbuild_v6_ubuntu-24.04-arm:
@@ -31,6 +31,6 @@ services:
       args:
         TOOLCHAIN_VERSION: "v6"
     extra_hosts:
-      - "mgdeps-cache:10.42.16.10"
-      - "bench-graph-api:10.42.16.10"
+      - "mgdeps-cache:host.docker.internal"
+      - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v6_ubuntu-24.04-arm"

--- a/release/package/arm-builders-v6.yml
+++ b/release/package/arm-builders-v6.yml
@@ -9,7 +9,7 @@ services:
       args:
         TOOLCHAIN_VERSION: "v6"
     extra_hosts:
-      - "mgdeps-cache:host.docker.internal"
+      - "mgdeps-cache:host-gateway"
       - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v6_debian-11-arm"
 
@@ -20,7 +20,7 @@ services:
       args:
         TOOLCHAIN_VERSION: "v6"
     extra_hosts:
-      - "mgdeps-cache:host.docker.internal"
+      - "mgdeps-cache:host-gateway"
       - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v6_debian-12-arm"
 
@@ -31,6 +31,6 @@ services:
       args:
         TOOLCHAIN_VERSION: "v6"
     extra_hosts:
-      - "mgdeps-cache:host.docker.internal"
+      - "mgdeps-cache:host-gateway"
       - "bench-graph-api:100.124.112.121"
     container_name: "mgbuild_v6_ubuntu-24.04-arm"


### PR DESCRIPTION
The mgbuild containers currently use the old hosts for `mgdeps-cache` and `bench-graph-api`. This updates the docker compose scripts to use the new hosts.

