### PR TITLE
fix: Address CVE-2026-39892 by updating cryptography to version 46.0.7

### DIFF
--- a/src/auth/reference_modules/requirements.txt
+++ b/src/auth/reference_modules/requirements.txt
@@ -1,4 +1,4 @@
-cryptography==46.0.5
+cryptography==46.0.7
 PyJWT==2.12.1
 requests==2.32.5
 ldap3==2.6

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -19,7 +19,7 @@ pulsar-client==3.5.0
 pyarrow==19.0.1
 PyJWT==2.10.1
 pymgclient==1.5.1
-pyopenssl==25.1.0
+pyopenssl==26.0.0
 pytest==7.3.2
 pytest-cov==6.0.0
 pytest-flake8==1.3.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 behave==1.2.6
 boto3==1.40.59
 chardet==4.0.0
-cryptography==44.0.0
+cryptography==46.0.7
 faker==37.3.0
 gensim==4.3.3
 gqlalchemy==1.8.0


### PR DESCRIPTION
Scans detected the critical vulnerability [CVE-2026-39892](https://nvd.nist.gov/vuln/detail/CVE-2026-39892) in our Docker images, updating `cryptography` to version 46.0.7 should address that. `pyopenssl` also needed upgrading to fix dependency conflict.
