### PR TITLE
refactor: Remove ranges namespace aliases from header files

### DIFF
--- a/src/storage/v2/property_value.hpp
+++ b/src/storage/v2/property_value.hpp
@@ -30,8 +30,6 @@ import memgraph.utils.fnv;
 
 #include <boost/container/flat_map.hpp>
 
-namespace r = ranges;
-
 namespace memgraph::storage {
 
 template <typename T>
@@ -1058,7 +1056,7 @@ inline auto operator<=>(const PropertyValueImpl<Alloc, KeyType, VectorIndexIdTyp
       auto const &m1 = first.ValueMap();
       auto const &m2 = second.ValueMap();
       if (m1.size() != m2.size()) return m1.size() <=> m2.size();
-      for (auto &&[v1, v2] : r::views::zip(m1, m2)) {
+      for (auto &&[v1, v2] : ranges::views::zip(m1, m2)) {
         auto key_cmp_res = v1.first <=> v2.first;
         if (key_cmp_res != std::weak_ordering::equivalent) return key_cmp_res;
         auto val_cmp_res = v1.second <=> v2.second;
@@ -1566,7 +1564,7 @@ inline PropertyValue ToPropertyValue(const ExternalPropertyValue &value, NameIdM
       typename PropertyValue::VectorIndexIdData data;
       const auto &external_vector_index_ids = value.ValueVectorIndexIds();
       data.ids.reserve(external_vector_index_ids.size());
-      r::transform(external_vector_index_ids, std::back_inserter(data.ids), [mapper](auto str) {
+      ranges::transform(external_vector_index_ids, std::back_inserter(data.ids), [mapper](auto str) {
         return mapper->NameToId(str);
       });
       data.vector = value.ValueVectorIndexList();
@@ -1623,7 +1621,7 @@ inline ExternalPropertyValue ToExternalPropertyValue(const PropertyValue &value,
       typename ExternalPropertyValue::VectorIndexIdData data;
       const auto &internal_vector_index_ids = value.ValueVectorIndexIds();
       data.ids.reserve(internal_vector_index_ids.size());
-      r::transform(
+      ranges::transform(
           internal_vector_index_ids, std::back_inserter(data.ids), [mapper](auto id) { return mapper->IdToName(id); });
       data.vector = value.ValueVectorIndexList();
       return ExternalPropertyValue(std::move(data));

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -39,9 +39,6 @@
 #include "utils/resource_lock.hpp"
 #include "utils/synchronized_metadata_store.hpp"
 
-namespace r = ranges;
-namespace rv = r::views;
-
 namespace memgraph::metrics {
 extern const Event SnapshotCreationLatency_us;
 
@@ -916,8 +913,8 @@ class Storage {
 
    private:
     std::vector<LabelId> ResolveLabels(std::span<std::string const> names) const {
-      return names | rv::transform([this](std::string_view name) { return storage_->NameToLabel(name); }) |
-             r::to<std::vector>();
+      return names | ranges::views::transform([this](std::string_view name) { return storage_->NameToLabel(name); }) |
+             ranges::to<std::vector>();
     }
 
    public:


### PR DESCRIPTION
Remove `std::ranges` namespace aliases from headers, as these leak into translation units.