### PR TITLE
Fix small mistake in mgbench docs

### DIFF
--- a/tests/mgbench/how_to_use_benchgraph.md
+++ b/tests/mgbench/how_to_use_benchgraph.md
@@ -172,7 +172,7 @@ You can use the `memgraph/mgbench-client:<version>-full` Docker image to benchma
 ```bash
 docker run --rm --network host --name mgbench \
   memgraph/mgbench-client:0.0.4-full \
-  --installation-type external
+  external-vendor \
   --num-workers-for-benchmark 4 \
   --export-results=benchmark_result.json \
   --no-authorization \


### PR DESCRIPTION
The example command to run `mgbench` using docker is wrong, it should be more like:

```bash
docker run --rm --network host --name mgbench \
  memgraph/mgbench-client:0.0.4-full  \
  external-vendor \
  --num-workers-for-benchmark 4 \
  --export-results=benchmark_result.json  \
  --no-authorization  \
  pokec/medium \
  --client-bolt-address 192.168.0.182
```

(not the exact example  in the docs, but a working example I am using)



