### PR TITLE
fix: Bump MAGE query module procedure count

### DIFF
--- a/mage/tests/smoke-release-testing/mgconsole/query_modules.bash
+++ b/mage/tests/smoke-release-testing/mgconsole/query_modules.bash
@@ -5,7 +5,7 @@ source "$SCRIPT_DIR/../utils.bash"
 test_query_modules() {
   IMAGE_TYPE=${1:-"mage"}
   if [ "$IMAGE_TYPE" == "mage" ]; then
-    expected_procedure_count=322
+    expected_procedure_count=326
     expected_function_count=47
   elif [ "$IMAGE_TYPE" == "memgraph" ]; then
     expected_procedure_count=138


### PR DESCRIPTION
The smoke tests for MAGE expect 322 procedures, but 4 new procedures were added in #3803, so we need to bump the count in order for the smoke tests to pass.
