### PR TITLE
pin to working pnpm version

### DIFF
--- a/tests/util.sh
+++ b/tests/util.sh
@@ -19,11 +19,9 @@ setup_node() {
     exit 1
   fi
 
-  if ! command -v pnpm >/dev/null; then
-    echo "pnpm not found, enabling via corepack."
-    corepack enable pnpm 2>/dev/null || corepack enable 2>/dev/null || true
-    corepack prepare pnpm@10.33.4 --activate 2>/dev/null || true
-  fi
+  echo "Activating pinned pnpm via corepack."
+  corepack enable pnpm 2>/dev/null || corepack enable 2>/dev/null || true
+  corepack prepare pnpm@10.33.4 --activate 2>/dev/null || true
 
   if ! command -v pnpm >/dev/null; then
     echo "Could NOT find pnpm. Make sure pnpm is installed."

--- a/tests/util.sh
+++ b/tests/util.sh
@@ -22,6 +22,7 @@ setup_node() {
   if ! command -v pnpm >/dev/null; then
     echo "pnpm not found, enabling via corepack."
     corepack enable pnpm 2>/dev/null || corepack enable 2>/dev/null || true
+    corepack prepare pnpm@10.33.4 --activate 2>/dev/null || true
   fi
 
   if ! command -v pnpm >/dev/null; then


### PR DESCRIPTION
Version 11 of `pnpm` is not compatible with our current `node` version used in CI. This change pins to a known working version of `pnpm` for a minimal fix before `node` is upgraded.

