### PR TITLE
feat: Make DROP GRAPH a self-contained operation across all storage modes 

### DIFF
--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -5598,20 +5598,12 @@ Callback SwitchMemoryDevice(storage::StorageMode current_mode, storage::StorageM
   return callback;
 }
 
-Callback DropGraph(memgraph::dbms::DatabaseAccess &db, DbAccessor *dba, storage::Storage::Accessor *raw_accessor) {
+Callback DropGraph(memgraph::dbms::DatabaseAccess &db, DbAccessor *dba) {
   Callback callback;
-  callback.fn = [&db, dba, raw_accessor]() mutable {
+  callback.fn = [&db, dba]() mutable {
     auto storage_mode = db->GetStorageMode();
     if (storage_mode == storage::StorageMode::ON_DISK_TRANSACTIONAL) {
       throw utils::BasicException("DROP GRAPH is not yet supported for on-disk storage.");
-    }
-
-    auto *storage = static_cast<storage::InMemoryStorage *>(db->storage());
-
-    if (storage_mode == storage::StorageMode::IN_MEMORY_TRANSACTIONAL) {
-      storage->SetStorageMode(storage::StorageMode::IN_MEMORY_ANALYTICAL,
-                              raw_accessor,
-                              /*skip_constraint_check=*/true);
     }
 
     dba->DropGraph();
@@ -5624,10 +5616,6 @@ Callback DropGraph(memgraph::dbms::DatabaseAccess &db, DbAccessor *dba, storage:
 
     auto &ttl = db->ttl();
     ttl.Disable();
-
-    if (storage_mode == storage::StorageMode::IN_MEMORY_TRANSACTIONAL) {
-      storage->SetStorageMode(storage::StorageMode::IN_MEMORY_TRANSACTIONAL, raw_accessor);
-    }
 
     auto *plan_cache = db->plan_cache();
     plan_cache->WithLock([&](auto &cache) { cache.reset(); });
@@ -5712,12 +5700,11 @@ PreparedQuery PrepareDropGraphQuery(ParsedQuery parsed_query, CurrentDB &current
 
   MG_ASSERT(current_db.db_transactional_accessor_, "Drop graph query expects a current DB transaction");
   auto *dba = &*current_db.execution_db_accessor_;
-  auto *raw_accessor = current_db.db_transactional_accessor_.get();
 
   auto *drop_graph_query = utils::Downcast<DropGraphQuery>(parsed_query.query);
   MG_ASSERT(drop_graph_query);
 
-  std::function<void()> callback = DropGraph(db_acc, dba, raw_accessor).fn;
+  std::function<void()> callback = DropGraph(db_acc, dba).fn;
 
   return PreparedQuery{
       .header = {},

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -5598,15 +5598,22 @@ Callback SwitchMemoryDevice(storage::StorageMode current_mode, storage::StorageM
   return callback;
 }
 
-Callback DropGraph(memgraph::dbms::DatabaseAccess &db, DbAccessor *dba) {
+Callback DropGraph(memgraph::dbms::DatabaseAccess &db, DbAccessor *dba, storage::Storage::Accessor *raw_accessor) {
   Callback callback;
-  callback.fn = [&db, dba]() mutable {
+  callback.fn = [&db, dba, raw_accessor]() mutable {
     auto storage_mode = db->GetStorageMode();
-    if (storage_mode != storage::StorageMode::IN_MEMORY_ANALYTICAL) {
-      throw utils::BasicException(
-          "Drop graph can only be used in the analytical mode. Switch to analytical mode by executing 'STORAGE MODE "
-          "IN_MEMORY_ANALYTICAL'");
+    if (storage_mode == storage::StorageMode::ON_DISK_TRANSACTIONAL) {
+      throw utils::BasicException("DROP GRAPH is not yet supported for on-disk storage.");
     }
+
+    auto *storage = static_cast<storage::InMemoryStorage *>(db->storage());
+
+    if (storage_mode == storage::StorageMode::IN_MEMORY_TRANSACTIONAL) {
+      storage->SetStorageMode(storage::StorageMode::IN_MEMORY_ANALYTICAL,
+                              raw_accessor,
+                              /*skip_constraint_check=*/true);
+    }
+
     dba->DropGraph();
 
     auto *trigger_store = db->trigger_store();
@@ -5617,6 +5624,13 @@ Callback DropGraph(memgraph::dbms::DatabaseAccess &db, DbAccessor *dba) {
 
     auto &ttl = db->ttl();
     ttl.Disable();
+
+    if (storage_mode == storage::StorageMode::IN_MEMORY_TRANSACTIONAL) {
+      storage->SetStorageMode(storage::StorageMode::IN_MEMORY_TRANSACTIONAL, raw_accessor);
+    }
+
+    auto *plan_cache = db->plan_cache();
+    plan_cache->WithLock([&](auto &cache) { cache.reset(); });
 
     return std::vector<std::vector<TypedValue>>();
   };
@@ -5698,11 +5712,12 @@ PreparedQuery PrepareDropGraphQuery(ParsedQuery parsed_query, CurrentDB &current
 
   MG_ASSERT(current_db.db_transactional_accessor_, "Drop graph query expects a current DB transaction");
   auto *dba = &*current_db.execution_db_accessor_;
+  auto *raw_accessor = current_db.db_transactional_accessor_.get();
 
   auto *drop_graph_query = utils::Downcast<DropGraphQuery>(parsed_query.query);
   MG_ASSERT(drop_graph_query);
 
-  std::function<void()> callback = DropGraph(db_acc, dba).fn;
+  std::function<void()> callback = DropGraph(db_acc, dba, raw_accessor).fn;
 
   return PreparedQuery{
       .header = {},

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2502,14 +2502,8 @@ Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, S
           last_durable_ts};
 }
 
-void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode, Storage::Accessor *existing_accessor,
-                                     bool skip_constraint_check) {
-  std::unique_ptr<Storage::Accessor> owned_accessor;
-  if (!existing_accessor) {
-    owned_accessor = UniqueAccess();
-  }
-  auto *accessor = existing_accessor ? existing_accessor : owned_accessor.get();
-
+void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
+  auto unique_accessor = UniqueAccess();
   MG_ASSERT(
       (storage_mode_ == StorageMode::IN_MEMORY_ANALYTICAL || storage_mode_ == StorageMode::IN_MEMORY_TRANSACTIONAL) &&
       (new_storage_mode == StorageMode::IN_MEMORY_ANALYTICAL ||
@@ -2517,14 +2511,12 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode, Storage::Acce
   if (storage_mode_ != new_storage_mode) {
     // Snapshot thread is already running, but setup periodic execution only if enabled
     if (new_storage_mode == StorageMode::IN_MEMORY_ANALYTICAL) {
-      if (!skip_constraint_check) {
-        auto active_constraints = GetActiveConstraints();
-        // Constraints violation require deltas so we can abort. Hence in analytical can not support any constraint
-        if (!active_constraints.empty()) {
-          throw utils::BasicException(
-              "Constraints are not supported in analytical storage mode. Please drop them before "
-              "changing storage mode to analytical or use transactional mode.");
-        }
+      auto active_constraints = GetActiveConstraints();
+      // Constraints violation require deltas so we can abort. Hence in analytical can not support any constraint
+      if (!active_constraints.empty()) {
+        throw utils::BasicException(
+            "Constraints are not supported in analytical storage mode. Please drop them before "
+            "changing storage mode to analytical or use transactional mode.");
       }
       // Ensure all pending work has been completed before changing to IN_MEMORY_ANALYTICAL
       async_indexer_.CompleteRemaining();
@@ -2533,7 +2525,7 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode, Storage::Acce
       // No need to resume async indexer, it is always running.
       // As IN_MEMORY_TRANSACTIONAL we will now start giving it new work
       const auto snapshot_path = durability::CreateSnapshot(this,
-                                                            accessor->GetTransaction(),
+                                                            unique_accessor->GetTransaction(),
                                                             recovery_.snapshot_directory_,
                                                             recovery_.wal_directory_,
                                                             &vertices_,
@@ -2547,9 +2539,7 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode, Storage::Acce
       snapshot_runner_.Resume();
     }
     storage_mode_ = new_storage_mode;
-    if (!existing_accessor) {
-      FreeMemory(std::unique_lock{main_lock_, std::adopt_lock}, false);
-    }
+    FreeMemory(std::unique_lock{main_lock_, std::adopt_lock}, false);
   }
 }
 
@@ -4446,10 +4436,14 @@ void InMemoryStorage::InMemoryAccessor::DropGraph() {
 
   if (mem_storage->config_.salient.items.enable_schema_info) mem_storage->schema_info_.Clear();
 
+  mem_storage->deleted_vertices_->clear();
+  mem_storage->deleted_edges_->clear();
   mem_storage->vertices_.clear();
   mem_storage->waiting_gc_deltas_->clear();
   mem_storage->edges_.clear();
   mem_storage->edge_count_.store(0, std::memory_order_release);
+  mem_storage->edges_metadata_.clear();
+  mem_storage->edges_metadata_.run_gc();
   mem_storage->description_store_.Clear();
 
   memory::PurgeUnusedMemory();

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2502,8 +2502,14 @@ Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, S
           last_durable_ts};
 }
 
-void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
-  auto unique_accessor = UniqueAccess();
+void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode, Storage::Accessor *existing_accessor,
+                                     bool skip_constraint_check) {
+  std::unique_ptr<Storage::Accessor> owned_accessor;
+  if (!existing_accessor) {
+    owned_accessor = UniqueAccess();
+  }
+  auto *accessor = existing_accessor ? existing_accessor : owned_accessor.get();
+
   MG_ASSERT(
       (storage_mode_ == StorageMode::IN_MEMORY_ANALYTICAL || storage_mode_ == StorageMode::IN_MEMORY_TRANSACTIONAL) &&
       (new_storage_mode == StorageMode::IN_MEMORY_ANALYTICAL ||
@@ -2511,12 +2517,14 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
   if (storage_mode_ != new_storage_mode) {
     // Snapshot thread is already running, but setup periodic execution only if enabled
     if (new_storage_mode == StorageMode::IN_MEMORY_ANALYTICAL) {
-      auto active_constraints = GetActiveConstraints();
-      // Constraints violation require deltas so we can abort. Hence in analytical can not support any constraint
-      if (!active_constraints.empty()) {
-        throw utils::BasicException(
-            "Constraints are not supported in analytical storage mode. Please drop them before "
-            "changing storage mode to analytical or use transactional mode.");
+      if (!skip_constraint_check) {
+        auto active_constraints = GetActiveConstraints();
+        // Constraints violation require deltas so we can abort. Hence in analytical can not support any constraint
+        if (!active_constraints.empty()) {
+          throw utils::BasicException(
+              "Constraints are not supported in analytical storage mode. Please drop them before "
+              "changing storage mode to analytical or use transactional mode.");
+        }
       }
       // Ensure all pending work has been completed before changing to IN_MEMORY_ANALYTICAL
       async_indexer_.CompleteRemaining();
@@ -2525,7 +2533,7 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
       // No need to resume async indexer, it is always running.
       // As IN_MEMORY_TRANSACTIONAL we will now start giving it new work
       const auto snapshot_path = durability::CreateSnapshot(this,
-                                                            unique_accessor->GetTransaction(),
+                                                            accessor->GetTransaction(),
                                                             recovery_.snapshot_directory_,
                                                             recovery_.wal_directory_,
                                                             &vertices_,
@@ -2539,7 +2547,9 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
       snapshot_runner_.Resume();
     }
     storage_mode_ = new_storage_mode;
-    FreeMemory(std::unique_lock{main_lock_, std::adopt_lock}, false);
+    if (!existing_accessor) {
+      FreeMemory(std::unique_lock{main_lock_, std::adopt_lock}, false);
+    }
   }
 }
 

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -744,7 +744,8 @@ class InMemoryStorage final : public Storage {
 
   Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode) override;
 
-  void SetStorageMode(StorageMode storage_mode);
+  void SetStorageMode(StorageMode storage_mode, Storage::Accessor *existing_accessor = nullptr,
+                      bool skip_constraint_check = false);
 
   const durability::Recovery &GetRecovery() const noexcept { return recovery_; }
 

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -744,8 +744,7 @@ class InMemoryStorage final : public Storage {
 
   Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode) override;
 
-  void SetStorageMode(StorageMode storage_mode, Storage::Accessor *existing_accessor = nullptr,
-                      bool skip_constraint_check = false);
+  void SetStorageMode(StorageMode storage_mode);
 
   const durability::Recovery &GetRecovery() const noexcept { return recovery_; }
 

--- a/tests/e2e/drop_queries/drop_graph.py
+++ b/tests/e2e/drop_queries/drop_graph.py
@@ -13,7 +13,6 @@ import sys
 
 import pytest
 from common import get_results_length, memgraph
-from gqlalchemy import GQLAlchemyError
 
 
 def test_create_everything_then_drop_graph(memgraph):
@@ -29,10 +28,6 @@ def test_create_everything_then_drop_graph(memgraph):
     assert get_results_length(memgraph, "SHOW INDEX INFO") == 3
     assert get_results_length(memgraph, "SHOW TRIGGERS") == 2
 
-    with pytest.raises(GQLAlchemyError):
-        memgraph.execute("DROP GRAPH")
-
-    memgraph.execute("STORAGE MODE IN_MEMORY_ANALYTICAL")
     memgraph.execute("DROP GRAPH")
 
     assert get_results_length(memgraph, "MATCH (n) RETURN n") == 0
@@ -41,12 +36,64 @@ def test_create_everything_then_drop_graph(memgraph):
     assert get_results_length(memgraph, "SHOW TRIGGERS") == 0
 
     storage_info = list(memgraph.execute_and_fetch("SHOW STORAGE INFO"))
-    print(storage_info)
     vertex_count = [x for x in storage_info if x["storage info"] == "vertex_count"][0]
     edge_count = [x for x in storage_info if x["storage info"] == "edge_count"][0]
 
     assert vertex_count["value"] == 0
     assert edge_count["value"] == 0
+
+
+def test_drop_graph_transactional_mode(memgraph):
+    memgraph.execute("CREATE (:A)-[:R]->(:B)")
+    assert get_results_length(memgraph, "MATCH (n) RETURN n") == 2
+
+    memgraph.execute("DROP GRAPH")
+
+    assert get_results_length(memgraph, "MATCH (n) RETURN n") == 0
+    assert get_results_length(memgraph, "MATCH (n)-[r]->(m) RETURN r") == 0
+
+
+def test_drop_graph_with_constraints(memgraph):
+    memgraph.execute("CREATE CONSTRAINT ON (n:Label) ASSERT EXISTS (n.prop)")
+    memgraph.execute("CREATE CONSTRAINT ON (n:Label) ASSERT n.prop IS UNIQUE")
+    memgraph.execute("CREATE (:Label {prop: 1})")
+
+    assert get_results_length(memgraph, "SHOW CONSTRAINT INFO") == 2
+    assert get_results_length(memgraph, "MATCH (n) RETURN n") == 1
+
+    memgraph.execute("DROP GRAPH")
+
+    assert get_results_length(memgraph, "MATCH (n) RETURN n") == 0
+    assert get_results_length(memgraph, "SHOW CONSTRAINT INFO") == 0
+
+
+def test_drop_graph_analytical_mode(memgraph):
+    memgraph.execute("STORAGE MODE IN_MEMORY_ANALYTICAL")
+    memgraph.execute("CREATE (:A)-[:R]->(:B)")
+    assert get_results_length(memgraph, "MATCH (n) RETURN n") == 2
+
+    memgraph.execute("DROP GRAPH")
+
+    assert get_results_length(memgraph, "MATCH (n) RETURN n") == 0
+
+
+def test_drop_graph_preserves_storage_mode(memgraph):
+    memgraph.execute("CREATE (:A)")
+    memgraph.execute("DROP GRAPH")
+
+    storage_info = list(memgraph.execute_and_fetch("SHOW STORAGE INFO"))
+    storage_mode = [x for x in storage_info if x["storage info"] == "storage_mode"][0]
+    assert storage_mode["value"] == "IN_MEMORY_TRANSACTIONAL"
+
+
+def test_drop_graph_clears_constraints(memgraph):
+    memgraph.execute("CREATE CONSTRAINT ON (n:L1) ASSERT EXISTS (n.p)")
+    memgraph.execute("CREATE CONSTRAINT ON (n:L2) ASSERT n.p IS UNIQUE")
+    assert get_results_length(memgraph, "SHOW CONSTRAINT INFO") == 2
+
+    memgraph.execute("DROP GRAPH")
+
+    assert get_results_length(memgraph, "SHOW CONSTRAINT INFO") == 0
 
 
 if __name__ == "__main__":

--- a/tests/e2e/memory/memory_control.cpp
+++ b/tests/e2e/memory/memory_control.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -34,13 +34,7 @@ int main(int argc, char **argv) {
 
   client->Execute("FREE MEMORY;");
   client->DiscardAll();
-  client->Execute("STORAGE MODE IN_MEMORY_ANALYTICAL;");
-  client->DiscardAll();
   client->Execute("DROP GRAPH;");
-  client->DiscardAll();
-  client->Execute("STORAGE MODE IN_MEMORY_TRANSACTIONAL;");
-  client->DiscardAll();
-  client->Execute("MATCH (n) DETACH DELETE n;");
   client->DiscardAll();
   client->Execute("FREE MEMORY;");
   client->DiscardAll();

--- a/tests/gql_behave/steps/graph.py
+++ b/tests/gql_behave/steps/graph.py
@@ -22,10 +22,6 @@ def clear_graph(context):
     storage_mode = next(record["value"] for record in result if record["storage info"] == "storage_mode")
     if storage_mode == "ON_DISK_TRANSACTIONAL":
         database.query("MATCH (n) DETACH DELETE n", context)
-    elif storage_mode == "IN_MEMORY_TRANSACTIONAL":
-        database.query("STORAGE MODE IN_MEMORY_ANALYTICAL", context)
-        database.query("DROP GRAPH", context)
-        database.query("STORAGE MODE IN_MEMORY_TRANSACTIONAL", context)
     else:
         database.query("DROP GRAPH", context)
     database.query("DELETE ALL PARAMETERS", context)


### PR DESCRIPTION
Fixes #4036

## Summary                                                                                              
                                                            
  - Refactored `InMemoryStorage::SetStorageMode()` to accept an optional existing accessor and constraint-check skip flag, enabling internal reuse without nested-lock deadlocks.
  - Rewrote the `DROP GRAPH` callback to internally switch to analytical mode (if needed), wipe the graph, clean up triggers/streams/TTL, restore the original storage mode with a durability snapshot, and invalidate the plan cache.
  - Added new and simplified tests that previously required manual `STORAGE MODE IN_MEMORY_ANALYTICAL` / `STORAGE MODE IN_MEMORY_TRANSACTIONAL` wrapping around `DROP GRAPH`.

## Test plan                                                                                            
                                                                                                          
  - [X] Existing `test_create_everything_then_drop_graph` passes without mode switching
  - [X] New: `test_drop_graph_transactional_mode`: succeeds in default mode                              
  - [X] New: `test_drop_graph_with_constraints`: succeeds with existence + unique constraints present
  - [X] New: `test_drop_graph_analytical_mode`: regression test for analytical path                      
  - [X] New: `test_drop_graph_preserves_storage_mode`: verifies mode restored to `IN_MEMORY_TRANSACTIONAL`                                                                               
  - [X] New: `test_drop_graph_clears_constraints`: verifies constraints are gone