### PR TITLE
Add compatibility methods for PySpark 5.4.0 connector

### DIFF
--- a/config/mappings.json
+++ b/config/mappings.json
@@ -136,6 +136,7 @@
 
   "apoc.xml.parse": "xml_module.parse",
 
+  "db.awaitIndexes": "mgps.await_indexes",
   "db.schema.nodeTypeProperties": "schema.node_type_properties",
   "db.schema.relTypeProperties": "schema.rel_type_properties",
 

--- a/query_modules/mgps.py
+++ b/query_modules/mgps.py
@@ -15,6 +15,7 @@ def components(
 
 @mgp.read_proc
 def await_indexes(context: mgp.ProcCtx, seconds: int):
+    # Nothing smart here
     time.sleep(1)
 
 

--- a/query_modules/mgps.py
+++ b/query_modules/mgps.py
@@ -1,3 +1,5 @@
+import time
+
 import mgp
 
 
@@ -5,7 +7,15 @@ import mgp
 def components(
     context: mgp.ProcCtx,
 ) -> mgp.Record(versions=list, edition=str, name=str):
-    return mgp.Record(versions=["5.9.0"], edition="community", name="Memgraph")
+    return [
+        mgp.Record(versions=["5.9.0"], edition="community", name="Memgraph"),
+        mgp.Record(versions=["5.9.0"], edition="community", name="Neo4j Kernel"),
+    ]
+
+
+@mgp.read_proc
+def await_indexes(context: mgp.ProcCtx, seconds: int):
+    time.sleep(1)
 
 
 @mgp.function

--- a/query_modules/mgps.py
+++ b/query_modules/mgps.py
@@ -16,6 +16,8 @@ def components(
 @mgp.read_proc
 def await_indexes(context: mgp.ProcCtx, seconds: int):
     # Nothing smart here
+    # This method exists only for compatibility with Neo4j's
+    # db.awaitIndexes, inside the Apache Spark Connector integration
     time.sleep(1)
 
 

--- a/tests/e2e/query_modules/mgps_test.py
+++ b/tests/e2e/query_modules/mgps_test.py
@@ -15,14 +15,14 @@ import pytest
 from common import connect, execute_and_fetch_all
 
 
-def test_mgps1():
+def test_mgps_components():
     cursor = connect().cursor()
-    result = list(
-        execute_and_fetch_all(
-            cursor, f"CALL mgps.components() YIELD edition, name, versions RETURN edition, name, versions;"
-        )[0]
+    results = execute_and_fetch_all(
+        cursor, f"CALL mgps.components() YIELD edition, name, versions RETURN edition, name, versions;"
     )
-    assert (result) == ["community", "Memgraph", ["5.9.0"]]
+    rows = [list(r) for r in results]
+    assert ["community", "Memgraph", ["5.9.0"]] in rows
+    assert ["community", "Neo4j Kernel", ["5.9.0"]] in rows
 
 
 def test_mgps_validate_py_false():
@@ -96,6 +96,11 @@ def test_apoc_version_mapping():
     cursor = connect().cursor()
     result = execute_and_fetch_all(cursor, "RETURN apoc.version();")
     assert list(result[0]) == ["5.9.0"]
+
+
+def test_mgps_await_indexes():
+    cursor = connect().cursor()
+    execute_and_fetch_all(cursor, "CALL mgps.await_indexes(1);")
 
 
 if __name__ == "__main__":

--- a/tests/query_modules/example_test/example_2/test.yml
+++ b/tests/query_modules/example_test/example_2/test.yml
@@ -3,3 +3,4 @@ query: >
 
 output:
   - name: Memgraph
+  - name: Neo4j Kernel


### PR DESCRIPTION
Add dummy methods to complete PySpark Neo4j Connector 5.4.0 compatibility

