### PR TITLE
fix: Potential leak with getaddrinfo, log more details on system error

### DIFF
--- a/src/io/network/addrinfo.cpp
+++ b/src/io/network/addrinfo.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -22,7 +22,7 @@ static_assert(std::forward_iterator<AddrInfo::Iterator> && std::equality_compara
 
 AddrInfo::AddrInfo(const Endpoint &endpoint) : AddrInfo(endpoint.GetAddress(), endpoint.GetPort()) {}
 
-AddrInfo::AddrInfo(const std::string &non_resolved_addr, uint16_t port) : info_{nullptr, nullptr} {
+AddrInfo::AddrInfo(const std::string &non_resolved_addr, uint16_t port) : info_{nullptr, &freeaddrinfo} {
   addrinfo hints{
       .ai_flags = AI_PASSIVE,
       .ai_family = AF_UNSPEC,      // IPv4 and IPv6
@@ -31,10 +31,18 @@ AddrInfo::AddrInfo(const std::string &non_resolved_addr, uint16_t port) : info_{
   };
   addrinfo *info = nullptr;
   auto status = getaddrinfo(non_resolved_addr.c_str(), std::to_string(port).c_str(), &hints, &info);
+  auto const err_ec = errno;
+  // Take ownership even on error so if info is non-null on error, it gets freed
+  info_.reset(info);
+  // If dealing with system error we want to get more info about what happened.
+  // As explained here https://man7.org/linux/man-pages/man3/getaddrinfo.3.html
+  // errno is then set to inidicate the error
+  if (status == EAI_SYSTEM) {
+    throw NetworkError("System error: {}", std::strerror(err_ec));
+  }
   if (status != 0) {
     throw NetworkError(gai_strerror(status));
   }
-  info_ = std::unique_ptr<addrinfo, decltype(&freeaddrinfo)>(info, &freeaddrinfo);
 }
 
 AddrInfo::Iterator::Iterator(addrinfo *p) noexcept : ptr_(p) {}


### PR DESCRIPTION
If getaddrinfo returns EAI_SYSTEM error, more details will be obtained using errno. 
Fixes potential leak in info if getaddrinfo failed. 