### PR TITLE
fix: Allow concurrent external test workflow runs

### DIFF
--- a/.github/workflows/external_diff.yaml
+++ b/.github/workflows/external_diff.yaml
@@ -1,6 +1,6 @@
 name: "Diff (External)"
 concurrency:
-  group: ${{ github.head_ref || github.sha }}
+  group: ${{ github.workflow }}-${{ inputs.pr_number }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/external_package.yaml
+++ b/.github/workflows/external_package.yaml
@@ -1,7 +1,7 @@
 name: "Package Memgraph (External)"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.inputs.pr_number }}
+  group: ${{ github.workflow }}-${{ inputs.pr_number }}
   cancel-in-progress: true
 on:
   workflow_dispatch:

--- a/.github/workflows/external_package.yaml
+++ b/.github/workflows/external_package.yaml
@@ -8,8 +8,8 @@ on:
     inputs:
       pr_number:
         type: string
+        required: true
         description: "PR number."
-        default: ''
       base_master:
         type: boolean
         description: "Base master?"

--- a/.github/workflows/external_package_mage.yaml
+++ b/.github/workflows/external_package_mage.yaml
@@ -1,5 +1,9 @@
 name: "Package mage (External)"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.pr_number }}
+  cancel-in-progress: true
+
 on:
   #push:
   workflow_dispatch:

--- a/.github/workflows/external_package_mage.yaml
+++ b/.github/workflows/external_package_mage.yaml
@@ -10,8 +10,8 @@ on:
     inputs:
       pr_number:
         type: string
+        required: true
         description: "PR number."
-        default: ''
       base_master:
         type: boolean
         description: "Base master?"


### PR DESCRIPTION
Updated the concurrency for all external contribution workflows such that running the same workflow on multiple PRs doesn't unintentionally cancel earlier runs.


