### PR TITLE
fix: Avoid static variables destruction fiasco on NuRaft's background commit exit

### DIFF
--- a/src/coordination/coordinator_state_manager.cpp
+++ b/src/coordination/coordinator_state_manager.cpp
@@ -210,7 +210,11 @@ auto CoordinatorStateManager::load_log_store() -> std::shared_ptr<log_store> { r
 auto CoordinatorStateManager::server_id() -> int32 { return my_id_; }
 
 auto CoordinatorStateManager::system_exit(int const exit_code) -> void {
-  spdlog::critical("NuRaft triggered system exit with code: {}", exit_code);
+  try {
+    spdlog::critical("NuRaft triggered system exit with code: {}", exit_code);
+    // NOLINTNEXTLINE(bugprone-empty-catch)
+  } catch (std::exception const & /*e*/) {
+  }
   // Use quick_exit() to terminate immediately without running global destructors.
   // NuRaft calls ::exit(-1) after this callback, which can cause the static
   // destruction order fiasco


### PR DESCRIPTION
## What

Implement `CoordinatorStateManager::system_exit()` to call `std::quick_exit()` instead of being a no-op. This preempts NuRaft's `::exit(-1)` call in its background commit thread, preventing a
static destruction order fiasco that causes a `SIGSEGV` during shutdown.

## Why

When NuRaft's `commit_in_bg` thread encounters an exception (e.g. during `CoordinatorStateMachine::commit()`), it calls `system_exit()` followed by `::exit(-1)`. The `::exit(-1)` triggers global
destructors in an unsafe order: spdlog sinks are destroyed before `gModuleRegistry`, so `SharedLibraryModule::Close()` calls `spdlog::info()` on an already-destroyed sink, hitting a pure virtual
function call → `std::terminate` → `abort` → `SIGSEGV`.

## How

- `CoordinatorStateManager::system_exit()` was previously a no-op. It now logs the exit code via `spdlog::critical()` (spdlog is still alive at callback time) and calls `std::quick_exit()`, which
terminates without running global destructors or `atexit` handlers — avoiding the destruction order problem entirely.

## Testing

No new tests added. The crash occurs under a specific race condition during coordinator startup where NuRaft's background commit thread fails while the main thread is still loading Python modules.
 The fix is a defensive safeguard against global destructor ordering issues and does not change any functional behavior.

## Notes for reviewers

- The root cause of *why* NuRaft's commit path throws an exception is a separate issue and is not addressed here. This PR only prevents the cascading crash.
- `std::quick_exit()` does not flush stdio buffers — acceptable for a fatal NuRaft error path.
- NuRaft has several other `::exit(-1)` call sites (bad log index, corrupted log, pre-commit order inversion, missing snapshot) — they all call `system_exit()` first, so this fix covers all of
them.