### PR TITLE
fix: Non-repeatable reads phenomenon in 2PC

### DIFF
--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -574,7 +574,7 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
     }
 
     // sort by path
-    std::sort(wal_files.begin(), wal_files.end());
+    std::ranges::sort(wal_files);
 
     // UUID used for durability is the UUID of the last WAL file.
     // Same for the epoch id.

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -8482,7 +8482,7 @@ RecoveredSnapshot LoadCurrentVersionSnapshot(Decoder &snapshot, std::filesystem:
   // Set success flag (to disable cleanup).
   success = true;
 
-  return {info, recovery_info, std::move(indices_constraints)};
+  return {.snapshot_info = info, .recovery_info = recovery_info, .indices_constraints = std::move(indices_constraints)};
 }
 
 RecoveredSnapshot LoadSnapshot(const std::filesystem::path &path, utils::SkipList<Vertex> *vertices,

--- a/src/storage/v2/durability/wal.cpp
+++ b/src/storage/v2/durability/wal.cpp
@@ -1427,8 +1427,8 @@ std::optional<RecoveryInfo> LoadWal(
 
   for (uint64_t i = 0; i < info.num_deltas; ++i) {
     // Read WAL delta header to find out the delta timestamp.
-    if (auto timestamp = ReadWalDeltaHeader(&wal);
-        (!last_applied_delta_timestamp || timestamp > *last_applied_delta_timestamp)) {
+    if (auto delta_ts = ReadWalDeltaHeader(&wal);
+        (!last_applied_delta_timestamp || delta_ts > *last_applied_delta_timestamp)) {
       // This delta should be loaded.
       auto delta = ReadWalDeltaData(&wal, *version);
 
@@ -1442,10 +1442,10 @@ std::optional<RecoveryInfo> LoadWal(
       if (should_commit) {
         // First delta which is not WalTransactionStart -> allocate RecoveryInfo
         if (!ret.has_value()) {
-          ret.emplace(RecoveryInfo{.next_timestamp = timestamp + 1, .last_durable_timestamp = timestamp});
+          ret.emplace(RecoveryInfo{.next_timestamp = delta_ts + 1, .last_durable_timestamp = delta_ts});
         } else {
-          ret->next_timestamp = std::max(ret->next_timestamp, timestamp + 1);
-          ret->last_durable_timestamp = timestamp;
+          ret->next_timestamp = std::max(ret->next_timestamp, delta_ts + 1);
+          ret->last_durable_timestamp = delta_ts;
         }
 
         std::visit(delta_apply, delta.data_);


### PR DESCRIPTION
If strict sync replica is invoking FinalizeCommitPhase, we need to take the engine lock again and get the new in-memory commit timestamp. Otherwise, the following situation is possible:
1. On replica, we start the explicit txn with BEGIN; and keep executing match (n) return n
2 .Main executes create() and sends PrepareCommitRpc to replica
3. After receiving FinalizeCommitRpc, replica will show there is a vertex, in that way manifesting non-repeatable reads phenomenon.