### PR TITLE
fix: Delete partially written aborted snapshot file

### DIFF
--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -146,7 +146,7 @@ std::vector<SnapshotDurabilityInfo> GetSnapshotFiles(const std::filesystem::path
         spdlog::warn("Skipping snapshot file '{}' because UUIDs does not match!", item.path());
       }
     } catch (const RecoveryFailure &e) {
-      spdlog::error("Couldn't read snapshot info in GetSnapshotFiles: {}", e.what());
+      spdlog::error("Couldn't read snapshot info in GetSnapshotFiles for file {}: {}", e.what(), item.path());
     }
   }
   MG_ASSERT(!error_code, "Couldn't recover data because an error occurred: {}!", error_code.message());

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -8682,16 +8682,6 @@ std::optional<std::filesystem::path> CreateSnapshot(
     std::atomic_bool *abort_snapshot) {
   utils::Timer timer;
 
-  auto const snapshot_aborted = [abort_snapshot, &timer]() -> bool {
-    if (abort_snapshot == nullptr) return false;
-    if (timer.Elapsed() >= kCheckIfSnapshotAborted) {
-      const bool abort = abort_snapshot->load(std::memory_order_acquire);
-      if (!abort) timer.ResetStartTime();  // Leave timer as elapsed, so future checks also retrun true
-      return abort;
-    }
-    return false;
-  };
-
   // Ensure that the storage directory exists.
   utils::EnsureDirOrDie(snapshot_directory);
 
@@ -8699,6 +8689,19 @@ std::optional<std::filesystem::path> CreateSnapshot(
   // For InMemoryStorage, we always have a value for last_durable_ts_
   auto path = snapshot_directory / MakeSnapshotName(transaction->last_durable_ts_ ? *transaction->last_durable_ts_
                                                                                   : transaction->start_timestamp);
+
+  auto const snapshot_aborted = [abort_snapshot, &timer, &path, file_retainer]() -> bool {
+    if (abort_snapshot == nullptr) return false;
+    if (timer.Elapsed() >= kCheckIfSnapshotAborted) {
+      const bool abort = abort_snapshot->load(std::memory_order_acquire);
+      if (!abort) timer.ResetStartTime();  // Leave timer as elapsed, so future checks also return true
+      // Delete a partially written snapshot file
+      file_retainer->DeleteFile(path);
+      return abort;
+    }
+    return false;
+  };
+
   spdlog::info("Starting snapshot creation to {}", path);
   SnapshotEncoder snapshot;
   snapshot.Initialize(path, kSnapshotMagic, kVersion);


### PR DESCRIPTION
Snapshots which are getting aborted, should get deleted immediately. Otherwise, we lose processing time on reading this snapshot and figuring out that it wasn't fully written. This PR currently solves this.

There is also a question how to delete snapshots which aren't fully written because an instance went down during snapshot creation. One way to do that would be to conclude that the snapshot is partially written if we cannot read section metadata, since that section is the last one in a snapshot file.

Another thing which is I think going on at the moment is that there could be snapshot getting created and in parallel GetSnapshotFiles which will read all snapshot files. This won't cause bugs but we again lose time on reading snapshot + in logs we are seeing all the time 'couldn't read marker' error messages => Bad UX.
