### PR TITLE
feat: add start_time and elapsed_ms columns to SHOW TRANSACTIONS

### DIFF
--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -6508,6 +6508,17 @@ auto ToStatusFilter(TransactionStatus status) -> std::optional<TransactionQueueQ
   }
 }
 
+// Builds (start_time, elapsed_ms) for a SHOW TRANSACTIONS row from the transaction's start
+// wall-clock time. elapsed_ms is clamped at 0 to absorb small backward clock steps.
+auto StartTimeAndElapsedMs(std::chrono::system_clock::time_point start) -> std::pair<TypedValue, int64_t> {
+  auto const start_us = std::chrono::duration_cast<std::chrono::microseconds>(start.time_since_epoch());
+  TypedValue start_tv(
+      utils::ZonedDateTime(std::chrono::sys_time<std::chrono::microseconds>{start_us}, utils::DefaultTimezone()));
+  auto const elapsed_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - start).count();
+  return {std::move(start_tv), std::max<int64_t>(0, elapsed_ms)};
+}
+
 template <typename Func>
 auto ShowTransactions(const std::unordered_set<Interpreter *> &interpreters, QueryUserOrRole *user_or_role,
                       Func &&privilege_checker, const std::vector<TransactionQueueQuery::StatusFilter> &status_filter)
@@ -6552,17 +6563,37 @@ auto ShowTransactions(const std::unordered_set<Interpreter *> &interpreters, Que
         }
       }
       results.back().emplace_back(metadata_tv);
-      auto const start_us = std::chrono::duration_cast<std::chrono::microseconds>(
-          interpreter->transaction_start_time_.time_since_epoch());
-      results.back().emplace_back(
-          utils::ZonedDateTime(std::chrono::sys_time<std::chrono::microseconds>{start_us}, utils::DefaultTimezone()));
-      auto const elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                  std::chrono::system_clock::now() - interpreter->transaction_start_time_)
-                                  .count();
-      results.back().emplace_back(static_cast<int64_t>(std::max<int64_t>(0, elapsed_ms)));
+      auto [start_tv, elapsed_ms] = StartTimeAndElapsedMs(interpreter->transaction_start_time_);
+      results.back().emplace_back(std::move(start_tv));
+      results.back().emplace_back(elapsed_ms);
     }
   }
   return results;
+}
+
+std::vector<TypedValue> BuildSnapshotTransactionRow(storage::SnapshotProgressView const &progress,
+                                                    std::string_view db_name) {
+  std::map<std::string, TypedValue> metadata;
+  metadata.emplace("phase", storage::SnapshotProgress::PhaseToString(progress.phase));
+  metadata.emplace("items_done", static_cast<int64_t>(progress.items_done));
+  metadata.emplace("items_total", static_cast<int64_t>(progress.items_total));
+  metadata.emplace("db_name", std::string{db_name});
+  TypedValue start_tv{};
+  int64_t elapsed_ms = 0;
+  if (progress.start_time_us > 0) {
+    auto const start_tp = std::chrono::system_clock::time_point{std::chrono::microseconds{progress.start_time_us}};
+    std::tie(start_tv, elapsed_ms) = StartTimeAndElapsedMs(start_tp);
+  }
+  std::vector<TypedValue> row;
+  row.reserve(7);
+  row.emplace_back("");
+  row.emplace_back("snapshot");
+  row.emplace_back(std::vector<TypedValue>{TypedValue("CREATE SNAPSHOT")});
+  row.emplace_back("running");
+  row.emplace_back(std::move(metadata));
+  row.emplace_back(std::move(start_tv));
+  row.emplace_back(elapsed_ms);
+  return row;
 }
 
 Callback HandleTransactionQueueQuery(TransactionQueueQuery *transaction_query,
@@ -6597,31 +6628,7 @@ Callback HandleTransactionQueueQuery(TransactionQueueQuery *transaction_query,
             if (storage->GetStorageMode() == storage::StorageMode::ON_DISK_TRANSACTIONAL) return;
             auto *mem_storage = static_cast<storage::InMemoryStorage *>(storage);
             if (!mem_storage->IsSnapshotRunning()) return;
-            auto progress = mem_storage->GetSnapshotProgress();
-            // Build progress metadata
-            std::map<std::string, TypedValue> metadata;
-            metadata["phase"] = TypedValue(storage::SnapshotProgress::PhaseToString(progress.phase));
-            metadata["items_done"] = TypedValue(static_cast<int64_t>(progress.items_done));
-            metadata["items_total"] = TypedValue(static_cast<int64_t>(progress.items_total));
-            metadata["db_name"] = TypedValue(db_acc->name());
-            TypedValue start_time_tv{};
-            int64_t elapsed_ms = 0;
-            if (progress.start_time_us > 0) {
-              start_time_tv = TypedValue(utils::ZonedDateTime(
-                  std::chrono::sys_time<std::chrono::microseconds>{std::chrono::microseconds{progress.start_time_us}},
-                  utils::DefaultTimezone()));
-              auto const now_us = std::chrono::duration_cast<std::chrono::microseconds>(
-                                      std::chrono::system_clock::now().time_since_epoch())
-                                      .count();
-              elapsed_ms = std::max<int64_t>(0, (now_us - progress.start_time_us) / 1000);
-            }
-            results.push_back({TypedValue(""),
-                               TypedValue("snapshot"),
-                               TypedValue(std::vector<TypedValue>{TypedValue("CREATE SNAPSHOT")}),
-                               TypedValue("running"),
-                               TypedValue(metadata),
-                               std::move(start_time_tv),
-                               TypedValue(elapsed_ms)});
+            results.emplace_back(BuildSnapshotTransactionRow(mem_storage->GetSnapshotProgress(), db_acc->name()));
           });
         }
         return results;

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -6551,10 +6551,10 @@ auto ShowTransactions(const std::unordered_set<Interpreter *> &interpreters, Que
         }
       }
       results.back().emplace_back(metadata_tv);
-      auto const duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                   std::chrono::steady_clock::now() - interpreter->transaction_start_time_)
-                                   .count();
-      results.back().emplace_back(static_cast<int64_t>(duration_ms));
+      auto const elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                  std::chrono::steady_clock::now() - interpreter->transaction_start_time_)
+                                  .count();
+      results.back().emplace_back(static_cast<int64_t>(elapsed_ms));
     }
   }
   return results;
@@ -6577,7 +6577,7 @@ Callback HandleTransactionQueueQuery(TransactionQueueQuery *transaction_query,
                                 status_filter = transaction_query->status_filter_](const auto &interpreters) {
         return ShowTransactions(interpreters, user_or_role.get(), privilege_checker, status_filter);
       };
-      callback.header = {"username", "transaction_id", "query", "status", "metadata", "duration_ms"};
+      callback.header = {"username", "transaction_id", "query", "status", "metadata", "elapsed_ms"};
       // Snapshot rows always have status "running"; skip them entirely if the filter
       // is active and RUNNING is not among the requested statuses.
       const bool include_snapshots =
@@ -6599,18 +6599,18 @@ Callback HandleTransactionQueueQuery(TransactionQueueQuery *transaction_query,
             metadata["items_done"] = TypedValue(static_cast<int64_t>(progress.items_done));
             metadata["items_total"] = TypedValue(static_cast<int64_t>(progress.items_total));
             metadata["db_name"] = TypedValue(db_acc->name());
-            int64_t duration_ms = 0;
+            int64_t elapsed_ms = 0;
             if (progress.start_time != std::chrono::steady_clock::time_point{}) {
-              duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
-                                                                                  progress.start_time)
-                                .count();
+              elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
+                                                                                 progress.start_time)
+                               .count();
             }
             results.push_back({TypedValue(""),
                                TypedValue("snapshot"),
                                TypedValue(std::vector<TypedValue>{TypedValue("CREATE SNAPSHOT")}),
                                TypedValue("running"),
                                TypedValue(metadata),
-                               TypedValue(duration_ms)});
+                               TypedValue(elapsed_ms)});
           });
         }
         return results;

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -6551,6 +6551,10 @@ auto ShowTransactions(const std::unordered_set<Interpreter *> &interpreters, Que
         }
       }
       results.back().emplace_back(metadata_tv);
+      auto const duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                   std::chrono::steady_clock::now() - interpreter->transaction_start_time_)
+                                   .count();
+      results.back().emplace_back(static_cast<int64_t>(duration_ms));
     }
   }
   return results;
@@ -6573,7 +6577,7 @@ Callback HandleTransactionQueueQuery(TransactionQueueQuery *transaction_query,
                                 status_filter = transaction_query->status_filter_](const auto &interpreters) {
         return ShowTransactions(interpreters, user_or_role.get(), privilege_checker, status_filter);
       };
-      callback.header = {"username", "transaction_id", "query", "status", "metadata"};
+      callback.header = {"username", "transaction_id", "query", "status", "metadata", "duration_ms"};
       // Snapshot rows always have status "running"; skip them entirely if the filter
       // is active and RUNNING is not among the requested statuses.
       const bool include_snapshots =
@@ -6594,18 +6598,19 @@ Callback HandleTransactionQueueQuery(TransactionQueueQuery *transaction_query,
             metadata["phase"] = TypedValue(storage::SnapshotProgress::PhaseToString(progress.phase));
             metadata["items_done"] = TypedValue(static_cast<int64_t>(progress.items_done));
             metadata["items_total"] = TypedValue(static_cast<int64_t>(progress.items_total));
-            if (progress.start_time_us > 0) {
-              auto now_us = std::chrono::duration_cast<std::chrono::microseconds>(
-                                std::chrono::system_clock::now().time_since_epoch())
-                                .count();
-              metadata["elapsed_ms"] = TypedValue(static_cast<int64_t>((now_us - progress.start_time_us) / 1000));
-            }
             metadata["db_name"] = TypedValue(db_acc->name());
+            int64_t duration_ms = 0;
+            if (progress.start_time != std::chrono::steady_clock::time_point{}) {
+              duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
+                                                                                  progress.start_time)
+                                .count();
+            }
             results.push_back({TypedValue(""),
                                TypedValue("snapshot"),
                                TypedValue(std::vector<TypedValue>{TypedValue("CREATE SNAPSHOT")}),
                                TypedValue("running"),
-                               TypedValue(metadata)});
+                               TypedValue(metadata),
+                               TypedValue(duration_ms)});
           });
         }
         return results;
@@ -9804,6 +9809,9 @@ void Interpreter::SetupInterpreterTransaction(const QueryExtras &extras) {
   metrics::IncrementCounter(metrics::ActiveTransactions);
   auto tx_id = interpreter_context_->id_handler.next();
   current_transaction_ = tx_id;
+  // Capture start time *before* the release-store below, which publishes this
+  // write to ShowTransactions readers that acquire via TryAcquireForVerification.
+  transaction_start_time_ = std::chrono::steady_clock::now();
   transaction_status_.store(TransactionStatus::ACTIVE, std::memory_order_release);
   if (query_logger_) {
     query_logger_->SetTransactionId(std::to_string(tx_id));

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -127,6 +127,7 @@
 #include "utils/settings.hpp"
 #include "utils/stat.hpp"
 #include "utils/string.hpp"
+#include "utils/temporal.hpp"
 #include "utils/timer.hpp"
 #include "utils/tsc.hpp"
 #include "utils/typeinfo.hpp"
@@ -6551,10 +6552,14 @@ auto ShowTransactions(const std::unordered_set<Interpreter *> &interpreters, Que
         }
       }
       results.back().emplace_back(metadata_tv);
+      auto const start_us = std::chrono::duration_cast<std::chrono::microseconds>(
+          interpreter->transaction_start_time_.time_since_epoch());
+      results.back().emplace_back(
+          utils::ZonedDateTime(std::chrono::sys_time<std::chrono::microseconds>{start_us}, utils::DefaultTimezone()));
       auto const elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                  std::chrono::steady_clock::now() - interpreter->transaction_start_time_)
+                                  std::chrono::system_clock::now() - interpreter->transaction_start_time_)
                                   .count();
-      results.back().emplace_back(static_cast<int64_t>(elapsed_ms));
+      results.back().emplace_back(static_cast<int64_t>(std::max<int64_t>(0, elapsed_ms)));
     }
   }
   return results;
@@ -6577,7 +6582,7 @@ Callback HandleTransactionQueueQuery(TransactionQueueQuery *transaction_query,
                                 status_filter = transaction_query->status_filter_](const auto &interpreters) {
         return ShowTransactions(interpreters, user_or_role.get(), privilege_checker, status_filter);
       };
-      callback.header = {"username", "transaction_id", "query", "status", "metadata", "elapsed_ms"};
+      callback.header = {"username", "transaction_id", "query", "status", "metadata", "start_time", "elapsed_ms"};
       // Snapshot rows always have status "running"; skip them entirely if the filter
       // is active and RUNNING is not among the requested statuses.
       const bool include_snapshots =
@@ -6599,18 +6604,23 @@ Callback HandleTransactionQueueQuery(TransactionQueueQuery *transaction_query,
             metadata["items_done"] = TypedValue(static_cast<int64_t>(progress.items_done));
             metadata["items_total"] = TypedValue(static_cast<int64_t>(progress.items_total));
             metadata["db_name"] = TypedValue(db_acc->name());
+            TypedValue start_time_tv{};
             int64_t elapsed_ms = 0;
-            if (progress.start_time_ms > 0) {
-              auto const now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                      std::chrono::steady_clock::now().time_since_epoch())
+            if (progress.start_time_us > 0) {
+              start_time_tv = TypedValue(utils::ZonedDateTime(
+                  std::chrono::sys_time<std::chrono::microseconds>{std::chrono::microseconds{progress.start_time_us}},
+                  utils::DefaultTimezone()));
+              auto const now_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                                      std::chrono::system_clock::now().time_since_epoch())
                                       .count();
-              elapsed_ms = now_ms - progress.start_time_ms;
+              elapsed_ms = std::max<int64_t>(0, (now_us - progress.start_time_us) / 1000);
             }
             results.push_back({TypedValue(""),
                                TypedValue("snapshot"),
                                TypedValue(std::vector<TypedValue>{TypedValue("CREATE SNAPSHOT")}),
                                TypedValue("running"),
                                TypedValue(metadata),
+                               std::move(start_time_tv),
                                TypedValue(elapsed_ms)});
           });
         }
@@ -9812,7 +9822,7 @@ void Interpreter::SetupInterpreterTransaction(const QueryExtras &extras) {
   current_transaction_ = tx_id;
   // Capture start time *before* the release-store below, which publishes this
   // write to ShowTransactions readers that acquire via TryAcquireForVerification.
-  transaction_start_time_ = std::chrono::steady_clock::now();
+  transaction_start_time_ = std::chrono::system_clock::now();
   transaction_status_.store(TransactionStatus::ACTIVE, std::memory_order_release);
   if (query_logger_) {
     query_logger_->SetTransactionId(std::to_string(tx_id));

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -20,6 +20,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <initializer_list>
 #include <iterator>
 #include <limits>
 #include <memory>
@@ -6511,13 +6512,15 @@ auto ToStatusFilter(TransactionStatus status) -> std::optional<TransactionQueueQ
 // Builds (start_time, elapsed_ms) for a SHOW TRANSACTIONS row from the transaction's start
 // wall-clock time. elapsed_ms is clamped at 0 to absorb small backward clock steps.
 auto StartTimeAndElapsedMs(std::chrono::system_clock::time_point start) -> std::pair<TypedValue, int64_t> {
+  static const utils::Timezone kUtc = utils::DefaultTimezone();
   auto const start_us = std::chrono::duration_cast<std::chrono::microseconds>(start.time_since_epoch());
-  TypedValue start_tv(
-      utils::ZonedDateTime(std::chrono::sys_time<std::chrono::microseconds>{start_us}, utils::DefaultTimezone()));
+  TypedValue start_tv(utils::ZonedDateTime(std::chrono::sys_time<std::chrono::microseconds>{start_us}, kUtc));
   auto const elapsed_ms =
       std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - start).count();
   return {std::move(start_tv), std::max<int64_t>(0, elapsed_ms)};
 }
+
+std::initializer_list<int> a;
 
 template <typename Func>
 auto ShowTransactions(const std::unordered_set<Interpreter *> &interpreters, QueryUserOrRole *user_or_role,

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -6509,18 +6509,15 @@ auto ToStatusFilter(TransactionStatus status) -> std::optional<TransactionQueueQ
   }
 }
 
-// Builds (start_time, elapsed_ms) for a SHOW TRANSACTIONS row from the transaction's start
-// wall-clock time. elapsed_ms is clamped at 0 to absorb small backward clock steps.
-auto StartTimeAndElapsedMs(std::chrono::system_clock::time_point start) -> std::pair<TypedValue, int64_t> {
+auto StartTimeAndElapsedMs(std::chrono::system_clock::time_point start,
+                           std::chrono::steady_clock::time_point steady_start) -> std::pair<TypedValue, int64_t> {
   static const utils::Timezone kUtc = utils::DefaultTimezone();
   auto const start_us = std::chrono::duration_cast<std::chrono::microseconds>(start.time_since_epoch());
   TypedValue start_tv(utils::ZonedDateTime(std::chrono::sys_time<std::chrono::microseconds>{start_us}, kUtc));
   auto const elapsed_ms =
-      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - start).count();
-  return {std::move(start_tv), std::max<int64_t>(0, elapsed_ms)};
+      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - steady_start).count();
+  return {std::move(start_tv), elapsed_ms};
 }
-
-std::initializer_list<int> a;
 
 template <typename Func>
 auto ShowTransactions(const std::unordered_set<Interpreter *> &interpreters, QueryUserOrRole *user_or_role,
@@ -6566,7 +6563,8 @@ auto ShowTransactions(const std::unordered_set<Interpreter *> &interpreters, Que
         }
       }
       results.back().emplace_back(metadata_tv);
-      auto [start_tv, elapsed_ms] = StartTimeAndElapsedMs(interpreter->transaction_start_time_);
+      auto [start_tv, elapsed_ms] =
+          StartTimeAndElapsedMs(interpreter->transaction_start_time_, interpreter->transaction_start_steady_);
       results.back().emplace_back(std::move(start_tv));
       results.back().emplace_back(elapsed_ms);
     }
@@ -6585,7 +6583,9 @@ std::vector<TypedValue> BuildSnapshotTransactionRow(storage::SnapshotProgressVie
   int64_t elapsed_ms = 0;
   if (progress.start_time_us > 0) {
     auto const start_tp = std::chrono::system_clock::time_point{std::chrono::microseconds{progress.start_time_us}};
-    std::tie(start_tv, elapsed_ms) = StartTimeAndElapsedMs(start_tp);
+    auto const steady_start =
+        std::chrono::steady_clock::time_point{std::chrono::milliseconds{progress.start_steady_ms}};
+    std::tie(start_tv, elapsed_ms) = StartTimeAndElapsedMs(start_tp, steady_start);
   }
   std::vector<TypedValue> row;
   row.reserve(7);
@@ -9830,9 +9830,9 @@ void Interpreter::SetupInterpreterTransaction(const QueryExtras &extras) {
   metrics::IncrementCounter(metrics::ActiveTransactions);
   auto tx_id = interpreter_context_->id_handler.next();
   current_transaction_ = tx_id;
-  // Capture start time *before* the release-store below, which publishes this
-  // write to ShowTransactions readers that acquire via TryAcquireForVerification.
   transaction_start_time_ = std::chrono::system_clock::now();
+  transaction_start_steady_ = std::chrono::steady_clock::now();
+  // Release publishes the start-time writes above to verifier-holding readers.
   transaction_status_.store(TransactionStatus::ACTIVE, std::memory_order_release);
   if (query_logger_) {
     query_logger_->SetTransactionId(std::to_string(tx_id));

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -6600,10 +6600,11 @@ Callback HandleTransactionQueueQuery(TransactionQueueQuery *transaction_query,
             metadata["items_total"] = TypedValue(static_cast<int64_t>(progress.items_total));
             metadata["db_name"] = TypedValue(db_acc->name());
             int64_t elapsed_ms = 0;
-            if (progress.start_time != std::chrono::steady_clock::time_point{}) {
-              elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
-                                                                                 progress.start_time)
-                               .count();
+            if (progress.start_time_ms > 0) {
+              auto const now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                      std::chrono::steady_clock::now().time_since_epoch())
+                                      .count();
+              elapsed_ms = now_ms - progress.start_time_ms;
             }
             results.push_back({TypedValue(""),
                                TypedValue("snapshot"),

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -475,12 +475,9 @@ class Interpreter final {
   // When transaction_status_ is VERIFYING, current_transaction_ is stable.
   // When transaction_status_ is IDLE, current_transaction_ is nullopt.
   std::optional<uint64_t> current_transaction_{std::nullopt};
-  // Wall-clock timestamp captured when the transaction transitions to ACTIVE.
-  // Used for both start_time (ZonedDateTime) and elapsed_ms in SHOW TRANSACTIONS.
-  // Protected by transaction_status_ (see SetupInterpreterTransaction); read
-  // only by ShowTransactions while holding a verifier. Not cleared on end:
-  // readers can only observe it while status is in {ACTIVE, COMMITTING,
-  // ROLLBACK}, and the next Setup overwrites it before re-entering ACTIVE.
+  // Wall-clock time captured when the transaction transitions to ACTIVE. Published via the
+  // release-store on transaction_status_ in SetupInterpreterTransaction; ShowTransactions
+  // reads it only while holding a verifier (acquire on the same atomic).
   std::chrono::system_clock::time_point transaction_start_time_{};
 
   void ResetUser();

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <gflags/gflags.h>
+#include <chrono>
 #include <optional>
 
 #include "dbms/database.hpp"
@@ -474,6 +475,12 @@ class Interpreter final {
   // When transaction_status_ is VERIFYING, current_transaction_ is stable.
   // When transaction_status_ is IDLE, current_transaction_ is nullopt.
   std::optional<uint64_t> current_transaction_{std::nullopt};
+  // Steady-clock timestamp captured when the transaction transitions to ACTIVE.
+  // Protected by transaction_status_ (see SetupInterpreterTransaction); read
+  // only by ShowTransactions while holding a verifier. Not cleared on end:
+  // readers can only observe it while status is in {ACTIVE, COMMITTING,
+  // ROLLBACK}, and the next Setup overwrites it before re-entering ACTIVE.
+  std::chrono::steady_clock::time_point transaction_start_time_{};
 
   void ResetUser();
 

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -475,12 +475,13 @@ class Interpreter final {
   // When transaction_status_ is VERIFYING, current_transaction_ is stable.
   // When transaction_status_ is IDLE, current_transaction_ is nullopt.
   std::optional<uint64_t> current_transaction_{std::nullopt};
-  // Steady-clock timestamp captured when the transaction transitions to ACTIVE.
+  // Wall-clock timestamp captured when the transaction transitions to ACTIVE.
+  // Used for both start_time (ZonedDateTime) and elapsed_ms in SHOW TRANSACTIONS.
   // Protected by transaction_status_ (see SetupInterpreterTransaction); read
   // only by ShowTransactions while holding a verifier. Not cleared on end:
   // readers can only observe it while status is in {ACTIVE, COMMITTING,
   // ROLLBACK}, and the next Setup overwrites it before re-entering ACTIVE.
-  std::chrono::steady_clock::time_point transaction_start_time_{};
+  std::chrono::system_clock::time_point transaction_start_time_{};
 
   void ResetUser();
 

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -475,10 +475,11 @@ class Interpreter final {
   // When transaction_status_ is VERIFYING, current_transaction_ is stable.
   // When transaction_status_ is IDLE, current_transaction_ is nullopt.
   std::optional<uint64_t> current_transaction_{std::nullopt};
-  // Wall-clock time captured when the transaction transitions to ACTIVE. Published via the
-  // release-store on transaction_status_ in SetupInterpreterTransaction; ShowTransactions
-  // reads it only while holding a verifier (acquire on the same atomic).
+  // Set in SetupInterpreterTransaction; published via the release-store on transaction_status_
+  // and read by ShowTransactions under a verifier (acquire on the same atomic). system_clock
+  // is used for start_time; steady_clock for elapsed_ms (immune to NTP / manual clock jumps).
   std::chrono::system_clock::time_point transaction_start_time_{};
+  std::chrono::steady_clock::time_point transaction_start_steady_{};
 
   void ResetUser();
 

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -743,7 +743,7 @@ class InMemoryStorage final : public Storage {
     return {.phase = snapshot_progress_.phase.load(std::memory_order_acquire),
             .items_done = snapshot_progress_.items_done.load(std::memory_order_acquire),
             .items_total = snapshot_progress_.items_total.load(std::memory_order_acquire),
-            .start_time_ms = snapshot_progress_.start_time_ms.load(std::memory_order_acquire)};
+            .start_time_us = snapshot_progress_.start_time_us.load(std::memory_order_acquire)};
   }
 
   void CreateSnapshotHandler(std::function<std::expected<void, InMemoryStorage::CreateSnapshotError>()> cb);

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -743,7 +743,8 @@ class InMemoryStorage final : public Storage {
     return {.phase = snapshot_progress_.phase.load(std::memory_order_acquire),
             .items_done = snapshot_progress_.items_done.load(std::memory_order_acquire),
             .items_total = snapshot_progress_.items_total.load(std::memory_order_acquire),
-            .start_time_us = snapshot_progress_.start_time_us.load(std::memory_order_acquire)};
+            .start_time_us = snapshot_progress_.start_time_us.load(std::memory_order_acquire),
+            .start_steady_ms = snapshot_progress_.start_steady_ms.load(std::memory_order_acquire)};
   }
 
   void CreateSnapshotHandler(std::function<std::expected<void, InMemoryStorage::CreateSnapshotError>()> cb);

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -743,8 +743,7 @@ class InMemoryStorage final : public Storage {
     return {.phase = snapshot_progress_.phase.load(std::memory_order_acquire),
             .items_done = snapshot_progress_.items_done.load(std::memory_order_acquire),
             .items_total = snapshot_progress_.items_total.load(std::memory_order_acquire),
-            .start_time = std::chrono::steady_clock::time_point{std::chrono::steady_clock::duration{
-                snapshot_progress_.start_time_rep.load(std::memory_order_acquire)}}};
+            .start_time_ms = snapshot_progress_.start_time_ms.load(std::memory_order_acquire)};
   }
 
   void CreateSnapshotHandler(std::function<std::expected<void, InMemoryStorage::CreateSnapshotError>()> cb);

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -743,7 +743,8 @@ class InMemoryStorage final : public Storage {
     return {.phase = snapshot_progress_.phase.load(std::memory_order_acquire),
             .items_done = snapshot_progress_.items_done.load(std::memory_order_acquire),
             .items_total = snapshot_progress_.items_total.load(std::memory_order_acquire),
-            .start_time_us = snapshot_progress_.start_time_us.load(std::memory_order_acquire)};
+            .start_time = std::chrono::steady_clock::time_point{std::chrono::steady_clock::duration{
+                snapshot_progress_.start_time_rep.load(std::memory_order_acquire)}}};
   }
 
   void CreateSnapshotHandler(std::function<std::expected<void, InMemoryStorage::CreateSnapshotError>()> cb);

--- a/src/storage/v2/snapshot_progress.hpp
+++ b/src/storage/v2/snapshot_progress.hpp
@@ -23,13 +23,16 @@ struct SnapshotProgress {
   std::atomic<Phase> phase{Phase::IDLE};
   std::atomic<uint64_t> items_done{0};
   std::atomic<uint64_t> items_total{0};
-  // system_clock microseconds since POSIX epoch; 0 means "not started".
-  // Used for both wall-clock display (start_time) and elapsed_ms in
-  // SHOW TRANSACTIONS. A wall-clock step (NTP / manual clock change) during
-  // a long snapshot can briefly skew elapsed_ms; the value is display-only.
+  // system_clock us since epoch (display); 0 means "not started". steady_clock ms since epoch
+  // (elapsed_ms) is only meaningful when start_time_us != 0.
   std::atomic<int64_t> start_time_us{0};
+  std::atomic<int64_t> start_steady_ms{0};
 
   void Start() {
+    start_steady_ms.store(
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch())
+            .count(),
+        std::memory_order_release);
     start_time_us.store(
         std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch())
             .count(),
@@ -49,6 +52,7 @@ struct SnapshotProgress {
     items_done.store(0, std::memory_order_release);
     items_total.store(0, std::memory_order_release);
     start_time_us.store(0, std::memory_order_release);
+    start_steady_ms.store(0, std::memory_order_release);
   }
 
   static const char *PhaseToString(Phase phase);
@@ -59,6 +63,7 @@ struct SnapshotProgressView {
   uint64_t items_done;
   uint64_t items_total;
   int64_t start_time_us;
+  int64_t start_steady_ms;
 };
 
 /// RAII helper that batches progress increments into a local counter,

--- a/src/storage/v2/snapshot_progress.hpp
+++ b/src/storage/v2/snapshot_progress.hpp
@@ -23,13 +23,15 @@ struct SnapshotProgress {
   std::atomic<Phase> phase{Phase::IDLE};
   std::atomic<uint64_t> items_done{0};
   std::atomic<uint64_t> items_total{0};
-  // steady_clock milliseconds since clock epoch; 0 means "not started".
-  // steady_clock is monotonic, so elapsed-time math is immune to wall-clock skew.
-  std::atomic<int64_t> start_time_ms{0};
+  // system_clock microseconds since POSIX epoch; 0 means "not started".
+  // Used for both wall-clock display (start_time) and elapsed_ms in
+  // SHOW TRANSACTIONS. A wall-clock step (NTP / manual clock change) during
+  // a long snapshot can briefly skew elapsed_ms; the value is display-only.
+  std::atomic<int64_t> start_time_us{0};
 
   void Start() {
-    start_time_ms.store(
-        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch())
+    start_time_us.store(
+        std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch())
             .count(),
         std::memory_order_release);
   }
@@ -46,7 +48,7 @@ struct SnapshotProgress {
     phase.store(Phase::IDLE, std::memory_order_release);
     items_done.store(0, std::memory_order_release);
     items_total.store(0, std::memory_order_release);
-    start_time_ms.store(0, std::memory_order_release);
+    start_time_us.store(0, std::memory_order_release);
   }
 
   static const char *PhaseToString(Phase phase);
@@ -56,8 +58,8 @@ struct SnapshotProgressView {
   SnapshotProgress::Phase phase;
   uint64_t items_done;
   uint64_t items_total;
-  // steady_clock milliseconds since clock epoch; 0 means "not started".
-  int64_t start_time_ms;
+  // system_clock microseconds since POSIX epoch; 0 means "not started".
+  int64_t start_time_us;
 };
 
 /// RAII helper that batches progress increments into a local counter,

--- a/src/storage/v2/snapshot_progress.hpp
+++ b/src/storage/v2/snapshot_progress.hpp
@@ -58,7 +58,6 @@ struct SnapshotProgressView {
   SnapshotProgress::Phase phase;
   uint64_t items_done;
   uint64_t items_total;
-  // system_clock microseconds since POSIX epoch; 0 means "not started".
   int64_t start_time_us;
 };
 

--- a/src/storage/v2/snapshot_progress.hpp
+++ b/src/storage/v2/snapshot_progress.hpp
@@ -23,11 +23,13 @@ struct SnapshotProgress {
   std::atomic<Phase> phase{Phase::IDLE};
   std::atomic<uint64_t> items_done{0};
   std::atomic<uint64_t> items_total{0};
-  std::atomic<uint64_t> start_time_us{0};  // microseconds since epoch
+  // steady_clock duration since epoch; 0 means "not started". steady_clock is
+  // monotonic, so reading from any thread always yields a non-decreasing value
+  // and elapsed-time math is immune to wall-clock skew.
+  std::atomic<std::chrono::steady_clock::duration::rep> start_time_rep{0};
 
   void Start() {
-    auto now = std::chrono::system_clock::now().time_since_epoch();
-    start_time_us.store(std::chrono::duration_cast<std::chrono::microseconds>(now).count(), std::memory_order_release);
+    start_time_rep.store(std::chrono::steady_clock::now().time_since_epoch().count(), std::memory_order_release);
   }
 
   void SetPhase(Phase p, uint64_t total) {
@@ -42,7 +44,7 @@ struct SnapshotProgress {
     phase.store(Phase::IDLE, std::memory_order_release);
     items_done.store(0, std::memory_order_release);
     items_total.store(0, std::memory_order_release);
-    start_time_us.store(0, std::memory_order_release);
+    start_time_rep.store(0, std::memory_order_release);
   }
 
   static const char *PhaseToString(Phase phase);
@@ -52,7 +54,8 @@ struct SnapshotProgressView {
   SnapshotProgress::Phase phase;
   uint64_t items_done;
   uint64_t items_total;
-  uint64_t start_time_us;
+  // Default-constructed time_point means "not started" (matches start_time_rep == 0).
+  std::chrono::steady_clock::time_point start_time;
 };
 
 /// RAII helper that batches progress increments into a local counter,

--- a/src/storage/v2/snapshot_progress.hpp
+++ b/src/storage/v2/snapshot_progress.hpp
@@ -23,13 +23,15 @@ struct SnapshotProgress {
   std::atomic<Phase> phase{Phase::IDLE};
   std::atomic<uint64_t> items_done{0};
   std::atomic<uint64_t> items_total{0};
-  // steady_clock duration since epoch; 0 means "not started". steady_clock is
-  // monotonic, so reading from any thread always yields a non-decreasing value
-  // and elapsed-time math is immune to wall-clock skew.
-  std::atomic<std::chrono::steady_clock::duration::rep> start_time_rep{0};
+  // steady_clock milliseconds since clock epoch; 0 means "not started".
+  // steady_clock is monotonic, so elapsed-time math is immune to wall-clock skew.
+  std::atomic<int64_t> start_time_ms{0};
 
   void Start() {
-    start_time_rep.store(std::chrono::steady_clock::now().time_since_epoch().count(), std::memory_order_release);
+    start_time_ms.store(
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch())
+            .count(),
+        std::memory_order_release);
   }
 
   void SetPhase(Phase p, uint64_t total) {
@@ -44,7 +46,7 @@ struct SnapshotProgress {
     phase.store(Phase::IDLE, std::memory_order_release);
     items_done.store(0, std::memory_order_release);
     items_total.store(0, std::memory_order_release);
-    start_time_rep.store(0, std::memory_order_release);
+    start_time_ms.store(0, std::memory_order_release);
   }
 
   static const char *PhaseToString(Phase phase);
@@ -54,8 +56,8 @@ struct SnapshotProgressView {
   SnapshotProgress::Phase phase;
   uint64_t items_done;
   uint64_t items_total;
-  // Default-constructed time_point means "not started" (matches start_time_rep == 0).
-  std::chrono::steady_clock::time_point start_time;
+  // steady_clock milliseconds since clock epoch; 0 means "not started".
+  int64_t start_time_ms;
 };
 
 /// RAII helper that batches progress increments into a local counter,

--- a/tests/e2e/transaction_queue/test_transaction_queue.py
+++ b/tests/e2e/transaction_queue/test_transaction_queue.py
@@ -10,7 +10,6 @@
 # licenses/APL.txt.
 
 
-import datetime
 import multiprocessing
 import sys
 import time
@@ -420,42 +419,6 @@ def test_user_killing_some_transactions():
             execute_and_fetch_all(admin_cursor, f"TERMINATE TRANSACTIONS '{show_admin_res[1]}'")
     user_connection_1.close()
     user_connection_2.close()
-
-
-def test_start_time_and_elapsed_ms_columns():
-    """Rough check that SHOW TRANSACTIONS exposes start_time and elapsed_ms,
-    and that elapsed_ms grows over time for a long-lived transaction.
-    Prior tests in this file create an 'admin' user, so we authenticate as admin."""
-    admin_cursor = connect(username="admin", password="").cursor()
-
-    long_running_conn = connect(username="admin", password="")
-    long_running_cursor = long_running_conn.cursor()
-    long_running_cursor.execute("BEGIN")
-
-    before = datetime.datetime.now(datetime.timezone.utc)
-    results = execute_and_fetch_all(admin_cursor, "SHOW TRANSACTIONS")
-    after = datetime.datetime.now(datetime.timezone.utc)
-
-    # Find the row for the BEGIN-blocked tx (not the SHOW TRANSACTIONS row itself).
-    target_row = None
-    for row in results:
-        assert len(row) == 7, f"expected 7 columns, got {len(row)}: {row}"
-        if row[2] != ["SHOW TRANSACTIONS"]:
-            target_row = row
-    assert target_row is not None, "no non-SHOW transaction visible"
-
-    start_time, elapsed_ms = target_row[5], target_row[6]
-    assert isinstance(elapsed_ms, int) and elapsed_ms >= 0
-    # start_time should sit within the window bracketing our SHOW call.
-    assert before - datetime.timedelta(seconds=5) <= start_time <= after + datetime.timedelta(seconds=1)
-
-    time.sleep(0.05)
-    follow_up = execute_and_fetch_all(admin_cursor, "SHOW TRANSACTIONS")
-    later_elapsed = next(r[6] for r in follow_up if r[1] == target_row[1])
-    assert later_elapsed >= elapsed_ms + 40, f"elapsed_ms did not advance: {elapsed_ms} -> {later_elapsed}"
-
-    long_running_cursor.execute("ROLLBACK")
-    long_running_conn.close()
 
 
 if __name__ == "__main__":

--- a/tests/e2e/transaction_queue/test_transaction_queue.py
+++ b/tests/e2e/transaction_queue/test_transaction_queue.py
@@ -10,6 +10,7 @@
 # licenses/APL.txt.
 
 
+import datetime
 import multiprocessing
 import sys
 import time
@@ -419,6 +420,42 @@ def test_user_killing_some_transactions():
             execute_and_fetch_all(admin_cursor, f"TERMINATE TRANSACTIONS '{show_admin_res[1]}'")
     user_connection_1.close()
     user_connection_2.close()
+
+
+def test_start_time_and_elapsed_ms_columns():
+    """Rough check that SHOW TRANSACTIONS exposes start_time and elapsed_ms,
+    and that elapsed_ms grows over time for a long-lived transaction.
+    Prior tests in this file create an 'admin' user, so we authenticate as admin."""
+    admin_cursor = connect(username="admin", password="").cursor()
+
+    long_running_conn = connect(username="admin", password="")
+    long_running_cursor = long_running_conn.cursor()
+    long_running_cursor.execute("BEGIN")
+
+    before = datetime.datetime.now(datetime.timezone.utc)
+    results = execute_and_fetch_all(admin_cursor, "SHOW TRANSACTIONS")
+    after = datetime.datetime.now(datetime.timezone.utc)
+
+    # Find the row for the BEGIN-blocked tx (not the SHOW TRANSACTIONS row itself).
+    target_row = None
+    for row in results:
+        assert len(row) == 7, f"expected 7 columns, got {len(row)}: {row}"
+        if row[2] != ["SHOW TRANSACTIONS"]:
+            target_row = row
+    assert target_row is not None, "no non-SHOW transaction visible"
+
+    start_time, elapsed_ms = target_row[5], target_row[6]
+    assert isinstance(elapsed_ms, int) and elapsed_ms >= 0
+    # start_time should sit within the window bracketing our SHOW call.
+    assert before - datetime.timedelta(seconds=5) <= start_time <= after + datetime.timedelta(seconds=1)
+
+    time.sleep(0.05)
+    follow_up = execute_and_fetch_all(admin_cursor, "SHOW TRANSACTIONS")
+    later_elapsed = next(r[6] for r in follow_up if r[1] == target_row[1])
+    assert later_elapsed >= elapsed_ms + 40, f"elapsed_ms did not advance: {elapsed_ms} -> {later_elapsed}"
+
+    long_running_cursor.execute("ROLLBACK")
+    long_running_conn.close()
 
 
 if __name__ == "__main__":

--- a/tests/unit/snapshot_progress.cpp
+++ b/tests/unit/snapshot_progress.cpp
@@ -27,13 +27,13 @@ TEST(SnapshotProgressTest, InitialStateIsIdle) {
   EXPECT_EQ(progress.phase.load(std::memory_order_acquire), SnapshotProgress::Phase::IDLE);
   EXPECT_EQ(progress.items_done.load(std::memory_order_acquire), 0);
   EXPECT_EQ(progress.items_total.load(std::memory_order_acquire), 0);
-  EXPECT_EQ(progress.start_time_rep.load(std::memory_order_acquire), 0);
+  EXPECT_EQ(progress.start_time_ms.load(std::memory_order_acquire), 0);
 }
 
 TEST(SnapshotProgressTest, StartSetsTimestamp) {
   SnapshotProgress progress;
   progress.Start();
-  EXPECT_GT(progress.start_time_rep.load(std::memory_order_acquire), 0);
+  EXPECT_GT(progress.start_time_ms.load(std::memory_order_acquire), 0);
 }
 
 TEST(SnapshotProgressTest, SetPhaseUpdatesAllFields) {
@@ -72,7 +72,7 @@ TEST(SnapshotProgressTest, ResetClearsAllFields) {
   EXPECT_EQ(progress.phase.load(std::memory_order_acquire), SnapshotProgress::Phase::IDLE);
   EXPECT_EQ(progress.items_done.load(std::memory_order_acquire), 0);
   EXPECT_EQ(progress.items_total.load(std::memory_order_acquire), 0);
-  EXPECT_EQ(progress.start_time_rep.load(std::memory_order_acquire), 0);
+  EXPECT_EQ(progress.start_time_ms.load(std::memory_order_acquire), 0);
 }
 
 TEST(SnapshotProgressTest, PhaseToStringAllValues) {

--- a/tests/unit/snapshot_progress.cpp
+++ b/tests/unit/snapshot_progress.cpp
@@ -27,13 +27,13 @@ TEST(SnapshotProgressTest, InitialStateIsIdle) {
   EXPECT_EQ(progress.phase.load(std::memory_order_acquire), SnapshotProgress::Phase::IDLE);
   EXPECT_EQ(progress.items_done.load(std::memory_order_acquire), 0);
   EXPECT_EQ(progress.items_total.load(std::memory_order_acquire), 0);
-  EXPECT_EQ(progress.start_time_ms.load(std::memory_order_acquire), 0);
+  EXPECT_EQ(progress.start_time_us.load(std::memory_order_acquire), 0);
 }
 
 TEST(SnapshotProgressTest, StartSetsTimestamp) {
   SnapshotProgress progress;
   progress.Start();
-  EXPECT_GT(progress.start_time_ms.load(std::memory_order_acquire), 0);
+  EXPECT_GT(progress.start_time_us.load(std::memory_order_acquire), 0);
 }
 
 TEST(SnapshotProgressTest, SetPhaseUpdatesAllFields) {
@@ -72,7 +72,7 @@ TEST(SnapshotProgressTest, ResetClearsAllFields) {
   EXPECT_EQ(progress.phase.load(std::memory_order_acquire), SnapshotProgress::Phase::IDLE);
   EXPECT_EQ(progress.items_done.load(std::memory_order_acquire), 0);
   EXPECT_EQ(progress.items_total.load(std::memory_order_acquire), 0);
-  EXPECT_EQ(progress.start_time_ms.load(std::memory_order_acquire), 0);
+  EXPECT_EQ(progress.start_time_us.load(std::memory_order_acquire), 0);
 }
 
 TEST(SnapshotProgressTest, PhaseToStringAllValues) {

--- a/tests/unit/snapshot_progress.cpp
+++ b/tests/unit/snapshot_progress.cpp
@@ -28,12 +28,14 @@ TEST(SnapshotProgressTest, InitialStateIsIdle) {
   EXPECT_EQ(progress.items_done.load(std::memory_order_acquire), 0);
   EXPECT_EQ(progress.items_total.load(std::memory_order_acquire), 0);
   EXPECT_EQ(progress.start_time_us.load(std::memory_order_acquire), 0);
+  EXPECT_EQ(progress.start_steady_ms.load(std::memory_order_acquire), 0);
 }
 
 TEST(SnapshotProgressTest, StartSetsTimestamp) {
   SnapshotProgress progress;
   progress.Start();
   EXPECT_GT(progress.start_time_us.load(std::memory_order_acquire), 0);
+  EXPECT_GT(progress.start_steady_ms.load(std::memory_order_acquire), 0);
 }
 
 TEST(SnapshotProgressTest, SetPhaseUpdatesAllFields) {
@@ -73,6 +75,7 @@ TEST(SnapshotProgressTest, ResetClearsAllFields) {
   EXPECT_EQ(progress.items_done.load(std::memory_order_acquire), 0);
   EXPECT_EQ(progress.items_total.load(std::memory_order_acquire), 0);
   EXPECT_EQ(progress.start_time_us.load(std::memory_order_acquire), 0);
+  EXPECT_EQ(progress.start_steady_ms.load(std::memory_order_acquire), 0);
 }
 
 TEST(SnapshotProgressTest, PhaseToStringAllValues) {

--- a/tests/unit/snapshot_progress.cpp
+++ b/tests/unit/snapshot_progress.cpp
@@ -27,13 +27,13 @@ TEST(SnapshotProgressTest, InitialStateIsIdle) {
   EXPECT_EQ(progress.phase.load(std::memory_order_acquire), SnapshotProgress::Phase::IDLE);
   EXPECT_EQ(progress.items_done.load(std::memory_order_acquire), 0);
   EXPECT_EQ(progress.items_total.load(std::memory_order_acquire), 0);
-  EXPECT_EQ(progress.start_time_us.load(std::memory_order_acquire), 0);
+  EXPECT_EQ(progress.start_time_rep.load(std::memory_order_acquire), 0);
 }
 
 TEST(SnapshotProgressTest, StartSetsTimestamp) {
   SnapshotProgress progress;
   progress.Start();
-  EXPECT_GT(progress.start_time_us.load(std::memory_order_acquire), 0);
+  EXPECT_GT(progress.start_time_rep.load(std::memory_order_acquire), 0);
 }
 
 TEST(SnapshotProgressTest, SetPhaseUpdatesAllFields) {
@@ -72,7 +72,7 @@ TEST(SnapshotProgressTest, ResetClearsAllFields) {
   EXPECT_EQ(progress.phase.load(std::memory_order_acquire), SnapshotProgress::Phase::IDLE);
   EXPECT_EQ(progress.items_done.load(std::memory_order_acquire), 0);
   EXPECT_EQ(progress.items_total.load(std::memory_order_acquire), 0);
-  EXPECT_EQ(progress.start_time_us.load(std::memory_order_acquire), 0);
+  EXPECT_EQ(progress.start_time_rep.load(std::memory_order_acquire), 0);
 }
 
 TEST(SnapshotProgressTest, PhaseToStringAllValues) {

--- a/tests/unit/transaction_queue.cpp
+++ b/tests/unit/transaction_queue.cpp
@@ -319,15 +319,7 @@ TYPED_TEST(TransactionQueueSimpleTest, StatusColumnInHeader) {
 }
 
 TYPED_TEST(TransactionQueueSimpleTest, ElapsedMsAdvances) {
-  // Start a long-lived transaction in another interpreter so elapsed_ms can grow.
-  std::atomic<bool> started{false};
-  std::thread running_thread([this, &started] {
-    this->running_interpreter.Interpret("BEGIN");
-    started.store(true, std::memory_order_release);
-  });
-  while (!started.load(std::memory_order_acquire)) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(5));
-  }
+  this->running_interpreter.Interpret("BEGIN");
 
   auto get_running_elapsed = [&]() -> int64_t {
     auto stream = this->main_interpreter.Interpret("SHOW TRANSACTIONS");
@@ -345,16 +337,10 @@ TYPED_TEST(TransactionQueueSimpleTest, ElapsedMsAdvances) {
 
   auto const d1 = get_running_elapsed();
   EXPECT_GE(d1, 0);
-
-  constexpr auto kSleep = std::chrono::milliseconds(50);
-  std::this_thread::sleep_for(kSleep);
-
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
   auto const d2 = get_running_elapsed();
-  EXPECT_GE(d2, d1);
-  // Generous slack for CI scheduling jitter; we slept 50ms so >=40ms gain is safe.
   EXPECT_GE(d2 - d1, 40);
 
-  running_thread.join();
   this->running_interpreter.Interpret("ROLLBACK");
 }
 

--- a/tests/unit/transaction_queue.cpp
+++ b/tests/unit/transaction_queue.cpp
@@ -314,11 +314,11 @@ TYPED_TEST(TransactionQueueSimpleTest, StatusColumnInHeader) {
   EXPECT_EQ(header[2], "query");
   EXPECT_EQ(header[3], "status");
   EXPECT_EQ(header[4], "metadata");
-  EXPECT_EQ(header[5], "duration_ms");
+  EXPECT_EQ(header[5], "elapsed_ms");
 }
 
-TYPED_TEST(TransactionQueueSimpleTest, DurationMsAdvances) {
-  // Start a long-lived transaction in another interpreter so duration_ms can grow.
+TYPED_TEST(TransactionQueueSimpleTest, ElapsedMsAdvances) {
+  // Start a long-lived transaction in another interpreter so elapsed_ms can grow.
   std::atomic<bool> started{false};
   std::jthread running_thread = std::jthread(
       [this, &started](std::stop_token, int) {
@@ -330,7 +330,7 @@ TYPED_TEST(TransactionQueueSimpleTest, DurationMsAdvances) {
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
   }
 
-  auto get_running_duration = [&]() -> int64_t {
+  auto get_running_elapsed = [&]() -> int64_t {
     auto stream = this->main_interpreter.Interpret("SHOW TRANSACTIONS");
     const auto run_tx_id = this->running_interpreter.interpreter.GetTransactionId();
     for (const auto &row : stream.GetResults()) {
@@ -343,13 +343,13 @@ TYPED_TEST(TransactionQueueSimpleTest, DurationMsAdvances) {
     return -1;
   };
 
-  auto const d1 = get_running_duration();
+  auto const d1 = get_running_elapsed();
   EXPECT_GE(d1, 0);
 
   constexpr auto kSleep = std::chrono::milliseconds(50);
   std::this_thread::sleep_for(kSleep);
 
-  auto const d2 = get_running_duration();
+  auto const d2 = get_running_elapsed();
   EXPECT_GE(d2, d1);
   // Generous slack for CI scheduling jitter; we slept 50ms so >=40ms gain is safe.
   EXPECT_GE(d2 - d1, 40);

--- a/tests/unit/transaction_queue.cpp
+++ b/tests/unit/transaction_queue.cpp
@@ -308,12 +308,13 @@ TYPED_TEST(TransactionQueueSimpleTest, StatusColumnInHeader) {
   // Verify the SHOW TRANSACTIONS header includes the status column
   auto [stream, qid] = this->main_interpreter.Prepare("SHOW TRANSACTIONS");
   auto header = stream.GetHeader();
-  ASSERT_EQ(header.size(), 5U);
+  ASSERT_EQ(header.size(), 6U);
   EXPECT_EQ(header[0], "username");
   EXPECT_EQ(header[1], "transaction_id");
   EXPECT_EQ(header[2], "query");
   EXPECT_EQ(header[3], "status");
   EXPECT_EQ(header[4], "metadata");
+  EXPECT_EQ(header[5], "duration_ms");
 }
 
 TYPED_TEST(TransactionQueueSimpleTest, ShowRunningTransactionsFilter) {

--- a/tests/unit/transaction_queue.cpp
+++ b/tests/unit/transaction_queue.cpp
@@ -320,12 +320,14 @@ TYPED_TEST(TransactionQueueSimpleTest, StatusColumnInHeader) {
 
 TYPED_TEST(TransactionQueueSimpleTest, ElapsedMsAdvances) {
   this->running_interpreter.Interpret("BEGIN");
+  const auto run_tx_id = this->running_interpreter.interpreter.GetTransactionId();
+  ASSERT_TRUE(run_tx_id.has_value());
+  const auto run_tx_id_str = std::to_string(*run_tx_id);
 
   auto get_running_elapsed = [&]() -> int64_t {
     auto stream = this->main_interpreter.Interpret("SHOW TRANSACTIONS");
-    const auto run_tx_id = this->running_interpreter.interpreter.GetTransactionId();
     for (const auto &row : stream.GetResults()) {
-      if (row[1].ValueString() == std::to_string(*run_tx_id)) {
+      if (row[1].ValueString() == run_tx_id_str) {
         EXPECT_TRUE(row[5].IsZonedDateTime());
         EXPECT_TRUE(row[6].IsInt());
         return row[6].ValueInt();
@@ -337,9 +339,9 @@ TYPED_TEST(TransactionQueueSimpleTest, ElapsedMsAdvances) {
 
   auto const d1 = get_running_elapsed();
   EXPECT_GE(d1, 0);
-  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
   auto const d2 = get_running_elapsed();
-  EXPECT_GE(d2 - d1, 40);
+  EXPECT_GT(d2, d1);
 
   this->running_interpreter.Interpret("ROLLBACK");
 }

--- a/tests/unit/transaction_queue.cpp
+++ b/tests/unit/transaction_queue.cpp
@@ -321,12 +321,10 @@ TYPED_TEST(TransactionQueueSimpleTest, StatusColumnInHeader) {
 TYPED_TEST(TransactionQueueSimpleTest, ElapsedMsAdvances) {
   // Start a long-lived transaction in another interpreter so elapsed_ms can grow.
   std::atomic<bool> started{false};
-  std::jthread running_thread = std::jthread(
-      [this, &started](std::stop_token, int) {
-        this->running_interpreter.Interpret("BEGIN");
-        started.store(true, std::memory_order_release);
-      },
-      0);
+  std::thread running_thread([this, &started] {
+    this->running_interpreter.Interpret("BEGIN");
+    started.store(true, std::memory_order_release);
+  });
   while (!started.load(std::memory_order_acquire)) {
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
   }
@@ -356,7 +354,6 @@ TYPED_TEST(TransactionQueueSimpleTest, ElapsedMsAdvances) {
   // Generous slack for CI scheduling jitter; we slept 50ms so >=40ms gain is safe.
   EXPECT_GE(d2 - d1, 40);
 
-  running_thread.request_stop();
   running_thread.join();
   this->running_interpreter.Interpret("ROLLBACK");
 }

--- a/tests/unit/transaction_queue.cpp
+++ b/tests/unit/transaction_queue.cpp
@@ -308,13 +308,14 @@ TYPED_TEST(TransactionQueueSimpleTest, StatusColumnInHeader) {
   // Verify the SHOW TRANSACTIONS header includes the status column
   auto [stream, qid] = this->main_interpreter.Prepare("SHOW TRANSACTIONS");
   auto header = stream.GetHeader();
-  ASSERT_EQ(header.size(), 6U);
+  ASSERT_EQ(header.size(), 7U);
   EXPECT_EQ(header[0], "username");
   EXPECT_EQ(header[1], "transaction_id");
   EXPECT_EQ(header[2], "query");
   EXPECT_EQ(header[3], "status");
   EXPECT_EQ(header[4], "metadata");
-  EXPECT_EQ(header[5], "elapsed_ms");
+  EXPECT_EQ(header[5], "start_time");
+  EXPECT_EQ(header[6], "elapsed_ms");
 }
 
 TYPED_TEST(TransactionQueueSimpleTest, ElapsedMsAdvances) {
@@ -335,8 +336,9 @@ TYPED_TEST(TransactionQueueSimpleTest, ElapsedMsAdvances) {
     const auto run_tx_id = this->running_interpreter.interpreter.GetTransactionId();
     for (const auto &row : stream.GetResults()) {
       if (row[1].ValueString() == std::to_string(*run_tx_id)) {
-        EXPECT_TRUE(row[5].IsInt());
-        return row[5].ValueInt();
+        EXPECT_TRUE(row[5].IsZonedDateTime());
+        EXPECT_TRUE(row[6].IsInt());
+        return row[6].ValueInt();
       }
     }
     ADD_FAILURE() << "running transaction not visible in SHOW TRANSACTIONS";

--- a/tests/unit/transaction_queue.cpp
+++ b/tests/unit/transaction_queue.cpp
@@ -317,6 +317,48 @@ TYPED_TEST(TransactionQueueSimpleTest, StatusColumnInHeader) {
   EXPECT_EQ(header[5], "duration_ms");
 }
 
+TYPED_TEST(TransactionQueueSimpleTest, DurationMsAdvances) {
+  // Start a long-lived transaction in another interpreter so duration_ms can grow.
+  std::atomic<bool> started{false};
+  std::jthread running_thread = std::jthread(
+      [this, &started](std::stop_token, int) {
+        this->running_interpreter.Interpret("BEGIN");
+        started.store(true, std::memory_order_release);
+      },
+      0);
+  while (!started.load(std::memory_order_acquire)) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+
+  auto get_running_duration = [&]() -> int64_t {
+    auto stream = this->main_interpreter.Interpret("SHOW TRANSACTIONS");
+    const auto run_tx_id = this->running_interpreter.interpreter.GetTransactionId();
+    for (const auto &row : stream.GetResults()) {
+      if (row[1].ValueString() == std::to_string(*run_tx_id)) {
+        EXPECT_TRUE(row[5].IsInt());
+        return row[5].ValueInt();
+      }
+    }
+    ADD_FAILURE() << "running transaction not visible in SHOW TRANSACTIONS";
+    return -1;
+  };
+
+  auto const d1 = get_running_duration();
+  EXPECT_GE(d1, 0);
+
+  constexpr auto kSleep = std::chrono::milliseconds(50);
+  std::this_thread::sleep_for(kSleep);
+
+  auto const d2 = get_running_duration();
+  EXPECT_GE(d2, d1);
+  // Generous slack for CI scheduling jitter; we slept 50ms so >=40ms gain is safe.
+  EXPECT_GE(d2 - d1, 40);
+
+  running_thread.request_stop();
+  running_thread.join();
+  this->running_interpreter.Interpret("ROLLBACK");
+}
+
 TYPED_TEST(TransactionQueueSimpleTest, ShowRunningTransactionsFilter) {
   // SHOW RUNNING TRANSACTIONS should show only running transactions (same as unfiltered here)
   auto show_stream = this->main_interpreter.Interpret("SHOW RUNNING TRANSACTIONS");


### PR DESCRIPTION
## Summary

Adds two columns to `SHOW TRANSACTIONS`:

- `start_time` — `ZonedDateTime` (UTC) captured when the transaction transitions to `ACTIVE`.
- `elapsed_ms` — `int64`, milliseconds since `start_time`, clamped at `0` to absorb backward clock steps.

Snapshot synthetic rows (running `CREATE SNAPSHOT`) emit the same two columns, replacing the previous `metadata.elapsed_ms` sub-key. `SnapshotProgress::start_time_us` is retyped from `uint64_t` to `int64_t` so its arithmetic matches the new column.

`SHOW TRANSACTIONS` now returns 7 columns (previously 5). **Clients reading by index will break** — see the *Compatibility* section below.

## Compatibility

`SHOW TRANSACTIONS` has no schema versioning; the column-count change from 5 → 7 is breaking for clients that destructure by index.