### PR TITLE
fix: Upgrade to the latest pymgclient

### DIFF
--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -106,7 +106,7 @@ env:
 jobs:
   BuildAndPush:
     name: "Build and Test MAGE"
-    runs-on: [self-hosted, DockerMgBuild, Linux, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
+    runs-on: [self-hosted, DockerMgBuild, Linux, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}", 'cable']
     timeout-minutes: ${{ inputs.cugraph && 45 || 35 }}
     outputs:
       s3_package_url: ${{ steps.output-url.outputs.s3_url }}

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -106,7 +106,7 @@ env:
 jobs:
   BuildAndPush:
     name: "Build and Test MAGE"
-    runs-on: [self-hosted, DockerMgBuild, Linux, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}", 'cable']
+    runs-on: [self-hosted, DockerMgBuild, Linux, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
     timeout-minutes: ${{ inputs.cugraph && 45 || 35 }}
     outputs:
       s3_package_url: ${{ steps.output-url.outputs.s3_url }}

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -391,20 +391,6 @@ jobs:
           DEB_PACKAGE="$(ls output/memgraph-mage*.deb)"
           echo "DEB_PACKAGE=${DEB_PACKAGE}" >> $GITHUB_ENV
 
-      - name: Build pymgclient in MGBUILD container
-        if: ${{ inputs.arch == 'arm' }}
-        run: |
-          # This has to be done here, otherwise we will need to build pymgclient from source within
-          # docker image build because we currently do not provide an arm64 wheel for Linux.
-          ./release/package/mgbuild.sh \
-            --toolchain $TOOLCHAIN \
-            --os "$OS" \
-            --arch $ARCH \
-            --build-type $BUILD_TYPE \
-            --cugraph $CUGRAPH \
-            build-pymgclient
-          ls -la mage/wheels
-
       - name: Run tests
         if: ${{ inputs.run_tests == true }}
         run: |

--- a/mage/Dockerfile.cugraph
+++ b/mage/Dockerfile.cugraph
@@ -35,9 +35,6 @@ USER memgraph
 COPY --chown=memgraph:memgraph install_python_requirements.sh /home/memgraph/install_python_requirements.sh
 COPY --chown=memgraph:memgraph ./wheels /tmp/wheels
 RUN cd $HOME && \
-    if [ "$TARGETARCH" = "arm64" ]; then \
-      pip install --no-cache-dir /tmp/wheels/pymgclient-*.whl --break-system-packages; \
-    fi && \
     pip install --no-cache-dir /tmp/wheels/gssapi-*.whl --break-system-packages && \
     chmod +x /home/memgraph/install_python_requirements.sh && \
     ./install_python_requirements.sh --arch ${TARGETARCH} --ci --cuda true --cache-present ${CACHE_PRESENT} --wheel-cache-dir /tmp/wheels && \

--- a/mage/Dockerfile.release
+++ b/mage/Dockerfile.release
@@ -31,9 +31,6 @@ USER memgraph
 COPY --chown=memgraph:memgraph install_python_requirements.sh /home/memgraph/install_python_requirements.sh
 COPY --chown=memgraph:memgraph ./wheels /tmp/wheels
 RUN cd $HOME && \
-    if [ "$TARGETARCH" = "arm64" ]; then \
-      pip install --no-cache-dir /tmp/wheels/pymgclient-*.whl --break-system-packages; \
-    fi && \
     pip install --no-cache-dir /tmp/wheels/gssapi-*.whl --break-system-packages && \
     chmod +x /home/memgraph/install_python_requirements.sh && \
     ./install_python_requirements.sh --arch ${TARGETARCH} --ci --cuda ${CUDA} --cache-present ${CACHE_PRESENT} --wheel-cache-dir /tmp/wheels && \

--- a/mage/python/tests/requirements.txt
+++ b/mage/python/tests/requirements.txt
@@ -2,7 +2,7 @@ pytest==8.3.4
 PyYAML==6.0.2
 black==24.10.0
 flake8==7.1.1
-pymgclient==1.3.1
+pymgclient==1.5.2
 pytest-pylint==0.21.0
 pytest-timeout==2.3.1
 pytest-cov==6.0.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -18,7 +18,7 @@ parse-type==0.5.2
 pulsar-client==3.5.0
 pyarrow==19.0.1
 PyJWT==2.10.1
-pymgclient==1.5.1
+pymgclient==1.5.2
 pyopenssl==26.0.0
 pytest==7.3.2
 pytest-cov==6.0.0

--- a/tools/ci/build-pymgclient.sh
+++ b/tools/ci/build-pymgclient.sh
@@ -4,5 +4,5 @@ set -euo pipefail
 
 git clone https://github.com/memgraph/pymgclient.git  --recurse-submodules
 cd pymgclient
-git checkout v1.5.1
+git checkout v1.5.2
 python3 setup.py bdist_wheel


### PR DESCRIPTION
Upgrade to the latest `pymgclient` so that it can be installed as a binary on Python 3.14, rather than relying on build tools which may or may not exist on the host.

