### PR TITLE
infra: Add action to fail fast while in the merge queue

### DIFF
--- a/.github/actions/cancel-on-failure-in-merge-queue/action.yml
+++ b/.github/actions/cancel-on-failure-in-merge-queue/action.yml
@@ -14,6 +14,7 @@ runs:
         set -euo pipefail
         echo "Cancelling workflow run ${RUN_ID} in ${GH_REPO} after merge_group job failure"
         curl -fsSL -X POST \
+          --proto '=https' --proto-redir '=https' \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${GH_TOKEN}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \

--- a/.github/actions/cancel-on-failure-in-merge-queue/action.yml
+++ b/.github/actions/cancel-on-failure-in-merge-queue/action.yml
@@ -1,0 +1,20 @@
+name: 'Cancel run on merge_group failure'
+description: 'Cancels the current workflow run via the GitHub API. The caller must gate this with `if: failure() && github.event_name == ''merge_group''` because composite actions cannot read the calling job''s runtime status.'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Cancel workflow run
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+        RUN_ID: ${{ github.run_id }}
+      run: |
+        set -euo pipefail
+        echo "Cancelling workflow run ${RUN_ID} in ${GH_REPO} after merge_group job failure"
+        curl -fsSL -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${GH_TOKEN}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "https://api.github.com/repos/${GH_REPO}/actions/runs/${RUN_ID}/cancel"

--- a/.github/workflows/diff_community.yaml
+++ b/.github/workflows/diff_community.yaml
@@ -112,3 +112,7 @@ jobs:
         continue-on-error: true
         run: |
           ./tools/ci/docker_cleanup.sh
+
+      - name: Cancel run on merge_group failure
+        if: ${{ failure() && github.event_name == 'merge_group' }}
+        uses: ./.github/actions/cancel-on-failure-in-merge-queue

--- a/.github/workflows/diff_community.yaml
+++ b/.github/workflows/diff_community.yaml
@@ -114,5 +114,6 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
+        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
+        if: ${{ failure() }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue

--- a/.github/workflows/diff_community.yaml
+++ b/.github/workflows/diff_community.yaml
@@ -114,6 +114,5 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue

--- a/.github/workflows/diff_coverage.yaml
+++ b/.github/workflows/diff_coverage.yaml
@@ -178,7 +178,8 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
+        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
+        if: ${{ failure() }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
 
   clang-tidy-community:
@@ -270,7 +271,8 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
+        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
+        if: ${{ failure() }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
 
   clang-tidy-enterprise:
@@ -362,5 +364,6 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
+        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
+        if: ${{ failure() }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue

--- a/.github/workflows/diff_coverage.yaml
+++ b/.github/workflows/diff_coverage.yaml
@@ -177,6 +177,10 @@ jobs:
         run: |
           ./tools/ci/docker_cleanup.sh
 
+      - name: Cancel run on merge_group failure
+        if: ${{ failure() && github.event_name == 'merge_group' }}
+        uses: ./.github/actions/cancel-on-failure-in-merge-queue
+
   clang-tidy-community:
     if: ${{ inputs.run_clang_tidy == 'true' }}
     name: "Clang tidy community"
@@ -265,6 +269,10 @@ jobs:
         run: |
           ./tools/ci/docker_cleanup.sh
 
+      - name: Cancel run on merge_group failure
+        if: ${{ failure() && github.event_name == 'merge_group' }}
+        uses: ./.github/actions/cancel-on-failure-in-merge-queue
+
   clang-tidy-enterprise:
     if: ${{ inputs.run_clang_tidy == 'true' }}
     name: "Clang tidy enterprise"
@@ -352,3 +360,7 @@ jobs:
         continue-on-error: true
         run: |
           ./tools/ci/docker_cleanup.sh
+
+      - name: Cancel run on merge_group failure
+        if: ${{ failure() && github.event_name == 'merge_group' }}
+        uses: ./.github/actions/cancel-on-failure-in-merge-queue

--- a/.github/workflows/diff_coverage.yaml
+++ b/.github/workflows/diff_coverage.yaml
@@ -178,8 +178,7 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
 
   clang-tidy-community:
@@ -271,8 +270,7 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
 
   clang-tidy-enterprise:
@@ -364,6 +362,5 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue

--- a/.github/workflows/diff_debug.yaml
+++ b/.github/workflows/diff_debug.yaml
@@ -167,8 +167,7 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
 
   integration:
@@ -251,6 +250,5 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue

--- a/.github/workflows/diff_debug.yaml
+++ b/.github/workflows/diff_debug.yaml
@@ -166,6 +166,10 @@ jobs:
         run: |
           ./tools/ci/docker_cleanup.sh
 
+      - name: Cancel run on merge_group failure
+        if: ${{ failure() && github.event_name == 'merge_group' }}
+        uses: ./.github/actions/cancel-on-failure-in-merge-queue
+
   integration:
     if: ${{ inputs.run_integration == 'true' }}
     name: "Integration test"
@@ -244,3 +248,7 @@ jobs:
         continue-on-error: true
         run: |
           ./tools/ci/docker_cleanup.sh
+
+      - name: Cancel run on merge_group failure
+        if: ${{ failure() && github.event_name == 'merge_group' }}
+        uses: ./.github/actions/cancel-on-failure-in-merge-queue

--- a/.github/workflows/diff_debug.yaml
+++ b/.github/workflows/diff_debug.yaml
@@ -167,7 +167,8 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
+        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
+        if: ${{ failure() }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
 
   integration:
@@ -250,5 +251,6 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
+        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
+        if: ${{ failure() }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue

--- a/.github/workflows/diff_jepsen.yaml
+++ b/.github/workflows/diff_jepsen.yaml
@@ -151,6 +151,5 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue

--- a/.github/workflows/diff_jepsen.yaml
+++ b/.github/workflows/diff_jepsen.yaml
@@ -151,5 +151,6 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
+        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
+        if: ${{ failure() }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue

--- a/.github/workflows/diff_jepsen.yaml
+++ b/.github/workflows/diff_jepsen.yaml
@@ -149,3 +149,7 @@ jobs:
         continue-on-error: true
         run: |
           ./tools/ci/docker_cleanup.sh
+
+      - name: Cancel run on merge_group failure
+        if: ${{ failure() && github.event_name == 'merge_group' }}
+        uses: ./.github/actions/cancel-on-failure-in-merge-queue

--- a/.github/workflows/diff_mage.yml
+++ b/.github/workflows/diff_mage.yml
@@ -81,9 +81,6 @@ jobs:
           echo "s3_dest_dir=$S3_DEST_DIR" >> "$GITHUB_OUTPUT"
           echo "S3 Destination Directory: $S3_DEST_DIR"
 
-      - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
-        uses: ./.github/actions/cancel-on-failure-in-merge-queue
 
   # NOTE: the naming of the following jobs is a hack so that the checks in the PR match those in the merge group even if the MAGE tests are not run
   amd_mage_tests:

--- a/.github/workflows/diff_mage.yml
+++ b/.github/workflows/diff_mage.yml
@@ -82,8 +82,7 @@ jobs:
           echo "S3 Destination Directory: $S3_DEST_DIR"
 
       - name: Cancel run on merge_group failure
-        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
 
   # NOTE: the naming of the following jobs is a hack so that the checks in the PR match those in the merge group even if the MAGE tests are not run

--- a/.github/workflows/diff_mage.yml
+++ b/.github/workflows/diff_mage.yml
@@ -82,7 +82,8 @@ jobs:
           echo "S3 Destination Directory: $S3_DEST_DIR"
 
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
+        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
+        if: ${{ failure() }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
 
   # NOTE: the naming of the following jobs is a hack so that the checks in the PR match those in the merge group even if the MAGE tests are not run

--- a/.github/workflows/diff_mage.yml
+++ b/.github/workflows/diff_mage.yml
@@ -81,6 +81,10 @@ jobs:
           echo "s3_dest_dir=$S3_DEST_DIR" >> "$GITHUB_OUTPUT"
           echo "S3 Destination Directory: $S3_DEST_DIR"
 
+      - name: Cancel run on merge_group failure
+        if: ${{ failure() && github.event_name == 'merge_group' }}
+        uses: ./.github/actions/cancel-on-failure-in-merge-queue
+
   # NOTE: the naming of the following jobs is a hack so that the checks in the PR match those in the merge group even if the MAGE tests are not run
   amd_mage_tests:
     name: "MAGE Tests (AMD)${{ !inputs.run_amd && ' / Build and Test MAGE' || '' }}"

--- a/.github/workflows/diff_malloc.yaml
+++ b/.github/workflows/diff_malloc.yaml
@@ -119,3 +119,7 @@ jobs:
         continue-on-error: true
         run: |
           ./tools/ci/docker_cleanup.sh
+
+      - name: Cancel run on merge_group failure
+        if: ${{ failure() && github.event_name == 'merge_group' }}
+        uses: ./.github/actions/cancel-on-failure-in-merge-queue

--- a/.github/workflows/diff_malloc.yaml
+++ b/.github/workflows/diff_malloc.yaml
@@ -121,5 +121,6 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
+        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
+        if: ${{ failure() }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue

--- a/.github/workflows/diff_malloc.yaml
+++ b/.github/workflows/diff_malloc.yaml
@@ -121,6 +121,5 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue

--- a/.github/workflows/diff_mgcxx.yml
+++ b/.github/workflows/diff_mgcxx.yml
@@ -40,6 +40,13 @@ jobs:
         make -j$(nproc)
         ctest --output-on-failure -j$(nproc)
 
+    # TEMP: synthetic failure to exercise fail-fast cancellation — remove before merging
+    - name: Sleep 2 minutes then fail
+      run: |
+        sleep 120
+        exit 1
+
     - name: Cancel run on merge_group failure
-      if: ${{ failure() && github.event_name == 'merge_group' }}
+      # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
+      if: ${{ failure() }}
       uses: ./.github/actions/cancel-on-failure-in-merge-queue

--- a/.github/workflows/diff_mgcxx.yml
+++ b/.github/workflows/diff_mgcxx.yml
@@ -39,3 +39,7 @@ jobs:
         cmake ..
         make -j$(nproc)
         ctest --output-on-failure -j$(nproc)
+
+    - name: Cancel run on merge_group failure
+      if: ${{ failure() && github.event_name == 'merge_group' }}
+      uses: ./.github/actions/cancel-on-failure-in-merge-queue

--- a/.github/workflows/diff_mgcxx.yml
+++ b/.github/workflows/diff_mgcxx.yml
@@ -40,13 +40,6 @@ jobs:
         make -j$(nproc)
         ctest --output-on-failure -j$(nproc)
 
-    # TEMP: synthetic failure to exercise fail-fast cancellation — remove before merging
-    - name: Sleep 2 minutes then fail
-      run: |
-        sleep 120
-        exit 1
-
     - name: Cancel run on merge_group failure
-      # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
-      if: ${{ failure() }}
+      if: ${{ failure() && github.event_name == 'merge_group' }}
       uses: ./.github/actions/cancel-on-failure-in-merge-queue

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -192,7 +192,8 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
+        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
+        if: ${{ failure() }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
 
   benchmark:
@@ -430,7 +431,8 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
+        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
+        if: ${{ failure() }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
 
   e2e:
@@ -556,7 +558,8 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
+        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
+        if: ${{ failure() }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
 
   stress:
@@ -690,7 +693,8 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
+        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
+        if: ${{ failure() }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
 
   query_modules:
@@ -795,5 +799,6 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
+        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
+        if: ${{ failure() }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -192,8 +192,7 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
 
   benchmark:
@@ -431,8 +430,7 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
 
   e2e:
@@ -558,8 +556,7 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
 
   stress:
@@ -693,8 +690,7 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue
 
   query_modules:
@@ -799,6 +795,5 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -191,6 +191,10 @@ jobs:
         run: |
           ./tools/ci/docker_cleanup.sh
 
+      - name: Cancel run on merge_group failure
+        if: ${{ failure() && github.event_name == 'merge_group' }}
+        uses: ./.github/actions/cancel-on-failure-in-merge-queue
+
   benchmark:
     if: ${{ inputs.run_benchmark == 'true' }}
     name: "Benchmark"
@@ -425,6 +429,10 @@ jobs:
         run: |
           ./tools/ci/docker_cleanup.sh
 
+      - name: Cancel run on merge_group failure
+        if: ${{ failure() && github.event_name == 'merge_group' }}
+        uses: ./.github/actions/cancel-on-failure-in-merge-queue
+
   e2e:
     if: ${{ inputs.run_e2e == 'true' }}
     name: "End to end tests"
@@ -546,6 +554,10 @@ jobs:
         continue-on-error: true
         run: |
           ./tools/ci/docker_cleanup.sh
+
+      - name: Cancel run on merge_group failure
+        if: ${{ failure() && github.event_name == 'merge_group' }}
+        uses: ./.github/actions/cancel-on-failure-in-merge-queue
 
   stress:
     if: ${{ inputs.run_stress == 'true' }}
@@ -677,6 +689,10 @@ jobs:
         run: |
           ./tools/ci/docker_cleanup.sh
 
+      - name: Cancel run on merge_group failure
+        if: ${{ failure() && github.event_name == 'merge_group' }}
+        uses: ./.github/actions/cancel-on-failure-in-merge-queue
+
   query_modules:
     if: ${{ inputs.run_query_modules == 'true' }}
     name: "Query modules tests"
@@ -777,3 +793,7 @@ jobs:
         continue-on-error: true
         run: |
           ./tools/ci/docker_cleanup.sh
+
+      - name: Cancel run on merge_group failure
+        if: ${{ failure() && github.event_name == 'merge_group' }}
+        uses: ./.github/actions/cancel-on-failure-in-merge-queue

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -642,6 +642,5 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name == 'merge_group' }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -640,3 +640,7 @@ jobs:
         if: always()
         run: |
           ./tools/ci/docker_cleanup.sh
+
+      - name: Cancel run on merge_group failure
+        if: ${{ failure() && github.event_name == 'merge_group' }}
+        uses: ./.github/actions/cancel-on-failure-in-merge-queue

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -642,5 +642,6 @@ jobs:
           ./tools/ci/docker_cleanup.sh
 
       - name: Cancel run on merge_group failure
-        if: ${{ failure() && github.event_name == 'merge_group' }}
+        # TEMP: ungated for manual testing — restore `&& github.event_name == 'merge_group'` before merging
+        if: ${{ failure() }}
         uses: ./.github/actions/cancel-on-failure-in-merge-queue


### PR DESCRIPTION
Added an action which will cancel the current workflow using the GitHub API. This action will run if any of the Diff workflow jobs fail while in the merge queue. This should not affect Diff workflow runs which are triggered by workflow dispatch or PR labels. This should free up CI machines when jobs fail in the merge queue.


