### PR TITLE
Fix relwithdebinfo Docker build

### DIFF
--- a/release/docker/v7_deb_relwithdebinfo.dockerfile
+++ b/release/docker/v7_deb_relwithdebinfo.dockerfile
@@ -19,9 +19,8 @@ RUN --mount=type=secret,id=ubuntu_sources,target=/ubuntu.sources,required=false 
     --no-install-recommends && \
   apt-get install -y \
     libcurl4 libseccomp2 python3 libpython3.12 python3-pip python3.12-venv libatomic1 adduser \
-    gdb procps linux-tools-common libc6-dbg libxmlsec1 \
+    gdb procps linux-tools-common libc6-dbg libxmlsec1 "linux-tools-$(uname -r)" \
     --no-install-recommends && \
-  (apt-get install -y linux-tools-generic --no-install-recommends || true) && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
   if [ "$CUSTOM_MIRROR" = "true" ] && [ -f /etc/apt/sources.list.d/ubuntu.sources.backup ]; then \
     mv -v /etc/apt/sources.list.d/ubuntu.sources.backup /etc/apt/sources.list.d/ubuntu.sources; \


### PR DESCRIPTION
Something has broken in the Ubuntu 24.04 image which we use as a base for building our Docker images. Now `linux-tools-generic` cannot be installed due to this error:
```
23.64 Some packages could not be installed. This may mean that you have
23.64 requested an impossible situation or if you are using the unstable
23.64 distribution that some required packages have not yet been created
23.64 or been moved out of Incoming.
23.64 The following information may help to resolve the situation:
23.64 
23.64 The following packages have unmet dependencies:
23.73  linux-tools-generic : Depends: linux-tools-6.8.0-100-generic but it is not installable
23.74 E: Unable to correct problems, you have held broken packages.
```
therefore breaking our RelWithDebInfo build.

This PR changes the package name to `linux-tools-$(uname -r)` to match the kernel version running on the host during the build.
