### PR TITLE
fix: Support LIMIT on both sides of a UNION

### DIFF
--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -11129,6 +11129,7 @@ bool Limit::LimitCursor::Pull(Frame &frame, ExecutionContext &context) {
   }
 
   // check we have not exceeded the limit before pulling
+  if (!shared_quota_) return false;
   if (shared_quota_->Decrement() == 0) {
     shared_quota_.reset();  // Important to release any remaining resource for other threads
     return false;

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -7398,18 +7398,18 @@ bool Union::UnionCursor::Pull(Frame &frame, ExecutionContext &context) {
   AbortCheck(context);
 
   utils::pmr::unordered_map<std::string, TypedValue> results(context.evaluation_context.memory);
-  if (left_cursor_->Pull(frame, context)) {
+  if (!is_left_exhausted_ && left_cursor_->Pull(frame, context)) {
     // collect values from the left child
     for (const auto &output_symbol : self_.left_symbols_) {
       results[output_symbol.name()] = frame[output_symbol];
     }
-  } else if (right_cursor_->Pull(frame, context)) {
+  } else {
+    is_left_exhausted_ = true;
+    if (!right_cursor_->Pull(frame, context)) return false;
     // collect values from the right child
     for (const auto &output_symbol : self_.right_symbols_) {
       results[output_symbol.name()] = frame[output_symbol];
     }
-  } else {
-    return false;
   }
 
   // put collected values on frame under union symbols
@@ -7428,6 +7428,7 @@ void Union::UnionCursor::Shutdown() {
 void Union::UnionCursor::Reset() {
   left_cursor_->Reset();
   right_cursor_->Reset();
+  is_left_exhausted_ = false;
 }
 
 std::vector<Symbol> Cartesian::ModifiedSymbols(const SymbolTable &table) const {
@@ -11129,7 +11130,6 @@ bool Limit::LimitCursor::Pull(Frame &frame, ExecutionContext &context) {
   }
 
   // check we have not exceeded the limit before pulling
-  if (!shared_quota_) return false;
   if (shared_quota_->Decrement() == 0) {
     shared_quota_.reset();  // Important to release any remaining resource for other threads
     return false;

--- a/src/query/plan/operator.hpp
+++ b/src/query/plan/operator.hpp
@@ -83,6 +83,9 @@ class Cursor {
   ///     other information.
   ///
   /// @throws QueryRuntimeException if something went wrong with execution
+  /// @return true if a result was produced, false if the cursor is exhausted.
+  /// Once false is returned, Pull must not be called again without first
+  /// calling Reset().
   virtual bool Pull(Frame &, ExecutionContext &) = 0;
 
   /// Resets the Cursor to its initial state.
@@ -2708,6 +2711,7 @@ class Union : public memgraph::query::plan::LogicalOperator {
    private:
     const Union &self_;
     const UniqueCursorPtr left_cursor_, right_cursor_;
+    bool is_left_exhausted_{false};
   };
 };
 

--- a/tests/gql_behave/tests/memgraph_V1/features/union.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/union.feature
@@ -134,3 +134,34 @@ Feature: Union
             """
         Then an error should be raised
 
+    Scenario: Union with limit on each branch
+        Given an empty graph
+        When executing query:
+            """
+            RETURN 1 AS x LIMIT 1 UNION RETURN 2 AS x LIMIT 1
+            """
+        Then the result should be:
+            | x |
+            | 1 |
+            | 2 |
+
+    Scenario: Union with limit deduplicates results
+        Given an empty graph
+        When executing query:
+            """
+            RETURN 1 AS x LIMIT 1 UNION RETURN 1 AS x LIMIT 1
+            """
+        Then the result should be:
+            | x |
+            | 1 |
+
+    Scenario: Union all with limit on each branch
+        Given an empty graph
+        When executing query:
+            """
+            RETURN 1 AS x LIMIT 1 UNION ALL RETURN 2 AS x LIMIT 1
+            """
+        Then the result should be:
+            | x |
+            | 1 |
+            | 2 |

--- a/tests/gql_behave/tests/memgraph_V1/features/union.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/union.feature
@@ -165,3 +165,25 @@ Feature: Union
             | x |
             | 1 |
             | 2 |
+
+    Scenario: Union all with limit on left branch only
+        Given an empty graph
+        When executing query:
+            """
+            RETURN 1 AS x LIMIT 1 UNION ALL RETURN 2 AS x
+            """
+        Then the result should be:
+            | x |
+            | 1 |
+            | 2 |
+
+    Scenario: Union all with limit on right branch only
+        Given an empty graph
+        When executing query:
+            """
+            RETURN 1 AS x UNION ALL RETURN 2 AS x LIMIT 1
+            """
+        Then the result should be:
+            | x |
+            | 1 |
+            | 2 |


### PR DESCRIPTION
Fixes `UNION` so that it no longer tries `Pull`ing from an already exhausted left-hand branch.

#fix [3909](https://github.com/memgraph/memgraph/issues/3909)