### PR TITLE
Use Linux distribution string in `build.sh` script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -106,6 +106,11 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Detect distro
+source environment/util.sh
+DISTRO="$(operating_system)"
+echo "Distro: $DISTRO"
+
 # Validate build type
 if [[ "$BUILD_TYPE" != "Release" && "$BUILD_TYPE" != "RelWithDebInfo" && "$BUILD_TYPE" != "Debug" ]]; then
     echo "Error: --build-type must be either 'Release', 'RelWithDebInfo', or 'Debug'"
@@ -203,7 +208,8 @@ MG_TOOLCHAIN_ROOT="/opt/toolchain-v7" conan install \
   --build=missing \
   -pr:h memgraph_template_profile \
   -pr:b memgraph_build_profile \
-  -s build_type="$BUILD_TYPE"
+  -s build_type="$BUILD_TYPE" \
+  -s os.distro="$DISTRO"
 
 export CLASSPATH=
 export LD_LIBRARY_PATH=


### PR DESCRIPTION
Use the existing `operating_system` function to detect the Linux distribution used to build memgraph in the `build.sh` script. This should make using the `conan` remote easier.
