### PR TITLE
fix: Limit threads on Debug builds in CI

### DIFF
--- a/.github/workflows/diff_coverage.yaml
+++ b/.github/workflows/diff_coverage.yaml
@@ -112,16 +112,16 @@ jobs:
 
       - name: Build combined coverage binary with ASAN and UBSAN
         run: |
-          THREADS=$(./tools/ci/compute-build-threads.sh 5)
-          echo "Building with $THREADS threads"
+          LINK_THREADS=$(./tools/ci/compute-build-threads.sh 5)
+          echo "Linking with $LINK_THREADS threads"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
-          --threads $THREADS \
           --no-ccache \
           build-memgraph --coverage --asan --ubsan \
+          --link-threads $LINK_THREADS \
           --conan-remote $CONAN_REMOTE \
           --conan-username $CONAN_USERNAME \
           --conan-password $CONAN_PASSWORD

--- a/.github/workflows/diff_coverage.yaml
+++ b/.github/workflows/diff_coverage.yaml
@@ -112,12 +112,14 @@ jobs:
 
       - name: Build combined coverage binary with ASAN and UBSAN
         run: |
+          THREADS=$(./tools/ci/compute-build-threads.sh 5)
+          echo "Building with $THREADS threads"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
-          --threads 8 \
+          --threads $THREADS \
           --no-ccache \
           build-memgraph --coverage --asan --ubsan \
           --conan-remote $CONAN_REMOTE \

--- a/.github/workflows/diff_debug.yaml
+++ b/.github/workflows/diff_debug.yaml
@@ -75,11 +75,14 @@ jobs:
 
       - name: Build debug binary
         run: |
+          BUILD_THREADS=$(./tools/ci/compute-build-threads.sh 3.5)
+          echo "Building with $BUILD_THREADS threads"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
+          --threads $BUILD_THREADS \
           build-memgraph \
           --conan-remote $CONAN_REMOTE \
           --conan-username $CONAN_USERNAME \
@@ -196,11 +199,14 @@ jobs:
 
       - name: Build debug binary
         run: |
+          BUILD_THREADS=$(./tools/ci/compute-build-threads.sh 3.5)
+          echo "Building with $BUILD_THREADS threads"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
+          --threads $BUILD_THREADS \
           build-memgraph \
           --conan-remote $CONAN_REMOTE \
           --conan-username $CONAN_USERNAME \

--- a/.github/workflows/diff_debug.yaml
+++ b/.github/workflows/diff_debug.yaml
@@ -75,15 +75,15 @@ jobs:
 
       - name: Build debug binary
         run: |
-          BUILD_THREADS=$(./tools/ci/compute-build-threads.sh 3.5)
-          echo "Building with $BUILD_THREADS threads"
+          LINK_THREADS=$(./tools/ci/compute-build-threads.sh 3.5)
+          echo "Linking with $LINK_THREADS threads"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
-          --threads $BUILD_THREADS \
           build-memgraph \
+          --link-threads $LINK_THREADS \
           --conan-remote $CONAN_REMOTE \
           --conan-username $CONAN_USERNAME \
           --conan-password $CONAN_PASSWORD
@@ -199,15 +199,15 @@ jobs:
 
       - name: Build debug binary
         run: |
-          BUILD_THREADS=$(./tools/ci/compute-build-threads.sh 3.5)
-          echo "Building with $BUILD_THREADS threads"
+          LINK_THREADS=$(./tools/ci/compute-build-threads.sh 3.5)
+          echo "Linking with $LINK_THREADS threads"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
-          --threads $BUILD_THREADS \
           build-memgraph \
+          --link-threads $LINK_THREADS \
           --conan-remote $CONAN_REMOTE \
           --conan-username $CONAN_USERNAME \
           --conan-password $CONAN_PASSWORD

--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -266,12 +266,14 @@ jobs:
 
       - name: Build debug binary
         run: |
+          BUILD_THREADS=$(./tools/ci/compute-build-threads.sh 3.5)
+          echo "Building with $BUILD_THREADS threads"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
-          --threads $THREADS \
+          --threads $BUILD_THREADS \
           build-memgraph \
           --conan-remote $CONAN_REMOTE \
           --conan-username $CONAN_USERNAME \
@@ -386,12 +388,14 @@ jobs:
 
       - name: Build debug binary
         run: |
+          BUILD_THREADS=$(./tools/ci/compute-build-threads.sh 3.5)
+          echo "Building with $BUILD_THREADS threads"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
-          --threads $THREADS \
+          --threads $BUILD_THREADS \
           build-memgraph \
           --conan-remote $CONAN_REMOTE \
           --conan-username $CONAN_USERNAME \

--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -266,15 +266,15 @@ jobs:
 
       - name: Build debug binary
         run: |
-          BUILD_THREADS=$(./tools/ci/compute-build-threads.sh 3.5)
-          echo "Building with $BUILD_THREADS threads"
+          LINK_THREADS=$(./tools/ci/compute-build-threads.sh 3.5)
+          echo "Linking with $LINK_THREADS threads"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
-          --threads $BUILD_THREADS \
           build-memgraph \
+          --link-threads $LINK_THREADS \
           --conan-remote $CONAN_REMOTE \
           --conan-username $CONAN_USERNAME \
           --conan-password $CONAN_PASSWORD
@@ -388,15 +388,15 @@ jobs:
 
       - name: Build debug binary
         run: |
-          BUILD_THREADS=$(./tools/ci/compute-build-threads.sh 3.5)
-          echo "Building with $BUILD_THREADS threads"
+          LINK_THREADS=$(./tools/ci/compute-build-threads.sh 3.5)
+          echo "Linking with $LINK_THREADS threads"
           ./release/package/mgbuild.sh \
           --toolchain $TOOLCHAIN \
           --os $OS \
           --arch $ARCH \
           --build-type $BUILD_TYPE \
-          --threads $BUILD_THREADS \
           build-memgraph \
+          --link-threads $LINK_THREADS \
           --conan-remote $CONAN_REMOTE \
           --conan-username $CONAN_USERNAME \
           --conan-password $CONAN_PASSWORD

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -140,6 +140,7 @@ print_help () {
   echo -e "  --ubsan                       Build with UBSAN"
   echo -e "  --disable-jemalloc            Build without jemalloc"
   echo -e "  --disable-testing             Build without tests (faster build for packaging)"
+  echo -e "  --link-threads int            Cap the number of concurrent link steps via Ninja's job pools (default 0, no cap). Compile parallelism is unaffected."
   echo -e "  --conan-remote string         Specify conan remote (default \"\")"
   echo -e "  --conan-username string       Specify conan username (default \"\")"
   echo -e "  --conan-password string       Specify conan password (default \"\")"
@@ -452,6 +453,7 @@ build_memgraph () {
   local conan_username=""
   local conan_password=""
   local build_dependency=""
+  local link_threads=0
   while [[ "$#" -gt 0 ]]; do
     case "$1" in
       --community)
@@ -509,6 +511,10 @@ build_memgraph () {
       ;;
       --build-dependency)
         build_dependency=$2
+        shift 2
+      ;;
+      --link-threads)
+        link_threads=$2
         shift 2
       ;;
       *)
@@ -665,6 +671,11 @@ build_memgraph () {
       additional_options="$additional_options $flag"
     fi
   done
+
+  # Cap link concurrency via Ninja job pools, leaving compile parallelism untouched.
+  if [[ "$link_threads" -gt 0 ]]; then
+    additional_options="$additional_options -DCMAKE_JOB_POOLS=link=$link_threads -DCMAKE_JOB_POOL_LINK=link"
+  fi
 
   if [[ -n "$additional_options" ]]; then
     echo "Adding additional CMake options: $additional_options"

--- a/tools/ci/compute-build-threads.sh
+++ b/tools/ci/compute-build-threads.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Print a safe build thread count: min(nproc, floor(MemTotalGB / mem_per_thread_gb)).
+# Print a safe build thread count: min(nproc, floor(MemAvailableGB / mem_per_thread_gb)).
 # Usage: compute-build-threads.sh <mem_per_thread_gb>
 
 set -euo pipefail
@@ -11,13 +11,13 @@ fi
 
 mem_per_thread_gb="$1"
 cpu_threads=$(nproc)
-mem_total_kb=$(awk '/^MemTotal:/ {print $2; exit}' /proc/meminfo)
-if [[ -z "$mem_total_kb" ]]; then
-  echo "Failed to read MemTotal from /proc/meminfo" >&2
+mem_available_kb=$(awk '/^MemAvailable:/ {print $2; exit}' /proc/meminfo)
+if [[ -z "$mem_available_kb" ]]; then
+  echo "Failed to read MemAvailable from /proc/meminfo" >&2
   exit 1
 fi
 
-awk -v cpus="$cpu_threads" -v mem_kb="$mem_total_kb" -v per="$mem_per_thread_gb" '
+awk -v cpus="$cpu_threads" -v mem_kb="$mem_available_kb" -v per="$mem_per_thread_gb" '
   BEGIN {
     if (per + 0 <= 0) { print "mem_per_thread_gb must be > 0" > "/dev/stderr"; exit 1 }
     mem_gb = mem_kb / 1024 / 1024

--- a/tools/ci/compute-build-threads.sh
+++ b/tools/ci/compute-build-threads.sh
@@ -11,7 +11,11 @@ fi
 
 mem_per_thread_gb="$1"
 cpu_threads=$(nproc)
-mem_total_kb=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)
+mem_total_kb=$(awk '/^MemTotal:/ {print $2; exit}' /proc/meminfo)
+if [[ -z "$mem_total_kb" ]]; then
+  echo "Failed to read MemTotal from /proc/meminfo" >&2
+  exit 1
+fi
 
 awk -v cpus="$cpu_threads" -v mem_kb="$mem_total_kb" -v per="$mem_per_thread_gb" '
   BEGIN {

--- a/tools/ci/compute-build-threads.sh
+++ b/tools/ci/compute-build-threads.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Print a safe build thread count: min(nproc, floor(MemTotalGB / mem_per_thread_gb)).
+# Usage: compute-build-threads.sh <mem_per_thread_gb>
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <mem_per_thread_gb>" >&2
+  exit 1
+fi
+
+mem_per_thread_gb="$1"
+cpu_threads=$(nproc)
+mem_total_kb=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)
+
+awk -v cpus="$cpu_threads" -v mem_kb="$mem_total_kb" -v per="$mem_per_thread_gb" '
+  BEGIN {
+    if (per + 0 <= 0) { print "mem_per_thread_gb must be > 0" > "/dev/stderr"; exit 1 }
+    mem_gb = mem_kb / 1024 / 1024
+    mem_threads = int(mem_gb / per)
+    if (mem_threads < 1) mem_threads = 1
+    print (mem_threads < cpus) ? mem_threads : cpus
+  }'


### PR DESCRIPTION
Debug builds sometimes OOM on workers while linking. Typically they take ~3.5 GB per thread, but the UBSAN/ASAN build takes ~ 5 GB per thread. This PR adds a script to calculate how many threads to use based on the RAM and adds the `--link-threads` flag to `mgbuild.sh`. This is then used to limit the number of threads used by the linker during debug builds in diff and release build workflows.
