### PR TITLE
Do not rename packages if RC workflow runs from master

### DIFF
--- a/.github/workflows/reusable_package.yaml
+++ b/.github/workflows/reusable_package.yaml
@@ -171,7 +171,7 @@ jobs:
           --dest-dir ${{ env.DOCKER_ARTIFACT_DIR }}
 
       - name: "Rename Package"
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' && !inputs.ref
         run: |
           # during testing, we will keep the default naming because it uses the
           # previous tag + number of commits since and the current commit hash


### PR DESCRIPTION
The addition of the external PR diff/packaging workflows had the unintended effect of breaking the package naming for release candidate builds that are started from `master` (i.e.  without creating the `release/x.y.z` branch beforehand). This should fix that.
