### PR TITLE
feat: Abort periodic snapshot on destruction when snapshot on exit is false

### DIFF
--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -3567,7 +3567,8 @@ std::expected<std::filesystem::path, InMemoryStorage::CreateSnapshotError> InMem
     return std::unexpected{CreateSnapshotError::AbortSnapshot};
   }
 
-  // Update digest only after the file has been created
+  // Update digest only after the file has been created. Only in transaction because digests are used only in
+  // transactional mode
   if (transaction->storage_mode == StorageMode::IN_MEMORY_TRANSACTIONAL) {
     last_snapshot_digest_ = std::move(current_digest);
   }


### PR DESCRIPTION
## What

Abort any in-progress periodic snapshot when `InMemoryStorage` is destroyed, and fix the snapshot digest update so it only records a successful snapshot.

In `~InMemoryStorage()`, `abort_snapshot_` is now set before `snapshot_runner_.Stop()` (unless `snapshot_on_exit` is enabled). In `CreateSnapshot()`, `last_snapshot_digest_` is
moved after `durability::CreateSnapshot()` returns successfully, instead of being updated optimistically before the file is written.

## Why

Previously, if a periodic snapshot was being created when the storage was destroyed, the destructor would block on `snapshot_runner_.Stop()` until the snapshot completed —
potentially a very long wait on large datasets. By signalling abort beforehand, the in-progress snapshot exits early, letting the destructor proceed without unnecessary delay.

The digest fix addresses a correctness issue: if snapshot creation was aborted (or otherwise failed), the digest was already updated, causing the *next* snapshot attempt to
believe nothing changed and skip writing, even though no valid snapshot file was actually produced.

## How

- **Destructor (`~InMemoryStorage`)**: Before stopping the snapshot runner, set `abort_snapshot_` to `true` (with release semantics). This is skipped when `snapshot_on_exit` is
true, because the subsequent `create_snapshot_handler()` call will compute the digest and correctly determine there's nothing new to write.

- **`CreateSnapshot()`**: `current_digest` is hoisted out of the transactional-mode `if` block so it survives to the post-write update. The `last_snapshot_digest_ =
std::move(current_digest)` assignment is moved from *before* the `durability::CreateSnapshot()` call to *after* it succeeds, ensuring the digest is only updated when a valid
snapshot file has been written to disk.

## Testing

No new tests were added. The abort mechanism (`abort_snapshot_`) was already exercised by existing snapshot tests, and the digest move is a straightforward ordering fix with no
new branches. The change is low-risk and confined to a single file.

## Notes for reviewers

- When `snapshot_on_exit` is true, `abort_snapshot_` is intentionally **not** set. The `create_snapshot_handler()` path computes its own digest and returns `NothingNewToWrite` if
 the data hasn't changed since the last snapshot — so the abort flag is unnecessary and would incorrectly prevent the exit snapshot.
- The `abort_snapshot_` flag is a one-shot: it is reset by the `OnScopeExit` guard at the top of `CreateSnapshot()`, so setting it in the destructor only affects the currently
in-flight (or immediately next) invocation.