### PR TITLE
feat: Ignore --query-modules-directory on coordinators

### DIFF
--- a/src/flags/run_time_configurable.cpp
+++ b/src/flags/run_time_configurable.cpp
@@ -461,47 +461,46 @@ void Initialize(utils::Settings &settings) {
    * Register periodic snapshot setting. In the case both flags are defined, --storage-snapshot-interval flag will be
    * used. Ideally, we rely on just a single flag but --storage-snapshot-interval-sec is for community,
    * --storage-snapshot-interval for enterprise.
+   *
+   * Coordinators don't support snapshots, so the setting is not registered on them. This also avoids validating
+   * a non-empty default value that the coordinator-side validator would otherwise reject.
    */
-  if (FLAGS_storage_snapshot_interval_sec != 0) {
-    if (FLAGS_storage_snapshot_interval.empty()) {
-      FLAGS_storage_snapshot_interval = std::to_string(FLAGS_storage_snapshot_interval_sec);
-    } else {
-      spdlog::warn(
-          "Periodic snapshot schedule defined via both --storage-snapshot-interval-sec and "
-          "--storage-snapshot-interval. Memgraph will use the configuration flag from --storage-snapshot-interval!");
+  if (!memgraph::flags::CoordinationSetupInstance().IsCoordinator()) {
+    if (FLAGS_storage_snapshot_interval_sec != 0) {
+      if (FLAGS_storage_snapshot_interval.empty()) {
+        FLAGS_storage_snapshot_interval = std::to_string(FLAGS_storage_snapshot_interval_sec);
+      } else {
+        spdlog::warn(
+            "Periodic snapshot schedule defined via both --storage-snapshot-interval-sec and "
+            "--storage-snapshot-interval. Memgraph will use the configuration flag from --storage-snapshot-interval!");
+      }
     }
+
+    // FATAL validation at startup; can't be part of the flag defintion, since we need to check for license
+    ValidPeriodicSnapshot<true>(FLAGS_storage_snapshot_interval);
+    register_flag(
+        kSnapshotPeriodicGFlagsKey,
+        kSnapshotPeriodicSettingKey,
+        !kRestore,
+        [](std::string_view val) {
+          try {
+            const auto period = ValidPeriod(val);
+            snapshot_periodic_.Modify(std::chrono::seconds{period});
+          } catch (const std::invalid_argument & /* unused */) {
+            // String is not a period; pass in as a cron expression
+            // Expression is guaranteed to be valid
+            snapshot_periodic_.Modify(std::string{val});
+          }
+        },
+        [](auto in) -> utils::Settings::ValidatorResult {
+          if (!ValidPeriodicSnapshot<false>(in)) {
+            return std::unexpected{
+                "Snapshot interval can be defined as an integer period in seconds or as a 6-field cron expression. "
+                "Please note that a valid license is needed in order to use cron expressions."};
+          }
+          return {};
+        });
   }
-
-  // FATAL validation at startup; can't be part of the flag defintion, since we need to check for license
-  ValidPeriodicSnapshot<true>(FLAGS_storage_snapshot_interval);
-  register_flag(
-      kSnapshotPeriodicGFlagsKey,
-      kSnapshotPeriodicSettingKey,
-      !kRestore,
-      [](std::string_view val) {
-        try {
-          const auto period = ValidPeriod(val);
-          snapshot_periodic_.Modify(std::chrono::seconds{period});
-        } catch (const std::invalid_argument & /* unused */) {
-          // String is not a period; pass in as a cron expression
-          // Expression is guaranteed to be valid
-          snapshot_periodic_.Modify(std::string{val});
-        }
-      },
-      [](auto in) -> utils::Settings::ValidatorResult {
-        auto const &coordination_setup = memgraph::flags::CoordinationSetupInstance();
-        if (coordination_setup.IsCoordinator()) {
-          return std::unexpected{
-              "Snapshot interval cannot be set on coordinators. Coordinators don't support snapshots."};
-        }
-
-        if (!ValidPeriodicSnapshot<false>(in)) {
-          return std::unexpected{
-              "Snapshot interval can be defined as an integer period in seconds or as a 6-field cron expression. "
-              "Please note that a valid license is needed in order to use cron expressions."};
-        }
-        return {};
-      });
 
   // AWS Section
   register_flag(kAwsRegionGFlagsKey, kAwsRegionSettingKey, kRestore);

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -530,27 +530,29 @@ int main(int argc, char **argv) {
   using enum memgraph::storage::StorageMode;
   using enum memgraph::storage::Config::Durability::SnapshotWalMode;
 
-  db_config.durability.snapshot_interval =
-      memgraph::utils::SchedulerInterval(memgraph::flags::run_time::GetStorageSnapshotInterval());
-  if (db_config.salient.storage_mode == IN_MEMORY_TRANSACTIONAL) {
-    if (!db_config.durability.snapshot_interval) {
-      if (FLAGS_storage_wal_enabled) {
-        LOG_FATAL(
-            "In order to use write-ahead-logging you must enable "
-            "periodic snapshots by setting the snapshot interval to a "
-            "value larger than 0!");
-      }
-      db_config.durability.snapshot_wal_mode = DISABLED;
-    } else {
-      if (FLAGS_storage_wal_enabled) {
-        db_config.durability.snapshot_wal_mode = PERIODIC_SNAPSHOT_WITH_WAL;
+  if (!is_coordinator_instance) {
+    db_config.durability.snapshot_interval =
+        memgraph::utils::SchedulerInterval(memgraph::flags::run_time::GetStorageSnapshotInterval());
+    if (db_config.salient.storage_mode == IN_MEMORY_TRANSACTIONAL) {
+      if (!db_config.durability.snapshot_interval) {
+        if (FLAGS_storage_wal_enabled) {
+          LOG_FATAL(
+              "In order to use write-ahead-logging you must enable "
+              "periodic snapshots by setting the snapshot interval to a "
+              "value larger than 0!");
+        }
+        db_config.durability.snapshot_wal_mode = DISABLED;
       } else {
-        db_config.durability.snapshot_wal_mode = PERIODIC_SNAPSHOT;
+        if (FLAGS_storage_wal_enabled) {
+          db_config.durability.snapshot_wal_mode = PERIODIC_SNAPSHOT_WITH_WAL;
+        } else {
+          db_config.durability.snapshot_wal_mode = PERIODIC_SNAPSHOT;
+        }
       }
+    } else {
+      // IN_MEMORY_ANALYTICAL and ON_DISK_TRANSACTIONAL do not support periodic snapshots
+      db_config.durability.snapshot_wal_mode = DISABLED;
     }
-  } else {
-    // IN_MEMORY_ANALYTICAL and ON_DISK_TRANSACTIONAL do not support periodic snapshots
-    db_config.durability.snapshot_wal_mode = DISABLED;
   }
 
 #ifdef MG_ENTERPRISE

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -297,30 +297,37 @@ int main(int argc, char **argv) {
   // Unhandled exception handler init.
   std::set_terminate(&memgraph::utils::TerminateHandler);
 
-  // Initialize Python
-  auto *program_name = Py_DecodeLocale(argv[0], nullptr);
-  MG_ASSERT(program_name);
-  // Set program name, so Python can find its way to runtime libraries relative
-  // to executable.
-  // TODO: Migrate to PyConfig API (Python 3.11+); Py_SetProgramName is deprecated.
-  Py_SetProgramName(program_name);
-  PyImport_AppendInittab("_mgp", &memgraph::query::procedure::PyInitMgpModule);
-  Py_InitializeEx(0 /* = initsigs */);
-  Py_BEGIN_ALLOW_THREADS;
+#ifdef MG_ENTERPRISE
+  memgraph::flags::SetFinalCoordinationSetup();
+  auto const &coordination_setup = memgraph::flags::CoordinationSetupInstance();
+  bool const is_coordinator_instance = coordination_setup.management_port && coordination_setup.coordinator_port &&
+                                       coordination_setup.coordinator_id &&
+                                       !coordination_setup.coordinator_hostname.empty();
 
-  // Add our Python modules to sys.path
-  try {
-    auto exe_path = memgraph::utils::GetExecutablePath();
-    auto py_support_dir = exe_path.parent_path() / "python_support";
-    if (std::filesystem::is_directory(py_support_dir)) {
-      auto gil = memgraph::py::EnsureGIL();
-      auto maybe_exc = memgraph::py::AppendToSysPath(py_support_dir.c_str());
-      if (maybe_exc) {
-        spdlog::error(memgraph::utils::MessageWithLink(
-            "Unable to load support for embedded Python: {}.", *maybe_exc, "https://memgr.ph/python"));
-      } else {
-        // Change how we load dynamic libraries on Python by using RTLD_NOW flag.
-        // This solves an issue with using the wrong version of libstdc++.
+#else
+  bool const is_coordinator_instance = false;
+#endif
+
+  std::optional<memgraph::utils::Scheduler> python_gc_scheduler{std::nullopt};
+  wchar_t *program_name{nullptr};
+  PyThreadState *python_thread_state{nullptr};
+
+  if (!is_coordinator_instance) {
+    // Initialize Python
+    program_name = Py_DecodeLocale(argv[0], nullptr);
+    MG_ASSERT(program_name);
+    // Set program name, so Python can find its way to runtime libraries relative
+    // to executable.
+    Py_SetProgramName(program_name);
+    PyImport_AppendInittab("_mgp", &memgraph::query::procedure::PyInitMgpModule);
+    Py_InitializeEx(0 /* = initsigs */);
+    python_thread_state = PyEval_SaveThread();
+
+    // Add our Python modules to sys.path
+    try {
+      auto exe_path = memgraph::utils::GetExecutablePath();
+      auto py_support_dir = exe_path.parent_path() / "python_support";
+      if (std::filesystem::is_directory(py_support_dir)) {
         auto gil = memgraph::py::EnsureGIL();
         // NOLINTNEXTLINE(hicpp-signed-bitwise)
         auto *flag = PyLong_FromLong(RTLD_NOW);
@@ -334,20 +341,15 @@ int main(int argc, char **argv) {
         // setdl is a borrowed ref from PySys_GetObject — do NOT Py_DECREF it
         Py_DECREF(arg);
       }
-    } else {
-      spdlog::error(
-          memgraph::utils::MessageWithLink("Unable to load support for embedded Python: missing directory {}.",
-                                           py_support_dir,
-                                           "https://memgr.ph/python"));
+    } catch (const std::filesystem::filesystem_error &e) {
+      spdlog::error(memgraph::utils::MessageWithLink(
+          "Unable to load support for embedded Python: {}.", e.what(), "https://memgr.ph/python"));
     }
-  } catch (const std::filesystem::filesystem_error &e) {
-    spdlog::error(memgraph::utils::MessageWithLink(
-        "Unable to load support for embedded Python: {}.", e.what(), "https://memgr.ph/python"));
-  }
 
-  memgraph::utils::Scheduler python_gc_scheduler;
-  python_gc_scheduler.SetInterval(std::chrono::seconds(FLAGS_storage_python_gc_cycle_sec));
-  python_gc_scheduler.Run("Python GC", [] { memgraph::query::procedure::PyCollectGarbage(); });
+    python_gc_scheduler.emplace();
+    python_gc_scheduler->SetInterval(std::chrono::seconds(FLAGS_storage_python_gc_cycle_sec));
+    python_gc_scheduler->Run("Python GC", [] { memgraph::query::procedure::PyCollectGarbage(); });
+  }
 
   // Initialize the communication library.
   memgraph::communication::SSLInit sslInit;
@@ -552,8 +554,6 @@ int main(int argc, char **argv) {
   }
 
 #ifdef MG_ENTERPRISE
-  memgraph::flags::SetFinalCoordinationSetup();
-  auto const &coordination_setup = memgraph::flags::CoordinationSetupInstance();
   if (coordination_setup.IsDataInstanceManagedByCoordinator() &&
       db_config.salient.storage_mode == IN_MEMORY_TRANSACTIONAL) {
     MG_ASSERT(db_config.durability.snapshot_wal_mode == PERIODIC_SNAPSHOT_WITH_WAL,
@@ -561,9 +561,6 @@ int main(int argc, char **argv) {
               "--storage-wal-enabled=true. One of the flags used for setting up snapshots "
               "--storage-snapshot-interval-sec or --storage-snapshot-interval also needs to be set.");
   }
-  auto const is_coordinator_instance = coordination_setup.management_port && coordination_setup.coordinator_port &&
-                                       coordination_setup.coordinator_id &&
-                                       !coordination_setup.coordinator_hostname.empty();
 
   if (is_coordinator_instance) {
     MG_ASSERT(
@@ -582,11 +579,6 @@ int main(int argc, char **argv) {
               "flag.");
   }
 
-#else
-  bool const is_coordinator_instance = false;
-#endif
-
-#ifdef MG_ENTERPRISE
   if (std::chrono::seconds(FLAGS_instance_down_timeout_sec) <
       std::chrono::seconds(FLAGS_instance_health_check_frequency_sec)) {
     LOG_FATAL(
@@ -779,10 +771,11 @@ int main(int argc, char **argv) {
     // procedures during parallel execution.
     // NOTE: We should also register cleanup, but since threads exist until the end of the program,
     //       everyhting will be cleaned up anyway at program exit.
-    auto python_thread_init = []() { memgraph::query::procedure::RegisterPyThread(); };
-    worker_pool_.emplace(/* low priority */ static_cast<uint16_t>(FLAGS_bolt_num_workers),
+
+    worker_pool_.emplace(/* low priority */
+                         static_cast<uint16_t>(FLAGS_bolt_num_workers),
                          /* high priority */ 1U,
-                         python_thread_init);
+                         is_coordinator_instance ? []() {} : []() { memgraph::query::procedure::RegisterPyThread(); });
     io_n_threads = 1U;
   }
 
@@ -819,12 +812,12 @@ int main(int argc, char **argv) {
   auto &interpreter_context_ = memgraph::query::InterpreterContextHolder::GetInstance();
   if (!is_coordinator_instance) {
     MG_ASSERT(db_acc.has_value(), "Failed to access the main database");
-  }
 
-  memgraph::query::procedure::gModuleRegistry.SetModulesDirectory(memgraph::flags::ParseQueryModulesDirectory(),
-                                                                  FLAGS_data_directory);
-  memgraph::query::procedure::gModuleRegistry.UnloadAndLoadModulesFromDirectories();
-  memgraph::query::procedure::gCallableAliasMapper.LoadMapping(FLAGS_query_callable_mappings_path);
+    memgraph::query::procedure::gModuleRegistry.SetModulesDirectory(memgraph::flags::ParseQueryModulesDirectory(),
+                                                                    FLAGS_data_directory);
+    memgraph::query::procedure::gModuleRegistry.UnloadAndLoadModulesFromDirectories();
+    memgraph::query::procedure::gCallableAliasMapper.LoadMapping(FLAGS_query_callable_mappings_path);
+  }
 
   // TODO Make multi-tenant
   // No need to check here if coordinator instance because we check above that --init-file is not set on coordinator
@@ -1067,19 +1060,23 @@ int main(int argc, char **argv) {
 #ifdef MG_ENTERPRISE
   metrics_server.AwaitShutdown();
 #endif
-  try {
-    memgraph::query::procedure::gModuleRegistry.UnloadAllModules();
-  } catch (memgraph::query::QueryException &) {
-    spdlog::warn("Failed to unload query modules while shutting down.");
+
+  if (!is_coordinator_instance) {
+    try {
+      memgraph::query::procedure::gModuleRegistry.UnloadAllModules();
+    } catch (memgraph::query::QueryException &) {
+      spdlog::warn("Failed to unload query modules while shutting down.");
+    }
+    python_gc_scheduler->Stop();
+
+    // NOTE: We intentionally skip Py_Finalize(). Third-party extensions (DGL,
+    // PyTorch, numpy) may have spawned background threads that race with
+    // CPython's TSS teardown, causing "gilstate_tss_set: failed to set current
+    // tstate" fatal errors (bpo-42969). Since the process is about to exit, the
+    // OS reclaims all resources. This is standard practice for embedded Python.
+    PyEval_RestoreThread(python_thread_state);
+    PyMem_RawFree(program_name);
   }
-  python_gc_scheduler.Stop();
-  Py_END_ALLOW_THREADS;
-  // NOTE: We intentionally skip Py_Finalize(). Third-party extensions (DGL,
-  // PyTorch, numpy) may have spawned background threads that race with
-  // CPython's TSS teardown, causing "gilstate_tss_set: failed to set current
-  // tstate" fatal errors (bpo-42969). Since the process is about to exit, the
-  // OS reclaims all resources. This is standard practice for embedded Python.
-  PyMem_RawFree(program_name);
 
   memgraph::utils::total_memory_tracker.LogPeakMemoryUsage();
   return 0;

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -329,17 +329,30 @@ int main(int argc, char **argv) {
       auto py_support_dir = exe_path.parent_path() / "python_support";
       if (std::filesystem::is_directory(py_support_dir)) {
         auto gil = memgraph::py::EnsureGIL();
-        // NOLINTNEXTLINE(hicpp-signed-bitwise)
-        auto *flag = PyLong_FromLong(RTLD_NOW);
-        auto *setdl = PySys_GetObject("setdlopenflags");
-        MG_ASSERT(setdl);
-        auto *arg = PyTuple_New(1);
-        MG_ASSERT(arg);
-        MG_ASSERT(PyTuple_SetItem(arg, 0, flag) == 0);  // steals flag
-        PyObject_CallObject(setdl, arg);
-        // flag stolen by SetItem — do NOT Py_DECREF it
-        // setdl is a borrowed ref from PySys_GetObject — do NOT Py_DECREF it
-        Py_DECREF(arg);
+        auto maybe_exc = memgraph::py::AppendToSysPath(py_support_dir.c_str());
+        if (maybe_exc) {
+          spdlog::error(memgraph::utils::MessageWithLink(
+              "Unable to load support for embedded Python: {}.", *maybe_exc, "https://memgr.ph/python"));
+        } else {
+          // Change how we load dynamic libraries on Python by using RTLD_NOW flag.
+          // This solves an issue with using the wrong version of libstdc++.
+          // NOLINTNEXTLINE(hicpp-signed-bitwise)
+          auto *flag = PyLong_FromLong(RTLD_NOW);
+          auto *setdl = PySys_GetObject("setdlopenflags");
+          MG_ASSERT(setdl);
+          auto *arg = PyTuple_New(1);
+          MG_ASSERT(arg);
+          MG_ASSERT(PyTuple_SetItem(arg, 0, flag) == 0);  // steals flag
+          PyObject_CallObject(setdl, arg);
+          // flag stolen by SetItem — do NOT Py_DECREF it
+          // setdl is a borrowed ref from PySys_GetObject — do NOT Py_DECREF it
+          Py_DECREF(arg);
+        }
+      } else {
+        spdlog::error(
+            memgraph::utils::MessageWithLink("Unable to load support for embedded Python: missing directory {}.",
+                                             py_support_dir,
+                                             "https://memgr.ph/python"));
       }
     } catch (const std::filesystem::filesystem_error &e) {
       spdlog::error(memgraph::utils::MessageWithLink(
@@ -1070,12 +1083,12 @@ int main(int argc, char **argv) {
       spdlog::warn("Failed to unload query modules while shutting down.");
     }
     python_gc_scheduler->Stop();
-
     // NOTE: We intentionally skip Py_Finalize(). Third-party extensions (DGL,
     // PyTorch, numpy) may have spawned background threads that race with
     // CPython's TSS teardown, causing "gilstate_tss_set: failed to set current
     // tstate" fatal errors (bpo-42969). Since the process is about to exit, the
     // OS reclaims all resources. This is standard practice for embedded Python.
+    MG_ASSERT(python_thread_state, "Invalid Python thread state");
     PyEval_RestoreThread(python_thread_state);
     PyMem_RawFree(program_name);
   }

--- a/tests/e2e/high_availability/coordinator.py
+++ b/tests/e2e/high_availability/coordinator.py
@@ -126,7 +126,7 @@ def test_disable_snp_interval(test_name):
         execute_and_fetch_all(cursor, "set database setting 'storage.snapshot.interval' to '1'")
         assert False
     except Exception as e:
-        assert "Coordinators don't support snapshots" in str(e)
+        assert "Unknown setting name" in str(e)
 
 
 def test_enable_show_license_info_queries(test_name):


### PR DESCRIPTION
The flag --query-modules-directory is ignored on coordinators. It is not completely removed because our packaging flags set it by default so every user would need to explicitly disable it when starting coordinators.