### PR TITLE
Add trigger for regression detection

### DIFF
--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -194,3 +194,13 @@ jobs:
         continue-on-error: true
         run: |
           ./tools/docker_cleanup.sh
+
+      - name: Trigger Regression Detection Job
+        env:
+          GITHUB_TOKEN: ${{ secrets.REPO_PAT }}
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            https://api.github.com/repos/memgraph/infra/dispatches \
+            -d "{\"event_type\": \"regression-detection\"}"


### PR DESCRIPTION
Use GitHub API to trigger workflow in the `infra` repo  which should detect regressions in Memgraph using the daily benchmarks.
