### PR TITLE
Release 3.10 fixes

### DIFF
--- a/.github/workflows/promote_rc_release.yml
+++ b/.github/workflows/promote_rc_release.yml
@@ -416,8 +416,8 @@ jobs:
       - name: Setup AWS credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6.0.0
         with:
-          aws-access-key-id: ${{ secrets.S3_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.S3_AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_AK_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SAK }}
           aws-region: ${{ env.s3_region }}
 
       - name: Check if RC image for this build exists

--- a/.github/workflows/promote_rc_release.yml
+++ b/.github/workflows/promote_rc_release.yml
@@ -295,7 +295,7 @@ jobs:
           fi
 
       - name: "Log in to Docker Hub"
-        uses: ./.github/actions/docker-login
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -532,7 +532,7 @@ jobs:
           echo "Copied Ubuntu 24.04 MAGE packages to s3://${release_bucket}/${mage_release_dir}/ubuntu-24.04/"
 
       - name: Log in to Docker Hub
-        uses: ./.github/actions/docker-login
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Fixes required for RC promotion to complete successfully:
- Use `docker/login-action` instead of custom action from the repo, because we don't checkout the repo before logging in.
- Use the same AWS credentials as those used for the Memgraph RC promotion.


