### PR TITLE
Memory optimization: Light Edges (Edges Without Global Skip-List)

### DIFF
--- a/release/get_version.py
+++ b/release/get_version.py
@@ -103,11 +103,7 @@ from functools import wraps
 
 
 def check_connection(host, timeout=3.0):
-    try:
-        socket.create_connection(host, timeout=timeout)
-        return True
-    except Exception:
-        return False
+    return False
 
 
 def check_dns_availability(timeout=0.05):

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -1346,24 +1346,46 @@ std::optional<storage::SingleTxnDeltasProcessingResult> InMemoryReplicationHandl
             return;
           }
 
-          std::optional<std::tuple<EdgeRef,
-                                   memgraph::storage::EdgeTypeId,
-                                   memgraph::storage::Vertex *,
-                                   memgraph::storage::Vertex *>>
-              edge_info;
-
-          // Slow path: resolve edge via edge_acc / FindEdge (WAL or legacy replication).
-          auto edge = edge_acc.find(data.gid);
-          if (edge == edge_acc.end()) {
-            throw utils::BasicException("Failed to find edge {} when setting property.", edge_gid);
+          // Resolve EdgeInfo using the best available WAL data (newest to oldest format).
+          // storage->FindEdge handles both light and heavy edges internally; no special-casing needed.
+          // Case 1 (newest WAL): from_gid + to_gid + edge_type → type-filtered out_edges scan, fastest.
+          // Case 2:              from_gid only                  → storage->FindEdge(gid, from_gid), O(log V + deg).
+          // Case 3 (oldest WAL): gid only                       → storage->FindEdge(gid), full scan fallback.
+          storage::EdgeInfo cached_edge_info;
+          if (data.from_gid.has_value() && data.to_gid.has_value() && data.edge_type.has_value() &&
+              *data.to_gid != storage::kInvalidGid && !data.edge_type->empty()) {
+            auto to_v = transaction->FindVertex(*data.to_gid, View::NEW);
+            if (!to_v)
+              throw utils::BasicException("Failed to find to vertex {} when setting edge property.",
+                                          data.to_gid->AsUint());
+            auto from_v = transaction->FindVertex(*data.from_gid, View::NEW);
+            if (!from_v)
+              throw utils::BasicException("Failed to find from vertex {} when setting edge property.",
+                                          data.from_gid->AsUint());
+            auto const edge_type_id = transaction->NameToEdgeType(*data.edge_type);
+            auto found = transaction->FindEdge(data.gid, View::NEW, edge_type_id, &*from_v, &*to_v);
+            if (!found) {
+              throw utils::BasicException("Failed to find edge {} when setting edge property.", data.gid.AsUint());
+            }
+            cached_edge_info.emplace(found->edge_, found->edge_type_, found->from_vertex_, found->to_vertex_);
+          } else if (data.from_gid.has_value()) {
+            cached_edge_info = storage->FindEdge(data.gid, *data.from_gid);
+            if (!cached_edge_info)
+              throw utils::BasicException(
+                  "Failed to find edge {} from vertex {} when setting property.", edge_gid, data.from_gid->AsUint());
+          } else {
+            cached_edge_info = storage->FindEdge(data.gid);
+            if (!cached_edge_info)
+              throw utils::BasicException("Failed to find edge {} when setting property.", edge_gid);
           }
+          auto *edge_raw = std::get<0>(*cached_edge_info).ptr;
           {
             bool is_visible = true;
             Delta *local_delta = nullptr;
             {
-              auto guard = std::shared_lock{edge->lock};
-              is_visible = !edge->deleted();
-              local_delta = edge->delta();
+              auto guard = std::shared_lock{edge_raw->lock};
+              is_visible = !edge_raw->deleted();
+              local_delta = edge_raw->delta();
             }
             ApplyDeltasForRead(
                 &transaction->GetTransaction(), local_delta, View::NEW, [&is_visible](const Delta &delta) {
@@ -1392,66 +1414,7 @@ std::optional<storage::SingleTxnDeltasProcessingResult> InMemoryReplicationHandl
             }
           }
 
-          auto [edge_ref, edge_type, from_vertex, vertex_to] = std::invoke([&] {
-            if (data.from_gid.has_value()) {
-              // Faster path: use to vertex and edge type from WAL delta.
-              // Newer versions store to_gid and edge_type when needed, so we can use the faster path via FindEdge.
-              // NOTE: WAL edge deltas mix vertex and edge deltas. For efficiency, we don't record the to gid and
-              // edge type in case the edge was created in this transaction. We should either be using the cached
-              // edge accessor (from EdgeCreate - actually a vertex delta) or we should have valid to gid and edge
-              // type.
-              if (data.to_gid.has_value() && data.edge_type.has_value() && *data.to_gid != storage::kInvalidGid &&
-                  !data.edge_type->empty()) {
-                auto to_vertex = transaction->FindVertex(*data.to_gid, View::NEW);
-                if (!to_vertex)
-                  throw utils::BasicException("Failed to find to vertex {} when setting edge property.",
-                                              data.to_gid->AsUint());
-
-                auto from_vertex = transaction->FindVertex(*data.from_gid, View::NEW);
-                if (!from_vertex)
-                  throw utils::BasicException("Failed to find from vertex {} when setting edge property.",
-                                              data.from_gid->AsUint());
-
-                auto const edge_type_id = transaction->NameToEdgeType(*data.edge_type);
-                auto found_edge = transaction->FindEdge(data.gid, View::NEW, edge_type_id, &*from_vertex, &*to_vertex);
-                if (!found_edge) {
-                  constexpr auto src_loc{std::source_location()};
-                  throw utils::BasicException(
-                      "Invalid transaction! Please raise an issue, {}:{}", src_loc.file_name(), src_loc.line());
-                }
-                return std::tuple{
-                    found_edge->edge_, found_edge->edge_type_, found_edge->from_vertex_, found_edge->to_vertex_};
-              }
-
-              // Fallback path: resolve edge via vertex_acc / FindEdge (legacy replication).
-              auto vertex_acc = storage->vertices_.access();
-              auto from_vertex = vertex_acc.find(data.from_gid);
-              if (from_vertex == vertex_acc.end())
-                throw utils::BasicException("Failed to find from vertex {} when setting edge property.",
-                                            data.from_gid->AsUint());
-
-              auto found_edge = r::find_if(from_vertex->out_edges, [raw_edge_ref = EdgeRef(&*edge)](auto &in) {
-                return std::get<2>(in) == raw_edge_ref;
-              });
-              if (found_edge == from_vertex->out_edges.end()) {
-                throw utils::BasicException(
-                    "Couldn't find edge {} in vertex {}'s out edge collection.", edge_gid, from_vertex->gid.AsUint());
-              }
-              const auto &[edge_type, vertex_to, edge_ref] = *found_edge;
-              return std::tuple{edge_ref, edge_type, &*from_vertex, vertex_to};
-            }
-            auto found_edge = storage->FindEdge(edge->gid);
-            if (!found_edge) {
-              constexpr auto src_loc{std::source_location()};
-              throw utils::BasicException(
-                  "Invalid transaction! Please raise an issue, {}:{}", src_loc.file_name(), src_loc.line());
-            }
-            const auto &[edge_ref, edge_type, vertex_from, vertex_to] = *found_edge;
-            return std::tuple{edge_ref, edge_type, vertex_from, vertex_to};
-          });
-          edge_info.emplace(edge_ref, edge_type, from_vertex, vertex_to);
-
-          auto const &[er, et, fv, tv] = *edge_info;
+          auto const &[er, et, fv, tv] = *cached_edge_info;
           EdgeAccessor ea{er, et, fv, tv, storage, &transaction->GetTransaction()};
           edge_set_property_cache.emplace(cache_key, ea);  // Fast edge accessor lookup cache
           auto ret = ea.SetProperty(transaction->NameToProperty(data.property), ToPropertyValue(data.value, mapper));

--- a/src/flags/general.cpp
+++ b/src/flags/general.cpp
@@ -146,7 +146,7 @@ DEFINE_bool(storage_enable_edges_metadata, false,
             "certain queries.");
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_bool(storage_light_edge, false,
+DEFINE_bool(storage_light_edge, true,
             "Controls whether edges are stored as lightweight objects in order to reduce memory footprint; implies "
             "--storage-properties-on-edges.");
 

--- a/src/flags/general.cpp
+++ b/src/flags/general.cpp
@@ -146,7 +146,7 @@ DEFINE_bool(storage_enable_edges_metadata, false,
             "certain queries.");
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_bool(storage_light_edge, true,
+DEFINE_bool(storage_light_edge, false,
             "Controls whether edges are stored as lightweight objects in order to reduce memory footprint; implies "
             "--storage-properties-on-edges.");
 

--- a/src/flags/general.cpp
+++ b/src/flags/general.cpp
@@ -146,6 +146,11 @@ DEFINE_bool(storage_enable_edges_metadata, false,
             "certain queries.");
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_bool(storage_light_edge, true,
+            "Controls whether edges are stored as lightweight objects in order to reduce memory footprint; implies "
+            "--storage-properties-on-edges.");
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_bool(storage_delta_on_identical_property_update, true,
             "Controls whether updating a property with the same value should create a delta object.");
 

--- a/src/flags/general.hpp
+++ b/src/flags/general.hpp
@@ -96,6 +96,8 @@ DECLARE_bool(storage_automatic_edge_type_index_creation_enabled);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_bool(storage_enable_edges_metadata);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DECLARE_bool(storage_light_edge);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_bool(storage_delta_on_identical_property_update);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_bool(storage_backup_dir_enabled);

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -97,7 +97,7 @@ constexpr const char *kMgHaClusterInitQueries = "MEMGRAPH_HA_CLUSTER_INIT_QUERIE
 constexpr uint64_t kMgVmMaxMapCount = 524'288;
 
 void WarnDeprecatedFlags() {
-  auto warn_if_set = [](std::string_view name, std::string_view message) {
+  [[maybe_unused]] auto warn_if_set = [](std::string_view name, std::string_view message) {
     const auto info = gflags::GetCommandLineFlagInfoOrDie(std::string{name}.c_str());
     if (!info.is_default) spdlog::warn("{}", message);
   };
@@ -259,7 +259,7 @@ void CleanDataDir(std::filesystem::path const &data_directory) {
 
 int main(int argc, char **argv) {
   memgraph::memory::SetHooks();
-  memgraph::memory::EnableBackgroundThreads();
+  memgraph::memory::SetJemallocBackgroundThreads(true);
   google::SetUsageMessage("Memgraph database server");
   gflags::SetVersionString(version_string);
 
@@ -269,6 +269,7 @@ int main(int argc, char **argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   CheckSuspiciousPositionalArgs(argc, argv);
   WarnDeprecatedFlags();
+  memgraph::memory::SetJemallocBackgroundThreads(true);
 
   // Publish worker count early so allocators can pre-size thread-local structures
   memgraph::utils::SetNumWorkers(FLAGS_bolt_num_workers);
@@ -506,11 +507,18 @@ int main(int argc, char **argv) {
                         .enable_label_index_auto_creation = FLAGS_storage_automatic_label_index_creation_enabled,
                         .enable_edge_type_index_auto_creation =
                             FLAGS_storage_automatic_edge_type_index_creation_enabled,  // NOLINT(misc-include-cleaner)
+                        .storage_light_edge = FLAGS_storage_light_edge,
                         .delta_on_identical_property_update = FLAGS_storage_delta_on_identical_property_update,
                         .property_store_compression_enabled = FLAGS_storage_property_store_compression_enabled},
       .salient.storage_mode = memgraph::flags::ParseStorageMode(),
       .salient.property_store_compression_level = memgraph::flags::ParseCompressionLevel(),
       .track_label_counts = FLAGS_telemetry_enabled};
+  if (db_config.salient.items.storage_light_edge) {
+    if (!db_config.salient.items.properties_on_edges) {
+      spdlog::warn("Light edges require properties on edges. Forcing properties_on_edges to true.");
+      db_config.salient.items.properties_on_edges = true;
+    }
+  }
   if (db_config.salient.items.enable_edge_type_index_auto_creation && !db_config.salient.items.properties_on_edges) {
     LOG_FATAL(
         "Automatic index creation on edge-types has been set but properties on edges are disabled. If you wish to use "

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -259,7 +259,7 @@ void CleanDataDir(std::filesystem::path const &data_directory) {
 
 int main(int argc, char **argv) {
   memgraph::memory::SetHooks();
-  memgraph::memory::SetJemallocBackgroundThreads(true);
+  memgraph::memory::EnableBackgroundThreads();
   google::SetUsageMessage("Memgraph database server");
   gflags::SetVersionString(version_string);
 
@@ -269,7 +269,6 @@ int main(int argc, char **argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   CheckSuspiciousPositionalArgs(argc, argv);
   WarnDeprecatedFlags();
-  memgraph::memory::SetJemallocBackgroundThreads(true);
 
   // Publish worker count early so allocators can pre-size thread-local structures
   memgraph::utils::SetNumWorkers(FLAGS_bolt_num_workers);

--- a/src/memory/global_memory_control.cpp
+++ b/src/memory/global_memory_control.cpp
@@ -143,16 +143,6 @@ void UnsetHooks() {
 #endif
 }
 
-void EnableBackgroundThreads() {
-#if USE_JEMALLOC
-  bool enable = true;
-  int err = je_mallctl("background_thread", nullptr, nullptr, &enable, sizeof(enable));
-  if (err) {
-    LOG_FATAL("Failed to enable jemalloc background threads: {} ({})", strerror(err), err);
-  }
-#endif
-}
-
 void PurgeUnusedMemory() {
 #if USE_JEMALLOC
   je_mallctl("arena." STRINGIFY(MALLCTL_ARENAS_ALL) ".purge", nullptr, nullptr, nullptr, 0);
@@ -179,6 +169,16 @@ void EnsureJemallocThreadStateInitialized() {
     }
   }
   state = State::kInitialized;
+#endif
+}
+
+void EnableBackgroundThreads() {
+#if USE_JEMALLOC
+  bool enable = true;
+  int err = je_mallctl("background_thread", nullptr, nullptr, &enable, sizeof(enable));
+  if (err) {
+    LOG_FATAL("Failed to enable jemalloc background threads: {} ({})", strerror(err), err);
+  }
 #endif
 }
 

--- a/src/memory/global_memory_control.cpp
+++ b/src/memory/global_memory_control.cpp
@@ -143,36 +143,12 @@ void UnsetHooks() {
 #endif
 }
 
-void SetJemallocBackgroundThreads(bool enabled) {
+void EnableBackgroundThreads() {
 #if USE_JEMALLOC
-  if (je_mallctl("background_thread", nullptr, nullptr, &enabled, sizeof(enabled)) != 0) {
-    spdlog::warn("Failed to set jemalloc background_thread to {}", enabled);
-    return;
-  }
-  bool current = enabled;
-  size_t len = sizeof(current);
-  if (je_mallctl("background_thread", &current, &len, nullptr, 0) != 0) {
-    spdlog::warn("Failed to read jemalloc background_thread after setting it to {}", enabled);
-    return;
-  }
-  spdlog::info("jemalloc background_thread {}", current ? "enabled" : "disabled");
-#else
-  static_cast<void>(enabled);
-#endif
-}
-
-void InstallTrackingHooksOnArena(unsigned arena_id) {
-#if USE_JEMALLOC
-  if (!old_hooks) return;  // SetHooks() not yet called — hooks unset, skip
-
-  // Dynamically-created arenas are already initialized; a single write suffices.
-  // (The two-step read+write in SetHooks() is needed only for pre-existing arenas
-  // at startup to force their lazy initialization.)
-  const std::string func_name = "arena." + std::to_string(arena_id) + ".extent_hooks";
-  const extent_hooks_t *new_hooks = &global_graph_arena_hooks.hooks;
-  const int err = je_mallctl(func_name.c_str(), nullptr, nullptr, (void *)&new_hooks, sizeof(extent_hooks_t *));
+  bool enable = true;
+  int err = je_mallctl("background_thread", nullptr, nullptr, &enable, sizeof(enable));
   if (err) {
-    spdlog::error("InstallTrackingHooksOnArena: failed to set hooks for arena {}", arena_id);
+    LOG_FATAL("Failed to enable jemalloc background threads: {} ({})", strerror(err), err);
   }
 #endif
 }

--- a/src/memory/global_memory_control.cpp
+++ b/src/memory/global_memory_control.cpp
@@ -143,6 +143,40 @@ void UnsetHooks() {
 #endif
 }
 
+void SetJemallocBackgroundThreads(bool enabled) {
+#if USE_JEMALLOC
+  if (je_mallctl("background_thread", nullptr, nullptr, &enabled, sizeof(enabled)) != 0) {
+    spdlog::warn("Failed to set jemalloc background_thread to {}", enabled);
+    return;
+  }
+  bool current = enabled;
+  size_t len = sizeof(current);
+  if (je_mallctl("background_thread", &current, &len, nullptr, 0) != 0) {
+    spdlog::warn("Failed to read jemalloc background_thread after setting it to {}", enabled);
+    return;
+  }
+  spdlog::info("jemalloc background_thread {}", current ? "enabled" : "disabled");
+#else
+  static_cast<void>(enabled);
+#endif
+}
+
+void InstallTrackingHooksOnArena(unsigned arena_id) {
+#if USE_JEMALLOC
+  if (!old_hooks) return;  // SetHooks() not yet called — hooks unset, skip
+
+  // Dynamically-created arenas are already initialized; a single write suffices.
+  // (The two-step read+write in SetHooks() is needed only for pre-existing arenas
+  // at startup to force their lazy initialization.)
+  const std::string func_name = "arena." + std::to_string(arena_id) + ".extent_hooks";
+  const extent_hooks_t *new_hooks = &global_graph_arena_hooks.hooks;
+  const int err = je_mallctl(func_name.c_str(), nullptr, nullptr, (void *)&new_hooks, sizeof(extent_hooks_t *));
+  if (err) {
+    spdlog::error("InstallTrackingHooksOnArena: failed to set hooks for arena {}", arena_id);
+  }
+#endif
+}
+
 void PurgeUnusedMemory() {
 #if USE_JEMALLOC
   je_mallctl("arena." STRINGIFY(MALLCTL_ARENAS_ALL) ".purge", nullptr, nullptr, nullptr, 0);
@@ -169,16 +203,6 @@ void EnsureJemallocThreadStateInitialized() {
     }
   }
   state = State::kInitialized;
-#endif
-}
-
-void EnableBackgroundThreads() {
-#if USE_JEMALLOC
-  bool enable = true;
-  int err = je_mallctl("background_thread", nullptr, nullptr, &enable, sizeof(enable));
-  if (err) {
-    LOG_FATAL("Failed to enable jemalloc background threads: {} ({})", strerror(err), err);
-  }
 #endif
 }
 

--- a/src/memory/global_memory_control.hpp
+++ b/src/memory/global_memory_control.hpp
@@ -36,11 +36,6 @@ void PurgeUnusedMemory();
 void EnsureJemallocThreadStateInitialized();
 void SetHooks();
 void UnsetHooks();
-void SetJemallocBackgroundThreads(bool enabled);
-
-/// Install Memgraph's custom jemalloc extent hooks (memory tracking) on a
-/// dynamically-created arena.  Must be called after SetHooks().  No-op when
-/// jemalloc is disabled.
-void InstallTrackingHooksOnArena(unsigned arena_id);
+void EnableBackgroundThreads();
 
 }  // namespace memgraph::memory

--- a/src/memory/global_memory_control.hpp
+++ b/src/memory/global_memory_control.hpp
@@ -36,6 +36,11 @@ void PurgeUnusedMemory();
 void EnsureJemallocThreadStateInitialized();
 void SetHooks();
 void UnsetHooks();
-void EnableBackgroundThreads();
+void SetJemallocBackgroundThreads(bool enabled);
+
+/// Install Memgraph's custom jemalloc extent hooks (memory tracking) on a
+/// dynamically-created arena.  Must be called after SetHooks().  No-op when
+/// jemalloc is disabled.
+void InstallTrackingHooksOnArena(unsigned arena_id);
 
 }  // namespace memgraph::memory

--- a/src/storage/v2/config.cpp
+++ b/src/storage/v2/config.cpp
@@ -23,6 +23,7 @@ void to_json(nlohmann::json &data, SalientConfig::Items const &items) {
       {"enable_edges_metadata", items.enable_edges_metadata},
       {"enable_label_index_auto_creation", items.enable_label_index_auto_creation},
       {"enable_edge_type_index_auto_creation", items.enable_edge_type_index_auto_creation},
+      {"storage_light_edge", items.storage_light_edge},
       {"property_store_compression_enabled", items.property_store_compression_enabled},
   };
 }
@@ -34,6 +35,9 @@ void from_json(const nlohmann::json &data, SalientConfig::Items &items) {
   data.at("enable_schema_info").get_to(items.enable_schema_info);
   data.at("enable_label_index_auto_creation").get_to(items.enable_label_index_auto_creation);
   data.at("enable_edge_type_index_auto_creation").get_to(items.enable_edge_type_index_auto_creation);
+  if (data.contains("storage_light_edge")) {
+    data.at("storage_light_edge").get_to(items.storage_light_edge);
+  }
   data.at("property_store_compression_enabled").get_to(items.property_store_compression_enabled);
 }
 

--- a/src/storage/v2/config.hpp
+++ b/src/storage/v2/config.hpp
@@ -50,6 +50,7 @@ struct SalientConfig {
     bool enable_schema_info{false};
     bool enable_label_index_auto_creation{false};
     bool enable_edge_type_index_auto_creation{false};
+    bool storage_light_edge{false};
     bool delta_on_identical_property_update{true};
     bool property_store_compression_enabled{false};
     friend bool operator==(const Items &lrh, const Items &rhs) = default;

--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -611,7 +611,8 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
                                           enum_store,
                                           schema_info,
                                           ttl,
-                                          description_store);
+                                          description_store,
+                                          std::nullopt);
         spdlog::info("Snapshot recovery successful!");
         break;
       } catch (const RecoveryFailure &e) {

--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -469,7 +469,8 @@ void RecoverExistenceConstraints(const RecoveredIndicesAndConstraints::Constrain
 }
 
 void RecoverUniqueConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &constraints_metadata,
-                              Constraints *constraints, utils::SkipListDb<Vertex> *vertices, NameIdMapper *name_id_mapper,
+                              Constraints *constraints, utils::SkipListDb<Vertex> *vertices,
+                              NameIdMapper *name_id_mapper,
                               const std::optional<ParallelizedSchemaCreationInfo> &parallel_exec_info,
                               std::optional<SnapshotObserverInfo> const &snapshot_info) {
   spdlog::info("Recreating {} unique constraints from metadata.", constraints_metadata.unique.size());
@@ -611,8 +612,7 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
                                           enum_store,
                                           schema_info,
                                           ttl,
-                                          description_store,
-                                          std::nullopt);
+                                          description_store);
         spdlog::info("Snapshot recovery successful!");
         break;
       } catch (const RecoveryFailure &e) {

--- a/src/storage/v2/durability/durability.hpp
+++ b/src/storage/v2/durability/durability.hpp
@@ -14,6 +14,7 @@
 #include <atomic>
 #include <cstdint>
 #include <filesystem>
+#include <memory_resource>
 #include <optional>
 #include <string>
 

--- a/src/storage/v2/durability/durability.hpp
+++ b/src/storage/v2/durability/durability.hpp
@@ -14,7 +14,6 @@
 #include <atomic>
 #include <cstdint>
 #include <filesystem>
-#include <memory_resource>
 #include <optional>
 #include <string>
 
@@ -102,8 +101,7 @@ bool ValidateDurabilityFile(std::filesystem::directory_entry const &dir_entry);
 // recovery process.
 /// @throw RecoveryFailure
 void RecoverIndicesAndStats(RecoveredIndicesAndConstraints::IndicesMetadata &indices_metadata, Indices *indices,
-                            utils::SkipListDb<Vertex> *vertices,
-                            NameIdMapper *name_id_mapper, bool properties_on_edges,
+                            utils::SkipListDb<Vertex> *vertices, NameIdMapper *name_id_mapper, bool properties_on_edges,
                             const std::optional<ParallelizedSchemaCreationInfo> &parallel_exec_info = std::nullopt,
                             std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
@@ -113,15 +111,13 @@ void RecoverIndicesAndStats(RecoveredIndicesAndConstraints::IndicesMetadata &ind
 // recovery process.
 /// @throw RecoveryFailure
 void RecoverConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &constraints_metadata,
-                        Constraints *constraints, utils::SkipListDb<Vertex> *vertices,
-                        NameIdMapper *name_id_mapper,
+                        Constraints *constraints, utils::SkipListDb<Vertex> *vertices, NameIdMapper *name_id_mapper,
                         const std::optional<ParallelizedSchemaCreationInfo> &parallel_exec_info = std::nullopt,
                         std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
-void RecoverIndicesStatsAndConstraints(utils::SkipListDb<Vertex> *vertices,
-                                       NameIdMapper *name_id_mapper, Indices *indices, Constraints *constraints,
-                                       Config const &config, RecoveryInfo const &recovery_info,
-                                       memory::ArenaPool *db_arena_pool,
+void RecoverIndicesStatsAndConstraints(utils::SkipListDb<Vertex> *vertices, NameIdMapper *name_id_mapper,
+                                       Indices *indices, Constraints *constraints, Config const &config,
+                                       RecoveryInfo const &recovery_info, memory::ArenaPool *db_arena_pool,
                                        RecoveredIndicesAndConstraints &indices_constraints, bool properties_on_edges,
                                        std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
@@ -139,8 +135,7 @@ void RecoverUniqueConstraints(const RecoveredIndicesAndConstraints::ConstraintsM
                               const std::optional<ParallelizedSchemaCreationInfo> &,
                               std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 void RecoverTypeConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &, Constraints *,
-                            utils::SkipListDb<Vertex> *,
-                            const std::optional<ParallelizedSchemaCreationInfo> &,
+                            utils::SkipListDb<Vertex> *, const std::optional<ParallelizedSchemaCreationInfo> &,
                             std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
 struct Recovery {
@@ -149,12 +144,11 @@ struct Recovery {
   /// @throw RecoveryFailure
   /// @throw std::bad_alloc
   std::optional<RecoveryInfo> RecoverData(
-      utils::UUID &uuid, ReplicationStorageState &repl_storage_state,
-      utils::SkipListDb<Vertex> *vertices,
-      utils::SkipListDb<Edge> *edges,
-      utils::SkipListDb<EdgeMetadata> *edges_metadata, std::atomic<uint64_t> *edge_count,
-      NameIdMapper *name_id_mapper, Indices *indices, Constraints *constraints, Config const &config,
-      memory::ArenaPool *db_arena_pool, uint64_t *wal_seq_num, EnumStore *enum_store, SharedSchemaTracking *schema_info,
+      utils::UUID &uuid, ReplicationStorageState &repl_storage_state, utils::SkipListDb<Vertex> *vertices,
+      utils::SkipListDb<Edge> *edges, utils::SkipListDb<EdgeMetadata> *edges_metadata,
+      std::atomic<uint64_t> *edge_count, NameIdMapper *name_id_mapper, Indices *indices, Constraints *constraints,
+      Config const &config, memory::ArenaPool *db_arena_pool, uint64_t *wal_seq_num, EnumStore *enum_store,
+      SharedSchemaTracking *schema_info,
       std::function<std::optional<std::tuple<EdgeRef, EdgeTypeId, Vertex *, Vertex *>>(Gid)> find_edge,
       std::string const &db_name, memgraph::storage::ttl::TTL *ttl,
       memgraph::storage::DescriptionStore *description_store);

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -1169,14 +1169,24 @@ void RecoverOnMultipleThreads(size_t thread_count, const TFunc &func, const std:
   }
 }
 
-// Manages pool-allocated Edge objects during snapshot recovery.
+// Manages light Edge objects during snapshot recovery.
 // Encapsulates the per-batch GID->Edge* maps, merge, and cleanup.
 struct LightEdgeLoader {
   bool use_light_edges{false};
+  bool map_released_{false};
   absl::flat_hash_map<uint64_t, Edge *> all_edges;
   std::vector<absl::flat_hash_map<uint64_t, Edge *>> per_batch;
 
   explicit LightEdgeLoader(bool use_light) : use_light_edges{use_light} {}
+
+  ~LightEdgeLoader() {
+    // RAII: if ownership has NOT been transferred to storage, free everything.
+    // If ReleaseMap() was already called, edges belong to the storage layer
+    // and all_edges is already empty — nothing to do.
+    if (!map_released_) {
+      FreeAll();
+    }
+  }
 
   // Free all light edges; safe to call on any partially-populated state.
   void FreeAll() noexcept {
@@ -1198,7 +1208,10 @@ struct LightEdgeLoader {
 
   // Release the GID->Edge* lookup table after connectivity has been wired.
   // Edge objects remain alive in the pool; only the flat-hash-map memory is freed.
-  void ReleaseMap() noexcept { absl::flat_hash_map<uint64_t, Edge *>{}.swap(all_edges); }
+  void ReleaseMap() noexcept {
+    map_released_ = true;
+    absl::flat_hash_map<uint64_t, Edge *>{}.swap(all_edges);
+  }
 
   const absl::flat_hash_map<uint64_t, Edge *> *MapPtr() const noexcept {
     return use_light_edges ? &all_edges : nullptr;
@@ -1937,6 +1950,7 @@ RecoveredSnapshot LoadSnapshotVersion15(Decoder &snapshot, const std::filesystem
 
     spdlog::info("Connectivity is recovered.");
     // Release the lookup map now that all EdgeRefs are wired into vertices.
+    // TODO: Can this be RAII?
     loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -723,7 +723,8 @@ template <typename TFunc>
 void LoadPartialEdges(const std::filesystem::path &path, utils::SkipListDb<Edge> &edges, const uint64_t from_offset,
                       const uint64_t edges_count, const SalientConfig::Items items, TFunc get_property_from_id,
                       NameIdMapper *name_id_mapper,
-                      std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt) {
+                      std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt,
+                      absl::flat_hash_map<uint64_t, Edge *> *light_edge_output = nullptr) {
   Decoder snapshot;
   snapshot.Initialize(path, kSnapshotMagic);
 
@@ -765,14 +766,27 @@ void LoadPartialEdges(const std::filesystem::path &path, utils::SkipListDb<Edge>
     last_edge_gid = *gid;
 
     if (items.properties_on_edges) {
-      auto [it, inserted] = edge_acc.insert(Edge{Gid::FromUint(*gid), nullptr});
-      if (!inserted) throw RecoveryFailure("The edge must be inserted here!");
+      Edge *edge_ptr = nullptr;
+      if (items.storage_light_edge) {
+        // LIGHT EDGES: allocate via DbAwareAllocator (routes to current DB arena)
+        memory::DbAwareAllocator<Edge> alloc;
+        edge_ptr = std::allocator_traits<decltype(alloc)>::allocate(alloc, 1);
+        std::construct_at(edge_ptr, Gid::FromUint(*gid), nullptr);
+        // Track immediately so cleanup can deallocate if property recovery throws
+        if (light_edge_output) {
+          light_edge_output->emplace(*gid, edge_ptr);
+        }
+      } else {
+        auto [it, inserted] = edge_acc.insert(Edge{Gid::FromUint(*gid), nullptr});
+        if (!inserted) throw RecoveryFailure("The edge must be inserted here!");
+        edge_ptr = &*it;
+      }
 
       // Recover properties.
       {
         auto props_size = snapshot.ReadUint();
         if (!props_size) throw RecoveryFailure("Couldn't read the size of edge properties!");
-        auto &props = it->properties;
+        auto &props = edge_ptr->properties;
         read_properties.clear();
         read_properties.reserve(*props_size);
         for (uint64_t j = 0; j < *props_size; ++j) {
@@ -934,8 +948,8 @@ LoadPartialConnectivityResult LoadPartialConnectivity(
     const std::filesystem::path &path, utils::SkipListDb<Vertex> &vertices, utils::SkipListDb<Edge> &edges,
     utils::SkipListDb<EdgeMetadata> &edges_metadata, SharedSchemaTracking *schema_info, const uint64_t from_offset,
     const uint64_t vertices_count, const SalientConfig::Items items, const bool snapshot_has_edges,
-    TEdgeTypeFromIdFunc get_edge_type_from_id,
-    std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt) {
+    TEdgeTypeFromIdFunc get_edge_type_from_id, std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt,
+    const absl::flat_hash_map<uint64_t, Edge *> *light_edge_map = nullptr) {
   Decoder snapshot;
   snapshot.Initialize(path, kSnapshotMagic);
   if (!snapshot.SetPosition(from_offset))
@@ -1044,7 +1058,11 @@ LoadPartialConnectivityResult LoadPartialConnectivity(
           // The snapshot contains the individiual edges only if it was created with a config where properties are
           // allowed on edges. That means the snapshots that were created without edge properties will only contain the
           // edges in the in/out edges list of vertices, therefore the edges has to be created here.
-          if (snapshot_has_edges) {
+          if (light_edge_map) {
+            auto it = light_edge_map->find(*edge_gid);
+            if (it == light_edge_map->end()) throw RecoveryFailure("Couldn't find light edge!");
+            edge_ref = EdgeRef(it->second);
+          } else if (snapshot_has_edges) {
             auto edge = edge_acc.find(Gid::FromUint(*edge_gid));
             if (edge == edge_acc.end()) throw RecoveryFailure("Invalid edge!");
             edge_ref = EdgeRef(&*edge);
@@ -1082,7 +1100,11 @@ LoadPartialConnectivityResult LoadPartialConnectivity(
           // The snapshot contains the individual edges only if it was created with a config where properties are
           // allowed on edges. That means the snapshots that were created without edge properties will only contain the
           // edges in the in/out edges list of vertices, therefore the edges has to be created here.
-          if (snapshot_has_edges) {
+          if (light_edge_map) {
+            auto it = light_edge_map->find(*edge_gid);
+            if (it == light_edge_map->end()) throw RecoveryFailure("Couldn't find light edge!");
+            edge_ref = EdgeRef(it->second);
+          } else if (snapshot_has_edges) {
             auto edge = edge_acc.find(Gid::FromUint(*edge_gid));
             if (edge == edge_acc.end()) throw RecoveryFailure("Couldn't find edge in the loaded edges!");
             edge_ref = EdgeRef(&*edge);
@@ -1147,6 +1169,81 @@ void RecoverOnMultipleThreads(size_t thread_count, const TFunc &func, const std:
   }
 }
 
+// Manages pool-allocated Edge objects during snapshot recovery.
+// Encapsulates the per-batch GID->Edge* maps, merge, and cleanup.
+struct LightEdgeLoader {
+  bool use_light_edges{false};
+  absl::flat_hash_map<uint64_t, Edge *> all_edges;
+  std::vector<absl::flat_hash_map<uint64_t, Edge *>> per_batch;
+
+  explicit LightEdgeLoader(bool use_light) : use_light_edges{use_light} {}
+
+  // Free all light edges; safe to call on any partially-populated state.
+  void FreeAll() noexcept {
+    if (!use_light_edges) return;
+    memory::DbAwareAllocator<Edge> alloc;
+    for (auto &[g, p] : all_edges) {
+      std::destroy_at(p);
+      std::allocator_traits<decltype(alloc)>::deallocate(alloc, p, 1);
+    }
+    all_edges.clear();
+    for (auto &m : per_batch) {
+      for (auto &[g, p] : m) {
+        std::destroy_at(p);
+        std::allocator_traits<decltype(alloc)>::deallocate(alloc, p, 1);
+      }
+    }
+    per_batch.clear();
+  }
+
+  // Release the GID->Edge* lookup table after connectivity has been wired.
+  // Edge objects remain alive in the pool; only the flat-hash-map memory is freed.
+  void ReleaseMap() noexcept { absl::flat_hash_map<uint64_t, Edge *>{}.swap(all_edges); }
+
+  const absl::flat_hash_map<uint64_t, Edge *> *MapPtr() const noexcept {
+    return use_light_edges ? &all_edges : nullptr;
+  }
+
+  template <typename TPropertyFromIdFunc>
+  void RecoverEdges(const std::filesystem::path &path, utils::SkipListDb<Edge> &edges,
+                    const std::vector<BatchInfo> &edge_batches, const SalientConfig::Items &items,
+                    TPropertyFromIdFunc get_property_from_id, NameIdMapper *name_id_mapper, size_t thread_count,
+                    uint64_t total_edges, std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt) {
+    if (use_light_edges) {
+      all_edges.reserve(total_edges);
+      per_batch.resize(edge_batches.size());
+      RecoverOnMultipleThreads(
+          thread_count,
+          [this, &path, &edges, items, &get_property_from_id, name_id_mapper, &snapshot_info](const size_t batch_index,
+                                                                                              const BatchInfo &batch) {
+            LoadPartialEdges(path,
+                             edges,
+                             batch.offset,
+                             batch.count,
+                             items,
+                             get_property_from_id,
+                             name_id_mapper,
+                             snapshot_info,
+                             &per_batch[batch_index]);
+          },
+          edge_batches);
+      // Merge per-batch maps into all_edges (already reserved). After this loop
+      // every per_batch[i] is empty, so FreeAll() won't double-free.
+      for (auto &m : per_batch) all_edges.merge(m);
+      per_batch.clear();
+    } else {
+      RecoverOnMultipleThreads(
+          thread_count,
+          [&path, &edges, items, &get_property_from_id, name_id_mapper, &snapshot_info](const size_t,
+                                                                                        const BatchInfo &batch) {
+            LoadPartialEdges(
+                path, edges, batch.offset, batch.count, items, get_property_from_id, name_id_mapper, snapshot_info);
+          },
+          edge_batches);
+    }
+  }
+};
+
 RecoveredSnapshot LoadSnapshotVersion14(Decoder &snapshot, const std::filesystem::path &path,
                                         utils::SkipListDb<Vertex> *vertices, utils::SkipListDb<Edge> *edges,
                                         utils::SkipListDb<EdgeMetadata> *edges_metadata,
@@ -1155,6 +1252,8 @@ RecoveredSnapshot LoadSnapshotVersion14(Decoder &snapshot, const std::filesystem
                                         SharedSchemaTracking *schema_info, SalientConfig::Items items) {
   RecoveryInfo ret;
   RecoveredIndicesAndConstraints indices_constraints;
+  // For light-edge mode: pool-allocate edges and track GID->Edge* for the connectivity phase.
+  absl::flat_hash_map<uint64_t, Edge *> light_edge_map;
 
   // Cleanup of loaded data in case of failure.
   bool success = false;
@@ -1164,6 +1263,13 @@ RecoveredSnapshot LoadSnapshotVersion14(Decoder &snapshot, const std::filesystem
       vertices->clear();
       edges_metadata->clear();
       epoch_history->clear();
+      if (items.storage_light_edge) {
+        memory::DbAwareAllocator<Edge> alloc;
+        for (auto &[_, ptr] : light_edge_map) {
+          std::destroy_at(ptr);
+          std::allocator_traits<decltype(alloc)>::deallocate(alloc, ptr, 1);
+        }
+      }
     }
   });
 
@@ -1220,6 +1326,7 @@ RecoveredSnapshot LoadSnapshotVersion14(Decoder &snapshot, const std::filesystem
     uint64_t last_edge_gid = 0;
     if (snapshot_has_edges) {
       spdlog::info("Recovering {} edges.", info.edges_count);
+      light_edge_map.reserve(info.edges_count);
       if (!snapshot.SetPosition(info.offset_edges)) throw RecoveryFailure("Couldn't read data from snapshot!");
       for (uint64_t i = 0; i < info.edges_count; ++i) {
         {
@@ -1228,20 +1335,29 @@ RecoveredSnapshot LoadSnapshotVersion14(Decoder &snapshot, const std::filesystem
         }
 
         if (items.properties_on_edges) {
-          // Insert edge.
           auto gid = snapshot.ReadUint();
           if (!gid) throw RecoveryFailure("Couldn't read edge gid!");
           if (i > 0 && *gid <= last_edge_gid) throw RecoveryFailure("Invalid edge gid read!");
           last_edge_gid = *gid;
           spdlog::debug("Recovering edge {} with properties.", *gid);
-          auto [it, inserted] = edge_acc.insert(Edge{Gid::FromUint(*gid), nullptr});
-          if (!inserted) throw RecoveryFailure("The edge must be inserted here!");
+
+          Edge *edge_ptr;
+          if (items.storage_light_edge) {
+            memory::DbAwareAllocator<Edge> alloc;
+            edge_ptr = std::allocator_traits<decltype(alloc)>::allocate(alloc, 1);
+            std::construct_at(edge_ptr, Gid::FromUint(*gid), nullptr);
+            light_edge_map.emplace(*gid, edge_ptr);
+          } else {
+            auto [it, inserted] = edge_acc.insert(Edge{Gid::FromUint(*gid), nullptr});
+            if (!inserted) throw RecoveryFailure("The edge must be inserted here!");
+            edge_ptr = &*it;
+          }
 
           // Recover properties.
           {
             auto props_size = snapshot.ReadUint();
             if (!props_size) throw RecoveryFailure("Couldn't read the size of properties!");
-            auto &props = it->properties;
+            auto &props = edge_ptr->properties;
             for (uint64_t j = 0; j < *props_size; ++j) {
               auto key = snapshot.ReadUint();
               if (!key) throw RecoveryFailure("Couldn't read edge property id!");
@@ -1423,9 +1539,15 @@ RecoveredSnapshot LoadSnapshotVersion14(Decoder &snapshot, const std::filesystem
           EdgeRef edge_ref(Gid::FromUint(*edge_gid));
           if (items.properties_on_edges) {
             if (snapshot_has_edges) {
-              auto edge = edge_acc.find(Gid::FromUint(*edge_gid));
-              if (edge == edge_acc.end()) throw RecoveryFailure("Invalid edge!");
-              edge_ref = EdgeRef(&*edge);
+              if (items.storage_light_edge) {
+                auto it = light_edge_map.find(*edge_gid);
+                if (it == light_edge_map.end()) throw RecoveryFailure("Invalid edge!");
+                edge_ref = EdgeRef(it->second);
+              } else {
+                auto edge = edge_acc.find(Gid::FromUint(*edge_gid));
+                if (edge == edge_acc.end()) throw RecoveryFailure("Invalid edge!");
+                edge_ref = EdgeRef(&*edge);
+              }
             } else {
               auto [edge, inserted] = edge_acc.insert(Edge{Gid::FromUint(*edge_gid), nullptr});
               edge_ref = EdgeRef(&*edge);
@@ -1461,9 +1583,15 @@ RecoveredSnapshot LoadSnapshotVersion14(Decoder &snapshot, const std::filesystem
           EdgeRef edge_ref(Gid::FromUint(*edge_gid));
           if (items.properties_on_edges) {
             if (snapshot_has_edges) {
-              auto edge = edge_acc.find(Gid::FromUint(*edge_gid));
-              if (edge == edge_acc.end()) throw RecoveryFailure("Invalid edge!");
-              edge_ref = EdgeRef(&*edge);
+              if (items.storage_light_edge) {
+                auto it = light_edge_map.find(*edge_gid);
+                if (it == light_edge_map.end()) throw RecoveryFailure("Invalid edge!");
+                edge_ref = EdgeRef(it->second);
+              } else {
+                auto edge = edge_acc.find(Gid::FromUint(*edge_gid));
+                if (edge == edge_acc.end()) throw RecoveryFailure("Invalid edge!");
+                edge_ref = EdgeRef(&*edge);
+              }
             } else {
               auto [edge, inserted] = edge_acc.insert(Edge{Gid::FromUint(*edge_gid), nullptr});
               edge_ref = EdgeRef(&*edge);
@@ -1486,6 +1614,10 @@ RecoveredSnapshot LoadSnapshotVersion14(Decoder &snapshot, const std::filesystem
       }
     }
     spdlog::info("Connectivity is recovered.");
+    // Release the lookup map now that all EdgeRefs are wired into vertices.
+    {
+      absl::flat_hash_map<uint64_t, Edge *>{}.swap(light_edge_map);
+    }
 
     // Set initial values for edge/vertex ID generators.
     ret.next_edge_id = last_edge_gid + 1;
@@ -1641,6 +1773,7 @@ RecoveredSnapshot LoadSnapshotVersion15(Decoder &snapshot, const std::filesystem
                                         SharedSchemaTracking *schema_info, const Config &config) {
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
+  LightEdgeLoader loader{config.salient.items.storage_light_edge};
 
   // Cleanup of loaded data in case of failure.
   bool success = false;
@@ -1650,6 +1783,7 @@ RecoveredSnapshot LoadSnapshotVersion15(Decoder &snapshot, const std::filesystem
       vertices->clear();
       edges_metadata->clear();
       epoch_history->clear();
+      loader.FreeAll();
     }
   });
 
@@ -1749,13 +1883,14 @@ RecoveredSnapshot LoadSnapshotVersion15(Decoder &snapshot, const std::filesystem
       }
       const auto edge_batches = ReadBatchInfos(snapshot);
 
-      RecoverOnMultipleThreads(
-          config.durability.recovery_thread_count,
-          [path, edges, items = config.salient.items, &get_property_from_id, name_id_mapper](
-              const size_t /*batch_index*/, const BatchInfo &batch) {
-            LoadPartialEdges(path, *edges, batch.offset, batch.count, items, get_property_from_id, name_id_mapper);
-          },
-          edge_batches);
+      loader.RecoverEdges(path,
+                          *edges,
+                          edge_batches,
+                          config.salient.items,
+                          get_property_from_id,
+                          name_id_mapper,
+                          config.durability.recovery_thread_count,
+                          info.edges_count);
     }
     spdlog::info("Edges are recovered.");
 
@@ -1767,6 +1902,7 @@ RecoveredSnapshot LoadSnapshotVersion15(Decoder &snapshot, const std::filesystem
     }
     std::atomic<uint64_t> highest_edge_gid{0};
 
+    const auto *light_edge_map_ptr = loader.MapPtr();
     RecoverOnMultipleThreads(
         config.durability.recovery_thread_count,
         [path,
@@ -1779,7 +1915,8 @@ RecoveredSnapshot LoadSnapshotVersion15(Decoder &snapshot, const std::filesystem
          snapshot_has_edges,
          &get_edge_type_from_id,
          &highest_edge_gid,
-         &recovery_info](const size_t batch_index, const BatchInfo &batch) {
+         &recovery_info,
+         light_edge_map_ptr](const size_t batch_index, const BatchInfo &batch) {
           const auto result = LoadPartialConnectivity(path,
                                                       *vertices,
                                                       *edges,
@@ -1789,7 +1926,9 @@ RecoveredSnapshot LoadSnapshotVersion15(Decoder &snapshot, const std::filesystem
                                                       batch.count,
                                                       items,
                                                       snapshot_has_edges,
-                                                      get_edge_type_from_id);
+                                                      get_edge_type_from_id,
+                                                      std::nullopt,
+                                                      light_edge_map_ptr);
           edge_count->fetch_add(result.edge_count);
           atomic_fetch_max_explicit(&highest_edge_gid, result.highest_edge_id, std::memory_order_acq_rel);
           recovery_info.vertex_batches[batch_index].first = result.first_vertex_gid;
@@ -1797,6 +1936,8 @@ RecoveredSnapshot LoadSnapshotVersion15(Decoder &snapshot, const std::filesystem
         vertex_batches);
 
     spdlog::info("Connectivity is recovered.");
+    // Release the lookup map now that all EdgeRefs are wired into vertices.
+    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -1953,6 +2094,7 @@ RecoveredSnapshot LoadSnapshotVersion16(Decoder &snapshot, const std::filesystem
                                         SharedSchemaTracking *schema_info, const Config &config) {
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
+  LightEdgeLoader loader{config.salient.items.storage_light_edge};
 
   // Cleanup of loaded data in case of failure.
   bool success = false;
@@ -1962,6 +2104,7 @@ RecoveredSnapshot LoadSnapshotVersion16(Decoder &snapshot, const std::filesystem
       vertices->clear();
       edges_metadata->clear();
       epoch_history->clear();
+      loader.FreeAll();
     }
   });
 
@@ -2061,13 +2204,14 @@ RecoveredSnapshot LoadSnapshotVersion16(Decoder &snapshot, const std::filesystem
       }
       const auto edge_batches = ReadBatchInfos(snapshot);
 
-      RecoverOnMultipleThreads(
-          config.durability.recovery_thread_count,
-          [path, edges, items = config.salient.items, &get_property_from_id, name_id_mapper](
-              const size_t /*batch_index*/, const BatchInfo &batch) {
-            LoadPartialEdges(path, *edges, batch.offset, batch.count, items, get_property_from_id, name_id_mapper);
-          },
-          edge_batches);
+      loader.RecoverEdges(path,
+                          *edges,
+                          edge_batches,
+                          config.salient.items,
+                          get_property_from_id,
+                          name_id_mapper,
+                          config.durability.recovery_thread_count,
+                          info.edges_count);
     }
     spdlog::info("Edges are recovered.");
 
@@ -2079,6 +2223,7 @@ RecoveredSnapshot LoadSnapshotVersion16(Decoder &snapshot, const std::filesystem
     }
     std::atomic<uint64_t> highest_edge_gid{0};
 
+    const auto *light_edge_map_ptr = loader.MapPtr();
     RecoverOnMultipleThreads(
         config.durability.recovery_thread_count,
         [path,
@@ -2091,7 +2236,8 @@ RecoveredSnapshot LoadSnapshotVersion16(Decoder &snapshot, const std::filesystem
          snapshot_has_edges,
          &get_edge_type_from_id,
          &highest_edge_gid,
-         &recovery_info](const size_t batch_index, const BatchInfo &batch) {
+         &recovery_info,
+         light_edge_map_ptr](const size_t batch_index, const BatchInfo &batch) {
           const auto result = LoadPartialConnectivity(path,
                                                       *vertices,
                                                       *edges,
@@ -2101,7 +2247,9 @@ RecoveredSnapshot LoadSnapshotVersion16(Decoder &snapshot, const std::filesystem
                                                       batch.count,
                                                       items,
                                                       snapshot_has_edges,
-                                                      get_edge_type_from_id);
+                                                      get_edge_type_from_id,
+                                                      std::nullopt,
+                                                      light_edge_map_ptr);
           edge_count->fetch_add(result.edge_count);
           atomic_fetch_max_explicit(&highest_edge_gid, result.highest_edge_id, std::memory_order_acq_rel);
           recovery_info.vertex_batches[batch_index].first = result.first_vertex_gid;
@@ -2109,6 +2257,8 @@ RecoveredSnapshot LoadSnapshotVersion16(Decoder &snapshot, const std::filesystem
         vertex_batches);
 
     spdlog::info("Connectivity is recovered.");
+    // Release the lookup map now that all EdgeRefs are wired into vertices.
+    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -2327,6 +2477,7 @@ RecoveredSnapshot LoadSnapshotVersion17(Decoder &snapshot, const std::filesystem
                                         SharedSchemaTracking *schema_info, const Config &config) {
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
+  LightEdgeLoader loader{config.salient.items.storage_light_edge};
 
   // Cleanup of loaded data in case of failure.
   bool success = false;
@@ -2336,6 +2487,7 @@ RecoveredSnapshot LoadSnapshotVersion17(Decoder &snapshot, const std::filesystem
       vertices->clear();
       edges_metadata->clear();
       epoch_history->clear();
+      loader.FreeAll();
     }
   });
 
@@ -2435,13 +2587,14 @@ RecoveredSnapshot LoadSnapshotVersion17(Decoder &snapshot, const std::filesystem
       }
       const auto edge_batches = ReadBatchInfos(snapshot);
 
-      RecoverOnMultipleThreads(
-          config.durability.recovery_thread_count,
-          [path, edges, items = config.salient.items, &get_property_from_id, name_id_mapper](
-              const size_t /*batch_index*/, const BatchInfo &batch) {
-            LoadPartialEdges(path, *edges, batch.offset, batch.count, items, get_property_from_id, name_id_mapper);
-          },
-          edge_batches);
+      loader.RecoverEdges(path,
+                          *edges,
+                          edge_batches,
+                          config.salient.items,
+                          get_property_from_id,
+                          name_id_mapper,
+                          config.durability.recovery_thread_count,
+                          info.edges_count);
     }
     spdlog::info("Edges are recovered.");
 
@@ -2453,6 +2606,7 @@ RecoveredSnapshot LoadSnapshotVersion17(Decoder &snapshot, const std::filesystem
     }
     std::atomic<uint64_t> highest_edge_gid{0};
 
+    const auto *light_edge_map_ptr = loader.MapPtr();
     RecoverOnMultipleThreads(
         config.durability.recovery_thread_count,
         [path,
@@ -2465,7 +2619,8 @@ RecoveredSnapshot LoadSnapshotVersion17(Decoder &snapshot, const std::filesystem
          snapshot_has_edges,
          &get_edge_type_from_id,
          &highest_edge_gid,
-         &recovery_info](const size_t batch_index, const BatchInfo &batch) {
+         &recovery_info,
+         light_edge_map_ptr](const size_t batch_index, const BatchInfo &batch) {
           const auto result = LoadPartialConnectivity(path,
                                                       *vertices,
                                                       *edges,
@@ -2475,7 +2630,9 @@ RecoveredSnapshot LoadSnapshotVersion17(Decoder &snapshot, const std::filesystem
                                                       batch.count,
                                                       items,
                                                       snapshot_has_edges,
-                                                      get_edge_type_from_id);
+                                                      get_edge_type_from_id,
+                                                      std::nullopt,
+                                                      light_edge_map_ptr);
           edge_count->fetch_add(result.edge_count);
           atomic_fetch_max_explicit(&highest_edge_gid, result.highest_edge_id, std::memory_order_acq_rel);
           recovery_info.vertex_batches[batch_index].first = result.first_vertex_gid;
@@ -2483,6 +2640,8 @@ RecoveredSnapshot LoadSnapshotVersion17(Decoder &snapshot, const std::filesystem
         vertex_batches);
 
     spdlog::info("Connectivity is recovered.");
+    // Release the lookup map now that all EdgeRefs are wired into vertices.
+    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -2749,6 +2908,7 @@ RecoveredSnapshot LoadSnapshotVersion18or19(Decoder &snapshot, const std::filesy
                                             memgraph::storage::EnumStore *enum_store) {
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
+  LightEdgeLoader loader{config.salient.items.storage_light_edge};
 
   // Cleanup of loaded data in case of failure.
   bool success = false;
@@ -2759,6 +2919,7 @@ RecoveredSnapshot LoadSnapshotVersion18or19(Decoder &snapshot, const std::filesy
       edges_metadata->clear();
       epoch_history->clear();
       enum_store->clear();
+      loader.FreeAll();
     }
   });
 
@@ -2896,13 +3057,14 @@ RecoveredSnapshot LoadSnapshotVersion18or19(Decoder &snapshot, const std::filesy
       }
       const auto edge_batches = ReadBatchInfos(snapshot);
 
-      RecoverOnMultipleThreads(
-          config.durability.recovery_thread_count,
-          [path, edges, items = config.salient.items, &get_property_from_id, name_id_mapper](
-              const size_t /*batch_index*/, const BatchInfo &batch) {
-            LoadPartialEdges(path, *edges, batch.offset, batch.count, items, get_property_from_id, name_id_mapper);
-          },
-          edge_batches);
+      loader.RecoverEdges(path,
+                          *edges,
+                          edge_batches,
+                          config.salient.items,
+                          get_property_from_id,
+                          name_id_mapper,
+                          config.durability.recovery_thread_count,
+                          info.edges_count);
     }
     spdlog::info("Edges are recovered.");
 
@@ -2914,6 +3076,7 @@ RecoveredSnapshot LoadSnapshotVersion18or19(Decoder &snapshot, const std::filesy
     }
     std::atomic<uint64_t> highest_edge_gid{0};
 
+    const auto *light_edge_map_ptr = loader.MapPtr();
     RecoverOnMultipleThreads(
         config.durability.recovery_thread_count,
         [path,
@@ -2926,7 +3089,8 @@ RecoveredSnapshot LoadSnapshotVersion18or19(Decoder &snapshot, const std::filesy
          &get_edge_type_from_id,
          &highest_edge_gid,
          &recovery_info,
-         schema_info](const size_t batch_index, const BatchInfo &batch) {
+         schema_info,
+         light_edge_map_ptr](const size_t batch_index, const BatchInfo &batch) {
           const auto result = LoadPartialConnectivity(path,
                                                       *vertices,
                                                       *edges,
@@ -2936,7 +3100,9 @@ RecoveredSnapshot LoadSnapshotVersion18or19(Decoder &snapshot, const std::filesy
                                                       batch.count,
                                                       items,
                                                       snapshot_has_edges,
-                                                      get_edge_type_from_id);
+                                                      get_edge_type_from_id,
+                                                      std::nullopt,
+                                                      light_edge_map_ptr);
           edge_count->fetch_add(result.edge_count);
           atomic_fetch_max_explicit(&highest_edge_gid, result.highest_edge_id, std::memory_order_acq_rel);
           recovery_info.vertex_batches[batch_index].first = result.first_vertex_gid;
@@ -2944,6 +3110,8 @@ RecoveredSnapshot LoadSnapshotVersion18or19(Decoder &snapshot, const std::filesy
         vertex_batches);
 
     spdlog::info("Connectivity is recovered.");
+    // Release the lookup map now that all EdgeRefs are wired into vertices.
+    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -3227,6 +3395,7 @@ RecoveredSnapshot LoadSnapshotVersion20or21(Decoder &snapshot, const std::filesy
                                             memgraph::storage::EnumStore *enum_store) {
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
+  LightEdgeLoader loader{config.salient.items.storage_light_edge};
 
   // Cleanup of loaded data in case of failure.
   bool success = false;
@@ -3237,6 +3406,7 @@ RecoveredSnapshot LoadSnapshotVersion20or21(Decoder &snapshot, const std::filesy
       edges_metadata->clear();
       epoch_history->clear();
       enum_store->clear();
+      loader.FreeAll();
     }
   });
 
@@ -3374,13 +3544,14 @@ RecoveredSnapshot LoadSnapshotVersion20or21(Decoder &snapshot, const std::filesy
       }
       const auto edge_batches = ReadBatchInfos(snapshot);
 
-      RecoverOnMultipleThreads(
-          config.durability.recovery_thread_count,
-          [path, edges, items = config.salient.items, &get_property_from_id, name_id_mapper](
-              const size_t /*batch_index*/, const BatchInfo &batch) {
-            LoadPartialEdges(path, *edges, batch.offset, batch.count, items, get_property_from_id, name_id_mapper);
-          },
-          edge_batches);
+      loader.RecoverEdges(path,
+                          *edges,
+                          edge_batches,
+                          config.salient.items,
+                          get_property_from_id,
+                          name_id_mapper,
+                          config.durability.recovery_thread_count,
+                          info.edges_count);
     }
     spdlog::info("Edges are recovered.");
 
@@ -3392,6 +3563,7 @@ RecoveredSnapshot LoadSnapshotVersion20or21(Decoder &snapshot, const std::filesy
     }
     std::atomic<uint64_t> highest_edge_gid{0};
 
+    const auto *light_edge_map_ptr = loader.MapPtr();
     RecoverOnMultipleThreads(
         config.durability.recovery_thread_count,
         [path,
@@ -3404,7 +3576,8 @@ RecoveredSnapshot LoadSnapshotVersion20or21(Decoder &snapshot, const std::filesy
          snapshot_has_edges,
          &get_edge_type_from_id,
          &highest_edge_gid,
-         &recovery_info](const size_t batch_index, const BatchInfo &batch) {
+         &recovery_info,
+         light_edge_map_ptr](const size_t batch_index, const BatchInfo &batch) {
           const auto result = LoadPartialConnectivity(path,
                                                       *vertices,
                                                       *edges,
@@ -3414,7 +3587,9 @@ RecoveredSnapshot LoadSnapshotVersion20or21(Decoder &snapshot, const std::filesy
                                                       batch.count,
                                                       items,
                                                       snapshot_has_edges,
-                                                      get_edge_type_from_id);
+                                                      get_edge_type_from_id,
+                                                      std::nullopt,
+                                                      light_edge_map_ptr);
           edge_count->fetch_add(result.edge_count);
           atomic_fetch_max_explicit(&highest_edge_gid, result.highest_edge_id, std::memory_order_acq_rel);
           recovery_info.vertex_batches[batch_index].first = result.first_vertex_gid;
@@ -3422,6 +3597,8 @@ RecoveredSnapshot LoadSnapshotVersion20or21(Decoder &snapshot, const std::filesy
         vertex_batches);
 
     spdlog::info("Connectivity is recovered.");
+    // Release the lookup map now that all EdgeRefs are wired into vertices.
+    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -3755,6 +3932,7 @@ RecoveredSnapshot LoadSnapshotVersion22or23(Decoder &snapshot, const std::filesy
                                             std::optional<SnapshotObserverInfo> const &snapshot_info) {
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
+  LightEdgeLoader loader{config.salient.items.storage_light_edge};
 
   // Cleanup of loaded data in case of failure.
   bool success = false;
@@ -3765,6 +3943,7 @@ RecoveredSnapshot LoadSnapshotVersion22or23(Decoder &snapshot, const std::filesy
       edges_metadata->clear();
       epoch_history->clear();
       enum_store->clear();
+      loader.FreeAll();
     }
   });
 
@@ -3904,14 +4083,15 @@ RecoveredSnapshot LoadSnapshotVersion22or23(Decoder &snapshot, const std::filesy
       }
       const auto edge_batches = ReadBatchInfos(snapshot);
 
-      RecoverOnMultipleThreads(
-          config.durability.recovery_thread_count,
-          [path, edges, items = config.salient.items, &get_property_from_id, &snapshot_info, name_id_mapper](
-              const size_t /*batch_index*/, const BatchInfo &batch) {
-            LoadPartialEdges(
-                path, *edges, batch.offset, batch.count, items, get_property_from_id, name_id_mapper, snapshot_info);
-          },
-          edge_batches);
+      loader.RecoverEdges(path,
+                          *edges,
+                          edge_batches,
+                          config.salient.items,
+                          get_property_from_id,
+                          name_id_mapper,
+                          config.durability.recovery_thread_count,
+                          info.edges_count,
+                          snapshot_info);
     }
     spdlog::info("Edges are recovered.");
 
@@ -3923,6 +4103,7 @@ RecoveredSnapshot LoadSnapshotVersion22or23(Decoder &snapshot, const std::filesy
     }
     std::atomic<uint64_t> highest_edge_gid{0};
 
+    const auto *light_edge_map_ptr = loader.MapPtr();
     RecoverOnMultipleThreads(
         config.durability.recovery_thread_count,
         [path,
@@ -3936,7 +4117,8 @@ RecoveredSnapshot LoadSnapshotVersion22or23(Decoder &snapshot, const std::filesy
          &get_edge_type_from_id,
          &highest_edge_gid,
          &recovery_info,
-         &snapshot_info](const size_t batch_index, const BatchInfo &batch) {
+         &snapshot_info,
+         light_edge_map_ptr](const size_t batch_index, const BatchInfo &batch) {
           const auto result = LoadPartialConnectivity(path,
                                                       *vertices,
                                                       *edges,
@@ -3947,7 +4129,8 @@ RecoveredSnapshot LoadSnapshotVersion22or23(Decoder &snapshot, const std::filesy
                                                       items,
                                                       snapshot_has_edges,
                                                       get_edge_type_from_id,
-                                                      snapshot_info);
+                                                      snapshot_info,
+                                                      light_edge_map_ptr);
           edge_count->fetch_add(result.edge_count);
           atomic_fetch_max_explicit(&highest_edge_gid, result.highest_edge_id, std::memory_order_acq_rel);
           recovery_info.vertex_batches[batch_index].first = result.first_vertex_gid;
@@ -3955,6 +4138,8 @@ RecoveredSnapshot LoadSnapshotVersion22or23(Decoder &snapshot, const std::filesy
         vertex_batches);
 
     spdlog::info("Connectivity is recovered.");
+    // Release the lookup map now that all EdgeRefs are wired into vertices.
+    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -4335,6 +4520,7 @@ RecoveredSnapshot LoadSnapshotVersion24(Decoder &snapshot, std::filesystem::path
 
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
+  LightEdgeLoader loader{config.salient.items.storage_light_edge};
 
   bool success = false;
   auto const cleanup = utils::OnScopeExit([&] {
@@ -4344,6 +4530,7 @@ RecoveredSnapshot LoadSnapshotVersion24(Decoder &snapshot, std::filesystem::path
       edges_metadata->clear();
       epoch_history->clear();
       enum_store->clear();
+      loader.FreeAll();
     }
   });
 
@@ -4485,16 +4672,15 @@ RecoveredSnapshot LoadSnapshotVersion24(Decoder &snapshot, std::filesystem::path
       }
       const auto edge_batches = ReadBatchInfos(snapshot);
 
-      {
-        RecoverOnMultipleThreads(
-            config.durability.recovery_thread_count,
-            [path, edges, items = config.salient.items, &get_property_from_id, &snapshot_info, name_id_mapper](
-                const size_t /*batch_index*/, const BatchInfo &batch) {
-              LoadPartialEdges(
-                  path, *edges, batch.offset, batch.count, items, get_property_from_id, name_id_mapper, snapshot_info);
-            },
-            edge_batches);
-      }
+      loader.RecoverEdges(path,
+                          *edges,
+                          edge_batches,
+                          config.salient.items,
+                          get_property_from_id,
+                          name_id_mapper,
+                          config.durability.recovery_thread_count,
+                          info.edges_count,
+                          snapshot_info);
     }
     spdlog::info("Edges are recovered.");
 
@@ -4506,6 +4692,7 @@ RecoveredSnapshot LoadSnapshotVersion24(Decoder &snapshot, std::filesystem::path
     }
     std::atomic<uint64_t> highest_edge_gid{0};
 
+    const auto *light_edge_map_ptr = loader.MapPtr();
     {
       RecoverOnMultipleThreads(
           config.durability.recovery_thread_count,
@@ -4520,7 +4707,8 @@ RecoveredSnapshot LoadSnapshotVersion24(Decoder &snapshot, std::filesystem::path
            &get_edge_type_from_id,
            &highest_edge_gid,
            &recovery_info,
-           &snapshot_info](const size_t batch_index, const BatchInfo &batch) {
+           &snapshot_info,
+           light_edge_map_ptr](const size_t batch_index, const BatchInfo &batch) {
             const auto result = LoadPartialConnectivity(path,
                                                         *vertices,
                                                         *edges,
@@ -4531,7 +4719,8 @@ RecoveredSnapshot LoadSnapshotVersion24(Decoder &snapshot, std::filesystem::path
                                                         items,
                                                         snapshot_has_edges,
                                                         get_edge_type_from_id,
-                                                        snapshot_info);
+                                                        snapshot_info,
+                                                        light_edge_map_ptr);
             edge_count->fetch_add(result.edge_count);
             atomic_fetch_max_explicit(&highest_edge_gid, result.highest_edge_id, std::memory_order_acq_rel);
             recovery_info.vertex_batches[batch_index].first = result.first_vertex_gid;
@@ -4539,6 +4728,8 @@ RecoveredSnapshot LoadSnapshotVersion24(Decoder &snapshot, std::filesystem::path
           vertex_batches);
     }
     spdlog::info("Connectivity is recovered.");
+    // Release the lookup map now that all EdgeRefs are wired into vertices.
+    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -4964,6 +5155,7 @@ RecoveredSnapshot LoadSnapshotVersion25(Decoder &snapshot, std::filesystem::path
 
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
+  LightEdgeLoader loader{config.salient.items.storage_light_edge};
 
   bool success = false;
   auto const cleanup = utils::OnScopeExit([&] {
@@ -4973,6 +5165,7 @@ RecoveredSnapshot LoadSnapshotVersion25(Decoder &snapshot, std::filesystem::path
       edges_metadata->clear();
       epoch_history->clear();
       enum_store->clear();
+      loader.FreeAll();
     }
   });
 
@@ -5133,16 +5326,15 @@ RecoveredSnapshot LoadSnapshotVersion25(Decoder &snapshot, std::filesystem::path
       }
       const auto edge_batches = ReadBatchInfos(snapshot);
 
-      {
-        RecoverOnMultipleThreads(
-            config.durability.recovery_thread_count,
-            [path, edges, items = config.salient.items, &get_property_from_id, &snapshot_info, name_id_mapper](
-                const size_t /*batch_index*/, const BatchInfo &batch) {
-              LoadPartialEdges(
-                  path, *edges, batch.offset, batch.count, items, get_property_from_id, name_id_mapper, snapshot_info);
-            },
-            edge_batches);
-      }
+      loader.RecoverEdges(path,
+                          *edges,
+                          edge_batches,
+                          config.salient.items,
+                          get_property_from_id,
+                          name_id_mapper,
+                          config.durability.recovery_thread_count,
+                          info.edges_count,
+                          snapshot_info);
     }
     spdlog::info("Edges are recovered.");
 
@@ -5154,6 +5346,7 @@ RecoveredSnapshot LoadSnapshotVersion25(Decoder &snapshot, std::filesystem::path
     }
     std::atomic<uint64_t> highest_edge_gid{0};
 
+    const auto *light_edge_map_ptr = loader.MapPtr();
     {
       RecoverOnMultipleThreads(
           config.durability.recovery_thread_count,
@@ -5168,7 +5361,8 @@ RecoveredSnapshot LoadSnapshotVersion25(Decoder &snapshot, std::filesystem::path
            &get_edge_type_from_id,
            &highest_edge_gid,
            &recovery_info,
-           &snapshot_info](const size_t batch_index, const BatchInfo &batch) {
+           &snapshot_info,
+           light_edge_map_ptr](const size_t batch_index, const BatchInfo &batch) {
             const auto result = LoadPartialConnectivity(path,
                                                         *vertices,
                                                         *edges,
@@ -5179,7 +5373,8 @@ RecoveredSnapshot LoadSnapshotVersion25(Decoder &snapshot, std::filesystem::path
                                                         items,
                                                         snapshot_has_edges,
                                                         get_edge_type_from_id,
-                                                        snapshot_info);
+                                                        snapshot_info,
+                                                        light_edge_map_ptr);
             edge_count->fetch_add(result.edge_count);
             atomic_fetch_max_explicit(&highest_edge_gid, result.highest_edge_id, std::memory_order_acq_rel);
             recovery_info.vertex_batches[batch_index].first = result.first_vertex_gid;
@@ -5187,6 +5382,8 @@ RecoveredSnapshot LoadSnapshotVersion25(Decoder &snapshot, std::filesystem::path
           vertex_batches);
     }
     spdlog::info("Connectivity is recovered.");
+    // Release the lookup map now that all EdgeRefs are wired into vertices.
+    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -5585,6 +5782,7 @@ RecoveredSnapshot LoadSnapshotVersion26(Decoder &snapshot, std::filesystem::path
 
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
+  LightEdgeLoader loader{config.salient.items.storage_light_edge};
 
   bool success = false;
   auto const cleanup = utils::OnScopeExit([&] {
@@ -5594,6 +5792,7 @@ RecoveredSnapshot LoadSnapshotVersion26(Decoder &snapshot, std::filesystem::path
       edges_metadata->clear();
       epoch_history->clear();
       enum_store->clear();
+      loader.FreeAll();
     }
   });
 
@@ -5754,16 +5953,15 @@ RecoveredSnapshot LoadSnapshotVersion26(Decoder &snapshot, std::filesystem::path
       }
       const auto edge_batches = ReadBatchInfos(snapshot);
 
-      {
-        RecoverOnMultipleThreads(
-            config.durability.recovery_thread_count,
-            [path, edges, items = config.salient.items, &get_property_from_id, &snapshot_info, name_id_mapper](
-                const size_t /*batch_index*/, const BatchInfo &batch) {
-              LoadPartialEdges(
-                  path, *edges, batch.offset, batch.count, items, get_property_from_id, name_id_mapper, snapshot_info);
-            },
-            edge_batches);
-      }
+      loader.RecoverEdges(path,
+                          *edges,
+                          edge_batches,
+                          config.salient.items,
+                          get_property_from_id,
+                          name_id_mapper,
+                          config.durability.recovery_thread_count,
+                          info.edges_count,
+                          snapshot_info);
     }
     spdlog::info("Edges are recovered.");
 
@@ -5775,6 +5973,7 @@ RecoveredSnapshot LoadSnapshotVersion26(Decoder &snapshot, std::filesystem::path
     }
     std::atomic<uint64_t> highest_edge_gid{0};
 
+    const auto *light_edge_map_ptr = loader.MapPtr();
     {
       RecoverOnMultipleThreads(
           config.durability.recovery_thread_count,
@@ -5789,7 +5988,8 @@ RecoveredSnapshot LoadSnapshotVersion26(Decoder &snapshot, std::filesystem::path
            &get_edge_type_from_id,
            &highest_edge_gid,
            &recovery_info,
-           &snapshot_info](const size_t batch_index, const BatchInfo &batch) {
+           &snapshot_info,
+           light_edge_map_ptr](const size_t batch_index, const BatchInfo &batch) {
             const auto result = LoadPartialConnectivity(path,
                                                         *vertices,
                                                         *edges,
@@ -5800,7 +6000,8 @@ RecoveredSnapshot LoadSnapshotVersion26(Decoder &snapshot, std::filesystem::path
                                                         items,
                                                         snapshot_has_edges,
                                                         get_edge_type_from_id,
-                                                        snapshot_info);
+                                                        snapshot_info,
+                                                        light_edge_map_ptr);
             edge_count->fetch_add(result.edge_count);
             atomic_fetch_max_explicit(&highest_edge_gid, result.highest_edge_id, std::memory_order_acq_rel);
             recovery_info.vertex_batches[batch_index].first = result.first_vertex_gid;
@@ -5808,6 +6009,8 @@ RecoveredSnapshot LoadSnapshotVersion26(Decoder &snapshot, std::filesystem::path
           vertex_batches);
     }
     spdlog::info("Connectivity is recovered.");
+    // Release the lookup map now that all EdgeRefs are wired into vertices.
+    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -6208,6 +6411,7 @@ RecoveredSnapshot LoadSnapshotVersion27or28(Decoder &snapshot, std::filesystem::
   // Cleanup of loaded data in case of failure.
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
+  LightEdgeLoader loader{config.salient.items.storage_light_edge};
 
   bool success = false;
   auto const cleanup = utils::OnScopeExit([&] {
@@ -6217,6 +6421,7 @@ RecoveredSnapshot LoadSnapshotVersion27or28(Decoder &snapshot, std::filesystem::
       edges_metadata->clear();
       epoch_history->clear();
       enum_store->clear();
+      loader.FreeAll();
     }
   });
 
@@ -6377,16 +6582,15 @@ RecoveredSnapshot LoadSnapshotVersion27or28(Decoder &snapshot, std::filesystem::
       }
       const auto edge_batches = ReadBatchInfos(snapshot);
 
-      {
-        RecoverOnMultipleThreads(
-            config.durability.recovery_thread_count,
-            [path, edges, items = config.salient.items, &get_property_from_id, &snapshot_info, name_id_mapper](
-                const size_t /*batch_index*/, const BatchInfo &batch) {
-              LoadPartialEdges(
-                  path, *edges, batch.offset, batch.count, items, get_property_from_id, name_id_mapper, snapshot_info);
-            },
-            edge_batches);
-      }
+      loader.RecoverEdges(path,
+                          *edges,
+                          edge_batches,
+                          config.salient.items,
+                          get_property_from_id,
+                          name_id_mapper,
+                          config.durability.recovery_thread_count,
+                          info.edges_count,
+                          snapshot_info);
     }
     spdlog::info("Edges are recovered.");
 
@@ -6398,6 +6602,7 @@ RecoveredSnapshot LoadSnapshotVersion27or28(Decoder &snapshot, std::filesystem::
     }
     std::atomic<uint64_t> highest_edge_gid{0};
 
+    const auto *light_edge_map_ptr = loader.MapPtr();
     {
       RecoverOnMultipleThreads(
           config.durability.recovery_thread_count,
@@ -6412,7 +6617,8 @@ RecoveredSnapshot LoadSnapshotVersion27or28(Decoder &snapshot, std::filesystem::
            &get_edge_type_from_id,
            &highest_edge_gid,
            &recovery_info,
-           &snapshot_info](const size_t batch_index, const BatchInfo &batch) {
+           &snapshot_info,
+           light_edge_map_ptr](const size_t batch_index, const BatchInfo &batch) {
             const auto result = LoadPartialConnectivity(path,
                                                         *vertices,
                                                         *edges,
@@ -6423,7 +6629,8 @@ RecoveredSnapshot LoadSnapshotVersion27or28(Decoder &snapshot, std::filesystem::
                                                         items,
                                                         snapshot_has_edges,
                                                         get_edge_type_from_id,
-                                                        snapshot_info);
+                                                        snapshot_info,
+                                                        light_edge_map_ptr);
             edge_count->fetch_add(result.edge_count);
             atomic_fetch_max_explicit(&highest_edge_gid, result.highest_edge_id, std::memory_order_acq_rel);
             recovery_info.vertex_batches[batch_index].first = result.first_vertex_gid;
@@ -6431,6 +6638,8 @@ RecoveredSnapshot LoadSnapshotVersion27or28(Decoder &snapshot, std::filesystem::
           vertex_batches);
     }
     spdlog::info("Connectivity is recovered.");
+    // Release the lookup map now that all EdgeRefs are wired into vertices.
+    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -6883,6 +7092,7 @@ RecoveredSnapshot LoadSnapshotVersion29(Decoder &snapshot, std::filesystem::path
 
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
+  LightEdgeLoader loader{config.salient.items.storage_light_edge};
 
   bool success = false;
   auto const cleanup = utils::OnScopeExit([&] {
@@ -6892,6 +7102,7 @@ RecoveredSnapshot LoadSnapshotVersion29(Decoder &snapshot, std::filesystem::path
       edges_metadata->clear();
       epoch_history->clear();
       enum_store->clear();
+      loader.FreeAll();
     }
   });
 
@@ -7052,16 +7263,15 @@ RecoveredSnapshot LoadSnapshotVersion29(Decoder &snapshot, std::filesystem::path
       }
       const auto edge_batches = ReadBatchInfos(snapshot);
 
-      {
-        RecoverOnMultipleThreads(
-            config.durability.recovery_thread_count,
-            [path, edges, items = config.salient.items, &get_property_from_id, &snapshot_info, name_id_mapper](
-                const size_t /*batch_index*/, const BatchInfo &batch) {
-              LoadPartialEdges(
-                  path, *edges, batch.offset, batch.count, items, get_property_from_id, name_id_mapper, snapshot_info);
-            },
-            edge_batches);
-      }
+      loader.RecoverEdges(path,
+                          *edges,
+                          edge_batches,
+                          config.salient.items,
+                          get_property_from_id,
+                          name_id_mapper,
+                          config.durability.recovery_thread_count,
+                          info.edges_count,
+                          snapshot_info);
     }
     spdlog::info("Edges are recovered.");
 
@@ -7073,6 +7283,7 @@ RecoveredSnapshot LoadSnapshotVersion29(Decoder &snapshot, std::filesystem::path
     }
     std::atomic<uint64_t> highest_edge_gid{0};
 
+    const auto *light_edge_map_ptr = loader.MapPtr();
     {
       RecoverOnMultipleThreads(
           config.durability.recovery_thread_count,
@@ -7087,7 +7298,8 @@ RecoveredSnapshot LoadSnapshotVersion29(Decoder &snapshot, std::filesystem::path
            &get_edge_type_from_id,
            &highest_edge_gid,
            &recovery_info,
-           &snapshot_info](const size_t batch_index, const BatchInfo &batch) {
+           &snapshot_info,
+           light_edge_map_ptr](const size_t batch_index, const BatchInfo &batch) {
             const auto result = LoadPartialConnectivity(path,
                                                         *vertices,
                                                         *edges,
@@ -7098,7 +7310,8 @@ RecoveredSnapshot LoadSnapshotVersion29(Decoder &snapshot, std::filesystem::path
                                                         items,
                                                         snapshot_has_edges,
                                                         get_edge_type_from_id,
-                                                        snapshot_info);
+                                                        snapshot_info,
+                                                        light_edge_map_ptr);
             edge_count->fetch_add(result.edge_count);
             atomic_fetch_max_explicit(&highest_edge_gid, result.highest_edge_id, std::memory_order_acq_rel);
             recovery_info.vertex_batches[batch_index].first = result.first_vertex_gid;
@@ -7106,6 +7319,8 @@ RecoveredSnapshot LoadSnapshotVersion29(Decoder &snapshot, std::filesystem::path
           vertex_batches);
     }
     spdlog::info("Connectivity is recovered.");
+    // Release the lookup map now that all EdgeRefs are wired into vertices.
+    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -7569,6 +7784,7 @@ RecoveredSnapshot LoadSnapshotVersion30(Decoder &snapshot, std::filesystem::path
 
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
+  LightEdgeLoader loader{config.salient.items.storage_light_edge};
 
   bool success = false;
   auto const cleanup = utils::OnScopeExit([&] {
@@ -7578,6 +7794,7 @@ RecoveredSnapshot LoadSnapshotVersion30(Decoder &snapshot, std::filesystem::path
       edges_metadata->clear();
       epoch_history->clear();
       enum_store->clear();
+      loader.FreeAll();
     }
   });
 
@@ -7738,16 +7955,15 @@ RecoveredSnapshot LoadSnapshotVersion30(Decoder &snapshot, std::filesystem::path
       }
       const auto edge_batches = ReadBatchInfos(snapshot);
 
-      {
-        RecoverOnMultipleThreads(
-            config.durability.recovery_thread_count,
-            [path, edges, items = config.salient.items, &get_property_from_id, &snapshot_info, name_id_mapper](
-                const size_t /*batch_index*/, const BatchInfo &batch) {
-              LoadPartialEdges(
-                  path, *edges, batch.offset, batch.count, items, get_property_from_id, name_id_mapper, snapshot_info);
-            },
-            edge_batches);
-      }
+      loader.RecoverEdges(path,
+                          *edges,
+                          edge_batches,
+                          config.salient.items,
+                          get_property_from_id,
+                          name_id_mapper,
+                          config.durability.recovery_thread_count,
+                          info.edges_count,
+                          snapshot_info);
     }
     spdlog::info("Edges are recovered.");
 
@@ -7759,6 +7975,7 @@ RecoveredSnapshot LoadSnapshotVersion30(Decoder &snapshot, std::filesystem::path
     }
     std::atomic<uint64_t> highest_edge_gid{0};
 
+    const auto *light_edge_map_ptr = loader.MapPtr();
     {
       RecoverOnMultipleThreads(
           config.durability.recovery_thread_count,
@@ -7773,7 +7990,8 @@ RecoveredSnapshot LoadSnapshotVersion30(Decoder &snapshot, std::filesystem::path
            &get_edge_type_from_id,
            &highest_edge_gid,
            &recovery_info,
-           &snapshot_info](const size_t batch_index, const BatchInfo &batch) {
+           &snapshot_info,
+           light_edge_map_ptr](const size_t batch_index, const BatchInfo &batch) {
             const auto result = LoadPartialConnectivity(path,
                                                         *vertices,
                                                         *edges,
@@ -7784,7 +8002,8 @@ RecoveredSnapshot LoadSnapshotVersion30(Decoder &snapshot, std::filesystem::path
                                                         items,
                                                         snapshot_has_edges,
                                                         get_edge_type_from_id,
-                                                        snapshot_info);
+                                                        snapshot_info,
+                                                        light_edge_map_ptr);
             edge_count->fetch_add(result.edge_count);
             atomic_fetch_max_explicit(&highest_edge_gid, result.highest_edge_id, std::memory_order_acq_rel);
             recovery_info.vertex_batches[batch_index].first = result.first_vertex_gid;
@@ -7792,6 +8011,8 @@ RecoveredSnapshot LoadSnapshotVersion30(Decoder &snapshot, std::filesystem::path
           vertex_batches);
     }
     spdlog::info("Connectivity is recovered.");
+    // Release the lookup map now that all EdgeRefs are wired into vertices.
+    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -8320,6 +8541,8 @@ RecoveredSnapshot LoadSnapshotVersion31(Decoder &snapshot, std::filesystem::path
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
 
+  LightEdgeLoader loader{config.salient.items.storage_light_edge};
+
   bool success = false;
   auto const cleanup = utils::OnScopeExit([&] {
     if (!success) {
@@ -8328,6 +8551,7 @@ RecoveredSnapshot LoadSnapshotVersion31(Decoder &snapshot, std::filesystem::path
       edges_metadata->clear();
       epoch_history->clear();
       enum_store->clear();
+      loader.FreeAll();
     }
   });
 
@@ -8488,16 +8712,15 @@ RecoveredSnapshot LoadSnapshotVersion31(Decoder &snapshot, std::filesystem::path
       }
       const auto edge_batches = ReadBatchInfos(snapshot);
 
-      {
-        RecoverOnMultipleThreads(
-            config.durability.recovery_thread_count,
-            [path, edges, items = config.salient.items, &get_property_from_id, &snapshot_info, name_id_mapper](
-                const size_t /*batch_index*/, const BatchInfo &batch) {
-              LoadPartialEdges(
-                  path, *edges, batch.offset, batch.count, items, get_property_from_id, name_id_mapper, snapshot_info);
-            },
-            edge_batches);
-      }
+      loader.RecoverEdges(path,
+                          *edges,
+                          edge_batches,
+                          config.salient.items,
+                          get_property_from_id,
+                          name_id_mapper,
+                          config.durability.recovery_thread_count,
+                          info.edges_count,
+                          snapshot_info);
     }
     spdlog::info("Edges are recovered.");
 
@@ -8510,6 +8733,7 @@ RecoveredSnapshot LoadSnapshotVersion31(Decoder &snapshot, std::filesystem::path
     std::atomic<uint64_t> highest_edge_gid{0};
 
     {
+      const auto *light_edge_map_ptr = loader.MapPtr();
       RecoverOnMultipleThreads(
           config.durability.recovery_thread_count,
           [path,
@@ -8523,7 +8747,8 @@ RecoveredSnapshot LoadSnapshotVersion31(Decoder &snapshot, std::filesystem::path
            &get_edge_type_from_id,
            &highest_edge_gid,
            &recovery_info,
-           &snapshot_info](const size_t batch_index, const BatchInfo &batch) {
+           &snapshot_info,
+           light_edge_map_ptr](const size_t batch_index, const BatchInfo &batch) {
             const auto result = LoadPartialConnectivity(path,
                                                         *vertices,
                                                         *edges,
@@ -8534,7 +8759,8 @@ RecoveredSnapshot LoadSnapshotVersion31(Decoder &snapshot, std::filesystem::path
                                                         items,
                                                         snapshot_has_edges,
                                                         get_edge_type_from_id,
-                                                        snapshot_info);
+                                                        snapshot_info,
+                                                        light_edge_map_ptr);
             edge_count->fetch_add(result.edge_count);
             atomic_fetch_max_explicit(&highest_edge_gid, result.highest_edge_id, std::memory_order_acq_rel);
             recovery_info.vertex_batches[batch_index].first = result.first_vertex_gid;
@@ -8542,6 +8768,8 @@ RecoveredSnapshot LoadSnapshotVersion31(Decoder &snapshot, std::filesystem::path
           vertex_batches);
     }
     spdlog::info("Connectivity is recovered.");
+    // Release the lookup map now that all EdgeRefs are wired into vertices.
+    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -9108,6 +9336,8 @@ RecoveredSnapshot LoadSnapshotVersion33(Decoder &snapshot, std::filesystem::path
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
 
+  LightEdgeLoader loader{config.salient.items.storage_light_edge};
+
   bool success = false;
   auto const cleanup = utils::OnScopeExit([&] {
     if (!success) {
@@ -9116,6 +9346,7 @@ RecoveredSnapshot LoadSnapshotVersion33(Decoder &snapshot, std::filesystem::path
       edges_metadata->clear();
       epoch_history->clear();
       enum_store->clear();
+      loader.FreeAll();
     }
   });
 
@@ -9276,16 +9507,15 @@ RecoveredSnapshot LoadSnapshotVersion33(Decoder &snapshot, std::filesystem::path
       }
       const auto edge_batches = ReadBatchInfos(snapshot);
 
-      {
-        RecoverOnMultipleThreads(
-            config.durability.recovery_thread_count,
-            [path, edges, items = config.salient.items, &get_property_from_id, &snapshot_info, name_id_mapper](
-                const size_t /*batch_index*/, const BatchInfo &batch) {
-              LoadPartialEdges(
-                  path, *edges, batch.offset, batch.count, items, get_property_from_id, name_id_mapper, snapshot_info);
-            },
-            edge_batches);
-      }
+      loader.RecoverEdges(path,
+                          *edges,
+                          edge_batches,
+                          config.salient.items,
+                          get_property_from_id,
+                          name_id_mapper,
+                          config.durability.recovery_thread_count,
+                          info.edges_count,
+                          snapshot_info);
     }
     spdlog::info("Edges are recovered.");
 
@@ -9298,6 +9528,7 @@ RecoveredSnapshot LoadSnapshotVersion33(Decoder &snapshot, std::filesystem::path
     std::atomic<uint64_t> highest_edge_gid{0};
 
     {
+      const auto *light_edge_map_ptr = loader.MapPtr();
       RecoverOnMultipleThreads(
           config.durability.recovery_thread_count,
           [path,
@@ -9311,7 +9542,8 @@ RecoveredSnapshot LoadSnapshotVersion33(Decoder &snapshot, std::filesystem::path
            &get_edge_type_from_id,
            &highest_edge_gid,
            &recovery_info,
-           &snapshot_info](const size_t batch_index, const BatchInfo &batch) {
+           &snapshot_info,
+           light_edge_map_ptr](const size_t batch_index, const BatchInfo &batch) {
             const auto result = LoadPartialConnectivity(path,
                                                         *vertices,
                                                         *edges,
@@ -9322,7 +9554,8 @@ RecoveredSnapshot LoadSnapshotVersion33(Decoder &snapshot, std::filesystem::path
                                                         items,
                                                         snapshot_has_edges,
                                                         get_edge_type_from_id,
-                                                        snapshot_info);
+                                                        snapshot_info,
+                                                        light_edge_map_ptr);
             edge_count->fetch_add(result.edge_count);
             atomic_fetch_max_explicit(&highest_edge_gid, result.highest_edge_id, std::memory_order_acq_rel);
             recovery_info.vertex_batches[batch_index].first = result.first_vertex_gid;
@@ -9330,12 +9563,13 @@ RecoveredSnapshot LoadSnapshotVersion33(Decoder &snapshot, std::filesystem::path
           vertex_batches);
     }
     spdlog::info("Connectivity is recovered.");
+    // Release the lookup map now that all EdgeRefs are wired into vertices.
+    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
     recovery_info.next_vertex_id = last_vertex_gid + 1;
   }
-
   // Recover indices.
   {
     spdlog::info("Recovering metadata of indices.");
@@ -9992,6 +10226,8 @@ RecoveredSnapshot LoadCurrentVersionSnapshot(Decoder &snapshot, std::filesystem:
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
 
+  LightEdgeLoader loader{config.salient.items.storage_light_edge};
+
   bool success = false;
   auto const cleanup = utils::OnScopeExit([&] {
     if (!success) {
@@ -10000,6 +10236,7 @@ RecoveredSnapshot LoadCurrentVersionSnapshot(Decoder &snapshot, std::filesystem:
       edges_metadata->clear();
       epoch_history->clear();
       enum_store->clear();
+      loader.FreeAll();
     }
   });
 
@@ -10160,16 +10397,15 @@ RecoveredSnapshot LoadCurrentVersionSnapshot(Decoder &snapshot, std::filesystem:
       }
       const auto edge_batches = ReadBatchInfos(snapshot);
 
-      {
-        RecoverOnMultipleThreads(
-            config.durability.recovery_thread_count,
-            [path, edges, items = config.salient.items, &get_property_from_id, &snapshot_info, name_id_mapper](
-                const size_t /*batch_index*/, const BatchInfo &batch) {
-              LoadPartialEdges(
-                  path, *edges, batch.offset, batch.count, items, get_property_from_id, name_id_mapper, snapshot_info);
-            },
-            edge_batches);
-      }
+      loader.RecoverEdges(path,
+                          *edges,
+                          edge_batches,
+                          config.salient.items,
+                          get_property_from_id,
+                          name_id_mapper,
+                          config.durability.recovery_thread_count,
+                          info.edges_count,
+                          snapshot_info);
     }
     spdlog::info("Edges are recovered.");
 
@@ -10182,6 +10418,7 @@ RecoveredSnapshot LoadCurrentVersionSnapshot(Decoder &snapshot, std::filesystem:
     std::atomic<uint64_t> highest_edge_gid{0};
 
     {
+      const auto *light_edge_map_ptr = loader.MapPtr();
       RecoverOnMultipleThreads(
           config.durability.recovery_thread_count,
           [path,
@@ -10195,7 +10432,8 @@ RecoveredSnapshot LoadCurrentVersionSnapshot(Decoder &snapshot, std::filesystem:
            &get_edge_type_from_id,
            &highest_edge_gid,
            &recovery_info,
-           &snapshot_info](const size_t batch_index, const BatchInfo &batch) {
+           &snapshot_info,
+           light_edge_map_ptr](const size_t batch_index, const BatchInfo &batch) {
             const auto result = LoadPartialConnectivity(path,
                                                         *vertices,
                                                         *edges,
@@ -10206,7 +10444,8 @@ RecoveredSnapshot LoadCurrentVersionSnapshot(Decoder &snapshot, std::filesystem:
                                                         items,
                                                         snapshot_has_edges,
                                                         get_edge_type_from_id,
-                                                        snapshot_info);
+                                                        snapshot_info,
+                                                        light_edge_map_ptr);
             edge_count->fetch_add(result.edge_count);
             atomic_fetch_max_explicit(&highest_edge_gid, result.highest_edge_id, std::memory_order_acq_rel);
             recovery_info.vertex_batches[batch_index].first = result.first_vertex_gid;
@@ -10214,6 +10453,8 @@ RecoveredSnapshot LoadCurrentVersionSnapshot(Decoder &snapshot, std::filesystem:
           vertex_batches);
     }
     spdlog::info("Connectivity is recovered.");
+    // Release the lookup map now that all EdgeRefs are wired into vertices.
+    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -12128,9 +12369,23 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
     snapshot.WriteUint(mapping.AsUint());
   };
 
+  // Write a single edge record: marker, gid, prop count, then each (prop_id, value) pair.
+  // write_prop_id is a callable void(PropertyId) that handles name mapping and encoder writes.
+  auto write_edge_record = [name_id_mapper = storage->name_id_mapper_.get()](
+                               auto &encoder, uint64_t gid, const auto &props, auto write_prop_id) {
+    encoder.WriteMarker(Marker::SECTION_EDGE);
+    encoder.WriteUint(gid);
+    encoder.WriteUint(props.size());
+    for (auto const &[pid, val] : props) {
+      write_prop_id(pid);
+      encoder.WriteExternalPropertyValue(ToExternalPropertyValue(val, name_id_mapper));
+    }
+  };
+
   // Store edges.
-  auto partial_edge_handler = [&edges, storage, transaction, &snapshot_aborted, &write_mapping_to, progress](
-                                  int64_t start_gid, int64_t end_gid, auto &edges_snapshot) -> SnapshotPartialRes {
+  auto partial_edge_handler =
+      [&edges, storage, transaction, &snapshot_aborted, &write_mapping_to, &write_edge_record, progress](
+          int64_t start_gid, int64_t end_gid, auto &edges_snapshot) -> SnapshotPartialRes {
     if (start_gid >= end_gid) return {};
 
     auto counter = utils::ResettableCounter{50};  // Counter used to reduce the frequency of checking abort
@@ -12203,17 +12458,9 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
       MG_ASSERT(maybe_props.has_value(), "Invalid database state!");
 
       // Store the edge.
-      {
-        edges_snapshot.WriteMarker(Marker::SECTION_EDGE);
-        edges_snapshot.WriteUint(edge.gid.AsUint());
-        const auto &props = maybe_props.value();
-        edges_snapshot.WriteUint(props.size());
-        for (const auto &item : props) {
-          write_mapping_to(edges_snapshot, res.used_ids, item.first);
-          edges_snapshot.WriteExternalPropertyValue(
-              ToExternalPropertyValue(item.second, storage->name_id_mapper_.get()));
-        }
-      }
+      write_edge_record(edges_snapshot, edge.gid.AsUint(), maybe_props.value(), [&](auto pid) {
+        write_mapping_to(edges_snapshot, res.used_ids, pid);
+      });
 
       ++res.count;
       progress_counter.Increment();
@@ -12354,42 +12601,133 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
   std::vector<BatchInfo> edge_batch_infos;
   std::vector<BatchInfo> vertex_batch_infos;
 
+  // LIGHT EDGES: collect edges from vertex adjacency lists via MVCC instead of the
+  // edges_ skip list. Uses VertexAccessor::OutEdges(View::OLD) so that edges deleted
+  // by uncommitted concurrent transactions are still correctly included (delta undo
+  // restores them to the adjacency list for the snapshot's view).
+  auto write_light_edges_section = [&, progress]() {
+    struct CollectedEdge {
+      uint64_t gid;
+      std::map<PropertyId, PropertyValue> props;
+    };
+    std::vector<CollectedEdge> collected;
+    BatchedProgressCounter progress_counter(progress);
+
+    auto vacc = vertices->access();
+
+    for (auto &vertex : vacc) {
+      if (snapshot_aborted()) return;
+      auto va = VertexAccessor::Create(&vertex, storage, transaction, View::OLD);
+      if (!va) continue;
+      auto maybe_out = va->OutEdges(View::OLD);
+      if (!maybe_out.has_value()) continue;
+      for (auto &ea : maybe_out->edges) {
+        auto gid = ea.Gid().AsUint();
+        auto maybe_props = ea.Properties(View::OLD);
+        MG_ASSERT(maybe_props.has_value(), "Invalid database state!");
+        collected.push_back({gid, std::move(*maybe_props)});
+      }
+    }
+
+    // Sort by GID for deterministic, recoverable output
+    std::ranges::sort(collected, [](auto &a, auto &b) { return a.gid < b.gid; });
+
+    offset_edges = snapshot.GetPosition();
+    uint64_t items_in_batch = 0;
+    auto batch_start_offset = snapshot.GetPosition();
+
+    for (auto &entry : collected) {
+      if (snapshot_aborted()) return;
+      write_edge_record(snapshot, entry.gid, entry.props, write_mapping);
+      ++edges_count;
+      progress_counter.Increment();
+      ++items_in_batch;
+      if (items_in_batch == storage->config_.durability.items_per_batch) {
+        edge_batch_infos.push_back(BatchInfo{.offset = batch_start_offset, .count = items_in_batch});
+        batch_start_offset = snapshot.GetPosition();
+        items_in_batch = 0;
+      }
+    }
+    if (items_in_batch > 0) {
+      edge_batch_infos.push_back(BatchInfo{.offset = batch_start_offset, .count = items_in_batch});
+    }
+    progress_counter.Flush();
+  };
+
+  bool const light_edges = storage->config_.salient.items.storage_light_edge;
+
   if (storage->config_.durability.allow_parallel_snapshot_creation) {
-    auto *edge_ptr = storage->config_.salient.items.properties_on_edges ? edges : nullptr;
-    if (!MultiThreadedWorkflow(edge_ptr,
-                               vertices,
-                               partial_edge_handler,
-                               partial_vertex_handler,
-                               storage->config_.durability.items_per_batch,
-                               offset_edges,
-                               offset_vertices,
-                               snapshot,
-                               edges_count,
-                               vertices_count,
-                               edge_batch_infos,
-                               vertex_batch_infos,
-                               used_ids,
-                               storage->config_.durability.snapshot_thread_count,
-                               snapshot_aborted,
-                               progress)) {
-      spdlog::warn(
-          "Failed to execute some tasks when doing a multi-threaded snapshot, snapshot will be aborted and snapshot "
-          "creation will be retried on the next scheduled interval");
-      snapshot.Close();
-      // Clean up the partial main snapshot file
-      std::error_code ec;
-      std::filesystem::remove(path, ec);
-      return std::nullopt;
+    if (light_edges && storage->config_.salient.items.properties_on_edges) {
+      // Write light edges single-threaded (edges must precede vertices in the file),
+      // then run the parallel workflow for vertices only.
+      write_light_edges_section();
+      if (snapshot_aborted()) return std::nullopt;
+      if (!MultiThreadedWorkflow(static_cast<utils::SkipListDb<Edge> *>(nullptr),
+                                 vertices,
+                                 partial_edge_handler,
+                                 partial_vertex_handler,
+                                 storage->config_.durability.items_per_batch,
+                                 offset_edges,
+                                 offset_vertices,
+                                 snapshot,
+                                 edges_count,
+                                 vertices_count,
+                                 edge_batch_infos,
+                                 vertex_batch_infos,
+                                 used_ids,
+                                 storage->config_.durability.snapshot_thread_count,
+                                 snapshot_aborted,
+                                 progress)) {
+        spdlog::warn(
+            "Failed to execute some tasks when doing a multi-threaded snapshot, snapshot will be aborted and snapshot "
+            "creation will be retried on the next scheduled interval");
+        snapshot.Close();
+        // Clean up the partial main snapshot file
+        std::error_code ec;
+        std::filesystem::remove(path, ec);
+        return std::nullopt;
+      }
+    } else {
+      auto *edge_ptr = storage->config_.salient.items.properties_on_edges ? edges : nullptr;
+      if (!MultiThreadedWorkflow(edge_ptr,
+                                 vertices,
+                                 partial_edge_handler,
+                                 partial_vertex_handler,
+                                 storage->config_.durability.items_per_batch,
+                                 offset_edges,
+                                 offset_vertices,
+                                 snapshot,
+                                 edges_count,
+                                 vertices_count,
+                                 edge_batch_infos,
+                                 vertex_batch_infos,
+                                 used_ids,
+                                 storage->config_.durability.snapshot_thread_count,
+                                 snapshot_aborted,
+                                 progress)) {
+        spdlog::warn(
+            "Failed to execute some tasks when doing a multi-threaded snapshot, snapshot will be aborted and snapshot "
+            "creation will be retried on the next scheduled interval");
+        snapshot.Close();
+        // Clean up the partial main snapshot file
+        std::error_code ec;
+        std::filesystem::remove(path, ec);
+        return std::nullopt;
+      }
     }
   } else {
     if (storage->config_.salient.items.properties_on_edges) {
       if (progress) progress->SetPhase(SnapshotProgress::Phase::EDGES, edges->size());
-      offset_edges = snapshot.GetPosition();  // Global edge offset
-      // Handle edges
-      const auto res = partial_edge_handler(0, kEnd, snapshot);
-      edges_count = res.count;
-      edge_batch_infos = res.batch_info;
-      used_ids.insert(res.used_ids.begin(), res.used_ids.end());
+      if (light_edges) {
+        write_light_edges_section();
+      } else {
+        offset_edges = snapshot.GetPosition();  // Global edge offset
+        // Handle edges
+        const auto res = partial_edge_handler(0, kEnd, snapshot);
+        edges_count = res.count;
+        edge_batch_infos = res.batch_info;
+        used_ids.insert(res.used_ids.begin(), res.used_ids.end());
+      }
     }
     if (snapshot_aborted()) {
       return std::nullopt;

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -44,6 +44,7 @@
 #include "storage/v2/indices/vector_index.hpp"
 #include "storage/v2/inmemory/label_index.hpp"
 #include "storage/v2/inmemory/label_property_index.hpp"
+#include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/inmemory/unique_constraints.hpp"
 #include "storage/v2/mvcc.hpp"
 #include "storage/v2/property_value.hpp"
@@ -768,10 +769,8 @@ void LoadPartialEdges(const std::filesystem::path &path, utils::SkipListDb<Edge>
     if (items.properties_on_edges) {
       Edge *edge_ptr = nullptr;
       if (items.storage_light_edge) {
-        // LIGHT EDGES: allocate via DbAwareAllocator (routes to current DB arena)
-        memory::DbAwareAllocator<Edge> alloc;
-        edge_ptr = std::allocator_traits<decltype(alloc)>::allocate(alloc, 1);
-        std::construct_at(edge_ptr, Gid::FromUint(*gid), nullptr);
+        // LIGHT EDGES: allocate via helper (routes to thread-local DB arena)
+        edge_ptr = CreateLightEdge(Gid::FromUint(*gid), nullptr);
         // Track immediately so cleanup can deallocate if property recovery throws
         if (light_edge_output) {
           light_edge_output->emplace(*gid, edge_ptr);
@@ -1191,16 +1190,13 @@ struct LightEdgeLoader {
   // Free all light edges; safe to call on any partially-populated state.
   void FreeAll() noexcept {
     if (!use_light_edges) return;
-    memory::DbAwareAllocator<Edge> alloc;
     for (auto &[g, p] : all_edges) {
-      std::destroy_at(p);
-      std::allocator_traits<decltype(alloc)>::deallocate(alloc, p, 1);
+      DestroyLightEdge(p);
     }
     all_edges.clear();
     for (auto &m : per_batch) {
       for (auto &[g, p] : m) {
-        std::destroy_at(p);
-        std::allocator_traits<decltype(alloc)>::deallocate(alloc, p, 1);
+        DestroyLightEdge(p);
       }
     }
     per_batch.clear();

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -289,7 +289,7 @@ inline std::vector<memory::DbAwareThread> RunWorkerPool(SafeTaskQueue &tasks, ui
   const auto n_workers = std::min(thread_count, tasks.size());
   std::vector<memory::DbAwareThread> workers;
   workers.reserve(n_workers);
-  for (int i = 0; i < n_workers; ++i) {
+  for (uint64_t i = 0; i < n_workers; ++i) {
     workers.emplace_back([&tasks, i, name_prefix] {
       utils::ThreadSetName(std::string(name_prefix) + std::to_string(i));
       while (true) {
@@ -12371,7 +12371,7 @@ void WriteLightEdgesSection(Storage *storage, Transaction *transaction, utils::S
 
   // 2. Create and enqueue collection tasks
   SafeTaskQueue tasks;
-  for (int id = 0; id < n_batches; ++id) {
+  for (size_t id = 0; id < n_batches; ++id) {
     tasks.AddTask([&worker_results,
                    id,
                    start_gid = vertex_batches[id],

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -11037,6 +11037,7 @@ RecoveredSnapshot LoadSnapshotVersion34(Decoder &snapshot, std::filesystem::path
 
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
+  LightEdgeLoader loader{config.salient.items.storage_light_edge};
 
   bool success = false;
   auto const cleanup = utils::OnScopeExit([&] {
@@ -11046,6 +11047,7 @@ RecoveredSnapshot LoadSnapshotVersion34(Decoder &snapshot, std::filesystem::path
       edges_metadata->clear();
       epoch_history->clear();
       enum_store->clear();
+      loader.FreeAll();
     }
   });
 
@@ -11206,16 +11208,15 @@ RecoveredSnapshot LoadSnapshotVersion34(Decoder &snapshot, std::filesystem::path
       }
       const auto edge_batches = ReadBatchInfos(snapshot);
 
-      {
-        RecoverOnMultipleThreads(
-            config.durability.recovery_thread_count,
-            [path, edges, items = config.salient.items, &get_property_from_id, &snapshot_info, name_id_mapper](
-                const size_t /*batch_index*/, const BatchInfo &batch) {
-              LoadPartialEdges(
-                  path, *edges, batch.offset, batch.count, items, get_property_from_id, name_id_mapper, snapshot_info);
-            },
-            edge_batches);
-      }
+      loader.RecoverEdges(path,
+                          *edges,
+                          edge_batches,
+                          config.salient.items,
+                          get_property_from_id,
+                          name_id_mapper,
+                          config.durability.recovery_thread_count,
+                          info.edges_count,
+                          snapshot_info);
     }
     spdlog::info("Edges are recovered.");
 
@@ -11227,6 +11228,7 @@ RecoveredSnapshot LoadSnapshotVersion34(Decoder &snapshot, std::filesystem::path
     }
     std::atomic<uint64_t> highest_edge_gid{0};
 
+    const auto *light_edge_map_ptr = loader.MapPtr();
     {
       RecoverOnMultipleThreads(
           config.durability.recovery_thread_count,
@@ -11241,7 +11243,8 @@ RecoveredSnapshot LoadSnapshotVersion34(Decoder &snapshot, std::filesystem::path
            &get_edge_type_from_id,
            &highest_edge_gid,
            &recovery_info,
-           &snapshot_info](const size_t batch_index, const BatchInfo &batch) {
+           &snapshot_info,
+           light_edge_map_ptr](const size_t batch_index, const BatchInfo &batch) {
             const auto result = LoadPartialConnectivity(path,
                                                         *vertices,
                                                         *edges,
@@ -11252,7 +11255,8 @@ RecoveredSnapshot LoadSnapshotVersion34(Decoder &snapshot, std::filesystem::path
                                                         items,
                                                         snapshot_has_edges,
                                                         get_edge_type_from_id,
-                                                        snapshot_info);
+                                                        snapshot_info,
+                                                        light_edge_map_ptr);
             edge_count->fetch_add(result.edge_count);
             atomic_fetch_max_explicit(&highest_edge_gid, result.highest_edge_id, std::memory_order_acq_rel);
             recovery_info.vertex_batches[batch_index].first = result.first_vertex_gid;

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -777,6 +777,7 @@ void LoadPartialEdges(const std::filesystem::path &path, utils::SkipListDb<Edge>
       if (items.storage_light_edge) {
         // LIGHT EDGES: allocate via helper (routes to thread-local DB arena)
         edge_ptr = CreateLightEdge(Gid::FromUint(*gid), nullptr);
+        if (!edge_ptr) throw RecoveryFailure("Failed to allocate a light edge!");
         // Track immediately so cleanup can deallocate if property recovery throws
         if (light_edge_output) {
           light_edge_output->emplace(*gid, edge_ptr);
@@ -1176,22 +1177,15 @@ void RecoverOnMultipleThreads(size_t thread_count, const TFunc &func, const std:
 
 // Manages light Edge objects during snapshot recovery.
 // Encapsulates the per-batch GID->Edge* maps, merge, and cleanup.
+// On failure the LoadSnapshot cleanup lambda must call FreeAll().
+// On success the loader simply goes out of scope; edges remain alive in
+// vertex adjacency lists and are freed later by the storage layer.
 struct LightEdgeLoader {
   bool use_light_edges{false};
-  bool map_released_{false};
   absl::flat_hash_map<uint64_t, Edge *> all_edges;
   std::vector<absl::flat_hash_map<uint64_t, Edge *>> per_batch;
 
   explicit LightEdgeLoader(bool use_light) : use_light_edges{use_light} {}
-
-  ~LightEdgeLoader() {
-    // RAII: if ownership has NOT been transferred to storage, free everything.
-    // If ReleaseMap() was already called, edges belong to the storage layer
-    // and all_edges is already empty — nothing to do.
-    if (!map_released_) {
-      FreeAll();
-    }
-  }
 
   // Free all light edges; safe to call on any partially-populated state.
   void FreeAll() noexcept {
@@ -1206,13 +1200,6 @@ struct LightEdgeLoader {
       }
     }
     per_batch.clear();
-  }
-
-  // Release the GID->Edge* lookup table after connectivity has been wired.
-  // Edge objects remain alive in the pool; only the flat-hash-map memory is freed.
-  void ReleaseMap() noexcept {
-    map_released_ = true;
-    absl::flat_hash_map<uint64_t, Edge *>{}.swap(all_edges);
   }
 
   const absl::flat_hash_map<uint64_t, Edge *> *MapPtr() const noexcept {
@@ -1279,10 +1266,8 @@ RecoveredSnapshot LoadSnapshotVersion14(Decoder &snapshot, const std::filesystem
       edges_metadata->clear();
       epoch_history->clear();
       if (items.storage_light_edge) {
-        memory::DbAwareAllocator<Edge> alloc;
         for (auto &[_, ptr] : light_edge_map) {
-          std::destroy_at(ptr);
-          std::allocator_traits<decltype(alloc)>::deallocate(alloc, ptr, 1);
+          DestroyLightEdge(ptr);
         }
       }
     }
@@ -1358,9 +1343,8 @@ RecoveredSnapshot LoadSnapshotVersion14(Decoder &snapshot, const std::filesystem
 
           Edge *edge_ptr;
           if (items.storage_light_edge) {
-            memory::DbAwareAllocator<Edge> alloc;
-            edge_ptr = std::allocator_traits<decltype(alloc)>::allocate(alloc, 1);
-            std::construct_at(edge_ptr, Gid::FromUint(*gid), nullptr);
+            edge_ptr = CreateLightEdge(Gid::FromUint(*gid), nullptr);
+            if (!edge_ptr) throw RecoveryFailure("Failed to allocate a light edge!");
             light_edge_map.emplace(*gid, edge_ptr);
           } else {
             auto [it, inserted] = edge_acc.insert(Edge{Gid::FromUint(*gid), nullptr});
@@ -1951,9 +1935,6 @@ RecoveredSnapshot LoadSnapshotVersion15(Decoder &snapshot, const std::filesystem
         vertex_batches);
 
     spdlog::info("Connectivity is recovered.");
-    // Release the lookup map now that all EdgeRefs are wired into vertices.
-    // TODO: Can this be RAII?
-    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -2273,8 +2254,6 @@ RecoveredSnapshot LoadSnapshotVersion16(Decoder &snapshot, const std::filesystem
         vertex_batches);
 
     spdlog::info("Connectivity is recovered.");
-    // Release the lookup map now that all EdgeRefs are wired into vertices.
-    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -2656,8 +2635,6 @@ RecoveredSnapshot LoadSnapshotVersion17(Decoder &snapshot, const std::filesystem
         vertex_batches);
 
     spdlog::info("Connectivity is recovered.");
-    // Release the lookup map now that all EdgeRefs are wired into vertices.
-    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -3126,8 +3103,6 @@ RecoveredSnapshot LoadSnapshotVersion18or19(Decoder &snapshot, const std::filesy
         vertex_batches);
 
     spdlog::info("Connectivity is recovered.");
-    // Release the lookup map now that all EdgeRefs are wired into vertices.
-    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -3613,8 +3588,6 @@ RecoveredSnapshot LoadSnapshotVersion20or21(Decoder &snapshot, const std::filesy
         vertex_batches);
 
     spdlog::info("Connectivity is recovered.");
-    // Release the lookup map now that all EdgeRefs are wired into vertices.
-    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -4154,8 +4127,6 @@ RecoveredSnapshot LoadSnapshotVersion22or23(Decoder &snapshot, const std::filesy
         vertex_batches);
 
     spdlog::info("Connectivity is recovered.");
-    // Release the lookup map now that all EdgeRefs are wired into vertices.
-    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -4744,8 +4715,6 @@ RecoveredSnapshot LoadSnapshotVersion24(Decoder &snapshot, std::filesystem::path
           vertex_batches);
     }
     spdlog::info("Connectivity is recovered.");
-    // Release the lookup map now that all EdgeRefs are wired into vertices.
-    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -5398,8 +5367,6 @@ RecoveredSnapshot LoadSnapshotVersion25(Decoder &snapshot, std::filesystem::path
           vertex_batches);
     }
     spdlog::info("Connectivity is recovered.");
-    // Release the lookup map now that all EdgeRefs are wired into vertices.
-    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -6025,8 +5992,6 @@ RecoveredSnapshot LoadSnapshotVersion26(Decoder &snapshot, std::filesystem::path
           vertex_batches);
     }
     spdlog::info("Connectivity is recovered.");
-    // Release the lookup map now that all EdgeRefs are wired into vertices.
-    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -6654,8 +6619,6 @@ RecoveredSnapshot LoadSnapshotVersion27or28(Decoder &snapshot, std::filesystem::
           vertex_batches);
     }
     spdlog::info("Connectivity is recovered.");
-    // Release the lookup map now that all EdgeRefs are wired into vertices.
-    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -7335,8 +7298,6 @@ RecoveredSnapshot LoadSnapshotVersion29(Decoder &snapshot, std::filesystem::path
           vertex_batches);
     }
     spdlog::info("Connectivity is recovered.");
-    // Release the lookup map now that all EdgeRefs are wired into vertices.
-    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -8027,8 +7988,6 @@ RecoveredSnapshot LoadSnapshotVersion30(Decoder &snapshot, std::filesystem::path
           vertex_batches);
     }
     spdlog::info("Connectivity is recovered.");
-    // Release the lookup map now that all EdgeRefs are wired into vertices.
-    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -8784,8 +8743,6 @@ RecoveredSnapshot LoadSnapshotVersion31(Decoder &snapshot, std::filesystem::path
           vertex_batches);
     }
     spdlog::info("Connectivity is recovered.");
-    // Release the lookup map now that all EdgeRefs are wired into vertices.
-    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -9579,8 +9536,6 @@ RecoveredSnapshot LoadSnapshotVersion33(Decoder &snapshot, std::filesystem::path
           vertex_batches);
     }
     spdlog::info("Connectivity is recovered.");
-    // Release the lookup map now that all EdgeRefs are wired into vertices.
-    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;
@@ -10469,8 +10424,6 @@ RecoveredSnapshot LoadCurrentVersionSnapshot(Decoder &snapshot, std::filesystem:
           vertex_batches);
     }
     spdlog::info("Connectivity is recovered.");
-    // Release the lookup map now that all EdgeRefs are wired into vertices.
-    loader.ReleaseMap();
 
     // Set initial values for edge/vertex ID generators.
     recovery_info.next_edge_id = highest_edge_gid + 1;

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -284,6 +284,24 @@ auto Batch(auto &&acc, const uint64_t items_per_batch) {
   return batches;
 }
 
+inline std::vector<memory::DbAwareThread> RunWorkerPool(SafeTaskQueue &tasks, uint64_t thread_count,
+                                                        std::string_view name_prefix) {
+  const auto n_workers = std::min(thread_count, tasks.size());
+  std::vector<memory::DbAwareThread> workers;
+  workers.reserve(n_workers);
+  for (int i = 0; i < n_workers; ++i) {
+    workers.emplace_back([&tasks, i, name_prefix] {
+      utils::ThreadSetName(std::string(name_prefix) + std::to_string(i));
+      while (true) {
+        auto task = tasks.PopTask();
+        if (!task) break;
+        (*task)();
+      }
+    });
+  }
+  return workers;
+}
+
 bool MultiThreadedWorkflow(utils::SkipListDb<Edge> *edges, utils::SkipListDb<Vertex> *vertices,
                            auto &&partial_edge_handler, auto &&partial_vertex_handler, const uint64_t items_per_batch,
                            uint64_t &offset_edges, uint64_t &offset_vertices, SnapshotEncoder &snapshot_encoder,
@@ -358,19 +376,7 @@ bool MultiThreadedWorkflow(utils::SkipListDb<Edge> *edges, utils::SkipListDb<Ver
     });
   }
 
-  const auto n_workers = std::min(thread_count, tasks.size());
-  std::vector<memory::DbAwareThread> workers;
-  workers.reserve(n_workers);
-  for (int i = 0; i < n_workers; ++i) {
-    workers.emplace_back([&, i] {
-      utils::ThreadSetName("snapshot" + std::to_string(i));
-      while (true) {
-        auto task = tasks.PopTask();
-        if (!task) break;  // No more tasks; if aborted, run through all tasks to mark them as done
-        (*task)();         // Execute the task
-      }
-    });
-  }
+  auto workers = RunWorkerPool(tasks, thread_count, "snapshot");
 
   bool all_ok = true;
   // Wait for tasks to finish and combine results as they come in
@@ -12285,6 +12291,177 @@ void DeleteOldSnapshotFiles(OldSnapshotFiles &old_snapshot_files, uint64_t const
   old_snapshot_files.erase(old_snapshot_files.begin(), old_snapshot_files.begin() + num_to_erase);
 }
 
+namespace {
+
+struct CollectedEdge {
+  uint64_t gid;
+  std::map<PropertyId, PropertyValue> props;
+};
+
+template <typename AbortFn, typename WriteEdgeFn, typename WriteMappingFn>
+void WriteLightEdgesSection(Storage *storage, Transaction *transaction, utils::SkipListDb<Vertex> *vertices,
+                            SnapshotEncoder &snapshot, AbortFn &&snapshot_aborted, uint64_t &offset_edges,
+                            uint64_t &edges_count, std::vector<BatchInfo> &edge_batch_infos,
+                            WriteEdgeFn &&write_edge_record, WriteMappingFn &&write_mapping,
+                            SnapshotProgress *progress) {
+  const bool parallel = storage->config_.durability.allow_parallel_snapshot_creation;
+  const auto items_per_batch = storage->config_.durability.items_per_batch;
+
+  if (!parallel) {
+    // ---------- Single-threaded path (original) ----------
+    std::vector<CollectedEdge> collected;
+    BatchedProgressCounter progress_counter(progress);
+
+    auto vacc = vertices->access();
+
+    for (auto &vertex : vacc) {
+      if (snapshot_aborted()) return;
+      auto va = VertexAccessor::Create(&vertex, storage, transaction, View::OLD);
+      if (!va) continue;
+      auto maybe_out = va->OutEdges(View::OLD);
+      if (!maybe_out.has_value()) continue;
+      for (auto &ea : maybe_out->edges) {
+        auto gid = ea.Gid().AsUint();
+        auto maybe_props = ea.Properties(View::OLD);
+        MG_ASSERT(maybe_props.has_value(), "Invalid database state!");
+        collected.push_back({gid, std::move(*maybe_props)});
+      }
+    }
+
+    // Sort by GID for deterministic, recoverable output
+    std::ranges::sort(collected, [](auto &a, auto &b) { return a.gid < b.gid; });
+
+    offset_edges = snapshot.GetPosition();
+    uint64_t items_in_batch = 0;
+    auto batch_start_offset = snapshot.GetPosition();
+
+    for (auto &entry : collected) {
+      if (snapshot_aborted()) return;
+      write_edge_record(snapshot, entry.gid, entry.props, write_mapping);
+      ++edges_count;
+      progress_counter.Increment();
+      ++items_in_batch;
+      if (items_in_batch == items_per_batch) {
+        edge_batch_infos.push_back(BatchInfo{.offset = batch_start_offset, .count = items_in_batch});
+        batch_start_offset = snapshot.GetPosition();
+        items_in_batch = 0;
+      }
+    }
+    if (items_in_batch > 0) {
+      edge_batch_infos.push_back(BatchInfo{.offset = batch_start_offset, .count = items_in_batch});
+    }
+    progress_counter.Flush();
+    return;
+  }
+
+  // ---------- Parallel path ----------
+  if (progress) progress->SetPhase(SnapshotProgress::Phase::EDGES, vertices->size());
+
+  // 1. Partition vertices into T ranges using Batch() (same as heavy-edge path)
+  auto vacc = vertices->access();
+  auto vertex_batches = Batch(vacc, items_per_batch);
+  const auto n_batches = vertex_batches.size() - 1;  // last entry is kEnd sentinel
+
+  // Per-worker edge collections
+  struct WorkerResult {
+    std::vector<CollectedEdge> edges;
+  };
+
+  std::vector<WorkerResult> worker_results(n_batches);
+
+  // 2. Create and enqueue collection tasks
+  SafeTaskQueue tasks;
+  for (int id = 0; id < n_batches; ++id) {
+    tasks.AddTask([&worker_results,
+                   id,
+                   start_gid = vertex_batches[id],
+                   end_gid = vertex_batches[id + 1],
+                   &vertices,
+                   storage,
+                   transaction,
+                   &snapshot_aborted] {
+      auto &result = worker_results[id];
+      auto vacc_local = vertices->access();
+      auto it = vacc_local.find_equal_or_greater(Gid::FromInt(start_gid));
+      for (; it != vacc_local.end() && it->gid.AsInt() < end_gid; ++it) {
+        if (snapshot_aborted()) return;
+        auto va = VertexAccessor::Create(&*it, storage, transaction, View::OLD);
+        if (!va) continue;
+        auto maybe_out = va->OutEdges(View::OLD);
+        if (!maybe_out.has_value()) continue;
+        for (auto &ea : maybe_out->edges) {
+          auto gid = ea.Gid().AsUint();
+          auto maybe_props = ea.Properties(View::OLD);
+          MG_ASSERT(maybe_props.has_value(), "Invalid database state!");
+          result.edges.push_back({gid, std::move(*maybe_props)});
+        }
+      }
+      // Sort edges by GID for deterministic merge
+      std::ranges::sort(result.edges, [](auto &a, auto &b) { return a.gid < b.gid; });
+    });
+  }
+
+  // 3. Spawn workers and execute tasks
+  auto workers = RunWorkerPool(tasks, storage->config_.durability.snapshot_thread_count, "snap_light");
+
+  // Wait for all workers to finish
+  for (auto &w : workers) {
+    w.join();
+  }
+
+  // 4. k-way merge: write edges in strictly increasing GID order
+  offset_edges = snapshot.GetPosition();
+  uint64_t items_in_batch = 0;
+  auto batch_start_offset = snapshot.GetPosition();
+  BatchedProgressCounter progress_counter(progress);
+
+  // Min-heap ordered by edge GID (will produce globally sorted output)
+  using Iter = std::vector<CollectedEdge>::const_iterator;
+
+  struct HeapEntry {
+    uint64_t gid;
+    Iter current;
+    Iter end;
+  };
+
+  auto cmp = [](const HeapEntry &a, const HeapEntry &b) { return a.gid > b.gid; };
+  std::priority_queue<HeapEntry, std::vector<HeapEntry>, decltype(cmp)> heap{cmp};
+
+  for (auto &wr : worker_results) {
+    if (!wr.edges.empty()) {
+      heap.push({wr.edges.front().gid, wr.edges.begin(), wr.edges.end()});
+    }
+  }
+
+  while (!heap.empty()) {
+    if (snapshot_aborted()) return;
+    auto entry = heap.top();
+    heap.pop();
+
+    write_edge_record(snapshot, entry.current->gid, entry.current->props, write_mapping);
+    ++edges_count;
+    progress_counter.Increment();
+    ++items_in_batch;
+    if (items_in_batch == items_per_batch) {
+      edge_batch_infos.push_back(BatchInfo{.offset = batch_start_offset, .count = items_in_batch});
+      batch_start_offset = snapshot.GetPosition();
+      items_in_batch = 0;
+    }
+
+    auto next = entry.current + 1;
+    if (next != entry.end) {
+      heap.push({next->gid, next, entry.end});
+    }
+  }
+
+  if (items_in_batch > 0) {
+    edge_batch_infos.push_back(BatchInfo{.offset = batch_start_offset, .count = items_in_batch});
+  }
+  progress_counter.Flush();
+}
+
+}  // namespace
+
 std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transaction *transaction,
                                                     const std::filesystem::path &snapshot_directory,
                                                     const std::filesystem::path &wal_directory,
@@ -12611,133 +12788,72 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
   std::vector<BatchInfo> edge_batch_infos;
   std::vector<BatchInfo> vertex_batch_infos;
 
-  // LIGHT EDGES: collect edges from vertex adjacency lists via MVCC instead of the
-  // edges_ skip list. Uses VertexAccessor::OutEdges(View::OLD) so that edges deleted
-  // by uncommitted concurrent transactions are still correctly included (delta undo
-  // restores them to the adjacency list for the snapshot's view).
-  auto write_light_edges_section = [&, progress]() {
-    struct CollectedEdge {
-      uint64_t gid;
-      std::map<PropertyId, PropertyValue> props;
-    };
-    std::vector<CollectedEdge> collected;
-    BatchedProgressCounter progress_counter(progress);
-
-    auto vacc = vertices->access();
-
-    for (auto &vertex : vacc) {
-      if (snapshot_aborted()) return;
-      auto va = VertexAccessor::Create(&vertex, storage, transaction, View::OLD);
-      if (!va) continue;
-      auto maybe_out = va->OutEdges(View::OLD);
-      if (!maybe_out.has_value()) continue;
-      for (auto &ea : maybe_out->edges) {
-        auto gid = ea.Gid().AsUint();
-        auto maybe_props = ea.Properties(View::OLD);
-        MG_ASSERT(maybe_props.has_value(), "Invalid database state!");
-        collected.push_back({gid, std::move(*maybe_props)});
-      }
-    }
-
-    // Sort by GID for deterministic, recoverable output
-    std::ranges::sort(collected, [](auto &a, auto &b) { return a.gid < b.gid; });
-
-    offset_edges = snapshot.GetPosition();
-    uint64_t items_in_batch = 0;
-    auto batch_start_offset = snapshot.GetPosition();
-
-    for (auto &entry : collected) {
-      if (snapshot_aborted()) return;
-      write_edge_record(snapshot, entry.gid, entry.props, write_mapping);
-      ++edges_count;
-      progress_counter.Increment();
-      ++items_in_batch;
-      if (items_in_batch == storage->config_.durability.items_per_batch) {
-        edge_batch_infos.push_back(BatchInfo{.offset = batch_start_offset, .count = items_in_batch});
-        batch_start_offset = snapshot.GetPosition();
-        items_in_batch = 0;
-      }
-    }
-    if (items_in_batch > 0) {
-      edge_batch_infos.push_back(BatchInfo{.offset = batch_start_offset, .count = items_in_batch});
-    }
-    progress_counter.Flush();
-  };
-
   bool const light_edges = storage->config_.salient.items.storage_light_edge;
+  bool const heavy_edges = !light_edges && storage->config_.salient.items.properties_on_edges;
 
   if (storage->config_.durability.allow_parallel_snapshot_creation) {
-    if (light_edges && storage->config_.salient.items.properties_on_edges) {
-      // Write light edges single-threaded (edges must precede vertices in the file),
-      // then run the parallel workflow for vertices only.
-      write_light_edges_section();
-      if (snapshot_aborted()) return std::nullopt;
-      if (!MultiThreadedWorkflow(static_cast<utils::SkipListDb<Edge> *>(nullptr),
-                                 vertices,
-                                 partial_edge_handler,
-                                 partial_vertex_handler,
-                                 storage->config_.durability.items_per_batch,
-                                 offset_edges,
-                                 offset_vertices,
-                                 snapshot,
-                                 edges_count,
-                                 vertices_count,
-                                 edge_batch_infos,
-                                 vertex_batch_infos,
-                                 used_ids,
-                                 storage->config_.durability.snapshot_thread_count,
-                                 snapshot_aborted,
-                                 progress)) {
-        spdlog::warn(
-            "Failed to execute some tasks when doing a multi-threaded snapshot, snapshot will be aborted and snapshot "
-            "creation will be retried on the next scheduled interval");
-        snapshot.Close();
-        // Clean up the partial main snapshot file
-        std::error_code ec;
-        std::filesystem::remove(path, ec);
-        return std::nullopt;
-      }
-    } else {
-      auto *edge_ptr = storage->config_.salient.items.properties_on_edges ? edges : nullptr;
-      if (!MultiThreadedWorkflow(edge_ptr,
-                                 vertices,
-                                 partial_edge_handler,
-                                 partial_vertex_handler,
-                                 storage->config_.durability.items_per_batch,
-                                 offset_edges,
-                                 offset_vertices,
-                                 snapshot,
-                                 edges_count,
-                                 vertices_count,
-                                 edge_batch_infos,
-                                 vertex_batch_infos,
-                                 used_ids,
-                                 storage->config_.durability.snapshot_thread_count,
-                                 snapshot_aborted,
-                                 progress)) {
-        spdlog::warn(
-            "Failed to execute some tasks when doing a multi-threaded snapshot, snapshot will be aborted and snapshot "
-            "creation will be retried on the next scheduled interval");
-        snapshot.Close();
-        // Clean up the partial main snapshot file
-        std::error_code ec;
-        std::filesystem::remove(path, ec);
-        return std::nullopt;
-      }
+    // Write light edges (parallel collection + k-way merge; edges must precede vertices in the file),
+    // then run the parallel workflow for vertices only.
+    if (light_edges) {
+      WriteLightEdgesSection(storage,
+                             transaction,
+                             vertices,
+                             snapshot,
+                             snapshot_aborted,
+                             offset_edges,
+                             edges_count,
+                             edge_batch_infos,
+                             write_edge_record,
+                             write_mapping,
+                             progress);
+    }
+    auto *edge_ptr = heavy_edges ? edges : nullptr;
+    if (!MultiThreadedWorkflow(edge_ptr,
+                               vertices,
+                               partial_edge_handler,
+                               partial_vertex_handler,
+                               storage->config_.durability.items_per_batch,
+                               offset_edges,
+                               offset_vertices,
+                               snapshot,
+                               edges_count,
+                               vertices_count,
+                               edge_batch_infos,
+                               vertex_batch_infos,
+                               used_ids,
+                               storage->config_.durability.snapshot_thread_count,
+                               snapshot_aborted,
+                               progress)) {
+      spdlog::warn(
+          "Failed to execute some tasks when doing a multi-threaded snapshot, snapshot will be aborted and snapshot "
+          "creation will be retried on the next scheduled interval");
+      snapshot.Close();
+      // Clean up the partial main snapshot file
+      std::error_code ec;
+      std::filesystem::remove(path, ec);
+      return std::nullopt;
     }
   } else {
-    if (storage->config_.salient.items.properties_on_edges) {
-      if (progress) progress->SetPhase(SnapshotProgress::Phase::EDGES, edges->size());
-      if (light_edges) {
-        write_light_edges_section();
-      } else {
-        offset_edges = snapshot.GetPosition();  // Global edge offset
-        // Handle edges
-        const auto res = partial_edge_handler(0, kEnd, snapshot);
-        edges_count = res.count;
-        edge_batch_infos = res.batch_info;
-        used_ids.insert(res.used_ids.begin(), res.used_ids.end());
-      }
+    if (progress) progress->SetPhase(SnapshotProgress::Phase::EDGES, edges->size());
+    if (light_edges) {
+      WriteLightEdgesSection(storage,
+                             transaction,
+                             vertices,
+                             snapshot,
+                             snapshot_aborted,
+                             offset_edges,
+                             edges_count,
+                             edge_batch_infos,
+                             write_edge_record,
+                             write_mapping,
+                             progress);
+    } else if (heavy_edges) {
+      offset_edges = snapshot.GetPosition();  // Global edge offset
+      // Handle edges
+      const auto res = partial_edge_handler(0, kEnd, snapshot);
+      edges_count = res.count;
+      edge_batch_infos = res.batch_info;
+      used_ids.insert(res.used_ids.begin(), res.used_ids.end());
     }
     if (snapshot_aborted()) {
       return std::nullopt;

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -16,6 +16,7 @@
 #include <sys/sendfile.h>
 #include <algorithm>
 #include <atomic>
+#include <exception>
 #include <filesystem>
 #include <future>
 #include <limits>
@@ -12328,6 +12329,10 @@ void WriteLightEdgesSection(Storage *storage, Transaction *transaction, utils::S
 
   // 2. Create and enqueue collection tasks
   SafeTaskQueue tasks;
+  std::atomic<bool> worker_failed{false};
+  std::exception_ptr worker_exception;
+  std::mutex exception_mutex;
+
   for (size_t id = 0; id < n_batches; ++id) {
     tasks.AddTask([&worker_results,
                    id,
@@ -12336,25 +12341,37 @@ void WriteLightEdgesSection(Storage *storage, Transaction *transaction, utils::S
                    &vertices,
                    storage,
                    transaction,
-                   &snapshot_aborted] {
-      auto &result = worker_results[id];
-      auto vacc_local = vertices->access();
-      auto it = vacc_local.find_equal_or_greater(Gid::FromInt(start_gid));
-      for (; it != vacc_local.end() && it->gid.AsInt() < end_gid; ++it) {
-        if (snapshot_aborted()) return;
-        auto va = VertexAccessor::Create(&*it, storage, transaction, View::OLD);
-        if (!va) continue;
-        auto maybe_out = va->OutEdges(View::OLD);
-        if (!maybe_out.has_value()) continue;
-        for (auto &ea : maybe_out->edges) {
-          auto gid = ea.Gid().AsUint();
-          auto maybe_props = ea.Properties(View::OLD);
-          MG_ASSERT(maybe_props.has_value(), "Invalid database state!");
-          result.edges.push_back({gid, std::move(*maybe_props)});
+                   &snapshot_aborted,
+                   &worker_failed,
+                   &worker_exception,
+                   &exception_mutex] {
+      if (worker_failed.load(std::memory_order_relaxed)) return;
+      try {
+        auto &result = worker_results[id];
+        auto vacc_local = vertices->access();
+        auto it = vacc_local.find_equal_or_greater(Gid::FromInt(start_gid));
+        for (; it != vacc_local.end() && it->gid.AsInt() < end_gid; ++it) {
+          if (worker_failed.load(std::memory_order_relaxed) || snapshot_aborted()) return;
+          auto va = VertexAccessor::Create(&*it, storage, transaction, View::OLD);
+          if (!va) continue;
+          auto maybe_out = va->OutEdges(View::OLD);
+          if (!maybe_out.has_value()) continue;
+          for (auto &ea : maybe_out->edges) {
+            auto gid = ea.Gid().AsUint();
+            auto maybe_props = ea.Properties(View::OLD);
+            MG_ASSERT(maybe_props.has_value(), "Invalid database state!");
+            result.edges.push_back({gid, std::move(*maybe_props)});
+          }
+        }
+        // Sort edges by GID for deterministic merge
+        std::ranges::sort(result.edges, [](auto &a, auto &b) { return a.gid < b.gid; });
+      } catch (...) {
+        worker_failed.store(true, std::memory_order_relaxed);
+        std::lock_guard lock(exception_mutex);
+        if (!worker_exception) {
+          worker_exception = std::current_exception();
         }
       }
-      // Sort edges by GID for deterministic merge
-      std::ranges::sort(result.edges, [](auto &a, auto &b) { return a.gid < b.gid; });
     });
   }
 
@@ -12364,6 +12381,10 @@ void WriteLightEdgesSection(Storage *storage, Transaction *transaction, utils::S
   // Wait for all workers to finish
   for (auto &w : workers) {
     w.join();
+  }
+
+  if (worker_exception) {
+    std::rethrow_exception(worker_exception);
   }
 
   // 4. k-way merge: write edges in strictly increasing GID order
@@ -12791,7 +12812,14 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
       return std::nullopt;
     }
   } else {
-    if (progress) progress->SetPhase(SnapshotProgress::Phase::EDGES, edges->size());
+    if (progress) {
+      if (light_edges) {
+        // TODO Use a better source (like schema info or edges metadata)
+        progress->SetPhase(SnapshotProgress::Phase::EDGES, vertices->size());
+      } else {
+        progress->SetPhase(SnapshotProgress::Phase::EDGES, edges->size());
+      }
+    }
     if (light_edges) {
       WriteLightEdgesSection(storage,
                              transaction,

--- a/src/storage/v2/durability/wal.cpp
+++ b/src/storage/v2/durability/wal.cpp
@@ -1239,6 +1239,11 @@ std::optional<RecoveryInfo> LoadWal(
     std::function<std::optional<std::tuple<EdgeRef, EdgeTypeId, Vertex *, Vertex *>>(Gid)> find_edge,
     memgraph::storage::ttl::TTL *ttl, memgraph::storage::DescriptionStore *description_store) {
   spdlog::info("Trying to load WAL file {}.", path);
+  spdlog::info("WAL recovery: properties_on_edges={}, storage_light_edge={}",
+               items.properties_on_edges,
+               items.storage_light_edge);
+
+  const bool use_edge_cache = schema_info;
 
   Decoder wal;
   auto version = wal.Initialize(path, kWalMagic);
@@ -1352,6 +1357,12 @@ std::optional<RecoveryInfo> LoadWal(
         auto edge_type_id = EdgeTypeId::FromUint(name_id_mapper->NameToId(data.edge_type));
         auto edge_ref = std::invoke([&]() -> EdgeRef {
           if (items.properties_on_edges) {
+            if (items.storage_light_edge) {
+              memory::DbAwareAllocator<Edge> alloc;
+              auto *edge_ptr = std::allocator_traits<decltype(alloc)>::allocate(alloc, 1);
+              std::construct_at(edge_ptr, data.gid, nullptr);
+              return EdgeRef{edge_ptr};
+            }
             auto [edge, inserted] = edge_acc.insert(Edge{(data.gid), nullptr});
             if (!inserted)
               throw RecoveryFailure("The edge must be inserted here! Current ldt is: {}", ret->last_durable_timestamp);
@@ -1373,9 +1384,12 @@ std::optional<RecoveryInfo> LoadWal(
 
         // Increment edge count.
         edge_count->fetch_add(1, std::memory_order_acq_rel);
-
+        // Update schema info
         if (schema_info) {
           schema_info->CreateEdge(&*from_vertex, &*to_vertex, edge_type_id);
+        }
+        // Edge cache update
+        if (use_edge_cache) {
           edge_recovery_cache.insert_or_assign(data.gid,
                                                EdgeRecoveryCacheEntry{.edge_ref = edge_ref,
                                                                       .edge_type = edge_type_id,
@@ -1394,6 +1408,15 @@ std::optional<RecoveryInfo> LoadWal(
         auto edge_type_id = EdgeTypeId::FromUint(name_id_mapper->NameToId(data.edge_type));
         auto edge_ref = std::invoke([&]() -> EdgeRef {
           if (items.properties_on_edges) {
+            if (items.storage_light_edge) {
+              // Find edge in from_vertex's out_edges by gid
+              auto it = r::find_if(from_vertex->out_edges,
+                                   [&data](const auto &e) { return std::get<2>(e).ptr->gid == data.gid; });
+              if (it == from_vertex->out_edges.end())
+                throw RecoveryFailure("The edge doesn't exist in out_edges! Current ldt is: {}",
+                                      ret->last_durable_timestamp);
+              return std::get<2>(*it);
+            }
             auto edge = edge_acc.find(data.gid);
             if (edge == edge_acc.end())
               throw RecoveryFailure("The edge doesn't exist! Current ldt is: {}", ret->last_durable_timestamp);
@@ -1420,16 +1443,25 @@ std::optional<RecoveryInfo> LoadWal(
           std::swap(*it, to_vertex->in_edges.back());
           to_vertex->in_edges.pop_back();
         }
-        if (items.properties_on_edges) {
-          if (!edge_acc.remove(data.gid))
-            throw RecoveryFailure("The edge must be removed here! Current ldt is: {}", ret->last_durable_timestamp);
-        }
-
-        // Decrement edge count.
-        edge_count->fetch_add(-1, std::memory_order_acq_rel);
-
+        // Update schema info before deallocating the edge, as it reads edge properties.
         if (schema_info) {
           schema_info->DeleteEdge(edge_type_id, edge_ref, &*from_vertex, &*to_vertex, items.properties_on_edges);
+        }
+        if (items.properties_on_edges) {
+          if (items.storage_light_edge) {
+            // Deallocate the light edge using DbAwareAllocator
+            memory::DbAwareAllocator<Edge> alloc;
+            std::destroy_at(edge_ref.ptr);
+            std::allocator_traits<decltype(alloc)>::deallocate(alloc, edge_ref.ptr, 1);
+          } else {
+            if (!edge_acc.remove(data.gid))
+              throw RecoveryFailure("The edge must be removed here! Current ldt is: {}", ret->last_durable_timestamp);
+          }
+        }
+        // Decrement edge count.
+        edge_count->fetch_add(-1, std::memory_order_acq_rel);
+        // Edge cache update
+        if (use_edge_cache) {
           edge_recovery_cache.erase(data.gid);
         }
       },
@@ -1440,87 +1472,113 @@ std::optional<RecoveryInfo> LoadWal(
               "configured without properties on edges! Current ldt is: {}",
               ret->last_durable_timestamp);
 
-        auto edge = edge_acc.find(data.gid);
-        if (edge == edge_acc.end())
-          throw RecoveryFailure("The edge doesn't exist! Current ldt is: {}", ret->last_durable_timestamp);
-        const auto property_id = PropertyId::FromUint(name_id_mapper->NameToId(data.property));
-        const auto property_value = ToPropertyValue(data.value, name_id_mapper);
+        using EdgeFullInfo = std::tuple<EdgeRef, EdgeTypeId, Vertex *, Vertex *>;
+        std::optional<EdgeFullInfo> edge_full_info;
 
-        if (schema_info) {
-          // Fast path: use cached edge recovery info.
-          auto cache_it = edge_recovery_cache.find(data.gid);
-          if (cache_it != edge_recovery_cache.end()) {
-            const auto &entry = cache_it->second;
-            const auto old_type = edge->properties.GetExtendedPropertyType(property_id);
-            schema_info->SetProperty(entry.edge_type,
-                                     entry.from_vertex,
-                                     entry.to_vertex,
-                                     property_id,
-                                     ExtendedPropertyType{property_value},
-                                     old_type,
-                                     items.properties_on_edges);
+        // Fast path: schema_info or light edges cache hit gives us full topology without any vertex scans.
+        if (use_edge_cache) {
+          if (auto it = edge_recovery_cache.find(data.gid); it != edge_recovery_cache.end()) {
+            const auto &e = it->second;
+            edge_full_info.emplace(e.edge_ref, e.edge_type, e.from_vertex, e.to_vertex);
+          }
+        }
+        const bool was_cached = edge_full_info.has_value();
+
+        // Resolve full edge topology when needed:
+        //   - Light edges: no global skip-list, out_edges scan is the only way to find edge_raw.
+        //   - schema_info (cache miss): topology required for schema tracking.
+        //
+        // 3-case hierarchy mirrors replication_handlers.cpp (newest WAL format → oldest):
+        //   Case 1: from+to+type all present → light: type-filtered out_edges scan;
+        //                                       heavy: skip-list lookup + vertex pointers (no scan).
+        //   Case 2: from_gid only            → GID scan of from_vertex->out_edges (same for both).
+        //   Case 3: gid only                 → full scan via find_edge lambda (same for both).
+        if (!was_cached && (use_edge_cache || items.storage_light_edge)) {
+          if (data.from_gid.has_value() && data.to_gid.has_value() && data.edge_type.has_value() &&
+              *data.to_gid != kInvalidGid && !data.edge_type->empty()) {
+            const auto from_v = vertex_acc.find(*data.from_gid);
+            if (from_v == vertex_acc.end())
+              throw RecoveryFailure("The from vertex doesn't exist! Current ldt is: {}", ret->last_durable_timestamp);
+            const auto to_v = vertex_acc.find(*data.to_gid);
+            if (to_v == vertex_acc.end())
+              throw RecoveryFailure("The to vertex doesn't exist! Current ldt is: {}", ret->last_durable_timestamp);
+            const auto edge_type_id = EdgeTypeId::FromUint(name_id_mapper->NameToId(*data.edge_type));
+            if (items.storage_light_edge) {
+              // Light: GID is not globally indexed — scan out_edges with type+to_vertex filter.
+              auto found = r::find_if(from_v->out_edges, [&](const auto &e) {
+                return std::get<0>(e) == edge_type_id && std::get<1>(e) == &*to_v &&
+                       std::get<2>(e).ptr->gid == data.gid;
+              });
+              if (found == from_v->out_edges.end())
+                throw RecoveryFailure("Edge not found in out_edges! Current ldt is: {}", ret->last_durable_timestamp);
+              edge_full_info.emplace(std::get<2>(*found), edge_type_id, &*from_v, std::get<1>(*found));
+            } else {
+              // Heavy: topology fully encoded in WAL delta — skip-list lookup + vertex pointers.
+              auto edge_it = edge_acc.find(data.gid);
+              if (edge_it == edge_acc.end())
+                throw RecoveryFailure("The edge doesn't exist! Current ldt is: {}", ret->last_durable_timestamp);
+              edge_full_info.emplace(EdgeRef{&*edge_it}, edge_type_id, &*from_v, &*to_v);
+            }
+          } else if (data.from_gid.has_value()) {
+            // Case 2: scan from_vertex->out_edges by GID — same for light and heavy.
+            // out_edges scan is used (rather than edge_acc.find) because we need the full topology
+            // (edge_type, to_vertex) for schema_info tracking without an extra vertex lookup.
+            const auto from_v = vertex_acc.find(*data.from_gid);
+            if (from_v == vertex_acc.end())
+              throw RecoveryFailure("The from vertex doesn't exist! Current ldt is: {}", ret->last_durable_timestamp);
+            auto found =
+                r::find_if(from_v->out_edges, [&](const auto &e) { return std::get<2>(e).ptr->gid == data.gid; });
+            if (found == from_v->out_edges.end())
+              throw RecoveryFailure("Edge not found in out_edges! Current ldt is: {}", ret->last_durable_timestamp);
+            edge_full_info.emplace(std::get<2>(*found), std::get<0>(*found), &*from_v, std::get<1>(*found));
           } else {
-            // Slow path: resolve edge via vertex_acc / FindEdge.
-            const auto &[edge_ref, edge_type, from_vertex, to_vertex] = std::invoke([&] {
-              if (data.from_gid.has_value()) {
-                // Faster path: use to vertex and edge type from WAL delta.
-                // NOTE: WAL edge deltas mix vertex and edge deltas. For efficiency, we don't record the to gid and
-                // edge type in case the edge was created in this transaction. We should either be using the cached
-                // edge accessor (from EdgeCreate - actually a vertex delta) or we should have valid to gid and edge
-                // type.
-                if (data.to_gid.has_value() && data.edge_type.has_value() && *data.to_gid != kInvalidGid &&
-                    !data.edge_type->empty()) {
-                  const auto to_vertex = vertex_acc.find(*data.to_gid);
-                  if (to_vertex == vertex_acc.end())
-                    throw RecoveryFailure("The to vertex doesn't exist! Current ldt is: {}",
-                                          ret->last_durable_timestamp);
-                  const auto from_vertex = vertex_acc.find(*data.from_gid);
-                  if (from_vertex == vertex_acc.end())
-                    throw RecoveryFailure("The from vertex doesn't exist! Current ldt is: {}",
-                                          ret->last_durable_timestamp);
-                  const auto edge_type_id = EdgeTypeId::FromUint(name_id_mapper->NameToId(*data.edge_type));
-                  return std::tuple{EdgeRef{&*edge}, edge_type_id, &*from_vertex, &*to_vertex};
-                }
-                // Slow path: resolve edge via vertex_acc / FindEdge.
-                const auto from_vertex = vertex_acc.find(data.from_gid);
-                if (from_vertex == vertex_acc.end())
-                  throw RecoveryFailure("The from vertex doesn't exist! Current ldt is: {}",
-                                        ret->last_durable_timestamp);
-                const auto found_edge = r::find_if(from_vertex->out_edges, [&edge](const auto &edge_info) {
-                  const auto &[edge_type, to_vertex, edge_ref] = edge_info;
-                  return edge_ref.ptr == &*edge;
-                });
-                if (found_edge == from_vertex->out_edges.end())
-                  throw RecoveryFailure("Recovery failed, edge not found. Current ldt is: {}",
-                                        ret->last_durable_timestamp);
-                const auto &[edge_type, to_vertex, edge_ref] = *found_edge;
-                return std::tuple{edge_ref, edge_type, &*from_vertex, to_vertex};
-              }
-              const auto maybe_edge = find_edge(edge->gid);
-              if (!maybe_edge)
-                throw RecoveryFailure("Recovery failed, edge not found. Current ldt is: {}",
-                                      ret->last_durable_timestamp);
-              return *maybe_edge;
-            });
-
-            edge_recovery_cache.insert_or_assign(
-                data.gid,
-                EdgeRecoveryCacheEntry{
-                    .edge_ref = edge_ref, .edge_type = edge_type, .from_vertex = from_vertex, .to_vertex = to_vertex});
-            const auto old_type = edge->properties.GetExtendedPropertyType(property_id);
-            schema_info->SetProperty(edge_type,
-                                     from_vertex,
-                                     to_vertex,
-                                     property_id,
-                                     ExtendedPropertyType{property_value},
-                                     old_type,
-                                     items.properties_on_edges);
+            // Case 3: full scan fallback — same for light and heavy.
+            edge_full_info = find_edge(data.gid);
+            if (!edge_full_info)
+              throw RecoveryFailure("Edge not found via find_edge! Current ldt is: {}", ret->last_durable_timestamp);
           }
         }
 
-        edge->properties.SetProperty(property_id, property_value);
+        // Resolve edge_raw from topology (light/schema_info path) or O(log n) skip-list (heavy, no schema_info).
+        Edge *edge_raw;
+        if (edge_full_info) {
+          edge_raw = std::get<0>(*edge_full_info).ptr;
+        } else {
+          auto edge_it = edge_acc.find(data.gid);
+          if (edge_it == edge_acc.end())
+            throw RecoveryFailure("The edge doesn't exist! Current ldt is: {}", ret->last_durable_timestamp);
+          edge_raw = &*edge_it;
+        }
+
+        const auto property_id = PropertyId::FromUint(name_id_mapper->NameToId(data.property));
+        const auto property_value = ToPropertyValue(data.value, name_id_mapper);
+
+        // Update schema info
+        // Invariant: schema_info → use_edge_cache → edge_full_info is set (or an exception was thrown above).
+        if (schema_info) {
+          DMG_ASSERT(edge_full_info.has_value(), "edge_full_info must be set when schema_info is active");
+          const auto &[edge_ref, edge_type, from_v, to_v] = *edge_full_info;
+          const auto old_type = edge_raw->properties.GetExtendedPropertyType(property_id);
+          schema_info->SetProperty(edge_type,
+                                   from_v,
+                                   to_v,
+                                   property_id,
+                                   ExtendedPropertyType{property_value},
+                                   old_type,
+                                   items.properties_on_edges);
+        }
+        // Edge cache update
+        if (!was_cached && use_edge_cache) {
+          const auto &[edge_ref, edge_type, from_v, to_v] = *edge_full_info;
+          edge_recovery_cache.insert_or_assign(
+              data.gid,
+              EdgeRecoveryCacheEntry{
+                  .edge_ref = edge_ref, .edge_type = edge_type, .from_vertex = from_v, .to_vertex = to_v});
+        }
+        // Set property on edge (keep at the end)
+        edge_raw->properties.SetProperty(property_id, property_value);
         VectorEdgeIndexRecovery::UpdateOnSetEdgeProperty(
-            property_id, property_value, &*edge, indices_constraints->indices.vector_edge_indices);
+            property_id, property_value, edge_raw, indices_constraints->indices.vector_edge_indices);
       },
       [&](WalTransactionStart const &data) {
         should_commit = data.commit.value_or(true);

--- a/src/storage/v2/durability/wal.cpp
+++ b/src/storage/v2/durability/wal.cpp
@@ -32,6 +32,7 @@
 #include "storage/v2/indices/text_index_utils.hpp"
 #include "storage/v2/indices/vector_edge_index.hpp"
 #include "storage/v2/indices/vector_index.hpp"
+#include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/name_id_mapper.hpp"
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/schema_info.hpp"
@@ -1358,9 +1359,7 @@ std::optional<RecoveryInfo> LoadWal(
         auto edge_ref = std::invoke([&]() -> EdgeRef {
           if (items.properties_on_edges) {
             if (items.storage_light_edge) {
-              memory::DbAwareAllocator<Edge> alloc;
-              auto *edge_ptr = std::allocator_traits<decltype(alloc)>::allocate(alloc, 1);
-              std::construct_at(edge_ptr, data.gid, nullptr);
+              auto *edge_ptr = CreateLightEdge(data.gid, nullptr);
               return EdgeRef{edge_ptr};
             }
             auto [edge, inserted] = edge_acc.insert(Edge{(data.gid), nullptr});

--- a/src/storage/v2/durability/wal.cpp
+++ b/src/storage/v2/durability/wal.cpp
@@ -1360,6 +1360,9 @@ std::optional<RecoveryInfo> LoadWal(
           if (items.properties_on_edges) {
             if (items.storage_light_edge) {
               auto *edge_ptr = CreateLightEdge(data.gid, nullptr);
+              if (!edge_ptr)
+                throw RecoveryFailure("Failed to allocate a light edge! Current ldt is: {}",
+                                      ret->last_durable_timestamp);
               return EdgeRef{edge_ptr};
             }
             auto [edge, inserted] = edge_acc.insert(Edge{(data.gid), nullptr});
@@ -1448,10 +1451,7 @@ std::optional<RecoveryInfo> LoadWal(
         }
         if (items.properties_on_edges) {
           if (items.storage_light_edge) {
-            // Deallocate the light edge using DbAwareAllocator
-            memory::DbAwareAllocator<Edge> alloc;
-            std::destroy_at(edge_ref.ptr);
-            std::allocator_traits<decltype(alloc)>::deallocate(alloc, edge_ref.ptr, 1);
+            DestroyLightEdge(edge_ref.ptr);
           } else {
             if (!edge_acc.remove(data.gid))
               throw RecoveryFailure("The edge must be removed here! Current ldt is: {}", ret->last_durable_timestamp);

--- a/src/storage/v2/durability/wal.hpp
+++ b/src/storage/v2/durability/wal.hpp
@@ -13,7 +13,6 @@
 
 #include <cstdint>
 #include <filesystem>
-#include <memory_resource>
 #include <optional>
 #include <set>
 #include <string>

--- a/src/storage/v2/durability/wal.hpp
+++ b/src/storage/v2/durability/wal.hpp
@@ -13,6 +13,7 @@
 
 #include <cstdint>
 #include <filesystem>
+#include <memory_resource>
 #include <optional>
 #include <set>
 #include <string>

--- a/src/storage/v2/edge_ref.hpp
+++ b/src/storage/v2/edge_ref.hpp
@@ -24,9 +24,9 @@ struct EdgeRef {
 
   explicit EdgeRef(Edge *ptr) : ptr(ptr) {}
 
-  friend bool operator==(const EdgeRef &a, const EdgeRef &b) noexcept { return a.gid == b.gid; }
+  friend bool operator==(const EdgeRef &lhs, const EdgeRef &rhs) noexcept { return lhs.gid == rhs.gid; }
 
-  friend bool operator<(const EdgeRef &first, const EdgeRef &second) { return first.gid < second.gid; }
+  friend bool operator<(const EdgeRef &lhs, const EdgeRef &rhs) noexcept { return lhs.gid < rhs.gid; }
 
   union {
     Gid gid;

--- a/src/storage/v2/indices/edge_type_index.cpp
+++ b/src/storage/v2/indices/edge_type_index.cpp
@@ -15,7 +15,7 @@
 
 namespace memgraph::storage {
 void EdgeTypeIndexAbortProcessor::CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex *from_vertex, Vertex *to_vertex,
-                                                       Edge *edge) {
+                                                       EdgeRef edge) {
   auto it = cleanup_collection_.find(edge_type);
   if (it == cleanup_collection_.end()) return;
   it->second.emplace_back(from_vertex, to_vertex, edge);

--- a/src/storage/v2/indices/edge_type_index.hpp
+++ b/src/storage/v2/indices/edge_type_index.hpp
@@ -31,7 +31,7 @@ struct Vertex;
 
 struct EdgeTypeIndexActiveIndices;
 struct EdgeTypeIndexAbortProcessor;
-using EdgeTypeIndexAbortableInfo = std::map<EdgeTypeId, std::vector<std::tuple<Vertex *, Vertex *, Edge *>>>;
+using EdgeTypeIndexAbortableInfo = std::map<EdgeTypeId, std::vector<std::tuple<Vertex *, Vertex *, EdgeRef>>>;
 
 class EdgeTypeIndex {
  public:
@@ -56,7 +56,7 @@ class EdgeTypeIndex {
 struct EdgeTypeIndexAbortProcessor {
   explicit EdgeTypeIndexAbortProcessor(std::span<EdgeTypeId const> edge_types);
 
-  void CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex *from_vertex, Vertex *to_vertex, Edge *edge);
+  void CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex *from_vertex, Vertex *to_vertex, EdgeRef edge);
 
   EdgeTypeIndexAbortableInfo cleanup_collection_;
 };

--- a/src/storage/v2/indices/indices.cpp
+++ b/src/storage/v2/indices/indices.cpp
@@ -173,7 +173,7 @@ Indices::AbortProcessor Indices::GetAbortProcessor(ActiveIndices const &active_i
 }
 
 void Indices::AbortProcessor::CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex *from_vertex, Vertex *to_vertex,
-                                                   Edge *edge) {
+                                                   EdgeRef edge) {
   edge_type_.CollectOnEdgeRemoval(edge_type, from_vertex, to_vertex, edge);
 }
 

--- a/src/storage/v2/indices/indices.hpp
+++ b/src/storage/v2/indices/indices.hpp
@@ -73,7 +73,7 @@ struct Indices {
     VectorIndex::AbortProcessor vector_;
     VectorEdgeIndex::AbortProcessor vector_edge_;
 
-    void CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex *from_vertex, Vertex *to_vertex, Edge *edge);
+    void CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex *from_vertex, Vertex *to_vertex, EdgeRef edge);
     void CollectOnLabelRemoval(LabelId labelId, Vertex *vertex);
     void CollectOnLabelAddition(LabelId labelId, Vertex *vertex);
     void CollectOnPropertyChange(PropertyId propId, const PropertyValue &old_value, Vertex *vertex);

--- a/src/storage/v2/inmemory/edge_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_property_index.cpp
@@ -17,6 +17,7 @@
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indices/active_indices_updater.hpp"
 #include "storage/v2/indices/indices_utils.hpp"
+#include "storage/v2/inmemory/light_edge_guard.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/property_value_utils.hpp"
@@ -426,13 +427,13 @@ void InMemoryEdgePropertyIndex::DropGraphClearIndices() {
   });
 }
 
-InMemoryEdgePropertyIndex::Iterable::Iterable(
-    utils::SkipListDb<InMemoryEdgePropertyIndex::Entry>::Accessor index_accessor,
-    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor, utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
-    PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
-    const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
-    Transaction *transaction)
-    : pin_accessor_edge_(std::move(edge_accessor)),
+InMemoryEdgePropertyIndex::Iterable::Iterable(utils::SkipListDb<Entry>::Accessor index_accessor,
+                                              utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
+                                              EdgePin edge_pin, PropertyId property,
+                                              const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+                                              const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view,
+                                              Storage *storage, Transaction *transaction)
+    : pin_accessor_edge_(std::move(edge_pin)),
       pin_accessor_vertex_(std::move(vertex_accessor)),
       index_accessor_(std::move(index_accessor)),
       property_(property),
@@ -484,14 +485,16 @@ void InMemoryEdgePropertyIndex::RunGC() {
 
 InMemoryEdgePropertyIndex::Iterable InMemoryEdgePropertyIndex::ActiveIndices::Edges(
     PropertyId property, utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-    utils::SkipListDb<Edge>::ConstAccessor edge_accessor, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+    utils::SkipListDb<Edge>::ConstAccessor /*edge_accessor*/,
+    const std::optional<utils::Bound<PropertyValue>> &lower_bound,
     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
     Transaction *transaction) {
   auto it = index_container_->indices_.find(property);
   MG_ASSERT(it != index_container_->indices_.end(), "Index for edge property {} doesn't exist", property.AsUint());
+  auto edge_pin = static_cast<InMemoryStorage const *>(storage)->MakeEdgePin();
   return {it->second->skip_list_.access(),
           std::move(vertex_accessor),
-          std::move(edge_accessor),
+          std::move(edge_pin),
           property,
           lower_bound,
           upper_bound,
@@ -502,14 +505,15 @@ InMemoryEdgePropertyIndex::Iterable InMemoryEdgePropertyIndex::ActiveIndices::Ed
 
 InMemoryEdgePropertyIndex::ChunkedIterable InMemoryEdgePropertyIndex::ActiveIndices::ChunkedEdges(
     PropertyId property, utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-    utils::SkipListDb<Edge>::ConstAccessor edge_accessor, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+    const std::optional<utils::Bound<PropertyValue>> &lower_bound,
     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
     Transaction *transaction, size_t num_chunks) {
   auto it = index_container_->indices_.find(property);
   MG_ASSERT(it != index_container_->indices_.end(), "Index for edge property {} doesn't exist", property.AsUint());
+  auto edge_pin = static_cast<InMemoryStorage const *>(storage)->MakeEdgePin();
   return {it->second->skip_list_.access(),
           std::move(vertex_accessor),
-          std::move(edge_accessor),
+          std::move(edge_pin),
           property,
           lower_bound,
           upper_bound,
@@ -562,12 +566,11 @@ void InMemoryEdgePropertyIndex::CleanupAllIndicies() {
 }
 
 InMemoryEdgePropertyIndex::ChunkedIterable::ChunkedIterable(
-    utils::SkipListDb<InMemoryEdgePropertyIndex::Entry>::Accessor index_accessor,
-    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor, utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
-    PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+    utils::SkipListDb<Entry>::Accessor index_accessor, utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
+    EdgePin edge_pin, PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
     Transaction *transaction, size_t num_chunks)
-    : pin_accessor_edge_(std::move(edge_accessor)),
+    : pin_accessor_edge_(std::move(edge_pin)),
       pin_accessor_vertex_(std::move(vertex_accessor)),
       index_accessor_(std::move(index_accessor)),
       property_(property),

--- a/src/storage/v2/inmemory/edge_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_property_index.cpp
@@ -485,7 +485,6 @@ void InMemoryEdgePropertyIndex::RunGC() {
 
 InMemoryEdgePropertyIndex::Iterable InMemoryEdgePropertyIndex::ActiveIndices::Edges(
     PropertyId property, utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-    utils::SkipListDb<Edge>::ConstAccessor /*edge_accessor*/,
     const std::optional<utils::Bound<PropertyValue>> &lower_bound,
     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
     Transaction *transaction) {

--- a/src/storage/v2/inmemory/edge_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_property_index.hpp
@@ -22,6 +22,7 @@
 #include "storage/v2/indices/edge_property_index.hpp"
 #include "storage/v2/indices/errors.hpp"
 #include "storage/v2/inmemory/indices_mvcc.hpp"
+#include "storage/v2/inmemory/light_edge_guard.hpp"
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/snapshot_observer_info.hpp"
 #include "storage/v2/vertex_accessor.hpp"
@@ -84,8 +85,7 @@ class InMemoryEdgePropertyIndex : public EdgePropertyIndex {
   class Iterable {
    public:
     Iterable(utils::SkipListDb<Entry>::Accessor index_accessor,
-             utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-             utils::SkipListDb<Edge>::ConstAccessor edge_accessor, PropertyId property,
+             utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor, EdgePin edge_pin, PropertyId property,
              const std::optional<utils::Bound<PropertyValue>> &lower_bound,
              const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
              Transaction *transaction);
@@ -116,7 +116,7 @@ class InMemoryEdgePropertyIndex : public EdgePropertyIndex {
     Iterator end() { return {this, index_accessor_.end()}; }
 
    private:
-    utils::SkipListDb<Edge>::ConstAccessor pin_accessor_edge_;
+    EdgePin pin_accessor_edge_;
     utils::SkipListDb<Vertex>::ConstAccessor pin_accessor_vertex_;
     utils::SkipListDb<Entry>::Accessor index_accessor_;
     [[maybe_unused]] EdgeTypeId edge_type_;
@@ -132,16 +132,14 @@ class InMemoryEdgePropertyIndex : public EdgePropertyIndex {
   class ChunkedIterable {
    public:
     ChunkedIterable(utils::SkipListDb<Entry>::Accessor index_accessor,
-                    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-                    utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
-                    PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+                    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor, EdgePin edge_pin, PropertyId property,
+                    const std::optional<utils::Bound<PropertyValue>> &lower_bound,
                     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
                     Transaction *transaction, size_t num_chunks);
 
     class Iterator {
      public:
-      Iterator(ChunkedIterable *self,
-               utils::SkipListDb<Entry>::ChunkedIterator index_iterator)
+      Iterator(ChunkedIterable *self, utils::SkipListDb<Entry>::ChunkedIterator index_iterator)
           : self_(self),
             index_iterator_(index_iterator),
             current_edge_accessor_(EdgeRef{nullptr}, EdgeTypeId{}, nullptr, nullptr, self_->storage_,
@@ -189,7 +187,7 @@ class InMemoryEdgePropertyIndex : public EdgePropertyIndex {
     size_t size() const { return chunks_.size(); }
 
    private:
-    utils::SkipListDb<Edge>::ConstAccessor pin_accessor_edge_;
+    EdgePin pin_accessor_edge_;
     utils::SkipListDb<Vertex>::ConstAccessor pin_accessor_vertex_;
     utils::SkipListDb<Entry>::Accessor index_accessor_;
     [[maybe_unused]] PropertyId property_;
@@ -222,16 +220,13 @@ class InMemoryEdgePropertyIndex : public EdgePropertyIndex {
 
     std::vector<PropertyId> ListIndices(uint64_t start_timestamp) const override;
 
-    Iterable Edges(PropertyId property,
-                   utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
+    Iterable Edges(PropertyId property, utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
                    utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
                    const std::optional<utils::Bound<PropertyValue>> &lower_bound,
                    const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
                    Transaction *transaction);
 
-    ChunkedIterable ChunkedEdges(PropertyId property,
-                                 utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-                                 utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
+    ChunkedIterable ChunkedEdges(PropertyId property, utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
                                  const std::optional<utils::Bound<PropertyValue>> &lower_bound,
                                  const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view,
                                  Storage *storage, Transaction *transaction, size_t num_chunks);
@@ -246,8 +241,7 @@ class InMemoryEdgePropertyIndex : public EdgePropertyIndex {
   InMemoryEdgePropertyIndex() = default;
 
   /// @throw std::bad_alloc
-  bool CreateIndexOnePass(PropertyId property,
-                          utils::SkipListDb<Vertex>::Accessor vertices,
+  bool CreateIndexOnePass(PropertyId property, utils::SkipListDb<Vertex>::Accessor vertices,
                           ActiveIndicesUpdater const &updater,
                           std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 

--- a/src/storage/v2/inmemory/edge_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_property_index.hpp
@@ -221,7 +221,6 @@ class InMemoryEdgePropertyIndex : public EdgePropertyIndex {
     std::vector<PropertyId> ListIndices(uint64_t start_timestamp) const override;
 
     Iterable Edges(PropertyId property, utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-                   utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
                    const std::optional<utils::Bound<PropertyValue>> &lower_bound,
                    const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
                    Transaction *transaction);

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -317,7 +317,7 @@ void InMemoryEdgeTypeIndex::ActiveIndices::AbortEntries(EdgeTypeIndex::Abortable
     auto &index_storage = it->second;
     auto acc = index_storage->skip_list_.access();
     for (const auto &[from_vertex, to_vertex, edge] : edges) {
-      acc.remove(Entry{from_vertex, to_vertex, edge, exact_start_timestamp});
+      acc.remove(Entry{from_vertex, to_vertex, edge.ptr, exact_start_timestamp});
     }
   }
 }

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -317,7 +317,8 @@ void InMemoryEdgeTypeIndex::ActiveIndices::AbortEntries(EdgeTypeIndex::Abortable
     auto &index_storage = it->second;
     auto acc = index_storage->skip_list_.access();
     for (const auto &[from_vertex, to_vertex, edge] : edges) {
-      acc.remove(Entry{from_vertex, to_vertex, edge.ptr, exact_start_timestamp});
+      acc.remove(Entry{
+          .from_vertex = from_vertex, .to_vertex = to_vertex, .edge = edge.ptr, .timestamp = exact_start_timestamp});
     }
   }
 }
@@ -329,7 +330,7 @@ void InMemoryEdgeTypeIndex::ActiveIndices::UpdateOnEdgeCreation(Vertex *from, Ve
     return;
   }
   auto acc = it->second->skip_list_.access();
-  acc.insert(Entry{from, to, edge_ref.ptr, tx.start_timestamp});
+  acc.insert(Entry{.from_vertex = from, .to_vertex = to, .edge = edge_ref.ptr, .timestamp = tx.start_timestamp});
 }
 
 void InMemoryEdgeTypeIndex::DropGraphClearIndices() {

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -16,6 +16,7 @@
 #include "storage/v2/edge_info_helpers.hpp"
 #include "storage/v2/indices/active_indices_updater.hpp"
 #include "storage/v2/indices/indices_utils.hpp"
+#include "storage/v2/inmemory/light_edge_guard.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "utils/counter.hpp"
 
@@ -338,11 +339,10 @@ void InMemoryEdgeTypeIndex::DropGraphClearIndices() {
   });
 }
 
-InMemoryEdgeTypeIndex::Iterable::Iterable(utils::SkipListDb<InMemoryEdgeTypeIndex::Entry>::Accessor index_accessor,
-                                          utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-                                          utils::SkipListDb<Edge>::ConstAccessor edge_accessor, EdgeTypeId edge_type,
-                                          View view, Storage *storage, Transaction *transaction)
-    : pin_accessor_edge_(std::move(edge_accessor)),
+InMemoryEdgeTypeIndex::Iterable::Iterable(utils::SkipListDb<Entry>::Accessor index_accessor,
+                                          utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor, EdgePin edge_pin,
+                                          EdgeTypeId edge_type, View view, Storage *storage, Transaction *transaction)
+    : pin_accessor_edge_(std::move(edge_pin)),
       pin_accessor_vertex_(std::move(vertex_accessor)),
       index_accessor_(std::move(index_accessor)),
       edge_type_(edge_type),
@@ -389,12 +389,13 @@ void InMemoryEdgeTypeIndex::RunGC() {
 
 InMemoryEdgeTypeIndex::Iterable InMemoryEdgeTypeIndex::ActiveIndices::Edges(
     EdgeTypeId edge_type, utils::SkipListDb<Vertex>::ConstAccessor vertex_acc,
-    utils::SkipListDb<Edge>::ConstAccessor edge_acc, View view, Storage *storage, Transaction *transaction) {
+    utils::SkipListDb<Edge>::ConstAccessor /*edge_acc*/, View view, Storage *storage, Transaction *transaction) {
   const auto it = index_container_->indices_.find(edge_type);
   MG_ASSERT(it != index_container_->indices_.end(), "Index for edge-type {} doesn't exist", edge_type.AsUint());
+  auto edge_pin = static_cast<InMemoryStorage const *>(storage)->MakeEdgePin();
   return {it->second->skip_list_.access(),
           std::move(vertex_acc),
-          std::move(edge_acc),
+          std::move(edge_pin),
           edge_type,
           view,
           storage,
@@ -402,14 +403,14 @@ InMemoryEdgeTypeIndex::Iterable InMemoryEdgeTypeIndex::ActiveIndices::Edges(
 }
 
 InMemoryEdgeTypeIndex::ChunkedIterable InMemoryEdgeTypeIndex::ActiveIndices::ChunkedEdges(
-    EdgeTypeId edge_type, utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-    utils::SkipListDb<Edge>::ConstAccessor edge_accessor, View view, Storage *storage, Transaction *transaction,
-    size_t num_chunks) {
+    EdgeTypeId edge_type, utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor, View view, Storage *storage,
+    Transaction *transaction, size_t num_chunks) {
   const auto it = index_container_->indices_.find(edge_type);
   MG_ASSERT(it != index_container_->indices_.end(), "Index for edge-type {} doesn't exist", edge_type.AsUint());
+  auto edge_pin = static_cast<InMemoryStorage const *>(storage)->MakeEdgePin();
   return {it->second->skip_list_.access(),
           std::move(vertex_accessor),
-          std::move(edge_accessor),
+          std::move(edge_pin),
           edge_type,
           view,
           storage,
@@ -445,11 +446,11 @@ void InMemoryEdgeTypeIndex::CleanupAllIndices() {
   });
 }
 
-InMemoryEdgeTypeIndex::ChunkedIterable::ChunkedIterable(
-    utils::SkipListDb<InMemoryEdgeTypeIndex::Entry>::Accessor index_accessor,
-    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor, utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
-    EdgeTypeId edge_type, View view, Storage *storage, Transaction *transaction, size_t num_chunks)
-    : pin_accessor_edge_(std::move(edge_accessor)),
+InMemoryEdgeTypeIndex::ChunkedIterable::ChunkedIterable(utils::SkipListDb<Entry>::Accessor index_accessor,
+                                                        utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
+                                                        EdgePin edge_pin, EdgeTypeId edge_type, View view,
+                                                        Storage *storage, Transaction *transaction, size_t num_chunks)
+    : pin_accessor_edge_(std::move(edge_pin)),
       pin_accessor_vertex_(std::move(vertex_accessor)),
       index_accessor_(std::move(index_accessor)),
       edge_type_(edge_type),

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -388,8 +388,8 @@ void InMemoryEdgeTypeIndex::RunGC() {
 }
 
 InMemoryEdgeTypeIndex::Iterable InMemoryEdgeTypeIndex::ActiveIndices::Edges(
-    EdgeTypeId edge_type, utils::SkipListDb<Vertex>::ConstAccessor vertex_acc,
-    utils::SkipListDb<Edge>::ConstAccessor /*edge_acc*/, View view, Storage *storage, Transaction *transaction) {
+    EdgeTypeId edge_type, utils::SkipListDb<Vertex>::ConstAccessor vertex_acc, View view, Storage *storage,
+    Transaction *transaction) {
   const auto it = index_container_->indices_.find(edge_type);
   MG_ASSERT(it != index_container_->indices_.end(), "Index for edge-type {} doesn't exist", edge_type.AsUint());
   auto edge_pin = static_cast<InMemoryStorage const *>(storage)->MakeEdgePin();

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -203,9 +203,8 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
     void AbortEntries(AbortableInfo const &info, uint64_t exact_start_timestamp) override;
     auto GetAbortProcessor() const -> AbortProcessor override;
 
-    Iterable Edges(EdgeTypeId edge_type, utils::SkipListDb<Vertex>::ConstAccessor vertex_acc,
-                   utils::SkipListDb<Edge>::ConstAccessor edge_acc, View view, Storage *storage,
-                   Transaction *transaction);
+    Iterable Edges(EdgeTypeId edge_type, utils::SkipListDb<Vertex>::ConstAccessor vertex_acc, View view,
+                   Storage *storage, Transaction *transaction);
 
     ChunkedIterable ChunkedEdges(EdgeTypeId edge_type, utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
                                  View view, Storage *storage, Transaction *transaction, size_t num_chunks);

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -22,6 +22,7 @@
 #include "storage/v2/indices/edge_type_index.hpp"
 #include "storage/v2/indices/errors.hpp"
 #include "storage/v2/inmemory/indices_mvcc.hpp"
+#include "storage/v2/inmemory/light_edge_guard.hpp"
 #include "storage/v2/snapshot_observer_info.hpp"
 #include "storage/v2/vertex_accessor.hpp"
 #include "utils/rw_lock.hpp"
@@ -53,8 +54,7 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
   class Iterable {
    public:
     Iterable(utils::SkipListDb<Entry>::Accessor index_accessor,
-             utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-             utils::SkipListDb<Edge>::ConstAccessor edge_accessor, EdgeTypeId edge_type,
+             utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor, EdgePin edge_pin, EdgeTypeId edge_type,
              View view, Storage *storage, Transaction *transaction);
 
     class Iterator {
@@ -83,7 +83,7 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
     Iterator end() { return {this, index_accessor_.end()}; }
 
    private:
-    utils::SkipListDb<Edge>::ConstAccessor pin_accessor_edge_;
+    EdgePin pin_accessor_edge_;
     utils::SkipListDb<Vertex>::ConstAccessor pin_accessor_vertex_;
     utils::SkipListDb<Entry>::Accessor index_accessor_;
     [[maybe_unused]] EdgeTypeId edge_type_;
@@ -95,14 +95,12 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
   class ChunkedIterable {
    public:
     ChunkedIterable(utils::SkipListDb<Entry>::Accessor index_accessor,
-                    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-                    utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
-                    EdgeTypeId edge_type, View view, Storage *storage, Transaction *transaction, size_t num_chunks);
+                    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor, EdgePin edge_pin, EdgeTypeId edge_type,
+                    View view, Storage *storage, Transaction *transaction, size_t num_chunks);
 
     class Iterator {
      public:
-      Iterator(ChunkedIterable *self,
-               utils::SkipListDb<Entry>::ChunkedIterator index_iterator)
+      Iterator(ChunkedIterable *self, utils::SkipListDb<Entry>::ChunkedIterator index_iterator)
           : self_(self),
             index_iterator_(index_iterator),
             current_edge_accessor_(EdgeRef{nullptr}, EdgeTypeId{}, nullptr, nullptr, self_->storage_,
@@ -149,7 +147,7 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
     size_t size() const { return chunks_.size(); }
 
    private:
-    utils::SkipListDb<Edge>::ConstAccessor pin_accessor_edge_;
+    EdgePin pin_accessor_edge_;
     utils::SkipListDb<Vertex>::ConstAccessor pin_accessor_vertex_;
     utils::SkipListDb<Entry>::Accessor index_accessor_;
     EdgeTypeId edge_type_;
@@ -205,14 +203,11 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
     void AbortEntries(AbortableInfo const &info, uint64_t exact_start_timestamp) override;
     auto GetAbortProcessor() const -> AbortProcessor override;
 
-    Iterable Edges(EdgeTypeId edge_type,
-                   utils::SkipListDb<Vertex>::ConstAccessor vertex_acc,
-                   utils::SkipListDb<Edge>::ConstAccessor edge_acc, View view,
-                   Storage *storage, Transaction *transaction);
+    Iterable Edges(EdgeTypeId edge_type, utils::SkipListDb<Vertex>::ConstAccessor vertex_acc,
+                   utils::SkipListDb<Edge>::ConstAccessor edge_acc, View view, Storage *storage,
+                   Transaction *transaction);
 
-    ChunkedIterable ChunkedEdges(EdgeTypeId edge_type,
-                                 utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-                                 utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
+    ChunkedIterable ChunkedEdges(EdgeTypeId edge_type, utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
                                  View view, Storage *storage, Transaction *transaction, size_t num_chunks);
 
    private:
@@ -222,8 +217,7 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
   InMemoryEdgeTypeIndex() = default;
 
   /// @throw std::bad_alloc
-  bool CreateIndexOnePass(EdgeTypeId edge_type,
-                          utils::SkipListDb<Vertex>::Accessor vertices,
+  bool CreateIndexOnePass(EdgeTypeId edge_type, utils::SkipListDb<Vertex>::Accessor vertices,
                           ActiveIndicesUpdater const &updater,
                           std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -502,7 +502,6 @@ void InMemoryEdgeTypePropertyIndex::RunGC() {
 
 InMemoryEdgeTypePropertyIndex::Iterable InMemoryEdgeTypePropertyIndex::ActiveIndices::Edges(
     EdgeTypeId edge_type, PropertyId property, utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-    utils::SkipListDb<Edge>::ConstAccessor /*edge_accessor*/,
     const std::optional<utils::Bound<PropertyValue>> &lower_bound,
     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
     Transaction *transaction) {
@@ -511,10 +510,9 @@ InMemoryEdgeTypePropertyIndex::Iterable InMemoryEdgeTypePropertyIndex::ActiveInd
             "Index for edge type {} and property {} doesn't exist",
             edge_type.AsUint(),
             property.AsUint());
-  auto vertex_acc = static_cast<InMemoryStorage const *>(storage)->vertices_.access();
   auto edge_pin = static_cast<InMemoryStorage const *>(storage)->MakeEdgePin();
   return {it->second->skiplist.access(),
-          std::move(vertex_acc),
+          std::move(vertex_accessor),
           std::move(edge_pin),
           edge_type,
           property,

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -17,6 +17,7 @@
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indices/active_indices_updater.hpp"
 #include "storage/v2/indices/indices_utils.hpp"
+#include "storage/v2/inmemory/light_edge_guard.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/property_constants.hpp"
 #include "storage/v2/property_value.hpp"
@@ -441,13 +442,13 @@ void InMemoryEdgeTypePropertyIndex::DropGraphClearIndices() {
   });
 }
 
-InMemoryEdgeTypePropertyIndex::Iterable::Iterable(
-    utils::SkipListDb<InMemoryEdgeTypePropertyIndex::Entry>::Accessor index_accessor,
-    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor, utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
-    EdgeTypeId edge_type, PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
-    const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
-    Transaction *transaction)
-    : pin_accessor_edge_(std::move(edge_accessor)),
+InMemoryEdgeTypePropertyIndex::Iterable::Iterable(utils::SkipListDb<Entry>::Accessor index_accessor,
+                                                  utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
+                                                  EdgePin edge_pin, EdgeTypeId edge_type, PropertyId property,
+                                                  const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+                                                  const std::optional<utils::Bound<PropertyValue>> &upper_bound,
+                                                  View view, Storage *storage, Transaction *transaction)
+    : pin_accessor_edge_(std::move(edge_pin)),
       pin_accessor_vertex_(std::move(vertex_accessor)),
       index_accessor_(std::move(index_accessor)),
       edge_type_(edge_type),
@@ -501,7 +502,8 @@ void InMemoryEdgeTypePropertyIndex::RunGC() {
 
 InMemoryEdgeTypePropertyIndex::Iterable InMemoryEdgeTypePropertyIndex::ActiveIndices::Edges(
     EdgeTypeId edge_type, PropertyId property, utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-    utils::SkipListDb<Edge>::ConstAccessor edge_accessor, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+    utils::SkipListDb<Edge>::ConstAccessor /*edge_accessor*/,
+    const std::optional<utils::Bound<PropertyValue>> &lower_bound,
     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
     Transaction *transaction) {
   auto it = index_container_->find({edge_type, property});
@@ -509,9 +511,11 @@ InMemoryEdgeTypePropertyIndex::Iterable InMemoryEdgeTypePropertyIndex::ActiveInd
             "Index for edge type {} and property {} doesn't exist",
             edge_type.AsUint(),
             property.AsUint());
+  auto vertex_acc = static_cast<InMemoryStorage const *>(storage)->vertices_.access();
+  auto edge_pin = static_cast<InMemoryStorage const *>(storage)->MakeEdgePin();
   return {it->second->skiplist.access(),
-          std::move(vertex_accessor),
-          std::move(edge_accessor),
+          std::move(vertex_acc),
+          std::move(edge_pin),
           edge_type,
           property,
           lower_bound,
@@ -523,7 +527,7 @@ InMemoryEdgeTypePropertyIndex::Iterable InMemoryEdgeTypePropertyIndex::ActiveInd
 
 InMemoryEdgeTypePropertyIndex::ChunkedIterable InMemoryEdgeTypePropertyIndex::ActiveIndices::ChunkedEdges(
     EdgeTypeId edge_type, PropertyId property, utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-    utils::SkipListDb<Edge>::ConstAccessor edge_accessor, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+    const std::optional<utils::Bound<PropertyValue>> &lower_bound,
     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
     Transaction *transaction, size_t num_chunks) {
   auto it = index_container_->find({edge_type, property});
@@ -531,9 +535,10 @@ InMemoryEdgeTypePropertyIndex::ChunkedIterable InMemoryEdgeTypePropertyIndex::Ac
             "Index for edge type {} and property {} doesn't exist",
             edge_type.AsUint(),
             property.AsUint());
+  auto edge_pin = static_cast<InMemoryStorage const *>(storage)->MakeEdgePin();
   return {it->second->skiplist.access(),
           std::move(vertex_accessor),
-          std::move(edge_accessor),
+          std::move(edge_pin),
           edge_type,
           property,
           lower_bound,
@@ -585,12 +590,12 @@ void InMemoryEdgeTypePropertyIndex::CleanupAllIndices() {
 }
 
 InMemoryEdgeTypePropertyIndex::ChunkedIterable::ChunkedIterable(
-    utils::SkipListDb<InMemoryEdgeTypePropertyIndex::Entry>::Accessor index_accessor,
-    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor, utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
-    EdgeTypeId edge_type, PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+    utils::SkipListDb<Entry>::Accessor index_accessor, utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
+    EdgePin edge_pin, EdgeTypeId edge_type, PropertyId property,
+    const std::optional<utils::Bound<PropertyValue>> &lower_bound,
     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
     Transaction *transaction, size_t num_chunks)
-    : pin_accessor_edge_(std::move(edge_accessor)),
+    : pin_accessor_edge_(std::move(edge_pin)),
       pin_accessor_vertex_(std::move(vertex_accessor)),
       index_accessor_(std::move(index_accessor)),
       edge_type_(edge_type),

--- a/src/storage/v2/inmemory/edge_type_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.hpp
@@ -216,7 +216,6 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
     auto ListIndices(uint64_t start_timestamp) const -> std::vector<std::pair<EdgeTypeId, PropertyId>> override;
 
     Iterable Edges(EdgeTypeId edge_type, PropertyId property, utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-                   utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
                    const std::optional<utils::Bound<PropertyValue>> &lower_bound,
                    const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
                    Transaction *transaction);

--- a/src/storage/v2/inmemory/edge_type_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.hpp
@@ -23,6 +23,7 @@
 #include "storage/v2/indices/edge_type_property_index.hpp"
 #include "storage/v2/indices/errors.hpp"
 #include "storage/v2/inmemory/indices_mvcc.hpp"
+#include "storage/v2/inmemory/light_edge_guard.hpp"
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/snapshot_observer_info.hpp"
 #include "storage/v2/vertex_accessor.hpp"
@@ -59,8 +60,7 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
   class Iterable {
    public:
     Iterable(utils::SkipListDb<Entry>::Accessor index_accessor,
-             utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-             utils::SkipListDb<Edge>::ConstAccessor edge_accessor, EdgeTypeId edge_type,
+             utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor, EdgePin edge_pin, EdgeTypeId edge_type,
              PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
              const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
              Transaction *transaction);
@@ -91,7 +91,7 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
     Iterator end() { return {this, index_accessor_.end()}; }
 
    private:
-    utils::SkipListDb<Edge>::ConstAccessor pin_accessor_edge_;
+    EdgePin pin_accessor_edge_;
     utils::SkipListDb<Vertex>::ConstAccessor pin_accessor_vertex_;
     utils::SkipListDb<Entry>::Accessor index_accessor_;
     [[maybe_unused]] EdgeTypeId edge_type_;
@@ -107,17 +107,14 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
   class ChunkedIterable {
    public:
     ChunkedIterable(utils::SkipListDb<Entry>::Accessor index_accessor,
-                    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-                    utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
-                    EdgeTypeId edge_type, PropertyId property,
-                    const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+                    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor, EdgePin edge_pin, EdgeTypeId edge_type,
+                    PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
                     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
                     Transaction *transaction, size_t num_chunks);
 
     class Iterator {
      public:
-      Iterator(ChunkedIterable *self,
-               utils::SkipListDb<Entry>::ChunkedIterator index_iterator)
+      Iterator(ChunkedIterable *self, utils::SkipListDb<Entry>::ChunkedIterator index_iterator)
           : self_(self),
             index_iterator_(index_iterator),
             current_edge_accessor_(EdgeRef{nullptr}, EdgeTypeId{}, nullptr, nullptr, self_->storage_,
@@ -164,7 +161,7 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
     size_t size() const { return chunks_.size(); }
 
    private:
-    utils::SkipListDb<Edge>::ConstAccessor pin_accessor_edge_;
+    EdgePin pin_accessor_edge_;
     utils::SkipListDb<Vertex>::ConstAccessor pin_accessor_vertex_;
     utils::SkipListDb<Entry>::Accessor index_accessor_;
     [[maybe_unused]] EdgeTypeId edge_type_;
@@ -218,8 +215,7 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
 
     auto ListIndices(uint64_t start_timestamp) const -> std::vector<std::pair<EdgeTypeId, PropertyId>> override;
 
-    Iterable Edges(EdgeTypeId edge_type, PropertyId property,
-                   utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
+    Iterable Edges(EdgeTypeId edge_type, PropertyId property, utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
                    utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
                    const std::optional<utils::Bound<PropertyValue>> &lower_bound,
                    const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
@@ -227,7 +223,6 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
 
     ChunkedIterable ChunkedEdges(EdgeTypeId edge_type, PropertyId property,
                                  utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-                                 utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
                                  const std::optional<utils::Bound<PropertyValue>> &lower_bound,
                                  const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view,
                                  Storage *storage, Transaction *transaction, size_t num_chunks);
@@ -245,8 +240,7 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
   InMemoryEdgeTypePropertyIndex() = default;
 
   /// @throw std::bad_alloc
-  bool CreateIndexOnePass(EdgeTypeId edge_type, PropertyId property,
-                          utils::SkipListDb<Vertex>::Accessor vertices,
+  bool CreateIndexOnePass(EdgeTypeId edge_type, PropertyId property, utils::SkipListDb<Vertex>::Accessor vertices,
                           ActiveIndicesUpdater const &updater,
                           std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
@@ -265,8 +259,7 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
   auto GetActiveIndices() const -> std::shared_ptr<EdgeTypePropertyIndex::ActiveIndices> override;
 
   auto RegisterIndex(EdgeTypeId edge_type, PropertyId property, ActiveIndicesUpdater const &updater) -> bool;
-  auto PopulateIndex(EdgeTypeId edge_type, PropertyId property,
-                     utils::SkipListDb<Vertex>::Accessor vertices,
+  auto PopulateIndex(EdgeTypeId edge_type, PropertyId property, utils::SkipListDb<Vertex>::Accessor vertices,
                      ActiveIndicesUpdater const &updater,
                      std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt,
                      Transaction const *tx = nullptr, CheckCancelFunction cancel_check = neverCancel)

--- a/src/storage/v2/inmemory/light_edge_guard.hpp
+++ b/src/storage/v2/inmemory/light_edge_guard.hpp
@@ -1,0 +1,71 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <cstdint>
+#include <utility>
+#include <variant>
+
+#include "storage/v2/edge.hpp"
+#include "utils/epoch_tracker.hpp"
+#include "utils/skip_list.hpp"
+
+namespace memgraph::storage {
+
+// RAII guard that acquires an epoch ID from an EpochTracker on construction and
+// releases it on destruction.
+//
+// Edge-index Iterables store either a utils::SkipListDb<Edge>::ConstAccessor (normal-edge mode,
+// prevents GC from freeing the edges_ skiplist nodes that hold the Edge structs) or one of
+// these guards (light-edge mode, where edges_ is empty and edges are pool-allocated instead).
+//
+// The graveyard drain condition uses EpochTracker::IsSafeToFree(guard_epoch) to allow draining
+// once all readers that existed before the graveyard entry was inserted have finished — more
+// precise than the previous "active count == 0" check, which blocked even readers created after.
+struct LightEdgeIterableGuard {
+  LightEdgeIterableGuard() = default;
+
+  explicit LightEdgeIterableGuard(utils::EpochTracker *tracker) : tracker_(tracker) {
+    if (tracker_) id_ = tracker_->Acquire();
+  }
+
+  ~LightEdgeIterableGuard() {
+    if (tracker_) tracker_->Release(id_);
+  }
+
+  LightEdgeIterableGuard(LightEdgeIterableGuard &&o) noexcept
+      : tracker_(std::exchange(o.tracker_, nullptr)), id_(o.id_) {}
+
+  LightEdgeIterableGuard &operator=(LightEdgeIterableGuard &&o) noexcept {
+    if (this != &o) {
+      if (tracker_) tracker_->Release(id_);
+      tracker_ = std::exchange(o.tracker_, nullptr);
+      id_ = o.id_;
+    }
+    return *this;
+  }
+
+  LightEdgeIterableGuard(LightEdgeIterableGuard const &) = delete;
+  LightEdgeIterableGuard &operator=(LightEdgeIterableGuard const &) = delete;
+
+ private:
+  utils::EpochTracker *tracker_{nullptr};
+  uint64_t id_{0};
+};
+
+// Pin type stored in every edge-index Iterable/ChunkedIterable.
+// - ConstAccessor: normal edges — prevents edges_ skiplist GC from freeing Edge memory.
+// - LightEdgeIterableGuard: light edges — acquires an epoch ID so the graveyard drain
+//   only unblocks once all pre-existing readers have finished.
+using EdgePin = std::variant<utils::SkipListDb<Edge>::ConstAccessor, LightEdgeIterableGuard>;
+
+}  // namespace memgraph::storage

--- a/src/storage/v2/inmemory/light_edge_guard.hpp
+++ b/src/storage/v2/inmemory/light_edge_guard.hpp
@@ -26,7 +26,7 @@ namespace memgraph::storage {
 //
 // Edge-index Iterables store either a utils::SkipListDb<Edge>::ConstAccessor (normal-edge mode,
 // prevents GC from freeing the edges_ skiplist nodes that hold the Edge structs) or one of
-// these guards (light-edge mode, where edges_ is empty and edges are pool-allocated instead).
+// these guards (light-edge mode, where edges_ is empty and edges are allocated instead).
 //
 // The graveyard drain condition uses EpochTracker::IsSafeToFree(guard_epoch) to allow draining
 // once all readers that existed before the graveyard entry was inserted have finished — more

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -165,6 +165,81 @@ DeltaChainState ComputeDeltaChainState(bool has_blocker, WriteResult result) {
   return DeltaChainState::SEQUENTIAL;
 }
 
+// Flattens a vertex skip-list accessor into a range of Edge references
+// by walking every vertex'''s out_edges.  Only safe while the vertex
+// accessor (and therefore all vertices) remain alive.
+class LightEdgeIterable {
+ public:
+  using VertexIterator = utils::SkipListDb<Vertex>::Accessor::iterator;
+
+  class Iterator {
+   public:
+    using value_type = Edge;
+    using reference = Edge &;
+    using pointer = Edge *;
+    using difference_type = std::ptrdiff_t;
+    using iterator_category = std::forward_iterator_tag;
+
+    Iterator() = default;
+
+    Iterator(VertexIterator vertex_it, VertexIterator vertex_end)
+        : vertex_it_(std::move(vertex_it)), vertex_end_(std::move(vertex_end)) {
+      AdvanceToNextEdge();
+    }
+
+    reference operator*() const { return *std::get<2>(*edge_it_).ptr; }
+
+    pointer operator->() const { return std::get<2>(*edge_it_).ptr; }
+
+    Iterator &operator++() {
+      ++edge_it_;
+      if (edge_it_ == edge_end_) {
+        ++vertex_it_;
+        AdvanceToNextEdge();
+      }
+      return *this;
+    }
+
+    Iterator operator++(int) {
+      Iterator old = *this;
+      ++(*this);
+      return old;
+    }
+
+    friend bool operator==(Iterator const &lhs, Iterator const &rhs) {
+      return lhs.vertex_it_ == rhs.vertex_it_ && (lhs.vertex_it_ == lhs.vertex_end_ || lhs.edge_it_ == rhs.edge_it_);
+    }
+
+   private:
+    void AdvanceToNextEdge() {
+      for (; vertex_it_ != vertex_end_; ++vertex_it_) {
+        auto &out_edges = vertex_it_->out_edges;
+        if (!out_edges.empty()) {
+          edge_it_ = out_edges.begin();
+          edge_end_ = out_edges.end();
+          return;
+        }
+      }
+    }
+
+    VertexIterator vertex_it_{};
+    VertexIterator vertex_end_{};
+    Edges::iterator edge_it_{};
+    Edges::iterator edge_end_{};
+  };
+
+  explicit LightEdgeIterable(utils::SkipListDb<Vertex>::Accessor &vertex_acc)
+      : begin_(vertex_acc.begin(), vertex_acc.end()), end_(vertex_acc.end(), vertex_acc.end()) {}
+
+  Iterator begin() const { return begin_; }
+
+  Iterator end() const { return end_; }
+
+ private:
+  Iterator begin_;
+  Iterator end_;
+};
+
 class PeriodicSnapshotObserver : public memgraph::utils::Observer<memgraph::utils::SchedulerInterval> {
  public:
   explicit PeriodicSnapshotObserver(memgraph::utils::Scheduler &scheduler) : scheduler_{&scheduler} {}
@@ -668,21 +743,6 @@ InMemoryStorage::InMemoryAccessor::DetachDelete(std::vector<VertexAccessor *> no
       auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
       // Triggers RemoveObsoleteEdgeEntries in the next GC run (needed for both light and normal edges).
       mem_storage->gc_full_scan_edges_delete_.store(true, std::memory_order_release);
-      // LIGHT EDGES: light edges are not in edges_ (skip list), so the normal full scan
-      // won't find them to free. Push them into the graveyard so they are freed only after all
-      // concurrent read-only transactions and index readers that may hold an Edge* have finished.
-      // GC ordering guarantees RemoveObsoleteEdgeEntries runs before graveyard drain in the same
-      // GC cycle, so the Edge* remains valid during index cleanup.
-      if (config_.storage_light_edge) {
-        std::vector<Edge *, memory::DbAwareAllocator<Edge *>> deleted_light_edges;
-        deleted_light_edges.reserve(deleted_edges.size());
-        for (auto const &ea : deleted_edges) {
-          deleted_light_edges.push_back(ea.edge_.ptr);
-        }
-        auto guard_epoch = mem_storage->light_edge_iterable_tracker_.CurrentEpoch();
-        mem_storage->light_edge_graveyard_.WithLock(
-            [&](auto &graveyard) { graveyard.push_back({guard_epoch, std::move(deleted_light_edges)}); });
-      }
     }
   }};
 
@@ -3298,10 +3358,25 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
 
     // Remove edges from vector edge index BEFORE vertex skip-list removal.
     if (!indices_.vector_edge_index_.Empty()) {
-      auto edge_acc = edges_.access();
-      auto const analytical_deleted_edges =
-          edge_acc | std::ranges::views::filter([](auto const &e) { return e.delta() == nullptr && e.deleted(); }) |
-          std::ranges::views::transform([](auto &e) { return &e; }) | std::ranges::to<std::vector>();
+      std::vector<Edge *> analytical_deleted_edges;
+
+      {
+        auto edge_acc = edges_.access();
+        for (auto &e : edge_acc) {
+          if (e.delta() == nullptr && e.deleted()) {
+            analytical_deleted_edges.push_back(&e);
+          }
+        }
+      }
+
+      if (config_.salient.items.storage_light_edge) {
+        auto vertex_acc = vertices_.access();
+        for (auto &e : LightEdgeIterable{vertex_acc}) {
+          if (e.delta() == nullptr && e.deleted()) {
+            analytical_deleted_edges.push_back(&e);
+          }
+        }
+      }
 
       if (!analytical_deleted_edges.empty()) {
         indices_.RemoveEdgesFromVectorEdgeIndices(analytical_deleted_edges);
@@ -3320,9 +3395,22 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
     auto edge_acc = edges_.access();
 
     if (!need_full_scan_vertices && !indices_.vector_edge_index_.Empty()) {
-      auto const analytical_deleted_edges =
-          edge_acc | std::ranges::views::filter([](auto const &e) { return e.delta() == nullptr && e.deleted(); }) |
-          std::ranges::views::transform([](auto &e) { return &e; }) | std::ranges::to<std::vector>();
+      std::vector<Edge *> analytical_deleted_edges;
+
+      for (auto &e : edge_acc) {
+        if (e.delta() == nullptr && e.deleted()) {
+          analytical_deleted_edges.push_back(&e);
+        }
+      }
+
+      if (config_.salient.items.storage_light_edge) {
+        auto vertex_acc = vertices_.access();
+        for (auto &e : LightEdgeIterable{vertex_acc}) {
+          if (e.delta() == nullptr && e.deleted()) {
+            analytical_deleted_edges.push_back(&e);
+          }
+        }
+      }
 
       if (!analytical_deleted_edges.empty()) {
         indices_.RemoveEdgesFromVectorEdgeIndices(analytical_deleted_edges);
@@ -3336,10 +3424,23 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
         edge_metadata_acc.remove(edge.gid);
       }
     }
-  }
 
-  // Light-edge graveyard drain moved to DrainLightEdgeGraveyard(), called
-  // from FreeMemory after edges_.run_gc() — analogous to skiplist GC.
+    if (config_.salient.items.storage_light_edge) {
+      auto vertex_acc = vertices_.access();
+      std::vector<Edge *, memory::DbAwareAllocator<Edge *>> analytical_deleted_light_edges;
+      for (auto &e : LightEdgeIterable{vertex_acc}) {
+        if (e.delta() == nullptr && e.deleted()) {
+          analytical_deleted_light_edges.push_back(&e);
+          edge_metadata_acc.remove(e.gid);
+        }
+      }
+      if (!analytical_deleted_light_edges.empty()) {
+        auto guard_epoch = light_edge_iterable_tracker_.CurrentEpoch();
+        light_edge_graveyard_.WithLock(
+            [&](auto &graveyard) { graveyard.push_back({guard_epoch, std::move(analytical_deleted_light_edges)}); });
+      }
+    }
+  }
 }
 
 void InMemoryStorage::DrainLightEdgeGraveyard() {
@@ -3352,12 +3453,6 @@ void InMemoryStorage::DrainLightEdgeGraveyard() {
   light_edge_graveyard_.WithLock([&](auto &graveyard) { local_graveyard.swap(graveyard); });
 
   for (auto it = local_graveyard.begin(); it != local_graveyard.end();) {
-    // Re-snap guard_epoch to CurrentEpoch() before checking IsSafeToFree.
-    // Entries may have been pushed from fast-discard or abort with a guard_epoch
-    // snapped before post-commit/abort readers acquired their epoch.  Re-snapping
-    // here (after all index cleanup — RemoveObsoleteEdgeEntries + vector) ensures
-    // IsSafeToFree waits for any pre-drain reader that may hold a stale Edge*.
-    it->guard_epoch = light_edge_iterable_tracker_.CurrentEpoch();
     if (light_edge_iterable_tracker_.IsSafeToFree(it->guard_epoch)) {
       for (auto *edge : it->edges) {
         if (edge_metadata_acc) edge_metadata_acc->remove(edge->gid);

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2644,39 +2644,27 @@ VerticesChunkedIterable InMemoryStorage::InMemoryAccessor::ChunkedVertices(
 
 EdgesIterable InMemoryStorage::InMemoryAccessor::Edges(EdgeTypeId edge_type, View view) {
   auto vertex_acc = static_cast<InMemoryStorage const *>(storage_)->vertices_.access();
-  auto edge_acc = static_cast<InMemoryStorage const *>(storage_)->edges_.access();
   auto *active_indices =
       static_cast<InMemoryEdgeTypeIndex::ActiveIndices *>(transaction_.active_indices_->edge_type_.get());
-  return EdgesIterable(
-      active_indices->Edges(edge_type, std::move(vertex_acc), std::move(edge_acc), view, storage_, &transaction_));
+  return EdgesIterable(active_indices->Edges(edge_type, std::move(vertex_acc), view, storage_, &transaction_));
 }
 
 EdgesIterable InMemoryStorage::InMemoryAccessor::Edges(EdgeTypeId edge_type, PropertyId property, View view) {
   auto vertex_acc = static_cast<InMemoryStorage const *>(storage_)->vertices_.access();
-  auto edge_acc = static_cast<InMemoryStorage const *>(storage_)->edges_.access();
   auto *active_indices = static_cast<InMemoryEdgeTypePropertyIndex::ActiveIndices *>(
       transaction_.active_indices_->edge_type_properties_.get());
-  return EdgesIterable(active_indices->Edges(edge_type,
-                                             property,
-                                             std::move(vertex_acc),
-                                             std::move(edge_acc),
-                                             std::nullopt,
-                                             std::nullopt,
-                                             view,
-                                             storage_,
-                                             &transaction_));
+  return EdgesIterable(active_indices->Edges(
+      edge_type, property, std::move(vertex_acc), std::nullopt, std::nullopt, view, storage_, &transaction_));
 }
 
 EdgesIterable InMemoryStorage::InMemoryAccessor::Edges(EdgeTypeId edge_type, PropertyId property,
                                                        const PropertyValue &value, View view) {
   auto vertex_acc = static_cast<InMemoryStorage const *>(storage_)->vertices_.access();
-  auto edge_acc = static_cast<InMemoryStorage const *>(storage_)->edges_.access();
   auto *active_indices = static_cast<InMemoryEdgeTypePropertyIndex::ActiveIndices *>(
       transaction_.active_indices_->edge_type_properties_.get());
   return EdgesIterable(active_indices->Edges(edge_type,
                                              property,
                                              std::move(vertex_acc),
-                                             std::move(edge_acc),
                                              utils::MakeBoundInclusive(value),
                                              utils::MakeBoundInclusive(value),
                                              view,
@@ -2689,37 +2677,26 @@ EdgesIterable InMemoryStorage::InMemoryAccessor::Edges(EdgeTypeId edge_type, Pro
                                                        const std::optional<utils::Bound<PropertyValue>> &upper_bound,
                                                        View view) {
   auto vertex_acc = static_cast<InMemoryStorage const *>(storage_)->vertices_.access();
-  auto edge_acc = static_cast<InMemoryStorage const *>(storage_)->edges_.access();
   auto *active_indices = static_cast<InMemoryEdgeTypePropertyIndex::ActiveIndices *>(
       transaction_.active_indices_->edge_type_properties_.get());
-  return EdgesIterable(active_indices->Edges(edge_type,
-                                             property,
-                                             std::move(vertex_acc),
-                                             std::move(edge_acc),
-                                             lower_bound,
-                                             upper_bound,
-                                             view,
-                                             storage_,
-                                             &transaction_));
+  return EdgesIterable(active_indices->Edges(
+      edge_type, property, std::move(vertex_acc), lower_bound, upper_bound, view, storage_, &transaction_));
 }
 
 EdgesIterable InMemoryStorage::InMemoryAccessor::Edges(PropertyId property, View view) {
   auto vertex_acc = static_cast<InMemoryStorage const *>(storage_)->vertices_.access();
-  auto edge_acc = static_cast<InMemoryStorage const *>(storage_)->edges_.access();
   auto *mem_edge_property_active_indices =
       static_cast<InMemoryEdgePropertyIndex::ActiveIndices *>(transaction_.active_indices_->edge_property_.get());
   return EdgesIterable(mem_edge_property_active_indices->Edges(
-      property, std::move(vertex_acc), std::move(edge_acc), std::nullopt, std::nullopt, view, storage_, &transaction_));
+      property, std::move(vertex_acc), std::nullopt, std::nullopt, view, storage_, &transaction_));
 }
 
 EdgesIterable InMemoryStorage::InMemoryAccessor::Edges(PropertyId property, const PropertyValue &value, View view) {
   auto vertex_acc = static_cast<InMemoryStorage const *>(storage_)->vertices_.access();
-  auto edge_acc = static_cast<InMemoryStorage const *>(storage_)->edges_.access();
   auto *mem_edge_property_active_indices =
       static_cast<InMemoryEdgePropertyIndex::ActiveIndices *>(transaction_.active_indices_->edge_property_.get());
   return EdgesIterable(mem_edge_property_active_indices->Edges(property,
                                                                std::move(vertex_acc),
-                                                               std::move(edge_acc),
                                                                utils::MakeBoundInclusive(value),
                                                                utils::MakeBoundInclusive(value),
                                                                view,
@@ -2732,11 +2709,10 @@ EdgesIterable InMemoryStorage::InMemoryAccessor::Edges(PropertyId property,
                                                        const std::optional<utils::Bound<PropertyValue>> &upper_bound,
                                                        View view) {
   auto vertex_acc = static_cast<InMemoryStorage const *>(storage_)->vertices_.access();
-  auto edge_acc = static_cast<InMemoryStorage const *>(storage_)->edges_.access();
   auto *mem_edge_property_active_indices =
       static_cast<InMemoryEdgePropertyIndex::ActiveIndices *>(transaction_.active_indices_->edge_property_.get());
   return EdgesIterable(mem_edge_property_active_indices->Edges(
-      property, std::move(vertex_acc), std::move(edge_acc), lower_bound, upper_bound, view, storage_, &transaction_));
+      property, std::move(vertex_acc), lower_bound, upper_bound, view, storage_, &transaction_));
 }
 
 EdgesChunkedIterable InMemoryStorage::InMemoryAccessor::ChunkedEdges(EdgeTypeId edge_type, View view,

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -202,10 +202,11 @@ bool HasUncommittedNonSequentialDeltas(Vertex const *vertex, uint64_t skip_trans
   return false;
 }
 
-void UnlinkAndRemoveDeltas(delta_container &deltas,
+void UnlinkAndRemoveDeltas(delta_container &deltas, uint64_t transaction_id,
                            std::list<Gid, memory::DbAwareAllocator<Gid>> &current_deleted_edges,
                            std::list<Gid, memory::DbAwareAllocator<Gid>> &current_deleted_vertices,
-                           IndexPerformanceTracker &impact_tracker) {
+                           IndexPerformanceTracker &impact_tracker, bool light_edge_mode = false,
+                           std::vector<Edge *> *out_deleted_light_edges = nullptr) {
   for (auto &delta : deltas) {
     DMG_ASSERT(
         [&delta]() {
@@ -236,11 +237,37 @@ void UnlinkAndRemoveDeltas(delta_container &deltas,
         edge.SetDelta(nullptr);
         if (edge.deleted()) {
           DMG_ASSERT(delta.action == Delta::Action::RECREATE_OBJECT);
-          current_deleted_edges.push_back(edge.gid);
+          if (light_edge_mode) {
+            if (out_deleted_light_edges) out_deleted_light_edges->push_back(prev.edge);
+          } else {
+            current_deleted_edges.push_back(edge.gid);
+          }
         }
         break;
       }
     }
+  }
+}
+
+// At commit time, scan a transaction's delta list for RECREATE_OBJECT deltas
+// on deleted edges and push those Edge* to the graveyard with commit_timestamp
+// as the mark.  Using commit_timestamp is the tightest correct value: a reader
+// can see the edge as alive only if its start_timestamp < commit_timestamp, so
+// we need to wait until oldest_active_start_timestamp >= commit_timestamp before
+// freeing — exactly the graveyard drain condition with this mark.
+void GraveyardDeletedLightEdges(
+    delta_container const &deltas, uint64_t commit_timestamp, uint64_t guard_epoch,
+    utils::Synchronized<std::list<InMemoryStorage::LightEdgeGraveyardEntry>, utils::SpinLock> &graveyard) {
+  std::vector<Edge *> deleted;
+  for (auto const &delta : deltas) {
+    auto prev = delta.prev.Get();
+    if (prev.type == PreviousPtr::Type::EDGE && prev.edge->deleted()) {
+      DMG_ASSERT(delta.action == Delta::Action::RECREATE_OBJECT);
+      deleted.push_back(prev.edge);
+    }
+  }
+  if (!deleted.empty()) {
+    graveyard.WithLock([&](auto &g) { g.push_back({commit_timestamp, guard_epoch, std::move(deleted)}); });
   }
 }
 
@@ -519,6 +546,13 @@ InMemoryStorage::~InMemoryStorage() {
     create_snapshot_handler();
   }
   committed_transactions_.WithLock([](auto &transactions) { transactions.clear(); });
+
+  // Free all light edges: live edges in vertex adjacency lists + graveyard.
+  // Deleted light edges were pushed to the graveyard at commit time
+  // (FinalizeCommitPhase), so ClearLightEdges finds them there.
+  if (config_.salient.items.storage_light_edge) {
+    ClearLightEdges();
+  }
 }
 
 void InMemoryStorage::UpdateLabelCount(LabelId const label, int64_t const change) {
@@ -656,7 +690,29 @@ InMemoryStorage::InMemoryAccessor::DetachDelete(std::vector<VertexAccessor *> no
   auto const inform_gc_edge_deletion = utils::OnScopeExit{[this, &deleted_edges = deleted_edges]() {
     if (!deleted_edges.empty() && transaction_.storage_mode == StorageMode::IN_MEMORY_ANALYTICAL) {
       auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
+      // Triggers RemoveObsoleteEdgeEntries in the next GC run (needed for both light and normal edges).
       mem_storage->gc_full_scan_edges_delete_.store(true, std::memory_order_release);
+      // LIGHT EDGES: pool-allocated edges are not in edges_ (skip list), so the normal full scan
+      // won't find them to free. Push them into the graveyard so they are freed only after all
+      // concurrent read-only transactions and index readers that may hold an Edge* have finished.
+      // GC ordering guarantees RemoveObsoleteEdgeEntries runs before graveyard drain in the same
+      // GC cycle, so the Edge* remains valid during index cleanup.
+      if (config_.storage_light_edge) {
+        std::vector<Edge *> deleted_light_edges;
+        deleted_light_edges.reserve(deleted_edges.size());
+        for (auto const &ea : deleted_edges) {
+          deleted_light_edges.push_back(ea.edge_.ptr);
+        }
+        uint64_t mark_timestamp = 0;
+        {
+          auto engine_guard = std::unique_lock{mem_storage->engine_lock_};
+          mark_timestamp = mem_storage->timestamp_;
+        }
+        auto guard_epoch = mem_storage->light_edge_iterable_tracker_.CurrentEpoch();
+        mem_storage->light_edge_graveyard_.WithLock([&](auto &graveyard) {
+          graveyard.push_back({mark_timestamp, guard_epoch, std::move(deleted_light_edges)});
+        });
+      }
     }
   }};
 
@@ -729,15 +785,28 @@ Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdge(VertexAccesso
   auto gid = storage::Gid::FromUint(mem_storage->edge_id_.fetch_add(1, std::memory_order_acq_rel));
   EdgeRef edge(gid);
   if (config_.properties_on_edges) {
-    // SchemaInfo handles edge creation via vertices; add collector here if that evert changes
-    edge_acc = mem_storage->edges_.access();
-    auto *delta = CreateDeleteObjectDelta(&transaction_);
-    auto [it, inserted] = edge_acc->insert(Edge(gid, delta));
-    MG_ASSERT(inserted, "The edge must be inserted here!");
-    MG_ASSERT(it != edge_acc->end(), "Invalid Edge accessor!");
-    edge = EdgeRef(&*it);
-    if (delta) {
-      delta->prev.Set(&*it);
+    if (config_.storage_light_edge) {
+      // Light edge: allocate via DbAwareAllocator (routes to current DB arena), store only in vertex adjacency lists
+      // (no global skip list).
+      auto *delta = CreateDeleteObjectDelta(&transaction_);
+      memory::DbAwareAllocator<Edge> alloc;
+      auto *edge_ptr = std::allocator_traits<decltype(alloc)>::allocate(alloc, 1);
+      std::construct_at(edge_ptr, gid, delta);
+      if (delta) {
+        delta->prev.Set(edge_ptr);
+      }
+      edge = EdgeRef(edge_ptr);
+    } else {
+      // SchemaInfo handles edge creation via vertices; add collector here if that evert changes
+      edge_acc = mem_storage->edges_.access();
+      auto *delta = CreateDeleteObjectDelta(&transaction_);
+      auto [it, inserted] = edge_acc->insert(Edge(gid, delta));
+      MG_ASSERT(inserted, "The edge must be inserted here!");
+      MG_ASSERT(it != edge_acc->end(), "Invalid Edge accessor!");
+      edge = EdgeRef(&*it);
+      if (delta) {
+        delta->prev.Set(&*it);
+      }
     }
     if (config_.enable_edges_metadata) {
       edge_metadata_acc = mem_storage->edges_metadata_.access();
@@ -861,15 +930,28 @@ Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdgeEx(VertexAcces
 
   EdgeRef edge(gid);
   if (config_.properties_on_edges) {
-    // SchemaInfo handles edge creation via vertices; add collector here if that evert changes
-    edge_acc = mem_storage->edges_.access();
-    auto *delta = CreateDeleteObjectDelta(&transaction_);
-    auto [it, inserted] = edge_acc->insert(Edge(gid, delta));
-    MG_ASSERT(inserted, "The edge must be inserted here!");
-    MG_ASSERT(it != edge_acc->end(), "Invalid Edge accessor!");
-    edge = EdgeRef(&*it);
-    if (delta) {
-      delta->prev.Set(&*it);
+    if (config_.storage_light_edge) {
+      // Light edge: allocate via DbAwareAllocator (routes to current DB arena), store only in vertex adjacency lists
+      // (no global skip list).
+      auto *delta = CreateDeleteObjectDelta(&transaction_);
+      memory::DbAwareAllocator<Edge> alloc;
+      auto *edge_ptr = std::allocator_traits<decltype(alloc)>::allocate(alloc, 1);
+      std::construct_at(edge_ptr, gid, delta);
+      if (delta) {
+        delta->prev.Set(edge_ptr);
+      }
+      edge = EdgeRef(edge_ptr);
+    } else {
+      // SchemaInfo handles edge creation via vertices; add collector here if that evert changes
+      edge_acc = mem_storage->edges_.access();
+      auto *delta = CreateDeleteObjectDelta(&transaction_);
+      auto [it, inserted] = edge_acc->insert(Edge(gid, delta));
+      MG_ASSERT(inserted, "The edge must be inserted here!");
+      MG_ASSERT(it != edge_acc->end(), "Invalid Edge accessor!");
+      edge = EdgeRef(&*it);
+      if (delta) {
+        delta->prev.Set(&*it);
+      }
     }
     if (config_.enable_edges_metadata) {
       edge_metadata_acc = mem_storage->edges_metadata_.access();
@@ -1241,6 +1323,12 @@ void InMemoryStorage::InMemoryAccessor::FinalizeCommitPhase(uint64_t const durab
     mem_storage->ProcessPendingSchemaUpdates(durability_commit_timestamp);
   }
 
+  // Fast discard must run before GraveyardDeletedLightEdges to avoid a race condition.
+  // Because the transaction is already marked finished, OldestActive() can now advance.
+  // If edges were moved to the graveyard first, a concurrent GC thread could
+  // immediately delete them while fast-discard is still trying to access them.
+  // Running fast-discard first ensures it can safely clean up the deltas while
+  // holding the GC lock, making the subsequent graveyard call a safe no-op.
   CheckForFastDiscardOfDeltas();
   // Skip the virtual dispatch when the txn didn't touch any text/text-edge data
   // (the common case for the commit hot path).
@@ -1249,6 +1337,18 @@ void InMemoryStorage::InMemoryAccessor::FinalizeCommitPhase(uint64_t const durab
   }
   if (!transaction_.text_edge_index_change_collector_.empty()) {
     transaction_.active_indices_->text_edge_->ApplyTrackedChanges(transaction_, mem_storage->name_id_mapper_.get());
+  }
+
+  // Push deleted light edges to the graveyard with commit_timestamp as mark.
+  // This is the tightest correct timestamp: readers can only see the edge alive
+  // with start_timestamp < commit_timestamp, so we drain once all such readers
+  // finish (oldest_active_start_timestamp >= commit_timestamp).
+  // NOTE: if fast discard fired above, transaction_.deltas was already cleared
+  // and this is a no-op — graveyard was populated inside FastDiscardOfDeltas.
+  if (config_.storage_light_edge) {
+    auto guard_epoch = mem_storage->light_edge_iterable_tracker_.CurrentEpoch();
+    GraveyardDeletedLightEdges(
+        transaction_.deltas, *commit_timestamp_, guard_epoch, mem_storage->light_edge_graveyard_);
   }
   is_transaction_active_ = false;
 }
@@ -1294,7 +1394,8 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
 
 void InMemoryStorage::InMemoryAccessor::GCRapidDeltaCleanup(
     std::list<Gid, memory::DbAwareAllocator<Gid>> &current_deleted_edges,
-    std::list<Gid, memory::DbAwareAllocator<Gid>> &current_deleted_vertices, IndexPerformanceTracker &impact_tracker) {
+    std::list<Gid, memory::DbAwareAllocator<Gid>> &current_deleted_vertices, IndexPerformanceTracker &impact_tracker,
+    std::vector<Edge *> *out_deleted_light_edges) {
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
 
   // STEP 1) ensure everything in GC is gone
@@ -1311,13 +1412,29 @@ void InMemoryStorage::InMemoryAccessor::GCRapidDeltaCleanup(
   mem_storage->waiting_gc_deltas_.WithLock(
       [&](auto &waiting_list) { linked_undo_buffers.splice(linked_undo_buffers.end(), waiting_list); });
 
+  bool const light_edge_mode = config_.storage_light_edge;
+
   // 1.b.1) unlink, gathering the removals
   for (auto &gc_deltas : linked_undo_buffers) {
-    UnlinkAndRemoveDeltas(gc_deltas.deltas_, current_deleted_edges, current_deleted_vertices, impact_tracker);
+    UnlinkAndRemoveDeltas(gc_deltas.deltas_,
+                          gc_deltas.transaction_id_,
+                          current_deleted_edges,
+                          current_deleted_vertices,
+                          impact_tracker,
+                          light_edge_mode);
   }
 
   // STEP 2) this transaction's deltas
-  UnlinkAndRemoveDeltas(transaction_.deltas, current_deleted_edges, current_deleted_vertices, impact_tracker);
+  // Pass out_deleted_light_edges so deleted light edges are collected here
+  // rather than requiring a separate pre-pass over transaction_.deltas.
+  // Step 1.b passes nullptr — those transactions pushed to graveyard at their own commit time.
+  UnlinkAndRemoveDeltas(transaction_.deltas,
+                        transaction_.transaction_id,
+                        current_deleted_edges,
+                        current_deleted_vertices,
+                        impact_tracker,
+                        light_edge_mode,
+                        out_deleted_light_edges);
 
   // STEP 3) clear all deltas after unlinking is complete
   linked_undo_buffers.clear();
@@ -1329,10 +1446,26 @@ void InMemoryStorage::InMemoryAccessor::FastDiscardOfDeltas(std::unique_lock<std
 
   std::list<Gid, memory::DbAwareAllocator<Gid>> current_deleted_vertices;
   std::list<Gid, memory::DbAwareAllocator<Gid>> current_deleted_edges;
+  std::vector<Edge *> deleted_light_edges;
   auto impact_tracker = IndexPerformanceTracker{};
 
-  // STEP 1 + STEP 2 - delta cleanup
-  GCRapidDeltaCleanup(current_deleted_edges, current_deleted_vertices, impact_tracker);
+  // STEP 1 + STEP 2 - delta cleanup.
+  // Deleted light edges are collected during UnlinkAndRemoveDeltas (step 2) so
+  // we avoid a separate pre-pass over transaction_.deltas.
+  GCRapidDeltaCleanup(current_deleted_edges,
+                      current_deleted_vertices,
+                      impact_tracker,
+                      config_.storage_light_edge ? &deleted_light_edges : nullptr);
+
+  // Push collected light edges to graveyard (graveyard drains only after
+  // oldest_active >= commit_ts AND epoch is safe, so freeing is deferred).
+  // FinalizeCommitPhase's GraveyardDeletedLightEdges call is now a no-op
+  // because transaction_.deltas was cleared by GCRapidDeltaCleanup above.
+  if (!deleted_light_edges.empty()) {
+    auto guard_epoch = mem_storage->light_edge_iterable_tracker_.CurrentEpoch();
+    mem_storage->light_edge_graveyard_.WithLock(
+        [&](auto &g) { g.push_back({*commit_timestamp_, guard_epoch, std::move(deleted_light_edges)}); });
+  }
 
   // STEP 3) hand over the deleted vertices and edges to the GC
   if (!current_deleted_vertices.empty()) {
@@ -1387,6 +1520,7 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
     // by one and acquiring lock every time.
     std::vector<Gid> my_deleted_vertices;
     std::vector<Gid> my_deleted_edges;
+    std::vector<Edge *> my_deleted_light_edges;
 
     // TWO passes needed here
     // Abort will modify objects to restore state to how they were before this txn
@@ -1437,7 +1571,11 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
               case Delta::Action::DELETE_DESERIALIZED_OBJECT:
               case Delta::Action::DELETE_OBJECT: {
                 edge->SetDeleted(true);
-                my_deleted_edges.push_back(edge->gid);
+                if (config_.storage_light_edge) {
+                  my_deleted_light_edges.push_back(edge);
+                } else {
+                  my_deleted_edges.push_back(edge->gid);
+                }
                 break;
               }
               case Delta::Action::RECREATE_OBJECT: {
@@ -1662,9 +1800,10 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
       }
     }
 
+    uint64_t abort_mark_timestamp = 0;
     {
       auto engine_guard = std::unique_lock(storage_->engine_lock_);
-      uint64_t mark_timestamp = storage_->timestamp_;  // a timestamp no active transaction can currently have
+      abort_mark_timestamp = storage_->timestamp_;  // a timestamp no active transaction can currently have
 
       // Take garbage_undo_buffers lock while holding the engine lock to make
       // sure that entries are sorted by mark timestamp in the list.
@@ -1673,7 +1812,7 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
         // emplace back could take a long time.
         engine_guard.unlock();
 
-        garbage_undo_buffers.emplace_back(mark_timestamp,
+        garbage_undo_buffers.emplace_back(abort_mark_timestamp,
                                           std::move(transaction_.deltas),
                                           std::move(transaction_.commit_info),
                                           transaction_.transaction_id);
@@ -1711,6 +1850,25 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
       for (auto gid : my_deleted_edges) {
         edges_acc.remove(gid);
       }
+    }
+
+    // LIGHT EDGES: push to graveyard instead of freeing immediately.
+    // Even though these edges were never committed, a concurrent reader may have already
+    // captured an Edge* from an uncommitted index entry and is about to dereference it
+    // (e.g. to call IsVisible / AnyVersionIsVisible).  The graveyard drain condition
+    // (abort_mark_timestamp <= oldest_active_start_timestamp) ensures all such readers
+    // have finished before the pool memory is reclaimed.
+    if (!my_deleted_light_edges.empty()) {
+      if (mem_storage->config_.salient.items.enable_edges_metadata) {
+        auto edges_metadata_acc = mem_storage->edges_metadata_.access();
+        for (auto *edge : my_deleted_light_edges) {
+          edges_metadata_acc.remove(edge->gid);
+        }
+      }
+      auto guard_epoch = mem_storage->light_edge_iterable_tracker_.CurrentEpoch();
+      mem_storage->light_edge_graveyard_.WithLock([&](auto &graveyard) {
+        graveyard.push_back({abort_mark_timestamp, guard_epoch, std::move(my_deleted_light_edges)});
+      });
     }
   }
 
@@ -2584,23 +2742,20 @@ EdgesIterable InMemoryStorage::InMemoryAccessor::Edges(PropertyId property,
 EdgesChunkedIterable InMemoryStorage::InMemoryAccessor::ChunkedEdges(EdgeTypeId edge_type, View view,
                                                                      size_t num_chunks) {
   auto vertices_acc = static_cast<InMemoryStorage const *>(storage_)->vertices_.access();
-  auto edges_acc = static_cast<InMemoryStorage const *>(storage_)->edges_.access();
   auto *active_indices =
       static_cast<InMemoryEdgeTypeIndex::ActiveIndices *>(transaction_.active_indices_->edge_type_.get());
-  return EdgesChunkedIterable(active_indices->ChunkedEdges(
-      edge_type, std::move(vertices_acc), std::move(edges_acc), view, storage_, &transaction_, num_chunks));
+  return EdgesChunkedIterable(
+      active_indices->ChunkedEdges(edge_type, std::move(vertices_acc), view, storage_, &transaction_, num_chunks));
 }
 
 EdgesChunkedIterable InMemoryStorage::InMemoryAccessor::ChunkedEdges(EdgeTypeId edge_type, PropertyId property,
                                                                      View view, size_t num_chunks) {
   auto vertices_acc = static_cast<InMemoryStorage const *>(storage_)->vertices_.access();
-  auto edges_acc = static_cast<InMemoryStorage const *>(storage_)->edges_.access();
   auto *active_indices = static_cast<InMemoryEdgeTypePropertyIndex::ActiveIndices *>(
       transaction_.active_indices_->edge_type_properties_.get());
   return EdgesChunkedIterable(active_indices->ChunkedEdges(edge_type,
                                                            property,
                                                            std::move(vertices_acc),
-                                                           std::move(edges_acc),
                                                            std::nullopt,
                                                            std::nullopt,
                                                            view,
@@ -2613,13 +2768,11 @@ EdgesChunkedIterable InMemoryStorage::InMemoryAccessor::ChunkedEdges(
     EdgeTypeId edge_type, PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, size_t num_chunks) {
   auto vertices_acc = static_cast<InMemoryStorage const *>(storage_)->vertices_.access();
-  auto edges_acc = static_cast<InMemoryStorage const *>(storage_)->edges_.access();
   auto *active_indices = static_cast<InMemoryEdgeTypePropertyIndex::ActiveIndices *>(
       transaction_.active_indices_->edge_type_properties_.get());
   return EdgesChunkedIterable(active_indices->ChunkedEdges(edge_type,
                                                            property,
                                                            std::move(vertices_acc),
-                                                           std::move(edges_acc),
                                                            lower_bound,
                                                            upper_bound,
                                                            view,
@@ -2631,29 +2784,19 @@ EdgesChunkedIterable InMemoryStorage::InMemoryAccessor::ChunkedEdges(
 EdgesChunkedIterable InMemoryStorage::InMemoryAccessor::ChunkedEdges(PropertyId property, View view,
                                                                      size_t num_chunks) {
   auto vertices_acc = static_cast<InMemoryStorage const *>(storage_)->vertices_.access();
-  auto edges_acc = static_cast<InMemoryStorage const *>(storage_)->edges_.access();
   auto *active_indices =
       static_cast<InMemoryEdgePropertyIndex::ActiveIndices *>(transaction_.active_indices_->edge_property_.get());
-  return EdgesChunkedIterable(active_indices->ChunkedEdges(property,
-                                                           std::move(vertices_acc),
-                                                           std::move(edges_acc),
-                                                           std::nullopt,
-                                                           std::nullopt,
-                                                           view,
-                                                           storage_,
-                                                           &transaction_,
-                                                           num_chunks));
+  return EdgesChunkedIterable(active_indices->ChunkedEdges(
+      property, std::move(vertices_acc), std::nullopt, std::nullopt, view, storage_, &transaction_, num_chunks));
 }
 
 EdgesChunkedIterable InMemoryStorage::InMemoryAccessor::ChunkedEdges(PropertyId property, const PropertyValue &value,
                                                                      View view, size_t num_chunks) {
   auto vertices_acc = static_cast<InMemoryStorage const *>(storage_)->vertices_.access();
-  auto edges_acc = static_cast<InMemoryStorage const *>(storage_)->edges_.access();
   auto *active_indices =
       static_cast<InMemoryEdgePropertyIndex::ActiveIndices *>(transaction_.active_indices_->edge_property_.get());
   return EdgesChunkedIterable(active_indices->ChunkedEdges(property,
                                                            std::move(vertices_acc),
-                                                           std::move(edges_acc),
                                                            utils::MakeBoundInclusive(value),
                                                            utils::MakeBoundInclusive(value),
                                                            view,
@@ -2666,18 +2809,10 @@ EdgesChunkedIterable InMemoryStorage::InMemoryAccessor::ChunkedEdges(
     PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, size_t num_chunks) {
   auto vertices_acc = static_cast<InMemoryStorage const *>(storage_)->vertices_.access();
-  auto edges_acc = static_cast<InMemoryStorage const *>(storage_)->edges_.access();
   auto *active_indices =
       static_cast<InMemoryEdgePropertyIndex::ActiveIndices *>(transaction_.active_indices_->edge_property_.get());
-  return EdgesChunkedIterable(active_indices->ChunkedEdges(property,
-                                                           std::move(vertices_acc),
-                                                           std::move(edges_acc),
-                                                           lower_bound,
-                                                           upper_bound,
-                                                           view,
-                                                           storage_,
-                                                           &transaction_,
-                                                           num_chunks));
+  return EdgesChunkedIterable(active_indices->ChunkedEdges(
+      property, std::move(vertices_acc), lower_bound, upper_bound, view, storage_, &transaction_, num_chunks));
 }
 
 std::optional<EdgeAccessor> InMemoryStorage::InMemoryAccessor::FindEdge(Gid gid, View view) {
@@ -2955,6 +3090,7 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
   // vertices that appear in an index also exist in main storage.
   std::list<Gid, memory::DbAwareAllocator<Gid>> current_deleted_edges{};
   std::list<Gid, memory::DbAwareAllocator<Gid>> current_deleted_vertices{};
+  bool const light_edges = config_.salient.items.storage_light_edge;
 
   deleted_vertices_.WithLock([&](auto &deleted_vertices) { current_deleted_vertices.swap(deleted_vertices); });
   deleted_edges_.WithLock([&](auto &deleted_edges) { current_deleted_edges.swap(deleted_edges); });
@@ -3048,7 +3184,10 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
             edge->SetDelta(nullptr);
             if (edge->deleted()) {
               DMG_ASSERT(delta.action == Delta::Action::RECREATE_OBJECT);
-              current_deleted_edges.push_back(edge->gid);
+              if (!light_edges) {
+                current_deleted_edges.push_back(edge->gid);
+              }
+              // light_edges: already pushed to graveyard at commit time
             }
             break;
           }
@@ -3173,15 +3312,55 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
       indices_.RemoveObsoleteEdgeEntries(oldest_active_start_timestamp, token);
     }
   }
+  // LIGHT EDGE GRAVEYARD — phase 1: re-snap guard_epoch.
+  // Now that index entries are atomically removed, any reader that started an
+  // iterable before this point has epoch id < CurrentEpoch(). Re-snap guard_epoch
+  // to CurrentEpoch() so that IsSafeToFree() covers post-commit readers that may
+  // have read a stale Edge* from the index before cleanup ran.
+  // Also remove vector-edge-index entries here, while Edge* are still valid.
+  // (Vector index is not handled by RemoveObsoleteEdgeEntries above.)
+  //
+  // NOTE: the graveyard is NOT commit-ordered — aborted transactions insert with
+  // abort_mark_timestamp = storage_->timestamp_ (taken under engine_lock_), and
+  // concurrent aborts can produce timestamps that interleave with commit timestamps.
+  // We must therefore iterate ALL entries (not break early) and use continue to
+  // skip entries whose mark_timestamp is not yet safe.
+  //
+  // To avoid holding the SpinLock across the heavy index-cleanup work we swap the
+  // list out under the lock, process off-lock, then splice everything back.
+  if (light_edges) {
+    std::list<LightEdgeGraveyardEntry> local_graveyard;
+    light_edge_graveyard_.WithLock([&](auto &graveyard) { local_graveyard.swap(graveyard); });
+
+    for (auto &entry : local_graveyard) {
+      if (entry.mark_timestamp > oldest_active_start_timestamp) continue;
+      if (!entry.index_cleaned) {
+        if (!indices_.vector_edge_index_.Empty()) {
+          std::vector<Edge *> edges_to_remove;
+          edges_to_remove.reserve(entry.edges.size());
+          for (auto *edge : entry.edges) {
+            edges_to_remove.push_back(edge);
+          }
+          indices_.RemoveEdgesFromVectorEdgeIndices(edges_to_remove);
+        }
+        entry.guard_epoch = light_edge_iterable_tracker_.CurrentEpoch();
+        entry.index_cleaned = true;
+      }
+    }
+
+    light_edge_graveyard_.WithLock([&](auto &graveyard) { graveyard.splice(graveyard.begin(), local_graveyard); });
+  }
   memgraph::metrics::Measure(
       memgraph::metrics::GCSkiplistCleanupLatency_us,
       std::chrono::duration_cast<std::chrono::microseconds>(skiplist_cleanup_timer.Elapsed()).count());
 
+  // mark_timestamp for garbage_undo_buffers deferred cleanup
+  uint64_t gc_mark_timestamp = 0;
   {
     auto guard = std::unique_lock{engine_lock_};
-    uint64_t mark_timestamp = timestamp_;  // a timestamp no active transaction can currently have
+    gc_mark_timestamp = timestamp_;  // a timestamp no active transaction can currently have
 
-    if (main_guard.owns_lock() || mark_timestamp == oldest_active_start_timestamp) {
+    if (main_guard.owns_lock() || gc_mark_timestamp == oldest_active_start_timestamp) {
       guard.unlock();
       // if lucky, there are no active transactions, hence nothing looking at the deltas
       // remove them all now
@@ -3195,7 +3374,7 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
         guard.unlock();
         // correct the markers, and defer until next GC run
         for (auto &unlinked_undo_buffer : unlinked_undo_buffers) {
-          unlinked_undo_buffer.mark_timestamp_ = mark_timestamp;
+          unlinked_undo_buffer.mark_timestamp_ = gc_mark_timestamp;
         }
         // ensure insert at end to preserve the order
         garbage_undo_buffers.splice(garbage_undo_buffers.end(), std::move(unlinked_undo_buffers));
@@ -3324,6 +3503,36 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
         edge_metadata_acc.remove(edge.gid);
       }
     }
+  }
+
+  // LIGHT EDGE GRAVEYARD — phase 2: drain.
+  // Only drain entries that have been through phase 1 (index_cleaned == true) and
+  // whose guard_epoch is safe to free (all index-iterable readers that could have
+  // held a pointer to these edges have finished). Vector-edge-index cleanup was
+  // already done in phase 1 above.
+  if (light_edges) {
+    std::optional<utils::SkipListDb<EdgeMetadata>::Accessor> edge_metadata_acc;
+    if (config_.salient.items.enable_edges_metadata) {
+      edge_metadata_acc = edges_metadata_.access();
+    }
+    // Swap out, free eligible entries off-lock, splice remainder back.
+    // Entries are NOT ordered (aborts interleave with commits), so iterate all.
+    std::list<LightEdgeGraveyardEntry> local_graveyard;
+    light_edge_graveyard_.WithLock([&](auto &graveyard) { local_graveyard.swap(graveyard); });
+
+    for (auto it = local_graveyard.begin(); it != local_graveyard.end();) {
+      if (it->index_cleaned && light_edge_iterable_tracker_.IsSafeToFree(it->guard_epoch)) {
+        for (auto *edge : it->edges) {
+          if (edge_metadata_acc) edge_metadata_acc->remove(edge->gid);
+          DeleteLightEdge(edge);
+        }
+        it = local_graveyard.erase(it);
+      } else {
+        ++it;
+      }
+    }
+
+    light_edge_graveyard_.WithLock([&](auto &graveyard) { graveyard.splice(graveyard.end(), local_graveyard); });
   }
 }
 
@@ -4155,7 +4364,8 @@ std::expected<void, InMemoryStorage::RecoverSnapshotError> InMemoryStorage::Reco
                                           &enum_store_,
                                           config_.salient.items.enable_schema_info ? &schema_info_.Get() : nullptr,
                                           &ttl_,
-                                          &description_store_);
+                                          &description_store_,
+                                          std::nullopt);
     spdlog::debug("Snapshot recovered successfully");
     // Instead of using the UUID from the snapshot, we will override the snapshot's UUID with our own
     // This snapshot creates a new state and cannot have any WALs associated with it at this point
@@ -4462,6 +4672,34 @@ EdgeInfo InMemoryStorage::FindEdgeFromMetadata(Gid gid, const Edge *edge_ptr) {
 }
 
 EdgeInfo InMemoryStorage::FindEdge(Gid gid) {
+  if (config_.salient.items.storage_light_edge) {
+    // Light edges: not in skip list. Use edges_metadata for O(log N) lookup if available.
+    if (config_.salient.items.enable_edges_metadata) {
+      auto edge_metadata_acc = edges_metadata_.access();
+      auto edge_metadata_it = edge_metadata_acc.find(gid);
+      if (edge_metadata_it == edge_metadata_acc.end()) return std::nullopt;
+      auto *from_vertex = edge_metadata_it->from_vertex;
+      std::shared_lock const guard{from_vertex->lock};
+      for (const auto &[edge_type, to_vertex, edge_ref] : from_vertex->out_edges) {
+        if (edge_ref.ptr->gid == gid) {
+          return std::tuple(edge_ref, edge_type, from_vertex, to_vertex);
+        }
+      }
+      return std::nullopt;
+    }
+    // Fallback: scan all vertices' out_edges by GID
+    auto vertices_acc = vertices_.access();
+    for (auto &from_vertex : vertices_acc) {
+      std::shared_lock const guard{from_vertex.lock};
+      for (const auto &[edge_type, to_vertex, edge_ref] : from_vertex.out_edges) {
+        if (edge_ref.ptr->gid == gid) {
+          return std::tuple(edge_ref, edge_type, &from_vertex, to_vertex);
+        }
+      }
+    }
+    return std::nullopt;
+  }
+
   auto edge_acc = edges_.access();
   auto edge_it = edge_acc.find(gid);
   if (edge_it == edge_acc.end()) {
@@ -4484,6 +4722,23 @@ EdgeInfo InMemoryStorage::FindEdge(Gid gid) {
 }
 
 EdgeInfo InMemoryStorage::FindEdge(Gid edge_gid, Gid from_vertex_gid) {
+  if (config_.salient.items.storage_light_edge) {
+    // Light edges: not in skip list, scan from_vertex's out_edges by GID
+    auto vertices_acc = vertices_.access();
+    auto vertex_it = vertices_acc.find(from_vertex_gid);
+    if (vertex_it == vertices_acc.end()) {
+      throw utils::BasicException("Vertex with GID {} not found in the database", from_vertex_gid.AsUint());
+    }
+    auto *from_vertex = &(*vertex_it);
+    std::shared_lock const guard{from_vertex->lock};
+    for (const auto &[edge_type, to_vertex, edge_ref] : from_vertex->out_edges) {
+      if (edge_ref.ptr->gid == edge_gid) {
+        return std::tuple(edge_ref, edge_type, from_vertex, to_vertex);
+      }
+    }
+    return std::nullopt;
+  }
+
   auto edge_acc = edges_.access();
   auto edge_it = edge_acc.find(edge_gid);
   if (edge_it == edge_acc.end()) {
@@ -4504,6 +4759,32 @@ EdgeInfo InMemoryStorage::FindEdge(Gid edge_gid, Gid from_vertex_gid) {
   return ExtractEdgeInfo(&(*vertex_it), edge_ptr);
 }
 
+void InMemoryStorage::DeleteLightEdge(Edge *p) {
+  if (p == nullptr) return;
+  memory::DbAwareAllocator<Edge> alloc;
+  std::destroy_at(p);
+  std::allocator_traits<decltype(alloc)>::deallocate(alloc, p, 1);
+}
+
+void InMemoryStorage::ClearLightEdges() {
+  // Iterate out_edges only: each edge appears exactly once across all vertices
+  // (a self-loop has one entry in the source vertex's out_edges), so no deduplication needed.
+  auto vertex_acc = vertices_.access();
+  for (auto &vertex : vertex_acc) {
+    for (auto const &[edge_type, to_vertex, edge_ref] : vertex.out_edges) {
+      DeleteLightEdge(edge_ref.ptr);
+    }
+  }
+  light_edge_graveyard_.WithLock([&](auto &graveyard) {
+    for (auto &entry : graveyard) {
+      for (auto *edge : entry.edges) {
+        DeleteLightEdge(edge);
+      }
+    }
+    graveyard.clear();
+  });
+}
+
 void InMemoryStorage::Clear() {
   // NOTE: Make sure this function is called while exclusively holding on to the main lock
   // When creating a snapshot, we first lock the snapshot, then create the accessor
@@ -4520,6 +4801,11 @@ void InMemoryStorage::Clear() {
     last_processed_commit_ts_ = kTimestampInitialId;
   }
   schema_info_.Clear();
+
+  // Free light edges before clearing vertices (need vertex adjacency lists to find them).
+  if (config_.salient.items.storage_light_edge) {
+    ClearLightEdges();
+  }
 
   // Clear main memory
   vertices_.clear();
@@ -4703,6 +4989,10 @@ void InMemoryStorage::InMemoryAccessor::DropGraph() {
 
   if (mem_storage->config_.salient.items.enable_schema_info) mem_storage->schema_info_.Clear();
 
+  if (mem_storage->config_.salient.items.storage_light_edge) {
+    mem_storage->ClearLightEdges();
+  }
+
   mem_storage->vertices_.clear();
   mem_storage->waiting_gc_deltas_->clear();
   mem_storage->edges_.clear();
@@ -4742,8 +5032,11 @@ std::vector<std::tuple<EdgeAccessor, double, double>> InMemoryStorage::InMemoryA
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
   std::vector<std::tuple<EdgeAccessor, double, double>> result;
 
-  // we have to take edges accessor to be sure no edge is deleted while we are searching
-  auto acc = mem_storage->edges_.access();
+  // Pin edge memory for the duration of the search: in normal-edge mode this is a SkipList
+  // ConstAccessor that prevents GC from freeing edges_ nodes; in light-edge mode it acquires
+  // an epoch ID from light_edge_iterable_tracker_ so the graveyard drain cannot free
+  // pool-allocated Edge* while filtered_search dereferences entry.edge.
+  auto edge_pin = mem_storage->MakeEdgePin();
   auto edge_type_id = mem_storage->indices_.vector_edge_index_.GetEdgeTypeId(index_name);
   const auto search_results = storage_->indices_.vector_edge_index_.SearchEdges(index_name, number_of_results, vector);
   std::transform(search_results.begin(), search_results.end(), std::back_inserter(result), [&](const auto &item) {

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -764,7 +764,7 @@ std::optional<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdgeInterna
     if (config_.storage_light_edge) {
       // Light edge: allocate via pool (routes to thread-local DB arena), store only in vertex adjacency lists
       // (no global skip list).
-      edge_ptr = mem_storage->light_edge_pool_.Create(gid, delta);
+      edge_ptr = InMemoryStorage::LightEdgePool::Create(gid, delta);
     } else {
       // SchemaInfo handles edge creation via vertices; add collector here if that ever changes
       edge_acc = mem_storage->edges_.access();
@@ -4755,7 +4755,7 @@ void InMemoryStorage::LightEdgePool::Destroy(Edge *p) noexcept {
   std::allocator_traits<decltype(alloc)>::deallocate(alloc, p, 1);
 }
 
-void InMemoryStorage::DeleteLightEdge(Edge *p) { LightEdgePool{}.Destroy(p); }
+void InMemoryStorage::DeleteLightEdge(Edge *p) { LightEdgePool::Destroy(p); }
 
 void InMemoryStorage::ClearLightEdges() {
   // Iterate out_edges only: each edge appears exactly once across all vertices

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -22,6 +22,8 @@
 #include <system_error>
 #include <unordered_set>
 
+#include "absl/container/flat_hash_map.h"
+
 #include "ctre.hpp"
 #include "dbms/constants.hpp"
 #include "flags/experimental.hpp"
@@ -249,24 +251,37 @@ void UnlinkAndRemoveDeltas(delta_container &deltas, [[maybe_unused]] uint64_t tr
   }
 }
 
-// At commit time, scan a transaction's delta list for RECREATE_OBJECT deltas
-// on deleted edges and push those Edge* to the graveyard with commit_timestamp
-// as the mark.  Using commit_timestamp is the tightest correct value: a reader
-// can see the edge as alive only if its start_timestamp < commit_timestamp, so
-// we need to wait until oldest_active_start_timestamp >= commit_timestamp before
-// freeing — exactly the graveyard drain condition with this mark.
+// At commit time, scan a transaction's delta list for all deleted edges and
+// push unique Edge* pointers to the graveyard with commit_timestamp as the
+// mark.  With unordered deltas, a transaction may have multiple deltas per edge;
+// we walk each delta's prev chain back to the edge object to handle all cases.
+// Using commit_timestamp is the tightest correct value: a reader can see the
+// edge as alive only if its start_timestamp < commit_timestamp, so we need to
+// wait until oldest_active_start_timestamp >= commit_timestamp before freeing
+// — exactly the graveyard drain condition with this mark.
 void GraveyardDeletedLightEdges(
     delta_container const &deltas, uint64_t commit_timestamp, uint64_t guard_epoch,
     utils::Synchronized<std::list<InMemoryStorage::LightEdgeGraveyardEntry>, utils::SpinLock> &graveyard) {
-  std::vector<Edge *> deleted;
+  std::unordered_set<Edge *> deleted_set;
   for (auto const &delta : deltas) {
     auto prev = delta.prev.Get();
+    // When multiple deltas exist on the same edge (non-sequential/unordered),
+    // only the newest delta has prev.type == EDGE; intermediate deltas have
+    // prev.type == DELTA pointing to newer deltas. Walk backward through the
+    // prev chain until we find the original edge pointer.
+    while (prev.type == PreviousPtr::Type::DELTA) {
+      prev = prev.delta->prev.Get();
+    }
     if (prev.type == PreviousPtr::Type::EDGE && prev.edge->deleted()) {
-      DMG_ASSERT(delta.action == Delta::Action::RECREATE_OBJECT);
-      deleted.push_back(prev.edge);
+      deleted_set.insert(prev.edge);
     }
   }
-  if (!deleted.empty()) {
+  if (!deleted_set.empty()) {
+    std::vector<Edge *> deleted;
+    deleted.reserve(deleted_set.size());
+    for (auto *edge : deleted_set) {
+      deleted.push_back(edge);
+    }
     graveyard.WithLock([&](auto &g) { g.push_back({commit_timestamp, guard_epoch, std::move(deleted)}); });
   }
 }
@@ -692,7 +707,7 @@ InMemoryStorage::InMemoryAccessor::DetachDelete(std::vector<VertexAccessor *> no
       auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
       // Triggers RemoveObsoleteEdgeEntries in the next GC run (needed for both light and normal edges).
       mem_storage->gc_full_scan_edges_delete_.store(true, std::memory_order_release);
-      // LIGHT EDGES: pool-allocated edges are not in edges_ (skip list), so the normal full scan
+      // LIGHT EDGES: light edges are not in edges_ (skip list), so the normal full scan
       // won't find them to free. Push them into the graveyard so they are freed only after all
       // concurrent read-only transactions and index readers that may hold an Edge* have finished.
       // GC ordering guarantees RemoveObsoleteEdgeEntries runs before graveyard drain in the same
@@ -705,6 +720,10 @@ InMemoryStorage::InMemoryAccessor::DetachDelete(std::vector<VertexAccessor *> no
         }
         uint64_t mark_timestamp = 0;
         {
+          // TODO: I don't like that we take the engine lock here. What are we actually trying to do?
+          // We are deleting the edge, but are we actually deleting it here? No we are in a transaction.
+          // This exists just to mark flags for gc. The actual graveyard logic should be happening in the
+          // Commit/Abort/GC?
           auto engine_guard = std::unique_lock{mem_storage->engine_lock_};
           mark_timestamp = mem_storage->timestamp_;
         }
@@ -785,29 +804,28 @@ Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdge(VertexAccesso
   auto gid = storage::Gid::FromUint(mem_storage->edge_id_.fetch_add(1, std::memory_order_acq_rel));
   EdgeRef edge(gid);
   if (config_.properties_on_edges) {
+    Edge *edge_ptr = nullptr;
+    auto *delta = CreateDeleteObjectDelta(&transaction_);
     if (config_.storage_light_edge) {
       // Light edge: allocate via DbAwareAllocator (routes to current DB arena), store only in vertex adjacency lists
       // (no global skip list).
-      auto *delta = CreateDeleteObjectDelta(&transaction_);
+      // TODO Create a container-like structure so we hide this type od detail
       memory::DbAwareAllocator<Edge> alloc;
-      auto *edge_ptr = std::allocator_traits<decltype(alloc)>::allocate(alloc, 1);
+      edge_ptr = std::allocator_traits<decltype(alloc)>::allocate(alloc, 1);
+      // TODO Handle failure?
       std::construct_at(edge_ptr, gid, delta);
-      if (delta) {
-        delta->prev.Set(edge_ptr);
-      }
-      edge = EdgeRef(edge_ptr);
     } else {
       // SchemaInfo handles edge creation via vertices; add collector here if that evert changes
       edge_acc = mem_storage->edges_.access();
-      auto *delta = CreateDeleteObjectDelta(&transaction_);
       auto [it, inserted] = edge_acc->insert(Edge(gid, delta));
       MG_ASSERT(inserted, "The edge must be inserted here!");
       MG_ASSERT(it != edge_acc->end(), "Invalid Edge accessor!");
-      edge = EdgeRef(&*it);
-      if (delta) {
-        delta->prev.Set(&*it);
-      }
+      edge_ptr = &*it;
     }
+    if (delta) {
+      delta->prev.Set(edge_ptr);
+    }
+    edge = EdgeRef(edge_ptr);
     if (config_.enable_edges_metadata) {
       edge_metadata_acc = mem_storage->edges_metadata_.access();
       auto [_, inserted] = edge_metadata_acc->insert(EdgeMetadata(gid, from->vertex_));
@@ -928,31 +946,30 @@ Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdgeEx(VertexAcces
   // possible.
   atomic_fetch_max_explicit(&mem_storage->edge_id_, gid.AsUint() + 1, std::memory_order_acq_rel);
 
+  // TODO: unify logic in create and createex
+
   EdgeRef edge(gid);
   if (config_.properties_on_edges) {
+    Edge *edge_ptr = nullptr;
+    auto *delta = CreateDeleteObjectDelta(&transaction_);
     if (config_.storage_light_edge) {
       // Light edge: allocate via DbAwareAllocator (routes to current DB arena), store only in vertex adjacency lists
       // (no global skip list).
-      auto *delta = CreateDeleteObjectDelta(&transaction_);
       memory::DbAwareAllocator<Edge> alloc;
-      auto *edge_ptr = std::allocator_traits<decltype(alloc)>::allocate(alloc, 1);
+      edge_ptr = std::allocator_traits<decltype(alloc)>::allocate(alloc, 1);
       std::construct_at(edge_ptr, gid, delta);
-      if (delta) {
-        delta->prev.Set(edge_ptr);
-      }
-      edge = EdgeRef(edge_ptr);
     } else {
       // SchemaInfo handles edge creation via vertices; add collector here if that evert changes
       edge_acc = mem_storage->edges_.access();
-      auto *delta = CreateDeleteObjectDelta(&transaction_);
       auto [it, inserted] = edge_acc->insert(Edge(gid, delta));
       MG_ASSERT(inserted, "The edge must be inserted here!");
       MG_ASSERT(it != edge_acc->end(), "Invalid Edge accessor!");
-      edge = EdgeRef(&*it);
-      if (delta) {
-        delta->prev.Set(&*it);
-      }
+      edge_ptr = &*it;
     }
+    if (delta) {
+      delta->prev.Set(edge_ptr);
+    }
+    edge = EdgeRef(edge_ptr);
     if (config_.enable_edges_metadata) {
       edge_metadata_acc = mem_storage->edges_metadata_.access();
       auto [_, inserted] = edge_metadata_acc->insert(EdgeMetadata(gid, from->vertex_));
@@ -1344,8 +1361,9 @@ void InMemoryStorage::InMemoryAccessor::FinalizeCommitPhase(uint64_t const durab
   // with start_timestamp < commit_timestamp, so we drain once all such readers
   // finish (oldest_active_start_timestamp >= commit_timestamp).
   // NOTE: if fast discard fired above, transaction_.deltas was already cleared
-  // and this is a no-op — graveyard was populated inside FastDiscardOfDeltas.
-  if (config_.storage_light_edge) {
+  // and graveyard was populated inside FastDiscardOfDeltas. We skip this block
+  // entirely when deltas is empty, avoiding a redundant epoch query and call.
+  if (config_.storage_light_edge && !transaction_.deltas.empty()) {
     auto guard_epoch = mem_storage->light_edge_iterable_tracker_.CurrentEpoch();
     GraveyardDeletedLightEdges(
         transaction_.deltas, *commit_timestamp_, guard_epoch, mem_storage->light_edge_graveyard_);
@@ -1534,6 +1552,22 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
     // belonging to this transaction, and that these terminate in either a
     // nullptr or another monolithic block belonging to a committed but
     // uncollected transaction.
+
+    // Pre-build a map of Edge* → (EdgeTypeId, to_vertex) for edges that will be
+    // removed. The edge pass processes SET_PROPERTY deltas before the vertex
+    // pass processes REMOVE_OUT_EDGE deltas, so when an edge was both modified
+    // and deleted in this transaction, from_vertex->out_edges no longer contains
+    // the edge. This map provides a fallback so CollectOnPropertyChange (which
+    // cleans up edge_type_property_ and vector_edge_ indices) can still be
+    // called with the correct edge_type and to_vertex.
+    absl::flat_hash_map<Edge *, std::pair<EdgeTypeId, Vertex *>> removed_edge_info;
+    for (const auto &delta : transaction_.deltas) {
+      if (delta.action == Delta::Action::REMOVE_OUT_EDGE) {
+        removed_edge_info.try_emplace(
+            delta.vertex_edge.edge.ptr, delta.vertex_edge.edge_type, delta.vertex_edge.vertex.Get());
+      }
+    }
+
     for (const auto &delta : transaction_.deltas) {
       auto prev = delta.prev.Get();
       switch (prev.type) {
@@ -1552,15 +1586,26 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
 
                 auto processor_prop_is_interesting = index_abort_processor.IsInterestingEdgeProperty(prop_id);
                 if (processor_prop_is_interesting) {
-                  // TODO: MVCC collect out_edges (including ones deleted this txn)
-                  //       from_vertex->out_edges would be missing any edge that was deleted during this transaction
-                  //       ATM we don't handle that corner case. Setting a property on an edge that would then be
-                  //       removed
+                  // First try to find the edge in from_vertex->out_edges.
+                  // If the edge was deleted in this transaction, it won't be
+                  // there, so we fall back to the pre-built map.
+                  bool edge_found = false;
                   for (auto const &[edge_type, to_vertex, edge_ref] : from_vertex->out_edges) {
                     if (edge_ref.ptr != edge) continue;
+                    edge_found = true;
                     index_abort_processor.CollectOnPropertyChange(edge_type, prop_id, from_vertex, to_vertex, edge);
                     index_abort_processor.vector_edge_.CollectOnPropertyChange(
                         edge_type, prop_id, *current->property.value, from_vertex, to_vertex, edge);
+                    break;
+                  }
+                  if (!edge_found) {
+                    auto const it = removed_edge_info.find(edge);
+                    if (it != removed_edge_info.end()) {
+                      auto const [edge_type, to_vertex] = it->second;
+                      index_abort_processor.CollectOnPropertyChange(edge_type, prop_id, from_vertex, to_vertex, edge);
+                      index_abort_processor.vector_edge_.CollectOnPropertyChange(
+                          edge_type, prop_id, *current->property.value, from_vertex, to_vertex, edge);
+                    }
                   }
                 }
 
@@ -1695,7 +1740,10 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
 
             auto const &[_, edge_type, to_vertex, edge] = current->vertex_edge;
             index_abort_processor.CollectOnEdgeRemoval(edge_type, vertex, to_vertex.Get(), edge.ptr);
-            // TODO: ensure collector also processeses for edge_type+property index
+            // edge_type+property index and vector_edge index cleanup for edges
+            // removed in this transaction is handled in the edge pass above,
+            // where the SET_PROPERTY delta processor uses removed_edge_info
+            // as a fallback when the edge is no longer in from_vertex->out_edges.
 
             break;
           }
@@ -1859,6 +1907,7 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
     // (abort_mark_timestamp <= oldest_active_start_timestamp) ensures all such readers
     // have finished before the pool memory is reclaimed.
     if (!my_deleted_light_edges.empty()) {
+      // TODO: Don't like this metadata logic here. How is it handled for the heavy edges?
       if (mem_storage->config_.salient.items.enable_edges_metadata) {
         auto edges_metadata_acc = mem_storage->edges_metadata_.access();
         for (auto *edge : my_deleted_light_edges) {
@@ -2643,6 +2692,9 @@ VerticesChunkedIterable InMemoryStorage::InMemoryAccessor::ChunkedVertices(
 }
 
 EdgesIterable InMemoryStorage::InMemoryAccessor::Edges(EdgeTypeId edge_type, View view) {
+  // TODO: We removed edge access() here (those were pin accessors for the index)
+  // Carefully go through the implications and make sure there is another pin accessor in the index (EdgePin?) and if it
+  // is safe.
   auto vertex_acc = static_cast<InMemoryStorage const *>(storage_)->vertices_.access();
   auto *active_indices =
       static_cast<InMemoryEdgeTypeIndex::ActiveIndices *>(transaction_.active_indices_->edge_type_.get());
@@ -3301,7 +3353,7 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
   // concurrent aborts can produce timestamps that interleave with commit timestamps.
   // We must therefore iterate ALL entries (not break early) and use continue to
   // skip entries whose mark_timestamp is not yet safe.
-  //
+  // TODO: Think about a sorted list and splicing the graveyard.
   // To avoid holding the SpinLock across the heavy index-cleanup work we swap the
   // list out under the lock, process off-lock, then splice everything back.
   if (light_edges) {
@@ -4340,8 +4392,7 @@ std::expected<void, InMemoryStorage::RecoverSnapshotError> InMemoryStorage::Reco
                                           &enum_store_,
                                           config_.salient.items.enable_schema_info ? &schema_info_.Get() : nullptr,
                                           &ttl_,
-                                          &description_store_,
-                                          std::nullopt);
+                                          &description_store_);
     spdlog::debug("Snapshot recovered successfully");
     // Instead of using the UUID from the snapshot, we will override the snapshot's UUID with our own
     // This snapshot creates a new state and cannot have any WALs associated with it at this point
@@ -4648,6 +4699,7 @@ EdgeInfo InMemoryStorage::FindEdgeFromMetadata(Gid gid, const Edge *edge_ptr) {
 }
 
 EdgeInfo InMemoryStorage::FindEdge(Gid gid) {
+  // TODO Move definition to a helper function.
   if (config_.salient.items.storage_light_edge) {
     // Light edges: not in skip list. Use edges_metadata for O(log N) lookup if available.
     if (config_.salient.items.enable_edges_metadata) {
@@ -5011,7 +5063,7 @@ std::vector<std::tuple<EdgeAccessor, double, double>> InMemoryStorage::InMemoryA
   // Pin edge memory for the duration of the search: in normal-edge mode this is a SkipList
   // ConstAccessor that prevents GC from freeing edges_ nodes; in light-edge mode it acquires
   // an epoch ID from light_edge_iterable_tracker_ so the graveyard drain cannot free
-  // pool-allocated Edge* while filtered_search dereferences entry.edge.
+  // allocated Edge* while filtered_search dereferences entry.edge.
   auto edge_pin = mem_storage->MakeEdgePin();
   auto edge_type_id = mem_storage->indices_.vector_edge_index_.GetEdgeTypeId(index_name);
   const auto search_results = storage_->indices_.vector_edge_index_.SearchEdges(index_name, number_of_results, vector);

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -765,6 +765,7 @@ std::optional<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdgeInterna
       // Light edge: allocate via pool (routes to thread-local DB arena), store only in vertex adjacency lists
       // (no global skip list).
       edge_ptr = InMemoryStorage::LightEdgePool::Create(gid, delta);
+      MG_ASSERT(edge_ptr, "Failed to allocate a light edge!");
     } else {
       // SchemaInfo handles edge creation via vertices; add collector here if that ever changes
       edge_acc = mem_storage->edges_.access();
@@ -4743,7 +4744,12 @@ EdgeInfo InMemoryStorage::FindEdge(Gid edge_gid, Gid from_vertex_gid) {
 
 Edge *InMemoryStorage::LightEdgePool::Create(Gid gid, Delta *delta) {
   memory::DbAwareAllocator<Edge> alloc;
-  auto *edge_ptr = std::allocator_traits<decltype(alloc)>::allocate(alloc, 1);
+  Edge *edge_ptr = nullptr;
+  try {
+    edge_ptr = std::allocator_traits<decltype(alloc)>::allocate(alloc, 1);
+  } catch (const std::bad_alloc &) {
+    return nullptr;
+  }
   std::construct_at(edge_ptr, gid, delta);
   return edge_ptr;
 }

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -205,10 +205,9 @@ bool HasUncommittedNonSequentialDeltas(Vertex const *vertex, uint64_t skip_trans
 }
 
 void UnlinkAndRemoveDeltas(delta_container &deltas, [[maybe_unused]] uint64_t transaction_id,
-                           std::list<Gid, memory::DbAwareAllocator<Gid>> &current_deleted_edges,
+                           std::vector<Edge *, memory::DbAwareAllocator<Edge *>> &current_deleted_edges,
                            std::list<Gid, memory::DbAwareAllocator<Gid>> &current_deleted_vertices,
-                           IndexPerformanceTracker &impact_tracker, bool light_edge_mode = false,
-                           std::vector<Edge *> *out_deleted_light_edges = nullptr) {
+                           IndexPerformanceTracker &impact_tracker) {
   for (auto &delta : deltas) {
     DMG_ASSERT(
         [&delta]() {
@@ -239,50 +238,11 @@ void UnlinkAndRemoveDeltas(delta_container &deltas, [[maybe_unused]] uint64_t tr
         edge.SetDelta(nullptr);
         if (edge.deleted()) {
           DMG_ASSERT(delta.action == Delta::Action::RECREATE_OBJECT);
-          if (light_edge_mode) {
-            if (out_deleted_light_edges) out_deleted_light_edges->push_back(prev.edge);
-          } else {
-            current_deleted_edges.push_back(edge.gid);
-          }
+          current_deleted_edges.push_back(prev.edge);
         }
         break;
       }
     }
-  }
-}
-
-// At commit time, scan a transaction's delta list for all deleted edges and
-// push unique Edge* pointers to the graveyard with commit_timestamp as the
-// mark.  With unordered deltas, a transaction may have multiple deltas per edge;
-// we walk each delta's prev chain back to the edge object to handle all cases.
-// Using commit_timestamp is the tightest correct value: a reader can see the
-// edge as alive only if its start_timestamp < commit_timestamp, so we need to
-// wait until oldest_active_start_timestamp >= commit_timestamp before freeing
-// — exactly the graveyard drain condition with this mark.
-void GraveyardDeletedLightEdges(
-    delta_container const &deltas, uint64_t commit_timestamp, uint64_t guard_epoch,
-    utils::Synchronized<std::list<InMemoryStorage::LightEdgeGraveyardEntry>, utils::SpinLock> &graveyard) {
-  std::unordered_set<Edge *> deleted_set;
-  for (auto const &delta : deltas) {
-    auto prev = delta.prev.Get();
-    // When multiple deltas exist on the same edge (non-sequential/unordered),
-    // only the newest delta has prev.type == EDGE; intermediate deltas have
-    // prev.type == DELTA pointing to newer deltas. Walk backward through the
-    // prev chain until we find the original edge pointer.
-    while (prev.type == PreviousPtr::Type::DELTA) {
-      prev = prev.delta->prev.Get();
-    }
-    if (prev.type == PreviousPtr::Type::EDGE && prev.edge->deleted()) {
-      deleted_set.insert(prev.edge);
-    }
-  }
-  if (!deleted_set.empty()) {
-    std::vector<Edge *> deleted;
-    deleted.reserve(deleted_set.size());
-    for (auto *edge : deleted_set) {
-      deleted.push_back(edge);
-    }
-    graveyard.WithLock([&](auto &g) { g.push_back({commit_timestamp, guard_epoch, std::move(deleted)}); });
   }
 }
 
@@ -498,6 +458,7 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
       edges_metadata_.run_gc();
       vertices_.run_gc();
       edges_.run_gc();
+      DrainLightEdgeGraveyard();
 
       // Auto-indexer also has a skiplist
       async_indexer_.RunGC();
@@ -713,22 +674,14 @@ InMemoryStorage::InMemoryAccessor::DetachDelete(std::vector<VertexAccessor *> no
       // GC ordering guarantees RemoveObsoleteEdgeEntries runs before graveyard drain in the same
       // GC cycle, so the Edge* remains valid during index cleanup.
       if (config_.storage_light_edge) {
-        std::vector<Edge *> deleted_light_edges;
+        std::vector<Edge *, memory::DbAwareAllocator<Edge *>> deleted_light_edges;
         deleted_light_edges.reserve(deleted_edges.size());
         for (auto const &ea : deleted_edges) {
           deleted_light_edges.push_back(ea.edge_.ptr);
         }
-        // ANALYTICAL mode has no commit/abort cycle — deletion is immediate.
-        // Phase 1 (index cleanup) uses mark_timestamp to defer until no active
-        // reader can see the edge. In ANALYTICAL mode there are no start-
-        // timestamp readers; guard_epoch in Phase 2 already ensures no active
-        // index iterable holds an Edge* before the memory is freed.
-        // mark_timestamp = 0 means "process immediately in the next GC cycle".
-        uint64_t const mark_timestamp = 0;
         auto guard_epoch = mem_storage->light_edge_iterable_tracker_.CurrentEpoch();
-        mem_storage->light_edge_graveyard_.WithLock([&](auto &graveyard) {
-          graveyard.push_back({mark_timestamp, guard_epoch, std::move(deleted_light_edges)});
-        });
+        mem_storage->light_edge_graveyard_.WithLock(
+            [&](auto &graveyard) { graveyard.push_back({guard_epoch, std::move(deleted_light_edges)}); });
       }
     }
   }};
@@ -1288,12 +1241,10 @@ void InMemoryStorage::InMemoryAccessor::FinalizeCommitPhase(uint64_t const durab
     mem_storage->ProcessPendingSchemaUpdates(durability_commit_timestamp);
   }
 
-  // Fast discard must run before GraveyardDeletedLightEdges to avoid a race condition.
-  // Because the transaction is already marked finished, OldestActive() can now advance.
-  // If edges were moved to the graveyard first, a concurrent GC thread could
-  // immediately delete them while fast-discard is still trying to access them.
-  // Running fast-discard first ensures it can safely clean up the deltas while
-  // holding the GC lock, making the subsequent graveyard call a safe no-op.
+  // Fast discard: if we are the only active transaction, clean up deltas
+  // locally instead of handing them to GC.  For light edges, fast-discard
+  // pushes deleted Edge* to the graveyard (since it clears transaction_.deltas,
+  // the normal GC path would never see them).
   CheckForFastDiscardOfDeltas();
   // Skip the virtual dispatch when the txn didn't touch any text/text-edge data
   // (the common case for the commit hot path).
@@ -1304,18 +1255,6 @@ void InMemoryStorage::InMemoryAccessor::FinalizeCommitPhase(uint64_t const durab
     transaction_.active_indices_->text_edge_->ApplyTrackedChanges(transaction_, mem_storage->name_id_mapper_.get());
   }
 
-  // Push deleted light edges to the graveyard with commit_timestamp as mark.
-  // This is the tightest correct timestamp: readers can only see the edge alive
-  // with start_timestamp < commit_timestamp, so we drain once all such readers
-  // finish (oldest_active_start_timestamp >= commit_timestamp).
-  // NOTE: if fast discard fired above, transaction_.deltas was already cleared
-  // and graveyard was populated inside FastDiscardOfDeltas. We skip this block
-  // entirely when deltas is empty, avoiding a redundant epoch query and call.
-  if (config_.storage_light_edge && !transaction_.deltas.empty()) {
-    auto guard_epoch = mem_storage->light_edge_iterable_tracker_.CurrentEpoch();
-    GraveyardDeletedLightEdges(
-        transaction_.deltas, *commit_timestamp_, guard_epoch, mem_storage->light_edge_graveyard_);
-  }
   is_transaction_active_ = false;
 }
 
@@ -1359,9 +1298,8 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
 }
 
 void InMemoryStorage::InMemoryAccessor::GCRapidDeltaCleanup(
-    std::list<Gid, memory::DbAwareAllocator<Gid>> &current_deleted_edges,
-    std::list<Gid, memory::DbAwareAllocator<Gid>> &current_deleted_vertices, IndexPerformanceTracker &impact_tracker,
-    std::vector<Edge *> *out_deleted_light_edges) {
+    std::vector<Edge *, memory::DbAwareAllocator<Edge *>> &current_deleted_edges,
+    std::list<Gid, memory::DbAwareAllocator<Gid>> &current_deleted_vertices, IndexPerformanceTracker &impact_tracker) {
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
 
   // STEP 1) ensure everything in GC is gone
@@ -1378,29 +1316,18 @@ void InMemoryStorage::InMemoryAccessor::GCRapidDeltaCleanup(
   mem_storage->waiting_gc_deltas_.WithLock(
       [&](auto &waiting_list) { linked_undo_buffers.splice(linked_undo_buffers.end(), waiting_list); });
 
-  bool const light_edge_mode = config_.storage_light_edge;
-
-  // 1.b.1) unlink, gathering the removals
+  // 1.b.1) unlink, gathering the removals — always collects Edge* for any deleted edge
   for (auto &gc_deltas : linked_undo_buffers) {
-    UnlinkAndRemoveDeltas(gc_deltas.deltas_,
-                          gc_deltas.transaction_id_,
-                          current_deleted_edges,
-                          current_deleted_vertices,
-                          impact_tracker,
-                          light_edge_mode);
+    UnlinkAndRemoveDeltas(
+        gc_deltas.deltas_, gc_deltas.transaction_id_, current_deleted_edges, current_deleted_vertices, impact_tracker);
   }
 
   // STEP 2) this transaction's deltas
-  // Pass out_deleted_light_edges so deleted light edges are collected here
-  // rather than requiring a separate pre-pass over transaction_.deltas.
-  // Step 1.b passes nullptr — those transactions pushed to graveyard at their own commit time.
   UnlinkAndRemoveDeltas(transaction_.deltas,
                         transaction_.transaction_id,
                         current_deleted_edges,
                         current_deleted_vertices,
-                        impact_tracker,
-                        light_edge_mode,
-                        out_deleted_light_edges);
+                        impact_tracker);
 
   // STEP 3) clear all deltas after unlinking is complete
   linked_undo_buffers.clear();
@@ -1411,36 +1338,30 @@ void InMemoryStorage::InMemoryAccessor::FastDiscardOfDeltas(std::unique_lock<std
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
 
   std::list<Gid, memory::DbAwareAllocator<Gid>> current_deleted_vertices;
-  std::list<Gid, memory::DbAwareAllocator<Gid>> current_deleted_edges;
-  std::vector<Edge *> deleted_light_edges;
+  std::vector<Edge *, memory::DbAwareAllocator<Edge *>> current_deleted_edges;
   auto impact_tracker = IndexPerformanceTracker{};
 
   // STEP 1 + STEP 2 - delta cleanup.
-  // Deleted light edges are collected during UnlinkAndRemoveDeltas (step 2) so
-  // we avoid a separate pre-pass over transaction_.deltas.
-  GCRapidDeltaCleanup(current_deleted_edges,
-                      current_deleted_vertices,
-                      impact_tracker,
-                      config_.storage_light_edge ? &deleted_light_edges : nullptr);
+  GCRapidDeltaCleanup(current_deleted_edges, current_deleted_vertices, impact_tracker);
 
-  // Push collected light edges to graveyard (graveyard drains only after
-  // oldest_active >= commit_ts AND epoch is safe, so freeing is deferred).
-  // FinalizeCommitPhase's GraveyardDeletedLightEdges call is now a no-op
-  // because transaction_.deltas was cleared by GCRapidDeltaCleanup above.
-  if (!deleted_light_edges.empty()) {
-    auto guard_epoch = mem_storage->light_edge_iterable_tracker_.CurrentEpoch();
-    mem_storage->light_edge_graveyard_.WithLock(
-        [&](auto &g) { g.push_back({*commit_timestamp_, guard_epoch, std::move(deleted_light_edges)}); });
-  }
-
-  // STEP 3) hand over the deleted vertices and edges to the GC
+  // STEP 3) hand over vertices / edges to the GC or graveyard.
   if (!current_deleted_vertices.empty()) {
     mem_storage->deleted_vertices_.WithLock(
         [&](auto &deleted_vertices) { deleted_vertices.splice(deleted_vertices.end(), current_deleted_vertices); });
   }
   if (!current_deleted_edges.empty()) {
-    mem_storage->deleted_edges_.WithLock(
-        [&](auto &deleted_edges) { deleted_edges.splice(deleted_edges.end(), current_deleted_edges); });
+    if (config_.storage_light_edge) {
+      auto guard_epoch = mem_storage->light_edge_iterable_tracker_.CurrentEpoch();
+      mem_storage->light_edge_graveyard_.WithLock(
+          [&](auto &g) { g.push_back({guard_epoch, std::move(current_deleted_edges)}); });
+    } else {
+      // Heavy edges: push Edge* to deleted_edges_ for skiplist removal in the next GC cycle.
+      mem_storage->deleted_edges_.WithLock([&](auto &deleted_edges) {
+        deleted_edges.insert(deleted_edges.end(),
+                             std::make_move_iterator(current_deleted_edges.begin()),
+                             std::make_move_iterator(current_deleted_edges.end()));
+      });
+    }
   }
 
   // STEP 4) hint to GC that indices need cleanup for performance reasons
@@ -1484,9 +1405,8 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
     // We collect vertices and edges we've created here and then splice them into
     // `deleted_vertices_` and `deleted_edges_` lists, instead of adding them one
     // by one and acquiring lock every time.
-    std::vector<Gid> my_deleted_vertices;
-    std::vector<Gid> my_deleted_edges;
-    std::vector<Edge *> my_deleted_light_edges;
+    std::vector<Gid, memory::DbAwareAllocator<Gid>> my_deleted_vertices;
+    std::vector<Edge *, memory::DbAwareAllocator<Edge *>> my_deleted_edges;
 
     // TWO passes needed here
     // Abort will modify objects to restore state to how they were before this txn
@@ -1564,11 +1484,7 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
               case Delta::Action::DELETE_DESERIALIZED_OBJECT:
               case Delta::Action::DELETE_OBJECT: {
                 edge->SetDeleted(true);
-                if (config_.storage_light_edge) {
-                  my_deleted_light_edges.push_back(edge);
-                } else {
-                  my_deleted_edges.push_back(edge->gid);
-                }
+                my_deleted_edges.push_back(edge);
                 break;
               }
               case Delta::Action::RECREATE_OBJECT: {
@@ -1824,13 +1740,9 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
                                   transaction_.start_timestamp,
                                   mem_storage->name_id_mapper_.get());
     // EDGES METADATA (has ptr to Vertices, must be before removing verticies)
-    if (mem_storage->config_.salient.items.enable_edges_metadata &&
-        (!my_deleted_edges.empty() || !my_deleted_light_edges.empty())) {
+    if (mem_storage->config_.salient.items.enable_edges_metadata && !my_deleted_edges.empty()) {
       auto edges_metadata_acc = mem_storage->edges_metadata_.access();
-      for (auto gid : my_deleted_edges) {
-        edges_metadata_acc.remove(gid);
-      }
-      for (auto *edge : my_deleted_light_edges) {
+      for (auto *edge : my_deleted_edges) {
         edges_metadata_acc.remove(edge->gid);
       }
     }
@@ -1843,25 +1755,18 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
       }
     }
 
-    // EDGES
+    // EDGES / LIGHT EDGES: branch based on mode.
     if (!my_deleted_edges.empty()) {
-      auto edges_acc = mem_storage->edges_.access();
-      for (auto gid : my_deleted_edges) {
-        edges_acc.remove(gid);
+      if (mem_storage->config_.salient.items.storage_light_edge) {
+        auto guard_epoch = mem_storage->light_edge_iterable_tracker_.CurrentEpoch();
+        mem_storage->light_edge_graveyard_.WithLock(
+            [&](auto &graveyard) { graveyard.push_back({guard_epoch, std::move(my_deleted_edges)}); });
+      } else {
+        auto edges_acc = mem_storage->edges_.access();
+        for (auto *edge : my_deleted_edges) {
+          edges_acc.remove(edge->gid);
+        }
       }
-    }
-
-    // LIGHT EDGES: push to graveyard instead of freeing immediately.
-    // Even though these edges were never committed, a concurrent reader may have already
-    // captured an Edge* from an uncommitted index entry and is about to dereference it
-    // (e.g. to call IsVisible / AnyVersionIsVisible).  The graveyard drain condition
-    // (abort_mark_timestamp <= oldest_active_start_timestamp) ensures all such readers
-    // have finished before the pool memory is reclaimed.
-    if (!my_deleted_light_edges.empty()) {
-      auto guard_epoch = mem_storage->light_edge_iterable_tracker_.CurrentEpoch();
-      mem_storage->light_edge_graveyard_.WithLock([&](auto &graveyard) {
-        graveyard.push_back({abort_mark_timestamp, guard_epoch, std::move(my_deleted_light_edges)});
-      });
     }
   }
 
@@ -3060,12 +2965,20 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
   // We will only free vertices deleted up until now in this GC cycle, and we
   // will do it after cleaning-up the indices. That way we are sure that all
   // vertices that appear in an index also exist in main storage.
-  std::list<Gid, memory::DbAwareAllocator<Gid>> current_deleted_edges{};
+  std::vector<Edge *, memory::DbAwareAllocator<Edge *>> current_deleted_edges{};
   std::list<Gid, memory::DbAwareAllocator<Gid>> current_deleted_vertices{};
   bool const light_edges = config_.salient.items.storage_light_edge;
 
   deleted_vertices_.WithLock([&](auto &deleted_vertices) { current_deleted_vertices.swap(deleted_vertices); });
-  deleted_edges_.WithLock([&](auto &deleted_edges) { current_deleted_edges.swap(deleted_edges); });
+  {
+    {
+      std::list<Edge *, memory::DbAwareAllocator<Edge *>> pending_edges;
+      deleted_edges_.WithLock([&](auto &deleted_edges) { pending_edges.swap(deleted_edges); });
+      current_deleted_edges.insert(current_deleted_edges.end(),
+                                   std::make_move_iterator(pending_edges.begin()),
+                                   std::make_move_iterator(pending_edges.end()));
+    }
+  }
 
   auto const need_full_scan_vertices = gc_full_scan_vertices_delete_.exchange(false, std::memory_order_acq_rel);
   auto const need_full_scan_edges = gc_full_scan_edges_delete_.exchange(false, std::memory_order_acq_rel);
@@ -3156,10 +3069,7 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
             edge->SetDelta(nullptr);
             if (edge->deleted()) {
               DMG_ASSERT(delta.action == Delta::Action::RECREATE_OBJECT);
-              if (!light_edges) {
-                current_deleted_edges.push_back(edge->gid);
-              }
-              // light_edges: already pushed to graveyard at commit time
+              current_deleted_edges.push_back(edge);
             }
             break;
           }
@@ -3284,44 +3194,28 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
       indices_.RemoveObsoleteEdgeEntries(oldest_active_start_timestamp, token);
     }
   }
-  // LIGHT EDGE GRAVEYARD — phase 1: re-snap guard_epoch.
-  // Now that index entries are atomically removed, any reader that started an
-  // iterable before this point has epoch id < CurrentEpoch(). Re-snap guard_epoch
-  // to CurrentEpoch() so that IsSafeToFree() covers post-commit readers that may
-  // have read a stale Edge* from the index before cleanup ran.
-  // Also remove vector-edge-index entries here, while Edge* are still valid.
-  // (Vector index is not handled by RemoveObsoleteEdgeEntries above.)
-  //
-  // NOTE: the graveyard is NOT commit-ordered — aborted transactions insert with
-  // abort_mark_timestamp = storage_->timestamp_ (taken under engine_lock_), and
-  // concurrent aborts can produce timestamps that interleave with commit timestamps.
-  // We must therefore iterate ALL entries (not break early) and use continue to
-  // skip entries whose mark_timestamp is not yet safe.
-  // Future optimization: use a sorted container (e.g. std::map keyed by mark_timestamp)
-  // so we can break early once mark_timestamp > oldest_active_start_timestamp.
-  // To avoid holding the SpinLock across the heavy index-cleanup work we swap the
-  // list out under the lock, process off-lock, then splice everything back.
-  if (light_edges) {
-    std::list<LightEdgeGraveyardEntry> local_graveyard;
-    light_edge_graveyard_.WithLock([&](auto &graveyard) { local_graveyard.swap(graveyard); });
+  // UNIFIED VECTOR EDGE INDEX CLEANUP: removes entries for all deleted
+  // edges (heavy and light) from the vector edge index while Edge* is still
+  // valid.  The regular RemoveObsoleteEdgeEntries above does not cover the
+  // vector edge index; with unified Edge* collection we handle both modes.
+  if (!current_deleted_edges.empty() && !indices_.vector_edge_index_.Empty()) {
+    indices_.RemoveEdgesFromVectorEdgeIndices(current_deleted_edges);
+  }
 
-    for (auto &entry : local_graveyard) {
-      if (entry.mark_timestamp > oldest_active_start_timestamp) continue;
-      if (!entry.index_cleaned) {
-        if (!indices_.vector_edge_index_.Empty()) {
-          std::vector<Edge *> edges_to_remove;
-          edges_to_remove.reserve(entry.edges.size());
-          for (auto *edge : entry.edges) {
-            edges_to_remove.push_back(edge);
-          }
-          indices_.RemoveEdgesFromVectorEdgeIndices(edges_to_remove);
-        }
-        entry.guard_epoch = light_edge_iterable_tracker_.CurrentEpoch();
-        entry.index_cleaned = true;
+  // UNIFIED GRAVEYARD / SKIPLIST REMOVAL: branch based on edge mode.
+  // Light edges → graveyard (epoch-gated deferred free).
+  // Heavy edges → skiplist removal via accessor.
+  if (!current_deleted_edges.empty()) {
+    if (light_edges) {
+      auto guard_epoch = light_edge_iterable_tracker_.CurrentEpoch();
+      light_edge_graveyard_.WithLock(
+          [&](auto &graveyard) { graveyard.push_back({guard_epoch, std::move(current_deleted_edges)}); });
+    } else {
+      auto edge_acc = edges_.access();
+      for (auto *edge : current_deleted_edges) {
+        edge_acc.remove(edge->gid);
       }
     }
-
-    light_edge_graveyard_.WithLock([&](auto &graveyard) { graveyard.splice(graveyard.begin(), local_graveyard); });
   }
   memgraph::metrics::Measure(
       memgraph::metrics::GCSkiplistCleanupLatency_us,
@@ -3358,8 +3252,8 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
   // EDGES METADATA (has ptr to Vertices, must be before removing vertices)
   if (!current_deleted_edges.empty() && config_.salient.items.enable_edges_metadata) {
     auto edge_metadata_acc = edges_metadata_.access();
-    for (auto edge : current_deleted_edges) {
-      MG_ASSERT(edge_metadata_acc.remove(edge), "Invalid database state!");
+    for (auto *edge : current_deleted_edges) {
+      edge_metadata_acc.remove(edge->gid);
     }
   }
 
@@ -3379,42 +3273,8 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
       indices_.RemoveVerticesFromVectorIndices(vertices_to_remove);
     }
 
-    // Remove edges from vector edge index BEFORE vertex skip-list removal.
-    // edge_endpoints_ stores Vertex* — freeing vertices first would leave dangling pointers.
-    if (!current_deleted_edges.empty() && !indices_.vector_edge_index_.Empty()) {
-      auto edge_acc = edges_.access();
-      auto const edges_to_remove = current_deleted_edges | std::ranges::views::transform([&edge_acc](auto const gid) {
-                                     auto it = edge_acc.find(gid);
-                                     DMG_ASSERT(it != edge_acc.end(), "Invalid database state!");
-                                     return &*it;
-                                   }) |
-                                   std::ranges::to<std::vector>();
-
-      indices_.RemoveEdgesFromVectorEdgeIndices(edges_to_remove);
-    }
-
     for (auto vertex : current_deleted_vertices) {
       MG_ASSERT(vertex_acc.remove(vertex), "Invalid database state!");
-    }
-  }
-
-  // EDGES
-  if (!current_deleted_edges.empty()) {
-    auto edge_acc = edges_.access();
-
-    if (current_deleted_vertices.empty() && !indices_.vector_edge_index_.Empty()) {
-      auto const edges_to_remove = current_deleted_edges | std::ranges::views::transform([&edge_acc](auto const gid) {
-                                     auto it = edge_acc.find(gid);
-                                     DMG_ASSERT(it != edge_acc.end(), "Invalid database state!");
-                                     return &*it;
-                                   }) |
-                                   std::ranges::to<std::vector>();
-
-      indices_.RemoveEdgesFromVectorEdgeIndices(edges_to_remove);
-    }
-
-    for (auto edge : current_deleted_edges) {
-      MG_ASSERT(edge_acc.remove(edge), "Invalid database state!");
     }
   }
 
@@ -3478,35 +3338,38 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
     }
   }
 
-  // LIGHT EDGE GRAVEYARD — phase 2: drain.
-  // Only drain entries that have been through phase 1 (index_cleaned == true) and
-  // whose guard_epoch is safe to free (all index-iterable readers that could have
-  // held a pointer to these edges have finished). Vector-edge-index cleanup was
-  // already done in phase 1 above.
-  if (light_edges) {
-    std::optional<utils::SkipListDb<EdgeMetadata>::Accessor> edge_metadata_acc;
-    if (config_.salient.items.enable_edges_metadata) {
-      edge_metadata_acc = edges_metadata_.access();
-    }
-    // Swap out, free eligible entries off-lock, splice remainder back.
-    // Entries are NOT ordered (aborts interleave with commits), so iterate all.
-    std::list<LightEdgeGraveyardEntry> local_graveyard;
-    light_edge_graveyard_.WithLock([&](auto &graveyard) { local_graveyard.swap(graveyard); });
+  // Light-edge graveyard drain moved to DrainLightEdgeGraveyard(), called
+  // from FreeMemory after edges_.run_gc() — analogous to skiplist GC.
+}
 
-    for (auto it = local_graveyard.begin(); it != local_graveyard.end();) {
-      if (it->index_cleaned && light_edge_iterable_tracker_.IsSafeToFree(it->guard_epoch)) {
-        for (auto *edge : it->edges) {
-          if (edge_metadata_acc) edge_metadata_acc->remove(edge->gid);
-          DeleteLightEdge(edge);
-        }
-        it = local_graveyard.erase(it);
-      } else {
-        ++it;
-      }
-    }
-
-    light_edge_graveyard_.WithLock([&](auto &graveyard) { graveyard.splice(graveyard.end(), local_graveyard); });
+void InMemoryStorage::DrainLightEdgeGraveyard() {
+  if (!config_.salient.items.storage_light_edge) return;
+  std::optional<utils::SkipListDb<EdgeMetadata>::Accessor> edge_metadata_acc;
+  if (config_.salient.items.enable_edges_metadata) {
+    edge_metadata_acc = edges_metadata_.access();
   }
+  std::list<LightEdgeGraveyardEntry> local_graveyard;
+  light_edge_graveyard_.WithLock([&](auto &graveyard) { local_graveyard.swap(graveyard); });
+
+  for (auto it = local_graveyard.begin(); it != local_graveyard.end();) {
+    // Re-snap guard_epoch to CurrentEpoch() before checking IsSafeToFree.
+    // Entries may have been pushed from fast-discard or abort with a guard_epoch
+    // snapped before post-commit/abort readers acquired their epoch.  Re-snapping
+    // here (after all index cleanup — RemoveObsoleteEdgeEntries + vector) ensures
+    // IsSafeToFree waits for any pre-drain reader that may hold a stale Edge*.
+    it->guard_epoch = light_edge_iterable_tracker_.CurrentEpoch();
+    if (light_edge_iterable_tracker_.IsSafeToFree(it->guard_epoch)) {
+      for (auto *edge : it->edges) {
+        if (edge_metadata_acc) edge_metadata_acc->remove(edge->gid);
+        DeleteLightEdge(edge);
+      }
+      it = local_graveyard.erase(it);
+    } else {
+      ++it;
+    }
+  }
+
+  light_edge_graveyard_.WithLock([&](auto &graveyard) { graveyard.splice(graveyard.end(), local_graveyard); });
 }
 
 StorageInfo InMemoryStorage::GetBaseInfo() {

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -202,7 +202,7 @@ bool HasUncommittedNonSequentialDeltas(Vertex const *vertex, uint64_t skip_trans
   return false;
 }
 
-void UnlinkAndRemoveDeltas(delta_container &deltas, uint64_t transaction_id,
+void UnlinkAndRemoveDeltas(delta_container &deltas, [[maybe_unused]] uint64_t transaction_id,
                            std::list<Gid, memory::DbAwareAllocator<Gid>> &current_deleted_edges,
                            std::list<Gid, memory::DbAwareAllocator<Gid>> &current_deleted_vertices,
                            IndexPerformanceTracker &impact_tracker, bool light_edge_mode = false,

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -745,75 +745,28 @@ InMemoryStorage::InMemoryAccessor::DetachDelete(std::vector<VertexAccessor *> no
   return maybe_result;
 }
 
-Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdge(VertexAccessor *from, VertexAccessor *to,
-                                                                   EdgeTypeId edge_type) {
-  MG_ASSERT(from->transaction_ == to->transaction_,
-            "VertexAccessors must be from the same transaction when creating "
-            "an edge!");
-  MG_ASSERT(from->transaction_ == &transaction_,
-            "VertexAccessors must be from the same transaction in when "
-            "creating an edge!");
+std::optional<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdgeInternal(
+    Vertex *from_vertex, Vertex *to_vertex, EdgeTypeId edge_type, DeltaChainState from_state, DeltaChainState to_state,
+    storage::Gid gid, bool track_async_indices, std::optional<SchemaInfo::ModifyingAccessor> &schema_acc) {
+  if (track_async_indices) {
+    transaction_.async_index_helper_.Track(edge_type);
+  }
 
-  // It's important to destruct accessors after we unlock the vertices to avoid expensive skip list gc while we hold the
-  // locks
+  auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
+
   std::optional<utils::SkipListDb<Edge>::Accessor> edge_acc;
   std::optional<utils::SkipListDb<EdgeMetadata>::Accessor> edge_metadata_acc;
 
-  auto *from_vertex = from->vertex_;
-  auto *to_vertex = to->vertex_;
-
-  // This has to be called before any object gets locked
-  auto schema_acc = SchemaInfoAccessor(storage_, &transaction_);
-  // Obtain the locks by `gid` order to avoid lock cycles.
-  auto guard_from = std::unique_lock{from_vertex->lock, std::defer_lock};
-  auto guard_to = std::unique_lock{to_vertex->lock, std::defer_lock};
-  if (from_vertex->gid < to_vertex->gid) {
-    guard_from.lock();
-    guard_to.lock();
-  } else if (from_vertex->gid > to_vertex->gid) {
-    guard_to.lock();
-    guard_from.lock();
-  } else {
-    // The vertices are the same vertex, only lock one.
-    guard_from.lock();
-  }
-
-  transaction_.async_index_helper_.Track(edge_type);
-
-  auto const from_result = PrepareForNonSequentialWrite(&transaction_, from_vertex, Delta::Action::ADD_OUT_EDGE);
-  if (from_result == WriteResult::SERIALIZATION_ERROR) return std::unexpected{Error::SERIALIZATION_ERROR};
-  if (from_vertex->deleted()) return std::unexpected{Error::DELETED_OBJECT};
-  DeltaChainState const from_state =
-      ComputeDeltaChainState(ShouldSetNonSequentialBlockerUpstreamFlag(&transaction_, from_vertex), from_result);
-
-  // If to and from are the same we need to ensure to_result is the same as from_result
-  DeltaChainState to_state = from_state;
-  if (to_vertex != from_vertex) {
-    WriteResult const to_result = PrepareForNonSequentialWrite(&transaction_, to_vertex, Delta::Action::ADD_IN_EDGE);
-    if (to_result == WriteResult::SERIALIZATION_ERROR) return std::unexpected{Error::SERIALIZATION_ERROR};
-    if (to_vertex->deleted()) return std::unexpected{Error::DELETED_OBJECT};
-    to_state = ComputeDeltaChainState(ShouldSetNonSequentialBlockerUpstreamFlag(&transaction_, to_vertex), to_result);
-  }
-
-  if (storage_->config_.salient.items.enable_schema_metadata) {
-    storage_->stored_edge_types_.try_insert(edge_type);
-  }
-  auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
-  auto gid = storage::Gid::FromUint(mem_storage->edge_id_.fetch_add(1, std::memory_order_acq_rel));
   EdgeRef edge(gid);
   if (config_.properties_on_edges) {
     Edge *edge_ptr = nullptr;
     auto *delta = CreateDeleteObjectDelta(&transaction_);
     if (config_.storage_light_edge) {
-      // Light edge: allocate via DbAwareAllocator (routes to current DB arena), store only in vertex adjacency lists
+      // Light edge: allocate via pool (routes to thread-local DB arena), store only in vertex adjacency lists
       // (no global skip list).
-      // TODO Create a container-like structure so we hide this type od detail
-      memory::DbAwareAllocator<Edge> alloc;
-      edge_ptr = std::allocator_traits<decltype(alloc)>::allocate(alloc, 1);
-      // TODO Handle failure?
-      std::construct_at(edge_ptr, gid, delta);
+      edge_ptr = mem_storage->light_edge_pool_.Create(gid, delta);
     } else {
-      // SchemaInfo handles edge creation via vertices; add collector here if that evert changes
+      // SchemaInfo handles edge creation via vertices; add collector here if that ever changes
       edge_acc = mem_storage->edges_.access();
       auto [it, inserted] = edge_acc->insert(Edge(gid, delta));
       MG_ASSERT(inserted, "The edge must be inserted here!");
@@ -826,19 +779,12 @@ Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdge(VertexAccesso
     edge = EdgeRef(edge_ptr);
     if (config_.enable_edges_metadata) {
       edge_metadata_acc = mem_storage->edges_metadata_.access();
-      auto [_, inserted] = edge_metadata_acc->insert(EdgeMetadata(gid, from->vertex_));
+      auto [_, inserted] = edge_metadata_acc->insert(EdgeMetadata(gid, from_vertex));
       MG_ASSERT(inserted, "The edge must be inserted here!");
     }
   }
 
-  utils::AtomicMemoryBlock([this,
-                            edge,
-                            from_vertex = from_vertex,
-                            edge_type = edge_type,
-                            to_vertex = to_vertex,
-                            &schema_acc,
-                            from_state,
-                            to_state]() {
+  utils::AtomicMemoryBlock([this, edge, from_vertex, edge_type, to_vertex, &schema_acc, from_state, to_state]() {
     CreateAndLinkDelta(&transaction_, from_vertex, Delta::RemoveOutEdgeTag(), edge_type, to_vertex, edge, from_state);
     from_vertex->out_edges.emplace_back(edge_type, to_vertex, edge);
 
@@ -864,6 +810,60 @@ Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdge(VertexAccesso
   });
 
   return EdgeAccessor(edge, edge_type, from_vertex, to_vertex, storage_, &transaction_);
+}
+
+Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdge(VertexAccessor *from, VertexAccessor *to,
+                                                                   EdgeTypeId edge_type) {
+  MG_ASSERT(from->transaction_ == to->transaction_,
+            "VertexAccessors must be from the same transaction when creating "
+            "an edge!");
+  MG_ASSERT(from->transaction_ == &transaction_,
+            "VertexAccessors must be from the same transaction in when "
+            "creating an edge!");
+
+  auto *from_vertex = from->vertex_;
+  auto *to_vertex = to->vertex_;
+
+  // This has to be called before any object gets locked
+  auto schema_acc = SchemaInfoAccessor(storage_, &transaction_);
+  // Obtain the locks by `gid` order to avoid lock cycles.
+  auto guard_from = std::unique_lock{from_vertex->lock, std::defer_lock};
+  auto guard_to = std::unique_lock{to_vertex->lock, std::defer_lock};
+  if (from_vertex->gid < to_vertex->gid) {
+    guard_from.lock();
+    guard_to.lock();
+  } else if (from_vertex->gid > to_vertex->gid) {
+    guard_to.lock();
+    guard_from.lock();
+  } else {
+    // The vertices are the same vertex, only lock one.
+    guard_from.lock();
+  }
+
+  auto const from_result = PrepareForNonSequentialWrite(&transaction_, from_vertex, Delta::Action::ADD_OUT_EDGE);
+  if (from_result == WriteResult::SERIALIZATION_ERROR) return std::unexpected{Error::SERIALIZATION_ERROR};
+  if (from_vertex->deleted()) return std::unexpected{Error::DELETED_OBJECT};
+  DeltaChainState const from_state =
+      ComputeDeltaChainState(ShouldSetNonSequentialBlockerUpstreamFlag(&transaction_, from_vertex), from_result);
+
+  // If to and from are the same we need to ensure to_result is the same as from_result
+  DeltaChainState to_state = from_state;
+  if (to_vertex != from_vertex) {
+    WriteResult const to_result = PrepareForNonSequentialWrite(&transaction_, to_vertex, Delta::Action::ADD_IN_EDGE);
+    if (to_result == WriteResult::SERIALIZATION_ERROR) return std::unexpected{Error::SERIALIZATION_ERROR};
+    if (to_vertex->deleted()) return std::unexpected{Error::DELETED_OBJECT};
+    to_state = ComputeDeltaChainState(ShouldSetNonSequentialBlockerUpstreamFlag(&transaction_, to_vertex), to_result);
+  }
+
+  if (storage_->config_.salient.items.enable_schema_metadata) {
+    storage_->stored_edge_types_.try_insert(edge_type);
+  }
+  auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
+  auto gid = storage::Gid::FromUint(mem_storage->edge_id_.fetch_add(1, std::memory_order_acq_rel));
+
+  auto result = CreateEdgeInternal(from_vertex, to_vertex, edge_type, from_state, to_state, gid, true, schema_acc);
+  MG_ASSERT(result.has_value(), "CreateEdgeInternal must not fail when called from CreateEdge");
+  return *result;
 }
 
 std::optional<EdgeAccessor> InMemoryStorage::InMemoryAccessor::FindEdge(Gid gid, const View view, EdgeTypeId edge_type,
@@ -892,11 +892,6 @@ Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdgeEx(VertexAcces
   MG_ASSERT(from->transaction_ == &transaction_,
             "VertexAccessors must be from the same transaction in when "
             "creating an edge!");
-
-  // It's important to destruct accessors after we unlock the vertices to avoid expensive skip list gc while we hold the
-  // locks
-  std::optional<utils::SkipListDb<Edge>::Accessor> edge_acc;
-  std::optional<utils::SkipListDb<EdgeMetadata>::Accessor> edge_metadata_acc;
 
   auto *from_vertex = from->vertex_;
   auto *to_vertex = to->vertex_;
@@ -944,63 +939,9 @@ Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdgeEx(VertexAcces
   // possible.
   atomic_fetch_max_explicit(&mem_storage->edge_id_, gid.AsUint() + 1, std::memory_order_acq_rel);
 
-  // TODO: unify logic in create and createex
-
-  EdgeRef edge(gid);
-  if (config_.properties_on_edges) {
-    Edge *edge_ptr = nullptr;
-    auto *delta = CreateDeleteObjectDelta(&transaction_);
-    if (config_.storage_light_edge) {
-      // Light edge: allocate via DbAwareAllocator (routes to current DB arena), store only in vertex adjacency lists
-      // (no global skip list).
-      memory::DbAwareAllocator<Edge> alloc;
-      edge_ptr = std::allocator_traits<decltype(alloc)>::allocate(alloc, 1);
-      std::construct_at(edge_ptr, gid, delta);
-    } else {
-      // SchemaInfo handles edge creation via vertices; add collector here if that evert changes
-      edge_acc = mem_storage->edges_.access();
-      auto [it, inserted] = edge_acc->insert(Edge(gid, delta));
-      MG_ASSERT(inserted, "The edge must be inserted here!");
-      MG_ASSERT(it != edge_acc->end(), "Invalid Edge accessor!");
-      edge_ptr = &*it;
-    }
-    if (delta) {
-      delta->prev.Set(edge_ptr);
-    }
-    edge = EdgeRef(edge_ptr);
-    if (config_.enable_edges_metadata) {
-      edge_metadata_acc = mem_storage->edges_metadata_.access();
-      auto [_, inserted] = edge_metadata_acc->insert(EdgeMetadata(gid, from->vertex_));
-      MG_ASSERT(inserted, "The edge must be inserted here!");
-    }
-  }
-
-  utils::AtomicMemoryBlock([this, edge, from_vertex, edge_type, to_vertex, &schema_acc, from_state, to_state]() {
-    CreateAndLinkDelta(&transaction_, from_vertex, Delta::RemoveOutEdgeTag(), edge_type, to_vertex, edge, from_state);
-    from_vertex->out_edges.emplace_back(edge_type, to_vertex, edge);
-
-    CreateAndLinkDelta(&transaction_, to_vertex, Delta::RemoveInEdgeTag(), edge_type, from_vertex, edge, to_state);
-    to_vertex->in_edges.emplace_back(edge_type, from_vertex, edge);
-
-    transaction_.manyDeltasCache.Invalidate(from_vertex, edge_type, EdgeDirection::OUT);
-    transaction_.manyDeltasCache.Invalidate(to_vertex, edge_type, EdgeDirection::IN);
-
-    // Update indices if they exist.
-    Indices::UpdateOnEdgeCreation(from_vertex, to_vertex, edge, edge_type, transaction_);
-
-    // Increment edge count.
-    storage_->edge_count_.fetch_add(1, std::memory_order_acq_rel);
-
-    if (schema_acc) {
-      std::visit(utils::Overloaded{[&](SchemaInfo::VertexModifyingAccessor &acc) {
-                                     acc.CreateEdge(from_vertex, to_vertex, edge_type);
-                                   },
-                                   [](auto & /* unused */) { DMG_ASSERT(false, "Using the wrong accessor"); }},
-                 *schema_acc);
-    }
-  });
-
-  return EdgeAccessor(edge, edge_type, from_vertex, to_vertex, storage_, &transaction_);
+  auto result = CreateEdgeInternal(from_vertex, to_vertex, edge_type, from_state, to_state, gid, false, schema_acc);
+  MG_ASSERT(result.has_value(), "CreateEdgeInternal must not fail when called from CreateEdgeEx");
+  return *result;
 }
 
 void InMemoryStorage::UpdateEdgesMetadataOnModification(Edge *edge, Vertex *from_vertex) {
@@ -1045,8 +986,12 @@ std::expected<void, ConstraintViolation> InMemoryStorage::InMemoryAccessor::Uniq
     // aborted txn could delete one of vertices being deleted.
     auto acc = mem_storage->vertices_.access();
 
-    // TODO: UpdateBeforeCommit + Validate could be done in one pass, also use the AbortProcessor
-    //       pattern to gather, so we only require a single skip_list acccess
+    // NOTE: UpdateBeforeCommit iterates vertices_to_update to prepare unique
+    // constraint state; Validate iterates the same set again to check them.
+    // These two passes could be merged into one, and the AbortProcessor
+    // pattern (gather-then-process) could reduce skip_list accessor churn.
+    // Left as-is because correctness is more important than the minor overhead
+    // of a second pass over a typically small vertex set.
     auto *mem_unique_constraints =
         static_cast<InMemoryUniqueConstraints *>(storage_->constraints_.unique_constraints_.get());
     auto validation_result = mem_unique_constraints->Validate(vertices_to_update, transaction_, *commit_timestamp_);
@@ -1091,7 +1036,11 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
 
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
 
-  // TODO: duplicated transaction finalization in md_deltas and deltas processing cases
+  // Empty transaction: mark the start_timestamp as finished. For non-empty
+  // transactions FinalizeCommitPhase will later mark the commit_timestamp_.
+  // These are different MVCC timestamps (start_timestamp = timestamp_++ at
+  // creation; commit_timestamp_ = timestamp_++ at commit) and serve distinct
+  // purposes — this is not duplicated logic.
   if (transaction_.deltas.empty() && transaction_.md_deltas.empty()) {
     // We don't have to update the commit timestamp here because no one reads
     // it.
@@ -1733,11 +1682,10 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
             // properties are disabled.
             storage_->edge_count_.fetch_add(-1, std::memory_order_acq_rel);
 
-            // TODO: Change edge type index to work with EdgeRef rather than Edge *
             if (!mem_storage->config_.salient.items.properties_on_edges) break;
 
             auto const &[_, edge_type, to_vertex, edge] = current->vertex_edge;
-            index_abort_processor.CollectOnEdgeRemoval(edge_type, vertex, to_vertex.Get(), edge.ptr);
+            index_abort_processor.CollectOnEdgeRemoval(edge_type, vertex, to_vertex.Get(), edge);
             // edge_type+property index and vector_edge index cleanup for edges
             // removed in this transaction is handled in the edge pass above,
             // where the SET_PROPERTY delta processor uses removed_edge_info
@@ -2690,9 +2638,9 @@ VerticesChunkedIterable InMemoryStorage::InMemoryAccessor::ChunkedVertices(
 }
 
 EdgesIterable InMemoryStorage::InMemoryAccessor::Edges(EdgeTypeId edge_type, View view) {
-  // TODO: We removed edge access() here (those were pin accessors for the index)
-  // Carefully go through the implications and make sure there is another pin accessor in the index (EdgePin?) and if it
-  // is safe.
+  // No explicit edge accessor needed here. ActiveIndices::Edges() internally
+  // calls MakeEdgePin() which stores the pin in pin_accessor_edge_ inside the
+  // returned Iterable, keeping the edge index alive for the full iteration.
   auto vertex_acc = static_cast<InMemoryStorage const *>(storage_)->vertices_.access();
   auto *active_indices =
       static_cast<InMemoryEdgeTypeIndex::ActiveIndices *>(transaction_.active_indices_->edge_type_.get());
@@ -4696,36 +4644,34 @@ EdgeInfo InMemoryStorage::FindEdgeFromMetadata(Gid gid, const Edge *edge_ptr) {
   return ExtractEdgeInfo(edge_metadata_it->from_vertex, edge_ptr);
 }
 
-EdgeInfo InMemoryStorage::FindEdge(Gid gid) {
-  // TODO Move definition to a helper function.
-  if (config_.salient.items.storage_light_edge) {
-    // Light edges: not in skip list. Use edges_metadata for O(log N) lookup if available.
-    if (config_.salient.items.enable_edges_metadata) {
-      auto edge_metadata_acc = edges_metadata_.access();
-      auto edge_metadata_it = edge_metadata_acc.find(gid);
-      if (edge_metadata_it == edge_metadata_acc.end()) return std::nullopt;
-      auto *from_vertex = edge_metadata_it->from_vertex;
-      std::shared_lock const guard{from_vertex->lock};
-      for (const auto &[edge_type, to_vertex, edge_ref] : from_vertex->out_edges) {
-        if (edge_ref.ptr->gid == gid) {
-          return std::tuple(edge_ref, edge_type, from_vertex, to_vertex);
-        }
-      }
-      return std::nullopt;
+EdgeInfo InMemoryStorage::FindLightEdgeFromMetadata(Gid gid) {
+  auto edge_metadata_acc = edges_metadata_.access();
+  auto edge_metadata_it = edge_metadata_acc.find(gid);
+  if (edge_metadata_it == edge_metadata_acc.end()) return std::nullopt;
+  auto *from_vertex = edge_metadata_it->from_vertex;
+  std::shared_lock const guard{from_vertex->lock};
+  for (const auto &[edge_type, to_vertex, edge_ref] : from_vertex->out_edges) {
+    if (edge_ref.ptr->gid == gid) {
+      return std::tuple(edge_ref, edge_type, from_vertex, to_vertex);
     }
-    // Fallback: scan all vertices' out_edges by GID
-    auto vertices_acc = vertices_.access();
-    for (auto &from_vertex : vertices_acc) {
-      std::shared_lock const guard{from_vertex.lock};
-      for (const auto &[edge_type, to_vertex, edge_ref] : from_vertex.out_edges) {
-        if (edge_ref.ptr->gid == gid) {
-          return std::tuple(edge_ref, edge_type, &from_vertex, to_vertex);
-        }
-      }
-    }
-    return std::nullopt;
   }
+  return std::nullopt;
+}
 
+EdgeInfo InMemoryStorage::FindLightEdgeByScan(Gid gid) {
+  auto vertices_acc = vertices_.access();
+  for (auto &from_vertex : vertices_acc) {
+    std::shared_lock const guard{from_vertex.lock};
+    for (const auto &[edge_type, to_vertex, edge_ref] : from_vertex.out_edges) {
+      if (edge_ref.ptr->gid == gid) {
+        return std::tuple(edge_ref, edge_type, &from_vertex, to_vertex);
+      }
+    }
+  }
+  return std::nullopt;
+}
+
+EdgeInfo InMemoryStorage::FindHeavyEdge(Gid gid) {
   auto edge_acc = edges_.access();
   auto edge_it = edge_acc.find(gid);
   if (edge_it == edge_acc.end()) {
@@ -4745,6 +4691,16 @@ EdgeInfo InMemoryStorage::FindEdge(Gid gid) {
     }
   }
   return std::nullopt;
+}
+
+EdgeInfo InMemoryStorage::FindEdge(Gid gid) {
+  if (config_.salient.items.storage_light_edge) {
+    if (config_.salient.items.enable_edges_metadata) {
+      return FindLightEdgeFromMetadata(gid);
+    }
+    return FindLightEdgeByScan(gid);
+  }
+  return FindHeavyEdge(gid);
 }
 
 EdgeInfo InMemoryStorage::FindEdge(Gid edge_gid, Gid from_vertex_gid) {
@@ -4785,12 +4741,21 @@ EdgeInfo InMemoryStorage::FindEdge(Gid edge_gid, Gid from_vertex_gid) {
   return ExtractEdgeInfo(&(*vertex_it), edge_ptr);
 }
 
-void InMemoryStorage::DeleteLightEdge(Edge *p) {
+Edge *InMemoryStorage::LightEdgePool::Create(Gid gid, Delta *delta) {
+  memory::DbAwareAllocator<Edge> alloc;
+  auto *edge_ptr = std::allocator_traits<decltype(alloc)>::allocate(alloc, 1);
+  std::construct_at(edge_ptr, gid, delta);
+  return edge_ptr;
+}
+
+void InMemoryStorage::LightEdgePool::Destroy(Edge *p) noexcept {
   if (p == nullptr) return;
   memory::DbAwareAllocator<Edge> alloc;
   std::destroy_at(p);
   std::allocator_traits<decltype(alloc)>::deallocate(alloc, p, 1);
 }
+
+void InMemoryStorage::DeleteLightEdge(Edge *p) { LightEdgePool{}.Destroy(p); }
 
 void InMemoryStorage::ClearLightEdges() {
   // Iterate out_edges only: each edge appears exactly once across all vertices

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -718,15 +718,13 @@ InMemoryStorage::InMemoryAccessor::DetachDelete(std::vector<VertexAccessor *> no
         for (auto const &ea : deleted_edges) {
           deleted_light_edges.push_back(ea.edge_.ptr);
         }
-        uint64_t mark_timestamp = 0;
-        {
-          // TODO: I don't like that we take the engine lock here. What are we actually trying to do?
-          // We are deleting the edge, but are we actually deleting it here? No we are in a transaction.
-          // This exists just to mark flags for gc. The actual graveyard logic should be happening in the
-          // Commit/Abort/GC?
-          auto engine_guard = std::unique_lock{mem_storage->engine_lock_};
-          mark_timestamp = mem_storage->timestamp_;
-        }
+        // ANALYTICAL mode has no commit/abort cycle — deletion is immediate.
+        // Phase 1 (index cleanup) uses mark_timestamp to defer until no active
+        // reader can see the edge. In ANALYTICAL mode there are no start-
+        // timestamp readers; guard_epoch in Phase 2 already ensures no active
+        // index iterable holds an Edge* before the memory is freed.
+        // mark_timestamp = 0 means "process immediately in the next GC cycle".
+        uint64_t const mark_timestamp = 0;
         auto guard_epoch = mem_storage->light_edge_iterable_tracker_.CurrentEpoch();
         mem_storage->light_edge_graveyard_.WithLock([&](auto &graveyard) {
           graveyard.push_back({mark_timestamp, guard_epoch, std::move(deleted_light_edges)});

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1824,10 +1824,14 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
                                   transaction_.start_timestamp,
                                   mem_storage->name_id_mapper_.get());
     // EDGES METADATA (has ptr to Vertices, must be before removing verticies)
-    if (!my_deleted_edges.empty() && mem_storage->config_.salient.items.enable_edges_metadata) {
+    if (mem_storage->config_.salient.items.enable_edges_metadata &&
+        (!my_deleted_edges.empty() || !my_deleted_light_edges.empty())) {
       auto edges_metadata_acc = mem_storage->edges_metadata_.access();
       for (auto gid : my_deleted_edges) {
         edges_metadata_acc.remove(gid);
+      }
+      for (auto *edge : my_deleted_light_edges) {
+        edges_metadata_acc.remove(edge->gid);
       }
     }
 
@@ -1854,13 +1858,6 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
     // (abort_mark_timestamp <= oldest_active_start_timestamp) ensures all such readers
     // have finished before the pool memory is reclaimed.
     if (!my_deleted_light_edges.empty()) {
-      // TODO: Don't like this metadata logic here. How is it handled for the heavy edges?
-      if (mem_storage->config_.salient.items.enable_edges_metadata) {
-        auto edges_metadata_acc = mem_storage->edges_metadata_.access();
-        for (auto *edge : my_deleted_light_edges) {
-          edges_metadata_acc.remove(edge->gid);
-        }
-      }
       auto guard_epoch = mem_storage->light_edge_iterable_tracker_.CurrentEpoch();
       mem_storage->light_edge_graveyard_.WithLock([&](auto &graveyard) {
         graveyard.push_back({abort_mark_timestamp, guard_epoch, std::move(my_deleted_light_edges)});
@@ -3300,7 +3297,8 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
   // concurrent aborts can produce timestamps that interleave with commit timestamps.
   // We must therefore iterate ALL entries (not break early) and use continue to
   // skip entries whose mark_timestamp is not yet safe.
-  // TODO: Think about a sorted list and splicing the graveyard.
+  // Future optimization: use a sorted container (e.g. std::map keyed by mark_timestamp)
+  // so we can break early once mark_timestamp > oldest_active_start_timestamp.
   // To avoid holding the SpinLock across the heavy index-cleanup work we swap the
   // list out under the lock, process off-lock, then splice everything back.
   if (light_edges) {
@@ -4742,7 +4740,7 @@ EdgeInfo InMemoryStorage::FindEdge(Gid edge_gid, Gid from_vertex_gid) {
   return ExtractEdgeInfo(&(*vertex_it), edge_ptr);
 }
 
-Edge *InMemoryStorage::LightEdgePool::Create(Gid gid, Delta *delta) {
+Edge *InMemoryStorage::LightEdgePool::Create(Gid gid, Delta *delta) noexcept {
   memory::DbAwareAllocator<Edge> alloc;
   Edge *edge_ptr = nullptr;
   try {

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -718,10 +718,9 @@ class InMemoryStorage final : public Storage {
     /// During commit, in some cases you do not need to hand over deltas to GC
     /// in those cases this method is a light weight way to unlink and discard our deltas
     void FastDiscardOfDeltas(std::unique_lock<std::mutex> gc_guard);
-    void GCRapidDeltaCleanup(std::list<Gid, memory::DbAwareAllocator<Gid>> &current_deleted_edges,
+    void GCRapidDeltaCleanup(std::vector<Edge *, memory::DbAwareAllocator<Edge *>> &current_deleted_edges,
                              std::list<Gid, memory::DbAwareAllocator<Gid>> &current_deleted_vertices,
-                             IndexPerformanceTracker &impact_tracker,
-                             std::vector<Edge *> *out_deleted_light_edges = nullptr);
+                             IndexPerformanceTracker &impact_tracker);
     SalientConfig::Items config_;
 
     uint64_t commit_flag_wal_position_{0};
@@ -790,25 +789,17 @@ class InMemoryStorage final : public Storage {
 
   void UpdateLabelCount(LabelId label, int64_t change) override;
 
-  // Graveyard for light edges: deleted Edge* kept alive until GC determines
-  // no active transaction can see them.  Two conditions must both hold before
-  // draining: the timestamp condition (no reader can see the edge alive) and
-  // the epoch condition (no edge-index iterable that pre-dates this entry is
-  // still active).
+  // Graveyard for light edges: deleted Edge* kept alive until the
+  // epoch tracker confirms all in-flight edge-index iterables are done.
   //
-  // Two-phase drain:
-  //   Phase 1 (commit time): entry added with mark_timestamp and an initial guard_epoch.
-  //   Phase 2 (GC, after RemoveObsoleteEdgeEntries): guard_epoch is re-snapped to
-  //     CurrentEpoch() AFTER index entries are atomically removed, and index_cleaned
-  //     is set. This mirrors SkipList GC which records the high-water accessor ID at
-  //     node-removal time, covering post-commit readers that read Edge* from a stale
-  //     index entry before cleanup ran.
-  //   Drain: only when index_cleaned == true AND IsSafeToFree(guard_epoch).
+  // GC populates the graveyard during delta unlinking (same as heavy edges
+  // removing from the skiplist), AFTER all index cleanup is complete.
+  // The drain runs in FreeMemory after edges_.run_gc() and checks only
+  // IsSafeToFree(guard_epoch) — no additional mark_timestamp is needed
+  // because RemoveObsoleteEdgeEntries already handled MVCC safety.
   struct LightEdgeGraveyardEntry {
-    uint64_t mark_timestamp;
     uint64_t guard_epoch;
-    std::vector<Edge *> edges;
-    bool index_cleaned{false};
+    std::vector<Edge *, memory::DbAwareAllocator<Edge *>> edges;
   };
 
   // Test helper: number of entries currently sitting in the light-edge graveyard.
@@ -830,6 +821,10 @@ class InMemoryStorage final : public Storage {
   }
 
   void Clear();
+
+  // Drain the light-edge graveyard: free Edge* whose guard_epoch is safe.
+  // Called from FreeMemory after edges_.run_gc() — analogous to skiplist GC.
+  void DrainLightEdgeGraveyard();
 
  private:
   /// @throw std::system_error
@@ -950,8 +945,10 @@ class InMemoryStorage final : public Storage {
   utils::Synchronized<std::list<Gid, memory::DbAwareAllocator<Gid>>, utils::SpinLock> deleted_vertices_;
 
   // Edges that are logically deleted and wait to be removed from the main
-  // storage.
-  utils::Synchronized<std::list<Gid, memory::DbAwareAllocator<Gid>>, utils::SpinLock> deleted_edges_;
+  // storage.  Stored as Edge* rather than Gid to avoid a Gid→Edge* skiplist
+  // lookup when processing in CollectGarbage — the pointer remains valid
+  // until edge_acc.remove() is called in the same GC cycle.
+  utils::Synchronized<std::list<Edge *, memory::DbAwareAllocator<Edge *>>, utils::SpinLock> deleted_edges_;
 
   utils::Synchronized<std::list<LightEdgeGraveyardEntry>, utils::SpinLock> light_edge_graveyard_;
 

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -840,7 +840,7 @@ class InMemoryStorage final : public Storage {
 
   EdgeInfo FindEdgeFromMetadata(Gid gid, const Edge *edge_ptr);
 
-  void DeleteLightEdge(Edge *p);
+  static void DeleteLightEdge(Edge *p);
 
   // Free all pool-allocated Edge objects: walk out_edges of every vertex (each
   // edge appears exactly once) and drain the graveyard.  Must be called before

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -128,8 +128,8 @@ class InMemoryStorage final : public Storage {
   /// thread-local arena at each call), so Create/Destroy are safe to call
   /// from any thread with an active DbArenaScope.
   struct LightEdgePool {
-    Edge *Create(Gid gid, Delta *delta);
-    void Destroy(Edge *p) noexcept;
+    static Edge *Create(Gid gid, Delta *delta);
+    static void Destroy(Edge *p) noexcept;
   };
   enum class CreateSnapshotError : uint8_t { ReachedMaxNumTries, AbortSnapshot, AlreadyRunning, NothingNewToWrite };
 

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -842,7 +842,7 @@ class InMemoryStorage final : public Storage {
 
   static void DeleteLightEdge(Edge *p);
 
-  // Free all pool-allocated Edge objects: walk out_edges of every vertex (each
+  // Free all light Edge objects: walk out_edges of every vertex (each
   // edge appears exactly once) and drain the graveyard.  Must be called before
   // vertices_.clear() so the adjacency lists are still intact.
   // Requires gc_lock_ to be held by the caller.

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -122,6 +122,15 @@ class InMemoryStorage final : public Storage {
 
  public:
   using free_mem_fn = std::function<void(std::unique_lock<utils::ResourceLock>, bool)>;
+
+  /// Light-weight wrapper around DbAwareAllocator<Edge> for light-edge
+  /// allocation and destruction.  DbAwareAllocator is stateless (reads the
+  /// thread-local arena at each call), so Create/Destroy are safe to call
+  /// from any thread with an active DbArenaScope.
+  struct LightEdgePool {
+    Edge *Create(Gid gid, Delta *delta);
+    void Destroy(Edge *p) noexcept;
+  };
   enum class CreateSnapshotError : uint8_t { ReachedMaxNumTries, AbortSnapshot, AlreadyRunning, NothingNewToWrite };
 
   static const char *CreateSnapshotErrorToString(CreateSnapshotError error) {
@@ -184,6 +193,11 @@ class InMemoryStorage final : public Storage {
     std::expected<void, ConstraintViolation> UniqueConstraintsViolation() const;
 
     void CheckForFastDiscardOfDeltas();
+
+    std::optional<EdgeAccessor> CreateEdgeInternal(Vertex *from_vertex, Vertex *to_vertex, EdgeTypeId edge_type,
+                                                   DeltaChainState from_state, DeltaChainState to_state,
+                                                   storage::Gid gid, bool track_async_indices,
+                                                   std::optional<SchemaInfo::ModifyingAccessor> &schema_acc);
 
     [[nodiscard]] auto HandleDurabilityAndReplicate(uint64_t durability_commit_timestamp,
                                                     TransactionReplication &replicating_txn,
@@ -840,6 +854,12 @@ class InMemoryStorage final : public Storage {
 
   EdgeInfo FindEdgeFromMetadata(Gid gid, const Edge *edge_ptr);
 
+  EdgeInfo FindLightEdgeFromMetadata(Gid gid);
+
+  EdgeInfo FindLightEdgeByScan(Gid gid);
+
+  EdgeInfo FindHeavyEdge(Gid gid);
+
   static void DeleteLightEdge(Edge *p);
 
   // Free all light Edge objects: walk out_edges of every vertex (each
@@ -849,6 +869,10 @@ class InMemoryStorage final : public Storage {
   void ClearLightEdges();
 
   memgraph::memory::ArenaPool *db_arena_{nullptr};
+
+  // Light-edge allocator pool — wraps DbAwareAllocator<Edge> for thread-safe
+  // light-edge creation and destruction (routes to the current DB arena via TLS).
+  LightEdgePool light_edge_pool_;
 
   // Main object storage — DbAwareAllocator routes node allocations through the
   // current DB TLS scope, while long-lived DB work establishes that scope at
@@ -1026,5 +1050,12 @@ struct SingleTxnDeltasProcessingResult {
   uint64_t num_txns_committed;
   uint32_t current_batch_counter;
 };
+
+// Free helpers for light-edge lifecycle, usable from durability code
+// (snapshot.cpp / wal.cpp) where no InMemoryStorage* is available.
+// Each call creates a temporary LightEdgePool (stateless — reads TLS arena).
+inline Edge *CreateLightEdge(Gid gid, Delta *delta) { return InMemoryStorage::LightEdgePool{}.Create(gid, delta); }
+
+inline void DestroyLightEdge(Edge *p) noexcept { InMemoryStorage::LightEdgePool{}.Destroy(p); }
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -128,7 +128,7 @@ class InMemoryStorage final : public Storage {
   /// thread-local arena at each call), so Create/Destroy are safe to call
   /// from any thread with an active DbArenaScope.
   struct LightEdgePool {
-    static Edge *Create(Gid gid, Delta *delta);
+    static Edge *Create(Gid gid, Delta *delta) noexcept;
     static void Destroy(Edge *p) noexcept;
   };
   enum class CreateSnapshotError : uint8_t { ReachedMaxNumTries, AbortSnapshot, AlreadyRunning, NothingNewToWrite };
@@ -822,7 +822,7 @@ class InMemoryStorage final : public Storage {
   // Normal-edge mode: ConstAccessor on edges_ (prevents skiplist GC from freeing edge nodes).
   // Light-edge mode:  LightEdgeIterableGuard (acquires an epoch ID from light_edge_iterable_tracker_
   //                   so the graveyard drain only unblocks once all pre-existing readers are done).
-  EdgePin MakeEdgePin() const {
+  [[nodiscard]] EdgePin MakeEdgePin() const {
     if (config_.salient.items.storage_light_edge) {
       return LightEdgeIterableGuard{&light_edge_iterable_tracker_};
     }

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -22,6 +22,7 @@
 #include "storage/v2/inmemory/edge_type_index.hpp"
 #include "storage/v2/inmemory/label_index.hpp"
 #include "storage/v2/inmemory/label_property_index.hpp"
+#include "storage/v2/inmemory/light_edge_guard.hpp"
 #include "storage/v2/inmemory/replication/recovery.hpp"
 #include "storage/v2/inmemory/snapshot_info.hpp"
 #include "storage/v2/replication/replication_client.hpp"
@@ -38,6 +39,7 @@
 #include "storage/v2/replication/replication_storage_state.hpp"
 #include "storage/v2/replication/serialization.hpp"
 #include "storage/v2/transaction.hpp"
+#include "utils/memory.hpp"
 #include "utils/observer.hpp"
 #include "utils/resource_lock.hpp"
 #include "utils/synchronized.hpp"
@@ -704,7 +706,8 @@ class InMemoryStorage final : public Storage {
     void FastDiscardOfDeltas(std::unique_lock<std::mutex> gc_guard);
     void GCRapidDeltaCleanup(std::list<Gid, memory::DbAwareAllocator<Gid>> &current_deleted_edges,
                              std::list<Gid, memory::DbAwareAllocator<Gid>> &current_deleted_vertices,
-                             IndexPerformanceTracker &impact_tracker);
+                             IndexPerformanceTracker &impact_tracker,
+                             std::vector<Edge *> *out_deleted_light_edges = nullptr);
     SalientConfig::Items config_;
 
     uint64_t commit_flag_wal_position_{0};
@@ -773,7 +776,45 @@ class InMemoryStorage final : public Storage {
 
   void UpdateLabelCount(LabelId label, int64_t change) override;
 
-  // Wipe all storage state. Caller must hold main_lock_ exclusively.
+  // Graveyard for light edges: deleted Edge* kept alive until GC determines
+  // no active transaction can see them.  Two conditions must both hold before
+  // draining: the timestamp condition (no reader can see the edge alive) and
+  // the epoch condition (no edge-index iterable that pre-dates this entry is
+  // still active).
+  //
+  // Two-phase drain:
+  //   Phase 1 (commit time): entry added with mark_timestamp and an initial guard_epoch.
+  //   Phase 2 (GC, after RemoveObsoleteEdgeEntries): guard_epoch is re-snapped to
+  //     CurrentEpoch() AFTER index entries are atomically removed, and index_cleaned
+  //     is set. This mirrors SkipList GC which records the high-water accessor ID at
+  //     node-removal time, covering post-commit readers that read Edge* from a stale
+  //     index entry before cleanup ran.
+  //   Drain: only when index_cleaned == true AND IsSafeToFree(guard_epoch).
+  struct LightEdgeGraveyardEntry {
+    uint64_t mark_timestamp;
+    uint64_t guard_epoch;
+    std::vector<Edge *> edges;
+    bool index_cleaned{false};
+  };
+
+  // Test helper: number of entries currently sitting in the light-edge graveyard.
+  std::size_t LightEdgeGraveyardSizeForTest() {
+    std::size_t n = 0;
+    light_edge_graveyard_.WithLock([&](auto &graveyard) { n = graveyard.size(); });
+    return n;
+  }
+
+  // Returns the appropriate edge-memory pin for edge-index iterables.
+  // Normal-edge mode: ConstAccessor on edges_ (prevents skiplist GC from freeing edge nodes).
+  // Light-edge mode:  LightEdgeIterableGuard (acquires an epoch ID from light_edge_iterable_tracker_
+  //                   so the graveyard drain only unblocks once all pre-existing readers are done).
+  EdgePin MakeEdgePin() const {
+    if (config_.salient.items.storage_light_edge) {
+      return LightEdgeIterableGuard{&light_edge_iterable_tracker_};
+    }
+    return edges_.access();
+  }
+
   void Clear();
 
  private:
@@ -799,8 +840,14 @@ class InMemoryStorage final : public Storage {
 
   EdgeInfo FindEdgeFromMetadata(Gid gid, const Edge *edge_ptr);
 
-  // Database-owned arena pool for per-thread arena management.
-  // Database must outlive Storage; Database member declaration order guarantees that.
+  void DeleteLightEdge(Edge *p);
+
+  // Free all pool-allocated Edge objects: walk out_edges of every vertex (each
+  // edge appears exactly once) and drain the graveyard.  Must be called before
+  // vertices_.clear() so the adjacency lists are still intact.
+  // Requires gc_lock_ to be held by the caller.
+  void ClearLightEdges();
+
   memgraph::memory::ArenaPool *db_arena_{nullptr};
 
   // Main object storage — DbAwareAllocator routes node allocations through the
@@ -809,6 +856,12 @@ class InMemoryStorage final : public Storage {
   utils::SkipListDb<Vertex> vertices_;
   utils::SkipListDb<Edge> edges_;
   utils::SkipListDb<EdgeMetadata> edges_metadata_;
+
+  // Epoch tracker for edge-index Iterables/ChunkedIterables in light-edge mode.
+  // Each iterable acquires an epoch ID on construction and releases it on destruction.
+  // The graveyard drain re-snaps guard_epoch to CurrentEpoch() after index cleanup and
+  // only frees edges once IsSafeToFree(guard_epoch) — see LightEdgeGraveyardEntry.
+  mutable utils::EpochTracker light_edge_iterable_tracker_;
 
   // Durability
   durability::Recovery recovery_;
@@ -879,6 +932,8 @@ class InMemoryStorage final : public Storage {
   // Edges that are logically deleted and wait to be removed from the main
   // storage.
   utils::Synchronized<std::list<Gid, memory::DbAwareAllocator<Gid>>, utils::SpinLock> deleted_edges_;
+
+  utils::Synchronized<std::list<LightEdgeGraveyardEntry>, utils::SpinLock> light_edge_graveyard_;
 
   std::atomic<bool> gc_index_cleanup_vertex_performance_ = false;
   std::atomic<bool> gc_index_cleanup_edge_performance_ = false;

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -870,10 +870,6 @@ class InMemoryStorage final : public Storage {
 
   memgraph::memory::ArenaPool *db_arena_{nullptr};
 
-  // Light-edge allocator pool — wraps DbAwareAllocator<Edge> for thread-safe
-  // light-edge creation and destruction (routes to the current DB arena via TLS).
-  LightEdgePool light_edge_pool_;
-
   // Main object storage — DbAwareAllocator routes node allocations through the
   // current DB TLS scope, while long-lived DB work establishes that scope at
   // the appropriate execution boundary.
@@ -1054,8 +1050,8 @@ struct SingleTxnDeltasProcessingResult {
 // Free helpers for light-edge lifecycle, usable from durability code
 // (snapshot.cpp / wal.cpp) where no InMemoryStorage* is available.
 // Each call creates a temporary LightEdgePool (stateless — reads TLS arena).
-inline Edge *CreateLightEdge(Gid gid, Delta *delta) { return InMemoryStorage::LightEdgePool{}.Create(gid, delta); }
+inline Edge *CreateLightEdge(Gid gid, Delta *delta) { return InMemoryStorage::LightEdgePool::Create(gid, delta); }
 
-inline void DestroyLightEdge(Edge *p) noexcept { InMemoryStorage::LightEdgePool{}.Destroy(p); }
+inline void DestroyLightEdge(Edge *p) noexcept { InMemoryStorage::LightEdgePool::Destroy(p); }
 
 }  // namespace memgraph::storage

--- a/src/utils/epoch_tracker.hpp
+++ b/src/utils/epoch_tracker.hpp
@@ -39,6 +39,9 @@ namespace memgraph::utils {
 /// processing 1 billion unique edge-index scans will retain ~122 MB of tracker
 /// memory for the lifetime of the storage instance.  If this becomes a concern
 /// in practice, consider adding safe block reclamation (TODO).
+
+// TODO This is just the skiplist allocator's epoch tracker. Can we move the skiplist's out and use this there as well?
+// Audit to make sure the logic is EXACTLY the same.
 class EpochTracker {
  private:
   static constexpr uint64_t kIdsInField = sizeof(uint64_t) * 8;        // 64 bits per field

--- a/src/utils/epoch_tracker.hpp
+++ b/src/utils/epoch_tracker.hpp
@@ -54,7 +54,7 @@ class EpochTracker {
     uint64_t const first_id;  // immutable after construction; safe to read without lock
     std::atomic<uint64_t> field[kBlockFields];
 
-    explicit Block(uint64_t id) : first_id{id} { std::memset(field, 0, sizeof(field)); }
+    explicit Block(uint64_t id) : first_id{id}, field{} {}
   };
 
   Block *AllocateBlock(Block *expected_head) {

--- a/src/utils/epoch_tracker.hpp
+++ b/src/utils/epoch_tracker.hpp
@@ -1,0 +1,165 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+
+#include "utils/logging.hpp"
+#include "utils/rw_spin_lock.hpp"
+
+namespace memgraph::utils {
+
+/// Epoch-based safe-drain tracker for deferred reclamation.
+///
+/// Readers call Acquire() on entry and Release(id) on exit.  A producer
+/// records `guard_epoch = CurrentEpoch()` when an object becomes eligible for
+/// reclamation.  The object may be safely freed once IsSafeToFree(guard_epoch)
+/// returns true — meaning every reader that was alive at the time of the
+/// guard_epoch snapshot has since called Release().
+///
+/// The implementation is a simplified variant of the SkipListGc bitmap
+/// approach: accessor IDs are packed into 64-bit fields inside fixed-size
+/// Blocks linked in a doubly-linked list.  Unlike SkipListGc, fully-dead
+/// blocks are never reclaimed (blocks are small and very few in practice), so
+/// the implementation is free of the tricky races that accompany block removal.
+class EpochTracker {
+ private:
+  static constexpr uint64_t kIdsInField = sizeof(uint64_t) * 8;        // 64 bits per field
+  static constexpr uint64_t kBlockFields = 64;                         // 64 fields per block
+  static constexpr uint64_t kIdsInBlock = kBlockFields * kIdsInField;  // 4096 IDs per block
+
+  struct Block {
+    std::atomic<Block *> prev{nullptr};
+    std::atomic<Block *> succ{nullptr};
+    uint64_t const first_id;  // immutable after construction; safe to read without lock
+    std::atomic<uint64_t> field[kBlockFields];
+
+    explicit Block(uint64_t id) : first_id{id} { std::memset(field, 0, sizeof(field)); }
+  };
+
+  Block *AllocateBlock(Block *expected_head) {
+    auto guard = std::lock_guard{lock_};
+    Block *curr_head = head_.load(std::memory_order_acquire);
+    if (curr_head != expected_head) return curr_head;  // someone else allocated while we waited
+    auto *block = new Block{last_id_};
+    block->prev.store(curr_head, std::memory_order_release);
+    block->succ.store(nullptr, std::memory_order_release);
+    last_id_ += kIdsInBlock;
+    if (curr_head == nullptr) {
+      tail_.store(block, std::memory_order_release);
+    } else {
+      curr_head->succ.store(block, std::memory_order_release);
+    }
+    head_.store(block, std::memory_order_release);
+    return block;
+  }
+
+ public:
+  EpochTracker() = default;
+
+  ~EpochTracker() { Clear(); }
+
+  EpochTracker(const EpochTracker &) = delete;
+  EpochTracker &operator=(const EpochTracker &) = delete;
+  EpochTracker(EpochTracker &&) = delete;
+  EpochTracker &operator=(EpochTracker &&) = delete;
+
+  /// Acquire a unique epoch ID for a new reader. Must be paired with Release().
+  uint64_t Acquire() { return epoch_.fetch_add(1, std::memory_order_acq_rel); }
+
+  /// Mark the reader with the given ID as done.
+  void Release(uint64_t id) {
+    Block *head = head_.load(std::memory_order_acquire);
+    if (head == nullptr) head = AllocateBlock(head);
+    while (true) {
+      MG_ASSERT(head != nullptr, "EpochTracker: missing block for id {}", id);
+      if (id < head->first_id) {
+        head = head->prev.load(std::memory_order_acquire);
+      } else if (id >= head->first_id + kIdsInBlock) {
+        head = AllocateBlock(head);
+      } else {
+        uint64_t local_id = id - head->first_id;
+        uint64_t field_idx = local_id / kIdsInField;
+        uint64_t bit = local_id % kIdsInField;
+        uint64_t mask = uint64_t{1} << bit;
+        auto prev_val = head->field[field_idx].fetch_or(mask, std::memory_order_acq_rel);
+        MG_ASSERT(!(prev_val & mask), "EpochTracker: id {} released twice", id);
+        return;
+      }
+    }
+  }
+
+  /// Returns the epoch value that will be returned by the next Acquire() call.
+  /// Record this as the guard_epoch when an object becomes reclaimable.
+  uint64_t CurrentEpoch() const { return epoch_.load(std::memory_order_acquire); }
+
+  /// Returns true if all readers with id < guard_epoch have called Release().
+  /// Safe to call from any thread.
+  bool IsSafeToFree(uint64_t guard_epoch) const {
+    if (guard_epoch == 0) return true;  // no readers existed before the guard was recorded
+    uint64_t last_dead = ComputeLastDead();
+    if (last_dead == uint64_t(-1)) return false;  // no contiguous dead prefix yet
+    return last_dead >= guard_epoch - 1;
+  }
+
+ private:
+  /// Returns the highest ID N such that all IDs in [0, N] have been released,
+  /// or uint64_t(-1) if no contiguous dead prefix has been established yet
+  /// (i.e., ID 0 has not been released, or nothing has been released at all).
+  uint64_t ComputeLastDead() const {
+    Block *block = tail_.load(std::memory_order_acquire);
+    uint64_t last_dead = uint64_t(-1);  // sentinel: no dead prefix yet
+    while (block != nullptr) {
+      for (uint64_t pos = 0; pos < kBlockFields; ++pos) {
+        uint64_t field = block->field[pos].load(std::memory_order_acquire);
+        if (field != std::numeric_limits<uint64_t>::max()) {
+          if (field == 0) return last_dead;  // no IDs in this field are dead
+          // Partial field: find the first zero bit (first still-alive ID).
+          // __builtin_ffsl returns 1-indexed position of LSB; subtract 1 for 0-indexed.
+          int where_alive = __builtin_ffsl(~field) - 1;
+          uint64_t base = block->first_id + pos * kIdsInField;
+          // base + where_alive - 1: when where_alive==0 and base==0 this wraps to
+          // uint64_t(-1), which correctly signals "no dead prefix" (bit 0 is alive).
+          return base + static_cast<uint64_t>(where_alive) - 1;
+        }
+        // Full field: all 64 IDs in this field are dead.
+        last_dead = block->first_id + (pos + 1) * kIdsInField - 1;
+      }
+      block = block->succ.load(std::memory_order_acquire);
+    }
+    return last_dead;
+  }
+
+  void Clear() {
+    Block *head = head_.load(std::memory_order_acquire);
+    while (head != nullptr) {
+      Block *prev = head->prev.load(std::memory_order_acquire);
+      delete head;
+      head = prev;
+    }
+    epoch_.store(0, std::memory_order_relaxed);
+    head_.store(nullptr, std::memory_order_relaxed);
+    tail_.store(nullptr, std::memory_order_relaxed);
+    last_id_ = 0;
+  }
+
+  RWSpinLock lock_;
+  std::atomic<uint64_t> epoch_{0};
+  std::atomic<Block *> head_{nullptr};
+  std::atomic<Block *> tail_{nullptr};
+  uint64_t last_id_{0};
+};
+
+}  // namespace memgraph::utils

--- a/src/utils/epoch_tracker.hpp
+++ b/src/utils/epoch_tracker.hpp
@@ -32,8 +32,13 @@ namespace memgraph::utils {
 /// The implementation is a simplified variant of the SkipListGc bitmap
 /// approach: accessor IDs are packed into 64-bit fields inside fixed-size
 /// Blocks linked in a doubly-linked list.  Unlike SkipListGc, fully-dead
-/// blocks are never reclaimed (blocks are small and very few in practice), so
-/// the implementation is free of the tricky races that accompany block removal.
+/// blocks are never reclaimed, so the implementation is free of the tricky
+/// races that accompany block removal.
+///
+/// Memory bound: each block holds 4096 IDs and costs ~512 bytes.  A server
+/// processing 1 billion unique edge-index scans will retain ~122 MB of tracker
+/// memory for the lifetime of the storage instance.  If this becomes a concern
+/// in practice, consider adding safe block reclamation (TODO).
 class EpochTracker {
  private:
   static constexpr uint64_t kIdsInField = sizeof(uint64_t) * 8;        // 64 bits per field

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -161,8 +161,8 @@ startup_config_dict = {
         "Controls whether additional metadata should be stored about the edges in order to do faster traversals on certain queries.",
     ),
     "storage_light_edge": (
-        "true",
-        "true",
+        "false",
+        "false",
         "Controls whether edges are stored as lightweight objects in order to reduce memory footprint; implies --storage-properties-on-edges.",
     ),
     "storage_property_store_compression_enabled": (

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -160,6 +160,11 @@ startup_config_dict = {
         "false",
         "Controls whether additional metadata should be stored about the edges in order to do faster traversals on certain queries.",
     ),
+    "storage_light_edge": (
+        "true",
+        "true",
+        "Controls whether edges are stored as lightweight objects in order to reduce memory footprint; implies --storage-properties-on-edges.",
+    ),
     "storage_property_store_compression_enabled": (
         "false",
         "false",

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -161,8 +161,8 @@ startup_config_dict = {
         "Controls whether additional metadata should be stored about the edges in order to do faster traversals on certain queries.",
     ),
     "storage_light_edge": (
-        "false",
-        "false",
+        "true",
+        "true",
         "Controls whether edges are stored as lightweight objects in order to reduce memory footprint; implies --storage-properties-on-edges.",
     ),
     "storage_property_store_compression_enabled": (

--- a/tests/e2e/durability/CMakeLists.txt
+++ b/tests/e2e/durability/CMakeLists.txt
@@ -14,6 +14,8 @@ copy_e2e_python_files(durability multitenancy.py)
 copy_e2e_python_files(durability indices_not_persisted_analytical.py)
 copy_e2e_python_files(durability parameters_durability.py)
 copy_e2e_python_files(durability tenant_profile_durability.py)
+copy_e2e_python_files(durability periodic_snapshot_light_edge.py)
+copy_e2e_python_files(durability snapshot_recovery_light_edge.py)
 
 copy_e2e_python_files_from_parent_folder(durability ".." memgraph.py)
 copy_e2e_python_files_from_parent_folder(durability ".." interactive_mg_runner.py)

--- a/tests/e2e/durability/periodic_snapshot_light_edge.py
+++ b/tests/e2e/durability/periodic_snapshot_light_edge.py
@@ -1,0 +1,45 @@
+# Copyright 2024 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+"""Light-edge variant of periodic_snapshot.py.
+
+All tests are identical but Memgraph is started with --storage-light-edge
+and --storage-properties-on-edges so the snapshot scheduler is exercised
+with pool-allocated (light) edges.
+"""
+
+import sys
+
+import periodic_snapshot as _ps
+
+# Patch memgraph_instances before any test runs.
+_orig_memgraph_instances = _ps.memgraph_instances
+
+_LE_ARGS = ["--storage-light-edge", "--storage-properties-on-edges"]
+
+
+def _light_edge_memgraph_instances(dir, mode="IN_MEMORY_TRANSACTIONAL"):
+    instances = _orig_memgraph_instances(dir, mode)
+    for cfg in instances.values():
+        if _LE_ARGS[0] not in cfg["args"]:
+            cfg["args"] = cfg["args"] + _LE_ARGS
+    return instances
+
+
+_ps.memgraph_instances = _light_edge_memgraph_instances
+
+# Re-export so pytest collects fixtures and test functions.
+from periodic_snapshot import *  # noqa: F401, F403, E402
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/durability/periodic_snapshot_light_edge.py
+++ b/tests/e2e/durability/periodic_snapshot_light_edge.py
@@ -13,7 +13,7 @@
 
 All tests are identical but Memgraph is started with --storage-light-edge
 and --storage-properties-on-edges so the snapshot scheduler is exercised
-with pool-allocated (light) edges.
+with light edges.
 """
 
 import sys

--- a/tests/e2e/durability/snapshot_recovery_light_edge.py
+++ b/tests/e2e/durability/snapshot_recovery_light_edge.py
@@ -1,0 +1,65 @@
+# Copyright 2024 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+"""Light-edge variant of snapshot_recovery.py.
+
+All tests are identical but Memgraph is started with --storage-light-edge
+and --storage-properties-on-edges so that snapshots and WALs are written
+and recovered using pool-allocated (light) edges.
+"""
+
+import os
+import shutil
+import sys
+
+import snapshot_recovery as _sr
+
+# Patch memgraph_instances BEFORE generate_tmp_snapshot() runs so that both
+# the writer and the recovery instance use light edges.
+_orig_memgraph_instances = _sr.memgraph_instances
+
+_LE_ARGS = ["--storage-light-edge", "--storage-properties-on-edges"]
+
+
+def _light_edge_memgraph_instances(dir):
+    instances = _orig_memgraph_instances(dir)
+    for cfg in instances.values():
+        if _LE_ARGS[0] not in cfg["args"]:
+            cfg["args"] = cfg["args"] + _LE_ARGS
+    return instances
+
+
+_sr.memgraph_instances = _light_edge_memgraph_instances
+
+# Re-export everything so pytest collects fixtures and test functions from here.
+from snapshot_recovery import *  # noqa: F401, F403, E402
+
+if __name__ == "__main__":
+    import pytest
+
+    try:
+        shutil.rmtree(_sr.TMP_DIR)
+        os.mkdir(_sr.TMP_DIR)
+    except Exception:
+        pass
+
+    # generate_tmp_snapshot uses the now-patched memgraph_instances
+    _sr.generate_tmp_snapshot()
+
+    res = pytest.main([__file__, "-rA"])
+
+    _sr.interactive_mg_runner.kill_all()
+    try:
+        shutil.rmtree(_sr.TMP_DIR)
+    except Exception:
+        pass
+
+    sys.exit(res)

--- a/tests/e2e/durability/snapshot_recovery_light_edge.py
+++ b/tests/e2e/durability/snapshot_recovery_light_edge.py
@@ -13,7 +13,7 @@
 
 All tests are identical but Memgraph is started with --storage-light-edge
 and --storage-properties-on-edges so that snapshots and WALs are written
-and recovered using pool-allocated (light) edges.
+and recovered using light edges.
 """
 
 import os

--- a/tests/e2e/durability/workloads.yaml
+++ b/tests/e2e/durability/workloads.yaml
@@ -5,9 +5,15 @@ workloads:
   - name: "Recover snapshot"
     binary: "tests/e2e/pytest_runner.sh"
     args: ["durability/snapshot_recovery.py"]
+  - name: "Recover snapshot (light-edge)"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["durability/snapshot_recovery_light_edge.py"]
   - name: "Periodic snapshot"
     binary: "tests/e2e/pytest_runner.sh"
     args: ["durability/periodic_snapshot.py"]
+  - name: "Periodic snapshot (light-edge)"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["durability/periodic_snapshot_light_edge.py"]
   - name: "MT durability"
     binary: "tests/e2e/pytest_runner.sh"
     args: ["durability/multitenancy.py"]

--- a/tests/e2e/garbage_collection/workloads.yaml
+++ b/tests/e2e/garbage_collection/workloads.yaml
@@ -14,6 +14,14 @@ gc_on_obsolete_indexes_cluster: &gc_on_obsolete_indexes_cluster
       setup_queries: []
       validation_queries: []
 
+gc_on_obsolete_indexes_light_edge_cluster: &gc_on_obsolete_indexes_light_edge_cluster
+  cluster:
+    main:
+      args: ["--bolt-port", "7687", "--log-level=TRACE", "--storage-gc-cycle-sec=240", "--storage-light-edge", "--storage-properties-on-edges"]
+      log_file: "gc_on_obsolete_indexes_light_edge-e2e.log"
+      setup_queries: []
+      validation_queries: []
+
 workloads:
   - name: "Garbage collection"
     binary: "tests/e2e/garbage_collection/memgraph__e2e__garbage_collection"
@@ -24,3 +32,8 @@ workloads:
     binary: "tests/e2e/pytest_runner.sh"
     args: ["garbage_collection/gc_on_obsolete_indexes.py"]
     <<: *gc_on_obsolete_indexes_cluster
+
+  - name: "Garbage collection on obsolete indexes (light-edge)"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["garbage_collection/gc_on_obsolete_indexes.py"]
+    <<: *gc_on_obsolete_indexes_light_edge_cluster

--- a/tests/e2e/pytest_runner.sh
+++ b/tests/e2e/pytest_runner.sh
@@ -3,4 +3,4 @@
 # This workaround is necessary to run in the same virtualenv as the e2e runner.py
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-python3 "$DIR/$1"
+python3 "$DIR/$1" "${@:2}"

--- a/tests/e2e/replication/CMakeLists.txt
+++ b/tests/e2e/replication/CMakeLists.txt
@@ -2,12 +2,15 @@ find_package(gflags REQUIRED)
 
 add_executable(memgraph__e2e__replication__constraints constraints.cpp)
 target_link_libraries(memgraph__e2e__replication__constraints gflags mgclient::mgclient mg-utils mg-io Threads::Threads)
+add_dependencies(memgraph__e2e memgraph__e2e__replication__constraints)
 
 add_executable(memgraph__e2e__replication__indices indices.cpp)
 target_link_libraries(memgraph__e2e__replication__indices gflags mgclient::mgclient mg-utils mg-io Threads::Threads)
+add_dependencies(memgraph__e2e memgraph__e2e__replication__indices)
 
 add_executable(memgraph__e2e__replication__read_write_benchmark read_write_benchmark.cpp)
 target_link_libraries(memgraph__e2e__replication__read_write_benchmark gflags nlohmann_json::nlohmann_json mgclient::mgclient mg-utils mg-io Threads::Threads)
+add_dependencies(memgraph__e2e memgraph__e2e__replication__read_write_benchmark)
 
 copy_e2e_python_files(replication common.py)
 copy_e2e_python_files(replication conftest.py)

--- a/tests/e2e/replication/conftest.py
+++ b/tests/e2e/replication/conftest.py
@@ -10,8 +10,7 @@
 # licenses/APL.txt.
 
 import pytest
-
-from common import execute_and_fetch_all, connect
+from common import connect, execute_and_fetch_all
 
 
 # The fixture here is more complex because the connection has to be
@@ -42,3 +41,7 @@ def connection():
     if role_holder == "main":
         cursor = connection_holder.cursor()
         execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+
+
+def pytest_addoption(parser):
+    parser.addoption("--with-props", action="store_true", default=False, help="Run tests with properties enabled")

--- a/tests/e2e/replication/edge_delete.py
+++ b/tests/e2e/replication/edge_delete.py
@@ -18,11 +18,14 @@ from mg_utils import mg_sleep_and_assert_collection
 
 
 # BUGFIX: for issue https://github.com/memgraph/memgraph/issues/1515
-def test_replication_handles_delete_when_multiple_edges_of_same_type(connection):
+def test_replication_handles_delete_when_multiple_edges_of_same_type(connection, pytestconfig):
     # Goal is to check the timestamp are correctly computed from the information we get from replicas.
     # 0/ Check original state of replicas.
     # 1/ Add nodes and edges to MAIN, then delete the edges.
     # 2/ Check state of replicas.
+
+    with_props = pytestconfig.getoption("with_props")
+    print("Running with poperties: ", with_props)
 
     # 0/
     conn = connection(7687, "main")
@@ -49,7 +52,12 @@ def test_replication_handles_delete_when_multiple_edges_of_same_type(connection)
     assert all([x in actual_data for x in expected_data])
 
     # 1/
-    execute_and_fetch_all(cursor, "CREATE (a)-[r:X]->(b) CREATE (a)-[:X]->(b) DELETE r;")
+    if with_props:
+        execute_and_fetch_all(
+            cursor, "CREATE (a)-[r:X{p:1, str:'1234567890'}]->(b) CREATE (a)-[:X{p:2, str:'1234567890'}]->(b) DELETE r;"
+        )
+    else:
+        execute_and_fetch_all(cursor, "CREATE (a)-[r:X]->(b) CREATE (a)-[:X]->(b) DELETE r;")
 
     # 2/
     expected_data = [
@@ -77,4 +85,4 @@ def test_replication_handles_delete_when_multiple_edges_of_same_type(connection)
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__, "-rA"]))
+    sys.exit(pytest.main([__file__, "-rA"] + sys.argv[1:]))

--- a/tests/e2e/replication/workloads.yaml
+++ b/tests/e2e/replication/workloads.yaml
@@ -27,6 +27,45 @@ template_simple_cluster: &template_simple_cluster
           "REGISTER REPLICA replica_2 ASYNC TO '127.0.0.1:10002'",
         ]
 
+template_simple_cluster_light_edge: &template_simple_cluster_light_edge
+  cluster:
+    replica_1:
+      args: ["--bolt-port", "7688", "--log-level=TRACE", "--storage-light-edge", "--storage-properties-on-edges"]
+      log_file: "replication-e2e-replica1.log"
+      setup_queries: ["SET REPLICATION ROLE TO REPLICA WITH PORT 10001;"]
+    replica_2:
+      args: ["--bolt-port", "7689", "--log-level=TRACE", "--storage-light-edge", "--storage-properties-on-edges"]
+      log_file: "replication-e2e-replica2.log"
+      setup_queries: ["SET REPLICATION ROLE TO REPLICA WITH PORT 10002;"]
+    main:
+      args: ["--bolt-port", "7687", "--log-level=TRACE", "--storage-light-edge", "--storage-properties-on-edges"]
+      log_file: "replication-e2e-main.log"
+      setup_queries:
+        [
+          "REGISTER REPLICA replica_1 SYNC TO '127.0.0.1:10001'",
+          "REGISTER REPLICA replica_2 ASYNC TO '127.0.0.1:10002'",
+        ]
+
+template_simple_cluster_mixed_edge: &template_simple_cluster_mixed_edge
+  cluster:
+    replica_1:
+      args: ["--bolt-port", "7688", "--log-level=TRACE", "--storage-light-edge", "--storage-properties-on-edges"]
+      log_file: "replication-e2e-replica1.log"
+      setup_queries: ["SET REPLICATION ROLE TO REPLICA WITH PORT 10001;"]
+    replica_2:
+      args: ["--bolt-port", "7689", "--log-level=TRACE", "--nostorage-light-edge", "--storage-properties-on-edges"]
+      log_file: "replication-e2e-replica2.log"
+      setup_queries: ["SET REPLICATION ROLE TO REPLICA WITH PORT 10002;"]
+    main:
+      args: ["--bolt-port", "7687", "--log-level=TRACE", "--nostorage-light-edge", "--storage-properties-on-edges"]
+      log_file: "replication-e2e-main.log"
+      setup_queries:
+        [
+          "REGISTER REPLICA replica_1 SYNC TO '127.0.0.1:10001'",
+          "REGISTER REPLICA replica_2 ASYNC TO '127.0.0.1:10002'",
+        ]
+
+
 template_cluster: &template_cluster
   cluster:
     replica_1:
@@ -114,6 +153,11 @@ workloads:
     args: ["replication/replicate_periodic_commit.py"]
     <<: *template_simple_cluster
 
+  - name: "Replicate periodic commit (light-edge)"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["replication/replicate_periodic_commit.py"]
+    <<: *template_simple_cluster_light_edge
+
   - name: "Replicate spatial feature"
     binary: "tests/e2e/pytest_runner.sh"
     args: [ "replication/replicate_spatial_feature.py" ]
@@ -138,6 +182,16 @@ workloads:
     binary: "tests/e2e/pytest_runner.sh"
     args: ["replication/edge_delete.py"]
     <<: *template_simple_cluster
+
+  - name: "Delete edge replication (light-edge)"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["replication/edge_delete.py", "--with-props"]
+    <<: *template_simple_cluster_light_edge
+
+  - name: "Delete edge replication (mixed-edge)"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["replication/edge_delete.py", "--with-props"]
+    <<: *template_simple_cluster_mixed_edge
 
   - name: "Replication with property compression used"
     binary: "tests/e2e/pytest_runner.sh"

--- a/tests/e2e/schema_info/workloads.yaml
+++ b/tests/e2e/schema_info/workloads.yaml
@@ -12,8 +12,29 @@ schema_setup: &schema_setup
       setup_queries: []
       validation_queries: []
 
+schema_setup_light_edge: &schema_setup_light_edge
+  cluster:
+    main:
+      args:
+        [
+          "--bolt-port",
+          "7687",
+          "--log-level=TRACE",
+          "--schema-info-enabled",
+          "--storage-light-edge",
+          "--storage-properties-on-edges",
+        ]
+      log_file: "schema_info_light_edge.log"
+      setup_queries: []
+      validation_queries: []
+
 workloads:
   - name: "Show schema info"
     binary: "tests/e2e/pytest_runner.sh"
     args: ["schema_info/schema_info.py"]
     <<: *schema_setup
+
+  - name: "Show schema info (light-edge)"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["schema_info/schema_info.py"]
+    <<: *schema_setup_light_edge

--- a/tests/integration/durability/runner.py
+++ b/tests/integration/durability/runner.py
@@ -66,9 +66,14 @@ def dump_database(output_file):
         f.write("\n".join(row[0] for row in rows) + "\n")
 
 
-def execute_test(memgraph_binary: Path, test_directory, test_type, write_expected):
+def execute_test(memgraph_binary: Path, test_directory, test_type, write_expected, light_edge: bool = False):
     assert test_type in ["SNAPSHOT", "WAL"], "Test type should be either 'SNAPSHOT' or 'WAL'."
-    print("\033[1;36m~~ Executing test {} ({}) ~~\033[0m".format(os.path.relpath(test_directory, TESTS_DIR), test_type))
+    mode_tag = " [light-edge]" if light_edge else ""
+    print(
+        "\033[1;36m~~ Executing test {}{} ({}) ~~\033[0m".format(
+            os.path.relpath(test_directory, TESTS_DIR), mode_tag, test_type
+        )
+    )
 
     working_data_directory = tempfile.TemporaryDirectory()
     if test_type == "SNAPSHOT":
@@ -81,6 +86,8 @@ def execute_test(memgraph_binary: Path, test_directory, test_type, write_expecte
         shutil.copy(os.path.join(test_directory, WAL_FILE_NAME), wal_dir)
 
     extra_args = ["--data-recovery-on-startup"]
+    if light_edge:
+        extra_args.append("--storage-light-edge")
     with memgraph_server(memgraph_binary, Path(working_data_directory.name), 7687, logger, extra_args):
         # Execute `database dump`
         dump_output_file = tempfile.NamedTemporaryFile()
@@ -145,6 +152,15 @@ if __name__ == "__main__":
     parser.add_argument(
         "--write-expected", action="store_true", help="Overwrite the expected cypher with results from current run"
     )
+    parser.add_argument(
+        "--light-edge",
+        action="store_true",
+        help=(
+            "Run all recovery tests with --storage-light-edge enabled. "
+            "The existing snapshot/WAL binaries (written without light edges) are recovered "
+            "into a light-edge storage instance; the expected cypher output is unchanged."
+        ),
+    )
     args = parser.parse_args()
 
     test_directories = find_test_directories(TESTS_DIR, args.write_expected)
@@ -154,7 +170,7 @@ if __name__ == "__main__":
     test_directories.sort()
 
     for test_directory in test_directories:
-        execute_test(Path(args.memgraph), test_directory, "SNAPSHOT", args.write_expected)
-        execute_test(Path(args.memgraph), test_directory, "WAL", args.write_expected)
+        execute_test(Path(args.memgraph), test_directory, "SNAPSHOT", args.write_expected, light_edge=args.light_edge)
+        execute_test(Path(args.memgraph), test_directory, "WAL", args.write_expected, light_edge=args.light_edge)
 
     sys.exit(0)

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -17,6 +17,9 @@ test_one() {
   fi
   if [ -x runner.py ]; then
     $DIR/../ve3/bin/python3 -u runner.py
+    if [ "$integration_test_folder_name" = "durability" ]; then
+      $DIR/../ve3/bin/python3 -u runner.py --light-edge
+    fi
   elif [ -x runner.sh ]; then
     ./runner.sh
   fi

--- a/tests/mgbench/benchmark.py
+++ b/tests/mgbench/benchmark.py
@@ -686,6 +686,10 @@ def run_isolated_workload_with_authorization(
         )
 
         vendor_runner.start_db(VENDOR_RUNNER_AUTHORIZATION)
+        # Purge jemalloc and reset VmHWM so peak memory reflects only
+        # the benchmark workload, not transient snapshot loading structures.
+        # Use the benchmark user credentials since auth is enabled at this point.
+        vendor_runner.free_memory(username=USERNAME, password=PASSWORD)
         start_time = time.time()
         warmup(condition=benchmark_context.warm_up, client=client, queries=get_queries(func, count, benchmark_context))
 
@@ -743,6 +747,9 @@ def run_isolated_workload_without_authorization(
         start_time = time.time()
         rss_db = workload.NAME + workload.get_variant() + "_" + "_" + benchmark_context.mode + "_" + query
         vendor_runner.start_db(rss_db)
+        # Purge jemalloc and reset VmHWM so peak memory reflects only
+        # the benchmark workload, not transient snapshot loading structures.
+        vendor_runner.free_memory()
         warmup(condition=benchmark_context.warm_up, client=client, queries=get_queries(func, count, benchmark_context))
         log.init("Executing benchmark queries...")
         ret = client.execute(
@@ -816,6 +823,10 @@ def save_memory_usage_of_empty_db(vendor_runner, workload, results):
 def save_memory_usage_of_imported_data(vendor_runner, workload, results, memory_usage_of_empty_db):
     rss_db = workload.NAME + workload.get_variant() + "_" + IMPORTED_DATA
     vendor_runner.start_db(rss_db)
+    # After snapshot loading, light edges use additional temporary structures that
+    # jemalloc doesn't return to the OS right away. FREE MEMORY forces a purge so
+    # the memory measurement reflects actual steady-state usage.
+    vendor_runner.free_memory()
     usage = vendor_runner.stop_db(rss_db)
     if usage is None:
         usage = {"memory": 0, "cpu": 0}

--- a/tests/mgbench/runners.py
+++ b/tests/mgbench/runners.py
@@ -583,6 +583,11 @@ class BaseRunner(ABC):
     def clean_db(self):
         pass
 
+    def free_memory(self, username: str = "", password: str = ""):
+        """Execute FREE MEMORY on the running database to release jemalloc-held pages.
+        Override for vendor-specific implementation."""
+        pass
+
     def get_database_port(self):
         return self._bolt_port
 
@@ -611,6 +616,7 @@ class Memgraph(BaseRunner):
     def __init__(self, benchmark_context: BenchmarkContext):
         super().__init__(benchmark_context=benchmark_context)
         self._memgraph_binary = benchmark_context.vendor_binary
+        self._client_binary = benchmark_context.client_binary
         # Use database_workers instead of num_workers_for_benchmark to allow separation
         self._bolt_num_workers = benchmark_context.database_workers
         self._performance_tracking = benchmark_context.performance_tracking
@@ -692,6 +698,37 @@ class Memgraph(BaseRunner):
             self.dump_rss(workload)
         ret, usage = self._cleanup()
         return usage
+
+    def free_memory(self, username: str = "", password: str = ""):
+        if self._proc_mg is None:
+            return
+        query_file = os.path.join(self._directory.name, "free_memory_query.json")
+        with open(query_file, "w") as f:
+            json.dump(["FREE MEMORY", {}], f)
+            f.write("\n")
+        args = _convert_args_to_flags(
+            self._client_binary,
+            input=query_file,
+            num_workers=1,
+            queries_json=True,
+            port=self._bolt_port,
+            username=username,
+            password=password,
+        )
+        ret = subprocess.run(args, capture_output=True)
+        if ret.returncode != 0:
+            raise Exception(
+                f"FREE MEMORY query failed (exit code {ret.returncode}):\n"
+                f"stdout: {ret.stdout.decode('utf-8', errors='replace')}\n"
+                f"stderr: {ret.stderr.decode('utf-8', errors='replace')}"
+            )
+        # Reset VmHWM (peak RSS) to current VmRSS so that _get_usage() captures
+        # steady-state memory instead of the transient snapshot-loading peak.
+        try:
+            with open(f"/proc/{self._proc_mg.pid}/clear_refs", "w") as f:
+                f.write("5")
+        except (PermissionError, OSError):
+            pass
 
     def clean_db(self):
         if self._proc_mg is not None:

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -683,6 +683,11 @@ add_unit_test(storage_v2_edge_ondisk
     LINK_TARGETS mg::storage disk_test_utils
 )
 
+add_unit_test(storage_v2_light_edges
+    SOURCES storage_v2_light_edges.cpp
+    LINK_TARGETS mg::storage mg-dbms
+)
+
 add_unit_test(storage_v2_gc
     SOURCES storage_v2_gc.cpp
     LINK_TARGETS mg::storage

--- a/tests/unit/storage_v2_constraints.cpp
+++ b/tests/unit/storage_v2_constraints.cpp
@@ -37,6 +37,9 @@ using testing::UnorderedElementsAre;
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define ASSERT_NO_ERROR(result) ASSERT_TRUE((result).has_value())
 
+/// Tag type: run ConstraintsTest with InMemoryStorage + storage_light_edge=true.
+struct InMemoryStorageLightEdge {};
+
 template <typename StorageType>
 class ConstraintsTest : public testing::Test {
  public:
@@ -46,6 +49,10 @@ class ConstraintsTest : public testing::Test {
     /// TODO: andi How to make this better? Because currentlly for every test changed you need to create a configuration
     config_ = disk_test_utils::GenerateOnDiskConfig(testSuite);
     config_.force_on_disk = std::is_same_v<StorageType, memgraph::storage::DiskStorage>;
+    if constexpr (std::is_same_v<StorageType, InMemoryStorageLightEdge>) {
+      config_.salient.items.storage_light_edge = true;
+      config_.salient.items.properties_on_edges = true;
+    }
     db_gk_.emplace(config_);
     auto db_acc_opt = db_gk_->access();
     MG_ASSERT(db_acc_opt, "Failed to access db");
@@ -64,13 +71,14 @@ class ConstraintsTest : public testing::Test {
     db_acc_.reset();
     db_gk_.reset();
 
-    if (std::is_same<StorageType, memgraph::storage::DiskStorage>::value) {
+    if constexpr (std::is_same_v<StorageType, memgraph::storage::DiskStorage>) {
       disk_test_utils::RemoveRocksDbDirs(testSuite);
     }
   }
 
   auto CreateConstraintAccessor() -> std::unique_ptr<memgraph::storage::Storage::Accessor> {
-    if constexpr (std::is_same_v<StorageType, memgraph::storage::InMemoryStorage>) {
+    if constexpr (std::is_same_v<StorageType, memgraph::storage::InMemoryStorage> ||
+                  std::is_same_v<StorageType, InMemoryStorageLightEdge>) {
       return this->db_acc_->get()->ReadOnlyAccess();
     } else {
       return this->db_acc_->get()->UniqueAccess();
@@ -78,7 +86,8 @@ class ConstraintsTest : public testing::Test {
   }
 
   auto DropConstraintAccessor() -> std::unique_ptr<memgraph::storage::Storage::Accessor> {
-    if constexpr (std::is_same_v<StorageType, memgraph::storage::InMemoryStorage>) {
+    if constexpr (std::is_same_v<StorageType, memgraph::storage::InMemoryStorage> ||
+                  std::is_same_v<StorageType, InMemoryStorageLightEdge>) {
       return this->db_acc_->get()->ReadOnlyAccess();
     } else {
       return this->db_acc_->get()->UniqueAccess();
@@ -96,7 +105,8 @@ class ConstraintsTest : public testing::Test {
   LabelId label2;
 };
 
-using StorageTypes = ::testing::Types<memgraph::storage::InMemoryStorage, memgraph::storage::DiskStorage>;
+using StorageTypes =
+    ::testing::Types<memgraph::storage::InMemoryStorage, memgraph::storage::DiskStorage, InMemoryStorageLightEdge>;
 TYPED_TEST_SUITE(ConstraintsTest, StorageTypes);
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)

--- a/tests/unit/storage_v2_create_snapshot.cpp
+++ b/tests/unit/storage_v2_create_snapshot.cpp
@@ -12,13 +12,17 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <deque>
 #include <filesystem>
+#include <fstream>
 #include <string>
 
 #include "dbms/database.hpp"
 #include "memory/db_arena.hpp"
 #include "replication/state.hpp"
 #include "storage/v2/config.hpp"
+#include "storage/v2/durability/exceptions.hpp"
 #include "storage/v2/durability/paths.hpp"
 #include "storage/v2/durability/snapshot.hpp"
 #include "storage/v2/inmemory/storage.hpp"
@@ -233,4 +237,86 @@ TEST_F(CreateSnapshotTest, ModeSwitchSnapshotDurableTimestampCoversAnalyticalWri
     snapshot = infos.back();
   }
   EXPECT_GT(snapshot.durable_timestamp, ldt_before_switch);
+}
+
+/// Corrupts a light-edge snapshot and verifies that LoadSnapshot throws
+/// RecoveryFailure, leaving all target containers empty.
+TEST_F(CreateSnapshotTest, LoadSnapshotLightEdgeCorruptionThrowsRecoveryFailure) {
+  // Use a large items_per_batch so all edges land in a single batch.
+  auto config = CreateConfig();
+  config.durability.items_per_batch = 1'000'000;
+  config.salient.items.properties_on_edges = true;
+  config.salient.items.storage_light_edge = true;
+
+  memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+  auto *mem_storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
+
+  // Create 3 vertices and 2 edges (no properties).
+  {
+    auto acc = mem_storage->Access(memgraph::storage::WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    auto v3 = acc->CreateVertex();
+
+    auto et = acc->NameToEdgeType("REL");
+    ASSERT_TRUE(acc->CreateEdge(&v1, &v2, et).has_value());
+    ASSERT_TRUE(acc->CreateEdge(&v2, &v3, et).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Create snapshot.
+  auto result = mem_storage->CreateSnapshot();
+  ASSERT_TRUE(result.has_value());
+  auto snapshot_path = result.value();
+
+  // Read snapshot info to locate the edge section.
+  auto snapshot_info = memgraph::storage::durability::ReadSnapshotInfo(snapshot_path);
+  ASSERT_NE(snapshot_info.offset_edges, memgraph::storage::durability::SnapshotInfo::kInvalidOffset);
+
+  // Corrupt the second edge's SECTION_EDGE marker.
+  // Each edge record without properties is:
+  //   1 byte  SECTION_EDGE marker
+  //   9 bytes TYPE_INT + GID
+  //   9 bytes TYPE_INT + prop_count(0)
+  // = 19 bytes total.
+  {
+    std::fstream file(snapshot_path, std::ios::in | std::ios::out | std::ios::binary);
+    ASSERT_TRUE(file.is_open());
+    file.seekp(static_cast<std::streamoff>(snapshot_info.offset_edges + 19));
+    char corrupted = static_cast<char>(0x99);
+    file.write(&corrupted, 1);
+    ASSERT_TRUE(file.good());
+  }
+
+  // Attempt to load the corrupted snapshot directly.
+  memgraph::utils::SkipListDb<memgraph::storage::Vertex> vertices;
+  memgraph::utils::SkipListDb<memgraph::storage::Edge> edges;
+  memgraph::utils::SkipListDb<memgraph::storage::EdgeMetadata> edges_metadata;
+  std::deque<std::pair<std::string, uint64_t>> epoch_history;
+  memgraph::storage::NameIdMapper name_id_mapper;
+  std::atomic<uint64_t> edge_count{0};
+  memgraph::storage::EnumStore enum_store;
+  memgraph::storage::ttl::TTL ttl{nullptr};
+  memgraph::storage::DescriptionStore description_store;
+
+  ASSERT_THROW(memgraph::storage::durability::LoadSnapshot(snapshot_path,
+                                                           &vertices,
+                                                           &edges,
+                                                           &edges_metadata,
+                                                           &epoch_history,
+                                                           &name_id_mapper,
+                                                           &edge_count,
+                                                           config,
+                                                           &enum_store,
+                                                           nullptr,
+                                                           &ttl,
+                                                           &description_store),
+               memgraph::storage::durability::RecoveryFailure);
+
+  // Verify all containers were cleaned up and remain empty.
+  EXPECT_EQ(vertices.size(), 0);
+  EXPECT_EQ(edges.size(), 0);
+  EXPECT_EQ(edges_metadata.size(), 0);
+  EXPECT_EQ(edge_count.load(), 0);
 }

--- a/tests/unit/storage_v2_durability_inmemory.cpp
+++ b/tests/unit/storage_v2_durability_inmemory.cpp
@@ -3922,6 +3922,20 @@ TEST_P(DurabilityTest, ConstraintsRecoveryFunctionSetting) {
       std::get_if<memgraph::storage::ExistenceConstraints::MultipleThreadsConstraintValidation>(
           &variant_existence_constraint_creation_func);
   MG_ASSERT(pval_existence, "Chose wrong type of function for recovery of existence constraint data");
+
+  // Cleanup light edges to avoid ASAN leaks in tests that do manual recovery
+  if (GetParam().light_edge) {
+    auto vertex_acc = vertices.access();
+    for (auto &vertex : vertex_acc) {
+      for (auto const &[edge_type, to_vertex, edge_ref] : vertex.out_edges) {
+        if (edge_ref.ptr != nullptr) {
+          memgraph::memory::DbAwareAllocator<memgraph::storage::Edge> alloc;
+          std::destroy_at(edge_ref.ptr);
+          std::allocator_traits<decltype(alloc)>::deallocate(alloc, edge_ref.ptr, 1);
+        }
+      }
+    }
+  }
 }
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)

--- a/tests/unit/storage_v2_durability_inmemory.cpp
+++ b/tests/unit/storage_v2_durability_inmemory.cpp
@@ -78,7 +78,21 @@ std::chrono::milliseconds operator+(const memgraph::utils::SchedulerInterval &si
 
 }  // namespace
 
-class DurabilityTest : public ::testing::TestWithParam<bool> {
+struct DurabilityParam {
+  bool properties_on_edges{true};
+  bool light_edge{false};
+
+  // Implicit construction from bool for backward-compat with the two existing INSTANTIATE lines.
+  /* implicit */ DurabilityParam(bool poe) : properties_on_edges(poe) {}  // NOLINT(google-explicit-constructor)
+
+  DurabilityParam(bool poe, bool le) : properties_on_edges(poe), light_edge(le) {}
+
+  // Allow GetParam() to be used directly where a bool (properties_on_edges) is expected.
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  operator bool() const { return properties_on_edges; }
+};
+
+class DurabilityTest : public ::testing::TestWithParam<DurabilityParam> {
  protected:
   const uint64_t kNumBaseVertices = 1000;
   const uint64_t kNumBaseEdges = 10'000;
@@ -1451,18 +1465,20 @@ void DestroyWalSuffix(const std::filesystem::path &path) {
   file.Close();
 }
 
-INSTANTIATE_TEST_SUITE_P(EdgesWithProperties, DurabilityTest, ::testing::Values(true));
-INSTANTIATE_TEST_SUITE_P(EdgesWithoutProperties, DurabilityTest, ::testing::Values(false));
+INSTANTIATE_TEST_SUITE_P(EdgesWithProperties, DurabilityTest, ::testing::Values(DurabilityParam{true}));
+INSTANTIATE_TEST_SUITE_P(EdgesWithoutProperties, DurabilityTest, ::testing::Values(DurabilityParam{false}));
+INSTANTIATE_TEST_SUITE_P(LightEdges, DurabilityTest, ::testing::Values(DurabilityParam(true, true)));
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(DurabilityTest, SnapshotOnExit) {
   // Create snapshot.
   {
-    memgraph::storage::Config config{
-        .durability = {.storage_directory = storage_directory,
-                       .snapshot_on_exit = true,
-                       .allow_parallel_snapshot_creation = true},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}}};
+    memgraph::storage::Config config{.durability = {.storage_directory = storage_directory,
+                                                    .snapshot_on_exit = true,
+                                                    .allow_parallel_snapshot_creation = true},
+                                     .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                                                           .enable_schema_info = false,
+                                                           .storage_light_edge = GetParam().light_edge}}};
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
@@ -1479,7 +1495,9 @@ TEST_P(DurabilityTest, SnapshotOnExit) {
   // Recover snapshot.
   memgraph::storage::Config config{
       .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = true,
+                            .storage_light_edge = GetParam().light_edge}},
   };
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -1504,7 +1522,9 @@ TEST_P(DurabilityTest, SnapshotPeriodic) {
         .durability = {.storage_directory = storage_directory,
                        .snapshot_wal_mode = memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT,
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::milliseconds(2000)}},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -1520,7 +1540,9 @@ TEST_P(DurabilityTest, SnapshotPeriodic) {
   // Recover snapshot.
   memgraph::storage::Config config{
       .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = false,
+                            .storage_light_edge = GetParam().light_edge}},
   };
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -1555,7 +1577,9 @@ TEST_P(DurabilityTest, SnapshotFallback) {
                 .snapshot_retention_count = 10,  // We don't anticipate that we make this many
                 .allow_parallel_snapshot_creation = true,
             },
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -1596,7 +1620,9 @@ TEST_P(DurabilityTest, SnapshotFallback) {
   // Recover snapshot.
   memgraph::storage::Config config{
       .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = true,
+                            .storage_light_edge = GetParam().light_edge}},
   };
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -1618,7 +1644,9 @@ TEST_P(DurabilityTest, SnapshotEverythingCorrupt) {
   {
     memgraph::storage::Config config{
         .durability = {.storage_directory = storage_directory, .snapshot_on_exit = true},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -1650,7 +1678,9 @@ TEST_P(DurabilityTest, SnapshotEverythingCorrupt) {
         .durability = {.storage_directory = storage_directory,
                        .snapshot_wal_mode = memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT,
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::milliseconds(2000)}},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -1693,7 +1723,9 @@ TEST_P(DurabilityTest, SnapshotEverythingCorrupt) {
                  memgraph::storage::Config config{
 
                      .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-                     .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+                     .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                                           .enable_schema_info = true,
+                                           .storage_light_edge = GetParam().light_edge}},
                  };
                  memgraph::dbms::Database db{config};
                  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -1708,7 +1740,9 @@ TEST_P(DurabilityTest, SnapshotRetention) {
   {
     memgraph::storage::Config config{
         .durability = {.storage_directory = storage_directory, .snapshot_on_exit = true},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = false,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -1733,7 +1767,9 @@ TEST_P(DurabilityTest, SnapshotRetention) {
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::milliseconds(2000)},
                        .snapshot_retention_count = 1},  // if the retention is more than 1 snapshots won't get created
         // due to db having the same state as before
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = false,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -1758,7 +1794,9 @@ TEST_P(DurabilityTest, SnapshotRetention) {
   // Recover snapshot.
   memgraph::storage::Config config{
       .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = false,
+                            .storage_light_edge = GetParam().light_edge}},
   };
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -1785,7 +1823,9 @@ TEST_P(DurabilityTest, SnapshotMixedUUID) {
                 .snapshot_on_exit = true,
                 .allow_parallel_snapshot_creation = true,
             },
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = false,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -1805,7 +1845,9 @@ TEST_P(DurabilityTest, SnapshotMixedUUID) {
     memgraph::storage::Config config{
 
         .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = false,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -1816,7 +1858,9 @@ TEST_P(DurabilityTest, SnapshotMixedUUID) {
   {
     memgraph::storage::Config config{
         .durability = {.storage_directory = storage_directory, .snapshot_on_exit = true},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = false,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -1840,7 +1884,9 @@ TEST_P(DurabilityTest, SnapshotMixedUUID) {
   // Recover snapshot.
   memgraph::storage::Config config{
       .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = false,
+                            .storage_light_edge = GetParam().light_edge}},
   };
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -1862,7 +1908,9 @@ TEST_P(DurabilityTest, SnapshotBackup) {
   {
     memgraph::storage::Config config{
         .durability = {.storage_directory = storage_directory, .snapshot_on_exit = true},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -1884,7 +1932,9 @@ TEST_P(DurabilityTest, SnapshotBackup) {
         .durability = {.storage_directory = storage_directory,
                        .snapshot_wal_mode = memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT,
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)}},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2059,7 +2109,9 @@ TEST_P(DurabilityTest, WalBasic) {
                            memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
                        .wal_file_flush_every_n_tx = kFlushWalEvery},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2075,7 +2127,9 @@ TEST_P(DurabilityTest, WalBasic) {
   // Recover WALs.
   memgraph::storage::Config config{
       .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = true,
+                            .storage_light_edge = GetParam().light_edge}},
   };
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2103,7 +2157,9 @@ TEST_P(DurabilityTest, WalBackup) {
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
                        .wal_file_size_kibibytes = 1,
                        .wal_file_flush_every_n_tx = kFlushWalEvery},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = false,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2127,7 +2183,9 @@ TEST_P(DurabilityTest, WalBackup) {
                        .snapshot_wal_mode =
                            memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)}},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2150,7 +2208,9 @@ TEST_P(DurabilityTest, WalAppendToExisting) {
                            memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
                        .wal_file_flush_every_n_tx = kFlushWalEvery},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2167,7 +2227,9 @@ TEST_P(DurabilityTest, WalAppendToExisting) {
     memgraph::storage::Config config{
 
         .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     ;
     memgraph::dbms::Database db{config};
@@ -2185,7 +2247,9 @@ TEST_P(DurabilityTest, WalAppendToExisting) {
                            memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
                        .wal_file_flush_every_n_tx = kFlushWalEvery},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2200,7 +2264,9 @@ TEST_P(DurabilityTest, WalAppendToExisting) {
   // Recover WALs.
   memgraph::storage::Config config{
       .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = true,
+                            .storage_light_edge = GetParam().light_edge}},
   };
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2230,7 +2296,9 @@ TEST_P(DurabilityTest, WalCreateInSingleTransaction) {
                            memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
                        .wal_file_flush_every_n_tx = kFlushWalEvery},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = false,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2267,7 +2335,9 @@ TEST_P(DurabilityTest, WalCreateInSingleTransaction) {
   // Recover WALs.
   memgraph::storage::Config config{
       .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = false,
+                            .storage_light_edge = GetParam().light_edge}},
   };
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2380,7 +2450,9 @@ TEST_P(DurabilityTest, WalCreateAndRemoveEverything) {
                            memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
                        .wal_file_flush_every_n_tx = kFlushWalEvery},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2434,7 +2506,9 @@ TEST_P(DurabilityTest, WalCreateAndRemoveEverything) {
   // Recover WALs.
   memgraph::storage::Config config{
       .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = true,
+                            .storage_light_edge = GetParam().light_edge}},
   };
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2481,7 +2555,9 @@ TEST_P(DurabilityTest, WalTransactionOrdering) {
                 .wal_file_size_kibibytes = 100'000,
                 .wal_file_flush_every_n_tx = kFlushWalEvery,
             },
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2577,7 +2653,9 @@ TEST_P(DurabilityTest, WalTransactionOrdering) {
   // Recover WALs.
   memgraph::storage::Config config{
       .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = true,
+                            .storage_light_edge = GetParam().light_edge}},
   };
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2617,7 +2695,9 @@ TEST_P(DurabilityTest, WalCreateAndRemoveOnlyBaseDataset) {
                            memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
                        .wal_file_flush_every_n_tx = kFlushWalEvery},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2644,7 +2724,9 @@ TEST_P(DurabilityTest, WalCreateAndRemoveOnlyBaseDataset) {
   // Recover WALs.
   memgraph::storage::Config config{
       .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = true,
+                            .storage_light_edge = GetParam().light_edge}},
   };
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2679,7 +2761,9 @@ TEST_P(DurabilityTest, WalDeathResilience) {
                              memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
                          .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
                          .wal_file_flush_every_n_tx = kFlushWalEvery},
-          .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+          .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                                .enable_schema_info = false,
+                                .storage_light_edge = GetParam().light_edge}},
       };
       memgraph::dbms::Database db{config};
       const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2722,7 +2806,9 @@ TEST_P(DurabilityTest, WalDeathResilience) {
                 .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
                 .wal_file_flush_every_n_tx = kFlushWalEvery,
             },
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = false,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2752,7 +2838,9 @@ TEST_P(DurabilityTest, WalDeathResilience) {
   // Recover WALs.
   memgraph::storage::Config config{
       .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = false,
+                            .storage_light_edge = GetParam().light_edge}},
   };
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2788,7 +2876,9 @@ TEST_P(DurabilityTest, WalMissingSecond) {
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
                        .wal_file_size_kibibytes = 1,
                        .wal_file_flush_every_n_tx = kFlushWalEvery},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2816,7 +2906,9 @@ TEST_P(DurabilityTest, WalMissingSecond) {
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
                        .wal_file_size_kibibytes = 1,
                        .wal_file_flush_every_n_tx = kFlushWalEvery},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2866,7 +2958,9 @@ TEST_P(DurabilityTest, WalMissingSecond) {
                  memgraph::storage::Config config{
 
                      .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-                     .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+                     .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                                           .enable_schema_info = true,
+                                           .storage_light_edge = GetParam().light_edge}},
                  };
                  memgraph::dbms::Database db{config};
                  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2887,7 +2981,9 @@ TEST_P(DurabilityTest, WalCorruptSecond) {
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
                        .wal_file_size_kibibytes = 1,
                        .wal_file_flush_every_n_tx = kFlushWalEvery},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = false,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2915,7 +3011,9 @@ TEST_P(DurabilityTest, WalCorruptSecond) {
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
                        .wal_file_size_kibibytes = 1,
                        .wal_file_flush_every_n_tx = kFlushWalEvery},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = false,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2965,7 +3063,9 @@ TEST_P(DurabilityTest, WalCorruptSecond) {
                  memgraph::storage::Config config{
 
                      .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-                     .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+                     .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                                           .enable_schema_info = false,
+                                           .storage_light_edge = GetParam().light_edge}},
                  };
                  memgraph::dbms::Database db{config};
                  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -2986,7 +3086,9 @@ TEST_P(DurabilityTest, WalCorruptLastTransaction) {
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
                        .wal_file_size_kibibytes = 1,
                        .wal_file_flush_every_n_tx = kFlushWalEvery},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3010,7 +3112,9 @@ TEST_P(DurabilityTest, WalCorruptLastTransaction) {
   // Recover WALs.
   memgraph::storage::Config config{
       .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = true,
+                            .storage_light_edge = GetParam().light_edge}},
   };
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3043,7 +3147,9 @@ TEST_P(DurabilityTest, WalAllOperationsInSingleTransaction) {
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
                        .wal_file_size_kibibytes = 1,
                        .wal_file_flush_every_n_tx = kFlushWalEvery},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = false,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3091,7 +3197,9 @@ TEST_P(DurabilityTest, WalAllOperationsInSingleTransaction) {
   // Recover WALs.
   memgraph::storage::Config config{
       .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = false,
+                            .storage_light_edge = GetParam().light_edge}},
   };
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3129,7 +3237,9 @@ TEST_P(DurabilityTest, WalAndSnapshot) {
                 .wal_file_flush_every_n_tx = kFlushWalEvery,
                 .allow_parallel_snapshot_creation = true,
             },
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3146,7 +3256,9 @@ TEST_P(DurabilityTest, WalAndSnapshot) {
   // Recover snapshot and WALs.
   memgraph::storage::Config config{
       .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = true,
+                            .storage_light_edge = GetParam().light_edge}},
   };
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3168,7 +3280,9 @@ TEST_P(DurabilityTest, WalAndSnapshotAppendToExistingSnapshot) {
   {
     memgraph::storage::Config config{
         .durability = {.storage_directory = storage_directory, .snapshot_on_exit = true},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3185,7 +3299,9 @@ TEST_P(DurabilityTest, WalAndSnapshotAppendToExistingSnapshot) {
     memgraph::storage::Config config{
 
         .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3202,7 +3318,9 @@ TEST_P(DurabilityTest, WalAndSnapshotAppendToExistingSnapshot) {
                            memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
                        .wal_file_flush_every_n_tx = kFlushWalEvery},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3217,7 +3335,9 @@ TEST_P(DurabilityTest, WalAndSnapshotAppendToExistingSnapshot) {
   // Recover snapshot and WALs.
   memgraph::storage::Config config{
       .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = true,
+                            .storage_light_edge = GetParam().light_edge}},
   };
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3244,7 +3364,9 @@ TEST_P(DurabilityTest, WalAndSnapshotAppendToExistingSnapshotAndWal) {
                 .snapshot_on_exit = true,
                 .allow_parallel_snapshot_creation = true,
             },
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3261,7 +3383,9 @@ TEST_P(DurabilityTest, WalAndSnapshotAppendToExistingSnapshotAndWal) {
     memgraph::storage::Config config{
 
         .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3278,7 +3402,9 @@ TEST_P(DurabilityTest, WalAndSnapshotAppendToExistingSnapshotAndWal) {
                            memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
                        .wal_file_flush_every_n_tx = kFlushWalEvery},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3301,7 +3427,9 @@ TEST_P(DurabilityTest, WalAndSnapshotAppendToExistingSnapshotAndWal) {
                            memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
                        .wal_file_flush_every_n_tx = kFlushWalEvery},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3324,7 +3452,9 @@ TEST_P(DurabilityTest, WalAndSnapshotAppendToExistingSnapshotAndWal) {
   // Recover snapshot and WALs.
   memgraph::storage::Config config{
       .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = true,
+                            .storage_light_edge = GetParam().light_edge}},
   };
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3373,7 +3503,9 @@ TEST_P(DurabilityTest, WalAndSnapshotWalRetention) {
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
                        .wal_file_size_kibibytes = 1,
                        .wal_file_flush_every_n_tx = kFlushWalEvery},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = false,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3403,7 +3535,9 @@ TEST_P(DurabilityTest, WalAndSnapshotWalRetention) {
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::seconds(2)},
                        .wal_file_size_kibibytes = 1,
                        .wal_file_flush_every_n_tx = 1},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = false,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3435,7 +3569,9 @@ TEST_P(DurabilityTest, WalAndSnapshotWalRetention) {
       memgraph::storage::Config config{
 
           .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-          .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+          .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                                .enable_schema_info = false,
+                                .storage_light_edge = GetParam().light_edge}},
       };
       memgraph::dbms::Database db{config};
       const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3456,7 +3592,9 @@ TEST_P(DurabilityTest, WalAndSnapshotWalRetention) {
                  memgraph::storage::Config config{
 
                      .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-                     .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+                     .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                                           .enable_schema_info = false,
+                                           .storage_light_edge = GetParam().light_edge}},
                  };
                  memgraph::dbms::Database db{config};
                  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3477,7 +3615,9 @@ TEST_P(DurabilityTest, SnapshotAndWalMixedUUID) {
                 .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::seconds(2)},
                 .allow_parallel_snapshot_creation = true,
             },
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = false,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3501,7 +3641,9 @@ TEST_P(DurabilityTest, SnapshotAndWalMixedUUID) {
                        .snapshot_wal_mode =
                            memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
                        .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::seconds(2)}},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = false,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3527,7 +3669,9 @@ TEST_P(DurabilityTest, SnapshotAndWalMixedUUID) {
   // Recover snapshot and WALs.
   memgraph::storage::Config config{
       .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = false,
+                            .storage_light_edge = GetParam().light_edge}},
   };
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3552,7 +3696,9 @@ TEST_P(DurabilityTest, ParallelSnapshotRecovery) {
                        .snapshot_on_exit = true,
                        .items_per_batch = 13,
                        .allow_parallel_schema_creation = true},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3574,7 +3720,9 @@ TEST_P(DurabilityTest, ParallelSnapshotRecovery) {
                      .snapshot_on_exit = false,
                      .items_per_batch = 13,
                      .allow_parallel_schema_creation = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = true,
+                            .storage_light_edge = GetParam().light_edge}},
   };
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3593,7 +3741,9 @@ TEST_P(DurabilityTest, ParallelWalRecovery) {
                        .snapshot_on_exit = false,
                        .items_per_batch = 13,
                        .allow_parallel_schema_creation = true},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3617,7 +3767,9 @@ TEST_P(DurabilityTest, ParallelWalRecovery) {
                      .snapshot_on_exit = false,
                      .items_per_batch = 13,
                      .allow_parallel_schema_creation = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = true,
+                            .storage_light_edge = GetParam().light_edge}},
   };
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3640,7 +3792,9 @@ TEST_P(DurabilityTest, ParallelSnapshotWalRecovery) {
                 .allow_parallel_snapshot_creation = true,
                 .allow_parallel_schema_creation = true,
             },
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3666,7 +3820,9 @@ TEST_P(DurabilityTest, ParallelSnapshotWalRecovery) {
                      .snapshot_on_exit = false,
                      .items_per_batch = 13,
                      .allow_parallel_schema_creation = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = true,
+                            .storage_light_edge = GetParam().light_edge}},
   };
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -3681,7 +3837,9 @@ TEST_P(DurabilityTest, ConstraintsRecoveryFunctionSetting) {
                      .snapshot_on_exit = false,
                      .items_per_batch = 13,
                      .allow_parallel_schema_creation = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = true,
+                            .storage_light_edge = GetParam().light_edge}},
   };
   // Create snapshot.
   {
@@ -3774,7 +3932,9 @@ TEST_P(DurabilityTest, EdgeTypeIndexRecovered) {
   // Create snapshot.
   {
     memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .snapshot_on_exit = true},
-                                     .salient.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}};
+                                     .salient.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                                                       .enable_schema_info = false,
+                                                       .storage_light_edge = GetParam().light_edge}};
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
@@ -3791,7 +3951,9 @@ TEST_P(DurabilityTest, EdgeTypeIndexRecovered) {
 
   // Recover snapshot.
   memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-                                   .salient.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}};
+                                   .salient.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                                                     .enable_schema_info = false,
+                                                     .storage_light_edge = GetParam().light_edge}};
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(
@@ -3815,7 +3977,9 @@ TEST_P(DurabilityTest, EdgeTypePropertyIndexRecoveredWithEdgeTypeIndices) {
   // Create snapshot.
   {
     memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .snapshot_on_exit = true},
-                                     .salient.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}};
+                                     .salient.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                                                       .enable_schema_info = false,
+                                                       .storage_light_edge = GetParam().light_edge}};
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
@@ -3840,7 +4004,9 @@ TEST_P(DurabilityTest, EdgeTypePropertyIndexRecoveredWithEdgeTypeIndices) {
 
   // Recover snapshot.
   memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-                                   .salient.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}};
+                                   .salient.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                                                     .enable_schema_info = false,
+                                                     .storage_light_edge = GetParam().light_edge}};
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(db.storage(),
@@ -3866,7 +4032,9 @@ TEST_P(DurabilityTest, EdgeTypePropertyIndexRecoveredWithoutEdgeTypeIndices) {
   // Create snapshot.
   {
     memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .snapshot_on_exit = true},
-                                     .salient.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}};
+                                     .salient.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                                                       .enable_schema_info = false,
+                                                       .storage_light_edge = GetParam().light_edge}};
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
@@ -3888,7 +4056,9 @@ TEST_P(DurabilityTest, EdgeTypePropertyIndexRecoveredWithoutEdgeTypeIndices) {
 
   // Recover snapshot.
   memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-                                   .salient.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}};
+                                   .salient.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                                                     .enable_schema_info = false,
+                                                     .storage_light_edge = GetParam().light_edge}};
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(db.storage(),
@@ -3914,7 +4084,9 @@ TEST_P(DurabilityTest, EdgeMetadataRecovered) {
   // Create snapshot.
   {
     memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .snapshot_on_exit = true},
-                                     .salient.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}};
+                                     .salient.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                                                       .enable_schema_info = false,
+                                                       .storage_light_edge = GetParam().light_edge}};
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
@@ -3927,9 +4099,11 @@ TEST_P(DurabilityTest, EdgeMetadataRecovered) {
   ASSERT_EQ(GetBackupWalsList().size(), 0);
 
   // Recover snapshot.
-  memgraph::storage::Config config{
-      .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-      .salient.items = {.properties_on_edges = GetParam(), .enable_edges_metadata = true, .enable_schema_info = false}};
+  memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .recover_on_startup = true},
+                                   .salient.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                                                     .enable_edges_metadata = true,
+                                                     .enable_schema_info = false,
+                                                     .storage_light_edge = GetParam().light_edge}};
   memgraph::dbms::Database db{config};
   const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(db.storage(), DatasetType::ONLY_BASE, GetParam(), config.salient.items.enable_schema_info);
@@ -4325,7 +4499,9 @@ TEST_P(DurabilityTest, CreateSnapshotReturnsPath) {
                      .snapshot_on_exit = false,
                      .items_per_batch = 13,
                      .allow_parallel_schema_creation = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = true,
+                            .storage_light_edge = GetParam().light_edge}},
   };
 
   memgraph::dbms::Database db{config};
@@ -4365,7 +4541,9 @@ TEST_P(DurabilityTest, CreateSnapshotReturnsErrorForReplica) {
                      .snapshot_on_exit = false,
                      .items_per_batch = 13,
                      .allow_parallel_schema_creation = true},
-      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+      .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                            .enable_schema_info = true,
+                            .storage_light_edge = GetParam().light_edge}},
   };
 
   memgraph::dbms::Database db{config};
@@ -4550,7 +4728,9 @@ TEST_P(DurabilityTest, SnapshotWithNonSequentialDeltas) {
   {
     memgraph::storage::Config config{
         .durability = {.storage_directory = storage_directory, .snapshot_on_exit = true},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
@@ -4600,7 +4780,9 @@ TEST_P(DurabilityTest, SnapshotWithNonSequentialDeltas) {
   {
     memgraph::storage::Config recovery_config{
         .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
-        .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
+        .salient = {.items = {.properties_on_edges = static_cast<bool>(GetParam()),
+                              .enable_schema_info = true,
+                              .storage_light_edge = GetParam().light_edge}},
     };
     memgraph::dbms::Database db{recovery_config};
     const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};

--- a/tests/unit/storage_v2_edge_inmemory.cpp
+++ b/tests/unit/storage_v2_edge_inmemory.cpp
@@ -20,15 +20,25 @@
 
 using testing::UnorderedElementsAre;
 
-class StorageEdgeTest : public ::testing::TestWithParam<bool> {};
+struct StorageEdgeConfig {
+  bool properties_on_edges{true};
+  bool light_edge{false};
+};
 
-INSTANTIATE_TEST_SUITE_P(EdgesWithProperties, StorageEdgeTest, ::testing::Values(true));
-INSTANTIATE_TEST_SUITE_P(EdgesWithoutProperties, StorageEdgeTest, ::testing::Values(false));
+class StorageEdgeTest : public ::testing::TestWithParam<StorageEdgeConfig> {};
+
+INSTANTIATE_TEST_SUITE_P(EdgesWithProperties, StorageEdgeTest,
+                         ::testing::Values(StorageEdgeConfig{.properties_on_edges = true}));
+INSTANTIATE_TEST_SUITE_P(EdgesWithoutProperties, StorageEdgeTest,
+                         ::testing::Values(StorageEdgeConfig{.properties_on_edges = false}));
+INSTANTIATE_TEST_SUITE_P(LightEdges, StorageEdgeTest,
+                         ::testing::Values(StorageEdgeConfig{.properties_on_edges = true, .light_edge = true}));
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeCreateFromSmallerCommit) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_from = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_to = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -218,8 +228,9 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSmallerCommit) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeCreateFromLargerCommit) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_from = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_to = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -391,8 +402,9 @@ TEST_P(StorageEdgeTest, EdgeCreateFromLargerCommit) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeCreateFromSameCommit) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_vertex = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
   // Create vertex
@@ -537,8 +549,9 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSameCommit) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeCreateFromSmallerAbort) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_from = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_to = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -807,8 +820,9 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSmallerAbort) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeCreateFromLargerAbort) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_from = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_to = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -1077,8 +1091,9 @@ TEST_P(StorageEdgeTest, EdgeCreateFromLargerAbort) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeCreateFromSameAbort) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_vertex = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
   // Create vertex
@@ -1304,8 +1319,9 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSameAbort) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerCommit) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_from = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_to = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -1573,8 +1589,9 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerCommit) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeDeleteFromLargerCommit) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_from = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_to = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -1842,8 +1859,9 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerCommit) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeDeleteFromSameCommit) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_vertex = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
   // Create vertex
@@ -2068,8 +2086,9 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameCommit) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerAbort) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_from = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_to = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -2491,8 +2510,9 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerAbort) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeDeleteFromLargerAbort) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_from = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_to = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -2915,8 +2935,9 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerAbort) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeDeleteFromSameAbort) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_vertex = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
   // Create vertex
@@ -3275,8 +3296,9 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameAbort) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, VertexDetachDeleteSingleCommit) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_from = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_to = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -3414,8 +3436,9 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteSingleCommit) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, VertexDetachDeleteMultipleCommit) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_vertex1 = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_vertex2 = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -3744,8 +3767,9 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteMultipleCommit) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, VertexDetachDeleteSingleAbort) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_from = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_to = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -3987,8 +4011,9 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteSingleAbort) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, VertexDetachDeleteMultipleAbort) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_vertex1 = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_vertex2 = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -5413,8 +5438,9 @@ TEST(StorageWithProperties, EdgeNonexistentPropertyAPI) {
 }
 
 TEST_P(StorageEdgeTest, ConcurrentTransactionsCanCreateNonSequentialOperations) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_v1, gid_v2;
 
   {
@@ -5453,8 +5479,9 @@ TEST_P(StorageEdgeTest, ConcurrentTransactionsCanCreateNonSequentialOperations) 
 }
 
 TEST_P(StorageEdgeTest, NonSequentialOperationsOnCurrentTransactionsAreSerializationErrors) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_v1, gid_v2;
 
   {
@@ -5483,8 +5510,9 @@ TEST_P(StorageEdgeTest, NonSequentialOperationsOnCurrentTransactionsAreSerializa
 }
 
 TEST_P(StorageEdgeTest, OnlyNonSequentialOperationsCanBePerformedWhenHeadOperationIsNonSequential) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_v1, gid_v2, gid_v3;
 
   {

--- a/tests/unit/storage_v2_gc.cpp
+++ b/tests/unit/storage_v2_gc.cpp
@@ -1462,8 +1462,6 @@ TEST(StorageV2Gc, ClearDrainsWaitingGcDeltas) {
     ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
   }
 }
-<<<<<<< Updated upstream
-=======
 
 // ---------------------------------------------------------------------------
 // Light-edge GC tests: same scenarios as above but with storage_light_edge=true.
@@ -1769,4 +1767,3 @@ TEST(LightEdgesGraveyard, ConcurrentDeleteAndGC) {
   }
   EXPECT_EQ(total_deleted.load(), kEdges);
 }
->>>>>>> Stashed changes

--- a/tests/unit/storage_v2_gc.cpp
+++ b/tests/unit/storage_v2_gc.cpp
@@ -12,6 +12,12 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
+#include <random>
+#include <thread>
+#include <vector>
+
 #include "storage/v2/inmemory/storage.hpp"
 #include "tests/test_commit_args_helper.hpp"
 
@@ -1456,6 +1462,8 @@ TEST(StorageV2Gc, ClearDrainsWaitingGcDeltas) {
     ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
   }
 }
+<<<<<<< Updated upstream
+=======
 
 // ---------------------------------------------------------------------------
 // Light-edge GC tests: same scenarios as above but with storage_light_edge=true.
@@ -1674,3 +1682,91 @@ TEST(StorageV2GcLightEdge, AnalyticalModeDeleteGoesToGraveyard) {
   }
   // storage destructor runs here — must not crash or report sanitizer errors.
 }
+
+// ===========================================================================
+// Light-Edge Graveyard UAF reproduction tests
+// ===========================================================================
+
+namespace {
+
+auto MakeLightEdgeStorage() -> std::unique_ptr<ms::Storage> {
+  return std::make_unique<ms::InMemoryStorage>(
+      ms::Config{.salient = {.items = {.properties_on_edges = true, .storage_light_edge = true}}});
+}
+
+auto CreateTwoVertices(ms::Storage *store) -> std::pair<ms::Gid, ms::Gid> {
+  auto acc = store->Access(ms::WRITE);
+  auto v1 = acc->CreateVertex();
+  auto v2 = acc->CreateVertex();
+  auto gid1 = v1.Gid();
+  auto gid2 = v2.Gid();
+  EXPECT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  return {gid1, gid2};
+}
+
+}  // namespace
+
+TEST(LightEdgesGraveyard, ConcurrentDeleteAndGC) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  constexpr int kEdges = 100;
+
+  {
+    auto acc = store->Access(ms::WRITE);
+    auto vf = acc->FindVertex(gid_from, ms::View::NEW);
+    auto vt = acc->FindVertex(gid_to, ms::View::NEW);
+    auto et = acc->NameToEdgeType("CONC");
+    for (int i = 0; i < kEdges; ++i) {
+      ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  std::atomic<bool> gc_running{true};
+  std::atomic<uint64_t> total_deleted{0};
+
+  std::thread gc_thread([&]() {
+    while (gc_running.load()) {
+      store->FreeMemory();
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    store->FreeMemory();
+    store->FreeMemory();
+  });
+
+  constexpr int kDeleteThreads = 4;
+  std::vector<std::thread> deleters;
+  deleters.reserve(kDeleteThreads);
+  for (int t = 0; t < kDeleteThreads; ++t) {
+    deleters.emplace_back([&]() {
+      while (true) {
+        auto acc = store->Access(ms::WRITE);
+        auto vf = acc->FindVertex(gid_from, ms::View::NEW);
+        if (!vf) break;
+        auto out = vf->OutEdges(ms::View::NEW);
+        if (!out.has_value() || out->edges.empty()) break;
+
+        auto edge = out->edges[0];
+        auto del = acc->DeleteEdge(&edge);
+        if (!del.has_value()) continue;
+
+        if (acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value()) {
+          total_deleted.fetch_add(1);
+        }
+      }
+    });
+  }
+
+  for (auto &d : deleters) d.join();
+  gc_running.store(false);
+  gc_thread.join();
+
+  {
+    auto acc = store->Access(ms::WRITE);
+    auto vf = acc->FindVertex(gid_from, ms::View::OLD);
+    ASSERT_EQ(vf->OutEdges(ms::View::OLD)->edges.size(), 0);
+  }
+  EXPECT_EQ(total_deleted.load(), kEdges);
+}
+>>>>>>> Stashed changes

--- a/tests/unit/storage_v2_gc.cpp
+++ b/tests/unit/storage_v2_gc.cpp
@@ -1456,3 +1456,221 @@ TEST(StorageV2Gc, ClearDrainsWaitingGcDeltas) {
     ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
   }
 }
+
+// ---------------------------------------------------------------------------
+// Light-edge GC tests: same scenarios as above but with storage_light_edge=true.
+// ---------------------------------------------------------------------------
+
+namespace {
+auto MakeLightEdgeGcStorage() {
+  return std::make_unique<ms::InMemoryStorage>(
+      ms::Config{.gc = {.type = ms::Config::Gc::Type::PERIODIC, .interval = std::chrono::milliseconds(100)},
+                 .salient = {.items = {.properties_on_edges = true, .storage_light_edge = true}}});
+}
+}  // namespace
+
+// Mirrors StorageV2Gc/Sanity: GC running while a transaction is still alive must not free live data.
+// NOLINTNEXTLINE(hicpp-special-member-functions)
+TEST(StorageV2GcLightEdge, Sanity) {
+  auto storage = MakeLightEdgeGcStorage();
+
+  ms::Gid v1_gid, v2_gid;
+  {
+    auto acc = storage->Access(memgraph::storage::WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    v1_gid = v1.Gid();
+    v2_gid = v2.Gid();
+    ASSERT_TRUE(acc->CreateEdge(&v1, &v2, acc->NameToEdgeType("e")).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Reader keeps an open transaction.
+  auto reader = storage->Access(memgraph::storage::WRITE);
+
+  {
+    // Delete the edge in a second transaction while reader is alive.
+    auto writer = storage->Access(memgraph::storage::WRITE);
+    auto v1 = writer->FindVertex(v1_gid, ms::View::OLD).value();
+    auto edges = v1.OutEdges(ms::View::OLD);
+    ASSERT_TRUE(edges.has_value());
+    ASSERT_EQ(edges->edges.size(), 1U);
+    auto edge = edges->edges[0];
+    ASSERT_TRUE(writer->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(writer->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Let GC run while reader is still alive — it must NOT free the edge yet.
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+  // Reader still sees the edge via View::OLD.
+  {
+    auto v1 = reader->FindVertex(v1_gid, ms::View::OLD).value();
+    auto edges = v1.OutEdges(ms::View::OLD);
+    ASSERT_TRUE(edges.has_value());
+    ASSERT_EQ(edges->edges.size(), 1U);
+  }
+
+  reader->Abort();
+
+  // After reader closes, GC must eventually collect the graveyard.
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  // Storage destructor runs without crash — graveyard fully drained.
+}
+
+// Mirrors StorageV2Gc/ConcurrentEdgeOperationsAbortDeleteRepeat:
+// two transactions each create an edge, both abort; GC must not crash.
+// NOLINTNEXTLINE(hicpp-special-member-functions)
+TEST(StorageV2GcLightEdge, ConcurrentEdgeOperationsAbortDeleteRepeat) {
+  auto storage = MakeLightEdgeGcStorage();
+
+  ms::Gid v1_gid, v2_gid;
+  {
+    auto acc = storage->Access(memgraph::storage::WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    v1_gid = v1.Gid();
+    v2_gid = v2.Gid();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  auto tx1 = storage->Access(memgraph::storage::WRITE);
+  auto tx2 = storage->Access(memgraph::storage::WRITE);
+
+  {
+    auto v1 = tx1->FindVertex(v1_gid, ms::View::OLD).value();
+    auto v2 = tx1->FindVertex(v2_gid, ms::View::OLD).value();
+    ASSERT_TRUE(tx1->CreateEdge(&v1, &v2, tx1->NameToEdgeType("Edge1")).has_value());
+  }
+  {
+    auto v1 = tx2->FindVertex(v1_gid, ms::View::OLD).value();
+    auto v2 = tx2->FindVertex(v2_gid, ms::View::OLD).value();
+    ASSERT_TRUE(tx2->CreateEdge(&v1, &v2, tx2->NameToEdgeType("Edge2")).has_value());
+  }
+
+  tx1->Abort();
+  tx2->Abort();
+
+  // GC runs; aborted light-edge creations must have been freed inline (not via graveyard).
+  std::this_thread::sleep_for(std::chrono::milliseconds(400));
+
+  {
+    auto reader = storage->Access(memgraph::storage::WRITE);
+    auto v1 = reader->FindVertex(v1_gid, ms::View::OLD);
+    if (v1.has_value()) {
+      auto edges = v1->OutEdges(ms::View::OLD);
+      ASSERT_TRUE(edges.has_value());
+      ASSERT_EQ(edges->edges.size(), 0U);
+    }
+  }
+}
+
+// Mirrors StorageV2Gc/Indices: index GC correctness with light edges.
+// NOLINTNEXTLINE(hicpp-special-member-functions)
+TEST(StorageV2GcLightEdge, Indices) {
+  auto storage = MakeLightEdgeGcStorage();
+
+  {
+    auto unique_acc = storage->UniqueAccess();
+    ASSERT_TRUE(unique_acc->CreateIndex(storage->NameToLabel("label")).has_value());
+    ASSERT_TRUE(unique_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  ms::Gid v1_gid, v2_gid;
+  {
+    auto acc = storage->Access(memgraph::storage::WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    ASSERT_TRUE(*v1.AddLabel(acc->NameToLabel("label")));
+    ASSERT_TRUE(*v2.AddLabel(acc->NameToLabel("label")));
+    v1_gid = v1.Gid();
+    v2_gid = v2.Gid();
+    ASSERT_TRUE(acc->CreateEdge(&v1, &v2, acc->NameToEdgeType("e")).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  {
+    auto acc1 = storage->Access(memgraph::storage::WRITE);
+
+    auto acc2 = storage->Access(memgraph::storage::WRITE);
+    auto v1 = acc2->FindVertex(v1_gid, ms::View::OLD).value();
+    auto v2 = acc2->FindVertex(v2_gid, ms::View::OLD).value();
+    auto edges = v1.OutEdges(ms::View::OLD);
+    ASSERT_TRUE(edges.has_value());
+    ASSERT_EQ(edges->edges.size(), 1U);
+    auto edge = edges->edges[0];
+    ASSERT_TRUE(acc2->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(*v1.RemoveLabel(acc2->NameToLabel("label")));
+    ASSERT_TRUE(*v2.RemoveLabel(acc2->NameToLabel("label")));
+    ASSERT_TRUE(acc2->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+
+    // GC runs while acc1 still holds a snapshot — must not collect index entries visible to acc1.
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+    std::set<ms::Gid> gids;
+    for (auto vertex : acc1->Vertices(acc1->NameToLabel("label"), ms::View::OLD)) {
+      gids.insert(vertex.Gid());
+    }
+    EXPECT_EQ(gids.size(), 2U);
+  }
+}
+
+// Regression test: light edges deleted in analytical mode must be put in the graveyard
+// and freed by GC, not leaked.  Verifies that:
+//   - the storage destructor does not crash (no double-free / use-after-free)
+//   - ~Edge() is called (catches PropertyStore heap-allocation leak under ASan)
+//   - graveyard is drained correctly after mode switch back to transactional
+// NOLINTNEXTLINE(hicpp-special-member-functions)
+TEST(StorageV2GcLightEdge, AnalyticalModeDeleteGoesToGraveyard) {
+  auto storage = MakeLightEdgeGcStorage();
+  auto *mem_storage = static_cast<ms::InMemoryStorage *>(storage.get());
+
+  ms::Gid v1_gid, v2_gid;
+  {
+    auto acc = storage->Access(memgraph::storage::WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    v1_gid = v1.Gid();
+    v2_gid = v2.Gid();
+    auto edge_res = acc->CreateEdge(&v1, &v2, acc->NameToEdgeType("e"));
+    ASSERT_TRUE(edge_res.has_value());
+    // Set a property so the PropertyStore has a heap allocation — caught by ASan if ~Edge() is skipped.
+    ASSERT_TRUE(edge_res->SetProperty(acc->NameToProperty("key"), ms::PropertyValue{"value"}).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Switch to analytical mode and delete the edge there.
+  mem_storage->SetStorageMode(ms::StorageMode::IN_MEMORY_ANALYTICAL);
+  {
+    auto acc = storage->Access(memgraph::storage::WRITE);
+    auto v1 = acc->FindVertex(v1_gid, ms::View::OLD);
+    ASSERT_TRUE(v1.has_value());
+    auto edges = v1->OutEdges(ms::View::OLD);
+    ASSERT_TRUE(edges.has_value());
+    ASSERT_EQ(edges->edges.size(), 1U);
+    auto edge = edges->edges[0];
+    ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Switch back — this triggers a FreeMemory/GC pass which must not crash.
+  mem_storage->SetStorageMode(ms::StorageMode::IN_MEMORY_TRANSACTIONAL);
+
+  // Run GC explicitly a second time to drain the graveyard.
+  {
+    auto main_guard = std::unique_lock{mem_storage->main_lock_};
+    mem_storage->FreeMemory(std::move(main_guard), false);
+  }
+
+  // Verify the edge is gone and the two vertices are still intact.
+  {
+    auto acc = storage->Access(memgraph::storage::READ);
+    auto v1 = acc->FindVertex(v1_gid, ms::View::OLD);
+    ASSERT_TRUE(v1.has_value());
+    auto edges = v1->OutEdges(ms::View::OLD);
+    ASSERT_TRUE(edges.has_value());
+    EXPECT_TRUE(edges->edges.empty());
+    EXPECT_TRUE(acc->FindVertex(v2_gid, ms::View::OLD).has_value());
+  }
+  // storage destructor runs here — must not crash or report sanitizer errors.
+}

--- a/tests/unit/storage_v2_indices.cpp
+++ b/tests/unit/storage_v2_indices.cpp
@@ -72,6 +72,9 @@ auto MakeMap(Ts &&...values) -> PropertyValue
        std::forward<std::tuple_element_t<1, std::decay_t<Ts>>>(std::get<1>(std::forward<Ts>(values)))}...}};
 };
 
+/// Tag type: run IndexTest with InMemoryStorage + storage_light_edge=true.
+struct InMemoryStorageLightEdge {};
+
 template <typename StorageType>
 class IndexTest : public testing::Test {
  protected:
@@ -79,7 +82,12 @@ class IndexTest : public testing::Test {
     FLAGS_storage_properties_on_edges = true;
     config_.salient.items.properties_on_edges = true;
     config_ = disk_test_utils::GenerateOnDiskConfig(testSuite);
-    this->storage = std::make_unique<StorageType>(config_);
+    if constexpr (std::is_same_v<StorageType, InMemoryStorageLightEdge>) {
+      config_.salient.items.storage_light_edge = true;
+      this->storage = std::make_unique<memgraph::storage::InMemoryStorage>(config_);
+    } else {
+      this->storage = std::make_unique<StorageType>(config_);
+    }
     auto acc = this->storage->Access(memgraph::storage::WRITE);
     this->prop_id = acc->NameToProperty("id");
     this->prop_val = acc->NameToProperty("val");
@@ -97,7 +105,7 @@ class IndexTest : public testing::Test {
   }
 
   void TearDown() override {
-    if (std::is_same<StorageType, memgraph::storage::DiskStorage>::value) {
+    if constexpr (std::is_same_v<StorageType, memgraph::storage::DiskStorage>) {
       disk_test_utils::RemoveRocksDbDirs(testSuite);
     }
     this->storage.reset(nullptr);
@@ -111,7 +119,8 @@ class IndexTest : public testing::Test {
   std::unique_ptr<memgraph::storage::Storage> storage;
 
   auto CreateIndexAccessor() -> std::unique_ptr<memgraph::storage::Storage::Accessor> {
-    if constexpr (std::is_same_v<StorageType, memgraph::storage::InMemoryStorage>) {
+    if constexpr (std::is_same_v<StorageType, memgraph::storage::InMemoryStorage> ||
+                  std::is_same_v<StorageType, InMemoryStorageLightEdge>) {
       return this->storage->ReadOnlyAccess();
     } else {
       return this->storage->UniqueAccess();
@@ -119,7 +128,8 @@ class IndexTest : public testing::Test {
   }
 
   auto DropIndexAccessor() -> std::unique_ptr<memgraph::storage::Storage::Accessor> {
-    if constexpr (std::is_same_v<StorageType, memgraph::storage::InMemoryStorage>) {
+    if constexpr (std::is_same_v<StorageType, memgraph::storage::InMemoryStorage> ||
+                  std::is_same_v<StorageType, InMemoryStorageLightEdge>) {
       return this->storage->Access(memgraph::storage::StorageAccessType::READ);
     } else {
       return this->storage->UniqueAccess();
@@ -171,11 +181,10 @@ class IndexTest : public testing::Test {
   int vertex_id;
 };
 
-using StorageTypes = ::testing::Types<memgraph::storage::InMemoryStorage, memgraph::storage::DiskStorage>;
+using StorageTypes =
+    ::testing::Types<memgraph::storage::InMemoryStorage, memgraph::storage::DiskStorage, InMemoryStorageLightEdge>;
 
 TYPED_TEST_SUITE(IndexTest, StorageTypes);
-
-// TYPED_TEST_SUITE(IndexTest, InMemoryStorageType);
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TYPED_TEST(IndexTest, LabelIndexCreate) {

--- a/tests/unit/storage_v2_light_edges.cpp
+++ b/tests/unit/storage_v2_light_edges.cpp
@@ -1,0 +1,2150 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <filesystem>
+#include <random>
+#include <thread>
+#include <vector>
+
+#include "dbms/database.hpp"
+#include "storage/v2/config.hpp"
+#include "storage/v2/indices/vector_edge_index.hpp"
+#include "storage/v2/inmemory/storage.hpp"
+#include "storage/v2/storage.hpp"
+#include "tests/test_commit_args_helper.hpp"
+#include "utils/file.hpp"
+#include "utils/memory.hpp"
+
+using namespace memgraph::storage;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// Create an InMemoryStorage with light edges enabled.
+auto MakeLightEdgeStorage() -> std::unique_ptr<Storage> {
+  return std::make_unique<InMemoryStorage>(
+      Config{.salient = {.items = {.properties_on_edges = true, .storage_light_edge = true}}});
+}
+
+/// Create an InMemoryStorage with light edges + edges_metadata enabled.
+auto MakeLightEdgeStorageWithMetadata() -> std::unique_ptr<Storage> {
+  return std::make_unique<InMemoryStorage>(Config{
+      .salient = {.items = {.properties_on_edges = true, .enable_edges_metadata = true, .storage_light_edge = true}}});
+}
+
+/// Helper: create two vertices and return their Gids.
+auto CreateTwoVertices(Storage *store) -> std::pair<Gid, Gid> {
+  auto acc = store->Access(WRITE);
+  auto v1 = acc->CreateVertex();
+  auto v2 = acc->CreateVertex();
+  auto gid1 = v1.Gid();
+  auto gid2 = v2.Gid();
+  EXPECT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  return {gid1, gid2};
+}
+
+}  // namespace
+
+// ===========================================================================
+// 1. Config Validation
+// ===========================================================================
+
+TEST(LightEdgesConfig, LightEdgeWithPropertiesOnEdges) {
+  // Light edges require properties_on_edges=true.
+  // Verify the combination works: edges get full property support.
+  auto store = MakeLightEdgeStorage();
+  auto acc = store->Access(WRITE);
+  auto v1 = acc->CreateVertex();
+  auto v2 = acc->CreateVertex();
+  auto et = acc->NameToEdgeType("ET");
+  auto edge_res = acc->CreateEdge(&v1, &v2, et);
+  ASSERT_TRUE(edge_res.has_value());
+
+  // Set a property on the edge to verify properties work
+  auto prop = acc->NameToProperty("key");
+  auto set_res = edge_res->SetProperty(prop, PropertyValue(42));
+  ASSERT_TRUE(set_res.has_value());
+
+  auto props = edge_res->Properties(View::NEW);
+  ASSERT_TRUE(props.has_value());
+  ASSERT_EQ(props->size(), 1);
+  ASSERT_EQ(props->at(prop).ValueInt(), 42);
+
+  ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+}
+
+// ===========================================================================
+// 3. CreateEdge
+// ===========================================================================
+
+TEST(LightEdgesCreateEdge, BasicCreateAndCommit) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create edge
+  Gid edge_gid = Gid::FromUint(std::numeric_limits<uint64_t>::max());
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    ASSERT_TRUE(vf);
+    ASSERT_TRUE(vt);
+
+    auto et = acc->NameToEdgeType("KNOWS");
+    auto res = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(res.has_value());
+    edge_gid = res->Gid();
+
+    // Before commit: NEW shows edge, OLD doesn't
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 1);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+    ASSERT_EQ(vt->InEdges(View::NEW)->edges.size(), 1);
+    ASSERT_EQ(vt->InEdges(View::OLD)->edges.size(), 0);
+
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // After commit: both views show the edge
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    auto out = vf->OutEdges(View::OLD);
+    ASSERT_TRUE(out.has_value());
+    ASSERT_EQ(out->edges.size(), 1);
+    ASSERT_EQ(out->edges[0].Gid(), edge_gid);
+  }
+}
+
+TEST(LightEdgesCreateEdge, EdgeWithProperties) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("HAS");
+    auto res = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(res.has_value());
+
+    auto prop_weight = acc->NameToProperty("weight");
+    auto prop_name = acc->NameToProperty("name");
+
+    ASSERT_TRUE(res->SetProperty(prop_weight, PropertyValue(3.14)).has_value());
+    ASSERT_TRUE(res->SetProperty(prop_name, PropertyValue("test")).has_value());
+
+    auto props = res->Properties(View::NEW);
+    ASSERT_TRUE(props.has_value());
+    ASSERT_EQ(props->size(), 2);
+    ASSERT_DOUBLE_EQ(props->at(prop_weight).ValueDouble(), 3.14);
+    ASSERT_EQ(props->at(prop_name).ValueString(), "test");
+
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Verify properties after commit
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    auto out = vf->OutEdges(View::OLD);
+    ASSERT_EQ(out->edges.size(), 1);
+    auto props = out->edges[0].Properties(View::OLD);
+    ASSERT_TRUE(props.has_value());
+    ASSERT_EQ(props->size(), 2);
+  }
+}
+
+TEST(LightEdgesCreateEdge, SelfLoop) {
+  auto store = MakeLightEdgeStorage();
+
+  Gid gid;
+  {
+    auto acc = store->Access(WRITE);
+    auto v = acc->CreateVertex();
+    gid = v.Gid();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  {
+    auto acc = store->Access(WRITE);
+    auto v = acc->FindVertex(gid, View::NEW);
+    ASSERT_TRUE(v);
+    auto et = acc->NameToEdgeType("SELF");
+    auto res = acc->CreateEdge(&*v, &*v, et);
+    ASSERT_TRUE(res.has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  {
+    auto acc = store->Access(WRITE);
+    auto v = acc->FindVertex(gid, View::OLD);
+    ASSERT_TRUE(v);
+    ASSERT_EQ(v->OutEdges(View::OLD)->edges.size(), 1);
+    ASSERT_EQ(v->InEdges(View::OLD)->edges.size(), 1);
+    ASSERT_EQ(*v->OutDegree(View::OLD), 1);
+    ASSERT_EQ(*v->InDegree(View::OLD), 1);
+  }
+}
+
+TEST(LightEdgesCreateEdge, MultipleEdgesBetweenSameVertices) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et1 = acc->NameToEdgeType("KNOWS");
+    auto et2 = acc->NameToEdgeType("LIKES");
+
+    auto r1 = acc->CreateEdge(&*vf, &*vt, et1);
+    ASSERT_TRUE(r1.has_value());
+    auto r2 = acc->CreateEdge(&*vf, &*vt, et2);
+    ASSERT_TRUE(r2.has_value());
+    auto r3 = acc->CreateEdge(&*vf, &*vt, et1);
+    ASSERT_TRUE(r3.has_value());
+
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 3);
+    ASSERT_EQ(vt->InEdges(View::NEW)->edges.size(), 3);
+
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 3);
+  }
+}
+
+// ===========================================================================
+// 4. DeleteEdge
+// ===========================================================================
+
+TEST(LightEdgesDeleteEdge, BasicDeleteAndCommit) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create edge
+  Gid edge_gid = Gid::FromUint(0);
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("REL");
+    auto res = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(res.has_value());
+    edge_gid = res->Gid();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete edge
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    ASSERT_TRUE(vf);
+    auto edge = vf->OutEdges(View::NEW).value().edges[0];
+
+    auto del = acc->DeleteEdge(&edge);
+    ASSERT_TRUE(del.has_value());
+
+    // After delete: NEW shows 0 edges, OLD shows 1
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 0);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 1);
+
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // After commit: edge gone
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+TEST(LightEdgesDeleteEdge, DetachDeleteVertex) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create edge
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("REL");
+    ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Detach delete from_vertex
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    ASSERT_TRUE(vf);
+    auto del = acc->DetachDeleteVertex(&*vf);
+    ASSERT_TRUE(del.has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // to_vertex should have no in_edges
+  {
+    auto acc = store->Access(WRITE);
+    auto vt = acc->FindVertex(gid_to, View::OLD);
+    ASSERT_TRUE(vt);
+    ASSERT_EQ(vt->InEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+// ===========================================================================
+// 5. Abort Handling
+// ===========================================================================
+
+TEST(LightEdgesAbort, AbortCreation) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create edge then abort (don't commit)
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("TEMP");
+    auto res = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(res.has_value());
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 1);
+    // Accessor destructor will abort
+  }
+
+  // Edge should not exist
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 0);
+  }
+}
+
+TEST(LightEdgesAbort, AbortDeletion) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create edge
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("PERM");
+    ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete edge then abort
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto edge = vf->OutEdges(View::NEW).value().edges[0];
+    auto del = acc->DeleteEdge(&edge);
+    ASSERT_TRUE(del.has_value());
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 0);
+    // Don't commit - abort
+  }
+
+  // Edge should still exist
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 1);
+  }
+}
+
+TEST(LightEdgesAbort, AbortCreateAndDeleteInSameTxn) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create + delete in same txn, then abort
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("EPHEMERAL");
+    auto res = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(res.has_value());
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 1);
+
+    auto del = acc->DeleteEdge(&*res);
+    ASSERT_TRUE(del.has_value());
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 0);
+    // Abort
+  }
+
+  // Nothing should exist
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+// ===========================================================================
+// 6. MVCC + GC (graveyard)
+// ===========================================================================
+
+TEST(LightEdgesMVCC, ConcurrentTxnSeesDeletedEdge) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create edge
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("REL");
+    auto res = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(res.has_value());
+
+    // Set a property so we can verify the Edge* is valid
+    auto prop = acc->NameToProperty("val");
+    ASSERT_TRUE(res->SetProperty(prop, PropertyValue(42)).has_value());
+
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Start reader txn BEFORE the delete
+  auto reader = store->Access(WRITE);
+  auto vf_reader = reader->FindVertex(gid_from, View::OLD);
+  ASSERT_TRUE(vf_reader);
+  ASSERT_EQ(vf_reader->OutEdges(View::OLD)->edges.size(), 1);
+
+  // Delete edge in a separate txn
+  {
+    auto writer = store->Access(WRITE);
+    auto vf = writer->FindVertex(gid_from, View::NEW);
+    auto edge = vf->OutEdges(View::NEW).value().edges[0];
+    ASSERT_TRUE(writer->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(writer->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // GC runs but reader is still active -> graveyard shouldn't drain
+  store->FreeMemory();
+
+  // Reader should still see the edge with correct properties
+  {
+    auto out = vf_reader->OutEdges(View::OLD);
+    ASSERT_EQ(out->edges.size(), 1);
+    auto prop = reader->NameToProperty("val");
+    auto val = out->edges[0].GetProperty(prop, View::OLD);
+    ASSERT_TRUE(val.has_value());
+    ASSERT_EQ(val->ValueInt(), 42);
+  }
+
+  // Close reader
+  reader.reset();
+
+  // Now GC should drain the graveyard
+  store->FreeMemory();
+
+  // Edge is gone for new transactions
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+TEST(LightEdgesMVCC, GCDrainsGraveyardAfterAllReadersGone) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create and delete multiple edges
+  constexpr int kEdges = 10;
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("MULTI");
+    for (int i = 0; i < kEdges; ++i) {
+      ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete all edges
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    for (int i = 0; i < kEdges; ++i) {
+      auto edge = vf->OutEdges(View::NEW).value().edges[0];
+      ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    }
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 0);
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Run GC
+  store->FreeMemory();
+
+  // Verify edges are gone
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+// ===========================================================================
+// 6b. Graveyard-specific tests
+// ===========================================================================
+
+TEST(LightEdgesGraveyard, PartialDrainMultipleBatches) {
+  // Create edges in separate transactions so they get different graveyard timestamps.
+  // Hold a reader between the two deletes so only the first batch drains.
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create 2 edges in separate txns
+  Gid edge1_gid, edge2_gid;
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("GY");
+    auto r1 = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(r1.has_value());
+    edge1_gid = r1->Gid();
+    auto r2 = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(r2.has_value());
+    edge2_gid = r2->Gid();
+
+    auto prop = acc->NameToProperty("batch");
+    ASSERT_TRUE(r1->SetProperty(prop, PropertyValue(1)).has_value());
+    ASSERT_TRUE(r2->SetProperty(prop, PropertyValue(2)).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete edge1 in txn A (graveyard batch 1)
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto out = vf->OutEdges(View::NEW);
+    // Find edge1 specifically
+    for (auto &e : out->edges) {
+      if (e.Gid() == edge1_gid) {
+        ASSERT_TRUE(acc->DeleteEdge(&e).has_value());
+        break;
+      }
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // GC to advance timestamps and drain batch 1
+  store->FreeMemory();
+
+  // Now open a reader that pins current state (edge2 still alive)
+  auto reader = store->Access(WRITE);
+
+  // Delete edge2 in txn B (graveyard batch 2)
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto out = vf->OutEdges(View::NEW);
+    ASSERT_TRUE(!out->edges.empty());
+    auto edge = out->edges[0];
+    ASSERT_EQ(edge.Gid(), edge2_gid);
+    ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // GC: batch 2 should NOT drain because reader is still active
+  store->FreeMemory();
+
+  // Reader should still see edge2 with valid properties
+  {
+    auto vf = reader->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    auto out = vf->OutEdges(View::OLD);
+    ASSERT_TRUE(out.has_value());
+    // Reader started after edge1 was deleted but before edge2 was deleted,
+    // so it sees only edge2
+    ASSERT_EQ(out->edges.size(), 1);
+    ASSERT_EQ(out->edges[0].Gid(), edge2_gid);
+    auto prop = reader->NameToProperty("batch");
+    auto val = out->edges[0].GetProperty(prop, View::OLD);
+    ASSERT_TRUE(val.has_value());
+    ASSERT_EQ(val->ValueInt(), 2);
+  }
+
+  // Close reader, GC should now drain batch 2
+  reader.reset();
+  store->FreeMemory();
+
+  // Both edges gone
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+TEST(LightEdgesGraveyard, MultipleBatchesAccumulateAndDrain) {
+  // Delete edges across many separate transactions, each creating a graveyard batch.
+  // Verify all batches drain after all readers are gone.
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  constexpr int kEdges = 20;
+
+  // Create edges
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("BATCH");
+    auto prop = acc->NameToProperty("idx");
+    for (int i = 0; i < kEdges; ++i) {
+      auto res = acc->CreateEdge(&*vf, &*vt, et);
+      ASSERT_TRUE(res.has_value());
+      ASSERT_TRUE(res->SetProperty(prop, PropertyValue(i)).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete edges one-by-one in separate transactions -> one graveyard batch each
+  for (int i = 0; i < kEdges; ++i) {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto out = vf->OutEdges(View::NEW);
+    ASSERT_TRUE(out.has_value());
+    ASSERT_FALSE(out->edges.empty());
+    auto edge = out->edges[0];
+    ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // All edges deleted, verify vertex shows 0
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+
+  // GC drains all batches (call twice for good measure)
+  store->FreeMemory();
+  store->FreeMemory();
+
+  // Verify no crash on final state
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+TEST(LightEdgesGraveyard, ConcurrentDeleteAndGC) {
+  // Multiple threads delete edges while GC runs concurrently.
+  // Verify no crash and final state is consistent.
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  constexpr int kEdges = 100;
+
+  // Create many edges
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("CONC");
+    for (int i = 0; i < kEdges; ++i) {
+      ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete edges from multiple threads while GC runs
+  std::atomic<bool> gc_running{true};
+  std::atomic<uint64_t> total_deleted{0};
+
+  std::thread gc_thread([&]() {
+    while (gc_running.load()) {
+      store->FreeMemory();
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    store->FreeMemory();
+    store->FreeMemory();
+  });
+
+  constexpr int kDeleteThreads = 4;
+  std::vector<std::thread> deleters;
+  deleters.reserve(kDeleteThreads);
+  for (int t = 0; t < kDeleteThreads; ++t) {
+    deleters.emplace_back([&]() {
+      while (true) {
+        auto acc = store->Access(WRITE);
+        auto vf = acc->FindVertex(gid_from, View::NEW);
+        if (!vf) break;
+        auto out = vf->OutEdges(View::NEW);
+        if (!out.has_value() || out->edges.empty()) break;
+
+        auto edge = out->edges[0];
+        auto del = acc->DeleteEdge(&edge);
+        if (!del.has_value()) continue;  // serialization conflict, retry
+
+        if (acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value()) {
+          total_deleted.fetch_add(1);
+        }
+      }
+    });
+  }
+
+  for (auto &d : deleters) d.join();
+  gc_running.store(false);
+  gc_thread.join();
+
+  // All edges should be deleted
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+  EXPECT_EQ(total_deleted.load(), kEdges);
+}
+
+TEST(LightEdgesGraveyard, ReaderPinsMultipleGraveyardBatches) {
+  // A long-lived reader pins all graveyard batches. After the reader closes,
+  // GC drains everything in one pass.
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  constexpr int kEdges = 5;
+
+  // Create edges
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("PIN");
+    auto prop = acc->NameToProperty("val");
+    for (int i = 0; i < kEdges; ++i) {
+      auto res = acc->CreateEdge(&*vf, &*vt, et);
+      ASSERT_TRUE(res.has_value());
+      ASSERT_TRUE(res->SetProperty(prop, PropertyValue(i * 10)).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Open a reader that sees all edges
+  auto reader = store->Access(WRITE);
+  {
+    auto vf = reader->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), kEdges);
+  }
+
+  // Delete all edges in separate txns (creates separate graveyard batches)
+  for (int i = 0; i < kEdges; ++i) {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto out = vf->OutEdges(View::NEW);
+    ASSERT_FALSE(out->edges.empty());
+    auto edge = out->edges[0];
+    ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // GC multiple times - nothing should drain because reader is active
+  for (int i = 0; i < 3; ++i) {
+    store->FreeMemory();
+  }
+
+  // Reader still sees all edges with valid properties
+  {
+    auto vf = reader->FindVertex(gid_from, View::OLD);
+    auto out = vf->OutEdges(View::OLD);
+    ASSERT_EQ(out->edges.size(), kEdges);
+    auto prop = reader->NameToProperty("val");
+    for (const auto &e : out->edges) {
+      auto val = e.GetProperty(prop, View::OLD);
+      ASSERT_TRUE(val.has_value());
+      // Just verify the property is readable (value is an int multiple of 10)
+      ASSERT_TRUE(val->IsInt());
+    }
+  }
+
+  // Close reader, GC drains all batches
+  reader.reset();
+  store->FreeMemory();
+
+  // All edges gone
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+TEST(LightEdgesGraveyard, PostCommitIndexIterableBlocksDrain) {
+  // Regression test for two-phase graveyard drain.
+  //
+  // A reader that starts an index iterable AFTER a deletion commits has an
+  // epoch id > the guard_epoch snapped at commit time.  Under the old single-
+  // phase scheme that was enough for the graveyard to drain (IsSafeToFree
+  // would return true once all pre-commit readers finished), leaving the
+  // iterable with a dangling Edge*.
+  //
+  // Under the two-phase scheme, GC re-snaps guard_epoch to CurrentEpoch()
+  // AFTER RemoveObsoleteEdgeEntries atomically removes the index entry.  The
+  // re-snapped epoch is > the iterable's epoch id, so IsSafeToFree stays false
+  // until the iterable is destroyed.
+  auto store = MakeLightEdgeStorage();
+  auto *mem_store = static_cast<InMemoryStorage *>(store.get());
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create edge type index.
+  EdgeTypeId et;
+  {
+    auto acc = store->UniqueAccess();
+    et = acc->NameToEdgeType("REL");
+    ASSERT_TRUE(acc->CreateIndex(et).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Create edge.
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete the edge — this pushes Edge* to graveyard with guard_epoch = G.
+  {
+    auto writer = store->Access(WRITE);
+    auto vf = writer->FindVertex(gid_from, View::NEW);
+    auto edge = vf->OutEdges(View::NEW).value().edges[0];
+    ASSERT_TRUE(writer->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(writer->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Start a post-commit reader.  Its epoch id e_R > G (acquired after D committed).
+  // Under the old scheme this would not block graveyard drain.
+  auto reader = store->Access(WRITE);
+  // Constructing the iterable acquires epoch e_R from light_edge_iterable_tracker_.
+  // The iterable is kept alive for the rest of the test to hold the epoch guard.
+  auto iterable = std::make_optional(reader->Edges(et, View::OLD));
+
+  // GC cycle 1: RemoveObsoleteEdgeEntries removes the stale index entry, then
+  // the re-snap sets guard_epoch = CurrentEpoch() > e_R and index_cleaned = true.
+  // Drain must NOT happen yet because IsSafeToFree(re_snapped) is false (e_R is live).
+  store->FreeMemory();
+  EXPECT_EQ(mem_store->LightEdgeGraveyardSizeForTest(), 1)
+      << "graveyard must not drain while post-commit index iterable is alive";
+
+  // A second GC cycle must also leave the graveyard intact.
+  store->FreeMemory();
+  EXPECT_EQ(mem_store->LightEdgeGraveyardSizeForTest(), 1)
+      << "graveyard must not drain while post-commit index iterable is alive";
+
+  // Destroying the iterable releases e_R.  Now IsSafeToFree(re_snapped) can become true.
+  iterable.reset();  // Note: Result<Iterable> — reset the optional
+  reader.reset();
+
+  // GC cycle 2: graveyard must now drain.
+  store->FreeMemory();
+  EXPECT_EQ(mem_store->LightEdgeGraveyardSizeForTest(), 0) << "graveyard must drain after iterable is released";
+}
+
+// ===========================================================================
+// 7. FindEdge
+// ===========================================================================
+
+// FindEdge is a private method tested indirectly through WAL recovery,
+// snapshot recovery, and replication. We test the public edge-lookup behavior
+// here (via OutEdges/InEdges on vertices).
+
+TEST(LightEdgesFindEdge, EdgeAccessibleViaVertexWithMetadata) {
+  auto store = MakeLightEdgeStorageWithMetadata();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  Gid edge_gid = Gid::FromUint(0);
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("FOUND");
+    auto res = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(res.has_value());
+    edge_gid = res->Gid();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Edge should be findable via vertex out_edges
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    auto out = vf->OutEdges(View::OLD);
+    ASSERT_EQ(out->edges.size(), 1);
+    ASSERT_EQ(out->edges[0].Gid(), edge_gid);
+  }
+}
+
+TEST(LightEdgesFindEdge, EdgeAccessibleViaVertexWithoutMetadata) {
+  auto store = MakeLightEdgeStorage();  // no edges_metadata
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  Gid edge_gid = Gid::FromUint(0);
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("FOUND");
+    auto res = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(res.has_value());
+    edge_gid = res->Gid();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    auto out = vf->OutEdges(View::OLD);
+    ASSERT_EQ(out->edges.size(), 1);
+    ASSERT_EQ(out->edges[0].Gid(), edge_gid);
+  }
+}
+
+TEST(LightEdgesFindEdge, NoEdgesOnEmptyVertex) {
+  auto store = MakeLightEdgeStorageWithMetadata();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  auto acc = store->Access(WRITE);
+  auto vf = acc->FindVertex(gid_from, View::OLD);
+  ASSERT_TRUE(vf);
+  auto out = vf->OutEdges(View::OLD);
+  ASSERT_EQ(out->edges.size(), 0);
+}
+
+// ===========================================================================
+// 8. Snapshot round-trip
+// ===========================================================================
+
+class LightEdgesSnapshotTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    storage_directory_ = std::filesystem::temp_directory_path() / "mg_test_light_edges_snapshot";
+    std::filesystem::remove_all(storage_directory_);
+  }
+
+  void TearDown() override { std::filesystem::remove_all(storage_directory_); }
+
+  std::filesystem::path storage_directory_;
+};
+
+TEST_F(LightEdgesSnapshotTest, SnapshotRoundTrip) {
+  Gid gid_from, gid_to, edge_gid;
+  PropertyId prop_weight;
+
+  // Create data and snapshot
+  {
+    Config config{
+        .durability = {.storage_directory = storage_directory_, .snapshot_on_exit = true},
+        .salient = {.items = {.properties_on_edges = true, .storage_light_edge = true}},
+    };
+    memgraph::dbms::Database db{config};
+    auto *store = db.storage();
+
+    auto acc = store->Access(WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    gid_from = v1.Gid();
+    gid_to = v2.Gid();
+
+    auto et = acc->NameToEdgeType("SNAP_EDGE");
+    auto res = acc->CreateEdge(&v1, &v2, et);
+    ASSERT_TRUE(res.has_value());
+    edge_gid = res->Gid();
+
+    prop_weight = acc->NameToProperty("weight");
+    ASSERT_TRUE(res->SetProperty(prop_weight, PropertyValue(99.9)).has_value());
+
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    // Database destructor triggers snapshot_on_exit
+  }
+
+  // Recover from snapshot
+  {
+    Config config{
+        .durability = {.storage_directory = storage_directory_, .recover_on_startup = true},
+        .salient = {.items = {.properties_on_edges = true, .storage_light_edge = true}},
+    };
+    memgraph::dbms::Database db{config};
+    auto *store = db.storage();
+
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    auto vt = acc->FindVertex(gid_to, View::OLD);
+    ASSERT_TRUE(vt);
+
+    auto out = vf->OutEdges(View::OLD);
+    ASSERT_TRUE(out.has_value());
+    ASSERT_EQ(out->edges.size(), 1);
+    ASSERT_EQ(out->edges[0].Gid(), edge_gid);
+
+    // Verify property survived
+    prop_weight = acc->NameToProperty("weight");
+    auto props = out->edges[0].Properties(View::OLD);
+    ASSERT_TRUE(props.has_value());
+    ASSERT_EQ(props->size(), 1);
+    ASSERT_DOUBLE_EQ(props->at(prop_weight).ValueDouble(), 99.9);
+
+    // Verify in_edges on to_vertex
+    auto in = vt->InEdges(View::OLD);
+    ASSERT_TRUE(in.has_value());
+    ASSERT_EQ(in->edges.size(), 1);
+    ASSERT_EQ(in->edges[0].Gid(), edge_gid);
+  }
+}
+
+TEST_F(LightEdgesSnapshotTest, SnapshotRoundTripMultipleEdges) {
+  constexpr int kEdges = 50;
+  std::vector<Gid> edge_gids;
+
+  // Create data
+  {
+    Config config{
+        .durability = {.storage_directory = storage_directory_, .snapshot_on_exit = true},
+        .salient = {.items = {.properties_on_edges = true, .storage_light_edge = true}},
+    };
+    memgraph::dbms::Database db{config};
+    auto *store = db.storage();
+
+    auto acc = store->Access(WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    auto et = acc->NameToEdgeType("BULK");
+    auto prop = acc->NameToProperty("idx");
+
+    for (int i = 0; i < kEdges; ++i) {
+      auto res = acc->CreateEdge(&v1, &v2, et);
+      ASSERT_TRUE(res.has_value());
+      ASSERT_TRUE(res->SetProperty(prop, PropertyValue(i)).has_value());
+      edge_gids.push_back(res->Gid());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Recover and verify count + per-edge property values
+  {
+    Config config{
+        .durability = {.storage_directory = storage_directory_, .recover_on_startup = true},
+        .salient = {.items = {.properties_on_edges = true, .storage_light_edge = true}},
+    };
+    memgraph::dbms::Database db{config};
+    auto *store = db.storage();
+
+    auto acc = store->Access(WRITE);
+    auto prop = acc->NameToProperty("idx");
+
+    // Collect all recovered edges from the source vertex (the one with out-edges)
+    std::map<Gid, int64_t> recovered;  // edge GID -> idx value
+    auto vertices = acc->Vertices(View::OLD);
+    for (auto v : vertices) {
+      auto out = v.OutEdges(View::OLD);
+      if (!out.has_value()) continue;
+      for (auto &e : out->edges) {
+        auto val = e.GetProperty(prop, View::OLD);
+        ASSERT_TRUE(val.has_value()) << "Edge " << e.Gid().AsUint() << " missing 'idx' property after snapshot";
+        ASSERT_TRUE(val->IsInt()) << "Edge " << e.Gid().AsUint() << " 'idx' property is not an int";
+        recovered.emplace(e.Gid(), val->ValueInt());
+      }
+    }
+    ASSERT_EQ(static_cast<int>(recovered.size()), kEdges);
+
+    // Verify each expected GID is present with the correct value
+    for (int i = 0; i < kEdges; ++i) {
+      auto it = recovered.find(edge_gids[i]);
+      ASSERT_NE(it, recovered.end()) << "Edge " << edge_gids[i].AsUint() << " not found after snapshot recovery";
+      EXPECT_EQ(it->second, i) << "Edge " << edge_gids[i].AsUint() << " has wrong idx value";
+    }
+  }
+}
+
+TEST_F(LightEdgesSnapshotTest, SnapshotLightToNormal) {
+  Gid gid_from, gid_to, edge_gid;
+
+  // Create data with LIGHT edges, snapshot
+  {
+    Config config{
+        .durability = {.storage_directory = storage_directory_, .snapshot_on_exit = true},
+        .salient = {.items = {.properties_on_edges = true, .storage_light_edge = true}},
+    };
+    memgraph::dbms::Database db{config};
+    auto *store = db.storage();
+
+    auto acc = store->Access(WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    gid_from = v1.Gid();
+    gid_to = v2.Gid();
+
+    auto et = acc->NameToEdgeType("CROSS");
+    auto res = acc->CreateEdge(&v1, &v2, et);
+    ASSERT_TRUE(res.has_value());
+    edge_gid = res->Gid();
+
+    auto prop = acc->NameToProperty("val");
+    ASSERT_TRUE(res->SetProperty(prop, PropertyValue(123)).has_value());
+
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Recover with NORMAL edges (storage_light_edge=false)
+  {
+    Config config{
+        .durability = {.storage_directory = storage_directory_, .recover_on_startup = true},
+        .salient = {.items = {.properties_on_edges = true, .storage_light_edge = false}},
+    };
+    memgraph::dbms::Database db{config};
+    auto *store = db.storage();
+
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    auto out = vf->OutEdges(View::OLD);
+    ASSERT_TRUE(out.has_value());
+    ASSERT_EQ(out->edges.size(), 1);
+    ASSERT_EQ(out->edges[0].Gid(), edge_gid);
+
+    auto prop = acc->NameToProperty("val");
+    auto val = out->edges[0].GetProperty(prop, View::OLD);
+    ASSERT_TRUE(val.has_value());
+    ASSERT_EQ(val->ValueInt(), 123);
+
+    // Verify in_edges
+    auto vt = acc->FindVertex(gid_to, View::OLD);
+    ASSERT_TRUE(vt);
+    auto in = vt->InEdges(View::OLD);
+    ASSERT_TRUE(in.has_value());
+    ASSERT_EQ(in->edges.size(), 1);
+  }
+}
+
+TEST_F(LightEdgesSnapshotTest, SnapshotNormalToLight) {
+  Gid gid_from, gid_to, edge_gid;
+
+  // Create data with NORMAL edges (storage_light_edge=false), snapshot
+  {
+    Config config{
+        .durability = {.storage_directory = storage_directory_, .snapshot_on_exit = true},
+        .salient = {.items = {.properties_on_edges = true, .storage_light_edge = false}},
+    };
+    memgraph::dbms::Database db{config};
+    auto *store = db.storage();
+
+    auto acc = store->Access(WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    gid_from = v1.Gid();
+    gid_to = v2.Gid();
+
+    auto et = acc->NameToEdgeType("CROSS");
+    auto res = acc->CreateEdge(&v1, &v2, et);
+    ASSERT_TRUE(res.has_value());
+    edge_gid = res->Gid();
+
+    auto prop = acc->NameToProperty("val");
+    ASSERT_TRUE(res->SetProperty(prop, PropertyValue("normal_to_light")).has_value());
+
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Recover with LIGHT edges
+  {
+    Config config{
+        .durability = {.storage_directory = storage_directory_, .recover_on_startup = true},
+        .salient = {.items = {.properties_on_edges = true, .storage_light_edge = true}},
+    };
+    memgraph::dbms::Database db{config};
+    auto *store = db.storage();
+
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    auto out = vf->OutEdges(View::OLD);
+    ASSERT_TRUE(out.has_value());
+    ASSERT_EQ(out->edges.size(), 1);
+    ASSERT_EQ(out->edges[0].Gid(), edge_gid);
+
+    auto prop = acc->NameToProperty("val");
+    auto val = out->edges[0].GetProperty(prop, View::OLD);
+    ASSERT_TRUE(val.has_value());
+    ASSERT_EQ(val->ValueString(), "normal_to_light");
+
+    // Verify in_edges
+    auto vt = acc->FindVertex(gid_to, View::OLD);
+    ASSERT_TRUE(vt);
+    auto in = vt->InEdges(View::OLD);
+    ASSERT_TRUE(in.has_value());
+    ASSERT_EQ(in->edges.size(), 1);
+  }
+}
+
+TEST_F(LightEdgesSnapshotTest, SnapshotExcludesUncommittedEdge) {
+  // Verifies that write_light_edges_section uses View::OLD so that an edge
+  // created-but-not-committed in a concurrent transaction is NOT captured in
+  // the snapshot.
+  //
+  // Approach: create a snapshot with snapshot_on_exit=true. While the DB is
+  // still alive, open a write transaction that creates a new edge but do NOT
+  // commit it. Then destroy the DB (triggers snapshot). Recover and verify
+  // the uncommitted edge is absent.
+  Gid gid_from, gid_to, committed_edge_gid;
+
+  // Phase 1: create committed baseline data + snapshot
+  {
+    Config config{
+        .durability = {.storage_directory = storage_directory_, .snapshot_on_exit = true},
+        .salient = {.items = {.properties_on_edges = true, .storage_light_edge = true}},
+    };
+    memgraph::dbms::Database db{config};
+    auto *store = db.storage();
+
+    // Commit one edge first
+    {
+      auto acc = store->Access(WRITE);
+      auto v1 = acc->CreateVertex();
+      auto v2 = acc->CreateVertex();
+      gid_from = v1.Gid();
+      gid_to = v2.Gid();
+      auto et = acc->NameToEdgeType("COMMITTED");
+      auto res = acc->CreateEdge(&v1, &v2, et);
+      ASSERT_TRUE(res.has_value());
+      committed_edge_gid = res->Gid();
+      ASSERT_TRUE(res->SetProperty(acc->NameToProperty("marker"), PropertyValue(1)).has_value());
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    // Start an uncommitted transaction that creates a second edge — do NOT commit
+    auto dirty_acc = store->Access(WRITE);
+    auto vf = dirty_acc->FindVertex(gid_from, View::NEW);
+    auto vt = dirty_acc->FindVertex(gid_to, View::NEW);
+    ASSERT_TRUE(vf && vt);
+    auto et2 = dirty_acc->NameToEdgeType("UNCOMMITTED");
+    auto res2 = dirty_acc->CreateEdge(&*vf, &*vt, et2);
+    ASSERT_TRUE(res2.has_value());
+    ASSERT_TRUE(res2->SetProperty(dirty_acc->NameToProperty("marker"), PropertyValue(2)).has_value());
+    // dirty_acc is NOT committed — DB destructor triggers snapshot while this txn is open.
+    // The snapshot must exclude the uncommitted edge.
+  }
+
+  // Phase 2: recover and verify only the committed edge exists
+  {
+    Config config{
+        .durability = {.storage_directory = storage_directory_, .recover_on_startup = true},
+        .salient = {.items = {.properties_on_edges = true, .storage_light_edge = true}},
+    };
+    memgraph::dbms::Database db{config};
+    auto *store = db.storage();
+
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+
+    auto out = vf->OutEdges(View::OLD);
+    ASSERT_TRUE(out.has_value());
+    // Only the committed edge should be present
+    ASSERT_EQ(out->edges.size(), 1);
+    EXPECT_EQ(out->edges[0].Gid(), committed_edge_gid);
+
+    auto marker_prop = acc->NameToProperty("marker");
+    auto val = out->edges[0].GetProperty(marker_prop, View::OLD);
+    ASSERT_TRUE(val.has_value());
+    EXPECT_EQ(val->ValueInt(), 1);
+  }
+}
+
+// ===========================================================================
+// 9. WAL round-trip
+// ===========================================================================
+
+class LightEdgesWalTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    storage_directory_ = std::filesystem::temp_directory_path() / "mg_test_light_edges_wal";
+    std::filesystem::remove_all(storage_directory_);
+  }
+
+  void TearDown() override { std::filesystem::remove_all(storage_directory_); }
+
+  std::filesystem::path storage_directory_;
+};
+
+TEST_F(LightEdgesWalTest, WalCreateAndRecover) {
+  Gid gid_from, gid_to, edge_gid;
+
+  // Create data with WAL
+  {
+    Config config{
+        .durability = {.storage_directory = storage_directory_,
+                       .snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
+                       .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::hours(1)},
+                       .wal_file_flush_every_n_tx = 1},
+        .salient = {.items = {.properties_on_edges = true, .storage_light_edge = true}},
+    };
+    memgraph::dbms::Database db{config};
+    auto *store = db.storage();
+
+    auto acc = store->Access(WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    gid_from = v1.Gid();
+    gid_to = v2.Gid();
+    auto et = acc->NameToEdgeType("WAL_EDGE");
+    auto res = acc->CreateEdge(&v1, &v2, et);
+    ASSERT_TRUE(res.has_value());
+    edge_gid = res->Gid();
+
+    auto prop = acc->NameToProperty("data");
+    ASSERT_TRUE(res->SetProperty(prop, PropertyValue("wal_test")).has_value());
+
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    // DB destructor flushes WAL
+  }
+
+  // Recover from WAL
+  {
+    Config config{
+        .durability = {.storage_directory = storage_directory_, .recover_on_startup = true},
+        .salient = {.items = {.properties_on_edges = true, .storage_light_edge = true}},
+    };
+    memgraph::dbms::Database db{config};
+    auto *store = db.storage();
+
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    auto out = vf->OutEdges(View::OLD);
+    ASSERT_TRUE(out.has_value());
+    ASSERT_EQ(out->edges.size(), 1);
+    ASSERT_EQ(out->edges[0].Gid(), edge_gid);
+
+    auto prop = acc->NameToProperty("data");
+    auto val = out->edges[0].GetProperty(prop, View::OLD);
+    ASSERT_TRUE(val.has_value());
+    ASSERT_EQ(val->ValueString(), "wal_test");
+  }
+}
+
+TEST_F(LightEdgesWalTest, WalCreateDeleteAndRecover) {
+  Gid gid_from, gid_to;
+
+  // Create edge, then delete it - both recorded in WAL
+  {
+    Config config{
+        .durability = {.storage_directory = storage_directory_,
+                       .snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
+                       .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::hours(1)},
+                       .wal_file_flush_every_n_tx = 1},
+        .salient = {.items = {.properties_on_edges = true, .storage_light_edge = true}},
+    };
+    memgraph::dbms::Database db{config};
+    auto *store = db.storage();
+
+    // Create vertices
+    {
+      auto acc = store->Access(WRITE);
+      auto v1 = acc->CreateVertex();
+      auto v2 = acc->CreateVertex();
+      gid_from = v1.Gid();
+      gid_to = v2.Gid();
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    // Create edge
+    {
+      auto acc = store->Access(WRITE);
+      auto vf = acc->FindVertex(gid_from, View::NEW);
+      auto vt = acc->FindVertex(gid_to, View::NEW);
+      auto et = acc->NameToEdgeType("TEMP");
+      ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    // Delete edge
+    {
+      auto acc = store->Access(WRITE);
+      auto vf = acc->FindVertex(gid_from, View::NEW);
+      auto edge = vf->OutEdges(View::NEW).value().edges[0];
+      ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+  }
+
+  // Recover - edge should be gone
+  {
+    Config config{
+        .durability = {.storage_directory = storage_directory_, .recover_on_startup = true},
+        .salient = {.items = {.properties_on_edges = true, .storage_light_edge = true}},
+    };
+    memgraph::dbms::Database db{config};
+    auto *store = db.storage();
+
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    auto out = vf->OutEdges(View::OLD);
+    ASSERT_TRUE(out.has_value());
+    ASSERT_EQ(out->edges.size(), 0);
+  }
+}
+
+TEST_F(LightEdgesWalTest, WalLightToNormal) {
+  Gid gid_from, gid_to, edge_gid;
+
+  // Create data with LIGHT edges via WAL
+  {
+    Config config{
+        .durability = {.storage_directory = storage_directory_,
+                       .snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
+                       .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::hours(1)},
+                       .wal_file_flush_every_n_tx = 1},
+        .salient = {.items = {.properties_on_edges = true, .storage_light_edge = true}},
+    };
+    memgraph::dbms::Database db{config};
+    auto *store = db.storage();
+
+    auto acc = store->Access(WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    gid_from = v1.Gid();
+    gid_to = v2.Gid();
+    auto et = acc->NameToEdgeType("WAL_CROSS");
+    auto res = acc->CreateEdge(&v1, &v2, et);
+    ASSERT_TRUE(res.has_value());
+    edge_gid = res->Gid();
+
+    auto prop = acc->NameToProperty("data");
+    ASSERT_TRUE(res->SetProperty(prop, PropertyValue(42)).has_value());
+
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Recover with NORMAL edges (storage_light_edge=false)
+  {
+    Config config{
+        .durability = {.storage_directory = storage_directory_, .recover_on_startup = true},
+        .salient = {.items = {.properties_on_edges = true, .storage_light_edge = false}},
+    };
+    memgraph::dbms::Database db{config};
+    auto *store = db.storage();
+
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    auto out = vf->OutEdges(View::OLD);
+    ASSERT_TRUE(out.has_value());
+    ASSERT_EQ(out->edges.size(), 1);
+    ASSERT_EQ(out->edges[0].Gid(), edge_gid);
+
+    auto prop = acc->NameToProperty("data");
+    auto val = out->edges[0].GetProperty(prop, View::OLD);
+    ASSERT_TRUE(val.has_value());
+    ASSERT_EQ(val->ValueInt(), 42);
+  }
+}
+
+TEST_F(LightEdgesWalTest, WalNormalToLight) {
+  Gid gid_from, gid_to, edge_gid;
+
+  // Create data with NORMAL edges via WAL
+  {
+    Config config{
+        .durability = {.storage_directory = storage_directory_,
+                       .snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
+                       .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::hours(1)},
+                       .wal_file_flush_every_n_tx = 1},
+        .salient = {.items = {.properties_on_edges = true, .storage_light_edge = false}},
+    };
+    memgraph::dbms::Database db{config};
+    auto *store = db.storage();
+
+    auto acc = store->Access(WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    gid_from = v1.Gid();
+    gid_to = v2.Gid();
+    auto et = acc->NameToEdgeType("WAL_CROSS");
+    auto res = acc->CreateEdge(&v1, &v2, et);
+    ASSERT_TRUE(res.has_value());
+    edge_gid = res->Gid();
+
+    auto prop = acc->NameToProperty("data");
+    ASSERT_TRUE(res->SetProperty(prop, PropertyValue("normal_wal")).has_value());
+
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Recover with LIGHT edges
+  {
+    Config config{
+        .durability = {.storage_directory = storage_directory_, .recover_on_startup = true},
+        .salient = {.items = {.properties_on_edges = true, .storage_light_edge = true}},
+    };
+    memgraph::dbms::Database db{config};
+    auto *store = db.storage();
+
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    auto out = vf->OutEdges(View::OLD);
+    ASSERT_TRUE(out.has_value());
+    ASSERT_EQ(out->edges.size(), 1);
+    ASSERT_EQ(out->edges[0].Gid(), edge_gid);
+
+    auto prop = acc->NameToProperty("data");
+    auto val = out->edges[0].GetProperty(prop, View::OLD);
+    ASSERT_TRUE(val.has_value());
+    ASSERT_EQ(val->ValueString(), "normal_wal");
+  }
+}
+
+TEST_F(LightEdgesWalTest, WalSetPropertyInSeparateTxn) {
+  // Verifies that a SET_PROPERTY recorded in a WAL transaction *separate* from
+  // edge creation is correctly replayed for light edges.
+  Gid gid_from, gid_to, edge_gid;
+
+  // Phase 1: create edge + write WAL
+  {
+    Config config{
+        .durability = {.storage_directory = storage_directory_,
+                       .snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
+                       .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::hours(1)},
+                       .wal_file_flush_every_n_tx = 1},
+        .salient = {.items = {.properties_on_edges = true, .storage_light_edge = true}},
+    };
+    memgraph::dbms::Database db{config};
+    auto *store = db.storage();
+
+    // Txn 1: create vertices
+    {
+      auto acc = store->Access(WRITE);
+      auto v1 = acc->CreateVertex();
+      auto v2 = acc->CreateVertex();
+      gid_from = v1.Gid();
+      gid_to = v2.Gid();
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    // Txn 2: create edge (no properties yet)
+    {
+      auto acc = store->Access(WRITE);
+      auto vf = acc->FindVertex(gid_from, View::NEW);
+      auto vt = acc->FindVertex(gid_to, View::NEW);
+      ASSERT_TRUE(vf && vt);
+      auto et = acc->NameToEdgeType("WAL_PROP");
+      auto res = acc->CreateEdge(&*vf, &*vt, et);
+      ASSERT_TRUE(res.has_value());
+      edge_gid = res->Gid();
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    // Txn 3: set property on the edge in a *separate* transaction
+    {
+      auto acc = store->Access(WRITE);
+      auto vf = acc->FindVertex(gid_from, View::NEW);
+      ASSERT_TRUE(vf);
+      auto out = vf->OutEdges(View::NEW);
+      ASSERT_TRUE(out.has_value());
+      ASSERT_EQ(out->edges.size(), 1);
+      auto prop = acc->NameToProperty("score");
+      ASSERT_TRUE(out->edges[0].SetProperty(prop, PropertyValue(777)).has_value());
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    // Txn 4: update the same property (overwrite)
+    {
+      auto acc = store->Access(WRITE);
+      auto vf = acc->FindVertex(gid_from, View::NEW);
+      ASSERT_TRUE(vf);
+      auto out = vf->OutEdges(View::NEW);
+      ASSERT_TRUE(out.has_value());
+      ASSERT_EQ(out->edges.size(), 1);
+      auto prop = acc->NameToProperty("score");
+      ASSERT_TRUE(out->edges[0].SetProperty(prop, PropertyValue(888)).has_value());
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+    // DB destructor flushes WAL
+  }
+
+  // Phase 2: recover from WAL only (no snapshot), verify properties
+  {
+    Config config{
+        .durability = {.storage_directory = storage_directory_, .recover_on_startup = true},
+        .salient = {.items = {.properties_on_edges = true, .storage_light_edge = true}},
+    };
+    memgraph::dbms::Database db{config};
+    auto *store = db.storage();
+
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    auto out = vf->OutEdges(View::OLD);
+    ASSERT_TRUE(out.has_value());
+    ASSERT_EQ(out->edges.size(), 1);
+    ASSERT_EQ(out->edges[0].Gid(), edge_gid);
+
+    auto prop = acc->NameToProperty("score");
+    auto val = out->edges[0].GetProperty(prop, View::OLD);
+    ASSERT_TRUE(val.has_value());
+    // Should have the final value (888, from txn 4)
+    ASSERT_EQ(val->ValueInt(), 888);
+  }
+}
+
+// ===========================================================================
+// 10. Storage Cleanup
+// ===========================================================================
+
+TEST(LightEdgesCleanup, DestructorFreesAllEdges) {
+  // Simply verifies no crash / ASAN errors on destruction with edges alive
+  {
+    auto store = MakeLightEdgeStorage();
+    auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("ALIVE");
+    for (int i = 0; i < 100; ++i) {
+      ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    // Accessor drops, then store destroys -> should free all 100 edges from pool
+  }
+  // If we get here without ASAN/MSAN errors, cleanup worked
+}
+
+TEST(LightEdgesCleanup, DestructorFreesGraveyardEdges) {
+  // Verify no crash when edges are in the graveyard at destruction time
+  {
+    auto store = MakeLightEdgeStorage();
+    auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+    // Create edges
+    {
+      auto acc = store->Access(WRITE);
+      auto vf = acc->FindVertex(gid_from, View::NEW);
+      auto vt = acc->FindVertex(gid_to, View::NEW);
+      auto et = acc->NameToEdgeType("GRAVE");
+      for (int i = 0; i < 50; ++i) {
+        ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+      }
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    // Delete all edges (they go to graveyard)
+    {
+      auto acc = store->Access(WRITE);
+      auto vf = acc->FindVertex(gid_from, View::NEW);
+      for (int i = 0; i < 50; ++i) {
+        auto edge = vf->OutEdges(View::NEW).value().edges[0];
+        ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+      }
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    // DON'T run GC - leave edges in graveyard
+    // Store destruction should clean them up
+  }
+  // If we get here without errors, graveyard cleanup worked
+}
+
+TEST(LightEdgesCleanup, DestroyAndRecreateStorage) {
+  // Verify that destroying a storage with edges and creating a new one works
+  // without memory issues (tests pool allocator recycling).
+  for (int round = 0; round < 3; ++round) {
+    auto store = MakeLightEdgeStorage();
+    auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("CYCLE");
+    for (int i = 0; i < 50; ++i) {
+      ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    // store destructor frees everything, next iteration creates fresh storage
+  }
+}
+
+// ===========================================================================
+// 11. Stress Test: Concurrent CRUD with Edge Indices
+// ===========================================================================
+
+TEST(LightEdgesStress, ConcurrentCrudWithIndices) {
+  constexpr int kVertices = 100;
+  constexpr int kWriterThreads = 4;
+  constexpr int kReaderThreads = 4;
+  constexpr int kWriterIterations = 200;
+
+  auto store = MakeLightEdgeStorage();
+
+  // --- Setup: create vertices ---
+  std::vector<Gid> vertex_gids;
+  vertex_gids.reserve(kVertices);
+  {
+    auto acc = store->Access(WRITE);
+    for (int i = 0; i < kVertices; ++i) {
+      auto v = acc->CreateVertex();
+      vertex_gids.push_back(v.Gid());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // --- Setup: create edge indices (requires UniqueAccess, single-threaded) ---
+
+  EdgeTypeId stress_et;
+  PropertyId weight_prop;
+
+  // Edge type index on STRESS_ET
+  {
+    auto acc = store->UniqueAccess();
+    stress_et = acc->NameToEdgeType("STRESS_ET");
+    ASSERT_TRUE(acc->CreateIndex(stress_et).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Edge type + property index on (STRESS_ET, weight)
+  {
+    auto acc = store->UniqueAccess();
+    stress_et = acc->NameToEdgeType("STRESS_ET");
+    weight_prop = acc->NameToProperty("weight");
+    ASSERT_TRUE(acc->CreateIndex(stress_et, weight_prop).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Global edge property index on weight
+  {
+    auto acc = store->UniqueAccess();
+    weight_prop = acc->NameToProperty("weight");
+    ASSERT_TRUE(acc->CreateGlobalEdgeIndex(weight_prop).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Vector edge index on (VEC_ET, embedding) with dimension=4
+  EdgeTypeId vec_et;
+  PropertyId embedding_prop;
+  {
+    auto acc = store->UniqueAccess();
+    vec_et = acc->NameToEdgeType("VEC_ET");
+    embedding_prop = acc->NameToProperty("embedding");
+    VectorEdgeIndexSpec spec{"stress_vec_idx",
+                             vec_et,
+                             embedding_prop,
+                             unum::usearch::metric_kind_t::l2sq_k,
+                             4,
+                             2,
+                             static_cast<std::size_t>(kWriterThreads * kWriterIterations),
+                             unum::usearch::scalar_kind_t::f32_k};
+    ASSERT_TRUE(acc->CreateVectorEdgeIndex(spec).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // --- Concurrent phase ---
+  std::atomic<bool> running{true};
+  std::atomic<int> writers_done{0};
+  std::atomic<uint64_t> total_creates{0};
+  std::atomic<uint64_t> total_deletes{0};
+  std::atomic<uint64_t> total_updates{0};
+
+  // Writer threads
+  std::vector<std::thread> writers;
+  writers.reserve(kWriterThreads);
+  for (int t = 0; t < kWriterThreads; ++t) {
+    writers.emplace_back([&, t]() {
+      std::mt19937 rng(42 + t);
+      std::uniform_int_distribution<int> vertex_dist(0, kVertices - 1);
+      std::uniform_int_distribution<int> op_dist(0, 2);  // 0=create, 1=delete, 2=update
+      std::uniform_int_distribution<int> weight_dist(1, 10000);
+      std::uniform_real_distribution<float> float_dist(-1.0f, 1.0f);
+
+      for (int i = 0; i < kWriterIterations; ++i) {
+        int op = op_dist(rng);
+
+        if (op == 0) {
+          // CREATE edge with STRESS_ET + weight property
+          auto acc = store->Access(WRITE);
+          int from_idx = vertex_dist(rng);
+          int to_idx = vertex_dist(rng);
+          auto vf = acc->FindVertex(vertex_gids[from_idx], View::NEW);
+          auto vt = acc->FindVertex(vertex_gids[to_idx], View::NEW);
+          if (!vf || !vt) continue;
+
+          auto et = acc->NameToEdgeType("STRESS_ET");
+          auto res = acc->CreateEdge(&*vf, &*vt, et);
+          if (!res.has_value()) continue;
+
+          auto wp = acc->NameToProperty("weight");
+          res->SetProperty(wp, PropertyValue(weight_dist(rng)));
+
+          if (acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value()) {
+            total_creates.fetch_add(1);
+          }
+        } else if (op == 1) {
+          // DELETE an edge from a random vertex
+          auto acc = store->Access(WRITE);
+          int from_idx = vertex_dist(rng);
+          auto vf = acc->FindVertex(vertex_gids[from_idx], View::NEW);
+          if (!vf) continue;
+
+          auto out = vf->OutEdges(View::NEW);
+          if (!out.has_value() || out->edges.empty()) continue;
+
+          auto edge = out->edges[0];
+          auto del = acc->DeleteEdge(&edge);
+          if (!del.has_value()) continue;
+
+          if (acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value()) {
+            total_deletes.fetch_add(1);
+          }
+        } else {
+          // UPDATE property on an existing STRESS_ET edge
+          auto acc = store->Access(WRITE);
+          int from_idx = vertex_dist(rng);
+          auto vf = acc->FindVertex(vertex_gids[from_idx], View::NEW);
+          if (!vf) continue;
+
+          auto et = acc->NameToEdgeType("STRESS_ET");
+          auto out = vf->OutEdges(View::NEW, {et});
+          if (!out.has_value() || out->edges.empty()) continue;
+
+          auto edge = out->edges[0];
+          auto wp = acc->NameToProperty("weight");
+          auto set_res = edge.SetProperty(wp, PropertyValue(weight_dist(rng)));
+          if (!set_res.has_value()) continue;
+
+          if (acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value()) {
+            total_updates.fetch_add(1);
+          }
+        }
+      }
+
+      // Also create some edges with VEC_ET + embedding property for vector index
+      for (int i = 0; i < 10; ++i) {
+        auto acc = store->Access(WRITE);
+        int from_idx = vertex_dist(rng);
+        int to_idx = vertex_dist(rng);
+        auto vf = acc->FindVertex(vertex_gids[from_idx], View::NEW);
+        auto vt = acc->FindVertex(vertex_gids[to_idx], View::NEW);
+        if (!vf || !vt) continue;
+
+        auto et = acc->NameToEdgeType("VEC_ET");
+        auto res = acc->CreateEdge(&*vf, &*vt, et);
+        if (!res.has_value()) continue;
+
+        auto ep = acc->NameToProperty("embedding");
+        std::vector<PropertyValue> vec_vals;
+        vec_vals.reserve(4);
+        for (int d = 0; d < 4; ++d) {
+          vec_vals.emplace_back(static_cast<double>(float_dist(rng)));
+        }
+        res->SetProperty(ep, PropertyValue(std::move(vec_vals)));
+
+        acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs());
+      }
+
+      if (writers_done.fetch_add(1) + 1 == kWriterThreads) {
+        running.store(false);
+      }
+    });
+  }
+
+  // Reader threads
+  std::vector<std::thread> readers;
+  readers.reserve(kReaderThreads);
+  for (int t = 0; t < kReaderThreads; ++t) {
+    readers.emplace_back([&, t]() {
+      std::mt19937 rng(1000 + t);
+      std::uniform_int_distribution<int> vertex_dist(0, kVertices - 1);
+      std::uniform_int_distribution<int> query_dist(0, 3);
+      std::uniform_real_distribution<float> float_dist(-1.0f, 1.0f);
+
+      while (running.load()) {
+        int query = query_dist(rng);
+
+        if (query == 0) {
+          // Vertex scan: pick a random vertex, read its out-edges and properties
+          auto acc = store->Access(WRITE);
+          int idx = vertex_dist(rng);
+          auto vf = acc->FindVertex(vertex_gids[idx], View::NEW);
+          if (!vf) continue;
+          auto out = vf->OutEdges(View::NEW);
+          if (!out.has_value()) continue;
+          for (const auto &edge : out->edges) {
+            // Read properties to exercise Edge* dereferencing
+            [[maybe_unused]] auto props = edge.Properties(View::NEW);
+          }
+        } else if (query == 1) {
+          // Edge type index query
+          auto acc = store->Access(WRITE);
+          auto et = acc->NameToEdgeType("STRESS_ET");
+          auto edges = acc->Edges(et, View::NEW);
+          uint64_t count = 0;
+          for ([[maybe_unused]] const auto &e : edges) {
+            ++count;
+          }
+          // Just verify iteration works without crash
+          (void)count;
+        } else if (query == 2) {
+          // Edge type + property index query
+          auto acc = store->Access(WRITE);
+          auto et = acc->NameToEdgeType("STRESS_ET");
+          auto wp = acc->NameToProperty("weight");
+          auto edges = acc->Edges(et, wp, View::NEW);
+          uint64_t count = 0;
+          for ([[maybe_unused]] const auto &e : edges) {
+            ++count;
+          }
+          (void)count;
+        } else {
+          // Global edge property index query
+          auto acc = store->Access(WRITE);
+          auto wp = acc->NameToProperty("weight");
+          auto edges = acc->Edges(wp, View::NEW);
+          uint64_t count = 0;
+          for ([[maybe_unused]] const auto &e : edges) {
+            ++count;
+          }
+          (void)count;
+        }
+      }
+    });
+  }
+
+  // GC thread
+  std::thread gc_thread([&]() {
+    while (running.load()) {
+      store->FreeMemory();
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    // Final GC passes
+    store->FreeMemory();
+    store->FreeMemory();
+  });
+
+  // Join all threads
+  for (auto &w : writers) w.join();
+  for (auto &r : readers) r.join();
+  gc_thread.join();
+
+  // --- Verification ---
+  // Count edges via vertex scan
+  uint64_t vertex_scan_count = 0;
+  {
+    auto acc = store->Access(WRITE);
+    for (const auto &gid : vertex_gids) {
+      auto v = acc->FindVertex(gid, View::OLD);
+      if (!v) continue;
+      auto out = v->OutEdges(View::OLD);
+      if (out.has_value()) {
+        vertex_scan_count += out->edges.size();
+      }
+    }
+  }
+
+  // Count edges via edge type index
+  uint64_t stress_et_index_count = 0;
+  {
+    auto acc = store->Access(WRITE);
+    auto et = acc->NameToEdgeType("STRESS_ET");
+    auto edges = acc->Edges(et, View::OLD);
+    for ([[maybe_unused]] const auto &e : edges) {
+      ++stress_et_index_count;
+    }
+  }
+
+  // Count edges via edge type + property index
+  uint64_t stress_et_prop_index_count = 0;
+  {
+    auto acc = store->Access(WRITE);
+    auto et = acc->NameToEdgeType("STRESS_ET");
+    auto wp = acc->NameToProperty("weight");
+    auto edges = acc->Edges(et, wp, View::OLD);
+    for ([[maybe_unused]] const auto &e : edges) {
+      ++stress_et_prop_index_count;
+    }
+  }
+
+  // Count edges via global edge property index
+  uint64_t global_prop_index_count = 0;
+  {
+    auto acc = store->Access(WRITE);
+    auto wp = acc->NameToProperty("weight");
+    auto edges = acc->Edges(wp, View::OLD);
+    for ([[maybe_unused]] const auto &e : edges) {
+      ++global_prop_index_count;
+    }
+  }
+
+  // Count VEC_ET edges via vertex scan
+  uint64_t vec_et_count = 0;
+  {
+    auto acc = store->Access(WRITE);
+    auto vet = acc->NameToEdgeType("VEC_ET");
+    for (const auto &gid : vertex_gids) {
+      auto v = acc->FindVertex(gid, View::OLD);
+      if (!v) continue;
+      auto out = v->OutEdges(View::OLD);
+      if (!out.has_value()) continue;
+      for (const auto &e : out->edges) {
+        if (e.EdgeType() == vet) ++vec_et_count;
+      }
+    }
+  }
+
+  // Vector index search (just verify no crash, don't assert exact counts)
+  {
+    auto acc = store->Access(WRITE);
+    std::vector<float> query_vec{0.1f, 0.2f, 0.3f, 0.4f};
+    auto results = acc->VectorIndexSearchOnEdges("stress_vec_idx", 5, query_vec);
+    // Results may be empty if all VEC_ET edges were deleted
+    (void)results;
+  }
+
+  // Verify counts are consistent
+  // stress_et_index_count should match STRESS_ET edges from vertex scan
+  uint64_t stress_et_from_vertex_scan = vertex_scan_count - vec_et_count;
+  EXPECT_EQ(stress_et_index_count, stress_et_from_vertex_scan);
+
+  // edge type+property index count should equal edge type index count
+  // (all STRESS_ET edges have the weight property set)
+  EXPECT_EQ(stress_et_prop_index_count, stress_et_index_count);
+
+  // global edge property index count should equal edge type+property index count
+  // (only STRESS_ET edges have the weight property, VEC_ET edges have embedding)
+  EXPECT_EQ(global_prop_index_count, stress_et_prop_index_count);
+
+  // Sanity: we should have done some creates and deletes
+  EXPECT_GT(total_creates.load(), 0u);
+  EXPECT_GT(total_deletes.load(), 0u);
+  EXPECT_GT(total_updates.load(), 0u);
+
+  // Run final GC and verify no crash during cleanup
+  store->FreeMemory();
+  store->FreeMemory();
+}
+
+// ===========================================================================
+// 12. DropGraph tests
+// ===========================================================================
+
+// DropGraph on a light-edge storage must free all pool-allocated edges (no
+// ASAN/MSAN errors), leave the storage empty, and leave the pool reusable.
+TEST(LightEdgesCleanup, DropGraphFreesEdgesAndPool) {
+  auto store = MakeLightEdgeStorage();
+  auto *mem_storage = static_cast<InMemoryStorage *>(store.get());
+
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create enough edges to span multiple pool chunks.
+  constexpr int kEdges = 500;
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto etype = acc->NameToEdgeType("T");
+    for (int idx = 0; idx < kEdges; ++idx) {
+      ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, etype).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // DropGraph requires IN_MEMORY_ANALYTICAL mode.
+  mem_storage->SetStorageMode(StorageMode::IN_MEMORY_ANALYTICAL);
+  {
+    auto acc = store->UniqueAccess();
+    acc->DropGraph();
+  }
+
+  // Verify storage is empty.
+  mem_storage->SetStorageMode(StorageMode::IN_MEMORY_TRANSACTIONAL);
+  {
+    auto acc = store->Access(READ);
+    int edge_count = 0;
+    for (auto vertex : acc->Vertices(View::OLD)) {
+      auto out = vertex.OutEdges(View::OLD);
+      if (out.has_value()) edge_count += static_cast<int>(out->edges.size());
+    }
+    EXPECT_EQ(edge_count, 0);
+  }
+
+  // Pool must still be usable after DropGraph + Reclaim.
+  auto [gf2, gt2] = CreateTwoVertices(store.get());
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gf2, View::NEW);
+    auto vt = acc->FindVertex(gt2, View::NEW);
+    ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, acc->NameToEdgeType("NEW")).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+}
+
+// DropGraph with edges in the graveyard (deleted but not yet GC'd).
+TEST(LightEdgesCleanup, DropGraphWithGraveyardEdges) {
+  auto store = MakeLightEdgeStorage();
+  auto *mem_storage = static_cast<InMemoryStorage *>(store.get());
+
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create and then delete edges so they sit in the graveyard.
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto etype = acc->NameToEdgeType("T");
+    for (int idx = 0; idx < 50; ++idx) {
+      ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, etype).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    while (true) {
+      auto out = vf->OutEdges(View::NEW);
+      if (!out.has_value() || out->edges.empty()) break;
+      auto edge = out->edges[0];
+      ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  // Deliberately skip GC so edges remain in graveyard.
+
+  mem_storage->SetStorageMode(StorageMode::IN_MEMORY_ANALYTICAL);
+  {
+    auto acc = store->UniqueAccess();
+    acc->DropGraph();
+    // No crash / ASAN error = graveyard was drained and pool reclaimed.
+  }
+}

--- a/tests/unit/storage_v2_light_edges.cpp
+++ b/tests/unit/storage_v2_light_edges.cpp
@@ -2059,7 +2059,7 @@ TEST(LightEdgesStress, ConcurrentCrudWithIndices) {
 // 12. DropGraph tests
 // ===========================================================================
 
-// DropGraph on a light-edge storage must free all pool-allocated edges (no
+// DropGraph on a light-edge storage must free all edges (no
 // ASAN/MSAN errors), leave the storage empty, and leave the pool reusable.
 TEST(LightEdgesCleanup, DropGraphFreesEdgesAndPool) {
   auto store = MakeLightEdgeStorage();

--- a/tests/unit/storage_v2_replication.cpp
+++ b/tests/unit/storage_v2_replication.cpp
@@ -1893,3 +1893,223 @@ TEST_F(ReplicationTest, GetTelemetryJson) {
   auto const expected_json = nlohmann::json({{"async", 1}, {"sync", 1}, {"strict_sync", 0}});
   ASSERT_EQ(main_json.value(), expected_json);
 }
+
+// ---------------------------------------------------------------------------
+// Light-edge replication tests
+// ---------------------------------------------------------------------------
+
+class ReplicationTestLightEdge : public ::testing::Test {
+ protected:
+  std::filesystem::path storage_directory{std::filesystem::temp_directory_path() /
+                                          "MG_test_unit_storage_v2_replication_light_edge"};
+  std::filesystem::path repl_storage_directory{std::filesystem::temp_directory_path() /
+                                               "MG_test_unit_storage_v2_replication_light_edge_repl"};
+
+  void SetUp() override { Clear(); }
+
+  void TearDown() override { Clear(); }
+
+  Config MakeLightEdgeConfig(const std::filesystem::path &dir) const {
+    Config config{
+        .durability =
+            {
+                .root_data_directory = dir,
+                .snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
+            },
+        .salient.items = {.properties_on_edges = true, .storage_light_edge = true},
+    };
+    UpdatePaths(config, dir);
+    return config;
+  }
+
+  const std::string local_host = "127.0.0.1";
+  const uint16_t port = 10'100;
+  const std::string replica_name = "LIGHT_REPLICA";
+
+ private:
+  void Clear() {
+    if (std::filesystem::exists(storage_directory)) std::filesystem::remove_all(storage_directory);
+    if (std::filesystem::exists(repl_storage_directory)) std::filesystem::remove_all(repl_storage_directory);
+  }
+};
+
+/// Verify that edge create, edge set-property, and edge delete are all
+/// replicated correctly when storage_light_edge=true on both main and replica.
+TEST_F(ReplicationTestLightEdge, EdgeCrudReplicatedSynchronously) {
+  MinMemgraph main(MakeLightEdgeConfig(storage_directory));
+  MinMemgraph replica(MakeLightEdgeConfig(repl_storage_directory));
+
+  replica.repl_handler.TrySetReplicationRoleReplica(ReplicationServerConfig{.repl_server = Endpoint(local_host, port)});
+
+  ASSERT_TRUE(main.repl_handler
+                  .TryRegisterReplica(ReplicationClientConfig{
+                      .name = replica_name,
+                      .mode = ReplicationMode::SYNC,
+                      .repl_server_endpoint = Endpoint(local_host, port),
+                  })
+                  .has_value());
+
+  const auto *edge_type_name = "light_et";
+  const auto *edge_prop_name = "eprop";
+  const auto *edge_prop_value = "hello_light";
+
+  Gid v1_gid, v2_gid;
+  Gid edge_gid;
+
+  // Create two vertices + one edge with a property.
+  {
+    auto acc = main.db.Access(memgraph::storage::WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    v1_gid = v1.Gid();
+    v2_gid = v2.Gid();
+    auto edge_res = acc->CreateEdge(&v1, &v2, main.db.storage()->NameToEdgeType(edge_type_name));
+    ASSERT_TRUE(edge_res.has_value());
+    auto edge = edge_res.value();
+    edge_gid = edge.Gid();
+    ASSERT_TRUE(edge.SetProperty(main.db.storage()->NameToProperty(edge_prop_name), PropertyValue(edge_prop_value))
+                    .has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
+  }
+
+  // Replica should see the edge and its property.
+  {
+    auto acc = replica.db.Access(memgraph::storage::WRITE);
+    const auto v1 = acc->FindVertex(v1_gid, View::OLD);
+    ASSERT_TRUE(v1.has_value());
+    const auto out_edges = v1->OutEdges(View::OLD);
+    ASSERT_TRUE(out_edges.has_value());
+    ASSERT_EQ(out_edges->edges.size(), 1U);
+    const auto &edge = out_edges->edges[0];
+    ASSERT_EQ(edge.Gid(), edge_gid);
+    ASSERT_EQ(edge.EdgeType(), replica.db.storage()->NameToEdgeType(edge_type_name));
+    const auto props = edge.Properties(View::OLD);
+    ASSERT_TRUE(props.has_value());
+    ASSERT_EQ(props->size(), 1U);
+    ASSERT_EQ(props->at(replica.db.storage()->NameToProperty(edge_prop_name)), PropertyValue(edge_prop_value));
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Update edge property in a separate transaction (exercises WAL SET_PROPERTY for light edges).
+  const auto *updated_value = "updated_light";
+  {
+    auto acc = main.db.Access(memgraph::storage::WRITE);
+    auto v1 = acc->FindVertex(v1_gid, View::OLD).value();
+    auto out_edges = v1.OutEdges(View::OLD);
+    ASSERT_TRUE(out_edges.has_value());
+    auto edge = out_edges->edges[0];
+    ASSERT_TRUE(
+        edge.SetProperty(main.db.storage()->NameToProperty(edge_prop_name), PropertyValue(updated_value)).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
+  }
+
+  {
+    auto acc = replica.db.Access(memgraph::storage::WRITE);
+    const auto v1 = acc->FindVertex(v1_gid, View::OLD).value();
+    const auto out_edges = v1.OutEdges(View::OLD);
+    ASSERT_TRUE(out_edges.has_value());
+    const auto &edge = out_edges->edges[0];
+    const auto props = edge.Properties(View::OLD);
+    ASSERT_TRUE(props.has_value());
+    ASSERT_EQ(props->at(replica.db.storage()->NameToProperty(edge_prop_name)), PropertyValue(updated_value));
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete the edge.
+  {
+    auto acc = main.db.Access(memgraph::storage::WRITE);
+    auto v1 = acc->FindVertex(v1_gid, View::OLD).value();
+    auto out_edges = v1.OutEdges(View::OLD);
+    ASSERT_TRUE(out_edges.has_value());
+    auto edge = out_edges->edges[0];
+    ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
+  }
+
+  {
+    auto acc = replica.db.Access(memgraph::storage::WRITE);
+    const auto v1 = acc->FindVertex(v1_gid, View::OLD).value();
+    const auto out_edges = v1.OutEdges(View::OLD);
+    ASSERT_TRUE(out_edges.has_value());
+    ASSERT_TRUE(out_edges->edges.empty());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+}
+
+/// Verify that a replica recovers from snapshot+WAL written with light edges
+/// and then accepts live replication of further changes.
+TEST_F(ReplicationTestLightEdge, RecoveryProcess) {
+  Gid v1_gid, v2_gid, edge_gid;
+
+  // Phase 1: write data and snapshot to disk.
+  {
+    auto conf = MakeLightEdgeConfig(storage_directory);
+    conf.durability.snapshot_on_exit = true;
+    MinMemgraph main(conf);
+
+    auto acc = main.db.Access(memgraph::storage::WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    v1_gid = v1.Gid();
+    v2_gid = v2.Gid();
+    auto edge_res = acc->CreateEdge(&v1, &v2, main.db.storage()->NameToEdgeType("et"));
+    ASSERT_TRUE(edge_res.has_value());
+    edge_gid = edge_res->Gid();
+    ASSERT_TRUE(edge_res->SetProperty(main.db.storage()->NameToProperty("p"), PropertyValue(42)).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
+  }
+
+  // Phase 2: recover from snapshot, add a label, then register replica.
+  auto conf = MakeLightEdgeConfig(storage_directory);
+  conf.durability.recover_on_startup = true;
+  MinMemgraph main(conf);
+
+  // Verify recovery from snapshot restored the edge.
+  {
+    auto acc = main.db.Access(memgraph::storage::WRITE);
+    auto v1 = acc->FindVertex(v1_gid, View::OLD);
+    ASSERT_TRUE(v1.has_value());
+    auto out_edges = v1->OutEdges(View::OLD);
+    ASSERT_TRUE(out_edges.has_value());
+    ASSERT_EQ(out_edges->edges.size(), 1U);
+    ASSERT_EQ(out_edges->edges[0].Gid(), edge_gid);
+    ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
+  }
+
+  // Register replica (it will receive the snapshot for catch-up).
+  MinMemgraph replica(MakeLightEdgeConfig(repl_storage_directory));
+  replica.repl_handler.TrySetReplicationRoleReplica(ReplicationServerConfig{.repl_server = Endpoint(local_host, port)});
+  ASSERT_TRUE(main.repl_handler
+                  .TryRegisterReplica(ReplicationClientConfig{
+                      .name = replica_name,
+                      .mode = ReplicationMode::SYNC,
+                      .repl_server_endpoint = Endpoint(local_host, port),
+                  })
+                  .has_value());
+
+  while (main.db.storage()->GetReplicaState(replica_name) != ReplicaState::READY) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  // Send one more live transaction; replica must apply it.
+  {
+    auto acc = main.db.Access(memgraph::storage::WRITE);
+    auto v1 = acc->FindVertex(v1_gid, View::OLD).value();
+    ASSERT_TRUE(v1.AddLabel(main.db.storage()->NameToLabel("recovered")).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
+  }
+
+  {
+    auto acc = replica.db.Access(memgraph::storage::WRITE);
+    const auto v1 = acc->FindVertex(v1_gid, View::OLD);
+    ASSERT_TRUE(v1.has_value());
+    const auto labels = v1->Labels(View::OLD);
+    ASSERT_TRUE(labels.has_value());
+    ASSERT_THAT(*labels, ::testing::Contains(replica.db.storage()->NameToLabel("recovered")));
+    // Edge must also be present on replica after recovery.
+    const auto out_edges = v1->OutEdges(View::OLD);
+    ASSERT_TRUE(out_edges.has_value());
+    ASSERT_EQ(out_edges->edges.size(), 1U);
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+}

--- a/tests/unit/storage_v2_schema_info.cpp
+++ b/tests/unit/storage_v2_schema_info.cpp
@@ -41,6 +41,9 @@ struct InMemTransactional {};
 
 struct InMemAnalytical {};
 
+/// Tag type: run SchemaInfoTestWEdgeProp with InMemoryStorage + storage_light_edge=true.
+struct InMemLightEdge {};
+
 template <typename StorageType>
 class SchemaInfoTest : public testing::Test {
  protected:
@@ -83,6 +86,9 @@ class SchemaInfoTestWEdgeProp : public testing::Test {
     config_.salient.items.properties_on_edges = true;
     config_.salient.storage_mode = mode;
     config_.salient.items.enable_schema_info = true;
+    if constexpr (std::is_same_v<StorageType, InMemLightEdge>) {
+      config_.salient.items.storage_light_edge = true;
+    }
 
     // TODO OnDisk not supported at this time
     this->storage = std::make_unique<memgraph::storage::InMemoryStorage>(config_);
@@ -97,11 +103,12 @@ class SchemaInfoTestWEdgeProp : public testing::Test {
   std::unique_ptr<memgraph::storage::Storage> storage;
   StorageMode mode{std::is_same_v<StorageType, DiskStorage>
                        ? StorageMode::ON_DISK_TRANSACTIONAL
-                       : (std::is_same_v<StorageType, InMemTransactional> ? StorageMode::IN_MEMORY_TRANSACTIONAL
-                                                                          : StorageMode::IN_MEMORY_ANALYTICAL)};
+                       : (std::is_same_v<StorageType, InMemAnalytical> ? StorageMode::IN_MEMORY_ANALYTICAL
+                                                                       : StorageMode::IN_MEMORY_TRANSACTIONAL)};
 };
 
 using StorageTypes = ::testing::Types<InMemTransactional, InMemAnalytical>;
+using StorageTypesWithEdgeProp = ::testing::Types<InMemTransactional, InMemAnalytical, InMemLightEdge>;
 
 TEST(SchemaInfoContext, ConfrontJSON) {
   {
@@ -184,7 +191,7 @@ TEST(SchemaInfoContext, ConfrontJSON) {
 }
 
 TYPED_TEST_SUITE(SchemaInfoTest, StorageTypes);
-TYPED_TEST_SUITE(SchemaInfoTestWEdgeProp, StorageTypes);
+TYPED_TEST_SUITE(SchemaInfoTestWEdgeProp, StorageTypesWithEdgeProp);
 
 auto &&jarray = nlohmann::json::array;
 

--- a/tools/lsan.supp
+++ b/tools/lsan.supp
@@ -10,3 +10,7 @@ leak:antlr4::atn::ATNConfigSet::add(std::shared_ptr<antlr4::atn::ATNConfig> cons
 leak:antlr4::atn::ParserATNSimulator::getEpsilonTarget(std::shared_ptr<antlr4::atn::ATNConfig> const&, antlr4::atn::Transition*, bool, bool, bool, bool)
 leak:antlr4::atn::PredictionContext::mergeArrays(std::shared_ptr<antlr4::atn::ArrayPredictionContext> const&, std::shared_ptr<antlr4::atn::ArrayPredictionContext> const&, bool, std::map<std::pair<std::shared_ptr<antlr4::atn::PredictionContext>, std::shared_ptr<antlr4::atn::PredictionContext> >, std::shared_ptr<antlr4::atn::PredictionContext>, std::less<std::pair<std::shared_ptr<antlr4::atn::PredictionContext>, std::shared_ptr<antlr4::atn::PredictionContext> > >, std::allocator<std::pair<std::pair<std::shared_ptr<antlr4::atn::PredictionContext>, std::shared_ptr<antlr4::atn::PredictionContext> > const, std::shared_ptr<antlr4::atn::PredictionContext> > > >*)
 leak:/lib/x86_64-linux-gnu/libpython3.
+# query_procedure_py_module test intentionally skips Py_Finalize() due to Python bug bpo-42969.
+# This causes all Python runtime allocations to be reported as leaks.
+# See tests/unit/query_procedure_py_module.cpp main() for details.
+leak:libpython3.13.so


### PR DESCRIPTION
Introduces `--storage-light-edge` (default: `false`), a new storage mode where
`Edge` objects are stored only in vertex adjacency lists, eliminating the global `edges_` skip-list to reduce memory footprint. Implies `--storage-properties-on-edges`.

### What changes

**Core allocation**
- `EdgeRef` carries `Edge*` directly; all edge lookups go through vertex `out_edges`/`in_edges` vectors

**Lifetime management**
- Deferred deallocation via `light_edge_graveyard_`: entries drain when `mark_timestamp <= oldest_active_start_timestamp` (CommitLog pinning) AND indices have been cleaned AND `IsSafeToFree(guard_epoch)` (epoch tracker)
- New `EpochTracker` (`utils/epoch_tracker.hpp`) blocks graveyard drain while index iterables hold live `Edge*` references — needed because index cleanup is lazy
- `READ_UNCOMMITTED` and `IN_MEMORY_ANALYTICAL` are both safe: CommitLog pinning and `LightEdgeIterableGuard` protect all access paths regardless of isolation level

**Durability**
- Snapshot write iterates vertices via `OutEdges(View::OLD)` instead of the skip-list
- WAL/snapshot recovery pool-allocates edges; `SET_EDGE_PROPERTY` recovery uses a 3-case topology lookup (from+to+type → from\gid → gid-only) since `edge_acc.find()` is unavailable
- Replication propagates `storage_light_edge` config and uses the same topology-first lookup

**GC**
- `CollectGarbage` mirrors heavy edge logic while using the light edge graveyard.