### PR TITLE
fix: Ensure jemalloc TLS state is set before enforcing allocation limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ CLAUDE.md
 .claude/
 CLAUDE.md
 
+# OpenCode
+.opencode/
+
 # Conan files
 conanbuild.sh
 conanbuildenv*

--- a/mage/cpp/community_detection_module/algorithm/louvain.cpp
+++ b/mage/cpp/community_detection_module/algorithm/louvain.cpp
@@ -11,6 +11,7 @@
 
 #include "louvain.hpp"
 #include <omp.h>
+#include <algorithm>
 #include "mg_utils.hpp"
 #include "mgp.hpp"
 
@@ -34,11 +35,27 @@ std::vector<int64_t> GrappoloCommunityDetection(GrappoloGraph &grappolo_graph, m
 
   // Dynamically set currently.
   if (coloring) {
-    runMultiPhaseColoring(&grappolo_graph, graph, cluster_array, coloring, kNumColors, kReplaceMap,
-                          static_cast<long>(min_graph_size), threshold, coloring_threshold, num_threads, kThreadsOpt);
+    runMultiPhaseColoring(&grappolo_graph,
+                          graph,
+                          cluster_array,
+                          coloring,
+                          kNumColors,
+                          kReplaceMap,
+                          static_cast<long>(min_graph_size),
+                          threshold,
+                          coloring_threshold,
+                          num_threads,
+                          kThreadsOpt);
   } else {
-    runMultiPhaseBasic(&grappolo_graph, graph, cluster_array, kReplaceMap, static_cast<long>(min_graph_size), threshold,
-                       coloring_threshold, num_threads, kThreadsOpt);
+    runMultiPhaseBasic(&grappolo_graph,
+                       graph,
+                       cluster_array,
+                       kReplaceMap,
+                       static_cast<long>(min_graph_size),
+                       threshold,
+                       coloring_threshold,
+                       num_threads,
+                       kThreadsOpt);
   }
 
   // Store clustering information in vector
@@ -131,8 +148,8 @@ LouvainGraph GetLouvainSubgraph(mgp_memory *memory, mgp_graph *memgraph_graph, m
     if (louvain_graph.memgraph_id_to_id.contains(source_id) &&
         louvain_graph.memgraph_id_to_id.contains(destination_id)) {
       const double weight = mg_utility::GetNumericProperty(edge, weight_property, memory, default_weight);
-      louvain_graph.edges.emplace_back(louvain_graph.memgraph_id_to_id[source_id],
-                                       louvain_graph.memgraph_id_to_id[destination_id], weight);
+      louvain_graph.edges.emplace_back(
+          louvain_graph.memgraph_id_to_id[source_id], louvain_graph.memgraph_id_to_id[destination_id], weight);
     }
   }
   return louvain_graph;
@@ -151,6 +168,7 @@ void GetGrappoloSuitableGraph(GrappoloGraph &grappolo_graph, int num_threads, co
   }
   const auto number_of_vertices = louvain_graph.memgraph_id_to_id.size();
 
+  num_threads = std::max(num_threads, 1);
   omp_set_num_threads(num_threads);
   auto *edge_list_ptrs = static_cast<int64_t *>(malloc((number_of_vertices + 1) * sizeof(int64_t)));
   if (edge_list_ptrs == nullptr) {
@@ -165,7 +183,7 @@ void GetGrappoloSuitableGraph(GrappoloGraph &grappolo_graph, int num_threads, co
 #pragma omp parallel for default(none) shared(number_of_vertices, edge_list_ptrs)
   for (std::size_t i = 0; i <= number_of_vertices; i++) edge_list_ptrs[i] = 0;  // For first touch purposes
 
-    // Build the EdgeListPtr Array: Cumulative addition
+  // Build the EdgeListPtr Array: Cumulative addition
 #pragma omp parallel for default(none) shared(number_of_edges, tmp_edge_list, edge_list_ptrs)
   for (std::size_t i = 0; i < number_of_edges; i++) {
     __sync_fetch_and_add(&edge_list_ptrs[tmp_edge_list[i].head + 1], 1);  // Leave 0th position intact
@@ -189,7 +207,7 @@ void GetGrappoloSuitableGraph(GrappoloGraph &grappolo_graph, int num_threads, co
 #pragma omp parallel for default(none) shared(number_of_vertices, added)
   for (std::size_t i = 0; i < number_of_vertices; i++) added[i] = 0;
 
-    // Build the edgeList from edgeListTmp:
+  // Build the edgeList from edgeListTmp:
 
 #pragma omp parallel for default(none) shared(number_of_edges, tmp_edge_list, edge_list_ptrs, added, edge_list)
   for (std::size_t i = 0; i < number_of_edges; i++) {
@@ -214,4 +232,5 @@ void GetGrappoloSuitableGraph(GrappoloGraph &grappolo_graph, int num_threads, co
   grappolo_graph.sVertices = static_cast<long>(number_of_vertices);
 }
 }  // namespace louvain_alg
+
 // NOLINTEND(google-runtime-int)

--- a/mage/cpp/community_detection_module/community_detection_module.cpp
+++ b/mage/cpp/community_detection_module/community_detection_module.cpp
@@ -9,9 +9,12 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+#include <algorithm>
+
 #include "algorithm/louvain.hpp"
 #include "mg_utils.hpp"
 #include "mgp.hpp"
+
 namespace {
 
 constexpr const char *kProcedureGet = "get";
@@ -60,24 +63,29 @@ void LouvainCommunityDetection(mgp_list *args, mgp_graph *memgraph_graph, mgp_re
   auto coloring_alg_threshold = mgp::value_get_double(mgp::list_at(args, i++));
   auto num_threads = mgp::value_get_int(mgp::list_at(args, i++));
   num_threads = num_threads > omp_get_max_threads() ? omp_get_max_threads() : num_threads;
-  auto louvain_graph = subgraph
-                           ? louvain_alg::GetLouvainSubgraph(memory, memgraph_graph, subgraph_nodes,
-                                                             subgraph_relationships, weight_property, kDefaultWeight)
-                           : louvain_alg::GetLouvainGraph(memgraph_graph, memory, weight_property, kDefaultWeight);
+  num_threads = std::max(num_threads, int64_t{1});
+  auto louvain_graph =
+      subgraph ? louvain_alg::GetLouvainSubgraph(
+                     memory, memgraph_graph, subgraph_nodes, subgraph_relationships, weight_property, kDefaultWeight)
+               : louvain_alg::GetLouvainGraph(memgraph_graph, memory, weight_property, kDefaultWeight);
   if (louvain_graph.edges.empty()) {
     return;
   }
   auto *grappolo_graph = static_cast<louvain_alg::GrappoloGraph *>(malloc(sizeof(louvain_alg::GrappoloGraph)));
   louvain_alg::GetGrappoloSuitableGraph(*grappolo_graph, static_cast<int>(num_threads), louvain_graph);
-  const auto communities = louvain_alg::GrappoloCommunityDetection(
-      *grappolo_graph, memgraph_graph, coloring, min_graph_shrink, community_alg_threshold, coloring_alg_threshold,
-      static_cast<int>(num_threads));
+  const auto communities = louvain_alg::GrappoloCommunityDetection(*grappolo_graph,
+                                                                   memgraph_graph,
+                                                                   coloring,
+                                                                   min_graph_shrink,
+                                                                   community_alg_threshold,
+                                                                   coloring_alg_threshold,
+                                                                   static_cast<int>(num_threads));
   for (const auto &[memgraph_id, _] : louvain_graph.memgraph_id_to_id) {
     if (mgp::must_abort(memgraph_graph)) [[unlikely]] {
       throw mgp::TerminatedMustAbortException();
     }
-    InsertLouvainRecord(memgraph_graph, result, memory, memgraph_id,
-                        communities[louvain_graph.memgraph_id_to_id[memgraph_id]]);
+    InsertLouvainRecord(
+        memgraph_graph, result, memory, memgraph_id, communities[louvain_graph.memgraph_id_to_id[memgraph_id]]);
   }
 }
 

--- a/mage/tests/smoke-release-testing/k8s/values-core.yaml
+++ b/mage/tests/smoke-release-testing/k8s/values-core.yaml
@@ -192,4 +192,4 @@ customQueryModules: []
 # https://memgraph.com/docs/database-management/system-configuration#recommended-values-for-the-vmmax_map_count-parameter
 sysctlInitContainer:
   enabled: true
-  maxMapCount: 262144
+  maxMapCount: 524288

--- a/mage/tests/smoke-release-testing/k8s/values-ha.yaml
+++ b/mage/tests/smoke-release-testing/k8s/values-ha.yaml
@@ -73,7 +73,7 @@ affinity:
 # you can increase the maxMapCount value.
 sysctlInitContainer:
   enabled: true
-  maxMapCount: 262144
+  maxMapCount: 524288
 
 # The explicit user and group setup is required because at the init container
 # time, there is not yet a user created. This seems fine because under both

--- a/mage/tests/smoke-release-testing/k8s/values-single.yaml
+++ b/mage/tests/smoke-release-testing/k8s/values-single.yaml
@@ -192,4 +192,4 @@ customQueryModules: []
 # https://memgraph.com/docs/database-management/system-configuration#recommended-values-for-the-vmmax_map_count-parameter
 sysctlInitContainer:
   enabled: true
-  maxMapCount: 262144
+  maxMapCount: 524288

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -94,7 +94,7 @@ constexpr const char *kMgExperimentalEnabled = "MEMGRAPH_EXPERIMENTAL_ENABLED";
 constexpr const char *kMgBoltPort = "MEMGRAPH_BOLT_PORT";
 constexpr const char *kMgHaClusterInitQueries = "MEMGRAPH_HA_CLUSTER_INIT_QUERIES";
 
-constexpr uint64_t kMgVmMaxMapCount = 262'144;
+constexpr uint64_t kMgVmMaxMapCount = 524'288;
 
 void WarnDeprecatedFlags() {
   auto warn_if_set = [](std::string_view name, std::string_view message) {

--- a/src/memory/db_arena.cpp
+++ b/src/memory/db_arena.cpp
@@ -56,7 +56,9 @@ void *db_arena_alloc(extent_hooks_t *hooks, void *new_addr, size_t size, size_t 
   const bool requested_commit = *commit;
   // Pre-track if commit was requested (mandatory — base hook must return committed or fail).
   if (requested_commit) {
-    if (!dh->tracker->Alloc(static_cast<int64_t>(size))) return nullptr;
+    if (!dh->tracker->Alloc(static_cast<int64_t>(size))) {
+      return nullptr;
+    }
   }
   void *ptr = dh->base_hooks->alloc(dh->base_hooks, new_addr, size, alignment, zero, commit, arena_ind);
   if (ptr == nullptr) {

--- a/src/memory/global_memory_control.cpp
+++ b/src/memory/global_memory_control.cpp
@@ -151,6 +151,27 @@ void PurgeUnusedMemory() {
 #endif
 }
 
+void EnsureJemallocThreadStateInitialized() {
+#if USE_JEMALLOC
+  enum class State : uint8_t { kUninitialized, kInitializing, kInitialized };
+  // NOLINTNEXTLINE (misc-use-internal-linkage)
+  constinit thread_local State state [[gnu::tls_model("initial-exec")]] = State::kUninitialized;
+
+  if (state != State::kUninitialized) {
+    return;
+  }
+
+  state = State::kInitializing;
+  {
+    const utils::MemoryTracker::OutOfMemoryExceptionBlocker blocker;
+    if (void *p = je_malloc(1); p != nullptr) {
+      je_free(p);
+    }
+  }
+  state = State::kInitialized;
+#endif
+}
+
 void EnableBackgroundThreads() {
 #if USE_JEMALLOC
   bool enable = true;

--- a/src/memory/global_memory_control.hpp
+++ b/src/memory/global_memory_control.hpp
@@ -14,6 +14,26 @@
 namespace memgraph::memory {
 
 void PurgeUnusedMemory();
+// Forces jemalloc to perform lazy per-thread state setup (TSD/tcache) while
+// OutOfMemoryExceptionBlocker is active.
+//
+// Why this exists:
+// The first allocation or deallocation on a fresh thread can enter jemalloc
+// before any Memgraph tracking code has established the thread's allocator
+// state. During that first entry jemalloc may lazily initialize internal
+// thread-local structures. If our memory-limit tracking rejects allocator-
+// internal work during that bootstrap phase, jemalloc can observe inconsistent
+// per-thread state and later trip internal assertions.
+//
+// This helper makes that first jemalloc entry happen under a blocker so
+// allocator-internal bootstrap work is never treated as user-visible OOM. It
+// is intentionally exposed from mg-memory-utils so the raw malloc/free wrappers
+// in mg-memory can call it without depending on utils::MemoryTracker directly.
+//
+// The function is idempotent per thread. A small thread-local state machine
+// prevents recursive warmup when the bootstrap allocation re-enters our malloc
+// wrappers.
+void EnsureJemallocThreadStateInitialized();
 void SetHooks();
 void UnsetHooks();
 void EnableBackgroundThreads();

--- a/src/memory/malloc_free.cpp
+++ b/src/memory/malloc_free.cpp
@@ -22,7 +22,7 @@
 
 namespace {
 inline auto alloc_tracking(size_t size, int flags = 0) -> bool {
-  if (memgraph::memory::IsQueryTracked()) [[unlikely]] {
+  if (size > 0 && memgraph::memory::IsQueryTracked()) [[unlikely]] {
     auto actual_size = je_nallocx(size, flags);
     return memgraph::memory::TrackAllocOnCurrentThread(actual_size);
   }
@@ -30,7 +30,7 @@ inline auto alloc_tracking(size_t size, int flags = 0) -> bool {
 }
 
 inline void failed_alloc_tracking(size_t size, int flags = 0) {
-  if (memgraph::memory::IsQueryTracked()) [[unlikely]] {
+  if (size > 0 && memgraph::memory::IsQueryTracked()) [[unlikely]] {
     const auto actual_size = je_nallocx(size, flags);
     memgraph::memory::TrackFreeOnCurrentThread(actual_size);
   }
@@ -46,7 +46,7 @@ inline void free_tracking(void *ptr, int flags = 0) {
 inline auto realloc_tracking(void *ptr, size_t size, int flags = 0) -> bool {
   if (memgraph::memory::IsQueryTracked()) [[unlikely]] {
     const auto prev_size = ptr ? je_sallocx(ptr, flags) : 0;
-    const auto next_size = je_nallocx(size, flags);
+    const auto next_size = size > 0 ? je_nallocx(size, flags) : 0;
     if (next_size > prev_size) {  // increasing memory
       return memgraph::memory::TrackAllocOnCurrentThread(next_size - prev_size);
     } else if (next_size < prev_size) {  // decreasing memory
@@ -59,7 +59,7 @@ inline auto realloc_tracking(void *ptr, size_t size, int flags = 0) -> bool {
 inline void failed_realloc_tracking(void *ptr, size_t size, int flags = 0) {
   if (memgraph::memory::IsQueryTracked()) [[unlikely]] {
     const auto prev_size = ptr ? je_sallocx(ptr, flags) : 0;
-    const auto next_size = je_nallocx(size, flags);
+    const auto next_size = size > 0 ? je_nallocx(size, flags) : 0;
     if (next_size > prev_size) {  // failed while increasing memory
       memgraph::memory::TrackFreeOnCurrentThread(next_size - prev_size);
     } else if (next_size < prev_size) {                                    // failed while decreasing memory

--- a/src/memory/malloc_free.cpp
+++ b/src/memory/malloc_free.cpp
@@ -17,6 +17,7 @@
 #include <cstddef>
 #include <cstdlib>
 
+#include "global_memory_control.hpp"
 #include "query_memory_control.hpp"
 
 namespace {
@@ -69,6 +70,8 @@ inline void failed_realloc_tracking(void *ptr, size_t size, int flags = 0) {
 }  // namespace
 
 extern "C" void *malloc(size_t size) {
+  // Warm up jemalloc thread state before any tracking helper can trigger OOM handling.
+  memgraph::memory::EnsureJemallocThreadStateInitialized();
   if (!alloc_tracking(size)) [[unlikely]] {
     return nullptr;
   }
@@ -81,6 +84,8 @@ extern "C" void *malloc(size_t size) {
 
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 __attribute__((visibility("default"))) void *JeMalloc(size_t size, int flags) {
+  // Warm up jemalloc thread state before any tracking helper can trigger OOM handling.
+  memgraph::memory::EnsureJemallocThreadStateInitialized();
   if (!alloc_tracking(size, flags)) [[unlikely]] {
     return nullptr;
   }
@@ -92,6 +97,8 @@ __attribute__((visibility("default"))) void *JeMalloc(size_t size, int flags) {
 }
 
 extern "C" void *calloc(size_t count, size_t size) {
+  // Warm up jemalloc thread state before any tracking helper can trigger OOM handling.
+  memgraph::memory::EnsureJemallocThreadStateInitialized();
   if (!alloc_tracking(count * size)) [[unlikely]] {
     return nullptr;
   }
@@ -103,6 +110,8 @@ extern "C" void *calloc(size_t count, size_t size) {
 }
 
 extern "C" void *realloc(void *ptr, size_t size) {
+  // Warm up jemalloc thread state before any tracking helper can trigger OOM handling.
+  memgraph::memory::EnsureJemallocThreadStateInitialized();
   if (!realloc_tracking(ptr, size)) [[unlikely]] {
     return nullptr;
   }
@@ -114,6 +123,8 @@ extern "C" void *realloc(void *ptr, size_t size) {
 }
 
 extern "C" void *aligned_alloc(size_t alignment, size_t size) {
+  // Warm up jemalloc thread state before any tracking helper can trigger OOM handling.
+  memgraph::memory::EnsureJemallocThreadStateInitialized();
   const int flags = MALLOCX_ALIGN(alignment);
   if (!alloc_tracking(size, flags)) [[unlikely]] {
     return nullptr;
@@ -126,6 +137,8 @@ extern "C" void *aligned_alloc(size_t alignment, size_t size) {
 }
 
 extern "C" int posix_memalign(void **p, size_t alignment, size_t size) {
+  // Warm up jemalloc thread state before any tracking helper can trigger OOM handling.
+  memgraph::memory::EnsureJemallocThreadStateInitialized();
   const int flags = MALLOCX_ALIGN(alignment);
   if (!alloc_tracking(size, flags)) [[unlikely]] {
     return ENOMEM;
@@ -138,6 +151,8 @@ extern "C" int posix_memalign(void **p, size_t alignment, size_t size) {
 }
 
 extern "C" void *valloc(size_t size) {
+  // Warm up jemalloc thread state before any tracking helper can trigger OOM handling.
+  memgraph::memory::EnsureJemallocThreadStateInitialized();
   const int flags = MALLOCX_ALIGN(4096);
   if (!alloc_tracking(size, flags)) [[unlikely]] {
     return nullptr;
@@ -150,6 +165,8 @@ extern "C" void *valloc(size_t size) {
 }
 
 extern "C" void *memalign(size_t alignment, size_t size) {
+  // Warm up jemalloc thread state before any tracking helper can trigger OOM handling.
+  memgraph::memory::EnsureJemallocThreadStateInitialized();
   const int flags = MALLOCX_ALIGN(alignment);
   if (!alloc_tracking(size, flags)) [[unlikely]] {
     return nullptr;
@@ -162,30 +179,42 @@ extern "C" void *memalign(size_t alignment, size_t size) {
 }
 
 extern "C" void free(void *ptr) {
-  if (!ptr) [[unlikely]]
+  // free(nullptr) is a no-op per C standard - return early without triggering
+  // jemalloc thread state initialization to avoid fork-safety issues.
+  if (ptr == nullptr) [[unlikely]] {
     return;
+  }
   free_tracking(ptr);
   je_free(ptr);
 }
 
 extern "C" void dallocx(void *ptr, int flags) {
-  if (!ptr) [[unlikely]]
+  // free(nullptr) is a no-op per C standard - return early without triggering
+  // jemalloc thread state initialization to avoid fork-safety issues.
+  if (ptr == nullptr) [[unlikely]] {
     return;
+  }
   free_tracking(ptr, flags);
   je_dallocx(ptr, flags);
 }
 
 extern "C" void sdallocx(void *ptr, size_t size, int flags) {
-  if (!ptr) [[unlikely]]
+  // free(nullptr) is a no-op per C standard - return early without triggering
+  // jemalloc thread state initialization to avoid fork-safety issues.
+  if (ptr == nullptr) [[unlikely]] {
     return;
+  }
   free_tracking(ptr, flags);
   je_sdallocx(ptr, size, flags);
 }
 
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 __attribute__((visibility("default"))) void JeDealloc(void *ptr, size_t size, int flags) noexcept {
-  if (ptr == nullptr) [[unlikely]]
+  // free(nullptr) is a no-op per C standard - return early without triggering
+  // jemalloc thread state initialization to avoid fork-safety issues.
+  if (ptr == nullptr) [[unlikely]] {
     return;
+  }
   free_tracking(ptr, flags);
   je_sdallocx(ptr, size, flags);
 }

--- a/tests/issu/values_template.yaml
+++ b/tests/issu/values_template.yaml
@@ -21,7 +21,7 @@ storage:
     logStorageClassName: csi-hostpath-delayed
     ## Create a Persistant Volume Claim for core dumps.
     createCoreDumpsClaim: false
-    coreDumpsStorageClassName: 
+    coreDumpsStorageClassName:
     coreDumpsStorageSize: 10Gi
     coreDumpsMountPath: /var/core/memgraph
   coordinators:
@@ -83,7 +83,7 @@ affinity:
 # https://memgraph.com/docs/database-management/system-configuration#recommended-values-for-the-vmmax_map_count-parameter
 sysctlInitContainer:
   enabled: true
-  maxMapCount: 262144
+  maxMapCount: 524288
   image:
     repository: library/busybox
     tag: latest

--- a/tests/stress/ha/eks/deployment/values.yaml
+++ b/tests/stress/ha/eks/deployment/values.yaml
@@ -132,7 +132,7 @@ affinity:
 # https://memgraph.com/docs/database-management/system-configuration#recommended-values-for-the-vmmax_map_count-parameter
 sysctlInitContainer:
   enabled: true
-  maxMapCount: 262144
+  maxMapCount: 524288
   image:
     repository: library/busybox
     tag: latest

--- a/tests/unit/jemalloc_hook_stress_test.cpp
+++ b/tests/unit/jemalloc_hook_stress_test.cpp
@@ -87,6 +87,8 @@ TEST(JemallocHookStress, OOMPathRecursion) {
   memgraph::memory::SetHooks();
 #endif
 
+  constexpr int kNThreads = 20;
+
   // Set a low limit to trigger "return false" in Alloc
   memgraph::utils::total_memory_tracker.SetHardLimit(1024);
 
@@ -99,13 +101,11 @@ TEST(JemallocHookStress, OOMPathRecursion) {
     }
   };
 
-  std::vector<std::thread> oom_threads;
-  oom_threads.reserve(20);
-  for (int i = 0; i < 20; ++i) {
+  std::vector<std::jthread> oom_threads;
+  oom_threads.reserve(kNThreads);
+  for (int i = 0; i < kNThreads; ++i) {
     oom_threads.emplace_back(run_oom);
   }
 
-  for (auto &oom_thread : oom_threads) {
-    oom_thread.join();
-  }
+  oom_threads.clear();
 }

--- a/tools/mage-dev/host_setup.bash
+++ b/tools/mage-dev/host_setup.bash
@@ -4,7 +4,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 echo "Running host setup..."
 # NOTE: Feel free to tweak the below code to what's required for you tests.
 
-sudo sysctl -w vm.max_map_count=1048576
+sudo sysctl -w vm.max_map_count=2097152
 
 # Copy the desired module, convenient to change the mage code and just run it
 # under the container (reload of module/modules required).


### PR DESCRIPTION
jemalloc sets up its TLS environment lazily (on first allocation for the thread)
This setup can fail if allocation limits are enforced, leading to a broken state that jemalloc does not handle.
We need to ensure the TLS setup by forcing an allocation on each thread. This is handled inside the malloc interface via EnsureJemallocThreadStateInitialized().