### PR TITLE
fix:Conflicting artifact names in ISSU test

### DIFF
--- a/.github/workflows/reusable_issu_test.yaml
+++ b/.github/workflows/reusable_issu_test.yaml
@@ -118,7 +118,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.run_id != '' && format('issu-logs-{0}', inputs.run_id) || 'issu-logs' }}
+          name: ${{ inputs.run_id != '' && format('issu-logs-{0}', inputs.run_id) || 'issu-logs' }}-${{ inputs.arch }}
           path: tests/issu/artifacts/**
           if-no-files-found: warn
           retention-days: 7


### PR DESCRIPTION
Daily build workflow ISSU test fails because both architectures upload an artifact with the same name, this uses the architecture as part of the name to fix that.
