### PR TITLE
build: reduce build time of memgraph__unit

### DIFF
--- a/src/dbms/database.cpp
+++ b/src/dbms/database.cpp
@@ -13,11 +13,14 @@
 
 #include <memory>
 
+#include "dbms/database_info.hpp"
 #include "dbms/inmemory/storage_helper.hpp"
 #include "query/stream/streams.hpp"
 #include "query/trigger.hpp"
 #include "storage/v2/disk/storage.hpp"
+#include "storage/v2/storage.hpp"
 #include "storage/v2/storage_mode.hpp"
+#include "storage/v2/ttl.hpp"
 
 template struct memgraph::utils::Gatekeeper<memgraph::dbms::Database>;
 
@@ -55,6 +58,34 @@ struct PlanInvalidatorForDatabase : storage::PlanInvalidator {
 };
 
 Database::~Database() = default;
+
+std::unique_ptr<storage::Accessor> Database::Access(storage::StorageAccessType rw_type,
+                                                    std::optional<storage::IsolationLevel> override_isolation_level,
+                                                    std::optional<std::chrono::milliseconds> timeout) {
+  return storage_->Access(rw_type, override_isolation_level, timeout);
+}
+
+std::unique_ptr<storage::Accessor> Database::UniqueAccess(
+    std::optional<storage::IsolationLevel> override_isolation_level, std::optional<std::chrono::milliseconds> timeout) {
+  return storage_->UniqueAccess(override_isolation_level, timeout);
+}
+
+std::unique_ptr<storage::Accessor> Database::ReadOnlyAccess(
+    std::optional<storage::IsolationLevel> override_isolation_level, std::optional<std::chrono::milliseconds> timeout) {
+  return storage_->ReadOnlyAccess(override_isolation_level, timeout);
+}
+
+std::string Database::name() const { return storage_->name(); }
+
+utils::SafeString::ConstSafeWrapper Database::name_view() const { return storage_->name_view(); }
+
+const utils::UUID &Database::uuid() const { return storage_->uuid(); }
+
+const storage::Config &Database::config() const { return storage_->config_; }
+
+storage::StorageMode Database::GetStorageMode() const noexcept { return storage_->GetStorageMode(); }
+
+storage::ttl::TTL &Database::ttl() { return storage_->ttl_; }
 
 Database::Database(storage::Config config, std::function<storage::DatabaseProtectorPtr()> database_protector_factory)
     : trigger_store_(std::make_unique<query::TriggerStore>(config.durability.storage_directory / "triggers")),

--- a/src/dbms/database.hpp
+++ b/src/dbms/database.hpp
@@ -11,12 +11,31 @@
 
 #pragma once
 
+#include <chrono>
+#include <functional>
 #include <memory>
 #include <optional>
+#include <string>
 
 #include "query/cypher_query_interpreter.hpp"
-#include "storage/v2/storage.hpp"
+#include "storage/v2/access_type.hpp"
+#include "storage/v2/config.hpp"
+#include "storage/v2/database_protector.hpp"
+#include "storage/v2/isolation_level.hpp"
+#include "storage/v2/storage_mode.hpp"
 #include "utils/gatekeeper.hpp"
+#include "utils/safe_string.hpp"
+#include "utils/thread_pool.hpp"
+#include "utils/uuid.hpp"
+
+namespace memgraph::storage {
+class Storage;
+class Accessor;
+
+namespace ttl {
+class TTL;
+}  // namespace ttl
+}  // namespace memgraph::storage
 
 namespace memgraph::query {
 struct TriggerStore;
@@ -28,13 +47,7 @@ class Streams;
 
 namespace memgraph::dbms {
 
-struct DatabaseInfo {
-  storage::StorageInfo storage_info;
-  uint64_t triggers;
-  uint64_t streams;
-};
-
-static inline nlohmann::json ToJson(const DatabaseInfo &info) { return ToJson(info.storage_info); }
+struct DatabaseInfo;
 
 /**
  * @brief Class containing everything associated with a single Database
@@ -68,56 +81,48 @@ class Database {
    * @brief Storage's Accessor
    *
    * @param override_isolation_level
-   * @return std::unique_ptr<storage::Storage::Accessor>
+   * @return std::unique_ptr<storage::Accessor>
    */
-  std::unique_ptr<storage::Storage::Accessor> Access(
-      storage::StorageAccessType rw_type = storage::StorageAccessType::WRITE,
-      std::optional<storage::IsolationLevel> override_isolation_level = {},
-      std::optional<std::chrono::milliseconds> timeout = std::nullopt) {
-    return storage_->Access(rw_type, override_isolation_level, timeout);
-  }
+  std::unique_ptr<storage::Accessor> Access(storage::StorageAccessType rw_type = storage::StorageAccessType::WRITE,
+                                            std::optional<storage::IsolationLevel> override_isolation_level = {},
+                                            std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
-  std::unique_ptr<storage::Storage::Accessor> UniqueAccess(
-      std::optional<storage::IsolationLevel> override_isolation_level = {},
-      std::optional<std::chrono::milliseconds> timeout = std::nullopt) {
-    return storage_->UniqueAccess(override_isolation_level, timeout);
-  }
+  std::unique_ptr<storage::Accessor> UniqueAccess(std::optional<storage::IsolationLevel> override_isolation_level = {},
+                                                  std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
-  std::unique_ptr<storage::Storage::Accessor> ReadOnlyAccess(
+  std::unique_ptr<storage::Accessor> ReadOnlyAccess(
       std::optional<storage::IsolationLevel> override_isolation_level = {},
-      std::optional<std::chrono::milliseconds> timeout = std::nullopt) {
-    return storage_->ReadOnlyAccess(override_isolation_level, timeout);
-  }
+      std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
   /**
    * @brief Unique storage identified (name)
    *
    * @return std::string
    */
-  std::string name() const { return storage_->name(); }
+  std::string name() const;
 
-  auto name_view() const { return storage_->name_view(); }
+  utils::SafeString::ConstSafeWrapper name_view() const;
 
   /**
    * @brief Unique storage identified (uuid)
    *
    * @return const utils::UUID&
    */
-  const utils::UUID &uuid() const { return storage_->uuid(); }
+  const utils::UUID &uuid() const;
 
   /**
    * @brief Returns the storage configuration
    *
    * @return const storage::Config&
    */
-  const storage::Config &config() const { return storage_->config_; }
+  const storage::Config &config() const;
 
   /**
    * @brief Get the storage mode
    *
    * @return storage::StorageMode
    */
-  storage::StorageMode GetStorageMode() const noexcept { return storage_->GetStorageMode(); }
+  storage::StorageMode GetStorageMode() const noexcept;
 
   /**
    * @brief Get the storage info
@@ -168,7 +173,7 @@ class Database {
    */
   query::PlanCacheLRU *plan_cache() { return &plan_cache_; }
 
-  storage::ttl::TTL &ttl() { return storage_->ttl_; }
+  storage::ttl::TTL &ttl();
 
   /**
    * @brief Useful when trying to gracefully destroy Database.

--- a/src/dbms/database_info.hpp
+++ b/src/dbms/database_info.hpp
@@ -1,0 +1,28 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <cstdint>
+
+#include "storage/v2/storage.hpp"
+
+namespace memgraph::dbms {
+
+struct DatabaseInfo {
+  storage::StorageInfo storage_info;
+  uint64_t triggers;
+  uint64_t streams;
+};
+
+static inline nlohmann::json ToJson(const DatabaseInfo &info) { return ToJson(info.storage_info); }
+
+}  // namespace memgraph::dbms

--- a/src/dbms/dbms_handler.hpp
+++ b/src/dbms/dbms_handler.hpp
@@ -26,10 +26,12 @@
 
 #include "constants.hpp"
 #include "dbms/database.hpp"
+#include "dbms/database_info.hpp"
 #include "kvstore/kvstore.hpp"
 #include "query/stream/streams.hpp"
 #include "query/trigger.hpp"
 #include "storage/v2/config.hpp"
+#include "storage/v2/storage.hpp"
 #ifdef MG_ENTERPRISE
 #include "dbms/database_handler.hpp"
 #endif

--- a/src/storage/v2/durability/wal.cpp
+++ b/src/storage/v2/durability/wal.cpp
@@ -41,6 +41,7 @@
 #include "utils/file_locker.hpp"
 #include "utils/logging.hpp"
 #include "utils/tag.hpp"
+#include "utils/variant_helpers.hpp"
 
 namespace r = ranges;
 namespace rv = r::views;
@@ -1001,6 +1002,73 @@ uint64_t ReadWalDeltaHeader(BaseDecoder *decoder) {
   auto timestamp = decoder->ReadUint();
   if (!timestamp) throw RecoveryFailure(kInvalidWalErrorMessage);
   return *timestamp;
+}
+
+bool operator==(const WalDeltaData &a, const WalDeltaData &b) {
+  return std::visit(utils::Overloaded{
+                        []<typename T>(T const &lhs, T const &rhs) { return lhs == rhs; },
+                        [](auto const &, auto const &) { return false; },
+                    },
+                    a.data_,
+                    b.data_);
+}
+
+bool IsWalDeltaDataImplicitTransactionEndVersion15(const WalDeltaData &delta) {
+  return std::visit(utils::Overloaded{
+                        // These delta actions are all found inside transactions so they don't
+                        // indicate a transaction end.
+                        [](WalVertexCreate const &) { return false; },
+                        [](WalVertexDelete const &) { return false; },
+                        [](WalVertexAddLabel const &) { return false; },
+                        [](WalVertexRemoveLabel const &) { return false; },
+                        [](WalVertexSetProperty const &) { return false; },
+                        [](WalEdgeCreate const &) { return false; },
+                        [](WalEdgeDelete const &) { return false; },
+                        [](WalEdgeSetProperty const &) { return false; },
+                        [](WalTransactionStart const &) { return false; },
+
+                        // This delta explicitly indicates that a transaction is done.
+                        [](WalTransactionEnd const &) { return true; },
+
+                        // These operations aren't transactional and they are encoded only using
+                        // a single delta, so they each individually mark the end of their
+                        // 'transaction'.
+                        [](WalLabelIndexCreate const &) { return true; },
+                        [](WalLabelIndexDrop const &) { return true; },
+                        [](WalLabelIndexStatsSet const &) { return true; },
+                        [](WalLabelIndexStatsClear const &) { return true; },
+                        [](WalLabelPropertyIndexCreate const &) { return true; },
+                        [](WalLabelPropertyIndexDrop const &) { return true; },
+                        [](WalLabelPropertyIndexStatsSet const &) { return true; },
+                        [](WalLabelPropertyIndexStatsClear const &) { return true; },
+                        [](WalEdgeTypeIndexCreate const &) { return true; },
+                        [](WalEdgeTypeIndexDrop const &) { return true; },
+                        [](WalEdgeTypePropertyIndexCreate const &) { return true; },
+                        [](WalEdgeTypePropertyIndexDrop const &) { return true; },
+                        [](WalEdgePropertyIndexCreate const &) { return true; },
+                        [](WalEdgePropertyIndexDrop const &) { return true; },
+                        [](WalTextIndexCreate const &) { return true; },
+                        [](WalTextIndexDrop const &) { return true; },
+                        [](WalTextEdgeIndexCreate const &) { return true; },
+                        [](WalExistenceConstraintCreate const &) { return true; },
+                        [](WalExistenceConstraintDrop const &) { return true; },
+                        [](WalUniqueConstraintCreate const &) { return true; },
+                        [](WalUniqueConstraintDrop const &) { return true; },
+                        [](WalEnumCreate const &) { return true; },
+                        [](WalEnumAlterAdd const &) { return true; },
+                        [](WalEnumAlterUpdate const &) { return true; },
+                        [](WalPointIndexCreate const &) { return true; },
+                        [](WalPointIndexDrop const &) { return true; },
+                        [](WalTypeConstraintCreate const &) { return true; },
+                        [](WalTypeConstraintDrop const &) { return true; },
+                        [](WalVectorIndexCreate const &) { return true; },
+                        [](WalVectorEdgeIndexCreate const &) { return true; },
+                        [](WalVectorIndexDrop const &) { return true; },
+                        [](WalTtlOperation const &) { return true; },
+                        [](WalDescriptionSet const &) { return true; },
+                        [](WalDescriptionDelete const &) { return true; },
+                    },
+                    delta.data_);
 }
 
 // Function used to read the current WAL delta data. The WAL delta header must

--- a/src/storage/v2/durability/wal.hpp
+++ b/src/storage/v2/durability/wal.hpp
@@ -47,6 +47,11 @@ class NameIdMapper;
 
 namespace memgraph::storage::durability {
 
+struct WalDeltaData;
+
+/// True iff this pre-v15 delta marks the end of its implicit transaction.
+bool IsWalDeltaDataImplicitTransactionEndVersion15(const WalDeltaData &delta);
+
 /// Structure used to hold information about a WAL.
 struct WalInfo {
   uint64_t offset_metadata;
@@ -414,16 +419,6 @@ struct WalTtlOperation {
 
 /// Structure used to return loaded WAL delta data.
 struct WalDeltaData {
-  friend bool operator==(const WalDeltaData &a, const WalDeltaData &b) {
-    return std::visit(utils::Overloaded{
-                          []<typename T>(T const &lhs, T const &rhs) { return lhs == rhs; },
-                          [](auto const &, auto const &) { return false; },
-
-                      },
-                      a.data_,
-                      b.data_);
-  }
-
   std::variant<WalVertexCreate, WalVertexDelete, WalVertexAddLabel, WalVertexRemoveLabel, WalVertexSetProperty,
                WalEdgeSetProperty, WalEdgeCreate, WalEdgeDelete, WalTransactionStart, WalTransactionEnd,
                WalLabelIndexCreate, WalLabelIndexDrop, WalLabelIndexStatsClear, WalLabelPropertyIndexStatsClear,
@@ -438,65 +433,9 @@ struct WalDeltaData {
       data_ = WalTransactionEnd{};
 };
 
-constexpr bool IsWalDeltaDataImplicitTransactionEndVersion15(const WalDeltaData &delta) {
-  return std::visit(utils::Overloaded{
-                        // These delta actions are all found inside transactions so they don't
-                        // indicate a transaction end.
-                        [](WalVertexCreate const &) { return false; },
-                        [](WalVertexDelete const &) { return false; },
-                        [](WalVertexAddLabel const &) { return false; },
-                        [](WalVertexRemoveLabel const &) { return false; },
-                        [](WalVertexSetProperty const &) { return false; },
-                        [](WalEdgeCreate const &) { return false; },
-                        [](WalEdgeDelete const &) { return false; },
-                        [](WalEdgeSetProperty const &) { return false; },
-                        [](WalTransactionStart const &) { return false; },
+bool operator==(const WalDeltaData &a, const WalDeltaData &b);
 
-                        // This delta explicitly indicates that a transaction is done.
-                        [](WalTransactionEnd const &) { return true; },
-
-                        // These operations aren't transactional and they are encoded only using
-                        // a single delta, so they each individually mark the end of their
-                        // 'transaction'.
-                        [](WalLabelIndexCreate const &) { return true; },
-                        [](WalLabelIndexDrop const &) { return true; },
-                        [](WalLabelIndexStatsSet const &) { return true; },
-                        [](WalLabelIndexStatsClear const &) { return true; },
-                        [](WalLabelPropertyIndexCreate const &) { return true; },
-                        [](WalLabelPropertyIndexDrop const &) { return true; },
-                        [](WalLabelPropertyIndexStatsSet const &) { return true; },
-                        [](WalLabelPropertyIndexStatsClear const &) { return true; },
-                        [](WalEdgeTypeIndexCreate const &) { return true; },
-                        [](WalEdgeTypeIndexDrop const &) { return true; },
-                        [](WalEdgeTypePropertyIndexCreate const &) { return true; },
-                        [](WalEdgeTypePropertyIndexDrop const &) { return true; },
-                        [](WalEdgePropertyIndexCreate const &) { return true; },
-                        [](WalEdgePropertyIndexDrop const &) { return true; },
-                        [](WalTextIndexCreate const &) { return true; },
-                        [](WalTextIndexDrop const &) { return true; },
-                        [](WalTextEdgeIndexCreate const &) { return true; },
-                        [](WalExistenceConstraintCreate const &) { return true; },
-                        [](WalExistenceConstraintDrop const &) { return true; },
-                        [](WalUniqueConstraintCreate const &) { return true; },
-                        [](WalUniqueConstraintDrop const &) { return true; },
-                        [](WalEnumCreate const &) { return true; },
-                        [](WalEnumAlterAdd const &) { return true; },
-                        [](WalEnumAlterUpdate const &) { return true; },
-                        [](WalPointIndexCreate const &) { return true; },
-                        [](WalPointIndexDrop const &) { return true; },
-                        [](WalTypeConstraintCreate const &) { return true; },
-                        [](WalTypeConstraintDrop const &) { return true; },
-                        [](WalVectorIndexCreate const &) { return true; },
-                        [](WalVectorEdgeIndexCreate const &) { return true; },
-                        [](WalVectorIndexDrop const &) { return true; },
-                        [](WalTtlOperation const &) { return true; },
-                        [](WalDescriptionSet const &) { return true; },
-                        [](WalDescriptionDelete const &) { return true; },
-                    },
-                    delta.data_);
-}
-
-constexpr bool IsWalDeltaDataTransactionEnd(const WalDeltaData &delta, const uint64_t version = kVersion) {
+inline bool IsWalDeltaDataTransactionEnd(const WalDeltaData &delta, const uint64_t version = kVersion) {
   if (version < kMetaDataDeltasHaveExplicitTransactionEnd) [[unlikely]] {
     return IsWalDeltaDataImplicitTransactionEndVersion15(delta);
   }

--- a/src/storage/v2/property_value.cppm
+++ b/src/storage/v2/property_value.cppm
@@ -1749,6 +1749,14 @@ inline auto ReadNestedPropertyValue(PropertyValue const &value, std::span<Proper
   return current;
 }
 
+extern template class PropertyValueImpl<std::pmr::polymorphic_allocator<std::byte>, PropertyId, uint64_t>;
+extern template bool operator==(
+    PropertyValueImpl<std::pmr::polymorphic_allocator<std::byte>, PropertyId, uint64_t> const &,
+    PropertyValueImpl<std::pmr::polymorphic_allocator<std::byte>, PropertyId, uint64_t> const &);
+extern template std::weak_ordering CompareLists(
+    PropertyValueImpl<std::pmr::polymorphic_allocator<std::byte>, PropertyId, uint64_t> const &,
+    PropertyValueImpl<std::pmr::polymorphic_allocator<std::byte>, PropertyId, uint64_t> const &);
+
 }  // namespace memgraph::storage
 
 export namespace std {
@@ -1828,3 +1836,16 @@ struct hash<memgraph::storage::PropertyValueImpl<Alloc, KeyType, VectorIndexIdTy
   }
 };
 }  // namespace std
+
+module :private;
+
+namespace memgraph::storage {
+template class PropertyValueImpl<std::pmr::polymorphic_allocator<std::byte>, PropertyId, uint64_t>;
+
+template bool operator==(PropertyValueImpl<std::pmr::polymorphic_allocator<std::byte>, PropertyId, uint64_t> const &,
+                         PropertyValueImpl<std::pmr::polymorphic_allocator<std::byte>, PropertyId, uint64_t> const &);
+
+template std::weak_ordering CompareLists(
+    PropertyValueImpl<std::pmr::polymorphic_allocator<std::byte>, PropertyId, uint64_t> const &,
+    PropertyValueImpl<std::pmr::polymorphic_allocator<std::byte>, PropertyId, uint64_t> const &);
+}  // namespace memgraph::storage

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -116,6 +116,22 @@ Storage::Storage(Config config, StorageMode storage_mode, PlanInvalidatorPtr inv
   spdlog::info("Created database with {} storage mode.", StorageModeToString(storage_mode));
 }
 
+std::unique_ptr<Accessor> Storage::Access(StorageAccessType rw_type) {
+  return Access(rw_type, std::nullopt, std::nullopt);
+}
+
+std::unique_ptr<Accessor> Storage::UniqueAccess(std::optional<IsolationLevel> override_isolation_level) {
+  return UniqueAccess(override_isolation_level, std::nullopt);
+}
+
+std::unique_ptr<Accessor> Storage::UniqueAccess() { return UniqueAccess({}, std::nullopt); }
+
+std::unique_ptr<Accessor> Storage::ReadOnlyAccess(std::optional<IsolationLevel> override_isolation_level) {
+  return ReadOnlyAccess(override_isolation_level, std::nullopt);
+}
+
+std::unique_ptr<Accessor> Storage::ReadOnlyAccess() { return ReadOnlyAccess({}, std::nullopt); }
+
 Storage::Accessor::Accessor(SharedAccess /* tag */, Storage *storage, IsolationLevel isolation_level,
                             StorageMode storage_mode, StorageAccessType rw_type,
                             const std::optional<std::chrono::milliseconds> timeout)

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -204,6 +204,8 @@ struct PlanInvalidatorDefault : public PlanInvalidator {
 
 using PlanInvalidatorPtr = std::unique_ptr<PlanInvalidator>;
 
+class Accessor;
+
 class Storage {
   friend class ReplicationServer;
   friend class ReplicationStorageClient;
@@ -228,767 +230,8 @@ class Storage {
 
   auto uuid() -> utils::UUID & { return config_.salient.uuid; }
 
-  class Accessor {
-   public:
-    static constexpr struct SharedAccess {
-    } shared_access;
-
-    static constexpr struct UniqueAccess {
-    } unique_access;
-
-    static constexpr struct ReadOnlyAccess {
-    } read_only_access;
-
-    Accessor(SharedAccess /* tag */, Storage *storage, IsolationLevel isolation_level, StorageMode storage_mode,
-             StorageAccessType rw_type = StorageAccessType::WRITE,
-             std::optional<std::chrono::milliseconds> timeout = std::nullopt);
-    Accessor(UniqueAccess /* tag */, Storage *storage, IsolationLevel isolation_level, StorageMode storage_mode,
-             std::optional<std::chrono::milliseconds> timeout = std::nullopt);
-    Accessor(ReadOnlyAccess /* tag */, Storage *storage, IsolationLevel isolation_level, StorageMode storage_mode,
-             std::optional<std::chrono::milliseconds> timeout = std::nullopt);
-    Accessor(const Accessor &) = delete;
-    Accessor &operator=(const Accessor &) = delete;
-    Accessor &operator=(Accessor &&other) = delete;
-
-    Accessor(Accessor &&other) noexcept;
-
-    virtual ~Accessor() = default;
-
-    StorageAccessType original_access_type() const { return original_access_type_; }
-
-    StorageAccessType type() const {
-      if (unique_guard_.owns_lock()) {
-        return UNIQUE;
-      }
-      if (storage_guard_.owns_lock()) {
-        switch (storage_guard_.type()) {
-          case utils::SharedResourceLockGuard::Type::WRITE:
-            return WRITE;
-          case utils::SharedResourceLockGuard::Type::READ:
-            return READ;
-          case utils::SharedResourceLockGuard::Type::READ_ONLY:
-            return READ_ONLY;
-        }
-      }
-      return NO_ACCESS;
-    }
-
-    virtual VertexAccessor CreateVertex() = 0;
-
-    virtual std::optional<VertexAccessor> FindVertex(Gid gid, View view) = 0;
-
-    virtual VerticesIterable Vertices(View view) = 0;
-
-    virtual VerticesIterable Vertices(LabelId label, View view) = 0;
-
-    virtual VerticesIterable Vertices(LabelId label, std::span<storage::PropertyPath const> properties,
-                                      std::span<storage::PropertyValueRange const> property_ranges, View view,
-                                      IndexOrder order = IndexOrder::ASC) = 0;
-
-    virtual VerticesIterable Vertices(LabelId label, std::span<storage::PropertyPath const> properties, View view) {
-      return Vertices(
-          label, properties, std::vector(properties.size(), storage::PropertyValueRange::IsNotNull()), view);
-    };
-
-    virtual VerticesChunkedIterable ChunkedVertices(View view, size_t num_chunks) = 0;
-
-    virtual VerticesChunkedIterable ChunkedVertices(LabelId label, View view, size_t num_chunks) = 0;
-
-    virtual VerticesChunkedIterable ChunkedVertices(LabelId label, std::span<storage::PropertyPath const> properties,
-                                                    std::span<storage::PropertyValueRange const> property_ranges,
-                                                    View view, size_t num_chunks,
-                                                    IndexOrder order = IndexOrder::ASC) = 0;
-
-    virtual std::optional<EdgeAccessor> FindEdge(Gid gid, View view) = 0;
-
-    virtual std::optional<EdgeAccessor> FindEdge(Gid edge_gid, Gid from_vertex_gid, View view) = 0;
-
-    virtual EdgesIterable Edges(EdgeTypeId edge_type, View view) = 0;
-
-    virtual EdgesIterable Edges(EdgeTypeId edge_type, PropertyId property, View view) = 0;
-
-    virtual EdgesIterable Edges(EdgeTypeId edge_type, PropertyId property, const PropertyValue &value, View view) = 0;
-
-    virtual EdgesIterable Edges(EdgeTypeId edge_type, PropertyId property,
-                                const std::optional<utils::Bound<PropertyValue>> &lower_bound,
-                                const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view) = 0;
-
-    virtual EdgesIterable Edges(PropertyId property, View view) = 0;
-
-    virtual EdgesIterable Edges(PropertyId property, const PropertyValue &value, View view) = 0;
-
-    virtual EdgesIterable Edges(PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
-                                const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view) = 0;
-
-    virtual EdgesChunkedIterable ChunkedEdges(EdgeTypeId edge_type, View view, size_t num_chunks) = 0;
-
-    virtual EdgesChunkedIterable ChunkedEdges(EdgeTypeId edge_type, PropertyId property, View view,
-                                              size_t num_chunks) = 0;
-
-    virtual EdgesChunkedIterable ChunkedEdges(EdgeTypeId edge_type, PropertyId property,
-                                              const std::optional<utils::Bound<PropertyValue>> &lower_bound,
-                                              const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view,
-                                              size_t num_chunks) = 0;
-
-    virtual EdgesChunkedIterable ChunkedEdges(PropertyId property, View view, size_t num_chunks) = 0;
-
-    virtual EdgesChunkedIterable ChunkedEdges(PropertyId property, const PropertyValue &value, View view,
-                                              size_t num_chunks) = 0;
-
-    virtual EdgesChunkedIterable ChunkedEdges(PropertyId property,
-                                              const std::optional<utils::Bound<PropertyValue>> &lower_bound,
-                                              const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view,
-                                              size_t num_chunks) = 0;
-
-    virtual auto DeleteVertex(VertexAccessor *vertex) -> Result<std::optional<VertexAccessor>>;
-
-    virtual auto DetachDeleteVertex(VertexAccessor *vertex)
-        -> Result<std::optional<std::pair<VertexAccessor, std::vector<EdgeAccessor>>>>;
-
-    virtual auto DetachDelete(std::vector<VertexAccessor *> nodes, std::vector<EdgeAccessor *> edges, bool detach)
-        -> Result<std::optional<std::pair<std::vector<VertexAccessor>, std::vector<EdgeAccessor>>>>;
-
-    virtual uint64_t ApproximateVertexCount() const = 0;
-
-    virtual uint64_t ApproximateVertexCount(LabelId label) const = 0;
-
-    virtual uint64_t ApproximateVertexCount(LabelId label, std::span<PropertyPath const> properties) const = 0;
-
-    virtual uint64_t ApproximateVertexCount(LabelId label, std::span<PropertyPath const> properties,
-                                            std::span<PropertyValue const> values) const = 0;
-
-    virtual uint64_t ApproximateVertexCount(LabelId label, std::span<PropertyPath const> properties,
-                                            std::span<PropertyValueRange const> bounds) const = 0;
-
-    virtual uint64_t ApproximateEdgeCount() const = 0;
-
-    virtual uint64_t ApproximateEdgeCount(EdgeTypeId edge_type) const = 0;
-
-    virtual uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property) const = 0;
-
-    virtual uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property,
-                                          const PropertyValue &value) const = 0;
-
-    virtual uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property,
-                                          const std::optional<utils::Bound<PropertyValue>> &lower,
-                                          const std::optional<utils::Bound<PropertyValue>> &upper) const = 0;
-
-    virtual uint64_t ApproximateEdgeCount(PropertyId property) const = 0;
-
-    virtual uint64_t ApproximateEdgeCount(PropertyId property, const PropertyValue &value) const = 0;
-
-    virtual uint64_t ApproximateEdgeCount(PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower,
-                                          const std::optional<utils::Bound<PropertyValue>> &upper) const = 0;
-
-    virtual std::optional<uint64_t> ApproximateVerticesPointCount(LabelId label, PropertyId property) const = 0;
-
-    virtual std::optional<uint64_t> ApproximateVerticesVectorCount(LabelId label, PropertyId property) const = 0;
-
-    virtual std::optional<uint64_t> ApproximateEdgesVectorCount(EdgeTypeId edge_type, PropertyId property) const = 0;
-
-    virtual std::optional<uint64_t> ApproximateVerticesTextCount(std::string_view index_name) const = 0;
-
-    virtual std::optional<uint64_t> ApproximateEdgesTextCount(std::string_view index_name) const = 0;
-
-    virtual auto GetIndexStats(const storage::LabelId &label) const -> std::optional<storage::LabelIndexStats> = 0;
-
-    virtual auto GetIndexStats(const storage::LabelId &label, std::span<storage::PropertyPath const> properties) const
-        -> std::optional<storage::LabelPropertyIndexStats> = 0;
-
-    virtual void SetIndexStats(const storage::LabelId &label, const LabelIndexStats &stats) = 0;
-
-    virtual void SetIndexStats(const storage::LabelId &label, std::span<storage::PropertyPath const> property,
-                               const LabelPropertyIndexStats &stats) = 0;
-
-    virtual auto DeleteLabelPropertyIndexStats(const storage::LabelId &label)
-        -> std::vector<std::pair<LabelId, std::vector<PropertyPath>>> = 0;
-
-    virtual bool DeleteLabelIndexStats(const storage::LabelId &label) = 0;
-
-    virtual Result<EdgeAccessor> CreateEdge(VertexAccessor *from, VertexAccessor *to, EdgeTypeId edge_type) = 0;
-
-    virtual std::optional<EdgeAccessor> FindEdge(Gid gid, View view, EdgeTypeId edge_type, VertexAccessor *from_vertex,
-                                                 VertexAccessor *to_vertex) = 0;
-
-    virtual auto DeleteEdge(EdgeAccessor *edge) -> Result<std::optional<EdgeAccessor>>;
-
-    virtual bool LabelIndexReady(LabelId label) const = 0;
-
-    virtual bool LabelPropertyIndexReady(LabelId label, std::span<PropertyPath const> properties) const = 0;
-
-    virtual bool LabelPropertyIndexExists(LabelId label, std::span<PropertyPath const> properties) const = 0;
-
-    auto RelevantLabelPropertiesIndicesInfo(std::span<LabelId const> labels,
-                                            std::span<PropertyPath const> properties) const
-        -> std::vector<LabelPropertiesIndicesInfo> {
-      return transaction_.active_indices_->label_properties_->RelevantLabelPropertiesIndicesInfo(labels, properties);
-    };
-
-    virtual bool EdgeTypeIndexReady(EdgeTypeId edge_type) const = 0;
-
-    virtual bool EdgeTypePropertyIndexReady(EdgeTypeId edge_type, PropertyId property) const = 0;
-
-    virtual bool EdgePropertyIndexReady(PropertyId property) const = 0;
-
-    virtual bool EdgePropertyIndexExists(PropertyId property) const = 0;
-
-    bool TextIndexExists(const std::string &index_name) const {
-      return transaction_.active_indices_->text_->IndexExists(index_name);
-    }
-
-    std::vector<TextSearchResult> TextIndexSearch(const std::string &index_name, const std::string &search_query,
-                                                  text_search_mode search_mode, std::size_t limit) const {
-      return transaction_.active_indices_->text_->Search(index_name, search_query, search_mode, limit, transaction_);
-    }
-
-    std::string TextIndexAggregate(const std::string &index_name, const std::string &search_query,
-                                   const std::string &aggregation_query) const {
-      return transaction_.active_indices_->text_->Aggregate(index_name, search_query, aggregation_query);
-    }
-
-    std::string TextEdgeIndexAggregate(const std::string &index_name, const std::string &search_query,
-                                       const std::string &aggregation_query) const {
-      return transaction_.active_indices_->text_edge_->Aggregate(index_name, search_query, aggregation_query);
-    }
-
-    std::vector<TextEdgeSearchResult> SearchEdgeTextIndex(const std::string &index_name,
-                                                          const std::string &search_query, text_search_mode search_mode,
-                                                          std::size_t limit) const {
-      return transaction_.active_indices_->text_edge_->Search(
-          index_name, search_query, search_mode, limit, transaction_);
-    }
-
-    virtual bool PointIndexExists(LabelId label, PropertyId property) const = 0;
-
-    virtual IndicesInfo ListAllIndices() const = 0;
-
-    virtual ConstraintsInfo ListAllConstraints() const = 0;
-
-    virtual void DropAllIndexes() = 0;
-
-    virtual void DropAllConstraints() = 0;
-
-    // NOLINTNEXTLINE(google-default-arguments)
-    virtual std::expected<void, StorageManipulationError> PrepareForCommitPhase(CommitArgs commit_args) = 0;
-
-    // NOLINTNEXTLINE(google-default-arguments)
-    virtual std::expected<void, StorageManipulationError> PeriodicCommit(CommitArgs commit_args) = 0;
-
-    virtual void Abort() = 0;
-
-    virtual void FinalizeTransaction() = 0;
-
-    std::optional<uint64_t> GetTransactionId() const;
-
-    utils::QueryMemoryTracker &GetTransactionMemoryTracker();
-
-    void AdvanceCommand();
-
-    const std::string &LabelToName(LabelId label) const { return storage_->LabelToName(label); }
-
-    const std::string &PropertyToName(PropertyId property) const { return storage_->PropertyToName(property); }
-
-    const std::string &EdgeTypeToName(EdgeTypeId edge_type) const { return storage_->EdgeTypeToName(edge_type); }
-
-    LabelId NameToLabel(std::string_view name) { return storage_->NameToLabel(name); }
-
-    PropertyId NameToProperty(std::string_view name) { return storage_->NameToProperty(name); }
-
-    std::optional<PropertyId> NameToPropertyIfExists(std::string_view name) const {
-      return storage_->NameToPropertyIfExists(name);
-    }
-
-    EdgeTypeId NameToEdgeType(std::string_view name) { return storage_->NameToEdgeType(name); }
-
-    StorageMode GetCreationStorageMode() const noexcept;
-
-    std::string id() const { return storage_->name(); }
-
-    auto id_view() const { return storage_->name_view(); }
-
-    auto const &uuid() const { return storage_->uuid(); }
-
-    virtual std::expected<void, StorageIndexDefinitionError> CreateIndex(LabelId label,
-                                                                         CheckCancelFunction cancel_check) = 0;
-
-    virtual std::expected<void, StorageIndexDefinitionError> CreateIndex(LabelId label, PropertiesPaths properties,
-                                                                         IndexOrder order,
-                                                                         CheckCancelFunction cancel_check) = 0;
-
-    virtual std::expected<void, StorageIndexDefinitionError> CreateIndex(EdgeTypeId edge_type,
-                                                                         CheckCancelFunction cancel_check) = 0;
-
-    virtual std::expected<void, StorageIndexDefinitionError> CreateIndex(EdgeTypeId edge_type, PropertyId property,
-                                                                         CheckCancelFunction cancel_check) = 0;
-
-    virtual std::expected<void, StorageIndexDefinitionError> CreateGlobalEdgeIndex(
-        PropertyId property, CheckCancelFunction cancel_check) = 0;
-
-    // Convenience overloads with default cancel check
-    auto CreateIndex(LabelId label) -> std::expected<void, StorageIndexDefinitionError> {
-      return CreateIndex(label, neverCancel);
-    }
-
-    auto CreateIndex(LabelId label, PropertiesPaths properties, IndexOrder order = IndexOrder::ASC)
-        -> std::expected<void, StorageIndexDefinitionError> {
-      return CreateIndex(label, std::move(properties), order, neverCancel);
-    }
-
-    auto CreateIndex(EdgeTypeId edge_type) -> std::expected<void, StorageIndexDefinitionError> {
-      return CreateIndex(edge_type, neverCancel);
-    }
-
-    auto CreateIndex(EdgeTypeId edge_type, PropertyId property) -> std::expected<void, StorageIndexDefinitionError> {
-      return CreateIndex(edge_type, property, neverCancel);
-    }
-
-    auto CreateGlobalEdgeIndex(PropertyId property) -> std::expected<void, StorageIndexDefinitionError> {
-      return CreateGlobalEdgeIndex(property, neverCancel);
-    }
-
-    virtual std::expected<void, StorageIndexDefinitionError> DropIndex(LabelId label) = 0;
-
-    virtual std::expected<void, StorageIndexDefinitionError> DropIndex(
-        LabelId label, std::vector<storage::PropertyPath> &&properties,
-        std::optional<IndexOrder> order = std::nullopt) = 0;
-
-    virtual std::expected<void, StorageIndexDefinitionError> DropIndex(EdgeTypeId edge_type) = 0;
-
-    virtual std::expected<void, StorageIndexDefinitionError> DropIndex(EdgeTypeId edge_type, PropertyId property) = 0;
-
-    virtual std::expected<void, StorageIndexDefinitionError> DropGlobalEdgeIndex(PropertyId property) = 0;
-
-    virtual std::expected<void, storage::StorageIndexDefinitionError> CreatePointIndex(
-        storage::LabelId label, storage::PropertyId property) = 0;
-
-    virtual std::expected<void, storage::StorageIndexDefinitionError> DropPointIndex(storage::LabelId label,
-                                                                                     storage::PropertyId property) = 0;
-
-    std::expected<void, storage::StorageIndexDefinitionError> CreateTextIndex(const TextIndexSpec &text_index_info);
-
-    std::expected<void, storage::StorageIndexDefinitionError> DropTextIndex(const std::string &index_name);
-
-    std::expected<void, storage::StorageIndexDefinitionError> CreateTextEdgeIndex(
-        const TextEdgeIndexSpec &text_edge_index_info);
-
-    virtual std::expected<void, storage::StorageIndexDefinitionError> CreateVectorIndex(VectorIndexSpec spec) = 0;
-
-    virtual std::expected<void, storage::StorageIndexDefinitionError> DropVectorIndex(std::string_view index_name) = 0;
-
-    virtual utils::small_vector<uint64_t> GetVectorIndexIdsForVertex(Vertex *vertex, PropertyId property) = 0;
-
-    virtual utils::small_vector<float> GetVectorFromVectorIndex(Vertex *vertex, std::string_view index_name) const = 0;
-
-    virtual std::expected<void, storage::StorageIndexDefinitionError> CreateVectorEdgeIndex(
-        VectorEdgeIndexSpec spec) = 0;
-
-    virtual std::expected<void, StorageExistenceConstraintDefinitionError> CreateExistenceConstraint(
-        LabelId label, PropertyId property) = 0;
-
-    virtual std::expected<void, StorageExistenceConstraintDroppingError> DropExistenceConstraint(
-        LabelId label, PropertyId property) = 0;
-
-    virtual std::expected<UniqueConstraints::CreationStatus, StorageUniqueConstraintDefinitionError>
-    CreateUniqueConstraint(LabelId label, const std::set<PropertyId> &properties) = 0;
-
-    virtual UniqueConstraints::DeletionStatus DropUniqueConstraint(LabelId label,
-                                                                   const std::set<PropertyId> &properties) = 0;
-
-    virtual std::expected<void, StorageExistenceConstraintDefinitionError> CreateTypeConstraint(
-        LabelId label, PropertyId property, TypeConstraintKind type) = 0;
-
-    virtual std::expected<void, StorageExistenceConstraintDroppingError> DropTypeConstraint(
-        LabelId label, PropertyId property, TypeConstraintKind type) = 0;
-
-    virtual void DropGraph() = 0;
-
-    auto GetTransaction() -> Transaction * { return std::addressof(transaction_); }
-
-    auto GetEnumStoreUnique() -> EnumStore & {
-      DMG_ASSERT(unique_guard_.owns_lock());
-      return storage_->enum_store_;
-    }
-
-    auto GetEnumStoreShared() const -> EnumStore const & { return storage_->enum_store_; }
-
-    auto CreateEnum(std::string_view name, std::span<std::string const> values)
-        -> std::expected<EnumTypeId, EnumStorageError> {
-      auto res = storage_->enum_store_.RegisterEnum(name, values);
-      if (res) {
-        transaction_.md_deltas.emplace_back(MetadataDelta::enum_create, res.value());
-      }
-      return res;
-    }
-
-    auto EnumAlterAdd(std::string_view name, std::string_view value)
-        -> std::expected<storage::Enum, storage::EnumStorageError> {
-      auto res = storage_->enum_store_.AddValue(name, value);
-      if (res) {
-        transaction_.md_deltas.emplace_back(MetadataDelta::enum_alter_add, res.value());
-      }
-      return res;
-    }
-
-    auto EnumAlterUpdate(std::string_view name, std::string_view old_value, std::string_view new_value)
-        -> std::expected<storage::Enum, storage::EnumStorageError> {
-      auto res = storage_->enum_store_.UpdateValue(name, old_value, new_value);
-      if (res) {
-        transaction_.md_deltas.emplace_back(MetadataDelta::enum_alter_update, res.value(), std::string{old_value});
-      }
-      return res;
-    }
-
-    auto ShowEnums() { return storage_->enum_store_.AllRegistered(); }
-
-    void SetLabelDescription(std::span<std::string const> label_names, std::string_view desc) {
-      auto labels = ResolveLabels(label_names);
-      storage_->description_store_.SetLabel(labels, desc);
-      transaction_.md_deltas.emplace_back(MetadataDelta::description_set,
-                                          DescriptionTargetKind::LABEL,
-                                          std::move(labels),
-                                          EdgeTypeId{},
-                                          PropertyId{},
-                                          std::string{desc});
-    }
-
-    bool DeleteLabelDescription(std::span<std::string const> label_names) {
-      auto labels = ResolveLabels(label_names);
-      auto deleted = storage_->description_store_.DeleteLabel(labels);
-      if (deleted) {
-        transaction_.md_deltas.emplace_back(MetadataDelta::description_delete,
-                                            DescriptionTargetKind::LABEL,
-                                            std::move(labels),
-                                            EdgeTypeId{},
-                                            PropertyId{});
-      }
-      return deleted;
-    }
-
-    std::optional<std::string> GetLabelDescription(std::span<std::string const> label_names) const {
-      return storage_->description_store_.GetLabel(ResolveLabels(label_names));
-    }
-
-    void SetEdgeTypeDescription(std::string_view name, std::string_view desc) {
-      auto edge_type = storage_->NameToEdgeType(name);
-      storage_->description_store_.SetEdgeType(edge_type, desc);
-      transaction_.md_deltas.emplace_back(MetadataDelta::description_set,
-                                          DescriptionTargetKind::EDGE_TYPE,
-                                          std::vector<LabelId>{},
-                                          edge_type,
-                                          PropertyId{},
-                                          std::string{desc});
-    }
-
-    bool DeleteEdgeTypeDescription(std::string_view name) {
-      auto edge_type = storage_->NameToEdgeType(name);
-      auto deleted = storage_->description_store_.DeleteEdgeType(edge_type);
-      if (deleted) {
-        transaction_.md_deltas.emplace_back(MetadataDelta::description_delete,
-                                            DescriptionTargetKind::EDGE_TYPE,
-                                            std::vector<LabelId>{},
-                                            edge_type,
-                                            PropertyId{});
-      }
-      return deleted;
-    }
-
-    std::optional<std::string> GetEdgeTypeDescription(std::string_view name) const {
-      return storage_->description_store_.GetEdgeType(storage_->NameToEdgeType(name));
-    }
-
-    void SetLabelPropertyDescription(std::span<std::string const> label_qualifier, std::string_view prop_name,
-                                     std::string_view desc) {
-      auto labels = ResolveLabels(label_qualifier);
-      auto prop = storage_->NameToProperty(prop_name);
-      storage_->description_store_.SetLabelProperty(labels, prop, desc);
-      transaction_.md_deltas.emplace_back(MetadataDelta::description_set,
-                                          DescriptionTargetKind::LABEL_PROPERTY,
-                                          std::move(labels),
-                                          EdgeTypeId{},
-                                          prop,
-                                          std::string{desc});
-    }
-
-    bool DeleteLabelPropertyDescription(std::span<std::string const> label_qualifier, std::string_view prop_name) {
-      auto labels = ResolveLabels(label_qualifier);
-      auto prop = storage_->NameToProperty(prop_name);
-      bool deleted = storage_->description_store_.DeleteLabelProperty(labels, prop);
-      if (deleted) {
-        transaction_.md_deltas.emplace_back(MetadataDelta::description_delete,
-                                            DescriptionTargetKind::LABEL_PROPERTY,
-                                            std::move(labels),
-                                            EdgeTypeId{},
-                                            prop);
-      }
-      return deleted;
-    }
-
-    std::optional<std::string> GetLabelPropertyDescription(std::span<std::string const> label_qualifier,
-                                                           std::string_view prop_name) const {
-      return storage_->description_store_.GetLabelProperty(ResolveLabels(label_qualifier),
-                                                           storage_->NameToProperty(prop_name));
-    }
-
-    void SetEdgeTypePropertyDescription(std::string_view edge_type_name, std::string_view prop_name,
-                                        std::string_view desc) {
-      auto edge_type = storage_->NameToEdgeType(edge_type_name);
-      auto prop = storage_->NameToProperty(prop_name);
-      storage_->description_store_.SetEdgeTypeProperty(edge_type, prop, desc);
-      transaction_.md_deltas.emplace_back(MetadataDelta::description_set,
-                                          DescriptionTargetKind::EDGE_TYPE_PROPERTY,
-                                          std::vector<LabelId>{},
-                                          edge_type,
-                                          prop,
-                                          std::string{desc});
-    }
-
-    bool DeleteEdgeTypePropertyDescription(std::string_view edge_type_name, std::string_view prop_name) {
-      auto edge_type = storage_->NameToEdgeType(edge_type_name);
-      auto prop = storage_->NameToProperty(prop_name);
-      bool deleted = storage_->description_store_.DeleteEdgeTypeProperty(edge_type, prop);
-      if (deleted) {
-        transaction_.md_deltas.emplace_back(MetadataDelta::description_delete,
-                                            DescriptionTargetKind::EDGE_TYPE_PROPERTY,
-                                            std::vector<LabelId>{},
-                                            edge_type,
-                                            prop);
-      }
-      return deleted;
-    }
-
-    std::optional<std::string> GetEdgeTypePropertyDescription(std::string_view edge_type_name,
-                                                              std::string_view prop_name) const {
-      return storage_->description_store_.GetEdgeTypeProperty(storage_->NameToEdgeType(edge_type_name),
-                                                              storage_->NameToProperty(prop_name));
-    }
-
-    void SetPropertyDescription(std::string_view prop_name, std::string_view desc) {
-      auto prop = storage_->NameToProperty(prop_name);
-      storage_->description_store_.SetProperty(prop, desc);
-      transaction_.md_deltas.emplace_back(MetadataDelta::description_set,
-                                          DescriptionTargetKind::PROPERTY,
-                                          std::vector<LabelId>{},
-                                          EdgeTypeId{},
-                                          prop,
-                                          std::string{desc});
-    }
-
-    bool DeletePropertyDescription(std::string_view prop_name) {
-      auto prop = storage_->NameToProperty(prop_name);
-      bool deleted = storage_->description_store_.DeleteProperty(prop);
-      if (deleted) {
-        transaction_.md_deltas.emplace_back(MetadataDelta::description_delete,
-                                            DescriptionTargetKind::PROPERTY,
-                                            std::vector<LabelId>{},
-                                            EdgeTypeId{},
-                                            prop);
-      }
-      return deleted;
-    }
-
-    std::optional<std::string> GetPropertyDescription(std::string_view prop_name) const {
-      return storage_->description_store_.GetProperty(storage_->NameToProperty(prop_name));
-    }
-
-    void SetEdgeTypePatternDescription(std::span<std::string const> from_label_names, std::string_view edge_type_name,
-                                       std::span<std::string const> to_label_names, std::string_view desc) {
-      auto from_labels = ResolveLabels(from_label_names);
-      auto edge_type = storage_->NameToEdgeType(edge_type_name);
-      auto to_labels = ResolveLabels(to_label_names);
-      storage_->description_store_.SetEdgeTypePattern(from_labels, edge_type, to_labels, desc);
-      transaction_.md_deltas.emplace_back(MetadataDelta::description_set,
-                                          DescriptionTargetKind::EDGE_TYPE_PATTERN,
-                                          std::vector<LabelId>{},
-                                          edge_type,
-                                          PropertyId{},
-                                          std::string{desc},
-                                          std::move(from_labels),
-                                          std::move(to_labels));
-    }
-
-    bool DeleteEdgeTypePatternDescription(std::span<std::string const> from_label_names,
-                                          std::string_view edge_type_name,
-                                          std::span<std::string const> to_label_names) {
-      auto from_labels = ResolveLabels(from_label_names);
-      auto edge_type = storage_->NameToEdgeType(edge_type_name);
-      auto to_labels = ResolveLabels(to_label_names);
-      auto deleted = storage_->description_store_.DeleteEdgeTypePattern(from_labels, edge_type, to_labels);
-      if (deleted) {
-        transaction_.md_deltas.emplace_back(MetadataDelta::description_delete,
-                                            DescriptionTargetKind::EDGE_TYPE_PATTERN,
-                                            std::vector<LabelId>{},
-                                            edge_type,
-                                            PropertyId{},
-                                            std::move(from_labels),
-                                            std::move(to_labels));
-      }
-      return deleted;
-    }
-
-    std::optional<std::string> GetEdgeTypePatternDescription(std::span<std::string const> from_label_names,
-                                                             std::string_view edge_type_name,
-                                                             std::span<std::string const> to_label_names) const {
-      return storage_->description_store_.GetEdgeTypePattern(
-          ResolveLabels(from_label_names), storage_->NameToEdgeType(edge_type_name), ResolveLabels(to_label_names));
-    }
-
-    void SetEdgeTypePatternPropertyDescription(std::span<std::string const> from_label_names,
-                                               std::string_view edge_type_name,
-                                               std::span<std::string const> to_label_names, std::string_view prop_name,
-                                               std::string_view desc) {
-      auto from_labels = ResolveLabels(from_label_names);
-      auto edge_type = storage_->NameToEdgeType(edge_type_name);
-      auto to_labels = ResolveLabels(to_label_names);
-      auto prop = storage_->NameToProperty(prop_name);
-      storage_->description_store_.SetEdgeTypePatternProperty(from_labels, edge_type, to_labels, prop, desc);
-      transaction_.md_deltas.emplace_back(MetadataDelta::description_set,
-                                          DescriptionTargetKind::EDGE_TYPE_PATTERN_PROPERTY,
-                                          std::vector<LabelId>{},
-                                          edge_type,
-                                          prop,
-                                          std::string{desc},
-                                          std::move(from_labels),
-                                          std::move(to_labels));
-    }
-
-    bool DeleteEdgeTypePatternPropertyDescription(std::span<std::string const> from_label_names,
-                                                  std::string_view edge_type_name,
-                                                  std::span<std::string const> to_label_names,
-                                                  std::string_view prop_name) {
-      auto from_labels = ResolveLabels(from_label_names);
-      auto edge_type = storage_->NameToEdgeType(edge_type_name);
-      auto to_labels = ResolveLabels(to_label_names);
-      auto prop = storage_->NameToProperty(prop_name);
-      auto deleted =
-          storage_->description_store_.DeleteEdgeTypePatternProperty(from_labels, edge_type, to_labels, prop);
-      if (deleted) {
-        transaction_.md_deltas.emplace_back(MetadataDelta::description_delete,
-                                            DescriptionTargetKind::EDGE_TYPE_PATTERN_PROPERTY,
-                                            std::vector<LabelId>{},
-                                            edge_type,
-                                            prop,
-                                            std::move(from_labels),
-                                            std::move(to_labels));
-      }
-      return deleted;
-    }
-
-    std::optional<std::string> GetEdgeTypePatternPropertyDescription(std::span<std::string const> from_label_names,
-                                                                     std::string_view edge_type_name,
-                                                                     std::span<std::string const> to_label_names,
-                                                                     std::string_view prop_name) const {
-      return storage_->description_store_.GetEdgeTypePatternProperty(ResolveLabels(from_label_names),
-                                                                     storage_->NameToEdgeType(edge_type_name),
-                                                                     ResolveLabels(to_label_names),
-                                                                     storage_->NameToProperty(prop_name));
-    }
-
-    void SetDatabaseDescription(std::string_view desc) {
-      storage_->description_store_.SetDatabase(desc);
-      transaction_.md_deltas.emplace_back(MetadataDelta::description_set,
-                                          DescriptionTargetKind::DATABASE,
-                                          std::vector<LabelId>{},
-                                          EdgeTypeId{},
-                                          PropertyId{},
-                                          std::string{desc});
-    }
-
-    bool DeleteDatabaseDescription() {
-      bool deleted = storage_->description_store_.DeleteDatabase();
-      if (deleted) {
-        transaction_.md_deltas.emplace_back(MetadataDelta::description_delete,
-                                            DescriptionTargetKind::DATABASE,
-                                            std::vector<LabelId>{},
-                                            EdgeTypeId{},
-                                            PropertyId{});
-      }
-      return deleted;
-    }
-
-    std::optional<std::string> GetDatabaseDescription() const { return storage_->description_store_.GetDatabase(); }
-
-    std::vector<DescriptionEntry> GetAllDescriptions() const { return storage_->description_store_.GetAll(); }
-
-   private:
-    std::vector<LabelId> ResolveLabels(std::span<std::string const> names) const {
-      return names | ranges::views::transform([this](std::string_view name) { return storage_->NameToLabel(name); }) |
-             ranges::to<std::vector>();
-    }
-
-   public:
-    auto GetEnumValue(std::string_view name, std::string_view value) const -> std::expected<Enum, EnumStorageError> {
-      return storage_->enum_store_.ToEnum(name, value);
-    }
-
-    auto GetEnumValue(std::string_view enum_str) -> std::expected<Enum, EnumStorageError> {
-      return storage_->enum_store_.ToEnum(enum_str);
-    }
-
-    virtual auto PointVertices(LabelId label, PropertyId property, CoordinateReferenceSystem crs,
-                               PropertyValue const &point_value, PropertyValue const &boundary_value,
-                               PointDistanceCondition condition) -> PointIterable = 0;
-
-    virtual auto PointVertices(LabelId label, PropertyId property, CoordinateReferenceSystem crs,
-                               PropertyValue const &bottom_left, PropertyValue const &top_right,
-                               WithinBBoxCondition condition) -> PointIterable = 0;
-
-    virtual std::vector<std::tuple<VertexAccessor, double, double>> VectorIndexSearchOnNodes(
-        const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector) = 0;
-
-    virtual std::vector<std::tuple<EdgeAccessor, double, double>> VectorIndexSearchOnEdges(
-        const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector) = 0;
-
-    virtual std::vector<VectorIndexInfo> ListAllVectorIndices() const = 0;
-
-    virtual std::vector<VectorEdgeIndexInfo> ListAllVectorEdgeIndices() const = 0;
-
-    auto GetNameIdMapper() const -> NameIdMapper * { return storage_->name_id_mapper_.get(); }
-
-    bool CheckIndicesAreReady(IndicesCollection const &required_indices) const {
-      return transaction_.active_indices_->CheckIndicesAreReady(required_indices);
-    }
-
-    bool TransactionHasSerializationError() const { return transaction_.has_serialization_error; }
-
-    // TTL methods
-    ttl::TTL &ttl() { return storage_->ttl_; }
-
-#ifdef MG_ENTERPRISE
-    // TTL management methods
-    virtual void StartTtl(TTLReplicationArgs repl_args = {}) = 0;
-    virtual void DisableTtl(TTLReplicationArgs repl_args = {}) = 0;
-    virtual void StopTtl() = 0;
-    virtual void ConfigureTtl(const storage::ttl::TtlInfo &ttl_info, TTLReplicationArgs repl_args = {}) = 0;
-    virtual storage::ttl::TtlInfo GetTtlConfig() const = 0;
-#endif
-   protected:
-    Storage *storage_;
-    utils::SharedResourceLockGuard storage_guard_;
-    std::unique_lock<utils::ResourceLock> unique_guard_;  // TODO: Split the accessor into Shared/Unique
-    /// IMPORTANT: transaction_ has to be constructed after the guards (so that destruction is in correct order)
-    Transaction transaction_;
-    std::optional<uint64_t> commit_timestamp_;
-    bool is_transaction_active_;
-    StorageAccessType original_access_type_;
-
-    // Detach delete private methods
-    Result<std::optional<std::unordered_set<Vertex *>>> PrepareDeletableNodes(
-        const std::vector<VertexAccessor *> &vertices);
-    EdgeInfoForDeletion PrepareDeletableEdges(const std::unordered_set<Vertex *> &vertices,
-                                              const std::vector<EdgeAccessor *> &edges, bool detach) noexcept;
-    Result<std::optional<std::vector<EdgeAccessor>>> ClearEdgesOnVertices(
-        const std::unordered_set<Vertex *> &vertices, std::unordered_set<Gid> &deleted_edge_ids,
-        std::optional<SchemaInfo::ModifyingAccessor> &schema_acc);
-    Result<std::optional<std::vector<EdgeAccessor>>> DetachRemainingEdges(
-        EdgeInfoForDeletion info, std::unordered_set<Gid> &partially_detached_edge_ids,
-        std::optional<SchemaInfo::ModifyingAccessor> &schema_acc);
-    Result<std::vector<VertexAccessor>> TryDeleteVertices(const std::unordered_set<Vertex *> &vertices,
-                                                          std::optional<SchemaInfo::ModifyingAccessor> &schema_acc);
-    void MarkEdgeAsDeleted(Edge *edge);
-
-   private:
-    StorageMode creation_storage_mode_;
-  };
+  using Accessor = memgraph::storage::Accessor;
+  friend class memgraph::storage::Accessor;
 
   const std::string &LabelToName(LabelId label) const { return name_id_mapper_->IdToName(label.AsUint()); }
 
@@ -1026,25 +269,19 @@ class Storage {
                                            std::optional<IsolationLevel> override_isolation_level,
                                            std::optional<std::chrono::milliseconds> timeout) = 0;
 
-  std::unique_ptr<Accessor> Access(StorageAccessType rw_type) { return Access(rw_type, std::nullopt, std::nullopt); }
+  std::unique_ptr<Accessor> Access(StorageAccessType rw_type);
 
   virtual std::unique_ptr<Accessor> UniqueAccess(std::optional<IsolationLevel> override_isolation_level,
                                                  std::optional<std::chrono::milliseconds> timeout) = 0;
 
-  std::unique_ptr<Accessor> UniqueAccess(std::optional<IsolationLevel> override_isolation_level) {
-    return UniqueAccess(override_isolation_level, std::nullopt);
-  }
-
-  std::unique_ptr<Accessor> UniqueAccess() { return UniqueAccess({}, std::nullopt); }
+  std::unique_ptr<Accessor> UniqueAccess(std::optional<IsolationLevel> override_isolation_level);
+  std::unique_ptr<Accessor> UniqueAccess();
 
   virtual std::unique_ptr<Accessor> ReadOnlyAccess(std::optional<IsolationLevel> override_isolation_level,
                                                    std::optional<std::chrono::milliseconds> timeout) = 0;
 
-  std::unique_ptr<Accessor> ReadOnlyAccess(std::optional<IsolationLevel> override_isolation_level) {
-    return ReadOnlyAccess(override_isolation_level, std::nullopt);
-  }
-
-  std::unique_ptr<Accessor> ReadOnlyAccess() { return ReadOnlyAccess({}, std::nullopt); }
+  std::unique_ptr<Accessor> ReadOnlyAccess(std::optional<IsolationLevel> override_isolation_level);
+  std::unique_ptr<Accessor> ReadOnlyAccess();
 
   enum class SetIsolationLevelError : uint8_t { DisabledForAnalyticalMode };
 
@@ -1193,5 +430,761 @@ inline std::ostream &operator<<(std::ostream &os, StorageAccessType type) {
   }
   return os;
 }
+
+class Accessor {
+ public:
+  static constexpr struct SharedAccess {
+  } shared_access;
+
+  static constexpr struct UniqueAccess {
+  } unique_access;
+
+  static constexpr struct ReadOnlyAccess {
+  } read_only_access;
+
+  Accessor(SharedAccess /* tag */, Storage *storage, IsolationLevel isolation_level, StorageMode storage_mode,
+           StorageAccessType rw_type = StorageAccessType::WRITE,
+           std::optional<std::chrono::milliseconds> timeout = std::nullopt);
+  Accessor(UniqueAccess /* tag */, Storage *storage, IsolationLevel isolation_level, StorageMode storage_mode,
+           std::optional<std::chrono::milliseconds> timeout = std::nullopt);
+  Accessor(ReadOnlyAccess /* tag */, Storage *storage, IsolationLevel isolation_level, StorageMode storage_mode,
+           std::optional<std::chrono::milliseconds> timeout = std::nullopt);
+  Accessor(const Accessor &) = delete;
+  Accessor &operator=(const Accessor &) = delete;
+  Accessor &operator=(Accessor &&other) = delete;
+
+  Accessor(Accessor &&other) noexcept;
+
+  virtual ~Accessor() = default;
+
+  StorageAccessType original_access_type() const { return original_access_type_; }
+
+  StorageAccessType type() const {
+    if (unique_guard_.owns_lock()) {
+      return UNIQUE;
+    }
+    if (storage_guard_.owns_lock()) {
+      switch (storage_guard_.type()) {
+        case utils::SharedResourceLockGuard::Type::WRITE:
+          return WRITE;
+        case utils::SharedResourceLockGuard::Type::READ:
+          return READ;
+        case utils::SharedResourceLockGuard::Type::READ_ONLY:
+          return READ_ONLY;
+      }
+    }
+    return NO_ACCESS;
+  }
+
+  virtual VertexAccessor CreateVertex() = 0;
+
+  virtual std::optional<VertexAccessor> FindVertex(Gid gid, View view) = 0;
+
+  virtual VerticesIterable Vertices(View view) = 0;
+
+  virtual VerticesIterable Vertices(LabelId label, View view) = 0;
+
+  virtual VerticesIterable Vertices(LabelId label, std::span<storage::PropertyPath const> properties,
+                                    std::span<storage::PropertyValueRange const> property_ranges, View view,
+                                    IndexOrder order = IndexOrder::ASC) = 0;
+
+  virtual VerticesIterable Vertices(LabelId label, std::span<storage::PropertyPath const> properties, View view) {
+    return Vertices(label, properties, std::vector(properties.size(), storage::PropertyValueRange::IsNotNull()), view);
+  };
+
+  virtual VerticesChunkedIterable ChunkedVertices(View view, size_t num_chunks) = 0;
+
+  virtual VerticesChunkedIterable ChunkedVertices(LabelId label, View view, size_t num_chunks) = 0;
+
+  virtual VerticesChunkedIterable ChunkedVertices(LabelId label, std::span<storage::PropertyPath const> properties,
+                                                  std::span<storage::PropertyValueRange const> property_ranges,
+                                                  View view, size_t num_chunks, IndexOrder order = IndexOrder::ASC) = 0;
+
+  virtual std::optional<EdgeAccessor> FindEdge(Gid gid, View view) = 0;
+
+  virtual std::optional<EdgeAccessor> FindEdge(Gid edge_gid, Gid from_vertex_gid, View view) = 0;
+
+  virtual EdgesIterable Edges(EdgeTypeId edge_type, View view) = 0;
+
+  virtual EdgesIterable Edges(EdgeTypeId edge_type, PropertyId property, View view) = 0;
+
+  virtual EdgesIterable Edges(EdgeTypeId edge_type, PropertyId property, const PropertyValue &value, View view) = 0;
+
+  virtual EdgesIterable Edges(EdgeTypeId edge_type, PropertyId property,
+                              const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+                              const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view) = 0;
+
+  virtual EdgesIterable Edges(PropertyId property, View view) = 0;
+
+  virtual EdgesIterable Edges(PropertyId property, const PropertyValue &value, View view) = 0;
+
+  virtual EdgesIterable Edges(PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+                              const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view) = 0;
+
+  virtual EdgesChunkedIterable ChunkedEdges(EdgeTypeId edge_type, View view, size_t num_chunks) = 0;
+
+  virtual EdgesChunkedIterable ChunkedEdges(EdgeTypeId edge_type, PropertyId property, View view,
+                                            size_t num_chunks) = 0;
+
+  virtual EdgesChunkedIterable ChunkedEdges(EdgeTypeId edge_type, PropertyId property,
+                                            const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+                                            const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view,
+                                            size_t num_chunks) = 0;
+
+  virtual EdgesChunkedIterable ChunkedEdges(PropertyId property, View view, size_t num_chunks) = 0;
+
+  virtual EdgesChunkedIterable ChunkedEdges(PropertyId property, const PropertyValue &value, View view,
+                                            size_t num_chunks) = 0;
+
+  virtual EdgesChunkedIterable ChunkedEdges(PropertyId property,
+                                            const std::optional<utils::Bound<PropertyValue>> &lower_bound,
+                                            const std::optional<utils::Bound<PropertyValue>> &upper_bound, View view,
+                                            size_t num_chunks) = 0;
+
+  virtual auto DeleteVertex(VertexAccessor *vertex) -> Result<std::optional<VertexAccessor>>;
+
+  virtual auto DetachDeleteVertex(VertexAccessor *vertex)
+      -> Result<std::optional<std::pair<VertexAccessor, std::vector<EdgeAccessor>>>>;
+
+  virtual auto DetachDelete(std::vector<VertexAccessor *> nodes, std::vector<EdgeAccessor *> edges, bool detach)
+      -> Result<std::optional<std::pair<std::vector<VertexAccessor>, std::vector<EdgeAccessor>>>>;
+
+  virtual uint64_t ApproximateVertexCount() const = 0;
+
+  virtual uint64_t ApproximateVertexCount(LabelId label) const = 0;
+
+  virtual uint64_t ApproximateVertexCount(LabelId label, std::span<PropertyPath const> properties) const = 0;
+
+  virtual uint64_t ApproximateVertexCount(LabelId label, std::span<PropertyPath const> properties,
+                                          std::span<PropertyValue const> values) const = 0;
+
+  virtual uint64_t ApproximateVertexCount(LabelId label, std::span<PropertyPath const> properties,
+                                          std::span<PropertyValueRange const> bounds) const = 0;
+
+  virtual uint64_t ApproximateEdgeCount() const = 0;
+
+  virtual uint64_t ApproximateEdgeCount(EdgeTypeId edge_type) const = 0;
+
+  virtual uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property) const = 0;
+
+  virtual uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property,
+                                        const PropertyValue &value) const = 0;
+
+  virtual uint64_t ApproximateEdgeCount(EdgeTypeId edge_type, PropertyId property,
+                                        const std::optional<utils::Bound<PropertyValue>> &lower,
+                                        const std::optional<utils::Bound<PropertyValue>> &upper) const = 0;
+
+  virtual uint64_t ApproximateEdgeCount(PropertyId property) const = 0;
+
+  virtual uint64_t ApproximateEdgeCount(PropertyId property, const PropertyValue &value) const = 0;
+
+  virtual uint64_t ApproximateEdgeCount(PropertyId property, const std::optional<utils::Bound<PropertyValue>> &lower,
+                                        const std::optional<utils::Bound<PropertyValue>> &upper) const = 0;
+
+  virtual std::optional<uint64_t> ApproximateVerticesPointCount(LabelId label, PropertyId property) const = 0;
+
+  virtual std::optional<uint64_t> ApproximateVerticesVectorCount(LabelId label, PropertyId property) const = 0;
+
+  virtual std::optional<uint64_t> ApproximateEdgesVectorCount(EdgeTypeId edge_type, PropertyId property) const = 0;
+
+  virtual std::optional<uint64_t> ApproximateVerticesTextCount(std::string_view index_name) const = 0;
+
+  virtual std::optional<uint64_t> ApproximateEdgesTextCount(std::string_view index_name) const = 0;
+
+  virtual auto GetIndexStats(const storage::LabelId &label) const -> std::optional<storage::LabelIndexStats> = 0;
+
+  virtual auto GetIndexStats(const storage::LabelId &label, std::span<storage::PropertyPath const> properties) const
+      -> std::optional<storage::LabelPropertyIndexStats> = 0;
+
+  virtual void SetIndexStats(const storage::LabelId &label, const LabelIndexStats &stats) = 0;
+
+  virtual void SetIndexStats(const storage::LabelId &label, std::span<storage::PropertyPath const> property,
+                             const LabelPropertyIndexStats &stats) = 0;
+
+  virtual auto DeleteLabelPropertyIndexStats(const storage::LabelId &label)
+      -> std::vector<std::pair<LabelId, std::vector<PropertyPath>>> = 0;
+
+  virtual bool DeleteLabelIndexStats(const storage::LabelId &label) = 0;
+
+  virtual Result<EdgeAccessor> CreateEdge(VertexAccessor *from, VertexAccessor *to, EdgeTypeId edge_type) = 0;
+
+  virtual std::optional<EdgeAccessor> FindEdge(Gid gid, View view, EdgeTypeId edge_type, VertexAccessor *from_vertex,
+                                               VertexAccessor *to_vertex) = 0;
+
+  virtual auto DeleteEdge(EdgeAccessor *edge) -> Result<std::optional<EdgeAccessor>>;
+
+  virtual bool LabelIndexReady(LabelId label) const = 0;
+
+  virtual bool LabelPropertyIndexReady(LabelId label, std::span<PropertyPath const> properties) const = 0;
+
+  virtual bool LabelPropertyIndexExists(LabelId label, std::span<PropertyPath const> properties) const = 0;
+
+  auto RelevantLabelPropertiesIndicesInfo(std::span<LabelId const> labels,
+                                          std::span<PropertyPath const> properties) const
+      -> std::vector<LabelPropertiesIndicesInfo> {
+    return transaction_.active_indices_->label_properties_->RelevantLabelPropertiesIndicesInfo(labels, properties);
+  };
+
+  virtual bool EdgeTypeIndexReady(EdgeTypeId edge_type) const = 0;
+
+  virtual bool EdgeTypePropertyIndexReady(EdgeTypeId edge_type, PropertyId property) const = 0;
+
+  virtual bool EdgePropertyIndexReady(PropertyId property) const = 0;
+
+  virtual bool EdgePropertyIndexExists(PropertyId property) const = 0;
+
+  bool TextIndexExists(const std::string &index_name) const {
+    return transaction_.active_indices_->text_->IndexExists(index_name);
+  }
+
+  std::vector<TextSearchResult> TextIndexSearch(const std::string &index_name, const std::string &search_query,
+                                                text_search_mode search_mode, std::size_t limit) const {
+    return transaction_.active_indices_->text_->Search(index_name, search_query, search_mode, limit, transaction_);
+  }
+
+  std::string TextIndexAggregate(const std::string &index_name, const std::string &search_query,
+                                 const std::string &aggregation_query) const {
+    return transaction_.active_indices_->text_->Aggregate(index_name, search_query, aggregation_query);
+  }
+
+  std::string TextEdgeIndexAggregate(const std::string &index_name, const std::string &search_query,
+                                     const std::string &aggregation_query) const {
+    return transaction_.active_indices_->text_edge_->Aggregate(index_name, search_query, aggregation_query);
+  }
+
+  std::vector<TextEdgeSearchResult> SearchEdgeTextIndex(const std::string &index_name, const std::string &search_query,
+                                                        text_search_mode search_mode, std::size_t limit) const {
+    return transaction_.active_indices_->text_edge_->Search(index_name, search_query, search_mode, limit, transaction_);
+  }
+
+  virtual bool PointIndexExists(LabelId label, PropertyId property) const = 0;
+
+  virtual IndicesInfo ListAllIndices() const = 0;
+
+  virtual ConstraintsInfo ListAllConstraints() const = 0;
+
+  virtual void DropAllIndexes() = 0;
+
+  virtual void DropAllConstraints() = 0;
+
+  // NOLINTNEXTLINE(google-default-arguments)
+  virtual std::expected<void, StorageManipulationError> PrepareForCommitPhase(CommitArgs commit_args) = 0;
+
+  // NOLINTNEXTLINE(google-default-arguments)
+  virtual std::expected<void, StorageManipulationError> PeriodicCommit(CommitArgs commit_args) = 0;
+
+  virtual void Abort() = 0;
+
+  virtual void FinalizeTransaction() = 0;
+
+  std::optional<uint64_t> GetTransactionId() const;
+
+  utils::QueryMemoryTracker &GetTransactionMemoryTracker();
+
+  void AdvanceCommand();
+
+  const std::string &LabelToName(LabelId label) const { return storage_->LabelToName(label); }
+
+  const std::string &PropertyToName(PropertyId property) const { return storage_->PropertyToName(property); }
+
+  const std::string &EdgeTypeToName(EdgeTypeId edge_type) const { return storage_->EdgeTypeToName(edge_type); }
+
+  LabelId NameToLabel(std::string_view name) { return storage_->NameToLabel(name); }
+
+  PropertyId NameToProperty(std::string_view name) { return storage_->NameToProperty(name); }
+
+  std::optional<PropertyId> NameToPropertyIfExists(std::string_view name) const {
+    return storage_->NameToPropertyIfExists(name);
+  }
+
+  EdgeTypeId NameToEdgeType(std::string_view name) { return storage_->NameToEdgeType(name); }
+
+  StorageMode GetCreationStorageMode() const noexcept;
+
+  std::string id() const { return storage_->name(); }
+
+  auto id_view() const { return storage_->name_view(); }
+
+  auto const &uuid() const { return storage_->uuid(); }
+
+  virtual std::expected<void, StorageIndexDefinitionError> CreateIndex(LabelId label,
+                                                                       CheckCancelFunction cancel_check) = 0;
+
+  virtual std::expected<void, StorageIndexDefinitionError> CreateIndex(LabelId label, PropertiesPaths properties,
+                                                                       IndexOrder order,
+                                                                       CheckCancelFunction cancel_check) = 0;
+
+  virtual std::expected<void, StorageIndexDefinitionError> CreateIndex(EdgeTypeId edge_type,
+                                                                       CheckCancelFunction cancel_check) = 0;
+
+  virtual std::expected<void, StorageIndexDefinitionError> CreateIndex(EdgeTypeId edge_type, PropertyId property,
+                                                                       CheckCancelFunction cancel_check) = 0;
+
+  virtual std::expected<void, StorageIndexDefinitionError> CreateGlobalEdgeIndex(PropertyId property,
+                                                                                 CheckCancelFunction cancel_check) = 0;
+
+  // Convenience overloads with default cancel check
+  auto CreateIndex(LabelId label) -> std::expected<void, StorageIndexDefinitionError> {
+    return CreateIndex(label, neverCancel);
+  }
+
+  auto CreateIndex(LabelId label, PropertiesPaths properties, IndexOrder order = IndexOrder::ASC)
+      -> std::expected<void, StorageIndexDefinitionError> {
+    return CreateIndex(label, std::move(properties), order, neverCancel);
+  }
+
+  auto CreateIndex(EdgeTypeId edge_type) -> std::expected<void, StorageIndexDefinitionError> {
+    return CreateIndex(edge_type, neverCancel);
+  }
+
+  auto CreateIndex(EdgeTypeId edge_type, PropertyId property) -> std::expected<void, StorageIndexDefinitionError> {
+    return CreateIndex(edge_type, property, neverCancel);
+  }
+
+  auto CreateGlobalEdgeIndex(PropertyId property) -> std::expected<void, StorageIndexDefinitionError> {
+    return CreateGlobalEdgeIndex(property, neverCancel);
+  }
+
+  virtual std::expected<void, StorageIndexDefinitionError> DropIndex(LabelId label) = 0;
+
+  virtual std::expected<void, StorageIndexDefinitionError> DropIndex(
+      LabelId label, std::vector<storage::PropertyPath> &&properties,
+      std::optional<IndexOrder> order = std::nullopt) = 0;
+
+  virtual std::expected<void, StorageIndexDefinitionError> DropIndex(EdgeTypeId edge_type) = 0;
+
+  virtual std::expected<void, StorageIndexDefinitionError> DropIndex(EdgeTypeId edge_type, PropertyId property) = 0;
+
+  virtual std::expected<void, StorageIndexDefinitionError> DropGlobalEdgeIndex(PropertyId property) = 0;
+
+  virtual std::expected<void, storage::StorageIndexDefinitionError> CreatePointIndex(storage::LabelId label,
+                                                                                     storage::PropertyId property) = 0;
+
+  virtual std::expected<void, storage::StorageIndexDefinitionError> DropPointIndex(storage::LabelId label,
+                                                                                   storage::PropertyId property) = 0;
+
+  std::expected<void, storage::StorageIndexDefinitionError> CreateTextIndex(const TextIndexSpec &text_index_info);
+
+  std::expected<void, storage::StorageIndexDefinitionError> DropTextIndex(const std::string &index_name);
+
+  std::expected<void, storage::StorageIndexDefinitionError> CreateTextEdgeIndex(
+      const TextEdgeIndexSpec &text_edge_index_info);
+
+  virtual std::expected<void, storage::StorageIndexDefinitionError> CreateVectorIndex(VectorIndexSpec spec) = 0;
+
+  virtual std::expected<void, storage::StorageIndexDefinitionError> DropVectorIndex(std::string_view index_name) = 0;
+
+  virtual utils::small_vector<uint64_t> GetVectorIndexIdsForVertex(Vertex *vertex, PropertyId property) = 0;
+
+  virtual utils::small_vector<float> GetVectorFromVectorIndex(Vertex *vertex, std::string_view index_name) const = 0;
+
+  virtual std::expected<void, storage::StorageIndexDefinitionError> CreateVectorEdgeIndex(VectorEdgeIndexSpec spec) = 0;
+
+  virtual std::expected<void, StorageExistenceConstraintDefinitionError> CreateExistenceConstraint(
+      LabelId label, PropertyId property) = 0;
+
+  virtual std::expected<void, StorageExistenceConstraintDroppingError> DropExistenceConstraint(LabelId label,
+                                                                                               PropertyId property) = 0;
+
+  virtual std::expected<UniqueConstraints::CreationStatus, StorageUniqueConstraintDefinitionError>
+  CreateUniqueConstraint(LabelId label, const std::set<PropertyId> &properties) = 0;
+
+  virtual UniqueConstraints::DeletionStatus DropUniqueConstraint(LabelId label,
+                                                                 const std::set<PropertyId> &properties) = 0;
+
+  virtual std::expected<void, StorageExistenceConstraintDefinitionError> CreateTypeConstraint(
+      LabelId label, PropertyId property, TypeConstraintKind type) = 0;
+
+  virtual std::expected<void, StorageExistenceConstraintDroppingError> DropTypeConstraint(LabelId label,
+                                                                                          PropertyId property,
+                                                                                          TypeConstraintKind type) = 0;
+
+  virtual void DropGraph() = 0;
+
+  auto GetTransaction() -> Transaction * { return std::addressof(transaction_); }
+
+  auto GetEnumStoreUnique() -> EnumStore & {
+    DMG_ASSERT(unique_guard_.owns_lock());
+    return storage_->enum_store_;
+  }
+
+  auto GetEnumStoreShared() const -> EnumStore const & { return storage_->enum_store_; }
+
+  auto CreateEnum(std::string_view name, std::span<std::string const> values)
+      -> std::expected<EnumTypeId, EnumStorageError> {
+    auto res = storage_->enum_store_.RegisterEnum(name, values);
+    if (res) {
+      transaction_.md_deltas.emplace_back(MetadataDelta::enum_create, res.value());
+    }
+    return res;
+  }
+
+  auto EnumAlterAdd(std::string_view name, std::string_view value)
+      -> std::expected<storage::Enum, storage::EnumStorageError> {
+    auto res = storage_->enum_store_.AddValue(name, value);
+    if (res) {
+      transaction_.md_deltas.emplace_back(MetadataDelta::enum_alter_add, res.value());
+    }
+    return res;
+  }
+
+  auto EnumAlterUpdate(std::string_view name, std::string_view old_value, std::string_view new_value)
+      -> std::expected<storage::Enum, storage::EnumStorageError> {
+    auto res = storage_->enum_store_.UpdateValue(name, old_value, new_value);
+    if (res) {
+      transaction_.md_deltas.emplace_back(MetadataDelta::enum_alter_update, res.value(), std::string{old_value});
+    }
+    return res;
+  }
+
+  auto ShowEnums() { return storage_->enum_store_.AllRegistered(); }
+
+  void SetLabelDescription(std::span<std::string const> label_names, std::string_view desc) {
+    auto labels = ResolveLabels(label_names);
+    storage_->description_store_.SetLabel(labels, desc);
+    transaction_.md_deltas.emplace_back(MetadataDelta::description_set,
+                                        DescriptionTargetKind::LABEL,
+                                        std::move(labels),
+                                        EdgeTypeId{},
+                                        PropertyId{},
+                                        std::string{desc});
+  }
+
+  bool DeleteLabelDescription(std::span<std::string const> label_names) {
+    auto labels = ResolveLabels(label_names);
+    auto deleted = storage_->description_store_.DeleteLabel(labels);
+    if (deleted) {
+      transaction_.md_deltas.emplace_back(MetadataDelta::description_delete,
+                                          DescriptionTargetKind::LABEL,
+                                          std::move(labels),
+                                          EdgeTypeId{},
+                                          PropertyId{});
+    }
+    return deleted;
+  }
+
+  std::optional<std::string> GetLabelDescription(std::span<std::string const> label_names) const {
+    return storage_->description_store_.GetLabel(ResolveLabels(label_names));
+  }
+
+  void SetEdgeTypeDescription(std::string_view name, std::string_view desc) {
+    auto edge_type = storage_->NameToEdgeType(name);
+    storage_->description_store_.SetEdgeType(edge_type, desc);
+    transaction_.md_deltas.emplace_back(MetadataDelta::description_set,
+                                        DescriptionTargetKind::EDGE_TYPE,
+                                        std::vector<LabelId>{},
+                                        edge_type,
+                                        PropertyId{},
+                                        std::string{desc});
+  }
+
+  bool DeleteEdgeTypeDescription(std::string_view name) {
+    auto edge_type = storage_->NameToEdgeType(name);
+    auto deleted = storage_->description_store_.DeleteEdgeType(edge_type);
+    if (deleted) {
+      transaction_.md_deltas.emplace_back(MetadataDelta::description_delete,
+                                          DescriptionTargetKind::EDGE_TYPE,
+                                          std::vector<LabelId>{},
+                                          edge_type,
+                                          PropertyId{});
+    }
+    return deleted;
+  }
+
+  std::optional<std::string> GetEdgeTypeDescription(std::string_view name) const {
+    return storage_->description_store_.GetEdgeType(storage_->NameToEdgeType(name));
+  }
+
+  void SetLabelPropertyDescription(std::span<std::string const> label_qualifier, std::string_view prop_name,
+                                   std::string_view desc) {
+    auto labels = ResolveLabels(label_qualifier);
+    auto prop = storage_->NameToProperty(prop_name);
+    storage_->description_store_.SetLabelProperty(labels, prop, desc);
+    transaction_.md_deltas.emplace_back(MetadataDelta::description_set,
+                                        DescriptionTargetKind::LABEL_PROPERTY,
+                                        std::move(labels),
+                                        EdgeTypeId{},
+                                        prop,
+                                        std::string{desc});
+  }
+
+  bool DeleteLabelPropertyDescription(std::span<std::string const> label_qualifier, std::string_view prop_name) {
+    auto labels = ResolveLabels(label_qualifier);
+    auto prop = storage_->NameToProperty(prop_name);
+    bool deleted = storage_->description_store_.DeleteLabelProperty(labels, prop);
+    if (deleted) {
+      transaction_.md_deltas.emplace_back(MetadataDelta::description_delete,
+                                          DescriptionTargetKind::LABEL_PROPERTY,
+                                          std::move(labels),
+                                          EdgeTypeId{},
+                                          prop);
+    }
+    return deleted;
+  }
+
+  std::optional<std::string> GetLabelPropertyDescription(std::span<std::string const> label_qualifier,
+                                                         std::string_view prop_name) const {
+    return storage_->description_store_.GetLabelProperty(ResolveLabels(label_qualifier),
+                                                         storage_->NameToProperty(prop_name));
+  }
+
+  void SetEdgeTypePropertyDescription(std::string_view edge_type_name, std::string_view prop_name,
+                                      std::string_view desc) {
+    auto edge_type = storage_->NameToEdgeType(edge_type_name);
+    auto prop = storage_->NameToProperty(prop_name);
+    storage_->description_store_.SetEdgeTypeProperty(edge_type, prop, desc);
+    transaction_.md_deltas.emplace_back(MetadataDelta::description_set,
+                                        DescriptionTargetKind::EDGE_TYPE_PROPERTY,
+                                        std::vector<LabelId>{},
+                                        edge_type,
+                                        prop,
+                                        std::string{desc});
+  }
+
+  bool DeleteEdgeTypePropertyDescription(std::string_view edge_type_name, std::string_view prop_name) {
+    auto edge_type = storage_->NameToEdgeType(edge_type_name);
+    auto prop = storage_->NameToProperty(prop_name);
+    bool deleted = storage_->description_store_.DeleteEdgeTypeProperty(edge_type, prop);
+    if (deleted) {
+      transaction_.md_deltas.emplace_back(MetadataDelta::description_delete,
+                                          DescriptionTargetKind::EDGE_TYPE_PROPERTY,
+                                          std::vector<LabelId>{},
+                                          edge_type,
+                                          prop);
+    }
+    return deleted;
+  }
+
+  std::optional<std::string> GetEdgeTypePropertyDescription(std::string_view edge_type_name,
+                                                            std::string_view prop_name) const {
+    return storage_->description_store_.GetEdgeTypeProperty(storage_->NameToEdgeType(edge_type_name),
+                                                            storage_->NameToProperty(prop_name));
+  }
+
+  void SetPropertyDescription(std::string_view prop_name, std::string_view desc) {
+    auto prop = storage_->NameToProperty(prop_name);
+    storage_->description_store_.SetProperty(prop, desc);
+    transaction_.md_deltas.emplace_back(MetadataDelta::description_set,
+                                        DescriptionTargetKind::PROPERTY,
+                                        std::vector<LabelId>{},
+                                        EdgeTypeId{},
+                                        prop,
+                                        std::string{desc});
+  }
+
+  bool DeletePropertyDescription(std::string_view prop_name) {
+    auto prop = storage_->NameToProperty(prop_name);
+    bool deleted = storage_->description_store_.DeleteProperty(prop);
+    if (deleted) {
+      transaction_.md_deltas.emplace_back(MetadataDelta::description_delete,
+                                          DescriptionTargetKind::PROPERTY,
+                                          std::vector<LabelId>{},
+                                          EdgeTypeId{},
+                                          prop);
+    }
+    return deleted;
+  }
+
+  std::optional<std::string> GetPropertyDescription(std::string_view prop_name) const {
+    return storage_->description_store_.GetProperty(storage_->NameToProperty(prop_name));
+  }
+
+  void SetEdgeTypePatternDescription(std::span<std::string const> from_label_names, std::string_view edge_type_name,
+                                     std::span<std::string const> to_label_names, std::string_view desc) {
+    auto from_labels = ResolveLabels(from_label_names);
+    auto edge_type = storage_->NameToEdgeType(edge_type_name);
+    auto to_labels = ResolveLabels(to_label_names);
+    storage_->description_store_.SetEdgeTypePattern(from_labels, edge_type, to_labels, desc);
+    transaction_.md_deltas.emplace_back(MetadataDelta::description_set,
+                                        DescriptionTargetKind::EDGE_TYPE_PATTERN,
+                                        std::vector<LabelId>{},
+                                        edge_type,
+                                        PropertyId{},
+                                        std::string{desc},
+                                        std::move(from_labels),
+                                        std::move(to_labels));
+  }
+
+  bool DeleteEdgeTypePatternDescription(std::span<std::string const> from_label_names, std::string_view edge_type_name,
+                                        std::span<std::string const> to_label_names) {
+    auto from_labels = ResolveLabels(from_label_names);
+    auto edge_type = storage_->NameToEdgeType(edge_type_name);
+    auto to_labels = ResolveLabels(to_label_names);
+    auto deleted = storage_->description_store_.DeleteEdgeTypePattern(from_labels, edge_type, to_labels);
+    if (deleted) {
+      transaction_.md_deltas.emplace_back(MetadataDelta::description_delete,
+                                          DescriptionTargetKind::EDGE_TYPE_PATTERN,
+                                          std::vector<LabelId>{},
+                                          edge_type,
+                                          PropertyId{},
+                                          std::move(from_labels),
+                                          std::move(to_labels));
+    }
+    return deleted;
+  }
+
+  std::optional<std::string> GetEdgeTypePatternDescription(std::span<std::string const> from_label_names,
+                                                           std::string_view edge_type_name,
+                                                           std::span<std::string const> to_label_names) const {
+    return storage_->description_store_.GetEdgeTypePattern(
+        ResolveLabels(from_label_names), storage_->NameToEdgeType(edge_type_name), ResolveLabels(to_label_names));
+  }
+
+  void SetEdgeTypePatternPropertyDescription(std::span<std::string const> from_label_names,
+                                             std::string_view edge_type_name,
+                                             std::span<std::string const> to_label_names, std::string_view prop_name,
+                                             std::string_view desc) {
+    auto from_labels = ResolveLabels(from_label_names);
+    auto edge_type = storage_->NameToEdgeType(edge_type_name);
+    auto to_labels = ResolveLabels(to_label_names);
+    auto prop = storage_->NameToProperty(prop_name);
+    storage_->description_store_.SetEdgeTypePatternProperty(from_labels, edge_type, to_labels, prop, desc);
+    transaction_.md_deltas.emplace_back(MetadataDelta::description_set,
+                                        DescriptionTargetKind::EDGE_TYPE_PATTERN_PROPERTY,
+                                        std::vector<LabelId>{},
+                                        edge_type,
+                                        prop,
+                                        std::string{desc},
+                                        std::move(from_labels),
+                                        std::move(to_labels));
+  }
+
+  bool DeleteEdgeTypePatternPropertyDescription(std::span<std::string const> from_label_names,
+                                                std::string_view edge_type_name,
+                                                std::span<std::string const> to_label_names,
+                                                std::string_view prop_name) {
+    auto from_labels = ResolveLabels(from_label_names);
+    auto edge_type = storage_->NameToEdgeType(edge_type_name);
+    auto to_labels = ResolveLabels(to_label_names);
+    auto prop = storage_->NameToProperty(prop_name);
+    auto deleted = storage_->description_store_.DeleteEdgeTypePatternProperty(from_labels, edge_type, to_labels, prop);
+    if (deleted) {
+      transaction_.md_deltas.emplace_back(MetadataDelta::description_delete,
+                                          DescriptionTargetKind::EDGE_TYPE_PATTERN_PROPERTY,
+                                          std::vector<LabelId>{},
+                                          edge_type,
+                                          prop,
+                                          std::move(from_labels),
+                                          std::move(to_labels));
+    }
+    return deleted;
+  }
+
+  std::optional<std::string> GetEdgeTypePatternPropertyDescription(std::span<std::string const> from_label_names,
+                                                                   std::string_view edge_type_name,
+                                                                   std::span<std::string const> to_label_names,
+                                                                   std::string_view prop_name) const {
+    return storage_->description_store_.GetEdgeTypePatternProperty(ResolveLabels(from_label_names),
+                                                                   storage_->NameToEdgeType(edge_type_name),
+                                                                   ResolveLabels(to_label_names),
+                                                                   storage_->NameToProperty(prop_name));
+  }
+
+  void SetDatabaseDescription(std::string_view desc) {
+    storage_->description_store_.SetDatabase(desc);
+    transaction_.md_deltas.emplace_back(MetadataDelta::description_set,
+                                        DescriptionTargetKind::DATABASE,
+                                        std::vector<LabelId>{},
+                                        EdgeTypeId{},
+                                        PropertyId{},
+                                        std::string{desc});
+  }
+
+  bool DeleteDatabaseDescription() {
+    bool deleted = storage_->description_store_.DeleteDatabase();
+    if (deleted) {
+      transaction_.md_deltas.emplace_back(MetadataDelta::description_delete,
+                                          DescriptionTargetKind::DATABASE,
+                                          std::vector<LabelId>{},
+                                          EdgeTypeId{},
+                                          PropertyId{});
+    }
+    return deleted;
+  }
+
+  std::optional<std::string> GetDatabaseDescription() const { return storage_->description_store_.GetDatabase(); }
+
+  std::vector<DescriptionEntry> GetAllDescriptions() const { return storage_->description_store_.GetAll(); }
+
+ private:
+  std::vector<LabelId> ResolveLabels(std::span<std::string const> names) const {
+    return names | ranges::views::transform([this](std::string_view name) { return storage_->NameToLabel(name); }) |
+           ranges::to<std::vector>();
+  }
+
+ public:
+  auto GetEnumValue(std::string_view name, std::string_view value) const -> std::expected<Enum, EnumStorageError> {
+    return storage_->enum_store_.ToEnum(name, value);
+  }
+
+  auto GetEnumValue(std::string_view enum_str) -> std::expected<Enum, EnumStorageError> {
+    return storage_->enum_store_.ToEnum(enum_str);
+  }
+
+  virtual auto PointVertices(LabelId label, PropertyId property, CoordinateReferenceSystem crs,
+                             PropertyValue const &point_value, PropertyValue const &boundary_value,
+                             PointDistanceCondition condition) -> PointIterable = 0;
+
+  virtual auto PointVertices(LabelId label, PropertyId property, CoordinateReferenceSystem crs,
+                             PropertyValue const &bottom_left, PropertyValue const &top_right,
+                             WithinBBoxCondition condition) -> PointIterable = 0;
+
+  virtual std::vector<std::tuple<VertexAccessor, double, double>> VectorIndexSearchOnNodes(
+      const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector) = 0;
+
+  virtual std::vector<std::tuple<EdgeAccessor, double, double>> VectorIndexSearchOnEdges(
+      const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector) = 0;
+
+  virtual std::vector<VectorIndexInfo> ListAllVectorIndices() const = 0;
+
+  virtual std::vector<VectorEdgeIndexInfo> ListAllVectorEdgeIndices() const = 0;
+
+  auto GetNameIdMapper() const -> NameIdMapper * { return storage_->name_id_mapper_.get(); }
+
+  bool CheckIndicesAreReady(IndicesCollection const &required_indices) const {
+    return transaction_.active_indices_->CheckIndicesAreReady(required_indices);
+  }
+
+  bool TransactionHasSerializationError() const { return transaction_.has_serialization_error; }
+
+  // TTL methods
+  ttl::TTL &ttl() { return storage_->ttl_; }
+
+#ifdef MG_ENTERPRISE
+  // TTL management methods
+  virtual void StartTtl(TTLReplicationArgs repl_args = {}) = 0;
+  virtual void DisableTtl(TTLReplicationArgs repl_args = {}) = 0;
+  virtual void StopTtl() = 0;
+  virtual void ConfigureTtl(const storage::ttl::TtlInfo &ttl_info, TTLReplicationArgs repl_args = {}) = 0;
+  virtual storage::ttl::TtlInfo GetTtlConfig() const = 0;
+#endif
+ protected:
+  Storage *storage_;
+  utils::SharedResourceLockGuard storage_guard_;
+  std::unique_lock<utils::ResourceLock> unique_guard_;  // TODO: Split the accessor into Shared/Unique
+  /// IMPORTANT: transaction_ has to be constructed after the guards (so that destruction is in correct order)
+  Transaction transaction_;
+  std::optional<uint64_t> commit_timestamp_;
+  bool is_transaction_active_;
+  StorageAccessType original_access_type_;
+
+  // Detach delete private methods
+  Result<std::optional<std::unordered_set<Vertex *>>> PrepareDeletableNodes(
+      const std::vector<VertexAccessor *> &vertices);
+  EdgeInfoForDeletion PrepareDeletableEdges(const std::unordered_set<Vertex *> &vertices,
+                                            const std::vector<EdgeAccessor *> &edges, bool detach) noexcept;
+  Result<std::optional<std::vector<EdgeAccessor>>> ClearEdgesOnVertices(
+      const std::unordered_set<Vertex *> &vertices, std::unordered_set<Gid> &deleted_edge_ids,
+      std::optional<SchemaInfo::ModifyingAccessor> &schema_acc);
+  Result<std::optional<std::vector<EdgeAccessor>>> DetachRemainingEdges(
+      EdgeInfoForDeletion info, std::unordered_set<Gid> &partially_detached_edge_ids,
+      std::optional<SchemaInfo::ModifyingAccessor> &schema_acc);
+  Result<std::vector<VertexAccessor>> TryDeleteVertices(const std::unordered_set<Vertex *> &vertices,
+                                                        std::optional<SchemaInfo::ModifyingAccessor> &schema_acc);
+  void MarkEdgeAsDeleted(Edge *edge);
+
+ private:
+  StorageMode creation_storage_mode_;
+};
 
 }  // namespace memgraph::storage

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -22,6 +22,9 @@ target_precompile_headers(memgraph_unit_main PRIVATE
 add_library(storage_test_utils storage_test_utils.cpp)
 target_link_libraries(storage_test_utils mg::storage)
 
+add_library(disk_test_utils disk_test_utils.cpp)
+target_link_libraries(disk_test_utils mg::storage)
+
 find_package(Boost REQUIRED CONFIG COMPONENTS filesystem)
 
 # Test integrations-kafka
@@ -47,22 +50,22 @@ add_unit_test(mgp_trans_c_api
 # Test mg-query
 add_unit_test(bfs_single_node
     SOURCES bfs_single_node.cpp
-    LINK_TARGETS mg-query mg-glue
+    LINK_TARGETS mg-query mg-glue disk_test_utils
 )
 
 add_unit_test(bfs_fine_grained
     SOURCES bfs_fine_grained.cpp
-    LINK_TARGETS mg-query mg-glue
+    LINK_TARGETS mg-query mg-glue disk_test_utils
 )
 
 add_unit_test(kshortest_fine_grained
     SOURCES kshortest_fine_grained.cpp
-    LINK_TARGETS mg-query mg-glue
+    LINK_TARGETS mg-query mg-glue disk_test_utils
 )
 
 add_unit_test(kshortest_general
     SOURCES kshortest_general.cpp
-    LINK_TARGETS mg-query mg-glue
+    LINK_TARGETS mg-query mg-glue disk_test_utils
 )
 
 add_unit_test(cypher_main_visitor
@@ -78,12 +81,12 @@ add_unit_test(event_map
 
 add_unit_test(interpreter
     SOURCES interpreter.cpp ${CMAKE_SOURCE_DIR}/src/glue/communication.cpp
-    LINK_TARGETS mg-communication mg-query mg-glue
+    LINK_TARGETS mg-communication mg-query mg-glue disk_test_utils
 )
 
 add_unit_test(plan_pretty_print
     SOURCES plan_pretty_print.cpp
-    LINK_TARGETS mg-query
+    LINK_TARGETS mg-query disk_test_utils
 )
 
 add_unit_test(query_cost_estimator
@@ -93,12 +96,12 @@ add_unit_test(query_cost_estimator
 
 add_unit_test(query_dump
     SOURCES query_dump.cpp ${CMAKE_SOURCE_DIR}/src/glue/communication.cpp
-    LINK_TARGETS mg-communication mg-query
+    LINK_TARGETS mg-communication mg-query disk_test_utils
 )
 
 add_unit_test(query_expression_evaluator
     SOURCES query_expression_evaluator.cpp
-    LINK_TARGETS mg-query
+    LINK_TARGETS mg-query disk_test_utils
 )
 
 add_unit_test(query_frame_change
@@ -128,42 +131,42 @@ add_unit_test(query_parallel_plan
 
 add_unit_test(query_plan_accumulate_aggregate
     SOURCES query_plan_accumulate_aggregate.cpp
-    LINK_TARGETS mg-query mg-glue
+    LINK_TARGETS mg-query mg-glue disk_test_utils
 )
 
 add_unit_test(query_plan_bag_semantics
     SOURCES query_plan_bag_semantics.cpp
-    LINK_TARGETS mg-query mg-glue
+    LINK_TARGETS mg-query mg-glue disk_test_utils
 )
 
 add_unit_test(query_plan_create_set_remove_delete
     SOURCES query_plan_create_set_remove_delete.cpp
-    LINK_TARGETS mg-query mg-glue
+    LINK_TARGETS mg-query mg-glue disk_test_utils
 )
 
 add_unit_test(query_plan_edge_cases
     SOURCES query_plan_edge_cases.cpp ${CMAKE_SOURCE_DIR}/src/glue/communication.cpp
-    LINK_TARGETS mg-communication mg-query
+    LINK_TARGETS mg-communication mg-query disk_test_utils
 )
 
 add_unit_test(query_plan_match_filter_return
     SOURCES query_plan_match_filter_return.cpp
-    LINK_TARGETS mg-query mg-glue
+    LINK_TARGETS mg-query mg-glue disk_test_utils
 )
 
 add_unit_test(query_plan_operator_to_string
     SOURCES query_plan_operator_to_string.cpp
-    LINK_TARGETS mg-query
+    LINK_TARGETS mg-query disk_test_utils
 )
 
 add_unit_test(query_plan_read_write_typecheck
     SOURCES query_plan_read_write_typecheck.cpp ${CMAKE_SOURCE_DIR}/src/query/plan/read_write_type_checker.cpp
-    LINK_TARGETS mg-query
+    LINK_TARGETS mg-query disk_test_utils
 )
 
 add_unit_test(query_plan_v2_create_set_remove_delete
     SOURCES query_plan_v2_create_set_remove_delete.cpp
-    LINK_TARGETS mg-query mg-glue
+    LINK_TARGETS mg-query mg-glue disk_test_utils
 )
 
 add_unit_test(query_plan_v2_rewrites
@@ -178,12 +181,12 @@ add_unit_test(query_plan_v2_pipeline
 
 add_unit_test(query_pretty_print
     SOURCES query_pretty_print.cpp
-    LINK_TARGETS mg-query
+    LINK_TARGETS mg-query disk_test_utils
 )
 
 add_unit_test(query_trigger
     SOURCES query_trigger.cpp
-    LINK_TARGETS mg-query mg-glue
+    LINK_TARGETS mg-query mg-glue disk_test_utils
 )
 
 add_unit_test(query_serialization_property_value
@@ -193,17 +196,17 @@ add_unit_test(query_serialization_property_value
 
 add_unit_test(query_streams
     SOURCES query_streams.cpp
-    LINK_TARGETS mg-query kafka-mock
+    LINK_TARGETS mg-query kafka-mock disk_test_utils
 )
 
 add_unit_test(transaction_queue
     SOURCES transaction_queue.cpp
-    LINK_TARGETS mg-communication mg-query mg-glue
+    LINK_TARGETS mg-communication mg-query mg-glue disk_test_utils
 )
 
 add_unit_test(transaction_queue_multiple
     SOURCES transaction_queue_multiple.cpp
-    LINK_TARGETS mg-communication mg-query mg-glue
+    LINK_TARGETS mg-communication mg-query mg-glue disk_test_utils
 )
 
 
@@ -218,7 +221,7 @@ add_unit_test(query_function_mgp_module
 # Test query/procedure
 add_unit_test(query_procedure_mgp_type
     SOURCES query_procedure_mgp_type.cpp
-    LINK_TARGETS mg-query
+    LINK_TARGETS mg-query disk_test_utils
     INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/include
 )
 
@@ -232,7 +235,7 @@ add_unit_test(query_procedure_mgp_module
 
 add_unit_test(query_procedure_py_module
     SOURCES query_procedure_py_module.cpp
-    LINK_TARGETS mg-query
+    LINK_TARGETS mg-query disk_test_utils
     CUSTOM_MAIN
     INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/include
 )
@@ -240,7 +243,7 @@ add_unit_test(query_procedure_py_module
 
 add_unit_test(query_procedures_mgp_graph
     SOURCES query_procedures_mgp_graph.cpp
-    LINK_TARGETS mg-query storage_test_utils
+    LINK_TARGETS mg-query storage_test_utils disk_test_utils
     INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/include
 )
 
@@ -258,12 +261,12 @@ add_unit_test(query_required_privileges
 
 add_unit_test(query_semantic
     SOURCES query_semantic.cpp
-    LINK_TARGETS mg-query
+    LINK_TARGETS mg-query disk_test_utils
 )
 
 add_unit_test(query_variable_start_planner
     SOURCES query_variable_start_planner.cpp
-    LINK_TARGETS mg-query mg-glue
+    LINK_TARGETS mg-query mg-glue disk_test_utils
 )
 
 add_unit_test(stripped
@@ -273,7 +276,7 @@ add_unit_test(stripped
 
 add_unit_test(typed_value
     SOURCES typed_value.cpp
-    LINK_TARGETS mg-query
+    LINK_TARGETS mg-query disk_test_utils
 )
 
 # Test mg-communication
@@ -294,7 +297,7 @@ add_unit_test(bolt_decoder
 
 add_unit_test(bolt_encoder
     SOURCES bolt_encoder.cpp ${CMAKE_SOURCE_DIR}/src/glue/communication.cpp
-    LINK_TARGETS mg-communication mg-query
+    LINK_TARGETS mg-communication mg-query disk_test_utils
 )
 
 add_unit_test(bolt_session
@@ -576,7 +579,7 @@ add_unit_test(property_value_v2
 
 add_unit_test(storage_v2
     SOURCES storage_v2.cpp
-    LINK_TARGETS mg::storage storage_test_utils
+    LINK_TARGETS mg::storage storage_test_utils disk_test_utils
 )
 
 add_unit_test(storage_v2_acc
@@ -606,7 +609,7 @@ add_unit_test(storage_v2_enum_store
 
 add_unit_test(storage_v2_constraints
     SOURCES storage_v2_constraints.cpp
-    LINK_TARGETS mg::storage mg-dbms
+    LINK_TARGETS mg::storage mg-dbms disk_test_utils
 )
 
 add_unit_test(storage_v2_decoder_encoder
@@ -636,17 +639,17 @@ add_unit_test(storage_v2_retention.
 
 add_unit_test(storage_rocks
     SOURCES storage_rocks.cpp
-    LINK_TARGETS mg::storage
+    LINK_TARGETS mg::storage disk_test_utils
 )
 
 add_unit_test(storage_v2_disk
     SOURCES storage_v2_disk.cpp
-    LINK_TARGETS mg::storage
+    LINK_TARGETS mg::storage disk_test_utils
 )
 
 add_unit_test(clearing_old_disk_data
     SOURCES clearing_old_disk_data.cpp
-    LINK_TARGETS mg::storage
+    LINK_TARGETS mg::storage disk_test_utils
 )
 
 add_unit_test(storage_v2_edge_inmemory
@@ -656,7 +659,7 @@ add_unit_test(storage_v2_edge_inmemory
 
 add_unit_test(storage_v2_edge_ondisk
     SOURCES storage_v2_edge_ondisk.cpp
-    LINK_TARGETS mg::storage
+    LINK_TARGETS mg::storage disk_test_utils
 )
 
 add_unit_test(storage_v2_gc
@@ -676,7 +679,7 @@ add_unit_test(storage_v2_delta_correctness
 
 add_unit_test(storage_v2_indices
     SOURCES storage_v2_indices.cpp
-    LINK_TARGETS mg::storage mg-utils
+    LINK_TARGETS mg::storage mg-utils disk_test_utils
 )
 
 add_unit_test(storage_v2_name_id_mapper
@@ -707,12 +710,12 @@ add_unit_test(storage_v2_error
 
 add_unit_test(storage_v2_isolation_level
     SOURCES storage_v2_isolation_level.cpp
-    LINK_TARGETS mg::storage
+    LINK_TARGETS mg::storage disk_test_utils
 )
 
 add_unit_test(storage_v2_show_storage_info
     SOURCES storage_v2_show_storage_info.cpp
-    LINK_TARGETS mg::storage
+    LINK_TARGETS mg::storage disk_test_utils
 )
 
 add_unit_test(storage_v2_get_info
@@ -722,7 +725,7 @@ add_unit_test(storage_v2_get_info
 
 add_unit_test(database_get_info
     SOURCES database_get_info.cpp
-    LINK_TARGETS mg::storage mg-glue mg-dbms
+    LINK_TARGETS mg::storage mg-glue mg-dbms disk_test_utils
 )
 
 add_unit_test(storage_v2_storage_mode
@@ -742,7 +745,7 @@ add_unit_test(replication_persistence_helper
 
 add_unit_test(auth_checker
     SOURCES auth_checker.cpp
-    LINK_TARGETS mg-glue mg-auth mg-query
+    LINK_TARGETS mg-glue mg-auth mg-query disk_test_utils
 )
 
 add_unit_test(auth_handler
@@ -764,7 +767,7 @@ endif ()
 
 add_unit_test(cpp_api
     SOURCES cpp_api.cpp
-    LINK_TARGETS mg-query
+    LINK_TARGETS mg-query disk_test_utils
     INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/include
 )
 
@@ -886,7 +889,7 @@ if (MG_ENTERPRISE)
 
     add_unit_test(multi_tenancy
         SOURCES multi_tenancy.cpp
-        LINK_TARGETS mg-query mg-auth mg-glue mg-dbms
+        LINK_TARGETS mg-query mg-auth mg-glue mg-dbms disk_test_utils
     )
 else ()
     add_unit_test(dbms_handler_community
@@ -1047,7 +1050,7 @@ endif ()
 if (MG_ENTERPRISE)
     add_unit_test(ttl
         SOURCES ttl.cpp
-        LINK_TARGETS mg-query
+        LINK_TARGETS mg-query disk_test_utils
         INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/include
     )
 

--- a/tests/unit/disk_test_utils.cpp
+++ b/tests/unit/disk_test_utils.cpp
@@ -1,0 +1,50 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "disk_test_utils.hpp"
+
+#include <rocksdb/utilities/transaction_db.h>
+#include <filesystem>
+
+#include "dbms/constants.hpp"
+
+namespace disk_test_utils {
+
+memgraph::storage::Config GenerateOnDiskConfig(const std::string &testName) {
+  return {.disk = {.main_storage_directory = "rocksdb_" + testName + "_db",
+                   .label_index_directory = "rocksdb_" + testName + "_label_index",
+                   .label_property_index_directory = "rocksdb_" + testName + "_label_property_index",
+                   .unique_constraints_directory = "rocksdb_" + testName + "_unique_constraints",
+                   .name_id_mapper_directory = "rocksdb_" + testName + "_name_id_mapper",
+                   .id_name_mapper_directory = "rocksdb_" + testName + "_id_name_mapper",
+                   .durability_directory = "rocksdb_" + testName + "_durability",
+                   .wal_directory = "rocksdb_" + testName + "_wal"},
+          .salient = {.name = memgraph::dbms::kDefaultDB}};
+}
+
+void RemoveRocksDbDirs(const std::string &testName) {
+  std::filesystem::remove_all("rocksdb_" + testName + "_db");
+  std::filesystem::remove_all("rocksdb_" + testName + "_label_index");
+  std::filesystem::remove_all("rocksdb_" + testName + "_label_property_index");
+  std::filesystem::remove_all("rocksdb_" + testName + "_unique_constraints");
+  std::filesystem::remove_all("rocksdb_" + testName + "_name_id_mapper");
+  std::filesystem::remove_all("rocksdb_" + testName + "_id_name_mapper");
+  std::filesystem::remove_all("rocksdb_" + testName + "_durability");
+  std::filesystem::remove_all("rocksdb_" + testName + "_wal");
+}
+
+uint64_t GetRealNumberOfEntriesInRocksDB(rocksdb::TransactionDB *disk_storage) {
+  uint64_t num_keys = 0;
+  disk_storage->GetAggregatedIntProperty("rocksdb.estimate-num-keys", &num_keys);
+  return num_keys;
+}
+
+}  // namespace disk_test_utils

--- a/tests/unit/disk_test_utils.hpp
+++ b/tests/unit/disk_test_utils.hpp
@@ -11,41 +11,22 @@
 
 #pragma once
 
-#include <rocksdb/utilities/transaction_db.h>
-#include <filesystem>
-#include "dbms/constants.hpp"
+#include <cstdint>
+#include <string>
+
 #include "storage/v2/config.hpp"
 #include "storage/v2/disk/storage.hpp"
 
+namespace rocksdb {
+class TransactionDB;
+}  // namespace rocksdb
+
 namespace disk_test_utils {
 
-memgraph::storage::Config GenerateOnDiskConfig(const std::string &testName) {
-  return {.disk = {.main_storage_directory = "rocksdb_" + testName + "_db",
-                   .label_index_directory = "rocksdb_" + testName + "_label_index",
-                   .label_property_index_directory = "rocksdb_" + testName + "_label_property_index",
-                   .unique_constraints_directory = "rocksdb_" + testName + "_unique_constraints",
-                   .name_id_mapper_directory = "rocksdb_" + testName + "_name_id_mapper",
-                   .id_name_mapper_directory = "rocksdb_" + testName + "_id_name_mapper",
-                   .durability_directory = "rocksdb_" + testName + "_durability",
-                   .wal_directory = "rocksdb_" + testName + "_wal"},
-          .salient = {.name = memgraph::dbms::kDefaultDB}};
-}
+memgraph::storage::Config GenerateOnDiskConfig(const std::string &testName);
 
-void RemoveRocksDbDirs(const std::string &testName) {
-  std::filesystem::remove_all("rocksdb_" + testName + "_db");
-  std::filesystem::remove_all("rocksdb_" + testName + "_label_index");
-  std::filesystem::remove_all("rocksdb_" + testName + "_label_property_index");
-  std::filesystem::remove_all("rocksdb_" + testName + "_unique_constraints");
-  std::filesystem::remove_all("rocksdb_" + testName + "_name_id_mapper");
-  std::filesystem::remove_all("rocksdb_" + testName + "_id_name_mapper");
-  std::filesystem::remove_all("rocksdb_" + testName + "_durability");
-  std::filesystem::remove_all("rocksdb_" + testName + "_wal");
-}
+void RemoveRocksDbDirs(const std::string &testName);
 
-uint64_t GetRealNumberOfEntriesInRocksDB(rocksdb::TransactionDB *disk_storage) {
-  uint64_t num_keys = 0;
-  disk_storage->GetAggregatedIntProperty("rocksdb.estimate-num-keys", &num_keys);
-  return num_keys;
-}
+uint64_t GetRealNumberOfEntriesInRocksDB(rocksdb::TransactionDB *disk_storage);
 
 }  // namespace disk_test_utils


### PR DESCRIPTION
Went from 10'053s to 9'196s single-threaded, ~8.5% saved.
- WalDeltaData visit out-of-line
- moved parts from disk_test_utils.hpp moved to .cpp
- PMR PropertyValue extern-templated via `module : private;`
