### PR TITLE
Cache GetExecutablePath() result

### DIFF
--- a/src/utils/file.cpp
+++ b/src/utils/file.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -61,7 +61,10 @@ auto CreateUniqueDownloadFile(std::filesystem::path const &base_path)
                               base_path.string());
 }
 
-std::filesystem::path GetExecutablePath() { return std::filesystem::read_symlink("/proc/self/exe"); }
+std::filesystem::path const &GetExecutablePath() {
+  static const auto path = std::filesystem::read_symlink("/proc/self/exe");
+  return path;
+}
 
 std::vector<std::string> ReadLines(const std::filesystem::path &path) noexcept {
   std::vector<std::string> lines;

--- a/src/utils/file.hpp
+++ b/src/utils/file.hpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -39,7 +39,7 @@ auto CreateUniqueDownloadFile(std::filesystem::path const &base_path)
 ///
 /// @throw std::filesystem::filesystem_error
 /// @throw std::bad_alloc
-std::filesystem::path GetExecutablePath();
+std::filesystem::path const &GetExecutablePath();
 
 /// Reads all lines from the file specified by path. If the file doesn't exist
 /// or there is an access error the function returns an empty list.


### PR DESCRIPTION
Cache the result of reading /proc/self/exe in a static local variable, eliminating a readlink syscall on every call after the first.

Impact: Reduces syscall overhead during startup and runtime. No user-visible behavior change.
