### PR TITLE
Run daily benchmarks on specific runner

### DIFF
--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   release_benchmarks:
     name: "Release benchmarks"
-    runs-on: [self-hosted, Linux, benchmark]
+    runs-on: [self-hosted, Linux, "${{ github.ref == 'refs/heads/master' && 'laufey' || 'benchmark' }}"]
     timeout-minutes: 330
     #  The timeout above is calculated based on a previous run where the loop count was 100
     #  Rough times per test:

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -181,7 +181,7 @@ jobs:
   benchmark:
     if: ${{ inputs.run_benchmark == 'true' }}
     name: "Benchmark"
-    runs-on: [self-hosted, Linux, benchmark]
+    runs-on: [self-hosted, Linux, "${{ github.event_name == 'merge_group' && 'laufey' || 'benchmark' }}"]
     timeout-minutes: 60
     steps:
       - name: Set up repository


### PR DESCRIPTION
Run daily benchmarks and diff benchmarks in merge queue on specific runner to reduce false regression detections due to subtle differences in the benchmarking servers.
