### PR TITLE
infra: Suppress additional rdhdrhistogram UBSAN errors

### DIFF
--- a/tools/ubsan.ignore
+++ b/tools/ubsan.ignore
@@ -9,3 +9,4 @@ src:*/rdvarint.h
 # librdkafka: signed integer overflow in timestamp conversion (rdkafka_int.h:1171)
 # TODO: file upstream issue at confluentinc/librdkafka
 src:*/rdkafka_int.h
+


### PR DESCRIPTION
Suppress some additional negative shift errors in rdhdrhistogram, as they are causing unit test failures.