### PR TITLE
RocksDB log level back to INFO_LEVEL

### DIFF
--- a/src/flags/general.cpp
+++ b/src/flags/general.cpp
@@ -147,10 +147,9 @@ DEFINE_bool(storage_delta_on_identical_property_update, true,
 
 // RocksDB flags
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_string(storage_rocksdb_info_log_level, "ERROR_LEVEL",
+DEFINE_string(storage_rocksdb_info_log_level, "INFO_LEVEL",
               "RocksDB info log level. Options: DEBUG_LEVEL, INFO_LEVEL, WARN_LEVEL, ERROR_LEVEL, "
-              "FATAL_LEVEL, HEADER_LEVEL. Default is ERROR_LEVEL for reduced syscall overhead. "
-              "Use INFO_LEVEL or DEBUG_LEVEL when debugging disk storage issues.");
+              "FATAL_LEVEL, HEADER_LEVEL. Default is INFO_LEVEL.");
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_bool(storage_rocksdb_enable_thread_tracking, false,
             "Enable RocksDB thread status tracking. Default is false for reduced syscall overhead. "

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -306,9 +306,9 @@ startup_config_dict = {
         "Enable RocksDB thread status tracking. Default is false for reduced syscall overhead. Enable when debugging disk storage performance issues (provides GetThreadList API).",
     ),
     "storage_rocksdb_info_log_level": (
-        "ERROR_LEVEL",
-        "ERROR_LEVEL",
-        "RocksDB info log level. Options: DEBUG_LEVEL, INFO_LEVEL, WARN_LEVEL, ERROR_LEVEL, FATAL_LEVEL, HEADER_LEVEL. Default is ERROR_LEVEL for reduced syscall overhead. Use INFO_LEVEL or DEBUG_LEVEL when debugging disk storage issues.",
+        "INFO_LEVEL",
+        "INFO_LEVEL",
+        "RocksDB info log level. Options: DEBUG_LEVEL, INFO_LEVEL, WARN_LEVEL, ERROR_LEVEL, FATAL_LEVEL, HEADER_LEVEL. Default is INFO_LEVEL.",
     ),
     "debug_query_plans": ("false", "false", "Enable DEBUG logging of potential query plans."),
 }


### PR DESCRIPTION
No idea why but changing to ERROR_LEVEL caused a throughput regression in some of our benchmarks. Root cause is not obvious, but for now we can change this default back.