### PR TITLE
fix: index/constraint ghost entries due to abort

### DIFF
--- a/src/storage/v2/constraints/existence_constraints.cpp
+++ b/src/storage/v2/constraints/existence_constraints.cpp
@@ -77,19 +77,19 @@ auto ExistenceConstraints::GetIndividualConstraint(LabelId label, PropertyId pro
   });
 }
 
-bool ExistenceConstraints::RegisterConstraint(LabelId label, PropertyId property) {
+bool ExistenceConstraints::InstallConstraint_(LabelId label, PropertyId property, IndividualConstraintPtr ptr) {
   return constraints_.WithLock([&](ContainerPtr &constraints) {
-    // Check if constraint already exists
-    if (constraints->contains({label, property})) {
-      return false;
-    }
-    // Copy-on-write: create new container with the new constraint
+    if (constraints->contains({label, property})) return false;
     auto new_constraints = std::make_shared<Container>(*constraints);
-    new_constraints->emplace(ConstraintKey{.label = label, .property = property},
-                             std::make_shared<IndividualConstraint>());  // Starts in populating state
+    new_constraints->emplace(ConstraintKey{.label = label, .property = property}, std::move(ptr));
     constraints = std::move(new_constraints);
     return true;
   });
+}
+
+bool ExistenceConstraints::RegisterConstraint(LabelId label, PropertyId property) {
+  // Starts in populating state; promoted to ready by PublishConstraint on commit.
+  return InstallConstraint_(label, property, std::make_shared<IndividualConstraint>());
 }
 
 bool ExistenceConstraints::PublishConstraint(LabelId label, PropertyId property, uint64_t commit_timestamp) const {
@@ -103,15 +103,23 @@ bool ExistenceConstraints::PublishConstraint(LabelId label, PropertyId property,
   return true;
 }
 
-bool ExistenceConstraints::DropConstraint(LabelId label, PropertyId property) {
-  return constraints_.WithLock([&](ContainerPtr &constraints) -> bool {
+ExistenceConstraints::IndividualConstraintPtr ExistenceConstraints::DropConstraint(LabelId label, PropertyId property) {
+  return constraints_.WithLock([&](ContainerPtr &constraints) -> IndividualConstraintPtr {
+    auto it = constraints->find({label, property});
+    if (it == constraints->end()) return nullptr;
+    auto evicted = it->second;
     auto new_constraints = std::make_shared<Container>(*constraints);
-    if (const auto count = new_constraints->erase({label, property}); count == 0) {
-      return false;
-    }
+    new_constraints->erase({label, property});
     constraints = std::move(new_constraints);
-    return true;
+    return evicted;
   });
+}
+
+void ExistenceConstraints::RestoreConstraint(LabelId label, PropertyId property, IndividualConstraintPtr evicted) {
+  if (!evicted) return;
+  // Concurrent CREATE under READ_ONLY may own the slot; discarding evicted is benign
+  // since the winning CREATE validated all existing rows.
+  (void)InstallConstraint_(label, property, std::move(evicted));
 }
 
 [[nodiscard]] std::expected<void, ConstraintViolation> ExistenceConstraints::Validate(

--- a/src/storage/v2/constraints/existence_constraints.hpp
+++ b/src/storage/v2/constraints/existence_constraints.hpp
@@ -89,14 +89,22 @@ class ExistenceConstraints {
   /// Returns true if constraint is registered (even if still populating). Only used by OnDisk
   bool ConstraintExists(LabelId label, PropertyId property) const;
 
+  /// Registers a fresh POPULATING constraint. Returns false if one already exists.
   [[nodiscard]] bool RegisterConstraint(LabelId label, PropertyId property);
 
   /// Publishes a constraint after validation, making it visible at the given commit timestamp.
   /// Returns true on success, false if constraint not found.
   bool PublishConstraint(LabelId label, PropertyId property, uint64_t commit_timestamp) const;
 
-  /// Drops a constraint. Returns false if constraint doesn't exist.
-  bool DropConstraint(LabelId label, PropertyId property);
+  /// Drops a constraint. Returns the evicted IndividualConstraint so the caller can
+  /// reinstall it via RestoreConstraint on abort, or nullptr if no constraint
+  /// existed for {label, property}.
+  [[nodiscard]] IndividualConstraintPtr DropConstraint(LabelId label, PropertyId property);
+
+  /// Reinstalls a previously-evicted IndividualConstraint. No-op if the slot
+  /// has been reclaimed by a concurrent CREATE (constraint DDL runs under
+  /// READ_ONLY/UNIQUE, which does not serialize peers).
+  void RestoreConstraint(LabelId label, PropertyId property, IndividualConstraintPtr evicted);
 
   /*
    * VALIDATION
@@ -123,6 +131,10 @@ class ExistenceConstraints {
 
  private:
   auto GetIndividualConstraint(LabelId label, PropertyId property) const -> IndividualConstraintPtr;
+
+  // Installs `ptr` under {label, property} if absent. Shared by RegisterConstraint
+  // (fresh populating ptr) and RestoreConstraint (evicted ptr).
+  bool InstallConstraint_(LabelId label, PropertyId property, IndividualConstraintPtr ptr);
 
   utils::Synchronized<ContainerPtr, utils::WritePrioritizedRWLock> constraints_{std::make_shared<Container const>()};
 };

--- a/src/storage/v2/constraints/type_constraints.cpp
+++ b/src/storage/v2/constraints/type_constraints.cpp
@@ -162,16 +162,32 @@ auto TypeConstraints::GetIndividualConstraint(LabelId label, PropertyId property
   });
 }
 
-bool TypeConstraints::RegisterConstraint(LabelId label, PropertyId property, TypeConstraintKind type) {
+bool TypeConstraints::InstallConstraint_(LabelId label, PropertyId property, IndividualConstraintPtr ptr,
+                                         bool restore_l2p) {
   return container_.WithLock([&](ContainerPtr &container) -> bool {
+    if (container->constraints_.contains({label, property})) return false;
     auto new_container = std::make_shared<Container>(*container);
-    auto [_, inserted] = new_container->constraints_.try_emplace(
-        {label, property},
-        std::make_shared<IndividualConstraint>(type));  // Starts in populating state
-    if (!inserted) return false;
+    auto type = ptr->type;
+    new_container->constraints_.try_emplace({label, property}, std::move(ptr));
+    if (restore_l2p) {
+      // Re-introduce the (property, type) into l2p_constraints_ for an evicted-but-
+      // committed constraint. RegisterConstraint skips this — l2p_ is populated by
+      // PublishConstraint when the populating entry promotes to ready.
+      if (auto l2p_it = new_container->l2p_constraints_.find(label); l2p_it != new_container->l2p_constraints_.end()) {
+        l2p_it->second.emplace(property, type);
+      } else {
+        new_container->l2p_constraints_.emplace(label,
+                                                absl::flat_hash_map<PropertyId, TypeConstraintKind>{{property, type}});
+      }
+    }
     container = std::move(new_container);
     return true;
   });
+}
+
+bool TypeConstraints::RegisterConstraint(LabelId label, PropertyId property, TypeConstraintKind type) {
+  // Starts in populating state; promoted (and l2p_ populated) by PublishConstraint on commit.
+  return InstallConstraint_(label, property, std::make_shared<IndividualConstraint>(type), /*restore_l2p=*/false);
 }
 
 void TypeConstraints::PublishConstraint(LabelId label, PropertyId property, TypeConstraintKind type,
@@ -204,32 +220,32 @@ void TypeConstraints::PublishConstraint(LabelId label, PropertyId property, Type
   memgraph::metrics::IncrementCounter(memgraph::metrics::ActiveTypeConstraints);
 }
 
-bool TypeConstraints::DropConstraint(LabelId label, PropertyId property, TypeConstraintKind type) {
-  return container_.WithLock([&](ContainerPtr &container) -> bool {
+TypeConstraints::IndividualConstraintPtr TypeConstraints::DropConstraint(LabelId label, PropertyId property,
+                                                                         TypeConstraintKind type) {
+  return container_.WithLock([&](ContainerPtr &container) -> IndividualConstraintPtr {
     auto it = container->constraints_.find({label, property});
-    if (it == container->constraints_.end()) {
-      return false;
-    }
-    if (it->second->type != type) {
-      return false;
-    }
+    if (it == container->constraints_.end()) return nullptr;
+    if (it->second->type != type) return nullptr;
+    auto evicted = it->second;
 
-    // Copy-on-write: create new container without this constraint
     auto new_container = std::make_shared<Container>(*container);
     new_container->constraints_.erase({label, property});
-
-    // Remove from l2p_constraints_
     auto l2p_it = new_container->l2p_constraints_.find(label);
     if (l2p_it != new_container->l2p_constraints_.end()) {
       l2p_it->second.erase(property);
-      if (l2p_it->second.empty()) {
-        new_container->l2p_constraints_.erase(l2p_it);
-      }
+      if (l2p_it->second.empty()) new_container->l2p_constraints_.erase(l2p_it);
     }
 
     container = std::move(new_container);
-    return true;
+    return evicted;
   });
+}
+
+void TypeConstraints::RestoreConstraint(LabelId label, PropertyId property, IndividualConstraintPtr evicted) {
+  if (!evicted) return;
+  // Concurrent CREATE under READ_ONLY may own the slot; discarding evicted is benign
+  // since the winning CREATE validated all existing rows.
+  (void)InstallConstraint_(label, property, std::move(evicted), /*restore_l2p=*/true);
 }
 
 void TypeConstraints::DropGraphClearConstraints() {

--- a/src/storage/v2/constraints/type_constraints.hpp
+++ b/src/storage/v2/constraints/type_constraints.hpp
@@ -94,8 +94,16 @@ class TypeConstraints {
 
   [[nodiscard]] bool RegisterConstraint(LabelId label, PropertyId property, TypeConstraintKind type);
   void PublishConstraint(LabelId label, PropertyId property, TypeConstraintKind type, uint64_t commit_timestamp);
-  /// Drops a constraint. Returns false if constraint doesn't exist or type doesn't match.
-  bool DropConstraint(LabelId label, PropertyId property, TypeConstraintKind type);
+
+  /// Drops a constraint. Returns the evicted IndividualConstraint so the caller can
+  /// reinstall it via RestoreConstraint on abort, or nullptr if no constraint
+  /// existed for {label, property} or the type didn't match.
+  [[nodiscard]] IndividualConstraintPtr DropConstraint(LabelId label, PropertyId property, TypeConstraintKind type);
+
+  /// Reinstalls a previously-evicted IndividualConstraint. No-op if the slot
+  /// has been reclaimed by a concurrent CREATE (constraint DDL runs under
+  /// READ_ONLY/UNIQUE, which does not serialize peers).
+  void RestoreConstraint(LabelId label, PropertyId property, IndividualConstraintPtr evicted);
 
   void DropGraphClearConstraints();
 
@@ -105,6 +113,10 @@ class TypeConstraints {
  private:
   /// Get individual constraint for in-place status modification.
   auto GetIndividualConstraint(LabelId label, PropertyId property) const -> IndividualConstraintPtr;
+
+  // Installs ptr if absent. restore_l2p=true on RestoreConstraint re-adds the
+  // (property, type) entry to l2p_ (RegisterConstraint defers that to PublishConstraint).
+  bool InstallConstraint_(LabelId label, PropertyId property, IndividualConstraintPtr ptr, bool restore_l2p);
 
   utils::Synchronized<ContainerPtr, utils::WritePrioritizedRWLock> container_{std::make_shared<Container const>()};
 };

--- a/src/storage/v2/constraints/unique_constraints.hpp
+++ b/src/storage/v2/constraints/unique_constraints.hpp
@@ -86,8 +86,6 @@ class UniqueConstraints {
     PROPERTIES_SIZE_LIMIT_EXCEEDED,
   };
 
-  virtual DeletionStatus DropConstraint(LabelId label, const std::set<PropertyId> &properties) = 0;
-
   virtual void Clear() = 0;
 
  protected:

--- a/src/storage/v2/disk/edge_property_index.hpp
+++ b/src/storage/v2/disk/edge_property_index.hpp
@@ -17,7 +17,7 @@ namespace memgraph::storage {
 
 class DiskEdgePropertyIndex : public EdgePropertyIndex {
  public:
-  bool DropIndex(PropertyId property, ActiveIndicesUpdater const &updater) override;
+  bool DropIndex(PropertyId property, ActiveIndicesUpdater const &updater);
 
   struct ActiveIndices : EdgePropertyIndex::ActiveIndices {
     void UpdateOnSetProperty(Vertex *from_vertex, Vertex *to_vertex, Edge *edge, EdgeTypeId edge_type,

--- a/src/storage/v2/disk/edge_type_index.hpp
+++ b/src/storage/v2/disk/edge_type_index.hpp
@@ -36,7 +36,7 @@ class DiskEdgeTypeIndex : public EdgeTypeIndex {
     auto GetAbortProcessor() const -> AbortProcessor override;
   };
 
-  bool DropIndex(EdgeTypeId edge_type, ActiveIndicesUpdater const &updater) override;
+  bool DropIndex(EdgeTypeId edge_type, ActiveIndicesUpdater const &updater);
 
   void DropGraphClearIndices() override;
 

--- a/src/storage/v2/disk/edge_type_property_index.hpp
+++ b/src/storage/v2/disk/edge_type_property_index.hpp
@@ -37,7 +37,7 @@ class DiskEdgeTypePropertyIndex : public EdgeTypePropertyIndex {
     void AbortEntries(AbortableInfo const &info, uint64_t start_timestamp) override;
   };
 
-  bool DropIndex(EdgeTypeId edge_type, PropertyId property, ActiveIndicesUpdater const &updater) override;
+  bool DropIndex(EdgeTypeId edge_type, PropertyId property, ActiveIndicesUpdater const &updater);
 
   void DropGraphClearIndices() override;
 

--- a/src/storage/v2/disk/label_index.hpp
+++ b/src/storage/v2/disk/label_index.hpp
@@ -69,7 +69,7 @@ class DiskLabelIndex : public storage::LabelIndex {
                                                             EntriesForDeletion const &entries_for_deletion);
 
   /// Returns false if there was no index to drop
-  bool DropIndex(LabelId label, ActiveIndicesUpdater const &updater) override;
+  bool DropIndex(LabelId label, ActiveIndicesUpdater const &updater);
 
   RocksDBStorage *GetRocksDBStorage() const;
 

--- a/src/storage/v2/disk/label_property_index.hpp
+++ b/src/storage/v2/disk/label_property_index.hpp
@@ -85,7 +85,7 @@ class DiskLabelPropertyIndex : public storage::LabelPropertyIndex {
                                                             EntriesForDeletion const &entries_for_deletion);
 
   DropResult DropIndex(LabelId label, std::vector<PropertyPath> const &properties, ActiveIndicesUpdater const &updater,
-                       std::optional<IndexOrder> order = std::nullopt) override;
+                       std::optional<IndexOrder> order = std::nullopt);
 
   RocksDBStorage *GetRocksDBStorage() const;
 

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -2009,6 +2009,7 @@ std::expected<void, StorageManipulationError> DiskStorage::DiskAccessor::Prepare
   // the txn is fully committed. Commit timestamp is 0 if the txn had no
   // writes — callbacks that care about ts can handle either case.
   transaction_.commit_callbacks_.RunAll(commit_timestamp_.value_or(0));
+  transaction_.abort_callbacks_.Clear();
   is_transaction_active_ = false;
 
   return {};
@@ -2135,6 +2136,9 @@ void DiskStorage::DiskAccessor::Abort() {
 
   delete transaction_.disk_transaction_;
   transaction_.disk_transaction_ = nullptr;
+
+  transaction_.abort_callbacks_.RunAll();
+
   is_transaction_active_ = false;
   UpdateObjectsCountOnAbort();
 }

--- a/src/storage/v2/disk/unique_constraints.hpp
+++ b/src/storage/v2/disk/unique_constraints.hpp
@@ -72,7 +72,7 @@ class DiskUniqueConstraints : public UniqueConstraints {
 
   [[nodiscard]] bool SyncVertexToUniqueConstraintsStorage(const Vertex &vertex, uint64_t commit_timestamp) const;
 
-  DeletionStatus DropConstraint(LabelId label, const std::set<PropertyId> &properties) override;
+  DeletionStatus DropConstraint(LabelId label, const std::set<PropertyId> &properties);
 
   void Clear() override;
 

--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -455,7 +455,7 @@ void RecoverExistenceConstraints(const RecoveredIndicesAndConstraints::Constrain
     if (auto validation_result = ExistenceConstraints::ValidateVerticesOnConstraint(
             vertices->access(), label, property, parallel_exec_info, snapshot_info);
         !validation_result.has_value()) [[unlikely]] {
-      constraints->existence_constraints_->DropConstraint(label, property);
+      (void)constraints->existence_constraints_->DropConstraint(label, property);
       throw RecoveryFailure("The existence constraint failed because it couldn't be validated!");
     }
 

--- a/src/storage/v2/indices/active_indices.hpp
+++ b/src/storage/v2/indices/active_indices.hpp
@@ -59,16 +59,11 @@ struct ActiveIndices {
         text_edge_{std::move(text_edge)},
         point_{std::move(point)},
         vector_{std::move(vector)},
-        vector_edge_{std::move(vector_edge)} {}
-
-  // TODO(follow-up): make non-null a hard ctor invariant. Currently
-  // `VectorEdgeIndexRecoveryTest` passes nullptrs for every slot except the
-  // one under test. The right fix is a shared test helper that default-builds
-  // empty sub-index snapshots (each concrete *ActiveIndices accepts an empty
-  // container), then DMG_ASSERT all fields in this ctor. Until then, the
-  // `DMG_ASSERT`s in `CheckIndicesAreReady` and at the `DatabaseInfoQuery`
-  // call-site guard prod paths, and `ActiveIndicesUpdater::operator()`
-  // guards DDL publish.
+        vector_edge_{std::move(vector_edge)} {
+    DMG_ASSERT(label_ && label_properties_ && edge_type_ && edge_type_properties_ && edge_property_ && text_ &&
+                   text_edge_ && point_ && vector_ && vector_edge_,
+               "ActiveIndices constructed with a null sub-index snapshot");
+  }
 
   /// Returns a new ActiveIndices with one field replaced, identified by
   /// pointer-to-member. Keeps layout knowledge in one place and avoids the
@@ -83,8 +78,6 @@ struct ActiveIndices {
   }
 
   bool CheckIndicesAreReady(IndicesCollection const &required_indices) const {
-    DMG_ASSERT(label_ && label_properties_ && edge_type_ && edge_type_properties_ && edge_property_,
-               "CheckIndicesAreReady called on partially-constructed ActiveIndices");
     // label
     for ([[maybe_unused]] auto const &label : required_indices.label_) {
       if (!label_->IndexReady(label)) return false;

--- a/src/storage/v2/indices/edge_property_index.hpp
+++ b/src/storage/v2/indices/edge_property_index.hpp
@@ -50,8 +50,6 @@ class EdgePropertyIndex {
 
   virtual ~EdgePropertyIndex() = default;
 
-  virtual bool DropIndex(PropertyId property, ActiveIndicesUpdater const &updater) = 0;
-
   virtual void DropGraphClearIndices() = 0;
 
   virtual auto GetActiveIndices() const -> std::shared_ptr<ActiveIndices> = 0;

--- a/src/storage/v2/indices/edge_type_index.hpp
+++ b/src/storage/v2/indices/edge_type_index.hpp
@@ -48,8 +48,6 @@ class EdgeTypeIndex {
 
   virtual ~EdgeTypeIndex() = default;
 
-  virtual bool DropIndex(EdgeTypeId edge_type, ActiveIndicesUpdater const &updater) = 0;
-
   virtual void DropGraphClearIndices() = 0;
 
   virtual auto GetActiveIndices() const -> std::shared_ptr<ActiveIndices> = 0;

--- a/src/storage/v2/indices/edge_type_property_index.hpp
+++ b/src/storage/v2/indices/edge_type_property_index.hpp
@@ -54,8 +54,6 @@ class EdgeTypePropertyIndex {
 
   virtual ~EdgeTypePropertyIndex() = default;
 
-  virtual bool DropIndex(EdgeTypeId edge_type, PropertyId property, ActiveIndicesUpdater const &updater) = 0;
-
   virtual void DropGraphClearIndices() = 0;
 };
 

--- a/src/storage/v2/indices/label_index.hpp
+++ b/src/storage/v2/indices/label_index.hpp
@@ -32,7 +32,6 @@ class LabelIndex {
 
   virtual ~LabelIndex() = default;
 
-  virtual bool DropIndex(LabelId label, ActiveIndicesUpdater const &updater) = 0;
   virtual void DropGraphClearIndices() = 0;
 
   using AbortableInfo = LabelIndexAbortableInfo;

--- a/src/storage/v2/indices/label_property_index.hpp
+++ b/src/storage/v2/indices/label_property_index.hpp
@@ -200,9 +200,6 @@ class LabelPropertyIndex {
     explicit operator bool() const { return dropped_asc || dropped_desc; }
   };
 
-  // `order == nullopt` drops both ASC and DESC entries for (label, properties).
-  virtual DropResult DropIndex(LabelId label, std::vector<PropertyPath> const &properties,
-                               ActiveIndicesUpdater const &updater, std::optional<IndexOrder> order = std::nullopt) = 0;
   virtual void DropGraphClearIndices() = 0;
   virtual auto GetActiveIndices() const -> std::shared_ptr<ActiveIndices> = 0;
 };

--- a/src/storage/v2/indices/point_index.cpp
+++ b/src/storage/v2/indices/point_index.cpp
@@ -181,15 +181,26 @@ bool PointIndexStorage::CreatePointIndex(LabelId label, PropertyId property, uti
   return true;
 }
 
-bool PointIndexStorage::DropPointIndex(LabelId label, PropertyId property) {
+void PointIndexStorage::RestorePointIndex(LabelId label, PropertyId property, std::shared_ptr<PointIndex const> index) {
+  if (!index) return;
   auto key = LabelPropKey{label, property};
-  if (!indexes_->contains(key)) return false;
+  if (indexes_->contains(key)) return;
+  auto new_indexes = std::make_shared<index_container_t>(*indexes_);
+  new_indexes->emplace(key, std::move(index));
+  indexes_ = std::move(new_indexes);
+}
+
+std::shared_ptr<PointIndex const> PointIndexStorage::DropPointIndex(LabelId label, PropertyId property) {
+  auto key = LabelPropKey{label, property};
+  auto it = indexes_->find(key);
+  if (it == indexes_->end()) return nullptr;
 
   // Copy-on-write: create a new map so existing ActiveIndices snapshots are not affected.
+  auto evicted = it->second;
   auto new_indexes = std::make_shared<index_container_t>(*indexes_);
   new_indexes->erase(key);
   indexes_ = std::move(new_indexes);
-  return true;
+  return evicted;
 }
 
 void PointIndexStorage::InstallNewPointIndex(PointIndexChangeCollector &collector, PointIndexContext &context,

--- a/src/storage/v2/indices/point_index.hpp
+++ b/src/storage/v2/indices/point_index.hpp
@@ -114,7 +114,15 @@ struct PointIndexStorage {
   // this is typically deferred through Transaction::commit_callbacks_.
   bool CreatePointIndex(LabelId label, PropertyId property, utils::SkipListDb<Vertex>::Accessor vertices,
                         std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
-  bool DropPointIndex(LabelId label, PropertyId property);
+  /// Removes the index from the live container and returns the evicted PointIndex,
+  /// or nullptr if no index existed for {label, property}. The caller can re-install
+  /// the result via RestorePointIndex on transaction abort.
+  [[nodiscard]] std::shared_ptr<PointIndex const> DropPointIndex(LabelId label, PropertyId property);
+
+  /// Re-installs an entry previously evicted by DropPointIndex. Used by abort
+  /// rollback of DROP POINT INDEX. No-op if a re-created entry with the same
+  /// key already exists.
+  void RestorePointIndex(LabelId label, PropertyId property, std::shared_ptr<PointIndex const> index);
 
   // Transaction (establish what to collect + able to build next index)
   auto CreatePointIndexContext() const -> PointIndexContext { return PointIndexContext{indexes_}; }

--- a/src/storage/v2/indices/text_edge_index.cpp
+++ b/src/storage/v2/indices/text_edge_index.cpp
@@ -195,6 +195,14 @@ std::shared_ptr<TextEdgeIndexData> TextEdgeIndex::DropIndex(const std::string &i
   return evicted;
 }
 
+void TextEdgeIndex::RestoreIndex(std::string const &index_name, std::shared_ptr<TextEdgeIndexData> data) {
+  if (!data) return;
+  if (index_->contains(index_name)) return;
+  auto new_map = std::make_shared<IndexContainer>(*index_);
+  new_map->emplace(index_name, std::move(data));
+  index_ = std::move(new_map);
+}
+
 bool TextEdgeIndex::IndexExists(const std::string &index_name) const { return index_->contains(index_name); }
 
 std::vector<TextEdgeIndexSpec> TextEdgeIndex::ListIndices() const {

--- a/src/storage/v2/indices/text_edge_index.hpp
+++ b/src/storage/v2/indices/text_edge_index.hpp
@@ -29,9 +29,10 @@ struct Transaction;
 
 struct ActiveIndicesUpdater;
 
-// TODO(follow-up): TextIndex and TextEdgeIndex are ~95% structurally identical
-// (Data/IndexContainer/ActiveIndices/deferred_drop/Create/Drop/Recover/Clear).
-// Extract a CRTP or template base before the duplication drifts.
+// TODO(follow-up, tracked): TextIndex and TextEdgeIndex are ~95% structurally
+// identical (Data/IndexContainer/ActiveIndices/deferred_drop/Create/Drop/Recover
+// /Clear). CRTP/template-base extraction is deferred as a separate follow-up;
+// keep the two files synchronized manually in the meantime.
 
 struct TextEdgeIndexData {
   mutable mgcxx::text_search::Context context;
@@ -153,6 +154,12 @@ class TextEdgeIndex {
   /// directory if the DDL transaction later aborts, because existing
   /// ActiveIndices snapshots still alias the same TextEdgeIndexData.
   [[nodiscard]] std::shared_ptr<TextEdgeIndexData> DropIndex(const std::string &index_name);
+
+  /// Re-installs an entry previously evicted by DropIndex. Used by abort
+  /// rollback of DROP TEXT INDEX when the evicted shared_ptr was captured
+  /// in the abort closure. No-op if a re-created entry with the same name
+  /// already exists.
+  void RestoreIndex(std::string const &index_name, std::shared_ptr<TextEdgeIndexData> data);
 
   bool IndexExists(const std::string &index_name) const;
 

--- a/src/storage/v2/indices/text_index.cpp
+++ b/src/storage/v2/indices/text_index.cpp
@@ -181,6 +181,14 @@ std::shared_ptr<TextIndexData> TextIndex::DropIndex(const std::string &index_nam
   return evicted;
 }
 
+void TextIndex::RestoreIndex(std::string const &index_name, std::shared_ptr<TextIndexData> data) {
+  if (!data) return;
+  if (index_->contains(index_name)) return;
+  auto new_map = std::make_shared<IndexContainer>(*index_);
+  new_map->emplace(index_name, std::move(data));
+  index_ = std::move(new_map);
+}
+
 bool TextIndex::IndexExists(const std::string &index_name) const { return index_->contains(index_name); }
 
 std::vector<TextIndexSpec> TextIndex::ListIndices() const {

--- a/src/storage/v2/indices/text_index.hpp
+++ b/src/storage/v2/indices/text_index.hpp
@@ -28,9 +28,10 @@ namespace memgraph::storage {
 struct ActiveIndicesUpdater;
 struct Transaction;
 
-// TODO(follow-up): TextIndex and TextEdgeIndex are ~95% structurally identical
-// (Data/IndexContainer/ActiveIndices/deferred_drop/Create/Drop/Recover/Clear).
-// Extract a CRTP or template base before the duplication drifts.
+// TODO(follow-up, tracked): TextIndex and TextEdgeIndex are ~95% structurally
+// identical (Data/IndexContainer/ActiveIndices/deferred_drop/Create/Drop/Recover
+// /Clear). CRTP/template-base extraction is deferred as a separate follow-up;
+// keep the two files synchronized manually in the meantime.
 
 struct TextIndexData {
   mutable mgcxx::text_search::Context context;
@@ -148,6 +149,12 @@ class TextIndex {
   /// if the DDL transaction later aborts, because existing ActiveIndices
   /// snapshots still alias the same TextIndexData.
   [[nodiscard]] std::shared_ptr<TextIndexData> DropIndex(const std::string &index_name);
+
+  /// Re-installs an entry previously evicted by DropIndex. Used by abort
+  /// rollback of DROP TEXT INDEX when the evicted shared_ptr was captured
+  /// in the abort closure. No-op if a re-created entry with the same name
+  /// already exists.
+  void RestoreIndex(std::string const &index_name, std::shared_ptr<TextIndexData> data);
 
   bool IndexExists(const std::string &index_name) const;
 

--- a/src/storage/v2/indices/vector_edge_index.cpp
+++ b/src/storage/v2/indices/vector_edge_index.cpp
@@ -186,19 +186,17 @@ void VectorEdgeIndex::RecoverIndex(VectorEdgeIndexRecoveryInfo &recovery_info,
   updater(GetActiveIndices());
 }
 
-bool VectorEdgeIndex::DropIndex(std::string_view index_name, NameIdMapper *name_id_mapper) {
+std::optional<VectorEdgeIndex::DroppedIndexCapture> VectorEdgeIndex::DropIndex(std::string_view index_name,
+                                                                               NameIdMapper *name_id_mapper) {
   auto maybe_id = name_id_mapper->NameToIdIfExists(index_name);
-  if (!maybe_id.has_value()) {
-    return false;
-  }
+  if (!maybe_id.has_value()) return std::nullopt;
   const auto index_id = *maybe_id;
   auto it = index_->find(index_id);
-  if (it == index_->end()) {
-    return false;
-  }
-  auto &item_ptr = it->second;
-  auto &mg_index = item_ptr->mg_index;
-  auto &spec = item_ptr->spec;
+  if (it == index_->end()) return std::nullopt;
+  auto evicted_item = it->second;  // keep usearch state alive
+  auto &mg_index = evicted_item->mg_index;
+  auto &spec = evicted_item->spec;
+
   std::vector<Edge *> dropped_edges;
   {
     auto guard = std::lock_guard{mg_index.mutex};
@@ -211,7 +209,7 @@ bool VectorEdgeIndex::DropIndex(std::string_view index_name, NameIdMapper *name_
     mg_index.index.export_keys(dropped_edges.data(), 0, index_size);
 
     // Convert indexed vectors back to property values with OOM protection.
-    // Track processed vertices so we can rollback on OOM.
+    // Track processed edges so we can roll back on OOM.
     std::size_t processed = 0;
     try {
       const utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_enabler;
@@ -228,45 +226,56 @@ bool VectorEdgeIndex::DropIndex(std::string_view index_name, NameIdMapper *name_
       }
     } catch (const utils::OutOfMemoryException &) {
       const utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_blocker;
-      // Rollback: restore already-processed edges to their indexed representation.
-      for (std::size_t i = 0; i < processed; ++i) {
-        auto *edge = dropped_edges[i];
-        auto property_value = edge->properties.GetProperty(spec.property);
-        if (property_value.IsVectorIndexId()) {
-          auto &ids = property_value.ValueVectorIndexIds();
-          ids.push_back(index_id);
-        } else {
-          property_value = PropertyValue(
-              PropertyValue::VectorIndexIdData{.ids = utils::small_vector<uint64_t>{index_id}, .vector = {}});
-        }
-        edge->properties.SetProperty(spec.property, property_value);
-      }
+      for (std::size_t i = 0; i < processed; ++i) ReinstallIndexIdInProperty(dropped_edges[i], spec.property, index_id);
       throw;
     }
   }
   auto new_map = std::make_shared<VectorEdgeIndexContainer>(*index_);
   new_map->erase(index_id);
   index_ = new_map;
-  // Clean up endpoints for edges no longer in any index.
+
+  // Remove endpoints for edges no longer indexed elsewhere; capture the evicted
+  // entries so RestoreIndex can put them back.
   std::unordered_set<Edge *> still_indexed;
   for (const auto &[_, iptr] : *index_) {
     auto guard = utils::SharedResourceLockGuard(iptr->mg_index.mutex, utils::SharedResourceLockGuard::READ_ONLY);
     for (auto *edge : dropped_edges) {
-      if (iptr->mg_index.index.contains(edge)) {
-        still_indexed.insert(edge);
-      }
+      if (iptr->mg_index.index.contains(edge)) still_indexed.insert(edge);
     }
   }
+  std::vector<std::pair<Edge *, std::pair<Vertex *, Vertex *>>> evicted_endpoints;
   {
     auto lock = std::unique_lock{edge_endpoints_mutex_};
     for (auto *edge : dropped_edges) {
       DMG_ASSERT(edge != nullptr, "Null edge pointer in vector edge index");
-      if (!still_indexed.contains(edge)) {
-        edge_endpoints_.erase(edge);
+      if (still_indexed.contains(edge)) continue;
+      if (auto ep_it = edge_endpoints_.find(edge); ep_it != edge_endpoints_.end()) {
+        evicted_endpoints.emplace_back(edge, ep_it->second);
+        edge_endpoints_.erase(ep_it);
       }
     }
   }
-  return true;
+  return DroppedIndexCapture{.index_id = index_id,
+                             .evicted_item = std::move(evicted_item),
+                             .rewritten_edges = std::move(dropped_edges),
+                             .evicted_endpoints = std::move(evicted_endpoints)};
+}
+
+void VectorEdgeIndex::RestoreIndex(DroppedIndexCapture &&capture) {
+  // Abort path: must not propagate OOM (called from a noexcept abort callback).
+  const utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_blocker;
+  for (auto *edge : capture.rewritten_edges) {
+    ReinstallIndexIdInProperty(edge, capture.evicted_item->spec.property, capture.index_id);
+  }
+  auto new_map = std::make_shared<VectorEdgeIndexContainer>(*index_);
+  new_map->try_emplace(capture.index_id, std::move(capture.evicted_item));
+  index_ = new_map;
+  {
+    auto lock = std::unique_lock{edge_endpoints_mutex_};
+    for (auto &[edge, endpoints] : capture.evicted_endpoints) {
+      edge_endpoints_.try_emplace(edge, endpoints);
+    }
+  }
 }
 
 void VectorEdgeIndex::Clear() {

--- a/src/storage/v2/indices/vector_edge_index.hpp
+++ b/src/storage/v2/indices/vector_edge_index.hpp
@@ -194,8 +194,23 @@ class VectorEdgeIndex {
                     NameIdMapper *name_id_mapper, ActiveIndicesUpdater const &updater,
                     std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
-  /// @brief Drops an existing index.
-  bool DropIndex(std::string_view index_name, NameIdMapper *name_id_mapper);
+  /// Mirror of VectorIndex::DroppedIndexCapture, plus evicted_endpoints — endpoint
+  /// records erased from edge_endpoints_ that RestoreIndex must put back.
+  struct DroppedIndexCapture {
+    uint64_t index_id;
+    std::shared_ptr<EdgeTypeIndexItem> evicted_item;
+    std::vector<Edge *> rewritten_edges;
+    std::vector<std::pair<Edge *, std::pair<Vertex *, Vertex *>>> evicted_endpoints;
+  };
+
+  /// @brief Drops an existing index. Returns enough state to undo the drop on
+  /// transaction abort, or std::nullopt if the index doesn't exist. Callers that
+  /// only need a fire-and-forget drop (e.g. CreateIndex's exception rollback)
+  /// can discard the return value.
+  std::optional<DroppedIndexCapture> DropIndex(std::string_view index_name, NameIdMapper *name_id_mapper);
+
+  /// @brief Reinstalls an edge index previously evicted by DropIndex.
+  void RestoreIndex(DroppedIndexCapture &&capture);
 
   /// @brief Drops all existing indexes.
   void Clear();

--- a/src/storage/v2/indices/vector_index.cpp
+++ b/src/storage/v2/indices/vector_index.cpp
@@ -162,19 +162,18 @@ void VectorIndex::AddVertexToIndex(uint64_t index_id, Vertex &vertex, const Inde
   UpdateVectorIndex(item_ptr->mg_index, spec, &vertex, vector, thread_id);
 }
 
-bool VectorIndex::DropIndex(std::string_view index_name, NameIdMapper *name_id_mapper) {
+std::optional<VectorIndex::DroppedIndexCapture> VectorIndex::DropIndex(std::string_view index_name,
+                                                                       NameIdMapper *name_id_mapper) {
   auto maybe_id = name_id_mapper->NameToIdIfExists(index_name);
-  if (!maybe_id.has_value()) {
-    return false;
-  }
+  if (!maybe_id.has_value()) return std::nullopt;
   const auto index_id = *maybe_id;
   auto it = index_->find(index_id);
-  if (it == index_->end()) {
-    return false;
-  }
-  auto &item_ptr = it->second;
-  auto &mg_index = item_ptr->mg_index;
-  auto &spec = item_ptr->spec;
+  if (it == index_->end()) return std::nullopt;
+  auto evicted_item = it->second;  // keep IndexItem (and its usearch state) alive
+  auto &mg_index = evicted_item->mg_index;
+  auto &spec = evicted_item->spec;
+
+  std::vector<Vertex *> rewritten_vertices;
   {
     auto guard = std::lock_guard{mg_index.mutex};
 
@@ -187,7 +186,7 @@ bool VectorIndex::DropIndex(std::string_view index_name, NameIdMapper *name_id_m
 
     // Convert indexed vectors back to property values with OOM protection.
     // Track processed vertices so we can rollback on OOM.
-    std::size_t processed = 0;
+    rewritten_vertices.reserve(indexed_vertices.size());
     try {
       const utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_enabler;
       std::vector<double> vector(dimension);
@@ -199,30 +198,31 @@ bool VectorIndex::DropIndex(std::string_view index_name, NameIdMapper *name_id_m
         } else {
           vertex->properties.SetProperty(spec.property, vector_property);
         }
-        ++processed;
+        rewritten_vertices.push_back(vertex);
       }
     } catch (const utils::OutOfMemoryException &) {
       const utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_blocker;
-      // Rollback: restore already-processed vertices to their indexed representation.
-      for (std::size_t i = 0; i < processed; ++i) {
-        auto *vertex = indexed_vertices[i];
-        auto property_value = vertex->properties.GetProperty(spec.property);
-        if (property_value.IsVectorIndexId()) {
-          auto &ids = property_value.ValueVectorIndexIds();
-          ids.push_back(index_id);
-        } else {
-          property_value = PropertyValue(
-              PropertyValue::VectorIndexIdData{.ids = utils::small_vector<uint64_t>{index_id}, .vector = {}});
-        }
-        vertex->properties.SetProperty(spec.property, property_value);
-      }
+      for (auto *vertex : rewritten_vertices) ReinstallIndexIdInProperty(vertex, spec.property, index_id);
       throw;
     }
   }
   auto new_map = std::make_shared<VectorIndexContainer>(*index_);
   new_map->erase(index_id);
   index_ = new_map;
-  return true;
+  return DroppedIndexCapture{.index_id = index_id,
+                             .evicted_item = std::move(evicted_item),
+                             .rewritten_vertices = std::move(rewritten_vertices)};
+}
+
+void VectorIndex::RestoreIndex(DroppedIndexCapture &&capture) {
+  // Abort path: must not propagate OOM (called from a noexcept abort callback).
+  const utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_blocker;
+  for (auto *vertex : capture.rewritten_vertices) {
+    ReinstallIndexIdInProperty(vertex, capture.evicted_item->spec.property, capture.index_id);
+  }
+  auto new_map = std::make_shared<VectorIndexContainer>(*index_);
+  new_map->try_emplace(capture.index_id, std::move(capture.evicted_item));
+  index_ = new_map;
 }
 
 void VectorIndex::Clear() { index_ = std::make_shared<VectorIndexContainer>(); }

--- a/src/storage/v2/indices/vector_index.hpp
+++ b/src/storage/v2/indices/vector_index.hpp
@@ -195,13 +195,6 @@ class VectorIndex {
   VectorIndex &operator=(VectorIndex &&) noexcept = default;
 
   /// Returns the current active indices snapshot for use in transactions.
-  // TODO(follow-up): return `shared_ptr<VectorIndexActiveIndices const>` -- all
-  // methods on the snapshot are const, the inner container is already
-  // `shared_ptr<VectorIndexContainer const>`, so the outer non-const shared_ptr
-  // is a weak const-correctness wart. Requires threading `const` through
-  // `ActiveIndices::vector_`, `ActiveIndicesUpdater::operator()`, and the 4
-  // other sub-indices (text, text_edge, point, vector_edge) for consistency.
-  // Do all 5 in one sweep.
   auto GetActiveIndices() const -> std::shared_ptr<VectorIndexActiveIndices> {
     return std::make_shared<ActiveIndices>(index_);
   }
@@ -232,11 +225,25 @@ class VectorIndex {
                     ActiveIndicesUpdater const &updater,
                     std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
-  /// @brief Drops an existing index.
-  /// @param index_name The name of the index to be dropped.
-  /// @param name_id_mapper Name id mapper (for property decoding).
-  /// @return true if the index was dropped successfully, false otherwise.
-  bool DropIndex(std::string_view index_name, NameIdMapper *name_id_mapper);
+  /// Captured state from DropIndex. evicted_item keeps the usearch state alive;
+  /// rewritten_vertices is the list whose properties were demoted to plain Vector
+  /// and that RestoreIndex must promote back.
+  struct DroppedIndexCapture {
+    uint64_t index_id;
+    std::shared_ptr<IndexItem> evicted_item;
+    std::vector<Vertex *> rewritten_vertices;
+  };
+
+  /// @brief Drops an existing index. Returns enough state to undo the drop on
+  /// transaction abort, or std::nullopt if the index doesn't exist. Callers that
+  /// only need a fire-and-forget drop (e.g. CreateIndex's exception rollback)
+  /// can discard the return value.
+  std::optional<DroppedIndexCapture> DropIndex(std::string_view index_name, NameIdMapper *name_id_mapper);
+
+  /// @brief Reinstalls an index previously evicted by DropIndex. Re-adds the
+  /// captured index_id to each rewritten vertex's property and re-inserts the
+  /// IndexItem into the container.
+  void RestoreIndex(DroppedIndexCapture &&capture);
 
   /// @brief Drops all existing indexes.
   void Clear();

--- a/src/storage/v2/indices/vector_index_utils.hpp
+++ b/src/storage/v2/indices/vector_index_utils.hpp
@@ -343,6 +343,20 @@ inline bool UnregisterIndexId(PropertyValue &property_value, uint64_t index_id) 
   return ids.empty();
 }
 
+/// Inverse of UnregisterIndexId: appends index_id to an existing VectorIndexId list,
+/// or promotes a plain Vector property back into a VectorIndexIdData{id}.
+template <typename Entity>
+inline void ReinstallIndexIdInProperty(Entity *entity, PropertyId property, uint64_t index_id) {
+  auto property_value = entity->properties.GetProperty(property);
+  if (property_value.IsVectorIndexId()) {
+    property_value.ValueVectorIndexIds().push_back(index_id);
+  } else {
+    property_value =
+        PropertyValue(PropertyValue::VectorIndexIdData{.ids = utils::small_vector<uint64_t>{index_id}, .vector = {}});
+  }
+  entity->properties.SetProperty(property, property_value);
+}
+
 /// @brief Checks if dropping a vector index would exceed the total memory limit.
 /// When an index is dropped, indexed vectors are converted back to property values in the property store,
 /// which increases memory usage. This function estimates the cost and throws OutOfMemoryException

--- a/src/storage/v2/inmemory/edge_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_property_index.cpp
@@ -188,35 +188,42 @@ bool InMemoryEdgePropertyIndex::CreateIndexOnePass(
   return PublishIndex(property, 0);
 }
 
-bool InMemoryEdgePropertyIndex::RegisterIndex(PropertyId property, ActiveIndicesUpdater const &updater) {
+bool InMemoryEdgePropertyIndex::InstallIndividualIndex_(PropertyId property, std::shared_ptr<IndividualIndex> entry,
+                                                        ActiveIndicesUpdater const &updater,
+                                                        bool register_in_all_indices) {
   return index_.WithLock([&](std::shared_ptr<IndicesContainer const> &indices_container) {
-    auto const &indices = indices_container->indices_;
-    {
-      auto it = indices.find(property);
-      if (it != indices.end()) return false;  // already exists
-    }
-
+    if (indices_container->indices_.find(property) != indices_container->indices_.cend()) return false;
     utils::MemoryTracker::OutOfMemoryExceptionEnabler oom_exception;
-    // Register
     auto new_container = std::make_shared<IndicesContainer>(*indices_container);
-    auto [new_it, _] = new_container->indices_.emplace(property, std::make_shared<IndividualIndex>());
-    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
-    all_indices_.WithLock([&](auto &all_indices) {
-      auto new_all_indices = *all_indices;
+    auto [new_it, _] = new_container->indices_.emplace(property, std::move(entry));
+
+    if (register_in_all_indices) {
       // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
-      new_all_indices.emplace_back(property, new_it->second);
-      all_indices = std::make_shared<std::vector<AllIndicesEntry>>(std::move(new_all_indices));
-    });
-    indices_container = new_container;
+      all_indices_.WithLock([&](auto &all_indices) {
+        auto new_all_indices = *all_indices;
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
+        new_all_indices.emplace_back(property, new_it->second);
+        all_indices = std::make_shared<std::vector<AllIndicesEntry>>(std::move(new_all_indices));
+      });
+    }
+    indices_container = std::move(new_container);
     updater(std::make_shared<ActiveIndices>(indices_container));
     return true;
   });
 }
 
-auto InMemoryEdgePropertyIndex::PopulateIndex(
-    PropertyId property, utils::SkipListDb<Vertex>::Accessor vertices,
-    ActiveIndicesUpdater const &updater, std::optional<SnapshotObserverInfo> const &snapshot_info,
-    Transaction const *tx, CheckCancelFunction cancel_check) -> std::expected<void, IndexPopulateError> {
+bool InMemoryEdgePropertyIndex::RegisterIndex(PropertyId property, ActiveIndicesUpdater const &updater) {
+  return InstallIndividualIndex_(property,
+                                 std::make_shared<IndividualIndex>(),
+                                 updater,
+                                 /*register_in_all_indices=*/true);
+}
+
+auto InMemoryEdgePropertyIndex::PopulateIndex(PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
+                                              ActiveIndicesUpdater const &updater,
+                                              std::optional<SnapshotObserverInfo> const &snapshot_info,
+                                              Transaction const *tx, CheckCancelFunction cancel_check)
+    -> std::expected<void, IndexPopulateError> {
   auto index = GetIndividualIndex(property);
   if (!index) {
     MG_ASSERT(false, "It should not be possible to remove the index before populating it.");
@@ -240,10 +247,10 @@ auto InMemoryEdgePropertyIndex::PopulateIndex(
           vertices, accessor_factory, insert_function, std::move(cancel_check), {} /*TODO: parallel*/);
     }
   } catch (const PopulateCancel &) {
-    DropIndex(property, updater);
+    (void)DropIndex(property, updater);
     return std::unexpected{IndexPopulateError::Cancellation};
   } catch (const utils::OutOfMemoryException &) {
-    DropIndex(property, updater);
+    (void)DropIndex(property, updater);
     throw;
   }
   return {};
@@ -267,25 +274,34 @@ InMemoryEdgePropertyIndex::IndividualIndex::~IndividualIndex() {
   }
 }
 
-bool InMemoryEdgePropertyIndex::DropIndex(PropertyId property, ActiveIndicesUpdater const &updater) {
-  auto const result = index_.WithLock([&](std::shared_ptr<IndicesContainer const> &indices_container) {
-    {
-      auto const it = indices_container->indices_.find(property);
-      if (it == indices_container->indices_.cend()) return false;
-    }
+auto InMemoryEdgePropertyIndex::DropIndex(PropertyId property, ActiveIndicesUpdater const &updater)
+    -> std::shared_ptr<IndividualIndex> {
+  auto evicted = index_.WithLock(
+      [&](std::shared_ptr<IndicesContainer const> &indices_container) -> std::shared_ptr<IndividualIndex> {
+        auto const it = indices_container->indices_.find(property);
+        if (it == indices_container->indices_.cend()) return {};
+        auto evicted_entry = it->second;
 
-    auto new_container = std::make_shared<IndicesContainer>();
-    for (auto const &[existing_property, index] : indices_container->indices_) {
-      if (existing_property != property) {
-        new_container->indices_.emplace(existing_property, index);
-      }
-    }
-    indices_container = new_container;
-    updater(std::make_shared<ActiveIndices>(indices_container));
-    return true;
-  });
+        auto new_container = std::make_shared<IndicesContainer>();
+        for (auto const &[existing_property, index] : indices_container->indices_) {
+          if (existing_property != property) {
+            new_container->indices_.emplace(existing_property, index);
+          }
+        }
+        indices_container = new_container;
+        updater(std::make_shared<ActiveIndices>(indices_container));
+        return evicted_entry;
+      });
   CleanupAllIndicies();
-  return result;
+  return evicted;
+}
+
+void InMemoryEdgePropertyIndex::RestoreIndex(PropertyId property, std::shared_ptr<IndividualIndex> evicted,
+                                             ActiveIndicesUpdater const &updater) {
+  if (!evicted) return;
+  // register_in_all_indices=false: captured shared_ptr already kept the entry alive
+  // through CleanupAllIndices; re-appending would create an unreapable duplicate.
+  (void)InstallIndividualIndex_(property, std::move(evicted), updater, /*register_in_all_indices=*/false);
 }
 
 bool InMemoryEdgePropertyIndex::ActiveIndices::IndexExists(PropertyId property) const {

--- a/src/storage/v2/inmemory/edge_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_property_index.cpp
@@ -176,9 +176,9 @@ void AdvanceUntilValid_(auto &index_iterator, auto end, EdgeRef &current_edge, E
 }
 }  // namespace
 
-bool InMemoryEdgePropertyIndex::CreateIndexOnePass(
-    PropertyId property, utils::SkipListDb<Vertex>::Accessor vertices,
-    ActiveIndicesUpdater const &updater, std::optional<SnapshotObserverInfo> const &snapshot_info) {
+bool InMemoryEdgePropertyIndex::CreateIndexOnePass(PropertyId property, utils::SkipListDb<Vertex>::Accessor vertices,
+                                                   ActiveIndicesUpdater const &updater,
+                                                   std::optional<SnapshotObserverInfo> const &snapshot_info) {
   auto res = RegisterIndex(property, updater);
   if (!res) return false;
   auto res2 = PopulateIndex(property, std::move(vertices), updater, snapshot_info);
@@ -219,7 +219,7 @@ bool InMemoryEdgePropertyIndex::RegisterIndex(PropertyId property, ActiveIndices
                                  /*register_in_all_indices=*/true);
 }
 
-auto InMemoryEdgePropertyIndex::PopulateIndex(PropertyId property, utils::SkipList<Vertex>::Accessor vertices,
+auto InMemoryEdgePropertyIndex::PopulateIndex(PropertyId property, utils::SkipListDb<Vertex>::Accessor vertices,
                                               ActiveIndicesUpdater const &updater,
                                               std::optional<SnapshotObserverInfo> const &snapshot_info,
                                               Transaction const *tx, CheckCancelFunction cancel_check)
@@ -428,9 +428,8 @@ void InMemoryEdgePropertyIndex::DropGraphClearIndices() {
 
 InMemoryEdgePropertyIndex::Iterable::Iterable(
     utils::SkipListDb<InMemoryEdgePropertyIndex::Entry>::Accessor index_accessor,
-    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-    utils::SkipListDb<Edge>::ConstAccessor edge_accessor, PropertyId property,
-    const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor, utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
+    PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
     Transaction *transaction)
     : pin_accessor_edge_(std::move(edge_accessor)),
@@ -445,8 +444,7 @@ InMemoryEdgePropertyIndex::Iterable::Iterable(
       transaction_(transaction) {}
 
 InMemoryEdgePropertyIndex::Iterable::Iterator::Iterator(
-    Iterable *self,
-    utils::SkipListDb<InMemoryEdgePropertyIndex::Entry>::Iterator index_iterator)
+    Iterable *self, utils::SkipListDb<InMemoryEdgePropertyIndex::Entry>::Iterator index_iterator)
     : self_(self),
       index_iterator_(index_iterator),
       current_edge_(nullptr),
@@ -486,8 +484,7 @@ void InMemoryEdgePropertyIndex::RunGC() {
 
 InMemoryEdgePropertyIndex::Iterable InMemoryEdgePropertyIndex::ActiveIndices::Edges(
     PropertyId property, utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-    utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
-    const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+    utils::SkipListDb<Edge>::ConstAccessor edge_accessor, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
     Transaction *transaction) {
   auto it = index_container_->indices_.find(property);
@@ -505,8 +502,7 @@ InMemoryEdgePropertyIndex::Iterable InMemoryEdgePropertyIndex::ActiveIndices::Ed
 
 InMemoryEdgePropertyIndex::ChunkedIterable InMemoryEdgePropertyIndex::ActiveIndices::ChunkedEdges(
     PropertyId property, utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-    utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
-    const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+    utils::SkipListDb<Edge>::ConstAccessor edge_accessor, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
     Transaction *transaction, size_t num_chunks) {
   auto it = index_container_->indices_.find(property);
@@ -567,9 +563,8 @@ void InMemoryEdgePropertyIndex::CleanupAllIndicies() {
 
 InMemoryEdgePropertyIndex::ChunkedIterable::ChunkedIterable(
     utils::SkipListDb<InMemoryEdgePropertyIndex::Entry>::Accessor index_accessor,
-    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-    utils::SkipListDb<Edge>::ConstAccessor edge_accessor, PropertyId property,
-    const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor, utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
+    PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
     Transaction *transaction, size_t num_chunks)
     : pin_accessor_edge_(std::move(edge_accessor)),
@@ -596,17 +591,16 @@ InMemoryEdgePropertyIndex::ChunkedIterable::ChunkedIterable(
 void InMemoryEdgePropertyIndex::ChunkedIterable::Iterator::AdvanceUntilValid() {
   // NOTE: Using the skiplist end here to not store the end iterator in the class
   // The higher level != end will still be correct
-  AdvanceUntilValid_(
-      index_iterator_,
-      utils::SkipListDb<InMemoryEdgePropertyIndex::Entry>::ChunkedIterator{},
-      current_edge_,
-      current_edge_accessor_,
-      self_->storage_,
-      self_->transaction_,
-      self_->view_,
-      self_->property_,
-      self_->lower_bound_,
-      self_->upper_bound_);
+  AdvanceUntilValid_(index_iterator_,
+                     utils::SkipListDb<InMemoryEdgePropertyIndex::Entry>::ChunkedIterator{},
+                     current_edge_,
+                     current_edge_accessor_,
+                     self_->storage_,
+                     self_->transaction_,
+                     self_->view_,
+                     self_->property_,
+                     self_->lower_bound_,
+                     self_->upper_bound_);
 }
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/inmemory/edge_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_property_index.hpp
@@ -259,8 +259,12 @@ class InMemoryEdgePropertyIndex : public EdgePropertyIndex {
       -> std::expected<void, IndexPopulateError>;
   bool PublishIndex(PropertyId property, uint64_t commit_timestamp);
 
-  /// Returns false if there was no index to drop
-  bool DropIndex(PropertyId property, ActiveIndicesUpdater const &updater) override;
+  /// Removes the index and returns the evicted IndividualIndex (nullptr if absent).
+  /// Caller can re-install via RestoreIndex on abort. The returned shared_ptr keeps
+  /// the entry alive in all_indices_, so RestoreIndex must not re-append there.
+  [[nodiscard]] auto DropIndex(PropertyId property, ActiveIndicesUpdater const &updater)
+      -> std::shared_ptr<IndividualIndex>;
+  void RestoreIndex(PropertyId property, std::shared_ptr<IndividualIndex> evicted, ActiveIndicesUpdater const &updater);
 
   void RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token);
 
@@ -272,6 +276,11 @@ class InMemoryEdgePropertyIndex : public EdgePropertyIndex {
 
  private:
   auto GetIndividualIndex(PropertyId property) const -> std::shared_ptr<IndividualIndex>;
+
+  // Atomic install into index_ + (optional) all_indices_. Returns false if the slot
+  // is taken. Shared by RegisterIndex (true) and RestoreIndex (false).
+  bool InstallIndividualIndex_(PropertyId property, std::shared_ptr<IndividualIndex> entry,
+                               ActiveIndicesUpdater const &updater, bool register_in_all_indices);
   void CleanupAllIndicies();
 
   utils::Synchronized<std::shared_ptr<IndicesContainer const>, utils::WritePrioritizedRWLock> index_{

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -115,9 +115,9 @@ inline void AdvanceUntilValid_(auto &index_iterator, const auto &end_iterator, E
 
 }  // namespace
 
-bool InMemoryEdgeTypeIndex::CreateIndexOnePass(
-    EdgeTypeId edge_type, utils::SkipListDb<Vertex>::Accessor vertices,
-    ActiveIndicesUpdater const &updater, std::optional<SnapshotObserverInfo> const &snapshot_info) {
+bool InMemoryEdgeTypeIndex::CreateIndexOnePass(EdgeTypeId edge_type, utils::SkipListDb<Vertex>::Accessor vertices,
+                                               ActiveIndicesUpdater const &updater,
+                                               std::optional<SnapshotObserverInfo> const &snapshot_info) {
   auto res = RegisterIndex(edge_type, updater);
   if (!res) return false;
   auto res2 = PopulateIndex(edge_type, std::move(vertices), updater, snapshot_info);
@@ -127,8 +127,7 @@ bool InMemoryEdgeTypeIndex::CreateIndexOnePass(
   return PublishIndex(edge_type, 0);
 }
 
-auto InMemoryEdgeTypeIndex::PopulateIndex(EdgeTypeId edge_type,
-                                          utils::SkipListDb<Vertex>::Accessor vertices,
+auto InMemoryEdgeTypeIndex::PopulateIndex(EdgeTypeId edge_type, utils::SkipListDb<Vertex>::Accessor vertices,
                                           ActiveIndicesUpdater const &updater,
                                           std::optional<SnapshotObserverInfo> const &snapshot_info,
                                           Transaction const *tx, CheckCancelFunction cancel_check)
@@ -171,7 +170,7 @@ bool InMemoryEdgeTypeIndex::InstallIndividualIndex_(EdgeTypeId edge_type, std::s
     auto [new_it, _] = new_container->indices_.emplace(edge_type, std::move(entry));
 
     if (register_in_all_indices) {
-      utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_blocker;
+      const utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_blocker;
       // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
       all_indices_.WithLock([&](auto &all_indices) {
         auto new_all_indices = *all_indices;
@@ -339,11 +338,10 @@ void InMemoryEdgeTypeIndex::DropGraphClearIndices() {
   });
 }
 
-InMemoryEdgeTypeIndex::Iterable::Iterable(
-    utils::SkipListDb<InMemoryEdgeTypeIndex::Entry>::Accessor index_accessor,
-    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-    utils::SkipListDb<Edge>::ConstAccessor edge_accessor, EdgeTypeId edge_type, View view,
-    Storage *storage, Transaction *transaction)
+InMemoryEdgeTypeIndex::Iterable::Iterable(utils::SkipListDb<InMemoryEdgeTypeIndex::Entry>::Accessor index_accessor,
+                                          utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
+                                          utils::SkipListDb<Edge>::ConstAccessor edge_accessor, EdgeTypeId edge_type,
+                                          View view, Storage *storage, Transaction *transaction)
     : pin_accessor_edge_(std::move(edge_accessor)),
       pin_accessor_vertex_(std::move(vertex_accessor)),
       index_accessor_(std::move(index_accessor)),
@@ -353,8 +351,7 @@ InMemoryEdgeTypeIndex::Iterable::Iterable(
       transaction_(transaction) {}
 
 InMemoryEdgeTypeIndex::Iterable::Iterator::Iterator(
-    Iterable *self,
-    utils::SkipListDb<InMemoryEdgeTypeIndex::Entry>::Iterator index_iterator)
+    Iterable *self, utils::SkipListDb<InMemoryEdgeTypeIndex::Entry>::Iterator index_iterator)
     : self_(self),
       index_iterator_(index_iterator),
       current_edge_(nullptr),
@@ -392,8 +389,7 @@ void InMemoryEdgeTypeIndex::RunGC() {
 
 InMemoryEdgeTypeIndex::Iterable InMemoryEdgeTypeIndex::ActiveIndices::Edges(
     EdgeTypeId edge_type, utils::SkipListDb<Vertex>::ConstAccessor vertex_acc,
-    utils::SkipListDb<Edge>::ConstAccessor edge_acc, View view, Storage *storage,
-    Transaction *transaction) {
+    utils::SkipListDb<Edge>::ConstAccessor edge_acc, View view, Storage *storage, Transaction *transaction) {
   const auto it = index_container_->indices_.find(edge_type);
   MG_ASSERT(it != index_container_->indices_.end(), "Index for edge-type {} doesn't exist", edge_type.AsUint());
   return {it->second->skip_list_.access(),
@@ -407,8 +403,8 @@ InMemoryEdgeTypeIndex::Iterable InMemoryEdgeTypeIndex::ActiveIndices::Edges(
 
 InMemoryEdgeTypeIndex::ChunkedIterable InMemoryEdgeTypeIndex::ActiveIndices::ChunkedEdges(
     EdgeTypeId edge_type, utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-    utils::SkipListDb<Edge>::ConstAccessor edge_accessor, View view, Storage *storage,
-    Transaction *transaction, size_t num_chunks) {
+    utils::SkipListDb<Edge>::ConstAccessor edge_accessor, View view, Storage *storage, Transaction *transaction,
+    size_t num_chunks) {
   const auto it = index_container_->indices_.find(edge_type);
   MG_ASSERT(it != index_container_->indices_.end(), "Index for edge-type {} doesn't exist", edge_type.AsUint());
   return {it->second->skip_list_.access(),
@@ -451,9 +447,8 @@ void InMemoryEdgeTypeIndex::CleanupAllIndices() {
 
 InMemoryEdgeTypeIndex::ChunkedIterable::ChunkedIterable(
     utils::SkipListDb<InMemoryEdgeTypeIndex::Entry>::Accessor index_accessor,
-    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-    utils::SkipListDb<Edge>::ConstAccessor edge_accessor, EdgeTypeId edge_type, View view,
-    Storage *storage, Transaction *transaction, size_t num_chunks)
+    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor, utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
+    EdgeTypeId edge_type, View view, Storage *storage, Transaction *transaction, size_t num_chunks)
     : pin_accessor_edge_(std::move(edge_accessor)),
       pin_accessor_vertex_(std::move(vertex_accessor)),
       index_accessor_(std::move(index_accessor)),
@@ -463,8 +458,7 @@ InMemoryEdgeTypeIndex::ChunkedIterable::ChunkedIterable(
       transaction_(transaction),
       chunks_{index_accessor_.create_chunks(num_chunks)} {
   // Index can have duplicate entries, we need to make sure each unique entry is inside a single chunk.
-  RechunkIndex<utils::SkipListDb<Entry>>(
-      chunks_, [](const auto &a, const auto &b) { return a.edge == b.edge; });
+  RechunkIndex<utils::SkipListDb<Entry>>(chunks_, [](const auto &a, const auto &b) { return a.edge == b.edge; });
 }
 
 void InMemoryEdgeTypeIndex::ChunkedIterable::Iterator::AdvanceUntilValid() {

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -154,39 +154,43 @@ auto InMemoryEdgeTypeIndex::PopulateIndex(EdgeTypeId edge_type,
       PopulateIndexDispatch(vertices, accessor_factory, insert_func, std::move(cancel_check), {} /*TODO: parallel*/);
     }
   } catch (const PopulateCancel &) {
-    DropIndex(edge_type, updater);
+    (void)DropIndex(edge_type, updater);
     return std::unexpected{IndexPopulateError::Cancellation};
   } catch (const utils::OutOfMemoryException &) {
-    DropIndex(edge_type, updater);
+    (void)DropIndex(edge_type, updater);
     throw;
   }
   return {};
 }
 
-bool InMemoryEdgeTypeIndex::RegisterIndex(EdgeTypeId edge_type, ActiveIndicesUpdater const &updater) {
+bool InMemoryEdgeTypeIndex::InstallIndividualIndex_(EdgeTypeId edge_type, std::shared_ptr<IndividualIndex> entry,
+                                                    ActiveIndicesUpdater const &updater, bool register_in_all_indices) {
   return index_.WithLock([&](std::shared_ptr<IndicesContainer const> &indices_container) {
-    auto const &indices = indices_container->indices_;
-    {
-      auto it = indices.find(edge_type);
-      if (it != indices.end()) return false;  // already exists
-    }
-
-    // Register
+    if (indices_container->indices_.find(edge_type) != indices_container->indices_.cend()) return false;
     auto new_container = std::make_shared<IndicesContainer>(*indices_container);
-    auto [new_it, _] = new_container->indices_.emplace(edge_type, std::make_shared<IndividualIndex>());
+    auto [new_it, _] = new_container->indices_.emplace(edge_type, std::move(entry));
 
-    utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_blocker;
-    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
-    all_indices_.WithLock([&](auto &all_indices) {
-      auto new_all_indices = *all_indices;
+    if (register_in_all_indices) {
+      utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_blocker;
       // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
-      new_all_indices.emplace_back(new_it->second);
-      all_indices = std::make_shared<std::vector<AllIndicesEntry>>(std::move(new_all_indices));
-    });
-    indices_container = new_container;
+      all_indices_.WithLock([&](auto &all_indices) {
+        auto new_all_indices = *all_indices;
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
+        new_all_indices.emplace_back(new_it->second);
+        all_indices = std::make_shared<std::vector<AllIndicesEntry>>(std::move(new_all_indices));
+      });
+    }
+    indices_container = std::move(new_container);
     updater(std::make_shared<ActiveIndices>(indices_container));
     return true;
   });
+}
+
+bool InMemoryEdgeTypeIndex::RegisterIndex(EdgeTypeId edge_type, ActiveIndicesUpdater const &updater) {
+  return InstallIndividualIndex_(edge_type,
+                                 std::make_shared<IndividualIndex>(),
+                                 updater,
+                                 /*register_in_all_indices=*/true);
 }
 
 bool InMemoryEdgeTypeIndex::PublishIndex(EdgeTypeId edge_type, uint64_t commit_timestamp) {
@@ -207,25 +211,34 @@ InMemoryEdgeTypeIndex::IndividualIndex::~IndividualIndex() {
   }
 }
 
-bool InMemoryEdgeTypeIndex::DropIndex(EdgeTypeId edge_type, ActiveIndicesUpdater const &updater) {
-  auto const result = index_.WithLock([&](std::shared_ptr<IndicesContainer const> &indices_container) {
-    {
-      auto const it = indices_container->indices_.find(edge_type);
-      if (it == indices_container->indices_.cend()) return false;
-    }
+auto InMemoryEdgeTypeIndex::DropIndex(EdgeTypeId edge_type, ActiveIndicesUpdater const &updater)
+    -> std::shared_ptr<IndividualIndex> {
+  auto evicted = index_.WithLock(
+      [&](std::shared_ptr<IndicesContainer const> &indices_container) -> std::shared_ptr<IndividualIndex> {
+        auto const it = indices_container->indices_.find(edge_type);
+        if (it == indices_container->indices_.cend()) return {};
+        auto evicted_entry = it->second;
 
-    auto new_container = std::make_shared<IndicesContainer>();
-    for (auto const &[existing_edge_type, index] : indices_container->indices_) {
-      if (existing_edge_type != edge_type) {
-        new_container->indices_.emplace(existing_edge_type, index);
-      }
-    }
-    indices_container = new_container;
-    updater(std::make_shared<ActiveIndices>(indices_container));
-    return true;
-  });
+        auto new_container = std::make_shared<IndicesContainer>();
+        for (auto const &[existing_edge_type, index] : indices_container->indices_) {
+          if (existing_edge_type != edge_type) {
+            new_container->indices_.emplace(existing_edge_type, index);
+          }
+        }
+        indices_container = new_container;
+        updater(std::make_shared<ActiveIndices>(indices_container));
+        return evicted_entry;
+      });
   CleanupAllIndices();
-  return result;
+  return evicted;
+}
+
+void InMemoryEdgeTypeIndex::RestoreIndex(EdgeTypeId edge_type, std::shared_ptr<IndividualIndex> evicted,
+                                         ActiveIndicesUpdater const &updater) {
+  if (!evicted) return;
+  // register_in_all_indices=false: captured shared_ptr already kept the entry alive
+  // through CleanupAllIndices; re-appending would create an unreapable duplicate.
+  (void)InstallIndividualIndex_(edge_type, std::move(evicted), updater, /*register_in_all_indices=*/false);
 }
 
 bool InMemoryEdgeTypeIndex::ActiveIndices::IndexReady(memgraph::storage::EdgeTypeId edge_type) const {

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -159,7 +159,7 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
     utils::SkipListDb<Entry>::ChunkCollection chunks_;
   };
 
- private:
+ public:
   struct IndividualIndex {
     explicit IndividualIndex() : skip_list_{} {}
 
@@ -170,6 +170,7 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
     IndexStatus status_{};
   };
 
+ private:
   struct IndicesContainer {
     IndicesContainer(IndicesContainer const &other) : indices_(other.indices_) {}
 
@@ -235,8 +236,13 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
 
   bool PublishIndex(EdgeTypeId edge_type, uint64_t commit_timestamp);
 
-  /// Returns false if there was no index to drop
-  bool DropIndex(EdgeTypeId edge_type, ActiveIndicesUpdater const &updater) override;
+  /// Removes the index and returns the evicted IndividualIndex (nullptr if absent).
+  /// Caller can re-install via RestoreIndex on abort. The returned shared_ptr keeps
+  /// the entry alive in all_indices_, so RestoreIndex must not re-append there.
+  [[nodiscard]] auto DropIndex(EdgeTypeId edge_type, ActiveIndicesUpdater const &updater)
+      -> std::shared_ptr<IndividualIndex>;
+  void RestoreIndex(EdgeTypeId edge_type, std::shared_ptr<IndividualIndex> evicted,
+                    ActiveIndicesUpdater const &updater);
 
   void RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token);
 
@@ -249,6 +255,11 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
  private:
   void CleanupAllIndices();
   auto GetIndividualIndex(EdgeTypeId edge_type) const -> std::shared_ptr<IndividualIndex>;
+
+  // Atomic install into index_ + (optional) all_indices_. Returns false if the slot
+  // is taken. Shared by RegisterIndex (true) and RestoreIndex (false).
+  bool InstallIndividualIndex_(EdgeTypeId edge_type, std::shared_ptr<IndividualIndex> entry,
+                               ActiveIndicesUpdater const &updater, bool register_in_all_indices);
 
   utils::Synchronized<std::shared_ptr<IndicesContainer const>, utils::WritePrioritizedRWLock> index_{
       std::make_shared<IndicesContainer const>()};

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -168,12 +168,12 @@ bool InMemoryEdgeTypePropertyIndex::InstallIndividualIndex_(EdgeTypeId edge_type
                                                             ActiveIndicesUpdater const &updater,
                                                             bool register_in_all_indices) {
   return index_.WithLock([&](std::shared_ptr<IndexContainer const> &index_container) {
-    if (index_container->find({edge_type, property}) != index_container->end()) return false;
+    if (index_container->contains({edge_type, property})) return false;
     auto new_container = std::make_shared<IndexContainer>(*index_container);
     auto [new_it, _] = new_container->emplace(std::make_pair(edge_type, property), std::move(entry));
 
     if (register_in_all_indices) {
-      utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_blocker;
+      const utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_blocker;
       // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
       all_indices_.WithLock([&](auto &all_indices) {
         auto new_all_indices = *all_indices;
@@ -215,10 +215,10 @@ InMemoryEdgeTypePropertyIndex::IndividualIndex::~IndividualIndex() {
   }
 }
 
-bool InMemoryEdgeTypePropertyIndex::CreateIndexOnePass(
-    EdgeTypeId edge_type, PropertyId property,
-    utils::SkipListDb<Vertex>::Accessor vertices, ActiveIndicesUpdater const &updater,
-    std::optional<SnapshotObserverInfo> const &snapshot_info) {
+bool InMemoryEdgeTypePropertyIndex::CreateIndexOnePass(EdgeTypeId edge_type, PropertyId property,
+                                                       utils::SkipListDb<Vertex>::Accessor vertices,
+                                                       ActiveIndicesUpdater const &updater,
+                                                       std::optional<SnapshotObserverInfo> const &snapshot_info) {
   auto res = RegisterIndex(edge_type, property, updater);
   if (!res) return false;
   auto res2 = PopulateIndex(edge_type, property, std::move(vertices), updater, snapshot_info);
@@ -264,10 +264,11 @@ auto InMemoryEdgeTypePropertyIndex::GetActiveIndices() const -> std::shared_ptr<
   return std::make_shared<ActiveIndices>(index_.ReadCopy());
 }
 
-auto InMemoryEdgeTypePropertyIndex::PopulateIndex(
-    EdgeTypeId edge_type, PropertyId property,
-    utils::SkipListDb<Vertex>::Accessor vertices, ActiveIndicesUpdater const &updater,
-    std::optional<SnapshotObserverInfo> const &snapshot_info, Transaction const *tx, CheckCancelFunction cancel_check)
+auto InMemoryEdgeTypePropertyIndex::PopulateIndex(EdgeTypeId edge_type, PropertyId property,
+                                                  utils::SkipListDb<Vertex>::Accessor vertices,
+                                                  ActiveIndicesUpdater const &updater,
+                                                  std::optional<SnapshotObserverInfo> const &snapshot_info,
+                                                  Transaction const *tx, CheckCancelFunction cancel_check)
     -> std::expected<void, IndexPopulateError> {
   auto index = GetIndividualIndex(edge_type, property);
   if (!index) {
@@ -442,9 +443,8 @@ void InMemoryEdgeTypePropertyIndex::DropGraphClearIndices() {
 
 InMemoryEdgeTypePropertyIndex::Iterable::Iterable(
     utils::SkipListDb<InMemoryEdgeTypePropertyIndex::Entry>::Accessor index_accessor,
-    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-    utils::SkipListDb<Edge>::ConstAccessor edge_accessor, EdgeTypeId edge_type,
-    PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor, utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
+    EdgeTypeId edge_type, PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
     Transaction *transaction)
     : pin_accessor_edge_(std::move(edge_accessor)),
@@ -460,8 +460,7 @@ InMemoryEdgeTypePropertyIndex::Iterable::Iterable(
       transaction_(transaction) {}
 
 InMemoryEdgeTypePropertyIndex::Iterable::Iterator::Iterator(
-    Iterable *self,
-    utils::SkipListDb<InMemoryEdgeTypePropertyIndex::Entry>::Iterator index_iterator)
+    Iterable *self, utils::SkipListDb<InMemoryEdgeTypePropertyIndex::Entry>::Iterator index_iterator)
     : self_(self),
       index_iterator_(index_iterator),
       current_edge_(nullptr),
@@ -501,10 +500,8 @@ void InMemoryEdgeTypePropertyIndex::RunGC() {
 }
 
 InMemoryEdgeTypePropertyIndex::Iterable InMemoryEdgeTypePropertyIndex::ActiveIndices::Edges(
-    EdgeTypeId edge_type, PropertyId property,
-    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-    utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
-    const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+    EdgeTypeId edge_type, PropertyId property, utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
+    utils::SkipListDb<Edge>::ConstAccessor edge_accessor, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
     Transaction *transaction) {
   auto it = index_container_->find({edge_type, property});
@@ -525,10 +522,8 @@ InMemoryEdgeTypePropertyIndex::Iterable InMemoryEdgeTypePropertyIndex::ActiveInd
 }
 
 InMemoryEdgeTypePropertyIndex::ChunkedIterable InMemoryEdgeTypePropertyIndex::ActiveIndices::ChunkedEdges(
-    EdgeTypeId edge_type, PropertyId property,
-    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-    utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
-    const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+    EdgeTypeId edge_type, PropertyId property, utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
+    utils::SkipListDb<Edge>::ConstAccessor edge_accessor, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
     Transaction *transaction, size_t num_chunks) {
   auto it = index_container_->find({edge_type, property});
@@ -591,9 +586,8 @@ void InMemoryEdgeTypePropertyIndex::CleanupAllIndices() {
 
 InMemoryEdgeTypePropertyIndex::ChunkedIterable::ChunkedIterable(
     utils::SkipListDb<InMemoryEdgeTypePropertyIndex::Entry>::Accessor index_accessor,
-    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor,
-    utils::SkipListDb<Edge>::ConstAccessor edge_accessor, EdgeTypeId edge_type,
-    PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+    utils::SkipListDb<Vertex>::ConstAccessor vertex_accessor, utils::SkipListDb<Edge>::ConstAccessor edge_accessor,
+    EdgeTypeId edge_type, PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
     const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view, Storage *storage,
     Transaction *transaction, size_t num_chunks)
     : pin_accessor_edge_(std::move(edge_accessor)),
@@ -622,18 +616,17 @@ InMemoryEdgeTypePropertyIndex::ChunkedIterable::ChunkedIterable(
 void InMemoryEdgeTypePropertyIndex::ChunkedIterable::Iterator::AdvanceUntilValid() {
   // NOTE: Using the skiplist end here to not store the end iterator in the class
   // The higher level != end will still be correct
-  AdvanceUntilValid_(
-      index_iterator_,
-      utils::SkipListDb<InMemoryEdgeTypePropertyIndex::Entry>::ChunkedIterator{},
-      current_edge_,
-      current_edge_accessor_,
-      self_->property_,
-      self_->lower_bound_,
-      self_->upper_bound_,
-      self_->view_,
-      self_->storage_,
-      self_->transaction_,
-      self_->edge_type_);
+  AdvanceUntilValid_(index_iterator_,
+                     utils::SkipListDb<InMemoryEdgeTypePropertyIndex::Entry>::ChunkedIterator{},
+                     current_edge_,
+                     current_edge_accessor_,
+                     self_->property_,
+                     self_->lower_bound_,
+                     self_->upper_bound_,
+                     self_->view_,
+                     self_->storage_,
+                     self_->transaction_,
+                     self_->edge_type_);
 }
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/inmemory/edge_type_property_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.cpp
@@ -163,29 +163,38 @@ void AdvanceUntilValid_(auto &index_iterator, const auto &end, EdgeRef &current_
 }
 }  // namespace
 
-bool InMemoryEdgeTypePropertyIndex::RegisterIndex(EdgeTypeId edge_type, PropertyId property,
-                                                  ActiveIndicesUpdater const &updater) {
+bool InMemoryEdgeTypePropertyIndex::InstallIndividualIndex_(EdgeTypeId edge_type, PropertyId property,
+                                                            std::shared_ptr<IndividualIndex> entry,
+                                                            ActiveIndicesUpdater const &updater,
+                                                            bool register_in_all_indices) {
   return index_.WithLock([&](std::shared_ptr<IndexContainer const> &index_container) {
-    {
-      auto it = index_container->find({edge_type, property});
-      if (it != index_container->end()) return false;
-    }
-
+    if (index_container->find({edge_type, property}) != index_container->end()) return false;
     auto new_container = std::make_shared<IndexContainer>(*index_container);
-    auto [new_it, _] = new_container->emplace(std::make_pair(edge_type, property), std::make_shared<IndividualIndex>());
+    auto [new_it, _] = new_container->emplace(std::make_pair(edge_type, property), std::move(entry));
 
-    utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_blocker;
-    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
-    all_indices_.WithLock([&](auto &all_indices) {
-      auto new_all_indices = *all_indices;
+    if (register_in_all_indices) {
+      utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_blocker;
       // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
-      new_all_indices.emplace_back(new_it->second, property);
-      all_indices = std::make_shared<std::vector<AllIndicesEntry>>(std::move(new_all_indices));
-    });
+      all_indices_.WithLock([&](auto &all_indices) {
+        auto new_all_indices = *all_indices;
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
+        new_all_indices.emplace_back(new_it->second, property);
+        all_indices = std::make_shared<std::vector<AllIndicesEntry>>(std::move(new_all_indices));
+      });
+    }
     index_container = std::move(new_container);
     updater(std::make_shared<ActiveIndices>(index_container));
     return true;
   });
+}
+
+bool InMemoryEdgeTypePropertyIndex::RegisterIndex(EdgeTypeId edge_type, PropertyId property,
+                                                  ActiveIndicesUpdater const &updater) {
+  return InstallIndividualIndex_(edge_type,
+                                 property,
+                                 std::make_shared<IndividualIndex>(),
+                                 updater,
+                                 /*register_in_all_indices=*/true);
 }
 
 bool InMemoryEdgeTypePropertyIndex::PublishIndex(EdgeTypeId edge_type, PropertyId property, uint64_t commit_timestamp) {
@@ -219,24 +228,36 @@ bool InMemoryEdgeTypePropertyIndex::CreateIndexOnePass(
   return PublishIndex(edge_type, property, 0);
 }
 
-bool InMemoryEdgeTypePropertyIndex::DropIndex(EdgeTypeId edge_type, PropertyId property,
-                                              ActiveIndicesUpdater const &updater) {
-  auto result = index_.WithLock([&](std::shared_ptr<IndexContainer const> &index_container) {
-    {
-      auto it = index_container->find({edge_type, property});
-      if (it == index_container->end()) [[unlikely]] {
-        return false;
-      }
-    }
-
-    auto new_container = std::make_shared<IndexContainer>(*index_container);
-    new_container->erase({edge_type, property});
-    index_container = std::move(new_container);
-    updater(std::make_shared<ActiveIndices>(index_container));
-    return true;
-  });
+auto InMemoryEdgeTypePropertyIndex::DropIndex(EdgeTypeId edge_type, PropertyId property,
+                                              ActiveIndicesUpdater const &updater) -> std::shared_ptr<IndividualIndex> {
+  auto evicted =
+      index_.WithLock([&](std::shared_ptr<IndexContainer const> &index_container) -> std::shared_ptr<IndividualIndex> {
+        auto it = index_container->find({edge_type, property});
+        if (it == index_container->end()) [[unlikely]] {
+          return {};
+        }
+        auto evicted_entry = it->second;
+        auto new_container = std::make_shared<IndexContainer>(*index_container);
+        new_container->erase({edge_type, property});
+        index_container = std::move(new_container);
+        updater(std::make_shared<ActiveIndices>(index_container));
+        return evicted_entry;
+      });
   CleanupAllIndices();
-  return result;
+  return evicted;
+}
+
+void InMemoryEdgeTypePropertyIndex::RestoreIndex(EdgeTypeId edge_type, PropertyId property,
+                                                 std::shared_ptr<IndividualIndex> evicted,
+                                                 ActiveIndicesUpdater const &updater) {
+  if (!evicted) return;
+  // register_in_all_indices=false: captured shared_ptr already kept the entry alive
+  // through CleanupAllIndices; re-appending would create an unreapable duplicate.
+  (void)InstallIndividualIndex_(edge_type,
+                                property,
+                                std::move(evicted),
+                                updater,
+                                /*register_in_all_indices=*/false);
 }
 
 auto InMemoryEdgeTypePropertyIndex::GetActiveIndices() const -> std::shared_ptr<EdgeTypePropertyIndex::ActiveIndices> {
@@ -271,10 +292,10 @@ auto InMemoryEdgeTypePropertyIndex::PopulateIndex(
           vertices, accessor_factory, insert_function, std::move(cancel_check), {} /*TODO: parallel*/);
     }
   } catch (const PopulateCancel &) {
-    DropIndex(edge_type, property, updater);
+    (void)DropIndex(edge_type, property, updater);
     return std::unexpected{IndexPopulateError::Cancellation};
   } catch (const utils::OutOfMemoryException &) {
-    DropIndex(edge_type, property, updater);
+    (void)DropIndex(edge_type, property, updater);
     throw;
   }
   return {};

--- a/src/storage/v2/inmemory/edge_type_property_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_property_index.hpp
@@ -250,8 +250,13 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
                           ActiveIndicesUpdater const &updater,
                           std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
-  /// Returns false if there was no index to drop
-  bool DropIndex(EdgeTypeId edge_type, PropertyId property, ActiveIndicesUpdater const &updater) override;
+  /// Removes the index and returns the evicted IndividualIndex (nullptr if absent).
+  /// Caller can re-install via RestoreIndex on abort. The returned shared_ptr keeps
+  /// the entry alive in all_indices_, so RestoreIndex must not re-append there.
+  [[nodiscard]] auto DropIndex(EdgeTypeId edge_type, PropertyId property, ActiveIndicesUpdater const &updater)
+      -> std::shared_ptr<IndividualIndex>;
+  void RestoreIndex(EdgeTypeId edge_type, PropertyId property, std::shared_ptr<IndividualIndex> evicted,
+                    ActiveIndicesUpdater const &updater);
 
   void RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token);
 
@@ -273,6 +278,11 @@ class InMemoryEdgeTypePropertyIndex : public storage::EdgeTypePropertyIndex {
  private:
   auto CleanupAllIndices() -> void;
   auto GetIndividualIndex(EdgeTypeId edge_type, PropertyId property) const -> std::shared_ptr<IndividualIndex>;
+
+  // Atomic install into index_ + (optional) all_indices_. Returns false if the slot
+  // is taken. Shared by RegisterIndex (true) and RestoreIndex (false).
+  bool InstallIndividualIndex_(EdgeTypeId edge_type, PropertyId property, std::shared_ptr<IndividualIndex> entry,
+                               ActiveIndicesUpdater const &updater, bool register_in_all_indices);
 
   utils::Synchronized<std::shared_ptr<IndexContainer const>, utils::WritePrioritizedRWLock> index_{
       std::make_shared<IndexContainer const>()};

--- a/src/storage/v2/inmemory/label_index.cpp
+++ b/src/storage/v2/inmemory/label_index.cpp
@@ -46,30 +46,31 @@ void AdvanceUntilValid_(auto &index_iterator, const auto &end, auto *&current_ve
 
 namespace memgraph::storage {
 
-bool InMemoryLabelIndex::RegisterIndex(LabelId label, ActiveIndicesUpdater const &updater) {
+bool InMemoryLabelIndex::InstallIndividualIndex_(LabelId label, std::shared_ptr<IndividualIndex> entry,
+                                                 ActiveIndicesUpdater const &updater, bool register_in_all_indices) {
   return index_.WithLock([&](std::shared_ptr<const IndexContainer> &index) {
-    auto const &indices = *index;
-    {
-      auto it = index->find(label);
-      if (it != indices.end()) return false;  // already exists
+    if (index->find(label) != index->cend()) return false;
+    auto new_index = std::make_shared<IndexContainer>(*index);
+    auto [new_it, _] = new_index->try_emplace(label, std::move(entry));
+
+    if (register_in_all_indices) {
+      utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_blocker;
+      all_indices_.WithLock([&](auto &all_indices) {
+        auto new_all_indices = *all_indices;
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
+        new_all_indices.emplace_back(new_it->second, label);
+        all_indices = std::make_shared<std::vector<AllIndicesEntry>>(std::move(new_all_indices));
+      });
     }
-
-    auto new_index = std::make_shared<IndexContainer>(indices);
-    auto [new_it, _] = new_index->try_emplace(label, std::make_shared<IndividualIndex>());
-
-    utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_blocker;
-
-    all_indices_.WithLock([&](auto &all_indices) {
-      auto new_all_indices = *all_indices;
-      // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
-      new_all_indices.emplace_back(new_it->second, label);
-      all_indices = std::make_shared<std::vector<AllIndicesEntry>>(std::move(new_all_indices));
-    });
 
     index = std::move(new_index);
     updater(std::make_shared<ActiveIndices>(index));
     return true;
   });
+}
+
+bool InMemoryLabelIndex::RegisterIndex(LabelId label, ActiveIndicesUpdater const &updater) {
+  return InstallIndividualIndex_(label, std::make_shared<IndividualIndex>(), updater, /*register_in_all_indices=*/true);
 }
 
 auto InMemoryLabelIndex::GetIndividualIndex(LabelId label) const -> std::shared_ptr<IndividualIndex> {
@@ -189,10 +190,10 @@ auto InMemoryLabelIndex::PopulateIndex(
           vertices, accessor_factory, try_insert_into_index, std::move(cancel_check), parallel_exec_info);
     }
   } catch (const PopulateCancel &) {
-    DropIndex(label, updater);
+    (void)DropIndex(label, updater);
     return std::unexpected{IndexPopulateError::Cancellation};
   } catch (const utils::OutOfMemoryException &) {
-    DropIndex(label, updater);
+    (void)DropIndex(label, updater);
     throw;
   }
 
@@ -224,22 +225,30 @@ void InMemoryLabelIndex::ActiveIndices::UpdateOnAddLabel(LabelId added_label, Ve
   acc.insert(Entry{vertex_after_update, tx.start_timestamp});
 }
 
-bool InMemoryLabelIndex::DropIndex(LabelId label, ActiveIndicesUpdater const &updater) {
-  auto result = index_.WithLock([&](std::shared_ptr<IndexContainer const> &index) -> bool {
-    {
-      auto it = index->find(label);
-      if (it == index->end()) [[unlikely]] {
-        return false;
-      }
+auto InMemoryLabelIndex::DropIndex(LabelId label, ActiveIndicesUpdater const &updater)
+    -> std::shared_ptr<IndividualIndex> {
+  auto evicted = index_.WithLock([&](std::shared_ptr<IndexContainer const> &index) -> std::shared_ptr<IndividualIndex> {
+    auto it = index->find(label);
+    if (it == index->end()) [[unlikely]] {
+      return {};
     }
+    auto evicted_entry = it->second;
     auto new_index = std::make_shared<IndexContainer>(*index);
     new_index->erase(label);
     index = std::move(new_index);
     updater(std::make_shared<ActiveIndices>(index));
-    return true;
+    return evicted_entry;
   });
   CleanupAllIndices();
-  return result;
+  return evicted;
+}
+
+void InMemoryLabelIndex::RestoreIndex(LabelId label, std::shared_ptr<IndividualIndex> evicted,
+                                      ActiveIndicesUpdater const &updater) {
+  if (!evicted) return;
+  // register_in_all_indices=false: captured shared_ptr kept the entry alive through
+  // CleanupAllIndices; re-appending would create an unreapable duplicate.
+  (void)InstallIndividualIndex_(label, std::move(evicted), updater, /*register_in_all_indices=*/false);
 }
 
 bool InMemoryLabelIndex::ActiveIndices::IndexRegistered(LabelId label) const {

--- a/src/storage/v2/inmemory/label_index.cpp
+++ b/src/storage/v2/inmemory/label_index.cpp
@@ -54,7 +54,7 @@ bool InMemoryLabelIndex::InstallIndividualIndex_(LabelId label, std::shared_ptr<
     auto [new_it, _] = new_index->try_emplace(label, std::move(entry));
 
     if (register_in_all_indices) {
-      utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_blocker;
+      const utils::MemoryTracker::OutOfMemoryExceptionBlocker oom_blocker;
       all_indices_.WithLock([&](auto &all_indices) {
         auto new_all_indices = *all_indices;
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
@@ -316,10 +316,9 @@ void InMemoryLabelIndex::ActiveIndices::AbortEntries(LabelIndex::AbortableInfo c
   }
 }
 
-InMemoryLabelIndex::Iterable::Iterable(
-    utils::SkipListDb<InMemoryLabelIndex::Entry>::Accessor index_accessor,
-    utils::SkipListDb<Vertex>::ConstAccessor vertices_accessor, LabelId label, View view,
-    Storage *storage, Transaction *transaction)
+InMemoryLabelIndex::Iterable::Iterable(utils::SkipListDb<InMemoryLabelIndex::Entry>::Accessor index_accessor,
+                                       utils::SkipListDb<Vertex>::ConstAccessor vertices_accessor, LabelId label,
+                                       View view, Storage *storage, Transaction *transaction)
     : pin_accessor_(std::move(vertices_accessor)),
       index_accessor_(std::move(index_accessor)),
       label_(label),
@@ -327,8 +326,8 @@ InMemoryLabelIndex::Iterable::Iterable(
       storage_(storage),
       transaction_(transaction) {}
 
-InMemoryLabelIndex::Iterable::Iterator::Iterator(
-    Iterable *self, utils::SkipListDb<InMemoryLabelIndex::Entry>::Iterator index_iterator)
+InMemoryLabelIndex::Iterable::Iterator::Iterator(Iterable *self,
+                                                 utils::SkipListDb<InMemoryLabelIndex::Entry>::Iterator index_iterator)
     : self_(self),
       index_iterator_(index_iterator),
       current_vertex_accessor_(nullptr, self_->storage_, nullptr),
@@ -379,16 +378,16 @@ InMemoryLabelIndex::Iterable InMemoryLabelIndex::ActiveIndices::Vertices(LabelId
 }
 
 InMemoryLabelIndex::Iterable InMemoryLabelIndex::ActiveIndices::Vertices(
-    LabelId label, utils::SkipListDb<Vertex>::ConstAccessor vertices_acc, View view,
-    Storage *storage, Transaction *transaction) {
+    LabelId label, utils::SkipListDb<Vertex>::ConstAccessor vertices_acc, View view, Storage *storage,
+    Transaction *transaction) {
   const auto it = index_container_->find(label);
   MG_ASSERT(it != index_container_->end(), "Index for label {} doesn't exist", label.AsUint());
   return {it->second->skiplist.access(), std::move(vertices_acc), label, view, storage, transaction};
 }
 
 InMemoryLabelIndex::ChunkedIterable InMemoryLabelIndex::ActiveIndices::ChunkedVertices(
-    LabelId label, utils::SkipListDb<Vertex>::ConstAccessor vertices_acc, View view,
-    Storage *storage, Transaction *transaction, size_t num_chunks) {
+    LabelId label, utils::SkipListDb<Vertex>::ConstAccessor vertices_acc, View view, Storage *storage,
+    Transaction *transaction, size_t num_chunks) {
   const auto it = index_container_->find(label);
   MG_ASSERT(it != index_container_->end(), "Index for label {} doesn't exist", label.AsUint());
   return {it->second->skiplist.access(), std::move(vertices_acc), label, view, storage, transaction, num_chunks};
@@ -473,8 +472,8 @@ void InMemoryLabelIndex::ChunkedIterable::Iterator::AdvanceUntilValid() {
 
 InMemoryLabelIndex::ChunkedIterable::ChunkedIterable(
     utils::SkipListDb<InMemoryLabelIndex::Entry>::Accessor index_accessor,
-    utils::SkipListDb<Vertex>::ConstAccessor vertices_accessor, LabelId label, View view,
-    Storage *storage, Transaction *transaction, size_t num_chunks)
+    utils::SkipListDb<Vertex>::ConstAccessor vertices_accessor, LabelId label, View view, Storage *storage,
+    Transaction *transaction, size_t num_chunks)
     : pin_accessor_(std::move(vertices_accessor)),
       index_accessor_(std::move(index_accessor)),
       label_(label),
@@ -483,8 +482,7 @@ InMemoryLabelIndex::ChunkedIterable::ChunkedIterable(
       transaction_(transaction),
       chunks_{index_accessor_.create_chunks(num_chunks)} {
   // Index can have duplicate entries, we need to make sure each unique entry is inside a single chunk.
-  RechunkIndex<utils::SkipListDb<Entry>>(
-      chunks_, [](const auto &a, const auto &b) { return a.vertex == b.vertex; });
+  RechunkIndex<utils::SkipListDb<Entry>>(chunks_, [](const auto &a, const auto &b) { return a.vertex == b.vertex; });
 }
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/inmemory/label_index.hpp
+++ b/src/storage/v2/inmemory/label_index.hpp
@@ -65,8 +65,11 @@ class InMemoryLabelIndex : public LabelIndex {
                           ActiveIndicesUpdater const &updater,
                           std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
-  /// Returns false if there was no index to drop
-  bool DropIndex(LabelId label, ActiveIndicesUpdater const &updater) override;
+  /// Removes the index and returns the evicted IndividualIndex (nullptr if absent).
+  /// Caller can re-install via RestoreIndex on abort. The returned shared_ptr keeps
+  /// the entry alive in all_indices_, so RestoreIndex must not re-append there.
+  [[nodiscard]] auto DropIndex(LabelId label, ActiveIndicesUpdater const &updater) -> std::shared_ptr<IndividualIndex>;
+  void RestoreIndex(LabelId label, std::shared_ptr<IndividualIndex> evicted, ActiveIndicesUpdater const &updater);
 
   void RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token);
 
@@ -237,6 +240,11 @@ class InMemoryLabelIndex : public LabelIndex {
  private:
   auto CleanupAllIndices() -> void;
   auto GetIndividualIndex(LabelId label) const -> std::shared_ptr<IndividualIndex>;
+
+  // Atomic install into index_ + (optional) all_indices_. Returns false if the slot
+  // is taken. Shared by RegisterIndex (true) and RestoreIndex (false).
+  bool InstallIndividualIndex_(LabelId label, std::shared_ptr<IndividualIndex> entry,
+                               ActiveIndicesUpdater const &updater, bool register_in_all_indices);
 
   utils::Synchronized<std::shared_ptr<IndexContainer const>, utils::WritePrioritizedRWLock> index_{
       std::make_shared<IndexContainer const>()};

--- a/src/storage/v2/inmemory/label_property_index.cpp
+++ b/src/storage/v2/inmemory/label_property_index.cpp
@@ -524,10 +524,10 @@ auto InMemoryLabelPropertyIndex::PopulateIndex(
     (order == IndexOrder::ASC) ? populate(GetIndividualIndex<Entry>(label, properties))
                                : populate(GetIndividualIndex<DescEntry>(label, properties));
   } catch (const PopulateCancel &) {
-    DropSingleOrder(label, properties, updater, order);
+    std::ignore = DropIndex(label, properties, updater, order);
     return std::unexpected{IndexPopulateError::Cancellation};
   } catch (const utils::OutOfMemoryException &) {
-    DropSingleOrder(label, properties, updater, order);
+    std::ignore = DropIndex(label, properties, updater, order);
     throw;
   }
 
@@ -776,40 +776,97 @@ void InMemoryLabelPropertyIndex::CleanupStatsForDrop(IndexContainer const &new_i
   }
 }
 
-LabelPropertyIndex::DropResult InMemoryLabelPropertyIndex::DropFromSelected(LabelId label,
-                                                                            std::vector<PropertyPath> const &properties,
-                                                                            ActiveIndicesUpdater const &updater,
-                                                                            std::optional<IndexOrder> order) {
+auto InMemoryLabelPropertyIndex::DropIndex(LabelId label, std::vector<PropertyPath> const &properties,
+                                           ActiveIndicesUpdater const &updater, std::optional<IndexOrder> order)
+    -> DropCapture {
+  std::shared_ptr<IndividualIndex<Entry>> asc_evicted;
+  std::shared_ptr<IndividualIndex<DescEntry>> desc_evicted;
+  std::optional<PropertiesIndicesStats> stats_evicted;
   auto result = index_.WithLock([&](std::shared_ptr<IndexContainer const> &index) -> DropResult {
-    auto new_index = std::make_shared<IndexContainer>(*index);
     bool const try_asc = !order || *order == IndexOrder::ASC;
     bool const try_desc = !order || *order == IndexOrder::DESC;
+
+    // Capture the per-key shared_ptrs *before* the drop. They survive
+    // CleanupAllIndices via the captured ref and let us re-insert just our keys
+    // on abort without clobbering concurrent drops/creates of other keys.
+    if (try_asc) {
+      if (auto lit = index->asc_indices_.find(label); lit != index->asc_indices_.end()) {
+        if (auto pit = lit->second.find(properties); pit != lit->second.end()) asc_evicted = pit->second;
+      }
+    }
+    if (try_desc) {
+      if (auto lit = index->desc_indices_.find(label); lit != index->desc_indices_.end()) {
+        if (auto pit = lit->second.find(properties); pit != lit->second.end()) desc_evicted = pit->second;
+      }
+    }
+
+    auto new_index = std::make_shared<IndexContainer>(*index);
     bool const dropped_asc =
         try_asc && DropFromOrder(new_index->asc_indices_, new_index->asc_reverse_lookup_, label, properties);
     bool const dropped_desc =
         try_desc && DropFromOrder(new_index->desc_indices_, new_index->desc_reverse_lookup_, label, properties);
-    if (!dropped_asc && !dropped_desc) return {};
+    if (!dropped_asc && !dropped_desc) {
+      asc_evicted.reset();
+      desc_evicted.reset();
+      return {};
+    }
+    if (!dropped_asc) asc_evicted.reset();
+    if (!dropped_desc) desc_evicted.reset();
 
+    // Capture the per-label stats slice before CleanupStatsForDrop erases it,
+    // so an aborted drop can re-emplace any keys it removed.
+    {
+      auto stats_ptr = stats_.Lock();
+      if (auto sit = stats_ptr->find(label); sit != stats_ptr->end()) {
+        stats_evicted = sit->second;
+      }
+    }
     CleanupStatsForDrop(*new_index, label, properties);
     index = std::move(new_index);
     updater(std::make_shared<ActiveIndices>(index));
     return {.dropped_asc = dropped_asc, .dropped_desc = dropped_desc};
   });
   CleanupAllIndices();
-  return result;
+  return {.result = result,
+          .asc_evicted = std::move(asc_evicted),
+          .desc_evicted = std::move(desc_evicted),
+          .stats_evicted = std::move(stats_evicted)};
 }
 
-LabelPropertyIndex::DropResult InMemoryLabelPropertyIndex::DropIndex(LabelId label,
-                                                                     std::vector<PropertyPath> const &properties,
-                                                                     ActiveIndicesUpdater const &updater,
-                                                                     std::optional<IndexOrder> order) {
-  // `order == nullopt` drops both ASC and DESC in one atomic update.
-  return DropFromSelected(label, properties, updater, order);
-}
+void InMemoryLabelPropertyIndex::RestoreIndex(LabelId label, std::vector<PropertyPath> properties,
+                                              std::shared_ptr<IndividualIndex<Entry>> asc_evicted,
+                                              std::shared_ptr<IndividualIndex<DescEntry>> desc_evicted,
+                                              std::optional<PropertiesIndicesStats> stats_evicted,
+                                              ActiveIndicesUpdater const &updater) {
+  if (!asc_evicted && !desc_evicted) return;
+  index_.WithLock([&](std::shared_ptr<IndexContainer const> &index) {
+    auto already_present = [&](auto const &indices_map) -> bool {
+      auto lit = indices_map.find(label);
+      return lit != indices_map.end() && lit->second.contains(properties);
+    };
+    bool const skip_asc = !asc_evicted || already_present(index->asc_indices_);
+    bool const skip_desc = !desc_evicted || already_present(index->desc_indices_);
+    if (skip_asc && skip_desc) return;  // concurrent re-create won for both orders
 
-void InMemoryLabelPropertyIndex::DropSingleOrder(LabelId label, std::vector<PropertyPath> const &properties,
-                                                 ActiveIndicesUpdater const &updater, IndexOrder order) {
-  DropFromSelected(label, properties, updater, order);
+    // Two copies: first to mutate the per-order maps, second to rebuild the
+    // reverse_lookup (the IndexContainer copy ctor calls BuildReverseLookup).
+    IndexContainer mutated{*index};
+    if (!skip_asc) mutated.asc_indices_[label].emplace(properties, std::move(asc_evicted));
+    if (!skip_desc) mutated.desc_indices_[label].emplace(properties, std::move(desc_evicted));
+    auto new_index = std::make_shared<IndexContainer>(std::move(mutated));
+    index = std::move(new_index);
+    updater(std::make_shared<ActiveIndices>(index));
+  });
+
+  // Re-emplace any stats keys that were erased on drop, leaving any concurrent
+  // SetIndexStats writes to other keys untouched (emplace is a no-op on conflict).
+  if (stats_evicted) {
+    auto stats_ptr = stats_.Lock();
+    auto &dst = (*stats_ptr)[label];
+    for (auto const &[key, value] : *stats_evicted) {
+      dst.emplace(key, value);
+    }
+  }
 }
 
 bool InMemoryLabelPropertyIndex::ActiveIndices::IndexExists(LabelId label,

--- a/src/storage/v2/inmemory/label_property_index.hpp
+++ b/src/storage/v2/inmemory/label_property_index.hpp
@@ -426,8 +426,27 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
 
   void RemoveObsoleteEntries(uint64_t oldest_active_start_timestamp, std::stop_token token);
 
-  DropResult DropIndex(LabelId label, std::vector<PropertyPath> const &properties, ActiveIndicesUpdater const &updater,
-                       std::optional<IndexOrder> order = std::nullopt) override;
+  // Captures the evicted asc/desc IndividualIndex shared_ptrs so the caller can
+  // re-insert them on abort. Pair with RestoreIndex. The captured shared_ptrs
+  // also keep their entries alive in `all_indices_` past CleanupAllIndices, so
+  // RestoreIndex must NOT re-insert there.
+  struct DropCapture {
+    DropResult result;
+    std::shared_ptr<IndividualIndex<Entry>> asc_evicted;       // null if asc not dropped
+    std::shared_ptr<IndividualIndex<DescEntry>> desc_evicted;  // null if desc not dropped
+    // Per-label stats slice captured before CleanupStatsForDrop erased entries.
+    // nullopt if the label had no stats at drop time.
+    std::optional<PropertiesIndicesStats> stats_evicted;
+  };
+
+  // `order == nullopt` drops both ASC and DESC entries for (label, properties).
+  [[nodiscard]] auto DropIndex(LabelId label, std::vector<PropertyPath> const &properties,
+                               ActiveIndicesUpdater const &updater, std::optional<IndexOrder> order = std::nullopt)
+      -> DropCapture;
+  void RestoreIndex(LabelId label, std::vector<PropertyPath> properties,
+                    std::shared_ptr<IndividualIndex<Entry>> asc_evicted,
+                    std::shared_ptr<IndividualIndex<DescEntry>> desc_evicted,
+                    std::optional<PropertiesIndicesStats> stats_evicted, ActiveIndicesUpdater const &updater);
 
   std::vector<std::pair<LabelId, std::vector<PropertyPath>>> ClearIndexStats();
 
@@ -444,11 +463,6 @@ class InMemoryLabelPropertyIndex : public storage::LabelPropertyIndex {
   void DropGraphClearIndices() override;
 
  private:
-  // Shared implementation of DropIndex / DropSingleOrder. `order == std::nullopt` drops both.
-  DropResult DropFromSelected(LabelId label, std::vector<PropertyPath> const &properties,
-                              ActiveIndicesUpdater const &updater, std::optional<IndexOrder> order);
-  void DropSingleOrder(LabelId label, std::vector<PropertyPath> const &properties, ActiveIndicesUpdater const &updater,
-                       IndexOrder order);
   void CleanupAllIndices();
   void CleanupStatsForDrop(IndexContainer const &new_index, LabelId label, std::vector<PropertyPath> const &properties);
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1218,7 +1218,12 @@ void InMemoryStorage::InMemoryAccessor::FinalizeCommitPhase(uint64_t const durab
   mem_storage->indices_.point_index_.InstallNewPointIndex(
       transaction_.point_index_change_collector_, transaction_.point_index_ctx_, point_updater);
 
-  // Call other callbacks that publish/install upon commit
+  // Drop abort callbacks before running publishers: from this point on we are
+  // committing — partially or fully — state that must NOT be undone by a later
+  // Abort(). If a commit_callback throws partway, the destructor's Abort() will
+  // see an empty abort list rather than tearing down indices that were already
+  // published.
+  transaction_.abort_callbacks_.Clear();
   transaction_.commit_callbacks_.RunAll(*commit_timestamp_);
 
   // Dispatch to another async work to create requested auto-indexes in their own transaction
@@ -1709,6 +1714,8 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
     }
   }
 
+  transaction_.abort_callbacks_.RunAll();
+
   mem_storage->commit_log_->MarkFinished(transaction_.start_timestamp);
   is_transaction_active_ = false;
 }
@@ -1792,6 +1799,8 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
       [=](uint64_t commit_timestamp) { return mem_label_index->PublishIndex(label, commit_timestamp); });
 
   transaction_.commit_callbacks_.Add(std::move(publisher));
+  transaction_.abort_callbacks_.Add(
+      [mem_label_index, label, updater]() { (void)mem_label_index->DropIndex(label, updater); });
 
   transaction_.md_deltas.emplace_back(MetadataDelta::label_index_create, label);
   // We don't care if there is a replication error because on main node the change will go through
@@ -1830,6 +1839,9 @@ auto InMemoryStorage::InMemoryAccessor::CreateIndex(LabelId label, PropertiesPat
     return mem_label_property_index->PublishIndex(label, properties, commit_timestamp, order);
   });
   transaction_.commit_callbacks_.Add(std::move(publisher));
+  transaction_.abort_callbacks_.Add([mem_label_property_index, label, properties, updater, order]() {
+    (void)mem_label_property_index->DropIndex(label, properties, updater, order);
+  });
 
   transaction_.md_deltas.emplace_back(MetadataDelta::label_property_index_create, label, std::move(properties), order);
   // We don't care if there is a replication error because on main node the change will go through
@@ -1864,6 +1876,8 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   auto publisher = storage_->invalidator_->invalidate_for_timestamp_wrapper(
       [=](uint64_t commit_timestamp) { return mem_edge_type_index->PublishIndex(edge_type, commit_timestamp); });
   transaction_.commit_callbacks_.Add(std::move(publisher));
+  transaction_.abort_callbacks_.Add(
+      [mem_edge_type_index, edge_type, updater]() { (void)mem_edge_type_index->DropIndex(edge_type, updater); });
 
   transaction_.md_deltas.emplace_back(MetadataDelta::edge_index_create, edge_type);
   return {};
@@ -1903,6 +1917,9 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
     return mem_edge_type_property_index->PublishIndex(edge_type, property, commit_timestamp);
   });
   transaction_.commit_callbacks_.Add(std::move(publisher));
+  transaction_.abort_callbacks_.Add([mem_edge_type_property_index, edge_type, property, updater]() {
+    (void)mem_edge_type_property_index->DropIndex(edge_type, property, updater);
+  });
 
   transaction_.md_deltas.emplace_back(MetadataDelta::edge_property_index_create, edge_type, property);
   return {};
@@ -1935,6 +1952,8 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   auto publisher = storage_->invalidator_->invalidate_for_timestamp_wrapper(
       [=](uint64_t commit_timestamp) { return mem_edge_property_index->PublishIndex(property, commit_timestamp); });
   transaction_.commit_callbacks_.Add(std::move(publisher));
+  transaction_.abort_callbacks_.Add(
+      [mem_edge_property_index, property, updater]() { (void)mem_edge_property_index->DropIndex(property, updater); });
 
   transaction_.md_deltas.emplace_back(MetadataDelta::global_edge_property_index_create, property);
   return {};
@@ -1948,11 +1967,20 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   auto *mem_label_index = static_cast<InMemoryLabelIndex *>(in_memory->indices_.label_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
 
-  // Done inside the wrapper to ensure plan cache invalidation is safe
-  auto was_dropped = storage_->invalidator_->invalidate_now([&] { return mem_label_index->DropIndex(label, updater); });
-  if (!was_dropped) {
+  // Done inside the wrapper to ensure plan cache invalidation is safe.
+  // Capture the evicted entry so an aborted DROP (e.g. STRICT_SYNC commit failure)
+  // can re-install it instead of leaving the index permanently gone on main.
+  std::shared_ptr<InMemoryLabelIndex::IndividualIndex> evicted;
+  storage_->invalidator_->invalidate_now([&] {
+    evicted = mem_label_index->DropIndex(label, updater);
+    return static_cast<bool>(evicted);
+  });
+  if (!evicted) {
     return std::unexpected{IndexDefinitionError{}};
   }
+  transaction_.abort_callbacks_.Add([mem_label_index, label, updater, evicted]() mutable {
+    mem_label_index->RestoreIndex(label, std::move(evicted), updater);
+  });
 
   transaction_.md_deltas.emplace_back(MetadataDelta::label_index_drop, label);
   // We don't care if there is a replication error because on main node the change will go through
@@ -1970,13 +1998,29 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   auto updater = storage_->indices_.MakeUpdater();
 
   LabelPropertyIndex::DropResult drop_result;
+  std::shared_ptr<InMemoryLabelPropertyIndex::IndividualIndex<InMemoryLabelPropertyIndex::Entry>> asc_evicted;
+  std::shared_ptr<InMemoryLabelPropertyIndex::IndividualIndex<InMemoryLabelPropertyIndex::DescEntry>> desc_evicted;
+  std::optional<InMemoryLabelPropertyIndex::PropertiesIndicesStats> stats_evicted;
   storage_->invalidator_->invalidate_now([&] {
-    drop_result = mem_label_property_index->DropIndex(label, properties, updater, order);
+    auto captured = mem_label_property_index->DropIndex(label, properties, updater, order);
+    drop_result = captured.result;
+    asc_evicted = std::move(captured.asc_evicted);
+    desc_evicted = std::move(captured.desc_evicted);
+    stats_evicted = std::move(captured.stats_evicted);
     return static_cast<bool>(drop_result);
   });
   if (!drop_result) {
     return std::unexpected{IndexDefinitionError{}};
   }
+  transaction_.abort_callbacks_.Add(
+      [mem_label_property_index, label, properties, updater, asc_evicted, desc_evicted, stats_evicted]() mutable {
+        mem_label_property_index->RestoreIndex(label,
+                                               std::move(properties),
+                                               std::move(asc_evicted),
+                                               std::move(desc_evicted),
+                                               std::move(stats_evicted),
+                                               updater);
+      });
 
   if (drop_result.dropped_asc) {
     transaction_.md_deltas.emplace_back(MetadataDelta::label_property_index_drop,
@@ -2002,12 +2046,18 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   auto *in_memory = static_cast<InMemoryStorage *>(storage_);
   auto *mem_edge_type_index = static_cast<InMemoryEdgeTypeIndex *>(in_memory->indices_.edge_type_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
-  // Done inside the wrapper to ensure plan cache invalidation is safe
-  auto was_dropped =
-      storage_->invalidator_->invalidate_now([&] { return mem_edge_type_index->DropIndex(edge_type, updater); });
-  if (!was_dropped) {
+  // Done inside the wrapper to ensure plan cache invalidation is safe.
+  std::shared_ptr<InMemoryEdgeTypeIndex::IndividualIndex> evicted;
+  storage_->invalidator_->invalidate_now([&] {
+    evicted = mem_edge_type_index->DropIndex(edge_type, updater);
+    return static_cast<bool>(evicted);
+  });
+  if (!evicted) {
     return std::unexpected{IndexDefinitionError{}};
   }
+  transaction_.abort_callbacks_.Add([mem_edge_type_index, edge_type, updater, evicted]() mutable {
+    mem_edge_type_index->RestoreIndex(edge_type, std::move(evicted), updater);
+  });
   transaction_.md_deltas.emplace_back(MetadataDelta::edge_index_drop, edge_type);
   return {};
 }
@@ -2025,12 +2075,18 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   auto *mem_edge_type_property_index =
       static_cast<InMemoryEdgeTypePropertyIndex *>(in_memory->indices_.edge_type_property_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
-  // Done inside the wrapper to ensure plan cache invalidation is safe
-  auto was_dropped = storage_->invalidator_->invalidate_now(
-      [&] { return mem_edge_type_property_index->DropIndex(edge_type, property, updater); });
-  if (!was_dropped) {
+  // Done inside the wrapper to ensure plan cache invalidation is safe.
+  std::shared_ptr<InMemoryEdgeTypePropertyIndex::IndividualIndex> evicted;
+  storage_->invalidator_->invalidate_now([&] {
+    evicted = mem_edge_type_property_index->DropIndex(edge_type, property, updater);
+    return static_cast<bool>(evicted);
+  });
+  if (!evicted) {
     return std::unexpected{IndexDefinitionError{}};
   }
+  transaction_.abort_callbacks_.Add([mem_edge_type_property_index, edge_type, property, updater, evicted]() mutable {
+    mem_edge_type_property_index->RestoreIndex(edge_type, property, std::move(evicted), updater);
+  });
   transaction_.md_deltas.emplace_back(MetadataDelta::edge_property_index_drop, edge_type, property);
   return {};
 }
@@ -2049,11 +2105,17 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   auto *mem_edge_property_index =
       static_cast<InMemoryEdgePropertyIndex *>(in_memory->indices_.edge_property_index_.get());
   auto updater = storage_->indices_.MakeUpdater();
-  auto was_dropped =
-      storage_->invalidator_->invalidate_now([&] { return mem_edge_property_index->DropIndex(property, updater); });
-  if (!was_dropped) {
+  std::shared_ptr<InMemoryEdgePropertyIndex::IndividualIndex> evicted;
+  storage_->invalidator_->invalidate_now([&] {
+    evicted = mem_edge_property_index->DropIndex(property, updater);
+    return static_cast<bool>(evicted);
+  });
+  if (!evicted) {
     return std::unexpected{IndexDefinitionError{}};
   }
+  transaction_.abort_callbacks_.Add([mem_edge_property_index, property, updater, evicted]() mutable {
+    mem_edge_property_index->RestoreIndex(property, std::move(evicted), updater);
+  });
 
   transaction_.md_deltas.emplace_back(MetadataDelta::global_edge_property_index_drop, property);
   return {};
@@ -2074,6 +2136,8 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
     point_index.PublishActiveIndices(updater);
     memgraph::metrics::IncrementCounter(memgraph::metrics::ActivePointIndices);
   });
+  transaction_.abort_callbacks_.Add(
+      [&point_index, label, property]() { (void)point_index.DropPointIndex(label, property); });
   transaction_.md_deltas.emplace_back(MetadataDelta::point_index_create, label, property);
   return {};
 }
@@ -2083,7 +2147,8 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   MG_ASSERT(type() == UNIQUE, "Dropping point index requires a unique access to the storage!");
   auto *in_memory = static_cast<InMemoryStorage *>(storage_);
   auto &point_index = in_memory->indices_.point_index_;
-  if (!point_index.DropPointIndex(label, property)) {
+  auto evicted = point_index.DropPointIndex(label, property);
+  if (!evicted) {
     return std::unexpected{IndexDefinitionError{}};
   }
   // Defer publication to commit time. See CreatePointIndex above.
@@ -2091,6 +2156,9 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   transaction_.commit_callbacks_.Add([&point_index, updater](uint64_t /*commit_ts*/) {
     point_index.PublishActiveIndices(updater);
     memgraph::metrics::DecrementCounter(memgraph::metrics::ActivePointIndices);
+  });
+  transaction_.abort_callbacks_.Add([&point_index, label, property, evicted = std::move(evicted)]() mutable {
+    point_index.RestorePointIndex(label, property, std::move(evicted));
   });
   transaction_.md_deltas.emplace_back(MetadataDelta::point_index_drop, label, property);
   return {};
@@ -2115,6 +2183,12 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
     vector_index.PublishActiveIndices(updater);
     memgraph::metrics::IncrementCounter(memgraph::metrics::ActiveVectorIndices);
   });
+  // DropIndex undoes both the owner install and the eager vertex property
+  // rewrite (Vector -> VectorIndexId) CreateIndex did.
+  auto *name_mapper = in_memory->name_id_mapper_.get();
+  auto const name = spec.index_name;
+  transaction_.abort_callbacks_.Add(
+      [&vector_index, name_mapper, name]() { vector_index.DropIndex(name, name_mapper); });
   transaction_.md_deltas.emplace_back(MetadataDelta::vector_index_create, spec);
   return {};
 }
@@ -2126,15 +2200,23 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   auto &vector_index = in_memory->indices_.vector_index_;
   auto &vector_edge_index = in_memory->indices_.vector_edge_index_;
   auto updater = in_memory->indices_.MakeUpdater();
-  if (vector_index.DropIndex(index_name, in_memory->name_id_mapper_.get())) {
+  if (auto vec_capture = vector_index.DropIndex(index_name, in_memory->name_id_mapper_.get())) {
     transaction_.commit_callbacks_.Add([&vector_index, updater](uint64_t /*commit_ts*/) {
       vector_index.PublishActiveIndices(updater);
       memgraph::metrics::DecrementCounter(memgraph::metrics::ActiveVectorIndices);
     });
-  } else if (vector_edge_index.DropIndex(index_name, in_memory->name_id_mapper_.get())) {
+    // RestoreIndex puts the IndexItem back (usearch state survives via the captured
+    // shared_ptr) and re-rewrites the touched vertex properties.
+    transaction_.abort_callbacks_.Add([&vector_index, capture = std::move(*vec_capture)]() mutable {
+      vector_index.RestoreIndex(std::move(capture));
+    });
+  } else if (auto edge_capture = vector_edge_index.DropIndex(index_name, in_memory->name_id_mapper_.get())) {
     transaction_.commit_callbacks_.Add([&vector_edge_index, updater](uint64_t /*commit_ts*/) {
       vector_edge_index.PublishActiveIndices(updater);
       memgraph::metrics::DecrementCounter(memgraph::metrics::ActiveVectorEdgeIndices);
+    });
+    transaction_.abort_callbacks_.Add([&vector_edge_index, capture = std::move(*edge_capture)]() mutable {
+      vector_edge_index.RestoreIndex(std::move(capture));
     });
   } else {
     return std::unexpected{IndexDefinitionError{}};
@@ -2170,6 +2252,11 @@ std::expected<void, StorageIndexDefinitionError> InMemoryStorage::InMemoryAccess
   }
   // Defer publication to commit time. See CreateVectorIndex above.
   auto updater = in_memory->indices_.MakeUpdater();
+  auto *name_mapper = in_memory->name_id_mapper_.get();
+  auto const edge_index_name = spec.index_name;
+  transaction_.abort_callbacks_.Add([&vector_edge_index, name_mapper, edge_index_name]() {
+    vector_edge_index.DropIndex(edge_index_name, name_mapper);
+  });
   transaction_.commit_callbacks_.Add([&vector_edge_index, updater](uint64_t /*commit_ts*/) {
     vector_edge_index.PublishActiveIndices(updater);
     memgraph::metrics::IncrementCounter(memgraph::metrics::ActiveVectorEdgeIndices);
@@ -2192,11 +2279,11 @@ InMemoryStorage::InMemoryAccessor::CreateExistenceConstraint(LabelId label, Prop
     if (auto validation_result = ExistenceConstraints::ValidateVerticesOnConstraint(
             in_memory->vertices_.access(), label, property, std::nullopt, std::nullopt);
         !validation_result.has_value()) {
-      existence_constraints->DropConstraint(label, property);
+      (void)existence_constraints->DropConstraint(label, property);
       return std::unexpected{StorageExistenceConstraintDefinitionError{validation_result.error()}};
     }
   } catch (const utils::OutOfMemoryException &) {
-    existence_constraints->DropConstraint(label, property);
+    (void)existence_constraints->DropConstraint(label, property);
     throw;
   }
   // Defer publication to commit time for MVCC correctness
@@ -2206,6 +2293,8 @@ InMemoryStorage::InMemoryAccessor::CreateExistenceConstraint(LabelId label, Prop
     updater(existence_constraints->GetActiveConstraints());
   };
   transaction_.commit_callbacks_.Add(std::move(publisher));
+  transaction_.abort_callbacks_.Add(
+      [existence_constraints, label, property]() { (void)existence_constraints->DropConstraint(label, property); });
   transaction_.md_deltas.emplace_back(MetadataDelta::existence_constraint_create, label, property);
   return {};
 }
@@ -2217,7 +2306,8 @@ std::expected<void, StorageExistenceConstraintDroppingError> InMemoryStorage::In
             "Dropping existence constraint requires a read only or unique access to the storage!");
   auto *in_memory = static_cast<InMemoryStorage *>(storage_);
   auto *existence_constraints = in_memory->constraints_.existence_constraints_.get();
-  if (!existence_constraints->DropConstraint(label, property)) {
+  auto evicted = existence_constraints->DropConstraint(label, property);
+  if (!evicted) {
     return std::unexpected{StorageExistenceConstraintDroppingError{ConstraintDefinitionError{}}};
   }
   // Defer publication to commit time so concurrent readers don't observe the
@@ -2225,6 +2315,10 @@ std::expected<void, StorageExistenceConstraintDroppingError> InMemoryStorage::In
   auto updater = in_memory->constraints_.MakeUpdater();
   transaction_.commit_callbacks_.Add([existence_constraints, updater](uint64_t /*commit_ts*/) {
     updater(existence_constraints->GetActiveConstraints());
+  });
+  // Reinstall the evicted entry on abort so the constraint stays live.
+  transaction_.abort_callbacks_.Add([existence_constraints, label, property, evicted = std::move(evicted)]() mutable {
+    existence_constraints->RestoreConstraint(label, property, std::move(evicted));
   });
   transaction_.md_deltas.emplace_back(MetadataDelta::existence_constraint_drop, label, property);
   return {};
@@ -2252,6 +2346,9 @@ InMemoryStorage::InMemoryAccessor::CreateUniqueConstraint(LabelId label, const s
     updater(mem_unique_constraints->GetActiveConstraints());
   };
   transaction_.commit_callbacks_.Add(std::move(publisher));
+  transaction_.abort_callbacks_.Add([mem_unique_constraints, label, properties]() {
+    (void)mem_unique_constraints->DropConstraint(label, properties);
+  });
   transaction_.md_deltas.emplace_back(MetadataDelta::unique_constraint_create, label, properties);
   return UniqueConstraints::CreationStatus::SUCCESS;
 }
@@ -2264,9 +2361,9 @@ UniqueConstraints::DeletionStatus InMemoryStorage::InMemoryAccessor::DropUniqueC
   auto *in_memory = static_cast<InMemoryStorage *>(storage_);
   auto *mem_unique_constraints =
       static_cast<InMemoryUniqueConstraints *>(in_memory->constraints_.unique_constraints_.get());
-  auto ret = mem_unique_constraints->DropConstraint(label, properties);
-  if (ret != UniqueConstraints::DeletionStatus::SUCCESS) {
-    return ret;
+  auto captured = mem_unique_constraints->DropConstraint(label, properties);
+  if (captured.status != UniqueConstraints::DeletionStatus::SUCCESS) {
+    return captured.status;
   }
   // Defer publication to commit time so concurrent readers don't observe the
   // drop if the DDL transaction aborts. Matches the CREATE path above.
@@ -2274,6 +2371,11 @@ UniqueConstraints::DeletionStatus InMemoryStorage::InMemoryAccessor::DropUniqueC
   transaction_.commit_callbacks_.Add([mem_unique_constraints, updater](uint64_t /*commit_ts*/) {
     updater(mem_unique_constraints->GetActiveConstraints());
   });
+  // Reinstall the evicted entry on abort so the constraint stays live.
+  transaction_.abort_callbacks_.Add(
+      [mem_unique_constraints, label, properties, evicted = std::move(captured.evicted)]() mutable {
+        mem_unique_constraints->RestoreConstraint(label, properties, std::move(evicted));
+      });
   transaction_.md_deltas.emplace_back(MetadataDelta::unique_constraint_drop, label, properties);
   return UniqueConstraints::DeletionStatus::SUCCESS;
 }
@@ -2292,11 +2394,11 @@ std::expected<void, StorageExistenceConstraintDefinitionError> InMemoryStorage::
     if (auto validation_result =
             TypeConstraints::ValidateVerticesOnConstraint(in_memory->vertices_.access(), label, property, kind);
         !validation_result.has_value()) {
-      type_constraints->DropConstraint(label, property, kind);
+      (void)type_constraints->DropConstraint(label, property, kind);
       return std::unexpected{StorageTypeConstraintDefinitionError{validation_result.error()}};
     }
   } catch (const utils::OutOfMemoryException &) {
-    type_constraints->DropConstraint(label, property, kind);
+    (void)type_constraints->DropConstraint(label, property, kind);
     throw;
   }
   // Defer publication to commit time for MVCC correctness
@@ -2306,6 +2408,8 @@ std::expected<void, StorageExistenceConstraintDefinitionError> InMemoryStorage::
     updater(type_constraints->GetActiveConstraints());
   };
   transaction_.commit_callbacks_.Add(std::move(publisher));
+  transaction_.abort_callbacks_.Add(
+      [type_constraints, label, property, kind]() { (void)type_constraints->DropConstraint(label, property, kind); });
   transaction_.md_deltas.emplace_back(MetadataDelta::type_constraint_create, label, property, kind);
   return {};
 }
@@ -2317,8 +2421,8 @@ std::expected<void, StorageTypeConstraintDroppingError> InMemoryStorage::InMemor
             "Dropping IS TYPED constraint requires a read only or unique access to the storage!");
   auto *in_memory = static_cast<InMemoryStorage *>(storage_);
   auto *type_constraints = in_memory->constraints_.type_constraints_.get();
-  auto deleted_constraint = type_constraints->DropConstraint(label, property, kind);
-  if (!deleted_constraint) {
+  auto evicted = type_constraints->DropConstraint(label, property, kind);
+  if (!evicted) {
     return std::unexpected{StorageTypeConstraintDroppingError{ConstraintDefinitionError{}}};
   }
   // Defer publication to commit time so concurrent readers don't observe the
@@ -2326,6 +2430,10 @@ std::expected<void, StorageTypeConstraintDroppingError> InMemoryStorage::InMemor
   auto updater = in_memory->constraints_.MakeUpdater();
   transaction_.commit_callbacks_.Add(
       [type_constraints, updater](uint64_t /*commit_ts*/) { updater(type_constraints->GetActiveConstraints()); });
+  // Reinstall the evicted entry on abort so the constraint stays live.
+  transaction_.abort_callbacks_.Add([type_constraints, label, property, evicted = std::move(evicted)]() mutable {
+    type_constraints->RestoreConstraint(label, property, std::move(evicted));
+  });
   transaction_.md_deltas.emplace_back(MetadataDelta::type_constraint_drop, label, property, kind);
   return {};
 }

--- a/src/storage/v2/inmemory/unique_constraints.cpp
+++ b/src/storage/v2/inmemory/unique_constraints.cpp
@@ -31,7 +31,8 @@ namespace memgraph::storage {
 
 namespace {
 
-auto DoValidate(const Vertex &vertex, utils::SkipListDb<InMemoryUniqueConstraints::Entry>::Accessor &constraint_accessor,
+auto DoValidate(const Vertex &vertex,
+                utils::SkipListDb<InMemoryUniqueConstraints::Entry>::Accessor &constraint_accessor,
                 const LabelId &label, const std::set<PropertyId> &properties)
     -> std::expected<void, ConstraintViolation> {
   if (vertex.deleted() || !std::ranges::contains(vertex.labels, label)) {
@@ -546,7 +547,7 @@ bool InMemoryUniqueConstraints::PublishConstraint(LabelId label, const std::set<
 auto InMemoryUniqueConstraints::DropConstraint(LabelId label, const std::set<PropertyId> &properties) -> DropResult {
   if (auto drop_properties_check_result = CheckPropertiesBeforeDeletion(properties);
       drop_properties_check_result != DeletionStatus::SUCCESS) {
-    return {drop_properties_check_result, nullptr};
+    return {.status = drop_properties_check_result, .evicted = nullptr};
   }
 
   auto evicted = container_.WithLock([&](ContainerPtr &container) -> IndividualConstraintPtr {
@@ -563,8 +564,8 @@ auto InMemoryUniqueConstraints::DropConstraint(LabelId label, const std::set<Pro
     return captured;
   });
 
-  if (!evicted) return {DeletionStatus::NOT_FOUND, nullptr};
-  return {DeletionStatus::SUCCESS, std::move(evicted)};
+  if (!evicted) return {.status = DeletionStatus::NOT_FOUND, .evicted = nullptr};
+  return {.status = DeletionStatus::SUCCESS, .evicted = std::move(evicted)};
 }
 
 auto InMemoryUniqueConstraints::InstallConstraint_(LabelId label, const std::set<PropertyId> &properties,

--- a/src/storage/v2/inmemory/unique_constraints.cpp
+++ b/src/storage/v2/inmemory/unique_constraints.cpp
@@ -504,23 +504,14 @@ auto InMemoryUniqueConstraints::CreateConstraint(
     return CreationStatus::PROPERTIES_SIZE_LIMIT_EXCEEDED;
   }
 
-  auto constraint_ptr =
-      container_.WithLock([&](ContainerPtr &container) -> std::expected<IndividualConstraintPtr, CreationStatus> {
-        auto new_container = std::make_shared<Container>(*container);
-        auto &inner = (*new_container)[label];
-        auto [it, inserted] = inner.try_emplace(properties, std::make_shared<IndividualConstraint>());
-        if (!inserted) return std::unexpected{CreationStatus::ALREADY_EXISTS};
-        container = std::move(new_container);
-        return it->second;
-      });
-
-  if (!constraint_ptr) return constraint_ptr.error();
+  auto constraint_ptr = InstallConstraint_(label, properties, std::make_shared<IndividualConstraint>());
+  if (!constraint_ptr) return CreationStatus::ALREADY_EXISTS;
 
   try {
     auto validation_result = std::invoke([&] {
       // `constraint_accessor` is inside this IIFE on purpose.
       // This accessor MUST be released before we erase if a violation was found
-      auto constraint_accessor = constraint_ptr.value()->skiplist.access();
+      auto constraint_accessor = constraint_ptr->skiplist.access();
 
       auto multi_single_thread_processing = GetCreationFunction(par_exec_info);
 
@@ -534,12 +525,12 @@ auto InMemoryUniqueConstraints::CreateConstraint(
     });
 
     if (!validation_result.has_value()) {
-      DropConstraint(label, properties);
+      (void)DropConstraint(label, properties);
       return std::unexpected{validation_result.error()};
     }
     return CreationStatus::SUCCESS;
   } catch (const utils::OutOfMemoryException &) {
-    DropConstraint(label, properties);
+    (void)DropConstraint(label, properties);
     throw;
   }
 }
@@ -552,30 +543,49 @@ bool InMemoryUniqueConstraints::PublishConstraint(LabelId label, const std::set<
   return true;
 }
 
-auto InMemoryUniqueConstraints::DropConstraint(LabelId label, const std::set<PropertyId> &properties)
-    -> DeletionStatus {
+auto InMemoryUniqueConstraints::DropConstraint(LabelId label, const std::set<PropertyId> &properties) -> DropResult {
   if (auto drop_properties_check_result = CheckPropertiesBeforeDeletion(properties);
       drop_properties_check_result != DeletionStatus::SUCCESS) {
-    return drop_properties_check_result;
+    return {drop_properties_check_result, nullptr};
   }
 
-  auto erased = container_.WithLock([&](ContainerPtr &container) -> bool {
+  auto evicted = container_.WithLock([&](ContainerPtr &container) -> IndividualConstraintPtr {
+    auto label_it = container->find(label);
+    if (label_it == container->end()) return nullptr;
+    auto props_it = label_it->second.find(properties);
+    if (props_it == label_it->second.end()) return nullptr;
+    auto captured = props_it->second;
     auto new_container = std::make_shared<Container>(*container);
-    auto label_it = new_container->find(label);
-    if (label_it == new_container->end()) {
-      return false;
-    }
-    auto const count = label_it->second.erase(properties);
-    if (count == 0) return false;
-    if (label_it->second.empty()) {
-      new_container->erase(label_it);
-    }
-
+    auto new_label_it = new_container->find(label);
+    new_label_it->second.erase(properties);
+    if (new_label_it->second.empty()) new_container->erase(new_label_it);
     container = std::move(new_container);
-    return true;
+    return captured;
   });
 
-  return erased ? DeletionStatus::SUCCESS : DeletionStatus::NOT_FOUND;
+  if (!evicted) return {DeletionStatus::NOT_FOUND, nullptr};
+  return {DeletionStatus::SUCCESS, std::move(evicted)};
+}
+
+auto InMemoryUniqueConstraints::InstallConstraint_(LabelId label, const std::set<PropertyId> &properties,
+                                                   IndividualConstraintPtr ptr) -> IndividualConstraintPtr {
+  return container_.WithLock([&](ContainerPtr &container) -> IndividualConstraintPtr {
+    auto label_it = container->find(label);
+    if (label_it != container->end() && label_it->second.contains(properties)) return nullptr;
+    auto new_container = std::make_shared<Container>(*container);
+    (*new_container)[label][properties] = ptr;
+    container = std::move(new_container);
+    return ptr;
+  });
+}
+
+void InMemoryUniqueConstraints::RestoreConstraint(LabelId label, const std::set<PropertyId> &properties,
+                                                  IndividualConstraintPtr evicted) {
+  if (!evicted) return;
+  // Concurrent CREATE under READ_ONLY may own the slot; discarding evicted is benign
+  // since the winning CREATE walks every labelled vertex during populate, so its
+  // skiplist holds the same logical entries.
+  (void)InstallConstraint_(label, properties, std::move(evicted));
 }
 
 auto InMemoryUniqueConstraints::Validate(const std::unordered_set<Vertex const *> &vertices, const Transaction &tx,

--- a/src/storage/v2/inmemory/unique_constraints.hpp
+++ b/src/storage/v2/inmemory/unique_constraints.hpp
@@ -136,7 +136,21 @@ class InMemoryUniqueConstraints : public UniqueConstraints {
   /// Publishes a constraint after validation, making it visible at the given commit timestamp.
   bool PublishConstraint(LabelId label, const std::set<PropertyId> &properties, uint64_t commit_timestamp);
 
-  auto DropConstraint(LabelId label, const std::set<PropertyId> &properties) -> DeletionStatus override;
+  /// Drops a constraint. Returns the evicted IndividualConstraint so the caller
+  /// can reinstall it via RestoreConstraint on abort, alongside the deletion
+  /// status. {SUCCESS, ptr} on success; {NOT_FOUND/EMPTY_PROPERTIES/..., nullptr}
+  /// otherwise.
+  struct DropResult {
+    DeletionStatus status;
+    IndividualConstraintPtr evicted;
+  };
+
+  [[nodiscard]] auto DropConstraint(LabelId label, const std::set<PropertyId> &properties) -> DropResult;
+
+  /// Reinstalls a previously-evicted IndividualConstraint. No-op if the slot
+  /// has been reclaimed by a concurrent CREATE (constraint DDL runs under
+  /// READ_ONLY/UNIQUE, which does not serialize peers).
+  void RestoreConstraint(LabelId label, const std::set<PropertyId> &properties, IndividualConstraintPtr evicted);
 
   /// Validates the given vertex against unique constraints before committing.
   /// This method should be called while commit lock is active with
@@ -160,6 +174,12 @@ class InMemoryUniqueConstraints : public UniqueConstraints {
  private:
   auto GetIndividualConstraint(const LabelId label, const std::set<PropertyId> &properties) const
       -> IndividualConstraintPtr;
+
+  // Installs ptr if the slot is absent; returns the installed ptr or nullptr.
+  // Shared by CreateConstraint (validates via the returned skiplist) and RestoreConstraint.
+  auto InstallConstraint_(LabelId label, const std::set<PropertyId> &properties, IndividualConstraintPtr ptr)
+      -> IndividualConstraintPtr;
+
   utils::Synchronized<ContainerPtr, utils::WritePrioritizedRWLock> container_{std::make_shared<Container const>()};
 };
 

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -760,6 +760,14 @@ std::expected<void, storage::StorageIndexDefinitionError> Storage::Accessor::Cre
     text_index.PublishActiveIndices(updater);
     memgraph::metrics::IncrementCounter(memgraph::metrics::ActiveTextIndices);
   });
+  auto const index_name = text_index_info.index_name;
+  transaction_.abort_callbacks_.Add([&text_index, index_name]() {
+    if (!text_index.IndexExists(index_name)) return;
+    auto evicted = text_index.DropIndex(index_name);
+    // Our aborted create owns the on-disk tantivy directory it just made; flip
+    // deferred_drop so ~TextIndexData unlinks it when the last ref here drops.
+    if (evicted) evicted->deferred_drop = true;
+  });
   transaction_.md_deltas.emplace_back(MetadataDelta::text_index_create, text_index_info);
   return {};
 }
@@ -787,6 +795,12 @@ std::expected<void, storage::StorageIndexDefinitionError> Storage::Accessor::Cre
     text_edge_index.PublishActiveIndices(updater);
     memgraph::metrics::IncrementCounter(memgraph::metrics::ActiveTextEdgeIndices);
   });
+  auto const edge_index_name = text_edge_index_info.index_name;
+  transaction_.abort_callbacks_.Add([&text_edge_index, edge_index_name]() {
+    if (!text_edge_index.IndexExists(edge_index_name)) return;
+    auto evicted = text_edge_index.DropIndex(edge_index_name);
+    if (evicted) evicted->deferred_drop = true;
+  });
   transaction_.md_deltas.emplace_back(MetadataDelta::text_edge_index_create, text_edge_index_info);
   return {};
 }
@@ -800,21 +814,30 @@ std::expected<void, storage::StorageIndexDefinitionError> Storage::Accessor::Dro
     auto &text_index = storage_->indices_.text_index_;
     // Flip deferred_drop only on commit so an aborted DROP leaves the on-disk
     // tantivy directory intact (other snapshots still alias the same data).
-    transaction_.commit_callbacks_.Add(
-        [&text_index, updater, evicted = std::move(evicted)](uint64_t /*commit_ts*/) mutable {
-          evicted->deferred_drop = true;
-          text_index.PublishActiveIndices(updater);
-          memgraph::metrics::DecrementCounter(memgraph::metrics::ActiveTextIndices);
-        });
+    auto shared_evicted = std::shared_ptr<TextIndexData>(std::move(evicted));
+    transaction_.commit_callbacks_.Add([&text_index, updater, shared_evicted](uint64_t /*commit_ts*/) mutable {
+      shared_evicted->deferred_drop = true;
+      text_index.PublishActiveIndices(updater);
+      memgraph::metrics::DecrementCounter(memgraph::metrics::ActiveTextIndices);
+    });
+    // Abort: re-install the evicted entry. deferred_drop stays false so
+    // ~TextIndexData keeps the on-disk directory when the shared_ptr in the
+    // reinstalled map is eventually released through normal snapshot churn.
+    transaction_.abort_callbacks_.Add([&text_index, index_name, shared_evicted]() mutable {
+      text_index.RestoreIndex(index_name, std::move(shared_evicted));
+    });
   } else if (storage_->indices_.text_edge_index_.IndexExists(index_name)) {
     auto evicted = storage_->indices_.text_edge_index_.DropIndex(index_name);
     auto &text_edge_index = storage_->indices_.text_edge_index_;
-    transaction_.commit_callbacks_.Add(
-        [&text_edge_index, updater, evicted = std::move(evicted)](uint64_t /*commit_ts*/) mutable {
-          evicted->deferred_drop = true;
-          text_edge_index.PublishActiveIndices(updater);
-          memgraph::metrics::DecrementCounter(memgraph::metrics::ActiveTextEdgeIndices);
-        });
+    auto shared_evicted = std::shared_ptr<TextEdgeIndexData>(std::move(evicted));
+    transaction_.commit_callbacks_.Add([&text_edge_index, updater, shared_evicted](uint64_t /*commit_ts*/) mutable {
+      shared_evicted->deferred_drop = true;
+      text_edge_index.PublishActiveIndices(updater);
+      memgraph::metrics::DecrementCounter(memgraph::metrics::ActiveTextEdgeIndices);
+    });
+    transaction_.abort_callbacks_.Add([&text_edge_index, index_name, shared_evicted]() mutable {
+      text_edge_index.RestoreIndex(index_name, std::move(shared_evicted));
+    });
   } else {
     return std::unexpected{storage::StorageIndexDefinitionError{IndexDefinitionError{}}};
   }

--- a/src/storage/v2/transaction.hpp
+++ b/src/storage/v2/transaction.hpp
@@ -74,7 +74,10 @@ struct AbortCallbacks {
 
   void Add(func_t callback) { callbacks_.emplace_back(std::move(callback)); }
 
-  // Best-effort: a leaked ghost is better than std::terminate on the abort path.
+  // noexcept: a throwing callback here will std::terminate. In practice this
+  // is fine — abort runs with the soft memory tracker disabled (no
+  // OutOfMemoryExceptionEnabler in scope), so OOM can't fire from these
+  // callbacks, and a true system bad_alloc means we're going down anyway.
   void RunAll() noexcept {
     for (auto &callback : callbacks_) {
       callback();

--- a/src/storage/v2/transaction.hpp
+++ b/src/storage/v2/transaction.hpp
@@ -12,10 +12,13 @@
 #pragma once
 
 #include <atomic>
+#include <exception>
 #include <memory>
 #include <optional>
 #include <unordered_map>
 #include <vector>
+
+#include <spdlog/spdlog.h>
 
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indices/text_index_utils.hpp"
@@ -61,6 +64,27 @@ struct CommitCallbacks {
   }
 
   std::vector<std::function<void(uint64_t)>> callbacks_;
+};
+
+/// Mirror of CommitCallbacks. Each site that adds a commit_callback typically
+/// adds a paired abort_callback that undoes the same eager mutation; commit
+/// runs commit_callbacks and discards abort_callbacks, abort the reverse.
+struct AbortCallbacks {
+  using func_t = std::function<void()>;
+
+  void Add(func_t callback) { callbacks_.emplace_back(std::move(callback)); }
+
+  // Best-effort: a leaked ghost is better than std::terminate on the abort path.
+  void RunAll() noexcept {
+    for (auto &callback : callbacks_) {
+      callback();
+    }
+    callbacks_.clear();
+  }
+
+  void Clear() noexcept { callbacks_.clear(); }
+
+  std::vector<func_t> callbacks_;
 };
 
 struct AsyncIndexHelper {
@@ -260,6 +284,9 @@ struct Transaction {
   /// Used for constraint validation during commit
   ActiveConstraintsPtr active_constraints_;
   CommitCallbacks commit_callbacks_;
+  /// Rollback hooks for eager DDL owner-side mutations. Runs on Abort(),
+  /// cleared on successful commit (see commit_callbacks_.RunAll site).
+  AbortCallbacks abort_callbacks_;
 
   /// Auto indexing infomation gathering
   AsyncIndexHelper async_index_helper_;

--- a/tests/concurrent/storage_indices.cpp
+++ b/tests/concurrent/storage_indices.cpp
@@ -35,6 +35,7 @@ TEST(Storage, LabelIndex) {
   {
     auto unique_acc = store->UniqueAccess();
     ASSERT_TRUE(unique_acc->CreateIndex(label).has_value());
+    ASSERT_TRUE(unique_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
   }
 
   std::vector<std::thread> verifiers;
@@ -120,6 +121,7 @@ TEST(Storage, LabelPropertyIndex) {
   {
     auto unique_acc = store->UniqueAccess();
     ASSERT_TRUE(unique_acc->CreateIndex(label, {prop}).has_value());
+    ASSERT_TRUE(unique_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
   }
 
   std::vector<std::thread> verifiers;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -25,6 +25,13 @@ target_link_libraries(storage_test_utils mg::storage)
 add_library(disk_test_utils disk_test_utils.cpp)
 target_link_libraries(disk_test_utils mg::storage)
 
+# Header-only helpers shared across storage test files
+# (parameterized DDL abort/ghost/restore tests).
+add_library(ddl_abort_helpers INTERFACE)
+target_sources(ddl_abort_helpers INTERFACE ddl_abort_helpers.hpp)
+target_link_libraries(ddl_abort_helpers INTERFACE mg::storage GTest::gtest)
+target_include_directories(ddl_abort_helpers INTERFACE ${CMAKE_SOURCE_DIR})
+
 find_package(Boost REQUIRED CONFIG COMPONENTS filesystem)
 
 # Test integrations-kafka
@@ -616,7 +623,7 @@ add_unit_test(storage_v2_enum_store
 
 add_unit_test(storage_v2_constraints
     SOURCES storage_v2_constraints.cpp
-    LINK_TARGETS mg::storage mg-dbms disk_test_utils
+    LINK_TARGETS mg::storage mg-dbms disk_test_utils ddl_abort_helpers
 )
 
 if(ENABLE_JEMALLOC)
@@ -693,7 +700,7 @@ add_unit_test(storage_v2_delta_correctness
 
 add_unit_test(storage_v2_indices
     SOURCES storage_v2_indices.cpp
-    LINK_TARGETS mg::storage mg-utils disk_test_utils
+    LINK_TARGETS mg::storage mg-utils disk_test_utils ddl_abort_helpers
 )
 
 add_unit_test(storage_v2_name_id_mapper
@@ -788,17 +795,17 @@ add_unit_test(cpp_api
 
 add_unit_test(vector_index
     SOURCES vector_index.cpp
-    LINK_TARGETS mg::storage
+    LINK_TARGETS mg::storage ddl_abort_helpers
 )
 
 add_unit_test(vector_edge_index
     SOURCES vector_edge_index.cpp
-    LINK_TARGETS mg::storage
+    LINK_TARGETS mg::storage ddl_abort_helpers
 )
 
 add_unit_test(text_index
     SOURCES text_index.cpp
-    LINK_TARGETS mg::storage
+    LINK_TARGETS mg::storage ddl_abort_helpers
 )
 
 # Test mg-auth

--- a/tests/unit/db_accessor_chunked_test.cpp
+++ b/tests/unit/db_accessor_chunked_test.cpp
@@ -42,25 +42,26 @@ class DbAccessorChunkedTest : public ::testing::Test {
       type_id_ = dba.NameToEdgeType("Type");
 
       ASSERT_TRUE(unique_acc->CreateIndex(label_id_).has_value());
+      ASSERT_TRUE(unique_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
     }
     {
       auto unique_acc = storage_->UniqueAccess();
       ASSERT_TRUE(unique_acc->CreateIndex(label_id_, {prop_id_}).has_value());
+      ASSERT_TRUE(unique_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
     }
     {
       auto unique_acc = storage_->UniqueAccess();
       ASSERT_TRUE(unique_acc->CreateIndex(type_id_).has_value());
+      ASSERT_TRUE(unique_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
     }
     {
       auto unique_acc = storage_->UniqueAccess();
       ASSERT_TRUE(unique_acc->CreateIndex(type_id_, prop_id_).has_value());
+      ASSERT_TRUE(unique_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
     }
     {
       auto unique_acc = storage_->UniqueAccess();
       ASSERT_TRUE(unique_acc->CreateGlobalEdgeIndex(prop_id_).has_value());
-    }
-    {
-      auto unique_acc = storage_->UniqueAccess();
       ASSERT_TRUE(unique_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
     }
   }

--- a/tests/unit/db_memory_tracking.cpp
+++ b/tests/unit/db_memory_tracking.cpp
@@ -253,37 +253,42 @@ TEST_F(DbMemoryTrackingTest, EmbeddingMemoryTracking) {
   StabilizeDbMemoryBaseline(db1.get());
   StabilizeDbMemoryBaseline(db2.get());
 
+  const int64_t db1_before = db1->DbEmbeddingMemoryUsage();
+  const int64_t db2_before = db2->DbEmbeddingMemoryUsage();
+  const int64_t db1_total_before = db1->DbMemoryUsage();
+
+  memgraph::storage::VectorIndexSpec spec{
+      .index_name = "db1_embedding_index",
+      .label_id = label,
+      .property = property,
+      .metric_kind = unum::usearch::metric_kind_t::cos_k,
+      .dimension = 256,
+      .resize_coefficient = 2,
+      .capacity = 4096,
+      .scalar_kind = unum::usearch::scalar_kind_t::f32_k,
+  };
+
   {
     memgraph::memory::DbArenaScope db_arena_scope{&db1->Arena()};
     auto unique_acc = db1->UniqueAccess();
-
-    const int64_t db1_before = db1->DbEmbeddingMemoryUsage();
-    const int64_t db2_before = db2->DbEmbeddingMemoryUsage();
-    const int64_t db1_total_before = db1->DbMemoryUsage();
-
-    memgraph::storage::VectorIndexSpec spec{
-        .index_name = "db1_embedding_index",
-        .label_id = label,
-        .property = property,
-        .metric_kind = unum::usearch::metric_kind_t::cos_k,
-        .dimension = 256,
-        .resize_coefficient = 2,
-        .capacity = 4096,
-        .scalar_kind = unum::usearch::scalar_kind_t::f32_k,
-    };
-
     ASSERT_NO_ERROR(unique_acc->CreateVectorIndex(spec));
-
-    const int64_t db1_delta = db1->DbEmbeddingMemoryUsage() - db1_before;
-    const int64_t db1_total_delta = db1->DbMemoryUsage() - db1_total_before;
-
-    EXPECT_GT(db1_delta, static_cast<int64_t>(256 * 1024)) << "Vector index should attribute embedding memory to DB1";
-    EXPECT_EQ(db2->DbEmbeddingMemoryUsage(), db2_before) << "DB2 embedding tracker must not grow";
-    EXPECT_GE(db1_total_delta, db1_delta) << "db_total should include embedding delta";
-
-    ASSERT_NO_ERROR(unique_acc->DropVectorIndex(spec.index_name));
-    EXPECT_EQ(db1->DbEmbeddingMemoryUsage(), db1_before) << "Dropping index should release embedding memory";
+    ASSERT_TRUE(unique_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
   }
+
+  const int64_t db1_delta = db1->DbEmbeddingMemoryUsage() - db1_before;
+  const int64_t db1_total_delta = db1->DbMemoryUsage() - db1_total_before;
+
+  EXPECT_GT(db1_delta, static_cast<int64_t>(256 * 1024)) << "Vector index should attribute embedding memory to DB1";
+  EXPECT_EQ(db2->DbEmbeddingMemoryUsage(), db2_before) << "DB2 embedding tracker must not grow";
+  EXPECT_GE(db1_total_delta, db1_delta) << "db_total should include embedding delta";
+
+  {
+    memgraph::memory::DbArenaScope db_arena_scope{&db1->Arena()};
+    auto unique_acc = db1->UniqueAccess();
+    ASSERT_NO_ERROR(unique_acc->DropVectorIndex(spec.index_name));
+    ASSERT_TRUE(unique_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  EXPECT_EQ(db1->DbEmbeddingMemoryUsage(), db1_before) << "Dropping index should release embedding memory";
 
   auto edge_type = db1->storage()->NameToEdgeType("EMBEDDED_EDGE");
   auto edge_property = db1->storage()->NameToProperty("edge_embedding");
@@ -326,6 +331,7 @@ TEST_F(DbMemoryTrackingTest, EmbeddingMemoryTracking) {
     memgraph::memory::DbArenaScope db_arena_scope{&db1->Arena()};
     auto unique_acc = db1->UniqueAccess();
     ASSERT_NO_ERROR(unique_acc->CreateVectorEdgeIndex(edge_spec));
+    ASSERT_TRUE(unique_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
   }
 
   const int64_t db1_edge_delta = db1->DbEmbeddingMemoryUsage() - db1_edge_before;
@@ -340,6 +346,7 @@ TEST_F(DbMemoryTrackingTest, EmbeddingMemoryTracking) {
     memgraph::memory::DbArenaScope db_arena_scope{&db1->Arena()};
     auto unique_acc = db1->UniqueAccess();
     ASSERT_NO_ERROR(unique_acc->DropVectorIndex(edge_spec.index_name));
+    ASSERT_TRUE(unique_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
   }
   EXPECT_EQ(db1->DbEmbeddingMemoryUsage(), db1_edge_before) << "Dropping edge index should release embedding memory";
 }
@@ -437,6 +444,7 @@ TEST_F(DbMemoryTrackingTest, IndexCreationTracked) {
   {
     auto ua = db->storage()->UniqueAccess();
     ASSERT_TRUE(ua->CreateIndex(label).has_value());
+    ASSERT_TRUE(ua->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
   }
   EXPECT_GT(db->DbMemoryUsage(), before_label) << "Label index creation should increase DbMemoryUsage";
 
@@ -448,6 +456,7 @@ TEST_F(DbMemoryTrackingTest, IndexCreationTracked) {
     memgraph::storage::PropertiesPaths props{{prop}};
     auto ua = db->storage()->UniqueAccess();
     ASSERT_TRUE(ua->CreateIndex(label, std::move(props)).has_value());
+    ASSERT_TRUE(ua->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
   }
   EXPECT_GT(db->DbMemoryUsage(), before_lp) << "Label-property index creation should increase DbMemoryUsage";
 
@@ -458,6 +467,7 @@ TEST_F(DbMemoryTrackingTest, IndexCreationTracked) {
   {
     auto ua = db->storage()->UniqueAccess();
     ASSERT_TRUE(ua->CreateIndex(edge_type).has_value());
+    ASSERT_TRUE(ua->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
   }
   EXPECT_GT(db->DbMemoryUsage(), before_et) << "Edge-type index creation should increase DbMemoryUsage";
 }

--- a/tests/unit/ddl_abort_helpers.hpp
+++ b/tests/unit/ddl_abort_helpers.hpp
@@ -1,0 +1,101 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+// Parameterized helpers for the DDL abort/ghost/restore test matrix shared
+// across the storage unit-test files (storage_v2_indices, storage_v2_constraints,
+// text_index, vector_index, vector_edge_index). Each helper captures the common
+// shape: open accessor → DDL call → abort/commit → verify. Per-DDL-kind
+// variation lives in the lambdas the call site supplies.
+//
+// SKIP_IF_NOT_IN_MEMORY must stay at the call site — `if constexpr` on TypeParam
+// needs to be lexically inside the TYPED_TEST body. Plain TEST_F bodies with a
+// non-templated fixture should just inline the abort/retry sequence (no skip
+// needed).
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+// Helpers are templates; the concrete storage types they touch (InMemoryStorage,
+// Accessor::Abort/PrepareForCommitPhase, ...) are required only at instantiation
+// time, where every caller already includes "storage/v2/inmemory/storage.hpp".
+// Keep this header lean — pulling storage.hpp here adds ~1200 lines to every
+// test TU that depends on the helpers.
+#include "storage/v2/access_type.hpp"  // memgraph::storage::WRITE
+#include "tests/test_commit_args_helper.hpp"
+
+namespace memgraph::storage {
+class InMemoryStorage;  // forward decl for the SKIP_IF_NOT_IN_MEMORY type-check
+}  // namespace memgraph::storage
+
+#define SKIP_IF_NOT_IN_MEMORY()                                                   \
+  if constexpr (!std::is_same_v<TypeParam, memgraph::storage::InMemoryStorage>) { \
+    GTEST_SKIP() << "Disk storage has different DDL semantics";                   \
+  }
+
+#ifndef ASSERT_NO_ERROR
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define ASSERT_NO_ERROR(result) ASSERT_TRUE((result).has_value())
+#endif
+
+namespace memgraph::tests {
+
+// Common shape: aborted CREATE must not leave a ghost; a retry CREATE must
+// succeed. `make_acc(self)` opens an accessor of the right type for the DDL.
+// `create(acc.get())` runs the CREATE call; its return is expected to expose
+// `.has_value()`.
+template <typename Self, typename AccFn, typename CreateFn>
+void ExpectCreateAbortLeavesNoGhostEntry(Self *self, AccFn make_acc, CreateFn create) {
+  {
+    auto a = make_acc(self);
+    ASSERT_TRUE(create(a.get()).has_value());
+    a->Abort();
+  }
+  {
+    auto a = make_acc(self);
+    ASSERT_TRUE(create(a.get()).has_value()) << "retry after aborted CREATE must succeed; ghost left behind.";
+    ASSERT_NO_ERROR(a->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+}
+
+// Common shape: aborted DROP must restore the entry, observable via the
+// `verify_ready(acc.get())` predicate on a fresh WRITE accessor.
+template <typename Self, typename CreateAccFn, typename DropAccFn, typename CreateFn, typename DropFn,
+          typename VerifyReadyFn>
+void ExpectDropAbortRestoresIndex(Self *self, CreateAccFn make_create_acc, DropAccFn make_drop_acc, CreateFn create,
+                                  DropFn drop, VerifyReadyFn verify_ready) {
+  {
+    auto a = make_create_acc(self);
+    ASSERT_TRUE(create(a.get()).has_value());
+    ASSERT_NO_ERROR(a->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+  {
+    auto a = make_drop_acc(self);
+    ASSERT_TRUE(drop(a.get()).has_value());
+    a->Abort();
+  }
+  {
+    auto a = self->storage->Access(memgraph::storage::WRITE);
+    EXPECT_TRUE(verify_ready(a.get())) << "after aborted DROP, the index must remain visible.";
+  }
+}
+
+// Common accessor lambdas: instantiate per-fixture by calling the fixture's
+// public CreateXxxAccessor / DropXxxAccessor methods. Fixtures must expose
+// these as public members.
+inline auto IndexAcc = [](auto *self) { return self->CreateIndexAccessor(); };
+inline auto DropAcc = [](auto *self) { return self->DropIndexAccessor(); };
+inline auto ConstraintAcc = [](auto *self) { return self->CreateConstraintAccessor(); };
+inline auto UniqueAcc = [](auto *self) { return self->storage->UniqueAccess(); };
+
+}  // namespace memgraph::tests

--- a/tests/unit/storage_v2_constraints.cpp
+++ b/tests/unit/storage_v2_constraints.cpp
@@ -25,6 +25,7 @@
 
 #include "disk_test_utils.hpp"
 #include "tests/test_commit_args_helper.hpp"
+#include "tests/unit/ddl_abort_helpers.hpp"
 
 // NOLINTNEXTLINE(google-build-using-namespace)
 using namespace memgraph::storage;
@@ -2124,4 +2125,115 @@ TYPED_TEST(ConstraintsTest, TypeConstraintMetrics) {
     ASSERT_NO_ERROR(constraint_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
   }
   EXPECT_EQ(memgraph::metrics::GetCounterValue(memgraph::metrics::ActiveTypeConstraints), initial_count);
+}
+
+using memgraph::tests::ConstraintAcc;
+using memgraph::tests::ExpectCreateAbortLeavesNoGhostEntry;
+
+TYPED_TEST(ConstraintsTest, ExistenceConstraintAbortLeavesNoGhostEntry) {
+  SKIP_IF_NOT_IN_MEMORY();
+  ExpectCreateAbortLeavesNoGhostEntry(
+      this, ConstraintAcc, [&](auto *acc) { return acc->CreateExistenceConstraint(this->label1, this->prop1); });
+}
+
+TYPED_TEST(ConstraintsTest, UniqueConstraintAbortLeavesNoGhostEntry) {
+  SKIP_IF_NOT_IN_MEMORY();
+  // CreateUniqueConstraint returns expected<CreationStatus, ...>; SUCCESS is the
+  // only "yes, installed" status — adapt to .has_value() shape for the helper.
+  std::set<PropertyId> const properties{this->prop1};
+  auto create = [&](auto *acc) -> std::expected<void, std::monostate> {
+    auto res = acc->CreateUniqueConstraint(this->label1, properties);
+    if (!res.has_value() || res.value() != memgraph::storage::UniqueConstraints::CreationStatus::SUCCESS) {
+      return std::unexpected{std::monostate{}};
+    }
+    return {};
+  };
+  ExpectCreateAbortLeavesNoGhostEntry(this, ConstraintAcc, create);
+}
+
+TYPED_TEST(ConstraintsTest, TypeConstraintAbortLeavesNoGhostEntry) {
+  SKIP_IF_NOT_IN_MEMORY();
+  ExpectCreateAbortLeavesNoGhostEntry(this, ConstraintAcc, [&](auto *acc) {
+    return acc->CreateTypeConstraint(this->label1, this->prop1, TypeConstraintKind::INTEGER);
+  });
+}
+
+// Drop-abort tests have a richer shape (verify still-in-list + verify retry-CREATE
+// fails because the slot is still live). The ExpectDropAbortRestoresIndex helper
+// verifies via a Ready-predicate which constraints don't expose; keep these
+// inline but compress the boilerplate.
+TYPED_TEST(ConstraintsTest, DropExistenceConstraintAbortRestoresConstraint) {
+  SKIP_IF_NOT_IN_MEMORY();
+  {
+    auto acc = this->CreateConstraintAccessor();
+    ASSERT_TRUE(acc->CreateExistenceConstraint(this->label1, this->prop1).has_value());
+    ASSERT_NO_ERROR(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+  {
+    auto acc = this->CreateConstraintAccessor();
+    ASSERT_TRUE(acc->DropExistenceConstraint(this->label1, this->prop1).has_value());
+    acc->Abort();
+  }
+  {
+    auto acc = this->storage->Access(memgraph::storage::READ);
+    EXPECT_THAT(acc->ListAllConstraints().existence, UnorderedElementsAre(std::make_pair(this->label1, this->prop1)));
+  }
+  {
+    auto acc = this->CreateConstraintAccessor();
+    EXPECT_FALSE(acc->CreateExistenceConstraint(this->label1, this->prop1).has_value());
+    acc->Abort();
+  }
+}
+
+TYPED_TEST(ConstraintsTest, DropUniqueConstraintAbortRestoresConstraint) {
+  SKIP_IF_NOT_IN_MEMORY();
+  std::set<PropertyId> const properties{this->prop1};
+  {
+    auto acc = this->CreateConstraintAccessor();
+    auto res = acc->CreateUniqueConstraint(this->label1, properties);
+    ASSERT_TRUE(res.has_value());
+    ASSERT_EQ(res.value(), memgraph::storage::UniqueConstraints::CreationStatus::SUCCESS);
+    ASSERT_NO_ERROR(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+  {
+    auto acc = this->CreateConstraintAccessor();
+    EXPECT_EQ(acc->DropUniqueConstraint(this->label1, properties),
+              memgraph::storage::UniqueConstraints::DeletionStatus::SUCCESS);
+    acc->Abort();
+  }
+  {
+    auto acc = this->storage->Access(memgraph::storage::READ);
+    EXPECT_THAT(acc->ListAllConstraints().unique, UnorderedElementsAre(std::make_pair(this->label1, properties)));
+  }
+  {
+    auto acc = this->CreateConstraintAccessor();
+    auto res = acc->CreateUniqueConstraint(this->label1, properties);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res.value(), memgraph::storage::UniqueConstraints::CreationStatus::ALREADY_EXISTS);
+    acc->Abort();
+  }
+}
+
+TYPED_TEST(ConstraintsTest, DropTypeConstraintAbortRestoresConstraint) {
+  SKIP_IF_NOT_IN_MEMORY();
+  {
+    auto acc = this->CreateConstraintAccessor();
+    ASSERT_TRUE(acc->CreateTypeConstraint(this->label1, this->prop1, TypeConstraintKind::INTEGER).has_value());
+    ASSERT_NO_ERROR(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+  {
+    auto acc = this->CreateConstraintAccessor();
+    ASSERT_TRUE(acc->DropTypeConstraint(this->label1, this->prop1, TypeConstraintKind::INTEGER).has_value());
+    acc->Abort();
+  }
+  {
+    auto acc = this->storage->Access(memgraph::storage::READ);
+    EXPECT_THAT(acc->ListAllConstraints().type,
+                UnorderedElementsAre(std::make_tuple(this->label1, this->prop1, TypeConstraintKind::INTEGER)));
+  }
+  {
+    auto acc = this->CreateConstraintAccessor();
+    EXPECT_FALSE(acc->CreateTypeConstraint(this->label1, this->prop1, TypeConstraintKind::INTEGER).has_value());
+    acc->Abort();
+  }
 }

--- a/tests/unit/storage_v2_indices.cpp
+++ b/tests/unit/storage_v2_indices.cpp
@@ -27,6 +27,7 @@
 #include "storage/v2/temporal.hpp"
 #include "storage_test_utils.hpp"
 #include "tests/test_commit_args_helper.hpp"
+#include "tests/unit/ddl_abort_helpers.hpp"
 #include "utils/rocksdb_serialization.hpp"
 
 // NOLINTNEXTLINE(google-build-using-namespace)
@@ -35,8 +36,7 @@ using testing::IsEmpty;
 using testing::Types;
 using testing::UnorderedElementsAre;
 
-// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define ASSERT_NO_ERROR(result) ASSERT_TRUE((result).has_value())
+// ASSERT_NO_ERROR provided by ddl_abort_helpers.hpp.
 
 namespace pvr {
 // Create a PropertyValueRange for testing against property equality
@@ -103,6 +103,13 @@ class IndexTest : public testing::Test {
     this->storage.reset(nullptr);
   }
 
+  const std::string testSuite = "storage_v2_indices";
+  memgraph::storage::Config config_;
+
+ public:
+  // public so namespace-scope test-helper lambdas can reach storage / accessor factories.
+  std::unique_ptr<memgraph::storage::Storage> storage;
+
   auto CreateIndexAccessor() -> std::unique_ptr<memgraph::storage::Storage::Accessor> {
     if constexpr (std::is_same_v<StorageType, memgraph::storage::InMemoryStorage>) {
       return this->storage->ReadOnlyAccess();
@@ -119,9 +126,7 @@ class IndexTest : public testing::Test {
     }
   }
 
-  const std::string testSuite = "storage_v2_indices";
-  memgraph::storage::Config config_;
-  std::unique_ptr<memgraph::storage::Storage> storage;
+ protected:
   PropertyId prop_id;
   PropertyId prop_val;
   LabelId label1;
@@ -4641,4 +4646,201 @@ TYPED_TEST(IndexTest, EdgeTypePropertyIndexRemoveObsoleteEntriesWithActiveTransa
     EXPECT_THAT(this->GetIds(acc_new->Edges(this->edge_type_id1, this->edge_prop_id1, View::NEW), View::NEW),
                 IsEmpty());
   }
+}
+
+using memgraph::tests::ConstraintAcc;
+using memgraph::tests::DropAcc;
+using memgraph::tests::ExpectCreateAbortLeavesNoGhostEntry;
+using memgraph::tests::ExpectDropAbortRestoresIndex;
+using memgraph::tests::IndexAcc;
+using memgraph::tests::UniqueAcc;
+
+TYPED_TEST(IndexTest, LabelIndexAbortLeavesNoGhostEntry) {
+  SKIP_IF_NOT_IN_MEMORY();
+  ExpectCreateAbortLeavesNoGhostEntry(this, IndexAcc, [&](auto *acc) { return acc->CreateIndex(this->label1); });
+}
+
+TYPED_TEST(IndexTest, LabelPropertyIndexAbortLeavesNoGhostEntry) {
+  SKIP_IF_NOT_IN_MEMORY();
+  PropertyPath props{this->prop_val};
+  ExpectCreateAbortLeavesNoGhostEntry(
+      this, IndexAcc, [&](auto *acc) { return acc->CreateIndex(this->label1, {props}); });
+}
+
+TYPED_TEST(IndexTest, EdgeTypeIndexAbortLeavesNoGhostEntry) {
+  SKIP_IF_NOT_IN_MEMORY();
+  ExpectCreateAbortLeavesNoGhostEntry(this, IndexAcc, [&](auto *acc) { return acc->CreateIndex(this->edge_type_id1); });
+}
+
+TYPED_TEST(IndexTest, EdgeTypePropertyIndexAbortLeavesNoGhostEntry) {
+  SKIP_IF_NOT_IN_MEMORY();
+  ExpectCreateAbortLeavesNoGhostEntry(
+      this, IndexAcc, [&](auto *acc) { return acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1); });
+}
+
+TYPED_TEST(IndexTest, EdgePropertyIndexAbortLeavesNoGhostEntry) {
+  SKIP_IF_NOT_IN_MEMORY();
+  ExpectCreateAbortLeavesNoGhostEntry(
+      this, IndexAcc, [&](auto *acc) { return acc->CreateGlobalEdgeIndex(this->edge_prop_id1); });
+}
+
+TYPED_TEST(IndexTest, PointIndexAbortLeavesNoGhostEntry) {
+  SKIP_IF_NOT_IN_MEMORY();
+  ExpectCreateAbortLeavesNoGhostEntry(
+      this, UniqueAcc, [&](auto *acc) { return acc->CreatePointIndex(this->label1, this->prop_val); });
+}
+
+TYPED_TEST(IndexTest, DropPointIndexAbortRestoresIndex) {
+  SKIP_IF_NOT_IN_MEMORY();
+  // Point index has no XxxReady() reader on the public accessor; verify by
+  // re-dropping (which only succeeds if the entry is still live).
+  {
+    auto a = this->storage->UniqueAccess();
+    ASSERT_TRUE(a->CreatePointIndex(this->label1, this->prop_val).has_value());
+    ASSERT_NO_ERROR(a->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+  {
+    auto a = this->storage->UniqueAccess();
+    ASSERT_TRUE(a->DropPointIndex(this->label1, this->prop_val).has_value());
+    a->Abort();
+  }
+  {
+    auto a = this->storage->UniqueAccess();
+    ASSERT_TRUE(a->DropPointIndex(this->label1, this->prop_val).has_value())
+        << "After an aborted DROP POINT INDEX, the index must be visible again and droppable.";
+    ASSERT_NO_ERROR(a->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+}
+
+TYPED_TEST(IndexTest, DropLabelIndexAbortRestoresIndex) {
+  SKIP_IF_NOT_IN_MEMORY();
+  ExpectDropAbortRestoresIndex(
+      this,
+      IndexAcc,
+      DropAcc,
+      [&](auto *acc) { return acc->CreateIndex(this->label1); },
+      [&](auto *acc) { return acc->DropIndex(this->label1); },
+      [&](auto *acc) { return acc->LabelIndexReady(this->label1); });
+}
+
+TYPED_TEST(IndexTest, DropLabelPropertyIndexAbortRestoresIndex) {
+  SKIP_IF_NOT_IN_MEMORY();
+  PropertyPath props{this->prop_val};
+  std::array<PropertyPath, 1> props_arr{props};
+  std::span<PropertyPath const> props_span{props_arr};
+  ExpectDropAbortRestoresIndex(
+      this,
+      IndexAcc,
+      DropAcc,
+      [&](auto *acc) { return acc->CreateIndex(this->label1, {props}); },
+      [&](auto *acc) { return acc->DropIndex(this->label1, std::vector<PropertyPath>{props}); },
+      [&](auto *acc) { return acc->LabelPropertyIndexReady(this->label1, props_span); });
+}
+
+TYPED_TEST(IndexTest, DropEdgeTypeIndexAbortRestoresIndex) {
+  SKIP_IF_NOT_IN_MEMORY();
+  ExpectDropAbortRestoresIndex(
+      this,
+      IndexAcc,
+      DropAcc,
+      [&](auto *acc) { return acc->CreateIndex(this->edge_type_id1); },
+      [&](auto *acc) { return acc->DropIndex(this->edge_type_id1); },
+      [&](auto *acc) { return acc->EdgeTypeIndexReady(this->edge_type_id1); });
+}
+
+TYPED_TEST(IndexTest, DropEdgeTypePropertyIndexAbortRestoresIndex) {
+  SKIP_IF_NOT_IN_MEMORY();
+  ExpectDropAbortRestoresIndex(
+      this,
+      IndexAcc,
+      DropAcc,
+      [&](auto *acc) { return acc->CreateIndex(this->edge_type_id1, this->edge_prop_id1); },
+      [&](auto *acc) { return acc->DropIndex(this->edge_type_id1, this->edge_prop_id1); },
+      [&](auto *acc) { return acc->EdgeTypePropertyIndexReady(this->edge_type_id1, this->edge_prop_id1); });
+}
+
+TYPED_TEST(IndexTest, DropLabelPropertyIndexAbortDoesNotClobberConcurrentDrop) {
+  if constexpr (!std::is_same_v<TypeParam, memgraph::storage::InMemoryStorage>) {
+    GTEST_SKIP() << "Disk storage has different DDL semantics";
+  }
+  PropertyPath p1{this->prop_val};
+  PropertyPath p2{this->prop_id};
+  std::array<PropertyPath, 1> p1_arr{p1};
+  std::array<PropertyPath, 1> p2_arr{p2};
+  std::span<PropertyPath const> p1_span{p1_arr};
+  std::span<PropertyPath const> p2_span{p2_arr};
+
+  // Setup: two label-property indices on the same label.
+  {
+    auto acc = this->CreateIndexAccessor();
+    ASSERT_TRUE(acc->CreateIndex(this->label1, {p1}).has_value());
+    ASSERT_NO_ERROR(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+  {
+    auto acc = this->CreateIndexAccessor();
+    ASSERT_TRUE(acc->CreateIndex(this->label1, {p2}).has_value());
+    ASSERT_NO_ERROR(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+
+  // Open A's drop accessor and drop p1, but don't abort yet.
+  auto acc_a = this->DropIndexAccessor();
+  ASSERT_TRUE(acc_a->DropIndex(this->label1, std::vector<PropertyPath>{p1}).has_value());
+
+  // Concurrently, B drops p2 and commits.
+  {
+    auto acc_b = this->DropIndexAccessor();
+    ASSERT_TRUE(acc_b->DropIndex(this->label1, std::vector<PropertyPath>{p2}).has_value());
+    ASSERT_NO_ERROR(acc_b->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+
+  // Now A aborts. Per-key reinsert must restore p1 only — must NOT undo B's drop of p2.
+  acc_a->Abort();
+
+  auto acc = this->storage->Access(memgraph::storage::WRITE);
+  EXPECT_TRUE(acc->LabelPropertyIndexReady(this->label1, p1_span)) << "A's aborted drop of p1 must be undone.";
+  EXPECT_FALSE(acc->LabelPropertyIndexReady(this->label1, p2_span))
+      << "B's committed drop of p2 must NOT be clobbered by A's abort.";
+}
+
+TYPED_TEST(IndexTest, DropLabelPropertyIndexAbortPreservesStats) {
+  if constexpr (!std::is_same_v<TypeParam, memgraph::storage::InMemoryStorage>) {
+    GTEST_SKIP() << "Disk storage has different DDL semantics";
+  }
+  PropertyPath props{this->prop_val};
+  std::array<PropertyPath, 1> props_arr{props};
+  std::span<PropertyPath const> props_span{props_arr};
+  auto const stats = memgraph::storage::LabelPropertyIndexStats{
+      .count = 7, .distinct_values_count = 3, .statistic = 1.5, .avg_group_size = 2.0, .avg_degree = 4.0};
+
+  {
+    auto acc = this->CreateIndexAccessor();
+    ASSERT_TRUE(acc->CreateIndex(this->label1, {props}).has_value());
+    ASSERT_NO_ERROR(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+  {
+    auto acc = this->storage->Access(memgraph::storage::WRITE);
+    acc->SetIndexStats(this->label1, props_span, stats);
+    ASSERT_NO_ERROR(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+  {
+    auto acc = this->DropIndexAccessor();
+    ASSERT_TRUE(acc->DropIndex(this->label1, std::vector<PropertyPath>{props}).has_value());
+    acc->Abort();
+  }
+  auto acc = this->storage->Access(memgraph::storage::WRITE);
+  auto recovered = acc->GetIndexStats(this->label1, props_span);
+  ASSERT_TRUE(recovered.has_value()) << "After an aborted DROP INDEX, the analytics stats must survive.";
+  EXPECT_EQ(recovered->count, stats.count);
+  EXPECT_EQ(recovered->distinct_values_count, stats.distinct_values_count);
+}
+
+TYPED_TEST(IndexTest, DropEdgePropertyIndexAbortRestoresIndex) {
+  SKIP_IF_NOT_IN_MEMORY();
+  ExpectDropAbortRestoresIndex(
+      this,
+      IndexAcc,
+      DropAcc,
+      [&](auto *acc) { return acc->CreateGlobalEdgeIndex(this->edge_prop_id1); },
+      [&](auto *acc) { return acc->DropGlobalEdgeIndex(this->edge_prop_id1); },
+      [&](auto *acc) { return acc->EdgePropertyIndexReady(this->edge_prop_id1); });
 }

--- a/tests/unit/text_index.cpp
+++ b/tests/unit/text_index.cpp
@@ -20,6 +20,7 @@
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/view.hpp"
 #include "tests/test_commit_args_helper.hpp"
+#include "tests/unit/ddl_abort_helpers.hpp"
 
 // NOLINTNEXTLINE(google-build-using-namespace)
 using namespace memgraph::storage;
@@ -267,5 +268,76 @@ TEST_F(TextIndexTest, ConcurrentDeleteAddAbortTest) {
     // Total should be 3 nodes (1 original + 2 new)
     auto all_results = acc->TextIndexSearch(test_index.data(), "*", text_search_mode::ALL_PROPERTIES, default_limit);
     EXPECT_EQ(all_results.size(), 3);
+  }
+}
+
+TEST_F(TextIndexTest, CreateTextIndexAbortLeavesNoGhostEntry) {
+  TextIndexSpec spec{};
+  {
+    auto acc = this->storage->UniqueAccess();
+    spec = TextIndexSpec{test_index.data(), acc->NameToLabel(test_label.data()), {}};
+  }
+  memgraph::tests::ExpectCreateAbortLeavesNoGhostEntry(
+      this, memgraph::tests::UniqueAcc, [&](auto *acc) { return acc->CreateTextIndex(spec); });
+}
+
+TEST_F(TextIndexTest, CreateTextEdgeIndexAbortLeavesNoGhostEntry) {
+  static constexpr std::string_view edge_index_name = "test_edge_index";
+  TextEdgeIndexSpec spec{};
+  {
+    auto acc = this->storage->UniqueAccess();
+    spec = TextEdgeIndexSpec{
+        edge_index_name.data(), acc->NameToEdgeType("TEST_EDGE"), std::vector{acc->NameToProperty("text_prop")}};
+  }
+  memgraph::tests::ExpectCreateAbortLeavesNoGhostEntry(
+      this, memgraph::tests::UniqueAcc, [&](auto *acc) { return acc->CreateTextEdgeIndex(spec); });
+  // Drop on commit so TearDown's Drop loop only cleans up the vertex text index.
+  {
+    auto drop_acc = this->storage->UniqueAccess();
+    ASSERT_TRUE(drop_acc->DropTextIndex(edge_index_name.data()).has_value());
+    ASSERT_NO_ERROR(drop_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+}
+
+TEST_F(TextIndexTest, DropTextEdgeIndexAbortRestoresIndex) {
+  static constexpr std::string_view edge_index_name = "test_edge_index";
+  static constexpr std::string_view edge_type_name = "TEST_EDGE";
+  {
+    auto acc = this->storage->UniqueAccess();
+    auto const edge_type = acc->NameToEdgeType(edge_type_name.data());
+    auto const prop = acc->NameToProperty("text_prop");
+    ASSERT_TRUE(
+        acc->CreateTextEdgeIndex(TextEdgeIndexSpec{edge_index_name.data(), edge_type, std::vector{prop}}).has_value());
+    ASSERT_NO_ERROR(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+  {
+    auto acc = this->storage->UniqueAccess();
+    ASSERT_TRUE(acc->DropTextIndex(edge_index_name.data()).has_value());
+    acc->Abort();
+  }
+  {
+    // Retry DROP must succeed — the aborted drop should have re-installed the
+    // entry so it's visible and droppable again.
+    auto acc = this->storage->UniqueAccess();
+    ASSERT_TRUE(acc->DropTextIndex(edge_index_name.data()).has_value())
+        << "After an aborted DROP, the text edge index must be visible again and droppable.";
+    ASSERT_NO_ERROR(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+}
+
+TEST_F(TextIndexTest, DropTextIndexAbortRestoresIndex) {
+  this->CreateIndex();
+  {
+    auto acc = this->storage->UniqueAccess();
+    ASSERT_TRUE(acc->DropTextIndex(test_index.data()).has_value());
+    acc->Abort();
+  }
+  {
+    // Retry DROP must succeed — the aborted drop should have re-installed
+    // the entry so it's visible and droppable again.
+    auto acc = this->storage->UniqueAccess();
+    ASSERT_TRUE(acc->DropTextIndex(test_index.data()).has_value())
+        << "After an aborted DROP, the text index must be visible again and droppable.";
+    ASSERT_NO_ERROR(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
   }
 }

--- a/tests/unit/vector_edge_index.cpp
+++ b/tests/unit/vector_edge_index.cpp
@@ -18,11 +18,21 @@
 #include "flags/general.hpp"
 #include "query/exceptions.hpp"
 #include "storage/v2/indices/active_indices_updater.hpp"
+#include "storage/v2/indices/point_index.hpp"
+#include "storage/v2/indices/text_edge_index.hpp"
+#include "storage/v2/indices/text_index.hpp"
+#include "storage/v2/indices/vector_index.hpp"
+#include "storage/v2/inmemory/edge_property_index.hpp"
+#include "storage/v2/inmemory/edge_type_index.hpp"
+#include "storage/v2/inmemory/edge_type_property_index.hpp"
+#include "storage/v2/inmemory/label_index.hpp"
+#include "storage/v2/inmemory/label_property_index.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/storage_mode.hpp"
 #include "storage/v2/view.hpp"
 #include "tests/test_commit_args_helper.hpp"
+#include "tests/unit/ddl_abort_helpers.hpp"
 
 // NOLINTNEXTLINE(google-build-using-namespace)
 using namespace memgraph::storage;
@@ -330,6 +340,57 @@ TEST_F(VectorEdgeIndexTest, DropIndexTest) {
   }
 }
 
+TEST_F(VectorEdgeIndexTest, CreateVectorEdgeIndexAbortLeavesNoGhostEntry) {
+  VectorEdgeIndexSpec spec{};
+  {
+    auto acc = this->storage->Access(memgraph::storage::WRITE);
+    spec = VectorEdgeIndexSpec{test_index.data(),
+                               acc->NameToEdgeType(test_edge_type.data()),
+                               acc->NameToProperty(test_property.data()),
+                               metric,
+                               2,
+                               resize_coefficient,
+                               16,
+                               scalar_kind};
+    ASSERT_NO_ERROR(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+  memgraph::tests::ExpectCreateAbortLeavesNoGhostEntry(
+      this, memgraph::tests::UniqueAcc, [&](auto *acc) { return acc->CreateVectorEdgeIndex(spec); });
+}
+
+TEST_F(VectorEdgeIndexTest, DropVectorEdgeIndexAbortRestoresIndex) {
+  this->CreateEdgeIndex(2, 16);
+  PropertyValue properties(std::vector<PropertyValue>{PropertyValue(1.0), PropertyValue(1.0)});
+  Gid edge_gid;
+  {
+    auto acc = this->storage->Access(memgraph::storage::WRITE);
+    auto [from_vertex, to_vertex, edge] = this->CreateEdge(acc.get(), test_property, properties, test_edge_type);
+    edge_gid = edge.Gid();
+    ASSERT_NO_ERROR(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+  {
+    auto unique_acc = this->storage->UniqueAccess();
+    ASSERT_TRUE(unique_acc->DropVectorIndex(test_index).has_value());
+    unique_acc->Abort();
+  }
+  // Index entry must still exist and the edge property must remain stored as
+  // VectorIndexId (not rewritten to plain Vector).
+  {
+    auto acc = this->storage->Access(memgraph::storage::READ);
+    ASSERT_EQ(acc->ListAllVectorEdgeIndices().size(), 1u);
+    auto edge = acc->FindEdge(edge_gid, View::OLD).value();
+    auto prop = edge.GetProperty(acc->NameToProperty(test_property), View::OLD);
+    ASSERT_TRUE(prop.has_value());
+    EXPECT_TRUE(prop->IsVectorIndexId()) << "Aborted DROP must not leave the edge property rewritten to plain Vector.";
+  }
+  // A second DROP must succeed (i.e. restored entry is reachable).
+  {
+    auto unique_acc = this->storage->UniqueAccess();
+    ASSERT_TRUE(unique_acc->DropVectorIndex(test_index).has_value());
+    ASSERT_NO_ERROR(unique_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+}
+
 TEST_F(VectorEdgeIndexTest, ClearTest) {
   this->CreateEdgeIndex(2, 10);
   {
@@ -490,15 +551,15 @@ class VectorEdgeIndexRecoveryTest : public testing::Test {
     // Initialize the active indices store with a valid ActiveIndices object
     // so that ActiveIndicesUpdater assertions pass during recovery.
     active_indices_store_.WithLock([&](ActiveIndicesPtr &ai) {
-      ai = std::make_shared<ActiveIndices>(nullptr,
-                                           nullptr,
-                                           nullptr,
-                                           nullptr,
-                                           nullptr,
-                                           nullptr,
-                                           nullptr,
-                                           nullptr,
-                                           nullptr,
+      ai = std::make_shared<ActiveIndices>(std::make_shared<InMemoryLabelIndex::ActiveIndices>(),
+                                           std::make_shared<InMemoryLabelPropertyIndex::ActiveIndices>(),
+                                           std::make_shared<InMemoryEdgeTypeIndex::ActiveIndices>(),
+                                           std::make_shared<InMemoryEdgeTypePropertyIndex::ActiveIndices>(),
+                                           std::make_shared<InMemoryEdgePropertyIndex::ActiveIndices>(),
+                                           std::make_shared<memgraph::storage::TextIndex::ActiveIndices>(),
+                                           std::make_shared<memgraph::storage::TextEdgeIndex::ActiveIndices>(),
+                                           std::make_shared<memgraph::storage::PointIndexStorage::ActiveIndices>(),
+                                           std::make_shared<memgraph::storage::VectorIndex::ActiveIndices>(),
                                            vector_edge_index_.GetActiveIndices());
     });
 

--- a/tests/unit/vector_index.cpp
+++ b/tests/unit/vector_index.cpp
@@ -23,6 +23,7 @@
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/view.hpp"
 #include "tests/test_commit_args_helper.hpp"
+#include "tests/unit/ddl_abort_helpers.hpp"
 
 // NOLINTNEXTLINE(google-build-using-namespace)
 using namespace memgraph::storage;
@@ -683,6 +684,63 @@ TEST_F(VectorIndexRecoveryTest, ConcurrentAddWithResizeTest) {
   EXPECT_EQ(vector_index_info.size(), 1);
   EXPECT_EQ(vector_index_info[0].size, kNumNodes);
   EXPECT_GE(vector_index_info[0].capacity, kNumNodes);
+}
+
+TEST_F(VectorIndexTest, DropVectorIndexAbortRestoresIndex) {
+  this->CreateIndex(2, 16);
+  // Add a couple of vertices so DropIndex actually walks property values.
+  {
+    auto acc = this->storage->Access(memgraph::storage::WRITE);
+    auto property_value = MakeVectorIndexProperty(acc.get(), memgraph::utils::small_vector<float>{1.0F, 2.0F});
+    [[maybe_unused]] auto v = this->CreateVertex(acc.get(), test_property, property_value, test_label);
+    ASSERT_NO_ERROR(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+
+  // Aborted DROP must leave the index live (and the vertex property reachable
+  // through the index, not rewritten to plain Vector).
+  {
+    auto acc = this->storage->UniqueAccess();
+    ASSERT_TRUE(acc->DropVectorIndex(test_index).has_value());
+    acc->Abort();
+  }
+
+  {
+    auto acc = this->storage->Access(memgraph::storage::READ);
+    auto info = acc->ListAllIndices().vector_indices_spec;
+    EXPECT_EQ(info.size(), 1u);
+  }
+
+  // A subsequent search must still find the vertex via the restored index.
+  {
+    auto acc = this->storage->Access(memgraph::storage::READ);
+    const auto result = acc->VectorIndexSearchOnNodes(test_index.data(), 1, std::vector<float>{1.0F, 2.0F});
+    EXPECT_EQ(result.size(), 1u);
+  }
+
+  // A second DROP must succeed (i.e. the restored entry is reachable, not a ghost).
+  {
+    auto acc = this->storage->UniqueAccess();
+    ASSERT_TRUE(acc->DropVectorIndex(test_index).has_value());
+    ASSERT_NO_ERROR(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+}
+
+TEST_F(VectorIndexTest, CreateVectorIndexAbortLeavesNoGhostEntry) {
+  VectorIndexSpec spec{};
+  {
+    auto acc = this->storage->Access(memgraph::storage::WRITE);
+    spec = VectorIndexSpec{.index_name = test_index.data(),
+                           .label_id = acc->NameToLabel(test_label.data()),
+                           .property = acc->NameToProperty(test_property.data()),
+                           .metric_kind = metric,
+                           .dimension = 2,
+                           .resize_coefficient = resize_coefficient,
+                           .capacity = 16,
+                           .scalar_kind = scalar_kind};
+    ASSERT_NO_ERROR(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+  memgraph::tests::ExpectCreateAbortLeavesNoGhostEntry(
+      this, memgraph::tests::UniqueAcc, [&](auto *acc) { return acc->CreateVectorIndex(spec); });
 }
 
 TEST_F(VectorIndexRecoveryTest, RecoverIndexWithPrecomputedEntries) {


### PR DESCRIPTION
Fixes a pre-existing bug where an aborted DDL transaction could leave a "ghost" entry in the index/constraint owner, blocking any retry CREATE for the same key until the process restarted.