### PR TITLE
Fix: Patch usearch tombstone bug in equal_range iterator

### DIFF
--- a/libs/.gitignore
+++ b/libs/.gitignore
@@ -8,3 +8,4 @@
 !rocksdb8.1.1.patch
 !nuraft.patch
 !usearch.patch
+!usearch-tombstone-fix.patch

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -364,6 +364,15 @@ if(usearch_patch_result AND NOT usearch_patch_result EQUAL 0)
   message(STATUS "usearch patch already applied or skipped (exit code: ${usearch_patch_result})")
 endif()
 
+execute_process(
+  COMMAND patch -p1 --forward -i "${CMAKE_CURRENT_SOURCE_DIR}/usearch-tombstone-fix.patch"
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/usearch"
+  RESULT_VARIABLE usearch_tombstone_patch_result
+)
+if(usearch_tombstone_patch_result AND NOT usearch_tombstone_patch_result EQUAL 0)
+  message(STATUS "usearch tombstone fix patch already applied or skipped (exit code: ${usearch_tombstone_patch_result})")
+endif()
+
 import_header_library(usearch ${CMAKE_CURRENT_SOURCE_DIR}/usearch/include)
 set_property(TARGET usearch PROPERTY INTERFACE_INCLUDE_DIRECTORIES
   ${CMAKE_CURRENT_SOURCE_DIR}/usearch/include

--- a/libs/usearch-tombstone-fix.patch
+++ b/libs/usearch-tombstone-fix.patch
@@ -1,0 +1,23 @@
+diff --git a/include/usearch/index_plugins.hpp b/include/usearch/index_plugins.hpp
+index 9ccf367c..2be082d7 100644
+--- a/include/usearch/index_plugins.hpp
++++ b/include/usearch/index_plugins.hpp
+@@ -2735,10 +2735,17 @@ class flat_hash_multi_set_gt {
+
+         // Pre-increment
+         equal_iterator_gt& operator++() {
++            auto should_skip = [&](std::size_t i) -> bool {
++                auto slot = parent_->slot_ref(i);
++                if (!(slot.header.populated & slot.mask))
++                    return false; // empty slot — stop
++                if (slot.header.deleted & slot.mask)
++                    return true; // tombstone — skip
++                return !equals_(slot.element, query_); // skip non-matching live entries
++            };
+             do {
+                 index_ = (index_ + 1) & (parent_->capacity_slots_ - 1);
+-            } while (!equals_(parent_->slot_ref(index_).element, query_) &&
+-                     (parent_->slot_ref(index_).header.populated & parent_->slot_ref(index_).mask));
++            } while (should_skip(index_));
+             return *this;
+         }


### PR DESCRIPTION
The `equal_range` iterator in `flat_hash_multi_set_gt` did not check the deleted flag when advancing, causing it to yield tombstone entries as live matches. In `index_dense_gt::remove()` this caused already-freed slots to be pushed to `free_keys_` again, corrupting `size()` accounting and leading to crashes ("cannot create `std::vector` larger than `max_size`").

Usearch related PR: https://github.com/unum-cloud/USearch/pull/727
