### PR TITLE
fix: FastDiscardOfDeltas for strict sync replication

### DIFF
--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -453,6 +453,8 @@ void InMemoryReplicationHandlers::FinalizeCommitHandler(dbms::DbmsHandler *dbms_
     auto &commit_ts = two_pc_cache_.commit_accessor_->GetCommitTimestamp();
     DMG_ASSERT(commit_ts.has_value(), "Commit ts without a value");
     auto guard = std::lock_guard{mem_storage->engine_lock_};
+    // Mark the old commit ts as finished before emplacing the new one
+    mem_storage->commit_log_->MarkFinished(*commit_ts);
     commit_ts.emplace(mem_storage->GetCommitTimestamp());
     two_pc_cache_.commit_accessor_->FinalizeCommitPhase(req.durability_commit_timestamp);
     spdlog::trace("Finalized txn on replica");


### PR DESCRIPTION
Old commit ts needs to be marked as finished so that FastDiscardOfDelta wouldn't see there are older transactions at the same time active.