### PR TITLE
Fix daily benchmark on new CI machines

### DIFF
--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   release_benchmarks:
     name: "Release benchmarks"
-    runs-on: [self-hosted, Linux, X64, Diff, x86-64-v3]
+    runs-on: [self-hosted, Linux, X64, x86-64-v3]
     timeout-minutes: 120
     env:
       ARCH: "amd"


### PR DESCRIPTION
Remove `Diff` label from `runs-on`, as this label is not used with the new CI machines.

