### PR TITLE
fix: Routing table with the negative lag and improve ReplicationException

### DIFF
--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -1164,6 +1164,15 @@ void CoordinatorInstance::InstanceSuccessCallback(std::string_view instance_name
   if (raft_state_->IsCurrentMain(instance_name)) {
     // Update cache with the information from the current main if there is a value received
     if (instance_state.inner_state.main_num_txns.has_value()) {
+      for (auto const &[db_uuid, num_txns] : *instance_state.inner_state.main_num_txns) {
+        auto it = main_num_txns_cache_.find(db_uuid);
+        if (it == main_num_txns_cache_.end() || it->second != num_txns) {
+          spdlog::info("main_num_txns_cache_ updated: db={} old={} new={}",
+                       db_uuid,
+                       it != main_num_txns_cache_.end() ? std::to_string(it->second) : "N/A",
+                       num_txns);
+        }
+      }
       main_num_txns_cache_ = *instance_state.inner_state.main_num_txns;
     }
 
@@ -1204,6 +1213,15 @@ void CoordinatorInstance::InstanceSuccessCallback(std::string_view instance_name
               return context.config.instance_name;
             }) != std::ranges::end(data_instances);
         if (instance_exists_in_raft) {
+          auto it = replicas_num_txns_cache_.find(replica_name);
+          if (it == replicas_num_txns_cache_.end() || it->second != replica_data) {
+            std::string detail;
+            for (auto const &[db_uuid, num_txns] : replica_data) {
+              if (!detail.empty()) detail += ", ";
+              detail += fmt::format("db={}:txns={}", db_uuid, num_txns);
+            }
+            spdlog::info("replicas_num_txns_cache_ updated: replica={} [{}]", replica_name, detail);
+          }
           replicas_num_txns_cache_.insert_or_assign(replica_name, replica_data);
         } else if (instance.SendRpc<UnregisterReplicaRpc>(replica_name)) {
           replicas_num_txns_cache_.erase(replica_name);

--- a/src/coordination/coordinator_instance.cpp
+++ b/src/coordination/coordinator_instance.cpp
@@ -1164,15 +1164,6 @@ void CoordinatorInstance::InstanceSuccessCallback(std::string_view instance_name
   if (raft_state_->IsCurrentMain(instance_name)) {
     // Update cache with the information from the current main if there is a value received
     if (instance_state.inner_state.main_num_txns.has_value()) {
-      for (auto const &[db_uuid, num_txns] : *instance_state.inner_state.main_num_txns) {
-        auto it = main_num_txns_cache_.find(db_uuid);
-        if (it == main_num_txns_cache_.end() || it->second != num_txns) {
-          spdlog::info("main_num_txns_cache_ updated: db={} old={} new={}",
-                       db_uuid,
-                       it != main_num_txns_cache_.end() ? std::to_string(it->second) : "N/A",
-                       num_txns);
-        }
-      }
       main_num_txns_cache_ = *instance_state.inner_state.main_num_txns;
     }
 
@@ -1213,15 +1204,6 @@ void CoordinatorInstance::InstanceSuccessCallback(std::string_view instance_name
               return context.config.instance_name;
             }) != std::ranges::end(data_instances);
         if (instance_exists_in_raft) {
-          auto it = replicas_num_txns_cache_.find(replica_name);
-          if (it == replicas_num_txns_cache_.end() || it->second != replica_data) {
-            std::string detail;
-            for (auto const &[db_uuid, num_txns] : replica_data) {
-              if (!detail.empty()) detail += ", ";
-              detail += fmt::format("db={}:txns={}", db_uuid, num_txns);
-            }
-            spdlog::info("replicas_num_txns_cache_ updated: replica={} [{}]", replica_name, detail);
-          }
           replicas_num_txns_cache_.insert_or_assign(replica_name, replica_data);
         } else if (instance.SendRpc<UnregisterReplicaRpc>(replica_name)) {
           replicas_num_txns_cache_.erase(replica_name);

--- a/src/coordination/include/coordination/replication_lag_info.hpp
+++ b/src/coordination/include/coordination/replication_lag_info.hpp
@@ -19,7 +19,9 @@ namespace memgraph::coordination {
 
 struct ReplicaDBLagData {
   uint64_t num_committed_txns_;
-  uint64_t num_txns_behind_main_;
+  // int64_t because for a brief time window replica can be in front of new main. That's because an instance can become
+  // main without having all old transactions. Possible with SYNC replication
+  int64_t num_txns_behind_main_;
 };
 
 struct ReplicationLagInfo {

--- a/src/coordination/include/coordination/utils.hpp
+++ b/src/coordination/include/coordination/utils.hpp
@@ -79,8 +79,9 @@ auto CreateRoutingTable(std::vector<DataInstanceContext> const &raft_log_data_in
           return true;
         }
         // return true if cached lag is smaller than max_allowed_replica_read_lag. This also allows routing to replicas
-        // with negative lag. negative lag can occur when an instance becomes main without comitting all txns
-        return db_it->second < max_replica_read_lag;
+        // with negative lag. negative lag can occur when an instance becomes main without comitting all txns. Check for
+        // overflow also
+        return db_it->second < 0 || db_it->second < max_replica_read_lag;
       };
 
   auto readers = raft_log_data_instances | ranges::views::filter(std::not_fn(is_instance_main_func)) |

--- a/src/coordination/include/coordination/utils.hpp
+++ b/src/coordination/include/coordination/utils.hpp
@@ -78,9 +78,6 @@ auto CreateRoutingTable(std::vector<DataInstanceContext> const &raft_log_data_in
         if (db_it == replica_it->second.end()) {
           return true;
         }
-
-        spdlog::trace("Comparing: {} < {}", db_it->second, max_replica_read_lag);
-
         // return true if cached lag is smaller than max_allowed_replica_read_lag. This also allows routing to replicas
         // with negative lag. negative lag can occur when an instance becomes main without comitting all txns
         return db_it->second < max_replica_read_lag;

--- a/src/coordination/include/coordination/utils.hpp
+++ b/src/coordination/include/coordination/utils.hpp
@@ -79,6 +79,8 @@ auto CreateRoutingTable(std::vector<DataInstanceContext> const &raft_log_data_in
           return true;
         }
 
+        spdlog::trace("Comparing: {} < {}", db_it->second, max_replica_read_lag);
+
         // return true if cached lag is smaller than max_allowed_replica_read_lag
         return db_it->second < max_replica_read_lag;
       };

--- a/src/coordination/include/coordination/utils.hpp
+++ b/src/coordination/include/coordination/utils.hpp
@@ -81,7 +81,8 @@ auto CreateRoutingTable(std::vector<DataInstanceContext> const &raft_log_data_in
 
         spdlog::trace("Comparing: {} < {}", db_it->second, max_replica_read_lag);
 
-        // return true if cached lag is smaller than max_allowed_replica_read_lag
+        // return true if cached lag is smaller than max_allowed_replica_read_lag. This also allows routing to replicas
+        // with negative lag. negative lag can occur when an instance becomes main without comitting all txns
         return db_it->second < max_replica_read_lag;
       };
 

--- a/src/coordination/include/coordination/utils.hpp
+++ b/src/coordination/include/coordination/utils.hpp
@@ -78,10 +78,9 @@ auto CreateRoutingTable(std::vector<DataInstanceContext> const &raft_log_data_in
         if (db_it == replica_it->second.end()) {
           return true;
         }
-        // return true if cached lag is smaller than max_allowed_replica_read_lag. This also allows routing to replicas
-        // with negative lag. negative lag can occur when an instance becomes main without comitting all txns. Check for
-        // overflow also
-        return db_it->second < 0 || db_it->second < max_replica_read_lag;
+        // return true if cached lag is smaller than max_allowed_replica_read_lag. Forbid routing to replicas
+        // with negative lag. A negative lag can occur when an instance becomes main without comitting all txns.
+        return db_it->second >= 0 && db_it->second <= max_replica_read_lag;
       };
 
   auto readers = raft_log_data_instances | ranges::views::filter(std::not_fn(is_instance_main_func)) |

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -2284,7 +2284,7 @@ Callback HandleCoordinatorQuery(CoordinatorQuery *coordinator_query, const Param
         auto const db_lag_data_to_tv = [](coordination::ReplicaDBLagData orig) {
           auto info = std::map<std::string, TypedValue>{};
           info.emplace("num_committed_txns", TypedValue{static_cast<int64_t>(orig.num_committed_txns_)});
-          info.emplace("num_txns_behind_main", TypedValue{static_cast<int64_t>(orig.num_txns_behind_main_)});
+          info.emplace("num_txns_behind_main", TypedValue{orig.num_txns_behind_main_});
           return TypedValue{std::move(info)};
         };
 

--- a/src/replication_handler/replication_handler.cpp
+++ b/src/replication_handler/replication_handler.cpp
@@ -440,31 +440,35 @@ std::pair<ReplicationHandler::MainResT, ReplicationHandler::ReplicasResT> Replic
     auto &repl_storage_state = db_acc->storage()->repl_storage_state_;
     auto const db_name = db_acc->name();
 
-    repl_storage_state.replication_storage_clients_.WithReadLock([&db_name, &replicas](auto &storage_clients) {
-      for (auto &repl_storage_client : storage_clients) {
-        auto const replica_name = repl_storage_client->Name();
-        auto const num_committed_txns_repl = repl_storage_client->GetNumCommittedTxns();
-        // Insert or find the already inserted element
-        auto [replica_it, _] = replicas.try_emplace(replica_name, std::map<std::string, int64_t>{});
-        replica_it->second.emplace(db_name, num_committed_txns_repl);
-      }
-    });
-
-    auto const num_main_committed_txns =
-        repl_storage_state.commit_ts_info_.load(std::memory_order_acquire).num_committed_txns_;
-    main.emplace(std::string{db_acc->storage()->uuid()}, num_main_committed_txns);
-
     repl_storage_state.replication_storage_clients_.WithReadLock(
-        [&db_name, &replicas, num_main_committed_txns](auto &storage_clients) {
+        [&db_name, &replicas, &repl_storage_state, &main, &db_acc](auto &storage_clients) {
+          // First observe replicas' num committed txns then main's so we avoid negative calculation
+          for (auto &repl_storage_client : storage_clients) {
+            auto const replica_name = repl_storage_client->Name();
+            uint64_t const num_committed_txns_repl = repl_storage_client->GetNumCommittedTxns();
+            // Insert or find the already inserted element
+            auto [replica_it, _] = replicas.try_emplace(replica_name, std::map<std::string, int64_t>{});
+            replica_it->second.emplace(db_name, num_committed_txns_repl);
+          }
+
+          auto const num_main_committed_txns =
+              repl_storage_state.commit_ts_info_.load(std::memory_order_acquire).num_committed_txns_;
+          main.emplace(std::string{db_acc->storage()->uuid()}, num_main_committed_txns);
+
           for (auto &repl_storage_client : storage_clients) {
             auto const replica_name = repl_storage_client->Name();
             auto replica_it = replicas.find(replica_name);
             DMG_ASSERT(replica_it != replicas.end(), "No info for replica {}", replica_name);
             auto old_value_it = replica_it->second.find(db_name);
             DMG_ASSERT(old_value_it != replica_it->second.end(), "No info for db {}", db_name);
-            old_value_it->second = num_main_committed_txns - old_value_it->second;
-            if (repl_storage_client->Mode() != replication_coordination_glue::ReplicationMode::ASYNC) {
-              MG_ASSERT(old_value_it->second >= 0, "Replica lag should not be negative");
+            // For SYNC replica it can happen that the instance becomes main without committing all transactions from
+            // before
+            // Avoid lossy compression for casting uint64_t to int64_t
+            auto const replica_num_committed_txns = static_cast<uint64_t>(old_value_it->second);
+            if (num_main_committed_txns >= replica_num_committed_txns) {
+              old_value_it->second = num_main_committed_txns - replica_num_committed_txns;
+            } else {
+              old_value_it->second = -static_cast<int64_t>(replica_num_committed_txns - num_main_committed_txns);
             }
           }
         });

--- a/src/replication_handler/replication_handler.cpp
+++ b/src/replication_handler/replication_handler.cpp
@@ -461,15 +461,7 @@ std::pair<ReplicationHandler::MainResT, ReplicationHandler::ReplicasResT> Replic
             DMG_ASSERT(replica_it != replicas.end(), "No info for replica {}", replica_name);
             auto old_value_it = replica_it->second.find(db_name);
             DMG_ASSERT(old_value_it != replica_it->second.end(), "No info for db {}", db_name);
-            // For SYNC replica it can happen that the instance becomes main without committing all transactions from
-            // before
-            // Avoid lossy compression for casting uint64_t to int64_t
-            auto const replica_num_committed_txns = static_cast<uint64_t>(old_value_it->second);
-            if (num_main_committed_txns >= replica_num_committed_txns) {
-              old_value_it->second = num_main_committed_txns - replica_num_committed_txns;
-            } else {
-              old_value_it->second = -static_cast<int64_t>(replica_num_committed_txns - num_main_committed_txns);
-            }
+            old_value_it->second = num_main_committed_txns - old_value_it->second;
           }
         });
   });

--- a/src/replication_handler/replication_handler.cpp
+++ b/src/replication_handler/replication_handler.cpp
@@ -439,19 +439,33 @@ std::pair<ReplicationHandler::MainResT, ReplicationHandler::ReplicasResT> Replic
   dbms_handler_.ForEach([&replicas, &main](dbms::DatabaseAccess db_acc) {
     auto &repl_storage_state = db_acc->storage()->repl_storage_state_;
     auto const db_name = db_acc->name();
+
+    repl_storage_state.replication_storage_clients_.WithReadLock([&db_name, &replicas](auto &storage_clients) {
+      for (auto &repl_storage_client : storage_clients) {
+        auto const replica_name = repl_storage_client->Name();
+        auto const num_committed_txns_repl = repl_storage_client->GetNumCommittedTxns();
+        // Insert or find the already inserted element
+        auto [replica_it, _] = replicas.try_emplace(replica_name, std::map<std::string, int64_t>{});
+        replica_it->second.emplace(db_name, num_committed_txns_repl);
+      }
+    });
+
     auto const num_main_committed_txns =
         repl_storage_state.commit_ts_info_.load(std::memory_order_acquire).num_committed_txns_;
     main.emplace(std::string{db_acc->storage()->uuid()}, num_main_committed_txns);
 
     repl_storage_state.replication_storage_clients_.WithReadLock(
-        [&db_name, &num_main_committed_txns, &replicas](auto &storage_clients) {
+        [&db_name, &replicas, num_main_committed_txns](auto &storage_clients) {
           for (auto &repl_storage_client : storage_clients) {
             auto const replica_name = repl_storage_client->Name();
-            auto const num_committed_txns_repl = repl_storage_client->GetNumCommittedTxns();
-            int64_t const replica_lag = num_main_committed_txns - num_committed_txns_repl;
-            // Insert or find the already inserted element
-            auto [replica_it, _] = replicas.try_emplace(replica_name, std::map<std::string, int64_t>{});
-            replica_it->second.emplace(db_name, replica_lag);
+            auto replica_it = replicas.find(replica_name);
+            DMG_ASSERT(replica_it != replicas.end(), "No info for replica {}", replica_name);
+            auto old_value_it = replica_it->second.find(db_name);
+            DMG_ASSERT(old_value_it != replica_it->second.end(), "No info for db {}", db_name);
+            old_value_it->second = num_main_committed_txns - old_value_it->second;
+            if (repl_storage_client->Mode() != replication_coordination_glue::ReplicationMode::ASYNC) {
+              MG_ASSERT(old_value_it->second >= 0, "Replica lag should not be negative");
+            }
           }
         });
   });

--- a/src/replication_handler/replication_handler.cpp
+++ b/src/replication_handler/replication_handler.cpp
@@ -418,7 +418,7 @@ auto ReplicationHandler::GetReplicationLag() const -> coordination::ReplicationL
           for (auto &repl_storage_client : storage_clients) {
             auto const replica_name = repl_storage_client->Name();
             auto const num_committed_txns_repl = repl_storage_client->GetNumCommittedTxns();
-            auto const replica_lag = num_main_committed_txns - num_committed_txns_repl;
+            auto const replica_lag = static_cast<int64_t>(num_main_committed_txns - num_committed_txns_repl);
             // Insert or find the already inserted element
             auto [replica_it, _] = lag_info.replicas_info_.try_emplace(
                 replica_name, std::map<std::string, coordination::ReplicaDBLagData>{});

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1042,7 +1042,7 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
 
   // If main executes this: Block until we receive votes from all replicas.
   // If replica executes this:,
-  auto const repl_prepare_phase_status =
+  auto const repl_prepare_phase_ok =
       HandleDurabilityAndReplicate(durability_commit_timestamp, replicating_txn, commit_args);
 
   // If replica executes this
@@ -1068,15 +1068,14 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
           // WAL file is already finalized
           FinalizeCommitPhase(durability_commit_timestamp);
 
-          auto failures = replicating_txn.CollectStartTxnErrors();
-          if (!repl_prepare_phase_status.has_value()) {
-            for (auto const &f : repl_prepare_phase_status.error().failures) {
-              // A replica that failed to start also fails during finalize — keep only the start error
-              if (!std::ranges::any_of(failures, [&](auto const &e) { return e.name == f.name; })) {
-                failures.push_back(f);
-              }
-            }
-          }
+          auto failures = replicating_txn.CollectAllFailures();
+          auto const update_func = [durability_commit_timestamp](CommitTsInfo const &old_ts_info) -> CommitTsInfo {
+            return CommitTsInfo{.ldt_ = durability_commit_timestamp,
+                                .num_committed_txns_ = old_ts_info.num_committed_txns_ + 1};
+          };
+          // update replicas' cached commit info
+          replicating_txn.UpdateCommitTsInfo(update_func);
+
           if (!failures.empty()) {
             return std::unexpected{ReplicationError{.failures = std::move(failures), .transaction_committed = true}};
           }
@@ -1086,7 +1085,7 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
         // If we are here, it means we are the main executing the commit and there are some STRICT_SYNC replicas in the
         // cluster.
 
-        if (repl_prepare_phase_status.has_value()) {
+        if (repl_prepare_phase_ok) {
           // All replicas voted yes, hence they want to commit the current transaction
           FinalizeCommitPhase(durability_commit_timestamp);
         }
@@ -1097,20 +1096,18 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
         }
         // Send to all replicas they can finalize a transaction
         replicating_txn.FinalizeTransaction(
-            repl_prepare_phase_status.has_value(), mem_storage->uuid(), protector, durability_commit_timestamp);
+            repl_prepare_phase_ok, mem_storage->uuid(), protector, durability_commit_timestamp);
 
-        // Collect all failures: start-txn errors and ship-delta errors are mutually exclusive per replica
-        // It is ok to put this after FinalizeTransaction because it is impossible for repl_prepare_phase_status
-        // to have a value if there were some start txn errors
-        auto failures = replicating_txn.CollectStartTxnErrors();
-        if (!repl_prepare_phase_status.has_value()) {
-          for (auto const &f : repl_prepare_phase_status.error().failures) {
-            // A replica that failed to start also fails during finalize — keep only the start error
-            if (!std::ranges::any_of(failures, [&](auto const &e) { return e.name == f.name; })) {
-              failures.push_back(f);
-            }
-          }
+        auto failures = replicating_txn.CollectAllFailures();
+        auto const update_func = [durability_commit_timestamp](CommitTsInfo const &old_ts_info) -> CommitTsInfo {
+          return CommitTsInfo{.ldt_ = durability_commit_timestamp,
+                              .num_committed_txns_ = old_ts_info.num_committed_txns_ + 1};
+        };
+        // update replicas' cached commit info only if the txn was actually committed
+        if (repl_prepare_phase_ok) {
+          replicating_txn.UpdateCommitTsInfo(update_func);
         }
+
         if (!failures.empty()) {
           // Release engine lock because we don't have to hold it anymore for abort
           engine_guard.unlock();
@@ -1195,6 +1192,7 @@ void InMemoryStorage::InMemoryAccessor::FinalizeCommitPhase(uint64_t const durab
     return CommitTsInfo{.ldt_ = durability_commit_timestamp,
                         .num_committed_txns_ = old_ts_info.num_committed_txns_ + 1};
   };
+  // update main's cached info
   atomic_struct_update<CommitTsInfo>(mem_storage->repl_storage_state_.commit_ts_info_, update_func);
 
   // Install the new point index, if needed
@@ -3172,8 +3170,7 @@ void InMemoryStorage::FinalizeWalFile() {
 
 auto InMemoryStorage::InMemoryAccessor::HandleDurabilityAndReplicate(uint64_t durability_commit_timestamp,
                                                                      TransactionReplication &replicating_txn,
-                                                                     CommitArgs const &commit_args)
-    -> std::expected<void, ShipDeltasError> {
+                                                                     CommitArgs const &commit_args) -> bool {
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
 
   // If replica executes this:

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -182,8 +182,7 @@ class InMemoryStorage final : public Storage {
 
     [[nodiscard]] auto HandleDurabilityAndReplicate(uint64_t durability_commit_timestamp,
                                                     TransactionReplication &replicating_txn,
-                                                    CommitArgs const &commit_args)
-        -> std::expected<void, ShipDeltasError>;
+                                                    CommitArgs const &commit_args) -> bool;
 
    public:
     InMemoryAccessor(const InMemoryAccessor &) = delete;

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -470,23 +470,23 @@ auto ReplicationStorageClient::FinalizePrepareCommitPhase(std::optional<ReplicaS
   try {
     auto response = replica_stream->Finalize();
     // NOLINTNEXTLINE
-    return replica_state_.WithLock([this, response, durability_commit_timestamp](auto &state) mutable
-                                       -> std::expected<void, io::network::ClientCommunicationError> {
-      // If we didn't receive successful response to PrepareCommit, or we got into MAYBE_BEHIND state since the
-      // moment we started committing as ASYNC replica, we cannot set the ready state. We could have got into
-      // MAYBE_BEHIND state if we missed next txn.
-      if (state != ReplicaState::REPLICATING) {
-        return std::unexpected{io::network::ClientCommunicationError::GENERIC_ERROR};
-      }
+    return replica_state_.WithLock(
+        [response](auto &state) mutable -> std::expected<void, io::network::ClientCommunicationError> {
+          // If we didn't receive successful response to PrepareCommit, or we got into MAYBE_BEHIND state since the
+          // moment we started committing as ASYNC replica, we cannot set the ready state. We could have got into
+          // MAYBE_BEHIND state if we missed next txn.
+          if (state != ReplicaState::REPLICATING) {
+            return std::unexpected{io::network::ClientCommunicationError::GENERIC_ERROR};
+          }
 
-      if (!response.success) {
-        state = ReplicaState::MAYBE_BEHIND;
-        return std::unexpected{io::network::ClientCommunicationError::GENERIC_ERROR};
-      }
+          if (!response.success) {
+            state = ReplicaState::MAYBE_BEHIND;
+            return std::unexpected{io::network::ClientCommunicationError::GENERIC_ERROR};
+          }
 
-      state = ReplicaState::READY;
-      return {};
-    });
+          state = ReplicaState::READY;
+          return {};
+        });
   } catch (rpc::RpcTimeoutException const &) {
     replica_state_.WithLock([&replica_stream](auto &state) {
       replica_stream.reset();

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -402,7 +402,6 @@ auto ReplicationStorageClient::StartTransactionReplication(Storage *storage, Dat
   }
 }
 
-// TODO: (andi) Catch correct error
 // RPC lock released at the end of this function
 // Used for STRICT_SYNC replica
 // We don't need to check here for timeout vs. generic error because we aren't handling errors in the 2nd phase of the

--- a/src/storage/v2/replication/replication_client.cpp
+++ b/src/storage/v2/replication/replication_client.cpp
@@ -402,6 +402,7 @@ auto ReplicationStorageClient::StartTransactionReplication(Storage *storage, Dat
   }
 }
 
+// TODO: (andi) Catch correct error
 // RPC lock released at the end of this function
 // Used for STRICT_SYNC replica
 // We don't need to check here for timeout vs. generic error because we aren't handling errors in the 2nd phase of the
@@ -421,14 +422,7 @@ auto ReplicationStorageClient::StartTransactionReplication(Storage *storage, Dat
                                                                           main_uuid_,
                                                                           storage_uuid,
                                                                           durability_commit_timestamp)};
-    auto const res = stream.SendAndWait().success;
-    if (res) {
-      auto update_func = [](CommitTsInfo const &commit_ts_info) -> CommitTsInfo {
-        return {.ldt_ = commit_ts_info.ldt_, .num_committed_txns_ = commit_ts_info.num_committed_txns_ + 1};
-      };
-      atomic_struct_update<CommitTsInfo>(commit_ts_info_, std::move(update_func));
-    }
-    return res;
+    return stream.SendAndWait().success;
   } catch (const rpc::RpcFailedException &) {
     // Frequent heartbeat should trigger the recovery. Until then, commits on MAIN won't be allowed
     return false;
@@ -490,11 +484,6 @@ auto ReplicationStorageClient::FinalizePrepareCommitPhase(std::optional<ReplicaS
         return std::unexpected{io::network::ClientCommunicationError::GENERIC_ERROR};
       }
 
-      auto update_func = [&durability_commit_timestamp](CommitTsInfo const &commit_ts_info) -> CommitTsInfo {
-        return {.ldt_ = durability_commit_timestamp, .num_committed_txns_ = commit_ts_info.num_committed_txns_};
-      };
-      atomic_struct_update<CommitTsInfo>(commit_ts_info_, std::move(update_func));
-
       state = ReplicaState::READY;
       return {};
     });
@@ -552,27 +541,20 @@ auto ReplicationStorageClient::FinalizeTransactionReplication(DatabaseProtector 
     return std::unexpected{io::network::ClientCommunicationError::GENERIC_ERROR};
   }
 
+  bool const is_async = client_.mode_ == replication_coordination_glue::ReplicationMode::ASYNC;
   auto task = [this,
                protector = protector.clone(),
                replica_stream_obj = std::move(replica_stream),
-               durability_commit_timestamp]() mutable -> std::expected<void, io::network::ClientCommunicationError> {
+               durability_commit_timestamp,
+               is_async]() mutable -> std::expected<void, io::network::ClientCommunicationError> {
     MG_ASSERT(replica_stream_obj, "Missing stream for transaction deltas for replica {}", client_.name_);
     try {
       auto response = replica_stream_obj->Finalize();
       // NOLINTNEXTLINE
       return replica_state_.WithLock(
-          [this, response, &replica_stream_obj, durability_commit_timestamp](
+          [this, response, &replica_stream_obj, durability_commit_timestamp, is_async](
               auto &state) mutable -> std::expected<void, io::network::ClientCommunicationError> {
             replica_stream_obj.reset();
-
-            // It doesn't matter whether we started a new txn or not, we can increment here the number of known
-            // committed txns for replica
-            if (response.success) {
-              auto update_func = [](CommitTsInfo const &commit_ts_info) -> CommitTsInfo {
-                return {.ldt_ = commit_ts_info.ldt_, .num_committed_txns_ = commit_ts_info.num_committed_txns_ + 1};
-              };
-              atomic_struct_update<CommitTsInfo>(commit_ts_info_, std::move(update_func));
-            }
 
             // If we didn't receive successful response to PrepareCommitReq, or we got into MAYBE_BEHIND state since the
             // moment we started committing as ASYNC replica, we cannot set the ready state. We could have got into
@@ -586,10 +568,14 @@ auto ReplicationStorageClient::FinalizeTransactionReplication(DatabaseProtector 
               return std::unexpected{io::network::ClientCommunicationError::GENERIC_ERROR};
             }
 
-            auto update_func = [durability_commit_timestamp](CommitTsInfo const &commit_ts_info) -> CommitTsInfo {
-              return {.ldt_ = durability_commit_timestamp, .num_committed_txns_ = commit_ts_info.num_committed_txns_};
-            };
-            atomic_struct_update<CommitTsInfo>(commit_ts_info_, std::move(update_func));
+            // ASYNC replicas update their own commit_ts_info_ here upon confirmed
+            // success rather than optimistically in the main commit path.
+            if (is_async) {
+              auto update_func = [durability_commit_timestamp](CommitTsInfo const &info) -> CommitTsInfo {
+                return {.ldt_ = durability_commit_timestamp, .num_committed_txns_ = info.num_committed_txns_ + 1};
+              };
+              atomic_struct_update<CommitTsInfo>(commit_ts_info_, std::move(update_func));
+            }
 
             state = ReplicaState::READY;
             return {};
@@ -611,7 +597,7 @@ auto ReplicationStorageClient::FinalizeTransactionReplication(DatabaseProtector 
     }
   };
 
-  if (client_.mode_ == replication_coordination_glue::ReplicationMode::ASYNC) {
+  if (is_async) {
     // When in ASYNC mode, we ignore the return value from task() and always return true
     client_.thread_pool_.AddTask(std::move(task));
     return {};

--- a/src/storage/v2/replication/replication_client.hpp
+++ b/src/storage/v2/replication/replication_client.hpp
@@ -92,6 +92,7 @@ class ReplicationStorageClient {
   friend class InMemoryCurrentWalHandler;
   friend class ReplicaStream;
   friend struct ::memgraph::replication::ReplicationClient;
+  friend class TransactionReplication;
 
  public:
   explicit ReplicationStorageClient(::memgraph::replication::ReplicationClient &client, utils::UUID main_uuid);

--- a/src/storage/v2/replication/replication_transaction.cpp
+++ b/src/storage/v2/replication/replication_transaction.cpp
@@ -12,7 +12,10 @@
 #include "storage/v2/replication/replication_transaction.hpp"
 
 #include "storage/v2/commit_args.hpp"
+#include "utils/atomic_utils.hpp"
 #include "utils/variant_helpers.hpp"
+
+#include <string>
 
 namespace memgraph::storage {
 
@@ -47,9 +50,8 @@ auto StartTxnErrorToReason(StartTxnReplicationError const &error) -> ReplicaFail
 // When handling some other type of replica, it is checked whether there is another STRICT_SYNC replica. There are 2
 // possible cluster combinations: STRICT_SYNC and ASYNC or SYNC and ASYNC. If there are no STRICT_SYNC replicas in the
 // cluster, we send all deltas and commit immediately on replicas.
-auto TransactionReplication::ShipDeltas(uint64_t durability_commit_timestamp, CommitArgs const &commit_args)
-    -> std::expected<void, ShipDeltasError> {
-  if (locked_clients->empty()) return {};
+auto TransactionReplication::ShipDeltas(uint64_t durability_commit_timestamp, CommitArgs const &commit_args) -> bool {
+  if (locked_clients->empty()) return true;
 
   MG_ASSERT(commit_args.replication_allowed(),
             "Any clients assumes we are MAIN, we should have gatekeeper_access_wrapper so we can correctly "
@@ -57,7 +59,6 @@ auto TransactionReplication::ShipDeltas(uint64_t durability_commit_timestamp, Co
 
   auto const &db_acc = commit_args.database_protector();
   bool const should_run_2pc = ShouldRunTwoPC();
-  std::vector<ReplicaFailure> failures;
   for (auto &&[client, replica_stream] : ranges::views::zip(*locked_clients, streams)) {
     client->IfStreamingTransaction([&](auto &stream) { stream.AppendTransactionEnd(durability_commit_timestamp); },
                                    replica_stream);
@@ -97,11 +98,10 @@ auto TransactionReplication::ShipDeltas(uint64_t durability_commit_timestamp, Co
             return ReplicaFailureReason::RPC_ERROR;
         }
       }();
-      failures.push_back({std::string{client->Name()}, ReplicationModeToString(client->Mode()), reason});
+      replication_failures_.push_back({std::string{client->Name()}, ReplicationModeToString(client->Mode()), reason});
     }
   }
-  if (!failures.empty()) return std::unexpected{ShipDeltasError{std::move(failures)}};
-  return {};
+  return replication_failures_.empty();
 }
 
 // RPC locks will get released at the end of this function for all STRICT_SYNC and ASYNC replicas
@@ -116,6 +116,9 @@ auto TransactionReplication::FinalizeTransaction(bool const decision, utils::UUI
     if (client->Mode() == replication_coordination_glue::ReplicationMode::STRICT_SYNC) {
       auto const commit_res =
           client->SendFinalizeCommitRpc(decision, storage_uuid, durability_commit_timestamp, std::move(replica_stream));
+      if (!commit_res) {
+        finalize_failures_.push_back({std::string{client->Name()}, "STRICT_SYNC", ReplicaFailureReason::RPC_ERROR});
+      }
       strict_sync_replicas_succ &= commit_res;
     } else if (client->Mode() == replication_coordination_glue::ReplicationMode::ASYNC) {
       if (decision) {
@@ -130,17 +133,31 @@ auto TransactionReplication::FinalizeTransaction(bool const decision, utils::UUI
   return strict_sync_replicas_succ;
 }
 
-auto TransactionReplication::CollectStartTxnErrors() const -> std::vector<ReplicaFailure> {
-  std::vector<ReplicaFailure> result;
-  for (auto &&[client, maybe_err] : ranges::views::zip(*locked_clients, errors_)) {
-    // ASYNC replica errors are not reported — fire-and-forget
-    if (maybe_err.has_value() && client->Mode() != replication_coordination_glue::ReplicationMode::ASYNC) {
-      result.push_back({.name = client->Name(),
-                        .mode = ReplicationModeToString(client->Mode()),
-                        .reason = StartTxnErrorToReason(*maybe_err)});
-    }
+auto TransactionReplication::CollectAllFailures() -> std::vector<ReplicaFailure> {
+  // Build failed_replicas_ from both replication failures and finalize failures
+  // so UpdateCommitTsInfo skips all of them.
+  failed_replicas_.clear();
+  for (auto const &f : replication_failures_) {
+    failed_replicas_.insert(f.name);
   }
-  return result;
+  for (auto const &f : finalize_failures_) {
+    failed_replicas_.insert(f.name);
+  }
+
+  // Only replication_failures_ are returned (triggers ReplicationException).
+  // finalize_failures_ only affect UpdateCommitTsInfo skipping — no exception thrown for them.
+  return replication_failures_;
+}
+
+void TransactionReplication::UpdateCommitTsInfo(std::function<CommitTsInfo(CommitTsInfo const &)> const &cb) {
+  for (auto const &client : *locked_clients) {
+    if (failed_replicas_.contains(client->Name())) continue;
+    // ASYNC replicas update their own commit_ts_info_ inside the async task
+    // upon confirmed success — updating here would be optimistic and could
+    // overcount if the async replication later fails.
+    if (client->Mode() == replication_coordination_glue::ReplicationMode::ASYNC) continue;
+    atomic_struct_update<CommitTsInfo>(client->commit_ts_info_, cb);
+  }
 }
 
 TransactionReplication::TransactionReplication(uint64_t const durability_commit_timestamp, Storage *storage,
@@ -148,7 +165,6 @@ TransactionReplication::TransactionReplication(uint64_t const durability_commit_
     : locked_clients{clients.ReadLock()} {
   if (!locked_clients->empty()) {
     streams.reserve(locked_clients->size());
-    errors_.reserve(locked_clients->size());
     auto const &db_acc = commit_args.database_protector();
     for (const auto &client : *locked_clients) {
       // If any client requires two phase commit, then we are running that phase
@@ -156,10 +172,14 @@ TransactionReplication::TransactionReplication(uint64_t const durability_commit_
       auto res = client->StartTransactionReplication(storage, db_acc, durability_commit_timestamp);
       if (res.has_value()) {
         streams.emplace_back(std::move(res.value()));
-        errors_.emplace_back(std::nullopt);
       } else {
         streams.emplace_back(std::nullopt);
-        errors_.emplace_back(res.error());
+        // ASYNC replica errors are not reported — fire-and-forget
+        if (client->Mode() != replication_coordination_glue::ReplicationMode::ASYNC) {
+          replication_failures_.push_back({.name = client->Name(),
+                                           .mode = ReplicationModeToString(client->Mode()),
+                                           .reason = StartTxnErrorToReason(res.error())});
+        }
       }
     }
   }

--- a/src/storage/v2/replication/replication_transaction.cpp
+++ b/src/storage/v2/replication/replication_transaction.cpp
@@ -15,6 +15,7 @@
 #include "utils/atomic_utils.hpp"
 #include "utils/variant_helpers.hpp"
 
+#include <algorithm>
 #include <string>
 
 namespace memgraph::storage {
@@ -88,17 +89,24 @@ auto TransactionReplication::ShipDeltas(uint64_t durability_commit_timestamp, Co
     });
 
     if (!finalized.has_value()) {
-      auto const reason = [&] {
-        switch (finalized.error()) {
-          case io::network::ClientCommunicationError::TIMEOUT_ERROR:
-            return ReplicaFailureReason::TIMEOUT;
-          case io::network::ClientCommunicationError::SOCKET_FAILED_TO_CONNECT:
-            return ReplicaFailureReason::NOT_IN_SYNC;
-          default:
-            return ReplicaFailureReason::RPC_ERROR;
-        }
-      }();
-      replication_failures_.push_back({std::string{client->Name()}, ReplicationModeToString(client->Mode()), reason});
+      auto const client_name = std::string{client->Name()};
+      // StartTransactionReplication may have already recorded a failure for this replica;
+      // avoid reporting the same instance twice with a follow-up reason derived from the empty stream.
+      auto const already_failed =
+          std::ranges::any_of(replication_failures_, [&](ReplicaFailure const &f) { return f.name == client_name; });
+      if (!already_failed) {
+        auto const reason = [&] {
+          switch (finalized.error()) {
+            case io::network::ClientCommunicationError::TIMEOUT_ERROR:
+              return ReplicaFailureReason::TIMEOUT;
+            case io::network::ClientCommunicationError::SOCKET_FAILED_TO_CONNECT:
+              return ReplicaFailureReason::NOT_IN_SYNC;
+            default:
+              return ReplicaFailureReason::RPC_ERROR;
+          }
+        }();
+        replication_failures_.push_back({client_name, ReplicationModeToString(client->Mode()), reason});
+      }
     }
   }
   return replication_failures_.empty();

--- a/src/storage/v2/replication/replication_transaction.hpp
+++ b/src/storage/v2/replication/replication_transaction.hpp
@@ -11,9 +11,8 @@
 
 #pragma once
 
-#include <expected>
 #include <optional>
-#include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "storage/v2/database_protector.hpp"
@@ -26,10 +25,6 @@
 namespace memgraph::storage {
 
 struct CommitArgs;
-
-struct ShipDeltasError {
-  std::vector<ReplicaFailure> failures;
-};
 
 using ReplicationStorageClientList =
     utils::Synchronized<std::vector<std::unique_ptr<ReplicationStorageClient>>, utils::RWSpinLock>;
@@ -74,24 +69,40 @@ class TransactionReplication {
     }
   }
 
-  // RPC stream won't be destroyed at the end of this function
-  auto ShipDeltas(uint64_t durability_commit_timestamp, CommitArgs const &commit_args)
-      -> std::expected<void, ShipDeltasError>;
+  // RPC stream won't be destroyed at the end of this function.
+  // Returns true if all SYNC/STRICT_SYNC replicas succeeded, false otherwise.
+  // Failures are cached internally in ship_failures_ for CollectAllFailures.
+  auto ShipDeltas(uint64_t durability_commit_timestamp, CommitArgs const &commit_args) -> bool;
 
   auto FinalizeTransaction(bool decision, utils::UUID const &storage_uuid, DatabaseProtector const &protector,
                            uint64_t durability_commit_timestamp) -> bool;
 
   auto ShouldRunTwoPC() const -> bool { return run_two_phase_commit; }
 
-  auto CollectStartTxnErrors() const -> std::vector<ReplicaFailure>;
+  // Returns all replication failures (start-txn + ship/finalize) and additionally
+  // marks 2nd-phase finalize failures in failed_replicas_ so UpdateCommitTsInfo skips them.
+  // Finalize failures are NOT included in the returned vector (no ReplicationException for them).
+  // Must be called after ShipDeltas and FinalizeTransaction (if applicable), and before UpdateCommitTsInfo.
+  auto CollectAllFailures() -> std::vector<ReplicaFailure>;
+
+  // Updates commit_ts_info only for replicas that committed successfully
+  // (i.e. not in failed_replicas_). Must be called after CollectAllFailures.
+  void UpdateCommitTsInfo(std::function<CommitTsInfo(CommitTsInfo const &)> const &cb);
 
  private:
   std::vector<std::optional<ReplicaStream>> streams;
-  // nullopt if connecting to replica passed successfully, else error stored
-  std::vector<std::optional<StartTxnReplicationError>> errors_;
   utils::Synchronized<std::vector<std::unique_ptr<ReplicationStorageClient>>, utils::RWSpinLock>::ReadLockedPtr
       locked_clients;
   bool run_two_phase_commit{false};
+  // Replicas that failed start-txn or ship/finalize (excludes ASYNC — fire-and-forget).
+  // Populated by the constructor and ShipDeltas. Returned by CollectAllFailures.
+  std::vector<ReplicaFailure> replication_failures_;
+  // Replicas that failed the 2nd phase of 2PC (SendFinalizeCommitRpc failed).
+  // Populated by FinalizeTransaction. NOT returned by CollectAllFailures (no ReplicationException),
+  // but added to failed_replicas_ so UpdateCommitTsInfo skips them.
+  std::vector<ReplicaFailure> finalize_failures_;
+  // Union of all failed replica names, built by CollectAllFailures.
+  std::unordered_set<std::string> failed_replicas_;
 };
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/storage_error.hpp
+++ b/src/storage/v2/storage_error.hpp
@@ -22,7 +22,7 @@
 
 namespace memgraph::storage {
 
-// --- Internal start-txn error types (used by CollectStartTxnErrors) ---
+// --- Internal start-txn error types (used by CollectAllFailures) ---
 
 struct FailedToConnectErr {};
 

--- a/tests/stress/continuous_integration
+++ b/tests/stress/continuous_integration
@@ -294,7 +294,7 @@ Examples:
 
     parser.add_argument(
         "--python",
-        default=os.path.join(BASE_DIR, "tests", "ve3", "bin", "python3"),
+        default="python3",
         type=str,
         help="Path to Python interpreter",
     )


### PR DESCRIPTION
Replication exception will now take into account also failures when starting txns in STRICT SYNC mode. Main's number of committed transactions is now updated before replicas', to prevent negative lag situations. Negative lag can occur however if an instance without having all txns committed becomes main. Such a situation is possible in SYNC replication mode. Previously, if a situation with the negative lag occurred, that number would overflow. We now explicitly disable routing to replicas which are "in front" of main. This in front should last for a short time but it is still possible. 