### PR TITLE
fix: Allow MAGE Docker image to build without custom OpenSSL being present

### DIFF
--- a/mage/Dockerfile.cugraph
+++ b/mage/Dockerfile.cugraph
@@ -87,8 +87,9 @@ RUN --mount=type=secret,id=ubuntu_sources,target=/ubuntu.sources,required=false 
     mv -v /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.backup; \
     cp -v /ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources; \
   fi && \
+  apt-get update && \
   if test -n "$(find /openssl -maxdepth 1 -name '*.deb' -print -quit 2>/dev/null)"; then \
-    apt-get update && apt-get install -y \
+    apt-get install -y \
     /openssl/*.deb \
     --no-install-recommends; \
   fi && \

--- a/mage/Dockerfile.release
+++ b/mage/Dockerfile.release
@@ -64,8 +64,9 @@ RUN --mount=type=secret,id=ubuntu_sources,target=/ubuntu.sources,required=false 
     mv -v /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.backup; \
     cp -v /ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources; \
   fi && \
+  apt-get update && \
   if test -n "$(find /openssl -maxdepth 1 -name '*.deb' -print -quit 2>/dev/null)"; then \
-    apt-get update && apt-get install -y \
+    apt-get install -y \
     /openssl/*.deb \
     --no-install-recommends; \
   fi && \


### PR DESCRIPTION
If building the MAGE Docker image without building the custom OpenSSL packages first, the build will fail because `apt-get update` only happens when the OpenSSL packages are found. This small change will fix that.

