### PR TITLE
Update packaging workflow timeouts

### DIFF
--- a/.github/workflows/reusable_package.yaml
+++ b/.github/workflows/reusable_package.yaml
@@ -76,7 +76,7 @@ env:
 jobs:
   PackageAndUpload:
     runs-on: ${{ (inputs.arch == 'arm') && fromJSON('["self-hosted", "DockerMgBuild", "ARM64"]') || fromJSON((inputs.os == 'centos-10' || inputs.os == 'rocky-10') && '["self-hosted", "DockerMgBuild", "X64", "x86-64-v3"]' || '["self-hosted", "DockerMgBuild", "X64"]') }}
-    timeout-minutes: ${{ inputs.arch == 'arm' && 120 || 60 }}
+    timeout-minutes: 30
     outputs:
       package_s3_url: ${{ steps.output_package_s3_url.outputs.package_s3_url }}
     steps:

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -105,7 +105,7 @@ jobs:
   BuildAndPush:
     name: "Build and Test MAGE"
     runs-on: [self-hosted, DockerMgBuild, Linux, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
-    timeout-minutes: ${{ inputs.cugraph && 45 || 30 }}
+    timeout-minutes: ${{ inputs.cugraph && 45 || 35 }}
     outputs:
       s3_package_url: ${{ steps.output-url.outputs.s3_url }}
     steps:


### PR DESCRIPTION
Increase MAGE packaging timeout by 5 minutes to allow for smoke tests to run (added to workflow in #3971) and reduce timeouts on Memgraph packaging because they are far too high.
