### PR TITLE
Fix: Subquery result is added to bound symbols

### DIFF
--- a/src/query/plan/rule_based_planner.hpp
+++ b/src/query/plan/rule_based_planner.hpp
@@ -1031,10 +1031,14 @@ class RuleBasedPlanner {
         impl::GetSubqueryBoundSymbols(subquery->query_parts[0].single_query_parts, symbol_table, storage, pc_ops);
 
     auto subquery_op = Plan(*subquery);
+    auto subquery_bound_symbols = subquery_op->OutputSymbols(*context_->symbol_table);
 
     context_->bound_symbols.clear();
     context_->bound_symbols.insert(std::make_move_iterator(outer_scope_bound_symbols.begin()),
                                    std::make_move_iterator(outer_scope_bound_symbols.end()));
+
+    context_->bound_symbols.insert(std::make_move_iterator(subquery_bound_symbols.begin()),
+                                   std::make_move_iterator(subquery_bound_symbols.end()));
 
     auto subquery_has_return = true;
     if (subquery_op->GetTypeInfo() == EmptyResult::kType) {

--- a/tests/unit/query_common.hpp
+++ b/tests/unit/query_common.hpp
@@ -431,6 +431,7 @@ void FillReturnBody(AstStorage &, ReturnBody &body, Expression *expr, NamedExpre
   // This overload supports `RETURN(expr, AS(name))` construct, since
   // NamedExpression does not inherit Expression.
   named_expr->expression_ = expr;
+  named_expr->is_aliased_ = true;  // Using AS() implies explicit aliasing
   body.named_expressions.emplace_back(named_expr);
 }
 void FillReturnBody(AstStorage &storage, ReturnBody &body, const std::string &name, NamedExpression *named_expr) {
@@ -439,7 +440,9 @@ void FillReturnBody(AstStorage &storage, ReturnBody &body, const std::string &na
 }
 template <class... T>
 void FillReturnBody(AstStorage &storage, ReturnBody &body, Expression *expr, NamedExpression *named_expr, T... rest) {
+  // This overload supports `RETURN(expr, AS(name), ...)`
   named_expr->expression_ = expr;
+  named_expr->is_aliased_ = true;  // Using AS() implies explicit aliasing
   body.named_expressions.emplace_back(named_expr);
   FillReturnBody(storage, body, rest...);
 }

--- a/tests/unit/query_semantic.cpp
+++ b/tests/unit/query_semantic.cpp
@@ -1291,6 +1291,12 @@ TYPED_TEST(TestSymbolGenerator, Subqueries) {
   auto query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), CALL_SUBQUERY(subquery), RETURN("n")));
   EXPECT_THROW(MakeSymbolTable(query), SemanticException);
 
+  // WITH 1 AS x CALL { RETURN 2 AS x } RETURN x
+  // Yields exception because aliased return in subquery conflicts with outer scope variable
+  subquery = QUERY(SINGLE_QUERY(RETURN(LITERAL(2), AS("x"))));
+  query = QUERY(SINGLE_QUERY(WITH(LITERAL(1), AS("x")), CALL_SUBQUERY(subquery), RETURN("x")));
+  EXPECT_THROW(MakeSymbolTable(query), SemanticException);
+
   // MATCH (n) CALL { MATCH (m) RETURN m.prop } RETURN n
   // Yields exception because m.prop must be aliased before returning
   subquery = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("m"))), RETURN("m.prop")));


### PR DESCRIPTION
There was in inconsistency between:
CALL { RETURN 1 AS x } RETURN *; # Empty set
and
CALL { RETURN 1 AS x } RETURN x; # One record

Problem was subqueries returned symbols were not added into the bound symbols for the next operator to use.