### PR TITLE
fix: Network leak and epoll exception on construction

### DIFF
--- a/src/communication/server.hpp
+++ b/src/communication/server.hpp
@@ -37,7 +37,8 @@ namespace memgraph::communication {
  * Listens for incoming connections on the server port and assigns them to the
  * connection listener. The listener processes the events with a thread pool
  * that has `num_workers` threads. It is started automatically on constructor,
- * and stopped at destructor.
+ * and stopped at destructor.Constructing communication server could throw because of Epoll object, make sure to catch
+ * the possible exception when constructing RPC server
  *
  * Current Server architecture:
  * incoming connection -> server -> listener -> session

--- a/src/communication/server.hpp
+++ b/src/communication/server.hpp
@@ -37,7 +37,7 @@ namespace memgraph::communication {
  * Listens for incoming connections on the server port and assigns them to the
  * connection listener. The listener processes the events with a thread pool
  * that has `num_workers` threads. It is started automatically on constructor,
- * and stopped at destructor.Constructing communication server could throw because of Epoll object, make sure to catch
+ * and stopped at destructor. Constructing communication server could throw because of Epoll object, make sure to catch
  * the possible exception when constructing RPC server
  *
  * Current Server architecture:

--- a/src/io/network/epoll.hpp
+++ b/src/io/network/epoll.hpp
@@ -40,7 +40,7 @@ class Epoll {
     }
   }
 
-  // This is important to be delete because otherwise we could get into a double-close bug for the same file descriptor
+  // "Copy/move deleted: epoll_fd_ is const, and ownership of the FD is non-transferable."
   Epoll(const Epoll &other) = delete;
   Epoll &operator=(const Epoll &other) = delete;
   Epoll(Epoll &&other) = delete;

--- a/src/io/network/epoll.hpp
+++ b/src/io/network/epoll.hpp
@@ -34,19 +34,21 @@ class Epoll {
 
   // Prevent FD from leaking to child processes by using EPOLL_CLOEXEC
   Epoll() : epoll_fd_(epoll_create1(EPOLL_CLOEXEC)) {
-    // epoll_create1 returns an error if there is a logical error in our code
-    // (for example invalid flags) or if there is irrecoverable error. In both
-    // cases it is best to terminate.
     if (epoll_fd_ == -1) {
-      // The exception should be caught wherever the listener is being created
+      // Exception is currently propagated: Epoll -> Listener -> communication::Server -> RpcServer
       throw utils::BasicException("Error on epoll create: ({}) {}", errno, strerror(errno));
     }
   }
 
+  // This is important to be delete because otherwise we could get into a double-close bug for the same file descriptor
+  Epoll(const Epoll &other) = delete;
+  Epoll &operator=(const Epoll &other) = delete;
+  Epoll(Epoll &&other) = delete;
+  Epoll &operator=(Epoll &&other) = delete;
+
   ~Epoll() {
-    if (epoll_fd_ != -1) {
-      close(epoll_fd_);
-    }
+    // epoll_fd_ can never be -1 because if it ever was, the exception would be thrown in the constructor
+    close(epoll_fd_);
   }
 
   /**

--- a/src/io/network/epoll.hpp
+++ b/src/io/network/epoll.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -32,11 +32,21 @@ class Epoll {
  public:
   using Event = struct epoll_event;
 
-  explicit Epoll(bool set_cloexec = false) : epoll_fd_(epoll_create1(set_cloexec ? EPOLL_CLOEXEC : 0)) {
+  // Prevent FD from leaking to child processes by using EPOLL_CLOEXEC
+  Epoll() : epoll_fd_(epoll_create1(EPOLL_CLOEXEC)) {
     // epoll_create1 returns an error if there is a logical error in our code
     // (for example invalid flags) or if there is irrecoverable error. In both
     // cases it is best to terminate.
-    MG_ASSERT(epoll_fd_ != -1, "Error on epoll create: ({}) {}", errno, strerror(errno));
+    if (epoll_fd_ == -1) {
+      // The exception should be caught wherever the listener is being created
+      throw utils::BasicException("Error on epoll create: ({}) {}", errno, strerror(errno));
+    }
+  }
+
+  ~Epoll() {
+    if (epoll_fd_ != -1) {
+      close(epoll_fd_);
+    }
   }
 
   /**

--- a/src/replication/include/replication/state.hpp
+++ b/src/replication/include/replication/state.hpp
@@ -149,8 +149,8 @@ struct ReplicationState {
   std::expected<ReplicationClient *, RegisterReplicaStatus> RegisterReplica(const ReplicationClientConfig &config);
 
   bool SetReplicationRoleMain(const utils::UUID &main_uuid);
-  bool SetReplicationRoleReplica(const ReplicationServerConfig &config,
-                                 std::optional<utils::UUID> const &maybe_main_uuid);
+  [[nodiscard]] bool SetReplicationRoleReplica(const ReplicationServerConfig &config,
+                                               std::optional<utils::UUID> const &maybe_main_uuid);
 
   std::optional<nlohmann::json> GetTelemetryJson() const;
 

--- a/src/replication/include/replication/state.hpp
+++ b/src/replication/include/replication/state.hpp
@@ -53,6 +53,7 @@ struct RoleMainData {
   bool writing_enabled_{false};
 };
 
+// Implicit move constructor is noexcept because all fields have also noexcept move constructor
 struct RoleReplicaData {
   ReplicationServerConfig config;
   std::unique_ptr<ReplicationServer> server;
@@ -81,10 +82,7 @@ struct ReplicationState {
   ReplicationState &operator=(ReplicationState const &) = delete;
   ReplicationState &operator=(ReplicationState &&) = delete;
 
-  enum class FetchReplicationError : uint8_t {
-    NOTHING_FETCHED,
-    PARSE_ERROR,
-  };
+  enum class FetchReplicationError : uint8_t { NOTHING_FETCHED, PARSE_ERROR, REPL_SERVER_FAILURE };
 
   using FetchReplicationResult_t = std::expected<ReplicationData_t, FetchReplicationError>;
   using FetchVariantResult_t = std::expected<std::variant<RoleMainData, RoleReplicaData>, FetchReplicationError>;

--- a/src/replication/state.cpp
+++ b/src/replication/state.cpp
@@ -58,7 +58,8 @@ ReplicationState::ReplicationState(std::optional<std::filesystem::path> durabili
         return;
       }
       case REPL_SERVER_FAILURE: {
-        LOG_FATAL("Couldn't initalize replication server");
+        LOG_FATAL("Couldn't initialize replication server");
+        return;
       }
       default: {
         std::unreachable();
@@ -338,7 +339,6 @@ bool ReplicationState::SetReplicationRoleReplica(const ReplicationServerConfig &
     return false;
   }
 
-  // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
   if (!TryPersistRoleReplica(config, main_uuid)) {
     return false;
   }

--- a/src/replication/state.cpp
+++ b/src/replication/state.cpp
@@ -49,7 +49,7 @@ ReplicationState::ReplicationState(std::optional<std::filesystem::path> durabili
     switch (fetched_replication_data.error()) {
       using enum ReplicationState::FetchReplicationError;
       case NOTHING_FETCHED: {
-        spdlog::debug("Cannot find data needed for restore replication role in persisted metadata.");
+        spdlog::warn("Cannot find data needed for restore replication role in persisted metadata.");
         replication_data_.data_ = RoleMainData{};
         return;
       }
@@ -58,7 +58,14 @@ ReplicationState::ReplicationState(std::optional<std::filesystem::path> durabili
         return;
       }
       case REPL_SERVER_FAILURE: {
-        LOG_FATAL("Couldn't initialize replication server");
+        if (part_of_ha_cluster) {
+          spdlog::warn(
+              "Couldn't initialize replication server on replica. Defaulting role to non-writeable main. Coordinators "
+              "will automatically demote the instance to become replica.");
+          replication_data_.data_ = RoleMainData{};
+        } else {
+          LOG_FATAL("Couldn't initialize replication server on replica.");
+        }
         return;
       }
       default: {
@@ -343,6 +350,7 @@ bool ReplicationState::SetReplicationRoleReplica(const ReplicationServerConfig &
     return false;
   }
 
+  // This should never throw an exception
   replication_data_.data_ = RoleReplicaData{.config = config, .server = std::move(new_repl_server), .uuid_ = main_uuid};
 
   // DeltasBatchProgressSize stay untouched

--- a/src/replication/state.cpp
+++ b/src/replication/state.cpp
@@ -57,6 +57,9 @@ ReplicationState::ReplicationState(std::optional<std::filesystem::path> durabili
         LOG_FATAL("Cannot parse previously saved configuration of replication role.");
         return;
       }
+      case REPL_SERVER_FAILURE: {
+        LOG_FATAL("Couldn't initalize replication server");
+      }
       default: {
         std::unreachable();
       }
@@ -182,7 +185,14 @@ auto ReplicationState::FetchReplicationData() -> FetchReplicationResult_t {
               return {std::move(res)};
             },
             [&](durability::ReplicaRole &&r) -> FetchVariantResult_t {
-              auto server = std::make_unique<ReplicationServer>(r.config);
+              std::unique_ptr<ReplicationServer> server;
+              try {
+                // Creating Epoll object could throw an exception
+                server = std::make_unique<ReplicationServer>(r.config);
+              } catch (utils::BasicException const &e) {
+                spdlog::warn(e.what());
+                return std::unexpected{FetchReplicationError::REPL_SERVER_FAILURE};
+              }
               return {RoleReplicaData{.config = r.config, .server = std::move(server), .uuid_ = r.main_uuid}};
             },
         },
@@ -310,7 +320,6 @@ bool ReplicationState::SetReplicationRoleMain(const utils::UUID &main_uuid) {
 
 bool ReplicationState::SetReplicationRoleReplica(const ReplicationServerConfig &config,
                                                  std::optional<utils::UUID> const &maybe_main_uuid) {
-  // False positive report for the std::make_unique
   // Random UUID when first setting replica role if main_uuid not provided already
   auto const main_uuid = std::invoke([&maybe_main_uuid]() -> utils::UUID {
     if (maybe_main_uuid) {
@@ -318,14 +327,24 @@ bool ReplicationState::SetReplicationRoleReplica(const ReplicationServerConfig &
     }
     return utils::UUID{};
   });
+
+  // Creating Epoll object could throw an exception so we first check if we can create repl server. If not, we return
+  // immediately, if ok we persist replica data and create in-memory struct which should not fail
+  std::unique_ptr<ReplicationServer> new_repl_server;
+  try {
+    new_repl_server = std::make_unique<ReplicationServer>(config);
+  } catch (utils::BasicException const &e) {
+    spdlog::warn(e.what());
+    return false;
+  }
+
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
   if (!TryPersistRoleReplica(config, main_uuid)) {
     return false;
   }
-  // False positive report for the std::make_unique
-  // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
-  replication_data_.data_ =
-      RoleReplicaData{.config = config, .server = std::make_unique<ReplicationServer>(config), .uuid_ = main_uuid};
+
+  replication_data_.data_ = RoleReplicaData{.config = config, .server = std::move(new_repl_server), .uuid_ = main_uuid};
+
   // DeltasBatchProgressSize stay untouched
   return true;
 }

--- a/src/replication_handler/include/replication_handler/replication_handler.hpp
+++ b/src/replication_handler/include/replication_handler/replication_handler.hpp
@@ -346,7 +346,9 @@ struct ReplicationHandler : public query::ReplicationQueryHandler {
       if (replica_data.config == config) {
         return true;
       }
-      locked_repl_state->SetReplicationRoleReplica(config, maybe_main_uuid);
+      if (!locked_repl_state->SetReplicationRoleReplica(config, maybe_main_uuid)) {
+        return false;
+      }
 #ifdef MG_ENTERPRISE
       return StartRpcServer(dbms_handler_, repl_state_, replica_data, auth_, system_, parameters_);
 #else
@@ -357,7 +359,9 @@ struct ReplicationHandler : public query::ReplicationQueryHandler {
     // Shutdown any clients we might have had
     ClientsShutdown(locked_repl_state);
     // Creates the server
-    locked_repl_state->SetReplicationRoleReplica(config, maybe_main_uuid);
+    if (!locked_repl_state->SetReplicationRoleReplica(config, maybe_main_uuid)) {
+      return false;
+    }
     spdlog::trace("Role set to replica, instance-level clients destroyed.");
 
     // Start

--- a/src/rpc/server.hpp
+++ b/src/rpc/server.hpp
@@ -25,6 +25,8 @@
 
 namespace memgraph::rpc {
 
+// Constructing communication server could throw because of Epoll object, make sure to catch the possible exception when
+// constructing RPC server
 class Server {
  public:
   Server(io::network::Endpoint endpoint, communication::ServerContext *context,


### PR DESCRIPTION
Fixed leak in listener epoll. Avoid the crash if epoll_create1 fails. We now throw an exception instead of crashing the database.