### PR TITLE
performance regression fix: use jemalloc database specific tcache along with arenas

### DIFF
--- a/src/dbms/database.cpp
+++ b/src/dbms/database.cpp
@@ -98,7 +98,7 @@ Database::Database(storage::Config config, std::function<storage::DatabaseProtec
                                  // After-commit triggers run on a dedicated DB worker.
                                  // Keep a DB arena scope alive for the full worker lifetime.
                                  [this]() -> utils::ThreadPool::TaskSignature {
-                                   auto db_arena_scope = std::make_unique<memory::DbArenaScope>(db_arena_.get());
+                                   auto db_arena_scope = std::make_unique<memory::DbArenaScope>(this);
                                    return [db_arena_scope = std::move(db_arena_scope)]() mutable {
                                      db_arena_scope.reset();
                                    };
@@ -107,7 +107,7 @@ Database::Database(storage::Config config, std::function<storage::DatabaseProtec
           std::make_unique<query::stream::Streams>(config.durability.storage_directory / "streams", db_arena_.get())),
       plan_cache_{FLAGS_query_plan_cache_max_size} {
   // Route all constructor-body allocations (storage init, recovery, index structures) to this DB's arena.
-  const memory::DbArenaScope db_arena_scope{this, memory::DbArenaScope::Type::FORCE};
+  const memory::DbArenaScope db_arena_scope{this};
 
   // Postpone creation after the scope has been created
   trigger_store_ = std::make_unique<query::TriggerStore>(config.durability.storage_directory / "triggers");
@@ -172,6 +172,5 @@ void Database::SwitchToOnDisk() {
 // DbArenaScope constructor implementation (Database* variant) - defined here
 // to avoid circular include between db_arena.cpp and database.hpp
 namespace memgraph::memory {
-DbArenaScope::DbArenaScope(const memgraph::dbms::Database *db, DbArenaScope::Type type)
-    : DbArenaScope(db != nullptr ? &db->Arena() : nullptr, type) {}
+DbArenaScope::DbArenaScope(const memgraph::dbms::Database *db) : DbArenaScope(db != nullptr ? &db->Arena() : nullptr) {}
 }  // namespace memgraph::memory

--- a/src/dbms/database.hpp
+++ b/src/dbms/database.hpp
@@ -213,6 +213,20 @@ class Database {
 
   int64_t TenantMemoryLimit() const noexcept { return db_total_memory_tracker_.HardLimit(); }
 
+  // RAII guard used by utils::Gatekeeper<Database> to ensure construction and
+  // destruction of Database happen with a clean arena TLS state, preventing
+  // cross-DB arena pool collisions and tcache mis-attribution.
+  struct GatekeeperGuard {
+    memory::DbArenaTlsState prev_;
+
+    GatekeeperGuard() noexcept : prev_(memory::tls_db_arena_state) { memory::tls_db_arena_state = {}; }
+
+    GatekeeperGuard(GatekeeperGuard &&) noexcept = default;
+    GatekeeperGuard &operator=(GatekeeperGuard &&) noexcept = default;
+
+    ~GatekeeperGuard() noexcept { memory::tls_db_arena_state = prev_; }
+  };
+
  private:
   // Enforcement-only: caps total per-DB memory (tenant profile limit).
   // No parent — does not roll up to any global. Per-DB domain trackers list this

--- a/src/dbms/database.hpp
+++ b/src/dbms/database.hpp
@@ -219,10 +219,12 @@ class Database {
   struct GatekeeperGuard {
     memory::DbArenaTlsState prev_;
 
-    GatekeeperGuard() noexcept : prev_(memory::tls_db_arena_state) { memory::tls_db_arena_state = {}; }
+    GatekeeperGuard() noexcept : prev_(std::exchange(memory::tls_db_arena_state, {})) {}
 
-    GatekeeperGuard(GatekeeperGuard &&) noexcept = default;
-    GatekeeperGuard &operator=(GatekeeperGuard &&) noexcept = default;
+    GatekeeperGuard(const GatekeeperGuard &) noexcept = delete;
+    GatekeeperGuard &operator=(const GatekeeperGuard &) noexcept = delete;
+    GatekeeperGuard(GatekeeperGuard &&) noexcept = delete;
+    GatekeeperGuard &operator=(GatekeeperGuard &&) noexcept = delete;
 
     ~GatekeeperGuard() noexcept { memory::tls_db_arena_state = prev_; }
   };

--- a/src/memory/db_arena.cpp
+++ b/src/memory/db_arena.cpp
@@ -306,6 +306,8 @@ ArenaPool::~ArenaPool() noexcept {
         LogDestructorCleanupFailure("ArenaPool", arena_idx, "release", "unknown exception");
       }
     }
+
+    DestroyAllTcaches();
   } catch (const std::exception &e) {
     LogDestructorCleanupFailure("ArenaPool", first_arena_idx_, "cleanup", e.what());
   } catch (...) {
@@ -397,6 +399,39 @@ void ArenaPool::PurgeAllArenas() const {
   }
 }
 
+unsigned ArenaPool::AcquireTcache() {
+  {
+    const std::lock_guard<std::mutex> lock(tcache_mutex_);
+    if (!tcaches_.empty()) {
+      const unsigned tcache_id = tcaches_.back();
+      tcaches_.pop_back();
+      return tcache_id;
+    }
+  }
+
+  unsigned tcache_id = 0;
+  size_t sz = sizeof(unsigned);
+  if (je_mallctl("tcache.create", &tcache_id, &sz, nullptr, 0) != 0) {
+    return 0;
+  }
+  return tcache_id;
+}
+
+void ArenaPool::ReleaseTcache(unsigned tcache_id) {
+  if (tcache_id == 0) return;
+  const std::lock_guard<std::mutex> lock(tcache_mutex_);
+  tcaches_.push_back(tcache_id);
+}
+
+void ArenaPool::DestroyAllTcaches() {
+  const std::lock_guard<std::mutex> lock(tcache_mutex_);
+  for (const unsigned tcache_id : tcaches_) {
+    size_t sz = sizeof(unsigned);
+    je_mallctl("tcache.destroy", nullptr, nullptr, const_cast<unsigned *>(&tcache_id), sz);
+  }
+  tcaches_.clear();
+}
+
 }  // namespace memgraph::memory
 
 #endif  // USE_JEMALLOC
@@ -419,6 +454,12 @@ bool ArenaPool::Owns(unsigned /*arena_idx*/) const { return false; }
 
 void ArenaPool::PurgeAllArenas() const {}
 
+unsigned ArenaPool::AcquireTcache() { return 0U; }
+
+void ArenaPool::ReleaseTcache(unsigned /*tcache_id*/) {}
+
+void ArenaPool::DestroyAllTcaches() {}
+
 #endif
 
 }  // namespace memgraph::memory
@@ -433,7 +474,12 @@ namespace memgraph::memory {
 void *DbAllocateBytes(std::size_t bytes, unsigned idx, std::size_t alignment) {
 #if USE_JEMALLOC
   if (idx != 0) {
-    int flags = MALLOCX_ARENA(idx) | MALLOCX_TCACHE_NONE;
+    int flags = MALLOCX_ARENA(idx);
+    if (tls_db_arena_state.tcache != 0) {
+      flags |= MALLOCX_TCACHE(tls_db_arena_state.tcache);
+    } else {
+      flags |= MALLOCX_TCACHE_NONE;
+    }
     if (alignment > alignof(std::max_align_t)) {
       flags |= MALLOCX_ALIGN(alignment);
     }
@@ -445,7 +491,12 @@ void *DbAllocateBytes(std::size_t bytes, unsigned idx, std::size_t alignment) {
 
 void DbDeallocateBytes(void *p, std::size_t bytes, std::size_t alignment) noexcept {
 #if USE_JEMALLOC
-  int flags = MALLOCX_TCACHE_NONE;
+  int flags = 0;
+  if (tls_db_arena_state.tcache != 0) {
+    flags |= MALLOCX_TCACHE(tls_db_arena_state.tcache);
+  } else {
+    flags |= MALLOCX_TCACHE_NONE;
+  }
   if (alignment > alignof(std::max_align_t)) {
     flags |= MALLOCX_ALIGN(alignment);
   }
@@ -462,6 +513,7 @@ DbArenaScope::DbArenaScope(ArenaPool *arena_pool, DbArenaScope::Type type)
     : prev_arena_pool_(tls_db_arena_state.arena_pool),
       prev_arena_(tls_db_arena_state.arena),
       prev_in_scope_{tls_db_arena_state.in_scope},
+      prev_tcache_(tls_db_arena_state.tcache),
       arena_pool_(arena_pool) {
   tls_db_arena_state.in_scope = true;
 #if USE_JEMALLOC
@@ -470,9 +522,12 @@ DbArenaScope::DbArenaScope(ArenaPool *arena_pool, DbArenaScope::Type type)
   if (prev_arena_pool_ == arena_pool) {
     if (prev_arena_ != 0) {  // Borrow
       arena_idx_ = prev_arena_;
+      tcache_id_ = prev_tcache_;
     } else {  // Acquire from pool
       arena_idx_ = arena_pool ? arena_pool->Acquire() : 0U;
       tls_db_arena_state.arena = arena_idx_;
+      tcache_id_ = arena_pool ? arena_pool->AcquireTcache() : 0U;
+      tls_db_arena_state.tcache = tcache_id_;
     }
     return;
   }
@@ -482,8 +537,12 @@ DbArenaScope::DbArenaScope(ArenaPool *arena_pool, DbArenaScope::Type type)
   if (!prev_in_scope_) {
     if (prev_arena_pool_ && prev_arena_ != 0) {
       prev_arena_pool_->Release(prev_arena_);
+      if (prev_tcache_ != 0) {
+        prev_arena_pool_->ReleaseTcache(prev_tcache_);
+      }
       prev_arena_pool_ = nullptr;
       prev_arena_ = 0;
+      prev_tcache_ = 0;
     }
   } else {
     DMG_ASSERT(type == Type::FORCE || prev_arena_pool_ == nullptr, "Crashing into a different DB arena pool!");
@@ -492,6 +551,8 @@ DbArenaScope::DbArenaScope(ArenaPool *arena_pool, DbArenaScope::Type type)
   // Acquire from pool (first time or different pool).
   arena_idx_ = arena_pool ? arena_pool->Acquire() : 0U;
   tls_db_arena_state.arena = arena_idx_;
+  tcache_id_ = arena_pool ? arena_pool->AcquireTcache() : 0U;
+  tls_db_arena_state.tcache = tcache_id_;
   tls_db_arena_state.arena_pool = arena_pool;
 #else
   (void)arena_pool;
@@ -506,12 +567,16 @@ DbArenaScope::~DbArenaScope() noexcept {
   if (prev_in_scope_ && prev_arena_pool_ != arena_pool_) {
     tls_db_arena_state.arena = prev_arena_;
     tls_db_arena_state.arena_pool = prev_arena_pool_;
+    tls_db_arena_state.tcache = prev_tcache_;
     if (arena_pool_ && arena_idx_ != 0) {
       arena_pool_->Release(arena_idx_);
     }
+    if (arena_pool_ && tcache_id_ != 0) {
+      arena_pool_->ReleaseTcache(tcache_id_);
+    }
   }
   tls_db_arena_state.in_scope = prev_in_scope_;
-  // The arena stays pinned in the persistent TLS cache (tls_arena_cache).
+  // The arena stays pinned in the persistent TLS cache.
   // It is released only on pool switch (in the constructor above) or on
   // explicit teardown via the DbArenaScope() no-arg constructor.
 }

--- a/src/memory/db_arena.cpp
+++ b/src/memory/db_arena.cpp
@@ -455,51 +455,44 @@ void DbDeallocateBytes(void *p, std::size_t bytes, std::size_t alignment) noexce
 #endif
 }
 
-DbArenaScope::DbArenaScope() noexcept : prev_arena_(tls_db_arena_state.arena) {
-  prev_arena_pool_ = tls_db_arena_state.arena_pool;
-#if USE_JEMALLOC
-  if (tls_arena_cache.owner && tls_arena_cache.arena != 0) {
-    tls_arena_cache.owner->Release(tls_arena_cache.arena);
-    tls_arena_cache = {};
-  }
-#endif
-  tls_db_arena_state.arena = 0U;
-  tls_db_arena_state.arena_pool = nullptr;
-}
-
+// TODO:
+// Clean up the member variables. Use DbArenaTlsState instead of the individual variables (unless not possible for some
+// reason)
 DbArenaScope::DbArenaScope(ArenaPool *arena_pool, DbArenaScope::Type type)
-    : prev_arena_pool_(tls_db_arena_state.arena_pool), prev_arena_(tls_db_arena_state.arena) {
+    : prev_arena_pool_(tls_db_arena_state.arena_pool),
+      prev_arena_(tls_db_arena_state.arena),
+      prev_in_scope_{tls_db_arena_state.in_scope},
+      arena_pool_(arena_pool) {
+  tls_db_arena_state.in_scope = true;
 #if USE_JEMALLOC
-  // Fast path: persistent TLS cache hit — reuse arena without pool interaction.
-  // Covers both nested AND sequential scopes from the same pool.
-  if (arena_pool && tls_arena_cache.owner == arena_pool && tls_arena_cache.arena != 0) {
-    arena_idx_ = tls_arena_cache.arena;
-    tls_db_arena_state.arena = arena_idx_;
-    tls_db_arena_state.arena_pool = arena_pool;
-    return;
-  }
 
   // Fast path: nested scope — same pool already active in TLS.
   if (prev_arena_pool_ == arena_pool) {
-    arena_idx_ = prev_arena_;
+    if (prev_arena_ != 0) {  // Borrow
+      arena_idx_ = prev_arena_;
+    } else {  // Acquire from pool
+      arena_idx_ = arena_pool ? arena_pool->Acquire() : 0U;
+      tls_db_arena_state.arena = arena_idx_;
+    }
     return;
   }
 
-  DMG_ASSERT(type == Type::FORCE || prev_arena_pool_ == nullptr, "Crashing into a different DB arena pool!");
-
-  // Release previous cached arena when switching pools.
-  if (tls_arena_cache.owner && tls_arena_cache.arena != 0) {
-    DMG_ASSERT(tls_arena_cache.owner != arena_pool, "Cache should have been a hit");
-    tls_arena_cache.owner->Release(tls_arena_cache.arena);
+  // Check if we are inheriting TLS from the previous run, we are not a nested scope
+  // Clean up if needed
+  if (!prev_in_scope_) {
+    if (prev_arena_pool_ && prev_arena_ != 0) {
+      prev_arena_pool_->Release(prev_arena_);
+      prev_arena_pool_ = nullptr;
+      prev_arena_ = 0;
+    }
+  } else {
+    DMG_ASSERT(type == Type::FORCE || prev_arena_pool_ == nullptr, "Crashing into a different DB arena pool!");
   }
 
   // Acquire from pool (first time or different pool).
   arena_idx_ = arena_pool ? arena_pool->Acquire() : 0U;
   tls_db_arena_state.arena = arena_idx_;
   tls_db_arena_state.arena_pool = arena_pool;
-
-  // Cache for subsequent scopes from the same pool.
-  tls_arena_cache = {arena_pool, arena_idx_};
 #else
   (void)arena_pool;
   tls_db_arena_state.arena = 0U;
@@ -509,8 +502,15 @@ DbArenaScope::DbArenaScope(ArenaPool *arena_pool, DbArenaScope::Type type)
 }
 
 DbArenaScope::~DbArenaScope() noexcept {
-  tls_db_arena_state.arena = prev_arena_;
-  tls_db_arena_state.arena_pool = prev_arena_pool_;
+  // Restore only if nested
+  if (prev_in_scope_ && prev_arena_pool_ != arena_pool_) {
+    tls_db_arena_state.arena = prev_arena_;
+    tls_db_arena_state.arena_pool = prev_arena_pool_;
+    if (arena_pool_ && arena_idx_ != 0) {
+      arena_pool_->Release(arena_idx_);
+    }
+  }
+  tls_db_arena_state.in_scope = prev_in_scope_;
   // The arena stays pinned in the persistent TLS cache (tls_arena_cache).
   // It is released only on pool switch (in the constructor above) or on
   // explicit teardown via the DbArenaScope() no-arg constructor.

--- a/src/memory/db_arena.cpp
+++ b/src/memory/db_arena.cpp
@@ -513,7 +513,7 @@ void DbDeallocateBytes(void *p, std::size_t bytes, std::size_t alignment) noexce
   if (p != nullptr && tls_db_arena_state.arena_pool != nullptr) {
     unsigned ptr_arena = 0;
     size_t sz = sizeof(ptr_arena);
-    if (je_mallctl("arenas.lookup", &ptr_arena, &sz, &p, sizeof(p)) == 0) {
+    if (je_mallctl("arenas.lookup", &ptr_arena, &sz, static_cast<void *>(&p), sizeof(p)) == 0) {
       if (!tls_db_arena_state.arena_pool->Owns(ptr_arena)) {
         LOG_FATAL(
             "DbDeallocateBytes: pointer {} belongs to arena {} which is NOT owned by current ArenaPool", p, ptr_arena);

--- a/src/memory/db_arena.cpp
+++ b/src/memory/db_arena.cpp
@@ -366,7 +366,7 @@ unsigned ArenaPool::Acquire() {
   return new_idx;
 }
 
-void ArenaPool::Release(unsigned arena_idx) {
+void ArenaPool::Release(unsigned arena_idx) noexcept {
   try {
     if (arena_idx == 0) return;
     const std::lock_guard<std::mutex> lock(arena_mux_);
@@ -386,8 +386,10 @@ void ArenaPool::Release(unsigned arena_idx) {
       }
     }
     DMG_ASSERT(false, "Trying to release an areana that is not under the current pool.");
-  } catch (std::exception &e) {
+  } catch (const std::exception &e) {
     SafeLog("Exception while releasing arena {}: {}", arena_idx, e.what());
+  } catch (...) {
+    SafeLog("Exception while releasing arena {}: unknown exception", arena_idx);
   }
 }
 
@@ -401,6 +403,7 @@ void ArenaPool::PurgeAllArenas() const {
   std::vector<unsigned> arena_indices;
   {
     const std::lock_guard<std::mutex> lock(arena_mux_);
+    arena_indices.reserve(arenas_.size());
     arena_indices = arenas_;
   }
 
@@ -428,21 +431,27 @@ unsigned ArenaPool::AcquireTcache() {
   return tcache_id;
 }
 
-void ArenaPool::ReleaseTcache(unsigned tcache_id) {
+void ArenaPool::ReleaseTcache(unsigned tcache_id) noexcept {
+  if (tcache_id == 0) return;
   try {
-    if (tcache_id == 0) return;
     const std::lock_guard<std::mutex> lock(tcache_mutex_);
     tcaches_.push_back(tcache_id);
-  } catch (std::exception &e) {
+  } catch (const std::exception &e) {
+    const size_t sz = sizeof(unsigned);
+    je_mallctl("tcache.destroy", nullptr, nullptr, &tcache_id, sz);
     SafeLog("Exception while releasing tcache {}: {}", tcache_id, e.what());
+  } catch (...) {
+    const size_t sz = sizeof(unsigned);
+    je_mallctl("tcache.destroy", nullptr, nullptr, &tcache_id, sz);
+    SafeLog("Exception while releasing tcache {}: unknown exception", tcache_id);
   }
 }
 
 void ArenaPool::DestroyAllTcaches() {
   const std::lock_guard<std::mutex> lock(tcache_mutex_);
-  for (const unsigned tcache_id : tcaches_) {
+  for (unsigned tcache_id : tcaches_) {
     const size_t sz = sizeof(unsigned);
-    je_mallctl("tcache.destroy", nullptr, nullptr, const_cast<unsigned *>(&tcache_id), sz);
+    je_mallctl("tcache.destroy", nullptr, nullptr, &tcache_id, sz);
   }
   tcaches_.clear();
 }
@@ -463,7 +472,7 @@ unsigned ArenaPool::idx() const noexcept { return 0U; }
 
 unsigned ArenaPool::Acquire() { return 0U; }
 
-void ArenaPool::Release(unsigned /*arena_idx*/) {}
+void ArenaPool::Release(unsigned /*arena_idx*/) noexcept {}
 
 bool ArenaPool::Owns(unsigned /*arena_idx*/) const { return false; }
 
@@ -471,7 +480,7 @@ void ArenaPool::PurgeAllArenas() const {}
 
 unsigned ArenaPool::AcquireTcache() { return 0U; }
 
-void ArenaPool::ReleaseTcache(unsigned /*tcache_id*/) {}
+void ArenaPool::ReleaseTcache(unsigned /*tcache_id*/) noexcept {}
 
 void ArenaPool::DestroyAllTcaches() {}
 

--- a/src/memory/db_arena.cpp
+++ b/src/memory/db_arena.cpp
@@ -360,24 +360,28 @@ unsigned ArenaPool::Acquire() {
 }
 
 void ArenaPool::Release(unsigned arena_idx) {
-  if (arena_idx == 0) return;
-  const std::lock_guard<std::mutex> lock(arena_mux_);
+  try {
+    if (arena_idx == 0) return;
+    const std::lock_guard<std::mutex> lock(arena_mux_);
 
-  if (arena_idx == first_arena_idx_) {
-    DMG_ASSERT(first_arena_use_count_ != 0, "Release: first arena not in use");
-    if (--first_arena_use_count_ > 0) return;
-    // If count reaches 0, fall through to move it to the free section of the vector
-  }
-
-  // Find the arena in the 'in-use' section [free_count_, size)
-  for (size_t i = free_count_; i < arenas_.size(); ++i) {
-    if (arenas_[i] == arena_idx) {
-      std::swap(arenas_[i], arenas_[free_count_]);
-      ++free_count_;
-      return;
+    if (arena_idx == first_arena_idx_) {
+      DMG_ASSERT(first_arena_use_count_ != 0, "Release: first arena not in use");
+      if (--first_arena_use_count_ > 0) return;
+      // If count reaches 0, fall through to move it to the free section of the vector
     }
+
+    // Find the arena in the 'in-use' section [free_count_, size)
+    for (size_t i = free_count_; i < arenas_.size(); ++i) {
+      if (arenas_[i] == arena_idx) {
+        std::swap(arenas_[i], arenas_[free_count_]);
+        ++free_count_;
+        return;
+      }
+    }
+    DMG_ASSERT(false, "Trying to release an areana that is not under the current pool.");
+  } catch (...) {
+    // silently fail
   }
-  DMG_ASSERT(false, "Trying to release an areana that is not under the current pool.");
 }
 
 bool ArenaPool::Owns(unsigned arena_idx) const {
@@ -418,9 +422,13 @@ unsigned ArenaPool::AcquireTcache() {
 }
 
 void ArenaPool::ReleaseTcache(unsigned tcache_id) {
-  if (tcache_id == 0) return;
-  const std::lock_guard<std::mutex> lock(tcache_mutex_);
-  tcaches_.push_back(tcache_id);
+  try {
+    if (tcache_id == 0) return;
+    const std::lock_guard<std::mutex> lock(tcache_mutex_);
+    tcaches_.push_back(tcache_id);
+  } catch (...) {
+    // silently fail
+  }
 }
 
 void ArenaPool::DestroyAllTcaches() {
@@ -506,79 +514,51 @@ void DbDeallocateBytes(void *p, std::size_t bytes, std::size_t alignment) noexce
 #endif
 }
 
-// TODO:
-// Clean up the member variables. Use DbArenaTlsState instead of the individual variables (unless not possible for some
-// reason)
-DbArenaScope::DbArenaScope(ArenaPool *arena_pool, DbArenaScope::Type type)
-    : prev_arena_pool_(tls_db_arena_state.arena_pool),
-      prev_arena_(tls_db_arena_state.arena),
-      prev_in_scope_{tls_db_arena_state.in_scope},
-      prev_tcache_(tls_db_arena_state.tcache),
-      arena_pool_(arena_pool) {
-  tls_db_arena_state.in_scope = true;
+DbArenaScope::DbArenaScope(ArenaPool *arena_pool, DbArenaScope::Type type) : prev_state_(tls_db_arena_state) {
+  cur_state_.arena_pool = arena_pool;
 #if USE_JEMALLOC
 
   // Fast path: nested scope — same pool already active in TLS.
-  if (prev_arena_pool_ == arena_pool) {
-    if (prev_arena_ != 0) {  // Borrow
-      arena_idx_ = prev_arena_;
-      tcache_id_ = prev_tcache_;
+  if (prev_state_.arena_pool == arena_pool) {
+    if (prev_state_.arena != 0) {  // Borrow
+      cur_state_.arena = prev_state_.arena;
+      cur_state_.tcache = prev_state_.tcache;
     } else {  // Acquire from pool
-      arena_idx_ = arena_pool ? arena_pool->Acquire() : 0U;
-      tls_db_arena_state.arena = arena_idx_;
-      tcache_id_ = arena_pool ? arena_pool->AcquireTcache() : 0U;
-      tls_db_arena_state.tcache = tcache_id_;
+      cur_state_.arena = arena_pool ? arena_pool->Acquire() : 0U;
+      cur_state_.tcache = arena_pool ? arena_pool->AcquireTcache() : 0U;
+      tls_db_arena_state.arena = cur_state_.arena;
+      tls_db_arena_state.tcache = cur_state_.tcache;
     }
     return;
   }
 
-  // Check if we are inheriting TLS from the previous run, we are not a nested scope
-  // Clean up if needed
-  if (!prev_in_scope_) {
-    if (prev_arena_pool_ && prev_arena_ != 0) {
-      prev_arena_pool_->Release(prev_arena_);
-      if (prev_tcache_ != 0) {
-        prev_arena_pool_->ReleaseTcache(prev_tcache_);
-      }
-      prev_arena_pool_ = nullptr;
-      prev_arena_ = 0;
-      prev_tcache_ = 0;
-    }
-  } else {
-    DMG_ASSERT(type == Type::FORCE || prev_arena_pool_ == nullptr, "Crashing into a different DB arena pool!");
-  }
+  DMG_ASSERT(type == Type::FORCE || prev_state_.arena_pool == nullptr, "Crashing into a different DB arena pool!");
 
   // Acquire from pool (first time or different pool).
-  arena_idx_ = arena_pool ? arena_pool->Acquire() : 0U;
-  tls_db_arena_state.arena = arena_idx_;
-  tcache_id_ = arena_pool ? arena_pool->AcquireTcache() : 0U;
-  tls_db_arena_state.tcache = tcache_id_;
-  tls_db_arena_state.arena_pool = arena_pool;
+  cur_state_.arena = arena_pool ? arena_pool->Acquire() : 0U;
+  cur_state_.tcache = arena_pool ? arena_pool->AcquireTcache() : 0U;
+  tls_db_arena_state = cur_state_;
 #else
   (void)arena_pool;
   tls_db_arena_state.arena = 0U;
   tls_db_arena_state.arena_pool = nullptr;
-  DMG_ASSERT(prev_arena_ == 0U, "Erasing DB scope!");
+  DMG_ASSERT(prev_state_.arena == 0U, "Erasing DB scope!");
 #endif
 }
 
 DbArenaScope::~DbArenaScope() noexcept {
-  // Restore only if nested
-  if (prev_in_scope_ && prev_arena_pool_ != arena_pool_) {
-    tls_db_arena_state.arena = prev_arena_;
-    tls_db_arena_state.arena_pool = prev_arena_pool_;
-    tls_db_arena_state.tcache = prev_tcache_;
-    if (arena_pool_ && arena_idx_ != 0) {
-      arena_pool_->Release(arena_idx_);
+  bool const borrowed = prev_state_.arena_pool == cur_state_.arena_pool && prev_state_.arena != 0;
+
+  tls_db_arena_state = prev_state_;
+
+  if (!borrowed) {
+    if (cur_state_.arena_pool && cur_state_.arena != 0) {
+      cur_state_.arena_pool->Release(cur_state_.arena);
     }
-    if (arena_pool_ && tcache_id_ != 0) {
-      arena_pool_->ReleaseTcache(tcache_id_);
+    if (cur_state_.arena_pool && cur_state_.tcache != 0) {
+      cur_state_.arena_pool->ReleaseTcache(cur_state_.tcache);
     }
   }
-  tls_db_arena_state.in_scope = prev_in_scope_;
-  // The arena stays pinned in the persistent TLS cache.
-  // It is released only on pool switch (in the constructor above) or on
-  // explicit teardown via the DbArenaScope() no-arg constructor.
 }
 
 }  // namespace memgraph::memory

--- a/src/memory/db_arena.cpp
+++ b/src/memory/db_arena.cpp
@@ -147,9 +147,9 @@ void InitDbArenaHooks(DbArenaHooks &h, utils::MemoryTracker *tracker, extent_hoo
 namespace {
 
 template <typename... Args>
-void SafeLog(Args &&...args) noexcept {
+void SafeLog(fmt::format_string<Args...> fmt, Args &&...args) noexcept {
   try {
-    spdlog::error(std::forward<Args>(args)...);
+    spdlog::error(fmt, std::forward<Args>(args)...);
   } catch (...) {
     (void)0;  // clang-tidy
   }
@@ -421,7 +421,7 @@ unsigned ArenaPool::AcquireTcache() {
   }
 
   unsigned tcache_id = 0;
-  const size_t sz = sizeof(unsigned);
+  size_t sz = sizeof(unsigned);
   if (je_mallctl("tcache.create", &tcache_id, &sz, nullptr, 0) != 0) {
     return 0;
   }
@@ -441,7 +441,7 @@ void ArenaPool::ReleaseTcache(unsigned tcache_id) {
 void ArenaPool::DestroyAllTcaches() {
   const std::lock_guard<std::mutex> lock(tcache_mutex_);
   for (const unsigned tcache_id : tcaches_) {
-    size_t sz = sizeof(unsigned);
+    const size_t sz = sizeof(unsigned);
     je_mallctl("tcache.destroy", nullptr, nullptr, const_cast<unsigned *>(&tcache_id), sz);
   }
   tcaches_.clear();
@@ -506,6 +506,21 @@ void *DbAllocateBytes(std::size_t bytes, unsigned idx, std::size_t alignment) {
 
 void DbDeallocateBytes(void *p, std::size_t bytes, std::size_t alignment) noexcept {
 #if USE_JEMALLOC
+#ifndef NDEBUG
+  // Debug-only: verify the pointer belongs to the current DB's arena pool.
+  // A mismatch means we are about to free memory via the wrong tcache or
+  // arena, which can corrupt jemalloc state.
+  if (p != nullptr && tls_db_arena_state.arena_pool != nullptr) {
+    unsigned ptr_arena = 0;
+    size_t sz = sizeof(ptr_arena);
+    if (je_mallctl("arenas.lookup", &ptr_arena, &sz, &p, sizeof(p)) == 0) {
+      if (!tls_db_arena_state.arena_pool->Owns(ptr_arena)) {
+        LOG_FATAL(
+            "DbDeallocateBytes: pointer {} belongs to arena {} which is NOT owned by current ArenaPool", p, ptr_arena);
+      }
+    }
+  }
+#endif
   int flags = 0;
   if (tls_db_arena_state.tcache != 0) {
     flags |= MALLOCX_TCACHE(tls_db_arena_state.tcache);
@@ -521,7 +536,7 @@ void DbDeallocateBytes(void *p, std::size_t bytes, std::size_t alignment) noexce
 #endif
 }
 
-DbArenaScope::DbArenaScope(ArenaPool *arena_pool, DbArenaScope::Type type) : prev_state_(tls_db_arena_state) {
+DbArenaScope::DbArenaScope(ArenaPool *arena_pool) : prev_state_(tls_db_arena_state) {
   cur_state_.arena_pool = arena_pool;
 #if USE_JEMALLOC
 
@@ -543,7 +558,7 @@ DbArenaScope::DbArenaScope(ArenaPool *arena_pool, DbArenaScope::Type type) : pre
     return;
   }
 
-  DMG_ASSERT(type == Type::FORCE || prev_state_.arena_pool == nullptr, "Crashing into a different DB arena pool!");
+  DMG_ASSERT(prev_state_.arena_pool == nullptr, "Crashing into a different DB arena pool!");
 
   // Acquire from pool (first time or different pool).
   acquire();

--- a/src/memory/db_arena.cpp
+++ b/src/memory/db_arena.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <exception>
 #include <mutex>
 #include <stdexcept>
 #include <string>
@@ -145,13 +146,18 @@ void InitDbArenaHooks(DbArenaHooks &h, utils::MemoryTracker *tracker, extent_hoo
 
 namespace {
 
-void LogDestructorCleanupFailure(std::string_view owner, unsigned arena_idx, std::string_view operation,
-                                 std::string_view error) noexcept {
+template <typename... Args>
+void SafeLog(Args &&...args) noexcept {
   try {
-    spdlog::error("{} {}: {} failed during destructor cleanup: {}", owner, arena_idx, operation, error);
+    spdlog::error(std::forward<Args>(args)...);
   } catch (...) {
     (void)0;  // clang-tidy
   }
+}
+
+void LogDestructorCleanupFailure(std::string_view owner, unsigned arena_idx, std::string_view operation,
+                                 std::string_view error) noexcept {
+  SafeLog("{} {}: {} failed during destructor cleanup: {}", owner, arena_idx, operation, error);
 }
 
 bool InstallDbArenaHooks(unsigned arena_idx, DbArenaHooks &hooks, std::string_view error_context) {
@@ -274,6 +280,9 @@ ArenaPool::~ArenaPool() noexcept {
     DMG_ASSERT(free_count_ == arenas_.size(), "Destroying DB ArenaPool while some arenas are still in use");
     DMG_ASSERT(first_arena_use_count_ == 0, "Destroying DB ArenaPool while the first arena is still in use");
 
+    // First release all the tcached memory back to the arenas, then purge them
+    DestroyAllTcaches();
+
     for (const auto arena_idx : arenas_) {
       const std::string arena_key = "arena." + std::to_string(arena_idx);
 
@@ -306,8 +315,6 @@ ArenaPool::~ArenaPool() noexcept {
         LogDestructorCleanupFailure("ArenaPool", arena_idx, "release", "unknown exception");
       }
     }
-
-    DestroyAllTcaches();
   } catch (const std::exception &e) {
     LogDestructorCleanupFailure("ArenaPool", first_arena_idx_, "cleanup", e.what());
   } catch (...) {
@@ -379,8 +386,8 @@ void ArenaPool::Release(unsigned arena_idx) {
       }
     }
     DMG_ASSERT(false, "Trying to release an areana that is not under the current pool.");
-  } catch (...) {
-    // silently fail
+  } catch (std::exception &e) {
+    SafeLog("Exception while releasing arena {}: {}", arena_idx, e.what());
   }
 }
 
@@ -414,7 +421,7 @@ unsigned ArenaPool::AcquireTcache() {
   }
 
   unsigned tcache_id = 0;
-  size_t sz = sizeof(unsigned);
+  const size_t sz = sizeof(unsigned);
   if (je_mallctl("tcache.create", &tcache_id, &sz, nullptr, 0) != 0) {
     return 0;
   }
@@ -426,8 +433,8 @@ void ArenaPool::ReleaseTcache(unsigned tcache_id) {
     if (tcache_id == 0) return;
     const std::lock_guard<std::mutex> lock(tcache_mutex_);
     tcaches_.push_back(tcache_id);
-  } catch (...) {
-    // silently fail
+  } catch (std::exception &e) {
+    SafeLog("Exception while releasing tcache {}: {}", tcache_id, e.what());
   }
 }
 
@@ -518,16 +525,20 @@ DbArenaScope::DbArenaScope(ArenaPool *arena_pool, DbArenaScope::Type type) : pre
   cur_state_.arena_pool = arena_pool;
 #if USE_JEMALLOC
 
+  auto acquire = [this]() {
+    cur_state_.arena = cur_state_.arena_pool ? cur_state_.arena_pool->Acquire() : 0U;
+    cur_state_.tcache = cur_state_.arena_pool ? cur_state_.arena_pool->AcquireTcache() : 0U;
+    tls_db_arena_state = cur_state_;
+  };
+
   // Fast path: nested scope — same pool already active in TLS.
   if (prev_state_.arena_pool == arena_pool) {
     if (prev_state_.arena != 0) {  // Borrow
+      borrowed_ = true;
       cur_state_.arena = prev_state_.arena;
       cur_state_.tcache = prev_state_.tcache;
     } else {  // Acquire from pool
-      cur_state_.arena = arena_pool ? arena_pool->Acquire() : 0U;
-      cur_state_.tcache = arena_pool ? arena_pool->AcquireTcache() : 0U;
-      tls_db_arena_state.arena = cur_state_.arena;
-      tls_db_arena_state.tcache = cur_state_.tcache;
+      acquire();
     }
     return;
   }
@@ -535,9 +546,7 @@ DbArenaScope::DbArenaScope(ArenaPool *arena_pool, DbArenaScope::Type type) : pre
   DMG_ASSERT(type == Type::FORCE || prev_state_.arena_pool == nullptr, "Crashing into a different DB arena pool!");
 
   // Acquire from pool (first time or different pool).
-  cur_state_.arena = arena_pool ? arena_pool->Acquire() : 0U;
-  cur_state_.tcache = arena_pool ? arena_pool->AcquireTcache() : 0U;
-  tls_db_arena_state = cur_state_;
+  acquire();
 #else
   (void)arena_pool;
   tls_db_arena_state.arena = 0U;
@@ -547,11 +556,10 @@ DbArenaScope::DbArenaScope(ArenaPool *arena_pool, DbArenaScope::Type type) : pre
 }
 
 DbArenaScope::~DbArenaScope() noexcept {
-  bool const borrowed = prev_state_.arena_pool == cur_state_.arena_pool && prev_state_.arena != 0;
-
+  // Restore pre state
   tls_db_arena_state = prev_state_;
-
-  if (!borrowed) {
+  // Cleanup
+  if (!borrowed_) {
     if (cur_state_.arena_pool && cur_state_.arena != 0) {
       cur_state_.arena_pool->Release(cur_state_.arena);
     }

--- a/src/memory/db_arena.cpp
+++ b/src/memory/db_arena.cpp
@@ -457,23 +457,49 @@ void DbDeallocateBytes(void *p, std::size_t bytes, std::size_t alignment) noexce
 
 DbArenaScope::DbArenaScope() noexcept : prev_arena_(tls_db_arena_state.arena) {
   prev_arena_pool_ = tls_db_arena_state.arena_pool;
+#if USE_JEMALLOC
+  if (tls_arena_cache.owner && tls_arena_cache.arena != 0) {
+    tls_arena_cache.owner->Release(tls_arena_cache.arena);
+    tls_arena_cache = {};
+  }
+#endif
   tls_db_arena_state.arena = 0U;
   tls_db_arena_state.arena_pool = nullptr;
-  DMG_ASSERT(prev_arena_ == 0U, "Erasing DB scope!");
 }
 
 DbArenaScope::DbArenaScope(ArenaPool *arena_pool, DbArenaScope::Type type)
-    : arena_pool_(arena_pool), prev_arena_pool_(tls_db_arena_state.arena_pool), prev_arena_(tls_db_arena_state.arena) {
+    : prev_arena_pool_(tls_db_arena_state.arena_pool), prev_arena_(tls_db_arena_state.arena) {
 #if USE_JEMALLOC
-  if (prev_arena_pool_ == arena_pool_) {
-    arena_idx_ = prev_arena_;
-    arena_pool_ = nullptr;  // Disable release, we are borrowing the arena from the same pool
+  // Fast path: persistent TLS cache hit — reuse arena without pool interaction.
+  // Covers both nested AND sequential scopes from the same pool.
+  if (arena_pool && tls_arena_cache.owner == arena_pool && tls_arena_cache.arena != 0) {
+    arena_idx_ = tls_arena_cache.arena;
+    tls_db_arena_state.arena = arena_idx_;
+    tls_db_arena_state.arena_pool = arena_pool;
     return;
   }
+
+  // Fast path: nested scope — same pool already active in TLS.
+  if (prev_arena_pool_ == arena_pool) {
+    arena_idx_ = prev_arena_;
+    return;
+  }
+
   DMG_ASSERT(type == Type::FORCE || prev_arena_pool_ == nullptr, "Crashing into a different DB arena pool!");
-  arena_idx_ = arena_pool_ ? arena_pool_->Acquire() : 0U;
+
+  // Release previous cached arena when switching pools.
+  if (tls_arena_cache.owner && tls_arena_cache.arena != 0) {
+    DMG_ASSERT(tls_arena_cache.owner != arena_pool, "Cache should have been a hit");
+    tls_arena_cache.owner->Release(tls_arena_cache.arena);
+  }
+
+  // Acquire from pool (first time or different pool).
+  arena_idx_ = arena_pool ? arena_pool->Acquire() : 0U;
   tls_db_arena_state.arena = arena_idx_;
-  tls_db_arena_state.arena_pool = arena_pool_;
+  tls_db_arena_state.arena_pool = arena_pool;
+
+  // Cache for subsequent scopes from the same pool.
+  tls_arena_cache = {arena_pool, arena_idx_};
 #else
   (void)arena_pool;
   tls_db_arena_state.arena = 0U;
@@ -483,14 +509,11 @@ DbArenaScope::DbArenaScope(ArenaPool *arena_pool, DbArenaScope::Type type)
 }
 
 DbArenaScope::~DbArenaScope() noexcept {
-  // Restore previous arena
   tls_db_arena_state.arena = prev_arena_;
   tls_db_arena_state.arena_pool = prev_arena_pool_;
-#if USE_JEMALLOC
-  if (arena_pool_) {
-    arena_pool_->Release(arena_idx_);
-  }
-#endif
+  // The arena stays pinned in the persistent TLS cache (tls_arena_cache).
+  // It is released only on pool switch (in the constructor above) or on
+  // explicit teardown via the DbArenaScope() no-arg constructor.
 }
 
 }  // namespace memgraph::memory

--- a/src/memory/db_arena.hpp
+++ b/src/memory/db_arena.hpp
@@ -61,7 +61,7 @@ class ArenaPool {
   unsigned Acquire();
 
   // Return an arena acquired from this pool so a future Acquire() can reuse it.
-  void Release(unsigned arena_idx);
+  void Release(unsigned arena_idx) noexcept;
 
   // Returns true if this pool owns the arena index.
   bool Owns(unsigned arena_idx) const;
@@ -74,7 +74,7 @@ class ArenaPool {
   unsigned AcquireTcache();
 
   // Return a tcache acquired from this pool so a future AcquireTcache() can reuse it.
-  void ReleaseTcache(unsigned tcache_id);
+  void ReleaseTcache(unsigned tcache_id) noexcept;
 
   // Destroy all pooled tcaches. Must only be called when no tcaches are in use.
   void DestroyAllTcaches();

--- a/src/memory/db_arena.hpp
+++ b/src/memory/db_arena.hpp
@@ -53,7 +53,8 @@ class ArenaPool {
   ArenaPool &operator=(ArenaPool &&) = delete;
 
   // Returns the constructor-created base arena used by long-lived arena-aware
-  // owners and short-lived DB-scoped work.
+  // owners (e.g. Storage containers). Short-lived DB-scoped work should use
+  // Acquire() / Release() so the pool can be shared across threads.
   unsigned idx() const noexcept;
 
   // Acquire an arena for DB-owned thread work.
@@ -89,7 +90,9 @@ class ArenaPool {
   std::vector<unsigned> arenas_;
   std::size_t free_count_{0};
 
-  // Cache of the first arena for backwards compatibility
+  // The base arena created in the ArenaPool constructor. Used as the fallback
+  // when Acquire() cannot create a new arena, and by long-lived owners that
+  // capture an explicit arena index (e.g. Storage containers).
   unsigned first_arena_idx_{0};
 
   unsigned first_arena_use_count_{0};

--- a/src/memory/db_arena.hpp
+++ b/src/memory/db_arena.hpp
@@ -69,6 +69,15 @@ class ArenaPool {
   // report released pages back to the DB memory tracker.
   void PurgeAllArenas() const;
 
+  // Acquire an explicit tcache for DB-owned thread work.
+  unsigned AcquireTcache();
+
+  // Return a tcache acquired from this pool so a future AcquireTcache() can reuse it.
+  void ReleaseTcache(unsigned tcache_id);
+
+  // Destroy all pooled tcaches. Must only be called when no tcaches are in use.
+  void DestroyAllTcaches();
+
  private:
 #if USE_JEMALLOC
   DbArenaHooks hooks_{};
@@ -84,6 +93,10 @@ class ArenaPool {
   unsigned first_arena_idx_{0};
 
   unsigned first_arena_use_count_{0};
+
+  // Tcache pool members
+  std::mutex tcache_mutex_;
+  std::vector<unsigned> tcaches_;
 #endif
 };
 

--- a/src/memory/db_arena.hpp
+++ b/src/memory/db_arena.hpp
@@ -107,7 +107,8 @@ class ArenaPool {
 // `base_hooks` – jemalloc's default hooks; the callbacks call through to these.
 // After calling this, install with:
 //   const extent_hooks_t *p = &h.hooks;
-//   je_mallctl("arena.N.extent_hooks", nullptr, nullptr, &p, sizeof(p));
+//   je_mallctl("arena.N.extent_hooks", nullptr, nullptr, static_cast<void *>(const_cast<extent_hooks_t **>(&p)),
+//   sizeof(p));
 void InitDbArenaHooks(DbArenaHooks &h, utils::MemoryTracker *tracker, extent_hooks_t *base_hooks);
 
 // Singleton pool that recycles jemalloc arena indices across database ArenaPool lifetimes.

--- a/src/memory/db_arena_fwd.hpp
+++ b/src/memory/db_arena_fwd.hpp
@@ -169,8 +169,8 @@ class DbAwareThread {
   explicit DbAwareThread(F &&f, Args &&...args)
       : DbAwareThread(tls_db_arena_state.arena_pool, std::forward<F>(f), std::forward<Args>(args)...) {}
 
-  // The new thread acquires from the pool for the lifetime
-  // of the supplied function and releases it when the function exits.
+  // The new thread acquires an arena and tcache from the pool for the
+  // lifetime of the supplied function and releases them when the function exits.
   template <typename F, typename... Args>
     requires(std::is_invocable_v<std::decay_t<F>, std::decay_t<Args>...> ||
              std::is_invocable_v<std::decay_t<F>, std::stop_token, std::decay_t<Args>...>)

--- a/src/memory/db_arena_fwd.hpp
+++ b/src/memory/db_arena_fwd.hpp
@@ -132,20 +132,15 @@ class ArenaPageSlabMemoryResource {
 // asserts there was no previous arena. It exists only for non-jemalloc builds
 // where all constructors compile to no-ops.
 struct DbArenaScope {
-  enum class Type : uint8_t {
-    DBG_CHECK,
-    FORCE,
-  };
-
   // No-op scope: resets TLS arena to 0 (asserts no previous arena was set).
   DbArenaScope() noexcept;
 
   // Acquire per-thread arena from the database's pool.
-  explicit DbArenaScope(const memgraph::dbms::Database *db, Type type = Type::DBG_CHECK);
+  explicit DbArenaScope(const memgraph::dbms::Database *db);
 
   // Acquire from the pool (or borrow if same pool already in TLS).
   // Releases back to the pool on destruction only when this scope acquired it.
-  explicit DbArenaScope(ArenaPool *arena_pool, Type type = Type::DBG_CHECK);
+  explicit DbArenaScope(ArenaPool *arena_pool);
 
   ~DbArenaScope() noexcept;
 

--- a/src/memory/db_arena_fwd.hpp
+++ b/src/memory/db_arena_fwd.hpp
@@ -157,6 +157,7 @@ struct DbArenaScope {
  private:
   DbArenaTlsState prev_state_;
   DbArenaTlsState cur_state_;  // pool = what we're scoping into; arena/tcache = acquired or borrowed
+  bool borrowed_{false};
 };
 
 // A std::jthread wrapper that sets tls_db_arena_state on the new thread so that

--- a/src/memory/db_arena_fwd.hpp
+++ b/src/memory/db_arena_fwd.hpp
@@ -18,6 +18,7 @@
 
 #include "utils/allocator/page_slab_memory_resource.hpp"
 #include "utils/db_aware_allocator.hpp"
+#include "utils/on_scope_exit.hpp"
 
 namespace memgraph::dbms {
 class Database;
@@ -159,6 +160,8 @@ struct DbArenaScope {
   unsigned arena_idx_{0};
   unsigned prev_arena_{0};
   bool prev_in_scope_{false};
+  unsigned prev_tcache_{0};
+  unsigned tcache_id_{0};
 };
 
 // A std::jthread wrapper that sets tls_db_arena_state on the new thread so that
@@ -183,13 +186,16 @@ class DbAwareThread {
   DbAwareThread(ArenaPool *arena_pool, F &&f, Args &&...args)
       : thread_(
             [arena_pool, func = std::forward<F>(f)](std::stop_token st, std::decay_t<Args>... a) mutable {
-              const auto cleanup = utils::OnScopeExit{[arena_pool]() noexcept {
-                // Thread is exiting — release the arena the scope pinned in TLS.
-                if (arena_pool && tls_db_arena_state.arena_pool == arena_pool && tls_db_arena_state.arena != 0) {
-                  arena_pool->Release(tls_db_arena_state.arena);
-                  tls_db_arena_state = {};
-                }
-              }};
+              // utils::OnScopeExit const cleanup{[arena_pool]() noexcept {
+              //   // Thread is exiting — release the arena and tcache the scope pinned in TLS.
+              //   if (arena_pool && tls_db_arena_state.arena_pool == arena_pool && tls_db_arena_state.arena != 0) {
+              //     arena_pool->Release(tls_db_arena_state.arena);
+              //     if (tls_db_arena_state.tcache != 0) {
+              //       arena_pool->ReleaseTcache(tls_db_arena_state.tcache);
+              //     }
+              //     tls_db_arena_state = {};
+              //   }
+              // }};
               {
                 const DbArenaScope db_arena_scope{arena_pool};
                 if constexpr (std::is_invocable_v<std::decay_t<F>, std::stop_token, std::decay_t<Args>...>) {

--- a/src/memory/db_arena_fwd.hpp
+++ b/src/memory/db_arena_fwd.hpp
@@ -183,12 +183,13 @@ class DbAwareThread {
   DbAwareThread(ArenaPool *arena_pool, F &&f, Args &&...args)
       : thread_(
             [arena_pool, func = std::forward<F>(f)](std::stop_token st, std::decay_t<Args>... a) mutable {
-              // utils::OnScopeExit on_scope_exit{[] {
-              //   // Thread is exiting — release the cached arena acquired by the scope above.
-              //   if (tls_arena_cache.owner && tls_arena_cache.arena != 0) {
-              //     tls_arena_cache.owner->Release(tls_arena_cache.arena);
-              //   }
-              // }};
+              const auto cleanup = utils::OnScopeExit{[arena_pool]() noexcept {
+                // Thread is exiting — release the arena the scope pinned in TLS.
+                if (arena_pool && tls_db_arena_state.arena_pool == arena_pool && tls_db_arena_state.arena != 0) {
+                  arena_pool->Release(tls_db_arena_state.arena);
+                  tls_db_arena_state = {};
+                }
+              }};
               {
                 const DbArenaScope db_arena_scope{arena_pool};
                 if constexpr (std::is_invocable_v<std::decay_t<F>, std::stop_token, std::decay_t<Args>...>) {

--- a/src/memory/db_arena_fwd.hpp
+++ b/src/memory/db_arena_fwd.hpp
@@ -155,13 +155,8 @@ struct DbArenaScope {
   DbArenaScope &operator=(DbArenaScope &&) = delete;
 
  private:
-  ArenaPool *arena_pool_{nullptr};
-  ArenaPool *prev_arena_pool_{nullptr};
-  unsigned arena_idx_{0};
-  unsigned prev_arena_{0};
-  bool prev_in_scope_{false};
-  unsigned prev_tcache_{0};
-  unsigned tcache_id_{0};
+  DbArenaTlsState prev_state_;
+  DbArenaTlsState cur_state_;  // pool = what we're scoping into; arena/tcache = acquired or borrowed
 };
 
 // A std::jthread wrapper that sets tls_db_arena_state on the new thread so that
@@ -186,23 +181,11 @@ class DbAwareThread {
   DbAwareThread(ArenaPool *arena_pool, F &&f, Args &&...args)
       : thread_(
             [arena_pool, func = std::forward<F>(f)](std::stop_token st, std::decay_t<Args>... a) mutable {
-              // utils::OnScopeExit const cleanup{[arena_pool]() noexcept {
-              //   // Thread is exiting — release the arena and tcache the scope pinned in TLS.
-              //   if (arena_pool && tls_db_arena_state.arena_pool == arena_pool && tls_db_arena_state.arena != 0) {
-              //     arena_pool->Release(tls_db_arena_state.arena);
-              //     if (tls_db_arena_state.tcache != 0) {
-              //       arena_pool->ReleaseTcache(tls_db_arena_state.tcache);
-              //     }
-              //     tls_db_arena_state = {};
-              //   }
-              // }};
-              {
-                const DbArenaScope db_arena_scope{arena_pool};
-                if constexpr (std::is_invocable_v<std::decay_t<F>, std::stop_token, std::decay_t<Args>...>) {
-                  func(std::move(st), std::move(a)...);
-                } else {
-                  func(std::move(a)...);
-                }
+              const DbArenaScope db_arena_scope{arena_pool};
+              if constexpr (std::is_invocable_v<std::decay_t<F>, std::stop_token, std::decay_t<Args>...>) {
+                func(std::move(st), std::move(a)...);
+              } else {
+                func(std::move(a)...);
               }
             },
             std::forward<Args>(args)...) {}

--- a/src/memory/db_arena_fwd.hpp
+++ b/src/memory/db_arena_fwd.hpp
@@ -18,7 +18,6 @@
 
 #include "utils/allocator/page_slab_memory_resource.hpp"
 #include "utils/db_aware_allocator.hpp"
-#include "utils/on_scope_exit.hpp"
 
 namespace memgraph::dbms {
 class Database;
@@ -132,9 +131,6 @@ class ArenaPageSlabMemoryResource {
 // asserts there was no previous arena. It exists only for non-jemalloc builds
 // where all constructors compile to no-ops.
 struct DbArenaScope {
-  // No-op scope: resets TLS arena to 0 (asserts no previous arena was set).
-  DbArenaScope() noexcept;
-
   // Acquire per-thread arena from the database's pool.
   explicit DbArenaScope(const memgraph::dbms::Database *db);
 

--- a/src/memory/db_arena_fwd.hpp
+++ b/src/memory/db_arena_fwd.hpp
@@ -158,6 +158,7 @@ struct DbArenaScope {
   ArenaPool *prev_arena_pool_{nullptr};
   unsigned arena_idx_{0};
   unsigned prev_arena_{0};
+  bool prev_in_scope_{false};
 };
 
 // A std::jthread wrapper that sets tls_db_arena_state on the new thread so that
@@ -182,12 +183,12 @@ class DbAwareThread {
   DbAwareThread(ArenaPool *arena_pool, F &&f, Args &&...args)
       : thread_(
             [arena_pool, func = std::forward<F>(f)](std::stop_token st, std::decay_t<Args>... a) mutable {
-              utils::OnScopeExit on_scope_exit{[] {
-                // Thread is exiting — release the cached arena acquired by the scope above.
-                if (tls_arena_cache.owner && tls_arena_cache.arena != 0) {
-                  tls_arena_cache.owner->Release(tls_arena_cache.arena);
-                }
-              }};
+              // utils::OnScopeExit on_scope_exit{[] {
+              //   // Thread is exiting — release the cached arena acquired by the scope above.
+              //   if (tls_arena_cache.owner && tls_arena_cache.arena != 0) {
+              //     tls_arena_cache.owner->Release(tls_arena_cache.arena);
+              //   }
+              // }};
               {
                 const DbArenaScope db_arena_scope{arena_pool};
                 if constexpr (std::is_invocable_v<std::decay_t<F>, std::stop_token, std::decay_t<Args>...>) {

--- a/src/memory/db_arena_fwd.hpp
+++ b/src/memory/db_arena_fwd.hpp
@@ -182,11 +182,19 @@ class DbAwareThread {
   DbAwareThread(ArenaPool *arena_pool, F &&f, Args &&...args)
       : thread_(
             [arena_pool, func = std::forward<F>(f)](std::stop_token st, std::decay_t<Args>... a) mutable {
-              const DbArenaScope db_arena_scope{arena_pool};
-              if constexpr (std::is_invocable_v<std::decay_t<F>, std::stop_token, std::decay_t<Args>...>) {
-                func(std::move(st), std::move(a)...);
-              } else {
-                func(std::move(a)...);
+              utils::OnScopeExit on_scope_exit{[] {
+                // Thread is exiting — release the cached arena acquired by the scope above.
+                if (tls_arena_cache.owner && tls_arena_cache.arena != 0) {
+                  tls_arena_cache.owner->Release(tls_arena_cache.arena);
+                }
+              }};
+              {
+                const DbArenaScope db_arena_scope{arena_pool};
+                if constexpr (std::is_invocable_v<std::decay_t<F>, std::stop_token, std::decay_t<Args>...>) {
+                  func(std::move(st), std::move(a)...);
+                } else {
+                  func(std::move(a)...);
+                }
               }
             },
             std::forward<Args>(args)...) {}

--- a/src/utils/db_aware_allocator.hpp
+++ b/src/utils/db_aware_allocator.hpp
@@ -28,7 +28,7 @@ class ArenaPool;
 // Thread-local state for the currently active database arena.
 // arena = 0 means "no DB arena pinned" — allocations go to jemalloc's default arena.
 //
-// Both fields are set by DbArenaScope. Background threads
+// All fields are set by DbArenaScope. Background threads
 // (TTL, GC, async indexer, stream consumers) install a pool-backed scope via
 // DbAwareThread at their work boundary; they do not write
 // TLS directly.
@@ -49,11 +49,13 @@ inline thread_local DbArenaTlsState tls_db_arena_state [[gnu::tls_model("initial
 
 // Allocate `bytes` bytes with the given `alignment`, attributed to arena `idx`.
 // Returns void* — use DbAllocate<T> for typed element-count based allocation.
-// Uses MALLOCX_TCACHE_NONE to avoid thread-cache overhead and ensure accurate tracking.
+// Uses MALLOCX_TCARENA(idx) and, if tls_db_arena_state.tcache is set,
+// MALLOCX_TCACHE(tcache); otherwise MALLOCX_TCACHE_NONE for accurate tracking.
 [[nodiscard]] void *DbAllocateBytes(std::size_t bytes, unsigned idx, std::size_t alignment);
 
 // Deallocate memory previously allocated via DbAllocateBytes.
-// Uses je_sdallocx with MALLOCX_TCACHE_NONE so the free goes directly to the
+// Uses je_sdallocx with MALLOCX_TCACHE(tls_db_arena_state.tcache) when a tcache
+// is pinned; otherwise MALLOCX_TCACHE_NONE so the free goes directly to the
 // arena bin, matching the allocation style and allowing decay=0 arenas to
 // return pages to the OS promptly without blocks sitting in the TLS cache.
 void DbDeallocateBytes(void *p, std::size_t bytes, std::size_t alignment) noexcept;
@@ -144,7 +146,8 @@ struct DbAwareAllocator {
   void deallocate(T *p, std::size_t n) noexcept {
     // NOTE: jemalloc tracks the owning arena per-extent in its own metadata, so GC can safely
     // free query-thread allocations regardless of which thread calls deallocate.
-    // MALLOCX_TCACHE_NONE matches the allocation style and lets decay=0 arenas return pages promptly.
+    // DbDeallocateBytes uses the current tcache if pinned, else MALLOCX_TCACHE_NONE,
+    // matching the allocation style and letting decay=0 arenas return pages promptly.
     DbDeallocateBytes(static_cast<void *>(p), n * sizeof(T), alignof(T));
   }
 

--- a/src/utils/db_aware_allocator.hpp
+++ b/src/utils/db_aware_allocator.hpp
@@ -40,6 +40,7 @@ class ArenaPool;
 //          not a shared library. Matches the pattern used by query_memory_control.
 struct DbArenaTlsState {
   unsigned arena{0};               // Current thread's arena for active DB (0 = none)
+  unsigned tcache{0};              // Current thread's explicit tcache for active DB (0 = none / bypass tcache)
   ArenaPool *arena_pool{nullptr};  // Pool that owns arena; nullptr when arena == 0
   bool in_scope{false};  // For perf reasons we want to allow subsequent executions to reuse, so this is the scope guard
 };

--- a/src/utils/db_aware_allocator.hpp
+++ b/src/utils/db_aware_allocator.hpp
@@ -46,6 +46,20 @@ struct DbArenaTlsState {
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 inline thread_local DbArenaTlsState tls_db_arena_state [[gnu::tls_model("initial-exec")]] = {};
 
+// Persistent TLS cache that survives individual DbArenaScope destruction.
+// While tls_db_arena_state is restored to prev_arena_/prev_arena_pool_ on scope
+// exit, this cache keeps the arena pinned so that the NEXT scope from the *same*
+// pool can reuse it without calling ArenaPool::Acquire() (which is mutex-protected).
+//
+// Cleared only on pool switch or explicit DbArenaScope() no-arg teardown.
+struct ArenaTlsCache {
+  ArenaPool *owner{nullptr};
+  unsigned arena{0};
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+inline thread_local ArenaTlsCache tls_arena_cache [[gnu::tls_model("initial-exec")]] = {};
+
 // Allocate `bytes` bytes with the given `alignment`, attributed to arena `idx`.
 // Returns void* — use DbAllocate<T> for typed element-count based allocation.
 // Uses MALLOCX_TCACHE_NONE to avoid thread-cache overhead and ensure accurate tracking.

--- a/src/utils/db_aware_allocator.hpp
+++ b/src/utils/db_aware_allocator.hpp
@@ -41,24 +41,11 @@ class ArenaPool;
 struct DbArenaTlsState {
   unsigned arena{0};               // Current thread's arena for active DB (0 = none)
   ArenaPool *arena_pool{nullptr};  // Pool that owns arena; nullptr when arena == 0
+  bool in_scope{false};  // For perf reasons we want to allow subsequent executions to reuse, so this is the scope guard
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 inline thread_local DbArenaTlsState tls_db_arena_state [[gnu::tls_model("initial-exec")]] = {};
-
-// Persistent TLS cache that survives individual DbArenaScope destruction.
-// While tls_db_arena_state is restored to prev_arena_/prev_arena_pool_ on scope
-// exit, this cache keeps the arena pinned so that the NEXT scope from the *same*
-// pool can reuse it without calling ArenaPool::Acquire() (which is mutex-protected).
-//
-// Cleared only on pool switch or explicit DbArenaScope() no-arg teardown.
-struct ArenaTlsCache {
-  ArenaPool *owner{nullptr};
-  unsigned arena{0};
-};
-
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-inline thread_local ArenaTlsCache tls_arena_cache [[gnu::tls_model("initial-exec")]] = {};
 
 // Allocate `bytes` bytes with the given `alignment`, attributed to arena `idx`.
 // Returns void* — use DbAllocate<T> for typed element-count based allocation.

--- a/src/utils/db_aware_allocator.hpp
+++ b/src/utils/db_aware_allocator.hpp
@@ -42,7 +42,6 @@ struct DbArenaTlsState {
   unsigned arena{0};               // Current thread's arena for active DB (0 = none)
   unsigned tcache{0};              // Current thread's explicit tcache for active DB (0 = none / bypass tcache)
   ArenaPool *arena_pool{nullptr};  // Pool that owns arena; nullptr when arena == 0
-  bool in_scope{false};  // For perf reasons we want to allow subsequent executions to reuse, so this is the scope guard
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/src/utils/gatekeeper.hpp
+++ b/src/utils/gatekeeper.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <type_traits>
 #include <utility>
 
 namespace memgraph::utils {
@@ -82,6 +83,19 @@ struct EvalResult {
 template <typename Func, typename T>
 EvalResult(run_t, Func &&, T &) -> EvalResult<std::invoke_result_t<Func, T &>>;
 
+// Opt-in RAII guard that Gatekeeper installs around the lifetime of the
+// managed object.  Types can declare a nested `GatekeeperGuard` to have
+// Gatekeeper construct it before the object and destroy it after.
+template <typename T, typename = void>
+struct GatekeeperGuardFor {
+  struct type {};
+};
+
+template <typename T>
+struct GatekeeperGuardFor<T, std::void_t<typename T::GatekeeperGuard>> {
+  using type = typename T::GatekeeperGuard;
+};
+
 template <typename T>
 struct GKInternals {
   template <typename... Args>
@@ -97,7 +111,12 @@ struct GKInternals {
 template <typename T>
 struct Gatekeeper {
   template <typename... Args>
-  explicit Gatekeeper(Args &&...args) : pimpl_(std::make_unique<GKInternals<T>>(std::forward<Args>(args)...)) {}
+  explicit Gatekeeper(Args &&...args) {
+    // Opt-in lifetime guard around object construction.
+    // Types without a nested GatekeeperGuard get a zero-size no-op.
+    typename GatekeeperGuardFor<T>::type guard;
+    pimpl_ = std::make_unique<GKInternals<T>>(std::forward<Args>(args)...);
+  }
 
   Gatekeeper(Gatekeeper const &) = delete;
   Gatekeeper(Gatekeeper &&) noexcept = default;
@@ -215,6 +234,8 @@ struct Gatekeeper {
       if (owner_->value_ == std::nullopt) return true;
       // Delete value if ok
       if (!predicate(*owner_->value_)) return false;
+      // Opt-in lifetime guard around object destruction.
+      typename GatekeeperGuardFor<T>::type arena_guard;
       owner_->value_ = std::nullopt;
       return true;
     }
@@ -261,8 +282,13 @@ struct Gatekeeper {
     if (!pimpl_) return;  // Moved out, nothing to do
     pimpl_->is_marked_for_deletion = true;
     // wait for count to drain to 0
-    auto lock = std::unique_lock{pimpl_->mutex_};
-    pimpl_->cv_.wait(lock, [this] { return pimpl_->count_ == 0; });
+    {
+      auto lock = std::unique_lock{pimpl_->mutex_};
+      pimpl_->cv_.wait(lock, [this] { return pimpl_->count_ == 0; });
+    }
+    // Opt-in lifetime guard around object destruction.
+    typename GatekeeperGuardFor<T>::type guard;
+    pimpl_.reset();  // destroys GKInternals<T> (and thus T) while guard is active
   }
 
  private:


### PR DESCRIPTION
Using TCACHE NONE caused a performance regression for queries that do lots of small allocations. 
These small allocations mostly come from temporary allocations inside the storage functions that currently use database specific allocators. 
While threads use individual arenas, the thread cache is still needed because the arena allocation/deallocation logic is complex and slower.
ArenaPool now handles arena and tcache per thread. Tcache exist for the lifetime of the ArenaPool, no need to keep them indefinitely (unlike arenas).
TODO: Ideally temporary objects use pmr query/runtime allocators instead. 