### PR TITLE
testing: Fix flaky unit test utils_scheduler

### DIFF
--- a/tests/unit/utils_scheduler.cpp
+++ b/tests/unit/utils_scheduler.cpp
@@ -64,7 +64,6 @@ TEST(Scheduler, SetupAndSpinOnce) {
 
   // SpinOne to unblock, but still don't execute
   scheduler.SpinOnce();
-  EXPECT_EQ(x, 0);
   std::this_thread::sleep_for(std::chrono::milliseconds(1500));
   EXPECT_GT(x, 0);
 


### PR DESCRIPTION
We just need to test that x gets from 0 to 1 and that spin unblocks the condition variable.