### PR TITLE
storage: soundness fixes

### DIFF
--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2648,9 +2648,15 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
       snapshot_runner_.Pause();
     } else {
       // No need to resume async indexer, it is always running.
-      // As IN_MEMORY_TRANSACTIONAL we will now start giving it new work
+      // As IN_MEMORY_TRANSACTIONAL we will now start giving it new work.
+      // The txn's last_durable_ts_ was captured at unique-acc construction
+      // from the pre-analytical-mode ldt; analytical-mode writes don't bump
+      // ldt, so without this the snapshot's durable_timestamp would lag its
+      // contents and consumers would skip it as "not newer".
+      auto *txn = unique_accessor->GetTransaction();
+      txn->last_durable_ts_ = txn->start_timestamp;
       const auto snapshot_path = durability::CreateSnapshot(this,
-                                                            unique_accessor->GetTransaction(),
+                                                            txn,
                                                             recovery_.snapshot_directory_,
                                                             recovery_.wal_directory_,
                                                             &vertices_,
@@ -4380,6 +4386,15 @@ void InMemoryStorage::Clear() {
   auto gc_lock = std::unique_lock{gc_lock_};
   auto engine_lock = std::unique_lock{engine_lock_};
 
+  // Reset schema tracking before vertices_.clear(); pending_schema_updates_
+  // entries hold raw Vertex* and would dangle.
+  {
+    std::lock_guard<std::mutex> const schema_lock{schema_queue_mutex_};
+    pending_schema_updates_.clear();
+    last_processed_commit_ts_ = kTimestampInitialId;
+  }
+  schema_info_.Clear();
+
   // Clear main memory
   vertices_.clear();
   vertices_.run_gc();
@@ -4423,7 +4438,6 @@ void InMemoryStorage::Clear() {
 
   // Reset helper classes
   enum_store_.clear();
-  schema_info_.Clear();
 
   // Replication epoch and timestamp reset
   repl_storage_state_.epoch_.SetEpoch(std::string(utils::UUID{}));

--- a/src/utils/skip_list.hpp
+++ b/src/utils/skip_list.hpp
@@ -314,6 +314,10 @@ class SkipListGc final {
 
   ~SkipListGc() { Clear(); }
 
+#ifndef NDEBUG
+  uint64_t AliveAccessors() const { return alive_accessors_.load(std::memory_order_acquire); }
+#endif
+
   uint64_t AllocateId() {
 #ifndef NDEBUG
     alive_accessors_.fetch_add(1, std::memory_order_acq_rel);
@@ -893,6 +897,9 @@ class SkipList final : detail::SkipListNode_base {
 
     Accessor &operator=(Accessor &&other) noexcept {
       if (this != &other) {
+        if (skiplist_ != nullptr) {
+          skiplist_->gc_.ReleaseId(id_);
+        }
         skiplist_ = other.skiplist_;
         id_ = other.id_;
         other.skiplist_ = nullptr;
@@ -1087,9 +1094,14 @@ class SkipList final : detail::SkipListNode_base {
     }
 
     ConstAccessor &operator=(ConstAccessor &&other) noexcept {
-      skiplist_ = other.skiplist_;
-      id_ = other.id_;
-      other.skiplist_ = nullptr;
+      if (this != &other) {
+        if (skiplist_ != nullptr) {
+          skiplist_->gc_.ReleaseId(id_);
+        }
+        skiplist_ = other.skiplist_;
+        id_ = other.id_;
+        other.skiplist_ = nullptr;
+      }
       return *this;
     }
 
@@ -1241,6 +1253,10 @@ class SkipList final : detail::SkipListNode_base {
   /// NOTE: The function *isn't* thread-safe. It must be called only if there are
   /// no more active accessors using the list.
   void clear() {
+#ifndef NDEBUG
+    auto const alive = gc_.AliveAccessors();
+    DMG_ASSERT(alive == 0, "SkipList::clear() called with {} live accessor(s)", alive);
+#endif
     auto alloc = gc_.get_allocator();
     TNode *curr = head_->nexts[0].load(std::memory_order_acquire);
     while (curr != nullptr) {

--- a/tests/unit/storage_v2_create_snapshot.cpp
+++ b/tests/unit/storage_v2_create_snapshot.cpp
@@ -19,6 +19,7 @@
 #include "replication/state.hpp"
 #include "storage/v2/config.hpp"
 #include "storage/v2/durability/paths.hpp"
+#include "storage/v2/durability/snapshot.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "storage_test_utils.hpp"
 #include "tests/test_commit_args_helper.hpp"
@@ -191,4 +192,37 @@ TEST_F(CreateSnapshotTest, SuccessCaseWithPathRetrieval) {
     ASSERT_EQ(snapshot_path.extension(), "");
     ASSERT_TRUE(snapshot_path.filename().string().find("timestamp_") != std::string::npos);
   }
+}
+
+TEST_F(CreateSnapshotTest, ModeSwitchSnapshotDurableTimestampCoversAnalyticalWrites) {
+  auto config = CreateConfig();
+  uint64_t ldt_before_switch{};
+  memgraph::storage::durability::SnapshotInfo snapshot;
+  {
+    memgraph::dbms::Database db{config};
+    auto *mem_storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
+
+    mem_storage->SetStorageMode(memgraph::storage::StorageMode::IN_MEMORY_ANALYTICAL);
+    auto label = mem_storage->NameToLabel("L");
+    for (int i = 0; i < 5; ++i) {
+      auto acc = mem_storage->Access(memgraph::storage::WRITE);
+      auto v = acc->CreateVertex();
+      ASSERT_TRUE(v.AddLabel(label).has_value());
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+    ldt_before_switch = mem_storage->repl_storage_state_.commit_ts_info_.load().ldt_;
+    mem_storage->SetStorageMode(memgraph::storage::StorageMode::IN_MEMORY_TRANSACTIONAL);
+
+    std::vector<memgraph::storage::durability::SnapshotInfo> infos;
+    for (auto const &entry : std::filesystem::directory_iterator(storage_directory / "snapshots")) {
+      if (!entry.is_regular_file()) continue;
+      infos.push_back(memgraph::storage::durability::ReadSnapshotInfo(entry.path()));
+    }
+    ASSERT_FALSE(infos.empty());
+    std::sort(infos.begin(), infos.end(), [](auto const &a, auto const &b) {
+      return a.durable_timestamp < b.durable_timestamp;
+    });
+    snapshot = infos.back();
+  }
+  EXPECT_GT(snapshot.durable_timestamp, ldt_before_switch);
 }

--- a/tests/unit/storage_v2_recover_snapshot.cpp
+++ b/tests/unit/storage_v2_recover_snapshot.cpp
@@ -163,14 +163,18 @@ TEST_F(RecoverSnapshotTest, RecoverSnapshotCreatesOldDirectory) {
   ASSERT_EQ(parsed_name->second, old_info->second)
       << "Recovered snapshot " << new_snapshot_path << " should have the same start timestamp as the original snapshot";
 
-  // Verify there is only one vertex (the one created in the first transaction)
-  auto acc = storage->Access(memgraph::storage::WRITE);
-  auto vertices = acc->Vertices(memgraph::storage::View::NEW);
-  int count = 0;
-  for (const auto &vertex : vertices) {
-    count++;
+  // Verify there is only one vertex (the one created in the first transaction).
+  // Scope the accessor so its SkipList accessor is released before the next
+  // RecoverSnapshot call (which Clears the storage).
+  {
+    auto acc = storage->Access(memgraph::storage::WRITE);
+    auto vertices = acc->Vertices(memgraph::storage::View::NEW);
+    int count = 0;
+    for (const auto &vertex : vertices) {
+      count++;
+    }
+    ASSERT_EQ(count, 1) << "Should have exactly one vertex after recovery";
   }
-  ASSERT_EQ(count, 1) << "Should have exactly one vertex after recovery";
 
   // Second recovery
   auto recover2_result =


### PR DESCRIPTION
* SkipList::clear(): DMG_ASSERT no live accessors (debug-only).
* InMemoryStorage::Clear(): drain pending_schema_updates_ before vertices_.clear(); reset watermark.
* SetStorageMode analytical->transactional: bump txn last_durable_ts_ to start_timestamp before CreateSnapshot so the persisted snapshot's durable_timestamp matches its contents.
