### PR TITLE
Replace sleep with polling in an e2e test

### DIFF
--- a/tests/e2e/replication/common.hpp
+++ b/tests/e2e/replication/common.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -70,5 +70,26 @@ class IntGenerator {
   std::mt19937 rng_;
   std::uniform_int_distribution<int> dist_;
 };
+
+/// Polls until a predicate returns true, or timeout is reached.
+/// @param predicate Function that returns true when condition is met
+/// @param timeout Maximum duration to wait
+/// @param poll_interval Time between polling attempts
+/// @return true if predicate succeeded, false if timeout
+template <typename Predicate>
+bool WaitForCondition(Predicate predicate, std::chrono::milliseconds timeout = std::chrono::milliseconds(5000),
+                      std::chrono::milliseconds poll_interval = std::chrono::milliseconds(100)) {
+  const auto start = std::chrono::steady_clock::now();
+  while (true) {
+    if (predicate()) {
+      return true;
+    }
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+    if (elapsed >= timeout) {
+      return false;
+    }
+    std::this_thread::sleep_for(poll_interval);
+  }
+}
 
 }  // namespace mg::e2e::replication


### PR DESCRIPTION
The constraints replication test was flaky because it used a fixed 500ms sleep to wait for constraints to replicate to replicas. Under load or with async replication, this delay was sometimes insufficient.

Changes:
- Add WaitForCondition() utility template in common.hpp that polls a predicate with configurable timeout (default 5s) and interval
- Replace sleep_for calls with WaitForCondition polling for the actual expected state (correct constraint count)
- Improve error messages to include actual state on timeout

This pattern should be preferred over fixed sleeps in replication tests since replication timing is inherently non-deterministic.
