### PR TITLE
build: enable -Werror=deprecated and fix Rule-of-Five violations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,6 +283,8 @@ add_compile_options(
         -Wno-missing-field-initializers # C++20 designated init, unspecified fields are zero-initialized
         -Wno-c99-designator
         -Werror=implicit-fallthrough
+        -Werror=deprecated
+        -Wno-error=deprecated-declarations
         $<$<CXX_COMPILER_ID:Clang>:-Werror=reorder-init-list>
 )
 

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -302,6 +302,7 @@ int main(int argc, char **argv) {
   MG_ASSERT(program_name);
   // Set program name, so Python can find its way to runtime libraries relative
   // to executable.
+  // TODO: Migrate to PyConfig API (Python 3.11+); Py_SetProgramName is deprecated.
   Py_SetProgramName(program_name);
   PyImport_AppendInittab("_mgp", &memgraph::query::procedure::PyInitMgpModule);
   Py_InitializeEx(0 /* = initsigs */);

--- a/src/query/auth_checker.hpp
+++ b/src/query/auth_checker.hpp
@@ -42,6 +42,13 @@ class AuthChecker {
   [[nodiscard]] virtual std::unique_ptr<FineGrainedAuthChecker> GetFineGrainedAuthChecker(
       const QueryUserOrRole &user, const DbAccessor *db_accessor) const = 0;
 #endif
+
+ protected:
+  AuthChecker() = default;
+  AuthChecker(const AuthChecker &) = default;
+  AuthChecker(AuthChecker &&) noexcept = default;
+  AuthChecker &operator=(const AuthChecker &) = default;
+  AuthChecker &operator=(AuthChecker &&) noexcept = default;
 };
 #ifdef MG_ENTERPRISE
 class FineGrainedAuthChecker {
@@ -78,6 +85,13 @@ class FineGrainedAuthChecker {
   // throw if not possible
   virtual void MakeThreadSafe() const = 0;
   virtual bool IsThreadSafe() const = 0;
+
+ protected:
+  FineGrainedAuthChecker() = default;
+  FineGrainedAuthChecker(const FineGrainedAuthChecker &) = default;
+  FineGrainedAuthChecker(FineGrainedAuthChecker &&) noexcept = default;
+  FineGrainedAuthChecker &operator=(const FineGrainedAuthChecker &) = default;
+  FineGrainedAuthChecker &operator=(FineGrainedAuthChecker &&) noexcept = default;
 };
 
 class AllowEverythingFineGrainedAuthChecker final : public FineGrainedAuthChecker {

--- a/src/query/frontend/ast/ast_storage.hpp
+++ b/src/query/frontend/ast/ast_storage.hpp
@@ -138,6 +138,12 @@ class Tree {
 
   virtual Tree *Clone(AstStorage *storage) const = 0;
 
+ protected:
+  Tree(const Tree &) = default;
+  Tree(Tree &&) noexcept = default;
+  Tree &operator=(const Tree &) = default;
+  Tree &operator=(Tree &&) noexcept = default;
+
  private:
   friend class AstStorage;
 };

--- a/src/query/hops_limit.hpp
+++ b/src/query/hops_limit.hpp
@@ -30,6 +30,11 @@ struct HopsLimit {
 
   ~HopsLimit() { Free(); }
 
+  HopsLimit(const HopsLimit &) = default;
+  HopsLimit(HopsLimit &&) noexcept = default;
+  HopsLimit &operator=(const HopsLimit &) = default;
+  HopsLimit &operator=(HopsLimit &&) noexcept = default;
+
   explicit HopsLimit(uint64_t limit, uint64_t batch = 1U)
       : limit(limit), batch(batch), shared_quota_{std::in_place, limit, std::max(batch, 1UL)} {}
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -9392,10 +9392,12 @@ std::optional<Interpreter::TxVerifier> Interpreter::TryAcquireForVerification() 
     // Transaction is not in a state we can verify
     return std::nullopt;
   }
-  // CAS to VERIFYING to own the transaction
+  // CAS to VERIFYING to own the transaction; in-place construction of the
+  // optional avoids any copy/move of the RAII guard, which would prematurely
+  // run the destructor's CAS and collapse the verification window.
   if (transaction_status_.compare_exchange_strong(
           status, TransactionStatus::VERIFYING, std::memory_order_acq_rel, std::memory_order_acquire)) {
-    return TxVerifier{status, transaction_status_};
+    return std::optional<TxVerifier>(std::in_place, status, transaction_status_);
   }
   // CAS failed, return to avoid busy loops
   return std::nullopt;

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -452,6 +452,11 @@ class Interpreter final {
           expected, original_status_, std::memory_order_release, std::memory_order_relaxed);
     }
 
+    TxVerifier(const TxVerifier &) = delete;
+    TxVerifier(TxVerifier &&) = delete;
+    TxVerifier &operator=(const TxVerifier &) = delete;
+    TxVerifier &operator=(TxVerifier &&) = delete;
+
     TransactionStatus status() const { return original_status_; }
 
    private:

--- a/src/query/plan/operator.hpp
+++ b/src/query/plan/operator.hpp
@@ -217,6 +217,13 @@ class NamedLogicalOperator {
   mutable const DbAccessor *dba_{nullptr};
   virtual std::string ToString() const = 0;
   virtual ~NamedLogicalOperator() = default;
+
+ protected:
+  NamedLogicalOperator() = default;
+  NamedLogicalOperator(const NamedLogicalOperator &) = default;
+  NamedLogicalOperator(NamedLogicalOperator &&) noexcept = default;
+  NamedLogicalOperator &operator=(const NamedLogicalOperator &) = default;
+  NamedLogicalOperator &operator=(NamedLogicalOperator &&) noexcept = default;
 };
 
 /// Base class for logical operators.
@@ -304,6 +311,13 @@ class LogicalOperator : public utils::Visitable<HierarchicalLogicalOperatorVisit
   std::string ToString() const override;
 
   virtual std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const = 0;
+
+ protected:
+  LogicalOperator() = default;
+  LogicalOperator(const LogicalOperator &) = default;
+  LogicalOperator(LogicalOperator &&) noexcept = default;
+  LogicalOperator &operator=(const LogicalOperator &) = default;
+  LogicalOperator &operator=(LogicalOperator &&) noexcept = default;
 };
 
 /// A logical operator whose Cursor returns true on the first Pull

--- a/src/query/query_user.hpp
+++ b/src/query/query_user.hpp
@@ -67,6 +67,11 @@ struct QueryUserOrRole {
   operator bool() const { return username_.has_value(); }
 
  protected:
+  QueryUserOrRole(const QueryUserOrRole &) = default;
+  QueryUserOrRole(QueryUserOrRole &&) noexcept = default;
+  QueryUserOrRole &operator=(const QueryUserOrRole &) = default;
+  QueryUserOrRole &operator=(QueryUserOrRole &&) noexcept = default;
+
   std::optional<std::string> username_;
   std::vector<std::string> rolenames_;
 };

--- a/src/query/replication_query_handler.hpp
+++ b/src/query/replication_query_handler.hpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -114,6 +114,13 @@ struct ReplicationQueryHandler {
   virtual bool IsReplica() const = 0;
 
   virtual auto ShowReplicas() const -> std::expected<ReplicasInfos, ShowReplicaError> = 0;
+
+ protected:
+  ReplicationQueryHandler() = default;
+  ReplicationQueryHandler(const ReplicationQueryHandler &) = default;
+  ReplicationQueryHandler(ReplicationQueryHandler &&) noexcept = default;
+  ReplicationQueryHandler &operator=(const ReplicationQueryHandler &) = default;
+  ReplicationQueryHandler &operator=(ReplicationQueryHandler &&) noexcept = default;
 };
 
 }  // namespace memgraph::query

--- a/src/utils/exceptions.hpp
+++ b/src/utils/exceptions.hpp
@@ -90,6 +90,11 @@ class BasicException : public std::exception {
   virtual std::string name() const { return "BasicException"; }
 
  protected:
+  BasicException(const BasicException &) = default;
+  BasicException(BasicException &&) noexcept = default;
+  BasicException &operator=(const BasicException &) = default;
+  BasicException &operator=(BasicException &&) noexcept = default;
+
   /**
    * @brief Error message.
    */

--- a/src/utils/visitor.hpp
+++ b/src/utils/visitor.hpp
@@ -275,8 +275,16 @@ template <class TVisitor>
 class Visitable {
  public:
   virtual ~Visitable() = default;
+
   /// @brief Accept the @c TVisitor instance and call its @c Visit method.
   virtual typename TVisitor::ReturnType Accept(TVisitor &) = 0;
+
+ protected:
+  Visitable() = default;
+  Visitable(const Visitable &) = default;
+  Visitable(Visitable &&) noexcept = default;
+  Visitable &operator=(const Visitable &) = default;
+  Visitable &operator=(Visitable &&) noexcept = default;
 };
 
 /// Default implementation for @c utils::Visitable::Accept, which works for

--- a/tests/unit/query_plan_checker.hpp
+++ b/tests/unit/query_plan_checker.hpp
@@ -32,6 +32,13 @@ class BaseOpChecker {
   virtual ~BaseOpChecker() = default;
 
   virtual void CheckOp(LogicalOperator &, const SymbolTable &) = 0;
+
+ protected:
+  BaseOpChecker() = default;
+  BaseOpChecker(const BaseOpChecker &) = default;
+  BaseOpChecker(BaseOpChecker &&) noexcept = default;
+  BaseOpChecker &operator=(const BaseOpChecker &) = default;
+  BaseOpChecker &operator=(BaseOpChecker &&) noexcept = default;
 };
 
 /// Type-erased wrapper for BaseOpChecker that allows value semantics.

--- a/tests/unit/query_procedure_py_module.cpp
+++ b/tests/unit/query_procedure_py_module.cpp
@@ -434,6 +434,7 @@ int main(int argc, char **argv) {
   MG_ASSERT(program_name);
   // Set program name, so Python can find its way to runtime libraries relative
   // to executable.
+  // TODO: Migrate to PyConfig API (Python 3.11+); some calls below are deprecated.
   Py_SetProgramName(program_name);
   PyImport_AppendInittab("_mgp", &memgraph::query::procedure::PyInitMgpModule);
   Py_InitializeEx(0 /* = initsigs */);


### PR DESCRIPTION
Promotes -Wdeprecated to error to catch implicit copy/move on polymorphic bases that declare a destructor (Rule-of-Five). Keeps -Wdeprecated-declarations as a non-fatal warning so [[deprecated]] API usage (e.g. Python 3.11+ Py_SetProgramName, PyEval_InitThreads) is visible without blocking the build.

Adds protected defaulted special members to polymorphic bases so slicing is prevented while satisfying the warning: BasicException, QueryUserOrRole, Tree, Visitable, LogicalOperator, NamedLogicalOperator, AuthChecker, FineGrainedAuthChecker, ReplicationQueryHandler, BaseOpChecker. Public defaults on value types HopsLimit and TxVerifier.
