### PR TITLE
fix: MAGE DEB package postinst script installs x86 Python packages

### DIFF
--- a/tools/ci/mage-build/package/build-deb.sh
+++ b/tools/ci/mage-build/package/build-deb.sh
@@ -49,8 +49,9 @@ tar -xvzf $PACKAGE_DIR -C $SCRIPT_DIR/build/usr/lib/memgraph/
 sed -i "s/@ARCH@/$ARCH/g" $SCRIPT_DIR/debian/control
 sed -i "s/@VERSION@/$CLEAN_VERSION/g" $SCRIPT_DIR/debian/changelog
 
-# set cuda in postinst
+# set cuda and arch in postinst
 sed -i "s/@CUDA@/$CUDA/g" $SCRIPT_DIR/debian/postinst
+sed -i "s/@ARCH@/$ARCH/g" $SCRIPT_DIR/debian/postinst
 
 dpkg-buildpackage -us -uc -b
 

--- a/tools/ci/mage-build/package/debian/postinst
+++ b/tools/ci/mage-build/package/debian/postinst
@@ -5,7 +5,8 @@ case "$1" in
     configure)
         # install requirements as user memgraph
         CUDA=@CUDA@
-        su - memgraph -c "/usr/lib/memgraph/install_python_requirements.sh --deb-package --cuda $CUDA"
+        ARCH=@ARCH@
+        su - memgraph -c "/usr/lib/memgraph/install_python_requirements.sh --deb-package --cuda $CUDA --arch $ARCH"
         systemctl restart memgraph.service
     ;;
 esac


### PR DESCRIPTION
The `postinst` script was missing the `--arch` flag in its call to the script which installs Python requirements, meaning that the script would try to install the default `x86_64` packages.

