### PR TITLE
refactor: deduplicate ASC/DESC label-property indexes in ANALYZE GRAPH

### DIFF
--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -31,6 +31,7 @@
 #include <thread>
 #include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <usearch/index_plugins.hpp>
 #include <utility>
 #include <variant>
@@ -3896,7 +3897,7 @@ std::vector<std::vector<TypedValue>> AnalyzeGraphQueryHandler::AnalyzeGraphCreat
     return label_stats;
   };
 
-  auto populate_label_property_stats = [execution_db_accessor, view](auto index_info) {
+  auto populate_label_property_stats = [execution_db_accessor, view](auto &index_info) {
     std::map<LPIndex, std::map<std::vector<storage::PropertyValue>, int64_t>> label_property_counter;
     std::map<LPIndex, uint64_t> vertex_degree_counter;
 
@@ -4026,6 +4027,15 @@ std::vector<std::vector<TypedValue>> AnalyzeGraphQueryHandler::AnalyzeGraphCreat
 
   std::vector<LPIndex> label_property_indices_info = index_info.label_properties;
   erase_not_specified_label_property_indices(label_property_indices_info);
+  // Stats are keyed by (label, properties) only — `IndexOrder` does not affect
+  // count/chi-squared/avg_degree. Collapse entries that differ only in order
+  // so we don't perform a redundant full vertex scan when both ASC and DESC
+  // indexes exist on the same key.
+  auto const stats_key_proj = [](LPIndex const &e) { return e.stats_key(); };
+  std::ranges::sort(label_property_indices_info, std::less{}, stats_key_proj);
+  label_property_indices_info.erase(
+      std::ranges::unique(label_property_indices_info, std::equal_to{}, stats_key_proj).begin(),
+      label_property_indices_info.end());
   auto label_property_stats = populate_label_property_stats(label_property_indices_info);
 
   std::vector<std::vector<TypedValue>> results;
@@ -4112,11 +4122,10 @@ std::vector<std::vector<TypedValue>> AnalyzeGraphQueryHandler::AnalyzeGraphDelet
   auto populate_label_property_results = [execution_db_accessor](auto const &index_info) {
     std::vector<std::pair<storage::LabelId, std::vector<storage::PropertyPath>>> label_property_results;
     label_property_results.reserve(index_info.size());
-
     std::for_each(index_info.begin(),
                   index_info.end(),
-                  [execution_db_accessor, &label_property_results](const storage::LabelPropertyIndexEntry &entry) {
-                    auto res = execution_db_accessor->DeleteLabelPropertyIndexStats(entry.label);
+                  [execution_db_accessor, &label_property_results](const storage::LabelId &label) {
+                    auto res = execution_db_accessor->DeleteLabelPropertyIndexStats(label);
                     label_property_results.insert(
                         label_property_results.end(), std::move_iterator{res.begin()}, std::move_iterator{res.end()});
                   });
@@ -4132,7 +4141,15 @@ std::vector<std::vector<TypedValue>> AnalyzeGraphQueryHandler::AnalyzeGraphDelet
 
   auto label_property_indices_info = index_info.label_properties;
   erase_not_specified_label_property_indices(label_property_indices_info);
-  auto label_prop_results = populate_label_property_results(label_property_indices_info);
+  // `DeleteLabelPropertyIndexStats` is keyed by label and wipes every
+  // (label, properties) entry in one call — collapse to unique labels so
+  // repeated entries (different property combos, or ASC/DESC pairs) don't
+  // produce redundant replicated metadata deltas.
+  auto unique_labels =
+      label_property_indices_info | rv::transform(&storage::LabelPropertyIndexEntry::label) | ranges::to<std::vector>();
+  std::ranges::sort(unique_labels);
+  unique_labels.erase(std::ranges::unique(unique_labels).begin(), unique_labels.end());
+  auto label_prop_results = populate_label_property_results(unique_labels);
 
   std::vector<std::vector<TypedValue>> results;
   results.reserve(label_results.size() + label_prop_results.size());

--- a/src/storage/v2/indices/label_property_index_entry.hpp
+++ b/src/storage/v2/indices/label_property_index_entry.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <compare>
+#include <tuple>
 #include <vector>
 
 #include "storage/v2/id_types.hpp"
@@ -24,6 +25,11 @@ struct LabelPropertyIndexEntry {
   LabelId label;
   std::vector<PropertyPath> properties;
   IndexOrder order{IndexOrder::ASC};
+
+  // Index statistics are independent of `order`.
+  auto stats_key() const noexcept -> std::tuple<LabelId const &, std::vector<PropertyPath> const &> {
+    return std::tie(label, properties);
+  }
 
   friend auto operator<=>(LabelPropertyIndexEntry const &, LabelPropertyIndexEntry const &) = default;
   friend bool operator==(LabelPropertyIndexEntry const &, LabelPropertyIndexEntry const &) = default;

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -12,6 +12,8 @@
 #include <algorithm>
 #include <cstdlib>
 #include <filesystem>
+#include <map>
+#include <set>
 
 #include "communication/bolt/v1/value.hpp"
 #include "communication/result_stream_faker.hpp"
@@ -1701,4 +1703,57 @@ TYPED_TEST(InterpreterTest, ShowConfigQueryPriorityIsHigh) {
 TYPED_TEST(InterpreterTest, ShowTransactionsQueryPriorityIsHigh) {
   auto [stream, qid] = this->Prepare("SHOW TRANSACTIONS");
   EXPECT_EQ(this->default_interpreter.interpreter.GetQueryPriority(qid), memgraph::utils::Priority::HIGH);
+}
+
+// When ASC and DESC label-property indexes coexist on the same
+// (label, properties), ANALYZE GRAPH would scan vertices and emit stats once
+// per index order, producing duplicate result rows and redundant
+// SetIndexStats writes for the same (label, properties) slot.
+//
+// The create-side dedup is observable through duplicate result rows. The
+// delete-side dedup eliminates redundant `MetadataDelta::label_property_index
+// _stats_clear` emissions, which are not visible through query results — the
+// assertion below only verifies that `DELETE STATISTICS` returns one row per
+// (label, properties) regardless of the number of (label, properties, order)
+// entries that were deduplicated.
+TYPED_TEST(InterpreterTest, AnalyzeGraphDeduplicatesAscDescIndexes) {
+  if constexpr (std::is_same_v<TypeParam, memgraph::storage::DiskStorage>) {
+    GTEST_SKIP() << "DESC label-property indexes are not supported on disk storage.";
+  }
+
+  this->Interpret("CREATE INDEX ON :LabelA(prop);");
+  this->Interpret(R"(CREATE INDEX ON :LabelA(prop) WITH CONFIG {"order": "DESC"};)");
+  this->Interpret("CREATE INDEX ON :LabelB(prop);");
+  this->Interpret(R"(CREATE INDEX ON :LabelB(prop) WITH CONFIG {"order": "DESC"};)");
+  this->Interpret("FOREACH (i IN range(1, 10) | CREATE (n:LabelA {prop: i}));");
+  this->Interpret("FOREACH (i IN range(1, 5) | CREATE (n:LabelB {prop: i}));");
+
+  // ANALYZE GRAPH result columns: label, property, num estimation nodes, ...
+  constexpr std::size_t kLabelCol = 0;
+  constexpr std::size_t kPropertyCol = 1;
+  constexpr std::size_t kCountCol = 2;
+
+  auto stream = this->Interpret("ANALYZE GRAPH;");
+  const auto &results = stream.GetResults();
+  ASSERT_EQ(results.size(), 2U) << "ANALYZE GRAPH should produce exactly one row per "
+                                   "(label, properties); ASC/DESC duplicates must be deduped.";
+  std::map<std::string, int64_t> counts_by_label;
+  for (const auto &row : results) {
+    const auto &props = row[kPropertyCol].ValueList();
+    ASSERT_EQ(props.size(), 1U);
+    EXPECT_EQ(props[0].ValueString(), "prop");
+    counts_by_label[row[kLabelCol].ValueString()] = row[kCountCol].ValueInt();
+  }
+  EXPECT_EQ(counts_by_label["LabelA"], 10);
+  EXPECT_EQ(counts_by_label["LabelB"], 5);
+
+  auto delete_stream = this->Interpret("ANALYZE GRAPH DELETE STATISTICS;");
+  const auto &delete_results = delete_stream.GetResults();
+  ASSERT_EQ(delete_results.size(), 2U) << "ANALYZE GRAPH DELETE STATISTICS should report each "
+                                          "(label, properties) at most once.";
+  std::set<std::string> deleted_labels;
+  for (const auto &row : delete_results) {
+    deleted_labels.insert(row[kLabelCol].ValueString());
+  }
+  EXPECT_EQ(deleted_labels, (std::set<std::string>{"LabelA", "LabelB"}));
 }


### PR DESCRIPTION
`ANALYZE GRAPH` and `ANALYZE GRAPH DELETE STATISTICS` drive their loops off `ListAllIndices().label_properties`, which lists ASC and DESC indexes on the same `(label, properties)` as separate entries even though stats are keyed by `(label, properties)` only. This caused redundant full vertex scans plus duplicate result rows in the create path, and redundant replicated `MetadataDelta::label_property_index_stats_clear` entries in the delete path (the latter also fired pre-existing whenever a label had multiple property combos).

Dedup once at the interpreter boundary, matching each storage API's granularity: by `LabelPropertyIndexEntry::stats_key()` for create (matches `SetIndexStats`) and by `LabelId` for delete (matches `DeleteLabelPropertyIndexStats`). A new `stats_key()` projection centralizes the order-independent `(label, properties)` key.