### PR TITLE
bugfix: fix pattern comprehension with where causing a crash 

### DIFF
--- a/src/query/interpret/eval.hpp
+++ b/src/query/interpret/eval.hpp
@@ -975,6 +975,10 @@ class ExpressionEvaluator : public ExpressionVisitor<TypedValue> {
 
   TypedValue Visit(PatternComprehension &pattern_comprehension) override {
     const TypedValue &frame_pattern_comprehension_value = frame_->at(symbol_table_->at(pattern_comprehension));
+    if (frame_pattern_comprehension_value.IsNull()) {
+      // didn't match anything
+      return {std::vector<TypedValue>(), ctx_->memory};
+    }
     if (!frame_pattern_comprehension_value.IsList()) [[unlikely]] {
       throw QueryRuntimeException(
           "Unexpected behavior: Pattern Comprehension expected a list, got {}. Please report the problem on GitHub "

--- a/src/query/plan/rule_based_planner.cpp
+++ b/src/query/plan/rule_based_planner.cpp
@@ -570,6 +570,10 @@ std::unique_ptr<LogicalOperator> GenReturnBody(std::unique_ptr<LogicalOperator> 
   if (body.has_pattern_comprehension()) {
     auto list_collection_datas = body.pattern_comprehension_data();
     for (auto &list_collection_data : list_collection_datas) {
+      // pattern comprehensions in WHERE clauses don't have their op set, only those in RETURN/WITH bodies do
+      if (!list_collection_data.op) {
+        continue;
+      }
       auto list_collection_symbols = list_collection_data.op->ModifiedSymbols(body.symbol_table());
       last_op = std::make_unique<RollUpApply>(std::move(last_op), std::move(list_collection_data.op),
                                               list_collection_symbols, list_collection_data.result_symbol);

--- a/tests/gql_behave/tests/memgraph_V1/features/pattern_comprehensions.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/pattern_comprehensions.feature
@@ -47,3 +47,15 @@ Feature: Pattern comprehensions
             | [[[2]]]                 |
             | [[[3]]]                 |
             | [[[]]]                  |
+
+    Scenario: Pattern comprehension in where
+        Given an empty graph
+        When executing query:
+            """
+            WITH 1 AS a
+            WHERE [(b)--() | b] = []
+            RETURN *;
+            """
+        Then the result should be:
+            | a  |
+            | 1  |


### PR DESCRIPTION
Queries like the one below would cause a crash
```
WITH 1 AS a 
WHERE [(b)--() | b] < 1
RETURN *;
```
