### PR TITLE
fix(migrate): evict batched-query state on fetch exceptions

### DIFF
--- a/mage/python/migrate.py
+++ b/mage/python/migrate.py
@@ -42,9 +42,7 @@ class Constants:
     USERNAME = "username"
 
 
-def _get_query_hash(
-    query: str, config: mgp.Map, params: mgp.Nullable[mgp.Any] = None
-) -> str:
+def _get_query_hash(query: str, config: mgp.Map, params: mgp.Nullable[mgp.Any] = None) -> str:
     """
     Create a hash from query, config, and params to use as a cache key.
 
@@ -68,9 +66,87 @@ def _get_query_hash(
     return hashlib.sha256(hash_input.encode("utf-8")).hexdigest()
 
 
+class _BatchedQueryState:
+    """
+    Lifecycle helper for batched cross-database procedures.
+
+    State is keyed by a content hash of (query, config, params). `fetch`
+    wraps the caller's fetcher in try/except so the entry is always evicted
+    (and its resources closed) when the fetcher raises, preventing the
+    "already running" error from permanently blocking a hash after a
+    transient fetch failure.
+
+    Concurrent invocations with the same hash still raise "already running" —
+    fixing that requires exposing a per-invocation ID from the mgp binding
+    and is tracked separately.
+    """
+
+    _ALREADY_RUNNING_MSG = (
+        "Migrate module with these parameters is already running. "
+        "Please wait for it to finish before starting a new one."
+    )
+
+    def __init__(self, backend_name, closer):
+        self._name = backend_name
+        self._closer = closer
+        self._entries = {}
+
+    def start(self, query_hash, entry):
+        if query_hash in self._entries:
+            raise RuntimeError(self._ALREADY_RUNNING_MSG)
+        self._entries[query_hash] = entry
+
+    def get(self, query_hash):
+        return self._entries[query_hash]
+
+    def fetch(self, query_hash, fetcher):
+        entry = self._entries[query_hash]
+        try:
+            result = fetcher(entry)
+        except BaseException:
+            self._evict(query_hash)
+            raise
+        if not result:
+            self._evict(query_hash)
+        return result
+
+    def _evict(self, query_hash):
+        entry = self._entries.pop(query_hash, None)
+        if entry is None:
+            return
+        try:
+            self._closer(entry)
+        except Exception:
+            pass
+
+
+def _close_dbapi_entry(entry, commit=True):
+    """Close a DB-API-style entry: cursor then (optionally commit and) connection.
+    Errors during close/commit are swallowed; the helper is best-effort."""
+    cursor = entry.get(Constants.CURSOR)
+    if cursor is not None:
+        try:
+            cursor.close()
+        except Exception:
+            pass
+    conn = entry.get(Constants.CONNECTION)
+    if conn is None:
+        return
+    if commit:
+        try:
+            conn.commit()
+        except Exception:
+            pass
+    try:
+        conn.close()
+    except Exception:
+        pass
+
+
 # MYSQL
 
-mysql_dict = {}
+
+mysql_state = _BatchedQueryState("mysql", _close_dbapi_entry)
 
 
 def init_migrate_mysql(
@@ -79,8 +155,6 @@ def init_migrate_mysql(
     config_path: str = "",
     params: mgp.Nullable[mgp.Any] = None,
 ):
-    global mysql_dict
-
     if params:
         _check_params_type(params)
     if len(config_path) > 0:
@@ -91,23 +165,18 @@ def init_migrate_mysql(
 
     query_hash = _get_query_hash(table_or_sql, config, params)
 
-    # check if query is already running
-    if query_hash in mysql_dict:
-        raise RuntimeError(
-            f"Migrate module with these parameters is already running. Please wait for it to finish before starting a new one."
-        )
-
-    mysql_dict[query_hash] = {}
-
     connection = mysql_connector.connect(**config)
     cursor = connection.cursor()
     cursor.execute(table_or_sql, params=params)
 
-    mysql_dict[query_hash][Constants.CONNECTION] = connection
-    mysql_dict[query_hash][Constants.CURSOR] = cursor
-    mysql_dict[query_hash][Constants.COLUMN_NAMES] = [
-        column[Constants.I_COLUMN_NAME] for column in cursor.description
-    ]
+    mysql_state.start(
+        query_hash,
+        {
+            Constants.CONNECTION: connection,
+            Constants.CURSOR: cursor,
+            Constants.COLUMN_NAMES: [column[Constants.I_COLUMN_NAME] for column in cursor.description],
+        },
+    )
 
 
 def mysql(
@@ -132,8 +201,6 @@ def mysql(
                    `params` provides parameter values
     :return: The result table as a stream of rows
     """
-    global mysql_dict
-
     if len(config_path) > 0:
         config = _combine_config(config=config, config_path=config_path)
 
@@ -141,35 +208,16 @@ def mysql(
         table_or_sql = f"SELECT * FROM {table_or_sql};"
 
     query_hash = _get_query_hash(table_or_sql, config, params)
-    cursor = mysql_dict[query_hash][Constants.CURSOR]
-    column_names = mysql_dict[query_hash][Constants.COLUMN_NAMES]
 
-    rows = cursor.fetchmany(Constants.BATCH_SIZE)
+    def _fetch(entry):
+        rows = entry[Constants.CURSOR].fetchmany(Constants.BATCH_SIZE)
+        column_names = entry[Constants.COLUMN_NAMES]
+        return [mgp.Record(row=_name_row_cells_mysql(row, column_names)) for row in rows]
 
-    result = [mgp.Record(row=_name_row_cells_mysql(row, column_names)) for row in rows]
-
-    # if results are empty, cleanup the query since cleanup doesn't accept any parameters
-    if not result:
-        _cleanup_mysql_by_hash(query_hash)
-
-    return result
-
-
-def _cleanup_mysql_by_hash(query_hash: str):
-    """Internal cleanup function that takes a query hash."""
-    global mysql_dict
-
-    if query_hash in mysql_dict:
-        mysql_dict[query_hash][Constants.CURSOR] = None
-        mysql_dict[query_hash][Constants.CONNECTION].commit()
-        mysql_dict[query_hash][Constants.CONNECTION].close()
-        mysql_dict[query_hash][Constants.CONNECTION] = None
-        mysql_dict[query_hash][Constants.COLUMN_NAMES] = None
-        mysql_dict.pop(query_hash, None)
+    return mysql_state.fetch(query_hash, _fetch)
 
 
 def cleanup_migrate_mysql():
-    """Cleanup function called by mgp framework (no parameters)."""
     pass
 
 
@@ -177,7 +225,8 @@ mgp.add_batch_read_proc(mysql, init_migrate_mysql, cleanup_migrate_mysql)
 
 # SQL SERVER
 
-sql_server_dict = {}
+
+sql_server_state = _BatchedQueryState("sql_server", _close_dbapi_entry)
 
 
 def init_migrate_sql_server(
@@ -186,8 +235,6 @@ def init_migrate_sql_server(
     config_path: str = "",
     params: mgp.Nullable[mgp.Any] = None,
 ):
-    global sql_server_dict
-
     if params:
         _check_params_type(params, (list, tuple))
     else:
@@ -201,23 +248,18 @@ def init_migrate_sql_server(
 
     query_hash = _get_query_hash(table_or_sql, config, params)
 
-    # check if query is already running
-    if query_hash in sql_server_dict:
-        raise RuntimeError(
-            f"Migrate module with these parameters is already running. Please wait for it to finish before starting a new one."
-        )
-
-    sql_server_dict[query_hash] = {}
-
     connection = pyodbc.connect(**config)
     cursor = connection.cursor()
     cursor.execute(table_or_sql, *params)
 
-    sql_server_dict[query_hash][Constants.CONNECTION] = connection
-    sql_server_dict[query_hash][Constants.CURSOR] = cursor
-    sql_server_dict[query_hash][Constants.COLUMN_NAMES] = [
-        column[Constants.I_COLUMN_NAME] for column in cursor.description
-    ]
+    sql_server_state.start(
+        query_hash,
+        {
+            Constants.CONNECTION: connection,
+            Constants.CURSOR: cursor,
+            Constants.COLUMN_NAMES: [column[Constants.I_COLUMN_NAME] for column in cursor.description],
+        },
+    )
 
 
 def sql_server(
@@ -241,8 +283,6 @@ def sql_server(
                    `params` provides parameter values
     :return: The result table as a stream of rows
     """
-    global sql_server_dict
-
     if not params:
         params = []
 
@@ -253,34 +293,16 @@ def sql_server(
         table_or_sql = f"SELECT * FROM {table_or_sql};"
 
     query_hash = _get_query_hash(table_or_sql, config, params)
-    cursor = sql_server_dict[query_hash][Constants.CURSOR]
-    column_names = sql_server_dict[query_hash][Constants.COLUMN_NAMES]
-    rows = cursor.fetchmany(Constants.BATCH_SIZE)
 
-    result = [mgp.Record(row=_name_row_cells(row, column_names)) for row in rows]
+    def _fetch(entry):
+        rows = entry[Constants.CURSOR].fetchmany(Constants.BATCH_SIZE)
+        column_names = entry[Constants.COLUMN_NAMES]
+        return [mgp.Record(row=_name_row_cells(row, column_names)) for row in rows]
 
-    # if results are empty, cleanup the query since cleanup doesn't accept any parameters
-    if not result:
-        _cleanup_sql_server_by_hash(query_hash)
-
-    return result
-
-
-def _cleanup_sql_server_by_hash(query_hash: str):
-    """Internal cleanup function that takes a query hash."""
-    global sql_server_dict
-
-    if query_hash in sql_server_dict:
-        sql_server_dict[query_hash][Constants.CURSOR] = None
-        sql_server_dict[query_hash][Constants.CONNECTION].commit()
-        sql_server_dict[query_hash][Constants.CONNECTION].close()
-        sql_server_dict[query_hash][Constants.CONNECTION] = None
-        sql_server_dict[query_hash][Constants.COLUMN_NAMES] = None
-        sql_server_dict.pop(query_hash, None)
+    return sql_server_state.fetch(query_hash, _fetch)
 
 
 def cleanup_migrate_sql_server():
-    """Cleanup function called by mgp framework (no parameters)."""
     pass
 
 
@@ -288,7 +310,8 @@ mgp.add_batch_read_proc(sql_server, init_migrate_sql_server, cleanup_migrate_sql
 
 # Oracle DB
 
-oracle_db_dict = {}
+
+oracle_db_state = _BatchedQueryState("oracle_db", _close_dbapi_entry)
 
 
 def init_migrate_oracle_db(
@@ -297,8 +320,6 @@ def init_migrate_oracle_db(
     config_path: str = "",
     params: mgp.Nullable[mgp.Any] = None,
 ):
-    global oracle_db_dict
-
     if params:
         _check_params_type(params)
 
@@ -316,14 +337,6 @@ def init_migrate_oracle_db(
 
     query_hash = _get_query_hash(table_or_sql, config, params)
 
-    # check if query is already running
-    if query_hash in oracle_db_dict:
-        raise RuntimeError(
-            f"Migrate module with these parameters is already running. Please wait for it to finish before starting a new one."
-        )
-
-    oracle_db_dict[query_hash] = {}
-
     connection = oracledb.connect(**config)
     cursor = connection.cursor()
 
@@ -334,11 +347,14 @@ def init_migrate_oracle_db(
     else:
         cursor.execute(table_or_sql, **params)
 
-    oracle_db_dict[query_hash][Constants.CONNECTION] = connection
-    oracle_db_dict[query_hash][Constants.CURSOR] = cursor
-    oracle_db_dict[query_hash][Constants.COLUMN_NAMES] = [
-        column[Constants.I_COLUMN_NAME] for column in cursor.description
-    ]
+    oracle_db_state.start(
+        query_hash,
+        {
+            Constants.CONNECTION: connection,
+            Constants.CURSOR: cursor,
+            Constants.COLUMN_NAMES: [column[Constants.I_COLUMN_NAME] for column in cursor.description],
+        },
+    )
 
 
 def oracle_db(
@@ -362,9 +378,6 @@ def oracle_db(
                    `params` provides parameter values
     :return: The result table as a stream of rows
     """
-
-    global oracle_db_dict
-
     if len(config_path) > 0:
         config = _combine_config(config=config, config_path=config_path)
 
@@ -376,42 +389,26 @@ def oracle_db(
     config["disable_oob"] = True
 
     query_hash = _get_query_hash(table_or_sql, config, params)
-    cursor = oracle_db_dict[query_hash][Constants.CURSOR]
-    column_names = oracle_db_dict[query_hash][Constants.COLUMN_NAMES]
-    rows = cursor.fetchmany(Constants.BATCH_SIZE)
 
-    result = [mgp.Record(row=_name_row_cells(row, column_names)) for row in rows]
+    def _fetch(entry):
+        rows = entry[Constants.CURSOR].fetchmany(Constants.BATCH_SIZE)
+        column_names = entry[Constants.COLUMN_NAMES]
+        return [mgp.Record(row=_name_row_cells(row, column_names)) for row in rows]
 
-    # if results are empty, cleanup the query since cleanup doesn't accept any parameters
-    if not result:
-        _cleanup_oracle_db_by_hash(query_hash)
-
-    return result
-
-
-def _cleanup_oracle_db_by_hash(query_hash: str):
-    """Internal cleanup function that takes a query hash."""
-    global oracle_db_dict
-
-    if query_hash in oracle_db_dict:
-        oracle_db_dict[query_hash][Constants.CURSOR] = None
-        oracle_db_dict[query_hash][Constants.CONNECTION].commit()
-        oracle_db_dict[query_hash][Constants.CONNECTION].close()
-        oracle_db_dict[query_hash][Constants.CONNECTION] = None
-        oracle_db_dict[query_hash][Constants.COLUMN_NAMES] = None
-        oracle_db_dict.pop(query_hash, None)
+    return oracle_db_state.fetch(query_hash, _fetch)
 
 
 def cleanup_migrate_oracle_db():
-    """Cleanup function called by mgp framework (no parameters)."""
     pass
 
 
 mgp.add_batch_read_proc(oracle_db, init_migrate_oracle_db, cleanup_migrate_oracle_db)
 
 
-# PostgreSQL dictionary to store connections and cursors by thread
-postgres_dict = {}
+# PostgreSQL
+
+
+postgresql_state = _BatchedQueryState("postgresql", _close_dbapi_entry)
 
 
 def init_migrate_postgresql(
@@ -420,8 +417,6 @@ def init_migrate_postgresql(
     config_path: str = "",
     params: mgp.Nullable[mgp.Any] = None,
 ):
-    global postgres_dict
-
     if params:
         _check_params_type(params, (list, tuple))
     else:
@@ -435,23 +430,18 @@ def init_migrate_postgresql(
 
     query_hash = _get_query_hash(table_or_sql, config, params)
 
-    # check if query is already running
-    if query_hash in postgres_dict:
-        raise RuntimeError(
-            f"Migrate module with these parameters is already running. Please wait for it to finish before starting a new one."
-        )
-
-    postgres_dict[query_hash] = {}
-
     connection = psycopg2.connect(**config)
     cursor = connection.cursor()
     cursor.execute(table_or_sql, params)
 
-    postgres_dict[query_hash][Constants.CONNECTION] = connection
-    postgres_dict[query_hash][Constants.CURSOR] = cursor
-    postgres_dict[query_hash][Constants.COLUMN_NAMES] = [
-        column.name for column in cursor.description
-    ]
+    postgresql_state.start(
+        query_hash,
+        {
+            Constants.CONNECTION: connection,
+            Constants.CURSOR: cursor,
+            Constants.COLUMN_NAMES: [column.name for column in cursor.description],
+        },
+    )
 
 
 def postgresql(
@@ -475,8 +465,6 @@ def postgresql(
                    `params` provides parameter values
     :return: The result table as a stream of rows
     """
-    global postgres_dict
-
     if not params:
         params = []
 
@@ -487,35 +475,16 @@ def postgresql(
         table_or_sql = f"SELECT * FROM {table_or_sql};"
 
     query_hash = _get_query_hash(table_or_sql, config, params)
-    cursor = postgres_dict[query_hash][Constants.CURSOR]
-    column_names = postgres_dict[query_hash][Constants.COLUMN_NAMES]
 
-    rows = cursor.fetchmany(Constants.BATCH_SIZE)
+    def _fetch(entry):
+        rows = entry[Constants.CURSOR].fetchmany(Constants.BATCH_SIZE)
+        column_names = entry[Constants.COLUMN_NAMES]
+        return [mgp.Record(row=_name_row_cells(row, column_names)) for row in rows]
 
-    result = [mgp.Record(row=_name_row_cells(row, column_names)) for row in rows]
-
-    # if results are empty, cleanup the query since cleanup doesn't accept any parameters
-    if not result:
-        _cleanup_postgresql_by_hash(query_hash)
-
-    return result
-
-
-def _cleanup_postgresql_by_hash(query_hash: str):
-    """Internal cleanup function that takes a query hash."""
-    global postgres_dict
-
-    if query_hash in postgres_dict:
-        postgres_dict[query_hash][Constants.CURSOR] = None
-        postgres_dict[query_hash][Constants.CONNECTION].commit()
-        postgres_dict[query_hash][Constants.CONNECTION].close()
-        postgres_dict[query_hash][Constants.CONNECTION] = None
-        postgres_dict[query_hash][Constants.COLUMN_NAMES] = None
-        postgres_dict.pop(query_hash, None)
+    return postgresql_state.fetch(query_hash, _fetch)
 
 
 def cleanup_migrate_postgresql():
-    """Cleanup function called by mgp framework (no parameters)."""
     pass
 
 
@@ -523,7 +492,20 @@ mgp.add_batch_read_proc(postgresql, init_migrate_postgresql, cleanup_migrate_pos
 
 
 # S3
-s3_dict = {}
+
+
+def _close_s3_entry(entry):
+    # The CSV reader wraps a TextIOWrapper over the S3 response body.
+    # Closing it releases the underlying HTTP connection.
+    text_stream = entry.get("text_stream")
+    if text_stream is not None:
+        try:
+            text_stream.close()
+        except Exception:
+            pass
+
+
+s3_state = _BatchedQueryState("s3", _close_s3_entry)
 
 
 def init_migrate_s3(
@@ -540,8 +522,6 @@ def init_migrate_s3(
                    (access_key, secret_key, region, etc.)
     :param config_path: Path to a JSON file containing configuration parameters
     """
-    global s3_dict
-
     if len(config_path) > 0:
         config = _combine_config(config=config, config_path=config_path)
 
@@ -554,12 +534,6 @@ def init_migrate_s3(
     s3_key = "/".join(key_parts)
 
     query_hash = _get_query_hash(file_path, config)
-
-    # check if query is already running
-    if query_hash in s3_dict:
-        raise RuntimeError(
-            f"Migrate module with these parameters is already running. Please wait for it to finish before starting a new one."
-        )
 
     # Initialize S3 client
     s3_client = boto3.client(
@@ -579,9 +553,14 @@ def init_migrate_s3(
     csv_reader = csv.reader(text_stream)
     column_names = next(csv_reader)  # First row contains column names
 
-    s3_dict[query_hash] = {}
-    s3_dict[query_hash][Constants.CURSOR] = csv_reader
-    s3_dict[query_hash][Constants.COLUMN_NAMES] = column_names
+    s3_state.start(
+        query_hash,
+        {
+            Constants.CURSOR: csv_reader,
+            Constants.COLUMN_NAMES: column_names,
+            "text_stream": text_stream,
+        },
+    )
 
 
 def s3(
@@ -598,47 +577,49 @@ def s3(
     :param config_path: Optional path to a JSON file containing AWS credentials
     :return: The result table as a stream of rows
     """
-    global s3_dict
-
     if len(config_path) > 0:
         config = _combine_config(config=config, config_path=config_path)
 
     query_hash = _get_query_hash(file_path, config)
-    csv_reader = s3_dict[query_hash][Constants.CURSOR]
-    column_names = s3_dict[query_hash][Constants.COLUMN_NAMES]
 
-    batch_rows = []
-    for _ in range(Constants.BATCH_SIZE):
-        try:
-            row = next(csv_reader)
+    def _fetch(entry):
+        csv_reader = entry[Constants.CURSOR]
+        column_names = entry[Constants.COLUMN_NAMES]
+        batch_rows = []
+        for _ in range(Constants.BATCH_SIZE):
+            try:
+                row = next(csv_reader)
+            except StopIteration:
+                break
             batch_rows.append(mgp.Record(row=_name_row_cells(row, column_names)))
-        except StopIteration:
-            break
+        return batch_rows
 
-    # if results are empty, cleanup the query since cleanup doesn't accept any parameters
-    if not batch_rows:
-        _cleanup_s3_by_hash(query_hash)
-
-    return batch_rows
-
-
-def _cleanup_s3_by_hash(query_hash: str):
-    """Internal cleanup function that takes a query hash."""
-    global s3_dict
-
-    if query_hash in s3_dict:
-        s3_dict.pop(query_hash, None)
+    return s3_state.fetch(query_hash, _fetch)
 
 
 def cleanup_migrate_s3():
-    """Cleanup function called by mgp framework (no parameters)."""
     pass
 
 
 mgp.add_batch_read_proc(s3, init_migrate_s3, cleanup_migrate_s3)
 
 
-neo4j_dict = {}
+def _close_neo4j_entry(entry):
+    session = entry.get(Constants.SESSION)
+    if session is not None:
+        try:
+            session.close()
+        except Exception:
+            pass
+    driver = entry.get(Constants.DRIVER)
+    if driver is not None:
+        try:
+            driver.close()
+        except Exception:
+            pass
+
+
+neo4j_state = _BatchedQueryState("neo4j", _close_neo4j_entry)
 
 
 def init_migrate_neo4j(
@@ -647,19 +628,11 @@ def init_migrate_neo4j(
     config_path: str = "",
     params: mgp.Nullable[mgp.Any] = None,
 ):
-    global neo4j_dict
-
     if len(config_path) > 0:
         config = _combine_config(config=config, config_path=config_path)
 
     query = _formulate_cypher_query(label_or_rel_or_query)
     query_hash = _get_query_hash(query, config, params)
-
-    # check if query is already running
-    if query_hash in neo4j_dict:
-        raise RuntimeError(
-            f"Migrate module with these parameters is already running. Please wait for it to finish before starting a new one."
-        )
 
     uri = _build_neo4j_uri(config)
     username = config.get(Constants.USERNAME, "neo4j")
@@ -678,10 +651,14 @@ def init_migrate_neo4j(
     cypher_params = params if params is not None else {}
     result = session.run(query, parameters=cypher_params)
 
-    neo4j_dict[query_hash] = {}
-    neo4j_dict[query_hash][Constants.DRIVER] = driver
-    neo4j_dict[query_hash][Constants.SESSION] = session
-    neo4j_dict[query_hash][Constants.RESULT] = result
+    neo4j_state.start(
+        query_hash,
+        {
+            Constants.DRIVER: driver,
+            Constants.SESSION: session,
+            Constants.RESULT: result,
+        },
+    )
 
 
 def neo4j(
@@ -699,56 +676,41 @@ def neo4j(
     :param params: Optional query parameters
     :return: Stream of rows from Neo4j
     """
-    global neo4j_dict
-
     if len(config_path) > 0:
         config = _combine_config(config=config, config_path=config_path)
 
     query = _formulate_cypher_query(label_or_rel_or_query)
     query_hash = _get_query_hash(query, config, params)
-    result = neo4j_dict[query_hash][Constants.RESULT]
 
-    # Fetch up to BATCH_SIZE records
-    batch = []
-    for record in result:
-        # Convert neo4j.Record to dict with proper type conversion
-        batch.append(mgp.Record(row=_convert_neo4j_record(record)))
+    def _fetch(entry):
+        result = entry[Constants.RESULT]
+        batch = []
+        for record in result:
+            batch.append(mgp.Record(row=_convert_neo4j_record(record)))
+            if len(batch) >= Constants.BATCH_SIZE:
+                break
+        return batch
 
-        # Check if we've reached the batch size limit
-        if len(batch) >= Constants.BATCH_SIZE:
-            break
-
-    # if results are empty, cleanup the query since cleanup doesn't accept any parameters
-    if not batch:
-        _cleanup_neo4j_by_hash(query_hash)
-
-    return batch
-
-
-def _cleanup_neo4j_by_hash(query_hash: str):
-    """Internal cleanup function that takes a query hash."""
-    global neo4j_dict
-
-    if query_hash in neo4j_dict:
-        session = neo4j_dict[query_hash].get(Constants.SESSION)
-        driver = neo4j_dict[query_hash].get(Constants.DRIVER)
-        if session:
-            session.close()
-        if driver:
-            driver.close()
-        neo4j_dict.pop(query_hash, None)
+    return neo4j_state.fetch(query_hash, _fetch)
 
 
 def cleanup_migrate_neo4j():
-    """Cleanup function called by mgp framework (no parameters)."""
     pass
 
 
 mgp.add_batch_read_proc(neo4j, init_migrate_neo4j, cleanup_migrate_neo4j)
 
 
-# Dictionary to store Flight connections per thread
-flight_dict = {}
+def _close_arrow_flight_entry(entry):
+    client = entry.get(Constants.CONNECTION)
+    if client is not None:
+        try:
+            client.close()
+        except Exception:
+            pass
+
+
+arrow_flight_state = _BatchedQueryState("arrow_flight", _close_arrow_flight_entry)
 
 
 def init_migrate_arrow_flight(
@@ -756,18 +718,10 @@ def init_migrate_arrow_flight(
     config: mgp.Map,
     config_path: str = "",
 ):
-    global flight_dict
-
     if len(config_path) > 0:
         config = _combine_config(config=config, config_path=config_path)
 
     query_hash = _get_query_hash(query, config)
-
-    # check if query is already running
-    if query_hash in flight_dict:
-        raise RuntimeError(
-            f"Migrate module with these parameters is already running. Please wait for it to finish before starting a new one."
-        )
 
     host = config.get(Constants.HOST, None)
     port = config.get(Constants.PORT, None)
@@ -786,10 +740,12 @@ def init_migrate_arrow_flight(
 
     flight_info = client.get_flight_info(flight.FlightDescriptor.for_command(query), options)
 
-    flight_dict[query_hash] = {}
-    flight_dict[query_hash][Constants.CONNECTION] = client
-    flight_dict[query_hash][Constants.CURSOR] = iter(
-        _fetch_flight_data(client, flight_info, options)
+    arrow_flight_state.start(
+        query_hash,
+        {
+            Constants.CONNECTION: client,
+            Constants.CURSOR: iter(_fetch_flight_data(client, flight_info, options)),
+        },
     )
 
 
@@ -818,46 +774,38 @@ def arrow_flight(
     :param config_path: Path to a JSON config file
     :return: Stream of rows from Arrow Flight
     """
-    global flight_dict
-
     if len(config_path) > 0:
         config = _combine_config(config=config, config_path=config_path)
 
     query_hash = _get_query_hash(query, config)
-    cursor = flight_dict[query_hash][Constants.CURSOR]
-    batch = []
-    for _ in range(Constants.BATCH_SIZE):
-        try:
-            row = _convert_row_types(next(cursor))
+
+    def _fetch(entry):
+        cursor = entry[Constants.CURSOR]
+        batch = []
+        for _ in range(Constants.BATCH_SIZE):
+            try:
+                row = _convert_row_types(next(cursor))
+            except StopIteration:
+                break
             batch.append(mgp.Record(row=row))
-        except StopIteration:
-            break
+        return batch
 
-    # if results are empty, cleanup the query since cleanup doesn't accept any parameters
-    if not batch:
-        _cleanup_arrow_flight_by_hash(query_hash)
-
-    return batch
-
-
-def _cleanup_arrow_flight_by_hash(query_hash: str):
-    """Internal cleanup function that takes a query hash."""
-    global flight_dict
-
-    if query_hash in flight_dict:
-        flight_dict.pop(query_hash, None)
+    return arrow_flight_state.fetch(query_hash, _fetch)
 
 
 def cleanup_migrate_arrow_flight():
-    """Cleanup function called by mgp framework (no parameters)."""
     pass
 
 
 mgp.add_batch_read_proc(arrow_flight, init_migrate_arrow_flight, cleanup_migrate_arrow_flight)
 
 
-# Dictionary to store DuckDB connections and cursors per thread
-duckdb_dict = {}
+duckdb_state = _BatchedQueryState("duckdb", lambda e: _close_dbapi_entry(e, commit=False))
+
+
+def _duckdb_query_hash(query, setup_queries):
+    setup_queries_str = json.dumps(setup_queries, sort_keys=False) if setup_queries else ""
+    return hashlib.sha256(f"{query}|{setup_queries_str}".encode("utf-8")).hexdigest()
 
 
 def init_migrate_duckdb(query: str, setup_queries: mgp.Nullable[List[str]] = None):
@@ -867,21 +815,7 @@ def init_migrate_duckdb(query: str, setup_queries: mgp.Nullable[List[str]] = Non
     :param query: SQL query to execute
     :param setup_queries: Optional list of setup queries to execute before the main query
     """
-    global duckdb_dict
-
-    # Create hash from query and setup_queries
-    setup_queries_str = (
-        json.dumps(setup_queries, sort_keys=False) if setup_queries else ""
-    )
-    query_hash = hashlib.sha256(
-        f"{query}|{setup_queries_str}".encode("utf-8")
-    ).hexdigest()
-
-    # check if query is already running
-    if query_hash in duckdb_dict:
-        raise RuntimeError(
-            f"Migrate module with these parameters is already running. Please wait for it to finish before starting a new one."
-        )
+    query_hash = _duckdb_query_hash(query, setup_queries)
 
     # Ensure a fresh in-memory DuckDB instance for each query
     connection = duckDB.connect()
@@ -892,12 +826,14 @@ def init_migrate_duckdb(query: str, setup_queries: mgp.Nullable[List[str]] = Non
 
     cursor.execute(query)
 
-    duckdb_dict[query_hash] = {}
-    duckdb_dict[query_hash][Constants.CONNECTION] = connection
-    duckdb_dict[query_hash][Constants.CURSOR] = cursor
-    duckdb_dict[query_hash][Constants.COLUMN_NAMES] = [
-        desc[0] for desc in cursor.description
-    ]
+    duckdb_state.start(
+        query_hash,
+        {
+            Constants.CONNECTION: connection,
+            Constants.CURSOR: cursor,
+            Constants.COLUMN_NAMES: [desc[0] for desc in cursor.description],
+        },
+    )
 
 
 def duckdb(query: str, setup_queries: mgp.Nullable[List[str]] = None) -> mgp.Record(row=mgp.Map):
@@ -908,46 +844,33 @@ def duckdb(query: str, setup_queries: mgp.Nullable[List[str]] = None) -> mgp.Rec
     :param setup_queries: Optional list of setup queries to execute before the main query
     :return: The result table as a stream of rows
     """
-    global duckdb_dict
+    query_hash = _duckdb_query_hash(query, setup_queries)
 
-    setup_queries_str = (
-        json.dumps(setup_queries, sort_keys=False) if setup_queries else ""
-    )
-    query_hash = hashlib.sha256(
-        f"{query}|{setup_queries_str}".encode("utf-8")
-    ).hexdigest()
-    cursor = duckdb_dict[query_hash][Constants.CURSOR]
-    column_names = duckdb_dict[query_hash][Constants.COLUMN_NAMES]
+    def _fetch(entry):
+        rows = entry[Constants.CURSOR].fetchmany(Constants.BATCH_SIZE)
+        column_names = entry[Constants.COLUMN_NAMES]
+        return [mgp.Record(row=_name_row_cells(row, column_names)) for row in rows]
 
-    rows = cursor.fetchmany(Constants.BATCH_SIZE)
-    result = [mgp.Record(row=_name_row_cells(row, column_names)) for row in rows]
-
-    # if results are empty, cleanup the query since cleanup doesn't accept any parameters
-    if not result:
-        _cleanup_duckdb_by_hash(query_hash)
-
-    return result
-
-
-def _cleanup_duckdb_by_hash(query_hash: str):
-    """Internal cleanup function that takes a query hash."""
-    global duckdb_dict
-
-    if query_hash in duckdb_dict:
-        if Constants.CONNECTION in duckdb_dict[query_hash]:
-            duckdb_dict[query_hash][Constants.CONNECTION].close()
-        duckdb_dict.pop(query_hash, None)
+    return duckdb_state.fetch(query_hash, _fetch)
 
 
 def cleanup_migrate_duckdb():
-    """Cleanup function called by mgp framework (no parameters)."""
     pass
 
 
 mgp.add_batch_read_proc(duckdb, init_migrate_duckdb, cleanup_migrate_duckdb)
 
 
-memgraph_dict = {}
+def _close_memgraph_entry(entry):
+    conn = entry.get(Constants.CONNECTION)
+    if conn is not None:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+memgraph_state = _BatchedQueryState("memgraph", _close_memgraph_entry)
 
 
 def init_migrate_memgraph(
@@ -956,26 +879,19 @@ def init_migrate_memgraph(
     config_path: str = "",
     params: mgp.Nullable[mgp.Any] = None,
 ):
-    global memgraph_dict
-
     if len(config_path) > 0:
         config = _combine_config(config=config, config_path=config_path)
 
     query = _formulate_cypher_query(label_or_rel_or_query)
     query_hash = _get_query_hash(query, config, params)
 
-    # check if query is already running
-    if query_hash in memgraph_dict:
-        raise RuntimeError(
-            f"Migrate module with these parameters is already running. Please wait for it to finish before starting a new one."
-        )
-
     memgraph_db = Memgraph(**config)
     cursor = memgraph_db.execute_and_fetch(query, params)
 
-    memgraph_dict[query_hash] = {}
-    memgraph_dict[query_hash][Constants.CONNECTION] = memgraph_db
-    memgraph_dict[query_hash][Constants.CURSOR] = cursor
+    memgraph_state.start(
+        query_hash,
+        {Constants.CONNECTION: memgraph_db, Constants.CURSOR: cursor},
+    )
 
 
 def memgraph(
@@ -993,47 +909,35 @@ def memgraph(
     :param params: Optional query parameters
     :return: Stream of rows from Memgraph
     """
-    global memgraph_dict
-
     if len(config_path) > 0:
         config = _combine_config(config=config, config_path=config_path)
 
     query = _formulate_cypher_query(label_or_rel_or_query)
     query_hash = _get_query_hash(query, config, params)
-    cursor = memgraph_dict[query_hash][Constants.CURSOR]
 
-    result = [
-        mgp.Record(row=row)
-        for row in (next(cursor, None) for _ in range(Constants.BATCH_SIZE))
-        if row is not None
-    ]
+    def _fetch(entry):
+        cursor = entry[Constants.CURSOR]
+        return [
+            mgp.Record(row=row) for row in (next(cursor, None) for _ in range(Constants.BATCH_SIZE)) if row is not None
+        ]
 
-    # if results are empty, cleanup the query since cleanup doesn't accept any parameters
-    if not result:
-        _cleanup_memgraph_by_hash(query_hash)
-
-    return result
-
-
-def _cleanup_memgraph_by_hash(query_hash: str):
-    """Internal cleanup function that takes a query hash."""
-    global memgraph_dict
-
-    if query_hash in memgraph_dict:
-        if Constants.CONNECTION in memgraph_dict[query_hash]:
-            memgraph_dict[query_hash][Constants.CONNECTION].close()
-        memgraph_dict.pop(query_hash, None)
+    return memgraph_state.fetch(query_hash, _fetch)
 
 
 def cleanup_migrate_memgraph():
-    """Cleanup function called by mgp framework (no parameters)."""
     pass
 
 
 mgp.add_batch_read_proc(memgraph, init_migrate_memgraph, cleanup_migrate_memgraph)
 
 
-servicenow_dict = {}
+def _close_servicenow_entry(entry):
+    # No resource to release — the response body was already consumed into
+    # an in-memory iterator during init.
+    return
+
+
+servicenow_state = _BatchedQueryState("servicenow", _close_servicenow_entry)
 
 
 def init_migrate_servicenow(
@@ -1050,18 +954,10 @@ def init_migrate_servicenow(
     :param config_path: Optional path to a JSON file containing authentication details
     :param params: Optional query parameters for filtering results
     """
-    global servicenow_dict
-
     if len(config_path) > 0:
         config = _combine_config(config=config, config_path=config_path)
 
     query_hash = _get_query_hash(endpoint, config, params)
-
-    # check if query is already running
-    if query_hash in servicenow_dict:
-        raise RuntimeError(
-            f"Migrate module with these parameters is already running. Please wait for it to finish before starting a new one."
-        )
 
     auth = (config.get(Constants.USERNAME), config.get(Constants.PASSWORD))
     headers = {"Accept": "application/json"}
@@ -1073,8 +969,7 @@ def init_migrate_servicenow(
     if not data:
         raise ValueError("No data found in ServiceNow response")
 
-    servicenow_dict[query_hash] = {}
-    servicenow_dict[query_hash][Constants.CURSOR] = iter(data)
+    servicenow_state.start(query_hash, {Constants.CURSOR: iter(data)})
 
 
 def servicenow(
@@ -1092,39 +987,26 @@ def servicenow(
     :param params: Optional query parameters for filtering results
     :return: The result data as a stream of rows
     """
-    global servicenow_dict
-
     if len(config_path) > 0:
         config = _combine_config(config=config, config_path=config_path)
 
     query_hash = _get_query_hash(endpoint, config, params)
-    data_iter = servicenow_dict[query_hash][Constants.CURSOR]
 
-    batch_rows = []
-    for _ in range(Constants.BATCH_SIZE):
-        try:
-            row = next(data_iter)
+    def _fetch(entry):
+        data_iter = entry[Constants.CURSOR]
+        batch_rows = []
+        for _ in range(Constants.BATCH_SIZE):
+            try:
+                row = next(data_iter)
+            except StopIteration:
+                break
             batch_rows.append(mgp.Record(row=row))
-        except StopIteration:
-            break
+        return batch_rows
 
-    # if results are empty, cleanup the query since cleanup doesn't accept any parameters
-    if not batch_rows:
-        _cleanup_servicenow_by_hash(query_hash)
-
-    return batch_rows
-
-
-def _cleanup_servicenow_by_hash(query_hash: str):
-    """Internal cleanup function that takes a query hash."""
-    global servicenow_dict
-
-    if query_hash in servicenow_dict:
-        servicenow_dict.pop(query_hash, None)
+    return servicenow_state.fetch(query_hash, _fetch)
 
 
 def cleanup_migrate_servicenow():
-    """Cleanup function called by mgp framework (no parameters)."""
     pass
 
 

--- a/mage/python/tests/migrate/conftest.py
+++ b/mage/python/tests/migrate/conftest.py
@@ -1,0 +1,168 @@
+"""
+Test setup for migrate.py.
+
+migrate.py imports a dozen third-party DB drivers at module load time; in a
+test environment most of them may be absent. This conftest installs minimal
+stubs into sys.modules so `import migrate` succeeds, and the tests themselves
+patch specific symbols per backend.
+"""
+
+import os
+import sys
+import types
+
+import pytest
+
+
+def _stub(name):
+    if name in sys.modules:
+        return sys.modules[name]
+    module = types.ModuleType(name)
+    sys.modules[name] = module
+    return module
+
+
+def _install_mgp_stub():
+    if "mgp" in sys.modules:
+        return
+
+    mgp = types.ModuleType("mgp")
+
+    class _Record:
+        def __init__(self, **fields):
+            self.fields = fields
+
+        def __repr__(self):
+            return f"Record({self.fields!r})"
+
+    def _record_factory(**fields):
+        # migrate.py both constructs `mgp.Record(...)` (a record) and uses
+        # `mgp.Record(row=mgp.Map)` as a type annotation. Both go through the
+        # same callable; we just return an instance either way.
+        return _Record(**fields)
+
+    def _noop_add(*_args, **_kwargs):
+        return None
+
+    class _Subscriptable:
+        """Supports `Nullable[X]` and similar type-annotation usage."""
+
+        def __class_getitem__(cls, _item):
+            return cls
+
+    class _Nullable(_Subscriptable):
+        pass
+
+    mgp.Record = _record_factory
+    mgp.Map = dict
+    mgp.Any = object
+    mgp.Nullable = _Nullable
+    mgp.add_batch_read_proc = _noop_add
+    mgp.add_batch_write_proc = _noop_add
+    mgp.read_proc = lambda f: f
+    mgp.write_proc = lambda f: f
+
+    sys.modules["mgp"] = mgp
+
+
+def _install_driver_stubs():
+    # Each of these is imported unconditionally at the top of migrate.py.
+    # We only need stubs sufficient to let `import migrate` succeed; tests
+    # that exercise a specific backend patch the symbols they need.
+    boto3_mod = _stub("boto3")
+    boto3_mod.client = lambda *a, **kw: None
+
+    duckdb_mod = _stub("duckdb")
+    duckdb_mod.connect = lambda *a, **kw: None
+
+    mysql_mod = _stub("mysql")
+    mysql_connector = _stub("mysql.connector")
+    mysql_mod.connector = mysql_connector
+    mysql_connector.connect = lambda *a, **kw: None
+
+    oracledb_mod = _stub("oracledb")
+    oracledb_mod.connect = lambda *a, **kw: None
+
+    psycopg2_mod = _stub("psycopg2")
+    psycopg2_mod.connect = lambda *a, **kw: None
+
+    pyarrow_mod = _stub("pyarrow")
+    flight_mod = _stub("pyarrow.flight")
+    pyarrow_mod.flight = flight_mod
+    flight_mod.connect = lambda *a, **kw: None
+    flight_mod.FlightCallOptions = lambda *a, **kw: None
+
+    class _FlightDescriptor:
+        @staticmethod
+        def for_command(_q):
+            return None
+
+    flight_mod.FlightDescriptor = _FlightDescriptor
+
+    pyodbc_mod = _stub("pyodbc")
+    pyodbc_mod.connect = lambda *a, **kw: None
+
+    gqla_mod = _stub("gqlalchemy")
+
+    class _Memgraph:
+        def __init__(self, *a, **kw):
+            pass
+
+        def execute_and_fetch(self, *a, **kw):
+            return iter([])
+
+        def close(self):
+            pass
+
+    gqla_mod.Memgraph = _Memgraph
+
+    neo4j_mod = _stub("neo4j")
+
+    class _Driver:
+        def session(self, *a, **kw):
+            return None
+
+        def close(self):
+            pass
+
+    class _GraphDatabase:
+        @staticmethod
+        def driver(*a, **kw):
+            return _Driver()
+
+    neo4j_mod.GraphDatabase = _GraphDatabase
+    neo4j_time = _stub("neo4j.time")
+    neo4j_mod.time = neo4j_time
+
+    class _Neo4jDate:
+        pass
+
+    class _Neo4jDateTime:
+        pass
+
+    neo4j_time.Date = _Neo4jDate
+    neo4j_time.DateTime = _Neo4jDateTime
+
+    requests_mod = _stub("requests")
+    requests_mod.get = lambda *a, **kw: None
+
+
+_install_mgp_stub()
+_install_driver_stubs()
+
+_MIGRATE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, "migrate.py"))
+
+
+@pytest.fixture
+def migrate_module():
+    """Load migrate.py fresh for each test so module-level state dicts don't
+    leak between tests. Loaded by explicit file path to avoid colliding with
+    the `migrate` test directory name on sys.path."""
+    import importlib.util
+
+    sys.modules.pop("migrate_under_test", None)
+    spec = importlib.util.spec_from_file_location("migrate_under_test", _MIGRATE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["migrate_under_test"] = module
+    spec.loader.exec_module(module)
+    return module

--- a/mage/python/tests/migrate/test_batched_query_state.py
+++ b/mage/python/tests/migrate/test_batched_query_state.py
@@ -1,0 +1,137 @@
+"""Unit tests for the _BatchedQueryState helper in migrate.py."""
+
+import pytest
+
+HASH = "abc123"
+
+
+class _Closer:
+    """A callable closer that records each call and can be told to raise."""
+
+    def __init__(self, raises=None):
+        self.calls = []
+        self.raises = raises
+
+    def __call__(self, entry):
+        self.calls.append(entry)
+        if self.raises is not None:
+            raise self.raises
+
+
+def _make(migrate_module, **kwargs):
+    closer = _Closer(**kwargs)
+    state = migrate_module._BatchedQueryState("test", closer)
+    return state, closer
+
+
+def test_start_records_entry(migrate_module):
+    state, _ = _make(migrate_module)
+    entry = {"x": 1}
+    state.start(HASH, entry)
+    assert state.get(HASH) is entry
+
+
+def test_start_raises_if_duplicate_hash(migrate_module):
+    state, _ = _make(migrate_module)
+    state.start(HASH, {"x": 1})
+    with pytest.raises(RuntimeError, match="already running"):
+        state.start(HASH, {"x": 2})
+
+
+def test_fetch_returns_result_and_keeps_entry(migrate_module):
+    state, closer = _make(migrate_module)
+    state.start(HASH, {"rows": [1, 2, 3]})
+    result = state.fetch(HASH, lambda e: [10, 20])
+    assert result == [10, 20]
+    assert state.get(HASH)["rows"] == [1, 2, 3]
+    assert closer.calls == []
+
+
+def test_fetch_evicts_on_empty_result(migrate_module):
+    state, closer = _make(migrate_module)
+    entry = {"x": 1}
+    state.start(HASH, entry)
+    result = state.fetch(HASH, lambda e: [])
+    assert result == []
+    assert closer.calls == [entry]
+    with pytest.raises(KeyError):
+        state.get(HASH)
+
+
+def test_fetch_evicts_on_exception_and_reraises(migrate_module):
+    """The direct bug-#2 fix: an exception during fetch must evict the entry."""
+    state, closer = _make(migrate_module)
+    entry = {"x": 1}
+    state.start(HASH, entry)
+
+    class BoomError(Exception):
+        pass
+
+    def _fetcher(_entry):
+        raise BoomError("convert failed")
+
+    with pytest.raises(BoomError, match="convert failed"):
+        state.fetch(HASH, _fetcher)
+
+    assert closer.calls == [entry]
+    with pytest.raises(KeyError):
+        state.get(HASH)
+
+
+def test_closer_exception_is_swallowed_during_fetch_exception(migrate_module):
+    """If the closer itself raises while tearing down, the original fetcher
+    exception is what propagates — closer errors are silent."""
+    state, closer = _make(migrate_module, raises=RuntimeError("close failed"))
+    state.start(HASH, {"x": 1})
+
+    class BoomError(Exception):
+        pass
+
+    with pytest.raises(BoomError):
+        state.fetch(HASH, lambda _e: (_ for _ in ()).throw(BoomError()))
+
+    # Closer was called once even though it raised.
+    assert len(closer.calls) == 1
+
+
+def test_start_after_eviction_due_to_exception_succeeds(migrate_module):
+    """The user-facing bug: after a fetch exception the same hash was
+    permanently blocked. A subsequent start() must succeed."""
+    state, _ = _make(migrate_module)
+    state.start(HASH, {"x": 1})
+
+    class BoomError(Exception):
+        pass
+
+    with pytest.raises(BoomError):
+        state.fetch(HASH, lambda _e: (_ for _ in ()).throw(BoomError()))
+
+    # This used to raise "already running" before the fix.
+    state.start(HASH, {"x": 2})
+    assert state.get(HASH)["x"] == 2
+
+
+def test_start_after_eviction_on_empty_succeeds(migrate_module):
+    state, _ = _make(migrate_module)
+    state.start(HASH, {"x": 1})
+    assert state.fetch(HASH, lambda _e: []) == []
+    state.start(HASH, {"x": 2})
+    assert state.get(HASH)["x"] == 2
+
+
+def test_different_hashes_are_independent(migrate_module):
+    state, closer = _make(migrate_module)
+    state.start("h1", {"x": 1})
+    state.start("h2", {"x": 2})
+
+    class BoomError(Exception):
+        pass
+
+    with pytest.raises(BoomError):
+        state.fetch("h1", lambda _e: (_ for _ in ()).throw(BoomError()))
+
+    # h1 evicted, h2 untouched.
+    with pytest.raises(KeyError):
+        state.get("h1")
+    assert state.get("h2")["x"] == 2
+    assert len(closer.calls) == 1

--- a/mage/python/tests/migrate/test_migrate_cleanup.py
+++ b/mage/python/tests/migrate/test_migrate_cleanup.py
@@ -1,0 +1,224 @@
+"""Integration-style tests: after a fetch exception, the same query can be
+re-initialised. Before the fix a RuntimeError("already running") would block
+any retry until the module was reloaded."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _FetchBoom(Exception):
+    pass
+
+
+def _make_sql_cursor_that_explodes_on_fetch():
+    """A cursor whose description works (used during init) but whose
+    fetchmany raises on the first call (simulates conversion errors, timeouts,
+    network blips during streaming)."""
+    cursor = MagicMock()
+    cursor.description = [("col_a",), ("col_b",)]
+    cursor.fetchmany.side_effect = _FetchBoom("simulated mid-stream failure")
+    return cursor
+
+
+def _make_sql_connection(cursor):
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    return conn
+
+
+def test_mysql_eviction_on_fetch_exception(migrate_module, monkeypatch):
+    cursor = _make_sql_cursor_that_explodes_on_fetch()
+    conn = _make_sql_connection(cursor)
+    monkeypatch.setattr(migrate_module.mysql_connector, "connect", lambda **cfg: conn)
+
+    args = ("SELECT 1", {"host": "h"}, "", None)
+
+    migrate_module.init_migrate_mysql(*args)
+    with pytest.raises(_FetchBoom):
+        migrate_module.mysql(*args)
+
+    # Entry was evicted — a re-init with identical args must succeed.
+    migrate_module.init_migrate_mysql(*args)
+
+    # And the teardown path actually closed the connection.
+    assert conn.close.called
+
+
+def test_postgresql_eviction_on_fetch_exception(migrate_module, monkeypatch):
+    cursor = MagicMock()
+    # psycopg2 uses .name on description columns
+    col_a = MagicMock()
+    col_a.name = "col_a"  # noqa: E702
+    col_b = MagicMock()
+    col_b.name = "col_b"  # noqa: E702
+    cursor.description = [col_a, col_b]
+    cursor.fetchmany.side_effect = _FetchBoom("boom")
+    conn = _make_sql_connection(cursor)
+    monkeypatch.setattr(migrate_module.psycopg2, "connect", lambda **cfg: conn)
+
+    args = ("SELECT 1", {"host": "h"}, "", None)
+
+    migrate_module.init_migrate_postgresql(*args)
+    with pytest.raises(_FetchBoom):
+        migrate_module.postgresql(*args)
+
+    migrate_module.init_migrate_postgresql(*args)
+    assert conn.close.called
+
+
+def test_sql_server_eviction_on_fetch_exception(migrate_module, monkeypatch):
+    cursor = _make_sql_cursor_that_explodes_on_fetch()
+    conn = _make_sql_connection(cursor)
+    monkeypatch.setattr(migrate_module.pyodbc, "connect", lambda **cfg: conn)
+
+    args = ("SELECT 1", {"driver": "x"}, "", None)
+
+    migrate_module.init_migrate_sql_server(*args)
+    with pytest.raises(_FetchBoom):
+        migrate_module.sql_server(*args)
+
+    migrate_module.init_migrate_sql_server(*args)
+    assert conn.close.called
+
+
+def test_oracle_eviction_on_fetch_exception(migrate_module, monkeypatch):
+    cursor = _make_sql_cursor_that_explodes_on_fetch()
+    conn = _make_sql_connection(cursor)
+    monkeypatch.setattr(migrate_module.oracledb, "connect", lambda **cfg: conn)
+
+    args = ("SELECT 1", {"user": "u"}, "", None)
+
+    migrate_module.init_migrate_oracle_db(*args)
+    with pytest.raises(_FetchBoom):
+        migrate_module.oracle_db(*args)
+
+    migrate_module.init_migrate_oracle_db(*args)
+    assert conn.close.called
+
+
+def test_duckdb_eviction_on_fetch_exception(migrate_module, monkeypatch):
+    cursor = _make_sql_cursor_that_explodes_on_fetch()
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    monkeypatch.setattr(migrate_module.duckDB, "connect", lambda: conn)
+
+    query = "SELECT 1"
+    migrate_module.init_migrate_duckdb(query)
+    with pytest.raises(_FetchBoom):
+        migrate_module.duckdb(query)
+
+    migrate_module.init_migrate_duckdb(query)
+    assert conn.close.called
+
+
+def test_servicenow_eviction_on_fetch_exception(migrate_module, monkeypatch):
+    # Make init succeed, then force an error from the iterator during fetch.
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"result": [{"a": 1}, {"a": 2}]}
+    monkeypatch.setattr(
+        migrate_module.requests,
+        "get",
+        lambda *a, **kw: response,
+    )
+
+    args = ("http://example/api", {"username": "u", "password": "p"}, "", None)
+    migrate_module.init_migrate_servicenow(*args)
+
+    # Replace the cursor inside the state with our exploding iterator.
+    query_hash = migrate_module._get_query_hash("http://example/api", {"username": "u", "password": "p"}, None)
+    migrate_module.servicenow_state._entries[query_hash][migrate_module.Constants.CURSOR] = _BoomIter()
+
+    with pytest.raises(_FetchBoom):
+        migrate_module.servicenow(*args)
+
+    # Re-init must succeed.
+    migrate_module.init_migrate_servicenow(*args)
+
+
+class _BoomIter:
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        raise _FetchBoom("boom")
+
+
+def test_s3_eviction_on_fetch_exception(migrate_module, monkeypatch):
+    import io
+
+    csv_bytes = b"col_a,col_b\n1,2\n3,4\n"
+    response = {"Body": io.BytesIO(csv_bytes)}
+    s3_client = MagicMock()
+    s3_client.get_object.return_value = response
+    monkeypatch.setattr(migrate_module.boto3, "client", lambda *a, **kw: s3_client)
+
+    file_path = "s3://bucket/data.csv"
+    cfg = {"region_name": "us-east-1"}
+    migrate_module.init_migrate_s3(file_path, cfg, "")
+
+    # Replace the underlying CSV iterator with one that raises during fetch.
+    query_hash = migrate_module._get_query_hash(file_path, cfg)
+    migrate_module.s3_state._entries[query_hash][migrate_module.Constants.CURSOR] = _BoomIter()
+
+    with pytest.raises(_FetchBoom):
+        migrate_module.s3(file_path, cfg, "")
+
+    # Re-init must succeed (was previously permanently blocked).
+    # Fresh BytesIO since the previous one was consumed.
+    response["Body"] = io.BytesIO(csv_bytes)
+    migrate_module.init_migrate_s3(file_path, cfg, "")
+
+
+def test_neo4j_eviction_on_fetch_exception(migrate_module, monkeypatch):
+    session = MagicMock()
+    session.run.return_value = _BoomIter()
+    driver = MagicMock()
+    driver.session.return_value = session
+    monkeypatch.setattr(migrate_module.GraphDatabase, "driver", lambda *a, **kw: driver)
+
+    args = ("MATCH (n) RETURN n", {"host": "h"}, "", None)
+    migrate_module.init_migrate_neo4j(*args)
+    with pytest.raises(_FetchBoom):
+        migrate_module.neo4j(*args)
+
+    # Re-init succeeds and exception path closed session + driver.
+    session.run.return_value = _BoomIter()
+    migrate_module.init_migrate_neo4j(*args)
+    assert session.close.called
+    assert driver.close.called
+
+
+def test_arrow_flight_eviction_on_fetch_exception(migrate_module, monkeypatch):
+    client = MagicMock()
+    client.get_flight_info.return_value = MagicMock(endpoints=[])
+    monkeypatch.setattr(migrate_module.flight, "connect", lambda *a, **kw: client)
+    # FlightCallOptions / FlightDescriptor are already stubbed in conftest.
+
+    args = ("SELECT 1", {"host": "h", "port": 1234}, "")
+    migrate_module.init_migrate_arrow_flight(*args)
+
+    # Swap cursor with an exploding iterator.
+    query_hash = migrate_module._get_query_hash(args[0], args[1])
+    migrate_module.arrow_flight_state._entries[query_hash][migrate_module.Constants.CURSOR] = _BoomIter()
+
+    with pytest.raises(_FetchBoom):
+        migrate_module.arrow_flight(*args)
+
+    migrate_module.init_migrate_arrow_flight(*args)
+    assert client.close.called
+
+
+def test_memgraph_eviction_on_fetch_exception(migrate_module, monkeypatch):
+    mg = MagicMock()
+    mg.execute_and_fetch.return_value = _BoomIter()
+    monkeypatch.setattr(migrate_module, "Memgraph", lambda **cfg: mg)
+
+    args = ("MATCH (n) RETURN n", {"host": "h"}, "", None)
+    migrate_module.init_migrate_memgraph(*args)
+    with pytest.raises(_FetchBoom):
+        migrate_module.memgraph(*args)
+
+    migrate_module.init_migrate_memgraph(*args)
+    assert mg.close.called


### PR DESCRIPTION
Partially Fixes #3990 (Bugs 2 and 3 currently)
 
## Summary                                                
 - Bug 2 - Fixes the "already running" deadlock after a mid-stream fetch exception in `migrate.py` batched procedures.                          
 - Bug 3 - Extracts `_BatchedQueryState` so all 10 backends share one init/fetch/evict lifecycle with guaranteed cleanup on exception.
 - Adds `tests/migrate/`- unit tests on the helper plus an integration test per backend that forces a fetcher exception.