### PR TITLE
Run all benchmarks on benchmarking servers

### DIFF
--- a/.github/workflows/benchmark_on_pokec_large.yaml
+++ b/.github/workflows/benchmark_on_pokec_large.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   benchmark_on_pokec_large:
     name: "Benchmark on pokec large dataset"
-    runs-on: [self-hosted, Linux, X64, DockerMgBuild, x86-64-v3]
+    runs-on: [self-hosted, Linux, benchmark]
     timeout-minutes: 720
     env:
       THREADS: 24

--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -1,5 +1,9 @@
 name: Daily Benchmark
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
     inputs:
@@ -13,7 +17,7 @@ on:
 jobs:
   release_benchmarks:
     name: "Release benchmarks"
-    runs-on: [self-hosted, Linux, X64, "${{ github.ref == 'refs/heads/master' && 'benchmark' || 'x86-64-v3' }}"]
+    runs-on: [self-hosted, Linux, benchmark]
     timeout-minutes: 330
     #  The timeout above is calculated based on a previous run where the loop count was 100
     #  Rough times per test:

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -181,7 +181,7 @@ jobs:
   benchmark:
     if: ${{ inputs.run_benchmark == 'true' }}
     name: "Benchmark"
-    runs-on: [self-hosted, Linux, X64, "${{ github.event_name == 'merge_group' && 'benchmark' || 'DockerMgBuild' }}"]
+    runs-on: [self-hosted, Linux, benchmark]
     timeout-minutes: 60
     steps:
       - name: Set up repository


### PR DESCRIPTION
Run all of the benchmarks on the benchmarking servers. Daily benchmark concurrency will be limited to stop it blocking other, shorter, benchmarks.


