### PR TITLE
refactor: Remove DBMS handler, repl state and replication handler from coordinators

### DIFF
--- a/src/dbms/inmemory/storage_helper.hpp
+++ b/src/dbms/inmemory/storage_helper.hpp
@@ -21,22 +21,18 @@ inline std::unique_ptr<storage::Storage> CreateInMemoryStorage(
     storage::Config config,
     storage::PlanInvalidatorPtr invalidator = std::make_unique<storage::PlanInvalidatorDefault>(),
     std::function<storage::DatabaseProtectorPtr()> database_protector_factory = nullptr) {
-  const bool is_coordinator = config.is_coordinator;
-
   // Use default safe factory from Storage constructor for basic usage
   auto storage = std::make_unique<storage::InMemoryStorage>(
       std::move(config), std::nullopt, std::move(invalidator), std::move(database_protector_factory));
 
-  if (!is_coordinator) {
-    storage->CreateSnapshotHandler(
-        [storage = storage.get()]() -> std::expected<void, storage::InMemoryStorage::CreateSnapshotError> {
-          auto result = storage->CreateSnapshot();
-          if (!result) {
-            return std::unexpected(result.error());
-          }
-          return {};
-        });
-  }
+  storage->CreateSnapshotHandler(
+      [storage = storage.get()]() -> std::expected<void, storage::InMemoryStorage::CreateSnapshotError> {
+        auto result = storage->CreateSnapshot();
+        if (!result) {
+          return std::unexpected(result.error());
+        }
+        return {};
+      });
 
   return storage;
 }

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -548,6 +548,8 @@ void SessionHL::BeginTransaction(const bolt_map_t &extra) {
 
 void SessionHL::Configure(const bolt_map_t &run_time_info) {
 #ifdef MG_ENTERPRISE
+  // Coordinators have no dbms_handler and no databases to switch to, so there is nothing to configure.
+  if (flags::CoordinationSetupInstance().IsCoordinator()) return;
   runtime_config_.Configure(run_time_info, interpreter_.in_explicit_transaction_);
 #else
   (void)run_time_info;
@@ -615,9 +617,6 @@ bolt_map_t SessionHL::DecodeSummary(const std::map<std::string, memgraph::query:
 
 #ifdef MG_ENTERPRISE
 void RuntimeConfig::Configure(const bolt_map_t &run_time_info, bool in_explicit_tx) {
-  // Coordinators have no dbms_handler and no databases to switch to, so there is nothing to configure.
-  if (flags::CoordinationSetupInstance().IsCoordinator()) return;
-
   // NOTE: Once in a transaction, the drivers stop explicitly sending the config and count on using it until commit
   // Runtime config is sent at the beginning of the transaction, but is missing during the transaction
   if (in_explicit_tx || (previous_run_time_info_ && run_time_info == *previous_run_time_info_)) return;

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -19,6 +19,7 @@
 #include "auth/auth.hpp"
 #include "auth/exceptions.hpp"
 #include "dbms/constants.hpp"
+#include "flags/coord_flag_env_handler.hpp"
 #include "flags/run_time_configurable.hpp"
 #include "frontend/ast/ast.hpp"
 #include "glue/SessionHL.hpp"
@@ -614,6 +615,9 @@ bolt_map_t SessionHL::DecodeSummary(const std::map<std::string, memgraph::query:
 
 #ifdef MG_ENTERPRISE
 void RuntimeConfig::Configure(const bolt_map_t &run_time_info, bool in_explicit_tx) {
+  // Coordinators have no dbms_handler and no databases to switch to, so there is nothing to configure.
+  if (flags::CoordinationSetupInstance().IsCoordinator()) return;
+
   // NOTE: Once in a transaction, the drivers stop explicitly sending the config and count on using it until commit
   // Runtime config is sent at the beginning of the transaction, but is missing during the transaction
   if (in_explicit_tx || (previous_run_time_info_ && run_time_info == *previous_run_time_info_)) return;

--- a/src/glue/communication.cpp
+++ b/src/glue/communication.cpp
@@ -118,7 +118,7 @@ storage::Result<communication::bolt::Edge> ToBoltEdge(const query::EdgeAccessor 
 storage::Result<Value> ToBoltValue(const query::TypedValue &value, const storage::Storage *db, storage::View view) {
   auto check_db = [db]() {
     if (db == nullptr) [[unlikely]]
-      throw communication::bolt::ValueException("Database needed for TypeValue conversion.");
+      throw communication::bolt::ValueException("Database needed for TypedValue conversion.");
   };
 
   switch (value.type()) {
@@ -157,7 +157,6 @@ storage::Result<Value> ToBoltValue(const query::TypedValue &value, const storage
 
     // Database is required
     case query::TypedValue::Type::List: {
-      check_db();
       std::vector<Value> values;
       values.reserve(value.ValueList().size());
       for (const auto &v : value.ValueList()) {

--- a/src/http_handlers/metrics.hpp
+++ b/src/http_handlers/metrics.hpp
@@ -123,6 +123,19 @@ class MetricsService {
   storage::Storage *const db_;
 
   MetricsResponse GetMetrics() {
+    if (!db_) {
+      return MetricsResponse{.vertex_count = 0,
+                             .edge_count = 0,
+                             .average_degree = 0,
+                             .memory_usage = 0,
+                             .peak_memory_usage = 0,
+                             .unreleased_delta_objects = 0,
+                             .disk_usage = 0,
+                             .event_counters = GetEventCounters(),
+                             .event_gauges = GetEventGauges(),
+                             .event_histograms = GetEventHistograms()};
+    }
+
     auto info = db_->GetBaseInfo();
 
     return MetricsResponse{.vertex_count = info.vertex_count,
@@ -137,7 +150,7 @@ class MetricsService {
                            .event_histograms = GetEventHistograms()};
   }
 
-  inline static nlohmann::json AsJson(MetricsResponse response) {
+  static nlohmann::json AsJson(MetricsResponse response) {
     auto metrics_response = nlohmann::json();
     const auto *general_type = "General";
 
@@ -292,7 +305,7 @@ class MetricsRequestHandler final {
     res.set(boost::beast::http::field::content_type, "application/json");
     res.content_length(size);
     res.keep_alive(req.keep_alive());
-    return send(std::move(res));
+    send(std::move(res));
   }
 
  private:

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -722,50 +722,56 @@ int main(int argc, char **argv) {
 #endif
 
   std::optional<memgraph::dbms::DbmsHandler> dbms_handler;
+#ifdef MG_ENTERPRISE
   if (!is_coordinator_instance) {
     dbms_handler.emplace(db_config);
   }
+#else
+  dbms_handler.emplace(db_config);
+#endif
 
   // singleton replication state
   // Important that repl_state gets destroyed before dbms_handler because some RPC handlers use dbms_handler
   std::optional<memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock>>
       repl_state;
 
-  if (!is_coordinator_instance) {
-    repl_state.emplace(ReplicationStateRootPath(db_config)
 #ifdef MG_ENTERPRISE
-                           ,
-                       coordinator_state && coordinator_state->IsDataInstance()
-#endif
-    );
-  }
-
-  // TTL will be stopped with StopAllBackgroundTasks in DatabaseHandler
   if (!is_coordinator_instance) {
+    repl_state.emplace(ReplicationStateRootPath(db_config), coordinator_state && coordinator_state->IsDataInstance());
+  }
+#else
+  repl_state.emplace(ReplicationStateRootPath(db_config));
+#endif
+
+// TTL will be stopped with StopAllBackgroundTasks in DatabaseHandler
+#ifdef MG_ENTERPRISE
+  if (!is_coordinator_instance) {
+#endif
     dbms_handler->ForEach([&repl_state](memgraph::dbms::DatabaseAccess db_acc) {
       db_acc->storage()->ttl_.SetUserCheck([&repl_state]() {
         const auto locked_repl_state = repl_state->ReadLock();
         return locked_repl_state->IsMainWriteable();
       });
     });
+#ifdef MG_ENTERPRISE
   }
+#endif
 
   // Note: Now that all system's subsystems are initialised (dbms & auth)
   //       We can now initialise the recovery of replication (which will include those subsystems)
   //       ReplicationHandler will handle the recovery
   std::optional<memgraph::replication::ReplicationHandler> replication_handler;
+  std::optional<memgraph::dbms::DatabaseAccess> db_acc;
+
 #ifdef MG_ENTERPRISE
   if (!is_coordinator_instance) {
     replication_handler.emplace(*repl_state, *dbms_handler, system, *auth_, *parameters);
+    db_acc.emplace(dbms_handler->Get());
   }
 #else
   replication_handler.emplace(*repl_state, *dbms_handler, system, *parameters);
+  db_acc.emplace(dbms_handler->Get());
 #endif
-
-  std::optional<memgraph::dbms::DatabaseAccess> db_acc;
-  if (!is_coordinator_instance) {
-    db_acc.emplace(dbms_handler->Get());
-  }
 
   // Global worker pool!
   // Used by sessions to schedule tasks.
@@ -817,9 +823,11 @@ int main(int argc, char **argv) {
       worker_pool_ ? &*worker_pool_ : nullptr);
 
   auto &interpreter_context_ = memgraph::query::InterpreterContextHolder::GetInstance();
+#ifdef MG_ENTERPRISE
   if (!is_coordinator_instance) {
     MG_ASSERT(db_acc.has_value(), "Failed to access the main database");
   }
+#endif
 
   memgraph::query::procedure::gModuleRegistry.SetModulesDirectory(memgraph::flags::ParseQueryModulesDirectory(),
                                                                   FLAGS_data_directory);
@@ -827,7 +835,9 @@ int main(int argc, char **argv) {
   memgraph::query::procedure::gCallableAliasMapper.LoadMapping(FLAGS_query_callable_mappings_path);
 
   // TODO Make multi-tenant
-  if (!FLAGS_init_file.empty() && !is_coordinator_instance) {
+  // No need to check here if coordinator instance because we check above that --init-file is not set on coordinator
+  // instances
+  if (!FLAGS_init_file.empty()) {
     spdlog::info("Running init file...");
 #ifdef MG_ENTERPRISE
     if (memgraph::license::global_license_checker.IsEnterpriseValidFast()) {
@@ -909,24 +919,22 @@ int main(int argc, char **argv) {
       spdlog::error("Failed to initialize telemetry. Error: {}", e.what());
       return EXIT_FAILURE;
     }
-    if (!is_coordinator_instance) {
-      telemetry->AddStorageCollector(*dbms_handler, *auth_, *parameters);
-    }
 #ifdef MG_ENTERPRISE
     if (!is_coordinator_instance) {
+      telemetry->AddStorageCollector(*dbms_handler, *auth_, *parameters);
       telemetry->AddDatabaseCollector(*dbms_handler);
+      telemetry->AddReplicationCollector(*repl_state);
     }
     telemetry->AddCoordinatorCollector(coordinator_state);
 #else
+    telemetry->AddStorageCollector(*dbms_handler, *auth_, *parameters);
     telemetry->AddDatabaseCollector();
+    telemetry->AddReplicationCollector(*repl_state);
 #endif
     telemetry->AddClientCollector();
     telemetry->AddEventsCollector();
     telemetry->AddQueryModuleCollector();
     telemetry->AddExceptionCollector();
-    if (!is_coordinator_instance) {
-      telemetry->AddReplicationCollector(*repl_state);
-    }
     telemetry->Start();
   }
   memgraph::license::LicenseInfoSender const license_info_sender(
@@ -989,13 +997,17 @@ int main(int argc, char **argv) {
 
     // Don't replicate on shutdown anymore
     {
-      // Read lock is fine because we are only shutting down all the state which should be concurrently safe to do with
-      // other operations This allow terminating current commit that is taking place
+// Read lock is fine because we are only shutting down all the state which should be concurrently safe to do with
+// other operations This allow terminating current commit that is taking place
+#ifdef MG_ENTERPRISE
       if (!is_coordinator_instance) {
+#endif
         auto locked_repl_state = repl_state->ReadLock();
         spdlog::trace("Closing repl state");
         locked_repl_state->Shutdown();
+#ifdef MG_ENTERPRISE
       }
+#endif
     }
 
     if (dbms_handler.has_value()) {

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -581,6 +581,8 @@ int main(int argc, char **argv) {
               "flag.");
   }
 
+#else
+  bool const is_coordinator_instance = false;
 #endif
 
 #ifdef MG_ENTERPRISE
@@ -722,40 +724,32 @@ int main(int argc, char **argv) {
 #endif
 
   std::optional<memgraph::dbms::DbmsHandler> dbms_handler;
-#ifdef MG_ENTERPRISE
   if (!is_coordinator_instance) {
     dbms_handler.emplace(db_config);
   }
-#else
-  dbms_handler.emplace(db_config);
-#endif
 
   // singleton replication state
   // Important that repl_state gets destroyed before dbms_handler because some RPC handlers use dbms_handler
   std::optional<memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock>>
       repl_state;
 
-#ifdef MG_ENTERPRISE
   if (!is_coordinator_instance) {
+#ifdef MG_ENTERPRISE
     repl_state.emplace(ReplicationStateRootPath(db_config), coordinator_state && coordinator_state->IsDataInstance());
-  }
 #else
-  repl_state.emplace(ReplicationStateRootPath(db_config));
+    repl_state.emplace(ReplicationStateRootPath(db_config));
 #endif
+  }
 
-// TTL will be stopped with StopAllBackgroundTasks in DatabaseHandler
-#ifdef MG_ENTERPRISE
+  // TTL will be stopped with StopAllBackgroundTasks in DatabaseHandler
   if (!is_coordinator_instance) {
-#endif
     dbms_handler->ForEach([&repl_state](memgraph::dbms::DatabaseAccess db_acc) {
       db_acc->storage()->ttl_.SetUserCheck([&repl_state]() {
         const auto locked_repl_state = repl_state->ReadLock();
         return locked_repl_state->IsMainWriteable();
       });
     });
-#ifdef MG_ENTERPRISE
   }
-#endif
 
   // Note: Now that all system's subsystems are initialised (dbms & auth)
   //       We can now initialise the recovery of replication (which will include those subsystems)
@@ -763,15 +757,14 @@ int main(int argc, char **argv) {
   std::optional<memgraph::replication::ReplicationHandler> replication_handler;
   std::optional<memgraph::dbms::DatabaseAccess> db_acc;
 
-#ifdef MG_ENTERPRISE
   if (!is_coordinator_instance) {
+#ifdef MG_ENTERPRISE
     replication_handler.emplace(*repl_state, *dbms_handler, system, *auth_, *parameters);
+#else
+    replication_handler.emplace(*repl_state, *dbms_handler, system, *parameters);
+#endif
     db_acc.emplace(dbms_handler->Get());
   }
-#else
-  replication_handler.emplace(*repl_state, *dbms_handler, system, *parameters);
-  db_acc.emplace(dbms_handler->Get());
-#endif
 
   // Global worker pool!
   // Used by sessions to schedule tasks.
@@ -823,11 +816,9 @@ int main(int argc, char **argv) {
       worker_pool_ ? &*worker_pool_ : nullptr);
 
   auto &interpreter_context_ = memgraph::query::InterpreterContextHolder::GetInstance();
-#ifdef MG_ENTERPRISE
   if (!is_coordinator_instance) {
     MG_ASSERT(db_acc.has_value(), "Failed to access the main database");
   }
-#endif
 
   memgraph::query::procedure::gModuleRegistry.SetModulesDirectory(memgraph::flags::ParseQueryModulesDirectory(),
                                                                   FLAGS_data_directory);
@@ -919,17 +910,17 @@ int main(int argc, char **argv) {
       spdlog::error("Failed to initialize telemetry. Error: {}", e.what());
       return EXIT_FAILURE;
     }
-#ifdef MG_ENTERPRISE
     if (!is_coordinator_instance) {
       telemetry->AddStorageCollector(*dbms_handler, *auth_, *parameters);
+#ifdef MG_ENTERPRISE
       telemetry->AddDatabaseCollector(*dbms_handler);
+#else
+      telemetry->AddDatabaseCollector();
+#endif
       telemetry->AddReplicationCollector(*repl_state);
     }
+#ifdef MG_ENTERPRISE
     telemetry->AddCoordinatorCollector(coordinator_state);
-#else
-    telemetry->AddStorageCollector(*dbms_handler, *auth_, *parameters);
-    telemetry->AddDatabaseCollector();
-    telemetry->AddReplicationCollector(*repl_state);
 #endif
     telemetry->AddClientCollector();
     telemetry->AddEventsCollector();
@@ -970,8 +961,8 @@ int main(int argc, char **argv) {
 #ifdef MG_ENTERPRISE
                       &coordinator_state,
                       &metrics_server,
-                      is_coordinator_instance,
 #endif
+                      is_coordinator_instance,
                       &websocket_server,
                       &server,
                       &interpreter_context_,
@@ -997,17 +988,13 @@ int main(int argc, char **argv) {
 
     // Don't replicate on shutdown anymore
     {
-// Read lock is fine because we are only shutting down all the state which should be concurrently safe to do with
-// other operations This allow terminating current commit that is taking place
-#ifdef MG_ENTERPRISE
+      // Read lock is fine because we are only shutting down all the state which should be concurrently safe to do with
+      // other operations This allow terminating current commit that is taking place
       if (!is_coordinator_instance) {
-#endif
         auto locked_repl_state = repl_state->ReadLock();
         spdlog::trace("Closing repl state");
         locked_repl_state->Shutdown();
-#ifdef MG_ENTERPRISE
       }
-#endif
     }
 
     if (dbms_handler.has_value()) {

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -144,9 +144,16 @@ void CheckSuspiciousPositionalArgs(int argc, char **argv) {
 }
 
 // TODO: move elsewhere so that we can remove need of interpreter.hpp
-void InitFromCypherlFile(memgraph::query::InterpreterContext &ctx, memgraph::dbms::DatabaseAccess &db_acc,
-                         std::string cypherl_file_path, memgraph::audit::Log *audit_log = nullptr) {
-  memgraph::query::Interpreter interpreter(&ctx, db_acc);
+void InitFromCypherlFile(memgraph::query::InterpreterContext &ctx,
+                         std::optional<memgraph::dbms::DatabaseAccess> &db_acc, std::string cypherl_file_path,
+                         memgraph::audit::Log *audit_log = nullptr) {
+  auto interpreter = std::invoke([&ctx, &db_acc]() {
+    if (db_acc.has_value()) {
+      return memgraph::query::Interpreter{&ctx, *db_acc};
+    }
+    return memgraph::query::Interpreter{&ctx};
+  });
+
   // Temporary empty user
   // TODO: Double check with buda
   memgraph::query::AllowEverythingAuthChecker tmp_auth_checker;
@@ -553,18 +560,17 @@ int main(int argc, char **argv) {
               "--storage-wal-enabled=true. One of the flags used for setting up snapshots "
               "--storage-snapshot-interval-sec or --storage-snapshot-interval also needs to be set.");
   }
-  auto const is_valid_coordinator_instance = coordination_setup.management_port &&
-                                             coordination_setup.coordinator_port && coordination_setup.coordinator_id &&
-                                             !coordination_setup.coordinator_hostname.empty();
+  auto const is_coordinator_instance = coordination_setup.management_port && coordination_setup.coordinator_port &&
+                                       coordination_setup.coordinator_id &&
+                                       !coordination_setup.coordinator_hostname.empty();
 
-  if (is_valid_coordinator_instance) {
+  if (is_coordinator_instance) {
     MG_ASSERT(
         FLAGS_init_file.empty(),
         "Coordinator instances don't support --init-file flag. Please restart the instance by removing this flag.");
     MG_ASSERT(FLAGS_init_data_file.empty(),
               "Coordinator instances don't support --init-data-file flag. Please restart the instance by removing this "
               "flag.");
-    db_config.is_coordinator = true;
   }
 
   if (coordination_setup.IsDataInstanceManagedByCoordinator()) {
@@ -671,7 +677,7 @@ int main(int argc, char **argv) {
   auto try_init_coord_state = [&coordinator_state,
                                &extracted_bolt_port,
                                &is_valid_data_instance,
-                               &is_valid_coordinator_instance](auto const &coordination_setup) {
+                               &is_coordinator_instance](auto const &coordination_setup) {
     if (!(coordination_setup.management_port || coordination_setup.coordinator_port ||
           coordination_setup.coordinator_id)) {
       spdlog::trace("Aborting coordinator initialization.");
@@ -679,7 +685,7 @@ int main(int argc, char **argv) {
     }
 
     spdlog::trace("Creating coordinator state.");
-    if (!(is_valid_coordinator_instance || is_valid_data_instance)) {
+    if (!(is_coordinator_instance || is_valid_data_instance)) {
       throw std::runtime_error(
           "You specified invalid combination of HA flags to start coordinator instance or data instance."
           "Coordinator must be started with coordinator_id, coordinator_hostname, coordinator_port and "
@@ -687,7 +693,7 @@ int main(int argc, char **argv) {
           "started only with management port.");
     }
 
-    if (is_valid_coordinator_instance) {
+    if (is_coordinator_instance) {
       constexpr auto kRaftDataDir = "/high_availability/raft_data";
       auto const high_availability_data_dir = FLAGS_data_directory + kRaftDataDir;
       memgraph::utils::EnsureDirOrDie(high_availability_data_dir);
@@ -715,37 +721,51 @@ int main(int argc, char **argv) {
 
 #endif
 
-  memgraph::dbms::DbmsHandler dbms_handler(db_config);
+  std::optional<memgraph::dbms::DbmsHandler> dbms_handler;
+  if (!is_coordinator_instance) {
+    dbms_handler.emplace(db_config);
+  }
 
   // singleton replication state
   // Important that repl_state gets destroyed before dbms_handler because some RPC handlers use dbms_handler
-  memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock> repl_state{
-      ReplicationStateRootPath(db_config)
+  std::optional<memgraph::utils::Synchronized<memgraph::replication::ReplicationState, memgraph::utils::RWSpinLock>>
+      repl_state;
+
+  if (!is_coordinator_instance) {
+    repl_state.emplace(ReplicationStateRootPath(db_config)
 #ifdef MG_ENTERPRISE
-          ,
-      coordinator_state && coordinator_state->IsDataInstance()
+                           ,
+                       coordinator_state && coordinator_state->IsDataInstance()
 #endif
-  };
+    );
+  }
 
   // TTL will be stopped with StopAllBackgroundTasks in DatabaseHandler
-  dbms_handler.ForEach([&repl_state](memgraph::dbms::DatabaseAccess db_acc) {
-    db_acc->storage()->ttl_.SetUserCheck([&repl_state]() {
-      const auto locked_repl_state = repl_state.ReadLock();
-      return locked_repl_state->IsMainWriteable();
+  if (!is_coordinator_instance) {
+    dbms_handler->ForEach([&repl_state](memgraph::dbms::DatabaseAccess db_acc) {
+      db_acc->storage()->ttl_.SetUserCheck([&repl_state]() {
+        const auto locked_repl_state = repl_state->ReadLock();
+        return locked_repl_state->IsMainWriteable();
+      });
     });
-  });
+  }
 
-// Note: Now that all system's subsystems are initialised (dbms & auth)
-//       We can now initialise the recovery of replication (which will include those subsystems)
-//       ReplicationHandler will handle the recovery
+  // Note: Now that all system's subsystems are initialised (dbms & auth)
+  //       We can now initialise the recovery of replication (which will include those subsystems)
+  //       ReplicationHandler will handle the recovery
+  std::optional<memgraph::replication::ReplicationHandler> replication_handler;
 #ifdef MG_ENTERPRISE
-  auto replication_handler = memgraph::replication::ReplicationHandler{
-      repl_state, dbms_handler, system, *auth_, *parameters, is_valid_coordinator_instance};
+  if (!is_coordinator_instance) {
+    replication_handler.emplace(*repl_state, *dbms_handler, system, *auth_, *parameters);
+  }
 #else
-  auto replication_handler = memgraph::replication::ReplicationHandler{repl_state, dbms_handler, system, *parameters};
+  replication_handler.emplace(*repl_state, *dbms_handler, system, *parameters);
 #endif
 
-  auto db_acc = dbms_handler.Get();
+  std::optional<memgraph::dbms::DatabaseAccess> db_acc;
+  if (!is_coordinator_instance) {
+    db_acc.emplace(dbms_handler->Get());
+  }
 
   // Global worker pool!
   // Used by sessions to schedule tasks.
@@ -783,8 +803,8 @@ int main(int argc, char **argv) {
       interp_config,
       settings.get(),
       parameters.get(),
-      &dbms_handler,
-      repl_state,
+      dbms_handler.has_value() ? &*dbms_handler : nullptr,
+      repl_state.has_value() ? &*repl_state : nullptr,
       system,
       &bolt_server_context,
 #ifdef MG_ENTERPRISE
@@ -793,11 +813,13 @@ int main(int argc, char **argv) {
 #endif
       auth_handler.get(),
       auth_checker.get(),
-      &replication_handler,
+      replication_handler.has_value() ? &*replication_handler : nullptr,
       worker_pool_ ? &*worker_pool_ : nullptr);
 
   auto &interpreter_context_ = memgraph::query::InterpreterContextHolder::GetInstance();
-  MG_ASSERT(db_acc, "Failed to access the main database");
+  if (!is_coordinator_instance) {
+    MG_ASSERT(db_acc.has_value(), "Failed to access the main database");
+  }
 
   memgraph::query::procedure::gModuleRegistry.SetModulesDirectory(memgraph::flags::ParseQueryModulesDirectory(),
                                                                   FLAGS_data_directory);
@@ -805,7 +827,7 @@ int main(int argc, char **argv) {
   memgraph::query::procedure::gCallableAliasMapper.LoadMapping(FLAGS_query_callable_mappings_path);
 
   // TODO Make multi-tenant
-  if (!FLAGS_init_file.empty()) {
+  if (!FLAGS_init_file.empty() && !is_coordinator_instance) {
     spdlog::info("Running init file...");
 #ifdef MG_ENTERPRISE
     if (memgraph::license::global_license_checker.IsEnterpriseValidFast()) {
@@ -828,10 +850,10 @@ int main(int argc, char **argv) {
 
   // Triggers can execute query procedures, so we need to reload the modules first and then the triggers.
   // Stream transformations use modules, so we need to restored streams after the query modules have been loaded.
-  if (db_config.durability.recover_on_startup) {
-    dbms_handler.RestoreTriggers(&interpreter_context_);
+  if (db_config.durability.recover_on_startup && dbms_handler.has_value()) {
+    dbms_handler->RestoreTriggers(&interpreter_context_);
     spdlog::trace("Triggers restored.");
-    dbms_handler.RestoreStreams(&interpreter_context_);
+    dbms_handler->RestoreStreams(&interpreter_context_);
     spdlog::trace("Streams restored.");
   }
 
@@ -845,7 +867,7 @@ int main(int argc, char **argv) {
   if (is_valid_data_instance) {
     spdlog::trace("Starting data instance management server.");
     memgraph::dbms::DataInstanceManagementServerHandlers::Register(coordinator_state->GetDataInstanceManagementServer(),
-                                                                   replication_handler);
+                                                                   *replication_handler);
     MG_ASSERT(coordinator_state->GetDataInstanceManagementServer().Start(), "Failed to start coordinator server!");
     spdlog::trace("Data instance management server started.");
   }
@@ -887,9 +909,13 @@ int main(int argc, char **argv) {
       spdlog::error("Failed to initialize telemetry. Error: {}", e.what());
       return EXIT_FAILURE;
     }
-    telemetry->AddStorageCollector(dbms_handler, *auth_, *parameters);
+    if (!is_coordinator_instance) {
+      telemetry->AddStorageCollector(*dbms_handler, *auth_, *parameters);
+    }
 #ifdef MG_ENTERPRISE
-    telemetry->AddDatabaseCollector(dbms_handler);
+    if (!is_coordinator_instance) {
+      telemetry->AddDatabaseCollector(*dbms_handler);
+    }
     telemetry->AddCoordinatorCollector(coordinator_state);
 #else
     telemetry->AddDatabaseCollector();
@@ -898,7 +924,9 @@ int main(int argc, char **argv) {
     telemetry->AddEventsCollector();
     telemetry->AddQueryModuleCollector();
     telemetry->AddExceptionCollector();
-    telemetry->AddReplicationCollector(repl_state);
+    if (!is_coordinator_instance) {
+      telemetry->AddReplicationCollector(*repl_state);
+    }
     telemetry->Start();
   }
   memgraph::license::LicenseInfoSender const license_info_sender(
@@ -923,8 +951,9 @@ int main(int argc, char **argv) {
 
 // TODO: Make multi-tenant
 #ifdef MG_ENTERPRISE
-  memgraph::glue::MonitoringServerT metrics_server{
-      {FLAGS_metrics_address, static_cast<uint16_t>(FLAGS_metrics_port)}, db_acc->storage(), &bolt_server_context};
+  memgraph::glue::MonitoringServerT metrics_server{{FLAGS_metrics_address, static_cast<uint16_t>(FLAGS_metrics_port)},
+                                                   db_acc.has_value() ? db_acc->get()->storage() : nullptr,
+                                                   &bolt_server_context};
   spdlog::trace("Metrics server created.");
 #endif
 
@@ -933,6 +962,7 @@ int main(int argc, char **argv) {
 #ifdef MG_ENTERPRISE
                       &coordinator_state,
                       &metrics_server,
+                      is_coordinator_instance,
 #endif
                       &websocket_server,
                       &server,
@@ -961,17 +991,22 @@ int main(int argc, char **argv) {
     {
       // Read lock is fine because we are only shutting down all the state which should be concurrently safe to do with
       // other operations This allow terminating current commit that is taking place
-      auto locked_repl_state = repl_state.ReadLock();
-      spdlog::trace("Closing repl state");
-      locked_repl_state->Shutdown();
+      if (!is_coordinator_instance) {
+        auto locked_repl_state = repl_state->ReadLock();
+        spdlog::trace("Closing repl state");
+        locked_repl_state->Shutdown();
+      }
     }
 
-    dbms_handler.ForEach([](memgraph::dbms::DatabaseAccess acc) {
-      spdlog::trace("Closing background tasks and deleting repl clients for db: {}", acc->name());
-      // Stop all triggers, streams and ttl
-      acc->StopAllBackgroundTasks();
-      acc->storage()->repl_storage_state_.replication_storage_clients_.WithLock([](auto &clients) { clients.clear(); });
-    });
+    if (dbms_handler.has_value()) {
+      dbms_handler->ForEach([](memgraph::dbms::DatabaseAccess acc) {
+        spdlog::trace("Closing background tasks and deleting repl clients for db: {}", acc->name());
+        // Stop all triggers, streams and ttl
+        acc->StopAllBackgroundTasks();
+        acc->storage()->repl_storage_state_.replication_storage_clients_.WithLock(
+            [](auto &clients) { clients.clear(); });
+      });
+    }
 
     // After the server is notified to stop accepting and processing
     // connections we tell the execution engine to stop processing all pending
@@ -1003,9 +1038,10 @@ int main(int argc, char **argv) {
   spdlog::trace("Metrics server started");
 #endif
 
-  if (!FLAGS_init_data_file.empty()) {
-    auto db_acc = dbms_handler.Get();
-    MG_ASSERT(db_acc, "Failed to gain access to the main database");
+  if (!FLAGS_init_data_file.empty() && dbms_handler.has_value()) {
+    std::optional<memgraph::dbms::DatabaseAccess> db_acc;
+    db_acc.emplace(dbms_handler->Get());
+    MG_ASSERT(*db_acc, "Failed to gain access to the main database");
 #ifdef MG_ENTERPRISE
     if (memgraph::license::global_license_checker.IsEnterpriseValidFast()) {
       InitFromCypherlFile(interpreter_context_, db_acc, FLAGS_init_data_file, &audit_log);

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -293,7 +293,7 @@ constexpr std::string_view kSocketErrorExplanation =
 
 #ifdef MG_ENTERPRISE
 void EnsureMainInstance(InterpreterContext *interpreter_context, const std::string &operation_name) {
-  if (interpreter_context->repl_state.ReadLock()->IsReplica()) {
+  if (interpreter_context->repl_state->ReadLock()->IsReplica()) {
     throw QueryException(
         fmt::format("{} forbidden on REPLICA! This operation must be executed on the MAIN instance.", operation_name));
   }
@@ -1022,7 +1022,7 @@ Callback HandleAuthQuery(AuthQuery *auth_query, InterpreterContext *interpreter_
   }
 
   const auto forbid_on_replica = [has_license = !license_check_result.has_value(),
-                                  is_replica = interpreter_context->repl_state.ReadLock()->IsReplica()]() {
+                                  is_replica = interpreter_context->repl_state->ReadLock()->IsReplica()]() {
     if (is_replica) {
 #if MG_ENTERPRISE
       if (has_license) {
@@ -3021,7 +3021,7 @@ PullPlan::PullPlan(const std::shared_ptr<PlanWrapper> plan, const Parameters &pa
   ctx_.frame_change_collector = frame_change_collector;
   ctx_.evaluation_context.memory = execution_memory;
   ctx_.protector = std::move(protector);
-  ctx_.is_main = interpreter_context->repl_state.ReadLock()->IsMain();
+  ctx_.is_main = interpreter_context->repl_state->ReadLock()->IsMain();
   ctx_.worker_pool = worker_pool;
 }
 
@@ -6824,6 +6824,9 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
 
   switch (info_query->info_type_) {
     case SystemInfoQuery::InfoType::STORAGE: {
+      if (interpreter_context->coordinator_state_ && interpreter_context->coordinator_state_->IsCoordinator()) {
+        throw QueryRuntimeException("Coordinators don't have storage!");
+      }
       MG_ASSERT(current_db.db_acc_, "System storage info query expects a current DB");
       header = {"storage info", "value"};
       handler = [storage = current_db.db_acc_->get()->storage(),
@@ -7261,7 +7264,7 @@ PreparedQuery PrepareMultiDatabaseQuery(ParsedQuery parsed_query, InterpreterCon
   auto *query = utils::Downcast<MultiDatabaseQuery>(parsed_query.query);
   auto *db_handler = interpreter_context->dbms_handler;
 
-  const bool is_replica = interpreter_context->repl_state.ReadLock()->IsReplica();
+  const bool is_replica = interpreter_context->repl_state->ReadLock()->IsReplica();
 
   switch (query->action_) {
     case MultiDatabaseQuery::Action::CREATE: {
@@ -7298,7 +7301,7 @@ PreparedQuery PrepareMultiDatabaseQuery(ParsedQuery parsed_query, InterpreterCon
             } else {
               res = "Successfully created database " + db_name;
               db_handler->Get(db_name)->storage()->ttl_.SetUserCheck([interpreter_context]() {
-                const auto locked_repl_state = interpreter_context->repl_state.ReadLock();
+                const auto locked_repl_state = interpreter_context->repl_state->ReadLock();
                 return locked_repl_state->IsMainWriteable();
               });
             }
@@ -8151,7 +8154,7 @@ PreparedQuery PrepareUserProfileQuery(ParsedQuery parsed_query, InterpreterConte
   }
 
   auto *query = utils::Downcast<UserProfileQuery>(parsed_query.query);
-  const bool is_replica = interpreter_context->repl_state.ReadLock()->IsReplica();
+  const bool is_replica = interpreter_context->repl_state->ReadLock()->IsReplica();
 
   Callback callback;
   // TODO: MemoryResource for EvaluationContext, it should probably be passed as
@@ -8441,7 +8444,7 @@ auto Interpreter::Route(std::map<std::string, std::string> const &routing, std::
     }
 
     auto result = RouteResult{};
-    if (interpreter_context_->repl_state.ReadLock()->IsMain()) {
+    if (interpreter_context_->repl_state->ReadLock()->IsMain()) {
       result.servers.emplace_back(std::vector<std::string>{address->second}, "WRITE");
     } else {
       result.servers.emplace_back(std::vector<std::string>{address->second}, "READ");
@@ -8833,6 +8836,19 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
       return system_txn;
     });
 
+#ifdef MG_ENTERPRISE
+    // TODO(antoniofilipovic) extend to cover Lab queries
+    // Must run before SetupDatabaseTransaction below: coordinators have no db_acc, so any query that
+    // requests a storage accessor (e.g. CypherQuery) would otherwise throw a generic "Database required"
+    // error instead of this clearer coordinator-specific message.
+    if (interpreter_context_->coordinator_state_ && interpreter_context_->coordinator_state_->IsCoordinator() &&
+        !utils::Downcast<CoordinatorQuery>(parsed_query.query) && !utils::Downcast<SettingQuery>(parsed_query.query) &&
+        !utils::Downcast<ReloadSSLQuery>(parsed_query.query) && !utils::Downcast<ShowConfigQuery>(parsed_query.query) &&
+        !utils::Downcast<SystemInfoQuery>(parsed_query.query)) {
+      throw QueryRuntimeException("Coordinator can run only coordinator queries!");
+    }
+#endif
+
     if (!in_explicit_transaction_) {
       auto storage_mode = current_db_.db_acc_
                               ? std::optional<storage::StorageMode>{(*current_db_.db_acc_)->storage()->GetStorageMode()}
@@ -8856,16 +8872,6 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
                                                        interpreter_context_->parameters,
                                                        std::string{current_db_.db_acc_->get()->uuid()});
     }
-
-#ifdef MG_ENTERPRISE
-    // TODO(antoniofilipovic) extend to cover Lab queries
-    if (interpreter_context_->coordinator_state_ && interpreter_context_->coordinator_state_->IsCoordinator() &&
-        !utils::Downcast<CoordinatorQuery>(parsed_query.query) && !utils::Downcast<SettingQuery>(parsed_query.query) &&
-        !utils::Downcast<ReloadSSLQuery>(parsed_query.query) && !utils::Downcast<ShowConfigQuery>(parsed_query.query) &&
-        !utils::Downcast<SystemInfoQuery>(parsed_query.query)) {
-      throw QueryRuntimeException("Coordinator can run only coordinator queries!");
-    }
-#endif
 
     const utils::Timer planning_timer;  // TODO: Think about moving it to Parse()
     LogQueryMessage("Query planning started!");
@@ -9052,7 +9058,7 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
     } else if (utils::Downcast<CreateSnapshotQuery>(parsed_query.query)) {
       prepared_query = PrepareCreateSnapshotQuery(std::move(parsed_query), in_explicit_transaction_, current_db_);
     } else if (utils::Downcast<RecoverSnapshotQuery>(parsed_query.query)) {
-      auto const replication_role = interpreter_context_->repl_state.ReadLock()->GetRole();
+      auto const replication_role = interpreter_context_->repl_state->ReadLock()->GetRole();
       prepared_query =
           PrepareRecoverSnapshotQuery(std::move(parsed_query), in_explicit_transaction_, current_db_, replication_role);
     } else if (utils::Downcast<ShowSnapshotsQuery>(parsed_query.query)) {
@@ -9162,12 +9168,12 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
     if (write_query) {
       // TODO: This is a catch all for operations that should not be allowed to run via user query on REPLICA
       //       prefer more explicit EnsureMainInstance(interpreter_context, "XYZ operations");
-      if (interpreter_context_->repl_state.ReadLock()->IsReplica()) {
+      if (interpreter_context_->repl_state->ReadLock()->IsReplica()) {
         query_execution = nullptr;
         throw WriteQueryOnReplicaException();
       }
 #ifdef MG_ENTERPRISE
-      if (!interpreter_context_->repl_state.ReadLock()->IsMainWriteable()) {
+      if (!interpreter_context_->repl_state->ReadLock()->IsMainWriteable()) {
         query_execution = nullptr;
         throw WriteQueryOnMainException();
       }
@@ -9367,7 +9373,7 @@ void RunTriggersAfterCommit(dbms::DatabaseAccess db_acc, InterpreterContext *int
     auto trigger_context = original_trigger_context;
     trigger_context.AdaptForAccessor(&db_accessor);
     try {
-      auto is_main = interpreter_context->repl_state.ReadLock()->IsMain();
+      auto is_main = interpreter_context->repl_state->ReadLock()->IsMain();
       trigger.Execute(&db_accessor,
                       db_acc,
                       execution_memory.resource(),
@@ -9385,7 +9391,7 @@ void RunTriggersAfterCommit(dbms::DatabaseAccess db_acc, InterpreterContext *int
     }
 
     auto maybe_commit_error = std::invoke([&]() {
-      auto locked_repl_state = interpreter_context->repl_state.ReadLock();
+      auto locked_repl_state = interpreter_context->repl_state->ReadLock();
       const bool is_main = locked_repl_state->IsMain();
       return db_accessor.Commit(make_commit_arg(is_main, db_acc));
     });
@@ -9529,7 +9535,8 @@ void Interpreter::Commit() {
     };
 
     auto const commit_method = utils::Overloaded{main_commit, replica_commit};
-    [[maybe_unused]] auto sync_result = std::visit(commit_method, interpreter_context_->repl_state->ReplicationData());
+    [[maybe_unused]] auto sync_result =
+        std::visit(commit_method, interpreter_context_->repl_state->Lock()->ReplicationData());
     // TODO: something with sync_result
     return;
   }
@@ -9598,7 +9605,7 @@ void Interpreter::Commit() {
       QueryAllocator execution_memory{};
       AdvanceCommand();
       try {
-        auto is_main = interpreter_context_->repl_state.ReadLock()->IsMain();
+        auto is_main = interpreter_context_->repl_state->ReadLock()->IsMain();
         trigger.Execute(&*current_db_.execution_db_accessor_,
                         *current_db_.db_acc_,
                         execution_memory.resource(),
@@ -9625,7 +9632,7 @@ void Interpreter::Commit() {
   };
   utils::OnScopeExit const reset_members(reset_necessary_members);
 
-  auto locked_repl_state = std::optional{interpreter_context_->repl_state.ReadLock()};
+  auto locked_repl_state = std::optional{interpreter_context_->repl_state->ReadLock()};
   bool const is_main = (*locked_repl_state)->IsMain();
   auto *curr_txn = current_db_.db_transactional_accessor_->GetTransaction();
   // if I was main with write txn which became replica, abort.

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -6824,9 +6824,11 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
 
   switch (info_query->info_type_) {
     case SystemInfoQuery::InfoType::STORAGE: {
+#ifdef MG_ENTERPRISE
       if (interpreter_context->coordinator_state_ && interpreter_context->coordinator_state_->IsCoordinator()) {
         throw QueryRuntimeException("Coordinators don't have storage!");
       }
+#endif
       MG_ASSERT(current_db.db_acc_, "System storage info query expects a current DB");
       header = {"storage info", "value"};
       handler = [storage = current_db.db_acc_->get()->storage(),

--- a/src/query/interpreter_context.cpp
+++ b/src/query/interpreter_context.cpp
@@ -28,7 +28,7 @@ std::optional<InterpreterContext> InterpreterContextHolder::instance{};
 
 InterpreterContext::InterpreterContext(InterpreterConfig interpreter_config, memgraph::utils::Settings *settings,
                                        memgraph::parameters::Parameters *parameters, dbms::DbmsHandler *dbms_handler,
-                                       utils::Synchronized<replication::ReplicationState, utils::RWSpinLock> &rs,
+                                       utils::Synchronized<replication::ReplicationState, utils::RWSpinLock> *rs,
                                        memgraph::system::System &system,
                                        communication::ServerContext *bolt_server_context,
 #ifdef MG_ENTERPRISE

--- a/src/query/interpreter_context.hpp
+++ b/src/query/interpreter_context.hpp
@@ -73,7 +73,7 @@ struct InterpreterContext {
   utils::SkipList<QueryCacheEntry> ast_cache;
 
   // GLOBAL
-  utils::Synchronized<replication::ReplicationState, utils::RWSpinLock> &repl_state;
+  utils::Synchronized<replication::ReplicationState, utils::RWSpinLock> *repl_state;
 #ifdef MG_ENTERPRISE
   coordination::CoordinatorState *coordinator_state_ = nullptr;
   utils::ResourceMonitoring *resource_monitoring;
@@ -111,7 +111,7 @@ struct InterpreterContext {
   // TODO: Make this constructor private
   InterpreterContext(InterpreterConfig interpreter_config, memgraph::utils::Settings *settings,
                      memgraph::parameters::Parameters *parameters, dbms::DbmsHandler *dbms_handler,
-                     utils::Synchronized<replication::ReplicationState, utils::RWSpinLock> &rs, system::System &system,
+                     utils::Synchronized<replication::ReplicationState, utils::RWSpinLock> *rs, system::System &system,
                      communication::ServerContext *bolt_server_context,
 #ifdef MG_ENTERPRISE
                      coordination::CoordinatorState *coordinator_state, utils::ResourceMonitoring *resource_monitoring,
@@ -132,7 +132,7 @@ class InterpreterContextHolder {
  private:
   static void Initialize(InterpreterConfig interpreter_config, utils::Settings *settings,
                          parameters::Parameters *parameters, dbms::DbmsHandler *dbms_handler,
-                         utils::Synchronized<replication::ReplicationState, utils::RWSpinLock> &rs,
+                         utils::Synchronized<replication::ReplicationState, utils::RWSpinLock> *rs,
                          system::System &system, communication::ServerContext *bolt_server_context,
 #ifdef MG_ENTERPRISE
                          coordination::CoordinatorState *coordinator_state,
@@ -174,7 +174,7 @@ class InterpreterContextHolder {
 struct InterpreterContextLifetimeControl {
   InterpreterContextLifetimeControl(InterpreterConfig interpreter_config, memgraph::utils::Settings *settings,
                                     memgraph::parameters::Parameters *parameters, dbms::DbmsHandler *dbms_handler,
-                                    utils::Synchronized<replication::ReplicationState, utils::RWSpinLock> &rs,
+                                    utils::Synchronized<replication::ReplicationState, utils::RWSpinLock> *rs,
                                     system::System &system, communication::ServerContext *bolt_server_context,
 #ifdef MG_ENTERPRISE
                                     coordination::CoordinatorState *coordinator_state,

--- a/src/replication_handler/include/replication_handler/replication_handler.hpp
+++ b/src/replication_handler/include/replication_handler/replication_handler.hpp
@@ -147,8 +147,7 @@ struct ReplicationHandler : public query::ReplicationQueryHandler {
 #ifdef MG_ENTERPRISE
   explicit ReplicationHandler(utils::Synchronized<ReplicationState, utils::RWSpinLock> &repl_state,
                               memgraph::dbms::DbmsHandler &dbms_handler, memgraph::system::System &system,
-                              memgraph::auth::SynchedAuth &auth, memgraph::parameters::Parameters &parameters,
-                              bool suppress_durability_warning = false);
+                              memgraph::auth::SynchedAuth &auth, memgraph::parameters::Parameters &parameters);
 #else
   explicit ReplicationHandler(utils::Synchronized<ReplicationState, utils::RWSpinLock> &repl_state,
                               memgraph::dbms::DbmsHandler &dbms_handler, memgraph::system::System &system,

--- a/src/replication_handler/replication_handler.cpp
+++ b/src/replication_handler/replication_handler.cpp
@@ -29,8 +29,7 @@ using namespace std::chrono_literals;
 namespace {
 #ifdef MG_ENTERPRISE
 void RecoverReplication(utils::Synchronized<ReplicationState, utils::RWSpinLock> &repl_state, system::System &system,
-                        dbms::DbmsHandler &dbms_handler, auth::SynchedAuth &auth, parameters::Parameters &parameters,
-                        bool const suppress_durability_warning = false) {
+                        dbms::DbmsHandler &dbms_handler, auth::SynchedAuth &auth, parameters::Parameters &parameters) {
   /*
    * REPLICATION RECOVERY AND STARTUP
    */
@@ -41,7 +40,7 @@ void RecoverReplication(utils::Synchronized<ReplicationState, utils::RWSpinLock>
   };
 
   // Replication recovery and frequent check start
-  auto main = [&system, &dbms_handler, &auth, &parameters, suppress_durability_warning](RoleMainData &mainData) {
+  auto main = [&system, &dbms_handler, &auth, &parameters](RoleMainData &mainData) {
     for (auto &client : mainData.registered_replicas_) {
       if (client.try_set_uuid &&
           replication_coordination_glue::SendSwapMainUUIDRpc(client.rpc_client_, mainData.uuid_)) {
@@ -60,8 +59,7 @@ void RecoverReplication(utils::Synchronized<ReplicationState, utils::RWSpinLock>
 
     // Warning
     if (dbms_handler.default_config().durability.snapshot_wal_mode ==
-            storage::Config::Durability::SnapshotWalMode::DISABLED &&
-        !suppress_durability_warning) {
+        storage::Config::Durability::SnapshotWalMode::DISABLED) {
       spdlog::warn(
           "The instance has the MAIN replication role, but durability logs and snapshots are disabled. Please "
           "consider "
@@ -187,7 +185,7 @@ void StartReplicaClient(replication::ReplicationClient &client, system::System &
 #ifdef MG_ENTERPRISE
 ReplicationHandler::ReplicationHandler(utils::Synchronized<ReplicationState, utils::RWSpinLock> &repl_state,
                                        dbms::DbmsHandler &dbms_handler, system::System &system, auth::SynchedAuth &auth,
-                                       parameters::Parameters &parameters, bool const suppress_durability_warning)
+                                       parameters::Parameters &parameters)
     : repl_state_{repl_state}, dbms_handler_{dbms_handler}, system_{system}, auth_{auth}, parameters_{parameters} {
 #else
 ReplicationHandler::ReplicationHandler(utils::Synchronized<ReplicationState, utils::RWSpinLock> &repl_state,
@@ -196,7 +194,7 @@ ReplicationHandler::ReplicationHandler(utils::Synchronized<ReplicationState, uti
     : repl_state_{repl_state}, dbms_handler_{dbms_handler}, system_{system}, parameters_{parameters} {
 #endif
 #ifdef MG_ENTERPRISE
-  RecoverReplication(repl_state_, system_, dbms_handler_, auth_, parameters_, suppress_durability_warning);
+  RecoverReplication(repl_state_, system_, dbms_handler_, auth_, parameters_);
 #else
   RecoverReplication(repl_state_, system_, dbms_handler_, parameters_);
 #endif

--- a/src/storage/v2/config.hpp
+++ b/src/storage/v2/config.hpp
@@ -127,8 +127,6 @@ struct Config {
 
   bool track_label_counts{false};
 
-  bool is_coordinator{false};  // PER INSTANCE - when true, snapshot handler is not wired up
-
   friend bool operator==(const Config &lrh, const Config &rhs) = default;
 };
 

--- a/tests/benchmark/expansion.cpp
+++ b/tests/benchmark/expansion.cpp
@@ -49,7 +49,7 @@ class ExpansionBenchFixture : public benchmark::Fixture {
                                 nullptr,
                                 nullptr,
                                 nullptr,
-                                repl_state.value(),
+                                &repl_state.value(),
                                 *system,
                                 nullptr
 #ifdef MG_ENTERPRISE

--- a/tests/e2e/high_availability/durability.py
+++ b/tests/e2e/high_availability/durability.py
@@ -11,8 +11,8 @@
 
 import os
 import sys
-import time
 from functools import partial
+from pathlib import Path
 
 import interactive_mg_runner
 import mgclient
@@ -230,7 +230,7 @@ def cleanup_after_test():
 
 
 def test_snapshots_on_coords(test_name):
-    # Set that snapshots are getting created every second
+    # Test that coords don't even have snapshot dir
     instances_description = get_instances_description_no_setup_snapshot_recovery(
         test_name=test_name, snapshot_interval_sec="1"
     )
@@ -238,11 +238,8 @@ def test_snapshots_on_coords(test_name):
 
     build_dir = os.path.join(interactive_mg_runner.PROJECT_DIR, "build", "e2e", "data")
     data_dir_coord_1 = f"{build_dir}/{get_data_path(file, test_name)}/coordinator_1"
-    snapshot_dir_coord_1 = f"{data_dir_coord_1}/snapshots"
-
-    time.sleep(3)
-
-    assert count_files(snapshot_dir_coord_1) == 0
+    snapshot_dir_coord_1 = Path(f"{data_dir_coord_1}/snapshots")
+    assert snapshot_dir_coord_1.exists() is False
 
 
 def test_snapshots_on_replica(test_name):

--- a/tests/integration/telemetry/client.cpp
+++ b/tests/integration/telemetry/client.cpp
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
                                                            nullptr,
                                                            nullptr,
                                                            &dbms_handler,
-                                                           repl_state,
+                                                           &repl_state,
                                                            system_state,
                                                            nullptr
 #ifdef MG_ENTERPRISE

--- a/tests/manual/single_query.cpp
+++ b/tests/manual/single_query.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[]) {
                                                           nullptr,
                                                           nullptr,
                                                           nullptr,
-                                                          repl_state,
+                                                          &repl_state,
                                                           system_state,
                                                           nullptr
 #ifdef MG_ENTERPRISE

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -102,7 +102,7 @@ class InterpreterTest : public ::testing::Test {
                                                           nullptr,
                                                           nullptr,
                                                           kNoHandler,
-                                                          repl_state,
+                                                          &repl_state,
                                                           system_state,
                                                           nullptr
 #ifdef MG_ENTERPRISE
@@ -1188,7 +1188,7 @@ TYPED_TEST(InterpreterTest, AllowLoadCsvConfig) {
                                                                 nullptr,
                                                                 nullptr,
                                                                 nullptr,
-                                                                repl_state,
+                                                                &repl_state,
                                                                 system_state,
                                                                 nullptr
 #ifdef MG_ENTERPRISE

--- a/tests/unit/multi_tenancy.cpp
+++ b/tests/unit/multi_tenancy.cpp
@@ -119,7 +119,7 @@ class MultiTenantTest : public ::testing::Test {
                               &settings,
                               &parameters,
                               &dbms,
-                              repl_state,
+                              &repl_state,
                               system,
                               nullptr
 #ifdef MG_ENTERPRISE

--- a/tests/unit/query_dump.cpp
+++ b/tests/unit/query_dump.cpp
@@ -445,7 +445,7 @@ class DumpTest : public ::testing::Test {
                                               nullptr,
                                               nullptr,
                                               nullptr,
-                                              repl_state,
+                                              &repl_state,
                                               system_state,
                                               nullptr
 #ifdef MG_ENTERPRISE
@@ -1284,7 +1284,7 @@ TYPED_TEST(DumpTest, CheckStateVertexWithMultipleProperties) {
                                                           nullptr,
                                                           nullptr,
                                                           nullptr,
-                                                          repl_state,
+                                                          &repl_state,
                                                           system_state,
                                                           nullptr
 #ifdef MG_ENTERPRISE
@@ -1492,7 +1492,7 @@ TYPED_TEST(DumpTest, CheckStateSimpleGraph) {
                                                           nullptr,
                                                           nullptr,
                                                           nullptr,
-                                                          repl_state,
+                                                          &repl_state,
                                                           system_state,
                                                           nullptr
 #ifdef MG_ENTERPRISE

--- a/tests/unit/query_plan_edge_cases.cpp
+++ b/tests/unit/query_plan_edge_cases.cpp
@@ -74,7 +74,7 @@ class QueryExecution : public testing::Test {
                                  nullptr,
                                  nullptr,
                                  nullptr,
-                                 repl_state.value(),
+                                 &repl_state.value(),
                                  *system_state,
                                  nullptr
 #ifdef MG_ENTERPRISE

--- a/tests/unit/query_streams.cpp
+++ b/tests/unit/query_streams.cpp
@@ -135,7 +135,7 @@ class StreamsTestFixture : public ::testing::Test {
                                                            nullptr,
                                                            nullptr,
                                                            nullptr,
-                                                           repl_state,
+                                                           &repl_state,
                                                            system_state,
                                                            nullptr,
 #ifdef MG_ENTERPRISE

--- a/tests/unit/storage_v2_storage_mode.cpp
+++ b/tests/unit/storage_v2_storage_mode.cpp
@@ -97,7 +97,7 @@ class StorageModeMultiTxTest : public ::testing::Test {
                                                           nullptr,
                                                           nullptr,
                                                           nullptr,
-                                                          repl_state,
+                                                          &repl_state,
                                                           system_state,
                                                           nullptr
 #ifdef MG_ENTERPRISE

--- a/tests/unit/transaction_queue.cpp
+++ b/tests/unit/transaction_queue.cpp
@@ -66,7 +66,7 @@ class TransactionQueueSimpleTest : public ::testing::Test {
                                                           nullptr,
                                                           nullptr,
                                                           nullptr,
-                                                          repl_state,
+                                                          &repl_state,
                                                           system_state,
                                                           nullptr
 #ifdef MG_ENTERPRISE

--- a/tests/unit/transaction_queue_multiple.cpp
+++ b/tests/unit/transaction_queue_multiple.cpp
@@ -74,7 +74,7 @@ class TransactionQueueMultipleTest : public ::testing::Test {
                                                           nullptr,
                                                           nullptr,
                                                           nullptr,
-                                                          repl_state,
+                                                          &repl_state,
                                                           system_state,
                                                           nullptr
 #ifdef MG_ENTERPRISE

--- a/tests/unit/ttl.cpp
+++ b/tests/unit/ttl.cpp
@@ -194,7 +194,7 @@ class TTLFixture : public ::testing::Test {
                                                            nullptr,
                                                            nullptr,
                                                            nullptr,
-                                                           repl_state,
+                                                           &repl_state,
                                                            system_state,
                                                            nullptr,
 #ifdef MG_ENTERPRISE


### PR DESCRIPTION
Code components dbms handler, replication state and replication handler are now nullopt for coordinator instances. This should make coordinators more stable because of independence with the disk for example, easier to run and manage. 
Fixes the bug in which storage was always required for List TypedValue. 

