### PR TITLE
fix: Jepsen on Ubuntu 26.04 host

### DIFF
--- a/tests/jepsen/run.sh
+++ b/tests/jepsen/run.sh
@@ -2,7 +2,7 @@
 set -Eeuo pipefail
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-MEMGRAPH_BUILD_PATH="$script_dir/../../build"
+MEMGRAPH_BUILD_PATH="$(realpath -m "$script_dir/../../build")"
 MEMGRAPH_BINARY_PATH="$MEMGRAPH_BUILD_PATH/memgraph"
 MEMGRAPH_MTENANCY_DATASETS="$script_dir/datasets/"
 # NOTE: Jepsen Git tags are not consistent, there are: 0.2.4, v0.3.0, 0.3.2, ...
@@ -85,7 +85,7 @@ GET_SHARED_LIBRARIES() {
                 fi
             fi
         fi
-    done < <(ldd "$binary_path" 2>/dev/null || echo "")
+    done < <(ldd "$binary_path" || echo "")
 
     echo "${libraries[@]}"
 }

--- a/tests/jepsen/run.sh
+++ b/tests/jepsen/run.sh
@@ -63,6 +63,12 @@ GET_SHARED_LIBRARIES() {
         # Skip lines that don't contain library paths
         if [[ "$line" =~ =\>[[:space:]]+([^[:space:]]+) ]]; then
             local lib_path="${BASH_REMATCH[1]}"
+            # Normalize away ../.. segments without resolving symlinks. glibc <2.42
+            # preserves the un-canonicalized $ORIGIN form here, glibc >=2.42 returns
+            # a kernel-canonicalized path; we want the prefix check below to work on both.
+            if [[ "$lib_path" == /* ]]; then
+                lib_path="$(realpath -m -s "$lib_path")"
+            fi
             # Skip "not found" and system libraries
             if [[ "$lib_path" != "not found" && "$lib_path" != "/lib"* && "$lib_path" != "/usr/lib"* ]]; then
                 # Check if the library is in the build directory


### PR DESCRIPTION
Canonicalize `MEMGRAPH_BUILD_PATH` with `realpath -m` so the build-dir prefix check against `ldd` output still matches on Ubuntu 26.04 (glibc 2.43) - change that broke it: https://github.com/bminor/glibc/commit/9b646f5dc933dfa019f2ed7f80b6198b43e31f62

