### PR TITLE
fix: Log rotation when instance restarts

### DIFF
--- a/src/flags/logging.cpp
+++ b/src/flags/logging.cpp
@@ -173,7 +173,7 @@ void TurnOnStdErr() {
 // Deletes old log files that should've been rotated by spdlog but aren't. Spdlog saves next rotation time in the memory
 // so if the instance restarts before the scheduled rotations the rotation event will never trigger. Therefore, we are
 // trying to fix this behavior by running manually rotation on the Memgraph startup
-// Assumes there are only log files in the drectory.
+// Assumes there are only log files in the directory.
 // Deletes all files whose last_write_time is older than --log-retention-days
 void CleanLogsDir() {
   if (FLAGS_log_file.empty()) return;
@@ -182,6 +182,7 @@ void CleanLogsDir() {
   auto const log_directory = log_path.parent_path();
   auto const cutoff = std::filesystem::file_time_type::clock::now() - std::chrono::days(FLAGS_log_retention_days);
 
+  // Logs error only at the end, doesn't log for each file
   std::error_code ec;
   for (auto const &entry : std::filesystem::directory_iterator(log_directory, ec)) {
     if (!entry.is_regular_file(ec)) continue;

--- a/src/flags/logging.cpp
+++ b/src/flags/logging.cpp
@@ -14,7 +14,6 @@
 #include <spdlog/logger.h>
 #include <spdlog/sinks/sink.h>
 #include <spdlog/spdlog.h>
-#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <ctime>
@@ -33,6 +32,7 @@
 #include "spdlog/sinks/daily_file_sink.h"
 #include "spdlog/sinks/dist_sink.h"
 #include "utils/enum.hpp"
+#include "utils/file.hpp"
 #include "utils/flag_validation.hpp"
 #include "utils/logging.hpp"
 #include "utils/string.hpp"
@@ -168,6 +168,30 @@ void TurnOffStdErr() { stderr_sink()->set_level(spdlog::level::off); }
 void TurnOnStdErr() {
   // stderr level allows everything, will be filtered on logger's elvel
   stderr_sink()->set_level(spdlog::level::trace);
+}
+
+// Deletes old log files that should've been rotated by spdlog but aren't. Spdlog saves next rotation time in the memory
+// so if the instance restarts before the scheduled rotations the rotation event will never trigger. Therefore, we are
+// trying to fix this behavior by running manually rotation on the Memgraph startup
+// Assumes there are only log files in the drectory.
+// Deletes all files whose last_write_time is older than --log-retention-days
+void CleanLogsDir() {
+  if (FLAGS_log_file.empty()) return;
+
+  auto const log_path = std::filesystem::path{FLAGS_log_file};
+  auto const log_directory = log_path.parent_path();
+  auto const cutoff = std::filesystem::file_time_type::clock::now() - std::chrono::days(FLAGS_log_retention_days);
+
+  std::error_code ec;
+  for (auto const &entry : std::filesystem::directory_iterator(log_directory, ec)) {
+    if (!entry.is_regular_file(ec)) continue;
+    if (entry.last_write_time(ec) < cutoff) {
+      memgraph::utils::DeleteFile(entry.path());
+    }
+  }
+  if (ec) {
+    spdlog::warn("Error occurred while trying to manually rotate old log files: {}", ec.message());
+  }
 }
 
 }  // namespace memgraph::flags

--- a/src/flags/logging.hpp
+++ b/src/flags/logging.hpp
@@ -42,4 +42,6 @@ void AddLoggerSink(spdlog::sink_ptr new_sink);
 void TurnOffStdErr();
 // Sets logging level to the global logging level
 void TurnOnStdErr();
+void CleanLogsDir();
+
 }  // namespace memgraph::flags

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -384,6 +384,7 @@ int main(int argc, char **argv) {
 
   auto data_directory = std::filesystem::path(FLAGS_data_directory);
   CleanDataDir(data_directory);
+  memgraph::flags::CleanLogsDir();
 
   memgraph::utils::EnsureDirOrDie(data_directory);
   // Verify that the user that started the process is the same user that is

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1071,4 +1071,9 @@ endif ()
 add_unit_test(safe_hardware_concurrency
     SOURCES safe_hardware_concurrency.cpp
     LINK_TARGETS mg-utils
+    
+# Test log retention cleanup
+add_unit_test(logging
+    SOURCES logging.cpp
+    LINK_TARGETS gflags mg-flags
 )

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1070,8 +1070,8 @@ endif ()
 
 add_unit_test(safe_hardware_concurrency
     SOURCES safe_hardware_concurrency.cpp
-    LINK_TARGETS mg-utils
-    
+    LINK_TARGETS mg-utils)
+
 # Test log retention cleanup
 add_unit_test(logging
     SOURCES logging.cpp

--- a/tests/unit/logging.cpp
+++ b/tests/unit/logging.cpp
@@ -1,0 +1,141 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "flags/logging.hpp"
+
+#include <gflags/gflags.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+
+DECLARE_string(log_file);
+DECLARE_uint64(log_retention_days);
+
+namespace {
+
+namespace fs = std::filesystem;
+
+class CleanLogsDirTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    test_dir_ = fs::temp_directory_path() / ("mg_log_test_" + std::to_string(::getpid()));
+    fs::create_directories(test_dir_);
+    original_log_file_ = FLAGS_log_file;
+    original_retention_days_ = FLAGS_log_retention_days;
+  }
+
+  void TearDown() override {
+    FLAGS_log_file = original_log_file_;
+    FLAGS_log_retention_days = original_retention_days_;
+    std::error_code ec;
+    fs::remove_all(test_dir_, ec);
+  }
+
+  void CreateFile(const std::string &name, std::chrono::days age) {
+    auto path = test_dir_ / name;
+    std::ofstream{path} << "log content";
+    auto const old_time = fs::file_time_type::clock::now() - age;
+    fs::last_write_time(path, old_time);
+  }
+
+  std::vector<std::string> RemainingFiles() {
+    std::vector<std::string> result;
+    for (auto const &entry : fs::directory_iterator(test_dir_)) {
+      if (entry.is_regular_file()) {
+        result.emplace_back(entry.path().filename().string());
+      }
+    }
+    std::sort(result.begin(), result.end());
+    return result;
+  }
+
+  fs::path test_dir_;
+  std::string original_log_file_;
+  uint64_t original_retention_days_{};
+};
+
+TEST_F(CleanLogsDirTest, EmptyLogFileFlag) {
+  FLAGS_log_file = "";
+  CreateFile("old.log", std::chrono::days{10});
+  memgraph::flags::CleanLogsDir();
+  EXPECT_EQ(RemainingFiles().size(), 1);
+}
+
+TEST_F(CleanLogsDirTest, AllFilesWithinRetention) {
+  FLAGS_log_file = (test_dir_ / "memgraph.log").string();
+  FLAGS_log_retention_days = 5;
+
+  CreateFile("recent_1.log", std::chrono::days{2});
+  CreateFile("recent_2.log", std::chrono::days{1});
+  CreateFile("recent_3.log", std::chrono::days{0});
+
+  memgraph::flags::CleanLogsDir();
+
+  EXPECT_EQ(RemainingFiles().size(), 3);
+}
+
+TEST_F(CleanLogsDirTest, OldFilesDeleted) {
+  FLAGS_log_file = (test_dir_ / "memgraph.log").string();
+  FLAGS_log_retention_days = 2;
+
+  CreateFile("old_1.log", std::chrono::days{7});
+  CreateFile("old_2.log", std::chrono::days{6});
+  CreateFile("old_3.log", std::chrono::days{5});
+  CreateFile("old_4.log", std::chrono::days{3});
+  CreateFile("recent_1.log", std::chrono::days{1});
+  CreateFile("recent_2.log", std::chrono::days{0});
+
+  memgraph::flags::CleanLogsDir();
+
+  auto remaining = RemainingFiles();
+  EXPECT_EQ(remaining.size(), 2);
+  EXPECT_EQ(remaining[0], "recent_1.log");
+  EXPECT_EQ(remaining[1], "recent_2.log");
+}
+
+TEST_F(CleanLogsDirTest, AllFilesOld) {
+  FLAGS_log_file = (test_dir_ / "memgraph.log").string();
+  FLAGS_log_retention_days = 1;
+
+  CreateFile("old_1.log", std::chrono::days{10});
+  CreateFile("old_2.log", std::chrono::days{9});
+  CreateFile("old_3.log", std::chrono::days{8});
+
+  memgraph::flags::CleanLogsDir();
+
+  EXPECT_TRUE(RemainingFiles().empty());
+}
+
+TEST_F(CleanLogsDirTest, DirectoriesAreNotDeleted) {
+  FLAGS_log_file = (test_dir_ / "memgraph.log").string();
+  FLAGS_log_retention_days = 1;
+
+  CreateFile("old.log", std::chrono::days{10});
+  fs::create_directory(test_dir_ / "subdir");
+
+  memgraph::flags::CleanLogsDir();
+
+  auto remaining = RemainingFiles();
+  EXPECT_TRUE(remaining.empty());
+  // subdir should still exist
+  EXPECT_TRUE(fs::exists(test_dir_ / "subdir"));
+}
+
+TEST_F(CleanLogsDirTest, NonExistentDirectory) {
+  FLAGS_log_file = "/tmp/mg_nonexistent_dir_test/memgraph.log";
+  FLAGS_log_retention_days = 2;
+  EXPECT_NO_THROW(memgraph::flags::CleanLogsDir());
+}
+
+}  // namespace


### PR DESCRIPTION
Spdlog caches next rotation time in-memory which means that if the instance restarts, it gets a new rotation time. it is easy to imagine then that if the instance often restarts, log files will never be rotated. Fixed by manually running rotation of log files at the Memgraph startup.