### PR TITLE
fix: Fix use-after-free due with non-sequential deltas in stress tests

### DIFF
--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2916,27 +2916,6 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
     }
   });
 
-  {
-    auto guard = std::unique_lock{engine_lock_};
-    uint64_t mark_timestamp = timestamp_;  // a timestamp no active transaction can currently have
-
-    // Deltas from previous GC runs or from aborts can be cleaned up here
-    garbage_undo_buffers_.WithLock([&](auto &garbage_undo_buffers) {
-      guard.unlock();
-      if (main_guard.owns_lock() || mark_timestamp == oldest_active_start_timestamp) {
-        // We know no transaction is active, it is safe to simply delete all the garbage undos
-        // Nothing can be reading them
-        garbage_undo_buffers.clear();
-      } else {
-        // garbage_undo_buffers is ordered, pop until we can't
-        while (!garbage_undo_buffers.empty() &&
-               garbage_undo_buffers.front().mark_timestamp_ <= oldest_active_start_timestamp) {
-          garbage_undo_buffers.pop_front();
-        }
-      }
-    });
-  }
-
   // We don't move undo buffers of unlinked transactions to garbage_undo_buffers
   // list immediately, because we would have to repeatedly take
   // garbage_undo_buffers lock.
@@ -3065,14 +3044,15 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
             }
 
             if (prev.delta->commit_info->timestamp.load() < oldest_active_start_timestamp) {
-              // If previous is from another inactive transaction, no need to
-              // lock the edge/vertex, nothing will read this far or relink to
-              // us directly
-              break;
+              // For a committed non-sequential predecessor, readers skip delta
+              // via next, so we must clear delta->next before freeing
+              // downstream delta to stop traversal into freed deltas.
+              if (!IsDeltaNonSequential(*prev.delta)) {
+                break;
+              }
             }
 
-            // Previous is either active (committed or uncommitted), we need to find
-            // the parent object in order to be able to use its lock.
+            // Previous is active, or inactive non-sequential; find the parent object in order to use its lock.
             auto parent = prev;
             while (parent.type == PreviousPtr::Type::DELTA) {
               parent = parent.delta->prev.Get();
@@ -3183,6 +3163,24 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
         garbage_undo_buffers.splice(garbage_undo_buffers.end(), std::move(unlinked_undo_buffers));
       });
     }
+  }
+
+  // Free garbage_undo_buffers after the unlinking loop so that prev pointers
+  // followed during unlinking are never into freed memory.
+  {
+    auto guard = std::unique_lock{engine_lock_};
+    uint64_t const mark_timestamp = timestamp_;
+    garbage_undo_buffers_.WithLock([&](auto &garbage_undo_buffers) {
+      guard.unlock();
+      if (main_guard.owns_lock() || mark_timestamp == oldest_active_start_timestamp) {
+        garbage_undo_buffers.clear();
+      } else {
+        while (!garbage_undo_buffers.empty() &&
+               garbage_undo_buffers.front().mark_timestamp_ <= oldest_active_start_timestamp) {
+          garbage_undo_buffers.pop_front();
+        }
+      }
+    });
   }
 
   // EDGES METADATA (has ptr to Vertices, must be before removing vertices)

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2916,6 +2916,27 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
     }
   });
 
+  {
+    auto guard = std::unique_lock{engine_lock_};
+    uint64_t mark_timestamp = timestamp_;  // a timestamp no active transaction can currently have
+
+    // Deltas from previous GC runs or from aborts can be cleaned up here
+    garbage_undo_buffers_.WithLock([&](auto &garbage_undo_buffers) {
+      guard.unlock();
+      if (main_guard.owns_lock() || mark_timestamp == oldest_active_start_timestamp) {
+        // We know no transaction is active, it is safe to simply delete all the garbage undos
+        // Nothing can be reading them
+        garbage_undo_buffers.clear();
+      } else {
+        // garbage_undo_buffers is ordered, pop until we can't
+        while (!garbage_undo_buffers.empty() &&
+               garbage_undo_buffers.front().mark_timestamp_ <= oldest_active_start_timestamp) {
+          garbage_undo_buffers.pop_front();
+        }
+      }
+    });
+  }
+
   // We don't move undo buffers of unlinked transactions to garbage_undo_buffers
   // list immediately, because we would have to repeatedly take
   // garbage_undo_buffers lock.
@@ -3052,7 +3073,9 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
               }
             }
 
-            // Previous is active, or inactive non-sequential; find the parent object in order to use its lock.
+            // Previous is either active (committed or uncommitted), or inactive
+            // non-sequential. We need to find the parent object in order to be
+            // able to use its lock.
             auto parent = prev;
             while (parent.type == PreviousPtr::Type::DELTA) {
               parent = parent.delta->prev.Get();
@@ -3163,24 +3186,6 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
         garbage_undo_buffers.splice(garbage_undo_buffers.end(), std::move(unlinked_undo_buffers));
       });
     }
-  }
-
-  // Free garbage_undo_buffers after the unlinking loop so that prev pointers
-  // followed during unlinking are never into freed memory.
-  {
-    auto guard = std::unique_lock{engine_lock_};
-    uint64_t const mark_timestamp = timestamp_;
-    garbage_undo_buffers_.WithLock([&](auto &garbage_undo_buffers) {
-      guard.unlock();
-      if (main_guard.owns_lock() || mark_timestamp == oldest_active_start_timestamp) {
-        garbage_undo_buffers.clear();
-      } else {
-        while (!garbage_undo_buffers.empty() &&
-               garbage_undo_buffers.front().mark_timestamp_ <= oldest_active_start_timestamp) {
-          garbage_undo_buffers.pop_front();
-        }
-      }
-    });
   }
 
   // EDGES METADATA (has ptr to Vertices, must be before removing vertices)

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -763,9 +763,6 @@ class InMemoryStorage final : public Storage {
   void StopAllBackgroundTasks() override {
     async_indexer_.Shutdown();
     Storage::StopAllBackgroundTasks();
-    if (config_.gc.type == Config::Gc::Type::PERIODIC) {
-      gc_runner_.Stop();
-    }
   }
 
   std::unordered_map<LabelId, uint64_t> GetLabelCounts() const override {

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -763,6 +763,9 @@ class InMemoryStorage final : public Storage {
   void StopAllBackgroundTasks() override {
     async_indexer_.Shutdown();
     Storage::StopAllBackgroundTasks();
+    if (config_.gc.type == Config::Gc::Type::PERIODIC) {
+      gc_runner_.Stop();
+    }
   }
 
   std::unordered_map<LabelId, uint64_t> GetLabelCounts() const override {


### PR DESCRIPTION
Fixes an issue discovered during testing of #4016. Delta chain traversals stop at a committed sequential delta, but skip past a committed non-sequential one via `next`. The old "fast-break" left `P->next` dangling to a delta about to be freed.  Restricting the fast-break to sequential predecessors and routing non-sequential ones through the `prev_delta->next.store(nullptr)` (under vertex lock) path correctly terminates such traversals at delta `P`, rather than reading into freed memory.

An example scenario in which this problem occurs:
- We have two vertices, `v1` and `v2`
- `TxA` creates an edge on `v1`, and prepends an edge delta to `v1`
- `TxB` creates an edge on `v2`, and prepends an edge delta to `v2`
- `TxC` creates edges on both `v1` and `v2`, prepending `NON_SEQ` edge deltas to both vertices. (`TxA's` and `TxB's` existing deltas are upgraded to `NON_SEQ`, but that is irrelevant for this issue.)
- `TxA` commits at `ts=40`, and its `GCDeltas` are moved to `committed_transactions_` with an unlinkable timestamp of `40`
- `TxC` commits at `ts=50`, and its `GCDeltas` are moved to `waiting_gc_deltas_` as it has the `has_non_sequential_deltas` flag set.
- `TxD` starts at `start_timestamp=55`
- `TxB` commits at `ts=60`, and its `GCDeltas` are moved to `committed_transactions_` with unlinkable timestamp of `60`
- The only in-flight transaction is now `TxD`, which establishes `oldest_active_timestamp=55`
- Later, periodic `CollectGarbage` runs:
  - `waiting_gc_deltas_` are processed. `TxC`s contributors are committed, so its `GCDelta`s are moved to `committed_transactions_` with an unlinkable timestamp of `60` (from the highest timestamp of its downstream contributors, i.e., `TxB`s delta)
  - `committed_transactions_` are swapped into the local `linked_undo_buffers`, which now contains all three `GCDelta` containers from `TxA`, `TxB`, and `TxC`
  - The unlinker loop processes `TxA`s `GCDelta`s, which have an unlinkable timestamp of 40. `40 < 55`, so we know we can unlink it.
  - This delta's `prev` is `TxC`'s delta with a commit timestamp of `50`, which hits the break at:
```cpp
if (prev.delta->commit_info->timestamp.load() < oldest_active_start_timestamp)
```
  - `TxA`s delta is moved to `unlinked_undo_buffers_`
  - But, `TxC`s `GCDeltas`, which have an unlinkable timestamp of 60 are *not* unlinked, and instead are moved back to `committed_transactions_` for later processing in another GC cycle. This leaves `TxC`s delta `.next` on `v1` pointing to a delta that is now supposedly unlinked and will be destructed in a later GC cycle.
- Later, a reader walks `v1`s chain, follows the `v1.delta.next` and arrives at the destructed delta. Boom.