### PR TITLE
testing: Fix the time needed to import the data when using multi tenancy

### DIFF
--- a/.github/workflows/reusable_stress_jepsen.yaml
+++ b/.github/workflows/reusable_stress_jepsen.yaml
@@ -105,7 +105,8 @@ jobs:
           trap "kill $CLEANUP_PID" EXIT
 
           if [[ "${{ inputs.mt }}" == "true" ]]; then
-            ARGS="--workload ha-mt --nodes-config resources/${{ env.CLUSTER }} --time-limit ${{ inputs.time-limit }} --concurrency $NODES_NO --num-tenants ${{ inputs.num-tenants }} --recovery-time 600 --nemesis-start-sleep 480"
+            NEMESIS_SLEEP_SEC=$((90 * ${{ inputs.num-tenants }}))
+           ARGS="--workload ha-mt --nodes-config resources/${{ env.CLUSTER }} --time-limit ${{ inputs.time-limit }} --concurrency $NODES_NO --num-tenants ${{ inputs.num-tenants }} --recovery-time 600 --nemesis-start-sleep $NEMESIS_SLEEP_SEC"
           else
             ARGS="--workload hacreate --nodes-config resources/${{ env.CLUSTER }} --time-limit ${{ inputs.time-limit }} --concurrency $NODES_NO --recovery-time 600 --nemesis-start-sleep 25"
           fi

--- a/src/utils/atomic_utils.hpp
+++ b/src/utils/atomic_utils.hpp
@@ -38,7 +38,7 @@ concept AtomicStruct =
     std::is_copy_assignable_v<T> && std::is_move_assignable_v<T> && std::is_same_v<T, std::remove_cv_t<T>>;
 
 template <AtomicStruct T, typename F>
-void atomic_struct_update(std::atomic<T> &data, F &&func) {
+void atomic_struct_update(std::atomic<T> &data, F func) {
   auto curr_info = data.load(std::memory_order_acquire);
   while (
       !data.compare_exchange_weak(curr_info, func(curr_info), std::memory_order_acq_rel, std::memory_order_acquire)) {


### PR DESCRIPTION
When specifying a number of tenants, we want to finish import on all databases before starting nemesis.