### PR TITLE
testing: Bound Jepsen test concurrency to 10

### DIFF
--- a/.github/workflows/reusable_stress_jepsen.yaml
+++ b/.github/workflows/reusable_stress_jepsen.yaml
@@ -127,7 +127,7 @@ jobs:
 
           if [ -z "$INPUT_CONCURRENCY" ]; then
             MIN=$NODES_NO
-            MAX=$((3 * NODES_NO))
+            MAX=10
             CONCURRENCY=$((MIN + RANDOM % (MAX - MIN + 1)))
             echo "Generated random concurrency: $CONCURRENCY (range: $MIN-$MAX)"
           else


### PR DESCRIPTION
Otherwise, we get to often OOM on CI machines.