### PR TITLE
Remove redundant vector search benchmark queries

### DIFF
--- a/tests/mgbench/workloads/vector_search_index.py
+++ b/tests/mgbench/workloads/vector_search_index.py
@@ -65,22 +65,6 @@ class VectorSearchIndex(Workload):
     def _get_random_vector(self):
         return [random.random() for _ in range(0, VectorSearchIndex.VECTOR_DIMENSIONS)]
 
-    def benchmark__vector__single_vertex_lookup(self):
-        match self._vendor:
-            case GraphVendors.MEMGRAPH:
-                return ("MATCH (n:User {id:$id}) RETURN n;", {"id": self._get_random_node()})
-            case _:
-                raise Exception(f"Unknown vendor {self._vendor}")
-
-    def benchmark__vector__single_vertex_create(self):
-        i = self._nodes_count
-        self._nodes_count += 1
-        match self._vendor:
-            case GraphVendors.MEMGRAPH:
-                return ("CREATE (:Node {id:%i, vector: $vector});" % (i), {"vector": self._get_random_vector()})
-            case _:
-                raise Exception(f"Unknown vendor {self._vendor}")
-
     def benchmark__vector__running_traversals(self):
         # NOTE: Vector is there but we are not returning it, that's on purpose to avoid measuring that part.
         match self._vendor:
@@ -88,16 +72,6 @@ class VectorSearchIndex(Workload):
                 return (
                     "MATCH (a:Node {id:$A_id})-[*bfs..4]->(b:Node {id:$B_id}) RETURN a.id, b.id;",
                     {"A_id": self._get_random_node(), "B_id": self._get_random_node()},
-                )
-            case _:
-                raise Exception(f"Unknown vendor {self._vendor}")
-
-    def benchmark__vector__single_index_lookup(self):
-        match self._vendor:
-            case GraphVendors.MEMGRAPH:
-                return (
-                    'CALL vector_search.search("index", 10, $query) YIELD * RETURN id(node), distance;',
-                    {"query": self._get_random_vector()},
                 )
             case _:
                 raise Exception(f"Unknown vendor {self._vendor}")


### PR DESCRIPTION
- single_vertex_lookup: matched :User instead of :Node, always returned nothing
- single_vertex_create: duplicate of insert_node but also mutated _nodes_count
- single_index_lookup: same query as search_top10 with different YIELD

Remaining benchmarks: search_top10, insert_node, delete_node, running_traversals.