### PR TITLE
fix: librdkafka coverage flakyness

### DIFF
--- a/tools/ubsan.ignore
+++ b/tools/ubsan.ignore
@@ -13,5 +13,9 @@ src:*/rdkafka_int.h
 # librdkafka: negative shift exponent in HDR histogram (rdhdrhistogram.c:212)
 src:*/rdhdrhistogram.c
 
+# librdkafka: member access within null pointer of type rd_kafka_metadata_internal_t (rdkafka_request.c:2568)
+# Metadata parse drops err on broker-terminating path; caller then derefs &mdi->metadata (mdi==NULL). Benign in practice.
+src:*/rdkafka_request.c
+
 # rocksdb: load of misaligned address 0x737fbff2a406 for type 'uint32_t' (aka 'unsigned int'), which requires 4 byte alignment
 src:*/util/crc32c.cc


### PR DESCRIPTION
Suppresses librdkafka's UB sites in `tools/ubsan.ignore` (staying on upstream `librdkafka/2.6.1`) to de-flake the kafka streams tests in the ASAN+UBSAN build.

The flaky failure was a fourth UB site never covered by `ubsan.ignore`:

```
rdkafka_request.c:2568: member access within null pointer of type 'rd_kafka_metadata_internal_t'
```

`rd_kafka_parse_Metadata0()` drops its error code on the broker-terminating path, so the caller derefs `&mdi->metadata` with `mdi == NULL`, reached by a destroy-while-Metadata-in-flight race. It's formal UB, not a crash: `&mdi->metadata` is an address-of and `metadata` is the first field, so it just yields `NULL`.

`ubsan.ignore` now covers all four sites (`rdvarint.h`, `rdkafka_int.h`, `rdhdrhistogram.c`, `rdkafka_request.c`). The real fix (`return err;`) will be submitted upstream so the suppression can later be dropped.