### PR TITLE
Reading properties of deleted object should error

### DIFF
--- a/src/query/interpret/eval.cpp
+++ b/src/query/interpret/eval.cpp
@@ -132,16 +132,14 @@ TypedValue ExpressionEvaluator::Visit(AllPropertiesLookup &all_properties_lookup
     case TypedValue::Type::Null:
       return TypedValue(ctx_->memory);
     case TypedValue::Type::Vertex: {
-      for (const auto properties = *expression_result.ValueVertex().Properties(view_);
-           const auto &[property_id, value] : properties) {
+      for (const auto &[property_id, value] : GetAllProperties(expression_result.ValueVertex())) {
         auto typed_value = TypedValue(value, GetNameIdMapper(), ctx_->memory);
         result.emplace(TypedValue::TString(dba_->PropertyToName(property_id), ctx_->memory), typed_value);
       }
       return {result, ctx_->memory};
     }
     case TypedValue::Type::Edge: {
-      for (const auto properties = *expression_result.ValueEdge().Properties(view_);
-           const auto &[property_id, value] : properties) {
+      for (const auto &[property_id, value] : GetAllProperties(expression_result.ValueEdge())) {
         auto typed_value = TypedValue(value, GetNameIdMapper(), ctx_->memory);
         result.emplace(TypedValue::TString(dba_->PropertyToName(property_id), ctx_->memory), typed_value);
       }

--- a/tests/gql_behave/tests/memgraph_V1/features/map_projection.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/map_projection.feature
@@ -85,3 +85,51 @@ Feature: Map projection
     Then the result should be:
       | actor["name"] | actor["awards"]["oscars"] |
       | 'Morgan'      | 1                         |
+
+  Scenario: Accessing a property of a deleted node should throw an exception
+    Given an empty graph
+    And having executed
+      """
+      CREATE (:TestNode {val: 1})
+      """
+    When executing query:
+      """
+      MATCH (n) DETACH DELETE n RETURN n.val
+      """
+    Then an error should be raised
+
+  Scenario: Accessing all properties of a deleted node should throw an exception
+    Given an empty graph
+    And having executed
+      """
+      CREATE (:TestNode {val: 1})
+      """
+    When executing query:
+      """
+      MATCH (n) DETACH DELETE n RETURN n {.*}
+      """
+    Then an error should be raised
+
+  Scenario: Accessing a property of a deleted edge should throw an exception
+    Given an empty graph
+    And having executed
+      """
+      CREATE (:A)-[:REL {val: 1}]->(:B)
+      """
+    When executing query:
+      """
+      MATCH ()-[r]-() DELETE r RETURN r.val
+      """
+    Then an error should be raised
+
+  Scenario: Accessing all properties of a deleted edge should throw an exception
+    Given an empty graph
+    And having executed
+      """
+      CREATE (:A)-[:REL {val: 1}]->(:B)
+      """
+    When executing query:
+      """
+      MATCH ()-[r]-() DELETE r RETURN r {.*}
+      """
+    Then an error should be raised


### PR DESCRIPTION
Invalid access of properties should error

CREATE (:TestNode {val: 1});
MATCH (n) DETACH DELETE n RETURN n {.*}; # <-- ERROR