### PR TITLE
Allow parameterized values in config maps

### DIFF
--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -1269,9 +1269,11 @@ void MapCommonStreamConfigs(auto &memory, StreamQuery &stream_query) {
 }  // namespace
 
 antlrcpp::Any CypherMainVisitor::visitConfigKeyValuePair(MemgraphCypher::ConfigKeyValuePairContext *ctx) {
-  MG_ASSERT(ctx->literal().size() == 2);
-  return std::pair{std::any_cast<Expression *>(ctx->literal(0)->accept(this)),
-                   std::any_cast<Expression *>(ctx->literal(1)->accept(this))};
+  auto *key = std::any_cast<Expression *>(ctx->literal(0)->accept(this));
+  auto *value = ctx->parameter()
+                    ? static_cast<Expression *>(std::any_cast<ParameterLookup *>(ctx->parameter()->accept(this)))
+                    : std::any_cast<Expression *>(ctx->literal(1)->accept(this));
+  return std::pair{key, value};
 }
 
 antlrcpp::Any CypherMainVisitor::visitConfigMap(MemgraphCypher::ConfigMapContext *ctx) {

--- a/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
+++ b/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
@@ -593,7 +593,7 @@ socketAddress : literal ;
 registerReplica : REGISTER REPLICA instanceName ( SYNC | ASYNC | STRICT_SYNC )
                 TO socketAddress ;
 
-configKeyValuePair : literal ':' literal ;
+configKeyValuePair : literal ':' ( literal | parameter ) ;
 
 configMap : '{' ( configKeyValuePair ( ',' configKeyValuePair )* )? '}' ;
 

--- a/tests/gql_behave/tests/memgraph_V1/features/vector_edge_search.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/vector_edge_search.feature
@@ -137,3 +137,46 @@ Feature: Vector edge search related features
             CALL vector_search.search_edges("test_index", 1, ["invalid", "invalid"]) YIELD * RETURN edge;
             """
         Then an error should be raised
+
+    Scenario: Create vector edge index with parameterized config with all options
+        Given an empty graph
+        And parameters are:
+            | config | {dimension: 2, capacity: 10, metric: "cos", resize_coefficient: 2, scalar_kind: "i8"} |
+        And having executed
+            """
+            CREATE VECTOR EDGE INDEX test_index ON :E1(prop1) WITH CONFIG $config
+            """
+        When executing query:
+            """
+            SHOW VECTOR INDEX INFO;
+            """
+        Then the result should be:
+            | capacity | dimension | index_name   | label | property | metric | size | scalar_kind | index_type                  |
+            | 64       | 2         | 'test_index' | 'E1'  | 'prop1'  | 'cos'  | 0    | 'i8'        | 'edge-type+property_vector' |
+
+    Scenario: Create vector edge index with parameterized config that is not a map raises error
+        Given an empty graph
+        And parameters are:
+            | config | not_a_map |
+        When executing query:
+            """
+            CREATE VECTOR EDGE INDEX test_index ON :E1(prop1) WITH CONFIG $config
+            """
+        Then an error should be raised
+
+    Scenario: Create vector edge index with parameterized config values
+        Given an empty graph
+        And parameters are:
+            | dim | 2  |
+            | cap | 10 |
+        And having executed
+            """
+            CREATE VECTOR EDGE INDEX test_index ON :E1(prop1) WITH CONFIG {"dimension": $dim, "capacity": $cap}
+            """
+        When executing query:
+            """
+            SHOW VECTOR INDEX INFO;
+            """
+        Then the result should be:
+            | capacity | dimension | index_name   | label | property | metric | size | scalar_kind | index_type                  |
+            | 64       | 2         | 'test_index' | 'E1'  | 'prop1'  | 'l2sq' | 0    | 'f32'       | 'edge-type+property_vector' |

--- a/tests/gql_behave/tests/memgraph_V1/features/vector_search.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/vector_search.feature
@@ -25,6 +25,49 @@ Feature: Vector search related features
             | capacity | dimension | index_name   | label | property | metric | size | scalar_kind | index_type              |
             | 64       | 2         | 'test_index' | 'L1'  | 'prop1'  | 'cos'  | 0    | 'i8'        | 'label+property_vector' |
 
+    Scenario: Create vector index with parameterized config with all options
+        Given an empty graph
+        And parameters are:
+            | config | {dimension: 2, capacity: 10, metric: "cos", resize_coefficient: 2, scalar_kind: "i8"} |
+        And having executed
+            """
+            CREATE VECTOR INDEX test_index ON :L1(prop1) WITH CONFIG $config
+            """
+        When executing query:
+            """
+            SHOW VECTOR INDEX INFO;
+            """
+        Then the result should be:
+            | capacity | dimension | index_name   | label | property | metric | size | scalar_kind | index_type              |
+            | 64       | 2         | 'test_index' | 'L1'  | 'prop1'  | 'cos'  | 0    | 'i8'        | 'label+property_vector' |
+
+    Scenario: Create vector index with parameterized config values
+        Given an empty graph
+        And parameters are:
+            | dim | 2  |
+            | cap | 10 |
+        And having executed
+            """
+            CREATE VECTOR INDEX test_index ON :L1(prop1) WITH CONFIG {"dimension": $dim, "capacity": $cap}
+            """
+        When executing query:
+            """
+            SHOW VECTOR INDEX INFO;
+            """
+        Then the result should be:
+            | capacity | dimension | index_name   | label | property | metric | size | scalar_kind | index_type              |
+            | 64       | 2         | 'test_index' | 'L1'  | 'prop1'  | 'l2sq' | 0    | 'f32'       | 'label+property_vector' |
+
+    Scenario: Create vector index with parameterized config that is not a map raises error
+        Given an empty graph
+        And parameters are:
+            | config | 42 |
+        When executing query:
+            """
+            CREATE VECTOR INDEX test_index ON :L1(prop1) WITH CONFIG $config
+            """
+        Then an error should be raised
+
     Scenario: Add node to vector index
         Given an empty graph
         And with new vector index test_index on :L1(prop1) with dimension 2 and capacity 10


### PR DESCRIPTION
Update `configKeyValuePair` grammar rule to accept parameters as values (e.g., `{"dimension": $dim, "capacity": $cap}`). This applies globally to all `WITH CONFIG` usage including vector index creation.

Closes #3050.