### PR TITLE
Bump Python package versions to address litellm and lxml vulnerabilities

### DIFF
--- a/mage/python/requirements-gpu.txt
+++ b/mage/python/requirements-gpu.txt
@@ -26,4 +26,4 @@ setuptools==81.0.0  # maximum version that can be used until torchmetrics doesn'
 six==1.17.0
 torch==2.9.0
 torchmetrics==0.10.0
-litellm==1.83.4
+litellm==1.83.7

--- a/mage/python/requirements.txt
+++ b/mage/python/requirements.txt
@@ -28,4 +28,4 @@ six==1.17.0
 torch==2.9.0+cpu; platform_machine != "aarch64"
 torch==2.9.0; platform_machine == "aarch64"
 torchmetrics==0.10.0 # current implementation of node_classification module depends on version <= 0.10.0
-litellm==1.83.4
+litellm==1.83.7

--- a/src/auth/reference_modules/requirements.txt
+++ b/src/auth/reference_modules/requirements.txt
@@ -4,6 +4,6 @@ requests==2.32.5
 ldap3==2.6
 pyyaml==6.0.1
 python3-saml==1.16.0
-lxml==6.0.0
+lxml==6.1.0
 xmlsec==1.3.16
 gssapi==1.11.1

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,7 +8,7 @@ gqlalchemy==1.8.0
 idna==2.10
 kafka-python==2.0.2
 ldap3==2.6
-lxml==6.0.0
+lxml==6.1.0
 neo4j==5.14.1
 neo4j-driver==4.1.1
 networkx==2.5.1


### PR DESCRIPTION
Bumped `litellm` and `lxml` to safe versions in order to address the following:

| Package | Severity | Vulnerability ID | URL | Fixed Version |
|:-------------|:------------|:-----------------------|:-------|:--------------------|
| litellm | critical | GHSA-r75f-5x8p-qvmc | https://github.com/advisories/GHSA-r75f-5x8p-qvmc  | >= 1.83.7 |
| litellm | high | GHSA-v4p8-mg3p-g94g | https://github.com/advisories/GHSA-v4p8-mg3p-g94g | >= 1.83.7 |
| lxml | high | CVE-2026-41066 | https://github.com/advisories/GHSA-vfmq-68hx-4jfw | >= 6.1.0 |
| lxml | high | GHSA-vfmq-68hx-4jfw | https://github.com/advisories/GHSA-vfmq-68hx-4jfw | >= 6.1.0 |



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only bump; potential risk is minor runtime/test behavior changes due to `litellm` and `lxml` patch-level updates.
> 
> **Overview**
> Updates pinned Python dependencies to address known vulnerabilities by bumping `litellm` from `1.83.4` to `1.83.7` in both `mage/python/requirements.txt` and `mage/python/requirements-gpu.txt`.
> 
> Also bumps `lxml` from `6.0.0` to `6.1.0` in `src/auth/reference_modules/requirements.txt` and `tests/requirements.txt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e3a8c459bf12d71423d197fbecc71ea5647ca36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->