### PR TITLE
refactor: Unify vertex lock and delta reader to prevent misuse

### DIFF
--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -1347,7 +1347,7 @@ std::optional<storage::SingleTxnDeltasProcessingResult> InMemoryReplicationHandl
           {
             bool is_visible = true;
             storage::MvccRead reader{&*edge, &transaction->GetTransaction(), View::NEW, [&](storage::Edge const &e) {
-                                       is_visible = !e.deleted;
+                                       is_visible = !e.deleted();
                                      }};
             reader.ApplyDeltasForRead([&is_visible](Delta const &delta) {
               switch (delta.action) {

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -1346,34 +1346,30 @@ std::optional<storage::SingleTxnDeltasProcessingResult> InMemoryReplicationHandl
           }
           {
             bool is_visible = true;
-            Delta *local_delta = nullptr;
-            {
-              auto guard = std::shared_lock{edge->lock};
-              is_visible = !edge->deleted();
-              local_delta = edge->delta();
-            }
-            ApplyDeltasForRead(
-                &transaction->GetTransaction(), local_delta, View::NEW, [&is_visible](const Delta &delta) {
-                  switch (delta.action) {
-                    case Delta::Action::ADD_LABEL:
-                    case Delta::Action::REMOVE_LABEL:
-                    case Delta::Action::SET_PROPERTY:
-                    case Delta::Action::ADD_IN_EDGE:
-                    case Delta::Action::ADD_OUT_EDGE:
-                    case Delta::Action::REMOVE_IN_EDGE:
-                    case Delta::Action::REMOVE_OUT_EDGE:
-                      break;
-                    case Delta::Action::RECREATE_OBJECT: {
-                      is_visible = true;
-                      break;
-                    }
-                    case Delta::Action::DELETE_DESERIALIZED_OBJECT:
-                    case Delta::Action::DELETE_OBJECT: {
-                      is_visible = false;
-                      break;
-                    }
-                  }
-                });
+            storage::MvccRead reader{&*edge, &transaction->GetTransaction(), View::NEW, [&](storage::Edge const &e) {
+                                       is_visible = !e.deleted;
+                                     }};
+            reader.ApplyDeltasForRead([&is_visible](Delta const &delta) {
+              switch (delta.action) {
+                case Delta::Action::ADD_LABEL:
+                case Delta::Action::REMOVE_LABEL:
+                case Delta::Action::SET_PROPERTY:
+                case Delta::Action::ADD_IN_EDGE:
+                case Delta::Action::ADD_OUT_EDGE:
+                case Delta::Action::REMOVE_IN_EDGE:
+                case Delta::Action::REMOVE_OUT_EDGE:
+                  break;
+                case Delta::Action::RECREATE_OBJECT: {
+                  is_visible = true;
+                  break;
+                }
+                case Delta::Action::DELETE_DESERIALIZED_OBJECT:
+                case Delta::Action::DELETE_OBJECT: {
+                  is_visible = false;
+                  break;
+                }
+              }
+            });
             if (!is_visible) {
               throw utils::BasicException("Edge {} isn't visible when setting property.", edge_gid);
             }

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -134,7 +134,7 @@ bool VertexHasLabel(const Vertex &vertex, LabelId label, Transaction *transactio
   bool deleted = vertex.deleted();
   bool has_label = std::ranges::contains(vertex.labels, label);
   Delta *delta = vertex.delta();
-  detail::ApplyDeltasForRead(transaction, delta, view, [&deleted, &has_label, label](const Delta &delta) {
+  ApplyDeltasForRead(transaction, delta, view, [&deleted, &has_label, label](const Delta &delta) {
     switch (delta.action) {
       case Delta::Action::REMOVE_LABEL: {
         if (delta.label.value == label) {
@@ -173,7 +173,7 @@ PropertyValue GetVertexProperty(const Vertex &vertex, PropertyId property, Trans
   bool deleted = vertex.deleted();
   PropertyValue value = vertex.properties.GetProperty(property);
   Delta *delta = vertex.delta();
-  detail::ApplyDeltasForRead(transaction, delta, view, [&deleted, &value, property](const Delta &delta) {
+  ApplyDeltasForRead(transaction, delta, view, [&deleted, &value, property](const Delta &delta) {
     switch (delta.action) {
       case Delta::Action::SET_PROPERTY: {
         if (delta.property.key == property) {

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -134,7 +134,7 @@ bool VertexHasLabel(const Vertex &vertex, LabelId label, Transaction *transactio
   bool deleted = vertex.deleted();
   bool has_label = std::ranges::contains(vertex.labels, label);
   Delta *delta = vertex.delta();
-  ApplyDeltasForRead(transaction, delta, view, [&deleted, &has_label, label](const Delta &delta) {
+  detail::ApplyDeltasForRead(transaction, delta, view, [&deleted, &has_label, label](const Delta &delta) {
     switch (delta.action) {
       case Delta::Action::REMOVE_LABEL: {
         if (delta.label.value == label) {
@@ -173,7 +173,7 @@ PropertyValue GetVertexProperty(const Vertex &vertex, PropertyId property, Trans
   bool deleted = vertex.deleted();
   PropertyValue value = vertex.properties.GetProperty(property);
   Delta *delta = vertex.delta();
-  ApplyDeltasForRead(transaction, delta, view, [&deleted, &value, property](const Delta &delta) {
+  detail::ApplyDeltasForRead(transaction, delta, view, [&deleted, &value, property](const Delta &delta) {
     switch (delta.action) {
       case Delta::Action::SET_PROPERTY: {
         if (delta.property.key == property) {

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -10302,7 +10302,7 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
       // The edge visibility check must be done here manually because we don't
       // allow direct access to the edges through the public API.
       bool is_visible = true;
-      MvccRead reader{&edge, transaction, View::OLD, [&](Edge const &e) { is_visible = !e.deleted; }};
+      MvccRead reader{&edge, transaction, View::OLD, [&](Edge const &e) { is_visible = !e.deleted(); }};
 
       reader.ApplyDeltasForRead([&is_visible](Delta const &delta) {
         switch (delta.action) {

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -10302,13 +10302,9 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
       // The edge visibility check must be done here manually because we don't
       // allow direct access to the edges through the public API.
       bool is_visible = true;
-      Delta *delta = nullptr;
-      {
-        auto guard = std::shared_lock{edge.lock};
-        is_visible = !edge.deleted();
-        delta = edge.delta();
-      }
-      ApplyDeltasForRead(transaction, delta, View::OLD, [&is_visible](const Delta &delta) {
+      MvccRead reader{&edge, transaction, View::OLD, [&](Edge const &e) { is_visible = !e.deleted; }};
+
+      reader.ApplyDeltasForRead([&is_visible](Delta const &delta) {
         switch (delta.action) {
           case Delta::Action::ADD_LABEL:
           case Delta::Action::REMOVE_LABEL:

--- a/src/storage/v2/edge_accessor.cpp
+++ b/src/storage/v2/edge_accessor.cpp
@@ -107,7 +107,7 @@ bool EdgeAccessor::IsVisible(const View view) const {
   };
   auto check_presence_of_edge = [&view, this]() -> bool {
     bool deleted = true;
-    MvccRead reader{edge_.ptr, transaction_, view, [&](Edge const &e) { deleted = e.deleted; }};
+    MvccRead reader{edge_.ptr, transaction_, view, [&](Edge const &e) { deleted = e.deleted(); }};
 
     reader.ApplyDeltasForRead([&](Delta const &delta) {
       switch (delta.action) {
@@ -354,7 +354,7 @@ Result<PropertyValue> EdgeAccessor::GetProperty(PropertyId property, View view) 
   bool deleted = false;
   std::optional<PropertyValue> value;
   MvccRead reader{edge_.ptr, transaction_, view, [&](Edge const &e) {
-                    deleted = e.deleted;
+                    deleted = e.deleted();
                     value.emplace(e.properties.GetProperty(property));
                   }};
 
@@ -416,7 +416,7 @@ Result<std::map<PropertyId, PropertyValue>> EdgeAccessor::Properties(View view) 
   bool deleted = false;
   std::map<PropertyId, PropertyValue> properties;
   MvccRead reader{edge_.ptr, transaction_, view, [&](Edge const &e) {
-                    deleted = e.deleted;
+                    deleted = e.deleted();
                     properties = e.properties.Properties();
                   }};
 
@@ -467,7 +467,7 @@ Result<std::map<PropertyId, PropertyValue>> EdgeAccessor::PropertiesByPropertyId
   std::vector<PropertyValue> property_values;
   property_values.reserve(properties.size());
   MvccRead reader{edge_.ptr, transaction_, view, [&](Edge const &e) {
-                    deleted = e.deleted;
+                    deleted = e.deleted();
                     auto property_paths =
                         properties |
                         rv::transform([](PropertyId property) { return storage::PropertyPath{property}; }) |

--- a/src/storage/v2/edge_accessor.cpp
+++ b/src/storage/v2/edge_accessor.cpp
@@ -71,56 +71,45 @@ bool EdgeAccessor::IsVisible(const View view) const {
 
   auto check_from_vertex_integrity = [&view, this]() -> bool {
     bool attached = true;
-    Delta *delta = nullptr;
-    {
-      auto guard = std::shared_lock{from_vertex_->lock};
-      // Initialize deleted by checking if out edges contain edge_
-      attached = std::ranges::any_of(from_vertex_->out_edges,
-                                     [&](const auto &out_edge) { return std::get<EdgeRef>(out_edge) == edge_; });
-      delta = from_vertex_->delta();
+    MvccRead reader{from_vertex_, transaction_, view, [&](Vertex const &v) {
+                      // Initialize deleted by checking if out edges contain edge_
+                      attached = std::ranges::any_of(
+                          v.out_edges, [&](auto const &out_edge) { return std::get<EdgeRef>(out_edge) == edge_; });
+                    }};
 
-      // If vertex has non-sequential deltas, hold lock while applying them
-      if (!from_vertex_->has_uncommitted_non_sequential_deltas()) {
-        guard.unlock();
-      }
-
-      ApplyDeltasForRead(transaction_, delta, view, [&](const Delta &delta) {
-        switch (delta.action) {
-          case Delta::Action::ADD_LABEL:
-          case Delta::Action::REMOVE_LABEL:
-          case Delta::Action::SET_PROPERTY:
-          case Delta::Action::REMOVE_IN_EDGE:
-          case Delta::Action::ADD_IN_EDGE:
-          case Delta::Action::RECREATE_OBJECT:
-          case Delta::Action::DELETE_DESERIALIZED_OBJECT:
-          case Delta::Action::DELETE_OBJECT:
-            break;
-          case Delta::Action::ADD_OUT_EDGE: {
-            if (delta.vertex_edge.edge == edge_) {
-              attached = true;
-            }
-            break;
+    reader.ApplyDeltasForRead([&](Delta const &delta) {
+      switch (delta.action) {
+        case Delta::Action::ADD_LABEL:
+        case Delta::Action::REMOVE_LABEL:
+        case Delta::Action::SET_PROPERTY:
+        case Delta::Action::REMOVE_IN_EDGE:
+        case Delta::Action::ADD_IN_EDGE:
+        case Delta::Action::RECREATE_OBJECT:
+        case Delta::Action::DELETE_DESERIALIZED_OBJECT:
+        case Delta::Action::DELETE_OBJECT:
+          break;
+        case Delta::Action::ADD_OUT_EDGE: {
+          if (delta.vertex_edge.edge == edge_) {
+            attached = true;
           }
-          case Delta::Action::REMOVE_OUT_EDGE: {
-            if (delta.vertex_edge.edge == edge_) {
-              attached = false;
-            }
-            break;
-          }
+          break;
         }
-      });
-    }
+        case Delta::Action::REMOVE_OUT_EDGE: {
+          if (delta.vertex_edge.edge == edge_) {
+            attached = false;
+          }
+          break;
+        }
+      }
+    });
+
     return attached;
   };
   auto check_presence_of_edge = [&view, this]() -> bool {
     bool deleted = true;
-    Delta *delta = nullptr;
-    {
-      auto guard = std::shared_lock{edge_.ptr->lock};
-      deleted = edge_.ptr->deleted();
-      delta = edge_.ptr->delta();
-    }
-    ApplyDeltasForRead(transaction_, delta, view, [&](const Delta &delta) {
+    MvccRead reader{edge_.ptr, transaction_, view, [&](Edge const &e) { deleted = e.deleted; }};
+
+    reader.ApplyDeltasForRead([&](Delta const &delta) {
       switch (delta.action) {
         case Delta::Action::ADD_LABEL:
         case Delta::Action::REMOVE_LABEL:
@@ -364,14 +353,12 @@ Result<PropertyValue> EdgeAccessor::GetProperty(PropertyId property, View view) 
   bool exists = true;
   bool deleted = false;
   std::optional<PropertyValue> value;
-  Delta *delta = nullptr;
-  {
-    auto guard = std::shared_lock{edge_.ptr->lock};
-    deleted = edge_.ptr->deleted();
-    value.emplace(edge_.ptr->properties.GetProperty(property));
-    delta = edge_.ptr->delta();
-  }
-  ApplyDeltasForRead(transaction_, delta, view, [&exists, &deleted, &value, property](const Delta &delta) {
+  MvccRead reader{edge_.ptr, transaction_, view, [&](Edge const &e) {
+                    deleted = e.deleted;
+                    value.emplace(e.properties.GetProperty(property));
+                  }};
+
+  reader.ApplyDeltasForRead([&exists, &deleted, &value, property](Delta const &delta) {
     switch (delta.action) {
       case Delta::Action::SET_PROPERTY: {
         if (delta.property.key == property) {
@@ -428,14 +415,12 @@ Result<std::map<PropertyId, PropertyValue>> EdgeAccessor::Properties(View view) 
   bool exists = true;
   bool deleted = false;
   std::map<PropertyId, PropertyValue> properties;
-  Delta *delta = nullptr;
-  {
-    auto guard = std::shared_lock{edge_.ptr->lock};
-    deleted = edge_.ptr->deleted();
-    properties = edge_.ptr->properties.Properties();
-    delta = edge_.ptr->delta();
-  }
-  ApplyDeltasForRead(transaction_, delta, view, [&exists, &deleted, &properties](const Delta &delta) {
+  MvccRead reader{edge_.ptr, transaction_, view, [&](Edge const &e) {
+                    deleted = e.deleted;
+                    properties = e.properties.Properties();
+                  }};
+
+  reader.ApplyDeltasForRead([&exists, &deleted, &properties](Delta const &delta) {
     switch (delta.action) {
       case Delta::Action::SET_PROPERTY: {
         auto it = properties.find(delta.property.key);
@@ -481,23 +466,21 @@ Result<std::map<PropertyId, PropertyValue>> EdgeAccessor::PropertiesByPropertyId
   bool deleted = false;
   std::vector<PropertyValue> property_values;
   property_values.reserve(properties.size());
-  Delta *delta = nullptr;
-  {
-    auto guard = std::shared_lock{edge_.ptr->lock};
-    deleted = edge_.ptr->deleted();
-    auto property_paths = properties |
-                          rv::transform([](PropertyId property) { return storage::PropertyPath{property}; }) |
-                          r::to<std::vector<storage::PropertyPath>>();
-    property_values = edge_.ptr->properties.ExtractPropertyValuesMissingAsNull(property_paths);
-    delta = edge_.ptr->delta();
-  }
+  MvccRead reader{edge_.ptr, transaction_, view, [&](Edge const &e) {
+                    deleted = e.deleted;
+                    auto property_paths =
+                        properties |
+                        rv::transform([](PropertyId property) { return storage::PropertyPath{property}; }) |
+                        r::to<std::vector<storage::PropertyPath>>();
+                    property_values = e.properties.ExtractPropertyValuesMissingAsNull(property_paths);
+                  }};
   auto properties_map =
-      rv::zip(properties, property_values) | rv::transform([](const auto &property_id_value_pair) {
+      rv::zip(properties, property_values) | rv::transform([](auto const &property_id_value_pair) {
         return std::make_pair(std::get<0>(property_id_value_pair), std::get<1>(property_id_value_pair));
       }) |
       r::to<std::map<PropertyId, PropertyValue>>();
 
-  ApplyDeltasForRead(transaction_, delta, view, [&exists, &deleted, &properties_map](const Delta &delta) {
+  reader.ApplyDeltasForRead([&exists, &deleted, &properties_map](Delta const &delta) {
     switch (delta.action) {
       case Delta::Action::SET_PROPERTY: {
         auto it = properties_map.find(delta.property.key);

--- a/src/storage/v2/edge_info_helpers.hpp
+++ b/src/storage/v2/edge_info_helpers.hpp
@@ -22,7 +22,7 @@ namespace memgraph::storage {
 inline bool IsEdgeVisible(Edge *edge, const Transaction *transaction, View view) {
   bool exists = true;
   bool deleted = true;
-  MvccRead reader{edge, transaction, view, [&](Edge const &e) { deleted = e.deleted; }};
+  MvccRead reader{edge, transaction, view, [&](Edge const &e) { deleted = e.deleted(); }};
 
   reader.ApplyDeltasForRead([&](Delta const &delta) {
     switch (delta.action) {

--- a/src/storage/v2/edge_info_helpers.hpp
+++ b/src/storage/v2/edge_info_helpers.hpp
@@ -22,13 +22,9 @@ namespace memgraph::storage {
 inline bool IsEdgeVisible(Edge *edge, const Transaction *transaction, View view) {
   bool exists = true;
   bool deleted = true;
-  Delta *delta = nullptr;
-  {
-    auto guard = std::shared_lock{edge->lock};
-    deleted = edge->deleted();
-    delta = edge->delta();
-  }
-  ApplyDeltasForRead(transaction, delta, view, [&](const Delta &delta) {
+  MvccRead reader{edge, transaction, view, [&](Edge const &e) { deleted = e.deleted; }};
+
+  reader.ApplyDeltasForRead([&](Delta const &delta) {
     switch (delta.action) {
       case Delta::Action::ADD_LABEL:
       case Delta::Action::REMOVE_LABEL:

--- a/src/storage/v2/indices/indices_utils.hpp
+++ b/src/storage/v2/indices/indices_utils.hpp
@@ -222,19 +222,15 @@ inline bool CurrentEdgeVersionHasProperty(const Edge &edge, PropertyId key, cons
                     current_value_equal_to_value = e.properties.IsPropertyEqual(key, value);
                   }};
 
-  // Checking cache has a cost, only do it if we have any deltas
-  // if we have no deltas then what we already have from the edge is correct.
-  if (reader.HasDeltas() && transaction->isolation_level != IsolationLevel::READ_UNCOMMITTED) {
-    reader.ApplyDeltasForRead([&, key](Delta const &delta) {
-      // clang-format off
-      DeltaDispatch(delta, utils::ChainedOverloaded{
-        Deleted_ActionMethod(deleted),
-        Exists_ActionMethod(exists),
-        PropertyValueMatch_ActionMethod(current_value_equal_to_value, key, value)
-      });
-      // clang-format on
+  reader.ApplyDeltasForRead([&, key](Delta const &delta) {
+    // clang-format off
+    DeltaDispatch(delta, utils::ChainedOverloaded{
+      Deleted_ActionMethod(deleted),
+      Exists_ActionMethod(exists),
+      PropertyValueMatch_ActionMethod(current_value_equal_to_value, key, value)
     });
-  }
+    // clang-format on
+  });
 
   return exists && !deleted && current_value_equal_to_value;
 }

--- a/src/storage/v2/indices/indices_utils.hpp
+++ b/src/storage/v2/indices/indices_utils.hpp
@@ -218,7 +218,7 @@ inline bool CurrentEdgeVersionHasProperty(const Edge &edge, PropertyId key, cons
   bool deleted = false;
   bool current_value_equal_to_value = value.IsNull();
   MvccRead reader{&edge, transaction, view, [&](Edge const &e) {
-                    deleted = e.deleted;
+                    deleted = e.deleted();
                     current_value_equal_to_value = e.properties.IsPropertyEqual(key, value);
                   }};
 

--- a/src/storage/v2/indices/indices_utils.hpp
+++ b/src/storage/v2/indices/indices_utils.hpp
@@ -217,23 +217,20 @@ inline bool CurrentEdgeVersionHasProperty(const Edge &edge, PropertyId key, cons
   bool exists = true;
   bool deleted = false;
   bool current_value_equal_to_value = value.IsNull();
-  const Delta *delta = nullptr;
-  {
-    auto guard = std::shared_lock{edge.lock};
-    deleted = edge.deleted();
-    current_value_equal_to_value = edge.properties.IsPropertyEqual(key, value);
-    delta = edge.delta();
-  }
+  MvccRead reader{&edge, transaction, view, [&](Edge const &e) {
+                    deleted = e.deleted;
+                    current_value_equal_to_value = e.properties.IsPropertyEqual(key, value);
+                  }};
 
   // Checking cache has a cost, only do it if we have any deltas
-  // if we have no deltas then what we already have from the vertex is correct.
-  if (delta && transaction->isolation_level != IsolationLevel::READ_UNCOMMITTED) {
-    ApplyDeltasForRead(transaction, delta, view, [&, key](const Delta &delta) {
+  // if we have no deltas then what we already have from the edge is correct.
+  if (reader.HasDeltas() && transaction->isolation_level != IsolationLevel::READ_UNCOMMITTED) {
+    reader.ApplyDeltasForRead([&, key](Delta const &delta) {
       // clang-format off
       DeltaDispatch(delta, utils::ChainedOverloaded{
         Deleted_ActionMethod(deleted),
         Exists_ActionMethod(exists),
-        PropertyValueMatch_ActionMethod(current_value_equal_to_value, key,value)
+        PropertyValueMatch_ActionMethod(current_value_equal_to_value, key, value)
       });
       // clang-format on
     });

--- a/src/storage/v2/inmemory/edge_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_property_index.cpp
@@ -81,7 +81,9 @@ inline void TryInsertEdgePropertyIndex(Vertex &from_vertex, PropertyId property,
     // clang-format on
   });
 
-  vertex_reader.Unlock();
+  if (vertex_reader.OwnsLock()) {
+    vertex_reader.Unlock();
+  }
 
   if (!exists || deleted || edges.empty()) {
     return;

--- a/src/storage/v2/inmemory/edge_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_property_index.cpp
@@ -65,59 +65,45 @@ inline void TryInsertEdgePropertyIndex(Vertex &from_vertex, PropertyId property,
                                        Transaction const &tx) {
   bool exists = true;
   bool deleted = false;
-  Delta *delta = nullptr;
   utils::small_vector<Vertex::EdgeTriple> edges;
+  MvccRead vertex_reader{&from_vertex, &tx, View::OLD, [&](Vertex const &v) {
+                           deleted = v.deleted;
+                           edges = v.out_edges;
+                         }};
 
-  {
-    auto guard = std::shared_lock{from_vertex.lock};
-    deleted = from_vertex.deleted();
-    delta = from_vertex.delta();
-    edges = from_vertex.out_edges;
+  vertex_reader.ApplyDeltasForRead([&](Delta const &delta) {
+    // clang-format off
+    DeltaDispatch(delta, utils::ChainedOverloaded{
+      Exists_ActionMethod(exists),
+      Deleted_ActionMethod(deleted),
+      Edges_ActionMethod<EdgeDirection::OUT>(edges),
+    });
+    // clang-format on
+  });
 
-    // If vertex has non-sequential deltas, hold lock while applying them
-    if (!from_vertex.has_uncommitted_non_sequential_deltas()) {
-      guard.unlock();
-    }
+  vertex_reader.Unlock();
 
-    // Create and drop index will always use snapshot isolation
-    if (delta) {
-      ApplyDeltasForRead(&tx, delta, View::OLD, [&](const Delta &delta) {
-        // clang-format off
-        DeltaDispatch(delta, utils::ChainedOverloaded{
-          Exists_ActionMethod(exists),
-          Deleted_ActionMethod(deleted),
-          Edges_ActionMethod<EdgeDirection::OUT>(edges),
-        });
-        // clang-format on
-      });
-    }
-  }
   if (!exists || deleted || edges.empty()) {
     return;
   }
 
   for (auto const &[edge_type, to_vertex, edge_ref] : edges) {
+    exists = true;
+    deleted = false;
     PropertyValue property_value;
-    {
-      auto guard = std::shared_lock{edge_ref.ptr->lock};
-      exists = true;
-      deleted = false;
-      delta = edge_ref.ptr->delta();
-      property_value = edge_ref.ptr->properties.GetProperty(property);
-    }
 
-    if (delta) {
-      // Edge type is immutable so we don't need to check it
-      ApplyDeltasForRead(&tx, delta, View::OLD, [&](const Delta &delta) {
-        // clang-format off
-        DeltaDispatch(delta, utils::ChainedOverloaded{
-          Exists_ActionMethod(exists),
-          Deleted_ActionMethod(deleted),
-          PropertyValue_ActionMethod(property_value, property),
-        });
-        // clang-format on
+    MvccRead edge_reader{
+        edge_ref.ptr, &tx, View::OLD, [&](Edge const &e) { property_value = e.properties.GetProperty(property); }};
+
+    edge_reader.ApplyDeltasForRead([&](Delta const &delta) {
+      // clang-format off
+      DeltaDispatch(delta, utils::ChainedOverloaded{
+        Exists_ActionMethod(exists),
+        Deleted_ActionMethod(deleted),
+        PropertyValue_ActionMethod(property_value, property),
       });
-    }
+      // clang-format on
+    });
 
     if (!exists || deleted || property_value.IsNull()) {
       continue;

--- a/src/storage/v2/inmemory/edge_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_property_index.cpp
@@ -67,7 +67,7 @@ inline void TryInsertEdgePropertyIndex(Vertex &from_vertex, PropertyId property,
   bool deleted = false;
   utils::small_vector<Vertex::EdgeTriple> edges;
   MvccRead vertex_reader{&from_vertex, &tx, View::OLD, [&](Vertex const &v) {
-                           deleted = v.deleted;
+                           deleted = v.deleted();
                            edges = v.out_edges;
                          }};
 

--- a/src/storage/v2/inmemory/edge_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_property_index.cpp
@@ -94,8 +94,10 @@ inline void TryInsertEdgePropertyIndex(Vertex &from_vertex, PropertyId property,
     deleted = false;
     PropertyValue property_value;
 
-    MvccRead edge_reader{
-        edge_ref.ptr, &tx, View::OLD, [&](Edge const &e) { property_value = e.properties.GetProperty(property); }};
+    MvccRead edge_reader{edge_ref.ptr, &tx, View::OLD, [&](Edge const &e) {
+                           deleted = e.deleted();
+                           property_value = e.properties.GetProperty(property);
+                         }};
 
     edge_reader.ApplyDeltasForRead([&](Delta const &delta) {
       // clang-format off

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -64,6 +64,10 @@ inline void TryInsertEdgeTypeIndex(Vertex &from_vertex, EdgeTypeId edge_type, au
     // clang-format on
   });
 
+  if (reader.OwnsLock()) {
+    reader.Unlock();
+  }
+
   if (!exists || deleted || edges.empty()) {
     return;
   }

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -49,7 +49,7 @@ inline void TryInsertEdgeTypeIndex(Vertex &from_vertex, EdgeTypeId edge_type, au
   auto matches_edge_type = [edge_type](auto const &each) { return std::get<EdgeTypeId>(each) == edge_type; };
 
   MvccRead reader{&from_vertex, &tx, View::OLD, [&](Vertex const &v) {
-                    deleted = v.deleted;
+                    deleted = v.deleted();
                     edges =
                         v.out_edges | rv::filter(matches_edge_type) | r::to<utils::small_vector<Vertex::EdgeTriple>>;
                   }};

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -45,33 +45,25 @@ inline void TryInsertEdgeTypeIndex(Vertex &from_vertex, EdgeTypeId edge_type, au
                                    std::optional<SnapshotObserverInfo> const &snapshot_info, Transaction const &tx) {
   bool exists = true;
   bool deleted = false;
-  Delta *delta = nullptr;
   utils::small_vector<Vertex::EdgeTriple> edges;
   auto matches_edge_type = [edge_type](auto const &each) { return std::get<EdgeTypeId>(each) == edge_type; };
-  {
-    auto guard = std::shared_lock{from_vertex.lock};
-    deleted = from_vertex.deleted();
-    delta = from_vertex.delta();
-    edges = from_vertex.out_edges | rv::filter(matches_edge_type) | r::to<utils::small_vector<Vertex::EdgeTriple>>;
 
-    // If vertex has non-sequential deltas, hold lock while applying them
-    if (!from_vertex.has_uncommitted_non_sequential_deltas()) {
-      guard.unlock();
-    }
+  MvccRead reader{&from_vertex, &tx, View::OLD, [&](Vertex const &v) {
+                    deleted = v.deleted;
+                    edges =
+                        v.out_edges | rv::filter(matches_edge_type) | r::to<utils::small_vector<Vertex::EdgeTriple>>;
+                  }};
 
-    // Create and drop index will always use snapshot isolation
-    if (delta) {
-      ApplyDeltasForRead(&tx, delta, View::OLD, [&](const Delta &delta) {
-        // clang-format off
-        DeltaDispatch(delta, utils::ChainedOverloaded{
-          Exists_ActionMethod(exists),
-          Deleted_ActionMethod(deleted),
-          Edges_ActionMethod<EdgeDirection::OUT>(edges, edge_type)
-        });
-        // clang-format on
-      });
-    }
-  }
+  reader.ApplyDeltasForRead([&](Delta const &delta) {
+    // clang-format off
+    DeltaDispatch(delta, utils::ChainedOverloaded{
+      Exists_ActionMethod(exists),
+      Deleted_ActionMethod(deleted),
+      Edges_ActionMethod<EdgeDirection::OUT>(edges, edge_type)
+    });
+    // clang-format on
+  });
+
   if (!exists || deleted || edges.empty()) {
     return;
   }

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -74,7 +74,7 @@ inline void TryInsertEdgeTypePropertyIndex(Vertex &from_vertex, EdgeTypeId edge_
     // clang-format on
   });
 
-  if (vertex_reader.OwnsLocks()) {
+  if (vertex_reader.OwnsLock()) {
     vertex_reader.Unlock();
   }
 

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -74,6 +74,10 @@ inline void TryInsertEdgeTypePropertyIndex(Vertex &from_vertex, EdgeTypeId edge_
     // clang-format on
   });
 
+  if (vertex_reader.OwnsLocks()) {
+    vertex_reader.Unlock();
+  }
+
   if (!exists || deleted || edges.empty()) {
     return;
   }

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -59,7 +59,7 @@ inline void TryInsertEdgeTypePropertyIndex(Vertex &from_vertex, EdgeTypeId edge_
   auto matches_edge_type = [edge_type](auto const &each) { return std::get<EdgeTypeId>(each) == edge_type; };
 
   MvccRead vertex_reader{&from_vertex, &tx, View::OLD, [&](Vertex const &v) {
-                           deleted = v.deleted;
+                           deleted = v.deleted();
                            edges = v.out_edges | rv::filter(matches_edge_type) |
                                    r::to<utils::small_vector<Vertex::EdgeTriple>>;
                          }};

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -54,60 +54,47 @@ inline void TryInsertEdgeTypePropertyIndex(Vertex &from_vertex, EdgeTypeId edge_
                                            Transaction const &tx) {
   bool exists = true;
   bool deleted = false;
-  Delta *delta = nullptr;
   utils::small_vector<Vertex::EdgeTriple> edges;
 
   auto matches_edge_type = [edge_type](auto const &each) { return std::get<EdgeTypeId>(each) == edge_type; };
-  {
-    auto guard = std::shared_lock{from_vertex.lock};
-    deleted = from_vertex.deleted();
-    delta = from_vertex.delta();
-    edges = from_vertex.out_edges | rv::filter(matches_edge_type) | r::to<utils::small_vector<Vertex::EdgeTriple>>;
 
-    // If vertex has non-sequential deltas, hold lock while applying them
-    if (!from_vertex.has_uncommitted_non_sequential_deltas()) {
-      guard.unlock();
-    }
+  MvccRead vertex_reader{&from_vertex, &tx, View::OLD, [&](Vertex const &v) {
+                           deleted = v.deleted;
+                           edges = v.out_edges | rv::filter(matches_edge_type) |
+                                   r::to<utils::small_vector<Vertex::EdgeTriple>>;
+                         }};
 
-    // Create and drop index will always use snapshot isolation
-    if (delta) {
-      ApplyDeltasForRead(&tx, delta, View::OLD, [&](const Delta &delta) {
-        // clang-format off
-        DeltaDispatch(delta, utils::ChainedOverloaded{
-          Exists_ActionMethod(exists),
-          Deleted_ActionMethod(deleted),
-          Edges_ActionMethod<EdgeDirection::OUT>(edges, edge_type),
-        });
-        // clang-format on
-      });
-    }
-  }
+  vertex_reader.ApplyDeltasForRead([&](Delta const &delta) {
+    // clang-format off
+    DeltaDispatch(delta, utils::ChainedOverloaded{
+      Exists_ActionMethod(exists),
+      Deleted_ActionMethod(deleted),
+      Edges_ActionMethod<EdgeDirection::OUT>(edges, edge_type),
+    });
+    // clang-format on
+  });
+
   if (!exists || deleted || edges.empty()) {
     return;
   }
 
   for (auto const &[type, to_vertex, edge_ref] : edges) {
+    exists = true;
+    deleted = false;
     PropertyValue property_value;
-    {
-      auto guard = std::shared_lock{edge_ref.ptr->lock};
-      exists = true;
-      deleted = false;
-      delta = edge_ref.ptr->delta();
-      property_value = edge_ref.ptr->properties.GetProperty(property);
-    }
 
-    if (delta) {
-      // Edge type is immutable so we don't need to check it
-      ApplyDeltasForRead(&tx, delta, View::OLD, [&](const Delta &delta) {
-        // clang-format off
-        DeltaDispatch(delta, utils::ChainedOverloaded{
-          Exists_ActionMethod(exists),
-          Deleted_ActionMethod(deleted),
-          PropertyValue_ActionMethod(property_value, property),
-        });
-        // clang-format on
+    MvccRead edge_reader{
+        edge_ref.ptr, &tx, View::OLD, [&](Edge const &e) { property_value = e.properties.GetProperty(property); }};
+
+    edge_reader.ApplyDeltasForRead([&](Delta const &delta) {
+      // clang-format off
+      DeltaDispatch(delta, utils::ChainedOverloaded{
+        Exists_ActionMethod(exists),
+        Deleted_ActionMethod(deleted),
+        PropertyValue_ActionMethod(property_value, property),
       });
-    }
+      // clang-format on
+    });
 
     if (!exists || deleted || property_value.IsNull()) {
       continue;

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -87,8 +87,10 @@ inline void TryInsertEdgeTypePropertyIndex(Vertex &from_vertex, EdgeTypeId edge_
     deleted = false;
     PropertyValue property_value;
 
-    MvccRead edge_reader{
-        edge_ref.ptr, &tx, View::OLD, [&](Edge const &e) { property_value = e.properties.GetProperty(property); }};
+    MvccRead edge_reader{edge_ref.ptr, &tx, View::OLD, [&](Edge const &e) {
+                           deleted = e.deleted();
+                           property_value = e.properties.GetProperty(property);
+                         }};
 
     edge_reader.ApplyDeltasForRead([&](Delta const &delta) {
       // clang-format off

--- a/src/storage/v2/inmemory/label_index.cpp
+++ b/src/storage/v2/inmemory/label_index.cpp
@@ -122,32 +122,23 @@ inline void TryInsertLabelIndex(Vertex &vertex, LabelId label, auto &&index_acce
 
   bool exists = true;
   bool deleted = false;
-  Delta *delta = nullptr;
   bool has_label = false;
-  {
-    auto guard = std::shared_lock{vertex.lock};
-    deleted = vertex.deleted();
-    delta = vertex.delta();
-    has_label = std::ranges::contains(vertex.labels, label);
 
-    // If vertex has non-sequential deltas, hold lock while applying them
-    if (!vertex.has_uncommitted_non_sequential_deltas()) {
-      guard.unlock();
-    }
+  MvccRead reader{&vertex, &tx, View::OLD, [&](Vertex const &v) {
+                    deleted = v.deleted;
+                    has_label = std::ranges::contains(v.labels, label);
+                  }};
 
-    // Create and drop index will always use snapshot isolation
-    if (delta) {
-      ApplyDeltasForRead(&tx, delta, View::OLD, [&](const Delta &delta) {
-        // clang-format off
-        DeltaDispatch(delta, utils::ChainedOverloaded{
-          Exists_ActionMethod(exists),
-          Deleted_ActionMethod(deleted),
-          HasLabel_ActionMethod(has_label, label),
-        });
-        // clang-format on
-      });
-    }
-  }
+  reader.ApplyDeltasForRead([&](Delta const &delta) {
+    // clang-format off
+    DeltaDispatch(delta, utils::ChainedOverloaded{
+      Exists_ActionMethod(exists),
+      Deleted_ActionMethod(deleted),
+      HasLabel_ActionMethod(has_label, label),
+    });
+    // clang-format on
+  });
+
   if (!exists || deleted || !has_label) {
     return;
   }

--- a/src/storage/v2/inmemory/label_index.cpp
+++ b/src/storage/v2/inmemory/label_index.cpp
@@ -139,6 +139,10 @@ inline void TryInsertLabelIndex(Vertex &vertex, LabelId label, auto &&index_acce
     // clang-format on
   });
 
+  if (reader.OwnsLock()) {
+    reader.Unlock();
+  }
+
   if (!exists || deleted || !has_label) {
     return;
   }

--- a/src/storage/v2/inmemory/label_index.cpp
+++ b/src/storage/v2/inmemory/label_index.cpp
@@ -125,7 +125,7 @@ inline void TryInsertLabelIndex(Vertex &vertex, LabelId label, auto &&index_acce
   bool has_label = false;
 
   MvccRead reader{&vertex, &tx, View::OLD, [&](Vertex const &v) {
-                    deleted = v.deleted;
+                    deleted = v.deleted();
                     has_label = std::ranges::contains(v.labels, label);
                   }};
 

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -397,6 +397,10 @@ inline void TryInsertLabelPropertiesIndex(Vertex &vertex, LabelId label, Propert
     // clang-format on
   });
 
+  if (reader.OwnsLock()) {
+    reader.Unlock();
+  }
+
   if (!exists || deleted || !has_label) {
     return;
   }

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -69,24 +69,17 @@ bool CurrentVersionHasLabelProperties(const Vertex &vertex, LabelId label, Prope
   bool exists = true;
   bool deleted = false;
   bool has_label = false;
-  auto current_values_equal_to_value = std::vector<bool>{};
-  const Delta *delta = nullptr;
-  auto guard = std::shared_lock{vertex.lock};
-  delta = vertex.delta();
-  deleted = vertex.deleted();
-  if (!delta && deleted) return false;
-  has_label = std::ranges::contains(vertex.labels, label);
-  if (!delta && !has_label) return false;
-  current_values_equal_to_value = helper.MatchesValues(vertex.properties, values);
+  std::vector<bool> current_values_equal_to_value;
 
-  // If vertex has non-sequential deltas, hold lock while applying them
-  if (!vertex.has_uncommitted_non_sequential_deltas()) {
-    guard.unlock();
-  }
+  MvccRead reader{&vertex, transaction, view, [&](Vertex const &v) {
+                    deleted = v.deleted;
+                    has_label = std::ranges::contains(v.labels, label);
+                    current_values_equal_to_value = helper.MatchesValues(v.properties, values);
+                  }};
 
   // Checking cache has a cost, only do it if we have any deltas
   // if we have no deltas then what we already have from the vertex is correct.
-  if (delta && transaction->isolation_level != IsolationLevel::READ_UNCOMMITTED) {
+  if (reader.HasDeltas() && transaction->isolation_level != IsolationLevel::READ_UNCOMMITTED) {
     // IsolationLevel::READ_COMMITTED would be tricky to propagate invalidation to
     // so for now only cache for IsolationLevel::SNAPSHOT_ISOLATION
     auto const useCache = use_cache && transaction->UseCache();
@@ -119,20 +112,19 @@ bool CurrentVersionHasLabelProperties(const Vertex &vertex, LabelId label, Prope
       }
     }
 
-    auto const n_processed = ApplyDeltasForRead(transaction, delta, view, [&](const Delta &delta) {
+    auto const n_processed = reader.ApplyDeltasForRead([&](Delta const &delta) {
       // clang-format off
-          DeltaDispatch(delta, utils::ChainedOverloaded{
-            Deleted_ActionMethod(deleted),
-            Exists_ActionMethod(exists),
-            HasLabel_ActionMethod(has_label, label),
-            PropertyValueMatch_ActionMethod(current_values_equal_to_value, helper, values)
-          });
+      DeltaDispatch(delta, utils::ChainedOverloaded{
+        Deleted_ActionMethod(deleted),
+        Exists_ActionMethod(exists),
+        HasLabel_ActionMethod(has_label, label),
+        PropertyValueMatch_ActionMethod(current_values_equal_to_value, helper, values)
+      });
       // clang-format on
     });
 
-    // Unlock if we still hold the lock (i.e., vertex had non-sequential deltas)
-    if (guard.owns_lock()) {
-      guard.unlock();
+    if (reader.OwnsLock()) {
+      reader.Unlock();
     }
 
     if (useCache && n_processed >= FLAGS_delta_chain_cache_threshold) {
@@ -381,35 +373,26 @@ inline void TryInsertLabelPropertiesIndex(Vertex &vertex, LabelId label, Propert
 
   bool exists = true;
   bool deleted = false;
-  Delta *delta = nullptr;
   bool has_label = false;
   std::vector<PropertyValue> properties;
-  {
-    auto guard = std::shared_lock{vertex.lock};
-    deleted = vertex.deleted();
-    delta = vertex.delta();
-    has_label = std::ranges::contains(vertex.labels, label);
-    properties = props.Extract(vertex.properties);
 
-    // If vertex has non-sequential deltas, hold lock while applying them
-    if (!vertex.has_uncommitted_non_sequential_deltas()) {
-      guard.unlock();
-    }
+  MvccRead reader{&vertex, &tx, View::OLD, [&](Vertex const &v) {
+                    deleted = v.deleted;
+                    has_label = std::ranges::contains(v.labels, label);
+                    properties = props.Extract(v.properties);
+                  }};
 
-    // Create and drop index will always use snapshot isolation
-    if (delta) {
-      ApplyDeltasForRead(&tx, delta, View::OLD, [&](const Delta &delta) {
-        // clang-format off
-        DeltaDispatch(delta, utils::ChainedOverloaded{
-          Exists_ActionMethod(exists),
-          Deleted_ActionMethod(deleted),
-          HasLabel_ActionMethod(has_label, label),
-          PropertyValuesUpdate_ActionMethod(props, properties)
-        });
-        // clang-format on
-      });
-    }
-  }
+  reader.ApplyDeltasForRead([&](Delta const &delta) {
+    // clang-format off
+    DeltaDispatch(delta, utils::ChainedOverloaded{
+      Exists_ActionMethod(exists),
+      Deleted_ActionMethod(deleted),
+      HasLabel_ActionMethod(has_label, label),
+      PropertyValuesUpdate_ActionMethod(props, properties)
+    });
+    // clang-format on
+  });
+
   if (!exists || deleted || !has_label) {
     return;
   }

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -72,10 +72,10 @@ bool CurrentVersionHasLabelProperties(const Vertex &vertex, LabelId label, Prope
   std::vector<bool> current_values_equal_to_value;
 
   MvccRead reader{&vertex, transaction, view, [&](Vertex const &v) {
-                    deleted = v.deleted;
-                    if (!v.delta && deleted) return;
+                    deleted = v.deleted();
+                    if (!v.delta() && deleted) return;
                     has_label = std::ranges::contains(v.labels, label);
-                    if (!v.delta && !has_label) return;
+                    if (!v.delta() && !has_label) return;
                     current_values_equal_to_value = helper.MatchesValues(v.properties, values);
                   }};
 
@@ -381,7 +381,7 @@ inline void TryInsertLabelPropertiesIndex(Vertex &vertex, LabelId label, Propert
   std::vector<PropertyValue> properties;
 
   MvccRead reader{&vertex, &tx, View::OLD, [&](Vertex const &v) {
-                    deleted = v.deleted;
+                    deleted = v.deleted();
                     has_label = std::ranges::contains(v.labels, label);
                     properties = props.Extract(v.properties);
                   }};

--- a/src/storage/v2/mvcc.hpp
+++ b/src/storage/v2/mvcc.hpp
@@ -23,12 +23,19 @@
 
 namespace memgraph::storage {
 
+namespace detail {
+
 /// This function iterates through the undo buffers from an object (starting
 /// from the supplied delta) and determines what deltas should be applied to get
 /// the currently visible version of the object. When the function finds a delta
 /// that should be applied it calls the callback function with the delta that
 /// should be applied passed as a parameter to the callback. It is up to the
 /// caller to apply the deltas.
+/// WARNING If you are calling this function directly, be very careful about
+/// object lock lifetime. The MvccRead class wraps this, using the correct and
+/// optimal locks, so you should probably be using that. The only reason this is
+/// still a free function is that on-disk uses it with its own locking
+/// mechanisms.
 /// @return number of deltas that were processed
 template <typename TCallback>
 inline std::size_t ApplyDeltasForRead(Transaction const *transaction, const Delta *delta, View view,
@@ -104,6 +111,13 @@ inline std::size_t ApplyDeltasForRead(Transaction const *transaction, const Delt
   return n_processed;
 }
 
+}  // namespace detail
+
+/// RAII wrapper for reading MVCC-versioned objects.  Acquires the appropriate
+/// shared lock, snapshots the delta pointer, and provides ApplyDeltasForRead to
+/// reconstruct the visible version. For objects with uncommitted non-sequential
+/// deltas, the lock is held during delta traversal; otherwise it is released
+/// early for better concurrency.
 template <typename TObject>
 class MvccRead {
  public:
@@ -139,7 +153,7 @@ class MvccRead {
 
   template <typename TCallback>
   std::size_t ApplyDeltasForRead(TCallback const &callback) {
-    return memgraph::storage::ApplyDeltasForRead(transaction_, delta_, view_, callback);
+    return detail::ApplyDeltasForRead(transaction_, delta_, view_, callback);
   }
 
  private:

--- a/src/storage/v2/mvcc.hpp
+++ b/src/storage/v2/mvcc.hpp
@@ -147,6 +147,9 @@ class MvccRead {
 
   bool OwnsLock() const { return lock_.owns_lock(); }
 
+  // In functions that use an MvccRead, it is safe to manually `Unlock` (if
+  // we currently `OwnsLock`) once we have read the deltas. This prevents
+  // object locks being held longer than is strictly necessary.
   void Unlock() { lock_.unlock(); }
 
   template <typename TCallback>

--- a/src/storage/v2/mvcc.hpp
+++ b/src/storage/v2/mvcc.hpp
@@ -123,9 +123,9 @@ class MvccRead {
   MvccRead(TObject const *object, Transaction const *transaction, View view, TWithLock &&with_lock)
       : transaction_{transaction}, view_{view}, lock_{object->lock} {
     std::forward<TWithLock>(with_lock)(*object);
-    delta_ = object->delta;
-    if constexpr (requires { object->has_uncommitted_non_sequential_deltas; }) {
-      if (!object->has_uncommitted_non_sequential_deltas) {
+    delta_ = object->delta();
+    if constexpr (requires { object->has_uncommitted_non_sequential_deltas(); }) {
+      if (!object->has_uncommitted_non_sequential_deltas()) {
         lock_.unlock();
       }
     } else {

--- a/src/storage/v2/vertex_accessor.cpp
+++ b/src/storage/v2/vertex_accessor.cpp
@@ -57,70 +57,17 @@ std::optional<PropertyValue> TryConvertToVectorIndexProperty(Storage *storage, V
       PropertyValue::VectorIndexIdData{.ids = std::move(vector_index_ids), .vector = ListToVector(value)});
 }
 
-// Manages lock lifetime based on whether vertex currently has uncommitted
-// non-sequential deltas. Any transaction that has created non-sequential deltas may
-// abort and have to remove deltas from the middle of the delta chain. When a
-// vertex has these uncommitted non-sequential deltas in its chain, this read lock
-// must be held both when we read the `vertex.delta` AND continue to be held
-// whilst we walk the delta chain. For vertices with no uncommitted non-sequential
-// deltas, this uses the shorter lock duration of just reading `vertex.delta`
-// under lock.
-class VertexReadLock {
- public:
-  explicit VertexReadLock(memgraph::storage::Vertex const *vertex)
-      : vertex_{vertex}, lock_{vertex->lock, std::defer_lock} {}
-
-  class SnapshotGuard {
-   public:
-    explicit SnapshotGuard(VertexReadLock *manager, bool has_uncommitted_non_sequential_deltas)
-        : manager_{manager}, has_uncommitted_non_sequential_deltas_{has_uncommitted_non_sequential_deltas} {}
-
-    ~SnapshotGuard() {
-      if (!has_uncommitted_non_sequential_deltas_) {
-        manager_->lock_.unlock();
-      }
-    }
-
-    SnapshotGuard(SnapshotGuard const &) = delete;
-    SnapshotGuard(SnapshotGuard &&) = delete;
-    SnapshotGuard &operator=(SnapshotGuard const &) = delete;
-    SnapshotGuard &operator=(SnapshotGuard &&) = delete;
-
-   private:
-    VertexReadLock *manager_;
-    bool has_uncommitted_non_sequential_deltas_;
-  };
-
-  // `AcquireLock` can be called at most once per `VertexReadLock` instance.
-  // Calling it again on a `VertexReadLock` for which you've already acquired
-  // the lock could result in deadlock.
-  SnapshotGuard AcquireLock() {
-    lock_.lock();
-    return SnapshotGuard{this, vertex_->has_uncommitted_non_sequential_deltas()};
-  }
-
- private:
-  memgraph::storage::Vertex const *vertex_;
-  std::shared_lock<memgraph::utils::RWSpinLock> lock_;
-};
-
 }  // namespace
 
 namespace detail {
 std::pair<bool, bool> IsVisible(Vertex const *vertex, Transaction const *transaction, View view) {
   bool exists = true;
   bool deleted = false;
-  Delta *delta = nullptr;
-  VertexReadLock read_lock(vertex);
-  {
-    auto const guard = read_lock.AcquireLock();
-    deleted = vertex->deleted();
-    delta = vertex->delta();
-  }
+  MvccRead reader{vertex, transaction, view, [&](Vertex const &v) { deleted = v.deleted; }};
 
   // Checking cache has a cost, only do it if we have any deltas
   // if we have no deltas then what we already have from the vertex is correct.
-  if (delta && transaction->isolation_level != IsolationLevel::READ_UNCOMMITTED) {
+  if (reader.HasDeltas() && transaction->isolation_level != IsolationLevel::READ_UNCOMMITTED) {
     // IsolationLevel::READ_COMMITTED would be tricky to propagate invalidation to
     // so for now only cache for IsolationLevel::SNAPSHOT_ISOLATION
     auto const useCache = transaction->UseCache();
@@ -132,7 +79,7 @@ std::pair<bool, bool> IsVisible(Vertex const *vertex, Transaction const *transac
       if (existsRes && deletedRes) return {*existsRes, *deletedRes};
     }
 
-    auto const n_processed = ApplyDeltasForRead(transaction, delta, view, [&](const Delta &delta) {
+    auto const n_processed = reader.ApplyDeltasForRead([&](Delta const &delta) {
       // clang-format off
       DeltaDispatch(delta, utils::ChainedOverloaded{
           Deleted_ActionMethod(deleted),
@@ -311,18 +258,14 @@ Result<bool> VertexAccessor::HasLabel(LabelId label, View view) const {
   bool exists = true;
   bool deleted = false;
   bool has_label = false;
-  Delta *delta = nullptr;
-  VertexReadLock read_lock{vertex_};
-  {
-    auto const guard = read_lock.AcquireLock();
-    deleted = vertex_->deleted();
-    has_label = std::ranges::contains(vertex_->labels, label);
-    delta = vertex_->delta();
-  }
+  MvccRead reader{vertex_, transaction_, view, [&](Vertex const &v) {
+                    deleted = v.deleted;
+                    has_label = std::ranges::contains(v.labels, label);
+                  }};
 
   // Checking cache has a cost, only do it if we have any deltas
   // if we have no deltas then what we already have from the vertex is correct.
-  if (delta && transaction_->isolation_level != IsolationLevel::READ_UNCOMMITTED) {
+  if (reader.HasDeltas() && transaction_->isolation_level != IsolationLevel::READ_UNCOMMITTED) {
     // IsolationLevel::READ_COMMITTED would be tricky to propagate invalidation to
     // so for now only cache for IsolationLevel::SNAPSHOT_ISOLATION
     auto const useCache = transaction_->UseCache();
@@ -332,7 +275,7 @@ Result<bool> VertexAccessor::HasLabel(LabelId label, View view) const {
       if (auto resLabel = cache.GetHasLabel(view, vertex_, label); resLabel) return {resLabel.value()};
     }
 
-    auto const n_processed = ApplyDeltasForRead(transaction_, delta, view, [&, label](const Delta &delta) {
+    auto const n_processed = reader.ApplyDeltasForRead([&, label](Delta const &delta) {
       // clang-format off
       DeltaDispatch(delta, utils::ChainedOverloaded{
         Deleted_ActionMethod(deleted),
@@ -359,18 +302,14 @@ Result<utils::small_vector<LabelId>> VertexAccessor::Labels(View view) const {
   bool exists = true;
   bool deleted = false;
   utils::small_vector<LabelId> labels;
-  Delta *delta = nullptr;
-  VertexReadLock read_lock{vertex_};
-  {
-    auto const guard = read_lock.AcquireLock();
-    deleted = vertex_->deleted();
-    labels = vertex_->labels;
-    delta = vertex_->delta();
-  }
+  MvccRead reader{vertex_, transaction_, view, [&](Vertex const &v) {
+                    deleted = v.deleted;
+                    labels = v.labels;
+                  }};
 
   // Checking cache has a cost, only do it if we have any deltas
   // if we have no deltas then what we already have from the vertex is correct.
-  if (delta && transaction_->isolation_level != IsolationLevel::READ_UNCOMMITTED) {
+  if (reader.HasDeltas() && transaction_->isolation_level != IsolationLevel::READ_UNCOMMITTED) {
     // IsolationLevel::READ_COMMITTED would be tricky to propagate invalidation to
     // so for now only cache for IsolationLevel::SNAPSHOT_ISOLATION
     auto const useCache = transaction_->UseCache();
@@ -380,7 +319,7 @@ Result<utils::small_vector<LabelId>> VertexAccessor::Labels(View view) const {
       if (auto resLabels = cache.GetLabels(view, vertex_); resLabels) return {*resLabels};
     }
 
-    auto const n_processed = ApplyDeltasForRead(transaction_, delta, view, [&](const Delta &delta) {
+    auto const n_processed = reader.ApplyDeltasForRead([&](Delta const &delta) {
       // clang-format off
       DeltaDispatch(delta, utils::ChainedOverloaded{
         Deleted_ActionMethod(deleted),
@@ -673,22 +612,20 @@ Result<std::map<PropertyId, PropertyValue>> VertexAccessor::ClearProperties() {
 Result<PropertyValue> VertexAccessor::GetProperty(PropertyId property, View view) const {
   bool exists = true;
   bool deleted = false;
-  Delta *delta = nullptr;
-  VertexReadLock read_lock{vertex_};
-  auto value = std::invoke([&]() -> PropertyValue {
-    auto const guard = read_lock.AcquireLock();
-    deleted = vertex_->deleted();
-    delta = vertex_->delta();
-    auto prop_value = vertex_->properties.GetProperty(
-        property,
-        IndexedPropertyDecoder<Vertex>{
-            .indices = &storage_->indices_, .name_id_mapper = storage_->name_id_mapper_.get(), .entity = vertex_});
-    return prop_value;
-  });
+  PropertyValue value;
+
+  MvccRead reader{
+      vertex_, transaction_, view, [&](Vertex const &v) {
+        deleted = v.deleted;
+        value = v.properties.GetProperty(
+            property,
+            IndexedPropertyDecoder<Vertex>{
+                .indices = &storage_->indices_, .name_id_mapper = storage_->name_id_mapper_.get(), .entity = vertex_});
+      }};
 
   // Checking cache has a cost, only do it if we have any deltas
   // if we have no deltas then what we already have from the vertex is correct.
-  if (delta && transaction_->isolation_level != IsolationLevel::READ_UNCOMMITTED) [[unlikely]] {
+  if (reader.HasDeltas() && transaction_->isolation_level != IsolationLevel::READ_UNCOMMITTED) [[unlikely]] {
     // IsolationLevel::READ_COMMITTED would be tricky to propagate invalidation to
     // so for now only cache for IsolationLevel::SNAPSHOT_ISOLATION
     auto const useCache = transaction_->UseCache();
@@ -698,16 +635,15 @@ Result<PropertyValue> VertexAccessor::GetProperty(PropertyId property, View view
       if (auto resProperty = cache.GetProperty(view, vertex_, property); resProperty) return {*resProperty};
     }
 
-    auto const n_processed =
-        ApplyDeltasForRead(transaction_, delta, view, [&exists, &deleted, &value, property](const Delta &delta) {
-          // clang-format off
-          DeltaDispatch(delta, utils::ChainedOverloaded{
-            Deleted_ActionMethod(deleted),
-            Exists_ActionMethod(exists),
-            PropertyValue_ActionMethod(value, property)
-          });
-          // clang-format on
-        });
+    auto const n_processed = reader.ApplyDeltasForRead([&exists, &deleted, &value, property](Delta const &delta) {
+      // clang-format off
+      DeltaDispatch(delta, utils::ChainedOverloaded{
+        Deleted_ActionMethod(deleted),
+        Exists_ActionMethod(exists),
+        PropertyValue_ActionMethod(value, property)
+      });
+      // clang-format on
+    });
 
     if (useCache && n_processed >= FLAGS_delta_chain_cache_threshold) {
       auto &cache = transaction_->manyDeltasCache;
@@ -746,19 +682,16 @@ Result<std::map<PropertyId, PropertyValue>> VertexAccessor::Properties(View view
   bool exists = true;
   bool deleted = false;
   std::map<PropertyId, PropertyValue> properties;
-  Delta *delta = nullptr;
-  VertexReadLock read_lock{vertex_};
-  {
-    auto const guard = read_lock.AcquireLock();
-    deleted = vertex_->deleted();
-    properties = vertex_->properties.Properties(IndexedPropertyDecoder<Vertex>{
-        .indices = &storage_->indices_, .name_id_mapper = storage_->name_id_mapper_.get(), .entity = vertex_});
-    delta = vertex_->delta();
-  }
+  MvccRead reader{
+      vertex_, transaction_, view, [&](Vertex const &v) {
+        deleted = v.deleted;
+        properties = v.properties.Properties(IndexedPropertyDecoder<Vertex>{
+            .indices = &storage_->indices_, .name_id_mapper = storage_->name_id_mapper_.get(), .entity = vertex_});
+      }};
 
   // Checking cache has a cost, only do it if we have any deltas
   // if we have no deltas then what we already have from the vertex is correct.
-  if (delta && transaction_->isolation_level != IsolationLevel::READ_UNCOMMITTED) {
+  if (reader.HasDeltas() && transaction_->isolation_level != IsolationLevel::READ_UNCOMMITTED) {
     // IsolationLevel::READ_COMMITTED would be tricky to propagate invalidation to
     // so for now only cache for IsolationLevel::SNAPSHOT_ISOLATION
     auto const useCache = transaction_->UseCache();
@@ -768,16 +701,15 @@ Result<std::map<PropertyId, PropertyValue>> VertexAccessor::Properties(View view
       if (auto resProperties = cache.GetProperties(view, vertex_); resProperties) return {*resProperties};
     }
 
-    auto const n_processed =
-        ApplyDeltasForRead(transaction_, delta, view, [&exists, &deleted, &properties](const Delta &delta) {
-          // clang-format off
-          DeltaDispatch(delta, utils::ChainedOverloaded{
-            Deleted_ActionMethod(deleted),
-            Exists_ActionMethod(exists),
-            Properties_ActionMethod(properties)
-          });
-          // clang-format on
-        });
+    auto const n_processed = reader.ApplyDeltasForRead([&exists, &deleted, &properties](Delta const &delta) {
+      // clang-format off
+      DeltaDispatch(delta, utils::ChainedOverloaded{
+        Deleted_ActionMethod(deleted),
+        Exists_ActionMethod(exists),
+        Properties_ActionMethod(properties)
+      });
+      // clang-format on
+    });
 
     if (useCache && n_processed >= FLAGS_delta_chain_cache_threshold) {
       auto &cache = transaction_->manyDeltasCache;
@@ -798,17 +730,14 @@ Result<std::map<PropertyId, PropertyValue>> VertexAccessor::PropertiesByProperty
   bool deleted = false;
   std::vector<PropertyValue> property_values;
   property_values.reserve(properties.size());
-  Delta *delta = nullptr;
-  VertexReadLock read_lock{vertex_};
-  {
-    auto const guard = read_lock.AcquireLock();
-    deleted = vertex_->deleted();
-    auto property_paths = properties |
-                          rv::transform([](PropertyId property) { return storage::PropertyPath{property}; }) |
-                          r::to<std::vector<storage::PropertyPath>>();
-    property_values = vertex_->properties.ExtractPropertyValuesMissingAsNull(property_paths);
-    delta = vertex_->delta();
-  }
+  MvccRead reader{vertex_, transaction_, view, [&](Vertex const &v) {
+                    deleted = v.deleted;
+                    auto property_paths =
+                        properties |
+                        rv::transform([](PropertyId property) { return storage::PropertyPath{property}; }) |
+                        r::to<std::vector<storage::PropertyPath>>();
+                    property_values = v.properties.ExtractPropertyValuesMissingAsNull(property_paths);
+                  }};
   auto properties_map =
       rv::zip(properties, property_values) | rv::transform([](const auto &property_id_value_pair) {
         return std::make_pair(std::get<0>(property_id_value_pair), std::get<1>(property_id_value_pair));
@@ -817,7 +746,7 @@ Result<std::map<PropertyId, PropertyValue>> VertexAccessor::PropertiesByProperty
 
   // Checking cache has a cost, only do it if we have any deltas
   // if we have no deltas then what we already have from the vertex is correct.
-  if (delta && transaction_->isolation_level != IsolationLevel::READ_UNCOMMITTED) {
+  if (reader.HasDeltas() && transaction_->isolation_level != IsolationLevel::READ_UNCOMMITTED) {
     // IsolationLevel::READ_COMMITTED would be tricky to propagate invalidation to
     // so for now only cache for IsolationLevel::SNAPSHOT_ISOLATION
     auto const useCache = transaction_->UseCache();
@@ -827,16 +756,15 @@ Result<std::map<PropertyId, PropertyValue>> VertexAccessor::PropertiesByProperty
       // Note: We don't have specific cache for properties by IDs, so we skip caching for now
     }
 
-    auto const n_processed =
-        ApplyDeltasForRead(transaction_, delta, view, [&exists, &deleted, &properties_map](const Delta &delta) {
-          // clang-format off
-          DeltaDispatch(delta, utils::ChainedOverloaded{
-            Deleted_ActionMethod(deleted),
-            Exists_ActionMethod(exists),
-            Properties_ActionMethod(properties_map)
-          });
-          // clang-format on
-        });
+    auto const n_processed = reader.ApplyDeltasForRead([&exists, &deleted, &properties_map](Delta const &delta) {
+      // clang-format off
+      DeltaDispatch(delta, utils::ChainedOverloaded{
+        Deleted_ActionMethod(deleted),
+        Exists_ActionMethod(exists),
+        Properties_ActionMethod(properties_map)
+      });
+      // clang-format on
+    });
 
     if (useCache && n_processed >= FLAGS_delta_chain_cache_threshold) {
       auto &cache = transaction_->manyDeltasCache;
@@ -927,23 +855,20 @@ Result<EdgesVertexAccessorResult> VertexAccessor::InEdges(View view, const std::
   bool exists = true;
   bool deleted = false;
   auto in_edges = edge_store{};
-  Delta *delta = nullptr;
   int64_t expanded_count = 0;
-  VertexReadLock read_lock{vertex_};
-  {
-    auto const guard = read_lock.AcquireLock();
-    deleted = vertex_->deleted();
-    if (edge_types.empty() && !destination) {
-      expanded_count = HandleExpansionsWithoutEdgeTypes(in_edges, hops_limit, EdgeDirection::IN);
-    } else {
-      expanded_count = HandleExpansionsWithEdgeTypes(in_edges, edge_types, destination, hops_limit, EdgeDirection::IN);
-    }
-    delta = vertex_->delta();
-  }
+  MvccRead reader{vertex_, transaction_, view, [&](Vertex const &v) {
+                    deleted = v.deleted;
+                    if (edge_types.empty() && !destination) {
+                      expanded_count = HandleExpansionsWithoutEdgeTypes(in_edges, hops_limit, EdgeDirection::IN);
+                    } else {
+                      expanded_count = HandleExpansionsWithEdgeTypes(
+                          in_edges, edge_types, destination, hops_limit, EdgeDirection::IN);
+                    }
+                  }};
 
   // Checking cache has a cost, only do it if we have any deltas
   // if we have no deltas then what we already have from the vertex is correct.
-  if (delta && transaction_->isolation_level != IsolationLevel::READ_UNCOMMITTED) {
+  if (reader.HasDeltas() && transaction_->isolation_level != IsolationLevel::READ_UNCOMMITTED) {
     // IsolationLevel::READ_COMMITTED would be tricky to propagate invalidation to
     // so for now only cache for IsolationLevel::SNAPSHOT_ISOLATION
     auto const useCache = transaction_->UseCache();
@@ -954,11 +879,8 @@ Result<EdgesVertexAccessorResult> VertexAccessor::InEdges(View view, const std::
         return EdgesVertexAccessorResult{.edges = BuildResultInEdges(*resInEdges), .expanded_count = expanded_count};
     }
 
-    auto const n_processed = ApplyDeltasForRead(
-        transaction_,
-        delta,
-        view,
-        [&exists, &deleted, &in_edges, &edge_types, &destination_vertex](const Delta &delta) {
+    auto const n_processed =
+        reader.ApplyDeltasForRead([&exists, &deleted, &in_edges, &edge_types, &destination_vertex](Delta const &delta) {
           // clang-format off
           DeltaDispatch(delta, utils::ChainedOverloaded{
             Deleted_ActionMethod(deleted),
@@ -1016,24 +938,20 @@ Result<EdgesVertexAccessorResult> VertexAccessor::OutEdges(View view, const std:
   bool exists = true;
   bool deleted = false;
   auto out_edges = edge_store{};
-  Delta *delta = nullptr;
   int64_t expanded_count = 0;
-  VertexReadLock read_lock{vertex_};
-  {
-    auto const guard = read_lock.AcquireLock();
-    deleted = vertex_->deleted();
-    if (edge_types.empty() && !destination) {
-      expanded_count = HandleExpansionsWithoutEdgeTypes(out_edges, hops_limit, EdgeDirection::OUT);
-    } else {
-      expanded_count =
-          HandleExpansionsWithEdgeTypes(out_edges, edge_types, destination, hops_limit, EdgeDirection::OUT);
-    }
-    delta = vertex_->delta();
-  }
+  MvccRead reader{vertex_, transaction_, view, [&](Vertex const &v) {
+                    deleted = v.deleted;
+                    if (edge_types.empty() && !destination) {
+                      expanded_count = HandleExpansionsWithoutEdgeTypes(out_edges, hops_limit, EdgeDirection::OUT);
+                    } else {
+                      expanded_count = HandleExpansionsWithEdgeTypes(
+                          out_edges, edge_types, destination, hops_limit, EdgeDirection::OUT);
+                    }
+                  }};
 
   // Checking cache has a cost, only do it if we have any deltas
   // if we have no deltas then what we already have from the vertex is correct.
-  if (delta && transaction_->isolation_level != IsolationLevel::READ_UNCOMMITTED) {
+  if (reader.HasDeltas() && transaction_->isolation_level != IsolationLevel::READ_UNCOMMITTED) {
     // IsolationLevel::READ_COMMITTED would be tricky to propagate invalidation to
     // so for now only cache for IsolationLevel::SNAPSHOT_ISOLATION
     auto const useCache = transaction_->UseCache();
@@ -1044,8 +962,8 @@ Result<EdgesVertexAccessorResult> VertexAccessor::OutEdges(View view, const std:
         return EdgesVertexAccessorResult{.edges = BuildResultOutEdges(*resOutEdges), .expanded_count = expanded_count};
     }
 
-    auto const n_processed = ApplyDeltasForRead(
-        transaction_, delta, view, [&exists, &deleted, &out_edges, &edge_types, &dst_vertex](const Delta &delta) {
+    auto const n_processed =
+        reader.ApplyDeltasForRead([&exists, &deleted, &out_edges, &edge_types, &dst_vertex](Delta const &delta) {
           // clang-format off
           DeltaDispatch(delta, utils::ChainedOverloaded{
             Deleted_ActionMethod(deleted),
@@ -1089,18 +1007,14 @@ Result<size_t> VertexAccessor::InDegree(View view) const {
   bool exists = true;
   bool deleted = false;
   size_t degree = 0;
-  Delta *delta = nullptr;
-  VertexReadLock read_lock{vertex_};
-  {
-    auto const guard = read_lock.AcquireLock();
-    deleted = vertex_->deleted();
-    degree = vertex_->in_edges.size();
-    delta = vertex_->delta();
-  }
+  MvccRead reader{vertex_, transaction_, view, [&](Vertex const &v) {
+                    deleted = v.deleted;
+                    degree = v.in_edges.size();
+                  }};
 
   // Checking cache has a cost, only do it if we have any deltas
   // if we have no deltas then what we already have from the vertex is correct.
-  if (delta && transaction_->isolation_level != IsolationLevel::READ_UNCOMMITTED) {
+  if (reader.HasDeltas() && transaction_->isolation_level != IsolationLevel::READ_UNCOMMITTED) {
     // IsolationLevel::READ_COMMITTED would be tricky to propagate invalidation to
     // so for now only cache for IsolationLevel::SNAPSHOT_ISOLATION
     auto const useCache = transaction_->UseCache();
@@ -1110,16 +1024,15 @@ Result<size_t> VertexAccessor::InDegree(View view) const {
       if (auto resInDegree = cache.GetInDegree(view, vertex_); resInDegree) return {*resInDegree};
     }
 
-    auto const n_processed =
-        ApplyDeltasForRead(transaction_, delta, view, [&exists, &deleted, &degree](const Delta &delta) {
-          // clang-format off
-          DeltaDispatch(delta, utils::ChainedOverloaded{
-            Deleted_ActionMethod(deleted),
-            Exists_ActionMethod(exists),
-            Degree_ActionMethod<EdgeDirection::IN>(degree)
-          });
-          // clang-format on
-        });
+    auto const n_processed = reader.ApplyDeltasForRead([&exists, &deleted, &degree](Delta const &delta) {
+      // clang-format off
+      DeltaDispatch(delta, utils::ChainedOverloaded{
+        Deleted_ActionMethod(deleted),
+        Exists_ActionMethod(exists),
+        Degree_ActionMethod<EdgeDirection::IN>(degree)
+      });
+      // clang-format on
+    });
 
     if (useCache && n_processed >= FLAGS_delta_chain_cache_threshold) {
       auto &cache = transaction_->manyDeltasCache;
@@ -1146,18 +1059,14 @@ Result<size_t> VertexAccessor::OutDegree(View view) const {
   bool exists = true;
   bool deleted = false;
   size_t degree = 0;
-  Delta *delta = nullptr;
-  VertexReadLock read_lock{vertex_};
-  {
-    auto const guard = read_lock.AcquireLock();
-    deleted = vertex_->deleted();
-    degree = vertex_->out_edges.size();
-    delta = vertex_->delta();
-  }
+  MvccRead reader{vertex_, transaction_, view, [&](Vertex const &v) {
+                    deleted = v.deleted;
+                    degree = v.out_edges.size();
+                  }};
 
   // Checking cache has a cost, only do it if we have any deltas
   // if we have no deltas then what we already have from the vertex is correct.
-  if (delta && transaction_->isolation_level != IsolationLevel::READ_UNCOMMITTED) {
+  if (reader.HasDeltas() && transaction_->isolation_level != IsolationLevel::READ_UNCOMMITTED) {
     // IsolationLevel::READ_COMMITTED would be tricky to propagate invalidation to
     // so for now only cache for IsolationLevel::SNAPSHOT_ISOLATION
     auto const useCache = transaction_->UseCache();
@@ -1167,16 +1076,15 @@ Result<size_t> VertexAccessor::OutDegree(View view) const {
       if (auto resOutDegree = cache.GetOutDegree(view, vertex_); resOutDegree) return {*resOutDegree};
     }
 
-    auto const n_processed =
-        ApplyDeltasForRead(transaction_, delta, view, [&exists, &deleted, &degree](const Delta &delta) {
-          // clang-format off
-          DeltaDispatch(delta, utils::ChainedOverloaded{
-            Deleted_ActionMethod(deleted),
-            Exists_ActionMethod(exists),
-            Degree_ActionMethod<EdgeDirection::OUT>(degree)
-          });
-          // clang-format on
-        });
+    auto const n_processed = reader.ApplyDeltasForRead([&exists, &deleted, &degree](Delta const &delta) {
+      // clang-format off
+      DeltaDispatch(delta, utils::ChainedOverloaded{
+        Deleted_ActionMethod(deleted),
+        Exists_ActionMethod(exists),
+        Degree_ActionMethod<EdgeDirection::OUT>(degree)
+      });
+      // clang-format on
+    });
 
     if (useCache && n_processed >= FLAGS_delta_chain_cache_threshold) {
       auto &cache = transaction_->manyDeltasCache;

--- a/src/storage/v2/vertex_accessor.cpp
+++ b/src/storage/v2/vertex_accessor.cpp
@@ -63,7 +63,7 @@ namespace detail {
 std::pair<bool, bool> IsVisible(Vertex const *vertex, Transaction const *transaction, View view) {
   bool exists = true;
   bool deleted = false;
-  MvccRead reader{vertex, transaction, view, [&](Vertex const &v) { deleted = v.deleted; }};
+  MvccRead reader{vertex, transaction, view, [&](Vertex const &v) { deleted = v.deleted(); }};
 
   // Checking cache has a cost, only do it if we have any deltas
   // if we have no deltas then what we already have from the vertex is correct.
@@ -259,7 +259,7 @@ Result<bool> VertexAccessor::HasLabel(LabelId label, View view) const {
   bool deleted = false;
   bool has_label = false;
   MvccRead reader{vertex_, transaction_, view, [&](Vertex const &v) {
-                    deleted = v.deleted;
+                    deleted = v.deleted();
                     has_label = std::ranges::contains(v.labels, label);
                   }};
 
@@ -303,7 +303,7 @@ Result<utils::small_vector<LabelId>> VertexAccessor::Labels(View view) const {
   bool deleted = false;
   utils::small_vector<LabelId> labels;
   MvccRead reader{vertex_, transaction_, view, [&](Vertex const &v) {
-                    deleted = v.deleted;
+                    deleted = v.deleted();
                     labels = v.labels;
                   }};
 
@@ -616,7 +616,7 @@ Result<PropertyValue> VertexAccessor::GetProperty(PropertyId property, View view
 
   MvccRead reader{
       vertex_, transaction_, view, [&](Vertex const &v) {
-        deleted = v.deleted;
+        deleted = v.deleted();
         value = v.properties.GetProperty(
             property,
             IndexedPropertyDecoder<Vertex>{
@@ -684,7 +684,7 @@ Result<std::map<PropertyId, PropertyValue>> VertexAccessor::Properties(View view
   std::map<PropertyId, PropertyValue> properties;
   MvccRead reader{
       vertex_, transaction_, view, [&](Vertex const &v) {
-        deleted = v.deleted;
+        deleted = v.deleted();
         properties = v.properties.Properties(IndexedPropertyDecoder<Vertex>{
             .indices = &storage_->indices_, .name_id_mapper = storage_->name_id_mapper_.get(), .entity = vertex_});
       }};
@@ -731,7 +731,7 @@ Result<std::map<PropertyId, PropertyValue>> VertexAccessor::PropertiesByProperty
   std::vector<PropertyValue> property_values;
   property_values.reserve(properties.size());
   MvccRead reader{vertex_, transaction_, view, [&](Vertex const &v) {
-                    deleted = v.deleted;
+                    deleted = v.deleted();
                     auto property_paths =
                         properties |
                         rv::transform([](PropertyId property) { return storage::PropertyPath{property}; }) |
@@ -857,7 +857,7 @@ Result<EdgesVertexAccessorResult> VertexAccessor::InEdges(View view, const std::
   auto in_edges = edge_store{};
   int64_t expanded_count = 0;
   MvccRead reader{vertex_, transaction_, view, [&](Vertex const &v) {
-                    deleted = v.deleted;
+                    deleted = v.deleted();
                     if (edge_types.empty() && !destination) {
                       expanded_count = HandleExpansionsWithoutEdgeTypes(in_edges, hops_limit, EdgeDirection::IN);
                     } else {
@@ -940,7 +940,7 @@ Result<EdgesVertexAccessorResult> VertexAccessor::OutEdges(View view, const std:
   auto out_edges = edge_store{};
   int64_t expanded_count = 0;
   MvccRead reader{vertex_, transaction_, view, [&](Vertex const &v) {
-                    deleted = v.deleted;
+                    deleted = v.deleted();
                     if (edge_types.empty() && !destination) {
                       expanded_count = HandleExpansionsWithoutEdgeTypes(out_edges, hops_limit, EdgeDirection::OUT);
                     } else {
@@ -1008,7 +1008,7 @@ Result<size_t> VertexAccessor::InDegree(View view) const {
   bool deleted = false;
   size_t degree = 0;
   MvccRead reader{vertex_, transaction_, view, [&](Vertex const &v) {
-                    deleted = v.deleted;
+                    deleted = v.deleted();
                     degree = v.in_edges.size();
                   }};
 
@@ -1060,7 +1060,7 @@ Result<size_t> VertexAccessor::OutDegree(View view) const {
   bool deleted = false;
   size_t degree = 0;
   MvccRead reader{vertex_, transaction_, view, [&](Vertex const &v) {
-                    deleted = v.deleted;
+                    deleted = v.deleted();
                     degree = v.out_edges.size();
                   }};
 


### PR DESCRIPTION
Non-sequential deltas imposed additional constraints on how long vertex locks needed to be held. This behaviour has now been unified in a single `MvccRead` class, which handles the intial read of the object state under lock, and maintains the correct lock duration needed for any calls to the member `ApplyDeltasForRead`.