### PR TITLE
Increase diagnostics for e2e server failures

### DIFF
--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -177,8 +177,6 @@ int main(int argc, char **argv) {
     exit(1);
   }
 
-  std::this_thread::sleep_for(std::chrono::seconds(30));  // @TODO to simulate failing startup
-
   auto flags_experimental = memgraph::flags::ReadExperimental(FLAGS_experimental_enabled);
   memgraph::flags::SetExperimental(flags_experimental);
   auto *maybe_experimental = std::getenv(kMgExperimentalEnabled);

--- a/tests/e2e/memgraph.py
+++ b/tests/e2e/memgraph.py
@@ -113,18 +113,6 @@ class MemgraphInstanceRunner:
                     except Exception as e:
                         pass
 
-        if self.data_directory:
-            if os.path.isdir(self.data_directory):
-                log_file = os.path.join(self.data_directory, "logs", "memgraph.log")
-                if os.path.exists(log_file):
-                    try:
-                        with open(log_file, "r") as f:
-                            lines = f.readlines()
-                            print(f"\nmemgraph.log tail")
-                            print("".join(lines[-50:]))
-                    except Exception as e:
-                        pass
-
         print("=" * 80 + "\n")
 
     # If the method with socket is ok, remove this TODO: (andi)


### PR DESCRIPTION
Increase diagnostic information for e2e tests when the server fails to start, fails to stop, or is refusing connections.

- Separate the checks for a stopped server and one that is refusing connections, so we can distinguish these two errors
- Gather additional information from the running process, including what it is waiting on, memory usage, etc