### PR TITLE
fix: Added missing query modules argument to native HA workload stress test

### DIFF
--- a/tests/stress/ha/native/workloads.yaml
+++ b/tests/stress/ha/native/workloads.yaml
@@ -6,7 +6,7 @@ defaults:
   memgraph:
     deployment:
       externally_managed: false
-    args: ["--log-level=TRACE", "--logger-type=async"]
+    args: ["--log-level=TRACE", "--logger-type=async", "--query-modules-directory=../../build/query_modules"]
     env: {}
   cluster:
     coordinators:


### PR DESCRIPTION
Added missing `--query-modules-directory=../../build/query_modules` argument so that Memgraph can find its query modules.
