### PR TITLE
feat: Handle transient disk failures when opening OutputFile

### DIFF
--- a/src/audit/log.cpp
+++ b/src/audit/log.cpp
@@ -128,17 +128,23 @@ Log::Log(std::filesystem::path storage_directory, int32_t buffer_size, int32_t b
       buffer_flush_interval_millis_(buffer_flush_interval_millis),
       started_(false) {}
 
-void Log::Start() {
+bool Log::Start() {
   MG_ASSERT(!started_.load(std::memory_order_acquire), "Trying to start an already started audit log!");
 
   utils::EnsureDirOrDie(storage_directory_);
 
   buffer_.emplace(buffer_size_);
-  started_.store(true, std::memory_order_release);
 
-  ReopenLog();
+  {
+    auto guard = std::lock_guard{lock_};
+    if (!log_.Open(storage_directory_ / "audit.log", utils::OutputFile::Mode::APPEND_TO_EXISTING)) {
+      return false;
+    }
+  }
+  started_.store(true, std::memory_order_release);
   scheduler_.SetInterval(std::chrono::milliseconds(buffer_flush_interval_millis_));
   scheduler_.Run("Audit", [&] { Flush(); });
+  return true;
 }
 
 Log::~Log() {
@@ -157,14 +163,15 @@ void Log::Record(const std::string &address, const std::string &username, const 
   auto timestamp =
       std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch())
           .count();
-  buffer_->emplace(Item{timestamp, address, username, query, params, db});
+  buffer_->emplace(Item{
+      .timestamp = timestamp, .address = address, .username = username, .query = query, .params = params, .db = db});
 }
 
-void Log::ReopenLog() {
-  if (!started_.load(std::memory_order_relaxed)) return;
+bool Log::ReopenLog() {
+  if (!started_.load(std::memory_order_relaxed)) return false;
   auto guard = std::lock_guard{lock_};
   if (log_.IsOpen()) log_.Close();
-  log_.Open(storage_directory_ / "audit.log", utils::OutputFile::Mode::APPEND_TO_EXISTING);
+  return log_.Open(storage_directory_ / "audit.log", utils::OutputFile::Mode::APPEND_TO_EXISTING);
 }
 
 void Log::Flush() {

--- a/src/audit/log.cpp
+++ b/src/audit/log.cpp
@@ -168,10 +168,17 @@ void Log::Record(const std::string &address, const std::string &username, const 
 }
 
 bool Log::ReopenLog() {
-  if (!started_.load(std::memory_order_relaxed)) return false;
+  if (!started_.load(std::memory_order_relaxed)) {
+    spdlog::warn("Failed to reopen audit log file since audit log isn't started.");
+    return false;
+  }
   auto guard = std::lock_guard{lock_};
   if (log_.IsOpen()) log_.Close();
-  return log_.Open(storage_directory_ / "audit.log", utils::OutputFile::Mode::APPEND_TO_EXISTING);
+  auto const res = log_.Open(storage_directory_ / "audit.log", utils::OutputFile::Mode::APPEND_TO_EXISTING);
+  if (!res) {
+    spdlog::warn("Failed to reopen audit log file. Audit log file couldn't be opened.");
+  }
+  return res;
 }
 
 void Log::Flush() {

--- a/src/audit/log.hpp
+++ b/src/audit/log.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Licensed as a Memgraph Enterprise file under the Memgraph Enterprise
 // License (the "License"); by using this file, you agree to be bound by the terms of the License, and you may not use
@@ -45,14 +45,14 @@ class Log {
   /// Starts the audit log. If you don't want to use the audit log just don't
   /// start it. All functions can still be used when the log isn't started and
   /// they won't do anything. Isn't thread-safe.
-  void Start();
+  bool Start();
 
   /// Adds an entry to the audit log. Thread-safe.
   void Record(const std::string &address, const std::string &username, const std::string &query,
               const memgraph::communication::bolt::map_t &params, const std::string &db);
 
   /// Reopens the log file. Used for log file rotation. Thread-safe.
-  void ReopenLog();
+  bool ReopenLog();
 
  private:
   void Flush();

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -394,7 +394,9 @@ int main(int argc, char **argv) {
   // database if it can't open the file for writing or if any other process is
   // holding the file opened after timeout occurs
   memgraph::utils::OutputFile lock_file_handle;
-  lock_file_handle.Open(data_directory / ".lock", memgraph::utils::OutputFile::Mode::OVERWRITE_EXISTING);
+  MG_ASSERT(lock_file_handle.Open(data_directory / ".lock", memgraph::utils::OutputFile::Mode::OVERWRITE_EXISTING),
+            "Failed to open {}/.lock file",
+            data_directory);
   MG_ASSERT(lock_file_handle.AcquireLockWithTimeout(FLAGS_data_dir_lock_acquisition_timeout_sec),
             "Couldn't acquire lock on the storage directory {} within {}s!"
             "Another Memgraph process is currently running with the same "
@@ -444,12 +446,18 @@ int main(int argc, char **argv) {
       data_directory / "audit", FLAGS_audit_buffer_size, FLAGS_audit_buffer_flush_interval_ms};
   // Start the log if enabled.
   if (FLAGS_audit_enabled) {
-    audit_log.Start();
+    MG_ASSERT(audit_log.Start(), "Failed to open audit file {}", data_directory / "audit");
   }
   // Setup SIGUSR2 to be used for reopening audit log files, when e.g. logrotate
   // rotates our audit logs.
   MG_ASSERT(memgraph::utils::SignalHandler::RegisterHandler(memgraph::utils::Signal::User2,
-                                                            [&audit_log]() { audit_log.ReopenLog(); }),
+                                                            [&audit_log]() {
+                                                              if (audit_log.ReopenLog()) {
+                                                                spdlog::info("Succesfully reopened audit log");
+                                                              } else {
+                                                                spdlog::warn("Failed to reopen audit log");
+                                                              }
+                                                            }),
             "Unable to register SIGUSR2 handler!");
 
   // End enterprise features initialization

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -453,9 +453,7 @@ int main(int argc, char **argv) {
   MG_ASSERT(memgraph::utils::SignalHandler::RegisterHandler(memgraph::utils::Signal::User2,
                                                             [&audit_log]() {
                                                               if (audit_log.ReopenLog()) {
-                                                                spdlog::info("Succesfully reopened audit log");
-                                                              } else {
-                                                                spdlog::warn("Failed to reopen audit log");
+                                                                spdlog::info("Successfully reopened audit log");
                                                               }
                                                             }),
             "Unable to register SIGUSR2 handler!");

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -5809,6 +5809,9 @@ PreparedQuery PrepareRecoverSnapshotQuery(ParsedQuery parsed_query, bool in_expl
             case S3MissingAwsSecretKey: {
               throw utils::BasicException(utils::AwsValidationErrorToStr(utils::AwsValidationError::AWS_SECRET_KEY));
             }
+            case FailedOverwritingUUID: {
+              throw utils::BasicException("Failed to overwrite snapshot with a new storage UUID");
+            }
             default: {
               std::unreachable();
             }

--- a/src/rpc/file_replication_handler.cpp
+++ b/src/rpc/file_replication_handler.cpp
@@ -64,8 +64,12 @@ std::optional<size_t> FileReplicationHandler::OpenFile(const uint8_t *data, size
   auto const path = save_dir / filename;
   paths_.emplace_back(path);
 
-  spdlog::info("Replica will be using file {} with size {}", path, file_size_);
-  file_.Open(path, utils::OutputFile::Mode::OVERWRITE_EXISTING);
+  spdlog::trace("Replica will be using file {} with size {}", path, file_size_);
+  if (!file_.Open(path, utils::OutputFile::Mode::OVERWRITE_EXISTING)) {
+    spdlog::error("Failed to open file {}. This is not a fatal failure, main will retry the sending of the file.",
+                  path);
+    return std::nullopt;
+  }
 
   // First N bytes are file_name and file_size, therefore we don't read full size
   size_t const processed_bytes = req_reader.GetPos();

--- a/src/storage/v2/durability/serialization.cpp
+++ b/src/storage/v2/durability/serialization.cpp
@@ -28,6 +28,7 @@ namespace memgraph::storage::durability {
 //////////////////////////
 
 namespace {
+
 template <typename FileType>
 void WriteSize(Encoder<FileType> *encoder, uint64_t size) {
   size = utils::HostToLittleEndian(size);
@@ -36,21 +37,24 @@ void WriteSize(Encoder<FileType> *encoder, uint64_t size) {
 }  // namespace
 
 template <typename FileType>
-void Encoder<FileType>::Initialize(const std::filesystem::path &path) {
-  file_.Open(path, FileType::Mode::OVERWRITE_EXISTING);
+bool Encoder<FileType>::Initialize(const std::filesystem::path &path) {
+  return file_.Open(path, FileType::Mode::OVERWRITE_EXISTING);
 }
 
 template <typename FileType>
-void Encoder<FileType>::Initialize(const std::filesystem::path &path, const std::string_view magic, uint64_t version) {
-  Initialize(path);
+bool Encoder<FileType>::Initialize(const std::filesystem::path &path, const std::string_view magic, uint64_t version) {
+  if (!Initialize(path)) {
+    return false;
+  }
   Write(reinterpret_cast<const uint8_t *>(magic.data()), magic.size());
   auto version_encoded = utils::HostToLittleEndian(version);
   Write(reinterpret_cast<const uint8_t *>(&version_encoded), sizeof(version_encoded));
+  return true;
 }
 
 template <typename FileType>
-void Encoder<FileType>::OpenExisting(const std::filesystem::path &path) {
-  file_.Open(path, FileType::Mode::APPEND_TO_EXISTING);
+bool Encoder<FileType>::OpenExisting(const std::filesystem::path &path) {
+  return file_.Open(path, FileType::Mode::APPEND_TO_EXISTING);
 }
 
 template <typename FileType>

--- a/src/storage/v2/durability/serialization.hpp
+++ b/src/storage/v2/durability/serialization.hpp
@@ -44,10 +44,10 @@ class BaseEncoder {
 template <typename FileType>
 class Encoder final : public BaseEncoder {
  public:
-  void Initialize(const std::filesystem::path &path);
-  void Initialize(const std::filesystem::path &path, std::string_view magic, uint64_t version);
+  bool Initialize(const std::filesystem::path &path);
+  bool Initialize(const std::filesystem::path &path, std::string_view magic, uint64_t version);
 
-  void OpenExisting(const std::filesystem::path &path);
+  bool OpenExisting(const std::filesystem::path &path);
 
   void Close();
   // Main write function, the only one that is allowed to write to the `file_`

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -199,12 +199,14 @@ using task_results_t = std::vector<std::pair<SnapshotPartialRes, std::promise<bo
 
 namespace {
 
-void WaitAndCombine(task_results_t &partial_results, SnapshotEncoder &snapshot_encoder, uint64_t &element_count,
+bool WaitAndCombine(task_results_t &partial_results, SnapshotEncoder &snapshot_encoder, uint64_t &element_count,
                     std::vector<BatchInfo> &batch_infos, std::unordered_set<uint64_t> &used_ids,
                     auto &&snapshot_aborted) {
+  bool all_ok = true;
   // NOTE: They have to be combined in order
   for (auto &[res, promise] : partial_results) {
-    promise.get_future().wait();  // Wait for incoming result
+    auto const task_ok = promise.get_future().get();  // Wait for incoming result
+    if (!task_ok) all_ok = false;
 
     spdlog::trace("Handling snapshot part {}, size {}, count {}...", res.snapshot_path, res.snapshot_size, res.count);
     utils::OnScopeExit cleanup{[path = res.snapshot_path] {
@@ -213,7 +215,7 @@ void WaitAndCombine(task_results_t &partial_results, SnapshotEncoder &snapshot_e
       if (ec) spdlog::warn("Couldn't remove temporary snapshot part {}: {}", path, ec.message());
     }};
 
-    if (snapshot_aborted()) {
+    if (!task_ok || snapshot_aborted()) {
       continue;  // Run through and clean up
     }
 
@@ -251,6 +253,7 @@ void WaitAndCombine(task_results_t &partial_results, SnapshotEncoder &snapshot_e
       }
     }
   }
+  return all_ok;
 }
 
 // Return at least one batch (at least 2 elements: start and end gid)
@@ -279,7 +282,7 @@ auto Batch(auto &&acc, const uint64_t items_per_batch) {
   return batches;
 }
 
-void MultiThreadedWorkflow(utils::SkipList<Edge> *edges, utils::SkipList<Vertex> *vertices, auto &&partial_edge_handler,
+bool MultiThreadedWorkflow(utils::SkipList<Edge> *edges, utils::SkipList<Vertex> *vertices, auto &&partial_edge_handler,
                            auto &&partial_vertex_handler, const uint64_t items_per_batch, uint64_t &offset_edges,
                            uint64_t &offset_vertices, SnapshotEncoder &snapshot_encoder, uint64_t &edges_count,
                            uint64_t &vertices_count, std::vector<BatchInfo> &edge_batch_infos,
@@ -304,7 +307,14 @@ void MultiThreadedWorkflow(utils::SkipList<Edge> *edges, utils::SkipList<Vertex>
         {
           SnapshotEncoder edges_snapshot;
           const auto snapshot_path = fmt::format("{}_edge_part_{}", path, id);
-          edges_snapshot.Initialize(snapshot_path);
+          if (!edges_snapshot.Initialize(snapshot_path)) {
+            spdlog::warn(
+                "Failed to open snapshot file {} in MultiThreadedWorkflow. Snapshot creation will be retried on the "
+                "next scheduled interval",
+                snapshot_path);
+            edge_res[id].second.set_value(false);
+            return;
+          }
           // Fill snapshot with edges
           edge_res[id].first = partial_edge_handler(start_gid, end_gid, edges_snapshot);
           edges_snapshot.Finalize();
@@ -329,8 +339,15 @@ void MultiThreadedWorkflow(utils::SkipList<Edge> *edges, utils::SkipList<Vertex>
       {
         SnapshotEncoder vertex_snapshot;
         const auto snapshot_path = fmt::format("{}_vertex_part_{}", path, id);
-        vertex_snapshot.Initialize(snapshot_path);
-        // Fill snapshot with edges
+        if (!vertex_snapshot.Initialize(snapshot_path)) {
+          spdlog::warn(
+              "Failed to open snapshot file {} in MultiThreadedWorkflow. Snapshot creation will be retried on the "
+              "next scheduled interval",
+              snapshot_path);
+          vertex_res[id].second.set_value(false);
+          return;
+        }
+        // Fill snapshot with vertices
         vertex_res[id].first = partial_vertex_handler(start_gid, end_gid, vertex_snapshot);
         vertex_snapshot.Finalize();
       }
@@ -353,15 +370,21 @@ void MultiThreadedWorkflow(utils::SkipList<Edge> *edges, utils::SkipList<Vertex>
     });
   }
 
+  bool all_ok = true;
   // Wait for tasks to finish and combine results as they come in
   if (!edge_res.empty()) {
     if (progress) progress->SetPhase(SnapshotProgress::Phase::EDGES, edges->size());
     offset_edges = snapshot_encoder.GetPosition();  // 0 -> edges without properties
-    WaitAndCombine(edge_res, snapshot_encoder, edges_count, edge_batch_infos, used_ids, snapshot_aborted);
+    if (!WaitAndCombine(edge_res, snapshot_encoder, edges_count, edge_batch_infos, used_ids, snapshot_aborted)) {
+      all_ok = false;
+    }
   }
   if (progress) progress->SetPhase(SnapshotProgress::Phase::VERTICES, vertices->size());
   offset_vertices = snapshot_encoder.GetPosition();
-  WaitAndCombine(vertex_res, snapshot_encoder, vertices_count, vertex_batch_infos, used_ids, snapshot_aborted);
+  if (!WaitAndCombine(vertex_res, snapshot_encoder, vertices_count, vertex_batch_infos, used_ids, snapshot_aborted)) {
+    all_ok = false;
+  }
+  return all_ok;
 };
 
 // Function used to read information about the snapshot file.
@@ -655,16 +678,19 @@ SnapshotInfo ReadSnapshotInfo(const std::filesystem::path &path) {
   return info;
 }
 
-void OverwriteSnapshotUUID(std::filesystem::path const &path, utils::UUID const &uuid) {
+bool OverwriteSnapshotUUID(std::filesystem::path const &path, utils::UUID const &uuid) {
   auto info = ReadSnapshotInfo(path);
-  if (info.uuid == uuid) return;  // No need to overwrite if the UUID is already correct.
+  if (info.uuid == uuid) return true;  // No need to overwrite if the UUID is already correct.
   SnapshotEncoder snapshot;
-  snapshot.Initialize(path);
+  if (!snapshot.Initialize(path)) {
+    return false;
+  }
   snapshot.SetPosition(info.offset_metadata);
   // Write the new UUID.
   snapshot.WriteMarker(Marker::SECTION_METADATA);
   snapshot.WriteString(std::string{uuid});
   snapshot.Sync();
+  return true;
 }
 
 namespace {
@@ -11169,7 +11195,13 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
 
   spdlog::info("Starting snapshot creation to {}", path);
   SnapshotEncoder snapshot;
-  snapshot.Initialize(path, kSnapshotMagic, kVersion);
+  if (!snapshot.Initialize(path, kSnapshotMagic, kVersion)) {
+    spdlog::warn(
+        "Failed to open snapshot file {}. Not a fatal failure, snapshot creation will be retried on the next scheduled "
+        "interval.",
+        path);
+    return std::nullopt;
+  }
 
   // Write placeholder offsets.
   uint64_t offset_offsets = 0;
@@ -11455,22 +11487,31 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
 
   if (storage->config_.durability.allow_parallel_snapshot_creation) {
     auto *edge_ptr = storage->config_.salient.items.properties_on_edges ? edges : nullptr;
-    MultiThreadedWorkflow(edge_ptr,
-                          vertices,
-                          partial_edge_handler,
-                          partial_vertex_handler,
-                          storage->config_.durability.items_per_batch,
-                          offset_edges,
-                          offset_vertices,
-                          snapshot,
-                          edges_count,
-                          vertices_count,
-                          edge_batch_infos,
-                          vertex_batch_infos,
-                          used_ids,
-                          storage->config_.durability.snapshot_thread_count,
-                          snapshot_aborted,
-                          progress);
+    if (!MultiThreadedWorkflow(edge_ptr,
+                               vertices,
+                               partial_edge_handler,
+                               partial_vertex_handler,
+                               storage->config_.durability.items_per_batch,
+                               offset_edges,
+                               offset_vertices,
+                               snapshot,
+                               edges_count,
+                               vertices_count,
+                               edge_batch_infos,
+                               vertex_batch_infos,
+                               used_ids,
+                               storage->config_.durability.snapshot_thread_count,
+                               snapshot_aborted,
+                               progress)) {
+      spdlog::warn(
+          "Failed to execute some tasks when doing a multi-threaded snapshot, snapshot will be aborted and snapshot "
+          "creation will be retried on the next scheduled interval");
+      snapshot.Close();
+      // Clean up the partial main snapshot file
+      std::error_code ec;
+      std::filesystem::remove(path, ec);
+      return std::nullopt;
+    }
   } else {
     if (storage->config_.salient.items.properties_on_edges) {
       if (progress) progress->SetPhase(SnapshotProgress::Phase::EDGES, edges->size());

--- a/src/storage/v2/durability/snapshot.hpp
+++ b/src/storage/v2/durability/snapshot.hpp
@@ -75,7 +75,7 @@ struct RecoveredSnapshot {
 /// @throw RecoveryFailure
 SnapshotInfo ReadSnapshotInfo(const std::filesystem::path &path);
 
-void OverwriteSnapshotUUID(std::filesystem::path const &path, utils::UUID const &uuid);
+bool OverwriteSnapshotUUID(std::filesystem::path const &path, utils::UUID const &uuid);
 
 /// Function used to load the snapshot data into the storage.
 /// @throw RecoveryFailure

--- a/src/storage/v2/durability/wal.cpp
+++ b/src/storage/v2/durability/wal.cpp
@@ -1889,7 +1889,7 @@ WalFile::WalFile(const std::filesystem::path &wal_directory, utils::UUID const &
   utils::EnsureDirOrDie(wal_directory);
 
   // Initialize the WAL file.
-  wal_.Initialize(path_, kWalMagic, kVersion);
+  MG_ASSERT(wal_.Initialize(path_, kWalMagic, kVersion), "Failed to open WAL file {}", path_);
 
   // Write placeholder offsets.
   wal_.WriteMarker(Marker::SECTION_OFFSETS);
@@ -1928,7 +1928,7 @@ WalFile::WalFile(std::filesystem::path current_wal_path, SalientConfig::Items it
       count_(count),
       seq_num_(seq_num),
       file_retainer_(file_retainer) {
-  wal_.OpenExisting(path_);
+  MG_ASSERT(wal_.OpenExisting(path_), "Failed to open existing WAL file {}", path_);
 }
 
 void WalFile::FinalizeWal() {

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -337,7 +337,9 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
     // Create the lock file and open a handle to it. This will crash the
     // database if it can't open the file for writing or if any other process is
     // holding the file opened.
-    lock_file_handle_->Open(lock_file_path_, utils::OutputFile::Mode::OVERWRITE_EXISTING);
+    MG_ASSERT(lock_file_handle_->Open(lock_file_path_, utils::OutputFile::Mode::OVERWRITE_EXISTING),
+              "Failed to open {}",
+              lock_file_path_);
     MG_ASSERT(lock_file_handle_->AcquireLock(),
               "Couldn't acquire lock on the storage directory {}"
               "!\nAnother Memgraph process is currently running with the same "
@@ -4011,7 +4013,9 @@ std::expected<void, InMemoryStorage::RecoverSnapshotError> InMemoryStorage::Reco
 
     if (uuid() != loaded_snapshot_uuid) {
       // Rewrite the UUID in the snapshot file
-      durability::OverwriteSnapshotUUID(local_path, uuid());
+      if (!durability::OverwriteSnapshotUUID(local_path, uuid())) {
+        return std::unexpected{InMemoryStorage::RecoverSnapshotError::FailedOverwritingUUID};
+      }
     }
     // Generate new name for the snapshot file
     // Must be after moving to .old, otherwise you will move the file itself

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -146,7 +146,8 @@ class InMemoryStorage final : public Storage {
     S3GetFailure,
     S3MissingAwsRegion,
     S3MissingAwsAccessKey,
-    S3MissingAwsSecretKey
+    S3MissingAwsSecretKey,
+    FailedOverwritingUUID
   };
 
   /// @throw std::system_error

--- a/src/utils/file.cpp
+++ b/src/utils/file.cpp
@@ -396,7 +396,7 @@ OutputFile &OutputFile::operator=(OutputFile &&other) noexcept {
   return *this;
 }
 
-void OutputFile::Open(const std::filesystem::path &path, Mode mode) {
+bool OutputFile::Open(const std::filesystem::path &path, Mode mode) {
   MG_ASSERT(!IsOpen(),
             "While trying to open {} for writing the database"
             " used a handle that already has {} opened in it!",
@@ -420,7 +420,11 @@ void OutputFile::Open(const std::filesystem::path &path, Mode mode) {
     break;
   }
 
-  MG_ASSERT(fd_ != -1, "While trying to open {} for writing an error occurred: {} ({})", path_, strerror(errno), errno);
+  auto const res = fd_ != -1;
+  if (!res) {
+    spdlog::error("While trying to open {} for writing an error occurred: {} ({})", path_, strerror(errno), errno);
+  }
+  return res;
 }
 
 bool OutputFile::IsOpen() const { return fd_ != -1; }
@@ -676,7 +680,7 @@ NonConcurrentOutputFile::~NonConcurrentOutputFile() {
   if (IsOpen()) Close();
 }
 
-void NonConcurrentOutputFile::Open(const std::filesystem::path &path, Mode mode) {
+bool NonConcurrentOutputFile::Open(const std::filesystem::path &path, Mode mode) {
   MG_ASSERT(!IsOpen(),
             "While trying to open {} for writing the database"
             " used a handle that already has {} opened in it!",
@@ -701,7 +705,11 @@ void NonConcurrentOutputFile::Open(const std::filesystem::path &path, Mode mode)
     }
   }
 
-  MG_ASSERT(fd_ != -1, "While trying to open {} for writing an error occurred: {} ({})", path_, strerror(errno), errno);
+  auto const res = fd_ != -1;
+  if (!res) {
+    spdlog::error("While trying to open {} for writing an error occurred: {} ({})", path_, strerror(errno), errno);
+  }
+  return res;
 }
 
 bool NonConcurrentOutputFile::IsOpen() const { return fd_ != -1; }

--- a/src/utils/file.hpp
+++ b/src/utils/file.hpp
@@ -206,9 +206,8 @@ class OutputFile {
   /// This method opens a new file used for writing. If the file doesn't exist
   /// it is created. The `mode` flags controls whether data is appended to the
   /// file or the file is wiped on first write. Files are created with a
-  /// restrictive permission mask (0640). On failure and misuse it crashes the
-  /// program.
-  void Open(const std::filesystem::path &path, Mode mode);
+  /// restrictive permission mask (0640). On failure and misuse it returns false.
+  bool Open(const std::filesystem::path &path, Mode mode);
 
   /// Returns a boolean indicating whether a file is opened.
   bool IsOpen() const;
@@ -322,7 +321,7 @@ class NonConcurrentOutputFile {
   /// file or the file is wiped on first write. Files are created with a
   /// restrictive permission mask (0640). On failure and misuse it crashes the
   /// program.
-  void Open(const std::filesystem::path &path, Mode mode);
+  bool Open(const std::filesystem::path &path, Mode mode);
 
   /// Returns a boolean indicating whether a file is opened.
   bool IsOpen() const;

--- a/tests/unit/utils_file.cpp
+++ b/tests/unit/utils_file.cpp
@@ -883,7 +883,7 @@ TEST_F(UtilsFileTest, OutputFileExisting) {
     for (const auto &file : kFilesAll) {
       memgraph::utils::OutputFile handle;
       if (memgraph::utils::EndsWith(dir, "000") || memgraph::utils::EndsWith(file, "000")) {
-        ASSERT_DEATH(handle.Open(storage / dir / file, memgraph::utils::OutputFile::Mode::APPEND_TO_EXISTING), "");
+        ASSERT_FALSE(handle.Open(storage / dir / file, memgraph::utils::OutputFile::Mode::APPEND_TO_EXISTING));
       } else {
         handle.Open(storage / dir / file, memgraph::utils::OutputFile::Mode::APPEND_TO_EXISTING);
         ASSERT_TRUE(handle.IsOpen());
@@ -901,7 +901,7 @@ TEST_F(UtilsFileTest, OutputFileNew) {
     memgraph::utils::OutputFile handle;
     auto path = storage / dir / "test";
     if (memgraph::utils::EndsWith(dir, "000")) {
-      ASSERT_DEATH(handle.Open(path, memgraph::utils::OutputFile::Mode::APPEND_TO_EXISTING), "");
+      ASSERT_FALSE(handle.Open(path, memgraph::utils::OutputFile::Mode::APPEND_TO_EXISTING));
     } else {
       handle.Open(path, memgraph::utils::OutputFile::Mode::APPEND_TO_EXISTING);
       ASSERT_TRUE(handle.IsOpen());


### PR DESCRIPTION
Failures to open output files and non-concurrent output files are not fatal anymore in all situations. If unable to open WAL file, this is considered a fatal failure. If unable to open snapshot file for writing whether in a single-threaded env or multi-thread writing env, this is not considered a fatal failure since the next snapshot will be created on the next scheduled interval.