### PR TITLE
fix: avoid AST corruption when variable start planner reuses expressions

### DIFF
--- a/src/query/plan/rewrite/edge_index_lookup.hpp
+++ b/src/query/plan/rewrite/edge_index_lookup.hpp
@@ -55,7 +55,7 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
 
   bool PostVisit(Filter &op) override {
     prev_ops_.pop_back();
-    ExpressionRemovalResult removal = RemoveExpressions(op.expression_, filter_exprs_for_removal_);
+    ExpressionRemovalResult removal = RemoveExpressions(op.expression_, filter_exprs_for_removal_, ast_storage_);
     op.expression_ = removal.trimmed_expression;
     if (op.expression_) {
       Filters leftover_filters;

--- a/src/query/plan/rewrite/general.cpp
+++ b/src/query/plan/rewrite/general.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -15,57 +15,69 @@
 
 namespace memgraph::query::plan {
 
-ExpressionRemovalResult RemoveExpressions(Expression *expr, const std::unordered_set<Expression *> &exprs_to_remove) {
+ExpressionRemovalResult RemoveExpressions(Expression *expr, const std::unordered_set<Expression *> &exprs_to_remove,
+                                          AstStorage *storage) {
+  // Handle null input
+  if (!expr) return ExpressionRemovalResult{.trimmed_expression = nullptr, .did_remove = false};
+
+  // If this expression should be removed, return null
   if (exprs_to_remove.contains(expr)) {
     return ExpressionRemovalResult{.trimmed_expression = nullptr, .did_remove = true};
   }
 
   auto *and_op = utils::Downcast<AndOperator>(expr);
 
-  // currently we are processing expressions by dividing them into and disjoint expressions
-  // no work needed if there is no multiple and expressions
-  if (!and_op) return ExpressionRemovalResult{.trimmed_expression = expr};
+  // Currently we are processing expressions by dividing them into and disjoint expressions
+  // No work needed if there is no multiple and expressions
+  if (!and_op) return ExpressionRemovalResult{.trimmed_expression = expr, .did_remove = false};
 
-  // and operation is fully contained inside the expressions to remove
-  if (exprs_to_remove.contains(and_op)) {
-    return ExpressionRemovalResult{.trimmed_expression = nullptr, .did_remove = true};
-  }
+  // Recursively process both children WITHOUT modifying the original
+  Expression *child1 = and_op->expression1_;
+  Expression *child2 = and_op->expression2_;
 
-  bool did_remove = false;
-  if (exprs_to_remove.contains(and_op->expression1_)) {
-    and_op->expression1_ = nullptr;
-    did_remove = true;
-  }
-  if (exprs_to_remove.contains(and_op->expression2_)) {
-    and_op->expression2_ = nullptr;
-    did_remove = true;
-  }
+  // Check if children are directly in exprs_to_remove
+  const bool child1_removed = exprs_to_remove.contains(child1);
+  const bool child2_removed = exprs_to_remove.contains(child2);
 
-  auto removal1 = RemoveExpressions(and_op->expression1_, exprs_to_remove);
-  and_op->expression1_ = removal1.trimmed_expression;
-  did_remove = did_remove || removal1.did_remove;
+  // Recursively process children that weren't directly removed
+  const ExpressionRemovalResult removal1 =
+      child1_removed ? ExpressionRemovalResult{.trimmed_expression = nullptr, .did_remove = true}
+                     : RemoveExpressions(child1, exprs_to_remove, storage);
+  const ExpressionRemovalResult removal2 =
+      child2_removed ? ExpressionRemovalResult{.trimmed_expression = nullptr, .did_remove = true}
+                     : RemoveExpressions(child2, exprs_to_remove, storage);
 
-  auto removal2 = RemoveExpressions(and_op->expression2_, exprs_to_remove);
-  and_op->expression2_ = removal2.trimmed_expression;
-  did_remove = did_remove || removal2.did_remove;
+  const bool did_remove = removal1.did_remove || removal2.did_remove;
+  Expression *new_child1 = removal1.trimmed_expression;
+  Expression *new_child2 = removal2.trimmed_expression;
 
-  // Removed both the right and left side of the AND => remove the whole AND operator
-  if (!and_op->expression1_ && !and_op->expression2_) {
+  // Removed both children => remove the whole AND operator
+  if (!new_child1 && !new_child2) {
     return ExpressionRemovalResult{.trimmed_expression = nullptr, .did_remove = did_remove};
   }
 
-  // Removed the left side => return only the right side
-  if (and_op->expression1_ && !and_op->expression2_) {
-    return ExpressionRemovalResult{.trimmed_expression = and_op->expression1_, .did_remove = did_remove};
+  // Only child1 survives => return child1
+  if (new_child1 && !new_child2) {
+    return ExpressionRemovalResult{.trimmed_expression = new_child1, .did_remove = did_remove};
   }
 
-  // Removed the right side => return only the left side
-  if (and_op->expression2_ && !and_op->expression1_) {
-    return ExpressionRemovalResult{.trimmed_expression = and_op->expression2_, .did_remove = did_remove};
+  // Only child2 survives => return child2
+  if (new_child2 && !new_child1) {
+    return ExpressionRemovalResult{.trimmed_expression = new_child2, .did_remove = did_remove};
   }
 
-  // Nothing removed => return whole expression as is
-  return ExpressionRemovalResult{.trimmed_expression = and_op, .did_remove = did_remove};
+  // Both children survive
+  // If neither child changed, return the original AND operator
+  if (new_child1 == child1 && new_child2 == child2) {
+    return ExpressionRemovalResult{.trimmed_expression = and_op, .did_remove = did_remove};
+  }
+
+  // At least one child changed, create a new AND operator with the new children
+  // to avoid mutating the original expression tree
+  auto *new_and_op = storage->Create<AndOperator>();
+  new_and_op->expression1_ = new_child1;
+  new_and_op->expression2_ = new_child2;
+  return ExpressionRemovalResult{.trimmed_expression = new_and_op, .did_remove = did_remove};
 }
 
 }  // namespace memgraph::query::plan

--- a/src/query/plan/rewrite/general.hpp
+++ b/src/query/plan/rewrite/general.hpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -20,6 +20,10 @@
 
 #include "query/frontend/ast/query/expression.hpp"
 
+namespace memgraph::query {
+class AstStorage;
+}  // namespace memgraph::query
+
 namespace memgraph::query::plan {
 
 struct ExpressionRemovalResult {
@@ -28,7 +32,9 @@ struct ExpressionRemovalResult {
 };
 
 // Return the new root expression after removing the given expressions from the
-// given expression tree.
-ExpressionRemovalResult RemoveExpressions(Expression *expr, const std::unordered_set<Expression *> &exprs_to_remove);
+// given expression tree. This function does NOT modify the original expression tree;
+// instead it creates new AndOperator nodes when needed using the provided storage.
+ExpressionRemovalResult RemoveExpressions(Expression *expr, const std::unordered_set<Expression *> &exprs_to_remove,
+                                          AstStorage *storage);
 
 }  // namespace memgraph::query::plan

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -170,7 +170,7 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
   // free the memory.
   bool PostVisit(Filter &op) override {
     prev_ops_.pop_back();
-    ExpressionRemovalResult removal = RemoveExpressions(op.expression_, filter_exprs_for_removal_);
+    ExpressionRemovalResult removal = RemoveExpressions(op.expression_, filter_exprs_for_removal_, ast_storage_);
     op.expression_ = removal.trimmed_expression;
     if (op.expression_) {
       Filters leftover_filters;

--- a/src/query/plan/rewrite/join.hpp
+++ b/src/query/plan/rewrite/join.hpp
@@ -56,7 +56,7 @@ class JoinRewriter final : public HierarchicalLogicalOperatorVisitor {
   bool PostVisit(Filter &op) override {
     prev_ops_.pop_back();
 
-    ExpressionRemovalResult removal = RemoveExpressions(op.expression_, filter_exprs_for_removal_);
+    ExpressionRemovalResult removal = RemoveExpressions(op.expression_, filter_exprs_for_removal_, ast_storage_);
     op.expression_ = removal.trimmed_expression;
     if (op.expression_) {
       Filters leftover_filters;

--- a/src/query/plan/rewrite/range.cpp
+++ b/src/query/plan/rewrite/range.cpp
@@ -133,7 +133,7 @@ Expression *CompactFilters(Expression *filter_expr, AstStorage &storage) {
         // Substitute the current filter
         filter_expr = SubstituteExpression(filter_expr, filter_old, range);
         // Remove the other filter
-        filter_expr = RemoveExpressions(filter_expr, {filter}).trimmed_expression;
+        filter_expr = RemoveExpressions(filter_expr, {filter}, &storage).trimmed_expression;
         // Remove these filters from any further consideration
         info.type = ComparisonFilterInfo::Type::UNKNOWN;
         info_old.type = ComparisonFilterInfo::Type::UNKNOWN;

--- a/tests/e2e/query_planning/CMakeLists.txt
+++ b/tests/e2e/query_planning/CMakeLists.txt
@@ -7,5 +7,6 @@ copy_query_planning_e2e_python_files(query_planning_cartesian.py)
 copy_query_planning_e2e_python_files(query_planning_point_index.py)
 copy_query_planning_e2e_python_files(query_planning_valid_query_plans.py)
 copy_query_planning_e2e_python_files(query_planning_optional.py)
+copy_query_planning_e2e_python_files(query_planning_subquery.py)
 
 copy_e2e_files(query_planning workloads.yaml)

--- a/tests/e2e/query_planning/query_planning_subquery.py
+++ b/tests/e2e/query_planning/query_planning_subquery.py
@@ -1,0 +1,69 @@
+import sys
+
+import pytest
+from common import memgraph
+
+
+def test_variable_start_planner_shared_ast_corruption(memgraph):
+    """
+    Regression test: Variable start planner generates multiple plan variations
+    that share AST expression nodes. When one plan is rewritten (index lookup
+    optimization removes filter expressions), it must not corrupt the shared AST
+    that subsequent plan generations will use.
+
+    Trigger conditions:
+    1. OPTIONAL MATCH with edge pattern - causes multiple plan variations
+    2. CALL subquery with WITH * - brings symbols into scope visited during plan generation
+    3. WHERE with AND containing id() - triggers RemoveExpressions during index rewriting
+
+    Previously, RemoveExpressions mutated AndOperator in-place, corrupting the
+    shared AST. Plan 2's generation would then crash when visiting the corrupted
+    expression via ReturnBodyContext.
+
+    The left side of AND can be any expression (even literal `true`).
+    """
+    # Query must complete without crash - empty result expected (no data)
+    # Minimal reproduction: undirected edge pattern + WITH * + AND with id()
+    result = list(
+        memgraph.execute_and_fetch(
+            "OPTIONAL MATCH ()-[]-() CALL { MATCH (n) WITH * WHERE true AND id(n) = 0 RETURN n } RETURN n"
+        )
+    )
+    assert result == []
+
+
+def test_variable_start_planner_nested_and_ast_corruption(memgraph):
+    """
+    Regression test: Similar to test_variable_start_planner_shared_ast_corruption
+    but with a nested AND expression that triggers storage->Create<AndOperator>()
+    during expression cloning.
+
+    The nested AND `(true AND id(n) = 0)` requires the cloning logic to create
+    a new AndOperator via storage, exercising the deep clone path.
+    """
+    result = list(
+        memgraph.execute_and_fetch(
+            "OPTIONAL MATCH ()-[]-() CALL { MATCH (n) WITH * WHERE true AND (true AND id(n) = 0) RETURN n } RETURN n"
+        )
+    )
+    assert result == []
+
+
+def test_variable_start_planner_nested_and_left_ast_corruption(memgraph):
+    """
+    Regression test: Variant with nested AND on the left side containing id().
+
+    The nested AND `(id(n) = 0 AND true)` on the left requires cloning when
+    the id() lookup is extracted, exercising the path where the nested
+    expression containing the filter target is on the left operand.
+    """
+    result = list(
+        memgraph.execute_and_fetch(
+            "OPTIONAL MATCH ()-[]-() CALL { MATCH (n) WITH * WHERE (id(n) = 0 AND true) AND true RETURN n } RETURN n"
+        )
+    )
+    assert result == []
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/query_planning/workloads.yaml
+++ b/tests/e2e/query_planning/workloads.yaml
@@ -27,3 +27,8 @@ workloads:
     binary: "tests/e2e/pytest_runner.sh"
     args: ["query_planning/query_planning_optional.py"]
     <<: *queries_cluster
+
+  - name: "Query planning subquery"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["query_planning/query_planning_subquery.py"]
+    <<: *queries_cluster


### PR DESCRIPTION
RemoveExpressions() was mutating AndOperator nodes in-place during index lookup optimization. When the variable start planner generates multiple plan variations that share AST expression nodes, this mutation corrupted the shared AST, causing crashes when subsequent plans were generated.

The fix creates new AndOperator nodes instead of mutating the originals, preserving the shared AST integrity across all plan variations.

Trigger conditions for the bug:
- OPTIONAL MATCH with edge pattern (generates multiple plan variations)
- CALL subquery with WITH * (brings symbols into scope during generation)
- WHERE with AND containing id() (triggers RemoveExpressions)

resolves #3648