### PR TITLE
Igraph betweeness centrality algorithm

### DIFF
--- a/mage/Dockerfile.release
+++ b/mage/Dockerfile.release
@@ -64,8 +64,9 @@ RUN --mount=type=secret,id=ubuntu_sources,target=/ubuntu.sources,required=false 
     mv -v /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.backup; \
     cp -v /ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources; \
   fi && \
+  apt-get update && \
   if test -n "$(find /openssl -maxdepth 1 -name '*.deb' -print -quit 2>/dev/null)"; then \
-    apt-get update && apt-get install -y \
+    apt-get install -y \
     /openssl/*.deb \
     --no-install-recommends; \
   fi && \

--- a/mage/python/igraphalg.py
+++ b/mage/python/igraphalg.py
@@ -200,6 +200,28 @@ def get_shortest_path(
     return mgp.Record(path=graph.get_shortest_path(source=source, target=target, weights=weights))
 
 
+@mgp.read_proc
+def betweenness_centrality(
+    ctx: mgp.ProcCtx,
+    directed: bool = True,
+    cutoff: int = -1,
+    weights: mgp.Nullable[str] = None,
+    sources: mgp.Nullable[mgp.List[mgp.Vertex]] = None,
+    targets: mgp.Nullable[mgp.List[mgp.Vertex]] = None,
+) -> mgp.Record(node=mgp.Vertex, betweenness=float):
+    graph = MemgraphIgraph(ctx=ctx, directed=directed)
+    igraph_sources = [graph.id_mappings[v.id] for v in sources] if sources else None
+    igraph_targets = [graph.id_mappings[v.id] for v in targets] if targets else None
+    results = graph.betweenness_centrality(
+        directed=directed,
+        cutoff=cutoff,
+        weights=weights,
+        sources=igraph_sources,
+        targets=igraph_targets,
+    )
+    return [mgp.Record(node=node, betweenness=score) for node, score in results]
+
+
 def dfs(node: mgp.Vertex, visited: Dict[int, bool], stack: Dict[int, bool]) -> bool:
     """Depth-first-search algorithm with modification.
 

--- a/mage/python/igraphalg.py
+++ b/mage/python/igraphalg.py
@@ -56,11 +56,19 @@ def get_all_simple_paths(
     ctx: mgp.ProcCtx,
     v: mgp.Vertex,
     to: mgp.Vertex,
-    cutoff: int = -1,
+    maxlen: int = -1,
+    minlen: int = 0,
+    mode: str = "out",
+    max_results: mgp.Nullable[int] = None,
 ) -> mgp.Record(path=mgp.List[mgp.Vertex]):
     graph = MemgraphIgraph(ctx=ctx, directed=True)
 
-    return [mgp.Record(path=path) for path in graph.get_all_simple_paths(v=v, to=to, cutoff=cutoff)]
+    return [
+        mgp.Record(path=path)
+        for path in graph.get_all_simple_paths(
+            v=v, to=to, maxlen=maxlen, minlen=minlen, mode=mode, max_results=max_results
+        )
+    ]
 
 
 @mgp.read_proc

--- a/mage/python/mgp_igraph.py
+++ b/mage/python/mgp_igraph.py
@@ -38,11 +38,24 @@ class MemgraphIgraph(igraph.Graph):
 
         return [(self.get_vertex_by_id(node_id), rank) for node_id, rank in enumerate(pagerank_values)]
 
-    def get_all_simple_paths(self, v: mgp.Vertex, to: mgp.Vertex, cutoff: int) -> List[List[mgp.Vertex]]:
+    def get_all_simple_paths(
+        self,
+        v: mgp.Vertex,
+        to: mgp.Vertex,
+        maxlen: int = -1,
+        minlen: int = 0,
+        mode: str = "out",
+        max_results: mgp.Nullable[int] = None,
+    ) -> List[List[mgp.Vertex]]:
         paths = [
             self._convert_vertex_ids_to_mgp_vertices(path)
             for path in super().get_all_simple_paths(
-                v=self.id_mappings[v.id], to=self.id_mappings[to.id], cutoff=cutoff
+                v=self.id_mappings[v.id],
+                to=self.id_mappings[to.id],
+                maxlen=maxlen,
+                minlen=minlen,
+                mode=mode,
+                max_results=max_results,
             )
         ]
         return paths
@@ -160,7 +173,7 @@ class MemgraphIgraph(igraph.Graph):
         """
 
         min_span_tree = []
-        for edge in min_spanning_tree_edges:
+        for edge in sorted(min_spanning_tree_edges, key=lambda e: (e.source, e.target)):
             min_span_tree.append(
                 [
                     self.ctx_graph.get_vertex_by_id(self.reverse_id_mappings[edge.source]),

--- a/mage/python/mgp_igraph.py
+++ b/mage/python/mgp_igraph.py
@@ -118,6 +118,24 @@ class MemgraphIgraph(igraph.Graph):
 
         return self._convert_vertex_ids_to_mgp_vertices(path)
 
+    def betweenness_centrality(
+        self,
+        directed: bool,
+        cutoff: int,
+        weights: str,
+        sources: List[int] = None,
+        targets: List[int] = None,
+    ) -> List[Tuple[mgp.Vertex, float]]:
+        cutoff_value = None if cutoff < 0 else cutoff
+        betweenness_values = super().betweenness(
+            directed=directed,
+            cutoff=cutoff_value,
+            weights=weights if weights else None,
+            sources=sources,
+            targets=targets,
+        )
+        return [(self.get_vertex_by_id(node_id), score) for node_id, score in enumerate(betweenness_values)]
+
     def get_vertex_by_id(self, id: int) -> mgp.Vertex:
         return self.ctx_graph.get_vertex_by_id(self.reverse_id_mappings[id])
 

--- a/mage/python/requirements-gpu.txt
+++ b/mage/python/requirements-gpu.txt
@@ -8,7 +8,7 @@ gekko==1.2.1
 gensim==4.3.3
 gqlalchemy==1.8.0
 huggingface-hub==0.35.1
-igraph==0.11.8
+igraph==1.0.0
 mysql-connector-python==9.1.0
 neo4j==5.28.2
 networkx==2.8.8

--- a/mage/python/requirements.txt
+++ b/mage/python/requirements.txt
@@ -8,7 +8,7 @@ gekko==1.2.1
 gensim==4.3.3
 gqlalchemy==1.8.0
 huggingface-hub==0.35.1
-igraph==0.11.8
+igraph==1.0.0
 jaraco-context==6.1.0
 mysql-connector-python==9.1.0
 neo4j==5.28.2

--- a/mage/tests/e2e/igraphalg_test/test_betweenness_centrality_directed/input.cyp
+++ b/mage/tests/e2e/igraphalg_test/test_betweenness_centrality_directed/input.cyp
@@ -1,0 +1,4 @@
+MERGE (a:Node {id: 0}) MERGE (b:Node {id: 1}) CREATE (a)-[:RELATION]->(b);
+MERGE (a:Node {id: 1}) MERGE (b:Node {id: 2}) CREATE (a)-[:RELATION]->(b);
+MERGE (a:Node {id: 2}) MERGE (b:Node {id: 3}) CREATE (a)-[:RELATION]->(b);
+MERGE (a:Node {id: 3}) MERGE (b:Node {id: 4}) CREATE (a)-[:RELATION]->(b);

--- a/mage/tests/e2e/igraphalg_test/test_betweenness_centrality_directed/test.yml
+++ b/mage/tests/e2e/igraphalg_test/test_betweenness_centrality_directed/test.yml
@@ -1,0 +1,16 @@
+query: >
+    CALL igraphalg.betweenness_centrality(True) YIELD node, betweenness
+    RETURN node.id as node_id, betweenness
+    ORDER BY node_id ASC
+
+output:
+    - node_id: 0
+      betweenness: 0.0
+    - node_id: 1
+      betweenness: 3.0
+    - node_id: 2
+      betweenness: 4.0
+    - node_id: 3
+      betweenness: 3.0
+    - node_id: 4
+      betweenness: 0.0

--- a/mage/tests/e2e/igraphalg_test/test_betweenness_centrality_empty/test.yml
+++ b/mage/tests/e2e/igraphalg_test/test_betweenness_centrality_empty/test.yml
@@ -1,0 +1,6 @@
+query: >
+    CALL igraphalg.betweenness_centrality() YIELD node, betweenness
+    RETURN node.id as node_id, betweenness
+    ORDER BY node_id ASC
+
+output: []

--- a/mage/tests/e2e/igraphalg_test/test_betweenness_centrality_sources/input.cyp
+++ b/mage/tests/e2e/igraphalg_test/test_betweenness_centrality_sources/input.cyp
@@ -1,0 +1,5 @@
+MERGE (a:Node {id: 0}) MERGE (b:Node {id: 1}) CREATE (a)-[:RELATION]->(b);
+MERGE (a:Node {id: 0}) MERGE (b:Node {id: 2}) CREATE (a)-[:RELATION]->(b);
+MERGE (a:Node {id: 1}) MERGE (b:Node {id: 3}) CREATE (a)-[:RELATION]->(b);
+MERGE (a:Node {id: 2}) MERGE (b:Node {id: 3}) CREATE (a)-[:RELATION]->(b);
+MERGE (a:Node {id: 3}) MERGE (b:Node {id: 4}) CREATE (a)-[:RELATION]->(b);

--- a/mage/tests/e2e/igraphalg_test/test_betweenness_centrality_sources/test.yml
+++ b/mage/tests/e2e/igraphalg_test/test_betweenness_centrality_sources/test.yml
@@ -1,0 +1,18 @@
+query: >
+    MATCH (s {id: 0})
+    WITH collect(s) AS sources
+    CALL igraphalg.betweenness_centrality(True, -1, NULL, sources) YIELD node, betweenness
+    RETURN node.id as node_id, betweenness
+    ORDER BY node_id ASC
+
+output:
+    - node_id: 0
+      betweenness: 0.0
+    - node_id: 1
+      betweenness: 1.0
+    - node_id: 2
+      betweenness: 1.0
+    - node_id: 3
+      betweenness: 1.0
+    - node_id: 4
+      betweenness: 0.0

--- a/mage/tests/e2e/igraphalg_test/test_betweenness_centrality_undirected/input.cyp
+++ b/mage/tests/e2e/igraphalg_test/test_betweenness_centrality_undirected/input.cyp
@@ -1,0 +1,4 @@
+MERGE (a:Node {id: 0}) MERGE (b:Node {id: 1}) CREATE (a)-[:RELATION]->(b);
+MERGE (a:Node {id: 0}) MERGE (b:Node {id: 2}) CREATE (a)-[:RELATION]->(b);
+MERGE (a:Node {id: 0}) MERGE (b:Node {id: 3}) CREATE (a)-[:RELATION]->(b);
+MERGE (a:Node {id: 0}) MERGE (b:Node {id: 4}) CREATE (a)-[:RELATION]->(b);

--- a/mage/tests/e2e/igraphalg_test/test_betweenness_centrality_undirected/test.yml
+++ b/mage/tests/e2e/igraphalg_test/test_betweenness_centrality_undirected/test.yml
@@ -1,0 +1,16 @@
+query: >
+    CALL igraphalg.betweenness_centrality(False) YIELD node, betweenness
+    RETURN node.id as node_id, betweenness
+    ORDER BY node_id ASC
+
+output:
+    - node_id: 0
+      betweenness: 6.0
+    - node_id: 1
+      betweenness: 0.0
+    - node_id: 2
+      betweenness: 0.0
+    - node_id: 3
+      betweenness: 0.0
+    - node_id: 4
+      betweenness: 0.0

--- a/mage/tests/e2e/igraphalg_test/test_betweenness_centrality_weighted/input.cyp
+++ b/mage/tests/e2e/igraphalg_test/test_betweenness_centrality_weighted/input.cyp
@@ -1,0 +1,3 @@
+MERGE (a:Node {id: 0}) MERGE (b:Node {id: 1}) CREATE (a)-[:RELATION {weight: 1}]->(b);
+MERGE (a:Node {id: 0}) MERGE (b:Node {id: 2}) CREATE (a)-[:RELATION {weight: 10}]->(b);
+MERGE (a:Node {id: 1}) MERGE (b:Node {id: 2}) CREATE (a)-[:RELATION {weight: 1}]->(b);

--- a/mage/tests/e2e/igraphalg_test/test_betweenness_centrality_weighted/test.yml
+++ b/mage/tests/e2e/igraphalg_test/test_betweenness_centrality_weighted/test.yml
@@ -1,0 +1,12 @@
+query: >
+    CALL igraphalg.betweenness_centrality(True, -1, "weight") YIELD node, betweenness
+    RETURN node.id as node_id, betweenness
+    ORDER BY node_id ASC
+
+output:
+    - node_id: 0
+      betweenness: 0.0
+    - node_id: 1
+      betweenness: 1.0
+    - node_id: 2
+      betweenness: 0.0

--- a/skills/README.md
+++ b/skills/README.md
@@ -7,6 +7,8 @@ Portable AI agent skills following the [Agent Skills Standard](https://agentskil
 | Skill | Description |
 |-------|-------------|
 | `memgraph-storage-reviewer` | Expert code reviewer for storage layer (MVCC, WAL, DDL, indices) |
+| `memgraph-generate-docker-images` | Build MAGE Docker images locally for testing |
+| `memgraph-mage-e2e-testing` | Build a MAGE Docker image and run e2e tests for query modules |
 
 ## Setup by Tool
 

--- a/skills/memgraph-generate-docker-images/SKILL.md
+++ b/skills/memgraph-generate-docker-images/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: memgraph-generate-docker-images
+description: Build MAGE Docker images locally for testing. Use when the user wants to build a local MAGE image, test new query modules in Docker, create custom MAGE builds, or package MAGE with specific Memgraph versions.
+---
+
+# Building MAGE Docker Images Locally
+
+This skill explains how to build MAGE Docker images locally for testing new query modules or custom configurations.
+
+## Quick Start
+
+From the repository root (`memgraph/`):
+
+```bash
+# Build with latest Memgraph release (simplest)
+./tools/ci/mage-build/build-docker-image.sh
+
+# Build with custom image tag
+./tools/ci/mage-build/build-docker-image.sh --image-tag my-test
+
+# Build with specific Memgraph package
+./tools/ci/mage-build/build-docker-image.sh \
+  --memgraph-url "https://download.memgraph.com/memgraph/v3.0.0/ubuntu-24.04/memgraph_3.0.0-1_amd64.deb" \
+  --image-tag v3.0.0-test
+```
+
+## Script Location
+
+```
+tools/ci/mage-build/build-docker-image.sh
+```
+
+## Available Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--image-tag <tag>` | Docker image tag name | `custom` |
+| `--memgraph-url <url>` | URL to Memgraph `.deb` package | Latest release (auto-fetched via `tools/ci/get_latest_tag.sh`) |
+| `--build-type <type>` | Build type: `Release` or `RelWithDebInfo` | `Release` |
+| `--cugraph` | Enable cuGraph GPU-accelerated module build | Disabled |
+
+## What the Script Does
+
+1. **Downloads Memgraph package** — Either from the provided `--memgraph-url` or fetches the latest release tag and constructs the download URL
+2. **Launches mgbuild container** — Runs `release/package/mgbuild.sh run` with the appropriate toolchain (`v7`), OS (`ubuntu-24.04`), arch, and build type
+3. **Builds MAGE modules** — Runs `release/package/mgbuild.sh build-mage` which compiles C++, Rust, and packages Python modules
+4. **Builds heaptrack** (RelWithDebInfo only) — Builds and copies heaptrack into the image for memory profiling
+5. **Packages Docker image** — Runs `release/package/mgbuild.sh package-mage-docker` to build `memgraph/memgraph-mage:<tag>` using `mage/Dockerfile.release`
+6. **Cleans up** — Removes temporary files (`mage/memgraph.deb`, `mage/mage.tar.gz`, `mage/openssl/`)
+
+## Architecture Detection
+
+The script automatically detects system architecture from `arch`:
+- `x86_64` → builds `amd64` image
+- Anything else (e.g. `aarch64`) → builds `arm64` image
+
+When no `--memgraph-url` is provided, the auto-constructed download URL uses the detected arch:
+```
+https://download.memgraph.com/memgraph/v${VERSION}/${OS_PATH}/memgraph_${VERSION}-1_${ARCH}64.deb
+```
+
+Where `OS_PATH` is `ubuntu-24.04` for Release or `ubuntu-24.04-relwithdebinfo` for RelWithDebInfo builds.
+
+## Build Types
+
+### Release (Default)
+Standard production build with optimizations. Docker image uses the `prod` stage from `mage/Dockerfile.release`.
+
+```bash
+./tools/ci/mage-build/build-docker-image.sh --build-type Release
+```
+
+### RelWithDebInfo
+Debug build with symbols, GDB support, and heaptrack for profiling. Docker image uses the `relwithdebinfo` stage which includes GDB, libc6-dbg, heaptrack, and the full MAGE source tree at `/mage/`.
+
+```bash
+./tools/ci/mage-build/build-docker-image.sh --build-type RelWithDebInfo
+```
+
+## Examples
+
+### Build and Test a New Query Module
+
+After creating or modifying a Python module (e.g., in `mage/python/`):
+
+```bash
+# 1. Build the Docker image
+./tools/ci/mage-build/build-docker-image.sh --image-tag test-module
+
+# 2. Run the container
+docker run --rm -p 7687:7687 -p 7444:7444 memgraph/memgraph-mage:test-module
+
+# 3. Connect and test your module (in another terminal)
+docker exec -it <container_id> mgconsole
+```
+
+### Build with Specific Memgraph Version
+
+```bash
+# x86_64
+./tools/ci/mage-build/build-docker-image.sh \
+  --memgraph-url "https://download.memgraph.com/memgraph/v3.0.0/ubuntu-24.04/memgraph_3.0.0-1_amd64.deb" \
+  --image-tag v3.0.0
+
+# ARM64
+./tools/ci/mage-build/build-docker-image.sh \
+  --memgraph-url "https://download.memgraph.com/memgraph/v3.0.0/ubuntu-24.04/memgraph_3.0.0-1_arm64.deb" \
+  --image-tag v3.0.0-arm
+```
+
+### Build Debug Image for Profiling
+
+```bash
+./tools/ci/mage-build/build-docker-image.sh \
+  --build-type RelWithDebInfo \
+  --image-tag debug
+
+docker run --rm -it -p 7687:7687 memgraph/memgraph-mage:debug
+```
+
+### Build with cuGraph (GPU) Support
+
+```bash
+./tools/ci/mage-build/build-docker-image.sh \
+  --cugraph \
+  --image-tag gpu-test
+```
+
+## Running the Built Image
+
+```bash
+# Basic run
+docker run --rm -p 7687:7687 -p 7444:7444 memgraph/memgraph-mage:<tag>
+
+# With persistent data
+docker run --rm -p 7687:7687 -p 7444:7444 \
+  -v mg_data:/var/lib/memgraph \
+  memgraph/memgraph-mage:<tag>
+
+# With custom configuration
+docker run --rm -p 7687:7687 -p 7444:7444 \
+  memgraph/memgraph-mage:<tag> \
+  --log-level=DEBUG \
+  --query-modules-directory=/usr/lib/memgraph/query_modules
+```
+
+## Verifying the Build
+
+After building, verify your modules are loaded:
+
+```bash
+# Connect to Memgraph
+docker exec -it <container_id> mgconsole
+
+# List all loaded modules
+CALL mg.procedures() YIELD name RETURN name;
+
+# Check a specific module
+CALL mg.procedures() YIELD name WHERE name STARTS WITH 'igraphalg' RETURN name;
+```
+
+## Troubleshooting
+
+### Build Fails with Container Issues
+The script uses `release/package/mgbuild.sh` which manages the mgbuild Docker container. Ensure Docker is running:
+```bash
+docker info
+```
+
+### Out of Disk Space
+MAGE builds can be large. Clean up old images:
+```bash
+docker system prune -a
+```
+
+### Module Not Found After Build
+Ensure your module is in the correct location (`mage/python/`) and has no syntax errors:
+```bash
+python3 -m py_compile mage/python/your_module.py
+```
+
+### Permission Denied
+Run the script from the repository root:
+```bash
+cd /path/to/memgraph
+./tools/ci/mage-build/build-docker-image.sh
+```
+
+## Clean Up
+
+```bash
+# Remove specific image
+docker rmi memgraph/memgraph-mage:<tag>
+
+# Remove all MAGE images
+docker rmi $(docker images memgraph/memgraph-mage -q)
+```
+
+## Related Files
+
+| File | Purpose |
+|------|---------|
+| `tools/ci/mage-build/build-docker-image.sh` | Main build orchestration script |
+| `tools/ci/mage-build/build.sh` | MAGE compilation script (runs inside mgbuild container) |
+| `tools/ci/mage-build/container-build.sh` | Container build helper |
+| `tools/ci/mage-build/container-package-deb.sh` | DEB packaging helper |
+| `tools/ci/mage-build/compress-query-modules.sh` | Query module compression |
+| `tools/ci/get_latest_tag.sh` | Fetches latest Memgraph release tag |
+| `mage/Dockerfile.release` | Docker image definition (`prod` and `relwithdebinfo` stages) |
+| `release/package/mgbuild.sh` | Build toolchain container manager |
+| `mage/python/requirements.txt` | Python dependencies |
+| `mage/python/requirements-gpu.txt` | Python GPU dependencies |

--- a/skills/memgraph-mage-e2e-testing/SKILL.md
+++ b/skills/memgraph-mage-e2e-testing/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: memgraph-mage-e2e-testing
+description: Build a MAGE Docker image and run e2e tests for MAGE query modules. Use when the user wants to test MAGE modules end-to-end, run the MAGE e2e test suite, or verify query module changes in a Docker container.
+---
+
+# Testing MAGE Query Modules (E2E)
+
+Two steps: build a Docker image with the latest code, then run the e2e test suite against it.
+
+## Step 1 — Build the MAGE Docker Image
+
+From the repository root (`memgraph/`):
+
+```bash
+./tools/ci/mage-build/build-docker-image.sh --image-tag <tag>
+```
+
+This compiles C++, Rust, and Python modules and packages them into `memgraph/memgraph-mage:<tag>`. See the `memgraph-generate-docker-images` skill for full build options.
+
+## Step 2 — Run the Container
+
+```bash
+docker run --rm -d -p 7687:7687 -p 7444:7444 --name mage-test memgraph/memgraph-mage:<tag>
+```
+
+Wait a few seconds for Memgraph to start before running tests.
+
+## Step 3 — Run E2E Tests
+
+Activate the shared virtual environment and run the test runner from `mage/tests/`:
+
+```bash
+source tests/query_modules/ve3/bin/activate
+cd mage/tests
+python3 test_e2e
+```
+
+### Filtering Tests
+
+Use `-k` to run tests for a specific module:
+
+```bash
+python3 test_e2e -k "igraphalg"
+python3 test_e2e -k "pagerank"
+python3 test_e2e -k "igraphalg and not leiden"
+```
+
+The `-k` flag is passed through to pytest, so any pytest filter expression works.
+
+### Connecting to a Non-Default Host/Port
+
+The test fixtures read `MG_HOST` and `MG_PORT` from the environment (defaults: `127.0.0.1:7687`):
+
+```bash
+MG_HOST=192.168.1.10 MG_PORT=17687 python3 test_e2e -k "igraphalg"
+```
+
+## How E2E Tests Work
+
+Each test is a subdirectory under `mage/tests/e2e/<module>_test/`:
+
+```
+mage/tests/e2e/igraphalg_test/
+├── test_pagerank_normal_directed/
+│   ├── input.cyp        # Cypher statements to set up the graph
+│   └── test.yml         # Query to run + expected output
+├── test_betweenness_centrality_directed/
+│   ├── input.cyp
+│   └── test.yml
+└── ...
+```
+
+- **`input.cyp`** — Cypher statements executed before the test (graph setup). Can be empty for empty-graph tests.
+- **`test.yml`** — Contains the `query` to execute and the `output` to assert against.
+
+Example `test.yml`:
+
+```yaml
+query: >
+  CALL igraphalg.betweenness_centrality()
+  YIELD node, betweenness
+  RETURN node.id as node_id, betweenness
+  ORDER BY node_id ASC
+
+output:
+  - node_id: 0
+    betweenness: 0.0
+  - node_id: 1
+    betweenness: 3.0
+```
+
+The test framework (`mage/tests/e2e/test_module.py`) discovers all subdirectories, runs `input.cyp`, executes the query, and asserts the result matches `output`. The database is cleared (`DROP DATABASE`) between tests.
+
+## Full Example Workflow
+
+```bash
+# 1. Build
+./tools/ci/mage-build/build-docker-image.sh --image-tag my-feature
+
+# 2. Run container
+docker run --rm -d -p 7687:7687 -p 7444:7444 --name mage-test memgraph/memgraph-mage:my-feature
+
+# 3. Activate venv and run tests
+source tests/query_modules/ve3/bin/activate
+cd mage/tests
+python3 test_e2e -k "igraphalg"
+
+# 4. Clean up
+docker stop mage-test
+```
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `mage/tests/test_e2e` | Test runner script (wraps pytest) |
+| `mage/tests/e2e/test_module.py` | Pytest test logic — discovers and runs test directories |
+| `mage/tests/e2e/conftest.py` | Pytest fixtures (`db` connects to Memgraph via `MG_HOST`/`MG_PORT`) |
+| `mage/tests/e2e/pytest.ini` | Pytest config (`--maxfail=10`, verbose output) |
+| `mage/tests/e2e/<module>_test/` | Test directories, one per module |
+| `tests/query_modules/ve3/` | Shared Python venv with test dependencies (pytest, gqlalchemy, PyYAML) |


### PR DESCRIPTION
Proxy to iGraph betweenness centrality algorithm because it offers more features than our implementation

### Standard development
- [x] Update unit/E2E tests
- [x] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch this branch

### CI Testing Labels
- [x] Select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_

### Documentation checklist
- [x] Add the documentation label
- [x] Add the bug / feature label
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [x] Write a release note, including added/changed clauses
    - Added iGraph betweenness centrality algorithm. Users can execute **`CALL igraphalg.betweenness_centrality` in order to run betweenness centrality with igraph** [#3830](https://github.com/memgraph/memgraph/pull/3830)
- [ ] **[ Documentation PR link memgraph/documentation#XXXX ]**
    - [ ] Is back linked to this development PR
