### PR TITLE
Add script for waiting on Memgraph to be ready

### DIFF
--- a/tools/ci/wait_for_memgraph_bolt.sh
+++ b/tools/ci/wait_for_memgraph_bolt.sh
@@ -21,3 +21,10 @@ wait_for_memgraph_bolt() {
   echo "Memgraph did not become ready at ${host}:${port} after ${max_retries} attempts."
   return 1
 }
+
+# If executed directly, run with CLI args.
+# If sourced, only define the function for caller use.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  wait_for_memgraph_bolt "$@"
+  exit $?
+fi


### PR DESCRIPTION
Added a script which can be ran directly, or sourced to provide a function for waiting for Memgraph to be ready.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 7518ed6878847ac072413f171556756b27ed8b7a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->