### PR TITLE
InList optimisation on more expressions

### DIFF
--- a/src/query/frame_change_caching.hpp
+++ b/src/query/frame_change_caching.hpp
@@ -1,0 +1,53 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <set>
+
+#include "query/dependant_symbol_visitor.hpp"
+#include "query/frame_change.hpp"
+#include "query/frontend/ast/ast.hpp"
+#include "utils/frame_change_id.hpp"
+#include "utils/typeinfo.hpp"
+
+namespace memgraph::query {
+
+// Scans all InList operations in the AST storage and sets up caching for cacheable expressions.
+// This function identifies InList operators that can benefit from caching (e.g., x IN range(1,100))
+// and registers them with the FrameChangeCollector along with their dependencies for invalidation.
+inline void PrepareInListCaching(const AstStorage &ast_storage, FrameChangeCollector *frame_change_collector) {
+  if (!frame_change_collector) return;
+
+  for (const auto &tree : ast_storage.storage_) {
+    if (tree->GetTypeInfo() != InListOperator::kType) {
+      continue;
+    }
+
+    auto *in_list_operator = utils::Downcast<InListOperator>(tree.get());
+    const auto cached_id = utils::GetFrameChangeId(*in_list_operator);
+
+    auto dependencies = std::set<Symbol::Position_t>{};
+    auto visitor = DependantSymbolVisitor(dependencies);
+    in_list_operator->expression2_->Accept(visitor);
+
+    if (visitor.is_cacheable()) {
+      // This InListOperator can be processed into a set and cached
+      frame_change_collector->AddInListKey(cached_id);
+      // If any dependency changes then the cache must be invalidated
+      for (auto const symbol_pos : dependencies) {
+        frame_change_collector->AddInListInvalidator(cached_id, symbol_pos);
+      }
+    }
+  }
+}
+
+}  // namespace memgraph::query

--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -349,18 +349,16 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
 
     if (frame_change_collector_) {
       const auto cached_id = memgraph::utils::GetFrameChangeId(in_list);
-      const auto do_cache{cached_id && frame_change_collector_->IsKeyTracked(*cached_id)};
-      if (do_cache) {
-        auto cached_value_ref = frame_change_collector_->TryGetCachedValue(*cached_id);
+      if (frame_change_collector_->IsKeyTracked(cached_id)) {
+        auto cached_value_ref = frame_change_collector_->TryGetCachedValue(cached_id);
         if (!cached_value_ref) {
           // Check only first time if everything is okay, later when we use
           // cache there is no need to check again as we did check first time
-          auto list = get_list_literal();
-          auto preoperational_checks = do_list_literal_checks(list);
-          if (preoperational_checks) {
+          const auto list = get_list_literal();
+          if (auto preoperational_checks = do_list_literal_checks(list)) {
             return std::move(*preoperational_checks);
           }
-          auto &cached_value = frame_change_collector_->GetCachedValue(*cached_id);
+          auto &cached_value = frame_change_collector_->GetCachedValue(cached_id);
           // Don't move here because we don't want to remove the element from the frame
           cached_value.CacheValue(list);
           cached_value_ref = std::cref(cached_value);

--- a/src/utils/frame_change_id.hpp
+++ b/src/utils/frame_change_id.hpp
@@ -18,8 +18,7 @@
 namespace memgraph::utils {
 
 struct FrameChangeId {
-  explicit FrameChangeId(query::ListLiteral *list_literal)
-      : kind_(Kind::ListExpr), hash_{std::hash<void *>{}(list_literal)}, list_expr_{list_literal} {}
+  explicit FrameChangeId(query::Expression *expr) : kind_(Kind::Expr), hash_{std::hash<void *>{}(expr)}, expr_{expr} {}
 
   explicit FrameChangeId(query::Symbol::Position_t const &symbol_pos)
       : kind_(Kind::Sym), hash_{std::hash<int32_t>{}(symbol_pos)}, symbol_pos_{symbol_pos} {}
@@ -27,8 +26,8 @@ struct FrameChangeId {
   friend bool operator==(const FrameChangeId &lhs, const FrameChangeId &rhs) {
     if (lhs.kind_ != rhs.kind_) return false;
     switch (lhs.kind_) {
-      case Kind::ListExpr:
-        return lhs.list_expr_ == rhs.list_expr_;
+      case Kind::Expr:
+        return lhs.expr_ == rhs.expr_;
       case Kind::Sym:
         return lhs.symbol_pos_ == rhs.symbol_pos_;
     }
@@ -37,28 +36,28 @@ struct FrameChangeId {
   size_t hash() const { return hash_; }
 
  private:
-  enum struct Kind : uint8_t { ListExpr, Sym };
+  enum struct Kind : uint8_t { Expr, Sym };
   Kind kind_;
   std::size_t hash_;
   union {
     query::Symbol::Position_t symbol_pos_;
-    query::ListLiteral *list_expr_;
+    query::Expression *expr_;
   };
 };
 
 // Get ID by which FrameChangeCollector struct can cache in_list.expression2_
-inline std::optional<FrameChangeId> GetFrameChangeId(memgraph::query::InListOperator &in_list) {
-  if (in_list.expression2_->GetTypeInfo() == memgraph::query::ListLiteral::kType) {
-    auto *list_literal = utils::Downcast<memgraph::query::ListLiteral>(in_list.expression2_);
-    return FrameChangeId{list_literal};
-  }
+inline FrameChangeId GetFrameChangeId(const memgraph::query::InListOperator &in_list) {
+  // Identifiers refer to a list already stored on the frame
+  // We only want to build one set for that identifier, hence key on that symbol
+  // e.g. `x IN lst AND y IN lst` that is 2 InListOperator that both use the same `lst`
   if (in_list.expression2_->GetTypeInfo() == memgraph::query::Identifier::kType) {
-    auto *identifier = utils::Downcast<memgraph::query::Identifier>(in_list.expression2_);
+    const auto *identifier = utils::Downcast<memgraph::query::Identifier>(in_list.expression2_);
     MG_ASSERT(identifier->symbol_pos_ != -1);
     return FrameChangeId{identifier->symbol_pos_};
   }
-  return {};
-};
+  // Otherwise we uniquely cache this expression
+  return FrameChangeId{in_list.expression2_};
+}
 
 }  // namespace memgraph::utils
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -90,6 +90,11 @@ add_unit_test(query_expression_evaluator
     LINK_TARGETS mg-query
 )
 
+add_unit_test(query_inlist_cache
+    SOURCES query_inlist_cache.cpp
+    LINK_TARGETS mg-query
+)
+
 add_unit_test(query_plan
     SOURCES query_plan.cpp
     LINK_TARGETS mg-query

--- a/tests/unit/helpers/query_test_utils.hpp
+++ b/tests/unit/helpers/query_test_utils.hpp
@@ -1,0 +1,216 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <memory>
+#include <set>
+#include <unordered_map>
+#include <vector>
+
+#include "query/context.hpp"
+#include "query/db_accessor.hpp"
+#include "query/frame_change.hpp"
+#include "query/frame_change_caching.hpp"
+#include "query/frontend/ast/ast.hpp"
+#include "query/interpret/eval.hpp"
+#include "query/interpret/frame.hpp"
+#include "query/typed_value.hpp"
+#include "storage/v2/inmemory/storage.hpp"
+#include "storage/v2/view.hpp"
+#include "utils/frame_change_id.hpp"
+
+#include <gtest/gtest.h>
+
+namespace memgraph::query::test {
+
+// RAII guard for temporarily setting spdlog logging level
+// Captures current level on construction, restores it on destruction
+struct ScopedLogLevel {
+  explicit ScopedLogLevel(const spdlog::level::level_enum level = spdlog::level::off)
+      : previous_level_(spdlog::default_logger()->level()) {
+    // Set the desired logging level
+    spdlog::set_level(level);
+  }
+
+  ~ScopedLogLevel() {
+    // Restore the previous logging level
+    spdlog::set_level(previous_level_);
+  }
+
+ private:
+  spdlog::level::level_enum previous_level_;
+};
+
+// User-defined literal for creating TypedValue from integer literals
+inline auto operator""_tv(const unsigned long long value) -> TypedValue {
+  return TypedValue(static_cast<int64_t>(value));
+}
+
+// User-defined literal for creating TypedValue from floating-point literals
+inline auto operator""_tv(const long double value) -> TypedValue { return TypedValue(static_cast<double>(value)); }
+
+// Helper to create a list of integers [start..end] for testing
+inline auto CreateIntList(const int64_t start, const int64_t end) -> TypedValue {
+  TypedValue::TVector list_values{};
+  for (int64_t i = start; i <= end; ++i) {
+    list_values.emplace_back(TypedValue(i));
+  }
+  return TypedValue(std::move(list_values));
+}
+
+// Minimal storage component for unit tests
+// Provides database setup and accessor management
+struct StorageComponent {
+  storage::Config config;
+  std::unique_ptr<storage::Storage> db;
+  std::unique_ptr<storage::Storage::Accessor> storage_dba;
+  DbAccessor dba;
+
+  StorageComponent()
+      : db(std::make_unique<storage::InMemoryStorage>(config)), storage_dba(db->Access()), dba(storage_dba.get()) {}
+};
+
+// Query building component for unit tests
+// Provides AST storage and helpers to create query expressions
+struct QueryBuildingComponent {
+  AstStorage ast_storage;
+  SymbolTable symbol_table;
+
+  // Helper to create an identifier (returns both the AST node and symbol)
+  auto CreateIdentifier(const std::string &name) -> std::pair<Identifier *, Symbol> {
+    auto *id = ast_storage.Create<Identifier>(name, true);
+    const auto symbol = symbol_table.CreateSymbol(name, true);
+    id->MapTo(symbol);
+    return {id, symbol};
+  }
+
+  // Helper to create range(start, end) function call
+  auto CreateRangeFunction(int64_t start, int64_t end) -> Function * {
+    return ast_storage.Create<Function>("range", std::vector<Expression *>{ast_storage.Create<PrimitiveLiteral>(start),
+                                                                           ast_storage.Create<PrimitiveLiteral>(end)});
+  }
+
+  // Helper to create a function with given name and arguments
+  auto CreateFunction(const std::string &name, std::vector<Expression *> args = {}) -> Function * {
+    return ast_storage.Create<Function>(name, args);
+  }
+
+  // Helper to create a list literal with given expressions
+  template <typename... Args>
+  // should all be pointers derived from Expression
+  auto CreateListLiteral(Args &&...args) -> ListLiteral * {
+    return ast_storage.Create<ListLiteral>(std::vector<Expression *>{std::forward<Args>(args)...});
+  }
+
+  // Helper to create a primitive literal
+  template <typename T>
+  auto CreateLiteral(T value) -> PrimitiveLiteral * {
+    return ast_storage.Create<PrimitiveLiteral>(value);
+  }
+
+  // Helper to create an InList operator
+  auto CreateInListOperator(Expression *lhs, Expression *rhs) -> InListOperator * {
+    return ast_storage.Create<InListOperator>(lhs, rhs);
+  }
+};
+
+// Query evaluation component for unit tests
+// Provides frame, context, and evaluation helpers
+struct QueryEvaluationComponent {
+  QueryBuildingComponent &builder;
+  StorageComponent &storage_component;
+
+  memgraph::utils::MonotonicBufferResource mem{1024 * 1024};
+  EvaluationContext ctx{.memory = &mem, .timestamp = QueryTimestamp()};
+  Frame frame{128};
+  FrameChangeCollector frame_change_collector{memgraph::utils::NewDeleteResource()};
+
+  QueryEvaluationComponent(QueryBuildingComponent &builder, StorageComponent &storage_component)
+      : builder(builder), storage_component(storage_component) {}
+
+  // Helper to populate a symbol with a value in the frame
+  void SetSymbolValue(const Symbol &symbol, const TypedValue &value) {
+    FrameWriter frame_writer(frame, &frame_change_collector, ctx.memory);
+    frame_writer.Write(symbol, value);
+  }
+
+  // Helper to prepare InList caching for all InList operators in the AST
+  void PrepareInListCaching() { ::memgraph::query::PrepareInListCaching(builder.ast_storage, &frame_change_collector); }
+
+  // Helper to evaluate expression with frame change collector
+  // Optionally accepts a map of symbols to values to populate just before evaluation
+  auto Eval(Expression *expr, const std::unordered_map<Symbol, TypedValue> &symbol_values = {}) -> TypedValue {
+    // Populate frame with provided symbol values just before evaluation
+    if (!symbol_values.empty()) {
+      FrameWriter frame_writer(frame, &frame_change_collector, ctx.memory);
+      for (const auto &[symbol, value] : symbol_values) {
+        frame_writer.Write(symbol, value);
+      }
+    }
+
+    ctx.properties = NamesToProperties(builder.ast_storage.properties_, &storage_component.dba);
+    ctx.labels = NamesToLabels(builder.ast_storage.labels_, &storage_component.dba);
+    ExpressionEvaluator eval(&frame, builder.symbol_table, ctx, &storage_component.dba, storage::View::OLD,
+                             &frame_change_collector);
+    return expr->Accept(eval);
+  }
+
+  // Helper to verify an InList is tracked for caching
+  void ExpectTrackedForCaching(const InListOperator *in_list, const bool should_be_tracked = true) const {
+    const auto cached_id = memgraph::utils::GetFrameChangeId(*in_list);
+    if (should_be_tracked) {
+      EXPECT_TRUE(frame_change_collector.IsKeyTracked(cached_id));
+    } else {
+      EXPECT_FALSE(frame_change_collector.IsKeyTracked(cached_id));
+    }
+  }
+
+  // Helper to get cached value reference
+  auto GetCachedValue(const memgraph::utils::FrameChangeId &cached_id) const
+      -> std::optional<std::reference_wrapper<const CachedValue>> {
+    return frame_change_collector.TryGetCachedValue(cached_id);
+  }
+
+  // Helper to verify cache is populated
+  void ExpectCachePopulated(const InListOperator *in_list) const {
+    const auto cached_id = memgraph::utils::GetFrameChangeId(*in_list);
+    const auto cached_value_ref = GetCachedValue(cached_id);
+    ASSERT_TRUE(cached_value_ref.has_value()) << "Cache should be populated";
+  }
+
+  // Helper to verify cache is NOT populated
+  void ExpectCacheNotPopulated(const InListOperator *in_list,
+                               const std::string &reason = "Cache should not be populated") const {
+    const auto cached_id = memgraph::utils::GetFrameChangeId(*in_list);
+    const auto cached_value_ref = GetCachedValue(cached_id);
+    EXPECT_FALSE(cached_value_ref.has_value()) << reason;
+  }
+
+  // Helper to verify cache contains specific values
+  auto ExpectCacheContains(const InListOperator *in_list, const std::vector<TypedValue> &should_contain,
+                           const std::vector<TypedValue> &should_not_contain = {}) const -> void {
+    const auto cached_id = memgraph::utils::GetFrameChangeId(*in_list);
+
+    const auto cached_value_ref = GetCachedValue(cached_id);
+    ASSERT_TRUE(cached_value_ref.has_value()) << "Cache should be populated";
+
+    const auto &cached_value = cached_value_ref->get();
+    for (const auto &value : should_contain) {
+      EXPECT_TRUE(cached_value.ContainsValue(value)) << "Cache missing expected value";
+    }
+    for (const auto &value : should_not_contain) {
+      EXPECT_FALSE(cached_value.ContainsValue(value)) << "Cache contains unexpected value";
+    }
+  }
+};
+
+}  // namespace memgraph::query::test

--- a/tests/unit/query_inlist_cache.cpp
+++ b/tests/unit/query_inlist_cache.cpp
@@ -1,0 +1,129 @@
+// Copyright 2025 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <gtest/gtest.h>
+
+#include "helpers/query_test_utils.hpp"
+
+using namespace memgraph::query;
+using namespace memgraph::query::test;
+
+class InListCacheTest : public testing::Test {
+ protected:
+  ScopedLogLevel scoped_log_level;  // Disable logging first
+  StorageComponent storage_component;
+  QueryBuildingComponent builder;
+  QueryEvaluationComponent evaluator{builder, storage_component};
+};
+
+// Test: x IN range(1,100) creates and uses cache
+TEST_F(InListCacheTest, RangeInListCaching) {
+  // Build: x IN range(1, 100)
+  auto [x_id, x_symbol] = builder.CreateIdentifier("x");
+  auto *range_func = builder.CreateRangeFunction(1, 100);
+  auto *in_list = builder.CreateInListOperator(x_id, range_func);
+
+  // Prepare caching
+  evaluator.PrepareInListCaching();
+
+  // Verify it's tracked for caching
+  evaluator.ExpectTrackedForCaching(in_list);
+
+  // Evaluate with x = 50
+  auto result = evaluator.Eval(in_list, {{x_symbol, 50_tv}});
+  EXPECT_TRUE(result.IsBool());
+  EXPECT_TRUE(result.ValueBool()) << "50 should be in range(1, 100)";
+
+  // Verify cache was populated with correct values
+  evaluator.ExpectCacheContains(in_list, {1_tv, 50_tv, 100_tv}, {0_tv, 101_tv});
+}
+
+// Test: Identifier-based list also supports caching
+TEST_F(InListCacheTest, IdentifierListCaching) {
+  // Build: x IN mylist (where mylist = [1..10])
+  auto [mylist_id, mylist_symbol] = builder.CreateIdentifier("mylist");
+  auto [x_id, x_symbol] = builder.CreateIdentifier("x");
+  auto *in_list = builder.CreateInListOperator(x_id, mylist_id);
+
+  // Prepare caching
+  evaluator.PrepareInListCaching();
+
+  // Verify it's tracked for caching
+  evaluator.ExpectTrackedForCaching(in_list);
+
+  // Evaluate with mylist = [1..10] and x = 5
+  auto result = evaluator.Eval(in_list, {{mylist_symbol, CreateIntList(1, 10)}, {x_symbol, 5_tv}});
+  EXPECT_TRUE(result.IsBool());
+  EXPECT_TRUE(result.ValueBool()) << "5 should be in the list";
+
+  // Verify cache was populated with correct values
+  evaluator.ExpectCacheContains(in_list, {1_tv, 5_tv, 10_tv}, {11_tv});
+}
+
+// Test: Cache invalidation
+TEST_F(InListCacheTest, CacheInvalidation) {
+  // Build: x IN mylist (where mylist = [1..5])
+  auto [mylist_id, mylist_symbol] = builder.CreateIdentifier("mylist");
+  auto [x_id, x_symbol] = builder.CreateIdentifier("x");
+  auto *in_list = builder.CreateInListOperator(x_id, mylist_id);
+
+  // Prepare caching
+  evaluator.PrepareInListCaching();
+
+  // Verify it's tracked for caching
+  evaluator.ExpectTrackedForCaching(in_list);
+
+  // Evaluate with mylist = [1..5] and x = 3
+  auto result = evaluator.Eval(in_list, {{mylist_symbol, CreateIntList(1, 5)}, {x_symbol, 3_tv}});
+  EXPECT_TRUE(result.ValueBool());
+  evaluator.ExpectCachePopulated(in_list);
+
+  // Invalidate the cache
+  evaluator.frame_change_collector.ResetInListCache(mylist_symbol);
+
+  // Verify cache was cleared
+  evaluator.ExpectCacheNotPopulated(in_list, "Cache should be cleared after invalidation");
+  // But still tracked
+  evaluator.ExpectTrackedForCaching(in_list);
+}
+
+// Test: Non-list expressions should throw QueryRuntimeException
+TEST_F(InListCacheTest, NonListExpressionThrows) {
+  // Build: x IN 5 (integer literal) -> should throw
+  auto [x_id, x_symbol] = builder.CreateIdentifier("x");
+  auto *int_literal = builder.CreateLiteral(5);
+  auto *in_list = builder.CreateInListOperator(x_id, int_literal);
+
+  // Should throw QueryRuntimeException when evaluated with x = 5
+  EXPECT_THROW(evaluator.Eval(in_list, {{x_symbol, 5_tv}}), QueryRuntimeException);
+}
+
+// Test: Non-pure expressions should not be cached
+TEST_F(InListCacheTest, NonPureExpressionsNotCached) {
+  // Build: x IN [rand()] - non-deterministic, should NOT be cached
+  auto [x_id, x_symbol] = builder.CreateIdentifier("x");
+  auto *rand_func = builder.CreateFunction("rand");
+  auto *list_literal = builder.CreateListLiteral(rand_func);
+  auto *in_list = builder.CreateInListOperator(x_id, list_literal);
+
+  // Prepare caching - should detect this is not cacheable
+  evaluator.PrepareInListCaching();
+
+  // Verify it was NOT tracked (because rand() is non-pure)
+  evaluator.ExpectTrackedForCaching(in_list, false);
+
+  // Evaluate with x = 0.5 - should work but not create cache
+  const auto result = evaluator.Eval(in_list, {{x_symbol, 0.5_tv}});
+  EXPECT_TRUE(result.IsBool());
+
+  // Verify cache was NOT populated
+  evaluator.ExpectCacheNotPopulated(in_list, "Non-pure expressions should not be cached");
+}


### PR DESCRIPTION
Now always generating a FrameChangeId for each InList operator.

This means we now support the optimisation for queries like `x IN range(0,1000)`.