### PR TITLE
Add RocksDB tuning flags for reduced syscall overhead

### DIFF
--- a/src/flags/general.cpp
+++ b/src/flags/general.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -144,6 +144,17 @@ DEFINE_bool(storage_enable_edges_metadata, false,
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_bool(storage_delta_on_identical_property_update, true,
             "Controls whether updating a property with the same value should create a delta object.");
+
+// RocksDB flags
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_string(storage_rocksdb_info_log_level, "ERROR_LEVEL",
+              "RocksDB info log level. Options: DEBUG_LEVEL, INFO_LEVEL, WARN_LEVEL, ERROR_LEVEL, "
+              "FATAL_LEVEL, HEADER_LEVEL. Default is ERROR_LEVEL for reduced syscall overhead. "
+              "Use INFO_LEVEL or DEBUG_LEVEL when debugging disk storage issues.");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_bool(storage_rocksdb_enable_thread_tracking, false,
+            "Enable RocksDB thread status tracking. Default is false for reduced syscall overhead. "
+            "Enable when debugging disk storage performance issues (provides GetThreadList API).");
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_bool(schema_info_enabled, false, "Set to true to enable run-time schema info tracking.");

--- a/src/flags/general.hpp
+++ b/src/flags/general.hpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -92,6 +92,12 @@ DECLARE_bool(storage_automatic_edge_type_index_creation_enabled);
 DECLARE_bool(storage_enable_edges_metadata);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_bool(storage_delta_on_identical_property_update);
+
+// RocksDB flags
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DECLARE_string(storage_rocksdb_info_log_level);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DECLARE_bool(storage_rocksdb_enable_thread_tracking);
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_bool(schema_info_enabled);

--- a/src/kvstore/CMakeLists.txt
+++ b/src/kvstore/CMakeLists.txt
@@ -1,7 +1,20 @@
 find_package(gflags REQUIRED)
 
-add_library(mg-kvstore STATIC kvstore.cpp)
+add_library(mg-kvstore STATIC)
 add_library(mg::kvstore ALIAS mg-kvstore)
+
+target_sources(mg-kvstore
+    PRIVATE
+    kvstore.cpp
+    rocksdb_utils.cpp
+
+    PUBLIC
+    FILE_SET HEADERS
+    BASE_DIRS ../
+    FILES
+    kvstore.hpp
+    rocksdb_utils.hpp
+)
 
 target_link_libraries(mg-kvstore stdc++fs mg-utils BZip2::BZip2 ZLIB::ZLIB gflags)
 # TODO(gitbuda): Once RocksDB is proparly compiled under toolchain.

--- a/src/kvstore/kvstore.cpp
+++ b/src/kvstore/kvstore.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -13,6 +13,7 @@
 #include <rocksdb/options.h>
 
 #include "kvstore/kvstore.hpp"
+#include "kvstore/rocksdb_utils.hpp"
 #include "utils/file.hpp"
 #include "utils/logging.hpp"
 
@@ -29,6 +30,7 @@ KVStore::KVStore(std::filesystem::path storage) : pimpl_(std::make_unique<impl>(
   if (!utils::EnsureDir(pimpl_->storage))
     throw KVStoreError("Folder for the key-value store " + pimpl_->storage.string() + " couldn't be initialized!");
   pimpl_->options.create_if_missing = true;
+  utils::ApplyRocksDBConfigFlags(pimpl_->options);
   rocksdb::DB *db = nullptr;
   auto s = rocksdb::DB::Open(pimpl_->options, pimpl_->storage.c_str(), &db);
   if (!s.ok())

--- a/src/kvstore/rocksdb_utils.cpp
+++ b/src/kvstore/rocksdb_utils.cpp
@@ -1,0 +1,39 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "kvstore/rocksdb_utils.hpp"
+
+#include "flags/general.hpp"
+#include "spdlog/spdlog.h"
+
+namespace memgraph::utils {
+
+namespace {
+
+rocksdb::InfoLogLevel ParseRocksDBInfoLogLevel(const std::string &level) {
+  if (level == "DEBUG_LEVEL") return rocksdb::InfoLogLevel::DEBUG_LEVEL;
+  if (level == "INFO_LEVEL") return rocksdb::InfoLogLevel::INFO_LEVEL;
+  if (level == "WARN_LEVEL") return rocksdb::InfoLogLevel::WARN_LEVEL;
+  if (level == "ERROR_LEVEL") return rocksdb::InfoLogLevel::ERROR_LEVEL;
+  if (level == "FATAL_LEVEL") return rocksdb::InfoLogLevel::FATAL_LEVEL;
+  if (level == "HEADER_LEVEL") return rocksdb::InfoLogLevel::HEADER_LEVEL;
+  spdlog::warn("Unknown RocksDB info log level '{}', using INFO_LEVEL", level);
+  return rocksdb::InfoLogLevel::INFO_LEVEL;
+}
+
+}  // namespace
+
+void ApplyRocksDBConfigFlags(rocksdb::Options &options) {
+  options.info_log_level = ParseRocksDBInfoLogLevel(FLAGS_storage_rocksdb_info_log_level);
+  options.enable_thread_tracking = FLAGS_storage_rocksdb_enable_thread_tracking;
+}
+
+}  // namespace memgraph::utils

--- a/src/kvstore/rocksdb_utils.hpp
+++ b/src/kvstore/rocksdb_utils.hpp
@@ -1,0 +1,21 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <rocksdb/options.h>
+
+namespace memgraph::utils {
+
+/// Apply RocksDB tuning flags to options.
+void ApplyRocksDBConfigFlags(rocksdb::Options &options);
+
+}  // namespace memgraph::utils

--- a/src/storage/v2/disk/rocksdb_storage.hpp
+++ b/src/storage/v2/disk/rocksdb_storage.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -18,6 +18,7 @@
 #include <rocksdb/status.h>
 #include <rocksdb/utilities/transaction_db.h>
 
+#include "kvstore/rocksdb_utils.hpp"
 #include "storage/v2/edge_direction.hpp"
 #include "storage/v2/edge_ref.hpp"
 #include "storage/v2/id_types.hpp"
@@ -32,7 +33,7 @@ namespace memgraph::storage {
 /// Wraps RocksDB objects inside a struct. Vertex_chandle and edge_chandle are column family handles that may be
 /// nullptr. In that case client should take care about them.
 struct RocksDBStorage {
-  explicit RocksDBStorage() = default;
+  explicit RocksDBStorage() { utils::ApplyRocksDBConfigFlags(options_); }
 
   RocksDBStorage(const RocksDBStorage &) = delete;
   RocksDBStorage &operator=(const RocksDBStorage &) = delete;

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -300,5 +300,15 @@ startup_config_dict = {
     ),
     "query_log_directory": ("", "", "Path to directory where the query logs should be stored."),
     "schema_info_enabled": ("false", "false", "Set to true to enable run-time schema info tracking."),
+    "storage_rocksdb_enable_thread_tracking": (
+        "false",
+        "false",
+        "Enable RocksDB thread status tracking. Default is false for reduced syscall overhead. Enable when debugging disk storage performance issues (provides GetThreadList API).",
+    ),
+    "storage_rocksdb_info_log_level": (
+        "ERROR_LEVEL",
+        "ERROR_LEVEL",
+        "RocksDB info log level. Options: DEBUG_LEVEL, INFO_LEVEL, WARN_LEVEL, ERROR_LEVEL, FATAL_LEVEL, HEADER_LEVEL. Default is ERROR_LEVEL for reduced syscall overhead. Use INFO_LEVEL or DEBUG_LEVEL when debugging disk storage issues.",
+    ),
     "debug_query_plans": ("false", "false", "Enable DEBUG logging of potential query plans."),
 }


### PR DESCRIPTION
Add two new flags to control RocksDB behavior:
- --storage-rocksdb-info-log-level: Controls log verbosity (default: ERROR_LEVEL)
- --storage-rocksdb-enable-thread-tracking: Controls thread status API (default: false)

Applied to all RocksDB instances: KVStore (auth, replication, coordination), and ON_DISK storage components (main storage, indexes, constraints).

Impact: Reduces gettimeofday/gettid syscalls from RocksDB. Users will see less RocksDB logging by default. To restore verbose logging, use:
  --storage-rocksdb-info-log-level=INFO_LEVEL
