### PR TITLE
Fix slow vector index recovery after index resize

### DIFF
--- a/src/storage/v2/indices/vector_index.cpp
+++ b/src/storage/v2/indices/vector_index.cpp
@@ -9,7 +9,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-#include <algorithm>
 #include <cstdint>
 #include <ranges>
 #include <shared_mutex>


### PR DESCRIPTION
This PR improves the performance of vector index recovery in cases where the index was previously resized.
The issue was in the resize logic, after the resize operation, the code didn’t update the vector index specification used for creating snapshots.
As a result, when recovering from a snapshot, the index was recreated with its initial capacity, triggering another resize during recovery.
By updating the index specification after the initial resize, we now avoid unnecessary resizing during recovery, improving overall performance.
