### PR TITLE
feat: Add dedicated failed query log for post-mortem debugging

### DIFF
--- a/config/flags.yaml
+++ b/config/flags.yaml
@@ -39,6 +39,10 @@ modifications:
     value: "/var/log/memgraph/memgraph.log"
     override: true
 
+  - name: "failed_query_log_file"
+    value: "/var/log/memgraph/failed_queries.log"
+    override: true
+
   - name: "log_level"
     value: "WARNING"
     override: true

--- a/src/flags/logging.cpp
+++ b/src/flags/logging.cpp
@@ -21,6 +21,8 @@
 #include <functional>
 #include <iostream>
 #include <limits>
+#include <optional>
+#include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
@@ -58,6 +60,9 @@ spdlog::level::level_enum ParseLogLevel() {
 DEFINE_string(log_file, "", "Path to where the log should be stored.");
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_string(failed_query_log_file, "", "Path to where failed queries should be stored.");
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_VALIDATED_string(logger_type, "sync",
                         "Controls whether synchronous or asynchronous logger will be used. Options: sync, async", {
                           auto const logger_lower = memgraph::utils::ToLowerCase(value);
@@ -79,6 +84,39 @@ inline constexpr std::array log_level_mappings{std::pair{"TRACE"sv, spdlog::leve
                                                std::pair{"WARNING"sv, spdlog::level::warn},
                                                std::pair{"ERROR"sv, spdlog::level::err},
                                                std::pair{"CRITICAL"sv, spdlog::level::critical}};
+
+namespace {
+
+auto FailedQueryLogPath() -> std::optional<std::string> {
+  if (!FLAGS_failed_query_log_file.empty()) {
+    return FLAGS_failed_query_log_file;
+  }
+  if (FLAGS_log_file.empty()) {
+    return std::nullopt;
+  }
+
+  auto path = std::filesystem::path{FLAGS_log_file};
+  return (path.parent_path() / "failed_queries.log").string();
+}
+
+void CleanLogDirectory(const std::string &path) {
+  auto const log_directory = std::filesystem::path{path}.parent_path();
+  auto const cutoff = std::filesystem::file_time_type::clock::now() - std::chrono::days(FLAGS_log_retention_days);
+
+  std::error_code ec;
+  for (auto const &entry : std::filesystem::directory_iterator(log_directory, ec)) {
+    if (!entry.is_regular_file(ec)) continue;
+    if (entry.last_write_time(ec) < cutoff) {
+      memgraph::utils::DeleteFile(entry.path());
+    }
+  }
+  if (ec) {
+    spdlog::warn(
+        "Error occurred while trying to manually rotate old log files in {}: {}", log_directory.string(), ec.message());
+  }
+}
+
+}  // namespace
 
 namespace memgraph::flags {
 const std::string &GetAllowedLogLevels() {
@@ -149,6 +187,44 @@ void InitializeLogger() {
   logger->set_level(ParseLogLevel());
   logger->flush_on(spdlog::level::trace);
   spdlog::set_default_logger(std::move(logger));
+
+  if (auto path = FailedQueryLogPath(); path) {
+    try {
+      time_t current_time{0};
+      struct tm *local_time{nullptr};
+
+      (void)time(&current_time);
+      local_time = localtime(&current_time);
+
+      auto sink = std::make_shared<spdlog::sinks::daily_file_sink_mt>(
+          *path, local_time->tm_hour, local_time->tm_min, false, FLAGS_log_retention_days);
+
+      std::shared_ptr<spdlog::logger> fq_logger;
+      if (FLAGS_logger_type == kAsync) {
+        if (!spdlog::thread_pool()) {
+          spdlog::init_thread_pool(8192, 1);
+        }
+        fq_logger = std::make_shared<spdlog::async_logger>(
+            "failed_query_log", std::move(sink), spdlog::thread_pool(), spdlog::async_overflow_policy::block);
+      } else {
+        fq_logger = std::make_shared<spdlog::logger>("failed_query_log", std::move(sink));
+      }
+
+      fq_logger->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%l] %v");
+      fq_logger->set_level(spdlog::level::trace);
+      fq_logger->flush_on(spdlog::level::trace);
+      spdlog::register_logger(fq_logger);
+    } catch (const spdlog::spdlog_ex &e) {
+      spdlog::warn("Failed to initialize failed query log at {}: {}", *path, e.what());
+    }
+  }
+}
+
+void LogFailedQuery(std::string_view entry) {
+  if (auto logger = spdlog::get("failed_query_log")) {
+    logger->error("{}", entry);
+    logger->flush();
+  }
 }
 
 // This is thread-safe now because add_sink takes a lock from base_sink before adding subsink
@@ -176,22 +252,14 @@ void TurnOnStdErr() {
 // Assumes there are only log files in the directory.
 // Deletes all files whose last_write_time is older than --log-retention-days
 void CleanLogsDir() {
-  if (FLAGS_log_file.empty()) return;
-
-  auto const log_path = std::filesystem::path{FLAGS_log_file};
-  auto const log_directory = log_path.parent_path();
-  auto const cutoff = std::filesystem::file_time_type::clock::now() - std::chrono::days(FLAGS_log_retention_days);
-
-  // Logs error only at the end, doesn't log for each file
-  std::error_code ec;
-  for (auto const &entry : std::filesystem::directory_iterator(log_directory, ec)) {
-    if (!entry.is_regular_file(ec)) continue;
-    if (entry.last_write_time(ec) < cutoff) {
-      memgraph::utils::DeleteFile(entry.path());
-    }
+  if (!FLAGS_log_file.empty()) {
+    CleanLogDirectory(FLAGS_log_file);
   }
-  if (ec) {
-    spdlog::warn("Error occurred while trying to manually rotate old log files: {}", ec.message());
+  if (auto failed_query_log_path = FailedQueryLogPath(); failed_query_log_path) {
+    if (std::filesystem::path{*failed_query_log_path}.parent_path() !=
+        std::filesystem::path{FLAGS_log_file}.parent_path()) {
+      CleanLogDirectory(*failed_query_log_path);
+    }
   }
 }
 

--- a/src/flags/logging.hpp
+++ b/src/flags/logging.hpp
@@ -37,6 +37,7 @@ bool ValidLogLevel(std::string_view value);
 std::optional<spdlog::level::level_enum> LogLevelToEnum(std::string_view value);
 
 void InitializeLogger();
+void LogFailedQuery(std::string_view entry);
 void AddLoggerSink(spdlog::sink_ptr new_sink);
 // Sets stderr log level to off
 void TurnOffStdErr();

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -47,6 +47,7 @@
 #include "dbms/dbms_handler.hpp"
 #include "dbms/global.hpp"
 #include "flags/experimental.hpp"
+#include "flags/logging.hpp"
 #include "flags/run_time_configurable.hpp"
 #include "frontend/ast/query/user_profile.hpp"
 #include "frontend/semantic/rw_checker.hpp"
@@ -8520,6 +8521,7 @@ Interpreter::ParseRes Interpreter::Parse(const std::string &query_string, UserPa
     return Interpreter::ParseInfo{.parsed_query = std::move(parsed_query), .parsing_time = parsing_time};
   } catch (const utils::BasicException &e) {
     LogQueryMessage(fmt::format("Failed query: {}", e.what()));
+    RecordFailedQuery("parse", query_string, e, current_db_.name());
     // Trigger first failed query
     metrics::FirstFailedQuery();
     memgraph::metrics::IncrementCounter(memgraph::metrics::FailedQuery);
@@ -8733,13 +8735,39 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
                                                 QueryExtras const &extras) {
   if (std::holds_alternative<TransactionQuery>(parse_res)) {
     const auto tx_query_enum = std::get<TransactionQuery>(parse_res);
+    const auto tx_query = [tx_query_enum]() -> std::string_view {
+      switch (tx_query_enum) {
+        case TransactionQuery::BEGIN:
+          return "BEGIN";
+        case TransactionQuery::COMMIT:
+          return "COMMIT";
+        case TransactionQuery::ROLLBACK:
+          return "ROLLBACK";
+      }
+      LOG_FATAL("Unknown transaction query!");
+      return {};
+    }();
     if (tx_query_enum == TransactionQuery::BEGIN) {
       ResetInterpreter();
     }
     auto &query_execution = query_executions_.emplace_back(QueryExecution::Create());
-    query_execution->prepared_query = PrepareTransactionQuery(tx_query_enum, extras);
-    auto qid = in_explicit_transaction_ ? static_cast<int>(query_executions_.size() - 1) : std::optional<int>{};
-    return {query_execution->prepared_query->header, query_execution->prepared_query->privileges, qid, {}};
+    query_execution->original_query = tx_query;
+    try {
+      query_execution->prepared_query = PrepareTransactionQuery(tx_query_enum, extras);
+      auto qid = in_explicit_transaction_ ? static_cast<int>(query_executions_.size() - 1) : std::optional<int>{};
+      return {.headers = query_execution->prepared_query->header,
+              .privileges = query_execution->prepared_query->privileges,
+              .qid = qid,
+              .db = {}};
+    } catch (const utils::BasicException &e) {
+      LogQueryMessage(fmt::format("Failed query: {}", e.what()));
+      RecordFailedQuery("prepare", tx_query, e, current_db_.name());
+      metrics::FirstFailedQuery();
+      memgraph::metrics::IncrementCounter(memgraph::metrics::FailedQuery);
+      memgraph::metrics::IncrementCounter(memgraph::metrics::FailedPrepare);
+      query_execution.reset();
+      throw;
+    }
   }
 
   MG_ASSERT(std::holds_alternative<ParseInfo>(parse_res), "Unkown ParseRes type");
@@ -8794,6 +8822,12 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
   }
 
   std::unique_ptr<QueryExecution> *query_execution_ptr = nullptr;
+  auto current_query_string = [&]() -> std::string_view {
+    if (query_execution_ptr && *query_execution_ptr) {
+      return (*query_execution_ptr)->original_query;
+    }
+    return parsed_query.query_string;
+  };
   try {
     // Setup QueryExecution
     // TODO: Use CreateThreadSafe for multi-threaded queries
@@ -8804,6 +8838,7 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
     }
     auto &query_execution = query_executions_.back();
     query_execution_ptr = &query_execution;
+    query_execution->original_query = parsed_query.query_string;
 
     std::optional<int> qid =
         in_explicit_transaction_ ? static_cast<int>(query_executions_.size() - 1) : std::optional<int>{};
@@ -9192,6 +9227,7 @@ Interpreter::PrepareResult Interpreter::Prepare(ParseRes parse_res, UserParamete
             .db = query_execution->prepared_query->db};
   } catch (const utils::BasicException &e) {
     LogQueryMessage(fmt::format("Failed query: {}", e.what()));
+    RecordFailedQuery("prepare", current_query_string(), e, current_db_.name());
     // Trigger first failed query
     metrics::FirstFailedQuery();
     memgraph::metrics::IncrementCounter(memgraph::metrics::FailedQuery);
@@ -9816,6 +9852,36 @@ void Interpreter::LogQueryMessage(std::string message) {
   if (query_logger_) {
     (*query_logger_).trace(message);
   }
+}
+
+void Interpreter::RecordFailedQuery(std::string_view phase, std::string_view query,
+                                    const utils::BasicException &exception, std::string_view db_name) {
+  std::string username;
+  if (user_or_role_ && user_or_role_->username()) {
+    username = *user_or_role_->username();
+  } else {
+    username = session_info_.username;
+  }
+
+  auto query_to_log = utils::Escape(query);
+  auto message_to_log = utils::Escape(exception.what());
+
+#ifdef MG_ENTERPRISE
+  if (license::global_license_checker.IsEnterpriseValidFast()) {
+    query_to_log = utils::Escape(memgraph::logging::MaskSensitiveInformation(query));
+  }
+#endif
+
+  flags::LogFailedQuery(
+      fmt::format("phase={} error_type={} db={} session_id={} user={} transaction_id={} query={} message={}",
+                  phase,
+                  utils::GetExceptionName(exception),
+                  utils::Escape(db_name),
+                  utils::Escape(session_info_.uuid),
+                  utils::Escape(username),
+                  current_transaction_ ? std::to_string(*current_transaction_) : "\"\"",
+                  query_to_log,
+                  message_to_log));
 }
 
 }  // namespace memgraph::query

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -488,6 +488,8 @@ class Interpreter final {
 
   bool IsQueryLoggingActive() const;
   void LogQueryMessage(std::string message);
+  void RecordFailedQuery(std::string_view phase, std::string_view query, const utils::BasicException &exception,
+                         std::string_view db_name = {});
 
  private:
   void ResetInterpreter() {
@@ -520,6 +522,7 @@ class Interpreter final {
     std::optional<PreparedQuery> prepared_query;
     std::map<std::string, TypedValue> summary;
     std::vector<Notification> notifications;
+    std::string original_query;
 
     static auto Create() -> std::unique_ptr<QueryExecution> { return std::make_unique<QueryExecution>(); }
 
@@ -654,10 +657,12 @@ std::map<std::string, TypedValue> Interpreter::Pull(TStream *result_stream, std:
     }
   } catch (const ExplicitTransactionUsageException &e) {
     LogQueryMessage(e.what());
+    RecordFailedQuery("pull", query_execution->original_query, e, current_db_.name());
     query_execution.reset(nullptr);
     throw;
   } catch (const utils::BasicException &e) {
     LogQueryMessage(e.what());
+    RecordFailedQuery("pull", query_execution->original_query, e, current_db_.name());
     metrics::FirstFailedQuery();
     memgraph::metrics::IncrementCounter(memgraph::metrics::FailedQuery);
     memgraph::metrics::IncrementCounter(memgraph::metrics::FailedPull);

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -100,6 +100,7 @@ startup_config_dict = {
         "sync",
         "Controls whether synchronous or asynchronous logger will be used. Options: sync, async",
     ),
+    "failed_query_log_file": ("", "", "Path to where failed queries should be stored."),
     "log_file": ("", "", "Path to where the log should be stored."),
     "log_retention_days": ("35", "35", "Controls for how many days will daily log files be preserved."),
     "nuraft_log_file": ("", "", "Path to the file where NuRaft logs are saved."),

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -12,6 +12,10 @@
 #include <algorithm>
 #include <cstdlib>
 #include <filesystem>
+#include <fstream>
+
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/spdlog.h>
 
 #include "communication/bolt/v1/value.hpp"
 #include "communication/result_stream_faker.hpp"
@@ -42,6 +46,10 @@
 
 import memgraph.csv.parsing;
 
+DECLARE_string(failed_query_log_file);
+DECLARE_string(log_file);
+DECLARE_string(logger_type);
+
 namespace {
 
 auto ToEdgeList(const memgraph::communication::bolt::Value &v) {
@@ -65,6 +73,7 @@ class InterpreterTest : public ::testing::Test {
   const std::string testSuite = "interpreter";
   const std::string testSuiteCsv = "interpreter_csv";
   std::filesystem::path data_directory = std::filesystem::temp_directory_path() / "MG_tests_unit_interpreter";
+  std::filesystem::path failed_query_log_file;
 
   InterpreterTest() = default;
 
@@ -112,12 +121,38 @@ class InterpreterTest : public ::testing::Test {
 #endif
   };
 
+  void SetUp() override {
+    original_log_file_ = FLAGS_log_file;
+    original_failed_query_log_file_ = FLAGS_failed_query_log_file;
+    original_logger_type_ = FLAGS_logger_type;
+    const auto *test_info = ::testing::UnitTest::GetInstance()->current_test_info();
+    auto sanitized_suite_name = std::string(test_info->test_suite_name());
+    std::replace(sanitized_suite_name.begin(), sanitized_suite_name.end(), '/', '_');
+    failed_query_log_file =
+        data_directory / ("failed_queries_" + sanitized_suite_name + "_" + std::string(test_info->name()) + ".log");
+    FLAGS_log_file = "";
+    FLAGS_failed_query_log_file = failed_query_log_file.string();
+    FLAGS_logger_type = "sync";
+    std::filesystem::create_directories(data_directory);
+
+    auto sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(failed_query_log_file.string(), true);
+    auto logger = std::make_shared<spdlog::logger>("failed_query_log", std::move(sink));
+    logger->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%l] %v");
+    logger->set_level(spdlog::level::trace);
+    logger->flush_on(spdlog::level::trace);
+    spdlog::register_logger(logger);
+  }
+
   void TearDown() override {
+    FLAGS_log_file = original_log_file_;
+    FLAGS_failed_query_log_file = original_failed_query_log_file_;
+    FLAGS_logger_type = original_logger_type_;
     if (std::is_same<StorageType, memgraph::storage::DiskStorage>::value) {
       disk_test_utils::RemoveRocksDbDirs(testSuite);
       disk_test_utils::RemoveRocksDbDirs(testSuiteCsv);
     }
 
+    spdlog::drop("failed_query_log");
     std::filesystem::remove_all(data_directory);
   }
 
@@ -134,6 +169,33 @@ class InterpreterTest : public ::testing::Test {
   auto Interpret(const std::string &query, const memgraph::storage::ExternalPropertyValue::map_t &params = {}) {
     return default_interpreter.Interpret(query, params);
   }
+
+  auto ReadFailedQueryLog() const {
+    const auto prefix = failed_query_log_file.stem().string();
+    const auto extension = failed_query_log_file.extension().string();
+
+    std::vector<std::filesystem::path> matching_logs;
+    for (const auto &entry : std::filesystem::directory_iterator(data_directory)) {
+      if (!entry.is_regular_file()) continue;
+      const auto filename = entry.path().filename().string();
+      if (filename.starts_with(prefix) && entry.path().extension() == extension) {
+        matching_logs.push_back(entry.path());
+      }
+    }
+    std::sort(matching_logs.begin(), matching_logs.end());
+
+    std::string log_contents;
+    for (const auto &log_path : matching_logs) {
+      std::ifstream log_file_stream(log_path);
+      log_contents.append(std::istreambuf_iterator<char>(log_file_stream), std::istreambuf_iterator<char>());
+    }
+    return log_contents;
+  }
+
+ private:
+  std::string original_log_file_;
+  std::string original_failed_query_log_file_;
+  std::string original_logger_type_;
 };
 
 using StorageTypes = ::testing::Types<memgraph::storage::InMemoryStorage, memgraph::storage::DiskStorage>;
@@ -162,6 +224,37 @@ TYPED_TEST(InterpreterTest, MultiplePulls) {
     ASSERT_EQ(stream.GetResults()[3][0].ValueInt(), 4);
     ASSERT_EQ(stream.GetResults()[4][0].ValueInt(), 5);
   }
+}
+
+TYPED_TEST(InterpreterTest, FailedQueryLogCapturesParseFailures) {
+  ASSERT_THROW(this->Interpret("RETURN )"), memgraph::query::SyntaxException);
+
+  const auto log_contents = this->ReadFailedQueryLog();
+  EXPECT_THAT(log_contents, testing::HasSubstr("phase=parse"));
+  EXPECT_THAT(log_contents, testing::HasSubstr("error_type=SyntaxException"));
+  EXPECT_THAT(log_contents, testing::HasSubstr("query=\"RETURN )\""));
+}
+
+TYPED_TEST(InterpreterTest, FailedQueryLogCapturesPrepareFailures) {
+  this->Interpret("BEGIN");
+
+  ASSERT_THROW(this->Interpret("CREATE INDEX ON :X"), memgraph::query::IndexInMulticommandTxException);
+
+  const auto log_contents = this->ReadFailedQueryLog();
+  EXPECT_THAT(log_contents, testing::HasSubstr("phase=prepare"));
+  EXPECT_THAT(log_contents, testing::HasSubstr("error_type=IndexInMulticommandTxException"));
+  EXPECT_THAT(log_contents, testing::HasSubstr("query=\"CREATE INDEX ON :X\""));
+}
+
+TYPED_TEST(InterpreterTest, FailedQueryLogCapturesPullFailures) {
+  this->Interpret("CREATE CONSTRAINT ON (n:A) ASSERT EXISTS (n.a);");
+
+  ASSERT_THROW(this->Interpret("CREATE (:A)"), memgraph::query::QueryException);
+
+  const auto log_contents = this->ReadFailedQueryLog();
+  EXPECT_THAT(log_contents, testing::HasSubstr("phase=pull"));
+  EXPECT_THAT(log_contents, testing::HasSubstr("error_type=QueryException"));
+  EXPECT_THAT(log_contents, testing::HasSubstr("query=\"CREATE (:A)\""));
 }
 
 // Run query with different ast twice to see if query executes correctly when


### PR DESCRIPTION
Closes #3934 

When a query fails, the error in the main log lacks the originating query text, making production debugging difficult. This adds a dedicated failed_queries.log that captures every failing query along with its error type, phase (parse/prepare/pull), database, session, and user context.

## Changes      

  - Adds a dedicated failed query log that captures query text, error type, execution phase, database, session ID, user, and transaction ID for every query that results in an error.
  - Logs failures at all three execution phases: parse, prepare, and pull.
  - New `--failed_query_log_file` flag for explicit path control; defaults to `failed_queries.log` in the `--log-file` directory.
  - Respects existing `--logger-type` (sync/async) and `--log-retention-days` settings.