### PR TITLE
Update auth error message when setting main database

### DIFF
--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -1598,14 +1598,24 @@ Auth::Result Auth::SetMainDatabase(std::string_view db, const std::string &name,
 
 void Auth::SetMainDatabase(std::string_view db, User &user, system::Transaction *system_tx) {
   if (!user.db_access().SetMain(db)) {
-    throw AuthException("Couldn't set default database '{}' for '{}'!", db, user.username());
+    throw AuthException(
+        "Cannot set default database '{}' for user '{}': either access has not been granted or it is explicitly "
+        "denied. Run `SHOW DATABASE PRIVILEGES FOR {}` to inspect current user privileges.",
+        db,
+        user.username(),
+        user.username());
   }
   SaveUser(user, system_tx);
 }
 
 void Auth::SetMainDatabase(std::string_view db, Role &role, system::Transaction *system_tx) {
   if (!role.db_access().SetMain(db)) {
-    throw AuthException("Couldn't set default database '{}' for '{}'!", db, role.rolename());
+    throw AuthException(
+        "Cannot set default database '{}' for role '{}': either access has not been granted or it is explicitly "
+        "denied. Run `SHOW DATABASE PRIVILEGES FOR {}` to inspect current role privileges.",
+        db,
+        role.rolename(),
+        role.rolename());
   }
   SaveRole(role, system_tx);
 }


### PR DESCRIPTION
Improves the error message thrown by `Auth::SetMainDatabase` (both the `User` and `Role` overloads) when the target database can't be set as the default.

Previously the code threw a generic:

> Couldn't set default database 'X' for 'Y'!

…which gave operators no indication of *why* the call failed. `Databases::SetMain` returns `false` whenever the database is not in the user/role's effective grant set — either because access was never granted, or because there's an explicit deny that overrides `allow_all_`.

The new message:

- States the actual cause: access has either not been granted or has been explicitly denied.
- Points the operator at the right diagnostic query (`SHOW DATABASE PRIVILEGES FOR <name>`) so they can inspect the current state themselves.
- Distinguishes user vs. role wording in the recovery hint.