### PR TITLE
Avoid expensive GC during edge accessor destruction while vertex locks are held

### DIFF
--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -40,7 +40,6 @@
 #include "storage/v2/replication/replication_transaction.hpp"
 #include "storage/v2/schema_info_glue.hpp"
 #include "utils/async_timer.hpp"
-#include "utils/skip_list.hpp"
 #include "utils/timer.hpp"
 
 /// REPLICATION ///


### PR DESCRIPTION
This PR addresses a performance bottleneck caused by skip list garbage collection (GC) occurring during edge accessor destruction while vertex locks are still held.
The skip list GC is not only expensive but also blocks other threads. This becomes critical under high concurrency, especially when queries create edges involving supernodes.

Here’s the scenario:
- Multiple threads call CreateEdge concurrently.
- One thread acquires unique locks on the vertices involved in the edge.
- Inside the locked section, an edge accessor is created.
- When the accessor goes out of scope, it may trigger skip list GC.
- If GC runs while vertex locks are still held, all threads attempting related operations are blocked.

This leads to significant performance degradation when operating on supernodes.