### PR TITLE
refactor: Implement various lower-priority code improvements spotted during ACID serialization review

### DIFF
--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -2060,7 +2060,7 @@ std::vector<std::pair<std::string, std::string>> DiskStorage::SerializeVerticesF
 
 void DiskStorage::DiskAccessor::UpdateObjectsCountOnAbort() {
   auto *disk_storage = static_cast<DiskStorage *>(storage_);
-  uint64_t transaction_id = transaction_.transaction_id;
+  auto const *commit_info = transaction_.commit_info.get();
 
   for (const auto &delta : transaction_.deltas) {
     auto prev = delta.prev.Get();
@@ -2068,8 +2068,7 @@ void DiskStorage::DiskAccessor::UpdateObjectsCountOnAbort() {
       case PreviousPtr::Type::VERTEX: {
         auto *vertex = prev.vertex;
         Delta *current = vertex->delta();
-        while (current != nullptr &&
-               current->commit_info->timestamp.load(std::memory_order_acquire) == transaction_id) {
+        while (current != nullptr && current->commit_info == commit_info) {
           switch (current->action) {
             case Delta::Action::DELETE_DESERIALIZED_OBJECT:
             case Delta::Action::DELETE_OBJECT: {

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -197,47 +197,6 @@ bool HasUncommittedNonSequentialDeltas(Vertex const *vertex, uint64_t skip_trans
   return false;
 }
 
-void UnlinkAndRemoveDeltas(delta_container &deltas, CommitInfo const *commit_info,
-                           std::list<Gid> &current_deleted_edges, std::list<Gid> &current_deleted_vertices,
-                           IndexPerformanceTracker &impact_tracker) {
-  for (auto &delta : deltas) {
-    DMG_ASSERT(
-        [&delta]() {
-          Delta *next = delta.next.load(std::memory_order_acquire);
-          if (next == nullptr) return true;
-          auto next_ts = next->commit_info->timestamp.load(std::memory_order_acquire);
-          return !(next_ts >= kTransactionInitialId && IsDeltaNonSequential(*next));
-        }(),
-        "downstream active non-sequential delta found during rapid cleanup");
-    impact_tracker.update(delta.action);
-    auto prev = delta.prev.Get();
-    switch (prev.type) {
-      case PreviousPtr::Type::NULL_PTR:
-      case PreviousPtr::Type::DELTA:
-        break;
-      case PreviousPtr::Type::VERTEX: {
-        auto &vertex = *prev.vertex;
-        vertex.SetDelta(nullptr);
-        vertex.set_has_uncommitted_non_sequential_deltas(false);
-        if (vertex.deleted()) {
-          DMG_ASSERT(delta.action == Delta::Action::RECREATE_OBJECT);
-          current_deleted_vertices.push_back(vertex.gid);
-        }
-        break;
-      }
-      case PreviousPtr::Type::EDGE: {
-        auto &edge = *prev.edge;
-        edge.SetDelta(nullptr);
-        if (edge.deleted()) {
-          DMG_ASSERT(delta.action == Delta::Action::RECREATE_OBJECT);
-          current_deleted_edges.push_back(edge.gid);
-        }
-        break;
-      }
-    }
-  }
-}
-
 /** When we have non-sequential deltas, we can no longer use the shortcut of
  * only processing deltas downstream from a "head" delta, i.e., one whose `prev`
  * is a vertex. Instead, we have to walk upstream, following `prev` pointers
@@ -1240,6 +1199,45 @@ void InMemoryStorage::InMemoryAccessor::GCRapidDeltaCleanup(std::list<Gid> &curr
                                                             IndexPerformanceTracker &impact_tracker) {
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
 
+  auto const unlink_and_remove_deltas = [&](delta_container &deltas) {
+    for (auto &delta : deltas) {
+      DMG_ASSERT(
+          [&delta]() {
+            Delta *next = delta.next.load(std::memory_order_acquire);
+            if (next == nullptr) return true;
+            auto next_ts = next->commit_info->timestamp.load(std::memory_order_acquire);
+            return !(next_ts >= kTransactionInitialId && IsDeltaNonSequential(*next));
+          }(),
+          "downstream active non-sequential delta found during rapid cleanup");
+      impact_tracker.update(delta.action);
+      auto prev = delta.prev.Get();
+      switch (prev.type) {
+        case PreviousPtr::Type::NULL_PTR:
+        case PreviousPtr::Type::DELTA:
+          break;
+        case PreviousPtr::Type::VERTEX: {
+          auto &vertex = *prev.vertex;
+          vertex.delta = nullptr;
+          vertex.has_uncommitted_non_sequential_deltas = false;
+          if (vertex.deleted) {
+            DMG_ASSERT(delta.action == Delta::Action::RECREATE_OBJECT);
+            current_deleted_vertices.push_back(vertex.gid);
+          }
+          break;
+        }
+        case PreviousPtr::Type::EDGE: {
+          auto &edge = *prev.edge;
+          edge.delta = nullptr;
+          if (edge.deleted) {
+            DMG_ASSERT(delta.action == Delta::Action::RECREATE_OBJECT);
+            current_deleted_edges.push_back(edge.gid);
+          }
+          break;
+        }
+      }
+    }
+  };
+
   // STEP 1) ensure everything in GC is gone
 
   // 1.a) old garbage_undo_buffers are safe to remove
@@ -1256,19 +1254,11 @@ void InMemoryStorage::InMemoryAccessor::GCRapidDeltaCleanup(std::list<Gid> &curr
 
   // 1.b.1) unlink, gathering the removals
   for (auto &gc_deltas : linked_undo_buffers) {
-    UnlinkAndRemoveDeltas(gc_deltas.deltas_,
-                          gc_deltas.commit_info_.get(),
-                          current_deleted_edges,
-                          current_deleted_vertices,
-                          impact_tracker);
+    unlink_and_remove_deltas(gc_deltas.deltas_);
   }
 
-  // STEP 2) this transaction's deltas
-  UnlinkAndRemoveDeltas(transaction_.deltas,
-                        transaction_.commit_info.get(),
-                        current_deleted_edges,
-                        current_deleted_vertices,
-                        impact_tracker);
+  // STEP 2) this transaction's deltas also minimal unlinking + remove
+  unlink_and_remove_deltas(transaction_.deltas);
 
   // STEP 3) clear all deltas after unlinking is complete
   linked_undo_buffers.clear();

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1217,9 +1217,9 @@ void InMemoryStorage::InMemoryAccessor::GCRapidDeltaCleanup(std::list<Gid> &curr
           break;
         case PreviousPtr::Type::VERTEX: {
           auto &vertex = *prev.vertex;
-          vertex.delta = nullptr;
-          vertex.has_uncommitted_non_sequential_deltas = false;
-          if (vertex.deleted) {
+          vertex.SetDelta(nullptr);
+          vertex.set_has_uncommitted_non_sequential_deltas(false);
+          if (vertex.deleted()) {
             DMG_ASSERT(delta.action == Delta::Action::RECREATE_OBJECT);
             current_deleted_vertices.push_back(vertex.gid);
           }
@@ -1227,8 +1227,8 @@ void InMemoryStorage::InMemoryAccessor::GCRapidDeltaCleanup(std::list<Gid> &curr
         }
         case PreviousPtr::Type::EDGE: {
           auto &edge = *prev.edge;
-          edge.delta = nullptr;
-          if (edge.deleted) {
+          edge.SetDelta(nullptr);
+          if (edge.deleted()) {
             DMG_ASSERT(delta.action == Delta::Action::RECREATE_OBJECT);
             current_deleted_edges.push_back(edge.gid);
           }
@@ -3283,7 +3283,6 @@ bool InMemoryStorage::InMemoryAccessor::HandleDurabilityAndReplicate(uint64_t du
     }
   }
   // A single transaction will always be fully-contained in a single WAL file.
-  auto current_commit_timestamp = transaction_.commit_info->timestamp.load(std::memory_order_acquire);
   DeltaVertexCache vertex_cache(transaction_.commit_info.get());
 
   auto append_deltas = [&](auto callback) {

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -197,8 +197,9 @@ bool HasUncommittedNonSequentialDeltas(Vertex const *vertex, uint64_t skip_trans
   return false;
 }
 
-void UnlinkAndRemoveDeltas(delta_container &deltas, uint64_t transaction_id, std::list<Gid> &current_deleted_edges,
-                           std::list<Gid> &current_deleted_vertices, IndexPerformanceTracker &impact_tracker) {
+void UnlinkAndRemoveDeltas(delta_container &deltas, CommitInfo const *commit_info,
+                           std::list<Gid> &current_deleted_edges, std::list<Gid> &current_deleted_vertices,
+                           IndexPerformanceTracker &impact_tracker) {
   for (auto &delta : deltas) {
     DMG_ASSERT(
         [&delta]() {
@@ -251,7 +252,7 @@ void UnlinkAndRemoveDeltas(delta_container &deltas, uint64_t transaction_id, std
  */
 class DeltaVertexCache {
  public:
-  explicit DeltaVertexCache(uint64_t commit_timestamp) : commit_timestamp_(commit_timestamp) {}
+  explicit DeltaVertexCache(CommitInfo const *commit_info) : commit_info_(commit_info) {}
 
   Vertex *GetVertexFromDelta(Delta const *delta) {
     auto prev = delta->prev.Get();
@@ -267,7 +268,7 @@ class DeltaVertexCache {
     };
 
     delta = prev.delta;
-    auto delta_ts = delta->commit_info->timestamp.load(std::memory_order_acquire);
+    auto delta_commit_info = delta->commit_info;
     while (true) {
       auto current_prev = delta->prev.Get();
       if (current_prev.type == PreviousPtr::Type::VERTEX) {
@@ -277,12 +278,12 @@ class DeltaVertexCache {
 
       DMG_ASSERT(current_prev.type == PreviousPtr::Type::DELTA, "Expected DELTA in vertex delta chain");
 
-      auto const prev_ts = current_prev.delta->commit_info->timestamp.load(std::memory_order_acquire);
-      // If the ts for the previous delta is different than this one's, we know
+      auto const prev_commit_info = current_prev.delta->commit_info;
+      // If the commit_info for the previous delta is different than this one's, we know
       // that they are from different transactions and so this delta is the
       // head of a non-sequential subchain.
-      if (delta_ts != prev_ts) {
-        if (delta_ts == commit_timestamp_) discovered_subchain_heads.push_back(delta);
+      if (delta_commit_info != prev_commit_info) {
+        if (delta_commit_info == commit_info_) discovered_subchain_heads.push_back(delta);
 
         auto cached = cache_.find(current_prev.delta);
         if (cached != cache_.end()) {
@@ -292,12 +293,12 @@ class DeltaVertexCache {
       }
 
       delta = current_prev.delta;
-      delta_ts = prev_ts;
+      delta_commit_info = prev_commit_info;
     }
   }
 
  private:
-  uint64_t commit_timestamp_;
+  CommitInfo const *commit_info_;
   std::unordered_map<Delta const *, Vertex *> cache_;
 };
 
@@ -1135,7 +1136,7 @@ void InMemoryStorage::InMemoryAccessor::FinalizeCommitPhase(uint64_t const durab
 
   if (needs_vertex_flag_cleanup) {
     std::unordered_set<Vertex *> vertices_to_check;
-    DeltaVertexCache delta_vertex_cache{transaction_.transaction_id};
+    DeltaVertexCache delta_vertex_cache{transaction_.commit_info.get()};
     for (Delta const &delta : transaction_.deltas) {
       auto prev = delta.prev.Get();
       if (prev.type == PreviousPtr::Type::VERTEX) {
@@ -1255,13 +1256,16 @@ void InMemoryStorage::InMemoryAccessor::GCRapidDeltaCleanup(std::list<Gid> &curr
 
   // 1.b.1) unlink, gathering the removals
   for (auto &gc_deltas : linked_undo_buffers) {
-    UnlinkAndRemoveDeltas(
-        gc_deltas.deltas_, gc_deltas.transaction_id_, current_deleted_edges, current_deleted_vertices, impact_tracker);
+    UnlinkAndRemoveDeltas(gc_deltas.deltas_,
+                          gc_deltas.commit_info_.get(),
+                          current_deleted_edges,
+                          current_deleted_vertices,
+                          impact_tracker);
   }
 
   // STEP 2) this transaction's deltas
   UnlinkAndRemoveDeltas(transaction_.deltas,
-                        transaction_.transaction_id,
+                        transaction_.commit_info.get(),
                         current_deleted_edges,
                         current_deleted_vertices,
                         impact_tracker);
@@ -1359,8 +1363,7 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
           auto *edge = prev.edge;
           auto guard = std::lock_guard{edge->lock};
           Delta *current = edge->delta();
-          while (current != nullptr &&
-                 current->commit_info->timestamp.load(std::memory_order_acquire) == transaction_.transaction_id) {
+          while (current != nullptr && current->commit_info == transaction_.commit_info.get()) {
             switch (current->action) {
               case Delta::Action::SET_PROPERTY: {
                 DMG_ASSERT(mem_storage->config_.salient.items.properties_on_edges, "Invalid database state!");
@@ -1457,8 +1460,7 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
       auto remove_out_edges = absl::flat_hash_set<EdgeRef>{};
 
       Delta *current = start;
-      while (current != nullptr &&
-             current->commit_info->timestamp.load(std::memory_order_acquire) == transaction_.transaction_id) {
+      while (current != nullptr && current->commit_info == transaction_.commit_info.get()) {
         switch (current->action) {
           case Delta::Action::REMOVE_LABEL: {
             auto it = r::find(vertex->labels, current->label.value);
@@ -1599,7 +1601,7 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
       }
     };
 
-    DeltaVertexCache delta_vertex_cache{transaction_.transaction_id};
+    DeltaVertexCache delta_vertex_cache{transaction_.commit_info.get()};
 
     for (Delta &delta : transaction_.deltas) {
       auto prev = delta.prev.Get();
@@ -1618,7 +1620,7 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
           // If prev delta belongs to another transaction, our deltas are downstream
           // and must wait in `waiting_gc_deltas_` until all contributor transactions
           // are finished.
-          if (prev.delta->commit_info->timestamp.load(std::memory_order_acquire) != transaction_.transaction_id) {
+          if (prev.delta->commit_info != transaction_.commit_info.get()) {
             Vertex *vertex = delta_vertex_cache.GetVertexFromDelta(&delta);
             auto guard = std::unique_lock{vertex->lock};
             // Check if we're still at the head - another tx may have prepended
@@ -3292,7 +3294,7 @@ bool InMemoryStorage::InMemoryAccessor::HandleDurabilityAndReplicate(uint64_t du
   }
   // A single transaction will always be fully-contained in a single WAL file.
   auto current_commit_timestamp = transaction_.commit_info->timestamp.load(std::memory_order_acquire);
-  DeltaVertexCache vertex_cache(current_commit_timestamp);
+  DeltaVertexCache vertex_cache(transaction_.commit_info.get());
 
   auto append_deltas = [&](auto callback) {
     // Helper lambda that traverses the delta chain to find the first delta

--- a/src/storage/v2/mvcc.hpp
+++ b/src/storage/v2/mvcc.hpp
@@ -291,8 +291,7 @@ inline bool ShouldSetNonSequentialBlockerUpstreamFlag(Transaction *transaction, 
     return false;
   }
 
-  auto const head_ts = head->commit_info->timestamp.load(std::memory_order_acquire);
-  if (head_ts != transaction->transaction_id) {
+  if (head->commit_info != transaction->commit_info.get()) {
     // Different transaction - we're non-sequential, so no upstream in our transaction
     return false;
   }


### PR DESCRIPTION
- When we need to check if a delta belongs to a particular transaction, it is faster to compare the timestamp/commit_info by pointer, rather than perform an atomic load and value comparison.