### PR TITLE
build: further reduce build time of memgraph__unit

### DIFF
--- a/src/query/db_accessor.cpp
+++ b/src/query/db_accessor.cpp
@@ -14,6 +14,11 @@
 #include <cppitertools/imap.hpp>
 #include "query/graph.hpp"
 #include "storage/v2/id_types.hpp"
+#include "storage/v2/indices/point_index.hpp"
+#include "storage/v2/indices/text_index.hpp"
+#include "storage/v2/indices/text_index_utils.hpp"
+#include "storage/v2/indices/vector_edge_index.hpp"
+#include "storage/v2/indices/vector_index.hpp"
 #include "storage/v2/storage_mode.hpp"
 
 namespace memgraph::query {
@@ -169,6 +174,54 @@ storage::Result<EdgeVertexAccessorResult> SubgraphVertexAccessor::InEdges(storag
       filteredOutEdges, std::back_inserter(resulting_edges), [](auto const &edge) { return EdgeAccessor(edge); });
 
   return EdgeVertexAccessorResult{.edges = std::move(resulting_edges), .expanded_count = maybe_edges->expanded_count};
+}
+
+bool DbAccessor::TextIndexExists(const std::string &index_name) const { return accessor_->TextIndexExists(index_name); }
+
+std::vector<storage::TextSearchResult> DbAccessor::TextIndexSearch(const std::string &index_name,
+                                                                   const std::string &search_query,
+                                                                   text_search_mode search_mode,
+                                                                   std::size_t limit) const {
+  return accessor_->TextIndexSearch(index_name, search_query, search_mode, limit);
+}
+
+std::string DbAccessor::TextIndexAggregate(const std::string &index_name, const std::string &search_query,
+                                           const std::string &aggregation_query) const {
+  return accessor_->TextIndexAggregate(index_name, search_query, aggregation_query);
+}
+
+std::string DbAccessor::TextEdgeIndexAggregate(const std::string &index_name, const std::string &search_query,
+                                               const std::string &aggregation_query) {
+  return accessor_->TextEdgeIndexAggregate(index_name, search_query, aggregation_query);
+}
+
+std::vector<storage::TextEdgeSearchResult> DbAccessor::SearchEdgeTextIndex(const std::string &index_name,
+                                                                           const std::string &search_query,
+                                                                           text_search_mode search_mode,
+                                                                           std::size_t limit) const {
+  return accessor_->SearchEdgeTextIndex(index_name, search_query, search_mode, limit);
+}
+
+bool DbAccessor::PointIndexExists(storage::LabelId label, storage::PropertyId prop) const {
+  return accessor_->PointIndexExists(label, prop);
+}
+
+std::vector<std::tuple<storage::VertexAccessor, double, double>> DbAccessor::VectorIndexSearchOnNodes(
+    const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector) {
+  return accessor_->VectorIndexSearchOnNodes(index_name, number_of_results, vector);
+}
+
+std::vector<std::tuple<storage::EdgeAccessor, double, double>> DbAccessor::VectorIndexSearchOnEdges(
+    const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector) {
+  return accessor_->VectorIndexSearchOnEdges(index_name, number_of_results, vector);
+}
+
+std::vector<storage::VectorIndexInfo> DbAccessor::ListAllVectorIndices() const {
+  return accessor_->ListAllVectorIndices();
+}
+
+std::vector<storage::VectorEdgeIndexInfo> DbAccessor::ListAllVectorEdgeIndices() const {
+  return accessor_->ListAllVectorEdgeIndices();
 }
 
 auto DbAccessor::PointVertices(storage::LabelId label, storage::PropertyId property,

--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -12,7 +12,6 @@
 #pragma once
 
 #include "memory/query_memory_control.hpp"
-#include "plan/point_distance_condition.hpp"
 #include "query/edge_accessor.hpp"
 #include "query/exceptions.hpp"
 #include "query/hops_limit.hpp"
@@ -22,11 +21,6 @@
 #include "storage/v2/constraints/type_constraints.hpp"
 #include "storage/v2/edge_accessor.hpp"
 #include "storage/v2/id_types.hpp"
-#include "storage/v2/indices/point_index.hpp"
-#include "storage/v2/indices/text_index.hpp"
-#include "storage/v2/indices/text_index_utils.hpp"
-#include "storage/v2/indices/vector_edge_index.hpp"
-#include "storage/v2/indices/vector_index.hpp"
 #include "storage/v2/property_value.hpp"
 #include "storage/v2/storage.hpp"
 #include "storage/v2/storage_mode.hpp"
@@ -37,6 +31,23 @@
 #include "utils/logging.hpp"
 #include "utils/pmr/unordered_set.hpp"
 #include "utils/variant_helpers.hpp"
+
+namespace memgraph::storage {
+enum class PointDistanceCondition : uint8_t;
+enum class WithinBBoxCondition : uint8_t;
+struct PointIterable;
+struct TextSearchResult;
+struct TextEdgeSearchResult;
+struct VectorIndexInfo;
+struct VectorEdgeIndexInfo;
+}  // namespace memgraph::storage
+
+namespace memgraph::query::plan {
+using PointDistanceCondition = memgraph::storage::PointDistanceCondition;
+using WithinBBoxCondition = memgraph::storage::WithinBBoxCondition;
+}  // namespace memgraph::query::plan
+
+enum class text_search_mode;
 
 #include <cstdint>
 #include <optional>
@@ -688,49 +699,32 @@ class DbAccessor final {
     return accessor_->EdgePropertyIndexReady(property);
   }
 
-  bool TextIndexExists(const std::string &index_name) const { return accessor_->TextIndexExists(index_name); }
+  bool TextIndexExists(const std::string &index_name) const;
 
   std::vector<storage::TextSearchResult> TextIndexSearch(const std::string &index_name, const std::string &search_query,
-                                                         text_search_mode search_mode, std::size_t limit) const {
-    return accessor_->TextIndexSearch(index_name, search_query, search_mode, limit);
-  }
+                                                         text_search_mode search_mode, std::size_t limit) const;
 
   std::string TextIndexAggregate(const std::string &index_name, const std::string &search_query,
-                                 const std::string &aggregation_query) const {
-    return accessor_->TextIndexAggregate(index_name, search_query, aggregation_query);
-  }
+                                 const std::string &aggregation_query) const;
 
   std::string TextEdgeIndexAggregate(const std::string &index_name, const std::string &search_query,
-                                     const std::string &aggregation_query) {
-    return accessor_->TextEdgeIndexAggregate(index_name, search_query, aggregation_query);
-  }
+                                     const std::string &aggregation_query);
 
   std::vector<storage::TextEdgeSearchResult> SearchEdgeTextIndex(const std::string &index_name,
                                                                  const std::string &search_query,
-                                                                 text_search_mode search_mode,
-                                                                 std::size_t limit) const {
-    return accessor_->SearchEdgeTextIndex(index_name, search_query, search_mode, limit);
-  }
+                                                                 text_search_mode search_mode, std::size_t limit) const;
 
-  bool PointIndexExists(storage::LabelId label, storage::PropertyId prop) const {
-    return accessor_->PointIndexExists(label, prop);
-  }
+  bool PointIndexExists(storage::LabelId label, storage::PropertyId prop) const;
 
   std::vector<std::tuple<storage::VertexAccessor, double, double>> VectorIndexSearchOnNodes(
-      const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector) {
-    return accessor_->VectorIndexSearchOnNodes(index_name, number_of_results, vector);
-  }
+      const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector);
 
   std::vector<std::tuple<storage::EdgeAccessor, double, double>> VectorIndexSearchOnEdges(
-      const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector) {
-    return accessor_->VectorIndexSearchOnEdges(index_name, number_of_results, vector);
-  }
+      const std::string &index_name, uint64_t number_of_results, const std::vector<float> &vector);
 
-  std::vector<storage::VectorIndexInfo> ListAllVectorIndices() const { return accessor_->ListAllVectorIndices(); }
+  std::vector<storage::VectorIndexInfo> ListAllVectorIndices() const;
 
-  std::vector<storage::VectorEdgeIndexInfo> ListAllVectorEdgeIndices() const {
-    return accessor_->ListAllVectorEdgeIndices();
-  }
+  std::vector<storage::VectorEdgeIndexInfo> ListAllVectorEdgeIndices() const;
 
   std::optional<storage::LabelIndexStats> GetIndexStats(const storage::LabelId &label) const {
     return accessor_->GetIndexStats(label);

--- a/src/storage/v2/disk/storage.hpp
+++ b/src/storage/v2/disk/storage.hpp
@@ -295,6 +295,7 @@ class DiskStorage final : public Storage {
     // Bring base class convenience overloads into scope (they provide default neverCancel)
     using Storage::Accessor::CreateGlobalEdgeIndex;
     using Storage::Accessor::CreateIndex;
+    using Storage::Accessor::Vertices;
 
     std::expected<void, StorageIndexDefinitionError> CreateIndex(LabelId label,
                                                                  CheckCancelFunction cancel_check) override;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -889,7 +889,7 @@ if (MG_ENTERPRISE)
 
     add_unit_test(multi_tenancy
         SOURCES multi_tenancy.cpp
-        LINK_TARGETS mg-query mg-auth mg-glue mg-dbms disk_test_utils
+        LINK_TARGETS mg-query mg-auth mg-glue mg-dbms
     )
 else ()
     add_unit_test(dbms_handler_community

--- a/tests/unit/bolt_encoder.cpp
+++ b/tests/unit/bolt_encoder.cpp
@@ -20,7 +20,6 @@
 #include "communication/bolt/v1/encoder/encoder.hpp"
 #include "disk_test_utils.hpp"
 #include "glue/communication.hpp"
-#include "storage/v2/disk/storage.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/storage.hpp"
 #include "timezone_handler.hpp"
@@ -245,7 +244,7 @@ TEST_F(BoltEncoder, VertexAndEdgeOnDiskStorage) {
   const std::string testSuite = "bolt_encoder";
   memgraph::storage::Config config = disk_test_utils::GenerateOnDiskConfig(testSuite);
 
-  std::unique_ptr<memgraph::storage::Storage> db{new memgraph::storage::DiskStorage(config)};
+  auto db = disk_test_utils::CreateDiskStorage(config);
   TestVertexAndEdgeWithDifferentStorages(std::move(db));
 
   disk_test_utils::RemoveRocksDbDirs(testSuite);

--- a/tests/unit/disk_test_utils.cpp
+++ b/tests/unit/disk_test_utils.cpp
@@ -13,8 +13,10 @@
 
 #include <rocksdb/utilities/transaction_db.h>
 #include <filesystem>
+#include <memory>
 
 #include "dbms/constants.hpp"
+#include "storage/v2/disk/storage.hpp"
 
 namespace disk_test_utils {
 
@@ -45,6 +47,10 @@ uint64_t GetRealNumberOfEntriesInRocksDB(rocksdb::TransactionDB *disk_storage) {
   uint64_t num_keys = 0;
   disk_storage->GetAggregatedIntProperty("rocksdb.estimate-num-keys", &num_keys);
   return num_keys;
+}
+
+std::unique_ptr<memgraph::storage::Storage> CreateDiskStorage(memgraph::storage::Config config) {
+  return std::make_unique<memgraph::storage::DiskStorage>(std::move(config));
 }
 
 }  // namespace disk_test_utils

--- a/tests/unit/disk_test_utils.hpp
+++ b/tests/unit/disk_test_utils.hpp
@@ -12,10 +12,14 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <string>
 
 #include "storage/v2/config.hpp"
-#include "storage/v2/disk/storage.hpp"
+
+namespace memgraph::storage {
+class Storage;
+}  // namespace memgraph::storage
 
 namespace rocksdb {
 class TransactionDB;
@@ -28,5 +32,7 @@ memgraph::storage::Config GenerateOnDiskConfig(const std::string &testName);
 void RemoveRocksDbDirs(const std::string &testName);
 
 uint64_t GetRealNumberOfEntriesInRocksDB(rocksdb::TransactionDB *disk_storage);
+
+std::unique_ptr<memgraph::storage::Storage> CreateDiskStorage(memgraph::storage::Config config);
 
 }  // namespace disk_test_utils

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -31,6 +31,7 @@
 #include "query/typed_value.hpp"
 #include "query_common.hpp"
 #include "replication/state.hpp"
+#include "storage/v2/disk/storage.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/isolation_level.hpp"
 #include "storage/v2/property_value.hpp"

--- a/tests/unit/multi_tenancy.cpp
+++ b/tests/unit/multi_tenancy.cpp
@@ -18,7 +18,6 @@
 #include "communication/bolt/v1/value.hpp"
 #include "communication/result_stream_faker.hpp"
 #include "dbms/dbms_handler.hpp"
-#include "disk_test_utils.hpp"
 #include "flags/run_time_configurable.hpp"
 #include "glue/communication.hpp"
 #include "gmock/gmock.h"

--- a/tests/unit/query_plan_edge_cases.cpp
+++ b/tests/unit/query_plan_edge_cases.cpp
@@ -26,6 +26,7 @@
 #include "query/interpreter.hpp"
 #include "query/interpreter_context.hpp"
 #include "query/stream/streams.hpp"
+#include "storage/v2/disk/storage.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/storage.hpp"
 

--- a/tests/unit/query_trigger.cpp
+++ b/tests/unit/query_trigger.cpp
@@ -22,6 +22,7 @@
 #include "query/trigger.hpp"
 #include "query/typed_value.hpp"
 #include "storage/v2/config.hpp"
+#include "storage/v2/disk/storage.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/property_value.hpp"

--- a/tests/unit/storage_rocks.cpp
+++ b/tests/unit/storage_rocks.cpp
@@ -19,7 +19,6 @@
 #include "disk_test_utils.hpp"
 #include "replication_coordination_glue/role.hpp"
 #include "storage/v2/delta.hpp"
-#include "storage/v2/disk/storage.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/isolation_level.hpp"
 #include "storage/v2/property_store.hpp"
@@ -40,7 +39,7 @@ class RocksDBStorageTest : public ::testing::TestWithParam<bool> {
 
   RocksDBStorageTest() {
     config_ = disk_test_utils::GenerateOnDiskConfig(testSuite);
-    storage = std::make_unique<DiskStorage>(config_);
+    storage = disk_test_utils::CreateDiskStorage(config_);
   }
 
   void TearDown() override {

--- a/tests/unit/storage_v2_disk.cpp
+++ b/tests/unit/storage_v2_disk.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -12,7 +12,6 @@
 #include <gtest/gtest.h>
 
 #include "disk_test_utils.hpp"
-#include "storage/v2/disk/storage.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "utils/file.hpp"
 
@@ -22,7 +21,7 @@ TEST_F(DiskStorageTest, CreateDiskStorageInDataDirectory) {
   const std::string testSuite = "storage_v2_disk";
 
   memgraph::storage::Config config = disk_test_utils::GenerateOnDiskConfig(testSuite);
-  auto storage = std::make_unique<memgraph::storage::DiskStorage>(config);
+  auto storage = disk_test_utils::CreateDiskStorage(config);
   ASSERT_TRUE(memgraph::utils::DirExists(config.disk.main_storage_directory));
 
   disk_test_utils::RemoveRocksDbDirs(testSuite);

--- a/tests/unit/storage_v2_isolation_level.cpp
+++ b/tests/unit/storage_v2_isolation_level.cpp
@@ -12,7 +12,6 @@
 #include <gtest/gtest.h>
 
 #include "disk_test_utils.hpp"
-#include "storage/v2/disk/storage.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/isolation_level.hpp"
 #include "tests/test_commit_args_helper.hpp"
@@ -119,7 +118,7 @@ TEST_P(StorageIsolationLevelTest, VisibilityOnDiskStorage) {
   config.transaction.isolation_level = default_isolation_level;
 
   for (const auto override_isolation_level : isolation_levels) {
-    std::unique_ptr<memgraph::storage::Storage> storage(new memgraph::storage::DiskStorage(config));
+    auto storage = disk_test_utils::CreateDiskStorage(config);
     auto on_exit = memgraph::utils::OnScopeExit{[&]() { disk_test_utils::RemoveRocksDbDirs(testSuite); }};
     try {
       this->TestVisibility(storage, default_isolation_level, override_isolation_level);

--- a/tests/unit/storage_v2_show_storage_info.cpp
+++ b/tests/unit/storage_v2_show_storage_info.cpp
@@ -14,7 +14,7 @@
 #include <filesystem>
 
 #include "disk_test_utils.hpp"
-#include "storage/v2/disk/storage.hpp"
+#include "storage/v2/storage.hpp"
 
 // NOLINTNEXTLINE(google-build-using-namespace)
 using namespace memgraph::storage;
@@ -31,7 +31,7 @@ class ShowStorageInfoTest : public testing::Test {
 
   ShowStorageInfoTest() {
     config_ = disk_test_utils::GenerateOnDiskConfig(testSuite);
-    storage = std::make_unique<memgraph::storage::DiskStorage>(config_);
+    storage = disk_test_utils::CreateDiskStorage(config_);
   }
 
   void TearDown() override {

--- a/tests/unit/transaction_queue.cpp
+++ b/tests/unit/transaction_queue.cpp
@@ -21,6 +21,7 @@
 #include "interpreter_faker.hpp"
 #include "query/context.hpp"
 #include "query/interpreter_context.hpp"
+#include "storage/v2/disk/storage.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 
 /*


### PR DESCRIPTION
Went from ~9'400s to ~8'930s single-threaded, ~5% saved.                                                
- tests/unit: drop disk/storage.hpp from disk_test_utils.hpp via CreateDiskStorage helper
- query: slim db_accessor.hpp via out-of-line search methods (drops 6 index headers)                    
- storage/disk: silence latent -Woverloaded-virtual on DiskAccessor::Vertices    
