### PR TITLE
feat: Retry locking data dir to allow distributed storage system to propagate file lock release

### DIFF
--- a/src/flags/general.cpp
+++ b/src/flags/general.cpp
@@ -58,6 +58,10 @@ DEFINE_bool(strict_flag_check, true, "If true, error and exit when suspicious po
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_string(data_directory, "mg_data", "Path to directory in which to save all permanent data.");
 
+// NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_uint32(data_dir_lock_acquisition_timeout_sec, 30,
+              "Timeout before the failure of acquiring file lock on data directory is considered a failure.");
+
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_bool(data_recovery_on_startup, true, "Controls whether the database recovers persisted data on startup.");
 

--- a/src/flags/general.hpp
+++ b/src/flags/general.hpp
@@ -43,6 +43,9 @@ DECLARE_bool(strict_flag_check);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_string(data_directory);
 
+// NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
+DECLARE_uint32(data_dir_lock_acquisition_timeout_sec);
+
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_bool(data_recovery_on_startup);
 

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -390,23 +390,13 @@ int main(int argc, char **argv) {
   // holding the file opened after timeout occurs
   memgraph::utils::OutputFile lock_file_handle;
   lock_file_handle.Open(data_directory / ".lock", memgraph::utils::OutputFile::Mode::OVERWRITE_EXISTING);
-  auto const start_time = std::chrono::steady_clock::now();
-  auto const lock_file_timeout = std::chrono::seconds{FLAGS_data_dir_lock_acquisition_timeout_sec};
-  constexpr uint16_t sleep_time_ms = 250;
-  while (true) {
-    if (lock_file_handle.AcquireLock()) break;
-    if (std::chrono::steady_clock::now() - start_time > lock_file_timeout) {
-      LOG_FATAL(
-          "Couldn't acquire lock on the storage directory {} within {}s"
-          "!\nAnother Memgraph process is currently running with the same "
-          "storage directory, please stop it first before starting this "
-          "process!",
-          data_directory,
-          lock_file_timeout.count());
-    }
-    spdlog::trace("Failed to acquire lock on data directory, retrying in {}ms...", sleep_time_ms);
-    std::this_thread::sleep_for(std::chrono::milliseconds(sleep_time_ms));
-  }
+  MG_ASSERT(lock_file_handle.AcquireLockWithTimeout(),
+            "Couldn't acquire lock on the storage directory {} within {}s"
+            "!\nAnother Memgraph process is currently running with the same "
+            "storage directory, please stop it first before starting this "
+            "process!",
+            data_directory,
+            FLAGS_data_dir_lock_acquisition_timeout_sec);
 
   spdlog::trace("Successfully acquired lock on data directory");
 

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -390,10 +390,10 @@ int main(int argc, char **argv) {
   // holding the file opened after timeout occurs
   memgraph::utils::OutputFile lock_file_handle;
   lock_file_handle.Open(data_directory / ".lock", memgraph::utils::OutputFile::Mode::OVERWRITE_EXISTING);
-  MG_ASSERT(lock_file_handle.AcquireLockWithTimeout(),
-            "Couldn't acquire lock on the storage directory {} within {}s"
-            "!\nAnother Memgraph process is currently running with the same "
-            "storage directory, please stop it first before starting this "
+  MG_ASSERT(lock_file_handle.AcquireLockWithTimeout(FLAGS_data_dir_lock_acquisition_timeout_sec),
+            "Couldn't acquire lock on the storage directory {} within {}s!"
+            "Another Memgraph process is currently running with the same "
+            "storage directory, please stop it first before restarting this "
             "process!",
             data_directory,
             FLAGS_data_dir_lock_acquisition_timeout_sec);

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -387,15 +387,28 @@ int main(int argc, char **argv) {
   memgraph::storage::durability::VerifyStorageDirectoryOwnerAndProcessUserOrDie(data_directory);
   // Create the lock file and open a handle to it. This will crash the
   // database if it can't open the file for writing or if any other process is
-  // holding the file opened.
+  // holding the file opened after timeout occurs
   memgraph::utils::OutputFile lock_file_handle;
   lock_file_handle.Open(data_directory / ".lock", memgraph::utils::OutputFile::Mode::OVERWRITE_EXISTING);
-  MG_ASSERT(lock_file_handle.AcquireLock(),
-            "Couldn't acquire lock on the storage directory {}"
-            "!\nAnother Memgraph process is currently running with the same "
-            "storage directory, please stop it first before starting this "
-            "process!",
-            data_directory);
+  auto const start_time = std::chrono::steady_clock::now();
+  auto const lock_file_timeout = std::chrono::seconds{FLAGS_data_dir_lock_acquisition_timeout_sec};
+  constexpr uint16_t sleep_time_ms = 250;
+  while (true) {
+    if (lock_file_handle.AcquireLock()) break;
+    if (std::chrono::steady_clock::now() - start_time > lock_file_timeout) {
+      LOG_FATAL(
+          "Couldn't acquire lock on the storage directory {} within {}s"
+          "!\nAnother Memgraph process is currently running with the same "
+          "storage directory, please stop it first before starting this "
+          "process!",
+          data_directory,
+          lock_file_timeout.count());
+    }
+    spdlog::trace("Failed to acquire lock on data directory, retrying in {}ms...", sleep_time_ms);
+    std::this_thread::sleep_for(std::chrono::milliseconds(sleep_time_ms));
+  }
+
+  spdlog::trace("Successfully acquired lock on data directory");
 
   const auto memory_limit = memgraph::flags::GetMemoryLimit();
   // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)

--- a/src/utils/file.cpp
+++ b/src/utils/file.cpp
@@ -14,15 +14,16 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <fstream>
 #include <mutex>
 #include <ranges>
+#include <thread>
 #include <type_traits>
 #include <vector>
 
-#include "flags/general.hpp"
 #include "utils/exceptions.hpp"
 #include "utils/logging.hpp"
 
@@ -488,7 +489,7 @@ size_t OutputFile::SetPosition(Position position, ssize_t offset) {
 }
 
 // logical constness
-// NOLINTNEXTLINE(readability-make-member-function-const)
+// NOLINTNEXTLINE (readability-make-member-function-const)
 bool OutputFile::AcquireLock() {
   MG_ASSERT(IsOpen(), "Trying to acquire a write lock on an unopened file!");
   int ret = -1;
@@ -506,9 +507,11 @@ bool OutputFile::AcquireLock() {
   return ret != -1;
 }
 
-auto OutputFile::AcquireLockWithTimeout(uint16_t const sleep_time_ms) -> bool {
+auto OutputFile::AcquireLockWithTimeout(uint32_t data_dir_lock_acquisition_timeout_sec, uint16_t const sleep_time_ms)
+    -> bool {
+  if (data_dir_lock_acquisition_timeout_sec == 0) return AcquireLock();
   auto const start_time = std::chrono::steady_clock::now();
-  auto const lock_file_timeout = std::chrono::seconds{FLAGS_data_dir_lock_acquisition_timeout_sec};
+  auto const lock_file_timeout = std::chrono::seconds{data_dir_lock_acquisition_timeout_sec};
   while (true) {
     if (AcquireLock()) return true;
     if (std::chrono::steady_clock::now() - start_time > lock_file_timeout) {
@@ -766,7 +769,7 @@ size_t NonConcurrentOutputFile::SetPosition(Position position, ssize_t offset) {
   return SeekFile(position, offset);
 }
 
-// NOLINTNEXTLINE(readability-make-member-function-const)
+// NOLINTNEXTLINE (readability-make-member-function-const)
 bool NonConcurrentOutputFile::AcquireLock() {
   MG_ASSERT(IsOpen(), "Trying to acquire a write lock on an unopened file!");
   int ret = -1;

--- a/src/utils/file.cpp
+++ b/src/utils/file.cpp
@@ -22,6 +22,7 @@
 #include <type_traits>
 #include <vector>
 
+#include "flags/general.hpp"
 #include "utils/exceptions.hpp"
 #include "utils/logging.hpp"
 
@@ -486,6 +487,8 @@ size_t OutputFile::SetPosition(Position position, ssize_t offset) {
   return SeekFile(position, offset);
 }
 
+// logical constness
+// NOLINTNEXTLINE(readability-make-member-function-const)
 bool OutputFile::AcquireLock() {
   MG_ASSERT(IsOpen(), "Trying to acquire a write lock on an unopened file!");
   int ret = -1;
@@ -501,6 +504,20 @@ bool OutputFile::AcquireLock() {
     }
   }
   return ret != -1;
+}
+
+auto OutputFile::AcquireLockWithTimeout(uint16_t const sleep_time_ms) -> bool {
+  auto const start_time = std::chrono::steady_clock::now();
+  auto const lock_file_timeout = std::chrono::seconds{FLAGS_data_dir_lock_acquisition_timeout_sec};
+  while (true) {
+    if (AcquireLock()) return true;
+    if (std::chrono::steady_clock::now() - start_time > lock_file_timeout) {
+      return false;
+    }
+    spdlog::trace("Failed to acquire lock on {}, retrying in {}ms...", path_, sleep_time_ms);
+    std::this_thread::sleep_for(std::chrono::milliseconds(sleep_time_ms));
+  }
+  std::unreachable();
 }
 
 void OutputFile::Sync() {
@@ -749,6 +766,7 @@ size_t NonConcurrentOutputFile::SetPosition(Position position, ssize_t offset) {
   return SeekFile(position, offset);
 }
 
+// NOLINTNEXTLINE(readability-make-member-function-const)
 bool NonConcurrentOutputFile::AcquireLock() {
   MG_ASSERT(IsOpen(), "Trying to acquire a write lock on an unopened file!");
   int ret = -1;

--- a/src/utils/file.hpp
+++ b/src/utils/file.hpp
@@ -240,6 +240,12 @@ class OutputFile {
   /// program.
   bool AcquireLock();
 
+  /// Does exactly the same as AcquireLock() function but addditionally waits for maximum of
+  /// FLAGS_data_dir_lock_acquisition_timeout_sec before returning false. Used when it's possible
+  /// that some other process cannot immediately release the lock but will do in a brief time window so it
+  /// pays off for us to wait
+  auto AcquireLockWithTimeout(uint16_t sleep_time_ms = 250) -> bool;
+
   /// Syncs currently pending data to the currently opened file. On failure
   /// and misuse it crashes the program.
   void Sync();

--- a/src/utils/file.hpp
+++ b/src/utils/file.hpp
@@ -240,11 +240,11 @@ class OutputFile {
   /// program.
   bool AcquireLock();
 
-  /// Does exactly the same as AcquireLock() function but addditionally waits for maximum of
+  /// Does exactly the same as AcquireLock() function but additionally waits for maximum of
   /// FLAGS_data_dir_lock_acquisition_timeout_sec before returning false. Used when it's possible
   /// that some other process cannot immediately release the lock but will do in a brief time window so it
   /// pays off for us to wait
-  auto AcquireLockWithTimeout(uint16_t sleep_time_ms = 250) -> bool;
+  auto AcquireLockWithTimeout(uint32_t data_dir_lock_acquisition_timeout_sec, uint16_t sleep_time_ms = 250) -> bool;
 
   /// Syncs currently pending data to the currently opened file. On failure
   /// and misuse it crashes the program.

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -70,6 +70,11 @@ startup_config_dict = {
     "coordinator_id": ("0", "0", "Unique ID of the raft server."),
     "coordinator_hostname": ("", "", "Instance's hostname. Used as output of SHOW INSTANCES query."),
     "data_directory": ("mg_data", "mg_data", "Path to directory in which to save all permanent data."),
+    "data_dir_lock_acquisition_timeout_sec": (
+        "30",
+        "30",
+        "Timeout before the failure of acquiring file lock on data directory is considered a failure.",
+    ),
     "data_recovery_on_startup": (
         "true",
         "true",


### PR DESCRIPTION
When users force kill a pod it can happen that the new pod is started while the old one didn't finish shutdown and didn't yet release file lock on data directory. Also, when using distributed storage systems like CephFs, there can be a small delay before ceph server accepts the request from the old pod's client for releasing a file lock. Fix contains of retrying in a loop acquiring the lock for the user-defined timeout.