### PR TITLE
feat: enable jemalloc background threads at runtime, remove redundant periodic purge

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -111,7 +111,7 @@ class Memgraph(ConanFile):
         self.requires("snappy/1.2.1", override=True)
 
     def build_requirements(self):
-        self.tool_requires("cmake/4.1.2")
+        self.tool_requires("cmake/[>=4 <5]")
         self.tool_requires("ninja/[>=1.13 <2]")
         self.tool_requires("ccache/[>=4.12 <5]")
         self.tool_requires("antlr4/4.13.1")

--- a/conanfile.py
+++ b/conanfile.py
@@ -65,7 +65,7 @@ class Memgraph(ConanFile):
         "jemalloc/*:enable_fill": False,
         "jemalloc/*:lg_page": "12",
         "jemalloc/*:lg_hugepage": "21",
-        "jemalloc/*:malloc_conf": "background_thread:true,retain:false,percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000",
+        "jemalloc/*:malloc_conf": "retain:false,percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000",
         "rapidcheck/*:enable_gtest": True,
         "rapidcheck/*:enable_gmock": True,
     }
@@ -111,7 +111,7 @@ class Memgraph(ConanFile):
         self.requires("snappy/1.2.1", override=True)
 
     def build_requirements(self):
-        self.tool_requires("cmake/[>=4 <5]")
+        self.tool_requires("cmake/4.1.2")
         self.tool_requires("ninja/[>=1.13 <2]")
         self.tool_requires("ccache/[>=4.12 <5]")
         self.tool_requires("antlr4/4.13.1")

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -251,6 +251,7 @@ void CleanDataDir(std::filesystem::path const &data_directory) {
 
 int main(int argc, char **argv) {
   memgraph::memory::SetHooks();
+  memgraph::memory::EnableBackgroundThreads();
   google::SetUsageMessage("Memgraph database server");
   gflags::SetVersionString(version_string);
 
@@ -508,10 +509,6 @@ int main(int argc, char **argv) {
   spdlog::info("config recover on startup {}, flags {}",
                db_config.durability.recover_on_startup,
                FLAGS_data_recovery_on_startup);
-  memgraph::utils::Scheduler jemalloc_purge_scheduler;
-  jemalloc_purge_scheduler.SetInterval(std::chrono::seconds(FLAGS_storage_gc_cycle_sec));
-  jemalloc_purge_scheduler.Run("Jemalloc purge", [] { memgraph::memory::PurgeUnusedMemory(); });
-
   using namespace std::chrono_literals;
   using enum memgraph::storage::StorageMode;
   using enum memgraph::storage::Config::Durability::SnapshotWalMode;

--- a/src/memory/global_memory_control.cpp
+++ b/src/memory/global_memory_control.cpp
@@ -246,6 +246,16 @@ void PurgeUnusedMemory() {
 #endif
 }
 
+void EnableBackgroundThreads() {
+#if USE_JEMALLOC
+  bool enable = true;
+  int err = je_mallctl("background_thread", nullptr, nullptr, &enable, sizeof(enable));
+  if (err) {
+    LOG_FATAL("Failed to enable jemalloc background threads: error code {}", err);
+  }
+#endif
+}
+
 #undef STRINGIFY
 #undef STRINGIFY_HELPER
 

--- a/src/memory/global_memory_control.cpp
+++ b/src/memory/global_memory_control.cpp
@@ -11,6 +11,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <string>
 
 #include "global_memory_control.hpp"
@@ -251,7 +252,7 @@ void EnableBackgroundThreads() {
   bool enable = true;
   int err = je_mallctl("background_thread", nullptr, nullptr, &enable, sizeof(enable));
   if (err) {
-    LOG_FATAL("Failed to enable jemalloc background threads: error code {}", err);
+    LOG_FATAL("Failed to enable jemalloc background threads: {} ({})", strerror(err), err);
   }
 #endif
 }

--- a/src/memory/global_memory_control.hpp
+++ b/src/memory/global_memory_control.hpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -16,5 +16,6 @@ namespace memgraph::memory {
 void PurgeUnusedMemory();
 void SetHooks();
 void UnsetHooks();
+void EnableBackgroundThreads();
 
 }  // namespace memgraph::memory


### PR DESCRIPTION
## Summary

- Enable jemalloc `background_thread` at runtime via `je_mallctl` instead of baking it into the binary via `--with-malloc-conf`. The jemalloc docs warn that compile-time `background_thread:true` can deadlock during initialization.
- Remove the periodic jemalloc purge scheduler — redundant since background threads already handle decay-based purging on the configured `dirty_decay_ms`/`muzzy_decay_ms` schedule.
- Explicit `PurgeUnusedMemory()` calls (DROP GRAPH, FREE MEMORY query) are kept as-is.