### PR TITLE
fix: Increase timeout for CUDA build of MAGE

### DIFF
--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -107,7 +107,7 @@ jobs:
   BuildAndPush:
     name: "Build and Test MAGE"
     runs-on: [self-hosted, DockerMgBuild, Linux, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
-    timeout-minutes: ${{ inputs.cugraph && 45 || 35 }}
+    timeout-minutes: ${{ (inputs.cugraph || inputs.cuda) && 45 || 35 }}
     outputs:
       s3_package_url: ${{ steps.output-url.outputs.s3_url }}
     steps:


### PR DESCRIPTION
The CUDA build of MAGE occasionally times out because it takes a little longer than non-CUDA builds, coming close to the 35 minute timeout. Fix: use the same 45 minute timeout that the cuGraph build does.

