### PR TITLE
Handle arrow debug suffix

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -417,7 +417,6 @@ macro(build_arrow)
       "${ARROW_LIBDIR}/libarrow.a" "${ARROW_LIBDIR}/libarrowd.a"
       "${ARROW_LIBDIR}/libparquet.a" "${ARROW_LIBDIR}/libparquetd.a"
       "${ARROW_LIBDIR}/libarrow_bundled_dependencies.a"
-      "${ARROW_LIBDIR}/libarrow_bundled_dependenciesd.a"
   )
 
   # handle debug build with `d` suffix


### PR DESCRIPTION
Handle the `d` suffix on two of Arrow's libs in Debug build.
