### PR TITLE
Fix INT64_MIN literal parsing (issue #471)

### DIFF
--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -11,8 +11,10 @@
 
 #include <algorithm>
 #include <any>
+#include <cstdint>
 #include <cstring>
 #include <iterator>
+#include <limits>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -3249,6 +3251,50 @@ antlrcpp::Any CypherMainVisitor::visitExpression5(MemgraphCypher::Expression5Con
 
 // Unary minus and plus.
 antlrcpp::Any CypherMainVisitor::visitExpression4(MemgraphCypher::Expression4Context *ctx) {
+  // Handle INT64_MIN edge case: the literal 9223372036854775808 overflows
+  // int64_t, but -9223372036854775808 is valid (INT64_MIN). When a single
+  // unary minus is applied to this literal, produce INT64_MIN directly
+  // instead of trying to parse the unsigned value first.
+  auto operators = ExtractOperators(ctx->children, {MemgraphCypher::PLUS, MemgraphCypher::MINUS});
+  if (!operators.empty()) {
+    // Count net sign: each MINUS flips the sign.
+    bool has_net_minus = false;
+    for (auto op : operators) {
+      if (op == MemgraphCypher::MINUS) has_net_minus = !has_net_minus;
+    }
+    if (has_net_minus) {
+      auto expr_text = ctx->expression3a()->getText();
+      try {
+        auto value = ParseIntegerLiteral(expr_text, true);
+        if (value == std::numeric_limits<int64_t>::min()) {
+          // The literal only fits as a negated value (INT64_MIN).
+          // Create the literal directly and apply remaining operators.
+          int token_position = ctx->expression3a()->getStart()->getTokenIndex();
+          Expression *expression = nullptr;
+          if (context_.is_query_cached) {
+            expression = storage_->Create<ParameterLookup>(token_position);
+          } else {
+            expression = storage_->Create<PrimitiveLiteral>(TypedValue(value), token_position);
+          }
+          // Apply the remaining operators (all except one MINUS which was
+          // absorbed into the literal value).
+          bool consumed_minus = false;
+          for (int i = static_cast<int>(operators.size()) - 1; i >= 0; --i) {
+            if (operators[i] == MemgraphCypher::MINUS && !consumed_minus) {
+              consumed_minus = true;
+              continue;
+            }
+            expression = CreateUnaryOperatorByToken(operators[i], expression);
+          }
+          return expression;
+        }
+      } catch (...) {
+        // Not the INT64_MIN case (e.g. expression3a is not a bare integer
+        // literal, or the value is genuinely too large). Fall through to
+        // normal handling which will produce the appropriate error.
+      }
+    }
+  }
   return PrefixUnaryOperator(ctx->expression3a(), ctx->children, {MemgraphCypher::PLUS, MemgraphCypher::MINUS});
 }
 

--- a/src/query/frontend/parsing.cpp
+++ b/src/query/frontend/parsing.cpp
@@ -21,11 +21,22 @@
 
 namespace memgraph::query::frontend {
 
-int64_t ParseIntegerLiteral(const std::string &s) {
+int64_t ParseIntegerLiteral(const std::string &s, bool negated) {
   try {
     // Not really correct since long long can have a bigger range than int64_t.
     return static_cast<int64_t>(std::stoll(s, 0, 0));
   } catch (const std::out_of_range &) {
+    // Handle INT64_MIN edge case: the absolute value 9223372036854775808
+    // overflows int64_t, but -9223372036854775808 is a valid int64_t value.
+    // When the caller indicates a preceding negation, try parsing the
+    // negated form directly.
+    if (negated) {
+      try {
+        return static_cast<int64_t>(std::stoll("-" + s, 0, 0));
+      } catch (...) {
+        // Fall through to throw the original error.
+      }
+    }
     throw SemanticException("Integer literal exceeds 64 bits.");
   }
 }

--- a/src/query/frontend/parsing.hpp
+++ b/src/query/frontend/parsing.hpp
@@ -19,7 +19,7 @@ namespace memgraph::query::frontend {
 
 // These are the functions for parsing literals and parameter names from
 // opencypher query.
-int64_t ParseIntegerLiteral(const std::string &s);
+int64_t ParseIntegerLiteral(const std::string &s, bool negated = false);
 std::string ParseStringLiteral(const std::string &s);
 double ParseDoubleLiteral(const std::string &s);
 std::string ParseParameter(const std::string &s);

--- a/src/query/frontend/stripped.cpp
+++ b/src/query/frontend/stripped.cpp
@@ -143,9 +143,39 @@ StrippedQuery::StrippedQuery(std::string query) : original_(std::move(query)) {
       case Token::STRING:
         replace_stripped(token_index, ParseStringLiteral(token.second), kStrippedStringToken);
         break;
-      case Token::INT:
-        replace_stripped(token_index, ParseIntegerLiteral(token.second), kStrippedIntToken);
-        break;
+      case Token::INT: {
+        // Handle INT64_MIN edge case: -9223372036854775808 is tokenized as
+        // SPECIAL("-") + INT("9223372036854775808"). The unsigned value
+        // overflows int64_t, but the negated value is valid (INT64_MIN).
+        // When parsing overflows, check if the previous non-space token is
+        // a minus sign and retry with negation.
+        bool merged_minus = false;
+        try {
+          replace_stripped(token_index, ParseIntegerLiteral(token.second), kStrippedIntToken);
+        } catch (const SemanticException &) {
+          if (!token_strings.empty() && token_strings.back() == "-") {
+            auto negated_value = ParseIntegerLiteral(token.second, true);
+            token_strings.pop_back();
+            // Recalculate token_index since we removed the minus token.
+            int adjusted_token_index = token_strings.size() + parameters_.size();
+            replace_stripped(adjusted_token_index, negated_value, kStrippedIntToken);
+            merged_minus = true;
+          } else {
+            throw;
+          }
+        }
+        if (merged_minus) {
+          // The position mapping for the minus token that was merged needs
+          // to be invalidated. Find its mapping entry and clear it.
+          for (int j = i - 1; j >= 0; --j) {
+            if (tokens[j].first == Token::SPACE) continue;
+            if (tokens[j].first == Token::SPECIAL && tokens[j].second == "-") {
+              position_mapping[j] = -1;
+            }
+            break;
+          }
+        }
+      } break;
       case Token::REAL:
         replace_stripped(token_index, ParseDoubleLiteral(token.second), kStrippedDoubleToken);
         break;

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -952,6 +952,39 @@ TEST_P(CypherMainVisitorTest, UnaryMinusPlusOperators) {
   CheckRWType(query, kRead);
 }
 
+TEST_P(CypherMainVisitorTest, Int64MinLiteral) {
+  // INT64_MIN (-9223372036854775808) should be accepted as a valid integer
+  // literal. The parser must handle the edge case where the absolute value
+  // 9223372036854775808 overflows int64_t but -9223372036854775808 is valid.
+  auto &ast_generator = *GetParam();
+  auto *query = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("RETURN -9223372036854775808"));
+  ASSERT_TRUE(query);
+  ASSERT_TRUE(query->single_query_);
+  auto *single_query = query->single_query_;
+  auto *return_clause = dynamic_cast<Return *>(single_query->clauses_[0]);
+  ASSERT_NE(return_clause, nullptr);
+  // The minus is absorbed into the literal, producing INT64_MIN directly.
+  ast_generator.CheckLiteral(return_clause->body_.named_expressions[0]->expression_,
+                             std::numeric_limits<int64_t>::min());
+  CheckRWType(query, kRead);
+}
+
+TEST_P(CypherMainVisitorTest, Int64MinInComparison) {
+  // Reproducer for https://github.com/memgraph/memgraph/issues/471
+  // RETURN $i = -9223372036854775808 should not throw.
+  auto &ast_generator = *GetParam();
+  auto *query = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("RETURN 1 = -9223372036854775808"));
+  ASSERT_TRUE(query);
+  ASSERT_TRUE(query->single_query_);
+  auto *single_query = query->single_query_;
+  auto *return_clause = dynamic_cast<Return *>(single_query->clauses_[0]);
+  ASSERT_NE(return_clause, nullptr);
+  auto *eq_op = dynamic_cast<EqualOperator *>(return_clause->body_.named_expressions[0]->expression_);
+  ASSERT_NE(eq_op, nullptr);
+  ast_generator.CheckLiteral(eq_op->expression2_, std::numeric_limits<int64_t>::min());
+  CheckRWType(query, kRead);
+}
+
 TEST_P(CypherMainVisitorTest, Aggregation) {
   auto &ast_generator = *GetParam();
   auto *query = dynamic_cast<CypherQuery *>(

--- a/tests/unit/stripped.cpp
+++ b/tests/unit/stripped.cpp
@@ -14,6 +14,9 @@
 // Created by Florijan Stamenkovic on 07.03.17.
 //
 
+#include <cstdint>
+#include <limits>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -508,6 +511,46 @@ TEST(QueryStripper, KeywordsCanBeUsedInStrippedQueries) {
     StrippedQuery stripped("MATCH (n:Constraints), (m:Indexes) RETURN n, m");
     EXPECT_EQ(stripped.stripped_query().str(), "MATCH ( n : Constraints ) , ( m : Indexes ) RETURN n , m");
   }
+}
+
+TEST(QueryStripper, NegativeInteger) {
+  StrippedQuery stripped("RETURN -42");
+  EXPECT_EQ(stripped.literals().size(), 1);
+  EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), 42);
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN - " + kStrippedIntToken);
+}
+
+TEST(QueryStripper, Int64Min) {
+  // INT64_MIN (-9223372036854775808) is a valid int64 value, but the
+  // absolute value 9223372036854775808 overflows int64. The stripper should
+  // merge the preceding minus sign with the literal to produce INT64_MIN.
+  StrippedQuery stripped("RETURN -9223372036854775808");
+  EXPECT_EQ(stripped.literals().size(), 1);
+  EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), std::numeric_limits<int64_t>::min());
+  // The minus sign is absorbed into the literal, so it does not appear
+  // in the stripped query.
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedIntToken);
+}
+
+TEST(QueryStripper, Int64MinInExpression) {
+  // INT64_MIN used in a comparison expression.
+  StrippedQuery stripped("RETURN $i = -9223372036854775808");
+  EXPECT_EQ(stripped.literals().size(), 1);
+  EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), std::numeric_limits<int64_t>::min());
+}
+
+TEST(QueryStripper, Int64Max) {
+  // INT64_MAX (9223372036854775807) should parse normally.
+  StrippedQuery stripped("RETURN 9223372036854775807");
+  EXPECT_EQ(stripped.literals().size(), 1);
+  EXPECT_EQ(stripped.literals().At(0).second.ValueInt(), std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(stripped.stripped_query().str(), "RETURN " + kStrippedIntToken);
+}
+
+TEST(QueryStripper, IntegerOverflow) {
+  // A value exceeding int64 range (even when negated) should throw.
+  EXPECT_THROW(StrippedQuery("RETURN 9223372036854775808"), SemanticException);
+  EXPECT_THROW(StrippedQuery("RETURN 99999999999999999999"), SemanticException);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

- Fixes the bug where Memgraph throws "Integer literal exceeds 64 bits" for the valid value `-9223372036854775808` (INT64_MIN)
- The root cause: the Cypher parser tokenizes `-9223372036854775808` as unary minus + the literal `9223372036854775808`, but `9223372036854775808` overflows `int64_t` before negation can be applied
- Fix detects this edge case at three levels: `ParseIntegerLiteral` (accepts a `negated` flag), query stripping (merges the preceding `-` token), and AST construction (produces `PrimitiveLiteral(INT64_MIN)` directly in `visitExpression4`)

## Changes

- `src/query/frontend/parsing.hpp` / `parsing.cpp`: Add `bool negated` parameter to `ParseIntegerLiteral`; when set and parsing overflows, retry with prepended `-`
- `src/query/frontend/stripped.cpp`: When an INT token overflows and the prior token is `-`, merge them and store INT64_MIN
- `src/query/frontend/ast/cypher_main_visitor.cpp`: In `visitExpression4` (unary +/- handler), detect the INT64_MIN pattern and produce the literal directly without going through `UnaryMinusOperator`

## Test plan

- [ ] New unit tests in `tests/unit/stripped.cpp`: `NegativeInteger`, `Int64Min`, `Int64MinInExpression`, `Int64Max`, `IntegerOverflow`
- [ ] New unit tests in `tests/unit/cypher_main_visitor.cpp`: `Int64MinLiteral`, `Int64MinInComparison`
- [ ] Existing tests should continue to pass (no behavioral change for values within int64 range)
- [ ] Manual test: `RETURN $i = -9223372036854775808` should no longer throw

Fixes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)