### PR TITLE
feat: Add built-in default roles

### DIFF
--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -954,6 +954,7 @@ void Auth::InitialiseFirstUser(User &user, system::Transaction *system_tx) {
       "{} is the first created user. Granting all privileges. The official advice and intention is to use this "
       "first user as the superuser with full privileges and capabilities on the Memgraph database.",
       user.username());
+#ifdef MG_ENTERPRISE
   if (license::global_license_checker.IsEnterpriseValidFast()) {
     auto admin = GetRole("admin");
     if (admin && admin->IsBuiltIn()) {
@@ -961,14 +962,13 @@ void Auth::InitialiseFirstUser(User &user, system::Transaction *system_tx) {
       SaveUser(user, system_tx);
       return;
     }
-  }
-  for (auto const permission : kPermissionsAll) {
-    user.permissions().Grant(permission);
-  }
-  if (license::global_license_checker.IsEnterpriseValidFast()) {
     user.fine_grained_access_handler().label_permissions().GrantGlobal(kAllLabelPermissions);
     user.fine_grained_access_handler().edge_type_permissions().GrantGlobal(kAllEdgeTypePermissions);
     user.db_access().GrantAll();
+  }
+#endif
+  for (auto const permission : kPermissionsAll) {
+    user.permissions().Grant(permission);
   }
   SaveUser(user, system_tx);
 }
@@ -1240,6 +1240,7 @@ std::optional<Role> Auth::AddRole(const std::string &rolename, system::Transacti
   return new_role;
 }
 
+#ifdef MG_ENTERPRISE
 bool Auth::CreateBuiltinRoles(system::Transaction *system_tx) {
   if (!license::global_license_checker.IsEnterpriseValidFast()) return false;
   if (!AllRolenames().empty()) {
@@ -1289,6 +1290,7 @@ bool Auth::CreateBuiltinRoles(system::Transaction *system_tx) {
 
   return true;
 }
+#endif
 
 bool Auth::RemoveRole(const std::string &rolename_orig, bool force, system::Transaction *system_tx) {
   auto rolename = utils::ToLowerCase(rolename_orig);

--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -966,10 +966,8 @@ void Auth::InitialiseFirstUser(User &user, system::Transaction *system_tx) {
     user.permissions().Grant(permission);
   }
   if (license::global_license_checker.IsEnterpriseValidFast()) {
-    constexpr auto kFullFineGrained = FineGrainedPermission::READ | FineGrainedPermission::UPDATE |
-                                      FineGrainedPermission::CREATE | FineGrainedPermission::DELETE;
-    user.fine_grained_access_handler().label_permissions().GrantGlobal(kFullFineGrained);
-    user.fine_grained_access_handler().edge_type_permissions().GrantGlobal(kFullFineGrained);
+    user.fine_grained_access_handler().label_permissions().GrantGlobal(kAllLabelPermissions);
+    user.fine_grained_access_handler().edge_type_permissions().GrantGlobal(kAllEdgeTypePermissions);
     user.db_access().GrantAll();
   }
   SaveUser(user, system_tx);
@@ -1253,10 +1251,6 @@ bool Auth::CreateBuiltinRoles(system::Transaction *system_tx) {
     SaveRole(role, system_tx);
   };
 
-  constexpr auto kFullFineGrained = static_cast<FineGrainedPermission>(
-      std::to_underlying(FineGrainedPermission::READ) | std::to_underlying(FineGrainedPermission::UPDATE) |
-      std::to_underlying(FineGrainedPermission::CREATE) | std::to_underlying(FineGrainedPermission::DELETE));
-
   auto const grant_privileges =
       [](Role &role, FineGrainedPermission labelPermissions, FineGrainedPermission edgePermissions) {
         role.fine_grained_access_handler().label_permissions().GrantGlobal(labelPermissions);
@@ -1267,7 +1261,7 @@ bool Auth::CreateBuiltinRoles(system::Transaction *system_tx) {
     for (auto permission : kPermissionsAll) {
       role.permissions().Grant(permission);
     }
-    grant_privileges(role, kFullFineGrained, kFullFineGrained);
+    grant_privileges(role, kAllLabelPermissions, kAllEdgeTypePermissions);
     role.db_access().GrantAll();
   });
 
@@ -1281,7 +1275,7 @@ bool Auth::CreateBuiltinRoles(system::Transaction *system_tx) {
                             Permission::MATCH}) {
       role.permissions().Grant(permission);
     }
-    grant_privileges(role, kFullFineGrained, kFullFineGrained);
+    grant_privileges(role, kAllLabelPermissions, kAllEdgeTypePermissions);
   });
 
   make_role("readonly", [&](Role &role) {

--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -942,10 +942,7 @@ std::optional<User> Auth::AddUser(const std::string &username, const std::option
   if (!NameRegexMatch(username)) {
     throw AuthException("Invalid user name.");
   }
-  auto existing_user = GetUser(username);
-  if (existing_user) return std::nullopt;
-  auto existing_role = GetRole(username);
-  if (existing_role) return std::nullopt;
+  if (GetUser(username)) return std::nullopt;
   auto new_user = User(username);
   UpdatePassword(new_user, password);
   SaveUser(new_user, system_tx);
@@ -957,15 +954,17 @@ void Auth::InitialiseFirstUser(User &user, system::Transaction *system_tx) {
       "{} is the first created user. Granting all privileges. The official advice and intention is to use this "
       "first user as the superuser with full privileges and capabilities on the Memgraph database.",
       user.username());
-#ifdef MG_ENTERPRISE
-  auto admin = GetRole("admin");
-  MG_ASSERT(admin, "admin role must exist when initialising first user");
-  user.AddRole(*admin);
-#else
+  if (license::global_license_checker.IsEnterpriseValidFast()) {
+    auto admin = GetRole("admin");
+    if (admin && admin->IsBuiltIn()) {
+      user.AddRole(*admin);
+      SaveUser(user, system_tx);
+      return;
+    }
+  }
   for (auto const permission : kPermissionsAll) {
     user.permissions().Grant(permission);
   }
-#endif
   SaveUser(user, system_tx);
 }
 
@@ -1230,14 +1229,16 @@ std::optional<Role> Auth::AddRole(const std::string &rolename, system::Transacti
   if (!NameRegexMatch(rolename)) {
     throw AuthException("Invalid role name.");
   }
-  if (auto existing_role = GetRole(rolename)) return std::nullopt;
-  if (auto existing_user = GetUser(rolename)) return std::nullopt;
+  if (GetRole(rolename)) return std::nullopt;
   auto new_role = Role(rolename);
   SaveRole(new_role, system_tx);
   return new_role;
 }
 
 void Auth::CreateBuiltinRoles(system::Transaction *system_tx) {
+  if (!license::global_license_checker.IsEnterpriseValidFast()) return;
+  if (!AllRolenames().empty()) return;
+
   auto const make_role = [&](const std::string &name, auto grant_permissions) {
     Role role{name};
     grant_permissions(role);

--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -1293,38 +1293,40 @@ bool Auth::CreateBuiltinRoles(system::Transaction *system_tx) {
   return true;
 }
 
-bool Auth::RemoveRole(const std::string &rolename_orig, system::Transaction *system_tx) {
+bool Auth::RemoveRole(const std::string &rolename_orig, bool force, system::Transaction *system_tx) {
   auto rolename = utils::ToLowerCase(rolename_orig);
   if (!storage_.Get(kRolePrefix + rolename)) return false;
 
   // Reject deletion if any user has the role assigned (global or per-database)
-  for (auto it = storage_.begin(kRoleLinkPrefix); it != storage_.end(kRoleLinkPrefix); ++it) {
-    try {
-      auto json_data = ParseJson(it->second);
-      if (!json_data.is_array()) continue;
-      for (auto const &role_name : json_data) {
-        if (role_name.is_string() && utils::ToLowerCase(role_name.get<std::string>()) == rolename) {
-          auto username = it->first.substr(kRoleLinkPrefix.size());
-          throw AuthException("Cannot delete role '{}': it is assigned to user '{}'.", rolename, username);
+  if (!force) {
+    for (auto it = storage_.begin(kRoleLinkPrefix); it != storage_.end(kRoleLinkPrefix); ++it) {
+      try {
+        auto json_data = ParseJson(it->second);
+        if (!json_data.is_array()) continue;
+        for (auto const &role_name : json_data) {
+          if (role_name.is_string() && utils::ToLowerCase(role_name.get<std::string>()) == rolename) {
+            auto username = it->first.substr(kRoleLinkPrefix.size());
+            throw AuthException("Cannot delete role '{}': it is assigned to user '{}'.", rolename, username);
+          }
         }
+      } catch (AuthException const &) {
+        throw;
+      } catch (nlohmann::detail::exception const &) {
+        continue;
       }
-    } catch (AuthException const &) {
-      throw;
-    } catch (nlohmann::detail::exception const &) {
-      continue;
     }
-  }
 
-  for (auto it = storage_.begin(kMtLinkPrefix); it != storage_.end(kMtLinkPrefix); ++it) {
-    auto username = it->first.substr(kMtLinkPrefix.size());
-    if (username != utils::ToLowerCase(username)) continue;
-    auto json_data = ParseJson(it->second);
-    for (auto const &[db_name, role_names] : json_data.items()) {
-      if (!role_names.is_array()) continue;
-      for (auto const &role_name : role_names) {
-        if (role_name.is_string() && utils::ToLowerCase(role_name.get<std::string>()) == rolename) {
-          throw AuthException(
-              "Cannot delete role '{}': it is assigned to user '{}' on database '{}'.", rolename, username, db_name);
+    for (auto it = storage_.begin(kMtLinkPrefix); it != storage_.end(kMtLinkPrefix); ++it) {
+      auto username = it->first.substr(kMtLinkPrefix.size());
+      if (username != utils::ToLowerCase(username)) continue;
+      auto json_data = ParseJson(it->second);
+      for (auto const &[db_name, role_names] : json_data.items()) {
+        if (!role_names.is_array()) continue;
+        for (auto const &role_name : role_names) {
+          if (role_name.is_string() && utils::ToLowerCase(role_name.get<std::string>()) == rolename) {
+            throw AuthException(
+                "Cannot delete role '{}': it is assigned to user '{}' on database '{}'.", rolename, username, db_name);
+          }
         }
       }
     }

--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -1305,8 +1305,7 @@ bool Auth::RemoveRole(const std::string &rolename_orig, bool force, system::Tran
         if (!json_data.is_array()) continue;
         for (auto const &role_name : json_data) {
           if (role_name.is_string() && utils::ToLowerCase(role_name.get<std::string>()) == rolename) {
-            auto username = it->first.substr(kRoleLinkPrefix.size());
-            throw AuthException("Cannot delete role '{}': it is assigned to user '{}'.", rolename, username);
+            throw AuthException("Cannot delete role '{}' as it is assigned to one or more users.", rolename);
           }
         }
       } catch (AuthException const &) {
@@ -1325,7 +1324,7 @@ bool Auth::RemoveRole(const std::string &rolename_orig, bool force, system::Tran
         for (auto const &role_name : role_names) {
           if (role_name.is_string() && utils::ToLowerCase(role_name.get<std::string>()) == rolename) {
             throw AuthException(
-                "Cannot delete role '{}': it is assigned to user '{}' on database '{}'.", rolename, username, db_name);
+                "Cannot delete role '{}': it is assigned to one or more users on database '{}'.", rolename, db_name);
           }
         }
       }

--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -952,6 +952,23 @@ std::optional<User> Auth::AddUser(const std::string &username, const std::option
   return new_user;
 }
 
+void Auth::InitialiseFirstUser(User &user, system::Transaction *system_tx) {
+  spdlog::info(
+      "{} is the first created user. Granting all privileges. The official advice and intention is to use this "
+      "first user as the superuser with full privileges and capabilities on the Memgraph database.",
+      user.username());
+#ifdef MG_ENTERPRISE
+  auto admin = GetRole("admin");
+  MG_ASSERT(admin, "admin role must exist when initialising first user");
+  user.AddRole(*admin);
+#else
+  for (auto const permission : kPermissionsAll) {
+    user.permissions().Grant(permission);
+  }
+#endif
+  SaveUser(user, system_tx);
+}
+
 bool Auth::RemoveUser(const std::string &username_orig, system::Transaction *system_tx) {
   auto username = utils::ToLowerCase(username_orig);
   if (!storage_.Get(kUserPrefix + username)) return false;
@@ -1218,6 +1235,52 @@ std::optional<Role> Auth::AddRole(const std::string &rolename, system::Transacti
   auto new_role = Role(rolename);
   SaveRole(new_role, system_tx);
   return new_role;
+}
+
+void Auth::CreateBuiltinRoles(system::Transaction *system_tx) {
+  auto const make_role = [&](const std::string &name, auto grant_permissions) {
+    Role role{name};
+    grant_permissions(role);
+    role.SetBuiltIn(true);
+    SaveRole(role, system_tx);
+  };
+
+  constexpr auto kFullFineGrained = static_cast<FineGrainedPermission>(
+      std::to_underlying(FineGrainedPermission::READ) | std::to_underlying(FineGrainedPermission::UPDATE) |
+      std::to_underlying(FineGrainedPermission::CREATE) | std::to_underlying(FineGrainedPermission::DELETE));
+
+  auto const grant_privileges =
+      [](Role &role, FineGrainedPermission labelPermissions, FineGrainedPermission edgePermissions) {
+        role.fine_grained_access_handler().label_permissions().GrantGlobal(labelPermissions);
+        role.fine_grained_access_handler().edge_type_permissions().GrantGlobal(edgePermissions);
+      };
+
+  make_role("admin", [&](Role &role) {
+    for (auto permission : kPermissionsAll) {
+      role.permissions().Grant(permission);
+    }
+    grant_privileges(role, kFullFineGrained, kFullFineGrained);
+    role.db_access().GrantAll();
+  });
+
+  make_role("readwrite", [&](Role &role) {
+    for (auto permission : {Permission::CREATE,
+                            Permission::DELETE,
+                            Permission::MERGE,
+                            Permission::SET,
+                            Permission::REMOVE,
+                            Permission::INDEX,
+                            Permission::MATCH}) {
+      role.permissions().Grant(permission);
+    }
+    grant_privileges(role, kFullFineGrained, kFullFineGrained);
+  });
+
+  make_role("readonly", [&](Role &role) {
+    role.permissions().Grant(Permission::MATCH);
+    role.permissions().Grant(Permission::STATS);
+    grant_privileges(role, FineGrainedPermission::READ, FineGrainedPermission::READ);
+  });
 }
 
 bool Auth::RemoveRole(const std::string &rolename_orig, system::Transaction *system_tx) {

--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -1242,9 +1242,9 @@ std::optional<Role> Auth::AddRole(const std::string &rolename, system::Transacti
   return new_role;
 }
 
-void Auth::CreateBuiltinRoles(system::Transaction *system_tx) {
-  if (!license::global_license_checker.IsEnterpriseValidFast()) return;
-  if (!AllRolenames().empty()) return;
+bool Auth::CreateBuiltinRoles(system::Transaction *system_tx) {
+  if (!license::global_license_checker.IsEnterpriseValidFast()) return false;
+  if (!AllRolenames().empty()) return false;
 
   auto const make_role = [&](const std::string &name, auto grant_permissions) {
     Role role{name};
@@ -1289,6 +1289,8 @@ void Auth::CreateBuiltinRoles(system::Transaction *system_tx) {
     role.permissions().Grant(Permission::STATS);
     grant_privileges(role, FineGrainedPermission::READ, FineGrainedPermission::READ);
   });
+
+  return true;
 }
 
 bool Auth::RemoveRole(const std::string &rolename_orig, system::Transaction *system_tx) {

--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -1242,7 +1242,10 @@ std::optional<Role> Auth::AddRole(const std::string &rolename, system::Transacti
 
 bool Auth::CreateBuiltinRoles(system::Transaction *system_tx) {
   if (!license::global_license_checker.IsEnterpriseValidFast()) return false;
-  if (!AllRolenames().empty()) return false;
+  if (!AllRolenames().empty()) {
+    spdlog::debug("Skipping built-in role creation: roles already exist");
+    return false;
+  }
 
   auto const make_role = [&](const std::string &name, auto grant_permissions) {
     Role role{name};
@@ -1294,27 +1297,31 @@ bool Auth::RemoveRole(const std::string &rolename_orig, bool force, system::Tran
   // Reject deletion if any user has the role assigned (global or per-database)
   if (!force) {
     for (auto it = storage_.begin(kRoleLinkPrefix); it != storage_.end(kRoleLinkPrefix); ++it) {
+      nlohmann::json json_data;
       try {
-        auto json_data = ParseJson(it->second);
-        if (!json_data.is_array()) continue;
-        for (auto const &role_name : json_data) {
-          if (role_name.is_string() && utils::ToLowerCase(role_name.get<std::string>()) == rolename) {
-            throw AuthException(
-                "Cannot delete role '{}' as it is assigned to one or more users. Drop or reassign the users first.",
-                rolename);
-          }
-        }
-      } catch (AuthException const &) {
-        throw;
+        json_data = ParseJson(it->second);
       } catch (nlohmann::detail::exception const &) {
         continue;
+      }
+      if (!json_data.is_array()) continue;
+      for (auto const &role_name : json_data) {
+        if (role_name.is_string() && utils::ToLowerCase(role_name.get<std::string>()) == rolename) {
+          throw AuthException(
+              "Cannot delete role '{}' as it is assigned to one or more users. Drop or reassign the users first.",
+              rolename);
+        }
       }
     }
 
     for (auto it = storage_.begin(kMtLinkPrefix); it != storage_.end(kMtLinkPrefix); ++it) {
       auto username = it->first.substr(kMtLinkPrefix.size());
       if (username != utils::ToLowerCase(username)) continue;
-      auto json_data = ParseJson(it->second);
+      nlohmann::json json_data;
+      try {
+        json_data = ParseJson(it->second);
+      } catch (nlohmann::detail::exception const &) {
+        continue;
+      }
       for (auto const &[db_name, role_names] : json_data.items()) {
         if (!role_names.is_array()) continue;
         for (auto const &role_name : role_names) {
@@ -1446,21 +1453,36 @@ std::vector<std::string> Auth::AllUsernamesForRole(const std::string &rolename_o
 }
 
 #ifdef MG_ENTERPRISE
-Auth::Result Auth::GrantDatabase(const std::string &db, const std::string &name, UserOrRoleType type,
-                                 system::Transaction *system_tx) {
+namespace {
+// Resolve `name` to a User or Role (respecting the explicit type hint) and
+// invoke the matching callback.  Throws if the name is ambiguous, i.e., both a
+// user and a role exist and no hint was supplied.
+Auth::Result DispatchUserOrRole(Auth &auth, const std::string &name, UserOrRoleType type, auto &&user_fn,
+                                auto &&role_fn) {
   using enum Auth::Result;
-  auto user = (type != UserOrRoleType::ROLE) ? GetUser(name) : std::nullopt;
-  auto role = (type != UserOrRoleType::USER) ? GetRole(name) : std::nullopt;
+  auto user = (type != UserOrRoleType::ROLE) ? auth.GetUser(name) : std::nullopt;
+  auto role = (type != UserOrRoleType::USER) ? auth.GetRole(name) : std::nullopt;
   if (user && role) throw AuthException("Ambiguous: '{}' is both a user and a role. Specify USER or ROLE.", name);
   if (user) {
-    GrantDatabase(db, *user, system_tx);
+    user_fn(*user);
     return SUCCESS;
   }
   if (role) {
-    GrantDatabase(db, *role, system_tx);
+    role_fn(*role);
     return SUCCESS;
   }
   return NO_USER_ROLE;
+}
+}  // namespace
+
+Auth::Result Auth::GrantDatabase(const std::string &db, const std::string &name, UserOrRoleType type,
+                                 system::Transaction *system_tx) {
+  return DispatchUserOrRole(
+      *this,
+      name,
+      type,
+      [&](User &user) { GrantDatabase(db, user, system_tx); },
+      [&](Role &role) { GrantDatabase(db, role, system_tx); });
 }
 
 void Auth::GrantDatabase(const std::string &db, User &user, system::Transaction *system_tx) {
@@ -1483,19 +1505,12 @@ void Auth::GrantDatabase(const std::string &db, Role &role, system::Transaction 
 
 Auth::Result Auth::DenyDatabase(const std::string &db, const std::string &name, UserOrRoleType type,
                                 system::Transaction *system_tx) {
-  using enum Auth::Result;
-  auto user = (type != UserOrRoleType::ROLE) ? GetUser(name) : std::nullopt;
-  auto role = (type != UserOrRoleType::USER) ? GetRole(name) : std::nullopt;
-  if (user && role) throw AuthException("Ambiguous: '{}' is both a user and a role. Specify USER or ROLE.", name);
-  if (user) {
-    DenyDatabase(db, *user, system_tx);
-    return SUCCESS;
-  }
-  if (role) {
-    DenyDatabase(db, *role, system_tx);
-    return SUCCESS;
-  }
-  return NO_USER_ROLE;
+  return DispatchUserOrRole(
+      *this,
+      name,
+      type,
+      [&](User &user) { DenyDatabase(db, user, system_tx); },
+      [&](Role &role) { DenyDatabase(db, role, system_tx); });
 }
 
 void Auth::DenyDatabase(const std::string &db, User &user, system::Transaction *system_tx) {
@@ -1518,19 +1533,12 @@ void Auth::DenyDatabase(const std::string &db, Role &role, system::Transaction *
 
 Auth::Result Auth::RevokeDatabase(const std::string &db, const std::string &name, UserOrRoleType type,
                                   system::Transaction *system_tx) {
-  using enum Auth::Result;
-  auto user = (type != UserOrRoleType::ROLE) ? GetUser(name) : std::nullopt;
-  auto role = (type != UserOrRoleType::USER) ? GetRole(name) : std::nullopt;
-  if (user && role) throw AuthException("Ambiguous: '{}' is both a user and a role. Specify USER or ROLE.", name);
-  if (user) {
-    RevokeDatabase(db, *user, system_tx);
-    return SUCCESS;
-  }
-  if (role) {
-    RevokeDatabase(db, *role, system_tx);
-    return SUCCESS;
-  }
-  return NO_USER_ROLE;
+  return DispatchUserOrRole(
+      *this,
+      name,
+      type,
+      [&](User &user) { RevokeDatabase(db, user, system_tx); },
+      [&](Role &role) { RevokeDatabase(db, role, system_tx); });
 }
 
 void Auth::RevokeDatabase(const std::string &db, User &user, system::Transaction *system_tx) {
@@ -1578,19 +1586,12 @@ void Auth::DeleteDatabase(const std::string &db, system::Transaction *system_tx)
 
 Auth::Result Auth::SetMainDatabase(std::string_view db, const std::string &name, UserOrRoleType type,
                                    system::Transaction *system_tx) {
-  using enum Auth::Result;
-  auto user = (type != UserOrRoleType::ROLE) ? GetUser(name) : std::nullopt;
-  auto role = (type != UserOrRoleType::USER) ? GetRole(name) : std::nullopt;
-  if (user && role) throw AuthException("Ambiguous: '{}' is both a user and a role. Specify USER or ROLE.", name);
-  if (user) {
-    SetMainDatabase(db, *user, system_tx);
-    return SUCCESS;
-  }
-  if (role) {
-    SetMainDatabase(db, *role, system_tx);
-    return SUCCESS;
-  }
-  return NO_USER_ROLE;
+  return DispatchUserOrRole(
+      *this,
+      name,
+      type,
+      [&](User &user) { SetMainDatabase(db, user, system_tx); },
+      [&](Role &role) { SetMainDatabase(db, role, system_tx); });
 }
 
 void Auth::SetMainDatabase(std::string_view db, User &user, system::Transaction *system_tx) {

--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -1305,7 +1305,9 @@ bool Auth::RemoveRole(const std::string &rolename_orig, bool force, system::Tran
         if (!json_data.is_array()) continue;
         for (auto const &role_name : json_data) {
           if (role_name.is_string() && utils::ToLowerCase(role_name.get<std::string>()) == rolename) {
-            throw AuthException("Cannot delete role '{}' as it is assigned to one or more users.", rolename);
+            throw AuthException(
+                "Cannot delete role '{}' as it is assigned to one or more users. Drop or reassign the users first.",
+                rolename);
           }
         }
       } catch (AuthException const &) {
@@ -1324,7 +1326,10 @@ bool Auth::RemoveRole(const std::string &rolename_orig, bool force, system::Tran
         for (auto const &role_name : role_names) {
           if (role_name.is_string() && utils::ToLowerCase(role_name.get<std::string>()) == rolename) {
             throw AuthException(
-                "Cannot delete role '{}': it is assigned to one or more users on database '{}'.", rolename, db_name);
+                "Cannot delete role '{}': it is assigned to one or more users on database '{}'. Drop or reassign the "
+                "users first.",
+                rolename,
+                db_name);
           }
         }
       }

--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -1471,13 +1471,17 @@ std::vector<std::string> Auth::AllUsernamesForRole(const std::string &rolename_o
 }
 
 #ifdef MG_ENTERPRISE
-Auth::Result Auth::GrantDatabase(const std::string &db, const std::string &name, system::Transaction *system_tx) {
+Auth::Result Auth::GrantDatabase(const std::string &db, const std::string &name, UserOrRoleType type,
+                                 system::Transaction *system_tx) {
   using enum Auth::Result;
-  if (auto user = GetUser(name)) {
+  auto user = (type != UserOrRoleType::ROLE) ? GetUser(name) : std::nullopt;
+  auto role = (type != UserOrRoleType::USER) ? GetRole(name) : std::nullopt;
+  if (user && role) throw AuthException("Ambiguous: '{}' is both a user and a role. Specify USER or ROLE.", name);
+  if (user) {
     GrantDatabase(db, *user, system_tx);
     return SUCCESS;
   }
-  if (auto role = GetRole(name)) {
+  if (role) {
     GrantDatabase(db, *role, system_tx);
     return SUCCESS;
   }
@@ -1502,13 +1506,17 @@ void Auth::GrantDatabase(const std::string &db, Role &role, system::Transaction 
   SaveRole(role, system_tx);
 }
 
-Auth::Result Auth::DenyDatabase(const std::string &db, const std::string &name, system::Transaction *system_tx) {
+Auth::Result Auth::DenyDatabase(const std::string &db, const std::string &name, UserOrRoleType type,
+                                system::Transaction *system_tx) {
   using enum Auth::Result;
-  if (auto user = GetUser(name)) {
+  auto user = (type != UserOrRoleType::ROLE) ? GetUser(name) : std::nullopt;
+  auto role = (type != UserOrRoleType::USER) ? GetRole(name) : std::nullopt;
+  if (user && role) throw AuthException("Ambiguous: '{}' is both a user and a role. Specify USER or ROLE.", name);
+  if (user) {
     DenyDatabase(db, *user, system_tx);
     return SUCCESS;
   }
-  if (auto role = GetRole(name)) {
+  if (role) {
     DenyDatabase(db, *role, system_tx);
     return SUCCESS;
   }
@@ -1533,13 +1541,17 @@ void Auth::DenyDatabase(const std::string &db, Role &role, system::Transaction *
   SaveRole(role, system_tx);
 }
 
-Auth::Result Auth::RevokeDatabase(const std::string &db, const std::string &name, system::Transaction *system_tx) {
+Auth::Result Auth::RevokeDatabase(const std::string &db, const std::string &name, UserOrRoleType type,
+                                  system::Transaction *system_tx) {
   using enum Auth::Result;
-  if (auto user = GetUser(name)) {
+  auto user = (type != UserOrRoleType::ROLE) ? GetUser(name) : std::nullopt;
+  auto role = (type != UserOrRoleType::USER) ? GetRole(name) : std::nullopt;
+  if (user && role) throw AuthException("Ambiguous: '{}' is both a user and a role. Specify USER or ROLE.", name);
+  if (user) {
     RevokeDatabase(db, *user, system_tx);
     return SUCCESS;
   }
-  if (auto role = GetRole(name)) {
+  if (role) {
     RevokeDatabase(db, *role, system_tx);
     return SUCCESS;
   }
@@ -1589,13 +1601,17 @@ void Auth::DeleteDatabase(const std::string &db, system::Transaction *system_tx)
   }
 }
 
-Auth::Result Auth::SetMainDatabase(std::string_view db, const std::string &name, system::Transaction *system_tx) {
+Auth::Result Auth::SetMainDatabase(std::string_view db, const std::string &name, UserOrRoleType type,
+                                   system::Transaction *system_tx) {
   using enum Auth::Result;
-  if (auto user = GetUser(name)) {
+  auto user = (type != UserOrRoleType::ROLE) ? GetUser(name) : std::nullopt;
+  auto role = (type != UserOrRoleType::USER) ? GetRole(name) : std::nullopt;
+  if (user && role) throw AuthException("Ambiguous: '{}' is both a user and a role. Specify USER or ROLE.", name);
+  if (user) {
     SetMainDatabase(db, *user, system_tx);
     return SUCCESS;
   }
-  if (auto role = GetRole(name)) {
+  if (role) {
     SetMainDatabase(db, *role, system_tx);
     return SUCCESS;
   }

--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -1288,45 +1288,21 @@ bool Auth::RemoveRole(const std::string &rolename_orig, system::Transaction *sys
   auto rolename = utils::ToLowerCase(rolename_orig);
   if (!storage_.Get(kRolePrefix + rolename)) return false;
 
-  // First, remove the role from all users who have it
+  // Reject deletion if any user has the role assigned (global or per-database)
   for (auto it = storage_.begin(kRoleLinkPrefix); it != storage_.end(kRoleLinkPrefix); ++it) {
-    auto username = it->first.substr(kRoleLinkPrefix.size());
-    bool needs_update = false;
-    nlohmann::json updated_roles;
-
     try {
-      // Parse as JSON array (V2 format)
       auto json_data = ParseJson(it->second);
-      if (!json_data.is_array()) {
-        spdlog::warn("Found invalid JSON in link format for user '{}'", username);
-        continue;
-      }
-      // V2 format: remove the role from the array
-      updated_roles = nlohmann::json::array();
-      for (const auto &role_name : json_data) {
-        if (role_name.is_string() && utils::ToLowerCase(role_name.get<std::string>()) != rolename) {
-          updated_roles.push_back(role_name);
-        } else if (role_name.is_string() && utils::ToLowerCase(role_name.get<std::string>()) == rolename) {
-          needs_update = true;
+      if (!json_data.is_array()) continue;
+      for (auto const &role_name : json_data) {
+        if (role_name.is_string() && utils::ToLowerCase(role_name.get<std::string>()) == rolename) {
+          auto username = it->first.substr(kRoleLinkPrefix.size());
+          throw AuthException("Cannot delete role '{}': it is assigned to user '{}'.", rolename, username);
         }
       }
-    } catch (const nlohmann::detail::exception &) {
-      // This shouldn't happen after V2 migration, but handle gracefully
-      spdlog::warn("Found invalid JSON in link format for user '{}', treating as single role", username);
+    } catch (AuthException const &) {
+      throw;
+    } catch (nlohmann::detail::exception const &) {
       continue;
-    }
-
-    if (needs_update) {
-      if (updated_roles.is_null()) {
-        // Remove the link entirely (old format or empty array)
-        storage_.Delete(it->first);
-      } else if (updated_roles.empty()) {
-        // Remove the link entirely (empty array)
-        storage_.Delete(it->first);
-      } else {
-        // Update with the remaining roles
-        storage_.Put(it->first, updated_roles.dump());
-      }
     }
   }
 
@@ -1334,24 +1310,13 @@ bool Auth::RemoveRole(const std::string &rolename_orig, system::Transaction *sys
     auto username = it->first.substr(kMtLinkPrefix.size());
     if (username != utils::ToLowerCase(username)) continue;
     auto json_data = ParseJson(it->second);
-    bool update = false;
-    for (auto &[db_name, role_names] : json_data.items()) {
-      if (role_names.is_array()) {
-        // Find and remove the role by index
-        for (size_t i = 0; i < role_names.size(); ++i) {
-          if (role_names[i].is_string() && utils::ToLowerCase(role_names[i].get<std::string>()) == rolename) {
-            role_names.erase(i);
-            update = true;
-            break;  // Remove only the first occurrence
-          }
+    for (auto const &[db_name, role_names] : json_data.items()) {
+      if (!role_names.is_array()) continue;
+      for (auto const &role_name : role_names) {
+        if (role_name.is_string() && utils::ToLowerCase(role_name.get<std::string>()) == rolename) {
+          throw AuthException(
+              "Cannot delete role '{}': it is assigned to user '{}' on database '{}'.", rolename, username, db_name);
         }
-      }
-    }
-    if (update) {
-      if (json_data.empty()) {
-        storage_.Delete(it->first);
-      } else {
-        storage_.Put(it->first, json_data.dump());
       }
     }
   }

--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -965,6 +965,13 @@ void Auth::InitialiseFirstUser(User &user, system::Transaction *system_tx) {
   for (auto const permission : kPermissionsAll) {
     user.permissions().Grant(permission);
   }
+  if (license::global_license_checker.IsEnterpriseValidFast()) {
+    constexpr auto kFullFineGrained = FineGrainedPermission::READ | FineGrainedPermission::UPDATE |
+                                      FineGrainedPermission::CREATE | FineGrainedPermission::DELETE;
+    user.fine_grained_access_handler().label_permissions().GrantGlobal(kFullFineGrained);
+    user.fine_grained_access_handler().edge_type_permissions().GrantGlobal(kFullFineGrained);
+    user.db_access().GrantAll();
+  }
   SaveUser(user, system_tx);
 }
 

--- a/src/auth/auth.hpp
+++ b/src/auth/auth.hpp
@@ -331,11 +331,13 @@ class Auth final {
    */
   std::optional<Role> AddRole(const std::string &rolename, system::Transaction *system_tx = nullptr);
 
+#ifdef MG_ENTERPRISE
   /**
    * Creates the built-in roles.
    * @return true if the roles were created, false if they already existed or license is invalid.
    */
   bool CreateBuiltinRoles(system::Transaction *system_tx = nullptr);
+#endif
 
   /**
    * Removes a role from the storage.

--- a/src/auth/auth.hpp
+++ b/src/auth/auth.hpp
@@ -192,6 +192,11 @@ class Auth final {
                               system::Transaction *system_tx = nullptr);
 
   /**
+   * Initializes the first user, which will be the super admin.
+   */
+  void InitialiseFirstUser(User &user, system::Transaction *system_tx = nullptr);
+
+  /**
    * Removes a user from the storage.
    *
    * @param username
@@ -325,6 +330,11 @@ class Auth final {
    * @throw AuthException if unable to save the role.
    */
   std::optional<Role> AddRole(const std::string &rolename, system::Transaction *system_tx = nullptr);
+
+  /**
+   * Creates the built-in roles.
+   */
+  void CreateBuiltinRoles(system::Transaction *system_tx = nullptr);
 
   /**
    * Removes a role from the storage.

--- a/src/auth/auth.hpp
+++ b/src/auth/auth.hpp
@@ -346,7 +346,7 @@ class Auth final {
    *         doesn't exist
    * @throw AuthException if unable to remove the role.
    */
-  bool RemoveRole(const std::string &rolename, system::Transaction *system_tx = nullptr);
+  bool RemoveRole(const std::string &rolename, bool force = false, system::Transaction *system_tx = nullptr);
 
   /**
    * Gets all roles from the storage.

--- a/src/auth/auth.hpp
+++ b/src/auth/auth.hpp
@@ -333,8 +333,9 @@ class Auth final {
 
   /**
    * Creates the built-in roles.
+   * @return true if the roles were created, false if they already existed or license is invalid.
    */
-  void CreateBuiltinRoles(system::Transaction *system_tx = nullptr);
+  bool CreateBuiltinRoles(system::Transaction *system_tx = nullptr);
 
   /**
    * Removes a role from the storage.

--- a/src/auth/auth.hpp
+++ b/src/auth/auth.hpp
@@ -383,7 +383,8 @@ class Auth final {
    * @return true on success
    * @throw AuthException if unable to find or update the user
    */
-  Result GrantDatabase(const std::string &db, const std::string &name, system::Transaction *system_tx = nullptr);
+  Result GrantDatabase(const std::string &db, const std::string &name, UserOrRoleType type,
+                       system::Transaction *system_tx = nullptr);
   void GrantDatabase(const std::string &db, User &user, system::Transaction *system_tx = nullptr);
   void GrantDatabase(const std::string &db, Role &role, system::Transaction *system_tx = nullptr);
 
@@ -395,7 +396,8 @@ class Auth final {
    * @return true on success
    * @throw AuthException if unable to find or update the user
    */
-  Result DenyDatabase(const std::string &db, const std::string &name, system::Transaction *system_tx = nullptr);
+  Result DenyDatabase(const std::string &db, const std::string &name, UserOrRoleType type,
+                      system::Transaction *system_tx = nullptr);
   void DenyDatabase(const std::string &db, User &user, system::Transaction *system_tx = nullptr);
   void DenyDatabase(const std::string &db, Role &role, system::Transaction *system_tx = nullptr);
 
@@ -407,7 +409,8 @@ class Auth final {
    * @return true on success
    * @throw AuthException if unable to find or update the user
    */
-  Result RevokeDatabase(const std::string &db, const std::string &name, system::Transaction *system_tx = nullptr);
+  Result RevokeDatabase(const std::string &db, const std::string &name, UserOrRoleType type,
+                        system::Transaction *system_tx = nullptr);
   void RevokeDatabase(const std::string &db, User &user, system::Transaction *system_tx = nullptr);
   void RevokeDatabase(const std::string &db, Role &role, system::Transaction *system_tx = nullptr);
 
@@ -427,7 +430,8 @@ class Auth final {
    * @return true on success
    * @throw AuthException if unable to find or update the user
    */
-  Result SetMainDatabase(std::string_view db, const std::string &name, system::Transaction *system_tx = nullptr);
+  Result SetMainDatabase(std::string_view db, const std::string &name, UserOrRoleType type,
+                         system::Transaction *system_tx = nullptr);
   void SetMainDatabase(std::string_view db, User &user, system::Transaction *system_tx = nullptr);
   void SetMainDatabase(std::string_view db, Role &role, system::Transaction *system_tx = nullptr);
 #endif

--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -1010,6 +1010,29 @@ void User::AddMultiTenantRole(Role role, const std::string &db_name) {
   roles_.AddRole(role);
 }
 
+void User::RemoveMultiTenantRole(const std::string &rolename, const std::string &db_name) {
+  auto db_it = db_role_map_.find(db_name);
+  if (db_it == db_role_map_.end() || !db_it->second.contains(rolename)) {
+    return;
+  }
+
+  role_db_map_[rolename].erase(db_name);
+  db_it->second.erase(rolename);
+  if (db_it->second.empty()) {
+    db_role_map_.erase(db_it);
+  }
+
+  auto role = roles_.GetRole(rolename);
+  if (!role) {
+    return;
+  }
+  roles_.RemoveRole(rolename);
+  if (role->db_access().GetGrants().size() > 1) {
+    role->db_access().Deny(db_name);
+    roles_.AddRole(*role);
+  }
+}
+
 void User::ClearMultiTenantRoles(const std::string &db_name) {
   // If role is specified on a database, that means it couldn't have been specified as a global role
   // In turn this means that we need to:

--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -773,13 +773,11 @@ Role Role::Deserialize(const nlohmann::json &data) {
   }
   auto role = Role{
       *role_name_it, permissions, std::move(fine_grained_access_handler), std::move(db_access), std::move(usr_imp)};
-  role.SetBuiltIn(is_builtin);
-  return role;
 #else
   auto role = Role{*role_name_it, permissions};
+#endif
   role.SetBuiltIn(is_builtin);
   return role;
-#endif
 }
 
 bool operator==(const Role &first, const Role &second) {

--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -25,6 +25,7 @@ namespace memgraph::auth {
 namespace {
 
 constexpr auto kRoleName = "rolename";
+constexpr auto kBuiltIn = "builtin";
 constexpr auto kPermissions = "permissions";
 constexpr auto kGrants = "grants";
 constexpr auto kDenies = "denies";
@@ -89,7 +90,6 @@ const std::vector<Permission> kPermissionsAll = {
     Permission::SERVER_SIDE_PARAMETERS,
     Permission::SERVER_SIDE_DESCRIPTIONS,
 };
-
 #ifdef MG_ENTERPRISE
 const FineGrainedAccessPermissions empty_permissions{};
 #endif
@@ -751,6 +751,7 @@ const FineGrainedAccessPermissions &Role::GetFineGrainedAccessEdgeTypePermission
 nlohmann::json Role::Serialize() const {
   nlohmann::json data = nlohmann::json::object();
   data[kRoleName] = rolename_;
+  data[kBuiltIn] = is_builtin_;
   data[kPermissions] = permissions_.Serialize();
 #ifdef MG_ENTERPRISE
   data[kFineGrainedPermissions] = fine_grained_access_handler_.Serialize();
@@ -773,6 +774,12 @@ Role Role::Deserialize(const nlohmann::json &data) {
     throw AuthException("Couldn't load role data!");
   }
   auto permissions = Permissions::Deserialize(*permissions_it);
+
+  bool is_builtin = false;
+  if (auto it = data.find(kBuiltIn); it != data.end() && it->is_boolean()) {
+    is_builtin = it->get<bool>();
+  }
+
 #ifdef MG_ENTERPRISE
   Databases db_access;
   auto db_access_it = data.find(kDatabases);
@@ -798,9 +805,14 @@ Role Role::Deserialize(const nlohmann::json &data) {
   } else {
     spdlog::warn("Role without impersonation information; defaulting to no impersonation ability.");
   }
-  return {*role_name_it, permissions, std::move(fine_grained_access_handler), std::move(db_access), std::move(usr_imp)};
+  auto role = Role{
+      *role_name_it, permissions, std::move(fine_grained_access_handler), std::move(db_access), std::move(usr_imp)};
+  role.SetBuiltIn(is_builtin);
+  return role;
 #else
-  return {*role_name_it, permissions};
+  auto role = Role{*role_name_it, permissions};
+  role.SetBuiltIn(is_builtin);
+  return role;
 #endif
 }
 

--- a/src/auth/models.cpp
+++ b/src/auth/models.cpp
@@ -56,40 +56,6 @@ constexpr auto kDenied = "denied";
 constexpr auto kMatching = "matching";
 #endif
 
-// Constant list of all available permissions.
-const std::vector<Permission> kPermissionsAll = {
-    Permission::MATCH,
-    Permission::CREATE,
-    Permission::MERGE,
-    Permission::DELETE,
-    Permission::SET,
-    Permission::REMOVE,
-    Permission::INDEX,
-    Permission::STATS,
-    Permission::CONSTRAINT,
-    Permission::DUMP,
-    Permission::AUTH,
-    Permission::REPLICATION,
-    Permission::DURABILITY,
-    Permission::READ_FILE,
-    Permission::FREE_MEMORY,
-    Permission::TRIGGER,
-    Permission::CONFIG,
-    Permission::STREAM,
-    Permission::MODULE_READ,
-    Permission::MODULE_WRITE,
-    Permission::WEBSOCKET,
-    Permission::TRANSACTION_MANAGEMENT,
-    Permission::STORAGE_MODE,
-    Permission::MULTI_DATABASE_EDIT,
-    Permission::MULTI_DATABASE_USE,
-    Permission::COORDINATOR,
-    Permission::IMPERSONATE_USER,
-    Permission::PROFILE_RESTRICTION,
-    Permission::PARALLEL_EXECUTION,
-    Permission::SERVER_SIDE_PARAMETERS,
-    Permission::SERVER_SIDE_DESCRIPTIONS,
-};
 #ifdef MG_ENTERPRISE
 const FineGrainedAccessPermissions empty_permissions{};
 #endif

--- a/src/auth/models.hpp
+++ b/src/auth/models.hpp
@@ -785,6 +785,7 @@ class User final {
 // Multi-tenant role support
 #ifdef MG_ENTERPRISE
   void AddMultiTenantRole(Role role, const std::string &db_name);
+  void RemoveMultiTenantRole(const std::string &rolename, const std::string &db_name);
   void ClearMultiTenantRoles(const std::string &db_name);
 #endif
 

--- a/src/auth/models.hpp
+++ b/src/auth/models.hpp
@@ -37,10 +37,13 @@
 
 namespace memgraph::auth {
 
+// Used to disambiguate commands that accept either a USER or ROLE argument in
+// cases where there exists both a user and role with the same name, which
+// is allowed since we split these into two namespaces in 3.10.
 enum class UserOrRoleType {
-  UNSPECIFIED,
-  USER,
-  ROLE,
+  UNSPECIFIED,  // Neither USER nor ROLE was explicitly specified; both are checked and an error is thrown if ambiguous.
+  USER,         // Explicitly specified as a USER; only the user namespace is checked.
+  ROLE,         // Explicitly specified as a ROLE; only the role namespace is checked.
 };
 
 // These permissions must have values that are applicable for usage in a

--- a/src/auth/models.hpp
+++ b/src/auth/models.hpp
@@ -74,6 +74,41 @@ enum class Permission : uint64_t {
 };
 // clang-format on
 
+// clang-format off
+inline constexpr std::array kPermissionsAll = {
+    Permission::MATCH,
+    Permission::CREATE,
+    Permission::MERGE,
+    Permission::DELETE,
+    Permission::SET,
+    Permission::REMOVE,
+    Permission::INDEX,
+    Permission::STATS,
+    Permission::CONSTRAINT,
+    Permission::DUMP,
+    Permission::AUTH,
+    Permission::REPLICATION,
+    Permission::DURABILITY,
+    Permission::READ_FILE,
+    Permission::FREE_MEMORY,
+    Permission::TRIGGER,
+    Permission::CONFIG,
+    Permission::STREAM,
+    Permission::MODULE_READ,
+    Permission::MODULE_WRITE,
+    Permission::WEBSOCKET,
+    Permission::TRANSACTION_MANAGEMENT,
+    Permission::STORAGE_MODE,
+    Permission::MULTI_DATABASE_EDIT,
+    Permission::MULTI_DATABASE_USE,
+    Permission::COORDINATOR,
+    Permission::IMPERSONATE_USER,
+    Permission::PROFILE_RESTRICTION,
+    Permission::PARALLEL_EXECUTION,
+    Permission::SERVER_SIDE_PARAMETERS,
+};
+// clang-format on
+
 #ifdef MG_ENTERPRISE
 // clang-format off
 enum class FineGrainedPermission : uint64_t {
@@ -556,6 +591,10 @@ class Role {
 
   // Profile management moved to UserProfiles class
 
+  bool IsBuiltIn() const { return is_builtin_; }
+
+  void SetBuiltIn(bool value) { is_builtin_ = value; }
+
   nlohmann::json Serialize() const;
 
   /// @throw AuthException if unable to deserialize.
@@ -566,6 +605,7 @@ class Role {
  private:
   std::string rolename_;
   Permissions permissions_;
+  bool is_builtin_{false};
 #ifdef MG_ENTERPRISE
   FineGrainedAccessHandler fine_grained_access_handler_;
   Databases db_access_;

--- a/src/auth/models.hpp
+++ b/src/auth/models.hpp
@@ -113,6 +113,7 @@ inline constexpr std::array kPermissionsAll = {
     Permission::PROFILE_RESTRICTION,
     Permission::PARALLEL_EXECUTION,
     Permission::SERVER_SIDE_PARAMETERS,
+    Permission::SERVER_SIDE_DESCRIPTIONS,
 };
 // clang-format on
 

--- a/src/auth/models.hpp
+++ b/src/auth/models.hpp
@@ -36,6 +36,13 @@
 #include "utils/uuid.hpp"
 
 namespace memgraph::auth {
+
+enum class UserOrRoleType {
+  UNSPECIFIED,
+  USER,
+  ROLE,
+};
+
 // These permissions must have values that are applicable for usage in a
 // bitmask.
 // clang-format off

--- a/src/glue/auth_handler.cpp
+++ b/src/glue/auth_handler.cpp
@@ -10,6 +10,7 @@
 // licenses/APL.txt.
 
 #include "glue/auth_handler.hpp"
+#include <algorithm>
 #include <range/v3/all.hpp>
 
 #include <optional>
@@ -533,6 +534,16 @@ std::vector<std::vector<memgraph::query::TypedValue>> AuthQueryHandler::GetDatab
   try {
     auto locked_auth = auth_->ReadLock();
     auto local_user = (type != auth::UserOrRoleType::ROLE) ? locked_auth->GetUser(user) : std::nullopt;
+    auto has_role = [&](const std::vector<std::string> &role_names) {
+      return ranges::any_of(role_names,
+                            [&](const auto &role_name) { return locked_auth->GetRole(role_name).has_value(); });
+    };
+
+    if (type == auth::UserOrRoleType::UNSPECIFIED && local_user && has_role(roles)) {
+      throw memgraph::query::QueryRuntimeException("Ambiguous: '{}' is both a user and a role. Specify USER or ROLE.",
+                                                   user);
+    }
+
     if (local_user) {
       return ShowDatabasePrivileges(local_user);
     }
@@ -591,10 +602,19 @@ void AuthQueryHandler::DeleteDatabase(std::string_view db_name, system::Transact
   }
 }
 
-std::optional<std::string> AuthQueryHandler::GetMainDatabase(const std::string &user_or_role) {
+std::optional<std::string> AuthQueryHandler::GetMainDatabase(const std::string &user_or_role,
+                                                             auth::UserOrRoleType type) {
   try {
     auto locked_auth = auth_->ReadLock();
-    if (auto user = locked_auth->GetUser(user_or_role)) {
+    auto user = (type != auth::UserOrRoleType::ROLE) ? locked_auth->GetUser(user_or_role) : std::nullopt;
+    auto role = (type != auth::UserOrRoleType::USER) ? locked_auth->GetRole(user_or_role) : std::nullopt;
+
+    if (type == auth::UserOrRoleType::UNSPECIFIED && user && role) {
+      throw memgraph::query::QueryRuntimeException("Ambiguous: '{}' is both a user and a role. Specify USER or ROLE.",
+                                                   user_or_role);
+    }
+
+    if (user) {
       try {
         return user->GetMain();
       } catch (const memgraph::auth::AuthException &) {
@@ -602,7 +622,7 @@ std::optional<std::string> AuthQueryHandler::GetMainDatabase(const std::string &
       }
     }
 
-    if (auto role = locked_auth->GetRole(user_or_role)) {
+    if (role) {
       try {
         return role->GetMain();
       } catch (const memgraph::auth::AuthException &) {

--- a/src/glue/auth_handler.cpp
+++ b/src/glue/auth_handler.cpp
@@ -402,18 +402,20 @@ namespace memgraph::glue {
 
 AuthQueryHandler::AuthQueryHandler(memgraph::auth::SynchedAuth *auth) : auth_(auth) {}
 
-bool AuthQueryHandler::CreateUser(const std::string &username, const std::optional<std::string> &password,
-                                  system::Transaction *system_tx) {
+query::CreateUserResult AuthQueryHandler::CreateUser(const std::string &username,
+                                                     const std::optional<std::string> &password,
+                                                     system::Transaction *system_tx) {
   try {
     auto locked_auth = auth_->Lock();
     const auto first_user = !locked_auth->HasUsers();
 
     auto new_user = locked_auth->AddUser(username, password, system_tx);
+    bool builtin_roles_created = false;
     if (first_user && new_user) {
-      locked_auth->CreateBuiltinRoles(system_tx);
+      builtin_roles_created = locked_auth->CreateBuiltinRoles(system_tx);
       locked_auth->InitialiseFirstUser(*new_user, system_tx);
     }
-    return new_user.has_value();
+    return {new_user.has_value(), builtin_roles_created};
   } catch (const memgraph::auth::AuthException &e) {
     throw memgraph::query::QueryRuntimeException(e.what());
   }

--- a/src/glue/auth_handler.cpp
+++ b/src/glue/auth_handler.cpp
@@ -749,7 +749,7 @@ void AuthQueryHandler::SetRoles(const std::string &username, const std::vector<s
   }
 }
 
-void AuthQueryHandler::ClearRoles(const std::string &username, const std::vector<std::string> &roles,
+void AuthQueryHandler::ClearRoles(const std::string &username, const std::vector<std::string> &,
                                   const std::unordered_set<std::string> &role_databases,
                                   system::Transaction *system_tx) {
   try {
@@ -762,26 +762,14 @@ void AuthQueryHandler::ClearRoles(const std::string &username, const std::vector
 #ifdef MG_ENTERPRISE
     if (!role_databases.empty()) {
       for (const auto &db_name : role_databases) {
-        if (roles.empty()) {
-          user->ClearMultiTenantRoles(db_name);
-        } else {
-          for (const auto &rolename : roles) {
-            user->RemoveMultiTenantRole(rolename, db_name);
-          }
-        }
+        user->ClearMultiTenantRoles(db_name);
       }
       locked_auth->SaveUser(*user, system_tx);
       return;
     }
 #endif
 
-    if (roles.empty()) {
-      user->ClearAllRoles();
-    } else {
-      for (const auto &rolename : roles) {
-        user->RemoveRole(rolename);
-      }
-    }
+    user->ClearAllRoles();
     locked_auth->SaveUser(*user, system_tx);
   } catch (const memgraph::auth::AuthException &e) {
     throw memgraph::query::QueryRuntimeException(e.what());

--- a/src/glue/auth_handler.cpp
+++ b/src/glue/auth_handler.cpp
@@ -641,14 +641,14 @@ std::vector<memgraph::query::TypedValue> AuthQueryHandler::GetUsernames() {
   }
 }
 
-std::vector<memgraph::query::TypedValue> AuthQueryHandler::GetRolenames() {
+std::vector<std::pair<std::string, bool>> AuthQueryHandler::GetRolenames() {
   try {
     auto locked_auth = auth_->ReadLock();
-    std::vector<memgraph::query::TypedValue> rolenames;
+    std::vector<std::pair<std::string, bool>> rolenames;
     const auto &roles = locked_auth->AllRoles();
     rolenames.reserve(roles.size());
     for (const auto &role : roles) {
-      rolenames.emplace_back(role.rolename());
+      rolenames.emplace_back(role.rolename(), role.IsBuiltIn());
     }
     return rolenames;
   } catch (const memgraph::auth::AuthException &e) {
@@ -656,8 +656,8 @@ std::vector<memgraph::query::TypedValue> AuthQueryHandler::GetRolenames() {
   }
 }
 
-std::vector<std::string> AuthQueryHandler::GetRolenamesForUser(const std::string &username,
-                                                               std::optional<std::string> db_name) {
+std::vector<std::pair<std::string, bool>> AuthQueryHandler::GetRolenamesForUser(const std::string &username,
+                                                                                std::optional<std::string> db_name) {
   try {
     auto locked_auth = auth_->ReadLock();
     auto user = locked_auth->GetUser(username);
@@ -665,18 +665,17 @@ std::vector<std::string> AuthQueryHandler::GetRolenamesForUser(const std::string
       throw query::QueryRuntimeException("User '{}' doesn't exist.", username);
     }
 
-    std::vector<std::string> rolenames;
+    std::vector<std::pair<std::string, bool>> rolenames;
     auto roles = user->roles().GetRoles();
 #ifdef MG_ENTERPRISE
     if (db_name) {
-      // Get roles filtered by database
       roles = user->GetMultiTenantRoles(db_name.value());
     }
 #endif
     if (!roles.empty()) {
       rolenames.reserve(roles.size());
       for (const auto &role : roles) {
-        rolenames.emplace_back(role.rolename());
+        rolenames.emplace_back(role.rolename(), role.IsBuiltIn());
       }
     }
     return rolenames;

--- a/src/glue/auth_handler.cpp
+++ b/src/glue/auth_handler.cpp
@@ -411,12 +411,17 @@ query::CreateUserResult AuthQueryHandler::CreateUser(const std::string &username
     const auto first_user = !locked_auth->HasUsers();
 
     auto new_user = locked_auth->AddUser(username, password, system_tx);
-    bool builtin_roles_created = false;
     if (first_user && new_user) {
-      builtin_roles_created = locked_auth->CreateBuiltinRoles(system_tx);
+#ifdef MG_ENTERPRISE
+      bool const builtin_roles_created = locked_auth->CreateBuiltinRoles(system_tx);
       locked_auth->InitialiseFirstUser(*new_user, system_tx);
+      return {
+          .created = new_user.has_value(), .first_user = first_user, .builtin_roles_created = builtin_roles_created};
+#else
+      locked_auth->InitialiseFirstUser(*new_user, system_tx);
+#endif
     }
-    return {.created = new_user.has_value(), .first_user = first_user, .builtin_roles_created = builtin_roles_created};
+    return {.created = new_user.has_value(), .first_user = first_user};
   } catch (const memgraph::auth::AuthException &e) {
     throw memgraph::query::QueryRuntimeException(e.what());
   }
@@ -783,8 +788,7 @@ void AuthQueryHandler::SetRoles(const std::string &username, const std::vector<s
   }
 }
 
-void AuthQueryHandler::ClearRoles(const std::string &username, const std::vector<std::string> &,
-                                  const std::unordered_set<std::string> &role_databases,
+void AuthQueryHandler::ClearRoles(const std::string &username, const std::unordered_set<std::string> &role_databases,
                                   system::Transaction *system_tx) {
   try {
     auto locked_auth = auth_->Lock();

--- a/src/glue/auth_handler.cpp
+++ b/src/glue/auth_handler.cpp
@@ -415,7 +415,7 @@ query::CreateUserResult AuthQueryHandler::CreateUser(const std::string &username
       builtin_roles_created = locked_auth->CreateBuiltinRoles(system_tx);
       locked_auth->InitialiseFirstUser(*new_user, system_tx);
     }
-    return {.created = new_user.has_value(), .builtin_roles_created = builtin_roles_created};
+    return {.created = new_user.has_value(), .first_user = first_user, .builtin_roles_created = builtin_roles_created};
   } catch (const memgraph::auth::AuthException &e) {
     throw memgraph::query::QueryRuntimeException(e.what());
   }

--- a/src/glue/auth_handler.cpp
+++ b/src/glue/auth_handler.cpp
@@ -613,7 +613,7 @@ bool AuthQueryHandler::DropRole(const std::string &rolename, system::Transaction
       return false;
     };
 
-    return locked_auth->RemoveRole(rolename, system_tx);
+    return locked_auth->RemoveRole(rolename, false, system_tx);
   } catch (const memgraph::auth::AuthException &e) {
     throw memgraph::query::QueryRuntimeException(e.what());
   }

--- a/src/glue/auth_handler.cpp
+++ b/src/glue/auth_handler.cpp
@@ -410,11 +410,7 @@ bool AuthQueryHandler::CreateUser(const std::string &username, const std::option
 
     auto new_user = locked_auth->AddUser(username, password, system_tx);
     if (first_user && new_user) {
-#ifdef MG_ENTERPRISE
-      if (locked_auth->AllRoles().empty()) {
-        locked_auth->CreateBuiltinRoles(system_tx);
-      }
-#endif
+      locked_auth->CreateBuiltinRoles(system_tx);
       locked_auth->InitialiseFirstUser(*new_user, system_tx);
     }
     return new_user.has_value();

--- a/src/glue/auth_handler.cpp
+++ b/src/glue/auth_handler.cpp
@@ -405,41 +405,19 @@ AuthQueryHandler::AuthQueryHandler(memgraph::auth::SynchedAuth *auth) : auth_(au
 bool AuthQueryHandler::CreateUser(const std::string &username, const std::optional<std::string> &password,
                                   system::Transaction *system_tx) {
   try {
-    const auto [first_user, user_added] = std::invoke([&, this] {
-      auto locked_auth = auth_->Lock();
-      const auto first_user = !locked_auth->HasUsers();
-      const auto user_added = locked_auth->AddUser(username, password, system_tx).has_value();
-      return std::make_pair(first_user, user_added);
-    });
+    auto locked_auth = auth_->Lock();
+    const auto first_user = !locked_auth->HasUsers();
 
-    if (first_user) {
-      spdlog::info(
-          "{} is the first created user. Granting all privileges. The official advice and intention is to use this "
-          "first user as the superuser with full privileges and capabilities on the Memgraph database.",
-          username);
-      GrantPrivilege(username,
-                     memgraph::query::kPrivilegesAll
+    auto new_user = locked_auth->AddUser(username, password, system_tx);
+    if (first_user && new_user) {
 #ifdef MG_ENTERPRISE
-                     ,
-                     {{{memgraph::query::AuthQuery::FineGrainedPrivilege::READ, {memgraph::query::kAsterisk}},
-                       {memgraph::query::AuthQuery::FineGrainedPrivilege::UPDATE, {memgraph::query::kAsterisk}},
-                       {memgraph::query::AuthQuery::FineGrainedPrivilege::CREATE, {memgraph::query::kAsterisk}},
-                       {memgraph::query::AuthQuery::FineGrainedPrivilege::DELETE, {memgraph::query::kAsterisk}}}},
-                     {memgraph::query::AuthQuery::LabelMatchingMode::ANY},
-                     {{{memgraph::query::AuthQuery::FineGrainedPrivilege::READ, {memgraph::query::kAsterisk}},
-                       {memgraph::query::AuthQuery::FineGrainedPrivilege::UPDATE, {memgraph::query::kAsterisk}},
-                       {memgraph::query::AuthQuery::FineGrainedPrivilege::CREATE, {memgraph::query::kAsterisk}},
-                       {memgraph::query::AuthQuery::FineGrainedPrivilege::DELETE, {memgraph::query::kAsterisk}}}}
+      if (locked_auth->AllRoles().empty()) {
+        locked_auth->CreateBuiltinRoles(system_tx);
+      }
 #endif
-                     ,
-                     system_tx);
-#ifdef MG_ENTERPRISE
-      GrantDatabase(auth::kAllDatabases, username, system_tx);
-      SetMainDatabase(dbms::kDefaultDB, username, system_tx);
-#endif
+      locked_auth->InitialiseFirstUser(*new_user, system_tx);
     }
-
-    return user_added;
+    return new_user.has_value();
   } catch (const memgraph::auth::AuthException &e) {
     throw memgraph::query::QueryRuntimeException(e.what());
   }
@@ -1091,6 +1069,7 @@ void AuthQueryHandler::EditPermissions(
 #endif
       locked_auth->SaveUser(*user, system_tx);
     } else if (auto role = locked_auth->GetRole(user_or_role)) {
+      role->SetBuiltIn(false);
       for (const auto &permission : permissions) {
         edit_permissions_fun(role->permissions(), permission);
       }

--- a/src/glue/auth_handler.cpp
+++ b/src/glue/auth_handler.cpp
@@ -788,6 +788,75 @@ void AuthQueryHandler::ClearRoles(const std::string &username, const std::vector
   }
 }
 
+void AuthQueryHandler::AddRoles(const std::string &username, const std::vector<std::string> &roles,
+                                const std::unordered_set<std::string> &role_databases, system::Transaction *system_tx) {
+  try {
+    auto locked_auth = auth_->Lock();
+    auto user = locked_auth->GetUser(username);
+    if (!user) {
+      throw memgraph::query::QueryRuntimeException("User '{}' doesn't exist.", username);
+    }
+
+#ifdef MG_ENTERPRISE
+    if (!role_databases.empty()) {
+      for (const auto &db_name : role_databases) {
+        for (const auto &rolename : roles) {
+          auto role = locked_auth->GetRole(rolename);
+          if (!role) {
+            throw memgraph::query::QueryRuntimeException("Role '{}' doesn't exist.", rolename);
+          }
+          user->AddMultiTenantRole(*role, db_name);
+        }
+      }
+      locked_auth->SaveUser(*user, system_tx);
+      return;
+    }
+#endif
+
+    for (const auto &rolename : roles) {
+      auto role = locked_auth->GetRole(rolename);
+      if (!role) {
+        throw memgraph::query::QueryRuntimeException("Role '{}' doesn't exist.", rolename);
+      }
+      user->AddRole(*role);
+    }
+    locked_auth->SaveUser(*user, system_tx);
+  } catch (const memgraph::auth::AuthException &e) {
+    throw memgraph::query::QueryRuntimeException(e.what());
+  }
+}
+
+void AuthQueryHandler::RevokeRoles(const std::string &username, const std::vector<std::string> &roles,
+                                   const std::unordered_set<std::string> &role_databases,
+                                   system::Transaction *system_tx) {
+  try {
+    auto locked_auth = auth_->Lock();
+    auto user = locked_auth->GetUser(username);
+    if (!user) {
+      throw memgraph::query::QueryRuntimeException("User '{}' doesn't exist.", username);
+    }
+
+#ifdef MG_ENTERPRISE
+    if (!role_databases.empty()) {
+      for (const auto &db_name : role_databases) {
+        for (const auto &rolename : roles) {
+          user->RemoveMultiTenantRole(rolename, db_name);
+        }
+      }
+      locked_auth->SaveUser(*user, system_tx);
+      return;
+    }
+#endif
+
+    for (const auto &rolename : roles) {
+      user->RemoveRole(rolename);
+    }
+    locked_auth->SaveUser(*user, system_tx);
+  } catch (const memgraph::auth::AuthException &e) {
+    throw memgraph::query::QueryRuntimeException(e.what());
+  }
+}
+
 void AuthQueryHandler::RemoveRole(const std::string &username, const std::string &rolename,
                                   system::Transaction *system_tx) {
   try {

--- a/src/glue/auth_handler.cpp
+++ b/src/glue/auth_handler.cpp
@@ -529,23 +529,36 @@ void AuthQueryHandler::RevokeDatabase(const std::string &db_name, const std::str
 }
 
 std::vector<std::vector<memgraph::query::TypedValue>> AuthQueryHandler::GetDatabasePrivileges(
-    const std::string &user, const std::vector<std::string> &roles) {
+    const std::string &user, const std::vector<std::string> &roles, auth::UserOrRoleType type) {
   try {
     auto locked_auth = auth_->ReadLock();
-    if (auto local_user = locked_auth->GetUser(user)) {
+    auto local_user = (type != auth::UserOrRoleType::ROLE) ? locked_auth->GetUser(user) : std::nullopt;
+    if (local_user) {
       return ShowDatabasePrivileges(local_user);
     }
-    // User doesn't exist, check if any of the roles exist (this can happen when auth module is used)
+
+    // User doesn't exist, check if any of the roles exist (this can happen when auth module is used).
     std::optional<memgraph::auth::Roles> roles_obj;
-    for (const auto &role : roles) {
-      if (auto role_obj = locked_auth->GetRole(role)) {
-        if (!roles_obj) roles_obj.emplace();
-        roles_obj->AddRole(std::move(*role_obj));
+    if (type != auth::UserOrRoleType::USER) {
+      for (const auto &role : roles) {
+        if (auto role_obj = locked_auth->GetRole(role)) {
+          if (!roles_obj) roles_obj.emplace();
+          roles_obj->AddRole(std::move(*role_obj));
+        }
       }
     }
     if (roles_obj) {
       return ShowDatabasePrivileges(roles_obj);
     }
+
+    if (type == auth::UserOrRoleType::USER) {
+      throw memgraph::query::QueryRuntimeException("Missing user '{}'.", user);
+    }
+    if (type == auth::UserOrRoleType::ROLE) {
+      throw memgraph::query::QueryRuntimeException("Missing one of roles: {}.",
+                                                   memgraph::utils::JoinVector(roles, ", "));
+    }
+
     throw memgraph::query::QueryRuntimeException(
         "Missing user '{}' or one of role: {}.", user, memgraph::utils::JoinVector(roles, ", "));
   } catch (const memgraph::auth::AuthException &e) {

--- a/src/glue/auth_handler.cpp
+++ b/src/glue/auth_handler.cpp
@@ -775,7 +775,8 @@ void AuthQueryHandler::SetRoles(const std::string &username, const std::vector<s
   }
 }
 
-void AuthQueryHandler::ClearRoles(const std::string &username, const std::unordered_set<std::string> &role_databases,
+void AuthQueryHandler::ClearRoles(const std::string &username, const std::vector<std::string> &roles,
+                                  const std::unordered_set<std::string> &role_databases,
                                   system::Transaction *system_tx) {
   try {
     auto locked_auth = auth_->Lock();
@@ -785,18 +786,28 @@ void AuthQueryHandler::ClearRoles(const std::string &username, const std::unorde
     }
 
 #ifdef MG_ENTERPRISE
-    // Multi-tenant support
     if (!role_databases.empty()) {
       for (const auto &db_name : role_databases) {
-        user->ClearMultiTenantRoles(db_name);
+        if (roles.empty()) {
+          user->ClearMultiTenantRoles(db_name);
+        } else {
+          for (const auto &rolename : roles) {
+            user->RemoveMultiTenantRole(rolename, db_name);
+          }
+        }
       }
       locked_auth->SaveUser(*user, system_tx);
       return;
     }
 #endif
 
-    // Clear all roles (default behavior)
-    user->ClearAllRoles();
+    if (roles.empty()) {
+      user->ClearAllRoles();
+    } else {
+      for (const auto &rolename : roles) {
+        user->RemoveRole(rolename);
+      }
+    }
     locked_auth->SaveUser(*user, system_tx);
   } catch (const memgraph::auth::AuthException &e) {
     throw memgraph::query::QueryRuntimeException(e.what());

--- a/src/glue/auth_handler.cpp
+++ b/src/glue/auth_handler.cpp
@@ -559,7 +559,7 @@ std::vector<std::vector<memgraph::query::TypedValue>> AuthQueryHandler::GetDatab
       for (const auto &role : roles) {
         if (auto role_obj = locked_auth->GetRole(role)) {
           if (!roles_obj) roles_obj.emplace();
-          roles_obj->AddRole(std::move(*role_obj));
+          roles_obj->AddRole(*role_obj);
         }
       }
     }
@@ -696,8 +696,8 @@ std::vector<query::RolenameResult> AuthQueryHandler::GetRolenames() {
   }
 }
 
-std::vector<query::RolenameResult> AuthQueryHandler::GetRolenamesForUser(const std::string &username,
-                                                                         std::optional<std::string> db_name) {
+std::vector<query::RolenameResult> AuthQueryHandler::GetRolenamesForUser(
+    const std::string &username, [[maybe_unused]] std::optional<std::string> db_name) {
   try {
     auto locked_auth = auth_->ReadLock();
     auto user = locked_auth->GetUser(username);
@@ -815,7 +815,8 @@ void AuthQueryHandler::ClearRoles(const std::string &username, const std::unorde
 }
 
 void AuthQueryHandler::AddRoles(const std::string &username, const std::vector<std::string> &roles,
-                                const std::unordered_set<std::string> &role_databases, system::Transaction *system_tx) {
+                                [[maybe_unused]] const std::unordered_set<std::string> &role_databases,
+                                system::Transaction *system_tx) {
   try {
     auto locked_auth = auth_->Lock();
     auto user = locked_auth->GetUser(username);
@@ -853,7 +854,7 @@ void AuthQueryHandler::AddRoles(const std::string &username, const std::vector<s
 }
 
 void AuthQueryHandler::RevokeRoles(const std::string &username, const std::vector<std::string> &roles,
-                                   const std::unordered_set<std::string> &role_databases,
+                                   [[maybe_unused]] const std::unordered_set<std::string> &role_databases,
                                    system::Transaction *system_tx) {
   try {
     auto locked_auth = auth_->Lock();

--- a/src/glue/auth_handler.cpp
+++ b/src/glue/auth_handler.cpp
@@ -415,7 +415,7 @@ query::CreateUserResult AuthQueryHandler::CreateUser(const std::string &username
       builtin_roles_created = locked_auth->CreateBuiltinRoles(system_tx);
       locked_auth->InitialiseFirstUser(*new_user, system_tx);
     }
-    return {new_user.has_value(), builtin_roles_created};
+    return {.created = new_user.has_value(), .builtin_roles_created = builtin_roles_created};
   } catch (const memgraph::auth::AuthException &e) {
     throw memgraph::query::QueryRuntimeException(e.what());
   }

--- a/src/glue/auth_handler.cpp
+++ b/src/glue/auth_handler.cpp
@@ -535,8 +535,8 @@ std::vector<std::vector<memgraph::query::TypedValue>> AuthQueryHandler::GetDatab
     auto locked_auth = auth_->ReadLock();
     auto local_user = (type != auth::UserOrRoleType::ROLE) ? locked_auth->GetUser(user) : std::nullopt;
     auto has_role = [&](const std::vector<std::string> &role_names) {
-      return ranges::any_of(role_names,
-                            [&](const auto &role_name) { return locked_auth->GetRole(role_name).has_value(); });
+      return std::ranges::any_of(role_names,
+                                 [&](const auto &role_name) { return locked_auth->GetRole(role_name).has_value(); });
     };
 
     if (type == auth::UserOrRoleType::UNSPECIFIED && local_user && has_role(roles)) {

--- a/src/glue/auth_handler.cpp
+++ b/src/glue/auth_handler.cpp
@@ -676,10 +676,10 @@ std::vector<memgraph::query::TypedValue> AuthQueryHandler::GetUsernames() {
   }
 }
 
-std::vector<std::pair<std::string, bool>> AuthQueryHandler::GetRolenames() {
+std::vector<query::RolenameResult> AuthQueryHandler::GetRolenames() {
   try {
     auto locked_auth = auth_->ReadLock();
-    std::vector<std::pair<std::string, bool>> rolenames;
+    std::vector<query::RolenameResult> rolenames;
     const auto &roles = locked_auth->AllRoles();
     rolenames.reserve(roles.size());
     for (const auto &role : roles) {
@@ -691,8 +691,8 @@ std::vector<std::pair<std::string, bool>> AuthQueryHandler::GetRolenames() {
   }
 }
 
-std::vector<std::pair<std::string, bool>> AuthQueryHandler::GetRolenamesForUser(const std::string &username,
-                                                                                std::optional<std::string> db_name) {
+std::vector<query::RolenameResult> AuthQueryHandler::GetRolenamesForUser(const std::string &username,
+                                                                         std::optional<std::string> db_name) {
   try {
     auto locked_auth = auth_->ReadLock();
     auto user = locked_auth->GetUser(username);
@@ -700,7 +700,7 @@ std::vector<std::pair<std::string, bool>> AuthQueryHandler::GetRolenamesForUser(
       throw query::QueryRuntimeException("User '{}' doesn't exist.", username);
     }
 
-    std::vector<std::pair<std::string, bool>> rolenames;
+    std::vector<query::RolenameResult> rolenames;
     auto roles = user->roles().GetRoles();
 #ifdef MG_ENTERPRISE
     if (db_name) {

--- a/src/glue/auth_handler.cpp
+++ b/src/glue/auth_handler.cpp
@@ -480,10 +480,10 @@ bool AuthQueryHandler::CreateRole(const std::string &rolename, system::Transacti
 
 #ifdef MG_ENTERPRISE
 void AuthQueryHandler::GrantDatabase(const std::string &db_name, const std::string &user_or_role,
-                                     system::Transaction *system_tx) {
+                                     auth::UserOrRoleType type, system::Transaction *system_tx) {
   try {
     auto locked_auth = auth_->Lock();
-    const auto res = locked_auth->GrantDatabase(db_name, user_or_role, system_tx);
+    const auto res = locked_auth->GrantDatabase(db_name, user_or_role, type, system_tx);
     switch (res) {
       using enum auth::Auth::Result;
       case SUCCESS:
@@ -497,10 +497,10 @@ void AuthQueryHandler::GrantDatabase(const std::string &db_name, const std::stri
 }
 
 void AuthQueryHandler::DenyDatabase(const std::string &db_name, const std::string &user_or_role,
-                                    system::Transaction *system_tx) {
+                                    auth::UserOrRoleType type, system::Transaction *system_tx) {
   try {
     auto locked_auth = auth_->Lock();
-    const auto res = locked_auth->DenyDatabase(db_name, user_or_role, system_tx);
+    const auto res = locked_auth->DenyDatabase(db_name, user_or_role, type, system_tx);
     switch (res) {
       using enum auth::Auth::Result;
       case SUCCESS:
@@ -514,10 +514,10 @@ void AuthQueryHandler::DenyDatabase(const std::string &db_name, const std::strin
 }
 
 void AuthQueryHandler::RevokeDatabase(const std::string &db_name, const std::string &user_or_role,
-                                      system::Transaction *system_tx) {
+                                      auth::UserOrRoleType type, system::Transaction *system_tx) {
   try {
     auto locked_auth = auth_->Lock();
-    const auto res = locked_auth->RevokeDatabase(db_name, user_or_role, system_tx);
+    const auto res = locked_auth->RevokeDatabase(db_name, user_or_role, type, system_tx);
     switch (res) {
       using enum auth::Auth::Result;
       case SUCCESS:
@@ -556,10 +556,10 @@ std::vector<std::vector<memgraph::query::TypedValue>> AuthQueryHandler::GetDatab
 }
 
 void AuthQueryHandler::SetMainDatabase(std::string_view db_name, const std::string &user_or_role,
-                                       system::Transaction *system_tx) {
+                                       auth::UserOrRoleType type, system::Transaction *system_tx) {
   try {
     auto locked_auth = auth_->Lock();
-    const auto res = locked_auth->SetMainDatabase(db_name, user_or_role, system_tx);
+    const auto res = locked_auth->SetMainDatabase(db_name, user_or_role, type, system_tx);
     switch (res) {
       using enum auth::Auth::Result;
       case SUCCESS:
@@ -822,21 +822,26 @@ void AuthQueryHandler::RemoveRole(const std::string &username, const std::string
 }
 
 std::vector<std::vector<memgraph::query::TypedValue>> AuthQueryHandler::GetPrivileges(
-    const std::string &user_or_role, std::optional<std::string> db_name) {
+    const std::string &user_or_role, std::optional<std::string> db_name, auth::UserOrRoleType type) {
   try {
     auto locked_auth = auth_->ReadLock();
+    auto user = (type != auth::UserOrRoleType::ROLE) ? locked_auth->GetUser(user_or_role) : std::nullopt;
+    auto role = (type != auth::UserOrRoleType::USER) ? locked_auth->GetRole(user_or_role) : std::nullopt;
+    if (user && role)
+      throw memgraph::query::QueryRuntimeException("Ambiguous: '{}' is both a user and a role. Specify USER or ROLE.",
+                                                   user_or_role);
     std::vector<std::vector<memgraph::query::TypedValue>> grants;
 #ifdef MG_ENTERPRISE
     std::vector<std::vector<memgraph::query::TypedValue>> fine_grained_grants;
 #endif
-    if (auto user = locked_auth->GetUser(user_or_role)) {
+    if (user) {
       grants = ShowUserPrivileges(user, db_name);
 #ifdef MG_ENTERPRISE
       if (memgraph::license::global_license_checker.IsEnterpriseValidFast()) {
         fine_grained_grants = ShowFineGrainedUserPrivileges(user, db_name);
       }
 #endif
-    } else if (auto role = locked_auth->GetRole(user_or_role)) {
+    } else if (role) {
       grants = ShowRolePrivileges(role, db_name);
 #ifdef MG_ENTERPRISE
       if (memgraph::license::global_license_checker.IsEnterpriseValidFast()) {
@@ -869,7 +874,7 @@ void AuthQueryHandler::GrantPrivilege(
         &edge_type_privileges
 #endif
     ,
-    system::Transaction *system_tx) {
+    auth::UserOrRoleType type, system::Transaction *system_tx) {
   EditPermissions(
       user_or_role,
       privileges,
@@ -906,6 +911,7 @@ void AuthQueryHandler::GrantPrivilege(
       }
 #endif
       ,
+      type,
       system_tx);
 }  // namespace memgraph::glue
 
@@ -920,7 +926,7 @@ void AuthQueryHandler::DenyPrivilege(
         &edge_type_privileges
 #endif
     ,
-    system::Transaction *system_tx) {
+    auth::UserOrRoleType type, system::Transaction *system_tx) {
   EditPermissions(
       user_or_role,
       privileges,
@@ -957,6 +963,7 @@ void AuthQueryHandler::DenyPrivilege(
       }
 #endif
       ,
+      type,
       system_tx);
 }
 
@@ -971,7 +978,7 @@ void AuthQueryHandler::RevokePrivilege(
         &edge_type_privileges
 #endif
     ,
-    system::Transaction *system_tx) {
+    auth::UserOrRoleType type, system::Transaction *system_tx) {
   EditPermissions(
       user_or_role,
       privileges,
@@ -1008,6 +1015,7 @@ void AuthQueryHandler::RevokePrivilege(
       }
 #endif
       ,
+      type,
       system_tx);
 }  // namespace memgraph::glue
 
@@ -1034,7 +1042,7 @@ void AuthQueryHandler::EditPermissions(
     const TEditFineGrainedPermissionsFun &edit_fine_grained_permissions_fun
 #endif
     ,
-    system::Transaction *system_tx) {
+    auth::UserOrRoleType type, system::Transaction *system_tx) {
   try {
     std::vector<memgraph::auth::Permission> permissions;
     permissions.reserve(privileges.size());
@@ -1043,7 +1051,13 @@ void AuthQueryHandler::EditPermissions(
     }
     auto locked_auth = auth_->Lock();
 
-    if (auto user = locked_auth->GetUser(user_or_role)) {
+    auto user = (type != auth::UserOrRoleType::ROLE) ? locked_auth->GetUser(user_or_role) : std::nullopt;
+    auto role = (type != auth::UserOrRoleType::USER) ? locked_auth->GetRole(user_or_role) : std::nullopt;
+    if (user && role)
+      throw memgraph::query::QueryRuntimeException("Ambiguous: '{}' is both a user and a role. Specify USER or ROLE.",
+                                                   user_or_role);
+
+    if (user) {
       for (const auto &permission : permissions) {
         edit_permissions_fun(user->permissions(), permission);
       }
@@ -1068,7 +1082,7 @@ void AuthQueryHandler::EditPermissions(
       }
 #endif
       locked_auth->SaveUser(*user, system_tx);
-    } else if (auto role = locked_auth->GetRole(user_or_role)) {
+    } else if (role) {
       role->SetBuiltIn(false);
       for (const auto &permission : permissions) {
         edit_permissions_fun(role->permissions(), permission);
@@ -1103,7 +1117,7 @@ void AuthQueryHandler::EditPermissions(
 
 #ifdef MG_ENTERPRISE
 void AuthQueryHandler::GrantImpersonateUser(const std::string &user_or_role, const std::vector<std::string> &targets,
-                                            system::Transaction *system_tx) {
+                                            auth::UserOrRoleType type, system::Transaction *system_tx) {
   try {
     auto locked_auth = auth_->Lock();
 
@@ -1119,7 +1133,13 @@ void AuthQueryHandler::GrantImpersonateUser(const std::string &user_or_role, con
       }
     }
 
-    if (auto user = locked_auth->GetUser(user_or_role)) {
+    auto user = (type != auth::UserOrRoleType::ROLE) ? locked_auth->GetUser(user_or_role) : std::nullopt;
+    auto role = (type != auth::UserOrRoleType::USER) ? locked_auth->GetRole(user_or_role) : std::nullopt;
+    if (user && role)
+      throw memgraph::query::QueryRuntimeException("Ambiguous: '{}' is both a user and a role. Specify USER or ROLE.",
+                                                   user_or_role);
+
+    if (user) {
       user->permissions().Grant(auth::Permission::IMPERSONATE_USER);
       if (all) {
         user->GrantUserImp();
@@ -1127,7 +1147,7 @@ void AuthQueryHandler::GrantImpersonateUser(const std::string &user_or_role, con
         user->GrantUserImp(target_users);
       }
       locked_auth->SaveUser(*user, system_tx);
-    } else if (auto role = locked_auth->GetRole(user_or_role)) {
+    } else if (role) {
       role->permissions().Grant(auth::Permission::IMPERSONATE_USER);
       if (all) {
         role->GrantUserImp();
@@ -1144,7 +1164,7 @@ void AuthQueryHandler::GrantImpersonateUser(const std::string &user_or_role, con
 }
 
 void AuthQueryHandler::DenyImpersonateUser(const std::string &user_or_role, const std::vector<std::string> &targets,
-                                           system::Transaction *system_tx) {
+                                           auth::UserOrRoleType type, system::Transaction *system_tx) {
   try {
     auto locked_auth = auth_->Lock();
 
@@ -1162,10 +1182,16 @@ void AuthQueryHandler::DenyImpersonateUser(const std::string &user_or_role, cons
       target_users.emplace_back(std::move(*user));
     }
 
-    if (auto user = locked_auth->GetUser(user_or_role)) {
+    auto user = (type != auth::UserOrRoleType::ROLE) ? locked_auth->GetUser(user_or_role) : std::nullopt;
+    auto role = (type != auth::UserOrRoleType::USER) ? locked_auth->GetRole(user_or_role) : std::nullopt;
+    if (user && role)
+      throw memgraph::query::QueryRuntimeException("Ambiguous: '{}' is both a user and a role. Specify USER or ROLE.",
+                                                   user_or_role);
+
+    if (user) {
       user->DenyUserImp(target_users);
       locked_auth->SaveUser(*user, system_tx);
-    } else if (auto role = locked_auth->GetRole(user_or_role)) {
+    } else if (role) {
       role->DenyUserImp(target_users);
       locked_auth->SaveRole(*role, system_tx);
     } else {

--- a/src/glue/auth_handler.hpp
+++ b/src/glue/auth_handler.hpp
@@ -82,6 +82,8 @@ class AuthQueryHandler final : public memgraph::query::AuthQueryHandler {
   void ClearRoles(const std::string &username, const std::vector<std::string> &roles,
                   const std::unordered_set<std::string> &role_databases, system::Transaction *system_tx) override;
 
+  using query::AuthQueryHandler::GetPrivileges;
+
   std::vector<std::vector<memgraph::query::TypedValue>> GetPrivileges(const std::string &user_or_role,
                                                                       std::optional<std::string>,
                                                                       auth::UserOrRoleType type) override;

--- a/src/glue/auth_handler.hpp
+++ b/src/glue/auth_handler.hpp
@@ -27,8 +27,8 @@ class AuthQueryHandler final : public memgraph::query::AuthQueryHandler {
  public:
   explicit AuthQueryHandler(memgraph::auth::SynchedAuth *auth);
 
-  bool CreateUser(const std::string &username, const std::optional<std::string> &password,
-                  system::Transaction *system_tx) override;
+  query::CreateUserResult CreateUser(const std::string &username, const std::optional<std::string> &password,
+                                     system::Transaction *system_tx) override;
 
   bool DropUser(const std::string &username, system::Transaction *system_tx) override;
 

--- a/src/glue/auth_handler.hpp
+++ b/src/glue/auth_handler.hpp
@@ -80,8 +80,8 @@ class AuthQueryHandler final : public memgraph::query::AuthQueryHandler {
 
   void RemoveRole(const std::string &username, const std::string &rolename, system::Transaction *system_tx) override;
 
-  void ClearRoles(const std::string &username, const std::vector<std::string> &roles,
-                  const std::unordered_set<std::string> &role_databases, system::Transaction *system_tx) override;
+  void ClearRoles(const std::string &username, const std::unordered_set<std::string> &role_databases,
+                  system::Transaction *system_tx) override;
 
   void AddRoles(const std::string &username, const std::vector<std::string> &roles,
                 const std::unordered_set<std::string> &role_databases, system::Transaction *system_tx) override;

--- a/src/glue/auth_handler.hpp
+++ b/src/glue/auth_handler.hpp
@@ -82,6 +82,12 @@ class AuthQueryHandler final : public memgraph::query::AuthQueryHandler {
   void ClearRoles(const std::string &username, const std::vector<std::string> &roles,
                   const std::unordered_set<std::string> &role_databases, system::Transaction *system_tx) override;
 
+  void AddRoles(const std::string &username, const std::vector<std::string> &roles,
+                const std::unordered_set<std::string> &role_databases, system::Transaction *system_tx) override;
+
+  void RevokeRoles(const std::string &username, const std::vector<std::string> &roles,
+                   const std::unordered_set<std::string> &role_databases, system::Transaction *system_tx) override;
+
   using query::AuthQueryHandler::GetPrivileges;
 
   std::vector<std::vector<memgraph::query::TypedValue>> GetPrivileges(const std::string &user_or_role,

--- a/src/glue/auth_handler.hpp
+++ b/src/glue/auth_handler.hpp
@@ -57,7 +57,7 @@ class AuthQueryHandler final : public memgraph::query::AuthQueryHandler {
 
   void DeleteDatabase(std::string_view db_name, system::Transaction *system_tx) override;
 
-  std::optional<std::string> GetMainDatabase(const std::string &user_or_role) override;
+  std::optional<std::string> GetMainDatabase(const std::string &user_or_role, auth::UserOrRoleType type) override;
 #endif
 
   bool CreateRole(const std::string &rolename, system::Transaction *system_tx) override;

--- a/src/glue/auth_handler.hpp
+++ b/src/glue/auth_handler.hpp
@@ -79,8 +79,8 @@ class AuthQueryHandler final : public memgraph::query::AuthQueryHandler {
 
   void RemoveRole(const std::string &username, const std::string &rolename, system::Transaction *system_tx) override;
 
-  void ClearRoles(const std::string &username, const std::unordered_set<std::string> &role_databases,
-                  system::Transaction *system_tx) override;
+  void ClearRoles(const std::string &username, const std::vector<std::string> &roles,
+                  const std::unordered_set<std::string> &role_databases, system::Transaction *system_tx) override;
 
   std::vector<std::vector<memgraph::query::TypedValue>> GetPrivileges(const std::string &user_or_role,
                                                                       std::optional<std::string>) override;

--- a/src/glue/auth_handler.hpp
+++ b/src/glue/auth_handler.hpp
@@ -68,10 +68,10 @@ class AuthQueryHandler final : public memgraph::query::AuthQueryHandler {
 
   std::vector<memgraph::query::TypedValue> GetUsernames() override;
 
-  std::vector<std::pair<std::string, bool>> GetRolenames() override;
+  std::vector<memgraph::query::RolenameResult> GetRolenames() override;
 
-  std::vector<std::pair<std::string, bool>> GetRolenamesForUser(const std::string &username,
-                                                                std::optional<std::string> db_name) override;
+  std::vector<memgraph::query::RolenameResult> GetRolenamesForUser(const std::string &username,
+                                                                   std::optional<std::string> db_name) override;
 
   std::vector<memgraph::query::TypedValue> GetUsernamesForRole(const std::string &rolename) override;
 

--- a/src/glue/auth_handler.hpp
+++ b/src/glue/auth_handler.hpp
@@ -67,10 +67,10 @@ class AuthQueryHandler final : public memgraph::query::AuthQueryHandler {
 
   std::vector<memgraph::query::TypedValue> GetUsernames() override;
 
-  std::vector<memgraph::query::TypedValue> GetRolenames() override;
+  std::vector<std::pair<std::string, bool>> GetRolenames() override;
 
-  std::vector<std::string> GetRolenamesForUser(const std::string &username,
-                                               std::optional<std::string> db_name) override;
+  std::vector<std::pair<std::string, bool>> GetRolenamesForUser(const std::string &username,
+                                                                std::optional<std::string> db_name) override;
 
   std::vector<memgraph::query::TypedValue> GetUsernamesForRole(const std::string &rolename) override;
 

--- a/src/glue/auth_handler.hpp
+++ b/src/glue/auth_handler.hpp
@@ -48,8 +48,9 @@ class AuthQueryHandler final : public memgraph::query::AuthQueryHandler {
   void RevokeDatabase(const std::string &db_name, const std::string &user_or_role, auth::UserOrRoleType type,
                       system::Transaction *system_tx) override;
 
-  std::vector<std::vector<memgraph::query::TypedValue>> GetDatabasePrivileges(
-      const std::string &user, const std::vector<std::string> &roles) override;
+  std::vector<std::vector<memgraph::query::TypedValue>> GetDatabasePrivileges(const std::string &user,
+                                                                              const std::vector<std::string> &roles,
+                                                                              auth::UserOrRoleType type) override;
 
   void SetMainDatabase(std::string_view db_name, const std::string &user_or_role, auth::UserOrRoleType type,
                        system::Transaction *system_tx) override;

--- a/src/glue/auth_handler.hpp
+++ b/src/glue/auth_handler.hpp
@@ -39,19 +39,19 @@ class AuthQueryHandler final : public memgraph::query::AuthQueryHandler {
                       const std::optional<std::string> &newPassword, system::Transaction *system_tx) override;
 
 #ifdef MG_ENTERPRISE
-  void GrantDatabase(const std::string &db_name, const std::string &user_or_role,
+  void GrantDatabase(const std::string &db_name, const std::string &user_or_role, auth::UserOrRoleType type,
                      system::Transaction *system_tx) override;
 
-  void DenyDatabase(const std::string &db_name, const std::string &user_or_role,
+  void DenyDatabase(const std::string &db_name, const std::string &user_or_role, auth::UserOrRoleType type,
                     system::Transaction *system_tx) override;
 
-  void RevokeDatabase(const std::string &db_name, const std::string &user_or_role,
+  void RevokeDatabase(const std::string &db_name, const std::string &user_or_role, auth::UserOrRoleType type,
                       system::Transaction *system_tx) override;
 
   std::vector<std::vector<memgraph::query::TypedValue>> GetDatabasePrivileges(
       const std::string &user, const std::vector<std::string> &roles) override;
 
-  void SetMainDatabase(std::string_view db_name, const std::string &user_or_role,
+  void SetMainDatabase(std::string_view db_name, const std::string &user_or_role, auth::UserOrRoleType type,
                        system::Transaction *system_tx) override;
 
   void DeleteDatabase(std::string_view db_name, system::Transaction *system_tx) override;
@@ -83,7 +83,8 @@ class AuthQueryHandler final : public memgraph::query::AuthQueryHandler {
                   const std::unordered_set<std::string> &role_databases, system::Transaction *system_tx) override;
 
   std::vector<std::vector<memgraph::query::TypedValue>> GetPrivileges(const std::string &user_or_role,
-                                                                      std::optional<std::string>) override;
+                                                                      std::optional<std::string>,
+                                                                      auth::UserOrRoleType type) override;
 
   void GrantPrivilege(
       const std::string &user_or_role, const std::vector<memgraph::query::AuthQuery::Privilege> &privileges
@@ -96,7 +97,7 @@ class AuthQueryHandler final : public memgraph::query::AuthQueryHandler {
           &edge_type_privileges
 #endif
       ,
-      system::Transaction *system_tx) override;
+      auth::UserOrRoleType type, system::Transaction *system_tx) override;
 
   void DenyPrivilege(
       const std::string &user_or_role, const std::vector<memgraph::query::AuthQuery::Privilege> &privileges
@@ -109,7 +110,7 @@ class AuthQueryHandler final : public memgraph::query::AuthQueryHandler {
           &edge_type_privileges
 #endif
       ,
-      system::Transaction *system_tx) override;
+      auth::UserOrRoleType type, system::Transaction *system_tx) override;
 
   void RevokePrivilege(
       const std::string &user_or_role, const std::vector<memgraph::query::AuthQuery::Privilege> &privileges
@@ -122,7 +123,7 @@ class AuthQueryHandler final : public memgraph::query::AuthQueryHandler {
           &edge_type_privileges
 #endif
       ,
-      system::Transaction *system_tx) override;
+      auth::UserOrRoleType type, system::Transaction *system_tx) override;
 
 // User profiles
 #ifdef MG_ENTERPRISE
@@ -166,13 +167,13 @@ class AuthQueryHandler final : public memgraph::query::AuthQueryHandler {
       const TEditFineGrainedPermissionsFun &edit_fine_grained_permissions_fun
 #endif
       ,
-      system::Transaction *system_tx);
+      auth::UserOrRoleType type, system::Transaction *system_tx);
 
 #ifdef MG_ENTERPRISE
   void GrantImpersonateUser(const std::string &user_or_role, const std::vector<std::string> &targets,
-                            system::Transaction *system_tx) override;
+                            auth::UserOrRoleType type, system::Transaction *system_tx) override;
   void DenyImpersonateUser(const std::string &user_or_role, const std::vector<std::string> &targets,
-                           system::Transaction *system_tx) override;
+                           auth::UserOrRoleType type, system::Transaction *system_tx) override;
 #endif
 };
 }  // namespace memgraph::glue

--- a/src/query/auth_query_handler.hpp
+++ b/src/query/auth_query_handler.hpp
@@ -150,8 +150,8 @@ class AuthQueryHandler {
   virtual void RemoveRole(const std::string &username, const std::string &rolename, system::Transaction *system_tx) = 0;
 
   /// @throw QueryRuntimeException if an error ocurred.
-  virtual void ClearRoles(const std::string &username, const std::vector<std::string> &roles,
-                          const std::unordered_set<std::string> &role_databases, system::Transaction *system_tx) = 0;
+  virtual void ClearRoles(const std::string &username, const std::unordered_set<std::string> &role_databases,
+                          system::Transaction *system_tx) = 0;
 
   /// @throw QueryRuntimeException if an error ocurred.
   virtual void AddRoles(const std::string &username, const std::vector<std::string> &roles,

--- a/src/query/auth_query_handler.hpp
+++ b/src/query/auth_query_handler.hpp
@@ -128,6 +128,14 @@ class AuthQueryHandler {
   virtual void ClearRoles(const std::string &username, const std::vector<std::string> &roles,
                           const std::unordered_set<std::string> &role_databases, system::Transaction *system_tx) = 0;
 
+  /// @throw QueryRuntimeException if an error ocurred.
+  virtual void AddRoles(const std::string &username, const std::vector<std::string> &roles,
+                        const std::unordered_set<std::string> &role_databases, system::Transaction *system_tx) = 0;
+
+  /// @throw QueryRuntimeException if an error ocurred.
+  virtual void RevokeRoles(const std::string &username, const std::vector<std::string> &roles,
+                           const std::unordered_set<std::string> &role_databases, system::Transaction *system_tx) = 0;
+
   virtual std::vector<std::vector<memgraph::query::TypedValue>> GetPrivileges(const std::string &user_or_role,
                                                                               std::optional<std::string> db,
                                                                               auth::UserOrRoleType type) = 0;

--- a/src/query/auth_query_handler.hpp
+++ b/src/query/auth_query_handler.hpp
@@ -121,8 +121,8 @@ class AuthQueryHandler {
   virtual void RemoveRole(const std::string &username, const std::string &rolename, system::Transaction *system_tx) = 0;
 
   /// @throw QueryRuntimeException if an error ocurred.
-  virtual void ClearRoles(const std::string &username, const std::unordered_set<std::string> &role_databases,
-                          system::Transaction *system_tx) = 0;
+  virtual void ClearRoles(const std::string &username, const std::vector<std::string> &roles,
+                          const std::unordered_set<std::string> &role_databases, system::Transaction *system_tx) = 0;
 
   virtual std::vector<std::vector<memgraph::query::TypedValue>> GetPrivileges(const std::string &user_or_role,
                                                                               std::optional<std::string>) = 0;

--- a/src/query/auth_query_handler.hpp
+++ b/src/query/auth_query_handler.hpp
@@ -104,7 +104,11 @@ class AuthQueryHandler {
   /// Get the main database for a user or role
   /// @return Optional database access if user/role exists and has a main database set
   /// @throw QueryRuntimeException if an error ocurred.
-  virtual std::optional<std::string> GetMainDatabase(const std::string &user_or_role) = 0;
+  virtual std::optional<std::string> GetMainDatabase(const std::string &user_or_role, auth::UserOrRoleType type) = 0;
+
+  std::optional<std::string> GetMainDatabase(const std::string &user_or_role) {
+    return GetMainDatabase(user_or_role, auth::UserOrRoleType::UNSPECIFIED);
+  }
 #endif
 
   /// Return false if the role already exists.

--- a/src/query/auth_query_handler.hpp
+++ b/src/query/auth_query_handler.hpp
@@ -54,15 +54,18 @@ class AuthQueryHandler {
 #ifdef MG_ENTERPRISE
   /// Return true if access granted successfully
   /// @throw QueryRuntimeException if an error ocurred.
-  virtual void GrantDatabase(const std::string &db, const std::string &username, system::Transaction *system_tx) = 0;
+  virtual void GrantDatabase(const std::string &db, const std::string &username, auth::UserOrRoleType type,
+                             system::Transaction *system_tx) = 0;
 
   /// Return true if access revoked successfully
   /// @throw QueryRuntimeException if an error ocurred.
-  virtual void DenyDatabase(const std::string &db, const std::string &username, system::Transaction *system_tx) = 0;
+  virtual void DenyDatabase(const std::string &db, const std::string &username, auth::UserOrRoleType type,
+                            system::Transaction *system_tx) = 0;
 
   /// Return true if access revoked successfully
   /// @throw QueryRuntimeException if an error ocurred.
-  virtual void RevokeDatabase(const std::string &db, const std::string &username, system::Transaction *system_tx) = 0;
+  virtual void RevokeDatabase(const std::string &db, const std::string &username, auth::UserOrRoleType type,
+                              system::Transaction *system_tx) = 0;
 
   using DatabasePrivileges = std::vector<std::vector<memgraph::query::TypedValue>>;
 
@@ -76,7 +79,8 @@ class AuthQueryHandler {
 
   /// Return true if main database set successfully
   /// @throw QueryRuntimeException if an error ocurred.
-  virtual void SetMainDatabase(std::string_view db, const std::string &username, system::Transaction *system_tx) = 0;
+  virtual void SetMainDatabase(std::string_view db, const std::string &username, auth::UserOrRoleType type,
+                               system::Transaction *system_tx) = 0;
 
   /// Delete database from all users
   /// @throw QueryRuntimeException if an error ocurred.
@@ -125,7 +129,13 @@ class AuthQueryHandler {
                           const std::unordered_set<std::string> &role_databases, system::Transaction *system_tx) = 0;
 
   virtual std::vector<std::vector<memgraph::query::TypedValue>> GetPrivileges(const std::string &user_or_role,
-                                                                              std::optional<std::string>) = 0;
+                                                                              std::optional<std::string> db,
+                                                                              auth::UserOrRoleType type) = 0;
+
+  std::vector<std::vector<memgraph::query::TypedValue>> GetPrivileges(const std::string &user_or_role,
+                                                                      std::optional<std::string> db) {
+    return GetPrivileges(user_or_role, db, auth::UserOrRoleType::UNSPECIFIED);
+  }
 
   /// @throw QueryRuntimeException if an error ocurred.
   virtual void GrantPrivilege(
@@ -139,7 +149,7 @@ class AuthQueryHandler {
           &edge_type_privileges
 #endif
       ,
-      system::Transaction *system_tx) = 0;
+      auth::UserOrRoleType type, system::Transaction *system_tx) = 0;
 
   /// @throw QueryRuntimeException if an error ocurred.
   virtual void DenyPrivilege(
@@ -153,7 +163,7 @@ class AuthQueryHandler {
           &edge_type_privileges
 #endif
       ,
-      system::Transaction *system_tx) = 0;
+      auth::UserOrRoleType type, system::Transaction *system_tx) = 0;
 
   /// @throw QueryRuntimeException if an error ocurred.
   virtual void RevokePrivilege(
@@ -167,13 +177,13 @@ class AuthQueryHandler {
           &edge_type_privileges
 #endif
       ,
-      system::Transaction *system_tx) = 0;
+      auth::UserOrRoleType type, system::Transaction *system_tx) = 0;
 
 #ifdef MG_ENTERPRISE
   virtual void GrantImpersonateUser(const std::string &user_or_role, const std::vector<std::string> &targets,
-                                    system::Transaction *system_tx) = 0;
+                                    auth::UserOrRoleType type, system::Transaction *system_tx) = 0;
   virtual void DenyImpersonateUser(const std::string &user_or_role, const std::vector<std::string> &targets,
-                                   system::Transaction *system_tx) = 0;
+                                   auth::UserOrRoleType type, system::Transaction *system_tx) = 0;
 #endif
 
 // User profiles

--- a/src/query/auth_query_handler.hpp
+++ b/src/query/auth_query_handler.hpp
@@ -108,11 +108,11 @@ class AuthQueryHandler {
   virtual std::vector<memgraph::query::TypedValue> GetUsernames() = 0;
 
   /// @throw QueryRuntimeException if an error ocurred.
-  virtual std::vector<memgraph::query::TypedValue> GetRolenames() = 0;
+  virtual std::vector<std::pair<std::string, bool>> GetRolenames() = 0;
 
   /// @throw QueryRuntimeException if an error ocurred.
-  virtual std::vector<std::string> GetRolenamesForUser(const std::string &username,
-                                                       std::optional<std::string> db_name) = 0;
+  virtual std::vector<std::pair<std::string, bool>> GetRolenamesForUser(const std::string &username,
+                                                                        std::optional<std::string> db_name) = 0;
 
   /// @throw QueryRuntimeException if an error ocurred.
   virtual std::vector<memgraph::query::TypedValue> GetUsernamesForRole(const std::string &rolename) = 0;

--- a/src/query/auth_query_handler.hpp
+++ b/src/query/auth_query_handler.hpp
@@ -16,6 +16,7 @@
 #include <string_view>
 #include <vector>
 
+#include "auth/models.hpp"
 #include "query/frontend/ast/query/auth_query.hpp"
 #include "query/frontend/ast/query/user_profile.hpp"
 #include "query/typed_value.hpp"
@@ -25,9 +26,14 @@
 namespace memgraph::query {
 
 struct CreateUserResult {
-  bool created;
-  bool first_user;
-  bool builtin_roles_created;
+  bool created{false};
+  bool first_user{false};
+  bool builtin_roles_created{false};
+};
+
+struct RolenameResult {
+  std::string name;
+  bool is_builtin{false};
 };
 
 class AuthQueryHandler {
@@ -127,11 +133,11 @@ class AuthQueryHandler {
   virtual std::vector<memgraph::query::TypedValue> GetUsernames() = 0;
 
   /// @throw QueryRuntimeException if an error ocurred.
-  virtual std::vector<std::pair<std::string, bool>> GetRolenames() = 0;
+  virtual std::vector<RolenameResult> GetRolenames() = 0;
 
   /// @throw QueryRuntimeException if an error ocurred.
-  virtual std::vector<std::pair<std::string, bool>> GetRolenamesForUser(const std::string &username,
-                                                                        std::optional<std::string> db_name) = 0;
+  virtual std::vector<RolenameResult> GetRolenamesForUser(const std::string &username,
+                                                          std::optional<std::string> db_name) = 0;
 
   /// @throw QueryRuntimeException if an error ocurred.
   virtual std::vector<memgraph::query::TypedValue> GetUsernamesForRole(const std::string &rolename) = 0;

--- a/src/query/auth_query_handler.hpp
+++ b/src/query/auth_query_handler.hpp
@@ -75,12 +75,21 @@ class AuthQueryHandler {
 
   using DatabasePrivileges = std::vector<std::vector<memgraph::query::TypedValue>>;
 
-  /// Returns database access rights for the user
+  /// Returns database access rights for the user or role.
   /// @throw QueryRuntimeException if an error ocurred.
-  virtual DatabasePrivileges GetDatabasePrivileges(const std::string &user, const std::vector<std::string> &roles) = 0;
+  virtual DatabasePrivileges GetDatabasePrivileges(const std::string &user, const std::vector<std::string> &roles,
+                                                   auth::UserOrRoleType type) = 0;
+
+  DatabasePrivileges GetDatabasePrivileges(const std::string &user, const std::vector<std::string> &roles) {
+    return GetDatabasePrivileges(user, roles, auth::UserOrRoleType::UNSPECIFIED);
+  }
 
   DatabasePrivileges GetDatabasePrivileges(const std::string &user_or_role) {
-    return GetDatabasePrivileges(user_or_role, {user_or_role});
+    return GetDatabasePrivileges(user_or_role, {user_or_role}, auth::UserOrRoleType::UNSPECIFIED);
+  }
+
+  DatabasePrivileges GetDatabasePrivileges(const std::string &user_or_role, auth::UserOrRoleType type) {
+    return GetDatabasePrivileges(user_or_role, {user_or_role}, type);
   }
 
   /// Return true if main database set successfully

--- a/src/query/auth_query_handler.hpp
+++ b/src/query/auth_query_handler.hpp
@@ -26,6 +26,7 @@ namespace memgraph::query {
 
 struct CreateUserResult {
   bool created;
+  bool first_user;
   bool builtin_roles_created;
 };
 

--- a/src/query/auth_query_handler.hpp
+++ b/src/query/auth_query_handler.hpp
@@ -24,6 +24,11 @@
 
 namespace memgraph::query {
 
+struct CreateUserResult {
+  bool created;
+  bool builtin_roles_created;
+};
+
 class AuthQueryHandler {
  public:
   AuthQueryHandler() = default;
@@ -34,10 +39,10 @@ class AuthQueryHandler {
   AuthQueryHandler &operator=(const AuthQueryHandler &) = delete;
   AuthQueryHandler &operator=(AuthQueryHandler &&) = delete;
 
-  /// Return false if the user already exists.
+  /// Return created=false if the user already exists.
   /// @throw QueryRuntimeException if an error ocurred.
-  virtual bool CreateUser(const std::string &username, const std::optional<std::string> &password,
-                          system::Transaction *system_tx) = 0;
+  virtual CreateUserResult CreateUser(const std::string &username, const std::optional<std::string> &password,
+                                      system::Transaction *system_tx) = 0;
 
   /// Return false if the user does not exist.
   /// @throw QueryRuntimeException if an error ocurred.

--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -2278,6 +2278,32 @@ antlrcpp::Any CypherMainVisitor::visitClearRole(MemgraphCypher::ClearRoleContext
   return auth;
 }
 
+antlrcpp::Any CypherMainVisitor::visitGrantRole(MemgraphCypher::GrantRoleContext *ctx) {
+  auto *auth = storage_->Create<AuthQuery>();
+  auth->action_ = AuthQuery::Action::GRANT_ROLE;
+  auth->user_ = std::any_cast<std::string>(ctx->user->accept(this));
+  auth->roles_ = std::any_cast<std::vector<std::string>>(ctx->roles->accept(this));
+  if (ctx->db) {
+    auto db_names = std::any_cast<std::vector<std::string>>(ctx->db->accept(this));
+    auth->role_databases_ = std::unordered_set<std::string>(std::make_move_iterator(db_names.begin()),
+                                                            std::make_move_iterator(db_names.end()));
+  }
+  return auth;
+}
+
+antlrcpp::Any CypherMainVisitor::visitRevokeRole(MemgraphCypher::RevokeRoleContext *ctx) {
+  auto *auth = storage_->Create<AuthQuery>();
+  auth->action_ = AuthQuery::Action::REVOKE_ROLE;
+  auth->user_ = std::any_cast<std::string>(ctx->user->accept(this));
+  auth->roles_ = std::any_cast<std::vector<std::string>>(ctx->roles->accept(this));
+  if (ctx->db) {
+    auto db_names = std::any_cast<std::vector<std::string>>(ctx->db->accept(this));
+    auth->role_databases_ = std::unordered_set<std::string>(std::make_move_iterator(db_names.begin()),
+                                                            std::make_move_iterator(db_names.end()));
+  }
+  return auth;
+}
+
 /**
  * @return AuthQuery*
  */

--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -2117,6 +2117,17 @@ antlrcpp::Any CypherMainVisitor::visitUserOrRoleName(MemgraphCypher::UserOrRoleN
   return std::any_cast<std::string>(ctx->symbolicName()->accept(this));
 }
 
+antlrcpp::Any CypherMainVisitor::visitUserOrRole(MemgraphCypher::UserOrRoleContext *ctx) {
+  auto name = std::any_cast<std::string>(ctx->userOrRoleName()->accept(this));
+  auto entity_type = auth::UserOrRoleType::UNSPECIFIED;
+  if (ctx->USER()) {
+    entity_type = auth::UserOrRoleType::USER;
+  } else if (ctx->ROLE()) {
+    entity_type = auth::UserOrRoleType::ROLE;
+  }
+  return std::make_pair(std::move(name), entity_type);
+}
+
 /**
  * @return AuthQuery*
  */
@@ -2273,7 +2284,8 @@ antlrcpp::Any CypherMainVisitor::visitClearRole(MemgraphCypher::ClearRoleContext
 antlrcpp::Any CypherMainVisitor::visitGrantPrivilege(MemgraphCypher::GrantPrivilegeContext *ctx) {
   auto *auth = storage_->Create<AuthQuery>();
   auth->action_ = AuthQuery::Action::GRANT_PRIVILEGE;
-  auth->user_or_role_ = std::any_cast<std::string>(ctx->userOrRole->accept(this));
+  std::tie(auth->user_or_role_, auth->entity_type_) =
+      std::any_cast<std::pair<std::string, auth::UserOrRoleType>>(ctx->target->accept(this));
   if (ctx->systemPrivileges) {
     auth->privileges_ = std::any_cast<std::vector<AuthQuery::Privilege>>(ctx->systemPrivileges->accept(this));
   } else if (ctx->entityPrivileges) {
@@ -2307,7 +2319,8 @@ antlrcpp::Any CypherMainVisitor::visitGrantPrivilege(MemgraphCypher::GrantPrivil
 antlrcpp::Any CypherMainVisitor::visitDenyPrivilege(MemgraphCypher::DenyPrivilegeContext *ctx) {
   auto *auth = storage_->Create<AuthQuery>();
   auth->action_ = AuthQuery::Action::DENY_PRIVILEGE;
-  auth->user_or_role_ = std::any_cast<std::string>(ctx->userOrRole->accept(this));
+  std::tie(auth->user_or_role_, auth->entity_type_) =
+      std::any_cast<std::pair<std::string, auth::UserOrRoleType>>(ctx->target->accept(this));
   if (ctx->systemPrivileges) {
     auth->privileges_ = std::any_cast<std::vector<AuthQuery::Privilege>>(ctx->systemPrivileges->accept(this));
   } else if (ctx->entityPrivileges) {
@@ -2353,7 +2366,8 @@ antlrcpp::Any CypherMainVisitor::visitPrivilegesList(MemgraphCypher::PrivilegesL
 antlrcpp::Any CypherMainVisitor::visitRevokePrivilege(MemgraphCypher::RevokePrivilegeContext *ctx) {
   auto *auth = storage_->Create<AuthQuery>();
   auth->action_ = AuthQuery::Action::REVOKE_PRIVILEGE;
-  auth->user_or_role_ = std::any_cast<std::string>(ctx->userOrRole->accept(this));
+  std::tie(auth->user_or_role_, auth->entity_type_) =
+      std::any_cast<std::pair<std::string, auth::UserOrRoleType>>(ctx->target->accept(this));
   if (ctx->systemPrivileges) {
     auth->privileges_ = std::any_cast<std::vector<AuthQuery::Privilege>>(ctx->systemPrivileges->accept(this));
   } else if (ctx->entityPrivileges) {
@@ -2482,7 +2496,8 @@ antlrcpp::Any CypherMainVisitor::visitWildcardListOfSymbolicNames(
 antlrcpp::Any CypherMainVisitor::visitGrantImpersonateUser(MemgraphCypher::GrantImpersonateUserContext *ctx) {
   auto *auth = storage_->Create<AuthQuery>();
   auth->action_ = AuthQuery::Action::GRANT_IMPERSONATE_USER;
-  auth->user_or_role_ = std::any_cast<std::string>(ctx->userOrRole->accept(this));
+  std::tie(auth->user_or_role_, auth->entity_type_) =
+      std::any_cast<std::pair<std::string, auth::UserOrRoleType>>(ctx->target->accept(this));
   auth->impersonation_targets_ = std::any_cast<std::vector<std::string>>(ctx->targets->accept(this));
   return auth;
 }
@@ -2493,7 +2508,8 @@ antlrcpp::Any CypherMainVisitor::visitGrantImpersonateUser(MemgraphCypher::Grant
 antlrcpp::Any CypherMainVisitor::visitDenyImpersonateUser(MemgraphCypher::DenyImpersonateUserContext *ctx) {
   auto *auth = storage_->Create<AuthQuery>();
   auth->action_ = AuthQuery::Action::DENY_IMPERSONATE_USER;
-  auth->user_or_role_ = std::any_cast<std::string>(ctx->userOrRole->accept(this));
+  std::tie(auth->user_or_role_, auth->entity_type_) =
+      std::any_cast<std::pair<std::string, auth::UserOrRoleType>>(ctx->target->accept(this));
   auth->impersonation_targets_ = std::any_cast<std::vector<std::string>>(ctx->targets->accept(this));
   return auth;
 }
@@ -2636,7 +2652,8 @@ antlrcpp::Any CypherMainVisitor::visitGranularPrivilegeList(MemgraphCypher::Gran
 antlrcpp::Any CypherMainVisitor::visitShowPrivileges(MemgraphCypher::ShowPrivilegesContext *ctx) {
   auto *auth = storage_->Create<AuthQuery>();
   auth->action_ = AuthQuery::Action::SHOW_PRIVILEGES;
-  auth->user_or_role_ = std::any_cast<std::string>(ctx->userOrRole->accept(this));
+  std::tie(auth->user_or_role_, auth->entity_type_) =
+      std::any_cast<std::pair<std::string, auth::UserOrRoleType>>(ctx->target->accept(this));
 
   // Handle optional ON clause
   if (ctx->ON()) {
@@ -2695,7 +2712,8 @@ antlrcpp::Any CypherMainVisitor::visitGrantDatabaseToUserOrRole(MemgraphCypher::
   auto *auth = storage_->Create<AuthQuery>();
   auth->action_ = AuthQuery::Action::GRANT_DATABASE_TO_USER;
   auth->database_ = std::any_cast<std::string>(ctx->wildcardName()->accept(this));
-  auth->user_ = std::any_cast<std::string>(ctx->userOrRole->accept(this));
+  std::tie(auth->user_or_role_, auth->entity_type_) =
+      std::any_cast<std::pair<std::string, auth::UserOrRoleType>>(ctx->target->accept(this));
   return auth;
 }
 
@@ -2707,7 +2725,8 @@ antlrcpp::Any CypherMainVisitor::visitDenyDatabaseFromUserOrRole(
   auto *auth = storage_->Create<AuthQuery>();
   auth->action_ = AuthQuery::Action::DENY_DATABASE_FROM_USER;
   auth->database_ = std::any_cast<std::string>(ctx->wildcardName()->accept(this));
-  auth->user_ = std::any_cast<std::string>(ctx->userOrRole->accept(this));
+  std::tie(auth->user_or_role_, auth->entity_type_) =
+      std::any_cast<std::pair<std::string, auth::UserOrRoleType>>(ctx->target->accept(this));
   return auth;
 }
 
@@ -2719,7 +2738,8 @@ antlrcpp::Any CypherMainVisitor::visitRevokeDatabaseFromUserOrRole(
   auto *auth = storage_->Create<AuthQuery>();
   auth->action_ = AuthQuery::Action::REVOKE_DATABASE_FROM_USER;
   auth->database_ = std::any_cast<std::string>(ctx->wildcardName()->accept(this));
-  auth->user_ = std::any_cast<std::string>(ctx->userOrRole->accept(this));
+  std::tie(auth->user_or_role_, auth->entity_type_) =
+      std::any_cast<std::pair<std::string, auth::UserOrRoleType>>(ctx->target->accept(this));
   return auth;
 }
 
@@ -2729,7 +2749,8 @@ antlrcpp::Any CypherMainVisitor::visitRevokeDatabaseFromUserOrRole(
 antlrcpp::Any CypherMainVisitor::visitShowDatabasePrivileges(MemgraphCypher::ShowDatabasePrivilegesContext *ctx) {
   auto *auth = storage_->Create<AuthQuery>();
   auth->action_ = AuthQuery::Action::SHOW_DATABASE_PRIVILEGES;
-  auth->user_ = std::any_cast<std::string>(ctx->userOrRole->accept(this));
+  std::tie(auth->user_or_role_, auth->entity_type_) =
+      std::any_cast<std::pair<std::string, auth::UserOrRoleType>>(ctx->target->accept(this));
   return auth;
 }
 
@@ -2740,7 +2761,8 @@ antlrcpp::Any CypherMainVisitor::visitSetMainDatabase(MemgraphCypher::SetMainDat
   auto *auth = storage_->Create<AuthQuery>();
   auth->action_ = AuthQuery::Action::SET_MAIN_DATABASE;
   auth->database_ = std::any_cast<std::string>(ctx->db->accept(this));
-  auth->user_ = std::any_cast<std::string>(ctx->userOrRole->accept(this));
+  std::tie(auth->user_or_role_, auth->entity_type_) =
+      std::any_cast<std::pair<std::string, auth::UserOrRoleType>>(ctx->target->accept(this));
   return auth;
 }
 

--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -2266,9 +2266,6 @@ antlrcpp::Any CypherMainVisitor::visitSetRole(MemgraphCypher::SetRoleContext *ct
 antlrcpp::Any CypherMainVisitor::visitClearRole(MemgraphCypher::ClearRoleContext *ctx) {
   auto *auth = storage_->Create<AuthQuery>();
   auth->action_ = AuthQuery::Action::CLEAR_ROLE;
-  if (ctx->roles) {
-    auth->roles_ = std::any_cast<std::vector<std::string>>(ctx->roles->accept(this));
-  }
   auth->user_ = std::any_cast<std::string>(ctx->user->accept(this));
   if (ctx->db) {
     auto db_names = std::any_cast<std::vector<std::string>>(ctx->db->accept(this));

--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -2255,8 +2255,10 @@ antlrcpp::Any CypherMainVisitor::visitSetRole(MemgraphCypher::SetRoleContext *ct
 antlrcpp::Any CypherMainVisitor::visitClearRole(MemgraphCypher::ClearRoleContext *ctx) {
   auto *auth = storage_->Create<AuthQuery>();
   auth->action_ = AuthQuery::Action::CLEAR_ROLE;
+  if (ctx->roles) {
+    auth->roles_ = std::any_cast<std::vector<std::string>>(ctx->roles->accept(this));
+  }
   auth->user_ = std::any_cast<std::string>(ctx->user->accept(this));
-  // Optionally limit the role to specific databases
   if (ctx->db) {
     auto db_names = std::any_cast<std::vector<std::string>>(ctx->db->accept(this));
     auth->role_databases_ = std::unordered_set<std::string>(std::make_move_iterator(db_names.begin()),

--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -124,6 +124,13 @@ std::string JoinSymbolicNamesWithDotsAndMinus(antlr4::tree::ParseTreeVisitor &vi
       [&](auto *token) { return JoinSymbolicNames(&visitor, token->symbolicName(), "-"); },
       ".");
 }
+
+std::unordered_set<std::string> GetRoleDatabases(MemgraphCypher::ListOfSymbolicNamesContext *db_ctx,
+                                                 antlr4::tree::ParseTreeVisitor *visitor) {
+  if (!db_ctx) return {};
+  auto db_names = std::any_cast<std::vector<std::string>>(db_ctx->accept(visitor));
+  return {std::make_move_iterator(db_names.begin()), std::make_move_iterator(db_names.end())};
+}
 }  // namespace
 
 antlrcpp::Any CypherMainVisitor::visitExplainQuery(MemgraphCypher::ExplainQueryContext *ctx) {
@@ -2119,11 +2126,11 @@ antlrcpp::Any CypherMainVisitor::visitUserOrRoleName(MemgraphCypher::UserOrRoleN
 
 antlrcpp::Any CypherMainVisitor::visitUserOrRole(MemgraphCypher::UserOrRoleContext *ctx) {
   auto name = std::any_cast<std::string>(ctx->userOrRoleName()->accept(this));
-  auto entity_type = auth::UserOrRoleType::UNSPECIFIED;
+  auto entity_type = AuthQuery::UserOrRoleType::UNSPECIFIED;
   if (ctx->USER()) {
-    entity_type = auth::UserOrRoleType::USER;
+    entity_type = AuthQuery::UserOrRoleType::USER;
   } else if (ctx->ROLE()) {
-    entity_type = auth::UserOrRoleType::ROLE;
+    entity_type = AuthQuery::UserOrRoleType::ROLE;
   }
   return std::make_pair(std::move(name), entity_type);
 }
@@ -2251,12 +2258,7 @@ antlrcpp::Any CypherMainVisitor::visitSetRole(MemgraphCypher::SetRoleContext *ct
   auth->action_ = AuthQuery::Action::SET_ROLE;
   auth->user_ = std::any_cast<std::string>(ctx->user->accept(this));
   auth->roles_ = std::any_cast<std::vector<std::string>>(ctx->roles->accept(this));
-  // Optionally limit the role to specific databases
-  if (ctx->db) {
-    auto db_names = std::any_cast<std::vector<std::string>>(ctx->db->accept(this));
-    auth->role_databases_ = std::unordered_set<std::string>(std::make_move_iterator(db_names.begin()),
-                                                            std::make_move_iterator(db_names.end()));
-  }
+  auth->role_databases_ = GetRoleDatabases(ctx->db, this);
   return auth;
 }
 
@@ -2267,11 +2269,7 @@ antlrcpp::Any CypherMainVisitor::visitClearRole(MemgraphCypher::ClearRoleContext
   auto *auth = storage_->Create<AuthQuery>();
   auth->action_ = AuthQuery::Action::CLEAR_ROLE;
   auth->user_ = std::any_cast<std::string>(ctx->user->accept(this));
-  if (ctx->db) {
-    auto db_names = std::any_cast<std::vector<std::string>>(ctx->db->accept(this));
-    auth->role_databases_ = std::unordered_set<std::string>(std::make_move_iterator(db_names.begin()),
-                                                            std::make_move_iterator(db_names.end()));
-  }
+  auth->role_databases_ = GetRoleDatabases(ctx->db, this);
   return auth;
 }
 
@@ -2280,11 +2278,7 @@ antlrcpp::Any CypherMainVisitor::visitGrantRole(MemgraphCypher::GrantRoleContext
   auth->action_ = AuthQuery::Action::GRANT_ROLE;
   auth->user_ = std::any_cast<std::string>(ctx->user->accept(this));
   auth->roles_ = std::any_cast<std::vector<std::string>>(ctx->roles->accept(this));
-  if (ctx->db) {
-    auto db_names = std::any_cast<std::vector<std::string>>(ctx->db->accept(this));
-    auth->role_databases_ = std::unordered_set<std::string>(std::make_move_iterator(db_names.begin()),
-                                                            std::make_move_iterator(db_names.end()));
-  }
+  auth->role_databases_ = GetRoleDatabases(ctx->db, this);
   return auth;
 }
 
@@ -2293,11 +2287,7 @@ antlrcpp::Any CypherMainVisitor::visitRevokeRole(MemgraphCypher::RevokeRoleConte
   auth->action_ = AuthQuery::Action::REVOKE_ROLE;
   auth->user_ = std::any_cast<std::string>(ctx->user->accept(this));
   auth->roles_ = std::any_cast<std::vector<std::string>>(ctx->roles->accept(this));
-  if (ctx->db) {
-    auto db_names = std::any_cast<std::vector<std::string>>(ctx->db->accept(this));
-    auth->role_databases_ = std::unordered_set<std::string>(std::make_move_iterator(db_names.begin()),
-                                                            std::make_move_iterator(db_names.end()));
-  }
+  auth->role_databases_ = GetRoleDatabases(ctx->db, this);
   return auth;
 }
 
@@ -2308,7 +2298,7 @@ antlrcpp::Any CypherMainVisitor::visitGrantPrivilege(MemgraphCypher::GrantPrivil
   auto *auth = storage_->Create<AuthQuery>();
   auth->action_ = AuthQuery::Action::GRANT_PRIVILEGE;
   std::tie(auth->user_or_role_, auth->entity_type_) =
-      std::any_cast<std::pair<std::string, auth::UserOrRoleType>>(ctx->target->accept(this));
+      std::any_cast<std::pair<std::string, AuthQuery::UserOrRoleType>>(ctx->target->accept(this));
   if (ctx->systemPrivileges) {
     auth->privileges_ = std::any_cast<std::vector<AuthQuery::Privilege>>(ctx->systemPrivileges->accept(this));
   } else if (ctx->entityPrivileges) {
@@ -2343,7 +2333,7 @@ antlrcpp::Any CypherMainVisitor::visitDenyPrivilege(MemgraphCypher::DenyPrivileg
   auto *auth = storage_->Create<AuthQuery>();
   auth->action_ = AuthQuery::Action::DENY_PRIVILEGE;
   std::tie(auth->user_or_role_, auth->entity_type_) =
-      std::any_cast<std::pair<std::string, auth::UserOrRoleType>>(ctx->target->accept(this));
+      std::any_cast<std::pair<std::string, AuthQuery::UserOrRoleType>>(ctx->target->accept(this));
   if (ctx->systemPrivileges) {
     auth->privileges_ = std::any_cast<std::vector<AuthQuery::Privilege>>(ctx->systemPrivileges->accept(this));
   } else if (ctx->entityPrivileges) {
@@ -2390,7 +2380,7 @@ antlrcpp::Any CypherMainVisitor::visitRevokePrivilege(MemgraphCypher::RevokePriv
   auto *auth = storage_->Create<AuthQuery>();
   auth->action_ = AuthQuery::Action::REVOKE_PRIVILEGE;
   std::tie(auth->user_or_role_, auth->entity_type_) =
-      std::any_cast<std::pair<std::string, auth::UserOrRoleType>>(ctx->target->accept(this));
+      std::any_cast<std::pair<std::string, AuthQuery::UserOrRoleType>>(ctx->target->accept(this));
   if (ctx->systemPrivileges) {
     auth->privileges_ = std::any_cast<std::vector<AuthQuery::Privilege>>(ctx->systemPrivileges->accept(this));
   } else if (ctx->entityPrivileges) {
@@ -2520,7 +2510,7 @@ antlrcpp::Any CypherMainVisitor::visitGrantImpersonateUser(MemgraphCypher::Grant
   auto *auth = storage_->Create<AuthQuery>();
   auth->action_ = AuthQuery::Action::GRANT_IMPERSONATE_USER;
   std::tie(auth->user_or_role_, auth->entity_type_) =
-      std::any_cast<std::pair<std::string, auth::UserOrRoleType>>(ctx->target->accept(this));
+      std::any_cast<std::pair<std::string, AuthQuery::UserOrRoleType>>(ctx->target->accept(this));
   auth->impersonation_targets_ = std::any_cast<std::vector<std::string>>(ctx->targets->accept(this));
   return auth;
 }
@@ -2532,7 +2522,7 @@ antlrcpp::Any CypherMainVisitor::visitDenyImpersonateUser(MemgraphCypher::DenyIm
   auto *auth = storage_->Create<AuthQuery>();
   auth->action_ = AuthQuery::Action::DENY_IMPERSONATE_USER;
   std::tie(auth->user_or_role_, auth->entity_type_) =
-      std::any_cast<std::pair<std::string, auth::UserOrRoleType>>(ctx->target->accept(this));
+      std::any_cast<std::pair<std::string, AuthQuery::UserOrRoleType>>(ctx->target->accept(this));
   auth->impersonation_targets_ = std::any_cast<std::vector<std::string>>(ctx->targets->accept(this));
   return auth;
 }
@@ -2676,7 +2666,7 @@ antlrcpp::Any CypherMainVisitor::visitShowPrivileges(MemgraphCypher::ShowPrivile
   auto *auth = storage_->Create<AuthQuery>();
   auth->action_ = AuthQuery::Action::SHOW_PRIVILEGES;
   std::tie(auth->user_or_role_, auth->entity_type_) =
-      std::any_cast<std::pair<std::string, auth::UserOrRoleType>>(ctx->target->accept(this));
+      std::any_cast<std::pair<std::string, AuthQuery::UserOrRoleType>>(ctx->target->accept(this));
 
   // Handle optional ON clause
   if (ctx->ON()) {
@@ -2736,7 +2726,7 @@ antlrcpp::Any CypherMainVisitor::visitGrantDatabaseToUserOrRole(MemgraphCypher::
   auth->action_ = AuthQuery::Action::GRANT_DATABASE_TO_USER;
   auth->database_ = std::any_cast<std::string>(ctx->wildcardName()->accept(this));
   std::tie(auth->user_or_role_, auth->entity_type_) =
-      std::any_cast<std::pair<std::string, auth::UserOrRoleType>>(ctx->target->accept(this));
+      std::any_cast<std::pair<std::string, AuthQuery::UserOrRoleType>>(ctx->target->accept(this));
   return auth;
 }
 
@@ -2749,7 +2739,7 @@ antlrcpp::Any CypherMainVisitor::visitDenyDatabaseFromUserOrRole(
   auth->action_ = AuthQuery::Action::DENY_DATABASE_FROM_USER;
   auth->database_ = std::any_cast<std::string>(ctx->wildcardName()->accept(this));
   std::tie(auth->user_or_role_, auth->entity_type_) =
-      std::any_cast<std::pair<std::string, auth::UserOrRoleType>>(ctx->target->accept(this));
+      std::any_cast<std::pair<std::string, AuthQuery::UserOrRoleType>>(ctx->target->accept(this));
   return auth;
 }
 
@@ -2762,7 +2752,7 @@ antlrcpp::Any CypherMainVisitor::visitRevokeDatabaseFromUserOrRole(
   auth->action_ = AuthQuery::Action::REVOKE_DATABASE_FROM_USER;
   auth->database_ = std::any_cast<std::string>(ctx->wildcardName()->accept(this));
   std::tie(auth->user_or_role_, auth->entity_type_) =
-      std::any_cast<std::pair<std::string, auth::UserOrRoleType>>(ctx->target->accept(this));
+      std::any_cast<std::pair<std::string, AuthQuery::UserOrRoleType>>(ctx->target->accept(this));
   return auth;
 }
 
@@ -2773,7 +2763,7 @@ antlrcpp::Any CypherMainVisitor::visitShowDatabasePrivileges(MemgraphCypher::Sho
   auto *auth = storage_->Create<AuthQuery>();
   auth->action_ = AuthQuery::Action::SHOW_DATABASE_PRIVILEGES;
   std::tie(auth->user_or_role_, auth->entity_type_) =
-      std::any_cast<std::pair<std::string, auth::UserOrRoleType>>(ctx->target->accept(this));
+      std::any_cast<std::pair<std::string, AuthQuery::UserOrRoleType>>(ctx->target->accept(this));
   return auth;
 }
 
@@ -2785,7 +2775,7 @@ antlrcpp::Any CypherMainVisitor::visitSetMainDatabase(MemgraphCypher::SetMainDat
   auth->action_ = AuthQuery::Action::SET_MAIN_DATABASE;
   auth->database_ = std::any_cast<std::string>(ctx->db->accept(this));
   std::tie(auth->user_or_role_, auth->entity_type_) =
-      std::any_cast<std::pair<std::string, auth::UserOrRoleType>>(ctx->target->accept(this));
+      std::any_cast<std::pair<std::string, AuthQuery::UserOrRoleType>>(ctx->target->accept(this));
   return auth;
 }
 

--- a/src/query/frontend/ast/cypher_main_visitor.hpp
+++ b/src/query/frontend/ast/cypher_main_visitor.hpp
@@ -571,7 +571,7 @@ class CypherMainVisitor : public antlropencypher::MemgraphCypherBaseVisitor {
   antlrcpp::Any visitUserOrRoleName(MemgraphCypher::UserOrRoleNameContext *ctx) override;
 
   /**
-   * @return std::pair<std::string, auth::UserOrRoleType>
+   * @return std::pair<std::string, AuthQuery::UserOrRoleType>
    */
   antlrcpp::Any visitUserOrRole(MemgraphCypher::UserOrRoleContext *ctx) override;
 

--- a/src/query/frontend/ast/cypher_main_visitor.hpp
+++ b/src/query/frontend/ast/cypher_main_visitor.hpp
@@ -17,7 +17,6 @@
 #include "query/frontend/opencypher/generated/MemgraphCypherBaseVisitor.h"
 #pragma pop_macro("EOF")  // bring EOF back
 
-#include "auth/models.hpp"
 #include "query/frontend/ast/ast.hpp"
 #include "query/parameters.hpp"
 #include "utils/exceptions.hpp"

--- a/src/query/frontend/ast/cypher_main_visitor.hpp
+++ b/src/query/frontend/ast/cypher_main_visitor.hpp
@@ -712,6 +712,10 @@ class CypherMainVisitor : public antlropencypher::MemgraphCypherBaseVisitor {
    */
   antlrcpp::Any visitClearRole(MemgraphCypher::ClearRoleContext *ctx) override;
 
+  antlrcpp::Any visitGrantRole(MemgraphCypher::GrantRoleContext *ctx) override;
+
+  antlrcpp::Any visitRevokeRole(MemgraphCypher::RevokeRoleContext *ctx) override;
+
   void extractPrivilege(AuthQuery *auth, antlropencypher::MemgraphCypher::PrivilegeContext *privilege);
 
   /**

--- a/src/query/frontend/ast/cypher_main_visitor.hpp
+++ b/src/query/frontend/ast/cypher_main_visitor.hpp
@@ -17,6 +17,7 @@
 #include "query/frontend/opencypher/generated/MemgraphCypherBaseVisitor.h"
 #pragma pop_macro("EOF")  // bring EOF back
 
+#include "auth/models.hpp"
 #include "query/frontend/ast/ast.hpp"
 #include "query/parameters.hpp"
 #include "utils/exceptions.hpp"
@@ -569,6 +570,11 @@ class CypherMainVisitor : public antlropencypher::MemgraphCypherBaseVisitor {
    * @return std::string
    */
   antlrcpp::Any visitUserOrRoleName(MemgraphCypher::UserOrRoleNameContext *ctx) override;
+
+  /**
+   * @return std::pair<std::string, auth::UserOrRoleType>
+   */
+  antlrcpp::Any visitUserOrRole(MemgraphCypher::UserOrRoleContext *ctx) override;
 
   /**
    * @return AuthQuery*

--- a/src/query/frontend/ast/query/auth_query.hpp
+++ b/src/query/frontend/ast/query/auth_query.hpp
@@ -39,6 +39,8 @@ class AuthQuery : public memgraph::query::Query {
     SHOW_USERS,
     SET_ROLE,
     CLEAR_ROLE,
+    GRANT_ROLE,
+    REVOKE_ROLE,
     GRANT_PRIVILEGE,
     DENY_PRIVILEGE,
     REVOKE_PRIVILEGE,

--- a/src/query/frontend/ast/query/auth_query.hpp
+++ b/src/query/frontend/ast/query/auth_query.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "auth/models.hpp"
 #include "query/frontend/ast/query/expression.hpp"
 #include "query/frontend/ast/query/query.hpp"
 
@@ -133,6 +134,7 @@ class AuthQuery : public memgraph::query::Query {
 
   // Database specification for SHOW PRIVILEGES query
   DatabaseSpecification database_specification_{DatabaseSpecification::NONE};
+  auth::UserOrRoleType entity_type_{auth::UserOrRoleType::UNSPECIFIED};
 
   AuthQuery *Clone(AstStorage *storage) const override {
     auto *object = storage->Create<AuthQuery>();
@@ -152,6 +154,7 @@ class AuthQuery : public memgraph::query::Query {
     object->edge_type_privileges_ = edge_type_privileges_;
     object->impersonation_targets_ = impersonation_targets_;
     object->database_specification_ = database_specification_;
+    object->entity_type_ = entity_type_;
     return object;
   }
 

--- a/src/query/frontend/ast/query/auth_query.hpp
+++ b/src/query/frontend/ast/query/auth_query.hpp
@@ -11,7 +11,6 @@
 
 #pragma once
 
-#include "auth/models.hpp"
 #include "query/frontend/ast/query/expression.hpp"
 #include "query/frontend/ast/query/query.hpp"
 
@@ -105,6 +104,13 @@ class AuthQuery : public memgraph::query::Query {
 
   enum class LabelMatchingMode { ANY, EXACTLY };
 
+  enum class UserOrRoleType {
+    UNSPECIFIED,  // Neither USER nor ROLE was explicitly specified; both are checked and an error is thrown if
+                  // ambiguous.
+    USER,         // Explicitly specified as a USER; only the user namespace is checked.
+    ROLE,         // Explicitly specified as a ROLE; only the role namespace is checked.
+  };
+
   enum class DatabaseSpecification {
     NONE,     // No database specification (non-enterprise)
     MAIN,     // MAIN database (enterprise)
@@ -136,7 +142,7 @@ class AuthQuery : public memgraph::query::Query {
 
   // Database specification for SHOW PRIVILEGES query
   DatabaseSpecification database_specification_{DatabaseSpecification::NONE};
-  auth::UserOrRoleType entity_type_{auth::UserOrRoleType::UNSPECIFIED};
+  UserOrRoleType entity_type_{UserOrRoleType::UNSPECIFIED};
 
   AuthQuery *Clone(AstStorage *storage) const override {
     auto *object = storage->Create<AuthQuery>();

--- a/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
+++ b/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
@@ -495,7 +495,7 @@ showUsers : SHOW USERS ;
 
 setRole : SET ( ROLE | ROLES ) FOR user=userOrRoleName TO roles=listOfSymbolicNames ( ON db=listOfSymbolicNames )? ;
 
-clearRole : CLEAR ( ROLE | ROLES ) FOR user=userOrRoleName ( ON db=listOfSymbolicNames )? ;
+clearRole : CLEAR ( ROLE | ROLES ) ( roles=listOfSymbolicNames )? FOR user=userOrRoleName ( ON db=listOfSymbolicNames )? ;
 
 grantPrivilege : GRANT ( ALL PRIVILEGES | systemPrivileges=privilegesList | entityPrivileges=entityPrivilegeList ) TO userOrRole=userOrRoleName ;
 

--- a/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
+++ b/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
@@ -499,7 +499,7 @@ showUsers : SHOW USERS ;
 
 setRole : SET ( ROLE | ROLES ) FOR user=userOrRoleName TO roles=listOfSymbolicNames ( ON db=listOfSymbolicNames )? ;
 
-clearRole : CLEAR ( ROLE | ROLES ) ( roles=listOfSymbolicNames )? FOR user=userOrRoleName ( ON db=listOfSymbolicNames )? ;
+clearRole : CLEAR ( ROLE | ROLES ) FOR user=userOrRoleName ( ON db=listOfSymbolicNames )? ;
 
 grantRole : GRANT ( ROLE | ROLES ) roles=listOfSymbolicNames TO user=userOrRoleName ( ON db=listOfSymbolicNames )? ;
 

--- a/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
+++ b/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
@@ -497,13 +497,13 @@ showCurrentRole : SHOW CURRENT ( ROLE | ROLES ) ;
 
 showUsers : SHOW USERS ;
 
-setRole : SET ( ROLE | ROLES ) FOR user=userOrRoleName TO roles=listOfSymbolicNames ( ON db=listOfSymbolicNames )? ;
+setRole : SET ( ROLE | ROLES ) FOR USER? user=userOrRoleName TO roles=listOfSymbolicNames ( ON db=listOfSymbolicNames )? ;
 
-clearRole : CLEAR ( ROLE | ROLES ) FOR user=userOrRoleName ( ON db=listOfSymbolicNames )? ;
+clearRole : CLEAR ( ROLE | ROLES ) FOR USER? user=userOrRoleName ( ON db=listOfSymbolicNames )? ;
 
-grantRole : GRANT ( ROLE | ROLES ) roles=listOfSymbolicNames TO user=userOrRoleName ( ON db=listOfSymbolicNames )? ;
+grantRole : GRANT ( ROLE | ROLES ) roles=listOfSymbolicNames TO USER? user=userOrRoleName ( ON db=listOfSymbolicNames )? ;
 
-revokeRole : REVOKE ( ROLE | ROLES ) roles=listOfSymbolicNames FROM user=userOrRoleName ( ON db=listOfSymbolicNames )? ;
+revokeRole : REVOKE ( ROLE | ROLES ) roles=listOfSymbolicNames FROM USER? user=userOrRoleName ( ON db=listOfSymbolicNames )? ;
 
 grantPrivilege : GRANT ( ALL PRIVILEGES | systemPrivileges=privilegesList | entityPrivileges=entityPrivilegeList ) TO target=userOrRole ;
 
@@ -592,9 +592,9 @@ colonSymbolicName : COLON symbolicName ;
 
 showPrivileges : SHOW PRIVILEGES FOR target=userOrRole ( ON ( MAIN | CURRENT | DATABASE db=symbolicName ) )? ;
 
-showRoleForUser : SHOW ( ROLE | ROLES ) FOR user=userOrRoleName ( ON ( MAIN | CURRENT | DATABASE db=symbolicName ) )? ;
+showRoleForUser : SHOW ( ROLE | ROLES ) FOR USER? user=userOrRoleName ( ON ( MAIN | CURRENT | DATABASE db=symbolicName ) )? ;
 
-showUsersForRole : SHOW USERS FOR role=userOrRoleName ;
+showUsersForRole : SHOW USERS FOR ROLE? role=userOrRoleName ;
 
 dumpQuery : DUMP DATABASE ;
 

--- a/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
+++ b/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
@@ -314,6 +314,8 @@ authQuery : createRole
           | showUsers
           | setRole
           | clearRole
+          | grantRole
+          | revokeRole
           | grantPrivilege
           | denyPrivilege
           | revokePrivilege
@@ -498,6 +500,10 @@ showUsers : SHOW USERS ;
 setRole : SET ( ROLE | ROLES ) FOR user=userOrRoleName TO roles=listOfSymbolicNames ( ON db=listOfSymbolicNames )? ;
 
 clearRole : CLEAR ( ROLE | ROLES ) ( roles=listOfSymbolicNames )? FOR user=userOrRoleName ( ON db=listOfSymbolicNames )? ;
+
+grantRole : GRANT ( ROLE | ROLES ) roles=listOfSymbolicNames TO user=userOrRoleName ( ON db=listOfSymbolicNames )? ;
+
+revokeRole : REVOKE ( ROLE | ROLES ) roles=listOfSymbolicNames FROM user=userOrRoleName ( ON db=listOfSymbolicNames )? ;
 
 grantPrivilege : GRANT ( ALL PRIVILEGES | systemPrivileges=privilegesList | entityPrivileges=entityPrivilegeList ) TO target=userOrRole ;
 

--- a/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
+++ b/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
@@ -470,6 +470,8 @@ rowVar : variable ;
 
 userOrRoleName : symbolicName ;
 
+userOrRole : ( USER | ROLE )? userOrRoleName ;
+
 createRole : CREATE ROLE ifNotExists? role=userOrRoleName ;
 
 dropRole : DROP ROLE role=userOrRoleName ;
@@ -497,29 +499,29 @@ setRole : SET ( ROLE | ROLES ) FOR user=userOrRoleName TO roles=listOfSymbolicNa
 
 clearRole : CLEAR ( ROLE | ROLES ) ( roles=listOfSymbolicNames )? FOR user=userOrRoleName ( ON db=listOfSymbolicNames )? ;
 
-grantPrivilege : GRANT ( ALL PRIVILEGES | systemPrivileges=privilegesList | entityPrivileges=entityPrivilegeList ) TO userOrRole=userOrRoleName ;
+grantPrivilege : GRANT ( ALL PRIVILEGES | systemPrivileges=privilegesList | entityPrivileges=entityPrivilegeList ) TO target=userOrRole ;
 
-denyPrivilege : DENY ( ALL PRIVILEGES | systemPrivileges=privilegesList | entityPrivileges=entityPrivilegeList ) TO userOrRole=userOrRoleName ;
+denyPrivilege : DENY ( ALL PRIVILEGES | systemPrivileges=privilegesList | entityPrivileges=entityPrivilegeList ) TO target=userOrRole ;
 
-revokePrivilege : REVOKE ( ALL PRIVILEGES | systemPrivileges=privilegesList | entityPrivileges=entityPrivilegeList ) FROM userOrRole=userOrRoleName ;
+revokePrivilege : REVOKE ( ALL PRIVILEGES | systemPrivileges=privilegesList | entityPrivileges=entityPrivilegeList ) FROM target=userOrRole ;
 
 listOfSymbolicNames : symbolicName ( ',' symbolicName )* ;
 
 wildcardListOfSymbolicNames : '*' | listOfSymbolicNames ;
 
-grantImpersonateUser : GRANT IMPERSONATE_USER targets=wildcardListOfSymbolicNames TO userOrRole=userOrRoleName ;
+grantImpersonateUser : GRANT IMPERSONATE_USER targets=wildcardListOfSymbolicNames TO target=userOrRole ;
 
-denyImpersonateUser : DENY IMPERSONATE_USER targets=wildcardListOfSymbolicNames TO userOrRole=userOrRoleName ;
+denyImpersonateUser : DENY IMPERSONATE_USER targets=wildcardListOfSymbolicNames TO target=userOrRole ;
 
-grantDatabaseToUserOrRole : GRANT DATABASE db=wildcardName TO userOrRole=userOrRoleName ;
+grantDatabaseToUserOrRole : GRANT DATABASE db=wildcardName TO target=userOrRole ;
 
-denyDatabaseFromUserOrRole : DENY DATABASE db=wildcardName FROM userOrRole=userOrRoleName ;
+denyDatabaseFromUserOrRole : DENY DATABASE db=wildcardName FROM target=userOrRole ;
 
-revokeDatabaseFromUserOrRole : REVOKE DATABASE db=wildcardName FROM userOrRole=userOrRoleName ;
+revokeDatabaseFromUserOrRole : REVOKE DATABASE db=wildcardName FROM target=userOrRole ;
 
-showDatabasePrivileges : SHOW DATABASE PRIVILEGES FOR userOrRole=userOrRoleName ;
+showDatabasePrivileges : SHOW DATABASE PRIVILEGES FOR target=userOrRole ;
 
-setMainDatabase : SET MAIN DATABASE db=symbolicName FOR userOrRole=userOrRoleName ;
+setMainDatabase : SET MAIN DATABASE db=symbolicName FOR target=userOrRole ;
 
 setSessionTraceQuery : SET SESSION TRACE (ON | OFF) ;
 
@@ -582,7 +584,7 @@ listOfColonSymbolicNames : colonSymbolicName ( ',' colonSymbolicName )* ;
 
 colonSymbolicName : COLON symbolicName ;
 
-showPrivileges : SHOW PRIVILEGES FOR userOrRole=userOrRoleName ( ON ( MAIN | CURRENT | DATABASE db=symbolicName ) )? ;
+showPrivileges : SHOW PRIVILEGES FOR target=userOrRole ( ON ( MAIN | CURRENT | DATABASE db=symbolicName ) )? ;
 
 showRoleForUser : SHOW ( ROLE | ROLES ) FOR user=userOrRoleName ( ON ( MAIN | CURRENT | DATABASE db=symbolicName ) )? ;
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -1475,17 +1475,20 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
         }
         std::optional<std::string> target_db;
         switch (database_specification) {
-          case AuthQuery::DatabaseSpecification::NONE:
+          case AuthQuery::DatabaseSpecification::NONE: {
             // Allow only if there are no other databases (or for roles)
             // Roles themselves cannot have MT specializations, so no need to filter for them (nullopt)
             // Users can have MT specializations, so we force them to specify the database
-            if (db_handler->Count() > 1 && !auth->HasRole(user_or_role)) {
+            auto const is_role = entity_type == auth::UserOrRoleType::ROLE ||
+                                 (entity_type == auth::UserOrRoleType::UNSPECIFIED && auth->HasRole(user_or_role));
+            if (db_handler->Count() > 1 && !is_role) {
               throw QueryRuntimeException(
                   "In a multi-tenant environment, SHOW PRIVILEGES query requires database specification. Use ON MAIN, "
                   "ON CURRENT or ON DATABASE db_name.");
             }
             target_db = dbms::kDefaultDB;  // HOTFIX: REMOVE ONCE MASTER IS FIXED
             break;
+          }
           case AuthQuery::DatabaseSpecification::MAIN: {
             auto main_db = auth->GetMainDatabase(user_or_role);
             if (!main_db) {

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -312,6 +312,17 @@ void Sort(std::vector<TypedValue, K> &vec) {
                     [](const TypedValue &lv, const TypedValue &rv) { return lv.ValueString() < rv.ValueString(); });
 }
 
+auth::UserOrRoleType ToAuthType(AuthQuery::UserOrRoleType t) {
+  switch (t) {
+    case AuthQuery::UserOrRoleType::USER:
+      return auth::UserOrRoleType::USER;
+    case AuthQuery::UserOrRoleType::ROLE:
+      return auth::UserOrRoleType::ROLE;
+    default:
+      return auth::UserOrRoleType::UNSPECIFIED;
+  }
+}
+
 void UpdateTypeCount(const plan::ReadWriteTypeChecker::RWType type) {
   switch (type) {
     case plan::ReadWriteTypeChecker::RWType::R:
@@ -982,7 +993,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
 
   std::string username = auth_query->user_;
   std::string user_or_role = auth_query->user_or_role_;
-  auto const entity_type = auth_query->entity_type_;
+  auto const entity_type = ToAuthType(auth_query->entity_type_);
   const bool if_not_exists = auth_query->if_not_exists_;
   std::string database = auth_query->database_;
   std::vector<AuthQuery::Privilege> privileges = auth_query->privileges_;

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -1551,7 +1551,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
       };
       return callback;
     case AuthQuery::Action::SHOW_ROLE_FOR_USER:
-      callback.header = {"role", "builtin"};
+      callback.header = {"role"};
       callback.fn = [auth,
                      username,
                      database_specification = auth_query->database_specification_
@@ -1605,8 +1605,8 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
         }
         std::vector<std::vector<TypedValue>> rows;
         rows.reserve(rolenames.size());
-        for (auto &&[rolename, is_builtin] : rolenames) {
-          rows.emplace_back(std::vector<TypedValue>{TypedValue(rolename), TypedValue(is_builtin)});
+        for (auto &&[rolename, _] : rolenames) {
+          rows.emplace_back(std::vector<TypedValue>{TypedValue(rolename)});
         }
         return rows;
       };

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -1520,7 +1520,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
             break;
           }
           case AuthQuery::DatabaseSpecification::MAIN: {
-            auto main_db = auth->GetMainDatabase(user_or_role);
+            auto main_db = auth->GetMainDatabase(user_or_role, entity_type);
             if (!main_db) {
               throw QueryRuntimeException("No user found for SHOW PRIVILEGES ON MAIN");
             }

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -1127,7 +1127,10 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
           runtime_notifications->emplace_back(
               SeverityLevel::INFO,
               NotificationCode::CREATE_USER,
-              fmt::format("User '{}' created. No roles or privileges assigned.", username));
+              result.first_user
+                  ? fmt::format("User '{}' created with full access to all data and privileges, and no roles assigned.",
+                                username)
+                  : fmt::format("User '{}' created. No roles or privileges assigned.", username));
         }
         return std::vector<std::vector<TypedValue>>{};
       };

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -1712,8 +1712,8 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
     case AuthQuery::Action::SHOW_DATABASE_PRIVILEGES:
       callback.header = {"grants", "denies"};
 #ifdef MG_ENTERPRISE
-      callback.fn = [auth, user_or_role] {  // NOLINT
-        return auth->GetDatabasePrivileges(user_or_role);
+      callback.fn = [auth, user_or_role, entity_type] {  // NOLINT
+        return auth->GetDatabasePrivileges(user_or_role, entity_type);
       };
 #else
       callback.fn = [] {  // NOLINT

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -1072,8 +1072,9 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
                 username);
           }
           spdlog::warn("User '{}' already exists.", username);
-          runtime_notifications->emplace_back(
-              SeverityLevel::WARNING, NotificationCode::CREATE_USER, fmt::format("User {} already exists.", username));
+          runtime_notifications->emplace_back(SeverityLevel::WARNING,
+                                              NotificationCode::CREATE_USER,
+                                              fmt::format("User '{}' already exists.", username));
           return std::vector<std::vector<TypedValue>>{};
         }
 
@@ -1099,7 +1100,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
                                &*interpreter->system_transaction_);
           runtime_notifications->emplace_back(SeverityLevel::INFO,
                                               NotificationCode::CREATE_USER,
-                                              fmt::format("User {} created. All privileges granted.", username));
+                                              fmt::format("User '{}' created. All privileges granted.", username));
           return std::vector<std::vector<TypedValue>>{};
         }
 
@@ -1109,15 +1110,16 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
             runtime_notifications->emplace_back(
                 SeverityLevel::INFO,
                 NotificationCode::CREATE_USER,
-                fmt::format("User {} created. Built-in roles created: admin, readwrite, readonly. User {} assigned "
-                            "built-in role admin, with full access to all data and privileges.",
-                            username,
-                            username));
+                fmt::format(
+                    "User '{}' created. Built-in roles created: 'admin', 'readwrite', 'readonly'. User '{}' assigned "
+                    "built-in role 'admin', with full access to all data and privileges.",
+                    username,
+                    username));
           } else {
             runtime_notifications->emplace_back(
                 SeverityLevel::INFO,
                 NotificationCode::CREATE_USER,
-                fmt::format("User {} created. Assigned built-in role admin, with full access to all data and "
+                fmt::format("User '{}' created. Assigned built-in role 'admin', with full access to all data and "
                             "privileges.",
                             username));
           }
@@ -1125,7 +1127,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
           runtime_notifications->emplace_back(
               SeverityLevel::INFO,
               NotificationCode::CREATE_USER,
-              fmt::format("User {} created. No roles or privileges assigned.", username));
+              fmt::format("User '{}' created. No roles or privileges assigned.", username));
         }
         return std::vector<std::vector<TypedValue>>{};
       };
@@ -1205,11 +1207,12 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
                 rolename);
           }
           spdlog::warn("Role '{}' already exists.", rolename);
-          runtime_notifications->emplace_back(
-              SeverityLevel::WARNING, NotificationCode::CREATE_ROLE, fmt::format("Role {} already exists.", rolename));
+          runtime_notifications->emplace_back(SeverityLevel::WARNING,
+                                              NotificationCode::CREATE_ROLE,
+                                              fmt::format("Role '{}' already exists.", rolename));
         } else {
           runtime_notifications->emplace_back(
-              SeverityLevel::INFO, NotificationCode::CREATE_ROLE, fmt::format("Role {} created.", rolename));
+              SeverityLevel::INFO, NotificationCode::CREATE_ROLE, fmt::format("Role '{}' created.", rolename));
         }
         return std::vector<std::vector<TypedValue>>();
       };

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -1045,6 +1045,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
   switch (auth_query->action_) {
     case AuthQuery::Action::CREATE_USER:
       forbid_on_replica();
+      callback.header = {"status"};
       callback.fn = [auth,
                      username,
                      password,
@@ -1056,10 +1057,11 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
         }
 
         MG_ASSERT(password.IsString() || password.IsNull());
-        if (!auth->CreateUser(
-                username,
-                password.IsString() ? std::make_optional(std::string(password.ValueString())) : std::nullopt,
-                &*interpreter->system_transaction_)) {
+        auto const created = auth->CreateUser(
+            username,
+            password.IsString() ? std::make_optional(std::string(password.ValueString())) : std::nullopt,
+            &*interpreter->system_transaction_);
+        if (!created) {
           if (!if_not_exists) {
             throw UserAlreadyExistsException(
                 "User or role with name '{}' already exists. Use the SHOW USERS or SHOW ROLES query to list all users "
@@ -1067,6 +1069,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
                 username);
           }
           spdlog::warn("User '{}' already exists.", username);
+          return std::vector<std::vector<TypedValue>>{{TypedValue(fmt::format("User {} already exists.", username))}};
         }
 
         // If the license is not valid we create users with admin access
@@ -1089,9 +1092,17 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
                                ,
                                auth::UserOrRoleType::USER,
                                &*interpreter->system_transaction_);
+          return std::vector<std::vector<TypedValue>>{
+              {TypedValue(fmt::format("User {} created. All privileges granted.", username))}};
         }
 
-        return std::vector<std::vector<TypedValue>>();
+        auto const roles = auth->GetRolenamesForUser(username, std::nullopt);
+        if (!roles.empty()) {
+          return std::vector<std::vector<TypedValue>>{
+              {TypedValue(fmt::format("User {} created. Assigned built-in role {}.", username, roles[0].first))}};
+        }
+        return std::vector<std::vector<TypedValue>>{
+            {TypedValue(fmt::format("User {} created. No roles or privileges assigned.", username))}};
       };
       return callback;
     case AuthQuery::Action::DROP_USER:

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -981,6 +981,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
 
   std::string username = auth_query->user_;
   std::string user_or_role = auth_query->user_or_role_;
+  auto const entity_type = auth_query->entity_type_;
   const bool if_not_exists = auth_query->if_not_exists_;
   std::string database = auth_query->database_;
   std::vector<AuthQuery::Privilege> privileges = auth_query->privileges_;
@@ -1084,6 +1085,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
                                  {AuthQuery::FineGrainedPrivilege::DELETE, {query::kAsterisk}}}}
 #endif
                                ,
+                               auth::UserOrRoleType::USER,
                                &*interpreter->system_transaction_);
         }
 
@@ -1290,6 +1292,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
       callback.fn = [auth,
                      user_or_role,
                      privileges,
+                     entity_type,
                      interpreter = &interpreter
 #ifdef MG_ENTERPRISE
                      ,
@@ -1311,6 +1314,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
                              edge_type_privileges
 #endif
                              ,
+                             entity_type,
                              &*interpreter->system_transaction_);
         return std::vector<std::vector<TypedValue>>();
       };
@@ -1320,6 +1324,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
       callback.fn = [auth,
                      user_or_role,
                      privileges,
+                     entity_type,
                      interpreter = &interpreter
 #ifdef MG_ENTERPRISE
                      ,
@@ -1341,6 +1346,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
                             edge_type_privileges
 #endif
                             ,
+                            entity_type,
                             &*interpreter->system_transaction_);
         return std::vector<std::vector<TypedValue>>();
       };
@@ -1350,6 +1356,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
       callback.fn = [auth,
                      user_or_role,
                      privileges,
+                     entity_type,
                      interpreter = &interpreter
 #ifdef MG_ENTERPRISE
                      ,
@@ -1371,6 +1378,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
                               edge_type_privileges
 #endif
                               ,
+                              entity_type,
                               &*interpreter->system_transaction_);
         return std::vector<std::vector<TypedValue>>();
       };
@@ -1380,6 +1388,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
       callback.header = {"privilege", "effective", "description"};
       callback.fn = [auth,
                      user_or_role,
+                     entity_type,
                      database_specification = auth_query->database_specification_
 #ifdef MG_ENTERPRISE
                      ,
@@ -1393,7 +1402,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
           if (database_specification != AuthQuery::DatabaseSpecification::NONE) {
             throw QueryRuntimeException("Multi-database queries are only available in enterprise edition");
           }
-          return auth->GetPrivileges(user_or_role, std::nullopt);
+          return auth->GetPrivileges(user_or_role, std::nullopt, entity_type);
         }
         std::optional<std::string> target_db;
         switch (database_specification) {
@@ -1430,12 +1439,12 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
           // Check that the db exists
           target_db_acc = db_handler->Get(*target_db);
         }
-        return auth->GetPrivileges(user_or_role, target_db);
+        return auth->GetPrivileges(user_or_role, target_db, entity_type);
 #else
         if (database_specification != AuthQuery::DatabaseSpecification::NONE) {
           throw QueryRuntimeException("Multi-database queries are only available in enterprise edition");
         }
-        return auth->GetPrivileges(user_or_role, std::nullopt);
+        return auth->GetPrivileges(user_or_role, std::nullopt, entity_type);
 #endif
       };
       return callback;
@@ -1520,7 +1529,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
     case AuthQuery::Action::GRANT_DATABASE_TO_USER:
       forbid_on_replica();
 #ifdef MG_ENTERPRISE
-      callback.fn = [auth, database, username, db_handler, interpreter = &interpreter] {  // NOLINT
+      callback.fn = [auth, database, user_or_role, entity_type, db_handler, interpreter = &interpreter] {  // NOLINT
         if (!interpreter->system_transaction_) {
           throw QueryException("Expected to be in a system transaction");
         }
@@ -1531,7 +1540,9 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
           if (database != memgraph::auth::kAllDatabases) {
             db = db_handler->Get(database);  // Will throw if databases doesn't exist and protect it during pull
           }
-          auth->GrantDatabase(database, username,
+          auth->GrantDatabase(database,
+                              user_or_role,
+                              entity_type,
                               &*interpreter->system_transaction_);  // Can throws query exception
         } catch (memgraph::dbms::UnknownDatabaseException &e) {
           throw QueryRuntimeException(e.what());
@@ -1545,7 +1556,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
     case AuthQuery::Action::DENY_DATABASE_FROM_USER:
       forbid_on_replica();
 #ifdef MG_ENTERPRISE
-      callback.fn = [auth, database, username, db_handler, interpreter = &interpreter] {  // NOLINT
+      callback.fn = [auth, database, user_or_role, entity_type, db_handler, interpreter = &interpreter] {  // NOLINT
         if (!interpreter->system_transaction_) {
           throw QueryException("Expected to be in a system transaction");
         }
@@ -1556,7 +1567,10 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
           if (database != memgraph::auth::kAllDatabases) {
             db = db_handler->Get(database);  // Will throw if databases doesn't exist and protect it during pull
           }
-          auth->DenyDatabase(database, username, &*interpreter->system_transaction_);  // Can throws query exception
+          auth->DenyDatabase(database,
+                             user_or_role,
+                             entity_type,
+                             &*interpreter->system_transaction_);  // Can throws query exception
         } catch (memgraph::dbms::UnknownDatabaseException &e) {
           throw QueryRuntimeException(e.what());
         }
@@ -1569,7 +1583,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
     case AuthQuery::Action::REVOKE_DATABASE_FROM_USER:
       forbid_on_replica();
 #ifdef MG_ENTERPRISE
-      callback.fn = [auth, database, username, db_handler, interpreter = &interpreter] {  // NOLINT
+      callback.fn = [auth, database, user_or_role, entity_type, db_handler, interpreter = &interpreter] {  // NOLINT
         if (!interpreter->system_transaction_) {
           throw QueryException("Expected to be in a system transaction");
         }
@@ -1580,7 +1594,9 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
           if (database != memgraph::auth::kAllDatabases) {
             db = db_handler->Get(database);  // Will throw if databases doesn't exist and protect it during pull
           }
-          auth->RevokeDatabase(database, username,
+          auth->RevokeDatabase(database,
+                               user_or_role,
+                               entity_type,
                                &*interpreter->system_transaction_);  // Can throws query exception
         } catch (memgraph::dbms::UnknownDatabaseException &e) {
           throw QueryRuntimeException(e.what());
@@ -1594,8 +1610,8 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
     case AuthQuery::Action::SHOW_DATABASE_PRIVILEGES:
       callback.header = {"grants", "denies"};
 #ifdef MG_ENTERPRISE
-      callback.fn = [auth, username] {  // NOLINT
-        return auth->GetDatabasePrivileges(username);
+      callback.fn = [auth, user_or_role] {  // NOLINT
+        return auth->GetDatabasePrivileges(user_or_role);
       };
 #else
       callback.fn = [] {  // NOLINT
@@ -1606,7 +1622,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
     case AuthQuery::Action::SET_MAIN_DATABASE:
       forbid_on_replica();
 #ifdef MG_ENTERPRISE
-      callback.fn = [auth, database, username, db_handler, interpreter = &interpreter] {  // NOLINT
+      callback.fn = [auth, database, user_or_role, entity_type, db_handler, interpreter = &interpreter] {  // NOLINT
         if (!interpreter->system_transaction_) {
           throw QueryException("Expected to be in a system transaction");
         }
@@ -1614,7 +1630,9 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
         try {
           const auto db =
               db_handler->Get(database);  // Will throw if databases doesn't exist and protect it during pull
-          auth->SetMainDatabase(database, username,
+          auth->SetMainDatabase(database,
+                                user_or_role,
+                                entity_type,
                                 &*interpreter->system_transaction_);  // Can throws query exception
         } catch (memgraph::dbms::UnknownDatabaseException &e) {
           throw QueryRuntimeException(e.what());
@@ -1635,6 +1653,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
       callback.fn = [auth,
                      user_or_role = std::move(user_or_role),
                      targets = std::move(impersonation_targets),
+                     entity_type,
                      interpreter = &interpreter] {  // NOLINT
         if (!interpreter->system_transaction_) {
           throw QueryException("Expected to be in a system transaction");
@@ -1642,6 +1661,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
         try {
           auth->GrantImpersonateUser(user_or_role,
                                      targets,
+                                     entity_type,
                                      &*interpreter->system_transaction_);  // Can throws query exception
         } catch (memgraph::dbms::UnknownDatabaseException &e) {
           throw QueryRuntimeException(e.what());
@@ -1662,6 +1682,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
       callback.fn = [auth,
                      user_or_role = std::move(user_or_role),
                      targets = std::move(impersonation_targets),
+                     entity_type,
                      interpreter = &interpreter] {  // NOLINT
         if (!interpreter->system_transaction_) {
           throw QueryException("Expected to be in a system transaction");
@@ -1669,6 +1690,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
         try {
           auth->DenyImpersonateUser(user_or_role,
                                     targets,
+                                    entity_type,
                                     &*interpreter->system_transaction_);  // Can throws query exception
         } catch (memgraph::dbms::UnknownDatabaseException &e) {
           throw QueryRuntimeException(e.what());

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -1005,6 +1005,8 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
                                                           AuthQuery::Action::DROP_ROLE,
                                                           AuthQuery::Action::SET_ROLE,
                                                           AuthQuery::Action::CLEAR_ROLE,
+                                                          AuthQuery::Action::GRANT_ROLE,
+                                                          AuthQuery::Action::REVOKE_ROLE,
                                                           AuthQuery::Action::GRANT_PRIVILEGE,
                                                           AuthQuery::Action::DENY_PRIVILEGE,
                                                           AuthQuery::Action::REVOKE_PRIVILEGE,
@@ -1283,6 +1285,48 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
           throw QueryException("Database specification is only available in the enterprise edition");
         }
         auth->ClearRoles(username, roles, std::unordered_set<std::string>{}, &*interpreter->system_transaction_);
+#endif
+        return std::vector<std::vector<TypedValue>>();
+      };
+      return callback;
+    case AuthQuery::Action::GRANT_ROLE:
+      forbid_on_replica();
+      callback.fn = [auth,
+                     username,
+                     roles = std::move(auth_query->roles_),
+                     interpreter = &interpreter,
+                     role_databases = std::move(role_databases)] {
+        if (!interpreter->system_transaction_) {
+          throw QueryException("Expected to be in a system transaction");
+        }
+#ifdef MG_ENTERPRISE
+        auth->AddRoles(username, roles, role_databases, &*interpreter->system_transaction_);
+#else
+        if (!role_databases.empty()) {
+          throw QueryException("Database specification is only available in the enterprise edition");
+        }
+        auth->AddRoles(username, roles, std::unordered_set<std::string>{}, &*interpreter->system_transaction_);
+#endif
+        return std::vector<std::vector<TypedValue>>();
+      };
+      return callback;
+    case AuthQuery::Action::REVOKE_ROLE:
+      forbid_on_replica();
+      callback.fn = [auth,
+                     username,
+                     roles = std::move(auth_query->roles_),
+                     interpreter = &interpreter,
+                     role_databases = std::move(role_databases)] {
+        if (!interpreter->system_transaction_) {
+          throw QueryException("Expected to be in a system transaction");
+        }
+#ifdef MG_ENTERPRISE
+        auth->RevokeRoles(username, roles, role_databases, &*interpreter->system_transaction_);
+#else
+        if (!role_databases.empty()) {
+          throw QueryException("Database specification is only available in the enterprise edition");
+        }
+        auth->RevokeRoles(username, roles, std::unordered_set<std::string>{}, &*interpreter->system_transaction_);
 #endif
         return std::vector<std::vector<TypedValue>>();
       };

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -337,6 +337,7 @@ struct Callback {
   std::vector<std::string> header;
   using CallbackFunction = std::function<std::vector<std::vector<TypedValue>>()>;
   CallbackFunction fn;
+  std::shared_ptr<std::vector<Notification>> notifications_ptr;
 };
 
 TypedValue EvaluateOptionalExpression(Expression *expression, ExpressionVisitor<TypedValue> &eval) {
@@ -1043,14 +1044,16 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
   };
 
   switch (auth_query->action_) {
-    case AuthQuery::Action::CREATE_USER:
+    case AuthQuery::Action::CREATE_USER: {
       forbid_on_replica();
-      callback.header = {"status"};
+      auto runtime_notifications = std::make_shared<std::vector<Notification>>();
+      callback.notifications_ptr = runtime_notifications;
       callback.fn = [auth,
                      username,
                      password,
                      if_not_exists,
                      valid_enterprise_license = license_check_result.has_value(),
+                     runtime_notifications,
                      interpreter = &interpreter] {
         if (!interpreter->system_transaction_) {
           throw QueryException("Expected to be in a system transaction");
@@ -1069,7 +1072,9 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
                 username);
           }
           spdlog::warn("User '{}' already exists.", username);
-          return std::vector<std::vector<TypedValue>>{{TypedValue(fmt::format("User {} already exists.", username))}};
+          runtime_notifications->emplace_back(
+              SeverityLevel::WARNING, NotificationCode::CREATE_USER, fmt::format("User {} already exists.", username));
+          return std::vector<std::vector<TypedValue>>{};
         }
 
         // If the license is not valid we create users with admin access
@@ -1092,19 +1097,28 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
                                ,
                                auth::UserOrRoleType::USER,
                                &*interpreter->system_transaction_);
-          return std::vector<std::vector<TypedValue>>{
-              {TypedValue(fmt::format("User {} created. All privileges granted.", username))}};
+          runtime_notifications->emplace_back(SeverityLevel::INFO,
+                                              NotificationCode::CREATE_USER,
+                                              fmt::format("User {} created. All privileges granted.", username));
+          return std::vector<std::vector<TypedValue>>{};
         }
 
         auto const roles = auth->GetRolenamesForUser(username, std::nullopt);
         if (!roles.empty()) {
-          return std::vector<std::vector<TypedValue>>{
-              {TypedValue(fmt::format("User {} created. Assigned built-in role {}.", username, roles[0].first))}};
+          runtime_notifications->emplace_back(
+              SeverityLevel::INFO,
+              NotificationCode::CREATE_USER,
+              fmt::format("User {} created. Assigned built-in role {}.", username, roles[0].first));
+        } else {
+          runtime_notifications->emplace_back(
+              SeverityLevel::INFO,
+              NotificationCode::CREATE_USER,
+              fmt::format("User {} created. No roles or privileges assigned.", username));
         }
-        return std::vector<std::vector<TypedValue>>{
-            {TypedValue(fmt::format("User {} created. No roles or privileges assigned.", username))}};
+        return std::vector<std::vector<TypedValue>>{};
       };
       return callback;
+    }
     case AuthQuery::Action::DROP_USER:
       forbid_on_replica();
       callback.fn = [auth, username, interpreter = &interpreter] {
@@ -5098,7 +5112,8 @@ PreparedQuery PrepareTtlQuery(ParsedQuery parsed_query, bool in_explicit_transac
 
 PreparedQuery PrepareAuthQuery(ParsedQuery parsed_query, bool in_explicit_transaction,
                                InterpreterContext *interpreter_context, Interpreter &interpreter,
-                               std::optional<memgraph::dbms::DatabaseAccess> db_acc) {
+                               std::optional<memgraph::dbms::DatabaseAccess> db_acc,
+                               std::vector<Notification> *notifications) {
   if (in_explicit_transaction) {
     throw UserModificationInMulticommandTxException();
   }
@@ -5119,13 +5134,19 @@ PreparedQuery PrepareAuthQuery(ParsedQuery parsed_query, bool in_explicit_transa
   return PreparedQuery{.header = std::move(callback.header),
                        .privileges = std::move(parsed_query.required_privileges),
                        .query_handler = [handler = std::move(callback.fn),
+                                         runtime_notifications = std::move(callback.notifications_ptr),
+                                         notifications,
                                          pull_plan = std::shared_ptr<PullPlanVector>(nullptr)](  // NOLINT
                                             AnyStream *stream,
                                             std::optional<int>
                                                 n) mutable -> std::optional<QueryHandlerResult> {
                          if (!pull_plan) {
-                           // Run the specific query
                            auto results = handler();
+                           if (runtime_notifications) {
+                             for (auto &notif : *runtime_notifications) {
+                               notifications->emplace_back(std::move(notif));
+                             }
+                           }
                            pull_plan = std::make_shared<PullPlanVector>(std::move(results));
                          }
 
@@ -9135,8 +9156,12 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
       prepared_query = PrepareAnalyzeGraphQuery(std::move(parsed_query), in_explicit_transaction_, current_db_);
     } else if (utils::Downcast<AuthQuery>(parsed_query.query)) {
       /// SYSTEM (Replication) PURE
-      prepared_query = PrepareAuthQuery(
-          std::move(parsed_query), in_explicit_transaction_, interpreter_context_, *this, current_db_.db_acc_);
+      prepared_query = PrepareAuthQuery(std::move(parsed_query),
+                                        in_explicit_transaction_,
+                                        interpreter_context_,
+                                        *this,
+                                        current_db_.db_acc_,
+                                        &query_execution->notifications);
     } else if (utils::Downcast<DatabaseInfoQuery>(parsed_query.query)) {
       prepared_query = PrepareDatabaseInfoQuery(std::move(parsed_query), in_explicit_transaction_, current_db_);
     } else if (utils::Downcast<SystemInfoQuery>(parsed_query.query)) {

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -1060,11 +1060,11 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
         }
 
         MG_ASSERT(password.IsString() || password.IsNull());
-        auto const created = auth->CreateUser(
+        auto const result = auth->CreateUser(
             username,
             password.IsString() ? std::make_optional(std::string(password.ValueString())) : std::nullopt,
             &*interpreter->system_transaction_);
-        if (!created) {
+        if (!result.created) {
           if (!if_not_exists) {
             throw UserAlreadyExistsException(
                 "User or role with name '{}' already exists. Use the SHOW USERS or SHOW ROLES query to list all users "
@@ -1105,10 +1105,22 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
 
         auto const roles = auth->GetRolenamesForUser(username, std::nullopt);
         if (!roles.empty()) {
-          runtime_notifications->emplace_back(
-              SeverityLevel::INFO,
-              NotificationCode::CREATE_USER,
-              fmt::format("User {} created. Assigned built-in role {}.", username, roles[0].first));
+          if (result.builtin_roles_created) {
+            runtime_notifications->emplace_back(
+                SeverityLevel::INFO,
+                NotificationCode::CREATE_USER,
+                fmt::format("User {} created. Built-in roles created: admin, readwrite, readonly. User {} assigned "
+                            "built-in role admin, with full access to all data and privileges.",
+                            username,
+                            username));
+          } else {
+            runtime_notifications->emplace_back(
+                SeverityLevel::INFO,
+                NotificationCode::CREATE_USER,
+                fmt::format("User {} created. Assigned built-in role admin, with full access to all data and "
+                            "privileges.",
+                            username));
+          }
         } else {
           runtime_notifications->emplace_back(
               SeverityLevel::INFO,
@@ -1167,9 +1179,15 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
         return std::vector<std::vector<TypedValue>>();
       };
       return callback;
-    case AuthQuery::Action::CREATE_ROLE:
+    case AuthQuery::Action::CREATE_ROLE: {
       forbid_on_replica();
-      callback.fn = [auth, roles = std::move(auth_query->roles_), if_not_exists, interpreter = &interpreter] {
+      auto runtime_notifications = std::make_shared<std::vector<Notification>>();
+      callback.notifications_ptr = runtime_notifications;
+      callback.fn = [auth,
+                     roles = std::move(auth_query->roles_),
+                     if_not_exists,
+                     runtime_notifications,
+                     interpreter = &interpreter] {
         if (!interpreter->system_transaction_) {
           throw QueryException("Expected to be in a system transaction");
         }
@@ -1187,10 +1205,16 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
                 rolename);
           }
           spdlog::warn("Role '{}' already exists.", rolename);
+          runtime_notifications->emplace_back(
+              SeverityLevel::WARNING, NotificationCode::CREATE_ROLE, fmt::format("Role {} already exists.", rolename));
+        } else {
+          runtime_notifications->emplace_back(
+              SeverityLevel::INFO, NotificationCode::CREATE_ROLE, fmt::format("Role {} created.", rolename));
         }
         return std::vector<std::vector<TypedValue>>();
       };
       return callback;
+    }
     case AuthQuery::Action::DROP_ROLE:
       forbid_on_replica();
       callback.fn = [auth, roles = std::move(auth_query->roles_), interpreter = &interpreter] {

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -1234,13 +1234,13 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
       };
       return callback;
     case AuthQuery::Action::SHOW_ROLES:
-      callback.header = {"role"};
+      callback.header = {"role", "builtin"};
       callback.fn = [auth] {
         std::vector<std::vector<TypedValue>> rows;
-        auto rolenames = auth->GetRolenames();
-        rows.reserve(rolenames.size());
-        for (auto &&rolename : rolenames) {
-          rows.emplace_back(std::vector<TypedValue>{rolename});
+        auto roles = auth->GetRolenames();
+        rows.reserve(roles.size());
+        for (auto &&[rolename, is_builtin] : roles) {
+          rows.emplace_back(std::vector<TypedValue>{TypedValue(rolename), TypedValue(is_builtin)});
         }
         return rows;
       };
@@ -1493,7 +1493,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
       };
       return callback;
     case AuthQuery::Action::SHOW_ROLE_FOR_USER:
-      callback.header = std::vector<std::string>{"role"};
+      callback.header = {"role", "builtin"};
       callback.fn = [auth,
                      username,
                      database_specification = auth_query->database_specification_
@@ -1543,12 +1543,12 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
         auto rolenames = auth->GetRolenamesForUser(username, std::nullopt);
 #endif
         if (rolenames.empty()) {
-          return std::vector<std::vector<TypedValue>>{std::vector<TypedValue>{TypedValue("null")}};
+          return std::vector<std::vector<TypedValue>>{};
         }
         std::vector<std::vector<TypedValue>> rows;
         rows.reserve(rolenames.size());
-        for (auto &&rolename : rolenames) {
-          rows.emplace_back(std::vector<TypedValue>{TypedValue{rolename}});
+        for (auto &&[rolename, is_builtin] : rolenames) {
+          rows.emplace_back(std::vector<TypedValue>{TypedValue(rolename), TypedValue(is_builtin)});
         }
         return rows;
       };

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -1115,6 +1115,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
           return std::vector<std::vector<TypedValue>>{};
         }
 
+#ifdef MG_ENTERPRISE
         auto const roles = auth->GetRolenamesForUser(username, std::nullopt);
         if (!roles.empty()) {
           if (result.builtin_roles_created) {
@@ -1134,7 +1135,9 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
                             "privileges.",
                             username));
           }
-        } else {
+        } else
+#endif
+        {
           runtime_notifications->emplace_back(
               SeverityLevel::INFO,
               NotificationCode::CREATE_USER,
@@ -1335,22 +1338,18 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
       return callback;
     case AuthQuery::Action::CLEAR_ROLE:
       forbid_on_replica();
-      callback.fn = [auth,
-                     username,
-                     roles = std::move(auth_query->roles_),
-                     interpreter = &interpreter,
-                     role_databases = std::move(role_databases)] {
+      callback.fn = [auth, username, interpreter = &interpreter, role_databases = std::move(role_databases)] {
         if (!interpreter->system_transaction_) {
           throw QueryException("Expected to be in a system transaction");
         }
 
 #ifdef MG_ENTERPRISE
-        auth->ClearRoles(username, roles, role_databases, &*interpreter->system_transaction_);
+        auth->ClearRoles(username, role_databases, &*interpreter->system_transaction_);
 #else
         if (!role_databases.empty()) {
           throw QueryException("Database specification is only available in the enterprise edition");
         }
-        auth->ClearRoles(username, roles, std::unordered_set<std::string>{}, &*interpreter->system_transaction_);
+        auth->ClearRoles(username, std::unordered_set<std::string>{}, &*interpreter->system_transaction_);
 #endif
         return std::vector<std::vector<TypedValue>>();
       };

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -1265,18 +1265,22 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
       return callback;
     case AuthQuery::Action::CLEAR_ROLE:
       forbid_on_replica();
-      callback.fn = [auth, username, interpreter = &interpreter, role_databases = std::move(role_databases)] {
+      callback.fn = [auth,
+                     username,
+                     roles = std::move(auth_query->roles_),
+                     interpreter = &interpreter,
+                     role_databases = std::move(role_databases)] {
         if (!interpreter->system_transaction_) {
           throw QueryException("Expected to be in a system transaction");
         }
 
 #ifdef MG_ENTERPRISE
-        auth->ClearRoles(username, role_databases, &*interpreter->system_transaction_);
+        auth->ClearRoles(username, roles, role_databases, &*interpreter->system_transaction_);
 #else
         if (!role_databases.empty()) {
           throw QueryException("Database specification is only available in the enterprise edition");
         }
-        auth->ClearRoles(username, std::unordered_set<std::string>{}, &*interpreter->system_transaction_);
+        auth->ClearRoles(username, roles, std::unordered_set<std::string>{}, &*interpreter->system_transaction_);
 #endif
         return std::vector<std::vector<TypedValue>>();
       };

--- a/src/query/metadata.cpp
+++ b/src/query/metadata.cpp
@@ -106,6 +106,8 @@ constexpr std::string_view GetCodeString(const NotificationCode code) {
       return "ReloadSSL"sv;
     case NotificationCode::INDEX_CONSTRAINT_NAME_IGNORED:
       return "IndexConstraintNameIgnored"sv;
+    case NotificationCode::CREATE_USER:
+      return "CreateUser"sv;
   }
 }
 }  // namespace

--- a/src/query/metadata.cpp
+++ b/src/query/metadata.cpp
@@ -108,6 +108,8 @@ constexpr std::string_view GetCodeString(const NotificationCode code) {
       return "IndexConstraintNameIgnored"sv;
     case NotificationCode::CREATE_USER:
       return "CreateUser"sv;
+    case NotificationCode::CREATE_ROLE:
+      return "CreateRole"sv;
   }
 }
 }  // namespace

--- a/src/query/metadata.hpp
+++ b/src/query/metadata.hpp
@@ -62,6 +62,7 @@ enum class NotificationCode : uint8_t {
   PARALLEL_EXECUTION_FALLBACK,
   RELOAD_SSL,
   INDEX_CONSTRAINT_NAME_IGNORED,
+  CREATE_USER,
 };
 
 struct Notification {

--- a/src/query/metadata.hpp
+++ b/src/query/metadata.hpp
@@ -63,6 +63,7 @@ enum class NotificationCode : uint8_t {
   RELOAD_SSL,
   INDEX_CONSTRAINT_NAME_IGNORED,
   CREATE_USER,
+  CREATE_ROLE,
 };
 
 struct Notification {

--- a/src/replication_handler/auth_replication_handlers.cpp
+++ b/src/replication_handler/auth_replication_handlers.cpp
@@ -126,7 +126,7 @@ void DropAuthDataHandler(memgraph::system::ReplicaHandlerAccessToState &system_s
         auth->RemoveUser(req.name);
       } break;
       case ROLE: {
-        auth->RemoveRole(req.name);
+        auth->RemoveRole(req.name, true);
       } break;
       case PROFILE: {
         auth->DropProfile(req.name);
@@ -190,7 +190,7 @@ bool SystemRecoveryHandler(auth::SynchedAuth &auth, auth::Auth::Config auth_conf
       }
       // Delete all the leftover roles
       for (const auto &role : old_roles) {
-        if (!locked_auth.RemoveRole(role)) {
+        if (!locked_auth.RemoveRole(role, true)) {
           spdlog::debug("SystemRecoveryHandler: Failed to remove role \"{}\".", role);
           return false;
         }

--- a/src/replication_handler/auth_replication_handlers.cpp
+++ b/src/replication_handler/auth_replication_handlers.cpp
@@ -126,7 +126,7 @@ void DropAuthDataHandler(memgraph::system::ReplicaHandlerAccessToState &system_s
         auth->RemoveUser(req.name);
       } break;
       case ROLE: {
-        auth->RemoveRole(req.name, true);
+        auth->RemoveRole(req.name, /*force=*/true);
       } break;
       case PROFILE: {
         auth->DropProfile(req.name);
@@ -190,7 +190,7 @@ bool SystemRecoveryHandler(auth::SynchedAuth &auth, auth::Auth::Config auth_conf
       }
       // Delete all the leftover roles
       for (const auto &role : old_roles) {
-        if (!locked_auth.RemoveRole(role, true)) {
+        if (!locked_auth.RemoveRole(role, /*force=*/true)) {
           spdlog::debug("SystemRecoveryHandler: Failed to remove role \"{}\".", role);
           return false;
         }

--- a/tests/drivers/python/v5_8/impersonate_user.py
+++ b/tests/drivers/python/v5_8/impersonate_user.py
@@ -52,7 +52,7 @@ with GraphDatabase.driver("bolt://localhost:7687", auth=None, encrypted=False) a
 with GraphDatabase.driver("bolt://localhost:7687", auth=None, encrypted=False) as driver:
     with driver.session() as session:
         session.run("CREATE USER admin;").consume()  # Has all permissions
-        session.run("GRANT IMPERSONATE_USER * TO admin;").consume()
+        session.run("GRANT IMPERSONATE_USER * TO USER admin;").consume()
         session.run("CREATE USER user;").consume()
         session.run("GRANT MATCH, SET, DELETE TO user;").consume()
         session.run("CREATE USER user2;").consume()
@@ -88,7 +88,7 @@ with GraphDatabase.driver("bolt://localhost:7687", auth=("admin", ""), encrypted
 # Try to impersonate a user you don't have access to
 with GraphDatabase.driver("bolt://localhost:7687", auth=("admin", ""), encrypted=False) as driver:
     with driver.session() as session:
-        session.run("GRANT IMPERSONATE_USER user2,user3 TO admin;").consume()
+        session.run("GRANT IMPERSONATE_USER user2,user3 TO USER admin;").consume()
 
 with GraphDatabase.driver("bolt://localhost:7687", auth=("admin", ""), encrypted=False) as driver:
     failed = False
@@ -111,7 +111,7 @@ with GraphDatabase.driver("bolt://localhost:7687", auth=("admin", ""), encrypted
 # Try to impersonate a user you are explicitly denied
 with GraphDatabase.driver("bolt://localhost:7687", auth=("admin", ""), encrypted=False) as driver:
     with driver.session() as session:
-        session.run("DENY IMPERSONATE_USER user3 TO admin;").consume()
+        session.run("DENY IMPERSONATE_USER user3 TO USER admin;").consume()
 
 with GraphDatabase.driver("bolt://localhost:7687", auth=("admin", ""), encrypted=False) as driver:
     failed = False
@@ -133,9 +133,13 @@ with GraphDatabase.driver("bolt://localhost:7687", auth=("admin", ""), encrypted
 
 
 # Try to impersonate a user without the correct permissions
+# The first user has both USER admin (direct GRANT ... TO USER admin) and the
+# built-in ROLE admin; effective permissions merge both, so IMPERSONATE must be
+# revoked from each namespace.
 with GraphDatabase.driver("bolt://localhost:7687", auth=("admin", ""), encrypted=False) as driver:
     with driver.session() as session:
-        session.run("REVOKE IMPERSONATE_USER FROM admin;").consume()
+        session.run("REVOKE IMPERSONATE_USER FROM USER admin;").consume()
+        session.run("REVOKE IMPERSONATE_USER FROM ROLE admin;").consume()
 
 with GraphDatabase.driver("bolt://localhost:7687", auth=("admin", ""), encrypted=False) as driver:
     failed = False
@@ -154,7 +158,7 @@ with GraphDatabase.driver("bolt://localhost:7687", auth=("admin", ""), encrypted
 # Try to impersonate a different user with the same username
 with GraphDatabase.driver("bolt://localhost:7687", auth=("admin", ""), encrypted=False) as driver:
     with driver.session() as session:
-        session.run("GRANT IMPERSONATE_USER user,user2,user3 TO admin;").consume()
+        session.run("GRANT IMPERSONATE_USER user,user2,user3 TO USER admin;").consume()
 
 
 with GraphDatabase.driver("bolt://localhost:7687", auth=("admin", ""), encrypted=False) as driver:
@@ -192,6 +196,15 @@ with GraphDatabase.driver("bolt://localhost:7687", auth=("admin", ""), encrypted
         session.run("CREATE DATABASE db1").consume()
         session.run("CREATE DATABASE db2").consume()
 
+        # Admin only had database access via the built-in admin role; for a
+        # named database, User::GetPermissions(db) folds to role-only unless the
+        # user has direct GRANT DATABASE on that db.  After REVOKE
+        # IMPERSONATE_USER FROM ROLE admin, impersonation on db1/db2 must come
+        # from USER admin.
+        session.run("GRANT DATABASE memgraph TO USER admin").consume()
+        session.run("GRANT DATABASE db1 TO USER admin").consume()
+        session.run("GRANT DATABASE db2 TO USER admin").consume()
+
         session.run("GRANT DATABASE memgraph TO user").consume()
         session.run("GRANT DATABASE db1 TO user").consume()
         session.run("GRANT DATABASE db2 TO user").consume()
@@ -206,7 +219,7 @@ with GraphDatabase.driver("bolt://localhost:7687", auth=("admin", ""), encrypted
         session.run("SET MAIN DATABASE db1 FOR user2").consume()
         session.run("SET MAIN DATABASE db2 FOR user3").consume()
 
-        session.run("GRANT IMPERSONATE_USER * TO admin;").consume()
+        session.run("GRANT IMPERSONATE_USER * TO USER admin;").consume()
         session.run("GRANT MULTI_DATABASE_USE TO user;").consume()
         session.run("GRANT MULTI_DATABASE_USE TO user2;").consume()
         session.run("GRANT MULTI_DATABASE_USE TO user3;").consume()
@@ -295,8 +308,12 @@ with GraphDatabase.driver("bolt://localhost:7687", auth=("admin", ""), encrypted
         session.run("GRANT IMPERSONATE_USER user2 TO db2_role;").consume()
         session.run("GRANT IMPERSONATE_USER user3 TO memgraph_role;").consume()
 
-        # Add roles to admin
-        session.run("SET ROLE FOR admin TO db1_role, db2_role, memgraph_role;").consume()
+        # Attach test roles per database only. A global SET ROLE would
+        # ClearAllRoles() and drop the built-in admin role, leaving admin
+        # without AUTH (cannot run SET ROLE / GRANT to recover).
+        session.run("SET ROLE FOR USER admin TO db1_role ON db1").consume()
+        session.run("SET ROLE FOR USER admin TO db2_role ON db2").consume()
+        session.run("SET ROLE FOR USER admin TO memgraph_role ON memgraph").consume()
 
 # Test database-specific impersonation through roles
 with GraphDatabase.driver("bolt://localhost:7687", auth=("admin", ""), encrypted=False) as driver:
@@ -356,7 +373,7 @@ print("Testing database access control during impersonation...")
 with GraphDatabase.driver("bolt://localhost:7687", auth=("admin", ""), encrypted=False) as driver:
     with driver.session() as session:
         # Grant all impersonation permissions back for the rest of the tests
-        session.run("GRANT IMPERSONATE_USER * TO admin;").consume()
+        session.run("GRANT IMPERSONATE_USER * TO USER admin;").consume()
 
     # Test user access (has access to memgraph, db1, db2)
     with driver.session(impersonated_user="user") as session:
@@ -419,6 +436,9 @@ print("Testing database-specific permissions during impersonation...")
 with GraphDatabase.driver("bolt://localhost:7687", auth=("admin", ""), encrypted=False) as driver:
     with driver.session() as session:
         # Grant different permissions per database
+        # Remove per-DB role links from the database-specific impersonation test
+        # so roles can be dropped.
+        session.run("CLEAR ROLES FOR USER admin ON db1, db2, memgraph").consume()
         session.run("DROP ROLE db1_role;").consume()
         session.run("DROP ROLE db2_role;").consume()
 
@@ -598,7 +618,7 @@ with GraphDatabase.driver("bolt://localhost:7687", auth=("admin", ""), encrypted
         session.run("SET PROFILE FOR admin TO admin_profile;").consume()
 
         # Grant impersonation permissions
-        session.run("GRANT IMPERSONATE_USER limit_user1,limit_user2 TO admin;").consume()
+        session.run("GRANT IMPERSONATE_USER limit_user1,limit_user2 TO USER admin;").consume()
 
 # Test user limits with impersonated users
 with GraphDatabase.driver("bolt://localhost:7687", auth=("admin", ""), encrypted=False) as driver:

--- a/tests/e2e/auth/auth_queries.py
+++ b/tests/e2e/auth/auth_queries.py
@@ -1034,6 +1034,23 @@ def test_show_role_no_database_specification_required(memgraph):
     memgraph.execute("DROP DATABASE test_db;")
 
 
+def test_first_user_creates_and_assigns_builtin_roles(memgraph):
+    memgraph.execute("CREATE USER alice;")
+
+    roles = list(memgraph.execute_and_fetch("SHOW ROLES;"))
+    role_map = {r["role"]: r for r in roles}
+
+    builtin_names = {"admin", "readwrite", "readonly"}
+    assert builtin_names.issubset(role_map.keys()), f"Expected builtin roles, found: {list(role_map.keys())}"
+    for name in builtin_names:
+        assert role_map[name]["builtin"] is True, f"Expected '{name}' to be builtin"
+
+    user_roles = list(memgraph.execute_and_fetch("SHOW ROLE FOR alice;"))
+    assert "admin" in [r["role"] for r in user_roles], "Expected first user to have builtin admin role"
+
+    memgraph.execute("DROP USER alice;")
+
+
 def test_show_roles_builtin_column(memgraph):
     memgraph.execute("CREATE ROLE regular_role;")
 

--- a/tests/e2e/auth/auth_queries.py
+++ b/tests/e2e/auth/auth_queries.py
@@ -164,6 +164,7 @@ def test_roles_function_multi_tenant(memgraph):
     memgraph.execute("CREATE DATABASE db2;")
     memgraph.execute("GRANT DATABASE * TO admin_role;")
     memgraph.execute("GRANT DATABASE * TO user_role;")
+    memgraph.execute("CLEAR ROLE FOR test_user;")
     memgraph.execute("SET ROLE FOR test_user TO admin_role, user_role ON db1;")
     memgraph.execute("SET ROLE FOR test_user TO user_role ON db2;")
     memgraph.execute("SET ROLE FOR test_user TO admin_role ON memgraph;")
@@ -216,7 +217,7 @@ def test_username_and_roles_functions_in_trigger(memgraph):
     memgraph.execute("CREATE USER test_user;")
     memgraph.execute("CREATE ROLE admin_role;")
     memgraph.execute("CREATE ROLE user_role;")
-    memgraph.execute("SET ROLE FOR test_user TO admin_role, user_role;")
+    memgraph.execute("GRANT ROLES admin_role, user_role TO test_user;")
 
     memgraph.execute(
         """
@@ -243,7 +244,8 @@ def test_username_and_roles_functions_in_trigger(memgraph):
     assert results[0]["username"] == "test_user"
     roles = results[0]["roles"]
     assert isinstance(roles, list)
-    assert len(roles) == 2
+    assert len(roles) == 3
+    assert "admin" in roles
     assert "admin_role" in roles
     assert "user_role" in roles
 
@@ -281,7 +283,8 @@ def test_username_and_roles_functions_in_trigger(memgraph):
     assert results[0]["username"] == "test_user"
     roles = results[0]["roles"]
     assert isinstance(roles, list)
-    assert len(roles) == 2
+    assert len(roles) == 3
+    assert "admin" in roles
     assert "admin_role" in roles
     assert "user_role" in roles
 
@@ -338,6 +341,7 @@ def test_show_current_roles_multi_tenant(memgraph):
     memgraph.execute("CREATE DATABASE db2;")
     memgraph.execute("GRANT DATABASE * TO admin_role;")
     memgraph.execute("GRANT DATABASE * TO user_role;")
+    memgraph.execute("CLEAR ROLE FOR test_user;")
     memgraph.execute("SET ROLE FOR test_user TO admin_role, user_role ON db1;")
     memgraph.execute("SET ROLE FOR test_user TO user_role ON db2;")
 
@@ -366,6 +370,8 @@ def test_show_current_roles_multi_tenant(memgraph):
     assert "admin_role" == results[0]["role"] or "admin_role" == results[1]["role"]
     assert "user_role" == results[0]["role"] or "user_role" == results[1]["role"]
 
+    # These tests cannot be used because gqlalchemy reconnects with every query,
+    # rather than exposing persistent connection objects.
     # # db1
     # memgraph_with_user.execute_and_fetch("USE DATABASE db1;", connection=connection)
     # results = list(memgraph_with_user.execute_and_fetch("SHOW CURRENT ROLES;", connection=connection))
@@ -683,7 +689,7 @@ def test_complex_role_privilege_flow(memgraph):
     memgraph.execute("CREATE ROLE user;")
     memgraph.execute("CREATE ROLE architect;")
     memgraph.execute("CREATE ROLE moderator;")
-    memgraph.execute("CREATE ROLE admin;")
+    memgraph.execute("CREATE ROLE superadmin;")
     memgraph.execute("CREATE ROLE support;")
 
     # Create databases
@@ -695,7 +701,7 @@ def test_complex_role_privilege_flow(memgraph):
     memgraph.execute("GRANT DATABASE db1 TO architect;")
     memgraph.execute("GRANT DATABASE db1 TO moderator;")
     memgraph.execute("GRANT DATABASE db2 TO support;")
-    memgraph.execute("GRANT DATABASE db2 TO admin;")
+    memgraph.execute("GRANT DATABASE db2 TO superadmin;")
 
     # Set main databases for roles
     memgraph.execute("SET MAIN DATABASE db1 FOR architect;")
@@ -704,7 +710,7 @@ def test_complex_role_privilege_flow(memgraph):
     # Set roles for charlie
     memgraph.execute("SET ROLE FOR charlie TO user;")
     memgraph.execute("SET ROLE FOR charlie TO architect, moderator ON db1;")
-    memgraph.execute("SET ROLE FOR charlie TO admin, support ON db2;")
+    memgraph.execute("SET ROLE FOR charlie TO superadmin, support ON db2;")
 
     # Check SHOW PRIVILEGES FOR charlie ON DATABASE db1 - should give empty result initially
     results = list(memgraph.execute_and_fetch("SHOW PRIVILEGES FOR charlie ON DATABASE db1;"))
@@ -748,7 +754,7 @@ def test_complex_role_privilege_flow(memgraph):
     memgraph.execute("DROP ROLE user;")
     memgraph.execute("DROP ROLE architect;")
     memgraph.execute("DROP ROLE moderator;")
-    memgraph.execute("DROP ROLE admin;")
+    memgraph.execute("DROP ROLE superadmin;")
     memgraph.execute("DROP ROLE support;")
     memgraph.execute("DROP DATABASE db1;")
     memgraph.execute("DROP DATABASE db2;")
@@ -758,7 +764,7 @@ def test_complex_role_privilege_flow(memgraph):
 def test_show_databases_for_user_and_role(memgraph):
     default_db = "memgraph"
     """Test SHOW DATABASES FOR <user> and SHOW DATABASES FOR <role> with multiple roles and grants/denies."""
-    # Setup: create databases, users, and roles
+    # Setup: create databases, users, and roles3
     memgraph.execute("CREATE DATABASE db1;")
     memgraph.execute("CREATE DATABASE db2;")
     memgraph.execute("CREATE DATABASE db3;")
@@ -766,18 +772,18 @@ def test_show_databases_for_user_and_role(memgraph):
     memgraph.execute("CREATE USER bob;")
     memgraph.execute("CREATE ROLE architect;")
     memgraph.execute("CREATE ROLE moderator;")
-    memgraph.execute("CREATE ROLE admin;")
+    memgraph.execute("CREATE ROLE superadmin;")
 
     # Grant/deny database access to roles
     memgraph.execute("GRANT DATABASE db1 TO architect;")
     memgraph.execute("GRANT DATABASE db2 TO architect;")
     memgraph.execute("GRANT DATABASE db2 TO moderator;")
-    memgraph.execute("GRANT DATABASE db3 TO admin;")
+    memgraph.execute("GRANT DATABASE db3 TO superadmin;")
     memgraph.execute("DENY DATABASE db2 FROM architect;")  # architect: db1 only
 
     # Assign roles to users
-    memgraph.execute("SET ROLE FOR alice TO architect, moderator;")
-    memgraph.execute("SET ROLE FOR bob TO admin, moderator;")
+    memgraph.execute("GRANT ROLES architect, moderator TO alice;")
+    memgraph.execute("GRANT ROLES superadmin, moderator TO bob;")
 
     # As admin, check SHOW DATABASES FOR <role>
     result = list(memgraph.execute_and_fetch("SHOW DATABASE PRIVILEGES FOR architect;"))
@@ -820,7 +826,7 @@ def test_show_databases_for_user_and_role(memgraph):
     memgraph.execute("DROP USER bob;")
     memgraph.execute("DROP ROLE architect;")
     memgraph.execute("DROP ROLE moderator;")
-    memgraph.execute("DROP ROLE admin;")
+    memgraph.execute("DROP ROLE superadmin;")
     memgraph.execute("DROP DATABASE db1;")
     memgraph.execute("DROP DATABASE db2;")
     memgraph.execute("DROP DATABASE db3;")

--- a/tests/e2e/auth/auth_queries.py
+++ b/tests/e2e/auth/auth_queries.py
@@ -551,32 +551,32 @@ def test_show_role_syntax_variations(memgraph):
 
     # Test SHOW ROLE ON MAIN
     results = list(memgraph.execute_and_fetch("SHOW ROLE FOR test_user ON MAIN;"))
-    assert results == [{"role": "null"}]
+    assert results == []
 
     # Test SHOW ROLES ON MAIN
     results = list(memgraph.execute_and_fetch("SHOW ROLES FOR test_user ON MAIN;"))
-    assert results == [{"role": "null"}]
+    assert results == []
 
     # Test SHOW ROLE ON CURRENT
     results = list(memgraph.execute_and_fetch("SHOW ROLE FOR test_user ON CURRENT;"))
-    assert results == [{"role": "null"}]
+    assert results == []
 
     memgraph.execute("USE DATABASE db1;")
     # Test SHOW ROLES ON CURRENT
     results = list(memgraph.execute_and_fetch("SHOW ROLES FOR test_user ON CURRENT;"))
-    assert results == [{"role": "role1"}]
+    assert [row["role"] for row in results] == ["role1"]
 
     # Test SHOW ROLE ON DATABASE
     results = list(memgraph.execute_and_fetch("SHOW ROLE FOR test_user ON DATABASE db1;"))
-    assert results == [{"role": "role1"}]
+    assert [row["role"] for row in results] == ["role1"]
 
     # Test SHOW ROLES ON DATABASE
     results = list(memgraph.execute_and_fetch("SHOW ROLES FOR test_user ON DATABASE db1;"))
-    assert results == [{"role": "role1"}]
+    assert [row["role"] for row in results] == ["role1"]
 
     # Test SHOW ROLES ON DATABASE
     results = list(memgraph.execute_and_fetch("SHOW ROLES FOR test_user ON DATABASE db2;"))
-    assert results == [{"role": "role2"}]
+    assert [row["role"] for row in results] == ["role2"]
 
     # Clean up
     memgraph.execute("USE DATABASE memgraph;")
@@ -615,10 +615,10 @@ def test_database_specific_role_management(memgraph):
 
     # Test showing roles for specific databases
     results = list(memgraph.execute_and_fetch("SHOW ROLE FOR test_user ON DATABASE db1;"))
-    assert results == [{"role": "null"}]
+    assert results == []
 
     results = list(memgraph.execute_and_fetch("SHOW ROLES FOR test_user ON DATABASE db2;"))
-    assert results == [{"role": "null"}]
+    assert results == []
 
     # Test that SHOW ROLE works without database specification even with database-specific roles
     # Set some database-specific roles

--- a/tests/e2e/auth/auth_queries.py
+++ b/tests/e2e/auth/auth_queries.py
@@ -1034,5 +1034,79 @@ def test_show_role_no_database_specification_required(memgraph):
     memgraph.execute("DROP DATABASE test_db;")
 
 
+def test_show_roles_builtin_column(memgraph):
+    memgraph.execute("CREATE ROLE regular_role;")
+
+    results = list(memgraph.execute_and_fetch("SHOW ROLES;"))
+    assert len(results) > 0
+
+    builtin_names = {"admin", "readwrite", "readonly"}
+    for row in results:
+        assert "builtin" in row
+        if row["role"] in builtin_names:
+            assert row["builtin"] is True
+        elif row["role"] == "regular_role":
+            assert row["builtin"] is False
+
+    memgraph.execute("DROP ROLE regular_role;")
+
+
+def test_show_roles_for_user_builtin_column(memgraph):
+    memgraph.execute("CREATE USER test_user;")
+    memgraph.execute("CREATE ROLE regular_role;")
+    memgraph.execute("GRANT ROLES admin, regular_role TO test_user;")
+
+    results = list(memgraph.execute_and_fetch("SHOW ROLE FOR test_user;"))
+    assert len(results) == 2
+
+    for row in results:
+        assert "builtin" in row
+        if row["role"] == "admin":
+            assert row["builtin"] is True
+        elif row["role"] == "regular_role":
+            assert row["builtin"] is False
+
+    memgraph.execute("DROP USER test_user;")
+    memgraph.execute("DROP ROLE regular_role;")
+
+
+def test_multiple_roles_on_database(memgraph):
+    memgraph.execute("CREATE DATABASE testdb;")
+    memgraph.execute("CREATE USER test_user;")
+    memgraph.execute("CREATE ROLE role1;")
+    memgraph.execute("CREATE ROLE role2;")
+    memgraph.execute("GRANT DATABASE testdb TO role1;")
+    memgraph.execute("GRANT DATABASE testdb TO role2;")
+
+    memgraph.execute("SET ROLE FOR test_user TO role1, role2 ON testdb;")
+
+    results = list(memgraph.execute_and_fetch("SHOW ROLE FOR test_user ON DATABASE testdb;"))
+    assert len(results) == 2
+    role_names = [row["role"] for row in results]
+    assert "role1" in role_names
+    assert "role2" in role_names
+
+    memgraph.execute("CREATE ROLE role3;")
+    memgraph.execute("GRANT DATABASE testdb TO role3;")
+    memgraph.execute("GRANT ROLE role3 TO test_user ON testdb;")
+
+    results = list(memgraph.execute_and_fetch("SHOW ROLE FOR test_user ON DATABASE testdb;"))
+    assert len(results) == 3
+    role_names = [row["role"] for row in results]
+    assert "role3" in role_names
+
+    memgraph.execute("REVOKE ROLE role2 FROM test_user ON testdb;")
+    results = list(memgraph.execute_and_fetch("SHOW ROLE FOR test_user ON DATABASE testdb;"))
+    assert len(results) == 2
+    role_names = [row["role"] for row in results]
+    assert "role2" not in role_names
+
+    memgraph.execute("DROP USER test_user;")
+    memgraph.execute("DROP ROLE role1;")
+    memgraph.execute("DROP ROLE role2;")
+    memgraph.execute("DROP ROLE role3;")
+    memgraph.execute("DROP DATABASE testdb;")
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/auth/auth_queries.py
+++ b/tests/e2e/auth/auth_queries.py
@@ -764,7 +764,7 @@ def test_complex_role_privilege_flow(memgraph):
 def test_show_databases_for_user_and_role(memgraph):
     default_db = "memgraph"
     """Test SHOW DATABASES FOR <user> and SHOW DATABASES FOR <role> with multiple roles and grants/denies."""
-    # Setup: create databases, users, and roles3
+    # Setup: create databases, users, and roles
     memgraph.execute("CREATE DATABASE db1;")
     memgraph.execute("CREATE DATABASE db2;")
     memgraph.execute("CREATE DATABASE db3;")

--- a/tests/e2e/auth/auth_queries.py
+++ b/tests/e2e/auth/auth_queries.py
@@ -1051,25 +1051,6 @@ def test_show_roles_builtin_column(memgraph):
     memgraph.execute("DROP ROLE regular_role;")
 
 
-def test_show_roles_for_user_builtin_column(memgraph):
-    memgraph.execute("CREATE USER test_user;")
-    memgraph.execute("CREATE ROLE regular_role;")
-    memgraph.execute("GRANT ROLES admin, regular_role TO test_user;")
-
-    results = list(memgraph.execute_and_fetch("SHOW ROLE FOR test_user;"))
-    assert len(results) == 2
-
-    for row in results:
-        assert "builtin" in row
-        if row["role"] == "admin":
-            assert row["builtin"] is True
-        elif row["role"] == "regular_role":
-            assert row["builtin"] is False
-
-    memgraph.execute("DROP USER test_user;")
-    memgraph.execute("DROP ROLE regular_role;")
-
-
 def test_multiple_roles_on_database(memgraph):
     memgraph.execute("CREATE DATABASE testdb;")
     memgraph.execute("CREATE USER test_user;")

--- a/tests/e2e/auth/common.py
+++ b/tests/e2e/auth/common.py
@@ -44,6 +44,18 @@ def memgraph(**kwargs) -> Memgraph:
     except Exception as e:
         pass
     try:
+        memgraph.execute("DROP ROLE admin;")
+    except Exception as e:
+        pass
+    try:
+        memgraph.execute("DROP ROLE readwrite;")
+    except Exception as e:
+        pass
+    try:
+        memgraph.execute("DROP ROLE readonly;")
+    except Exception as e:
+        pass
+    try:
         memgraph.execute("DROP PROFILE profile;")
     except Exception as e:
         pass
@@ -61,9 +73,12 @@ def memgraph(**kwargs) -> Memgraph:
 def provide_user() -> Memgraph:
     memgraph = Memgraph()
 
+    # Create superuser first so anthony is not the first user and gets no builtin role
+    memgraph.execute("CREATE USER superuser IDENTIFIED BY 'superpassword';")
     memgraph.execute("CREATE USER anthony IDENTIFIED BY 'password';")
 
     yield None
 
-    memgraph = Memgraph(username="anthony", password="password")
+    memgraph = Memgraph(username="superuser", password="superpassword")
     memgraph.execute("DROP USER anthony;")
+    memgraph.execute("DROP USER superuser;")

--- a/tests/e2e/auth/common.py
+++ b/tests/e2e/auth/common.py
@@ -25,47 +25,47 @@ def memgraph(**kwargs) -> Memgraph:
 
     try:
         memgraph.execute("DROP USER mrma;")
-    except Exception as e:
+    except Exception:
         pass
     try:
         memgraph.execute("DROP USER sha256;")
-    except Exception as e:
+    except Exception:
         pass
     try:
         memgraph.execute("DROP USER sha256_multiple;")
-    except Exception as e:
+    except Exception:
         pass
     try:
         memgraph.execute("DROP USER bcrypt;")
-    except Exception as e:
+    except Exception:
         pass
     try:
         memgraph.execute("DROP ROLE mrma;")
-    except Exception as e:
+    except Exception:
         pass
     try:
         memgraph.execute("DROP ROLE admin;")
-    except Exception as e:
+    except Exception:
         pass
     try:
         memgraph.execute("DROP ROLE readwrite;")
-    except Exception as e:
+    except Exception:
         pass
     try:
         memgraph.execute("DROP ROLE readonly;")
-    except Exception as e:
+    except Exception:
         pass
     try:
         memgraph.execute("DROP PROFILE profile;")
-    except Exception as e:
+    except Exception:
         pass
     try:
         memgraph.execute("DROP PROFILE Profile;")
-    except Exception as e:
+    except Exception:
         pass
     try:
         memgraph.execute("DROP PROFILE profile2;")
-    except Exception as e:
+    except Exception:
         pass
 
 

--- a/tests/e2e/auth/test_show_privileges_isolation.py
+++ b/tests/e2e/auth/test_show_privileges_isolation.py
@@ -33,10 +33,11 @@ def _ensure_clean_state_and_create_admin(memgraph):
     except Exception:
         assert False, "Failed to check users"
 
-    # Check that there are no existing roles
+    # Check that there are no existing non-builtin roles
     try:
         roles = list(memgraph.execute_and_fetch("SHOW ROLES;"))
-        assert len(roles) == 0, f"Expected no roles, found: {roles}"
+        non_builtin_roles = [r for r in roles if not r.get("builtin", False)]
+        assert len(non_builtin_roles) == 0, f"Expected no non-builtin roles, found: {non_builtin_roles}"
     except Exception:
         assert False, "Failed to check roles"
 

--- a/tests/e2e/fine_grained_access/workloads.yaml
+++ b/tests/e2e/fine_grained_access/workloads.yaml
@@ -4,6 +4,7 @@ args: &args
   - "--log-level=TRACE"
 
 base_setup_queries: &base_setup_queries
+  - "CREATE ROLE _dummy_role;"
   - "CREATE USER admin IDENTIFIED BY 'test';"
   - "CREATE USER user IDENTIFIED BY 'test';"
   - "GRANT ALL PRIVILEGES TO admin;"
@@ -15,6 +16,7 @@ base_setup_queries: &base_setup_queries
   - "CREATE DATABASE clean;"
 
 edge_type_filtering_setup_queries: &edge_type_filtering_setup_queries
+  - "CREATE ROLE _dummy_role;"
   - "CREATE USER admin IDENTIFIED BY 'test';"
   - "CREATE USER user IDENTIFIED BY 'test';"
   - "GRANT ALL PRIVILEGES TO admin;"
@@ -43,6 +45,7 @@ edge_type_filtering_setup_queries: &edge_type_filtering_setup_queries
   - "USE DATABASE memgraph"
 
 path_filtering_setup_queries: &path_filtering_setup_queries
+  - "CREATE ROLE _dummy_role;"
   - "CREATE USER admin IDENTIFIED BY 'test';"
   - "CREATE USER user IDENTIFIED BY 'test';"
   - "GRANT ALL PRIVILEGES TO admin;"
@@ -77,6 +80,7 @@ path_filtering_setup_queries: &path_filtering_setup_queries
   - "USE DATABASE memgraph"
 
 show_databases_w_user_setup_queries: &show_databases_w_user_setup_queries
+  - "CREATE ROLE _dummy_role;"
   - "CREATE USER admin IDENTIFIED BY 'test';"
   - "CREATE USER user IDENTIFIED BY 'test';"
   - "CREATE USER user2 IDENTIFIED BY 'test';"

--- a/tests/e2e/fine_grained_access/workloads.yaml
+++ b/tests/e2e/fine_grained_access/workloads.yaml
@@ -4,6 +4,7 @@ args: &args
   - "--log-level=TRACE"
 
 base_setup_queries: &base_setup_queries
+  # Create a role before the first user so builtin role creation (admin/readwrite/readonly) is suppressed.
   - "CREATE ROLE _dummy_role;"
   - "CREATE USER admin IDENTIFIED BY 'test';"
   - "CREATE USER user IDENTIFIED BY 'test';"
@@ -16,6 +17,7 @@ base_setup_queries: &base_setup_queries
   - "CREATE DATABASE clean;"
 
 edge_type_filtering_setup_queries: &edge_type_filtering_setup_queries
+  # Create a role before the first user so builtin role creation (admin/readwrite/readonly) is suppressed.
   - "CREATE ROLE _dummy_role;"
   - "CREATE USER admin IDENTIFIED BY 'test';"
   - "CREATE USER user IDENTIFIED BY 'test';"
@@ -45,6 +47,7 @@ edge_type_filtering_setup_queries: &edge_type_filtering_setup_queries
   - "USE DATABASE memgraph"
 
 path_filtering_setup_queries: &path_filtering_setup_queries
+  # Create a role before the first user so builtin role creation (admin/readwrite/readonly) is suppressed.
   - "CREATE ROLE _dummy_role;"
   - "CREATE USER admin IDENTIFIED BY 'test';"
   - "CREATE USER user IDENTIFIED BY 'test';"
@@ -80,6 +83,7 @@ path_filtering_setup_queries: &path_filtering_setup_queries
   - "USE DATABASE memgraph"
 
 show_databases_w_user_setup_queries: &show_databases_w_user_setup_queries
+  # Create a role before the first user so builtin role creation (admin/readwrite/readonly) is suppressed.
   - "CREATE ROLE _dummy_role;"
   - "CREATE USER admin IDENTIFIED BY 'test';"
   - "CREATE USER user IDENTIFIED BY 'test';"

--- a/tests/e2e/high_availability/auth.py
+++ b/tests/e2e/high_availability/auth.py
@@ -368,6 +368,7 @@ def test_ha_mt_auth_scenario(test_name):
 
     # Create users with different access levels
     with driver.session() as session:
+        session.run("CREATE ROLE _dummy_role")
         # Create admin user with access to all databases
         session.run("CREATE USER admin IDENTIFIED BY 'admin123'")
         session.run("GRANT ALL PRIVILEGES TO admin")

--- a/tests/e2e/high_availability/auth.py
+++ b/tests/e2e/high_availability/auth.py
@@ -368,6 +368,7 @@ def test_ha_mt_auth_scenario(test_name):
 
     # Create users with different access levels
     with driver.session() as session:
+        # Create a role before the first user so builtin role creation (admin/readwrite/readonly) is suppressed.
         session.run("CREATE ROLE _dummy_role")
         # Create admin user with access to all databases
         session.run("CREATE USER admin IDENTIFIED BY 'admin123'")

--- a/tests/e2e/lba_procedures/workloads.yaml
+++ b/tests/e2e/lba_procedures/workloads.yaml
@@ -4,6 +4,7 @@ args: &args
   - "--schema-info-enabled=true"
 
 query_modules_setup_queries: &query_modules_setup_queries
+  # Create a role before the first user so builtin role creation (admin/readwrite/readonly) is suppressed.
   - "CREATE ROLE _dummy_role;"
   - "CREATE USER admin IDENTIFIED BY 'test';"
   - "GRANT ALL PRIVILEGES TO admin"
@@ -13,6 +14,7 @@ query_modules_setup_queries: &query_modules_setup_queries
   - "GRANT DATABASE * TO user"
 
 show_privileges_setup_queries: &show_privileges_setup_queries
+  # Create a role before the first user so builtin role creation (admin/readwrite/readonly) is suppressed.
   - "CREATE ROLE _dummy_role;"
   - "Create User Josip;"
   - "GRANT READ ON NODES CONTAINING LABELS :Label1 TO Josip;"
@@ -42,6 +44,7 @@ show_privileges_setup_queries: &show_privileges_setup_queries
   - "GRANT UPDATE ON NODES CONTAINING LABELS * TO Bruno;"
 
 schema_info_setup_queries: &schema_info_setup_queries
+  # Create a role before the first user so builtin role creation (admin/readwrite/readonly) is suppressed.
   - "CREATE ROLE _dummy_role;"
   - "CREATE USER admin;"
   - "GRANT ALL PRIVILEGES TO admin;"

--- a/tests/e2e/lba_procedures/workloads.yaml
+++ b/tests/e2e/lba_procedures/workloads.yaml
@@ -4,6 +4,7 @@ args: &args
   - "--schema-info-enabled=true"
 
 query_modules_setup_queries: &query_modules_setup_queries
+  - "CREATE ROLE _dummy_role;"
   - "CREATE USER admin IDENTIFIED BY 'test';"
   - "GRANT ALL PRIVILEGES TO admin"
   - "GRANT DATABASE * TO admin"
@@ -12,6 +13,7 @@ query_modules_setup_queries: &query_modules_setup_queries
   - "GRANT DATABASE * TO user"
 
 show_privileges_setup_queries: &show_privileges_setup_queries
+  - "CREATE ROLE _dummy_role;"
   - "Create User Josip;"
   - "GRANT READ ON NODES CONTAINING LABELS :Label1 TO Josip;"
   - "DENY * ON NODES CONTAINING LABELS :Label2 TO Josip;"
@@ -40,6 +42,7 @@ show_privileges_setup_queries: &show_privileges_setup_queries
   - "GRANT UPDATE ON NODES CONTAINING LABELS * TO Bruno;"
 
 schema_info_setup_queries: &schema_info_setup_queries
+  - "CREATE ROLE _dummy_role;"
   - "CREATE USER admin;"
   - "GRANT ALL PRIVILEGES TO admin;"
   - "GRANT CREATE, DELETE ON NODES CONTAINING LABELS * TO admin;"

--- a/tests/e2e/show_privileges/show_privileges.py
+++ b/tests/e2e/show_privileges/show_privileges.py
@@ -21,7 +21,7 @@ def test_show_privileges_basic(connect):
 
     # Test that users require ON clause in multi-database environment
     try:
-        result = execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR admin;")
+        result = execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR USER admin;")
         # If this succeeds, we might be in single-database mode
         # Check if we have multiple databases
         databases = execute_and_fetch_all(cursor, "SHOW DATABASES;")
@@ -120,7 +120,7 @@ def test_show_privileges_user_vs_role_behavior(connect):
 
     # Test user behavior - should require ON clause in multi-database environment
     try:
-        result = execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR admin;")
+        result = execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR USER admin;")
         # If this succeeds, check if we're in single-database mode
         databases = execute_and_fetch_all(cursor, "SHOW DATABASES;")
         if len(databases) > 1:
@@ -156,10 +156,10 @@ def test_show_privileges_on_main(connect):
     cursor = connect.cursor()
 
     # Set main database for admin
-    execute_and_fetch_all(cursor, "SET MAIN DATABASE memgraph FOR admin;")
+    execute_and_fetch_all(cursor, "SET MAIN DATABASE memgraph FOR USER admin;")
 
     # Test ON MAIN
-    result = execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR admin ON MAIN;")
+    result = execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR USER admin ON MAIN;")
     assert len(result) > 0, "Should return privileges for admin on main database"
 
 
@@ -171,7 +171,7 @@ def test_show_privileges_on_current(connect):
     execute_and_fetch_all(cursor, "USE DATABASE memgraph;")
 
     # Test ON CURRENT
-    result = execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR admin ON CURRENT;")
+    result = execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR USER admin ON CURRENT;")
     assert len(result) > 0, "Should return privileges for admin on current database"
 
 
@@ -180,12 +180,12 @@ def test_show_privileges_on_database(connect):
     cursor = connect.cursor()
 
     # Test ON DATABASE with specific database
-    result = execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR admin ON DATABASE memgraph;")
+    result = execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR USER admin ON DATABASE memgraph;")
     assert len(result) > 0, "Should return privileges for admin on specified database"
 
     # Test with database name containing special characters
     try:
-        result = execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR admin ON DATABASE `test-db`;")
+        result = execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR USER admin ON DATABASE `test-db`;")
         assert len(result) > 0, "Should return privileges for admin on database with special characters"
     except Exception:
         # Expected to fail in single db mode
@@ -198,7 +198,7 @@ def test_show_privileges_enterprise_only_features(connect):
 
     # These should work in enterprise builds but may throw errors in non-enterprise builds
     try:
-        result = execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR admin ON MAIN;")
+        result = execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR USER admin ON MAIN;")
         # If this succeeds, we're in enterprise mode
         assert len(result) > 0, "Should return privileges for admin on main database"
     except Exception as e:
@@ -206,7 +206,7 @@ def test_show_privileges_enterprise_only_features(connect):
         assert "ON MAIN is only available in enterprise edition" in str(e) or "enterprise" in str(e).lower()
 
     try:
-        result = execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR admin ON CURRENT;")
+        result = execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR USER admin ON CURRENT;")
         # If this succeeds, we're in enterprise mode
         assert len(result) > 0, "Should return privileges for admin on current database"
     except Exception as e:
@@ -214,7 +214,7 @@ def test_show_privileges_enterprise_only_features(connect):
         assert "ON CURRENT is only available in enterprise edition" in str(e) or "enterprise" in str(e).lower()
 
     try:
-        result = execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR admin ON DATABASE memgraph;")
+        result = execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR USER admin ON DATABASE memgraph;")
         # If this succeeds, we're in enterprise mode
         assert len(result) > 0, "Should return privileges for admin on specified database"
     except Exception as e:
@@ -244,7 +244,7 @@ def test_show_privileges_error_cases(connect):
 
     # Test with non-existent database
     try:
-        execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR admin ON DATABASE nonexistent_db;")
+        execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR USER admin ON DATABASE nonexistent_db;")
         # This should work but return empty results or throw an error
         pass
     except Exception:
@@ -252,13 +252,13 @@ def test_show_privileges_error_cases(connect):
 
     # Test syntax errors
     try:
-        execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR admin ON;")
+        execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR USER admin ON;")
         assert False, "Should throw syntax error"
     except Exception:
         pass  # Expected to fail
 
     try:
-        execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR admin ON DATABASE;")
+        execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR USER admin ON DATABASE;")
         assert False, "Should throw syntax error"
     except Exception:
         pass  # Expected to fail
@@ -270,13 +270,13 @@ def test_show_privileges_no_main_database(connect):
 
     # Clear main database for admin
     try:
-        execute_and_fetch_all(cursor, 'SET MAIN DATABASE "" FOR admin;')
+        execute_and_fetch_all(cursor, 'SET MAIN DATABASE "" FOR USER admin;')
     except Exception:
         pass  # May not be supported in all builds
 
     # Test ON MAIN without main database set
     try:
-        result = execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR admin ON MAIN;")
+        result = execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR USER admin ON MAIN;")
         # If this succeeds, we're in enterprise mode and it should work
         assert len(result) > 0, "Should return privileges for admin on main database"
     except Exception as e:
@@ -290,7 +290,7 @@ def test_show_privileges_no_current_database(connect):
 
     # Test ON CURRENT without current database
     try:
-        result = execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR admin ON CURRENT;")
+        result = execute_and_fetch_all(cursor, "SHOW PRIVILEGES FOR USER admin ON CURRENT;")
         # If this succeeds, we're in enterprise mode and it should work
         assert len(result) > 0, "Should return privileges for admin on current database"
     except Exception as e:

--- a/tests/e2e/show_privileges/workloads.yaml
+++ b/tests/e2e/show_privileges/workloads.yaml
@@ -5,11 +5,11 @@ show_privileges: &show_privileges
       log_file: "show_privileges.log"
       setup_queries: [
         "CREATE USER admin;",
-        "GRANT ALL PRIVILEGES TO admin",
-        "GRANT DATABASE * TO admin",
+        "GRANT ALL PRIVILEGES TO USER admin",
+        "GRANT DATABASE * TO USER admin",
         "CREATE ROLE admin_role;",
-        "GRANT ALL PRIVILEGES TO admin_role",
-        "GRANT DATABASE * TO admin_role",
+        "GRANT ALL PRIVILEGES TO ROLE admin_role",
+        "GRANT DATABASE * TO ROLE admin_role",
       ]
       validation_queries: []
 
@@ -20,11 +20,11 @@ show_privileges_cluster: &show_privileges_cluster
       log_file: "show_privileges.log"
       setup_queries: [
         "CREATE USER admin;",
-        "GRANT ALL PRIVILEGES TO admin",
-        "GRANT DATABASE * TO admin",
+        "GRANT ALL PRIVILEGES TO USER admin",
+        "GRANT DATABASE * TO USER admin",
         "CREATE ROLE admin_role;",
-        "GRANT ALL PRIVILEGES TO admin_role",
-        "GRANT DATABASE * TO admin_role",
+        "GRANT ALL PRIVILEGES TO ROLE admin_role",
+        "GRANT DATABASE * TO ROLE admin_role",
         "CREATE DATABASE test_db;",
         "CREATE DATABASE `test-db`;"
       ]

--- a/tests/e2e/system_replication/auth.py
+++ b/tests/e2e/system_replication/auth.py
@@ -483,12 +483,12 @@ def test_manual_roles_recovery(connection, test_name):
     mg_sleep_and_assert(expected_data, show_users_func(cursor_replica_2))
 
     # 2/
-    expected_data = {("role1",), ("role2",), ("role3",), ("role8",)}
+    expected_data = {("role1", False), ("role2", False), ("role3", False), ("role8", False)}
     mg_sleep_and_assert(expected_data, show_roles_func(cursor_replica_1))
     mg_sleep_and_assert(expected_data, show_roles_func(cursor_replica_2))
 
     # 3/
-    expected_data = {("role2",), ("role3",), ("role8",)}
+    expected_data = {("role2", False), ("role3", False), ("role8", False)}
     mg_sleep_and_assert(
         expected_data,
         show_role_for_user_func(cursor_replica_1, "user2"),
@@ -510,13 +510,13 @@ def test_manual_roles_recovery(connection, test_name):
     # Test SET ROLE
     execute_and_fetch_all(cursor_main, "SET ROLE FOR test_user TO test_role1, test_role2")
     results1 = execute_and_fetch_all(cursor_main, "SHOW ROLE FOR test_user")
-    role_set1 = {row[0] for row in results1 if row[0] != "null"}
+    role_set1 = {row[0] for row in results1}
 
     # Test SET ROLES
     execute_and_fetch_all(cursor_main, "CLEAR ROLE FOR test_user")
     execute_and_fetch_all(cursor_main, "SET ROLES FOR test_user TO test_role1, test_role2")
     results2 = execute_and_fetch_all(cursor_main, "SHOW ROLES FOR test_user")
-    role_set2 = {row[0] for row in results2 if row[0] != "null"}
+    role_set2 = {row[0] for row in results2}
 
     # Both should show the same roles
     assert role_set1 == role_set2
@@ -525,12 +525,12 @@ def test_manual_roles_recovery(connection, test_name):
     # Test CLEAR ROLE vs CLEAR ROLES
     execute_and_fetch_all(cursor_main, "CLEAR ROLE FOR test_user")
     results3 = execute_and_fetch_all(cursor_main, "SHOW ROLE FOR test_user")
-    assert len(results3) == 1 and results3[0][0] == "null"
+    assert len(results3) == 0
 
     execute_and_fetch_all(cursor_main, "SET ROLES FOR test_user TO test_role1, test_role2")
     execute_and_fetch_all(cursor_main, "CLEAR ROLES FOR test_user")
     results4 = execute_and_fetch_all(cursor_main, "SHOW ROLES FOR test_user")
-    assert len(results4) == 1 and results4[0][0] == "null"
+    assert len(results4) == 0
 
 
 def test_auth_config_recovery(connection, test_name):
@@ -727,42 +727,37 @@ def test_auth_replication(connection, test_name):
     connection(BOLT_PORTS["replica_1"], "replica").cursor()  # Just check connection
     connection(BOLT_PORTS["replica_2"], "replica").cursor()  # Just check connection
 
+    builtin_roles = {("admin", True), ("readwrite", True), ("readonly", True)}
+
     # CREATE ROLE
     execute_and_fetch_all(cursor_main, "CREATE ROLE role1")
     check(
         show_roles_func,
-        {
-            ("role1",),
-        },
+        builtin_roles | {("role1", False)},
     )
     execute_and_fetch_all(cursor_main, "CREATE ROLE role2")
     check(
         show_roles_func,
-        {
-            ("role2",),
-            ("role1",),
-        },
+        builtin_roles | {("role2", False), ("role1", False)},
     )
 
     # DROP ROLE
     execute_and_fetch_all(cursor_main, "DROP ROLE role2")
     check(
         show_roles_func,
-        {
-            ("role1",),
-        },
+        builtin_roles | {("role1", False)},
     )
     execute_and_fetch_all(cursor_main, "DROP ROLE role1")
-    check(show_roles_func, set())
+    check(show_roles_func, builtin_roles)
 
     # SET ROLE
     execute_and_fetch_all(cursor_main, "CREATE USER user3")
     execute_and_fetch_all(cursor_main, "CREATE ROLE role3")
     execute_and_fetch_all(cursor_main, "SET ROLE FOR user3 TO role3")
-    check(partial(show_role_for_user_func, username="user3"), {("role3",)})
+    check(partial(show_role_for_user_func, username="user3"), {("role3", False)})
     execute_and_fetch_all(cursor_main, "CREATE USER user3b")
     execute_and_fetch_all(cursor_main, "SET ROLE FOR user3b TO role3")
-    check(partial(show_role_for_user_func, username="user3b"), {("role3",)})
+    check(partial(show_role_for_user_func, username="user3b"), {("role3", False)})
     check(
         partial(show_users_for_role_func, rolename="role3"),
         {
@@ -776,7 +771,7 @@ def test_auth_replication(connection, test_name):
     execute_and_fetch_all(cursor_main, "CREATE ROLE role5")
     execute_and_fetch_all(cursor_main, "CREATE USER user5")
     execute_and_fetch_all(cursor_main, "SET ROLE FOR user5 TO role3, role4, role5")
-    check(partial(show_role_for_user_func, username="user5"), {("role3",), ("role4",), ("role5",)})
+    check(partial(show_role_for_user_func, username="user5"), {("role3", False), ("role4", False), ("role5", False)})
     check(
         partial(show_users_for_role_func, rolename="role3"),
         {
@@ -800,7 +795,7 @@ def test_auth_replication(connection, test_name):
 
     # CLEAR ROLE
     execute_and_fetch_all(cursor_main, "CLEAR ROLE FOR user3")
-    check(partial(show_role_for_user_func, username="user3"), {("null",)})
+    check(partial(show_role_for_user_func, username="user3"), set())
     check(
         partial(show_users_for_role_func, rolename="role3"),
         {
@@ -1043,9 +1038,11 @@ def test_auth_replication(connection, test_name):
     check(partial(get_mt_roles, username="mt_user", database="mt_db1"), {"mt_role1", "mt_role2"})
     check(partial(get_mt_roles, username="mt_user", database="mt_db2"), {"mt_role2"})
 
-    # Remove role
+    # Remove role (must unassign first since roles cannot be dropped while assigned)
+    execute_and_fetch_all(cursor_main, "CLEAR ROLE FOR mt_user ON mt_db1")
+    execute_and_fetch_all(cursor_main, "CLEAR ROLE FOR mt_user ON mt_db2")
     execute_and_fetch_all(cursor_main, "DROP ROLE mt_role2")
-    check(partial(get_mt_roles, username="mt_user", database="mt_db1"), {"mt_role1"})
+    check(partial(get_mt_roles, username="mt_user", database="mt_db1"), set())
     check(partial(get_mt_roles, username="mt_user", database="mt_db2"), set())
 
     # Test CLEAR ROLES (plural form)
@@ -1178,8 +1175,11 @@ def test_user_profile_replication(connection, test_name):
         },
     )
 
+    # Suppress builtin role creation so admin/readwrite/readonly don't appear in SHOW ROLES
+    execute_and_fetch_all(cursor_main, "CREATE ROLE _dummy_role")
     # CREATE USER
     execute_and_fetch_all(cursor_main, "CREATE USER user1")
+    execute_and_fetch_all(cursor_main, "DROP ROLE _dummy_role")
     execute_and_fetch_all(cursor_main, "CREATE USER user2")
     execute_and_fetch_all(cursor_main, "GRANT PROFILE_RESTRICTION TO user2")
     execute_and_fetch_all(cursor_main, "GRANT AUTH TO user2")
@@ -1318,16 +1318,14 @@ def test_user_profile_replication(connection, test_name):
     execute_and_fetch_all(cursor_main, "CREATE ROLE role1")
     check(
         show_roles_func,
-        {
-            ("role1",),
-        },
+        {("role1", False)},
     )
 
     execute_and_fetch_all(cursor_main, "SET ROLE FOR user1 TO role1")
     check(
         partial(show_role_for_user_func, username="user1"),
         {
-            ("role1",),
+            ("role1", False),
         },
     )
 
@@ -1381,12 +1379,11 @@ def test_user_profile_replication(connection, test_name):
 
     # drop profile of user
 
+    execute_and_fetch_all(cursor_main, "CLEAR ROLE FOR user1")
     execute_and_fetch_all(cursor_main, "DROP ROLE role1")
     check(
         partial(show_role_for_user_func, username="user1"),
-        {
-            ("null",),
-        },
+        set(),
     )
     check(
         partial(show_profile_for_user_func, username="user1"),

--- a/tests/e2e/system_replication/auth.py
+++ b/tests/e2e/system_replication/auth.py
@@ -488,7 +488,7 @@ def test_manual_roles_recovery(connection, test_name):
     mg_sleep_and_assert(expected_data, show_roles_func(cursor_replica_2))
 
     # 3/
-    expected_data = {("role2", False), ("role3", False), ("role8", False)}
+    expected_data = {("role2",), ("role3",), ("role8",)}
     mg_sleep_and_assert(
         expected_data,
         show_role_for_user_func(cursor_replica_1, "user2"),
@@ -754,10 +754,10 @@ def test_auth_replication(connection, test_name):
     execute_and_fetch_all(cursor_main, "CREATE USER user3")
     execute_and_fetch_all(cursor_main, "CREATE ROLE role3")
     execute_and_fetch_all(cursor_main, "SET ROLE FOR user3 TO role3")
-    check(partial(show_role_for_user_func, username="user3"), {("role3", False)})
+    check(partial(show_role_for_user_func, username="user3"), {("role3",)})
     execute_and_fetch_all(cursor_main, "CREATE USER user3b")
     execute_and_fetch_all(cursor_main, "SET ROLE FOR user3b TO role3")
-    check(partial(show_role_for_user_func, username="user3b"), {("role3", False)})
+    check(partial(show_role_for_user_func, username="user3b"), {("role3",)})
     check(
         partial(show_users_for_role_func, rolename="role3"),
         {
@@ -771,7 +771,7 @@ def test_auth_replication(connection, test_name):
     execute_and_fetch_all(cursor_main, "CREATE ROLE role5")
     execute_and_fetch_all(cursor_main, "CREATE USER user5")
     execute_and_fetch_all(cursor_main, "SET ROLE FOR user5 TO role3, role4, role5")
-    check(partial(show_role_for_user_func, username="user5"), {("role3", False), ("role4", False), ("role5", False)})
+    check(partial(show_role_for_user_func, username="user5"), {("role3",), ("role4",), ("role5",)})
     check(
         partial(show_users_for_role_func, rolename="role3"),
         {
@@ -1325,7 +1325,7 @@ def test_user_profile_replication(connection, test_name):
     check(
         partial(show_role_for_user_func, username="user1"),
         {
-            ("role1", False),
+            ("role1",),
         },
     )
 

--- a/tests/e2e/transaction_queue/test_transaction_queue.py
+++ b/tests/e2e/transaction_queue/test_transaction_queue.py
@@ -19,6 +19,17 @@ import mgclient
 import pytest
 from common import connect, execute_and_fetch_all
 
+# Module-level setup
+# -------------------------
+
+
+@pytest.fixture(scope="module", autouse=True)
+def suppress_builtin_roles():
+    """Create a dummy role before any users so builtin role creation is suppressed."""
+    cursor = connect().cursor()
+    execute_and_fetch_all(cursor, "CREATE ROLE _dummy_role;")
+
+
 # Utility functions
 # -------------------------
 

--- a/tests/integration/audit/runner.py
+++ b/tests/integration/audit/runner.py
@@ -61,7 +61,7 @@ AUTH_QUERIES = [
     ("CREATE USER admin", {}),
     ("CREATE USER user1", {}),
     ("CREATE USER user2", {}),
-    ("GRANT IMPERSONATE_USER * TO admin", {}),
+    ("GRANT IMPERSONATE_USER * TO USER admin", {}),
     ("GRANT MULTI_DATABASE_USE TO user1", {}),
     ("GRANT MULTI_DATABASE_USE TO user2", {}),
     ("GRANT DATABASE memgraph TO user1", {}),

--- a/tests/integration/auth/runner.py
+++ b/tests/integration/auth/runner.py
@@ -201,8 +201,8 @@ def execute_test(memgraph_binary, tester_binary, checker_binary):
     execute_admin_queries(
         [
             "CREATE USER ADmin IDENTIFIED BY 'admin'",
-            "GRANT ALL PRIVILEGES TO admIN",
-            "GRANT DATABASE * TO admin",
+            "GRANT ALL PRIVILEGES TO USER admIN",
+            "GRANT DATABASE * TO USER admin",
             "CREATE USER usEr IDENTIFIED BY 'user'",
             "GRANT DATABASE db1 TO user",
             "GRANT DATABASE db2 TO user",

--- a/tests/unit/auth.cpp
+++ b/tests/unit/auth.cpp
@@ -1939,8 +1939,7 @@ TEST_F(AuthWithStorage, CaseInsensitivity) {
   // AllRoles
   {
     auto roles = auth->AllRoles();
-    ASSERT_TRUE(std::find_if(roles.begin(), roles.end(), [](auto const &r) { return r.rolename() == "moderator"; }) !=
-                roles.end());
+    ASSERT_TRUE(std::ranges::find_if(roles, [](auto const &r) { return r.rolename() == "moderator"; }) != roles.end());
   }
 
   // SaveRole

--- a/tests/unit/auth.cpp
+++ b/tests/unit/auth.cpp
@@ -1736,13 +1736,6 @@ TEST_F(AuthWithStorage, UserWithRoleSerializeDeserialize) {
   ASSERT_EQ(*user, *new_user);
 }
 
-TEST_F(AuthWithStorage, UserRoleUniqueName) {
-  ASSERT_TRUE(auth->AddUser("user"));
-  ASSERT_TRUE(auth->AddRole("role"));
-  ASSERT_FALSE(auth->AddRole("user"));
-  ASSERT_FALSE(auth->AddUser("role"));
-}
-
 TEST_F(AuthWithStorage, MultipleRoles) {
   // Create a user and multiple roles
   auto user = auth->AddUser("user");
@@ -1911,15 +1904,8 @@ TEST_F(AuthWithStorage, CaseInsensitivity) {
     ASSERT_FALSE(auth->AddRole("moderator"));
     ASSERT_FALSE(auth->AddRole("MODERATOR"));
   }
-  {
-    auto role = auth->AddRole("adMIN");
-    ASSERT_TRUE(role);
-    ASSERT_EQ(role->rolename(), "admin");
-    ASSERT_FALSE(auth->AddRole("Admin"));
-    ASSERT_FALSE(auth->AddRole("ADMIn"));
-  }
-  ASSERT_FALSE(auth->AddRole("ALICE"));
-  ASSERT_FALSE(auth->AddUser("ModeRAtor"));
+  ASSERT_FALSE(auth->AddRole("moderator"));
+  ASSERT_FALSE(auth->AddRole("MODERATOR"));
 
   // GetRole
   {
@@ -1947,10 +1933,8 @@ TEST_F(AuthWithStorage, CaseInsensitivity) {
   // AllRoles
   {
     auto roles = auth->AllRoles();
-    ASSERT_EQ(roles.size(), 2);
-    std::sort(roles.begin(), roles.end(), [](const auto &a, const auto &b) { return a.rolename() < b.rolename(); });
-    ASSERT_EQ(roles[0].rolename(), "admin");
-    ASSERT_EQ(roles[1].rolename(), "moderator");
+    ASSERT_TRUE(std::find_if(roles.begin(), roles.end(), [](auto const &r) { return r.rolename() == "moderator"; }) !=
+                roles.end());
   }
 
   // SaveRole
@@ -1997,27 +1981,23 @@ TEST_F(AuthWithStorage, CaseInsensitivity) {
     auto dave = auth->AddUser("daVe");
     ASSERT_TRUE(dave);
     ASSERT_EQ(dave->username(), "dave");
-    auto admin = auth->GetRole("aDMin");
-    ASSERT_TRUE(admin);
-    ASSERT_EQ(admin->rolename(), "admin");
+    auto moderator = auth->GetRole("moDErator");
+    ASSERT_TRUE(moderator);
+    ASSERT_EQ(moderator->rolename(), "moderator");
     carol->ClearAllRoles();
-    carol->AddRole(*admin);
+    carol->AddRole(*moderator);
     auth->SaveUser(*carol);
     dave->ClearAllRoles();
-    dave->AddRole(*admin);
+    dave->AddRole(*moderator);
     auth->SaveUser(*dave);
   }
   {
     auto users = auth->AllUsersForRole("modeRAtoR");
-    ASSERT_EQ(users.size(), 1);
-    ASSERT_EQ(users[0].username(), "alice");
-  }
-  {
-    auto users = auth->AllUsersForRole("AdmiN");
-    ASSERT_EQ(users.size(), 2);
+    ASSERT_EQ(users.size(), 3);
     std::sort(users.begin(), users.end(), [](const auto &a, const auto &b) { return a.username() < b.username(); });
-    ASSERT_EQ(users[0].username(), "carol");
-    ASSERT_EQ(users[1].username(), "dave");
+    ASSERT_EQ(users[0].username(), "alice");
+    ASSERT_EQ(users[1].username(), "carol");
+    ASSERT_EQ(users[2].username(), "dave");
   }
 }
 

--- a/tests/unit/auth.cpp
+++ b/tests/unit/auth.cpp
@@ -963,6 +963,12 @@ TEST_F(AuthWithStorage, RoleManipulations) {
     ASSERT_EQ(roles2.rolenames().front(), "role2");
   }
 
+  {
+    auto user1 = auth->GetUser("user1");
+    ASSERT_TRUE(user1);
+    user1->ClearAllRoles();
+    auth->SaveUser(*user1);
+  }
   ASSERT_TRUE(auth->RemoveRole("role1"));
 
   {
@@ -2663,20 +2669,20 @@ TEST_F(AuthWithStorage, MultiTenantRoleRemoveRole) {
     ASSERT_EQ(updated_user->roles().size(), 1);
   }
 
+  // Unassign role before removing
+  {
+    auto updated_user = auth->GetUser("test_user");
+    ASSERT_NE(updated_user, std::nullopt);
+    updated_user->ClearAllRoles();
+    auth->SaveUser(*updated_user);
+  }
+
   // Remove the role
   ASSERT_TRUE(auth->RemoveRole("test_role"));
 
   // Verify role is removed
   auto removed_role = auth->GetRole("test_role");
   ASSERT_EQ(removed_role, std::nullopt);
-
-  // Verify user is updated
-  {
-    auto updated_user = auth->GetUser("test_user");
-    ASSERT_NE(updated_user, std::nullopt);
-    ASSERT_EQ(updated_user->GetMultiTenantRoles("db1").size(), 0);
-    ASSERT_EQ(updated_user->roles().size(), 0);
-  }
 
   // Re-add the role
   ASSERT_TRUE(auth->AddRole("test_role"));
@@ -2985,6 +2991,13 @@ TEST_F(AuthWithStorage, SetProfileUserWRole) {
     const auto profile = auth->GetProfileForUsername("user");
     ASSERT_TRUE(profile);
     ASSERT_EQ(*profile, "profile");
+  }
+
+  // Unassign role before removing
+  {
+    auto u = auth->GetUser("user");
+    u->ClearAllRoles();
+    auth->SaveUser(*u);
   }
 
   // Remove role and verify profile is still there

--- a/tests/unit/auth.cpp
+++ b/tests/unit/auth.cpp
@@ -1095,6 +1095,24 @@ TEST_F(AuthWithStorage, UserPasswordCreation) {
   }
 }
 
+#ifndef MG_ENTERPRISE
+TEST_F(AuthWithStorage, CommunityFirstUserHasAllPermissions) {
+  memgraph::license::global_license_checker.DisableTesting();
+  ASSERT_FALSE(memgraph::license::global_license_checker.IsEnterpriseValidFast());
+
+  auto user = auth->AddUser("admin");
+  ASSERT_TRUE(user);
+  auth->InitialiseFirstUser(*user, nullptr);
+
+  auto saved = auth->GetUser("admin");
+  ASSERT_TRUE(saved);
+  for (auto const permission : memgraph::auth::kPermissionsAll) {
+    EXPECT_EQ(saved->permissions().Has(permission), memgraph::auth::PermissionLevel::GRANT);
+  }
+  EXPECT_EQ(saved->permissions().denies(), 0);
+}
+#endif
+
 TEST_F(AuthWithStorage, PasswordStrength) {
   const std::string kWeakRegex = ".+";
   // https://stackoverflow.com/questions/5142103/regex-to-validate-password-strength

--- a/tests/unit/auth_handler.cpp
+++ b/tests/unit/auth_handler.cpp
@@ -2113,6 +2113,114 @@ TEST_F(AuthQueryHandlerFixture, ClearNamedRoleFromOneDatabaseLeavesOther) {
   ASSERT_EQ(updated_user->GetMultiTenantRoles("db2").begin()->rolename(), "role1");
 }
 
+TEST_F(AuthQueryHandlerFixture, AddRolesAddsRolesToUser) {
+  memgraph::auth::Role role1("role1");
+  memgraph::auth::Role role2("role2");
+  auth.value()->SaveRole(role1);
+  auth.value()->SaveRole(role2);
+
+  memgraph::auth::User user("test_user");
+  auth.value()->SaveUser(user);
+
+  ASSERT_NO_THROW(auth_handler.AddRoles("test_user", {"role1"}, {}, nullptr));
+  ASSERT_NO_THROW(auth_handler.AddRoles("test_user", {"role2"}, {}, nullptr));
+
+  auto updated_user = auth.value()->GetUser("test_user");
+  ASSERT_TRUE(updated_user);
+  auto const &roles = updated_user->roles().GetRoles();
+  ASSERT_EQ(roles.size(), 2);
+}
+
+TEST_F(AuthQueryHandlerFixture, AddRolesThrowsIfRoleDoesNotExist) {
+  memgraph::auth::User user("test_user");
+  auth.value()->SaveUser(user);
+
+  ASSERT_THROW(auth_handler.AddRoles("test_user", {"nonexistent"}, {}, nullptr),
+               memgraph::query::QueryRuntimeException);
+}
+
+TEST_F(AuthQueryHandlerFixture, AddRolesThrowsIfUserDoesNotExist) {
+  memgraph::auth::Role role("role1");
+  auth.value()->SaveRole(role);
+
+  ASSERT_THROW(auth_handler.AddRoles("nonexistent", {"role1"}, {}, nullptr), memgraph::query::QueryRuntimeException);
+}
+
+TEST_F(AuthQueryHandlerFixture, AddRolesDoesNotDuplicateExistingRole) {
+  memgraph::auth::Role role("role1");
+  auth.value()->SaveRole(role);
+
+  memgraph::auth::User user("test_user");
+  user.AddRole(role);
+  auth.value()->SaveUser(user);
+
+  ASSERT_NO_THROW(auth_handler.AddRoles("test_user", {"role1"}, {}, nullptr));
+
+  auto updated_user = auth.value()->GetUser("test_user");
+  ASSERT_TRUE(updated_user);
+  ASSERT_EQ(updated_user->roles().GetRoles().size(), 1);
+}
+
+TEST_F(AuthQueryHandlerFixture, RevokeRolesRemovesRoleFromUser) {
+  memgraph::auth::Role role1("role1");
+  memgraph::auth::Role role2("role2");
+  auth.value()->SaveRole(role1);
+  auth.value()->SaveRole(role2);
+
+  memgraph::auth::User user("test_user");
+  user.AddRole(role1);
+  user.AddRole(role2);
+  auth.value()->SaveUser(user);
+
+  ASSERT_NO_THROW(auth_handler.RevokeRoles("test_user", {"role1"}, {}, nullptr));
+
+  auto updated_user = auth.value()->GetUser("test_user");
+  ASSERT_TRUE(updated_user);
+  auto const &roles = updated_user->roles().GetRoles();
+  ASSERT_EQ(roles.size(), 1);
+  ASSERT_EQ(roles.begin()->rolename(), "role2");
+}
+
+TEST_F(AuthQueryHandlerFixture, RevokeRolesThrowsIfUserDoesNotExist) {
+  ASSERT_THROW(auth_handler.RevokeRoles("nonexistent", {"role1"}, {}, nullptr), memgraph::query::QueryRuntimeException);
+}
+
+TEST_F(AuthQueryHandlerFixture, RevokeRolesOnDatabaseLeavesOtherDatabases) {
+  memgraph::auth::Role role1("role1");
+  role1.db_access().Grant("db1");
+  role1.db_access().Grant("db2");
+  auth.value()->SaveRole(role1);
+
+  memgraph::auth::User user("test_user");
+  user.AddMultiTenantRole(role1, "db1");
+  user.AddMultiTenantRole(role1, "db2");
+  auth.value()->SaveUser(user);
+
+  ASSERT_NO_THROW(auth_handler.RevokeRoles("test_user", {"role1"}, {"db1"}, nullptr));
+
+  auto updated_user = auth.value()->GetUser("test_user");
+  ASSERT_TRUE(updated_user);
+  ASSERT_EQ(updated_user->GetMultiTenantRoles("db1").size(), 0);
+  ASSERT_EQ(updated_user->GetMultiTenantRoles("db2").size(), 1);
+}
+
+TEST_F(AuthQueryHandlerFixture, AddRolesOnDatabaseAddsToSpecifiedDatabase) {
+  memgraph::auth::Role role1("role1");
+  role1.db_access().Grant("db1");
+  role1.db_access().Grant("db2");
+  auth.value()->SaveRole(role1);
+
+  memgraph::auth::User user("test_user");
+  auth.value()->SaveUser(user);
+
+  ASSERT_NO_THROW(auth_handler.AddRoles("test_user", {"role1"}, {"db1"}, nullptr));
+
+  auto updated_user = auth.value()->GetUser("test_user");
+  ASSERT_TRUE(updated_user);
+  ASSERT_EQ(updated_user->GetMultiTenantRoles("db1").size(), 1);
+  ASSERT_EQ(updated_user->GetMultiTenantRoles("db2").size(), 0);
+}
+
 #endif
 
 TEST_F(AuthQueryHandlerFixture, SetRole_MultipleRoles_Success) {

--- a/tests/unit/auth_handler.cpp
+++ b/tests/unit/auth_handler.cpp
@@ -1997,57 +1997,10 @@ TEST_F(AuthQueryHandlerFixture, ClearRole_ClearsMultiTenantRoles) {
 
   auto roles = updated_user->GetMultiTenantRoles("db1");
   ASSERT_EQ(roles.size(), 0);
-  ASSERT_TRUE(updated_user->roles().empty());
+  ASSERT_TRUE(updated_user->roles().GetRoles().empty());
 }
 
-TEST_F(AuthQueryHandlerFixture, ClearRoleRemovesNamedRolesFromDatabase) {
-  memgraph::auth::Role role1("role1");
-  role1.db_access().Grant("db1");
-  auth.value()->SaveRole(role1);
-
-  memgraph::auth::Role role2("role2");
-  role2.db_access().Grant("db1");
-  auth.value()->SaveRole(role2);
-
-  memgraph::auth::User user("test_user");
-  user.AddMultiTenantRole(role1, "db1");
-  user.AddMultiTenantRole(role2, "db1");
-  auth.value()->SaveUser(user);
-
-  std::unordered_set<std::string> databases = {"db1"};
-  ASSERT_NO_THROW(auth_handler.ClearRoles("test_user", {"role1"}, databases, nullptr));
-
-  auto updated_user = auth.value()->GetUser("test_user");
-  ASSERT_TRUE(updated_user);
-
-  auto db1_roles = updated_user->GetMultiTenantRoles("db1");
-  ASSERT_EQ(db1_roles.size(), 1);
-  ASSERT_EQ(db1_roles.begin()->rolename(), "role2");
-}
-
-TEST_F(AuthQueryHandlerFixture, ClearRoleRemovesNamedRoleOnly) {
-  auto role1 = auth.value()->AddRole("role1");
-  auto role2 = auth.value()->AddRole("role2");
-  ASSERT_TRUE(role1);
-  ASSERT_TRUE(role2);
-
-  auto user = auth.value()->AddUser("test_user");
-  ASSERT_TRUE(user);
-  user->AddRole(*role1);
-  user->AddRole(*role2);
-  auth.value()->SaveUser(*user);
-
-  ASSERT_NO_THROW(auth_handler.ClearRoles("test_user", {"role1"}, {}, nullptr));
-
-  auto updated_user = auth.value()->GetUser("test_user");
-  ASSERT_TRUE(updated_user);
-
-  auto remaining = updated_user->roles().GetRoles();
-  ASSERT_EQ(remaining.size(), 1);
-  ASSERT_EQ(remaining.begin()->rolename(), "role2");
-}
-
-TEST_F(AuthQueryHandlerFixture, ClearRoleWithEmptyRoleListRemovesAllRoles) {
+TEST_F(AuthQueryHandlerFixture, ClearRolesRemovesAllRoles) {
   memgraph::auth::Role role1("role1");
   role1.db_access().Grant("db1");
   role1.db_access().Grant("db2");
@@ -2069,7 +2022,7 @@ TEST_F(AuthQueryHandlerFixture, ClearRoleWithEmptyRoleListRemovesAllRoles) {
 
   auto updated_user = auth.value()->GetUser("test_user");
   ASSERT_TRUE(updated_user);
-  ASSERT_TRUE(updated_user->roles().empty());
+  ASSERT_TRUE(updated_user->roles().GetRoles().empty());
   ASSERT_EQ(updated_user->GetMultiTenantRoles("db1").size(), 0);
   ASSERT_EQ(updated_user->GetMultiTenantRoles("db2").size(), 0);
 }
@@ -2091,26 +2044,6 @@ TEST_F(AuthQueryHandlerFixture, ClearRoleOnDatabaseLeavesOtherDatabases) {
   ASSERT_TRUE(updated_user);
   ASSERT_EQ(updated_user->GetMultiTenantRoles("db1").size(), 0);
   ASSERT_EQ(updated_user->GetMultiTenantRoles("db2").size(), 1);
-}
-
-TEST_F(AuthQueryHandlerFixture, ClearNamedRoleFromOneDatabaseLeavesOther) {
-  memgraph::auth::Role role1("role1");
-  role1.db_access().Grant("db1");
-  role1.db_access().Grant("db2");
-  auth.value()->SaveRole(role1);
-
-  memgraph::auth::User user("test_user");
-  user.AddMultiTenantRole(role1, "db1");
-  user.AddMultiTenantRole(role1, "db2");
-  auth.value()->SaveUser(user);
-
-  ASSERT_NO_THROW(auth_handler.ClearRoles("test_user", {"role1"}, {"db1"}, nullptr));
-
-  auto updated_user = auth.value()->GetUser("test_user");
-  ASSERT_TRUE(updated_user);
-  ASSERT_EQ(updated_user->GetMultiTenantRoles("db1").size(), 0);
-  ASSERT_EQ(updated_user->GetMultiTenantRoles("db2").size(), 1);
-  ASSERT_EQ(updated_user->GetMultiTenantRoles("db2").begin()->rolename(), "role1");
 }
 
 TEST_F(AuthQueryHandlerFixture, AddRolesAddsRolesToUser) {
@@ -2267,7 +2200,7 @@ TEST_F(AuthQueryHandlerFixture, SetRole_EmptyRoles_ClearsRoles) {
   ASSERT_NO_THROW(auth_handler.SetRoles("user1", roles, std::unordered_set<std::string>{}, nullptr));
   auto updated_user = auth.value()->GetUser("user1");
   ASSERT_TRUE(updated_user);
-  ASSERT_TRUE(updated_user->roles().empty());
+  ASSERT_TRUE(updated_user->roles().GetRoles().empty());
 }
 
 TEST_F(AuthQueryHandlerFixture, SetRole_NonExistentRole_Throws) {

--- a/tests/unit/auth_handler.cpp
+++ b/tests/unit/auth_handler.cpp
@@ -3005,8 +3005,13 @@ TEST_F(AuthQueryHandlerFixture, DenyPrivilegeOnBuiltinRoleClearsBuiltinFlag) {
   builtin_role.SetBuiltIn(true);
   auth.value()->SaveRole(builtin_role);
 
-  auth_handler.DenyPrivilege(
-      "builtin_role", {memgraph::query::AuthQuery::Privilege::MATCH}, memgraph::auth::UserOrRoleType::ROLE, nullptr);
+  auth_handler.DenyPrivilege("builtin_role",
+                             {memgraph::query::AuthQuery::Privilege::MATCH},
+                             {},
+                             {},
+                             {},
+                             memgraph::auth::UserOrRoleType::ROLE,
+                             nullptr);
 
   EXPECT_FALSE(auth->ReadLock()->GetRole("builtin_role")->IsBuiltIn());
 }

--- a/tests/unit/auth_handler.cpp
+++ b/tests/unit/auth_handler.cpp
@@ -1890,7 +1890,7 @@ TEST_F(AuthQueryHandlerFixture, GetRolenameForUser_WithDatabaseSpecification) {
   // Get roles for specific database
   auto rolenames = auth_handler.GetRolenamesForUser("test_user", "db1");
   ASSERT_EQ(rolenames.size(), 1);
-  ASSERT_EQ(rolenames[0], "test_role");
+  ASSERT_EQ(rolenames[0].first, "test_role");
 
   // Get roles for different database (should be empty)
   auto rolenames_db2 = auth_handler.GetRolenamesForUser("test_user", "db2");
@@ -2821,7 +2821,8 @@ TEST_F(AuthQueryHandlerFixture, FirstUserEnterpriseGetsAdminRoleAndBuiltinRolesC
   EXPECT_EQ(locked->AllRolenames().size(), 3);
   auto const roles = auth_handler.GetRolenamesForUser("alice", std::nullopt);
   EXPECT_EQ(roles.size(), 1);
-  EXPECT_EQ(roles[0], "admin");
+  EXPECT_EQ(roles[0].first, "admin");
+  EXPECT_TRUE(roles[0].second);
 }
 
 TEST_F(AuthQueryHandlerFixture, FirstUserWhenRolesExistGetsPermissionsNoAdminRole) {
@@ -2923,3 +2924,103 @@ TEST_F(AuthQueryHandlerFixture, DisambiguationRoleKeywordBothExistResolvesToRole
   ASSERT_EQ(result.size(), 1);
   ASSERT_EQ(result[0][2].ValueString(), "GRANTED TO ROLE");
 }
+
+TEST_F(AuthQueryHandlerFixture, GetRolenamesReturnsBuiltinFlag) {
+  ASSERT_TRUE(auth_handler.CreateRole("regular_role", nullptr));
+
+  auto regular_role = auth->ReadLock()->GetRole("regular_role");
+  ASSERT_TRUE(regular_role.has_value());
+  EXPECT_FALSE(regular_role->IsBuiltIn());
+
+  memgraph::auth::Role builtin_role{"builtin_role"};
+  builtin_role.SetBuiltIn(true);
+  auth.value()->SaveRole(builtin_role);
+
+  auto const roles = auth_handler.GetRolenames();
+  ASSERT_EQ(roles.size(), 2);
+
+  auto find = [&](std::string_view name) {
+    return std::find_if(roles.begin(), roles.end(), [&](auto const &p) { return p.first == name; });
+  };
+
+  auto regular_it = find("regular_role");
+  ASSERT_NE(regular_it, roles.end());
+  EXPECT_FALSE(regular_it->second);
+
+  auto builtin_it = find("builtin_role");
+  ASSERT_NE(builtin_it, roles.end());
+  EXPECT_TRUE(builtin_it->second);
+}
+
+TEST_F(AuthQueryHandlerFixture, GetRolenamesForUserReturnsBuiltinFlag) {
+  auth.value()->SaveUser(memgraph::auth::User{"alice"});
+  ASSERT_TRUE(auth_handler.CreateRole("regular_role", nullptr));
+
+  memgraph::auth::Role builtin_role{"builtin_role"};
+  builtin_role.SetBuiltIn(true);
+  auth.value()->SaveRole(builtin_role);
+
+  ASSERT_NO_THROW(auth_handler.AddRoles("alice", {"regular_role", "builtin_role"}, {}, nullptr));
+
+  auto const roles = auth_handler.GetRolenamesForUser("alice", std::nullopt);
+  ASSERT_EQ(roles.size(), 2);
+
+  auto find = [&](std::string_view name) {
+    return std::find_if(roles.begin(), roles.end(), [&](auto const &p) { return p.first == name; });
+  };
+
+  auto regular_it = find("regular_role");
+  ASSERT_NE(regular_it, roles.end());
+  EXPECT_FALSE(regular_it->second);
+
+  auto builtin_it = find("builtin_role");
+  ASSERT_NE(builtin_it, roles.end());
+  EXPECT_TRUE(builtin_it->second);
+}
+
+#ifdef MG_ENTERPRISE
+TEST_F(AuthQueryHandlerFixture, GrantPrivilegeOnBuiltinRoleClearsBuiltinFlag) {
+  memgraph::auth::Role builtin_role{"builtin_role"};
+  builtin_role.SetBuiltIn(true);
+  auth.value()->SaveRole(builtin_role);
+
+  ASSERT_TRUE(auth->ReadLock()->GetRole("builtin_role")->IsBuiltIn());
+
+  auth_handler.GrantPrivilege("builtin_role",
+                              {memgraph::query::AuthQuery::Privilege::MATCH},
+                              {},
+                              {},
+                              {},
+                              memgraph::auth::UserOrRoleType::ROLE,
+                              nullptr);
+
+  EXPECT_FALSE(auth->ReadLock()->GetRole("builtin_role")->IsBuiltIn());
+}
+
+TEST_F(AuthQueryHandlerFixture, DenyPrivilegeOnBuiltinRoleClearsBuiltinFlag) {
+  memgraph::auth::Role builtin_role{"builtin_role"};
+  builtin_role.SetBuiltIn(true);
+  auth.value()->SaveRole(builtin_role);
+
+  auth_handler.DenyPrivilege(
+      "builtin_role", {memgraph::query::AuthQuery::Privilege::MATCH}, memgraph::auth::UserOrRoleType::ROLE, nullptr);
+
+  EXPECT_FALSE(auth->ReadLock()->GetRole("builtin_role")->IsBuiltIn());
+}
+
+TEST_F(AuthQueryHandlerFixture, RevokePrivilegeOnBuiltinRoleClearsBuiltinFlag) {
+  memgraph::auth::Role builtin_role{"builtin_role"};
+  builtin_role.SetBuiltIn(true);
+  auth.value()->SaveRole(builtin_role);
+
+  auth_handler.RevokePrivilege("builtin_role",
+                               {memgraph::query::AuthQuery::Privilege::MATCH},
+                               {},
+                               {},
+                               {},
+                               memgraph::auth::UserOrRoleType::ROLE,
+                               nullptr);
+
+  EXPECT_FALSE(auth->ReadLock()->GetRole("builtin_role")->IsBuiltIn());
+}
+#endif

--- a/tests/unit/auth_handler.cpp
+++ b/tests/unit/auth_handler.cpp
@@ -2928,6 +2928,33 @@ TEST_F(AuthQueryHandlerFixture, DisambiguationRoleKeywordBothExistResolvesToRole
   ASSERT_EQ(result[0][2].ValueString(), "GRANTED TO ROLE");
 }
 
+#ifdef MG_ENTERPRISE
+TEST_F(AuthQueryHandlerFixture, DatabasePrivilegesDisambiguationUserAndRoleKeywordsResolveCorrectTarget) {
+  memgraph::auth::User user{"alice"};
+  user.db_access().GrantAll();
+  auth.value()->SaveUser(user);
+
+  memgraph::auth::Role role{"alice"};
+  role.db_access().Grant("role_db");
+  auth.value()->SaveRole(role);
+
+  auto user_result = auth_handler.GetDatabasePrivileges("alice", {"alice"}, memgraph::auth::UserOrRoleType::USER);
+  ASSERT_EQ(user_result.size(), 1);
+  ASSERT_EQ(user_result[0].size(), 2);
+  ASSERT_TRUE(user_result[0][0].IsString());
+  ASSERT_EQ(user_result[0][0].ValueString(), "*");
+
+  auto role_result = auth_handler.GetDatabasePrivileges("alice", {"alice"}, memgraph::auth::UserOrRoleType::ROLE);
+  ASSERT_EQ(role_result.size(), 1);
+  ASSERT_EQ(role_result[0].size(), 2);
+  ASSERT_TRUE(role_result[0][0].IsList());
+  auto const &grants = role_result[0][0].ValueList();
+  ASSERT_TRUE(std::find_if(grants.begin(), grants.end(), [](const auto &db) {
+                return db.IsString() && db.ValueString() == "role_db";
+              }) != grants.end());
+}
+#endif
+
 TEST_F(AuthQueryHandlerFixture, GetRolenamesReturnsBuiltinFlag) {
   ASSERT_TRUE(auth_handler.CreateRole("regular_role", nullptr));
 

--- a/tests/unit/auth_handler.cpp
+++ b/tests/unit/auth_handler.cpp
@@ -2930,21 +2930,24 @@ TEST_F(AuthQueryHandlerFixture, DisambiguationRoleKeywordBothExistResolvesToRole
 
 #ifdef MG_ENTERPRISE
 TEST_F(AuthQueryHandlerFixture, DatabasePrivilegesDisambiguationUserAndRoleKeywordsResolveCorrectTarget) {
-  memgraph::auth::User user{"alice"};
+  memgraph::auth::User user{"admin"};
   user.db_access().GrantAll();
   auth.value()->SaveUser(user);
 
-  memgraph::auth::Role role{"alice"};
+  memgraph::auth::Role role{"admin"};
   role.db_access().Grant("role_db");
   auth.value()->SaveRole(role);
 
-  auto user_result = auth_handler.GetDatabasePrivileges("alice", {"alice"}, memgraph::auth::UserOrRoleType::USER);
+  ASSERT_THROW(auth_handler.GetDatabasePrivileges("admin", {"admin"}, memgraph::auth::UserOrRoleType::UNSPECIFIED),
+               memgraph::query::QueryRuntimeException);
+
+  auto user_result = auth_handler.GetDatabasePrivileges("admin", {"admin"}, memgraph::auth::UserOrRoleType::USER);
   ASSERT_EQ(user_result.size(), 1);
   ASSERT_EQ(user_result[0].size(), 2);
   ASSERT_TRUE(user_result[0][0].IsString());
   ASSERT_EQ(user_result[0][0].ValueString(), "*");
 
-  auto role_result = auth_handler.GetDatabasePrivileges("alice", {"alice"}, memgraph::auth::UserOrRoleType::ROLE);
+  auto role_result = auth_handler.GetDatabasePrivileges("admin", {"admin"}, memgraph::auth::UserOrRoleType::ROLE);
   ASSERT_EQ(role_result.size(), 1);
   ASSERT_EQ(role_result[0].size(), 2);
   ASSERT_TRUE(role_result[0][0].IsList());
@@ -2952,6 +2955,39 @@ TEST_F(AuthQueryHandlerFixture, DatabasePrivilegesDisambiguationUserAndRoleKeywo
   ASSERT_TRUE(std::find_if(grants.begin(), grants.end(), [](const auto &db) {
                 return db.IsString() && db.ValueString() == "role_db";
               }) != grants.end());
+}
+
+TEST_F(AuthQueryHandlerFixture, ShowPrivilegesOnMainForRoleUsesRoleMainDatabaseWhenNamesCollide) {
+  memgraph::auth::Permissions user_perms;
+  user_perms.Grant(memgraph::auth::Permission::CREATE);
+  memgraph::auth::User user{"admin", std::nullopt, user_perms};
+  user.db_access().Grant("user_db");
+  ASSERT_TRUE(user.db_access().SetMain("user_db"));
+  auth.value()->SaveUser(user);
+
+  memgraph::auth::Permissions role_perms;
+  role_perms.Grant(memgraph::auth::Permission::MATCH);
+  memgraph::auth::Role role{"admin", role_perms};
+  role.db_access().Grant("role_db");
+  ASSERT_TRUE(role.db_access().SetMain("role_db"));
+  auth.value()->SaveRole(role);
+
+  ASSERT_THROW(auth_handler.GetMainDatabase("admin", memgraph::auth::UserOrRoleType::UNSPECIFIED),
+               memgraph::query::QueryRuntimeException);
+
+  auto role_main_db = auth_handler.GetMainDatabase("admin", memgraph::auth::UserOrRoleType::ROLE);
+  ASSERT_TRUE(role_main_db.has_value());
+  auto role_result = auth_handler.GetPrivileges("admin", role_main_db, memgraph::auth::UserOrRoleType::ROLE);
+  ASSERT_EQ(role_result.size(), 1);
+  ASSERT_EQ(role_result[0][0].ValueString(), "MATCH");
+  ASSERT_EQ(role_result[0][2].ValueString(), "GRANTED TO ROLE");
+
+  auto user_main_db = auth_handler.GetMainDatabase("admin", memgraph::auth::UserOrRoleType::USER);
+  ASSERT_TRUE(user_main_db.has_value());
+  auto user_result = auth_handler.GetPrivileges("admin", user_main_db, memgraph::auth::UserOrRoleType::USER);
+  ASSERT_EQ(user_result.size(), 1);
+  ASSERT_EQ(user_result[0][0].ValueString(), "CREATE");
+  ASSERT_EQ(user_result[0][2].ValueString(), "GRANTED TO USER");
 }
 #endif
 

--- a/tests/unit/auth_handler.cpp
+++ b/tests/unit/auth_handler.cpp
@@ -2757,3 +2757,69 @@ TEST_F(AuthQueryHandlerFixture, MemoryExhaustionUnderLoad) {
   ASSERT_EQ(failure_count.load(), 4);
 }
 #endif
+
+TEST_F(AuthQueryHandlerFixture, FirstUserCommunityGetsPermissionsNoRoles) {
+  memgraph::license::global_license_checker.DisableTesting();
+
+  ASSERT_TRUE(auth_handler.CreateUser("alice", {}, nullptr));
+
+  auto user = auth->ReadLock()->GetUser("alice");
+  ASSERT_TRUE(user.has_value());
+  EXPECT_EQ(auth_handler.GetRolenames().size(), 0);
+  EXPECT_TRUE(user->roles().GetRoles().empty());
+  EXPECT_NE(user->permissions().grants(), 0);
+}
+
+#ifdef MG_ENTERPRISE
+TEST_F(AuthQueryHandlerFixture, FirstUserEnterpriseGetsAdminRoleAndBuiltinRolesCreated) {
+  ASSERT_TRUE(auth_handler.CreateUser("alice", {}, nullptr));
+
+  auto locked = auth->ReadLock();
+  auto user = locked->GetUser("alice");
+  ASSERT_TRUE(user.has_value());
+  EXPECT_EQ(locked->AllRolenames().size(), 3);
+  auto const roles = auth_handler.GetRolenamesForUser("alice", std::nullopt);
+  EXPECT_EQ(roles.size(), 1);
+  EXPECT_EQ(roles[0], "admin");
+}
+
+TEST_F(AuthQueryHandlerFixture, FirstUserWhenRolesExistGetsPermissionsNoAdminRole) {
+  ASSERT_TRUE(auth_handler.CreateRole("somerole", nullptr));
+
+  ASSERT_TRUE(auth_handler.CreateUser("alice", {}, nullptr));
+
+  auto locked = auth->ReadLock();
+  auto user = locked->GetUser("alice");
+  ASSERT_TRUE(user.has_value());
+
+  EXPECT_EQ(locked->AllRolenames().size(), 1);
+  EXPECT_TRUE(user->roles().GetRoles().empty());
+  EXPECT_NE(user->permissions().grants(), 0);
+}
+
+TEST_F(AuthQueryHandlerFixture, FirstUserWhenNonBuiltinAdminExistsGetsPermissionsNotAdminRole) {
+  ASSERT_TRUE(auth_handler.CreateRole("admin", nullptr));
+
+  ASSERT_TRUE(auth_handler.CreateUser("alice", {}, nullptr));
+
+  auto locked = auth->ReadLock();
+  auto user = locked->GetUser("alice");
+  ASSERT_TRUE(user.has_value());
+  EXPECT_TRUE(user->roles().GetRoles().empty());
+  EXPECT_NE(user->permissions().grants(), 0);
+
+  auto admin_role = auth->ReadLock()->GetRole("admin");
+  ASSERT_TRUE(admin_role.has_value());
+  EXPECT_FALSE(admin_role->IsBuiltIn());
+}
+#endif
+
+TEST_F(AuthQueryHandlerFixture, CreateRoleWhenUserWithSameNameExists) {
+  ASSERT_TRUE(auth_handler.CreateUser("developer", {}, nullptr));
+  ASSERT_TRUE(auth_handler.CreateRole("developer", nullptr));
+}
+
+TEST_F(AuthQueryHandlerFixture, CreateUserWhenRoleWithSameNameExists) {
+  ASSERT_TRUE(auth_handler.CreateRole("developer", nullptr));
+  ASSERT_TRUE(auth_handler.CreateUser("developer", {}, nullptr));
+}

--- a/tests/unit/auth_handler.cpp
+++ b/tests/unit/auth_handler.cpp
@@ -14,6 +14,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <openssl/x509_vfy.h>
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <latch>
@@ -35,6 +36,8 @@
 #include "utils/synchronized.hpp"
 
 #include <nlohmann/json.hpp>
+
+namespace r = std::ranges;
 
 class AuthQueryHandlerFixture : public testing::Test {
  protected:
@@ -2952,9 +2955,8 @@ TEST_F(AuthQueryHandlerFixture, DatabasePrivilegesDisambiguationUserAndRoleKeywo
   ASSERT_EQ(role_result[0].size(), 2);
   ASSERT_TRUE(role_result[0][0].IsList());
   auto const &grants = role_result[0][0].ValueList();
-  ASSERT_TRUE(std::find_if(grants.begin(), grants.end(), [](const auto &db) {
-                return db.IsString() && db.ValueString() == "role_db";
-              }) != grants.end());
+  ASSERT_TRUE(r::find_if(grants, [](const auto &db) { return db.IsString() && db.ValueString() == "role_db"; }) !=
+              grants.end());
 }
 
 TEST_F(AuthQueryHandlerFixture, ShowPrivilegesOnMainForRoleUsesRoleMainDatabaseWhenNamesCollide) {
@@ -3005,9 +3007,7 @@ TEST_F(AuthQueryHandlerFixture, GetRolenamesReturnsBuiltinFlag) {
   auto const roles = auth_handler.GetRolenames();
   ASSERT_EQ(roles.size(), 2);
 
-  auto find = [&](std::string_view name) {
-    return std::find_if(roles.begin(), roles.end(), [&](auto const &p) { return p.first == name; });
-  };
+  auto find = [&](std::string_view name) { return r::find_if(roles, [&](auto const &p) { return p.first == name; }); };
 
   auto regular_it = find("regular_role");
   ASSERT_NE(regular_it, roles.end());
@@ -3031,9 +3031,7 @@ TEST_F(AuthQueryHandlerFixture, GetRolenamesForUserReturnsBuiltinFlag) {
   auto const roles = auth_handler.GetRolenamesForUser("alice", std::nullopt);
   ASSERT_EQ(roles.size(), 2);
 
-  auto find = [&](std::string_view name) {
-    return std::find_if(roles.begin(), roles.end(), [&](auto const &p) { return p.first == name; });
-  };
+  auto find = [&](std::string_view name) { return r::find_if(roles, [&](auto const &p) { return p.first == name; }); };
 
   auto regular_it = find("regular_role");
   ASSERT_NE(regular_it, roles.end());

--- a/tests/unit/auth_handler.cpp
+++ b/tests/unit/auth_handler.cpp
@@ -2864,3 +2864,62 @@ TEST_F(AuthQueryHandlerFixture, CreateUserWhenRoleWithSameNameExists) {
   ASSERT_TRUE(auth_handler.CreateRole("developer", nullptr));
   ASSERT_TRUE(auth_handler.CreateUser("developer", {}, nullptr));
 }
+
+TEST_F(AuthQueryHandlerFixture, DisambiguationUnspecifiedOnlyUserExists) {
+  auth.value()->SaveUser(memgraph::auth::User{"alice"});
+  ASSERT_NO_THROW(auth_handler.GetPrivileges("alice", std::nullopt, memgraph::auth::UserOrRoleType::UNSPECIFIED));
+}
+
+TEST_F(AuthQueryHandlerFixture, DisambiguationUnspecifiedOnlyRoleExists) {
+  auth.value()->SaveRole(memgraph::auth::Role{"alice"});
+  ASSERT_NO_THROW(auth_handler.GetPrivileges("alice", std::nullopt, memgraph::auth::UserOrRoleType::UNSPECIFIED));
+}
+
+TEST_F(AuthQueryHandlerFixture, DisambiguationUnspecifiedBothExistThrows) {
+  auth.value()->SaveUser(memgraph::auth::User{"alice"});
+  auth.value()->SaveRole(memgraph::auth::Role{"alice"});
+  ASSERT_THROW(auth_handler.GetPrivileges("alice", std::nullopt, memgraph::auth::UserOrRoleType::UNSPECIFIED),
+               memgraph::query::QueryRuntimeException);
+}
+
+TEST_F(AuthQueryHandlerFixture, DisambiguationUserKeywordWithUser) {
+  auth.value()->SaveUser(memgraph::auth::User{"alice"});
+  ASSERT_NO_THROW(auth_handler.GetPrivileges("alice", std::nullopt, memgraph::auth::UserOrRoleType::USER));
+}
+
+TEST_F(AuthQueryHandlerFixture, DisambiguationRoleKeywordWithRole) {
+  auth.value()->SaveRole(memgraph::auth::Role{"alice"});
+  ASSERT_NO_THROW(auth_handler.GetPrivileges("alice", std::nullopt, memgraph::auth::UserOrRoleType::ROLE));
+}
+
+TEST_F(AuthQueryHandlerFixture, DisambiguationUserKeywordButOnlyRoleExistsThrows) {
+  auth.value()->SaveRole(memgraph::auth::Role{"alice"});
+  ASSERT_THROW(auth_handler.GetPrivileges("alice", std::nullopt, memgraph::auth::UserOrRoleType::USER),
+               memgraph::query::QueryRuntimeException);
+}
+
+TEST_F(AuthQueryHandlerFixture, DisambiguationRoleKeywordButOnlyUserExistsThrows) {
+  auth.value()->SaveUser(memgraph::auth::User{"alice"});
+  ASSERT_THROW(auth_handler.GetPrivileges("alice", std::nullopt, memgraph::auth::UserOrRoleType::ROLE),
+               memgraph::query::QueryRuntimeException);
+}
+
+TEST_F(AuthQueryHandlerFixture, DisambiguationUserKeywordBothExistResolvesToUser) {
+  memgraph::auth::Permissions perms;
+  perms.Grant(memgraph::auth::Permission::MATCH);
+  auth.value()->SaveUser(memgraph::auth::User{"alice", std::nullopt, perms});
+  auth.value()->SaveRole(memgraph::auth::Role{"alice"});
+  auto result = auth_handler.GetPrivileges("alice", std::nullopt, memgraph::auth::UserOrRoleType::USER);
+  ASSERT_EQ(result.size(), 1);
+  ASSERT_EQ(result[0][2].ValueString(), "GRANTED TO USER");
+}
+
+TEST_F(AuthQueryHandlerFixture, DisambiguationRoleKeywordBothExistResolvesToRole) {
+  memgraph::auth::Permissions role_perms;
+  role_perms.Grant(memgraph::auth::Permission::MATCH);
+  auth.value()->SaveUser(memgraph::auth::User{"alice"});
+  auth.value()->SaveRole(memgraph::auth::Role{"alice", role_perms});
+  auto result = auth_handler.GetPrivileges("alice", std::nullopt, memgraph::auth::UserOrRoleType::ROLE);
+  ASSERT_EQ(result.size(), 1);
+  ASSERT_EQ(result[0][2].ValueString(), "GRANTED TO ROLE");
+}

--- a/tests/unit/auth_handler.cpp
+++ b/tests/unit/auth_handler.cpp
@@ -1115,6 +1115,9 @@ TEST_F(AuthQueryHandlerFixture, UserProfileRole) {
     ASSERT_EQ(resource->GetTransactionsMemory().second, -1);
   }
 
+  // Revoke role from user before dropping
+  auth_handler.RevokeRoles("user", {"role"}, {}, nullptr);
+
   // Drop role and verify user still exists
   auth_handler.DropRole("role", nullptr);
   {
@@ -3022,5 +3025,31 @@ TEST_F(AuthQueryHandlerFixture, RevokePrivilegeOnBuiltinRoleClearsBuiltinFlag) {
                                nullptr);
 
   EXPECT_FALSE(auth->ReadLock()->GetRole("builtin_role")->IsBuiltIn());
+}
+#endif
+
+TEST_F(AuthQueryHandlerFixture, DropRoleFailsIfAssignedToUser) {
+  ASSERT_TRUE(auth_handler.CreateRole("role1", nullptr));
+  auth.value()->SaveUser(memgraph::auth::User{"alice"});
+  ASSERT_NO_THROW(auth_handler.AddRoles("alice", {"role1"}, {}, nullptr));
+
+  ASSERT_THROW(auth_handler.DropRole("role1", nullptr), memgraph::query::QueryRuntimeException);
+}
+
+#ifdef MG_ENTERPRISE
+TEST_F(AuthQueryHandlerFixture, DropRoleFailsIfAssignedToUserOnDatabase) {
+  ASSERT_TRUE(auth_handler.CreateRole("role1", nullptr));
+  auto role = auth->ReadLock()->GetRole("role1");
+  ASSERT_TRUE(role.has_value());
+
+  memgraph::auth::Role role_with_access = *role;
+  role_with_access.db_access().Grant("db1");
+  auth.value()->SaveRole(role_with_access);
+
+  memgraph::auth::User user{"alice"};
+  user.AddMultiTenantRole(role_with_access, "db1");
+  auth.value()->SaveUser(user);
+
+  ASSERT_THROW(auth_handler.DropRole("role1", nullptr), memgraph::query::QueryRuntimeException);
 }
 #endif

--- a/tests/unit/auth_handler.cpp
+++ b/tests/unit/auth_handler.cpp
@@ -1896,7 +1896,7 @@ TEST_F(AuthQueryHandlerFixture, GetRolenameForUser_WithDatabaseSpecification) {
   // Get roles for specific database
   auto rolenames = auth_handler.GetRolenamesForUser("test_user", "db1");
   ASSERT_EQ(rolenames.size(), 1);
-  ASSERT_EQ(rolenames[0].first, "test_role");
+  ASSERT_EQ(rolenames[0].name, "test_role");
 
   // Get roles for different database (should be empty)
   auto rolenames_db2 = auth_handler.GetRolenamesForUser("test_user", "db2");
@@ -2827,8 +2827,8 @@ TEST_F(AuthQueryHandlerFixture, FirstUserEnterpriseGetsAdminRoleAndBuiltinRolesC
   EXPECT_EQ(locked->AllRolenames().size(), 3);
   auto const roles = auth_handler.GetRolenamesForUser("alice", std::nullopt);
   EXPECT_EQ(roles.size(), 1);
-  EXPECT_EQ(roles[0].first, "admin");
-  EXPECT_TRUE(roles[0].second);
+  EXPECT_EQ(roles[0].name, "admin");
+  EXPECT_TRUE(roles[0].is_builtin);
 }
 
 TEST_F(AuthQueryHandlerFixture, FirstUserWhenRolesExistGetsPermissionsNoAdminRole) {
@@ -3007,15 +3007,15 @@ TEST_F(AuthQueryHandlerFixture, GetRolenamesReturnsBuiltinFlag) {
   auto const roles = auth_handler.GetRolenames();
   ASSERT_EQ(roles.size(), 2);
 
-  auto find = [&](std::string_view name) { return r::find_if(roles, [&](auto const &p) { return p.first == name; }); };
+  auto find = [&](std::string_view name) { return r::find_if(roles, [&](auto const &p) { return p.name == name; }); };
 
   auto regular_it = find("regular_role");
   ASSERT_NE(regular_it, roles.end());
-  EXPECT_FALSE(regular_it->second);
+  EXPECT_FALSE(regular_it->is_builtin);
 
   auto builtin_it = find("builtin_role");
   ASSERT_NE(builtin_it, roles.end());
-  EXPECT_TRUE(builtin_it->second);
+  EXPECT_TRUE(builtin_it->is_builtin);
 }
 
 TEST_F(AuthQueryHandlerFixture, GetRolenamesForUserReturnsBuiltinFlag) {
@@ -3031,15 +3031,15 @@ TEST_F(AuthQueryHandlerFixture, GetRolenamesForUserReturnsBuiltinFlag) {
   auto const roles = auth_handler.GetRolenamesForUser("alice", std::nullopt);
   ASSERT_EQ(roles.size(), 2);
 
-  auto find = [&](std::string_view name) { return r::find_if(roles, [&](auto const &p) { return p.first == name; }); };
+  auto find = [&](std::string_view name) { return r::find_if(roles, [&](auto const &p) { return p.name == name; }); };
 
   auto regular_it = find("regular_role");
   ASSERT_NE(regular_it, roles.end());
-  EXPECT_FALSE(regular_it->second);
+  EXPECT_FALSE(regular_it->is_builtin);
 
   auto builtin_it = find("builtin_role");
   ASSERT_NE(builtin_it, roles.end());
-  EXPECT_TRUE(builtin_it->second);
+  EXPECT_TRUE(builtin_it->is_builtin);
 }
 
 #ifdef MG_ENTERPRISE

--- a/tests/unit/auth_handler.cpp
+++ b/tests/unit/auth_handler.cpp
@@ -1868,7 +1868,7 @@ TEST_F(AuthQueryHandlerFixture, ClearRole_WithDatabaseSpecification_Success) {
 
   // Clear roles for specific database
   std::unordered_set<std::string> databases = {"db1"};
-  ASSERT_NO_THROW(auth_handler.ClearRoles("test_user", {}, databases, nullptr));
+  ASSERT_NO_THROW(auth_handler.ClearRoles("test_user", databases, nullptr));
 
   // Verify roles are cleared for db1 but remain for db2
   auto updated_user = auth.value()->GetUser("test_user");
@@ -2024,7 +2024,7 @@ TEST_F(AuthQueryHandlerFixture, ClearRolesRemovesAllRoles) {
   user.AddMultiTenantRole(role2, "db2");
   auth.value()->SaveUser(user);
 
-  ASSERT_NO_THROW(auth_handler.ClearRoles("test_user", {}, {}, nullptr));
+  ASSERT_NO_THROW(auth_handler.ClearRoles("test_user", {}, nullptr));
 
   auto updated_user = auth.value()->GetUser("test_user");
   ASSERT_TRUE(updated_user);
@@ -2044,7 +2044,7 @@ TEST_F(AuthQueryHandlerFixture, ClearRoleOnDatabaseLeavesOtherDatabases) {
   user.AddMultiTenantRole(role1, "db2");
   auth.value()->SaveUser(user);
 
-  ASSERT_NO_THROW(auth_handler.ClearRoles("test_user", {}, {"db1"}, nullptr));
+  ASSERT_NO_THROW(auth_handler.ClearRoles("test_user", {"db1"}, nullptr));
 
   auto updated_user = auth.value()->GetUser("test_user");
   ASSERT_TRUE(updated_user);

--- a/tests/unit/auth_handler.cpp
+++ b/tests/unit/auth_handler.cpp
@@ -1862,7 +1862,7 @@ TEST_F(AuthQueryHandlerFixture, ClearRole_WithDatabaseSpecification_Success) {
 
   // Clear roles for specific database
   std::unordered_set<std::string> databases = {"db1"};
-  ASSERT_NO_THROW(auth_handler.ClearRoles("test_user", databases, nullptr));
+  ASSERT_NO_THROW(auth_handler.ClearRoles("test_user", {}, databases, nullptr));
 
   // Verify roles are cleared for db1 but remain for db2
   auto updated_user = auth.value()->GetUser("test_user");
@@ -1999,6 +1999,120 @@ TEST_F(AuthQueryHandlerFixture, ClearRole_ClearsMultiTenantRoles) {
   ASSERT_EQ(roles.size(), 0);
   ASSERT_TRUE(updated_user->roles().empty());
 }
+
+TEST_F(AuthQueryHandlerFixture, ClearRoleRemovesNamedRolesFromDatabase) {
+  memgraph::auth::Role role1("role1");
+  role1.db_access().Grant("db1");
+  auth.value()->SaveRole(role1);
+
+  memgraph::auth::Role role2("role2");
+  role2.db_access().Grant("db1");
+  auth.value()->SaveRole(role2);
+
+  memgraph::auth::User user("test_user");
+  user.AddMultiTenantRole(role1, "db1");
+  user.AddMultiTenantRole(role2, "db1");
+  auth.value()->SaveUser(user);
+
+  std::unordered_set<std::string> databases = {"db1"};
+  ASSERT_NO_THROW(auth_handler.ClearRoles("test_user", {"role1"}, databases, nullptr));
+
+  auto updated_user = auth.value()->GetUser("test_user");
+  ASSERT_TRUE(updated_user);
+
+  auto db1_roles = updated_user->GetMultiTenantRoles("db1");
+  ASSERT_EQ(db1_roles.size(), 1);
+  ASSERT_EQ(db1_roles.begin()->rolename(), "role2");
+}
+
+TEST_F(AuthQueryHandlerFixture, ClearRoleRemovesNamedRoleOnly) {
+  auto role1 = auth.value()->AddRole("role1");
+  auto role2 = auth.value()->AddRole("role2");
+  ASSERT_TRUE(role1);
+  ASSERT_TRUE(role2);
+
+  auto user = auth.value()->AddUser("test_user");
+  ASSERT_TRUE(user);
+  user->AddRole(*role1);
+  user->AddRole(*role2);
+  auth.value()->SaveUser(*user);
+
+  ASSERT_NO_THROW(auth_handler.ClearRoles("test_user", {"role1"}, {}, nullptr));
+
+  auto updated_user = auth.value()->GetUser("test_user");
+  ASSERT_TRUE(updated_user);
+
+  auto remaining = updated_user->roles().GetRoles();
+  ASSERT_EQ(remaining.size(), 1);
+  ASSERT_EQ(remaining.begin()->rolename(), "role2");
+}
+
+TEST_F(AuthQueryHandlerFixture, ClearRoleWithEmptyRoleListRemovesAllRoles) {
+  memgraph::auth::Role role1("role1");
+  role1.db_access().Grant("db1");
+  role1.db_access().Grant("db2");
+  auth.value()->SaveRole(role1);
+
+  memgraph::auth::Role role2("role2");
+  role2.db_access().Grant("db1");
+  role2.db_access().Grant("db2");
+  auth.value()->SaveRole(role2);
+
+  memgraph::auth::User user("test_user");
+  user.AddMultiTenantRole(role1, "db1");
+  user.AddMultiTenantRole(role1, "db2");
+  user.AddMultiTenantRole(role2, "db1");
+  user.AddMultiTenantRole(role2, "db2");
+  auth.value()->SaveUser(user);
+
+  ASSERT_NO_THROW(auth_handler.ClearRoles("test_user", {}, {}, nullptr));
+
+  auto updated_user = auth.value()->GetUser("test_user");
+  ASSERT_TRUE(updated_user);
+  ASSERT_TRUE(updated_user->roles().empty());
+  ASSERT_EQ(updated_user->GetMultiTenantRoles("db1").size(), 0);
+  ASSERT_EQ(updated_user->GetMultiTenantRoles("db2").size(), 0);
+}
+
+TEST_F(AuthQueryHandlerFixture, ClearRoleOnDatabaseLeavesOtherDatabases) {
+  memgraph::auth::Role role1("role1");
+  role1.db_access().Grant("db1");
+  role1.db_access().Grant("db2");
+  auth.value()->SaveRole(role1);
+
+  memgraph::auth::User user("test_user");
+  user.AddMultiTenantRole(role1, "db1");
+  user.AddMultiTenantRole(role1, "db2");
+  auth.value()->SaveUser(user);
+
+  ASSERT_NO_THROW(auth_handler.ClearRoles("test_user", {}, {"db1"}, nullptr));
+
+  auto updated_user = auth.value()->GetUser("test_user");
+  ASSERT_TRUE(updated_user);
+  ASSERT_EQ(updated_user->GetMultiTenantRoles("db1").size(), 0);
+  ASSERT_EQ(updated_user->GetMultiTenantRoles("db2").size(), 1);
+}
+
+TEST_F(AuthQueryHandlerFixture, ClearNamedRoleFromOneDatabaseLeavesOther) {
+  memgraph::auth::Role role1("role1");
+  role1.db_access().Grant("db1");
+  role1.db_access().Grant("db2");
+  auth.value()->SaveRole(role1);
+
+  memgraph::auth::User user("test_user");
+  user.AddMultiTenantRole(role1, "db1");
+  user.AddMultiTenantRole(role1, "db2");
+  auth.value()->SaveUser(user);
+
+  ASSERT_NO_THROW(auth_handler.ClearRoles("test_user", {"role1"}, {"db1"}, nullptr));
+
+  auto updated_user = auth.value()->GetUser("test_user");
+  ASSERT_TRUE(updated_user);
+  ASSERT_EQ(updated_user->GetMultiTenantRoles("db1").size(), 0);
+  ASSERT_EQ(updated_user->GetMultiTenantRoles("db2").size(), 1);
+  ASSERT_EQ(updated_user->GetMultiTenantRoles("db2").begin()->rolename(), "role1");
+}
+
 #endif
 
 TEST_F(AuthQueryHandlerFixture, SetRole_MultipleRoles_Success) {

--- a/tests/unit/auth_handler.cpp
+++ b/tests/unit/auth_handler.cpp
@@ -993,7 +993,7 @@ TEST_F(AuthQueryHandlerFixture, SetProfile) {
       {memgraph::query::UserProfileQuery::limit_t{memgraph::auth::UserProfiles::kLimits[0], quantity}},
       nullptr));
 
-  ASSERT_TRUE(auth_handler.CreateUser("user", {}, nullptr));
+  ASSERT_TRUE(auth_handler.CreateUser("user", {}, nullptr).created);
 
   ASSERT_NO_THROW(auth_handler.SetProfile("profile", "user", nullptr));
   {
@@ -1031,7 +1031,7 @@ TEST_F(AuthQueryHandlerFixture, RevokeProfile) {
       {memgraph::query::UserProfileQuery::limit_t{memgraph::auth::UserProfiles::kLimits[0], quantity}},
       nullptr));
 
-  ASSERT_TRUE(auth_handler.CreateUser("user", {}, nullptr));
+  ASSERT_TRUE(auth_handler.CreateUser("user", {}, nullptr).created);
 
   ASSERT_NO_THROW(auth_handler.SetProfile("profile", "user", nullptr));
   {
@@ -1076,7 +1076,7 @@ TEST_F(AuthQueryHandlerFixture, UserProfileRole) {
       {memgraph::query::UserProfileQuery::limit_t{memgraph::auth::UserProfiles::kLimits[0], quantity}},
       nullptr));
 
-  ASSERT_TRUE(auth_handler.CreateUser("user", {}, nullptr));
+  ASSERT_TRUE(auth_handler.CreateUser("user", {}, nullptr).created);
   ASSERT_TRUE(auth_handler.CreateRole("role", nullptr));
   auth_handler.SetRoles("user", {"role"}, {}, nullptr);
 
@@ -1136,7 +1136,7 @@ TEST_F(AuthQueryHandlerFixture, GetProfileForUser) {
       {memgraph::query::UserProfileQuery::limit_t{memgraph::auth::UserProfiles::kLimits[0], quantity}},
       nullptr));
 
-  ASSERT_TRUE(auth_handler.CreateUser("user", {}, nullptr));
+  ASSERT_TRUE(auth_handler.CreateUser("user", {}, nullptr).created);
 
   ASSERT_FALSE(auth_handler.GetProfileForUser("user"));
   ASSERT_NO_THROW(auth_handler.SetProfile("profile", "user", nullptr));
@@ -1178,10 +1178,10 @@ TEST_F(AuthQueryHandlerFixture, GetUsersForProfile) {
       {memgraph::query::UserProfileQuery::limit_t{memgraph::auth::UserProfiles::kLimits[0], quantity}},
       nullptr));
 
-  ASSERT_TRUE(auth_handler.CreateUser("user1", {}, nullptr));
-  ASSERT_TRUE(auth_handler.CreateUser("user2", {}, nullptr));
-  ASSERT_TRUE(auth_handler.CreateUser("user3", {}, nullptr));
-  ASSERT_TRUE(auth_handler.CreateUser("user4", {}, nullptr));
+  ASSERT_TRUE(auth_handler.CreateUser("user1", {}, nullptr).created);
+  ASSERT_TRUE(auth_handler.CreateUser("user2", {}, nullptr).created);
+  ASSERT_TRUE(auth_handler.CreateUser("user3", {}, nullptr).created);
+  ASSERT_TRUE(auth_handler.CreateUser("user4", {}, nullptr).created);
 
   ASSERT_EQ(auth_handler.GetUsernamesForProfile("profile").size(), 0);
 
@@ -2325,8 +2325,8 @@ TEST_F(AuthQueryHandlerFixture, ConcurrentProfileAssignment) {
   // Create profiles and users
   ASSERT_NO_THROW(auth_handler.CreateProfile("profile1", {}, {}, nullptr));
   ASSERT_NO_THROW(auth_handler.CreateProfile("profile2", {}, {}, nullptr));
-  ASSERT_TRUE(auth_handler.CreateUser("user1", {}, nullptr));
-  ASSERT_TRUE(auth_handler.CreateUser("user2", {}, nullptr));
+  ASSERT_TRUE(auth_handler.CreateUser("user1", {}, nullptr).created);
+  ASSERT_TRUE(auth_handler.CreateUser("user2", {}, nullptr).created);
 
   constexpr size_t kNumThreads = 4;
   std::vector<std::thread> threads;
@@ -2414,7 +2414,7 @@ TEST_F(AuthQueryHandlerFixture, ConcurrentResourceAccess) {
       {memgraph::query::UserProfileQuery::limit_t{memgraph::auth::UserProfiles::kLimits[0], limit}},
       {},
       nullptr));
-  ASSERT_TRUE(auth_handler.CreateUser("test_user", {}, nullptr));
+  ASSERT_TRUE(auth_handler.CreateUser("test_user", {}, nullptr).created);
   ASSERT_NO_THROW(auth_handler.SetProfile("limited_profile", "test_user", nullptr));
 
   constexpr size_t kNumThreads = 10;
@@ -2462,7 +2462,7 @@ TEST_F(AuthQueryHandlerFixture, SessionLimitExhaustion) {
       {memgraph::query::UserProfileQuery::limit_t{memgraph::auth::UserProfiles::kLimits[0], limit}},
       {},
       nullptr));
-  ASSERT_TRUE(auth_handler.CreateUser("test_user", {}, nullptr));
+  ASSERT_TRUE(auth_handler.CreateUser("test_user", {}, nullptr).created);
   ASSERT_NO_THROW(auth_handler.SetProfile("single_session_profile", "test_user", nullptr));
 
   auto resource = resources.GetUser("test_user");
@@ -2497,7 +2497,7 @@ TEST_F(AuthQueryHandlerFixture, MemoryLimitExhaustion) {
       {memgraph::query::UserProfileQuery::limit_t{memgraph::auth::UserProfiles::kLimits[1], limit}},
       {},
       nullptr));
-  ASSERT_TRUE(auth_handler.CreateUser("test_user", {}, nullptr));
+  ASSERT_TRUE(auth_handler.CreateUser("test_user", {}, nullptr).created);
   ASSERT_NO_THROW(auth_handler.SetProfile("memory_limited_profile", "test_user", nullptr));
 
   auto resource = resources.GetUser("test_user");
@@ -2537,7 +2537,7 @@ TEST_F(AuthQueryHandlerFixture, MemoryLimitExhaustionWithLargeAllocation) {
       {memgraph::query::UserProfileQuery::limit_t{memgraph::auth::UserProfiles::kLimits[1], limit}},
       {},
       nullptr));
-  ASSERT_TRUE(auth_handler.CreateUser("test_user", {}, nullptr));
+  ASSERT_TRUE(auth_handler.CreateUser("test_user", {}, nullptr).created);
   ASSERT_NO_THROW(auth_handler.SetProfile("moderate_memory_profile", "test_user", nullptr));
 
   auto resource = resources.GetUser("test_user");
@@ -2565,7 +2565,7 @@ TEST_F(AuthQueryHandlerFixture, MemoryLimitExhaustionWithLargeAllocationAndNoThr
       {memgraph::query::UserProfileQuery::limit_t{memgraph::auth::UserProfiles::kLimits[1], limit}},
       {},
       nullptr));
-  ASSERT_TRUE(auth_handler.CreateUser("test_user", {}, nullptr));
+  ASSERT_TRUE(auth_handler.CreateUser("test_user", {}, nullptr).created);
   ASSERT_NO_THROW(auth_handler.SetProfile("moderate_memory_profile", "test_user", nullptr));
 
   auto resource = resources.GetUser("test_user");
@@ -2601,7 +2601,7 @@ TEST_F(AuthQueryHandlerFixture, ResourceExhaustionRecovery) {
        memgraph::query::UserProfileQuery::limit_t{memgraph::auth::UserProfiles::kLimits[1], memory_limit}},
       {},
       nullptr));
-  ASSERT_TRUE(auth_handler.CreateUser("test_user", {}, nullptr));
+  ASSERT_TRUE(auth_handler.CreateUser("test_user", {}, nullptr).created);
   ASSERT_NO_THROW(auth_handler.SetProfile("recovery_test_profile", "test_user", nullptr));
 
   auto resource = resources.GetUser("test_user");
@@ -2648,7 +2648,7 @@ TEST_F(AuthQueryHandlerFixture, ProfileUpdateDuringResourceExhaustion) {
       {memgraph::query::UserProfileQuery::limit_t{memgraph::auth::UserProfiles::kLimits[0], session_limit}},
       {},
       nullptr));
-  ASSERT_TRUE(auth_handler.CreateUser("test_user", {}, nullptr));
+  ASSERT_TRUE(auth_handler.CreateUser("test_user", {}, nullptr).created);
   ASSERT_NO_THROW(auth_handler.SetProfile("update_test_profile", "test_user", nullptr));
 
   auto resource = resources.GetUser("test_user");
@@ -2687,7 +2687,7 @@ TEST_F(AuthQueryHandlerFixture, ProfileDeletionDuringResourceUsage) {
       {memgraph::query::UserProfileQuery::limit_t{memgraph::auth::UserProfiles::kLimits[0], session_limit}},
       {},
       nullptr));
-  ASSERT_TRUE(auth_handler.CreateUser("test_user", {}, nullptr));
+  ASSERT_TRUE(auth_handler.CreateUser("test_user", {}, nullptr).created);
   ASSERT_NO_THROW(auth_handler.SetProfile("delete_test_profile", "test_user", nullptr));
 
   auto resource = resources.GetUser("test_user");
@@ -2722,7 +2722,7 @@ TEST_F(AuthQueryHandlerFixture, ConcurrentResourceExhaustion) {
       {memgraph::query::UserProfileQuery::limit_t{memgraph::auth::UserProfiles::kLimits[0], session_limit}},
       {},
       nullptr));
-  ASSERT_TRUE(auth_handler.CreateUser("test_user", {}, nullptr));
+  ASSERT_TRUE(auth_handler.CreateUser("test_user", {}, nullptr).created);
   ASSERT_NO_THROW(auth_handler.SetProfile("concurrent_exhaustion_profile", "test_user", nullptr));
 
   constexpr size_t kNumThreads = 10;
@@ -2770,7 +2770,7 @@ TEST_F(AuthQueryHandlerFixture, MemoryExhaustionUnderLoad) {
       {memgraph::query::UserProfileQuery::limit_t{memgraph::auth::UserProfiles::kLimits[1], memory_limit}},
       {},
       nullptr));
-  ASSERT_TRUE(auth_handler.CreateUser("test_user", {}, nullptr));
+  ASSERT_TRUE(auth_handler.CreateUser("test_user", {}, nullptr).created);
   ASSERT_NO_THROW(auth_handler.SetProfile("memory_load_profile", "test_user", nullptr));
 
   constexpr size_t kNumThreads = 8;
@@ -2805,7 +2805,7 @@ TEST_F(AuthQueryHandlerFixture, MemoryExhaustionUnderLoad) {
 TEST_F(AuthQueryHandlerFixture, FirstUserCommunityGetsPermissionsNoRoles) {
   memgraph::license::global_license_checker.DisableTesting();
 
-  ASSERT_TRUE(auth_handler.CreateUser("alice", {}, nullptr));
+  ASSERT_TRUE(auth_handler.CreateUser("alice", {}, nullptr).created);
 
   auto user = auth->ReadLock()->GetUser("alice");
   ASSERT_TRUE(user.has_value());
@@ -2816,7 +2816,7 @@ TEST_F(AuthQueryHandlerFixture, FirstUserCommunityGetsPermissionsNoRoles) {
 
 #ifdef MG_ENTERPRISE
 TEST_F(AuthQueryHandlerFixture, FirstUserEnterpriseGetsAdminRoleAndBuiltinRolesCreated) {
-  ASSERT_TRUE(auth_handler.CreateUser("alice", {}, nullptr));
+  ASSERT_TRUE(auth_handler.CreateUser("alice", {}, nullptr).created);
 
   auto locked = auth->ReadLock();
   auto user = locked->GetUser("alice");
@@ -2831,7 +2831,7 @@ TEST_F(AuthQueryHandlerFixture, FirstUserEnterpriseGetsAdminRoleAndBuiltinRolesC
 TEST_F(AuthQueryHandlerFixture, FirstUserWhenRolesExistGetsPermissionsNoAdminRole) {
   ASSERT_TRUE(auth_handler.CreateRole("somerole", nullptr));
 
-  ASSERT_TRUE(auth_handler.CreateUser("alice", {}, nullptr));
+  ASSERT_TRUE(auth_handler.CreateUser("alice", {}, nullptr).created);
 
   auto locked = auth->ReadLock();
   auto user = locked->GetUser("alice");
@@ -2845,7 +2845,7 @@ TEST_F(AuthQueryHandlerFixture, FirstUserWhenRolesExistGetsPermissionsNoAdminRol
 TEST_F(AuthQueryHandlerFixture, FirstUserWhenNonBuiltinAdminExistsGetsPermissionsNotAdminRole) {
   ASSERT_TRUE(auth_handler.CreateRole("admin", nullptr));
 
-  ASSERT_TRUE(auth_handler.CreateUser("alice", {}, nullptr));
+  ASSERT_TRUE(auth_handler.CreateUser("alice", {}, nullptr).created);
 
   auto locked = auth->ReadLock();
   auto user = locked->GetUser("alice");
@@ -2860,13 +2860,13 @@ TEST_F(AuthQueryHandlerFixture, FirstUserWhenNonBuiltinAdminExistsGetsPermission
 #endif
 
 TEST_F(AuthQueryHandlerFixture, CreateRoleWhenUserWithSameNameExists) {
-  ASSERT_TRUE(auth_handler.CreateUser("developer", {}, nullptr));
+  ASSERT_TRUE(auth_handler.CreateUser("developer", {}, nullptr).created);
   ASSERT_TRUE(auth_handler.CreateRole("developer", nullptr));
 }
 
 TEST_F(AuthQueryHandlerFixture, CreateUserWhenRoleWithSameNameExists) {
   ASSERT_TRUE(auth_handler.CreateRole("developer", nullptr));
-  ASSERT_TRUE(auth_handler.CreateUser("developer", {}, nullptr));
+  ASSERT_TRUE(auth_handler.CreateUser("developer", {}, nullptr).created);
 }
 
 TEST_F(AuthQueryHandlerFixture, DisambiguationUnspecifiedOnlyUserExists) {

--- a/tests/unit/auth_models.cpp
+++ b/tests/unit/auth_models.cpp
@@ -55,6 +55,7 @@ auto User2Role(auto json) {
   json.erase(kUsername);
   json.erase(kUUID);
   json.erase(kPasswordHash);
+  json["builtin"] = false;
   return json;
 }
 
@@ -1177,7 +1178,8 @@ TEST(AuthModule, RoleSerialization) {
           },
           "permissions":{"denies":0,"grants":0},
           "rolename":"",
-          "user_imp":null
+          "user_imp":null,
+          "builtin":false
           })");
 
   // Empty role

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -2747,6 +2747,96 @@ void check_auth_query(
   EXPECT_EQ(auth_query->label_matching_modes_, label_matching_modes);
 }
 
+// TODO(colinbarry) - Passing mainly deduced {} to the massive parameter
+// list for check_auth_query is very ugly. Instead, I've added a fluent API
+// to make this easier. Rather than introducing too much noise into this PR,
+// I'll migrate the testing after this PR is merged.
+struct AuthQueryChecker {
+  AuthQueryChecker(Base *ast_generator, std::string input, AuthQuery::Action action)
+      : ast_generator_(ast_generator), input_(std::move(input)), action_(action) {}
+
+  AuthQueryChecker &WithUser(std::string user) {
+    user_ = std::move(user);
+    return *this;
+  }
+
+  AuthQueryChecker &WithRoles(std::vector<std::string> roles) {
+    roles_ = std::move(roles);
+    return *this;
+  }
+
+  AuthQueryChecker &WithUserOrRole(std::string user_or_role) {
+    user_or_role_ = std::move(user_or_role);
+    return *this;
+  }
+
+  AuthQueryChecker &WithPassword(TypedValue password) {
+    password_ = std::move(password);
+    return *this;
+  }
+
+  AuthQueryChecker &WithPrivileges(std::vector<AuthQuery::Privilege> privileges) {
+    privileges_ = std::move(privileges);
+    return *this;
+  }
+
+  AuthQueryChecker &WithLabelPrivileges(
+      std::vector<std::unordered_map<AuthQuery::FineGrainedPrivilege, std::vector<std::string>>> label_privileges) {
+    label_privileges_ = std::move(label_privileges);
+    return *this;
+  }
+
+  AuthQueryChecker &WithEdgeTypePrivileges(
+      std::vector<std::unordered_map<AuthQuery::FineGrainedPrivilege, std::vector<std::string>>> edge_type_privileges) {
+    edge_type_privileges_ = std::move(edge_type_privileges);
+    return *this;
+  }
+
+  AuthQueryChecker &WithLabelMatchingModes(std::vector<AuthQuery::LabelMatchingMode> modes) {
+    label_matching_modes_ = std::move(modes);
+    return *this;
+  }
+
+  AuthQueryChecker &WithDatabases(std::unordered_set<std::string> databases) {
+    role_databases_ = std::move(databases);
+    return *this;
+  }
+
+  void Check() const {
+    auto *q = dynamic_cast<AuthQuery *>(ast_generator_->ParseQuery(input_));
+    ASSERT_TRUE(q);
+    EXPECT_EQ(q->action_, action_);
+    EXPECT_EQ(q->user_, user_);
+    EXPECT_EQ(q->roles_, roles_);
+    EXPECT_EQ(q->user_or_role_, user_or_role_);
+    ASSERT_EQ(static_cast<bool>(q->password_), static_cast<bool>(password_));
+    if (password_) {
+      ast_generator_->CheckLiteral(q->password_, *password_);
+    }
+    EXPECT_EQ(q->privileges_, privileges_);
+    EXPECT_EQ(q->label_privileges_, label_privileges_);
+    EXPECT_EQ(q->edge_type_privileges_, edge_type_privileges_);
+    EXPECT_EQ(q->label_matching_modes_, label_matching_modes_);
+    if (role_databases_) {
+      EXPECT_EQ(q->role_databases_, *role_databases_);
+    }
+  }
+
+ private:
+  Base *ast_generator_;
+  std::string input_;
+  AuthQuery::Action action_;
+  std::string user_;
+  std::vector<std::string> roles_;
+  std::string user_or_role_;
+  std::optional<TypedValue> password_;
+  std::vector<AuthQuery::Privilege> privileges_;
+  std::vector<std::unordered_map<AuthQuery::FineGrainedPrivilege, std::vector<std::string>>> label_privileges_;
+  std::vector<std::unordered_map<AuthQuery::FineGrainedPrivilege, std::vector<std::string>>> edge_type_privileges_;
+  std::vector<AuthQuery::LabelMatchingMode> label_matching_modes_;
+  std::optional<std::unordered_set<std::string>> role_databases_;
+};
+
 TEST_P(CypherMainVisitorTest, UserOrRoleName) {
   auto &ast_generator = *GetParam();
   check_auth_query(
@@ -2953,8 +3043,37 @@ TEST_P(CypherMainVisitorTest, ClearRole) {
   ASSERT_THROW(ast_generator.ParseQuery("CLEAR ROLE"), SyntaxException);
   ASSERT_THROW(ast_generator.ParseQuery("CLEAR ROLE user"), SyntaxException);
   ASSERT_THROW(ast_generator.ParseQuery("CLEAR ROLE FOR user TO"), SyntaxException);
-  check_auth_query(
-      &ast_generator, "CLEAR ROLE FOR user", AuthQuery::Action::CLEAR_ROLE, "user", {}, "", {}, {}, {}, {});
+
+  AuthQueryChecker(&ast_generator, "CLEAR ROLE FOR user", AuthQuery::Action::CLEAR_ROLE).WithUser("user").Check();
+  AuthQueryChecker(&ast_generator, "CLEAR ROLES FOR user", AuthQuery::Action::CLEAR_ROLE).WithUser("user").Check();
+
+  AuthQueryChecker(&ast_generator, "CLEAR ROLE admin FOR user", AuthQuery::Action::CLEAR_ROLE)
+      .WithUser("user")
+      .WithRoles({"admin"})
+      .Check();
+  AuthQueryChecker(&ast_generator, "CLEAR ROLES admin FOR user", AuthQuery::Action::CLEAR_ROLE)
+      .WithUser("user")
+      .WithRoles({"admin"})
+      .Check();
+  AuthQueryChecker(&ast_generator, "CLEAR ROLE admin, reader FOR user", AuthQuery::Action::CLEAR_ROLE)
+      .WithUser("user")
+      .WithRoles({"admin", "reader"})
+      .Check();
+
+  AuthQueryChecker(&ast_generator, "CLEAR ROLE FOR user ON db1", AuthQuery::Action::CLEAR_ROLE)
+      .WithUser("user")
+      .WithDatabases({"db1"})
+      .Check();
+  AuthQueryChecker(&ast_generator, "CLEAR ROLE admin FOR user ON db1", AuthQuery::Action::CLEAR_ROLE)
+      .WithUser("user")
+      .WithRoles({"admin"})
+      .WithDatabases({"db1"})
+      .Check();
+  AuthQueryChecker(&ast_generator, "CLEAR ROLE admin, reader FOR user ON db1, db2", AuthQuery::Action::CLEAR_ROLE)
+      .WithUser("user")
+      .WithRoles({"admin", "reader"})
+      .WithDatabases({"db1", "db2"})
+      .Check();
 }
 
 TEST_P(CypherMainVisitorTest, GrantPrivilege) {

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -2978,6 +2978,16 @@ TEST_P(CypherMainVisitorTest, SetRole) {
   // Single role tests (backward compatibility)
   check_auth_query(
       &ast_generator, "SET ROLE FOR user TO role", AuthQuery::Action::SET_ROLE, "user", {"role"}, "", {}, {}, {}, {});
+  check_auth_query(&ast_generator,
+                   "SET ROLE FOR USER user TO role",
+                   AuthQuery::Action::SET_ROLE,
+                   "user",
+                   {"role"},
+                   "",
+                   {},
+                   {},
+                   {},
+                   {});
   check_auth_query(
       &ast_generator, "SET ROLE FOR user TO null", AuthQuery::Action::SET_ROLE, "user", {"null"}, "", {}, {}, {}, {});
 
@@ -3045,6 +3055,7 @@ TEST_P(CypherMainVisitorTest, ClearRole) {
 
   AuthQueryChecker(&ast_generator, "CLEAR ROLE FOR user", AuthQuery::Action::CLEAR_ROLE).WithUser("user").Check();
   AuthQueryChecker(&ast_generator, "CLEAR ROLES FOR user", AuthQuery::Action::CLEAR_ROLE).WithUser("user").Check();
+  AuthQueryChecker(&ast_generator, "CLEAR ROLE FOR USER user", AuthQuery::Action::CLEAR_ROLE).WithUser("user").Check();
 
   AuthQueryChecker(&ast_generator, "CLEAR ROLE FOR user ON db1", AuthQuery::Action::CLEAR_ROLE)
       .WithUser("user")
@@ -3063,6 +3074,10 @@ TEST_P(CypherMainVisitorTest, GrantRole) {
   ASSERT_THROW(ast_generator.ParseQuery("GRANT ROLE TO user"), SyntaxException);
   ASSERT_THROW(ast_generator.ParseQuery("GRANT ROLE admin"), SyntaxException);
 
+  AuthQueryChecker(&ast_generator, "GRANT ROLE admin TO USER user", AuthQuery::Action::GRANT_ROLE)
+      .WithUser("user")
+      .WithRoles({"admin"})
+      .Check();
   AuthQueryChecker(&ast_generator, "GRANT ROLE admin TO user", AuthQuery::Action::GRANT_ROLE)
       .WithUser("user")
       .WithRoles({"admin"})
@@ -3094,6 +3109,10 @@ TEST_P(CypherMainVisitorTest, RevokeRole) {
   ASSERT_THROW(ast_generator.ParseQuery("REVOKE ROLE FROM user"), SyntaxException);
   ASSERT_THROW(ast_generator.ParseQuery("REVOKE ROLE admin"), SyntaxException);
 
+  AuthQueryChecker(&ast_generator, "REVOKE ROLE admin FROM USER user", AuthQuery::Action::REVOKE_ROLE)
+      .WithUser("user")
+      .WithRoles({"admin"})
+      .Check();
   AuthQueryChecker(&ast_generator, "REVOKE ROLE admin FROM user", AuthQuery::Action::REVOKE_ROLE)
       .WithUser("user")
       .WithRoles({"admin"})
@@ -4464,6 +4483,8 @@ TEST_P(CypherMainVisitorTest, ShowRoleForUser) {
   ASSERT_THROW(ast_generator.ParseQuery("SHOW ROLE FOR "), SyntaxException);
   check_auth_query(
       &ast_generator, "SHOW ROLE FOR user", AuthQuery::Action::SHOW_ROLE_FOR_USER, "user", {}, "", {}, {}, {}, {});
+  check_auth_query(
+      &ast_generator, "SHOW ROLE FOR USER user", AuthQuery::Action::SHOW_ROLE_FOR_USER, "user", {}, "", {}, {}, {}, {});
   ASSERT_THROW(ast_generator.ParseQuery("SHOW ROLE FOR user1, user2"), SyntaxException);
 }
 
@@ -4472,6 +4493,16 @@ TEST_P(CypherMainVisitorTest, ShowUsersForRole) {
   ASSERT_THROW(ast_generator.ParseQuery("SHOW USERS FOR "), SyntaxException);
   check_auth_query(
       &ast_generator, "SHOW USERS FOR role", AuthQuery::Action::SHOW_USERS_FOR_ROLE, "", {"role"}, "", {}, {}, {}, {});
+  check_auth_query(&ast_generator,
+                   "SHOW USERS FOR ROLE role",
+                   AuthQuery::Action::SHOW_USERS_FOR_ROLE,
+                   "",
+                   {"role"},
+                   "",
+                   {},
+                   {},
+                   {},
+                   {});
   ASSERT_THROW(ast_generator.ParseQuery("SHOW USERS FOR role1, role2"), SyntaxException);
 }
 

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -3076,6 +3076,68 @@ TEST_P(CypherMainVisitorTest, ClearRole) {
       .Check();
 }
 
+TEST_P(CypherMainVisitorTest, GrantRole) {
+  auto &ast_generator = *GetParam();
+
+  ASSERT_THROW(ast_generator.ParseQuery("GRANT ROLE"), SyntaxException);
+  ASSERT_THROW(ast_generator.ParseQuery("GRANT ROLE TO user"), SyntaxException);
+  ASSERT_THROW(ast_generator.ParseQuery("GRANT ROLE admin"), SyntaxException);
+
+  AuthQueryChecker(&ast_generator, "GRANT ROLE admin TO user", AuthQuery::Action::GRANT_ROLE)
+      .WithUser("user")
+      .WithRoles({"admin"})
+      .Check();
+  AuthQueryChecker(&ast_generator, "GRANT ROLES admin TO user", AuthQuery::Action::GRANT_ROLE)
+      .WithUser("user")
+      .WithRoles({"admin"})
+      .Check();
+  AuthQueryChecker(&ast_generator, "GRANT ROLE admin, reader TO user", AuthQuery::Action::GRANT_ROLE)
+      .WithUser("user")
+      .WithRoles({"admin", "reader"})
+      .Check();
+  AuthQueryChecker(&ast_generator, "GRANT ROLE admin TO user ON db1", AuthQuery::Action::GRANT_ROLE)
+      .WithUser("user")
+      .WithRoles({"admin"})
+      .WithDatabases({"db1"})
+      .Check();
+  AuthQueryChecker(&ast_generator, "GRANT ROLE admin, reader TO user ON db1, db2", AuthQuery::Action::GRANT_ROLE)
+      .WithUser("user")
+      .WithRoles({"admin", "reader"})
+      .WithDatabases({"db1", "db2"})
+      .Check();
+}
+
+TEST_P(CypherMainVisitorTest, RevokeRole) {
+  auto &ast_generator = *GetParam();
+
+  ASSERT_THROW(ast_generator.ParseQuery("REVOKE ROLE"), SyntaxException);
+  ASSERT_THROW(ast_generator.ParseQuery("REVOKE ROLE FROM user"), SyntaxException);
+  ASSERT_THROW(ast_generator.ParseQuery("REVOKE ROLE admin"), SyntaxException);
+
+  AuthQueryChecker(&ast_generator, "REVOKE ROLE admin FROM user", AuthQuery::Action::REVOKE_ROLE)
+      .WithUser("user")
+      .WithRoles({"admin"})
+      .Check();
+  AuthQueryChecker(&ast_generator, "REVOKE ROLES admin FROM user", AuthQuery::Action::REVOKE_ROLE)
+      .WithUser("user")
+      .WithRoles({"admin"})
+      .Check();
+  AuthQueryChecker(&ast_generator, "REVOKE ROLE admin, reader FROM user", AuthQuery::Action::REVOKE_ROLE)
+      .WithUser("user")
+      .WithRoles({"admin", "reader"})
+      .Check();
+  AuthQueryChecker(&ast_generator, "REVOKE ROLE admin FROM user ON db1", AuthQuery::Action::REVOKE_ROLE)
+      .WithUser("user")
+      .WithRoles({"admin"})
+      .WithDatabases({"db1"})
+      .Check();
+  AuthQueryChecker(&ast_generator, "REVOKE ROLE admin, reader FROM user ON db1, db2", AuthQuery::Action::REVOKE_ROLE)
+      .WithUser("user")
+      .WithRoles({"admin", "reader"})
+      .WithDatabases({"db1", "db2"})
+      .Check();
+}
+
 TEST_P(CypherMainVisitorTest, GrantPrivilege) {
   auto &ast_generator = *GetParam();
   ASSERT_THROW(ast_generator.ParseQuery("GRANT"), SyntaxException);

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -3042,36 +3042,16 @@ TEST_P(CypherMainVisitorTest, ClearRole) {
   auto &ast_generator = *GetParam();
   ASSERT_THROW(ast_generator.ParseQuery("CLEAR ROLE"), SyntaxException);
   ASSERT_THROW(ast_generator.ParseQuery("CLEAR ROLE user"), SyntaxException);
-  ASSERT_THROW(ast_generator.ParseQuery("CLEAR ROLE FOR user TO"), SyntaxException);
 
   AuthQueryChecker(&ast_generator, "CLEAR ROLE FOR user", AuthQuery::Action::CLEAR_ROLE).WithUser("user").Check();
   AuthQueryChecker(&ast_generator, "CLEAR ROLES FOR user", AuthQuery::Action::CLEAR_ROLE).WithUser("user").Check();
-
-  AuthQueryChecker(&ast_generator, "CLEAR ROLE admin FOR user", AuthQuery::Action::CLEAR_ROLE)
-      .WithUser("user")
-      .WithRoles({"admin"})
-      .Check();
-  AuthQueryChecker(&ast_generator, "CLEAR ROLES admin FOR user", AuthQuery::Action::CLEAR_ROLE)
-      .WithUser("user")
-      .WithRoles({"admin"})
-      .Check();
-  AuthQueryChecker(&ast_generator, "CLEAR ROLE admin, reader FOR user", AuthQuery::Action::CLEAR_ROLE)
-      .WithUser("user")
-      .WithRoles({"admin", "reader"})
-      .Check();
 
   AuthQueryChecker(&ast_generator, "CLEAR ROLE FOR user ON db1", AuthQuery::Action::CLEAR_ROLE)
       .WithUser("user")
       .WithDatabases({"db1"})
       .Check();
-  AuthQueryChecker(&ast_generator, "CLEAR ROLE admin FOR user ON db1", AuthQuery::Action::CLEAR_ROLE)
+  AuthQueryChecker(&ast_generator, "CLEAR ROLE FOR user ON db1, db2", AuthQuery::Action::CLEAR_ROLE)
       .WithUser("user")
-      .WithRoles({"admin"})
-      .WithDatabases({"db1"})
-      .Check();
-  AuthQueryChecker(&ast_generator, "CLEAR ROLE admin, reader FOR user ON db1, db2", AuthQuery::Action::CLEAR_ROLE)
-      .WithUser("user")
-      .WithRoles({"admin", "reader"})
       .WithDatabases({"db1", "db2"})
       .Check();
 }


### PR DESCRIPTION
Extends the auth system with several related improvements:                                                                                                                     

- Adds three built-in roles: `admin`, `readonly`, and `readwrite`. The first enterprise user is automatically assigned the `admin` role. Built-in roles are created atomically and only once.                                       
- Allows users and roles to share the same name (as `admin` is both a common username and rolename). Disambiguates auth commands (`SHOW PRIVILEGES`, `GET MAIN DATABASE`, etc.) by accepting an optional `USER` or `ROLE` keyword.           
- Stack roles in pieces with `GRANT ROLE[S] <roles> TO <user>` and `REVOKE ROLE[S] <roles> FROM <user>` commands. `SET ROLE FOR` is kept for backwards compatibility.
- Roles can only be deleted when no users are assigned to them.