### PR TITLE
Run daily benchmarks after midnight

### DIFF
--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -8,7 +8,7 @@ on:
         description: "Number of times to run the benchmarks. Default is 10."
         default: 10
   schedule:
-    - cron: "0 22 * * *"
+    - cron: "0 1 * * *"
 
 jobs:
   release_benchmarks:


### PR DESCRIPTION
Run daily benchmarks after midnight to simplify regression detection by allowing results to be aggregated by day.

