### PR TITLE
fix: Add self coord instance shouldn't call std::terminate

### DIFF
--- a/src/coordination/include/coordination/coordinator_instance.hpp
+++ b/src/coordination/include/coordination/coordinator_instance.hpp
@@ -129,6 +129,13 @@ class CoordinatorInstance {
   auto GetTelemetryJson() const -> nlohmann::json;
 
  private:
+  auto AddNewCoordinator(CoordinatorInstanceConfig const &config,
+                         std::vector<CoordinatorInstanceContext> const &coordinator_instances_context) const
+      -> AddCoordinatorInstanceStatus;
+  auto AddSelfCoordinator(CoordinatorInstanceConfig const &config,
+                          std::vector<CoordinatorInstanceContext> const &coordinator_instances_context) const
+      -> AddCoordinatorInstanceStatus;
+
   auto ReconcileClusterState_() -> ReconcileClusterStateStatus;
   auto ShowInstancesStatusAsFollower() const -> std::vector<InstanceStatus>;
 

--- a/src/coordination/include/coordination/coordinator_ops_status.hpp
+++ b/src/coordination/include/coordination/coordinator_ops_status.hpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -58,7 +58,8 @@ enum class AddCoordinatorInstanceStatus : uint8_t {
   SUCCESS = 0,
   ID_ALREADY_EXISTS,
   MGMT_ENDPOINT_ALREADY_EXISTS,
-  COORDINATOR_ENDPOINT_ALREADY_EXISTS
+  COORDINATOR_ENDPOINT_ALREADY_EXISTS,
+  RAFT_LOG_ERROR
 };
 
 enum class RemoveCoordinatorInstanceStatus : uint8_t {


### PR DESCRIPTION
Adding a coordinator instance could fail. When adding a coordinator instance on which the query is actually run (self), there is no need to call std::terminate in the case of the failure. 