### PR TITLE
Update pyjwt version installed by pip

### DIFF
--- a/src/auth/reference_modules/requirements.txt
+++ b/src/auth/reference_modules/requirements.txt
@@ -1,5 +1,5 @@
 cryptography==46.0.5
-PyJWT==2.10.1
+PyJWT==2.12.1
 requests==2.32.5
 ldap3==2.6
 pyyaml==6.0.1


### PR DESCRIPTION
This updates the version of PyJWT installed with Memgraph to `2.12.1` in order to address `CVE-2026-32597`.
