### PR TITLE
fix coverage tests

### DIFF
--- a/tests/unit/database_get_info.cpp
+++ b/tests/unit/database_get_info.cpp
@@ -17,6 +17,7 @@
 #include "dbms/database.hpp"
 #include "dbms/dbms_handler.hpp"
 #include "disk_test_utils.hpp"
+#include "memory/db_arena.hpp"
 #include "query/interpret/awesome_memgraph_functions.hpp"
 #include "query/interpreter_context.hpp"
 #include "replication/state.hpp"
@@ -95,9 +96,11 @@ class InfoTest : public testing::Test {
                                                : memgraph::storage::StorageMode::IN_MEMORY_TRANSACTIONAL),
               "Wrong storage mode!");
     db_acc_ = std::move(db_acc);
+    db_arena_scope_.emplace(&db_acc_->get()->Arena());
   }
 
   void TearDown() {
+    db_arena_scope_.reset();
     db_acc_.reset();
     dbms_handler_.reset();
     if (std::is_same<StorageType, memgraph::storage::DiskStorage>::value) {
@@ -123,6 +126,7 @@ class InfoTest : public testing::Test {
   };
   std::optional<memgraph::dbms::DbmsHandler> dbms_handler_;
   std::optional<memgraph::dbms::DatabaseAccess> db_acc_;
+  std::optional<memgraph::memory::DbArenaScope> db_arena_scope_;
 };
 
 using TestTypes = ::testing::Types<std::pair<memgraph::storage::InMemoryStorage, DefaultConfig>,

--- a/tests/unit/dbms_database.cpp
+++ b/tests/unit/dbms_database.cpp
@@ -16,6 +16,7 @@
 
 #include "dbms/database_handler.hpp"
 #include "dbms/global.hpp"
+#include "memory/db_arena.hpp"
 
 #include "license/license.hpp"
 #include "query_plan_common.hpp"
@@ -167,6 +168,7 @@ TEST_F(DBMS_Database, DeleteAndRecover) {
 
     // Add data to graphs
     {
+      const memgraph::memory::DbArenaScope arena_scope{&db1.value()->Arena()};
       auto storage_dba = db1.value()->Access(memgraph::storage::WRITE);
       memgraph::query::DbAccessor dba{storage_dba.get()};
       memgraph::query::VertexAccessor v1{dba.InsertVertex()};
@@ -176,6 +178,7 @@ TEST_F(DBMS_Database, DeleteAndRecover) {
       ASSERT_TRUE(dba.Commit(memgraph::tests::MakeMainCommitArgs()).has_value());
     }
     {
+      const memgraph::memory::DbArenaScope arena_scope{&db3.value()->Arena()};
       auto storage_dba = db3.value()->Access(memgraph::storage::WRITE);
       memgraph::query::DbAccessor dba{storage_dba.get()};
       memgraph::query::VertexAccessor v1{dba.InsertVertex()};
@@ -211,18 +214,21 @@ TEST_F(DBMS_Database, DeleteAndRecover) {
     // Check content
     {
       // Empty
+      const memgraph::memory::DbArenaScope arena_scope{&db1.value()->Arena()};
       auto storage_dba = db1.value()->Access(memgraph::storage::WRITE);
       memgraph::query::DbAccessor dba{storage_dba.get()};
       ASSERT_EQ(dba.VerticesCount(), 0);
     }
     {
       // Empty
+      const memgraph::memory::DbArenaScope arena_scope{&db2.value()->Arena()};
       auto storage_dba = db2.value()->Access(memgraph::storage::WRITE);
       memgraph::query::DbAccessor dba{storage_dba.get()};
       ASSERT_EQ(dba.VerticesCount(), 0);
     }
     {
       // Full
+      const memgraph::memory::DbArenaScope arena_scope{&db3.value()->Arena()};
       auto storage_dba = db3.value()->Access(memgraph::storage::WRITE);
       memgraph::query::DbAccessor dba{storage_dba.get()};
       ASSERT_EQ(dba.VerticesCount(), 3);

--- a/tests/unit/storage_v2_constraints.cpp
+++ b/tests/unit/storage_v2_constraints.cpp
@@ -17,6 +17,7 @@
 
 #include "dbms/database.hpp"
 #include "dbms/database_protector.hpp"
+#include "memory/db_arena.hpp"
 #include "storage/v2/constraints/constraints.hpp"
 #include "storage/v2/disk/storage.hpp"
 #include "storage/v2/disk/unique_constraints.hpp"
@@ -49,6 +50,7 @@ class ConstraintsTest : public testing::Test {
     auto db_acc_opt = db_gk_->access();
     MG_ASSERT(db_acc_opt, "Failed to access db");
     db_acc_ = *db_acc_opt;
+    db_arena_scope_.emplace(&db_acc_->get()->Arena());
     storage = db_acc_->get()->storage();
     prop1 = storage->NameToProperty("prop1");
     prop2 = storage->NameToProperty("prop2");
@@ -58,6 +60,7 @@ class ConstraintsTest : public testing::Test {
 
   void TearDown() override {
     storage = nullptr;
+    db_arena_scope_.reset();
     db_acc_.reset();
     db_gk_.reset();
 
@@ -86,6 +89,7 @@ class ConstraintsTest : public testing::Test {
   memgraph::storage::Config config_;
   std::optional<memgraph::dbms::DatabaseAccess> db_acc_;
   std::optional<memgraph::utils::Gatekeeper<memgraph::dbms::Database>> db_gk_;
+  std::optional<memgraph::memory::DbArenaScope> db_arena_scope_;
   PropertyId prop1;
   PropertyId prop2;
   LabelId label1;

--- a/tests/unit/storage_v2_create_snapshot.cpp
+++ b/tests/unit/storage_v2_create_snapshot.cpp
@@ -16,6 +16,7 @@
 #include <string>
 
 #include "dbms/database.hpp"
+#include "memory/db_arena.hpp"
 #include "replication/state.hpp"
 #include "storage/v2/config.hpp"
 #include "storage/v2/durability/paths.hpp"
@@ -54,6 +55,7 @@ class CreateSnapshotTest : public testing::Test {
 TEST_F(CreateSnapshotTest, CreateSnapshotReturnsPathOnSuccess) {
   auto config = CreateConfig();
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
   auto *mem_storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
 
@@ -85,6 +87,7 @@ TEST_F(CreateSnapshotTest, CreateSnapshotReturnsPathOnSuccess) {
 TEST_F(CreateSnapshotTest, CreateSnapshotReturnsErrorForReplica) {
   auto config = CreateConfig();
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
   auto *mem_storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
 
@@ -95,6 +98,7 @@ TEST_F(CreateSnapshotTest, CreateSnapshotReturnsErrorForReplica) {
 TEST_F(CreateSnapshotTest, CreateSnapshotReturnsErrorWhenNothingNewToWrite) {
   auto config = CreateConfig();
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
   auto *mem_storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
 
@@ -122,6 +126,7 @@ TEST_F(CreateSnapshotTest, CreateSnapshotReturnsErrorWhenNothingNewToWrite) {
 TEST_F(CreateSnapshotTest, CreateSnapshotPathFormat) {
   auto config = CreateConfig();
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
   auto *mem_storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
 
@@ -157,6 +162,7 @@ TEST_F(CreateSnapshotTest, CreateSnapshotPathFormat) {
 TEST_F(CreateSnapshotTest, BackwardCompatibilityWithErrorHandling) {
   auto config = CreateConfig();
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
   auto *mem_storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
 
@@ -168,6 +174,7 @@ TEST_F(CreateSnapshotTest, BackwardCompatibilityWithErrorHandling) {
 TEST_F(CreateSnapshotTest, SuccessCaseWithPathRetrieval) {
   auto config = CreateConfig();
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
   auto *mem_storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
 
@@ -200,6 +207,7 @@ TEST_F(CreateSnapshotTest, ModeSwitchSnapshotDurableTimestampCoversAnalyticalWri
   memgraph::storage::durability::SnapshotInfo snapshot;
   {
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     auto *mem_storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
 
     mem_storage->SetStorageMode(memgraph::storage::StorageMode::IN_MEMORY_ANALYTICAL);

--- a/tests/unit/storage_v2_durability_inmemory.cpp
+++ b/tests/unit/storage_v2_durability_inmemory.cpp
@@ -33,6 +33,7 @@
 #include "flags/experimental.hpp"
 #include "flags/general.hpp"
 #include "license/license.hpp"
+#include "memory/db_arena.hpp"
 #include "replication/state.hpp"
 #include "storage/v2/config.hpp"
 #include "storage/v2/constraints/constraints.hpp"
@@ -1463,6 +1464,7 @@ TEST_P(DurabilityTest, SnapshotOnExit) {
                        .allow_parallel_snapshot_creation = true},
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}}};
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
     VerifyDataset(db.storage(), DatasetType::ONLY_BASE, GetParam(), config.salient.items.enable_schema_info);
     CreateExtendedDataset(db.storage());
@@ -1480,6 +1482,7 @@ TEST_P(DurabilityTest, SnapshotOnExit) {
       .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
   };
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(db.storage(), DatasetType::BASE_WITH_EXTENDED, GetParam(), config.salient.items.enable_schema_info);
 
   // Try to use the storage.
@@ -1504,6 +1507,7 @@ TEST_P(DurabilityTest, SnapshotPeriodic) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
     std::this_thread::sleep_for(std::chrono::milliseconds(2500));
   }
@@ -1519,6 +1523,7 @@ TEST_P(DurabilityTest, SnapshotPeriodic) {
       .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
   };
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(db.storage(), DatasetType::ONLY_BASE, GetParam(), config.salient.items.enable_schema_info);
 
   // Try to use the storage.
@@ -1553,6 +1558,7 @@ TEST_P(DurabilityTest, SnapshotFallback) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
     auto const ensure_snapshot_is_written = [&](auto &&func) {
       auto const pre_count = GetSnapshotsList().size();
@@ -1593,6 +1599,7 @@ TEST_P(DurabilityTest, SnapshotFallback) {
       .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
   };
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(db.storage(), DatasetType::ONLY_BASE, GetParam(), config.salient.items.enable_schema_info);
 
   // Try to use the storage.
@@ -1614,6 +1621,7 @@ TEST_P(DurabilityTest, SnapshotEverythingCorrupt) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
     auto acc = db.Access(memgraph::storage::WRITE);
     for (uint64_t i = 0; i < 1000; ++i) {
@@ -1645,6 +1653,7 @@ TEST_P(DurabilityTest, SnapshotEverythingCorrupt) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
     CreateBaseDataset(db.storage(), GetParam());
     std::this_thread::sleep_for(std::chrono::milliseconds(2500));
@@ -1687,6 +1696,7 @@ TEST_P(DurabilityTest, SnapshotEverythingCorrupt) {
                      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
                  };
                  memgraph::dbms::Database db{config};
+                 const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
                }())  // iile
                ,
                "");
@@ -1701,6 +1711,7 @@ TEST_P(DurabilityTest, SnapshotRetention) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     auto acc = db.Access(memgraph::storage::WRITE);
     for (uint64_t i = 0; i < 1000; ++i) {
       acc->CreateVertex();
@@ -1725,6 +1736,7 @@ TEST_P(DurabilityTest, SnapshotRetention) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     // Restore unrelated snapshots after the database has been started.
     RestoreBackups();
     CreateBaseDataset(db.storage(), GetParam());
@@ -1749,6 +1761,7 @@ TEST_P(DurabilityTest, SnapshotRetention) {
       .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
   };
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(db.storage(), DatasetType::ONLY_BASE, GetParam(), config.salient.items.enable_schema_info);
 
   // Try to use the storage.
@@ -1775,6 +1788,7 @@ TEST_P(DurabilityTest, SnapshotMixedUUID) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
     VerifyDataset(db.storage(), DatasetType::ONLY_BASE, GetParam(), config.salient.items.enable_schema_info);
     CreateExtendedDataset(db.storage());
@@ -1794,6 +1808,7 @@ TEST_P(DurabilityTest, SnapshotMixedUUID) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     VerifyDataset(db.storage(), DatasetType::BASE_WITH_EXTENDED, GetParam(), config.salient.items.enable_schema_info);
   }
 
@@ -1804,6 +1819,7 @@ TEST_P(DurabilityTest, SnapshotMixedUUID) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
     VerifyDataset(db.storage(), DatasetType::ONLY_BASE, GetParam(), config.salient.items.enable_schema_info);
   }
@@ -1827,6 +1843,7 @@ TEST_P(DurabilityTest, SnapshotMixedUUID) {
       .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
   };
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(db.storage(), DatasetType::ONLY_BASE, GetParam(), config.salient.items.enable_schema_info);
 
   // Try to use the storage.
@@ -1848,6 +1865,7 @@ TEST_P(DurabilityTest, SnapshotBackup) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     auto acc = db.Access(memgraph::storage::WRITE);
     for (uint64_t i = 0; i < 1000; ++i) {
       acc->CreateVertex();
@@ -1869,6 +1887,7 @@ TEST_P(DurabilityTest, SnapshotBackup) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   }
 
   ASSERT_EQ(GetSnapshotsList().size(), 0);
@@ -1891,6 +1910,7 @@ TEST_F(DurabilityTest, SnapshotWithoutPropertiesOnEdgesRecoveryWithPropertiesOnE
         .salient = {.items = {.properties_on_edges = false}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), false);
     VerifyDataset(db.storage(), DatasetType::ONLY_BASE, false, false);
     CreateExtendedDataset(db.storage());
@@ -1908,6 +1928,7 @@ TEST_F(DurabilityTest, SnapshotWithoutPropertiesOnEdgesRecoveryWithPropertiesOnE
       .salient = {.items = {.properties_on_edges = true}},
   };
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(db.storage(), DatasetType::BASE_WITH_EXTENDED, false, false);
 
   // Try to use the storage.
@@ -1934,6 +1955,7 @@ TEST_F(DurabilityTest, SnapshotWithPropertiesOnEdgesRecoveryWithoutPropertiesOnE
         .salient = {.items = {.properties_on_edges = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), true);
     VerifyDataset(db.storage(), DatasetType::ONLY_BASE, true, false);
     CreateExtendedDataset(db.storage());
@@ -1953,6 +1975,7 @@ TEST_F(DurabilityTest, SnapshotWithPropertiesOnEdgesRecoveryWithoutPropertiesOnE
                      .salient = {.items = {.properties_on_edges = false}},
                  };
                  memgraph::dbms::Database db{config};
+                 const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
                }())  // iile
                ,
                "");
@@ -1967,6 +1990,7 @@ TEST_F(DurabilityTest, SnapshotWithPropertiesOnEdgesButUnusedRecoveryWithoutProp
         .salient = {.items = {.properties_on_edges = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), true);
     VerifyDataset(db.storage(), DatasetType::ONLY_BASE, true, false);
     CreateExtendedDataset(db.storage());
@@ -2011,6 +2035,7 @@ TEST_F(DurabilityTest, SnapshotWithPropertiesOnEdgesButUnusedRecoveryWithoutProp
       .salient = {.items = {.properties_on_edges = false}},
   };
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(db.storage(), DatasetType::BASE_WITH_EXTENDED, false, false);
 
   // Try to use the storage.
@@ -2037,6 +2062,7 @@ TEST_P(DurabilityTest, WalBasic) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
     CreateExtendedDataset(db.storage());
   }
@@ -2052,6 +2078,7 @@ TEST_P(DurabilityTest, WalBasic) {
       .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
   };
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(db.storage(), DatasetType::BASE_WITH_EXTENDED, GetParam(), config.salient.items.enable_schema_info);
 
   // Try to use the storage.
@@ -2079,6 +2106,7 @@ TEST_P(DurabilityTest, WalBackup) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     auto acc = db.Access(memgraph::storage::WRITE);
     for (uint64_t i = 0; i < 1000; ++i) {
       acc->CreateVertex();
@@ -2102,6 +2130,7 @@ TEST_P(DurabilityTest, WalBackup) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   }
 
   ASSERT_EQ(GetSnapshotsList().size(), 0);
@@ -2124,6 +2153,7 @@ TEST_P(DurabilityTest, WalAppendToExisting) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
   }
 
@@ -2141,6 +2171,7 @@ TEST_P(DurabilityTest, WalAppendToExisting) {
     };
     ;
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     VerifyDataset(db.storage(), DatasetType::ONLY_BASE, GetParam(), config.salient.items.enable_schema_info);
   }
 
@@ -2157,6 +2188,7 @@ TEST_P(DurabilityTest, WalAppendToExisting) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateExtendedDataset(db.storage());
   }
 
@@ -2171,6 +2203,7 @@ TEST_P(DurabilityTest, WalAppendToExisting) {
       .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
   };
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(db.storage(), DatasetType::BASE_WITH_EXTENDED, GetParam(), config.salient.items.enable_schema_info);
 
   // Try to use the storage.
@@ -2200,6 +2233,7 @@ TEST_P(DurabilityTest, WalCreateInSingleTransaction) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     auto acc = db.Access(memgraph::storage::WRITE);
     auto v1 = acc->CreateVertex();
     gid_v1 = v1.Gid();
@@ -2236,6 +2270,7 @@ TEST_P(DurabilityTest, WalCreateInSingleTransaction) {
       .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
   };
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   {
     auto acc = db.Access(memgraph::storage::WRITE);
 
@@ -2348,6 +2383,7 @@ TEST_P(DurabilityTest, WalCreateAndRemoveEverything) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
     CreateExtendedDataset(db.storage());
     auto indices = [&] {
@@ -2401,6 +2437,7 @@ TEST_P(DurabilityTest, WalCreateAndRemoveEverything) {
       .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
   };
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   {
     auto acc = db.Access(memgraph::storage::WRITE);
     auto indices = acc->ListAllIndices();
@@ -2447,6 +2484,7 @@ TEST_P(DurabilityTest, WalTransactionOrdering) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     auto acc1 = db.Access(memgraph::storage::WRITE);
     auto acc2 = db.Access(memgraph::storage::WRITE);
 
@@ -2542,6 +2580,7 @@ TEST_P(DurabilityTest, WalTransactionOrdering) {
       .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
   };
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   {
     auto acc = db.Access(memgraph::storage::WRITE);
     for (auto [gid, id] : std::vector<std::pair<memgraph::storage::Gid, int64_t>>{{gid1, 1}, {gid2, 2}, {gid3, 3}}) {
@@ -2581,6 +2620,7 @@ TEST_P(DurabilityTest, WalCreateAndRemoveOnlyBaseDataset) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
     CreateExtendedDataset(db.storage());
     auto label_indexed = db.storage()->NameToLabel("base_indexed");
@@ -2607,6 +2647,7 @@ TEST_P(DurabilityTest, WalCreateAndRemoveOnlyBaseDataset) {
       .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
   };
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(db.storage(),
                 DatasetType::ONLY_EXTENDED_WITH_BASE_INDICES_AND_CONSTRAINTS,
                 GetParam(),
@@ -2641,6 +2682,7 @@ TEST_P(DurabilityTest, WalDeathResilience) {
           .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
       };
       memgraph::dbms::Database db{config};
+      const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
       // Create one million vertices.
       for (uint64_t i = 0; i < 1'000'000; ++i) {
         auto acc = db.Access(memgraph::storage::WRITE);
@@ -2683,6 +2725,7 @@ TEST_P(DurabilityTest, WalDeathResilience) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     {
       auto acc = db.Access(memgraph::storage::WRITE);
       auto iterable = acc->Vertices(memgraph::storage::View::OLD);
@@ -2712,6 +2755,7 @@ TEST_P(DurabilityTest, WalDeathResilience) {
       .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
   };
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   {
     uint64_t current = 0;
     auto acc = db.Access(memgraph::storage::WRITE);
@@ -2747,6 +2791,7 @@ TEST_P(DurabilityTest, WalMissingSecond) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     auto acc = db.Access(memgraph::storage::WRITE);
     for (uint64_t i = 0; i < 1000; ++i) {
       acc->CreateVertex();
@@ -2774,6 +2819,7 @@ TEST_P(DurabilityTest, WalMissingSecond) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     const uint64_t kNumVertices = 1000;
     std::vector<memgraph::storage::Gid> gids;
     gids.reserve(kNumVertices);
@@ -2823,6 +2869,7 @@ TEST_P(DurabilityTest, WalMissingSecond) {
                      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
                  };
                  memgraph::dbms::Database db{config};
+                 const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
                }())  // iile
                ,
                "");
@@ -2843,6 +2890,7 @@ TEST_P(DurabilityTest, WalCorruptSecond) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     auto acc = db.Access(memgraph::storage::WRITE);
     for (uint64_t i = 0; i < 1000; ++i) {
       acc->CreateVertex();
@@ -2870,6 +2918,7 @@ TEST_P(DurabilityTest, WalCorruptSecond) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     const uint64_t kNumVertices = 1000;
     std::vector<memgraph::storage::Gid> gids;
     gids.reserve(kNumVertices);
@@ -2919,6 +2968,7 @@ TEST_P(DurabilityTest, WalCorruptSecond) {
                      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
                  };
                  memgraph::dbms::Database db{config};
+                 const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
                }())  // iile
                ,
                "");
@@ -2939,6 +2989,7 @@ TEST_P(DurabilityTest, WalCorruptLastTransaction) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
     CreateExtendedDataset(db.storage(), /* single_transaction = */ true);
   }
@@ -2962,6 +3013,7 @@ TEST_P(DurabilityTest, WalCorruptLastTransaction) {
       .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
   };
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   // The extended dataset shouldn't be recovered because its WAL transaction was
   // corrupt.
   VerifyDataset(db.storage(),
@@ -2994,6 +3046,7 @@ TEST_P(DurabilityTest, WalAllOperationsInSingleTransaction) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     auto acc = db.Access(memgraph::storage::WRITE);
     auto vertex1 = acc->CreateVertex();
     auto vertex2 = acc->CreateVertex();
@@ -3041,6 +3094,7 @@ TEST_P(DurabilityTest, WalAllOperationsInSingleTransaction) {
       .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
   };
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   {
     auto acc = db.Access(memgraph::storage::WRITE);
     uint64_t count = 0;
@@ -3078,6 +3132,7 @@ TEST_P(DurabilityTest, WalAndSnapshot) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
     std::this_thread::sleep_for(std::chrono::milliseconds(2500));
     CreateExtendedDataset(db.storage());
@@ -3094,6 +3149,7 @@ TEST_P(DurabilityTest, WalAndSnapshot) {
       .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
   };
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(db.storage(), DatasetType::BASE_WITH_EXTENDED, GetParam(), config.salient.items.enable_schema_info);
 
   // Try to use the storage.
@@ -3115,6 +3171,7 @@ TEST_P(DurabilityTest, WalAndSnapshotAppendToExistingSnapshot) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
   }
 
@@ -3131,6 +3188,7 @@ TEST_P(DurabilityTest, WalAndSnapshotAppendToExistingSnapshot) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     VerifyDataset(db.storage(), DatasetType::ONLY_BASE, GetParam(), config.salient.items.enable_schema_info);
   }
 
@@ -3147,6 +3205,7 @@ TEST_P(DurabilityTest, WalAndSnapshotAppendToExistingSnapshot) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateExtendedDataset(db.storage());
   }
 
@@ -3161,6 +3220,7 @@ TEST_P(DurabilityTest, WalAndSnapshotAppendToExistingSnapshot) {
       .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
   };
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(db.storage(), DatasetType::BASE_WITH_EXTENDED, GetParam(), config.salient.items.enable_schema_info);
 
   // Try to use the storage.
@@ -3187,6 +3247,7 @@ TEST_P(DurabilityTest, WalAndSnapshotAppendToExistingSnapshotAndWal) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
   }
 
@@ -3203,6 +3264,7 @@ TEST_P(DurabilityTest, WalAndSnapshotAppendToExistingSnapshotAndWal) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     VerifyDataset(db.storage(), DatasetType::ONLY_BASE, GetParam(), config.salient.items.enable_schema_info);
   }
 
@@ -3219,6 +3281,7 @@ TEST_P(DurabilityTest, WalAndSnapshotAppendToExistingSnapshotAndWal) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateExtendedDataset(db.storage());
   }
 
@@ -3241,6 +3304,7 @@ TEST_P(DurabilityTest, WalAndSnapshotAppendToExistingSnapshotAndWal) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     VerifyDataset(db.storage(), DatasetType::BASE_WITH_EXTENDED, GetParam(), config.salient.items.enable_schema_info);
     auto acc = db.Access(memgraph::storage::WRITE);
     auto vertex = acc->CreateVertex();
@@ -3263,6 +3327,7 @@ TEST_P(DurabilityTest, WalAndSnapshotAppendToExistingSnapshotAndWal) {
       .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
   };
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(db.storage(),
                 DatasetType::BASE_WITH_EXTENDED,
                 GetParam(),
@@ -3311,6 +3376,7 @@ TEST_P(DurabilityTest, WalAndSnapshotWalRetention) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     auto acc = db.Access(memgraph::storage::WRITE);
     for (uint64_t i = 0; i < 1000; ++i) {
       acc->CreateVertex();
@@ -3340,6 +3406,7 @@ TEST_P(DurabilityTest, WalAndSnapshotWalRetention) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     // Restore unrelated snapshots after the database has been started.
     RestoreBackups();
     memgraph::utils::Timer timer;
@@ -3371,6 +3438,7 @@ TEST_P(DurabilityTest, WalAndSnapshotWalRetention) {
           .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
       };
       memgraph::dbms::Database db{config};
+      const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
       auto acc = db.Access(memgraph::storage::WRITE);
       for (uint64_t j = 0; j < items_created; ++j) {
         auto vertex = acc->FindVertex(memgraph::storage::Gid::FromUint(j), memgraph::storage::View::OLD);
@@ -3391,6 +3459,7 @@ TEST_P(DurabilityTest, WalAndSnapshotWalRetention) {
                      .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
                  };
                  memgraph::dbms::Database db{config};
+                 const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
                }())  // iile
                ,
                "");
@@ -3411,6 +3480,7 @@ TEST_P(DurabilityTest, SnapshotAndWalMixedUUID) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     auto acc = db.Access(memgraph::storage::WRITE);
     for (uint64_t i = 0; i < 1000; ++i) {
       acc->CreateVertex();
@@ -3434,6 +3504,7 @@ TEST_P(DurabilityTest, SnapshotAndWalMixedUUID) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
     std::this_thread::sleep_for(std::chrono::milliseconds(2500));
     CreateExtendedDataset(db.storage());
@@ -3459,6 +3530,7 @@ TEST_P(DurabilityTest, SnapshotAndWalMixedUUID) {
       .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}},
   };
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(db.storage(), DatasetType::BASE_WITH_EXTENDED, GetParam(), config.salient.items.enable_schema_info);
 
   // Try to use the storage.
@@ -3483,6 +3555,7 @@ TEST_P(DurabilityTest, ParallelSnapshotRecovery) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
     VerifyDataset(db.storage(), DatasetType::ONLY_BASE, GetParam(), config.salient.items.enable_schema_info);
     CreateExtendedDataset(db.storage());
@@ -3504,6 +3577,7 @@ TEST_P(DurabilityTest, ParallelSnapshotRecovery) {
       .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
   };
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(db.storage(), DatasetType::BASE_WITH_EXTENDED, GetParam(), config.salient.items.enable_schema_info);
 }
 
@@ -3522,6 +3596,7 @@ TEST_P(DurabilityTest, ParallelWalRecovery) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
     VerifyDataset(db.storage(), DatasetType::ONLY_BASE, GetParam(), config.salient.items.enable_schema_info);
     CreateExtendedDataset(db.storage());
@@ -3545,6 +3620,7 @@ TEST_P(DurabilityTest, ParallelWalRecovery) {
       .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
   };
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(db.storage(), DatasetType::BASE_WITH_EXTENDED, GetParam(), config.salient.items.enable_schema_info);
 }
 
@@ -3567,6 +3643,7 @@ TEST_P(DurabilityTest, ParallelSnapshotWalRecovery) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
     VerifyDataset(db.storage(), DatasetType::ONLY_BASE, GetParam(), config.salient.items.enable_schema_info);
     // Manually create database in the middle
@@ -3592,6 +3669,7 @@ TEST_P(DurabilityTest, ParallelSnapshotWalRecovery) {
       .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
   };
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(db.storage(), DatasetType::BASE_WITH_EXTENDED, GetParam(), config.salient.items.enable_schema_info);
 }
 
@@ -3610,6 +3688,7 @@ TEST_P(DurabilityTest, ConstraintsRecoveryFunctionSetting) {
     config.durability.recover_on_startup = false;
     config.durability.snapshot_on_exit = true;
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
     VerifyDataset(db.storage(), DatasetType::ONLY_BASE, GetParam(), config.salient.items.enable_schema_info);
     CreateExtendedDataset(db.storage());
@@ -3697,6 +3776,7 @@ TEST_P(DurabilityTest, EdgeTypeIndexRecovered) {
     memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .snapshot_on_exit = true},
                                      .salient.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}};
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
     VerifyDataset(db.storage(), DatasetType::ONLY_BASE, GetParam(), config.salient.items.enable_schema_info);
     CreateEdgeIndex(db.storage(), db.storage()->NameToEdgeType("base_et1"));
@@ -3713,6 +3793,7 @@ TEST_P(DurabilityTest, EdgeTypeIndexRecovered) {
   memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .recover_on_startup = true},
                                    .salient.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}};
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(
       db.storage(), DatasetType::BASE_WITH_EDGE_TYPE_INDEXED, GetParam(), config.salient.items.enable_schema_info);
 
@@ -3736,6 +3817,7 @@ TEST_P(DurabilityTest, EdgeTypePropertyIndexRecoveredWithEdgeTypeIndices) {
     memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .snapshot_on_exit = true},
                                      .salient.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}};
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
     VerifyDataset(db.storage(), DatasetType::ONLY_BASE, GetParam(), config.salient.items.enable_schema_info);
     CreateEdgeIndex(db.storage(), db.storage()->NameToEdgeType("base_et1"));
@@ -3760,6 +3842,7 @@ TEST_P(DurabilityTest, EdgeTypePropertyIndexRecoveredWithEdgeTypeIndices) {
   memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .recover_on_startup = true},
                                    .salient.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}};
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(db.storage(),
                 DatasetType::BASE_WITH_EDGE_TYPE_PROPERTY_INDEXED,
                 GetParam(),
@@ -3785,6 +3868,7 @@ TEST_P(DurabilityTest, EdgeTypePropertyIndexRecoveredWithoutEdgeTypeIndices) {
     memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .snapshot_on_exit = true},
                                      .salient.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}};
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
     VerifyDataset(db.storage(), DatasetType::ONLY_BASE, GetParam(), config.salient.items.enable_schema_info);
     CreateEdgePropertyIndex(db.storage(), db.storage()->NameToEdgeType("base_et1"), db.storage()->NameToProperty("id"));
@@ -3806,6 +3890,7 @@ TEST_P(DurabilityTest, EdgeTypePropertyIndexRecoveredWithoutEdgeTypeIndices) {
   memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .recover_on_startup = true},
                                    .salient.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}};
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(db.storage(),
                 DatasetType::BASE_WITH_EDGE_TYPE_PROPERTY_INDEXED,
                 GetParam(),
@@ -3831,6 +3916,7 @@ TEST_P(DurabilityTest, EdgeMetadataRecovered) {
     memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .snapshot_on_exit = true},
                                      .salient.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}};
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
     CreateBaseDataset(db.storage(), GetParam());
     VerifyDataset(db.storage(), DatasetType::ONLY_BASE, GetParam(), config.salient.items.enable_schema_info);
   }
@@ -3845,6 +3931,7 @@ TEST_P(DurabilityTest, EdgeMetadataRecovered) {
       .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
       .salient.items = {.properties_on_edges = GetParam(), .enable_edges_metadata = true, .enable_schema_info = false}};
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   VerifyDataset(db.storage(), DatasetType::ONLY_BASE, GetParam(), config.salient.items.enable_schema_info);
 
   // Check if data has been loaded correctly.
@@ -3886,6 +3973,7 @@ TEST_F(DurabilityTest, TtlDurability) {
     memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .snapshot_on_exit = true},
                                      .salient.items = {.properties_on_edges = true}};
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
     // Configure TTL with edge TTL enabled
     {
@@ -3918,6 +4006,7 @@ TEST_F(DurabilityTest, TtlDurability) {
     memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .recover_on_startup = true},
                                      .salient.items = {.properties_on_edges = true}};
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
     // Verify TTL configuration was recovered
     {
@@ -3933,6 +4022,7 @@ TEST_F(DurabilityTest, TtlDurability) {
     memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .snapshot_on_exit = true},
                                      .salient.items = {.properties_on_edges = true}};
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
     // Configure TTL with edge TTL disabled
     {
@@ -3961,6 +4051,7 @@ TEST_F(DurabilityTest, TtlDurability) {
     memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .snapshot_on_exit = true},
                                      .salient.items = {.properties_on_edges = true}};
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
     // Disable TTL
     {
@@ -3986,6 +4077,7 @@ TEST_F(DurabilityTest, TtlDurability) {
                            memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL},
         .salient.items = {.properties_on_edges = true}};
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
     // Perform various TTL operations that will be logged to WAL
     {
@@ -4045,6 +4137,7 @@ TEST_F(DurabilityTest, TtlDurability) {
     memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .recover_on_startup = true},
                                      .salient.items = {.properties_on_edges = true}};
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
     // Verify final TTL configuration (last operation was ConfigureTtl with 1-hour period and edge TTL enabled)
     {
@@ -4067,6 +4160,7 @@ TEST_F(DurabilityTest, TtlDurability) {
                            memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL},
         .salient.items = {.properties_on_edges = true}};
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
     ASSERT_FALSE(db.storage()->ttl_.Running());
     ASSERT_FALSE(db.storage()->ttl_.Enabled());
@@ -4104,6 +4198,7 @@ TEST_F(DurabilityTest, TtlDurability) {
     memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .recover_on_startup = true},
                                      .salient.items = {.properties_on_edges = true}};
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
     // Verify TTL is stopped
     {
@@ -4126,6 +4221,7 @@ TEST_F(DurabilityTest, TtlDurability) {
                            memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL},
         .salient.items = {.properties_on_edges = true}};
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
     // Verify setup and stopped TTL
     {
@@ -4149,6 +4245,7 @@ TEST_F(DurabilityTest, TtlDurability) {
                            memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL},
         .salient.items = {.properties_on_edges = true}};
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
     // Verify setup and stopped TTL
     {
@@ -4181,6 +4278,7 @@ TEST_F(DurabilityTest, TtlDurability) {
                            memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL},
         .salient.items = {.properties_on_edges = true}};
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
     // Verify setup and running TTL
     {
@@ -4204,6 +4302,7 @@ TEST_F(DurabilityTest, TtlDurability) {
                            memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL},
         .salient.items = {.properties_on_edges = true}};
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
     // Verify setup and running TTL
     {
@@ -4230,6 +4329,7 @@ TEST_P(DurabilityTest, CreateSnapshotReturnsPath) {
   };
 
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
   auto *mem_storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
 
@@ -4269,6 +4369,7 @@ TEST_P(DurabilityTest, CreateSnapshotReturnsErrorForReplica) {
   };
 
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
   auto *mem_storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
   auto result = mem_storage->CreateSnapshot();
@@ -4452,6 +4553,7 @@ TEST_P(DurabilityTest, SnapshotWithNonSequentialDeltas) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
     {
       auto acc = db.Access(memgraph::storage::WRITE);
@@ -4501,6 +4603,7 @@ TEST_P(DurabilityTest, SnapshotWithNonSequentialDeltas) {
         .salient = {.items = {.properties_on_edges = GetParam(), .enable_schema_info = true}},
     };
     memgraph::dbms::Database db{recovery_config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
     auto acc = db.Access(memgraph::storage::WRITE);
     auto v1 = acc->FindVertex(v1_gid, memgraph::storage::View::OLD);
@@ -4540,6 +4643,7 @@ TEST_P(DurabilityTest, DescriptionsRecoveredFromSnapshot) {
     memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .snapshot_on_exit = true},
                                      .salient.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}};
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
     {
       auto acc = db.Access(memgraph::storage::WRITE);
@@ -4578,6 +4682,7 @@ TEST_P(DurabilityTest, DescriptionsRecoveredFromSnapshot) {
   memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .recover_on_startup = true},
                                    .salient.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}};
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
   {
     auto acc = db.Access(memgraph::storage::READ);
@@ -4605,6 +4710,7 @@ TEST_P(DurabilityTest, DescriptionsRecoveredFromWal) {
                        .snapshot_on_exit = false},
         .salient.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}};
     memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
     {
       auto acc = db.Access(memgraph::storage::WRITE);
@@ -4634,6 +4740,7 @@ TEST_P(DurabilityTest, DescriptionsRecoveredFromWal) {
   memgraph::storage::Config config{.durability = {.storage_directory = storage_directory, .recover_on_startup = true},
                                    .salient.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}};
   memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
 
   {
     auto acc = db.Access(memgraph::storage::READ);

--- a/tests/unit/storage_v2_recover_snapshot.cpp
+++ b/tests/unit/storage_v2_recover_snapshot.cpp
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 
 #include "dbms/database.hpp"
+#include "memory/db_arena.hpp"
 #include "replication/state.hpp"
 #include "storage/v2/config.hpp"
 #include "storage/v2/durability/paths.hpp"
@@ -88,6 +89,7 @@ class RecoverSnapshotTest : public ::testing::Test {
 TEST_F(RecoverSnapshotTest, RecoverSnapshotCreatesOldDirectory) {
   // Create initial storage and add some data
   memgraph::dbms::Database db{config_};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
   auto *storage = static_cast<memgraph::storage::InMemoryStorage *>(db.storage());
 
   // Add some data
@@ -219,30 +221,35 @@ TEST_F(RecoverSnapshotTest, RecoverSnapshotFromLocalStorage) {
   // Create initial storage and add some data
   std::optional<memgraph::dbms::Database> db = std::make_optional<memgraph::dbms::Database>(config_);
   ASSERT_TRUE(db.has_value()) << "Database should be created";
-  auto *storage = static_cast<memgraph::storage::InMemoryStorage *>(db->storage());
-
-  // Add some data
-  {
-    auto acc = storage->Access(memgraph::storage::WRITE);
-    auto vertex = acc->CreateVertex();
-    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
-  }
-
-  // Create a snapshot
-  auto snapshot_result = storage->CreateSnapshot();
-  ASSERT_TRUE(snapshot_result.has_value());
-
-  // Move the snapshot to the local storage
+  std::filesystem::path snapshot_path;
   TmpDirManager local_dir{"MG_test_unit_storage_v2_recover_snapshot_local"};
-  auto snapshot_path = snapshot_result.value();
-  std::filesystem::rename(snapshot_path, local_dir.Path() / snapshot_path.filename());
-  snapshot_path = local_dir.Path() / snapshot_path.filename();
+  {
+    const memgraph::memory::DbArenaScope arena_scope{&db->Arena()};
+    auto *storage = static_cast<memgraph::storage::InMemoryStorage *>(db->storage());
+
+    // Add some data
+    {
+      auto acc = storage->Access(memgraph::storage::WRITE);
+      auto vertex = acc->CreateVertex();
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    // Create a snapshot
+    auto snapshot_result = storage->CreateSnapshot();
+    ASSERT_TRUE(snapshot_result.has_value());
+
+    // Move the snapshot to the local storage
+    snapshot_path = snapshot_result.value();
+    std::filesystem::rename(snapshot_path, local_dir.Path() / snapshot_path.filename());
+    snapshot_path = local_dir.Path() / snapshot_path.filename();
+  }
 
   // Restart storage
   db.reset();
   db.emplace(config_);
   ASSERT_TRUE(db.has_value()) << "Database should be created";
-  storage = static_cast<memgraph::storage::InMemoryStorage *>(db->storage());
+  const memgraph::memory::DbArenaScope arena_scope{&db->Arena()};
+  auto *storage = static_cast<memgraph::storage::InMemoryStorage *>(db->storage());
 
   // Verify storage is empty
   {
@@ -317,6 +324,7 @@ TEST_F(RecoverSnapshotTest, RecoverSnapshotWithWALs) {
   // Create initial storage and add some data
   std::optional<memgraph::dbms::Database> db = std::make_optional<memgraph::dbms::Database>(config_);
   ASSERT_TRUE(db.has_value()) << "Database should be created";
+  const memgraph::memory::DbArenaScope arena_scope{&db->Arena()};
   auto *storage = static_cast<memgraph::storage::InMemoryStorage *>(db->storage());
 
   // Add some data

--- a/tests/unit/storage_v2_replication.cpp
+++ b/tests/unit/storage_v2_replication.cpp
@@ -1521,12 +1521,6 @@ TEST_F(ReplicationTest, SchemaReplication) {
   auto p2 = main->db.storage()->NameToProperty("p2");
   auto e = main->db.storage()->NameToEdgeType("E");
 
-  // Pin test-thread allocations to main's arena pool while we drive accessors below.
-  // Background GC runs inside main's DbArenaScope and asserts (in debug) that any
-  // pointer it frees belongs to main's arena pool — without this scope, vertices
-  // created on the test thread come from the default arena and trip the assertion.
-  // Scope ends before stop_replica/main.reset() so we don't conflict with replica
-  // construction (which enters its own pool via the Database constructor).
   std::optional<memgraph::memory::DbArenaScope> main_scope{std::in_place, &main->db.Arena()};
 
   // Check current delta replication
@@ -1632,9 +1626,6 @@ TEST_F(ReplicationTest, SchemaReplication) {
     EXPECT_TRUE(ConfrontJSON(get_schema(*main), get_schema(*replica)));
   }
 
-  // Release main's pool from the test thread before tearing down or rebuilding
-  // either MinMemgraph — those construct/destruct Databases (each with their
-  // own DbArenaScope), and DbArenaScope forbids switching across pools.
   main_scope.reset();
 
   auto stop_replica = [&]() {

--- a/tests/unit/storage_v2_replication.cpp
+++ b/tests/unit/storage_v2_replication.cpp
@@ -202,6 +202,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
   const auto *vertex_property_value = "vertex_property_value";
   std::optional<Gid> vertex_gid;
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto acc = main.db.Access(memgraph::storage::WRITE);
     auto v = acc->CreateVertex();
     vertex_gid.emplace(v.Gid());
@@ -212,6 +213,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
   }
 
   {
+    const memgraph::memory::DbArenaScope arena_scope{&replica.db.Arena()};
     auto acc = replica.db.Access(memgraph::storage::WRITE);
     const auto v = acc->FindVertex(*vertex_gid, View::OLD);
     ASSERT_TRUE(v);
@@ -231,6 +233,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
 
   // vertex remove label
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto acc = main.db.Access(memgraph::storage::WRITE);
     auto v = acc->FindVertex(*vertex_gid, View::OLD);
     ASSERT_TRUE(v);
@@ -239,6 +242,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
   }
 
   {
+    const memgraph::memory::DbArenaScope arena_scope{&replica.db.Arena()};
     auto acc = replica.db.Access(memgraph::storage::WRITE);
     const auto v = acc->FindVertex(*vertex_gid, View::OLD);
     ASSERT_TRUE(v);
@@ -250,6 +254,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
 
   // vertex delete
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto acc = main.db.Access(memgraph::storage::WRITE);
     auto v = acc->FindVertex(*vertex_gid, View::OLD);
     ASSERT_TRUE(v);
@@ -258,6 +263,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
   }
 
   {
+    const memgraph::memory::DbArenaScope arena_scope{&replica.db.Arena()};
     auto acc = replica.db.Access(memgraph::storage::WRITE);
     const auto v = acc->FindVertex(*vertex_gid, View::OLD);
     ASSERT_FALSE(v);
@@ -272,6 +278,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
   const auto *edge_property_value = "edge_property_value";
   std::optional<Gid> edge_gid;
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto acc = main.db.Access(memgraph::storage::WRITE);
     auto v = acc->CreateVertex();
     vertex_gid.emplace(v.Gid());
@@ -294,6 +301,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
   };
 
   {
+    const memgraph::memory::DbArenaScope arena_scope{&replica.db.Arena()};
     auto acc = replica.db.Access(memgraph::storage::WRITE);
     const auto v = acc->FindVertex(*vertex_gid, View::OLD);
     ASSERT_TRUE(v);
@@ -312,6 +320,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
 
   // delete edge
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto acc = main.db.Access(memgraph::storage::WRITE);
     auto v = acc->FindVertex(*vertex_gid, View::OLD);
     ASSERT_TRUE(v);
@@ -323,6 +332,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
   }
 
   {
+    const memgraph::memory::DbArenaScope arena_scope{&replica.db.Arena()};
     auto acc = replica.db.Access(memgraph::storage::WRITE);
     const auto v = acc->FindVertex(*vertex_gid, View::OLD);
     ASSERT_TRUE(v);
@@ -346,16 +356,19 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
   const memgraph::storage::LabelPropertyIndexStats lp_stats{98, 76, 5.4, 3.2, 1.0};
 
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto unique_acc = main.db.UniqueAccess();
     ASSERT_TRUE(unique_acc->CreateIndex(main.db.storage()->NameToLabel(label)).has_value());
     ASSERT_TRUE(unique_acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
   }
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto unique_acc = main.db.UniqueAccess();
     unique_acc->SetIndexStats(main.db.storage()->NameToLabel(label), l_stats);
     ASSERT_TRUE(unique_acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
   }
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto unique_acc = main.CreateIndexAccessor();
     ASSERT_FALSE(
         !unique_acc->CreateIndex(main.db.storage()->NameToLabel(label), {main.db.storage()->NameToProperty(property)})
@@ -363,6 +376,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
     ASSERT_TRUE(unique_acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
   }
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto unique_acc = main.CreateIndexAccessor();
     ASSERT_FALSE(!unique_acc
                       ->CreateIndex(main.db.storage()->NameToLabel(label),
@@ -372,6 +386,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
     ASSERT_TRUE(unique_acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
   }
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto unique_acc = main.db.UniqueAccess();
     unique_acc->SetIndexStats(main.db.storage()->NameToLabel(label),
                               std::array{memgraph::storage::PropertyPath{main.db.storage()->NameToProperty(property)}},
@@ -379,6 +394,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
     ASSERT_TRUE(unique_acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
   }
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto unique_acc = main.db.UniqueAccess();
     unique_acc->SetIndexStats(
         main.db.storage()->NameToLabel(label),
@@ -388,6 +404,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
     ASSERT_TRUE(unique_acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
   }
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     // Create nested index
     auto unique_acc = main.CreateIndexAccessor();
     memgraph::storage::PropertyPath property_path{main.db.storage()->NameToProperty(nested_property1),
@@ -397,6 +414,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
     ASSERT_TRUE(unique_acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
   }
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     // Create nested index stats
     auto unique_acc = main.db.UniqueAccess();
     memgraph::storage::PropertyPath property_path{main.db.storage()->NameToProperty(nested_property1),
@@ -406,6 +424,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
     ASSERT_TRUE(unique_acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
   }
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto read_only_access = main.db.ReadOnlyAccess();
     ASSERT_TRUE(read_only_access
                     ->CreateExistenceConstraint(main.db.storage()->NameToLabel(label),
@@ -414,6 +433,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
     ASSERT_TRUE(read_only_access->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
   }
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto read_only_access = main.db.ReadOnlyAccess();
     ASSERT_TRUE(read_only_access
                     ->CreateUniqueConstraint(main.db.storage()->NameToLabel(label),
@@ -424,6 +444,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
   }
 
   {
+    const memgraph::memory::DbArenaScope arena_scope{&replica.db.Arena()};
     const auto indices = replica.db.Access(memgraph::storage::WRITE)->ListAllIndices();
     ASSERT_THAT(indices.label, UnorderedElementsAre(replica.db.storage()->NameToLabel(label)));
     ASSERT_THAT(
@@ -501,21 +522,25 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
   // existence constraint drop
   // unique constriant drop
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto unique_acc = main.db.UniqueAccess();
     unique_acc->DeleteLabelIndexStats(main.db.storage()->NameToLabel(label));
     ASSERT_TRUE(unique_acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
   }
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto unique_acc = main.db.UniqueAccess();
     ASSERT_TRUE(unique_acc->DropIndex(main.db.storage()->NameToLabel(label)).has_value());
     ASSERT_TRUE(unique_acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
   }
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto unique_acc = main.db.UniqueAccess();
     unique_acc->DeleteLabelPropertyIndexStats(main.db.storage()->NameToLabel(label));
     ASSERT_TRUE(unique_acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
   }
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto unique_acc = main.DropIndexAccessor();
     ASSERT_FALSE(
         !unique_acc->DropIndex(main.db.storage()->NameToLabel(label), {main.db.storage()->NameToProperty(property)})
@@ -523,6 +548,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
     ASSERT_TRUE(unique_acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
   }
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     // Drop nested index
     auto unique_acc = main.DropIndexAccessor();
     memgraph::storage::PropertyPath property_path{main.db.storage()->NameToProperty(nested_property1),
@@ -532,12 +558,14 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
     ASSERT_TRUE(unique_acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
   }
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     // Drop nested index stats
     auto unique_acc = main.db.UniqueAccess();
     unique_acc->DeleteLabelPropertyIndexStats(main.db.storage()->NameToLabel(label));
     ASSERT_TRUE(unique_acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
   }
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto unique_acc = main.DropIndexAccessor();
     ASSERT_FALSE(!unique_acc
                       ->DropIndex(main.db.storage()->NameToLabel(label),
@@ -547,6 +575,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
     ASSERT_TRUE(unique_acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
   }
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto read_only_access = main.db.ReadOnlyAccess();
     ASSERT_TRUE(read_only_access
                     ->DropExistenceConstraint(main.db.storage()->NameToLabel(label),
@@ -555,6 +584,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
     ASSERT_TRUE(read_only_access->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
   }
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto read_only_access = main.db.ReadOnlyAccess();
     ASSERT_EQ(read_only_access->DropUniqueConstraint(
                   main.db.storage()->NameToLabel(label),
@@ -564,6 +594,7 @@ TEST_F(ReplicationTest, BasicSynchronousReplicationTest) {
   }
 
   {
+    const memgraph::memory::DbArenaScope arena_scope{&replica.db.Arena()};
     const auto indices = replica.db.Access(memgraph::storage::WRITE)->ListAllIndices();
     ASSERT_EQ(indices.label.size(), 0);
     ASSERT_EQ(indices.label_properties.size(), 0);
@@ -616,6 +647,7 @@ TEST_F(ReplicationTest, MultipleSynchronousReplicationTest) {
   const auto *vertex_property_value = "property_value";
   std::optional<Gid> vertex_gid;
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto acc = main.db.Access(memgraph::storage::WRITE);
     auto v = acc->CreateVertex();
     ASSERT_TRUE(v.AddLabel(main.db.storage()->NameToLabel(vertex_label)).has_value());
@@ -626,6 +658,7 @@ TEST_F(ReplicationTest, MultipleSynchronousReplicationTest) {
   }
 
   const auto check_replica = [&](memgraph::dbms::Database &replica_database) {
+    const memgraph::memory::DbArenaScope arena_scope{&replica_database.Arena()};
     auto acc = replica_database.Access(memgraph::storage::WRITE);
     const auto v = acc->FindVertex(*vertex_gid, View::OLD);
     ASSERT_TRUE(v);
@@ -641,6 +674,7 @@ TEST_F(ReplicationTest, MultipleSynchronousReplicationTest) {
   auto handler = main.repl_handler;
   handler.UnregisterReplica(replicas[1]);
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto acc = main.db.Access(memgraph::storage::WRITE);
     auto v = acc->CreateVertex();
     vertex_gid.emplace(v.Gid());
@@ -649,6 +683,7 @@ TEST_F(ReplicationTest, MultipleSynchronousReplicationTest) {
 
   // REPLICA1 should contain the new vertex
   {
+    const memgraph::memory::DbArenaScope arena_scope{&replica1.db.Arena()};
     auto acc = replica1.db.Access(memgraph::storage::WRITE);
     const auto v = acc->FindVertex(*vertex_gid, View::OLD);
     ASSERT_TRUE(v);
@@ -657,6 +692,7 @@ TEST_F(ReplicationTest, MultipleSynchronousReplicationTest) {
 
   // REPLICA2 should not contain the new vertex
   {
+    const memgraph::memory::DbArenaScope arena_scope{&replica2.db.Arena()};
     auto acc = replica2.db.Access(memgraph::storage::WRITE);
     const auto v = acc->FindVertex(*vertex_gid, View::OLD);
     ASSERT_FALSE(v);
@@ -679,6 +715,7 @@ TEST_F(ReplicationTest, RecoveryProcess) {
     MinMemgraph main(conf);
 
     {
+      const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
       auto acc = main.db.Access(memgraph::storage::WRITE);
       // Create the vertex before registering a replica
       auto v = acc->CreateVertex();
@@ -697,12 +734,14 @@ TEST_F(ReplicationTest, RecoveryProcess) {
     MinMemgraph main(conf);
     // Create vertices in 2 different transactions
     {
+      const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
       auto acc = main.db.Access(memgraph::storage::WRITE);
       auto v = acc->CreateVertex();
       vertex_gids.emplace_back(v.Gid());
       ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
     }
     {
+      const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
       auto acc = main.db.Access(memgraph::storage::WRITE);
       auto v = acc->CreateVertex();
       vertex_gids.emplace_back(v.Gid());
@@ -723,6 +762,7 @@ TEST_F(ReplicationTest, RecoveryProcess) {
   static constexpr const auto *property_name = "property_name";
   static constexpr const auto property_value = 1;
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     // Force the creation of current WAL file
     auto acc = main.db.Access(memgraph::storage::WRITE);
     for (const auto &vertex_gid : vertex_gids) {
@@ -755,6 +795,7 @@ TEST_F(ReplicationTest, RecoveryProcess) {
     }
 
     {
+      const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
       auto acc = main.db.Access(memgraph::storage::WRITE);
       for (const auto &vertex_gid : vertex_gids) {
         auto v = acc->FindVertex(vertex_gid, View::OLD);
@@ -764,6 +805,7 @@ TEST_F(ReplicationTest, RecoveryProcess) {
       ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
     }
     {
+      const memgraph::memory::DbArenaScope arena_scope{&replica.db.Arena()};
       auto acc = replica.db.Access(memgraph::storage::WRITE);
       for (const auto &vertex_gid : vertex_gids) {
         auto v = acc->FindVertex(vertex_gid, View::OLD);
@@ -788,6 +830,7 @@ TEST_F(ReplicationTest, RecoveryProcess) {
     UpdatePaths(repl_conf, repl_storage_directory);
     MinMemgraph replica(repl_conf);
     {
+      const memgraph::memory::DbArenaScope arena_scope{&replica.db.Arena()};
       auto acc = replica.db.Access(memgraph::storage::WRITE);
       for (const auto &vertex_gid : vertex_gids) {
         auto v = acc->FindVertex(vertex_gid, View::OLD);
@@ -826,6 +869,7 @@ TEST_F(ReplicationTest, BasicAsynchronousReplicationTest) {
   static constexpr size_t vertices_create_num = 10;
   std::vector<Gid> created_vertices;
   for (size_t i = 0; i < vertices_create_num; ++i) {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto acc = main.db.Access(memgraph::storage::WRITE);
     auto v = acc->CreateVertex();
     created_vertices.push_back(v.Gid());
@@ -844,6 +888,7 @@ TEST_F(ReplicationTest, BasicAsynchronousReplicationTest) {
   }
 
   ASSERT_TRUE(std::ranges::all_of(created_vertices, [&](const auto vertex_gid) {
+    const memgraph::memory::DbArenaScope arena_scope{&replica_async.db.Arena()};
     auto acc = replica_async.db.Access(memgraph::storage::WRITE);
     auto v = acc->FindVertex(vertex_gid, View::OLD);
     const bool exists = v.has_value();
@@ -883,18 +928,21 @@ TEST_F(ReplicationTest, EpochTest) {
 
   std::optional<Gid> vertex_gid;
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto acc = main.db.Access(memgraph::storage::WRITE);
     const auto v = acc->CreateVertex();
     vertex_gid.emplace(v.Gid());
     ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
   }
   {
+    const memgraph::memory::DbArenaScope arena_scope{&replica1.db.Arena()};
     auto acc = replica1.db.Access(memgraph::storage::WRITE);
     const auto v = acc->FindVertex(*vertex_gid, View::OLD);
     ASSERT_TRUE(v);
     ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
   }
   {
+    const memgraph::memory::DbArenaScope arena_scope{&replica2.db.Arena()};
     auto acc = replica2.db.Access(memgraph::storage::WRITE);
     const auto v = acc->FindVertex(*vertex_gid, View::OLD);
     ASSERT_TRUE(v);
@@ -915,11 +963,13 @@ TEST_F(ReplicationTest, EpochTest) {
                   .has_value());
 
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto acc = main.db.Access(memgraph::storage::WRITE);
     acc->CreateVertex();
     ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
   }
   {
+    const memgraph::memory::DbArenaScope arena_scope{&replica1.db.Arena()};
     auto acc = replica1.db.Access(memgraph::storage::WRITE);
     auto v = acc->CreateVertex();
     vertex_gid.emplace(v.Gid());
@@ -927,6 +977,7 @@ TEST_F(ReplicationTest, EpochTest) {
   }
   // Replica1 should forward it's vertex to Replica2
   {
+    const memgraph::memory::DbArenaScope arena_scope{&replica2.db.Arena()};
     auto acc = replica2.db.Access(memgraph::storage::WRITE);
     const auto v = acc->FindVertex(*vertex_gid, View::OLD);
     ASSERT_TRUE(v);
@@ -946,6 +997,7 @@ TEST_F(ReplicationTest, EpochTest) {
 
   {
     auto acc = main.db.Access(memgraph::storage::WRITE);
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     const auto v = acc->CreateVertex();
     vertex_gid.emplace(v.Gid());
     ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
@@ -953,6 +1005,7 @@ TEST_F(ReplicationTest, EpochTest) {
   // Replica1 is not compatible with the main so it shouldn't contain
   // it's newest vertex
   {
+    const memgraph::memory::DbArenaScope arena_scope{&replica1.db.Arena()};
     auto acc = replica1.db.Access(memgraph::storage::WRITE);
     const auto v = acc->FindVertex(*vertex_gid, View::OLD);
     ASSERT_FALSE(v);
@@ -1237,6 +1290,7 @@ TEST_F(ReplicationTest, RecoverySteps) {
   auto file_locker = file_retainer.AddLocker();
 
   auto large_write_to_finalize_wal = [&]() {
+    const memgraph::memory::DbArenaScope arena_scope{&main->db.Arena()};
     auto acc = in_mem->Access(memgraph::storage::WRITE);
     auto v = acc->CreateVertex();
     ASSERT_TRUE(v.SetProperty(p, large_property).has_value());
@@ -1244,6 +1298,7 @@ TEST_F(ReplicationTest, RecoverySteps) {
   };
 
   auto create_vertex_and_commit = [&]() {
+    const memgraph::memory::DbArenaScope arena_scope{&main->db.Arena()};
     auto acc = in_mem->Access(memgraph::storage::WRITE);
     acc->CreateVertex();
     ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
@@ -1251,12 +1306,14 @@ TEST_F(ReplicationTest, RecoverySteps) {
 
   // Nothing
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main->db.Arena()};
     const auto recovery_steps = GetRecoverySteps(0, &file_locker, in_mem).value();
     ASSERT_EQ(recovery_steps.size(), 0);
   }
 
   // Only Current
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main->db.Arena()};
     create_vertex_and_commit();
     const auto recovery_steps = GetRecoverySteps(0, &file_locker, in_mem).value();
     ASSERT_EQ(recovery_steps.size(), 1);
@@ -1265,6 +1322,7 @@ TEST_F(ReplicationTest, RecoverySteps) {
 
   // Only a single WAL
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main->db.Arena()};
     // Create a vertex with a property large enough to trigger WAL finalization and closing
     // Current is generated on the next transaction
     large_write_to_finalize_wal();
@@ -1275,6 +1333,7 @@ TEST_F(ReplicationTest, RecoverySteps) {
 
   // Multiple WALs
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main->db.Arena()};
     // Create a vertex with a property large enough to trigger WAL finalization and closing
     // Current is generated on the next transaction
     large_write_to_finalize_wal();
@@ -1288,6 +1347,7 @@ TEST_F(ReplicationTest, RecoverySteps) {
 
   // WALs + Current
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main->db.Arena()};
     // A new current WAL is created on the next transaction after the previous one has been finalized
     create_vertex_and_commit();
     const auto recovery_steps = GetRecoverySteps(0, &file_locker, in_mem).value();
@@ -1298,6 +1358,7 @@ TEST_F(ReplicationTest, RecoverySteps) {
 
   // Snapshot (with dirty WALs)
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main->db.Arena()};
     large_write_to_finalize_wal();
     ASSERT_TRUE(in_mem->CreateSnapshot().has_value());
     const auto recovery_steps = GetRecoverySteps(0, &file_locker, in_mem).value();
@@ -1310,6 +1371,7 @@ TEST_F(ReplicationTest, RecoverySteps) {
 
   // Only snapshot (without dirty WALs)
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main->db.Arena()};
     // Once we are over the allowed number of snapshots, we clean both snapshots and wals
     // Have to make a change to the db so the snapshot doesn't get aborted (to bypass SnapshotDigest)
     create_vertex_and_commit();
@@ -1325,6 +1387,7 @@ TEST_F(ReplicationTest, RecoverySteps) {
 
   // Snapshot + Current
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main->db.Arena()};
     auto acc = in_mem->Access(memgraph::storage::WRITE);
     acc->CreateVertex();
     ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
@@ -1336,6 +1399,7 @@ TEST_F(ReplicationTest, RecoverySteps) {
 
   // Snapshot + WALs (chain starts before snapshot)
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main->db.Arena()};
     large_write_to_finalize_wal();
     const auto recovery_steps = GetRecoverySteps(0, &file_locker, in_mem).value();
     ASSERT_EQ(recovery_steps.size(), 2);
@@ -1345,6 +1409,7 @@ TEST_F(ReplicationTest, RecoverySteps) {
 
   // Snapshot + WALs + Current
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main->db.Arena()};
     auto acc = in_mem->Access(memgraph::storage::WRITE);
     acc->CreateVertex();
     ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
@@ -1392,12 +1457,14 @@ TEST_F(ReplicationTest, RecoverySteps) {
   main.emplace(config);
   in_mem = static_cast<InMemoryStorage *>(main->db.storage());
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main->db.Arena()};
     // On start we only have the snapshot to send
     const auto recovery_steps = GetRecoverySteps(0, &file_locker, in_mem).value();
     ASSERT_EQ(recovery_steps.size(), 1);
     ASSERT_TRUE(std::holds_alternative<memgraph::storage::RecoverySnapshot>(recovery_steps[0]));
   }
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main->db.Arena()};
     // Add current wal
     auto acc = in_mem->Access(memgraph::storage::WRITE);
     acc->CreateVertex();
@@ -1408,6 +1475,7 @@ TEST_F(ReplicationTest, RecoverySteps) {
     ASSERT_TRUE(std::holds_alternative<memgraph::storage::RecoveryCurrentWal>(recovery_steps[1]));
   }
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main->db.Arena()};
     // Add finalized wal
     large_write_to_finalize_wal();
     const auto recovery_steps = GetRecoverySteps(0, &file_locker, in_mem).value();
@@ -1416,6 +1484,7 @@ TEST_F(ReplicationTest, RecoverySteps) {
     ASSERT_TRUE(std::holds_alternative<memgraph::storage::RecoveryWals>(recovery_steps[1]));
   }
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main->db.Arena()};
     // Add both
     auto acc = in_mem->Access(memgraph::storage::WRITE);
     acc->CreateVertex();
@@ -1433,6 +1502,7 @@ TEST_F(ReplicationTest, RecoverySteps) {
   // Create more WALs
   // Break the WAL chain somewhere before the snapshot
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main->db.Arena()};
     large_write_to_finalize_wal();
     large_write_to_finalize_wal();
     std::filesystem::path wal_file;
@@ -1462,6 +1532,7 @@ TEST_F(ReplicationTest, RecoverySteps) {
   }
   // + Current
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main->db.Arena()};
     auto acc = in_mem->Access(memgraph::storage::WRITE);
     acc->CreateVertex();
     ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
@@ -1514,14 +1585,14 @@ TEST_F(ReplicationTest, SchemaReplication) {
                                                       instance.db.storage()->enum_store_);
   };
 
+  std::optional<memgraph::memory::DbArenaScope> main_scope{std::in_place, &main->db.Arena()};
+
   auto l1 = main->db.storage()->NameToLabel("L1");
   auto l2 = main->db.storage()->NameToLabel("L2");
   auto l3 = main->db.storage()->NameToLabel("L3");
   auto p1 = main->db.storage()->NameToProperty("p1");
   auto p2 = main->db.storage()->NameToProperty("p2");
   auto e = main->db.storage()->NameToEdgeType("E");
-
-  std::optional<memgraph::memory::DbArenaScope> main_scope{std::in_place, &main->db.Arena()};
 
   // Check current delta replication
   {
@@ -1701,6 +1772,7 @@ TEST_F(ReplicationTest, ReplicationWithNonSequentialDeltas) {
 
   // Create base vertices
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto acc = main.db.Access(memgraph::storage::WRITE);
     auto v1 = acc->CreateVertex();
     auto v2 = acc->CreateVertex();
@@ -1716,6 +1788,7 @@ TEST_F(ReplicationTest, ReplicationWithNonSequentialDeltas) {
 
   // Transaction 1: Create edge from v1 to v2
   {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
     auto tx1 = main.db.Access(memgraph::storage::WRITE);
     auto v1_tx1 = tx1->FindVertex(v1_gid, View::OLD);
     auto v2_tx1 = tx1->FindVertex(v2_gid, View::OLD);
@@ -1751,6 +1824,7 @@ TEST_F(ReplicationTest, ReplicationWithNonSequentialDeltas) {
 
   // Verify replica has both edges
   {
+    const memgraph::memory::DbArenaScope arena_scope{&replica.db.Arena()};
     auto acc = replica.db.Access(memgraph::storage::WRITE);
     auto v1 = acc->FindVertex(v1_gid, View::OLD);
     ASSERT_TRUE(v1.has_value());

--- a/tests/unit/storage_v2_replication.cpp
+++ b/tests/unit/storage_v2_replication.cpp
@@ -26,6 +26,7 @@
 #include "dbms/database.hpp"
 #include "dbms/database_protector.hpp"
 #include "dbms/dbms_handler.hpp"
+#include "memory/db_arena.hpp"
 #include "parameters/parameters.hpp"
 #include "query/interpreter_context.hpp"
 #include "replication/config.hpp"
@@ -1520,6 +1521,14 @@ TEST_F(ReplicationTest, SchemaReplication) {
   auto p2 = main->db.storage()->NameToProperty("p2");
   auto e = main->db.storage()->NameToEdgeType("E");
 
+  // Pin test-thread allocations to main's arena pool while we drive accessors below.
+  // Background GC runs inside main's DbArenaScope and asserts (in debug) that any
+  // pointer it frees belongs to main's arena pool — without this scope, vertices
+  // created on the test thread come from the default arena and trip the assertion.
+  // Scope ends before stop_replica/main.reset() so we don't conflict with replica
+  // construction (which enters its own pool via the Database constructor).
+  std::optional<memgraph::memory::DbArenaScope> main_scope{std::in_place, &main->db.Arena()};
+
   // Check current delta replication
   {
     auto acc = main->db.Access(memgraph::storage::WRITE);
@@ -1622,6 +1631,11 @@ TEST_F(ReplicationTest, SchemaReplication) {
     ASSERT_TRUE(acc2->PrepareForCommitPhase(MakeCommitArgs(main->db_acc)).has_value());
     EXPECT_TRUE(ConfrontJSON(get_schema(*main), get_schema(*replica)));
   }
+
+  // Release main's pool from the test thread before tearing down or rebuilding
+  // either MinMemgraph — those construct/destruct Databases (each with their
+  // own DbArenaScope), and DbArenaScope forbids switching across pools.
+  main_scope.reset();
 
   auto stop_replica = [&]() {
     replica.reset();

--- a/tests/unit/ttl.cpp
+++ b/tests/unit/ttl.cpp
@@ -20,6 +20,7 @@
 #include "dbms/database_protector.hpp"
 #include "disk_test_utils.hpp"
 #include "flags/run_time_configurable.hpp"
+#include "memory/db_arena.hpp"
 #include "query/auth_checker.hpp"
 #include "query/interpreter_context.hpp"
 #include "storage/v2/disk/storage.hpp"
@@ -188,6 +189,11 @@ class TTLFixture : public ::testing::Test {
         return db_acc;
       }()  // iile
   };
+  // Pin test-thread allocations to this DB's arena pool so background GC/TTL
+  // (which run inside their own DbArenaScope) don't trip the debug-only
+  // arena-ownership assertion in DbDeallocateBytes when freeing memory the
+  // test thread allocated via accessors.
+  memgraph::memory::DbArenaScope arena_scope_{&db_->Arena()};
   memgraph::system::System system_state;
   memgraph::query::AllowEverythingAuthChecker auth_checker;
   memgraph::query::InterpreterContext interpreter_context_{memgraph::query::InterpreterConfig{},
@@ -592,6 +598,9 @@ TEST(TTLUserCheckTest, UserCheckFunctionality) {
   auto db_acc_opt = db_gk.access();
   ASSERT_TRUE(db_acc_opt) << "Failed to access db";
   auto &db_acc = *db_acc_opt;
+
+  // Pin test-thread allocations to this DB's arena pool; see TTLFixture for rationale.
+  const memgraph::memory::DbArenaScope arena_scope{&db_acc->Arena()};
 
   auto *ttl = &db_acc->ttl();
   auto ttl_lbl = db_acc->storage()->NameToLabel("TTL");

--- a/tests/unit/ttl.cpp
+++ b/tests/unit/ttl.cpp
@@ -189,10 +189,7 @@ class TTLFixture : public ::testing::Test {
         return db_acc;
       }()  // iile
   };
-  // Pin test-thread allocations to this DB's arena pool so background GC/TTL
-  // (which run inside their own DbArenaScope) don't trip the debug-only
-  // arena-ownership assertion in DbDeallocateBytes when freeing memory the
-  // test thread allocated via accessors.
+
   memgraph::memory::DbArenaScope arena_scope_{&db_->Arena()};
   memgraph::system::System system_state;
   memgraph::query::AllowEverythingAuthChecker auth_checker;
@@ -599,7 +596,6 @@ TEST(TTLUserCheckTest, UserCheckFunctionality) {
   ASSERT_TRUE(db_acc_opt) << "Failed to access db";
   auto &db_acc = *db_acc_opt;
 
-  // Pin test-thread allocations to this DB's arena pool; see TTLFixture for rationale.
   const memgraph::memory::DbArenaScope arena_scope{&db_acc->Arena()};
 
   auto *ttl = &db_acc->ttl();


### PR DESCRIPTION
Wrap test-thread allocations in DbArenaScope (matching production) so the new debug-only arena-ownership assertion in DbDeallocateBytes doesn't trip when background GC frees memory the test thread allocated outside any scope.



