### PR TITLE
Fix: audit logs timestamp, log directory

### DIFF
--- a/config/flags.yaml
+++ b/config/flags.yaml
@@ -39,6 +39,10 @@ modifications:
     value: "/var/log/memgraph/memgraph.log"
     override: true
 
+  - name: "audit_log_file"
+    value: "/var/log/memgraph/audit/audit.log"
+    override: true
+
   - name: "log_level"
     value: "WARNING"
     override: true

--- a/src/audit/log.cpp
+++ b/src/audit/log.cpp
@@ -19,6 +19,7 @@
 #include "utils/logging.hpp"
 #include "utils/string.hpp"
 #include "utils/temporal.hpp"
+#include "utils/timestamp.hpp"
 
 #include <mutex>
 
@@ -122,10 +123,12 @@ inline nlohmann::json BoltValueToJson(const communication::bolt::Value &value) {
   return ret;
 }
 
-Log::Log(std::filesystem::path log_file, int32_t buffer_size, int32_t buffer_flush_interval_millis)
+Log::Log(std::filesystem::path log_file, int32_t buffer_size, int32_t buffer_flush_interval_millis,
+         TimestampFormat timestamp_format)
     : log_file_(std::move(log_file)),
       buffer_size_(buffer_size),
       buffer_flush_interval_millis_(buffer_flush_interval_millis),
+      timestamp_format_(timestamp_format),
       started_(false) {}
 
 bool Log::Start() {
@@ -162,6 +165,7 @@ Log::~Log() {
 void Log::Record(const std::string &address, const std::string &username, const std::string &query,
                  const memgraph::communication::bolt::map_t &params, const std::string &db) {
   if (!started_.load(std::memory_order_relaxed)) return;
+  // Captured as epoch microseconds; --audit-log-timestamp-format controls rendering at flush time.
   auto timestamp =
       std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch())
           .count();
@@ -194,9 +198,20 @@ void Log::Flush() {
       params_json.push_back(nlohmann::json::object_t::value_type(k, BoltValueToJson(v)));
     }
 
-    log_.Write(fmt::format("{}.{:06d},{},{},{},{},{}\n",
-                           item->timestamp / 1'000'000,
-                           item->timestamp % 1'000'000,
+    auto const timestamp_str = [&]() -> std::string {
+      switch (timestamp_format_) {
+        case TimestampFormat::Epoch:
+          return fmt::format("{}.{:06d}", item->timestamp / 1'000'000, item->timestamp % 1'000'000);
+        case TimestampFormat::ISO8601:
+          return utils::Timestamp{static_cast<std::time_t>(item->timestamp / 1'000'000),
+                                  (item->timestamp % 1'000'000) * 1000}
+              .ToIso8601();
+      }
+      std::unreachable();
+    }();
+
+    log_.Write(fmt::format("{},{},{},{},{},{}\n",
+                           timestamp_str,
                            item->address,
                            item->username,
                            item->db,

--- a/src/audit/log.cpp
+++ b/src/audit/log.cpp
@@ -122,8 +122,8 @@ inline nlohmann::json BoltValueToJson(const communication::bolt::Value &value) {
   return ret;
 }
 
-Log::Log(std::filesystem::path storage_directory, int32_t buffer_size, int32_t buffer_flush_interval_millis)
-    : storage_directory_(std::move(storage_directory)),
+Log::Log(std::filesystem::path log_file, int32_t buffer_size, int32_t buffer_flush_interval_millis)
+    : log_file_(std::move(log_file)),
       buffer_size_(buffer_size),
       buffer_flush_interval_millis_(buffer_flush_interval_millis),
       started_(false) {}
@@ -131,13 +131,15 @@ Log::Log(std::filesystem::path storage_directory, int32_t buffer_size, int32_t b
 bool Log::Start() {
   MG_ASSERT(!started_.load(std::memory_order_acquire), "Trying to start an already started audit log!");
 
-  utils::EnsureDirOrDie(storage_directory_);
+  if (auto parent = log_file_.parent_path(); !parent.empty()) {
+    utils::EnsureDirOrDie(parent);
+  }
 
   buffer_.emplace(buffer_size_);
 
   {
     auto guard = std::lock_guard{lock_};
-    if (!log_.Open(storage_directory_ / "audit.log", utils::OutputFile::Mode::APPEND_TO_EXISTING)) {
+    if (!log_.Open(log_file_, utils::OutputFile::Mode::APPEND_TO_EXISTING)) {
       return false;
     }
   }
@@ -174,7 +176,7 @@ bool Log::ReopenLog() {
   }
   auto guard = std::lock_guard{lock_};
   if (log_.IsOpen()) log_.Close();
-  auto const res = log_.Open(storage_directory_ / "audit.log", utils::OutputFile::Mode::APPEND_TO_EXISTING);
+  auto const res = log_.Open(log_file_, utils::OutputFile::Mode::APPEND_TO_EXISTING);
   if (!res) {
     spdlog::warn("Failed to reopen audit log file. Audit log file couldn't be opened.");
   }

--- a/src/audit/log.hpp
+++ b/src/audit/log.hpp
@@ -19,6 +19,8 @@
 
 namespace memgraph::audit {
 
+enum class TimestampFormat { Epoch, ISO8601 };
+
 /// This class implements an audit log. Functions used for logging are
 /// thread-safe, functions used for setup aren't thread-safe.
 class Log {
@@ -33,7 +35,8 @@ class Log {
   };
 
  public:
-  Log(std::filesystem::path log_file, int32_t buffer_size, int32_t buffer_flush_interval_millis);
+  Log(std::filesystem::path log_file, int32_t buffer_size, int32_t buffer_flush_interval_millis,
+      TimestampFormat timestamp_format);
 
   ~Log();
 
@@ -60,6 +63,7 @@ class Log {
   std::filesystem::path log_file_;
   int32_t buffer_size_;
   int32_t buffer_flush_interval_millis_;
+  TimestampFormat timestamp_format_;
   std::atomic<bool> started_;
 
   std::optional<RingBuffer<Item>> buffer_;

--- a/src/audit/log.hpp
+++ b/src/audit/log.hpp
@@ -33,7 +33,7 @@ class Log {
   };
 
  public:
-  Log(std::filesystem::path storage_directory, int32_t buffer_size, int32_t buffer_flush_interval_millis);
+  Log(std::filesystem::path log_file, int32_t buffer_size, int32_t buffer_flush_interval_millis);
 
   ~Log();
 
@@ -57,7 +57,7 @@ class Log {
  private:
   void Flush();
 
-  std::filesystem::path storage_directory_;
+  std::filesystem::path log_file_;
   int32_t buffer_size_;
   int32_t buffer_flush_interval_millis_;
   std::atomic<bool> started_;

--- a/src/flags/audit.cpp
+++ b/src/flags/audit.cpp
@@ -12,11 +12,15 @@
 
 #include <gflags/gflags.h>
 #include <cstdint>
+#include <iostream>
 
 #include "utils/flag_validation.hpp"
+#include "utils/string.hpp"
 
 const uint64_t kBufferSizeDefault = 100'000;
 const uint64_t kBufferFlushIntervalMillisDefault = 200;
+constexpr auto kAuditTimestampEpoch = "epoch";
+constexpr auto kAuditTimestampIso8601 = "iso8601";
 
 // Audit logging flags.
 #ifdef MG_ENTERPRISE
@@ -33,4 +37,14 @@ DEFINE_VALIDATED_int32(audit_buffer_flush_interval_ms, kBufferFlushIntervalMilli
 DEFINE_string(audit_log_file, "",
               "Path to where the audit log should be stored. "
               "If empty, defaults to '<data-directory>/audit/audit.log'.");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_VALIDATED_string(audit_log_timestamp_format, kAuditTimestampEpoch,
+                        "Timestamp format for audit log entries. Options: epoch, iso8601.", {
+                          auto const lower = memgraph::utils::ToLowerCase(value);
+                          if (lower != kAuditTimestampEpoch && lower != kAuditTimestampIso8601) {
+                            std::cout << "Expected --" << flagname << " to be 'epoch' or 'iso8601'\n";
+                            return false;
+                          }
+                          return true;
+                        });
 #endif

--- a/src/flags/audit.cpp
+++ b/src/flags/audit.cpp
@@ -34,9 +34,7 @@ DEFINE_VALIDATED_int32(audit_buffer_flush_interval_ms, kBufferFlushIntervalMilli
                        "Interval (in milliseconds) used for flushing the audit log buffer.",
                        FLAG_IN_RANGE(10, INT32_MAX));
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_string(audit_log_file, "",
-              "Path to where the audit log should be stored. "
-              "If empty, defaults to '<data-directory>/audit/audit.log'.");
+DEFINE_string(audit_log_file, "", "Path to where the audit log should be stored.");
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_VALIDATED_string(audit_log_timestamp_format, kAuditTimestampEpoch,
                         "Timestamp format for audit log entries. Options: epoch, iso8601.", {

--- a/src/flags/audit.cpp
+++ b/src/flags/audit.cpp
@@ -29,4 +29,8 @@ DEFINE_VALIDATED_int32(audit_buffer_size, kBufferSizeDefault, "Maximum number of
 DEFINE_VALIDATED_int32(audit_buffer_flush_interval_ms, kBufferFlushIntervalMillisDefault,
                        "Interval (in milliseconds) used for flushing the audit log buffer.",
                        FLAG_IN_RANGE(10, INT32_MAX));
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_string(audit_log_file, "",
+              "Path to where the audit log should be stored. "
+              "If empty, defaults to '<data-directory>/audit/audit.log'.");
 #endif

--- a/src/flags/audit.hpp
+++ b/src/flags/audit.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -20,4 +20,6 @@ DECLARE_bool(audit_enabled);
 DECLARE_int32(audit_buffer_size);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_int32(audit_buffer_flush_interval_ms);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DECLARE_string(audit_log_file);
 #endif

--- a/src/flags/audit.hpp
+++ b/src/flags/audit.hpp
@@ -22,4 +22,6 @@ DECLARE_int32(audit_buffer_size);
 DECLARE_int32(audit_buffer_flush_interval_ms);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_string(audit_log_file);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DECLARE_string(audit_log_timestamp_format);
 #endif

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -444,11 +444,12 @@ int main(int argc, char **argv) {
 
 #ifdef MG_ENTERPRISE
   // Audit log
-  memgraph::audit::Log audit_log{
-      data_directory / "audit", FLAGS_audit_buffer_size, FLAGS_audit_buffer_flush_interval_ms};
+  auto const audit_log_file = FLAGS_audit_log_file.empty() ? (data_directory / "audit" / "audit.log")
+                                                           : std::filesystem::path{FLAGS_audit_log_file};
+  memgraph::audit::Log audit_log{audit_log_file, FLAGS_audit_buffer_size, FLAGS_audit_buffer_flush_interval_ms};
   // Start the log if enabled.
   if (FLAGS_audit_enabled) {
-    MG_ASSERT(audit_log.Start(), "Failed to open audit file {}", data_directory / "audit");
+    MG_ASSERT(audit_log.Start(), "Failed to open audit file {}", audit_log_file);
   }
   // Setup SIGUSR2 to be used for reopening audit log files, when e.g. logrotate
   // rotates our audit logs.

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -444,16 +444,14 @@ int main(int argc, char **argv) {
 
 #ifdef MG_ENTERPRISE
   // Audit log
-  auto const audit_log_file = FLAGS_audit_log_file.empty() ? (data_directory / "audit" / "audit.log")
-                                                           : std::filesystem::path{FLAGS_audit_log_file};
   auto const audit_timestamp_format = memgraph::utils::ToLowerCase(FLAGS_audit_log_timestamp_format) == "iso8601"
                                           ? memgraph::audit::TimestampFormat::ISO8601
                                           : memgraph::audit::TimestampFormat::Epoch;
   memgraph::audit::Log audit_log{
-      audit_log_file, FLAGS_audit_buffer_size, FLAGS_audit_buffer_flush_interval_ms, audit_timestamp_format};
-  // Start the log if enabled.
-  if (FLAGS_audit_enabled) {
-    MG_ASSERT(audit_log.Start(), "Failed to open audit file {}", audit_log_file);
+      FLAGS_audit_log_file, FLAGS_audit_buffer_size, FLAGS_audit_buffer_flush_interval_ms, audit_timestamp_format};
+  // Start the log only if enabled and a path was provided (mirrors --log-file semantics).
+  if (FLAGS_audit_enabled && !FLAGS_audit_log_file.empty()) {
+    MG_ASSERT(audit_log.Start(), "Failed to open audit file {}", FLAGS_audit_log_file);
   }
   // Setup SIGUSR2 to be used for reopening audit log files, when e.g. logrotate
   // rotates our audit logs.

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -446,7 +446,11 @@ int main(int argc, char **argv) {
   // Audit log
   auto const audit_log_file = FLAGS_audit_log_file.empty() ? (data_directory / "audit" / "audit.log")
                                                            : std::filesystem::path{FLAGS_audit_log_file};
-  memgraph::audit::Log audit_log{audit_log_file, FLAGS_audit_buffer_size, FLAGS_audit_buffer_flush_interval_ms};
+  auto const audit_timestamp_format = memgraph::utils::ToLowerCase(FLAGS_audit_log_timestamp_format) == "iso8601"
+                                          ? memgraph::audit::TimestampFormat::ISO8601
+                                          : memgraph::audit::TimestampFormat::Epoch;
+  memgraph::audit::Log audit_log{
+      audit_log_file, FLAGS_audit_buffer_size, FLAGS_audit_buffer_flush_interval_ms, audit_timestamp_format};
   // Start the log if enabled.
   if (FLAGS_audit_enabled) {
     MG_ASSERT(audit_log.Start(), "Failed to open audit file {}", audit_log_file);

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -50,6 +50,11 @@ startup_config_dict = {
         "",
         "Path to where the audit log should be stored. If empty, defaults to '<data-directory>/audit/audit.log'.",
     ),
+    "audit_log_timestamp_format": (
+        "epoch",
+        "epoch",
+        "Timestamp format for audit log entries. Options: epoch, iso8601.",
+    ),
     "auth_user_or_role_name_regex": (
         "[a-zA-Z0-9_.+-@]+",
         "[a-zA-Z0-9_.+-@]+",

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -45,6 +45,11 @@ startup_config_dict = {
     ),
     "audit_buffer_size": ("100000", "100000", "Maximum number of items in the audit log buffer."),
     "audit_enabled": ("false", "false", "Set to true to enable audit logging."),
+    "audit_log_file": (
+        "",
+        "",
+        "Path to where the audit log should be stored. If empty, defaults to '<data-directory>/audit/audit.log'.",
+    ),
     "auth_user_or_role_name_regex": (
         "[a-zA-Z0-9_.+-@]+",
         "[a-zA-Z0-9_.+-@]+",

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -45,11 +45,7 @@ startup_config_dict = {
     ),
     "audit_buffer_size": ("100000", "100000", "Maximum number of items in the audit log buffer."),
     "audit_enabled": ("false", "false", "Set to true to enable audit logging."),
-    "audit_log_file": (
-        "",
-        "",
-        "Path to where the audit log should be stored. If empty, defaults to '<data-directory>/audit/audit.log'.",
-    ),
+    "audit_log_file": ("", "", "Path to where the audit log should be stored."),
     "audit_log_timestamp_format": (
         "epoch",
         "epoch",

--- a/tests/integration/audit/runner.py
+++ b/tests/integration/audit/runner.py
@@ -93,6 +93,7 @@ def execute_test(memgraph_binary, tester_binary):
         "--data-directory",
         storage_directory.name,
         "--audit-enabled",
+        "--audit-log-file=" + os.path.join(storage_directory.name, "audit", "audit.log"),
         "--log-file=memgraph.log",
         "--log-level=TRACE",
     ]


### PR DESCRIPTION
Added:
- configuration flag for timestamp format in audit logs
- configured default directory for audit logs to be in the `/var/log/memgraph`, not `/var/lib/memgraph`
