### PR TITLE
fix: clang_tidy.sh silently aborts on partial build

### DIFF
--- a/tests/code_analysis/clang_tidy.sh
+++ b/tests/code_analysis/clang_tidy.sh
@@ -100,8 +100,11 @@ fi
 # - .cppm.o and .modmap files are listed as inputs in the ninja graph
 # - .bmi (Binary Module Interface) files are build targets that clang-tidy
 #   needs to resolve `import` statements in non-module translation units
-ninja -C build -t inputs | grep -E '\.cppm\.o$|\.o\.modmap$' | xargs -r ninja -C build
-ninja -C build -t targets all | grep -oP '^[^:]*\.bmi(?=:)' | xargs -r ninja -C build
+# `|| [[ $? -eq 1 ]]` tolerates grep's "no match" (exit 1) without masking
+# real grep errors (exit 2, e.g. missing -P support or I/O failure) — those
+# still propagate and abort the script.
+ninja -C build -t inputs | { grep -E '\.cppm\.o$|\.o\.modmap$' || [[ $? -eq 1 ]]; } | xargs -r ninja -C build
+ninja -C build -t targets all | { grep -oP '^[^:]*\.bmi(?=:)' || [[ $? -eq 1 ]]; } | xargs -r ninja -C build
 
 # Merge mage's compile_commands.json into the main one if it exists
 if [[ -f "mage/cpp/build/compile_commands.json" ]]; then


### PR DESCRIPTION
## Summary

The pre-analysis steps in `tests/code_analysis/clang_tidy.sh` that build module-related artifacts (`.cppm.o`, `.o.modmap`, `.bmi`) pipe `ninja` output through `grep`. When the current local build hasn't instantiated any module targets — e.g. a fresh clone where only a single component has been built to review a diff — `grep` returns 1, `pipefail` trips the whole pipeline, and `set -e` silently aborts the script before `clang-tidy` ever runs. The only diagnostic is a confusing `Error: Script failed at line 104 with exit code 1`.

Wrap each `grep` in `{ grep ... || [[ $? -eq 1 ]]; }` so the pipeline tolerates grep's "no matches" case (exit 1) while still propagating real grep errors (exit 2 — e.g. missing `-P` support or I/O failure), which would otherwise be masked by a bare `|| true`.

The `.bmi` prebuild line was introduced in #4027; the `.cppm.o` / `.o.modmap` line pre-dates it (#3373) but has the same latent footgun and is fixed here too.

## Why this is safe

- CI is unaffected: the full build always produces `@synth_*.bmi` targets, so `grep` exits 0 there.
- The adjacent `xargs -r` already tolerates empty input on the receiving side — the missing no-match tolerance on the producing side is an oversight.
- No behavior change when there are matches; only the "no matches" case is fixed.
- Real grep errors (exit 2) still abort the script.
