### PR TITLE
cleanup: header hygiene and startup safety

### DIFF
--- a/src/auth/crypto.cpp
+++ b/src/auth/crypto.cpp
@@ -56,11 +56,11 @@ DEFINE_VALIDATED_string(password_encryption_algorithm, "bcrypt",
                             const auto error = result.error();
                             switch (error) {
                               case memgraph::utils::ValidationError::EmptyValue: {
-                                std::cout << "Password encryption algorithm cannot be empty." << std::endl;
+                                std::cerr << "Password encryption algorithm cannot be empty." << std::endl;
                                 break;
                               }
                               case memgraph::utils::ValidationError::InvalidValue: {
-                                std::cout << "Invalid value for password encryption algorithm. Allowed values: "
+                                std::cerr << "Invalid value for password encryption algorithm. Allowed values: "
                                           << memgraph::utils::GetAllowedEnumValuesString(password_hash_mappings)
                                           << std::endl;
                                 break;

--- a/src/flags/general.cpp
+++ b/src/flags/general.cpp
@@ -198,8 +198,8 @@ DEFINE_VALIDATED_string(query_modules_directory, "",
                           const auto directories = memgraph::utils::Split(value, ",");
                           for (const auto &dir : directories) {
                             if (!memgraph::utils::DirExists(dir)) {
-                              std::cout << "Expected --" << flagname << " to point to directories." << std::endl;
-                              std::cout << dir << " is not a directory." << std::endl;
+                              std::cerr << "Expected --" << flagname << " to point to directories." << std::endl;
+                              std::cerr << dir << " is not a directory." << std::endl;
                               return false;
                             }
                           }

--- a/src/flags/isolation_level.cpp
+++ b/src/flags/isolation_level.cpp
@@ -40,11 +40,11 @@ DEFINE_VALIDATED_string(isolation_level, "SNAPSHOT_ISOLATION", isolation_level_h
       !result.has_value()) {
     switch (result.error()) {
       case memgraph::utils::ValidationError::EmptyValue: {
-        std::cout << "Isolation level cannot be empty." << std::endl;
+        std::cerr << "Isolation level cannot be empty." << std::endl;
         break;
       }
       case memgraph::utils::ValidationError::InvalidValue: {
-        std::cout << "Invalid value for isolation level. Allowed values: "
+        std::cerr << "Invalid value for isolation level. Allowed values: "
                   << memgraph::utils::GetAllowedEnumValuesString(isolation_level_mappings) << std::endl;
         break;
       }

--- a/src/flags/logging.cpp
+++ b/src/flags/logging.cpp
@@ -62,7 +62,7 @@ DEFINE_VALIDATED_string(logger_type, "sync",
                         "Controls whether synchronous or asynchronous logger will be used. Options: sync, async", {
                           auto const logger_lower = memgraph::utils::ToLowerCase(value);
                           if (logger_lower != kSync && logger_lower != kAsync) {
-                            std::cout << "Expected --" << flagname << " to be 'sync' or 'async' string\n";
+                            std::cerr << "Expected --" << flagname << " to be 'sync' or 'async' string\n";
                             return false;
                           }
                           return true;
@@ -91,11 +91,11 @@ bool ValidLogLevel(std::string_view value) {
     const auto error = result.error();
     switch (error) {
       case memgraph::utils::ValidationError::EmptyValue: {
-        std::cout << "Log level cannot be empty." << '\n';
+        std::cerr << "Log level cannot be empty." << '\n';
         break;
       }
       case memgraph::utils::ValidationError::InvalidValue: {
-        std::cout << "Invalid value for log level. Allowed values: " << GetAllowedLogLevels() << '\n';
+        std::cerr << "Invalid value for log level. Allowed values: " << GetAllowedLogLevels() << '\n';
         break;
       }
     }

--- a/src/flags/storage_mode.cpp
+++ b/src/flags/storage_mode.cpp
@@ -36,11 +36,11 @@ DEFINE_VALIDATED_string(storage_mode, "IN_MEMORY_TRANSACTIONAL", storage_mode_he
       !result.has_value()) {
     switch (result.error()) {
       case memgraph::utils::ValidationError::EmptyValue: {
-        std::cout << "Storage mode cannot be empty." << std::endl;
+        std::cerr << "Storage mode cannot be empty." << std::endl;
         break;
       }
       case memgraph::utils::ValidationError::InvalidValue: {
-        std::cout << "Invalid value for storage mode. Allowed values: "
+        std::cerr << "Invalid value for storage mode. Allowed values: "
                   << memgraph::utils::GetAllowedEnumValuesString(memgraph::storage::storage_mode_mappings) << std::endl;
         break;
       }

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -107,8 +107,10 @@ void WarnDeprecatedFlags() {
 /// argv[1..argc-1] entries are unexpected — typically caused by writing `--bool-flag false`
 /// (space-separated) instead of `--bool-flag=false`. gflags bool flags don't consume the
 /// next argument; `--flag false` silently sets the flag to true and orphans "false".
-void CheckSuspiciousPositionalArgs(int argc, char **argv) {
-  if (argc <= 1) return;
+///
+/// @return true if startup should continue, false if `--strict-flag-check` requires aborting.
+[[nodiscard]] bool CheckSuspiciousPositionalArgs(int argc, char **argv) {
+  if (argc <= 1) return true;
 
   auto is_bool_like = [](std::string_view arg) {
     using namespace std::string_view_literals;
@@ -140,7 +142,7 @@ void CheckSuspiciousPositionalArgs(int argc, char **argv) {
     spdlog::log(
         level, "Unexpected positional argument(s): {}. Memgraph does not accept positional arguments.", all_args);
   }
-  if (FLAGS_strict_flag_check) std::exit(EXIT_FAILURE);
+  return !FLAGS_strict_flag_check;
 }
 
 // TODO: move elsewhere so that we can remove need of interpreter.hpp
@@ -267,7 +269,7 @@ int main(int argc, char **argv) {
   // overwrite the config.
   LoadConfig("memgraph");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
-  CheckSuspiciousPositionalArgs(argc, argv);
+  if (!CheckSuspiciousPositionalArgs(argc, argv)) return EXIT_FAILURE;
   WarnDeprecatedFlags();
 
   // Publish worker count early so allocators can pre-size thread-local structures

--- a/src/planner/include/planner/rewrite/rewriter.hpp
+++ b/src/planner/include/planner/rewrite/rewriter.hpp
@@ -317,7 +317,7 @@ class Rewriter {
   EGraph<Symbol, Analysis> *egraph_;
   RuleSet<Symbol, Analysis> rules_;  ///< Shared rules (cheap to copy)
   MatcherIndex<Symbol, Analysis> matcher_;
-  vm::VMExecutor<Symbol, Analysis> vm_executor_;  ///< VM pattern matcher
+  pattern::vm::VMExecutor<Symbol, Analysis> vm_executor_;  ///< VM pattern matcher
   ProcessingContext<Symbol> proc_ctx_;
   RewriteContext<Symbol, Analysis> ctx_;
 };

--- a/src/planner/include/planner/rewrite/rule.hpp
+++ b/src/planner/include/planner/rewrite/rule.hpp
@@ -27,9 +27,6 @@
 
 namespace memgraph::planner::core::rewrite {
 
-// Namespace alias for VM types
-namespace vm = pattern::vm;
-
 // Import specific types from pattern namespace
 using pattern::EMatchContext;
 using pattern::Match;
@@ -82,7 +79,7 @@ class RewriteRule {
     /// @pre At least one pattern must have been added
     template <typename F>
     auto apply(F &&fn) && -> RewriteRule {
-      vm::PatternsCompiler<Symbol> compiler;
+      pattern::vm::PatternsCompiler<Symbol> compiler;
       auto compiled = compiler.compile(patterns_);
       return RewriteRule{std::move(patterns_),
                          std::move(pattern_names_),
@@ -102,7 +99,7 @@ class RewriteRule {
   [[nodiscard]] auto patterns() const -> std::span<Pattern<Symbol> const> { return patterns_; }
 
   /// Access the compiled bytecode for VM execution
-  [[nodiscard]] auto compiled() const -> vm::CompiledMatcher<Symbol> const & { return compiled_; }
+  [[nodiscard]] auto compiled() const -> pattern::vm::CompiledMatcher<Symbol> const & { return compiled_; }
 
   /// Get the root symbol of the first pattern (for index-based candidate lookup)
   [[nodiscard]] auto first_pattern_root_symbol() const -> std::optional<Symbol> {
@@ -132,7 +129,7 @@ class RewriteRule {
 
  private:
   RewriteRule(std::vector<Pattern<Symbol>> patterns, std::vector<std::string> pattern_names, ApplyFn apply_fn,
-              std::string name, vm::CompiledMatcher<Symbol> compiled)
+              std::string name, pattern::vm::CompiledMatcher<Symbol> compiled)
       : patterns_(std::move(patterns)),
         pattern_names_(std::move(pattern_names)),
         apply_fn_(std::move(apply_fn)),
@@ -143,7 +140,7 @@ class RewriteRule {
   std::vector<std::string> pattern_names_;
   ApplyFn apply_fn_;
   std::string name_;
-  vm::CompiledMatcher<Symbol> compiled_;
+  pattern::vm::CompiledMatcher<Symbol> compiled_;
 };
 
 }  // namespace memgraph::planner::core::rewrite

--- a/src/storage/v2/indices/point_index.cpp
+++ b/src/storage/v2/indices/point_index.cpp
@@ -26,6 +26,9 @@
 
 namespace memgraph::storage {
 
+namespace bg = boost::geometry;
+namespace bgi = boost::geometry::index;
+
 struct PointIndex {
   PointIndex() = default;
 
@@ -124,7 +127,8 @@ void PointIndexStorage::PublishActiveIndices(ActiveIndicesUpdater const &updater
   updater(std::make_shared<PointIndexStorage::ActiveIndices>(indexes_));
 }
 
-bool PointIndexStorage::CreatePointIndex(LabelId label, PropertyId property, utils::SkipListDb<Vertex>::Accessor vertices,
+bool PointIndexStorage::CreatePointIndex(LabelId label, PropertyId property,
+                                         utils::SkipListDb<Vertex>::Accessor vertices,
                                          std::optional<SnapshotObserverInfo> const &snapshot_info) {
   auto key = LabelPropKey{label, property};
   if (indexes_->contains(key)) return false;

--- a/src/storage/v2/indices/point_index_expensive_header.hpp
+++ b/src/storage/v2/indices/point_index_expensive_header.hpp
@@ -17,9 +17,6 @@
 #include <boost/geometry/geometries/point.hpp>
 #include <boost/geometry/index/rtree.hpp>
 
-namespace bg = boost::geometry;
-namespace bgi = boost::geometry::index;
-
 namespace memgraph::storage {
 
 struct Vertex;
@@ -27,21 +24,21 @@ struct Vertex;
 struct IndexPointWGS2d {
   explicit IndexPointWGS2d(Point2d point) : rep{point.x(), point.y()} { DMG_ASSERT(IsWGS(point.crs())); }
 
-  using point_type = bg::model::point<double, 2, bg::cs::geographic<bg::degree>>;
+  using point_type = boost::geometry::model::point<double, 2, boost::geometry::cs::geographic<boost::geometry::degree>>;
   point_type rep;
 };
 
 struct IndexPointWGS3d {
   explicit IndexPointWGS3d(Point3d point) : rep{point.x(), point.y(), point.z()} { DMG_ASSERT(IsWGS(point.crs())); }
 
-  using point_type = bg::model::point<double, 3, bg::cs::geographic<bg::degree>>;
+  using point_type = boost::geometry::model::point<double, 3, boost::geometry::cs::geographic<boost::geometry::degree>>;
   point_type rep;
 };
 
 struct IndexPointCartesian2d {
   explicit IndexPointCartesian2d(Point2d point) : rep{point.x(), point.y()} { DMG_ASSERT(IsCartesian(point.crs())); }
 
-  using point_type = bg::model::point<double, 2, bg::cs::cartesian>;
+  using point_type = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>;
   point_type rep;
 };
 
@@ -50,7 +47,7 @@ struct IndexPointCartesian3d {
     DMG_ASSERT(IsCartesian(point.crs()));
   }
 
-  using point_type = bg::model::point<double, 3, bg::cs::cartesian>;
+  using point_type = boost::geometry::model::point<double, 3, boost::geometry::cs::cartesian>;
   point_type rep;
 };
 
@@ -77,7 +74,7 @@ struct Entry {
 };  // namespace memgraph::storage
 
 template <typename IndexPoint>
-struct bg::index::indexable<memgraph::storage::Entry<IndexPoint>> {
+struct boost::geometry::index::indexable<memgraph::storage::Entry<IndexPoint>> {
   using result_type = typename IndexPoint::point_type;
 
   auto operator()(memgraph::storage::Entry<IndexPoint> const &val) const -> result_type const & { return val.point(); }
@@ -85,6 +82,7 @@ struct bg::index::indexable<memgraph::storage::Entry<IndexPoint>> {
 
 namespace memgraph::storage {
 template <typename IndexPoint>
-using index_t = bgi::rtree<Entry<IndexPoint>, bgi::quadratic<64>>;  // TODO: tune this
+using index_t =
+    boost::geometry::index::rtree<Entry<IndexPoint>, boost::geometry::index::quadratic<64>>;  // TODO: tune this
 
 }

--- a/src/storage/v2/point_functions.cpp
+++ b/src/storage/v2/point_functions.cpp
@@ -21,6 +21,8 @@
 
 namespace memgraph::storage {
 
+namespace bg = boost::geometry;
+
 double Haversine(Point2d const &point1, Point2d const &point2) {
   using pt = IndexPointWGS2d::point_type;
   auto boost_p1 = pt{point1.x(), point1.y()};

--- a/src/storage/v2/property_store.cpp
+++ b/src/storage/v2/property_store.cpp
@@ -50,7 +50,7 @@ DEFINE_VALIDATED_uint64(storage_floating_point_resolution_bits, 64,
                         "Smaller values save space but reduce precision (32=float, 16=half).",
                         {
                           if (value == 16 || value == 32 || value == 64) return true;
-                          std::cout << "Expected --" << flagname << " to be one of 16, 32, 64\n";
+                          std::cerr << "Expected --" << flagname << " to be one of 16, 32, 64\n";
                           return false;
                         });
 

--- a/src/utils/compressor.cpp
+++ b/src/utils/compressor.cpp
@@ -33,11 +33,11 @@ bool ValidStoragePropertyStoreCompressionLevel(std::string_view value) {
     const auto error = result.error();
     switch (error) {
       case memgraph::utils::ValidationError::EmptyValue: {
-        std::cout << "Compression level cannot be empty." << '\n';
+        std::cerr << "Compression level cannot be empty." << '\n';
         break;
       }
       case memgraph::utils::ValidationError::InvalidValue: {
-        std::cout << "Invalid value for compression level. Allowed values: "
+        std::cerr << "Invalid value for compression level. Allowed values: "
                   << memgraph::utils::GetAllowedEnumValuesString(compression_level_mappings) << '\n';
         break;
       }

--- a/src/utils/concurrency_hint.hpp
+++ b/src/utils/concurrency_hint.hpp
@@ -10,6 +10,7 @@
 // licenses/APL.txt.
 #pragma once
 
+#include <algorithm>
 #include <atomic>
 #include <cstddef>
 #include <thread>
@@ -25,7 +26,9 @@ inline void SetNumWorkers(std::size_t n) { global_num_workers.store(n, std::memo
 
 inline auto GetNumWorkers() -> std::size_t {
   auto n = global_num_workers.load(std::memory_order_acquire);
-  return n > 0 ? n : std::thread::hardware_concurrency();
+  if (n > 0) return n;
+  // hardware_concurrency() may return 0 in restricted environments (cgroups, sandboxes).
+  return std::max<std::size_t>(std::thread::hardware_concurrency(), 1);
 }
 
 }  // namespace memgraph::utils

--- a/src/utils/flag_validation.hpp
+++ b/src/utils/flag_validation.hpp
@@ -181,6 +181,6 @@
 #define FLAG_IN_RANGE(lower_bound, upper_bound)                                                                   \
   {                                                                                                               \
     if (value >= lower_bound && value <= upper_bound) return true;                                                \
-    std::cout << "Expected --" << flagname << " to be in range [" << lower_bound << ", " << upper_bound << "]\n"; \
+    std::cerr << "Expected --" << flagname << " to be in range [" << lower_bound << ", " << upper_bound << "]\n"; \
     return false;                                                                                                 \
   }


### PR DESCRIPTION
- Drop leaking namespace aliases from point_index_expensive_header.hpp (bg/bgi) and planner/rewrite/rule.hpp (vm); qualify or alias locally.
- Clamp hardware_concurrency() wrapper in concurrency_hint.hpp to >= 1.
- Flag-validator error paths: std::cout -> std::cerr (stdout is fully buffered when redirected and can be lost on abort).
- CheckSuspiciousPositionalArgs: remove std::exit, return bool and propagate via EXIT_FAILURE to avoid running global destructors.