### PR TITLE
feat: Remote text embeddings compute

### DIFF
--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -92,6 +92,9 @@ env:
   POSTGRESQL_CONTAINER: "postgresql_test"
   MEMGRAPH_ENTERPRISE_LICENSE: ${{ secrets.MEMGRAPH_ENTERPRISE_LICENSE }}
   MEMGRAPH_ORGANIZATION_NAME: ${{ secrets.MEMGRAPH_ORGANIZATION_NAME }}
+  # Forwarded into the Memgraph container so the embeddings.* e2e tests can
+  # exercise the real OpenAI API. Tests skip gracefully if this is unset.
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
   GENERATE_SBOM: "${{ inputs.generate_sbom }}"
   TOOLCHAIN: "v7"
   CONAN_REMOTE: ${{ secrets.CONAN_REMOTE }}
@@ -496,6 +499,7 @@ jobs:
             -p $MEMGRAPH_PORT:$MEMGRAPH_PORT \
             -e MEMGRAPH_ENTERPRISE_LICENSE=$MEMGRAPH_ENTERPRISE_LICENSE \
             -e MEMGRAPH_ORGANIZATION_NAME=$MEMGRAPH_ORGANIZATION_NAME \
+            -e OPENAI_API_KEY=$OPENAI_API_KEY \
             ${DOCKER_REPOSITORY_NAME}:$IMAGE_TAG \
             --telemetry-enabled=False
 

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -92,9 +92,8 @@ env:
   POSTGRESQL_CONTAINER: "postgresql_test"
   MEMGRAPH_ENTERPRISE_LICENSE: ${{ secrets.MEMGRAPH_ENTERPRISE_LICENSE }}
   MEMGRAPH_ORGANIZATION_NAME: ${{ secrets.MEMGRAPH_ORGANIZATION_NAME }}
-  # Forwarded into the Memgraph container so the embeddings.* e2e tests can
-  # exercise the real OpenAI API. Tests skip gracefully if this is unset.
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  MAGE_E2E_OPENAI: "1"
   GENERATE_SBOM: "${{ inputs.generate_sbom }}"
   TOOLCHAIN: "v7"
   CONAN_REMOTE: ${{ secrets.CONAN_REMOTE }}

--- a/mage/python/embeddings.py
+++ b/mage/python/embeddings.py
@@ -6,7 +6,12 @@ from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_compl
 from typing import List
 
 import huggingface_hub  # noqa: F401
+import litellm
 import mgp
+
+# Suppress LiteLLM's "Provider List: ..." banner that fires on every
+# get_llm_provider() miss — we probe deliberately for local names.
+litellm.suppress_debug_info = True
 
 # We need to import huggingface_hub, otherwise sentence_transformers will fail to load the model.
 
@@ -407,24 +412,6 @@ def multi_gpu_compute(
     )
 
 
-_litellm_configured = False
-
-
-def _ensure_litellm_configured():
-    # Silence LiteLLM's "Provider List: ..." banner that fires on every
-    # get_llm_provider() miss — we probe deliberately for local names.
-    global _litellm_configured
-    if _litellm_configured:
-        return
-    try:
-        import litellm
-
-        litellm.suppress_debug_info = True
-    except ImportError:
-        return
-    _litellm_configured = True
-
-
 def resolve_remote_model(model_name):
     """Ask LiteLLM whether ``model_name`` belongs to one of its providers.
 
@@ -435,12 +422,7 @@ def resolve_remote_model(model_name):
     if not isinstance(model_name, str) or not model_name:
         return None
     try:
-        from litellm import get_llm_provider
-    except ImportError:
-        return None
-    _ensure_litellm_configured()
-    try:
-        model, provider, _dynamic_key, default_api_base = get_llm_provider(model_name)
+        model, provider, _dynamic_key, default_api_base = litellm.get_llm_provider(model_name)
     except Exception:
         return None
     return model, provider, default_api_base
@@ -481,7 +463,6 @@ def remote_compute(
     matches the local sentence_transformers path. Raises on permanent failure
     — the caller catches and converts to ``success=False``.
     """
-    from litellm import embedding as litellm_embedding
 
     _model, provider, default_api_base = resolved
     vertex_input = isinstance(cfg["embedding_property"], str)
@@ -514,7 +495,7 @@ def remote_compute(
         base_kwargs["dimensions"] = cfg["dimensions"]
 
     def _call(chunk_texts):
-        resp = litellm_embedding(input=chunk_texts, **base_kwargs)
+        resp = litellm.embedding(input=chunk_texts, **base_kwargs)
         return [d["embedding"] for d in resp["data"]]
 
     results = [None] * len(chunks)
@@ -813,8 +794,6 @@ def _remote_model_info(configuration, resolved):
     if cached is not None:
         return cached
 
-    from litellm import embedding as litellm_embedding
-
     kwargs = {
         "model": configuration["model_name"],
         "input": ["probe"],
@@ -826,7 +805,7 @@ def _remote_model_info(configuration, resolved):
     if configuration.get("dimensions"):
         kwargs["dimensions"] = configuration["dimensions"]
 
-    resp = litellm_embedding(**kwargs)
+    resp = litellm.embedding(**kwargs)
     dim = len(resp["data"][0]["embedding"])
     info = {
         "model_name": configuration["model_name"],

--- a/mage/python/embeddings.py
+++ b/mage/python/embeddings.py
@@ -487,10 +487,20 @@ def remote_compute(
         return [d["embedding"] for d in resp["data"]]
 
     results = [None] * len(chunks)
-    with ThreadPoolExecutor(max_workers=cfg["concurrency"]) as ex:
+    ex = ThreadPoolExecutor(max_workers=cfg["concurrency"])
+    try:
         fut2idx = {ex.submit(_call, c): i for i, c in enumerate(chunks)}
         for fut in as_completed(fut2idx):
-            results[fut2idx[fut]] = fut.result()
+            results[fut2idx[fut]] = fut.result()  # raises on permanent failure
+    except Exception:
+        # Cancel queued chunks and return promptly. In-flight chunks will
+        # complete in the background and be discarded — Python can't safely
+        # interrupt running threads, but we don't want to wait for a stuck
+        # request to hit `timeout` before surfacing success=False.
+        ex.shutdown(wait=False, cancel_futures=True)
+        raise
+    else:
+        ex.shutdown(wait=True)
 
     flat = [e for part in results for e in part]
     if cfg["normalize"]:

--- a/mage/python/embeddings.py
+++ b/mage/python/embeddings.py
@@ -584,7 +584,7 @@ def validate_configuration(configuration: mgp.Map):
     # (e.g. range(0, n, 0) raises, ThreadPoolExecutor(max_workers=0) raises).
     _require_positive_number(configuration, "timeout")
     _require_int_ge(configuration, "num_retries", minimum=0)
-    _require_int_ge(configuration, "concurrency", minimum=1)
+    _require_int_ge(configuration, "concurrency", minimum=1, maximum=_CONCURRENCY_MAX)
     _require_int_ge(configuration, "remote_batch_size", minimum=1, allow_none=True)
     _require_int_ge(configuration, "dimensions", minimum=1, allow_none=True)
 
@@ -600,7 +600,11 @@ def validate_configuration(configuration: mgp.Map):
     return configuration
 
 
-def _require_int_ge(cfg, key, minimum, allow_none=False):
+# Upper bound on `concurrency` (in-flight HTTP requests per remote_compute call).
+_CONCURRENCY_MAX = 32
+
+
+def _require_int_ge(cfg, key, minimum, allow_none=False, maximum=None):
     value = cfg[key]
     if value is None:
         if allow_none:
@@ -609,6 +613,8 @@ def _require_int_ge(cfg, key, minimum, allow_none=False):
     # bool is a subclass of int — reject explicitly.
     if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
         raise ValueError(f"'{key}' must be an integer >= {minimum}, got {value!r}")
+    if maximum is not None and value > maximum:
+        raise ValueError(f"'{key}' must be <= {maximum}, got {value}")
 
 
 def _require_positive_number(cfg, key):

--- a/mage/python/embeddings.py
+++ b/mage/python/embeddings.py
@@ -512,8 +512,6 @@ def remote_compute(
         base_kwargs["input_type"] = cfg["input_type"]
     if cfg["dimensions"]:
         base_kwargs["dimensions"] = cfg["dimensions"]
-    if cfg["extra_kwargs"]:
-        base_kwargs.update(cfg["extra_kwargs"])
 
     def _call(chunk_texts):
         resp = litellm_embedding(input=chunk_texts, **base_kwargs)
@@ -596,7 +594,6 @@ def validate_configuration(configuration: mgp.Map):
         "normalize": True,
         "remote_batch_size": None,
         "concurrency": 4,
-        "extra_kwargs": {},
     }
     configuration = {**default_configuration, **configuration}
 
@@ -625,31 +622,19 @@ def validate_configuration(configuration: mgp.Map):
     return configuration
 
 
-_SECRET_KEY_PATTERNS = ("key", "secret", "token", "password", "credential")
-
-
 def _redacted_config(cfg):
-    """Return a shallow-copied config with secret-looking fields masked.
+    """Return a shallow-copied config with URL-embedded credentials masked.
 
-    We don't currently accept an api_key config key (LiteLLM reads env vars),
-    but `extra_kwargs` is a user-supplied passthrough that could carry one, and
-    `api_base` URLs can embed credentials (``https://user:pass@host/...``).
-    Defense in depth.
+    We don't accept secret-bearing config keys (credentials come from provider
+    env vars), so the only vector left is an ``api_base`` URL of the form
+    ``https://user:pass@host/...`` — scrub just those.
     """
     import re
 
-    def _scrub(value):
-        if isinstance(value, dict):
-            return {k: ("<redacted>" if _looks_secret(k) else _scrub(v)) for k, v in value.items()}
-        if isinstance(value, str):
-            return re.sub(r"(://)[^/@\s]+:[^/@\s]+@", r"\1<redacted>@", value)
-        return value
-
-    def _looks_secret(key):
-        k = str(key).lower()
-        return any(p in k for p in _SECRET_KEY_PATTERNS)
-
-    return {k: ("<redacted>" if _looks_secret(k) else _scrub(v)) for k, v in cfg.items()}
+    api_base = cfg.get("api_base")
+    if not isinstance(api_base, str) or "@" not in api_base:
+        return cfg
+    return {**cfg, "api_base": re.sub(r"(://)[^/@\s]+:[^/@\s]+@", r"\1<redacted>@", api_base)}
 
 
 def compute_embeddings(

--- a/mage/python/embeddings.py
+++ b/mage/python/embeddings.py
@@ -428,21 +428,6 @@ def resolve_remote_model(model_name):
     return model, provider, default_api_base
 
 
-def default_remote_batch_size(provider):
-    """Default `remote_batch_size` when the user doesn't set one.
-
-    Only lists providers with a *documented hard cap* — exceeding those
-    returns HTTP 400. Everything else falls through to a generic default.
-    Users override per-call via `remote_batch_size`.
-    """
-    return {
-        "voyage": 1000,  # docs.voyageai.com/docs/embeddings
-        "cohere": 96,  # docs.cohere.com/reference/embed
-        "openai": 2048,  # 2048 items + 300K tokens/request; token limit may bite first
-        "azure": 2048,  # mirrors OpenAI
-    }.get(provider, 256)
-
-
 def l2_normalize(vec):
     s = sum(x * x for x in vec) ** 0.5
     if s == 0:
@@ -478,7 +463,10 @@ def remote_compute(
             dimension=dimension,
         )
 
-    chunk_size = cfg["remote_batch_size"] or default_remote_batch_size(provider)
+    # Cohere's /embed endpoint enforces a hard 96-item cap (HTTP 400 above).
+    # 256 is a conservative default for everyone else; users tune via
+    # `remote_batch_size` for throughput.
+    chunk_size = cfg["remote_batch_size"] or (96 if provider == "cohere" else 256)
     chunks = [texts[i : i + chunk_size] for i in range(0, n, chunk_size)]
 
     api_base = cfg["api_base"] or default_api_base
@@ -499,7 +487,7 @@ def remote_compute(
         return [d["embedding"] for d in resp["data"]]
 
     results = [None] * len(chunks)
-    with ThreadPoolExecutor(max_workers=max(1, cfg["concurrency"])) as ex:
+    with ThreadPoolExecutor(max_workers=cfg["concurrency"]) as ex:
         fut2idx = {ex.submit(_call, c): i for i, c in enumerate(chunks)}
         for fut in as_completed(fut2idx):
             results[fut2idx[fut]] = fut.result()
@@ -591,6 +579,15 @@ def validate_configuration(configuration: mgp.Map):
     if configuration["embedding_property"] is not None and configuration["embedding_property"] not in excluded:
         excluded.append(configuration["embedding_property"])
 
+    # Validate numeric remote-path keys at config time so we fail loudly with
+    # a clear message rather than producing weird runtime errors downstream
+    # (e.g. range(0, n, 0) raises, ThreadPoolExecutor(max_workers=0) raises).
+    _require_positive_number(configuration, "timeout")
+    _require_int_ge(configuration, "num_retries", minimum=0)
+    _require_int_ge(configuration, "concurrency", minimum=1)
+    _require_int_ge(configuration, "remote_batch_size", minimum=1, allow_none=True)
+    _require_int_ge(configuration, "dimensions", minimum=1, allow_none=True)
+
     # When routing remote, a local `device` setting has no meaning — warn so the
     # user knows we're ignoring it rather than silently doing the wrong thing.
     if resolve_remote_model(configuration["model_name"]) is not None and configuration["device"] is not None:
@@ -601,6 +598,23 @@ def validate_configuration(configuration: mgp.Map):
     logger.debug(f"Using embedding configuration: {_redacted_config(configuration)}")
 
     return configuration
+
+
+def _require_int_ge(cfg, key, minimum, allow_none=False):
+    value = cfg[key]
+    if value is None:
+        if allow_none:
+            return
+        raise ValueError(f"'{key}' must be an integer >= {minimum}, got None")
+    # bool is a subclass of int — reject explicitly.
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise ValueError(f"'{key}' must be an integer >= {minimum}, got {value!r}")
+
+
+def _require_positive_number(cfg, key):
+    value = cfg[key]
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+        raise ValueError(f"'{key}' must be a positive number, got {value!r}")
 
 
 def _redacted_config(cfg):

--- a/mage/python/embeddings.py
+++ b/mage/python/embeddings.py
@@ -618,7 +618,7 @@ def _redacted_config(cfg):
     return {**cfg, "api_base": re.sub(r"(://)[^/@\s]+:[^/@\s]+@", r"\1<redacted>@", api_base)}
 
 
-def compute_embeddings(
+def compute_embeddings(  # noqa: C901
     input_items: mgp.Any,
     configuration: mgp.Map,
 ) -> mgp.Any:

--- a/mage/python/embeddings.py
+++ b/mage/python/embeddings.py
@@ -667,6 +667,9 @@ def compute_embeddings(  # noqa: C901
     input_items: mgp.Any,
     configuration: mgp.Map,
 ) -> mgp.Any:
+    # Initialized up front so the outer except handler can reference it even
+    # if we raise before the local-path assignment below.
+    dimension = None
     try:
         n = len(input_items)
 

--- a/mage/python/embeddings.py
+++ b/mage/python/embeddings.py
@@ -200,7 +200,7 @@ def cpu_compute(
     batch_size: int = 2000,
     return_embeddings: bool = False,
     dimension: int = None,
-) -> mgp.Record(success=bool, embeddings=mgp.Nullable[mgp.List[list]], dimension=int):
+) -> mgp.Record(success=bool, embeddings=mgp.Nullable[mgp.List[list]], dimension=mgp.Nullable[int]):
     model = _get_or_load_model(model_name, "cpu")
     vertex_input = isinstance(embedding_property, str)
     if vertex_input:
@@ -242,7 +242,7 @@ def single_gpu_compute(
     device: int = 0,
     return_embeddings: bool = False,
     dimension: int = None,
-) -> mgp.Record(success=bool, embeddings=mgp.Nullable[mgp.List[list]], dimension=int):
+) -> mgp.Record(success=bool, embeddings=mgp.Nullable[mgp.List[list]], dimension=mgp.Nullable[int]):
     vertex_input = isinstance(embedding_property, str)
     try:
         model = _get_or_load_model(model_name, f"cuda:{device}")
@@ -305,7 +305,7 @@ def multi_gpu_compute(
     gpus: List[int] = [0],
     return_embeddings: bool = False,
     dimension: int = None,
-) -> mgp.Record(success=bool, embeddings=mgp.Nullable[mgp.List[list]], dimension=int):
+) -> mgp.Record(success=bool, embeddings=mgp.Nullable[mgp.List[list]], dimension=mgp.Nullable[int]):
     vertex_input = isinstance(embedding_property, str)
 
     try:
@@ -473,7 +473,7 @@ def remote_compute(
     cfg: mgp.Map,
     dimension: int,
     resolved,
-) -> mgp.Record(success=bool, embeddings=mgp.Nullable[mgp.List[list]], dimension=int):
+) -> mgp.Record(success=bool, embeddings=mgp.Nullable[mgp.List[list]], dimension=mgp.Nullable[int]):
     """LiteLLM-routed remote embedding path.
 
     Fans chunks across a small thread pool, preserves input order, and
@@ -869,7 +869,7 @@ def node_sentence(
     ctx: mgp.ProcCtx,
     input_nodes: mgp.Nullable[mgp.List[mgp.Vertex]] = None,
     configuration: mgp.Map = {},
-) -> mgp.Record(success=bool, embeddings=mgp.Nullable[mgp.List[list]], dimension=int):
+) -> mgp.Record(success=bool, embeddings=mgp.Nullable[mgp.List[list]], dimension=mgp.Nullable[int]):
     logger.info(f"compute_embeddings: starting (py_exec={sys.executable}, py_ver={sys.version.split()[0]})")
 
     configuration = validate_configuration(configuration)
@@ -886,7 +886,7 @@ def text(
     ctx: mgp.ProcCtx,
     input_strings: mgp.List[str],
     configuration: mgp.Map = {},
-) -> mgp.Record(success=bool, embeddings=mgp.Nullable[mgp.List[list]], dimension=int):
+) -> mgp.Record(success=bool, embeddings=mgp.Nullable[mgp.List[list]], dimension=mgp.Nullable[int]):
     logger.info(f"embed: starting (py_exec={sys.executable}, py_ver={sys.version.split()[0]})")
 
     # hard code embedding_property to None for string input

--- a/mage/python/embeddings.py
+++ b/mage/python/embeddings.py
@@ -633,18 +633,34 @@ def _require_positive_number(cfg, key):
 
 
 def _redacted_config(cfg):
-    """Return a shallow-copied config with URL-embedded credentials masked.
+    """Return a shallow-copied config with credentials in ``api_base`` masked.
 
-    We don't accept secret-bearing config keys (credentials come from provider
-    env vars), so the only vector left is an ``api_base`` URL of the form
-    ``https://user:pass@host/...`` — scrub just those.
+    The only vector for leaks is the api_base URL — we don't accept any
+    secret-bearing config keys (credentials come from provider env vars).
+    Covers all three places auth can hide in a URL: userinfo
+    (``user:pass@host``), query string (``?token=...``, ``?api_key=...``),
+    and fragment. Scheme/host/port/path are preserved so the log line is
+    still useful for debugging where Memgraph thinks it's calling.
     """
-    import re
+    from urllib.parse import urlsplit, urlunsplit
 
     api_base = cfg.get("api_base")
-    if not isinstance(api_base, str) or "@" not in api_base:
+    if not isinstance(api_base, str):
         return cfg
-    return {**cfg, "api_base": re.sub(r"(://)[^/@\s]+:[^/@\s]+@", r"\1<redacted>@", api_base)}
+    try:
+        parts = urlsplit(api_base)
+    except ValueError:
+        return cfg
+    if not (parts.username or parts.password or parts.query or parts.fragment):
+        return cfg
+    netloc = parts.hostname or ""
+    if parts.port is not None:
+        netloc = f"{netloc}:{parts.port}"
+    if parts.username or parts.password:
+        netloc = f"<redacted>@{netloc}"
+    query = "<redacted>" if parts.query else ""
+    fragment = "<redacted>" if parts.fragment else ""
+    return {**cfg, "api_base": urlunsplit((parts.scheme, netloc, parts.path, query, fragment))}
 
 
 def compute_embeddings(  # noqa: C901

--- a/mage/python/embeddings.py
+++ b/mage/python/embeddings.py
@@ -429,18 +429,18 @@ def resolve_remote_model(model_name):
 
 
 def default_remote_batch_size(provider):
-    # Conservative defaults that stay under each provider's per-request input cap.
+    """Default `remote_batch_size` when the user doesn't set one.
+
+    Only lists providers with a *documented hard cap* — exceeding those
+    returns HTTP 400. Everything else falls through to a generic default.
+    Users override per-call via `remote_batch_size`.
+    """
     return {
-        "voyage": 128,
-        "cohere": 96,
-        "openai": 512,
-        "azure": 512,
-        "mistral": 512,
-        "jina_ai": 512,
-        "ollama": 64,
-        "huggingface": 64,
-        "bedrock": 64,
-    }.get(provider, 64)
+        "voyage": 1000,  # docs.voyageai.com/docs/embeddings
+        "cohere": 96,  # docs.cohere.com/reference/embed
+        "openai": 2048,  # 2048 items + 300K tokens/request; token limit may bite first
+        "azure": 2048,  # mirrors OpenAI
+    }.get(provider, 256)
 
 
 def l2_normalize(vec):

--- a/mage/python/embeddings.py
+++ b/mage/python/embeddings.py
@@ -2,7 +2,7 @@ import multiprocessing as mp
 import os
 import sys
 import threading
-from concurrent.futures import ProcessPoolExecutor, as_completed
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
 from typing import List
 
 import huggingface_hub  # noqa: F401
@@ -407,6 +407,142 @@ def multi_gpu_compute(
     )
 
 
+_litellm_configured = False
+
+
+def _ensure_litellm_configured():
+    # Silence LiteLLM's "Provider List: ..." banner that fires on every
+    # get_llm_provider() miss — we probe deliberately for local names.
+    global _litellm_configured
+    if _litellm_configured:
+        return
+    try:
+        import litellm
+
+        litellm.suppress_debug_info = True
+    except ImportError:
+        return
+    _litellm_configured = True
+
+
+def resolve_remote_model(model_name):
+    """Ask LiteLLM whether ``model_name`` belongs to one of its providers.
+
+    Returns ``(model, provider, default_api_base)`` if recognized (e.g.
+    ``"openai/text-embedding-3-small"``), otherwise ``None`` — in which case
+    the caller should fall through to the local SentenceTransformer path.
+    """
+    if not isinstance(model_name, str) or not model_name:
+        return None
+    try:
+        from litellm import get_llm_provider
+    except ImportError:
+        return None
+    _ensure_litellm_configured()
+    try:
+        model, provider, _dynamic_key, default_api_base = get_llm_provider(model_name)
+    except Exception:
+        return None
+    return model, provider, default_api_base
+
+
+def default_remote_batch_size(provider):
+    # Conservative defaults that stay under each provider's per-request input cap.
+    return {
+        "voyage": 128,
+        "cohere": 96,
+        "openai": 512,
+        "azure": 512,
+        "mistral": 512,
+        "jina_ai": 512,
+        "ollama": 64,
+        "huggingface": 64,
+        "bedrock": 64,
+    }.get(provider, 64)
+
+
+def l2_normalize(vec):
+    s = sum(x * x for x in vec) ** 0.5
+    if s == 0:
+        return vec
+    return [x / s for x in vec]
+
+
+def remote_compute(
+    input_items: mgp.Any,
+    cfg: mgp.Map,
+    dimension: int,
+    resolved,
+) -> mgp.Record(success=bool, embeddings=mgp.Nullable[mgp.List[list]], dimension=int):
+    """LiteLLM-routed remote embedding path.
+
+    Fans chunks across a small thread pool, preserves input order, and
+    L2-normalizes client-side when ``cfg["normalize"]`` (default) so behavior
+    matches the local sentence_transformers path. Raises on permanent failure
+    — the caller catches and converts to ``success=False``.
+    """
+    from litellm import embedding as litellm_embedding
+
+    _model, provider, default_api_base = resolved
+    vertex_input = isinstance(cfg["embedding_property"], str)
+    texts = build_texts(input_items, cfg["excluded_properties"]) if vertex_input else list(input_items)
+
+    n = len(texts)
+    if n == 0:
+        return return_data(
+            input_items if vertex_input else [],
+            embedding_property_name=cfg["embedding_property"] if vertex_input else None,
+            return_embeddings=cfg["return_embeddings"],
+            success=True,
+            dimension=dimension,
+        )
+
+    chunk_size = cfg["remote_batch_size"] or default_remote_batch_size(provider)
+    chunks = [texts[i : i + chunk_size] for i in range(0, n, chunk_size)]
+
+    api_base = cfg["api_base"] or default_api_base
+    base_kwargs = {
+        "model": cfg["model_name"],
+        "num_retries": cfg["num_retries"],
+        "timeout": cfg["timeout"],
+    }
+    if api_base:
+        base_kwargs["api_base"] = api_base
+    if cfg["input_type"]:
+        base_kwargs["input_type"] = cfg["input_type"]
+    if cfg["dimensions"]:
+        base_kwargs["dimensions"] = cfg["dimensions"]
+    if cfg["extra_kwargs"]:
+        base_kwargs.update(cfg["extra_kwargs"])
+
+    def _call(chunk_texts):
+        resp = litellm_embedding(input=chunk_texts, **base_kwargs)
+        return [d["embedding"] for d in resp["data"]]
+
+    results = [None] * len(chunks)
+    with ThreadPoolExecutor(max_workers=max(1, cfg["concurrency"])) as ex:
+        fut2idx = {ex.submit(_call, c): i for i, c in enumerate(chunks)}
+        for fut in as_completed(fut2idx):
+            results[fut2idx[fut]] = fut.result()
+
+    flat = [e for part in results for e in part]
+    if cfg["normalize"]:
+        flat = [l2_normalize(e) for e in flat]
+
+    if vertex_input:
+        for v, e in zip(input_items, flat):
+            v.properties[cfg["embedding_property"]] = e
+
+    logger.info(f"Processed {n} items via LiteLLM provider '{provider}' (model={cfg['model_name']}).")
+    return return_data(
+        input_items if vertex_input else flat,
+        embedding_property_name=cfg["embedding_property"] if vertex_input else None,
+        return_embeddings=cfg["return_embeddings"],
+        success=True,
+        dimension=dimension or (len(flat[0]) if flat else None),
+    )
+
+
 def return_data(
     input_items: mgp.Any,
     embedding_property_name: mgp.Nullable[str] = "embedding",
@@ -440,6 +576,7 @@ def return_data(
 
 def validate_configuration(configuration: mgp.Map):
     default_configuration = {
+        # Local path
         "embedding_property": "embedding",
         "excluded_properties": ["embedding"],
         "model_name": "all-MiniLM-L6-v2",
@@ -447,6 +584,19 @@ def validate_configuration(configuration: mgp.Map):
         "chunk_size": 48,
         "device": None,
         "return_embeddings": False,
+        # Remote path (via LiteLLM). These are only used when model_name resolves
+        # to a LiteLLM-known provider (e.g. "openai/text-embedding-3-small").
+        # API keys are NOT accepted here — LiteLLM reads canonical provider env
+        # vars (OPENAI_API_KEY, COHERE_API_KEY, VOYAGE_API_KEY, ...).
+        "api_base": None,
+        "input_type": "document",
+        "dimensions": None,
+        "timeout": 60,
+        "num_retries": 3,
+        "normalize": True,
+        "remote_batch_size": None,
+        "concurrency": 4,
+        "extra_kwargs": {},
     }
     configuration = {**default_configuration, **configuration}
 
@@ -463,21 +613,86 @@ def validate_configuration(configuration: mgp.Map):
     if configuration["embedding_property"] is not None and configuration["embedding_property"] not in excluded:
         excluded.append(configuration["embedding_property"])
 
-    logger.debug(f"Using embedding configuration: {configuration}")
+    # When routing remote, a local `device` setting has no meaning — warn so the
+    # user knows we're ignoring it rather than silently doing the wrong thing.
+    if resolve_remote_model(configuration["model_name"]) is not None and configuration["device"] is not None:
+        logger.warning(
+            f"'device' is ignored when model_name '{configuration['model_name']}' routes to a remote provider."
+        )
+
+    logger.debug(f"Using embedding configuration: {_redacted_config(configuration)}")
 
     return configuration
+
+
+_SECRET_KEY_PATTERNS = ("key", "secret", "token", "password", "credential")
+
+
+def _redacted_config(cfg):
+    """Return a shallow-copied config with secret-looking fields masked.
+
+    We don't currently accept an api_key config key (LiteLLM reads env vars),
+    but `extra_kwargs` is a user-supplied passthrough that could carry one, and
+    `api_base` URLs can embed credentials (``https://user:pass@host/...``).
+    Defense in depth.
+    """
+    import re
+
+    def _scrub(value):
+        if isinstance(value, dict):
+            return {k: ("<redacted>" if _looks_secret(k) else _scrub(v)) for k, v in value.items()}
+        if isinstance(value, str):
+            return re.sub(r"(://)[^/@\s]+:[^/@\s]+@", r"\1<redacted>@", value)
+        return value
+
+    def _looks_secret(key):
+        k = str(key).lower()
+        return any(p in k for p in _SECRET_KEY_PATTERNS)
+
+    return {k: ("<redacted>" if _looks_secret(k) else _scrub(v)) for k, v in cfg.items()}
 
 
 def compute_embeddings(
     input_items: mgp.Any,
     configuration: mgp.Map,
 ) -> mgp.Any:
-    dimension = get_model_info(configuration).get("dimension", None)
-    if dimension is None:
-        logger.warning("Failed to get model dimension.")
-
     try:
         n = len(input_items)
+
+        # Route to LiteLLM if model_name names a known remote provider
+        # (e.g. "openai/text-embedding-3-small", "ollama/nomic-embed-text").
+        # Bare names and HF-style names like "BAAI/bge-small-en-v1.5" fall
+        # through to the local SentenceTransformer path below.
+        resolved = resolve_remote_model(configuration["model_name"])
+        if resolved is not None:
+            if n == 0:
+                logger.info("No items to process.")
+                return return_data(
+                    input_items,
+                    configuration["embedding_property"],
+                    configuration["return_embeddings"],
+                    True,
+                    dimension=None,
+                )
+            try:
+                # Dimension is derived from the encode response inside
+                # remote_compute — no separate probe needed.
+                return remote_compute(input_items, configuration, None, resolved)
+            except Exception as e:
+                logger.error(f"Remote path failed: {e}")
+                return return_data(
+                    input_items,
+                    configuration["embedding_property"],
+                    configuration["return_embeddings"],
+                    False,
+                    dimension=None,
+                )
+
+        # Local path: probe the SentenceTransformer for dimension up front.
+        dimension = get_model_info(configuration).get("dimension", None)
+        if dimension is None:
+            logger.warning("Failed to get model dimension.")
+
         if n == 0:
             logger.info("No vertices to process.")
             return return_data(
@@ -579,7 +794,15 @@ def compute_embeddings(
         )
 
 
+_remote_info_cache = {}
+_remote_info_lock = threading.Lock()
+
+
 def get_model_info(configuration: mgp.Map):
+    resolved = resolve_remote_model(configuration["model_name"])
+    if resolved is not None:
+        return _remote_model_info(configuration, resolved)
+
     model = _get_or_load_model(configuration["model_name"], "cpu")
 
     info = {
@@ -588,6 +811,46 @@ def get_model_info(configuration: mgp.Map):
         "max_sequence_length": model.get_max_seq_length(),
     }
 
+    return info
+
+
+def _remote_model_info(configuration, resolved):
+    """Probe a remote provider once to learn its embedding dimension.
+
+    Cached per (model_name, api_base) so subsequent calls don't re-hit the API.
+    """
+    _model, _provider, default_api_base = resolved
+    api_base = configuration.get("api_base") or default_api_base
+    cache_key = (configuration["model_name"], api_base)
+
+    with _remote_info_lock:
+        cached = _remote_info_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    from litellm import embedding as litellm_embedding
+
+    kwargs = {
+        "model": configuration["model_name"],
+        "input": ["probe"],
+        "num_retries": configuration.get("num_retries", 3),
+        "timeout": configuration.get("timeout", 60),
+    }
+    if api_base:
+        kwargs["api_base"] = api_base
+    if configuration.get("dimensions"):
+        kwargs["dimensions"] = configuration["dimensions"]
+
+    resp = litellm_embedding(**kwargs)
+    dim = len(resp["data"][0]["embedding"])
+    info = {
+        "model_name": configuration["model_name"],
+        "dimension": dim,
+        "max_sequence_length": None,
+    }
+
+    with _remote_info_lock:
+        _remote_info_cache[cache_key] = info
     return info
 
 

--- a/mage/python/embeddings.py
+++ b/mage/python/embeddings.py
@@ -478,7 +478,20 @@ def remote_compute(
 
     def _call(chunk_texts):
         resp = litellm.embedding(input=chunk_texts, **base_kwargs)
-        return [d["embedding"] for d in resp["data"]]
+        data = resp["data"]
+        # Defensive: count mismatch silently truncates the vertex write-back loop;
+        # out-of-order responses misalign embeddings to inputs. OpenAI's schema
+        # exposes an `index` field for exactly this reason — sort by it when
+        # every item has one, otherwise fall back to provider order.
+        if len(data) != len(chunk_texts):
+            raise ValueError(f"Embedding provider returned {len(data)} vectors for {len(chunk_texts)} inputs")
+
+        def _idx(item):
+            return item.get("index") if isinstance(item, dict) else getattr(item, "index", None)
+
+        if data and all(_idx(d) is not None for d in data):
+            data = sorted(data, key=_idx)
+        return [d["embedding"] for d in data]
 
     results = [None] * len(chunks)
     ex = ThreadPoolExecutor(max_workers=cfg["concurrency"])

--- a/mage/python/embeddings.py
+++ b/mage/python/embeddings.py
@@ -8,6 +8,7 @@ from typing import List
 import huggingface_hub  # noqa: F401
 import litellm
 import mgp
+import numpy as np
 
 # Suppress LiteLLM's "Provider List: ..." banner that fires on every
 # get_llm_provider() miss — we probe deliberately for local names.
@@ -428,13 +429,6 @@ def resolve_remote_model(model_name):
     return model, provider, default_api_base
 
 
-def l2_normalize(vec):
-    s = sum(x * x for x in vec) ** 0.5
-    if s == 0:
-        return vec
-    return [x / s for x in vec]
-
-
 def remote_compute(
     input_items: mgp.Any,
     cfg: mgp.Map,
@@ -504,7 +498,12 @@ def remote_compute(
 
     flat = [e for part in results for e in part]
     if cfg["normalize"]:
-        flat = [l2_normalize(e) for e in flat]
+        # Vectorized L2 normalization via numpy (transitively available
+        # through sentence_transformers/torch). Substitute 1.0 for any
+        # zero norms to leave zero vectors untouched after division.
+        arr = np.asarray(flat, dtype=np.float64)
+        norms = np.linalg.norm(arr, axis=1, keepdims=True)
+        flat = (arr / np.where(norms == 0.0, 1.0, norms)).tolist()
 
     if vertex_input:
         for v, e in zip(input_items, flat):

--- a/mage/tests/e2e/embeddings_test/test_remote_node_sentence_failure/input.cyp
+++ b/mage/tests/e2e/embeddings_test/test_remote_node_sentence_failure/input.cyp
@@ -1,0 +1,1 @@
+CREATE (:Doc {title: "remote routing failure fixture"});

--- a/mage/tests/e2e/embeddings_test/test_remote_node_sentence_failure/test.yml
+++ b/mage/tests/e2e/embeddings_test/test_remote_node_sentence_failure/test.yml
@@ -1,0 +1,17 @@
+query: >
+    WITH {
+      model_name: "openai/text-embedding-3-small",
+      api_base: "http://127.0.0.1:1/v1",
+      num_retries: 0,
+      timeout: 2,
+      extra_kwargs: {api_key: "ci-dummy-no-real-calls"}
+    } AS configuration
+    CALL embeddings.node_sentence(NULL, configuration)
+    YIELD success
+    WITH success
+    MATCH (n:Doc)
+    RETURN success, n.embedding IS NULL AS no_embedding_written;
+
+output:
+    - success: false
+      no_embedding_written: true

--- a/mage/tests/e2e/embeddings_test/test_remote_node_sentence_failure/test.yml
+++ b/mage/tests/e2e/embeddings_test/test_remote_node_sentence_failure/test.yml
@@ -1,10 +1,9 @@
 query: >
     WITH {
-      model_name: "openai/text-embedding-3-small",
-      api_base: "http://127.0.0.1:1/v1",
+      model_name: "ollama/nomic-embed-text",
+      api_base: "http://127.0.0.1:1",
       num_retries: 0,
-      timeout: 2,
-      extra_kwargs: {api_key: "ci-dummy-no-real-calls"}
+      timeout: 2
     } AS configuration
     CALL embeddings.node_sentence(NULL, configuration)
     YIELD success

--- a/mage/tests/e2e/embeddings_test/test_remote_node_sentence_failure/test.yml
+++ b/mage/tests/e2e/embeddings_test/test_remote_node_sentence_failure/test.yml
@@ -1,14 +1,13 @@
 query: >
-    WITH {
+    MATCH (n:Doc)
+    WITH n, {
       model_name: "ollama/nomic-embed-text",
       api_base: "http://127.0.0.1:1",
       num_retries: 0,
       timeout: 2
     } AS configuration
-    CALL embeddings.node_sentence(NULL, configuration)
+    CALL embeddings.node_sentence([n], configuration)
     YIELD success
-    WITH success
-    MATCH (n:Doc)
     RETURN success, n.embedding IS NULL AS no_embedding_written;
 
 output:

--- a/mage/tests/e2e/embeddings_test/test_remote_ollama.py
+++ b/mage/tests/e2e/embeddings_test/test_remote_ollama.py
@@ -1,0 +1,134 @@
+"""Opt-in e2e test: embeddings.* against a local Ollama daemon.
+
+Skipped by default. To run locally:
+
+    # 1. install & start ollama (https://ollama.com), then pull a small model
+    ollama pull nomic-embed-text
+
+    # 2. Ensure Memgraph+MAGE is running on localhost:7687. If Memgraph runs
+    #    inside Docker and Ollama runs on the host, set MAGE_E2E_OLLAMA_BASE
+    #    to a URL the Memgraph container can reach (e.g. http://host.docker.internal:11434).
+
+    # 3. opt in and run
+    export MAGE_E2E_OLLAMA=1
+    pytest tests/e2e/embeddings_test/test_remote_ollama.py -v
+
+Not run in CI: the gating env var is unset in the CI workflow.
+"""
+
+import os
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+import mgclient
+import pytest
+
+MEMGRAPH_HOST = os.environ.get("MAGE_E2E_MEMGRAPH_HOST", "127.0.0.1")
+MEMGRAPH_PORT = int(os.environ.get("MAGE_E2E_MEMGRAPH_PORT", "7687"))
+OLLAMA_BASE = os.environ.get("MAGE_E2E_OLLAMA_BASE", "http://127.0.0.1:11434")
+OLLAMA_MODEL = os.environ.get("MAGE_E2E_OLLAMA_MODEL", "nomic-embed-text")
+MODEL = f"ollama/{OLLAMA_MODEL}"
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("MAGE_E2E_OLLAMA"),
+    reason="MAGE_E2E_OLLAMA not set — skipping opt-in Ollama e2e test",
+)
+
+
+def _probe_ollama():
+    """Return True if the Ollama daemon responds at OLLAMA_BASE."""
+    try:
+        parsed = urlparse(OLLAMA_BASE)
+        assert parsed.scheme in ("http", "https")
+        with urlopen(Request(f"{OLLAMA_BASE}/api/tags"), timeout=2) as r:
+            return r.status == 200
+    except Exception:
+        return False
+
+
+def _connect():
+    conn = mgclient.connect(host=MEMGRAPH_HOST, port=MEMGRAPH_PORT)
+    conn.autocommit = True
+    return conn
+
+
+@pytest.fixture(scope="module")
+def db():
+    if not _probe_ollama():
+        pytest.skip(
+            f"Ollama not reachable at {OLLAMA_BASE} — start it or set " "MAGE_E2E_OLLAMA_BASE to a reachable URL"
+        )
+    try:
+        conn = _connect()
+        cur = conn.cursor()
+        cur.execute("CALL mg.procedures() YIELD name RETURN name")
+        names = {row[0] for row in cur.fetchall()}
+        if "embeddings.text" not in names:
+            pytest.skip("embeddings module not loaded in Memgraph")
+    except Exception as e:
+        pytest.skip(f"Memgraph not reachable: {e}")
+    yield
+    c = _connect()
+    c.cursor().execute("MATCH (n:E2ETestOllama) DETACH DELETE n")
+    c.close()
+
+
+def _run(cypher, params=None):
+    conn = _connect()
+    cur = conn.cursor()
+    cur.execute(cypher, params or {})
+    rows = cur.fetchall()
+    conn.close()
+    return rows
+
+
+def test_text_returns_normalized_embeddings(db):
+    rows = _run(
+        "CALL embeddings.text(['hello world', 'graph databases are fun'], "
+        "{model_name: $m, api_base: $b}) "
+        "YIELD success, embeddings, dimension "
+        "RETURN success, embeddings, dimension",
+        {"m": MODEL, "b": OLLAMA_BASE},
+    )
+    assert len(rows) == 1
+    success, embeddings, dimension = rows[0]
+    assert success is True, f"call failed; is '{OLLAMA_MODEL}' pulled? (ollama pull {OLLAMA_MODEL})"
+    assert dimension is not None and dimension > 0
+    assert len(embeddings) == 2
+    for v in embeddings:
+        assert len(v) == dimension
+        magnitude = sum(x * x for x in v) ** 0.5
+        assert abs(magnitude - 1.0) < 1e-3, f"expected normalized vector, got |v|={magnitude}"
+
+
+def test_model_info_populates_dimension(db):
+    rows = _run(
+        "CALL embeddings.model_info({model_name: $m, api_base: $b}) YIELD info RETURN info",
+        {"m": MODEL, "b": OLLAMA_BASE},
+    )
+    info = rows[0][0]
+    assert info["model_name"] == MODEL
+    assert info["dimension"] > 0
+    assert info["max_sequence_length"] is None
+
+
+def test_node_sentence_writes_back_property(db):
+    _run("MATCH (n:E2ETestOllama) DETACH DELETE n")
+    _run(
+        "CREATE (:E2ETestOllama {title: 'Magnetospheric field line resonances', id: 1}),"
+        "       (:E2ETestOllama {title: 'Vector indexes in graph databases',  id: 2})"
+    )
+    rows = _run(
+        "MATCH (n:E2ETestOllama) WITH collect(n) AS nodes "
+        "CALL embeddings.node_sentence(nodes, {model_name: $m, api_base: $b}) "
+        "YIELD success, dimension "
+        "RETURN success, dimension",
+        {"m": MODEL, "b": OLLAMA_BASE},
+    )
+    success, dimension = rows[0]
+    assert success is True
+    assert dimension > 0
+
+    check = _run("MATCH (n:E2ETestOllama) " "RETURN n.id AS id, size(n.embedding) AS dim " "ORDER BY n.id")
+    assert [r[0] for r in check] == [1, 2]
+    assert all(r[1] == dimension for r in check), "each node should carry a vector of the reported dimension"

--- a/mage/tests/e2e/embeddings_test/test_remote_openai.py
+++ b/mage/tests/e2e/embeddings_test/test_remote_openai.py
@@ -1,17 +1,15 @@
-"""E2E test: embeddings.* against the real OpenAI embeddings API.
+"""Opt-in e2e test: embeddings.* against the real OpenAI embeddings API.
 
-Runs whenever Memgraph is reachable AND its process environment carries a
-working ``OPENAI_API_KEY``. The CI workflow forwards the secret into the
-container's env (see ``.github/workflows/reusable_package_mage.yaml``);
-locally:
+Skipped by default. To run locally:
 
-    docker run -e OPENAI_API_KEY=$OPENAI_API_KEY ... memgraph/memgraph-mage
+    # 1. Ensure Memgraph+MAGE is running on localhost:7687 with OPENAI_API_KEY
+    #    in its process environment (e.g. docker run -e OPENAI_API_KEY=$OPENAI_API_KEY ...).
+
+    # 2. opt in and run
+    export MAGE_E2E_OPENAI=1
     pytest tests/e2e/embeddings_test/test_remote_openai.py -v
 
-If the key is missing or the OpenAI probe call fails, the suite skips with
-a clear message rather than failing — local devs without a key won't see
-spurious red, but CI failures (where the key is supposed to be set) still
-surface as real regressions.
+Not run in CI: the gating env var is unset in the CI workflow.
 """
 
 import os
@@ -22,6 +20,11 @@ import pytest
 MEMGRAPH_HOST = os.environ.get("MAGE_E2E_MEMGRAPH_HOST", "127.0.0.1")
 MEMGRAPH_PORT = int(os.environ.get("MAGE_E2E_MEMGRAPH_PORT", "7687"))
 MODEL = os.environ.get("MAGE_E2E_OPENAI_MODEL", "openai/text-embedding-3-small")
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("MAGE_E2E_OPENAI"),
+    reason="MAGE_E2E_OPENAI not set — skipping opt-in OpenAI e2e test",
+)
 
 
 def _connect():

--- a/mage/tests/e2e/embeddings_test/test_remote_openai.py
+++ b/mage/tests/e2e/embeddings_test/test_remote_openai.py
@@ -1,16 +1,17 @@
-"""Opt-in e2e test: embeddings.* against the real OpenAI embeddings API.
+"""E2E test: embeddings.* against the real OpenAI embeddings API.
 
-Skipped by default. To run locally:
+Runs whenever Memgraph is reachable AND its process environment carries a
+working ``OPENAI_API_KEY``. The CI workflow forwards the secret into the
+container's env (see ``.github/workflows/reusable_package_mage.yaml``);
+locally:
 
-    export OPENAI_API_KEY=sk-...
-    # Ensure Memgraph+MAGE is running on localhost:7687 with OPENAI_API_KEY
-    # available inside the Memgraph process environment (e.g.
-    #   docker run -e OPENAI_API_KEY=$OPENAI_API_KEY ... memgraph/memgraph-mage
-    # or run Memgraph natively with the var exported).
+    docker run -e OPENAI_API_KEY=$OPENAI_API_KEY ... memgraph/memgraph-mage
     pytest tests/e2e/embeddings_test/test_remote_openai.py -v
 
-Not run in CI: the gating env var is unset in the CI workflow, so pytest
-collects and immediately skips these tests.
+If the key is missing or the OpenAI probe call fails, the suite skips with
+a clear message rather than failing — local devs without a key won't see
+spurious red, but CI failures (where the key is supposed to be set) still
+surface as real regressions.
 """
 
 import os
@@ -21,11 +22,6 @@ import pytest
 MEMGRAPH_HOST = os.environ.get("MAGE_E2E_MEMGRAPH_HOST", "127.0.0.1")
 MEMGRAPH_PORT = int(os.environ.get("MAGE_E2E_MEMGRAPH_PORT", "7687"))
 MODEL = os.environ.get("MAGE_E2E_OPENAI_MODEL", "openai/text-embedding-3-small")
-
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("OPENAI_API_KEY"),
-    reason="OPENAI_API_KEY not set — skipping opt-in OpenAI e2e test",
-)
 
 
 def _connect():
@@ -41,10 +37,26 @@ def db():
         cur = conn.cursor()
         cur.execute("CALL mg.procedures() YIELD name RETURN name")
         names = {row[0] for row in cur.fetchall()}
+        conn.close()
         if "embeddings.text" not in names:
             pytest.skip("embeddings module not loaded in Memgraph")
     except Exception as e:
         pytest.skip(f"Memgraph not reachable: {e}")
+
+    # Probe OpenAI through the Memgraph process. Skips (rather than fails) when
+    # OPENAI_API_KEY is missing from Memgraph's env or OpenAI is unreachable —
+    # so local devs without a key see "skipped" instead of red, while a CI run
+    # that *should* have the key forwarded gets real assertion failures below.
+    rows = _run(
+        "CALL embeddings.text(['probe'], {model_name: $m}) YIELD success RETURN success",
+        {"m": MODEL},
+    )
+    if not rows or not rows[0][0]:
+        pytest.skip(
+            f"OpenAI probe via {MODEL} returned success=false — is OPENAI_API_KEY "
+            "set in the Memgraph process environment?"
+        )
+
     yield
     # cleanup any fixture data the tests created
     c = _connect()

--- a/mage/tests/e2e/embeddings_test/test_remote_openai.py
+++ b/mage/tests/e2e/embeddings_test/test_remote_openai.py
@@ -1,0 +1,115 @@
+"""Opt-in e2e test: embeddings.* against the real OpenAI embeddings API.
+
+Skipped by default. To run locally:
+
+    export OPENAI_API_KEY=sk-...
+    # Ensure Memgraph+MAGE is running on localhost:7687 with OPENAI_API_KEY
+    # available inside the Memgraph process environment (e.g.
+    #   docker run -e OPENAI_API_KEY=$OPENAI_API_KEY ... memgraph/memgraph-mage
+    # or run Memgraph natively with the var exported).
+    pytest tests/e2e/embeddings_test/test_remote_openai.py -v
+
+Not run in CI: the gating env var is unset in the CI workflow, so pytest
+collects and immediately skips these tests.
+"""
+
+import os
+
+import mgclient
+import pytest
+
+MEMGRAPH_HOST = os.environ.get("MAGE_E2E_MEMGRAPH_HOST", "127.0.0.1")
+MEMGRAPH_PORT = int(os.environ.get("MAGE_E2E_MEMGRAPH_PORT", "7687"))
+MODEL = os.environ.get("MAGE_E2E_OPENAI_MODEL", "openai/text-embedding-3-small")
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY not set — skipping opt-in OpenAI e2e test",
+)
+
+
+def _connect():
+    conn = mgclient.connect(host=MEMGRAPH_HOST, port=MEMGRAPH_PORT)
+    conn.autocommit = True
+    return conn
+
+
+@pytest.fixture(scope="module")
+def db():
+    try:
+        conn = _connect()
+        cur = conn.cursor()
+        cur.execute("CALL mg.procedures() YIELD name RETURN name")
+        names = {row[0] for row in cur.fetchall()}
+        if "embeddings.text" not in names:
+            pytest.skip("embeddings module not loaded in Memgraph")
+    except Exception as e:
+        pytest.skip(f"Memgraph not reachable: {e}")
+    yield
+    # cleanup any fixture data the tests created
+    c = _connect()
+    c.cursor().execute("MATCH (n:E2ETestOpenAI) DETACH DELETE n")
+    c.close()
+
+
+def _run(cypher, params=None):
+    conn = _connect()
+    cur = conn.cursor()
+    cur.execute(cypher, params or {})
+    rows = cur.fetchall()
+    conn.close()
+    return rows
+
+
+def test_text_returns_normalized_embeddings(db):
+    rows = _run(
+        "CALL embeddings.text(['hello world', 'graph databases are fun'], "
+        "{model_name: $m}) "
+        "YIELD success, embeddings, dimension "
+        "RETURN success, embeddings, dimension",
+        {"m": MODEL},
+    )
+    assert len(rows) == 1
+    success, embeddings, dimension = rows[0]
+    assert success is True
+    assert dimension is not None and dimension > 0
+    assert len(embeddings) == 2
+    for v in embeddings:
+        assert len(v) == dimension
+        magnitude = sum(x * x for x in v) ** 0.5
+        # normalize=True is the default, so magnitudes should be ~1.0
+        assert abs(magnitude - 1.0) < 1e-3, f"expected normalized vector, got |v|={magnitude}"
+
+
+def test_model_info_populates_dimension(db):
+    rows = _run(
+        "CALL embeddings.model_info({model_name: $m}) YIELD info RETURN info",
+        {"m": MODEL},
+    )
+    info = rows[0][0]
+    assert info["model_name"] == MODEL
+    assert info["dimension"] > 0
+    # Remote providers don't expose a sequence length — field is present but null.
+    assert info["max_sequence_length"] is None
+
+
+def test_node_sentence_writes_back_property(db):
+    _run("MATCH (n:E2ETestOpenAI) DETACH DELETE n")
+    _run(
+        "CREATE (:E2ETestOpenAI {title: 'Magnetospheric field line resonances', id: 1}),"
+        "       (:E2ETestOpenAI {title: 'Vector indexes in graph databases',  id: 2})"
+    )
+    rows = _run(
+        "MATCH (n:E2ETestOpenAI) WITH collect(n) AS nodes "
+        "CALL embeddings.node_sentence(nodes, {model_name: $m}) "
+        "YIELD success, dimension "
+        "RETURN success, dimension",
+        {"m": MODEL},
+    )
+    success, dimension = rows[0]
+    assert success is True
+    assert dimension > 0
+
+    check = _run("MATCH (n:E2ETestOpenAI) " "RETURN n.id AS id, size(n.embedding) AS dim " "ORDER BY n.id")
+    assert [r[0] for r in check] == [1, 2]
+    assert all(r[1] == dimension for r in check), "each node should carry a vector of the reported dimension"

--- a/mage/tests/e2e/embeddings_test/test_remote_text_failure/test.yml
+++ b/mage/tests/e2e/embeddings_test/test_remote_text_failure/test.yml
@@ -1,0 +1,18 @@
+query: >
+    WITH {
+      model_name: "openai/text-embedding-3-small",
+      api_base: "http://127.0.0.1:1/v1",
+      num_retries: 0,
+      timeout: 2,
+      extra_kwargs: {api_key: "ci-dummy-no-real-calls"}
+    } AS configuration
+    CALL embeddings.text(["probe"], configuration)
+    YIELD success, embeddings, dimension
+    RETURN success,
+           embeddings IS NULL AS embeddings_null,
+           dimension IS NULL AS dimension_null;
+
+output:
+    - success: false
+      embeddings_null: true
+      dimension_null: true

--- a/mage/tests/e2e/embeddings_test/test_remote_text_failure/test.yml
+++ b/mage/tests/e2e/embeddings_test/test_remote_text_failure/test.yml
@@ -1,10 +1,9 @@
 query: >
     WITH {
-      model_name: "openai/text-embedding-3-small",
-      api_base: "http://127.0.0.1:1/v1",
+      model_name: "ollama/nomic-embed-text",
+      api_base: "http://127.0.0.1:1",
       num_retries: 0,
-      timeout: 2,
-      extra_kwargs: {api_key: "ci-dummy-no-real-calls"}
+      timeout: 2
     } AS configuration
     CALL embeddings.text(["probe"], configuration)
     YIELD success, embeddings, dimension

--- a/mage/tests/e2e/test_module.py
+++ b/mage/tests/e2e/test_module.py
@@ -275,23 +275,14 @@ def _test_standalone(test_file: Path):
     """
     Run a self-contained Python test script via pytest subprocess.
     These scripts manage their own connections and cleanup.
-
-    Always prints the inner pytest output so per-test PASSED/SKIPPED lines
-    reach the CI log. Without this, a wholly-skipped opt-in suite (gated
-    by an env var like MAGE_E2E_OLLAMA) exits 0 and is indistinguishable
-    from a passing suite at this level. ``-rs`` adds a short summary of
-    skip reasons at the bottom for at-a-glance verification.
     """
     result = subprocess.run(
-        ["python3", "-m", "pytest", str(test_file), "-v", "-rs"],
+        ["python3", "-m", "pytest", str(test_file), "-v"],
         capture_output=True,
         text=True,
     )
-    print(f"\n--- {test_file.name} stdout ---\n{result.stdout}", flush=True)
-    if result.stderr:
-        print(f"--- {test_file.name} stderr ---\n{result.stderr}", flush=True)
     if result.returncode != 0:
-        pytest.fail(f"Standalone test {test_file.name} failed (exit {result.returncode})")
+        pytest.fail(f"Standalone test {test_file.name} failed:\n" f"{result.stdout}\n{result.stderr}")
 
 
 @pytest.mark.parametrize("test_dir", tests)

--- a/mage/tests/e2e/test_module.py
+++ b/mage/tests/e2e/test_module.py
@@ -275,14 +275,23 @@ def _test_standalone(test_file: Path):
     """
     Run a self-contained Python test script via pytest subprocess.
     These scripts manage their own connections and cleanup.
+
+    Always prints the inner pytest output so per-test PASSED/SKIPPED lines
+    reach the CI log. Without this, a wholly-skipped opt-in suite (gated
+    by an env var like MAGE_E2E_OLLAMA) exits 0 and is indistinguishable
+    from a passing suite at this level. ``-rs`` adds a short summary of
+    skip reasons at the bottom for at-a-glance verification.
     """
     result = subprocess.run(
-        ["python3", "-m", "pytest", str(test_file), "-v"],
+        ["python3", "-m", "pytest", str(test_file), "-v", "-rs"],
         capture_output=True,
         text=True,
     )
+    print(f"\n--- {test_file.name} stdout ---\n{result.stdout}", flush=True)
+    if result.stderr:
+        print(f"--- {test_file.name} stderr ---\n{result.stderr}", flush=True)
     if result.returncode != 0:
-        pytest.fail(f"Standalone test {test_file.name} failed:\n" f"{result.stdout}\n{result.stderr}")
+        pytest.fail(f"Standalone test {test_file.name} failed (exit {result.returncode})")
 
 
 @pytest.mark.parametrize("test_dir", tests)

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -1900,6 +1900,8 @@ build_gssapi() {
     esac
   done
   mkdir -p "$dest_dir"
+  # TODO(matt): remove in toolchain v8
+  # we need to install libkrb5-dev in the container to build gssapi as it has been added as a build dependency sing the container image was built
   docker exec -u root "$build_container" bash -c "$MGBUILD_ROOT_DIR/environment/os/install_deps.sh check MEMGRAPH_BUILD_DEPS || $MGBUILD_ROOT_DIR/environment/os/install_deps.sh install MEMGRAPH_BUILD_DEPS"
   docker exec -i -u mg $build_container bash -c "cd \$HOME/memgraph/tools/ci && ./build-gssapi.sh"
   local package_name

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -1900,6 +1900,7 @@ build_gssapi() {
     esac
   done
   mkdir -p "$dest_dir"
+  docker exec -u root "$build_container" bash -c "$MGBUILD_ROOT_DIR/environment/os/install_deps.sh check MEMGRAPH_BUILD_DEPS || $MGBUILD_ROOT_DIR/environment/os/install_deps.sh install MEMGRAPH_BUILD_DEPS"
   docker exec -i -u mg $build_container bash -c "cd \$HOME/memgraph/tools/ci && ./build-gssapi.sh"
   local package_name
   package_name=$(docker exec -i -u mg $build_container bash -c "ls -1 \$HOME/memgraph/tools/ci/gssapi/dist/*.whl | head -n 1 | xargs -n1 basename")


### PR DESCRIPTION
## Add remote embedding providers to the embeddings query module                                                                                                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
  Adds support for any embedding provider supported by LiteLLM — OpenAI, Azure OpenAI, Ollama, Cohere, Voyage, Mistral, Jina, Bedrock, Vertex AI, Hugging Face, and any OpenAI‑compatible endpoint — while keeping the local sentence-transformers path unchanged.                                                                                                                                                                                                                            
   
###  Summary                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
                                                                       
  - Routing decided by model_name: a LiteLLM provider prefix (e.g. openai/text-embedding-3-small, ollama/nomic-embed-text) routes remote; bare names and HF paths (e.g. BAAI/bge-small-en-v1.5) stay local.                                                                                                                                                                                                                                                                                   
  - New config keys (only used on the remote path): api_base, input_type, dimensions, timeout, num_retries, normalize, remote_batch_size, concurrency.
  - Credentials read from the Memgraph process environment only (matches llm.py — OPENAI_API_KEY, COHERE_API_KEY, etc.); no api_key config key exists, so secrets cannot leak into Cypher or query logs.                                                                                                                                                                                                                                                                                      
  - Remote calls chunked and fanned out with a per-call ThreadPoolExecutor (default concurrency=4), L2-normalized client-side by default to match local behavior.                                                                                                                                                                                                                                                                                                                             
  - dimension return field is now Nullable[int] — procs surface success=false, dimension=null on failure rather than throwing.                                                                                                                                                                                                                                                                                                                                                                
  - embeddings.model_info probes remote providers once for their dimension, cached per (model_name, api_base).                                                                                                                                                                                                                                                                                                                                                                                
  - Zero new dependencies — litellm is already pinned in mage/python/requirements*.txt (used by llm.py).                                                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
###  Backwards compatibility                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
  Zero Cypher changes required. CALL embeddings.node_sentence(null, {}) and CALL embeddings.text([...], {}) keep the local path with the same default model and return shape.                                                                                                                                                                                                                                                                                                                 
   
###  Tests                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
                                                                       
  - Two new YAML e2e tests that exercise the remote route without network egress (api_base: "http://127.0.0.1:1" → ECONNREFUSED → graceful success=false). These run in CI.                                                                                                                                                                                                                                                                                                                   
  - Two opt-in pytest files for real providers, skipped unless MAGE_E2E_OPENAI / MAGE_E2E_OLLAMA=1 are set. The OpenAI test runs in CI. Ollama is not run in CI -> intended for local verification.

