### PR TITLE
experiment: precompiled headers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 # CMake configuration for the main memgraph library and executable
 
 # add memgraph sub libraries, ordered by dependency
+add_subdirectory(pch)
 add_subdirectory(csv)
 add_subdirectory(utils)
 add_subdirectory(parameters)

--- a/src/auth/CMakeLists.txt
+++ b/src/auth/CMakeLists.txt
@@ -18,6 +18,8 @@ target_link_libraries(mg-auth
     mg-utils mg::system mg-slk ${Seccomp_LIBRARIES} openssl::openssl)
 target_include_directories(mg-auth SYSTEM PRIVATE ${Seccomp_INCLUDE_DIRS})
 
+target_precompile_headers(mg-auth REUSE_FROM mg-pch-base)
+
 # Install reference auth modules and their configuration files.
 install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/reference_modules/common.py
         DESTINATION lib/memgraph/auth_module)

--- a/src/communication/CMakeLists.txt
+++ b/src/communication/CMakeLists.txt
@@ -29,3 +29,5 @@ target_sources(mg-communication
 target_link_libraries(mg-communication
     PUBLIC Boost::headers mg-io mg-utils gflags
     PRIVATE Threads::Threads mg-auth fmt::fmt mg-communication-metrics mg-events openssl::openssl)
+
+target_precompile_headers(mg-communication REUSE_FROM mg-pch-base)

--- a/src/coordination/CMakeLists.txt
+++ b/src/coordination/CMakeLists.txt
@@ -68,3 +68,5 @@ find_package(range-v3 REQUIRED)
 target_link_libraries(mg-coordination
     PUBLIC mg::utils mg::rpc mg::slk mg::io mg::repl_coord_glue range-v3::range-v3 nuraft mg-replication_handler
 )
+
+target_precompile_headers(mg-coordination REUSE_FROM mg-pch-base)

--- a/src/dbms/CMakeLists.txt
+++ b/src/dbms/CMakeLists.txt
@@ -18,3 +18,5 @@ target_sources(mg-dbms
 )
 
 target_link_libraries(mg-dbms PUBLIC mg-utils mg::storage mg-query mg-auth mg-replication PRIVATE mg-coordination)
+
+target_precompile_headers(mg-dbms REUSE_FROM mg-pch-heavy)

--- a/src/glue/CMakeLists.txt
+++ b/src/glue/CMakeLists.txt
@@ -9,3 +9,5 @@ target_sources(mg-glue PRIVATE auth.cpp
                                run_id.cpp
                                query_user.cpp)
 target_link_libraries(mg-glue PRIVATE mg-query mg-auth mg-audit mg-flags)
+
+target_precompile_headers(mg-glue REUSE_FROM mg-pch-base)

--- a/src/pch/CMakeLists.txt
+++ b/src/pch/CMakeLists.txt
@@ -1,0 +1,62 @@
+# Precompiled header donor targets.
+#
+# Two donors for different consumer groups:
+#   - mg-pch-base: the 17 stdlib/fmt/spdlog headers universally hot across
+#     memgraph libraries (>=70% TU coverage in every consumer).
+#   - mg-pch-heavy: base + absl/flat_hash_map.h + boost/container_hash/hash.hpp,
+#     which are 69-88% hot in mg-query/mg-storage-v2/mg-dbms but rare elsewhere.
+#
+# Consumers attach via `target_precompile_headers(<target> REUSE_FROM mg-pch-*)`,
+# sharing the compiled .pch binary instead of each building their own.
+
+add_library(mg-pch-base STATIC pch_dummy.cpp)
+target_precompile_headers(mg-pch-base PRIVATE
+    <chrono>
+    <filesystem>
+    <format>
+    <istream>
+    <memory>
+    <optional>
+    <ostream>
+    <ranges>
+    <sstream>
+    <string>
+    <unordered_map>
+    <vector>
+    <fmt/chrono.h>
+    <fmt/format.h>
+    <fmt/ostream.h>
+    <spdlog/common.h>
+    <spdlog/spdlog.h>
+)
+
+add_library(mg-pch-heavy STATIC pch_dummy.cpp)
+target_precompile_headers(mg-pch-heavy PRIVATE
+    <chrono>
+    <filesystem>
+    <format>
+    <istream>
+    <memory>
+    <optional>
+    <ostream>
+    <ranges>
+    <sstream>
+    <string>
+    <unordered_map>
+    <vector>
+    <fmt/chrono.h>
+    <fmt/format.h>
+    <fmt/ostream.h>
+    <spdlog/common.h>
+    <spdlog/spdlog.h>
+    <absl/container/flat_hash_map.h>
+    <boost/container_hash/hash.hpp>
+)
+
+# PCH donors need to see the same include paths as consumers for fmt/spdlog/absl/boost.
+find_package(fmt REQUIRED)
+find_package(spdlog REQUIRED)
+find_package(absl REQUIRED)
+find_package(Boost REQUIRED)
+target_link_libraries(mg-pch-base PRIVATE fmt::fmt spdlog::spdlog)
+target_link_libraries(mg-pch-heavy PRIVATE fmt::fmt spdlog::spdlog abseil::abseil Boost::headers)

--- a/src/pch/pch_dummy.cpp
+++ b/src/pch/pch_dummy.cpp
@@ -1,0 +1,12 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Placeholder source so the PCH donor targets have something to compile.

--- a/src/query/CMakeLists.txt
+++ b/src/query/CMakeLists.txt
@@ -227,3 +227,5 @@ target_include_directories(antlr_opencypher_parser_lib PUBLIC ${antlr4-runtime_I
 target_link_libraries(antlr_opencypher_parser_lib PRIVATE antlr4_static)
 
 target_link_libraries(mg-query PUBLIC antlr_opencypher_parser_lib)
+
+target_precompile_headers(mg-query REUSE_FROM mg-pch-heavy)

--- a/src/query/common.hpp
+++ b/src/query/common.hpp
@@ -14,10 +14,10 @@
 
 #include <concepts>
 #include <cstdint>
+#include <ranges>
 #include <string>
 #include <string_view>
 
-#include <range/v3/view/zip.hpp>
 #include "query/exceptions.hpp"
 #include "query/fmt.hpp"
 #include "query/frontend/ast/ordering.hpp"
@@ -152,7 +152,7 @@ class TypedValueVectorCompare final {
   auto lex_cmp() const {
     return [orderings = &orderings_]<typename TAllocator>(const std::vector<TypedValue, TAllocator> &lhs,
                                                           const std::vector<TypedValue, TAllocator> &rhs) {
-      auto rng = ranges::views::zip(*orderings, lhs, rhs);
+      auto rng = std::views::zip(*orderings, lhs, rhs);
       for (auto const &[cmp, l, r] : rng) {
         auto res = cmp(l, r);
         if (res == std::partial_ordering::less) return true;

--- a/src/query/frontend/ast/ast.hpp
+++ b/src/query/frontend/ast/ast.hpp
@@ -12,7 +12,7 @@
 #pragma once
 
 #include <memory>
-#include <range/v3/view/transform.hpp>
+#include <ranges>
 #include <unordered_map>
 #include <variant>
 #include <vector>
@@ -2054,9 +2054,7 @@ struct PropertyIxPath {
 
   std::vector<memgraph::query::PropertyIx> path;
 
-  auto AsPathString() const -> std::string {
-    return utils::Join(path | ranges::views::transform(&PropertyIx::name), ".");
-  }
+  auto AsPathString() const -> std::string { return utils::Join(path | std::views::transform(&PropertyIx::name), "."); }
 
   auto Clone(AstStorage *storage) const -> PropertyIxPath;
   friend bool operator==(PropertyIxPath const &, PropertyIxPath const &) = default;

--- a/src/query/typed_value.hpp
+++ b/src/query/typed_value.hpp
@@ -23,7 +23,6 @@
 #include "query/path.hpp"
 #include "utils/exceptions.hpp"
 #include "utils/memory.hpp"
-#include "utils/pmr/flat_map.hpp"
 #include "utils/pmr/string.hpp"
 #include "utils/pmr/vector.hpp"
 #include "utils/temporal.hpp"

--- a/src/replication/CMakeLists.txt
+++ b/src/replication/CMakeLists.txt
@@ -27,3 +27,5 @@ target_link_libraries(mg-replication
     PUBLIC mg::utils mg::kvstore nlohmann_json::nlohmann_json mg::rpc mg::slk mg::io mg::repl_coord_glue
     PRIVATE fmt::fmt mg-flags
 )
+
+target_precompile_headers(mg-replication REUSE_FROM mg-pch-base)

--- a/src/replication_handler/CMakeLists.txt
+++ b/src/replication_handler/CMakeLists.txt
@@ -19,3 +19,5 @@ target_sources(mg-replication_handler
 
 target_link_libraries(mg-replication_handler
         PUBLIC mg-auth mg-dbms mg-replication mg-coordination)
+
+target_precompile_headers(mg-replication_handler REUSE_FROM mg-pch-base)

--- a/src/storage/v2/CMakeLists.txt
+++ b/src/storage/v2/CMakeLists.txt
@@ -177,4 +177,6 @@ target_link_libraries(mg-storage-v2
     ctre::ctre
 )
 
+target_precompile_headers(mg-storage-v2 REUSE_FROM mg-pch-heavy)
+
 add_subdirectory(fuzz EXCLUDE_FROM_ALL)

--- a/src/storage/v2/indexed_property_decoder.hpp
+++ b/src/storage/v2/indexed_property_decoder.hpp
@@ -11,13 +11,14 @@
 
 #pragma once
 
-#include "edge.hpp"
 #include "indices/indices.hpp"
 #include "name_id_mapper.hpp"
 #include "property_value.hpp"
-#include "vertex.hpp"
 
 namespace memgraph::storage {
+
+struct Vertex;
+struct Edge;
 
 template <typename T>
 struct IndexedPropertyDecoder {

--- a/src/storage/v2/indices/text_index_utils.hpp
+++ b/src/storage/v2/indices/text_index_utils.hpp
@@ -17,10 +17,10 @@
 #include <variant>
 #include <vector>
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "nlohmann/json_fwd.hpp"
 #include "storage/v2/id_types.hpp"
-#include "storage/v2/property_store.hpp"
 #include "storage/v2/property_value.hpp"
 
 namespace mgcxx::text_search {
@@ -31,6 +31,7 @@ struct SearcherContext;
 namespace memgraph::storage {
 
 class NameIdMapper;
+class PropertyStore;
 struct Vertex;
 struct Edge;
 struct TextIndexData;

--- a/src/storage/v2/property_value.hpp
+++ b/src/storage/v2/property_value.hpp
@@ -11,12 +11,12 @@
 
 #pragma once
 
+#include <algorithm>
 #include <iosfwd>
+#include <ranges>
 #include <string>
 #include <vector>
 
-#include <range/v3/algorithm/transform.hpp>
-#include <range/v3/view/zip.hpp>
 #include "storage/v2/enum.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/name_id_mapper.hpp"
@@ -1056,7 +1056,7 @@ inline auto operator<=>(const PropertyValueImpl<Alloc, KeyType, VectorIndexIdTyp
       auto const &m1 = first.ValueMap();
       auto const &m2 = second.ValueMap();
       if (m1.size() != m2.size()) return m1.size() <=> m2.size();
-      for (auto &&[v1, v2] : ranges::views::zip(m1, m2)) {
+      for (auto &&[v1, v2] : std::views::zip(m1, m2)) {
         auto key_cmp_res = v1.first <=> v2.first;
         if (key_cmp_res != std::weak_ordering::equivalent) return key_cmp_res;
         auto val_cmp_res = v1.second <=> v2.second;
@@ -1564,7 +1564,7 @@ inline PropertyValue ToPropertyValue(const ExternalPropertyValue &value, NameIdM
       typename PropertyValue::VectorIndexIdData data;
       const auto &external_vector_index_ids = value.ValueVectorIndexIds();
       data.ids.reserve(external_vector_index_ids.size());
-      ranges::transform(external_vector_index_ids, std::back_inserter(data.ids), [mapper](auto str) {
+      std::ranges::transform(external_vector_index_ids, std::back_inserter(data.ids), [mapper](auto str) {
         return mapper->NameToId(str);
       });
       data.vector = value.ValueVectorIndexList();
@@ -1621,7 +1621,7 @@ inline ExternalPropertyValue ToExternalPropertyValue(const PropertyValue &value,
       typename ExternalPropertyValue::VectorIndexIdData data;
       const auto &internal_vector_index_ids = value.ValueVectorIndexIds();
       data.ids.reserve(internal_vector_index_ids.size());
-      ranges::transform(
+      std::ranges::transform(
           internal_vector_index_ids, std::back_inserter(data.ids), [mapper](auto id) { return mapper->IdToName(id); });
       data.vector = value.ValueVectorIndexList();
       return ExternalPropertyValue(std::move(data));

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -12,7 +12,6 @@
 #pragma once
 
 #include "common_function_signatures.hpp"
-#include "mg_procedure.h"
 #include "storage/v2/access_type.hpp"
 #include "storage/v2/async_indexer.hpp"
 #include "storage/v2/commit_args.hpp"

--- a/src/storage/v2/storage_error.cpp
+++ b/src/storage/v2/storage_error.cpp
@@ -11,6 +11,8 @@
 
 #include "storage/v2/storage_error.hpp"
 
+#include <fmt/format.h>
+
 namespace memgraph::storage {
 
 auto ReplicaFailureReasonToString(ReplicaFailureReason reason) -> std::string {

--- a/src/storage/v2/storage_error.hpp
+++ b/src/storage/v2/storage_error.hpp
@@ -13,8 +13,6 @@
 
 #include "storage/v2/constraints/constraint_violation.hpp"
 
-#include <fmt/core.h>
-
 #include <cstdint>
 #include <string>
 #include <variant>

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -82,6 +82,8 @@ find_package(croncpp REQUIRED)
 target_link_libraries(mg-utils PUBLIC Boost::headers fmt::fmt spdlog::spdlog nlohmann_json::nlohmann_json ZLIB::ZLIB croncpp::croncpp rollbear::strong_type gflags mg-fnv)
 target_link_libraries(mg-utils PRIVATE AWS::aws-sdk-cpp-core AWS::aws-sdk-cpp-s3 AWS::aws-sdk-cpp-transfer librdtsc::librdtsc stdc++fs Threads::Threads uuid rt range-v3::range-v3)
 
+target_precompile_headers(mg-utils REUSE_FROM mg-pch-base)
+
 add_library(mg-aws STATIC)
 add_library(mg::aws ALIAS mg-aws)
 target_sources(mg-aws

--- a/tools/analyze_pch_gain.py
+++ b/tools/analyze_pch_gain.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Estimate PCH gain per CMake target from Clang -ftime-trace output.
+
+For every target (inferred from the trace file path
+`build/.../CMakeFiles/<target>.dir/...`), aggregate Source events to rank
+headers by total parse time and number of TUs within that target that parsed
+them.
+
+The "PCH gain estimate" for a given header in a target is approximately its
+total parse time in that target: that is how much frontend time PCH'ing the
+header in that target would remove (before subtracting the PCH load-tax
+overhead, which scales with total PCH size).
+
+Caveat: headers already in PCH for a target won't appear in that target's
+traces (they're pre-loaded, not parsed). To evaluate headers already PCH'd,
+rebuild from a state where they aren't.
+
+Usage:
+  python3 tools/analyze_pch_gain.py [BUILD_DIR] [--target GLOB] [--top N]
+                                    [--min-tus M] [--external-only]
+
+Options:
+  --target GLOB     Only print targets whose name matches this shell glob.
+                    Default: all targets.
+  --top N           Top N headers per target. Default: 20.
+  --min-tus M       Skip headers used by fewer than M TUs (reduces noise).
+                    Default: 3.
+  --external-only   Only show headers outside src/ (stdlib, conan, libs).
+                    These are the safe PCH candidates.
+"""
+
+import argparse
+import fnmatch
+import glob
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+
+TARGET_RE = re.compile(r"/CMakeFiles/([^/]+)\.dir/")
+
+
+def target_of(path: str) -> str:
+    m = TARGET_RE.search(path)
+    return m.group(1) if m else "<unknown>"
+
+
+def is_external(header: str) -> bool:
+    """True if header is NOT a project source header — i.e. safe for PCH."""
+    # project headers live under <repo>/src/ or <repo>/libs/memgraph/
+    # everything else (toolchain, conan, libs/*) is external and stable
+    return "/memgraph/src/" not in header
+
+
+def parse_trace(path: str) -> dict:
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return {}
+    events = data if isinstance(data, list) else data.get("traceEvents", [])
+    begin = {}
+    out = defaultdict(float)
+    for ev in events:
+        if ev.get("name") != "Source":
+            continue
+        ph = ev.get("ph")
+        eid = ev.get("id")
+        if eid is None:
+            if ph == "X" and "dur" in ev:
+                d = ev.get("args", {}).get("detail", "")
+                if d:
+                    out[d] += ev["dur"]
+            continue
+        key = (ev.get("tid"), eid)
+        if ph == "b":
+            out_detail = ev.get("args", {}).get("detail", "")
+            begin[key] = (out_detail, ev.get("ts", 0))
+        elif ph == "e" and key in begin:
+            d, ts0 = begin.pop(key)
+            dur = ev.get("ts", 0) - ts0
+            if d and dur > 0:
+                out[d] += dur
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("build_dir", nargs="?", default="build")
+    ap.add_argument("--target", default="*")
+    ap.add_argument("--top", type=int, default=20)
+    ap.add_argument("--min-tus", type=int, default=3)
+    ap.add_argument("--external-only", action="store_true")
+    args = ap.parse_args()
+
+    build_dir = os.path.abspath(args.build_dir)
+    files = [f for f in glob.glob(os.path.join(build_dir, "**/*.cpp.json"), recursive=True)]
+    print(f"Found {len(files)} trace files in {build_dir}\n", file=sys.stderr)
+
+    # target -> header -> {total_us, tus}
+    per_target = defaultdict(lambda: defaultdict(lambda: {"us": 0.0, "tus": 0}))
+    tu_count = defaultdict(int)
+
+    for i, f in enumerate(files):
+        tgt = target_of(f)
+        tu_count[tgt] += 1
+        headers = parse_trace(f)
+        for h, us in headers.items():
+            d = per_target[tgt][h]
+            d["us"] += us
+            d["tus"] += 1
+
+    targets = sorted(
+        per_target.keys(),
+        key=lambda t: -sum(d["us"] for d in per_target[t].values()),
+    )
+
+    for tgt in targets:
+        if not fnmatch.fnmatch(tgt, args.target):
+            continue
+        headers = per_target[tgt]
+        rows = []
+        for h, d in headers.items():
+            if d["tus"] < args.min_tus:
+                continue
+            if args.external_only and not is_external(h):
+                continue
+            rows.append((h, d["us"], d["tus"]))
+        rows.sort(key=lambda r: -r[1])
+        if not rows:
+            continue
+        n_tus = tu_count[tgt]
+        tgt_total = sum(d["us"] for d in headers.values()) / 1e6
+        print(f"=== {tgt}  ({n_tus} TUs, {tgt_total:.1f}s total parse time) ===")
+        print(f"{'Rank':>4}  {'Total(ms)':>10}  {'Avg(ms)':>8}  " f"{'TUs':>4}/{n_tus:<3}  Header")
+        print("-" * 110)
+        for i, (h, us, tus) in enumerate(rows[: args.top]):
+            total_ms = us / 1000
+            avg_ms = total_ms / tus if tus else 0
+            pct_tus = 100 * tus / n_tus
+            tag = f"{tus:>4}/{n_tus:<3} ({pct_tus:>3.0f}%)"
+            # shorten common prefixes
+            short = h
+            short = short.replace(os.path.expanduser("~") + "/.conan2/p/b/", "[conan]/")
+            short = short.replace(os.path.expanduser("~") + "/.conan2/p/", "[conan]/")
+            short = re.sub(r"/opt/toolchain-v7/[^ ]*/include/c\+\+/[0-9.]+/", "[libstdc++]/", short)
+            short = short.replace(os.path.expanduser("~") + "/work/memgraph/", "")
+            print(f"{i+1:>4}  {total_ms:>10.1f}  {avg_ms:>8.1f}  {tag:>15}  {short}")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/score_pch_candidates.py
+++ b/tools/score_pch_candidates.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Score a fixed list of PCH candidate headers per CMake target.
+
+For each (target, header) pair, report total parse time, number of TUs that
+include it, and TU %. Use this to decide which headers are worth PCH'ing in
+each specific target, instead of applying a one-size-fits-all list.
+
+A header is a good PCH candidate for a target when:
+  - TU % is high (≥70%): most TUs in the target pay for it anyway.
+  - Total parse time is non-trivial relative to the target's total.
+
+Usage:
+  python3 tools/score_pch_candidates.py [BUILD_DIR]
+
+Candidate list and target list are hard-coded below; edit as needed.
+"""
+
+import glob
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+
+CANDIDATES = [
+    # stdlib
+    "chrono",
+    "filesystem",
+    "format",
+    "istream",
+    "memory",
+    "optional",
+    "ostream",
+    "ranges",
+    "sstream",
+    "string",
+    "unordered_map",
+    "vector",
+    # fmt
+    "fmt/chrono.h",
+    "fmt/format.h",
+    "fmt/ostream.h",
+    # spdlog
+    "spdlog/common.h",
+    "spdlog/spdlog.h",
+    # candidates to add
+    "absl/container/flat_hash_map.h",
+    "boost/container_hash/hash.hpp",
+    "nlohmann/json.hpp",
+    "boost/asio/io_context.hpp",
+    "boost/asio/ssl/context.hpp",
+    "libnuraft/nuraft.hxx",
+]
+
+TARGETS = [
+    "mg-query",
+    "mg-storage-v2",
+    "mg-dbms",
+    "mg-glue",
+    "mg-replication_handler",
+    "mg-coordination",
+    "mg-utils",
+    "mg-communication",
+    "mg-replication",
+    "mg-auth",
+]
+
+TARGET_RE = re.compile(r"/CMakeFiles/([^/]+)\.dir/")
+
+
+def target_of(path):
+    m = TARGET_RE.search(path)
+    return m.group(1) if m else "<unknown>"
+
+
+def matches_candidate(header, candidate):
+    """True if this full header path matches the candidate suffix."""
+    # stdlib headers: no slash, match against libstdc++ basename
+    if "/" not in candidate:
+        # e.g. "chrono" matches /opt/toolchain-v7/.../include/c++/15.1.0/chrono
+        return header.endswith("/" + candidate) and "include/c++" in header
+    # with slash: match trailing path component
+    return header.endswith("/" + candidate)
+
+
+def parse_trace(path):
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return {}
+    events = data if isinstance(data, list) else data.get("traceEvents", [])
+    begin = {}
+    out = defaultdict(float)
+    for ev in events:
+        if ev.get("name") != "Source":
+            continue
+        ph = ev.get("ph")
+        eid = ev.get("id")
+        if eid is None:
+            if ph == "X" and "dur" in ev:
+                d = ev.get("args", {}).get("detail", "")
+                if d:
+                    out[d] += ev["dur"]
+            continue
+        key = (ev.get("tid"), eid)
+        if ph == "b":
+            d = ev.get("args", {}).get("detail", "")
+            begin[key] = (d, ev.get("ts", 0))
+        elif ph == "e" and key in begin:
+            d, ts0 = begin.pop(key)
+            dur = ev.get("ts", 0) - ts0
+            if d and dur > 0:
+                out[d] += dur
+    return out
+
+
+def main():
+    build_dir = os.path.abspath(sys.argv[1] if len(sys.argv) > 1 else "build")
+    files = glob.glob(os.path.join(build_dir, "**/*.cpp.json"), recursive=True)
+
+    # target -> candidate -> {us, tus}; per-target total TU count
+    scores = defaultdict(lambda: defaultdict(lambda: {"us": 0.0, "tus": 0}))
+    tu_count = defaultdict(int)
+
+    for f in files:
+        tgt = target_of(f)
+        if tgt not in TARGETS:
+            continue
+        tu_count[tgt] += 1
+        headers = parse_trace(f)
+        # For each candidate, find matching headers in this TU and sum
+        for cand in CANDIDATES:
+            tu_total_us = 0.0
+            hit = False
+            for h, us in headers.items():
+                if matches_candidate(h, cand):
+                    tu_total_us += us
+                    hit = True
+            if hit:
+                scores[tgt][cand]["us"] += tu_total_us
+                scores[tgt][cand]["tus"] += 1
+
+    # Print a grid: rows = candidates, columns = targets
+    # Each cell shows: "totalms/tu%%"
+    print(f"{'header':<42}", end="")
+    for t in TARGETS:
+        print(f" {t:>20}", end="")
+    print()
+    print("-" * (42 + 21 * len(TARGETS)))
+
+    for cand in CANDIDATES:
+        print(f"{cand:<42}", end="")
+        for t in TARGETS:
+            n_tus = tu_count.get(t, 0)
+            d = scores[t].get(cand)
+            if not d or n_tus == 0:
+                print(f" {'—':>20}", end="")
+                continue
+            ms = d["us"] / 1000
+            pct = 100 * d["tus"] / n_tus
+            cell = f"{ms:>6.0f}ms {d['tus']:>2}/{n_tus:<2}={pct:>3.0f}%"
+            print(f" {cell:>20}", end="")
+        print()
+
+    # Per-target TU totals line
+    print()
+    print(f"{'(TUs in target)':<42}", end="")
+    for t in TARGETS:
+        print(f" {tu_count.get(t, 0):>20}", end="")
+    print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Recover build-time regression and expand PCH coverage. Four commits:

- **Header fan-out cleanup** — drop unused `<fmt/core.h>` from `storage_error.hpp`, forward-declare `PropertyStore` in `text_index_utils.hpp`, forward-declare `Vertex`/`Edge` in `indexed_property_decoder.hpp`. Parse: 1640s → 1309s over 300 TUs.
- **Drop heavy includes** — remove unused `mg_procedure.h` from `storage.hpp`, unused `utils/pmr/flat_map.hpp` from `typed_value.hpp`; swap range/v3 `transform`/`zip` for std in `property_value.hpp`, `ast.hpp`, `common.hpp`.
- **Share PCH across 10 libs** — new `src/pch/` with `mg-pch-base` (17 stdlib/fmt/spdlog headers) and `mg-pch-heavy` (+ `absl/flat_hash_map`, `boost/container_hash`), attached via `REUSE_FROM`. Clean `-j6` build: 240s → 191s wall (−20%), 1319s → 1030s parse CPU (−22%).
- **Extend PCH to unit tests** — `mg-pch-tests` donor (stdlib/fmt + gtest/gmock) wired through `add_unit_test()`. spdlog omitted (redefinition via `daily_file_sink.h`). Clean `memgraph__unit`: 566s → 442s wall (−22%).

PCH scoring scripts added under `tools/`.