### PR TITLE
feat: Remove OpenSSL from conanfile.py

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -72,7 +72,6 @@ class Memgraph(ConanFile):
         self.requires("croncpp/2023.03.30")
         self.requires("range-v3/0.12.0")
         self.requires("asio/1.34.2")
-        self.requires("openssl/3.5.1")
         self.requires("mgclient/1.4.3", options={"with_cpp": True})
 
     def package(self):


### PR DESCRIPTION
We are dynamically linking OpenSSL so bringing it statically through Conan shouldn't be needed