### PR TITLE
Fix Issue 3559: Cypher compatibility: ORDER BY fails for list values

### DIFF
--- a/src/query/common.hpp
+++ b/src/query/common.hpp
@@ -63,6 +63,12 @@ std::partial_ordering TypedValueCompare(TypedValue const &a, TypedValue const &b
         return a.UnsafeValuePoint3d() <=> b.UnsafeValuePoint3d();
         break;
       case TypedValue::Type::List:
+        return std::lexicographical_compare_three_way(a.UnsafeValueList().begin(),
+                                                      a.UnsafeValueList().end(),
+                                                      b.UnsafeValueList().begin(),
+                                                      b.UnsafeValueList().end(),
+                                                      TypedValueCompare);
+        break;
       case TypedValue::Type::Map:
       case TypedValue::Type::Vertex:
       case TypedValue::Type::Edge:

--- a/tests/gql_behave/tests/openCypher_M09/features/OrderByAcceptance.feature
+++ b/tests/gql_behave/tests/openCypher_M09/features/OrderByAcceptance.feature
@@ -291,3 +291,69 @@ Feature: OrderByAcceptance
       LIMIT -1
       """
     Then a SyntaxError should be raised at compile time: NegativeIntegerArgument
+
+  Scenario: UNWIND list ordering
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [[1],[2]] AS l
+      RETURN l
+      ORDER BY l;
+      """
+    Then the result should be:
+      | l   |
+      | [1] |
+      | [2] |
+
+  Scenario: ORDER BY with collected value
+    Given an empty graph
+    When executing query:
+      """
+      WITH collect(1) AS a1
+      UNWIND [1,2] AS x
+      RETURN a1, x
+      ORDER BY a1 DESC;
+      """
+    Then the result should be:
+      | a1  | x |
+      | [1] | 1 |
+      | [1] | 2 |
+
+  Scenario: ORDER BY list of strings
+    Given an empty graph
+    When executing query:
+      """
+      WITH [["ccc"],["aaa"],["ddd"],["bbb"]] AS l
+      UNWIND l AS x
+      WITH x ORDER BY x
+      RETURN collect(x);
+      """
+    Then the result should be:
+      | collect(x)                        |
+      | [['aaa'],['bbb'],['ccc'],['ddd']] |
+
+  Scenario: ORDER BY DESC list of strings
+    Given an empty graph
+    When executing query:
+      """
+      WITH [["ccc"],["aaa"],["ddd"],["bbb"]] AS l
+      UNWIND l AS x
+      WITH x ORDER BY x DESC
+      RETURN collect(x);
+      """
+    Then the result should be:
+      | collect(x)                        |
+      | [['ddd'],['ccc'],['bbb'],['aaa']] |
+
+  Scenario: ORDER BY list values
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [[1, 2, 4],[1, 2, 6]] AS l
+      RETURN l
+      ORDER BY l;
+      """
+    Then the result should be:
+      | l        |
+      | [1,2,4]  |
+      | [1,2,6]  |

--- a/tests/unit/query_plan_bag_semantics.cpp
+++ b/tests/unit/query_plan_bag_semantics.cpp
@@ -306,9 +306,13 @@ TYPED_TEST(QueryPlanTest, OrderByExceptions) {
            std::vector<memgraph::storage::PropertyValue>{memgraph::storage::PropertyValue("bla")})},
       // illegal comparisons of same-type values
       {memgraph::storage::PropertyValue(
-           std::vector<memgraph::storage::PropertyValue>{memgraph::storage::PropertyValue(42)}),
+           std::vector<memgraph::storage::PropertyValue>{memgraph::storage::PropertyValue("bla")}),
        memgraph::storage::PropertyValue(
-           std::vector<memgraph::storage::PropertyValue>{memgraph::storage::PropertyValue(42)})}};
+           std::vector<memgraph::storage::PropertyValue>{memgraph::storage::PropertyValue(42)})},
+      {memgraph::storage::PropertyValue(std::vector<memgraph::storage::PropertyValue>{
+           memgraph::storage::PropertyValue("bla"), memgraph::storage::PropertyValue("bla")}),
+       memgraph::storage::PropertyValue(std::vector<memgraph::storage::PropertyValue>{
+           memgraph::storage::PropertyValue("bla"), memgraph::storage::PropertyValue(42)})}};
 
   for (const auto &pair : exception_pairs) {
     // empty database


### PR DESCRIPTION
- ORDER BY should be able to sort list values using Cypher/openCypher list ordering semantics (dictionary/lexicographic order). 
- Added test cases for sorting list of integers and strings.