### PR TITLE
perf: Fix slow delta chain walk in garbage collection

### DIFF
--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -3073,17 +3073,24 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
             }
 
             if (prev.delta->commit_info->timestamp.load() < oldest_active_start_timestamp) {
-              // For a committed non-sequential predecessor, readers skip delta
-              // via next, so we must clear delta->next before freeing
-              // downstream delta to stop traversal into freed deltas.
-              if (!IsDeltaNonSequential(*prev.delta)) {
-                break;
+              if (IsDeltaNonSequential(*prev.delta)) {
+                // Non-sequential predecessor: readers follow next, so we must
+                // null it to stop traversal into freed memory. We can skip the
+                // lock because we know we are the only potential modifiers,
+                // since:
+                // - the predecessor delta is inactive
+                // - prepends only happen at the chain head
+                // - the GC is serialized via gc_lock_.
+                // Safe for concurrent readers: all deltas beyond this point are
+                // also inactive (guaranteed by waiting_gc_deltas_), so no
+                // active transaction needs to read past here.
+                prev.delta->next.store(nullptr, std::memory_order_release);
               }
+              break;
             }
 
-            // Previous is either active (committed or uncommitted), or inactive
-            // non-sequential. We need to find the parent object in order to be
-            // able to use its lock.
+            // Previous is active (committed or uncommitted). We need to find
+            // the parent object in order to be able to use its lock.
             auto parent = prev;
             while (parent.type == PreviousPtr::Type::DELTA) {
               parent = parent.delta->prev.Get();


### PR DESCRIPTION
Optimises the case of severing the `next` link when unlinking a non-sequential delta in `CollectGarbage`. Consider the case of `TxA`'s deltas being unlinked, and one of `TxA`'s delta to be downstream from an inactive non-sequential delta from `TxB`, i.e.:

```
(vertex) ->...->[TxB's delta]->[TxA's delta]->...
```

#4020 fixed a correctness issue by ensuring that TxB's `next` was correctly set to `nullptr`, but it did so in a way that required both an `O(n)` walk up the chain to locate the vertex, and for the vertex's lock to be acquired. Correct, but regressive from a performance standpoint.

This approach instead just sets `TxB`'s delta's `.next` to `nullptr` atomically, bypassing the `O(n)` walk and the lock. Doing so is safe because:
- There can be no concurrent modification of `TxB's` `delta->next`. Prepends only happen at the chain head, garbage collection is serialized by `gc_lock_`, and the abort path only operates on active deltas. We know both the deltas in this operation are inactive because they cannot escape `waiting_gc_deltas_` unless all downstream contributors are committed, so we can be the only thing modifying `next`.
- No concurrent reader needs to read anything beyond `TxB`'s delta, as any deltas that would be needed are protected by the `oldest_active_start_timestamp` horizon.

Regession discovered by stress test #4115.