### PR TITLE
add distro package smoke tests

### DIFF
--- a/.github/workflows/package_memgraph.yaml
+++ b/.github/workflows/package_memgraph.yaml
@@ -132,6 +132,7 @@ jobs:
       workflow_input_s3_dest_dir: ${{ steps.setup.outputs.workflow_input_s3_dest_dir }}
       workflow_input_malloc: ${{ steps.setup.outputs.workflow_input_malloc }}
       workflow_input_generate_sbom: ${{ steps.setup.outputs.workflow_input_generate_sbom }}
+      workflow_input_run_smoke_tests: ${{ steps.setup.outputs.workflow_input_run_smoke_tests }}
     env:
       GH_CONTEXT: ${{ toJson(github) }}
       GH_CONTEXT_FILE_NAME: github_context.json
@@ -163,7 +164,7 @@ jobs:
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
       ref: ${{ inputs.ref || github.ref }}
       generate_sbom: ${{ needs.PackageSetup.outputs.workflow_input_generate_sbom == 'true' }}
-      run_smoke_tests: false
+      run_smoke_tests: ${{ needs.PackageSetup.outputs.workflow_input_run_smoke_tests == 'true' }}
     secrets: inherit
 
   CentOS10:
@@ -182,7 +183,7 @@ jobs:
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
       ref: ${{ inputs.ref || github.ref }}
       generate_sbom: ${{ needs.PackageSetup.outputs.workflow_input_generate_sbom == 'true' }}
-      run_smoke_tests: false
+      run_smoke_tests: ${{ needs.PackageSetup.outputs.workflow_input_run_smoke_tests == 'true' }}
     secrets: inherit
 
   Debian12:
@@ -201,7 +202,7 @@ jobs:
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
       ref: ${{ inputs.ref || github.ref }}
       generate_sbom: ${{ needs.PackageSetup.outputs.workflow_input_generate_sbom == 'true' }}
-      run_smoke_tests: false
+      run_smoke_tests: ${{ needs.PackageSetup.outputs.workflow_input_run_smoke_tests == 'true' }}
     secrets: inherit
 
   Debian12-arm:
@@ -220,7 +221,7 @@ jobs:
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
       ref: ${{ inputs.ref || github.ref }}
       generate_sbom: ${{ needs.PackageSetup.outputs.workflow_input_generate_sbom == 'true' }}
-      run_smoke_tests: false
+      run_smoke_tests: ${{ needs.PackageSetup.outputs.workflow_input_run_smoke_tests == 'true' }}
     secrets: inherit
 
   Debian13:
@@ -239,7 +240,7 @@ jobs:
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
       ref: ${{ inputs.ref || github.ref }}
       generate_sbom: ${{ needs.PackageSetup.outputs.workflow_input_generate_sbom == 'true' }}
-      run_smoke_tests: false
+      run_smoke_tests: ${{ needs.PackageSetup.outputs.workflow_input_run_smoke_tests == 'true' }}
     secrets: inherit
 
   Debian13-arm:
@@ -258,7 +259,7 @@ jobs:
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
       ref: ${{ inputs.ref || github.ref }}
       generate_sbom: ${{ needs.PackageSetup.outputs.workflow_input_generate_sbom == 'true' }}
-      run_smoke_tests: false
+      run_smoke_tests: ${{ needs.PackageSetup.outputs.workflow_input_run_smoke_tests == 'true' }}
     secrets: inherit
 
   Docker:
@@ -277,7 +278,7 @@ jobs:
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
       ref: ${{ inputs.ref || github.ref }}
       generate_sbom: ${{ needs.PackageSetup.outputs.workflow_input_generate_sbom == 'true' }}
-      run_smoke_tests: ${{ inputs.run_smoke_tests == true }}
+      run_smoke_tests: ${{ needs.PackageSetup.outputs.workflow_input_run_smoke_tests == 'true' }}
     secrets: inherit
 
   Docker-arm:
@@ -296,7 +297,7 @@ jobs:
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
       ref: ${{ inputs.ref || github.ref }}
       generate_sbom: ${{ needs.PackageSetup.outputs.workflow_input_generate_sbom == 'true' }}
-      run_smoke_tests: ${{ inputs.run_smoke_tests == true }}
+      run_smoke_tests: ${{ needs.PackageSetup.outputs.workflow_input_run_smoke_tests == 'true' }}
     secrets: inherit
 
   Fedora42:
@@ -315,7 +316,7 @@ jobs:
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
       ref: ${{ inputs.ref || github.ref }}
       generate_sbom: ${{ needs.PackageSetup.outputs.workflow_input_generate_sbom == 'true' }}
-      run_smoke_tests: false
+      run_smoke_tests: ${{ needs.PackageSetup.outputs.workflow_input_run_smoke_tests == 'true' }}
     secrets: inherit
 
   Fedora42-arm:
@@ -334,7 +335,7 @@ jobs:
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
       ref: ${{ inputs.ref || github.ref }}
       generate_sbom: ${{ needs.PackageSetup.outputs.workflow_input_generate_sbom == 'true' }}
-      run_smoke_tests: false
+      run_smoke_tests: ${{ needs.PackageSetup.outputs.workflow_input_run_smoke_tests == 'true' }}
     secrets: inherit
 
   RockyLinux10:
@@ -353,7 +354,7 @@ jobs:
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
       ref: ${{ inputs.ref || github.ref }}
       generate_sbom: ${{ needs.PackageSetup.outputs.workflow_input_generate_sbom == 'true' }}
-      run_smoke_tests: false
+      run_smoke_tests: ${{ needs.PackageSetup.outputs.workflow_input_run_smoke_tests == 'true' }}
     secrets: inherit
 
   Ubuntu22_04:
@@ -372,7 +373,7 @@ jobs:
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
       ref: ${{ inputs.ref || github.ref }}
       generate_sbom: ${{ needs.PackageSetup.outputs.workflow_input_generate_sbom == 'true' }}
-      run_smoke_tests: false
+      run_smoke_tests: ${{ needs.PackageSetup.outputs.workflow_input_run_smoke_tests == 'true' }}
     secrets: inherit
 
   Ubuntu24_04:
@@ -391,7 +392,7 @@ jobs:
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
       ref: ${{ inputs.ref || github.ref }}
       generate_sbom: ${{ needs.PackageSetup.outputs.workflow_input_generate_sbom == 'true' }}
-      run_smoke_tests: false
+      run_smoke_tests: ${{ needs.PackageSetup.outputs.workflow_input_run_smoke_tests == 'true' }}
     secrets: inherit
 
   Ubuntu24_04-arm:
@@ -410,7 +411,7 @@ jobs:
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
       ref: ${{ inputs.ref || github.ref }}
       generate_sbom: ${{ needs.PackageSetup.outputs.workflow_input_generate_sbom == 'true' }}
-      run_smoke_tests: false
+      run_smoke_tests: ${{ needs.PackageSetup.outputs.workflow_input_run_smoke_tests == 'true' }}
     secrets: inherit
 
   Ubuntu24_04-malloc:
@@ -429,5 +430,5 @@ jobs:
       s3_dest_dir: ${{ needs.PackageSetup.outputs.workflow_input_s3_dest_dir }}
       ref: ${{ inputs.ref || github.ref }}
       generate_sbom: ${{ needs.PackageSetup.outputs.workflow_input_generate_sbom == 'true' }}
-      run_smoke_tests: false
+      run_smoke_tests: ${{ needs.PackageSetup.outputs.workflow_input_run_smoke_tests == 'true' }}
     secrets: inherit

--- a/.github/workflows/reusable_package.yaml
+++ b/.github/workflows/reusable_package.yaml
@@ -190,6 +190,20 @@ jobs:
           copy \
           --sbom
 
+      - name: "Build gssapi wheel for smoke image"
+        if: ${{ env.FOR_DOCKER != 'true' && inputs.run_smoke_tests }}
+        run: |
+          # gssapi has no prebuilt linux wheels on PyPI, so build one inside
+          # the MGBUILD container (which has libkrb5/krb5-devel available) and
+          # drop it into a local wheels dir that the smoke image build will
+          # pip-install from via --find-links.
+          ./release/package/mgbuild.sh \
+            --toolchain $TOOLCHAIN \
+            --os "$OS" \
+            --arch $ARCH \
+            build-gssapi \
+            --dest-dir build/output/smoke-wheels
+
       - name: "Build smoke image from package"
         if: ${{ env.FOR_DOCKER != 'true' && inputs.run_smoke_tests }}
         run: |
@@ -200,7 +214,8 @@ jobs:
             --arch $ARCH \
             package-smoke-image \
             --src-dir $PACKAGE_ARTIFACT_DIR \
-            --image-tag "$image_tag"
+            --image-tag "$image_tag" \
+            --wheels-dir build/output/smoke-wheels
           echo "IMAGE_TAG=$image_tag" >> $GITHUB_ENV
           echo "Resolved IMAGE_TAG=$image_tag"
 

--- a/.github/workflows/reusable_package.yaml
+++ b/.github/workflows/reusable_package.yaml
@@ -190,6 +190,20 @@ jobs:
           copy \
           --sbom
 
+      - name: "Build smoke image from package"
+        if: ${{ env.FOR_DOCKER != 'true' && inputs.run_smoke_tests }}
+        run: |
+          image_tag="smoke-${OS}-${ARCH}-${BUILD_TYPE}"
+          ./release/package/mgbuild.sh \
+            --toolchain $TOOLCHAIN \
+            --os "$OS" \
+            --arch $ARCH \
+            package-smoke-image \
+            --src-dir $PACKAGE_ARTIFACT_DIR \
+            --image-tag "$image_tag"
+          echo "IMAGE_TAG=$image_tag" >> $GITHUB_ENV
+          echo "Resolved IMAGE_TAG=$image_tag"
+
       - name: "Build heaptrack"
         if: ${{ inputs.build_type == 'RelWithDebInfo' && env.FOR_DOCKER == 'true' }}
         run: |
@@ -307,8 +321,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ inputs.s3_region }}
 
-      - name: Run Docker smoke tests
-        if: ${{ env.FOR_DOCKER == 'true' && inputs.run_smoke_tests }}
+      - name: Run smoke tests
+        if: ${{ inputs.run_smoke_tests }}
         env:
           MEMGRAPH_ENTERPRISE_LICENSE: ${{ secrets.MEMGRAPH_ENTERPRISE_LICENSE }}
           MEMGRAPH_ORGANIZATION_NAME: ${{ secrets.MEMGRAPH_ORGANIZATION_NAME }}

--- a/mage/tests/smoke-release-testing/check_container_licenses.sh
+++ b/mage/tests/smoke-release-testing/check_container_licenses.sh
@@ -12,8 +12,7 @@ check_container_licenses() {
         "APL.txt"
     )
     for license in "${licenses[@]}"; do
-        docker exec -u root memgraph_next_data bash -c "test -f /usr/share/doc/memgraph/$license" 2>&1 > /dev/null
-        if [ $? -ne 0 ]; then
+        if ! docker exec -u root memgraph_next_data bash -c "test -f /usr/share/doc/memgraph/$license" > /dev/null 2>&1; then
             echo "Error: $license license not found"
             exit 1
         else

--- a/mage/tests/smoke-release-testing/mgconsole/mgconsole.sh
+++ b/mage/tests/smoke-release-testing/mgconsole/mgconsole.sh
@@ -6,7 +6,10 @@ test_mgconsole() {
     # tests whether the `mgconsole` binary exists and works inside the container
     expected_version="${1:-1.5}"
     expected_path="/usr/bin/mgconsole"
-    path="$(docker exec -u memgraph memgraph_next_data which mgconsole)"
+    # Use `command -v` (bash builtin) instead of `which` — minimal CentOS 10
+    # and similar base images don't ship the `which` utility, causing
+    # exit 127 + silent script abort under `set -e`.
+    path="$(docker exec -u memgraph memgraph_next_data bash -c 'command -v mgconsole')"
     if [ "$path" != "$expected_path" ]; then
         echo "Error: mgconsole binary not found inside container PATH"
         echo "Expected path: $expected_path"

--- a/mage/tests/smoke-release-testing/mgconsole/mgconsole.sh
+++ b/mage/tests/smoke-release-testing/mgconsole/mgconsole.sh
@@ -9,7 +9,10 @@ test_mgconsole() {
     # Use `command -v` (bash builtin) instead of `which` — minimal CentOS 10
     # and similar base images don't ship the `which` utility, causing
     # exit 127 + silent script abort under `set -e`.
-    path="$(docker exec -u memgraph memgraph_next_data bash -c 'command -v mgconsole')"
+    # Pipe through `realpath` so UsrMerge distros (Fedora, modern RHEL) where
+    # /usr/sbin is a symlink to /usr/bin resolve to the canonical path
+    # regardless of PATH ordering.
+    path="$(docker exec -u memgraph memgraph_next_data bash -c 'realpath "$(command -v mgconsole)"')"
     if [ "$path" != "$expected_path" ]; then
         echo "Error: mgconsole binary not found inside container PATH"
         echo "Expected path: $expected_path"

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -962,7 +962,7 @@ package_smoke_image() {
     centos-9*)     base_image="quay.io/centos/centos:stream9";  pkg_format="rpm"; networkx_version="3.2.1" ;;
     centos-10*)    base_image="quay.io/centos/centos:stream10"; pkg_format="rpm" ;;
     rocky-9.3*)    base_image="rockylinux:9.3"; pkg_format="rpm"; networkx_version="3.2.1" ;;
-    rocky-10*)     base_image="rockylinux:10";  pkg_format="rpm" ;;
+    rocky-10*)     base_image="rockylinux/rockylinux:10";  pkg_format="rpm" ;;
     fedora-38*)    base_image="fedora:38"; pkg_format="rpm" ;;
     fedora-39*)    base_image="fedora:39"; pkg_format="rpm" ;;
     fedora-41*)    base_image="fedora:41"; pkg_format="rpm"; numpy_version="2.1.0"; scipy_version="1.15.0" ;;

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -944,21 +944,25 @@ package_smoke_image() {
   local base_image=""
   local pkg_format=""
   local libpython_pkg=""
+  # numpy 1.26.4 has no prebuilt wheel for Python 3.13, and the source build
+  # fails inside the smoke image (no compiler/headers). Distros that ship
+  # Python 3.13 as the default (debian-13, fedora-41+) need numpy 2.1.0.
+  local numpy_version="1.26.4"
   case "$os" in
     ubuntu-24.04*) base_image="ubuntu:24.04"; pkg_format="deb"; libpython_pkg="libpython3.12" ;;
     ubuntu-22.04*) base_image="ubuntu:22.04"; pkg_format="deb"; libpython_pkg="libpython3.10" ;;
     ubuntu-20.04*) base_image="ubuntu:20.04"; pkg_format="deb"; libpython_pkg="libpython3.8" ;;
     debian-11*)    base_image="debian:11";    pkg_format="deb"; libpython_pkg="libpython3.9" ;;
     debian-12*)    base_image="debian:12";    pkg_format="deb"; libpython_pkg="libpython3.11" ;;
-    debian-13*)    base_image="debian:13";    pkg_format="deb"; libpython_pkg="libpython3.13" ;;
+    debian-13*)    base_image="debian:13";    pkg_format="deb"; libpython_pkg="libpython3.13"; numpy_version="2.1.0" ;;
     centos-9*)     base_image="quay.io/centos/centos:stream9";  pkg_format="rpm" ;;
     centos-10*)    base_image="quay.io/centos/centos:stream10"; pkg_format="rpm" ;;
     rocky-9.3*)    base_image="rockylinux:9.3"; pkg_format="rpm" ;;
     rocky-10*)     base_image="rockylinux:10";  pkg_format="rpm" ;;
     fedora-38*)    base_image="fedora:38"; pkg_format="rpm" ;;
     fedora-39*)    base_image="fedora:39"; pkg_format="rpm" ;;
-    fedora-41*)    base_image="fedora:41"; pkg_format="rpm" ;;
-    fedora-42*)    base_image="fedora:42"; pkg_format="rpm" ;;
+    fedora-41*)    base_image="fedora:41"; pkg_format="rpm"; numpy_version="2.1.0" ;;
+    fedora-42*)    base_image="fedora:42"; pkg_format="rpm"; numpy_version="2.1.0" ;;
     *)
       echo "Error: Unsupported OS for package-smoke-image: $os"
       exit 1
@@ -972,7 +976,7 @@ package_smoke_image() {
   # so it must be supplied as a pre-built wheel via --wheels-dir.
   local pip_packages="cryptography==46.0.7 PyJWT==2.12.1 requests==2.32.5 \
 ldap3==2.6 pyyaml==6.0.1 python3-saml==1.16.0 lxml==6.1.0 xmlsec==1.3.16 \
-gssapi==1.11.1 numpy==1.26.4 scipy==1.13.0 networkx==3.4.2 gensim==4.3.3"
+gssapi==1.11.1 numpy==${numpy_version} scipy==1.13.0 networkx==3.4.2 gensim==4.3.3"
 
   local build_dir
   build_dir=$(mktemp -d)
@@ -989,26 +993,44 @@ gssapi==1.11.1 numpy==1.26.4 scipy==1.13.0 networkx==3.4.2 gensim==4.3.3"
     fi
   fi
 
+  # PIP_BREAK_SYSTEM_PACKAGES env var is honoured by pip on distros that
+  # ship the PEP 668 marker (e.g. Ubuntu 24.04, Debian 12+). Older pip
+  # versions (e.g. Ubuntu 22.04's) don't recognise the --break-system-packages
+  # CLI flag at all, but they ignore the env var so it's safe everywhere.
   local install_cmd
   if [[ "$pkg_format" == "deb" ]]; then
     # Mirror release/docker/v7_deb.dockerfile runtime deps so the smoke image
     # has the same package surface memgraph expects in production. libpython3.X
     # provides libpython3.X.so which memgraph dlopens to embed Python; python3
     # alone only pulls in libpython3.X-minimal.
-    install_cmd="export DEBIAN_FRONTEND=noninteractive && apt-get update && \
+    #
+    # Ubuntu Docker base images filter /usr/share/doc/* via
+    # /etc/dpkg/dpkg.cfg.d/excludes, dropping memgraph's license files
+    # (MEL.pdf/BSL.txt/APL.txt) which the smoke license check verifies.
+    # Add a path-include exception before installing the package, matching
+    # the workaround in release/docker/v7_deb.dockerfile.
+    install_cmd="export DEBIAN_FRONTEND=noninteractive && \
+      export PIP_BREAK_SYSTEM_PACKAGES=1 && \
+      apt-get update && \
       apt-get install -y --no-install-recommends \
         libcurl4 libseccomp2 python3 ${libpython_pkg} python3-pip \
         libatomic1 adduser ca-certificates libkrb5-3 && \
       apt-get install -y libxmlsec1 && \
+      if [ -f /etc/dpkg/dpkg.cfg.d/excludes ]; then \
+        echo '' >> /etc/dpkg/dpkg.cfg.d/excludes && \
+        echo '# Include all memgraph documentation files (licenses, etc.)' >> /etc/dpkg/dpkg.cfg.d/excludes && \
+        echo 'path-include=/usr/share/doc/memgraph/*' >> /etc/dpkg/dpkg.cfg.d/excludes; \
+      fi && \
       apt-get install -y --no-install-recommends /pkg/$package_name && \
-      pip3 install --no-cache-dir --break-system-packages ${pip_find_links} ${pip_packages} && \
+      pip3 install --no-cache-dir ${pip_find_links} ${pip_packages} && \
       rm -rf /var/lib/apt/lists/*"
   else
     # RPM declares Requires for openssl/curl/python3/logrotate/shadow-utils;
     # dnf will resolve them. Add the runtime libs memgraph dlopens but which
     # aren't part of the declared Requires, then pip-install the Python
     # packages needed by bundled query modules.
-    install_cmd="dnf install -y xmlsec1 libseccomp libatomic python3-libs python3-pip krb5-libs /pkg/$package_name && \
+    install_cmd="export PIP_BREAK_SYSTEM_PACKAGES=1 && \
+      dnf install -y xmlsec1 libseccomp libatomic python3-libs python3-pip krb5-libs /pkg/$package_name && \
       pip3 install --no-cache-dir ${pip_find_links} ${pip_packages} && \
       dnf clean all"
   fi

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -964,9 +964,19 @@ package_smoke_image() {
 
   local install_cmd
   if [[ "$pkg_format" == "deb" ]]; then
-    install_cmd="export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y --no-install-recommends /pkg/$package_name && rm -rf /var/lib/apt/lists/*"
+    # Mirror release/docker/v7_deb.dockerfile runtime deps so the smoke image
+    # has the same package surface memgraph expects in production.
+    install_cmd="export DEBIAN_FRONTEND=noninteractive && apt-get update && \
+      apt-get install -y --no-install-recommends \
+        libcurl4 libseccomp2 python3 libatomic1 adduser ca-certificates && \
+      apt-get install -y libxmlsec1 && \
+      apt-get install -y --no-install-recommends /pkg/$package_name && \
+      rm -rf /var/lib/apt/lists/*"
   else
-    install_cmd="dnf install -y /pkg/$package_name && dnf clean all"
+    # RPM declares Requires for openssl/curl/python3/logrotate/shadow-utils;
+    # dnf will resolve them. Add the runtime libs memgraph dlopens but which
+    # aren't part of the declared Requires.
+    install_cmd="dnf install -y xmlsec1 libseccomp libatomic /pkg/$package_name && dnf clean all"
   fi
 
   cat > "$build_dir/Dockerfile" <<EOF

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -978,6 +978,11 @@ gssapi==1.11.1 numpy==${numpy_version} scipy==${scipy_version} networkx==${netwo
 
   local build_dir
   build_dir=$(mktemp -d)
+  # Ensure the temp build context is removed on any exit path — the script
+  # runs under `set -e`, so a failing docker build below would otherwise skip
+  # an unguarded cleanup line. Expanded eagerly so the path is captured even
+  # if $build_dir's scope has unwound by the time the trap fires.
+  trap "rm -rf '$build_dir'" EXIT
   cp "$package_dir/$package_name" "$build_dir/"
 
   local pip_find_links=""
@@ -1040,12 +1045,9 @@ EOF
   cat "$build_dir/Dockerfile"
   echo "------------------"
 
-  docker build -t "memgraph/memgraph:$image_tag" "$build_dir"
-  local rc=$?
-  rm -rf "$build_dir"
-  if [[ $rc -ne 0 ]]; then
+  if ! docker build -t "memgraph/memgraph:$image_tag" "$build_dir"; then
     echo "Error: docker build failed for memgraph/memgraph:$image_tag" >&2
-    exit $rc
+    exit 1
   fi
   echo "Built smoke image: memgraph/memgraph:$image_tag"
 }

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -91,6 +91,7 @@ print_help () {
   echo -e "  copy [OPTIONS]                     Copy an artifact from mgbuild container to host"
   echo -e "  package-memgraph                   Create memgraph package from built binary inside mgbuild container"
   echo -e "  package-docker [OPTIONS]           Create memgraph docker image and pack it as .tar.gz"
+  echo -e "  package-smoke-image [OPTIONS]      Build a Docker image with the .deb/.rpm package installed (for smoke tests)"
   echo -e "  package-mage-deb [OPTIONS]         Create MAGE DEB package"
   echo -e "  package-mage-docker [OPTIONS]      Create MAGE docker image"
   echo -e "  pull                               Pull mgbuild image from dockerhub"
@@ -165,6 +166,10 @@ print_help () {
   echo -e "  --src-dir string              Specify a custom path for the source directory on host. Provide relative path inside memgraph directory."
   echo -e "                                This directory should contain the memgraph package."
   echo -e "  --keep-image-loaded bool      Keep built Docker image loaded after packaging (default false)."
+
+  echo -e "\npackage-smoke-image options:"
+  echo -e "  --src-dir string              Relative path inside memgraph directory containing the .deb/.rpm package."
+  echo -e "  --image-tag string            Tag to apply to the resulting memgraph/memgraph:<tag> image (required)."
 
   echo -e "\npush options:"
   echo -e "  -p, --password string         Specify password for docker login (default empty)"
@@ -892,6 +897,101 @@ package_docker() {
   mkdir -p "$docker_host_folder"
   cp "$docker_build_folder/$docker_image_name" "$docker_host_folder"
   echo "Docker images saved to $docker_host_image_path."
+}
+
+package_smoke_image() {
+  # Build a Docker image with the produced .deb/.rpm installed, tagged so the
+  # existing smoke test framework (which expects a Docker image) can run it.
+  local package_dir="$PROJECT_ROOT/build/output/$os"
+  local image_tag=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --src-dir)
+        package_dir="$PROJECT_ROOT/$2"
+        shift 2
+      ;;
+      --image-tag)
+        image_tag=$2
+        shift 2
+      ;;
+      *)
+        echo "Error: Unknown flag '$1'"
+        print_help
+        exit 1
+      ;;
+    esac
+  done
+
+  if [[ -z "$image_tag" ]]; then
+    echo "Error: --image-tag is required for package-smoke-image"
+    exit 1
+  fi
+
+  local package_name
+  package_name=$(cd "$package_dir" && ls -t memgraph* 2>/dev/null | head -1)
+  if [[ -z "$package_name" ]]; then
+    echo "Error: No memgraph package found in $package_dir"
+    exit 1
+  fi
+  echo "Building smoke image from package: $package_dir/$package_name"
+
+  local base_image=""
+  local pkg_format=""
+  case "$os" in
+    ubuntu-24.04*) base_image="ubuntu:24.04"; pkg_format="deb" ;;
+    ubuntu-22.04*) base_image="ubuntu:22.04"; pkg_format="deb" ;;
+    ubuntu-20.04*) base_image="ubuntu:20.04"; pkg_format="deb" ;;
+    debian-11*)    base_image="debian:11";    pkg_format="deb" ;;
+    debian-12*)    base_image="debian:12";    pkg_format="deb" ;;
+    debian-13*)    base_image="debian:13";    pkg_format="deb" ;;
+    centos-9*)     base_image="quay.io/centos/centos:stream9";  pkg_format="rpm" ;;
+    centos-10*)    base_image="quay.io/centos/centos:stream10"; pkg_format="rpm" ;;
+    rocky-9.3*)    base_image="rockylinux:9.3"; pkg_format="rpm" ;;
+    rocky-10*)     base_image="rockylinux:10";  pkg_format="rpm" ;;
+    fedora-38*)    base_image="fedora:38"; pkg_format="rpm" ;;
+    fedora-39*)    base_image="fedora:39"; pkg_format="rpm" ;;
+    fedora-41*)    base_image="fedora:41"; pkg_format="rpm" ;;
+    fedora-42*)    base_image="fedora:42"; pkg_format="rpm" ;;
+    *)
+      echo "Error: Unsupported OS for package-smoke-image: $os"
+      exit 1
+    ;;
+  esac
+
+  local build_dir
+  build_dir=$(mktemp -d)
+  cp "$package_dir/$package_name" "$build_dir/"
+
+  local install_cmd
+  if [[ "$pkg_format" == "deb" ]]; then
+    install_cmd="export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y --no-install-recommends /pkg/$package_name && rm -rf /var/lib/apt/lists/*"
+  else
+    install_cmd="dnf install -y /pkg/$package_name && dnf clean all"
+  fi
+
+  cat > "$build_dir/Dockerfile" <<EOF
+FROM $base_image
+COPY $package_name /pkg/$package_name
+RUN $install_cmd
+USER memgraph
+WORKDIR /usr/lib/memgraph
+EXPOSE 7687
+ENTRYPOINT ["/usr/lib/memgraph/memgraph"]
+CMD [""]
+EOF
+
+  echo "--- Dockerfile ---"
+  cat "$build_dir/Dockerfile"
+  echo "------------------"
+
+  docker build -t "memgraph/memgraph:$image_tag" "$build_dir"
+  local rc=$?
+  rm -rf "$build_dir"
+  if [[ $rc -ne 0 ]]; then
+    echo "Error: docker build failed for memgraph/memgraph:$image_tag"
+    exit $rc
+  fi
+  echo "Built smoke image: memgraph/memgraph:$image_tag"
 }
 
 copy_memgraph() {
@@ -2442,6 +2542,9 @@ case $command in
     ;;
     package-docker)
       package_docker $@
+    ;;
+    package-smoke-image)
+      package_smoke_image $@
     ;;
     build-heaptrack)
       build_heaptrack $@

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -170,6 +170,7 @@ print_help () {
   echo -e "\npackage-smoke-image options:"
   echo -e "  --src-dir string              Relative path inside memgraph directory containing the .deb/.rpm package."
   echo -e "  --image-tag string            Tag to apply to the resulting memgraph/memgraph:<tag> image (required)."
+  echo -e "  --wheels-dir string           Optional relative path containing pre-built Python wheels (e.g. gssapi)."
 
   echo -e "\npush options:"
   echo -e "  -p, --password string         Specify password for docker login (default empty)"
@@ -904,6 +905,7 @@ package_smoke_image() {
   # existing smoke test framework (which expects a Docker image) can run it.
   local package_dir="$PROJECT_ROOT/build/output/$os"
   local image_tag=""
+  local wheels_dir=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --src-dir)
@@ -912,6 +914,10 @@ package_smoke_image() {
       ;;
       --image-tag)
         image_tag=$2
+        shift 2
+      ;;
+      --wheels-dir)
+        wheels_dir="$PROJECT_ROOT/$2"
         shift 2
       ;;
       *)
@@ -937,13 +943,14 @@ package_smoke_image() {
 
   local base_image=""
   local pkg_format=""
+  local libpython_pkg=""
   case "$os" in
-    ubuntu-24.04*) base_image="ubuntu:24.04"; pkg_format="deb" ;;
-    ubuntu-22.04*) base_image="ubuntu:22.04"; pkg_format="deb" ;;
-    ubuntu-20.04*) base_image="ubuntu:20.04"; pkg_format="deb" ;;
-    debian-11*)    base_image="debian:11";    pkg_format="deb" ;;
-    debian-12*)    base_image="debian:12";    pkg_format="deb" ;;
-    debian-13*)    base_image="debian:13";    pkg_format="deb" ;;
+    ubuntu-24.04*) base_image="ubuntu:24.04"; pkg_format="deb"; libpython_pkg="libpython3.12" ;;
+    ubuntu-22.04*) base_image="ubuntu:22.04"; pkg_format="deb"; libpython_pkg="libpython3.10" ;;
+    ubuntu-20.04*) base_image="ubuntu:20.04"; pkg_format="deb"; libpython_pkg="libpython3.8" ;;
+    debian-11*)    base_image="debian:11";    pkg_format="deb"; libpython_pkg="libpython3.9" ;;
+    debian-12*)    base_image="debian:12";    pkg_format="deb"; libpython_pkg="libpython3.11" ;;
+    debian-13*)    base_image="debian:13";    pkg_format="deb"; libpython_pkg="libpython3.13" ;;
     centos-9*)     base_image="quay.io/centos/centos:stream9";  pkg_format="rpm" ;;
     centos-10*)    base_image="quay.io/centos/centos:stream10"; pkg_format="rpm" ;;
     rocky-9.3*)    base_image="rockylinux:9.3"; pkg_format="rpm" ;;
@@ -958,30 +965,58 @@ package_smoke_image() {
     ;;
   esac
 
+  # Python packages installed globally so memgraph's embedded Python can
+  # import them when loading bundled query modules (node2vec_online,
+  # mgp_networkx, nxalg, wcc, graph_analyzer, etc.). Mirrors the pip
+  # installs in release/docker/v7_deb.dockerfile. gssapi has no PyPI wheels
+  # so it must be supplied as a pre-built wheel via --wheels-dir.
+  local pip_packages="cryptography==46.0.7 PyJWT==2.12.1 requests==2.32.5 \
+ldap3==2.6 pyyaml==6.0.1 python3-saml==1.16.0 lxml==6.1.0 xmlsec==1.3.16 \
+gssapi==1.11.1 numpy==1.26.4 scipy==1.13.0 networkx==3.4.2 gensim==4.3.3"
+
   local build_dir
   build_dir=$(mktemp -d)
   cp "$package_dir/$package_name" "$build_dir/"
 
+  local pip_find_links=""
+  local copy_wheels_line=""
+  if [[ -n "$wheels_dir" && -d "$wheels_dir" ]]; then
+    mkdir -p "$build_dir/wheels"
+    cp "$wheels_dir"/*.whl "$build_dir/wheels/" 2>/dev/null || true
+    if compgen -G "$build_dir/wheels/*.whl" >/dev/null; then
+      pip_find_links="--find-links=/wheels"
+      copy_wheels_line="COPY wheels /wheels"
+    fi
+  fi
+
   local install_cmd
   if [[ "$pkg_format" == "deb" ]]; then
     # Mirror release/docker/v7_deb.dockerfile runtime deps so the smoke image
-    # has the same package surface memgraph expects in production.
+    # has the same package surface memgraph expects in production. libpython3.X
+    # provides libpython3.X.so which memgraph dlopens to embed Python; python3
+    # alone only pulls in libpython3.X-minimal.
     install_cmd="export DEBIAN_FRONTEND=noninteractive && apt-get update && \
       apt-get install -y --no-install-recommends \
-        libcurl4 libseccomp2 python3 libatomic1 adduser ca-certificates && \
+        libcurl4 libseccomp2 python3 ${libpython_pkg} python3-pip \
+        libatomic1 adduser ca-certificates libkrb5-3 && \
       apt-get install -y libxmlsec1 && \
       apt-get install -y --no-install-recommends /pkg/$package_name && \
+      pip3 install --no-cache-dir --break-system-packages ${pip_find_links} ${pip_packages} && \
       rm -rf /var/lib/apt/lists/*"
   else
     # RPM declares Requires for openssl/curl/python3/logrotate/shadow-utils;
     # dnf will resolve them. Add the runtime libs memgraph dlopens but which
-    # aren't part of the declared Requires.
-    install_cmd="dnf install -y xmlsec1 libseccomp libatomic /pkg/$package_name && dnf clean all"
+    # aren't part of the declared Requires, then pip-install the Python
+    # packages needed by bundled query modules.
+    install_cmd="dnf install -y xmlsec1 libseccomp libatomic python3-libs python3-pip krb5-libs /pkg/$package_name && \
+      pip3 install --no-cache-dir ${pip_find_links} ${pip_packages} && \
+      dnf clean all"
   fi
 
   cat > "$build_dir/Dockerfile" <<EOF
 FROM $base_image
 COPY $package_name /pkg/$package_name
+${copy_wheels_line}
 RUN $install_cmd
 USER memgraph
 WORKDIR /usr/lib/memgraph

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -947,19 +947,21 @@ package_smoke_image() {
   # numpy 1.26.4 / scipy 1.13.0 have no prebuilt wheels for Python 3.13, and
   # the source builds fail inside the smoke image (no compiler/headers).
   # Distros that ship Python 3.13 as the default (debian-13, fedora-41+) need
-  # numpy 2.1.0 / scipy 1.15.0.
+  # numpy 2.1.0 / scipy 1.15.0. networkx 3.4 requires Python 3.10+, so
+  # centos-9 (Python 3.9) needs to stay on 3.2.1.
   local numpy_version="1.26.4"
   local scipy_version="1.13.0"
+  local networkx_version="3.4.2"
   case "$os" in
     ubuntu-24.04*) base_image="ubuntu:24.04"; pkg_format="deb"; libpython_pkg="libpython3.12" ;;
     ubuntu-22.04*) base_image="ubuntu:22.04"; pkg_format="deb"; libpython_pkg="libpython3.10" ;;
     ubuntu-20.04*) base_image="ubuntu:20.04"; pkg_format="deb"; libpython_pkg="libpython3.8" ;;
-    debian-11*)    base_image="debian:11";    pkg_format="deb"; libpython_pkg="libpython3.9" ;;
+    debian-11*)    base_image="debian:11";    pkg_format="deb"; libpython_pkg="libpython3.9"; networkx_version="3.2.1" ;;
     debian-12*)    base_image="debian:12";    pkg_format="deb"; libpython_pkg="libpython3.11" ;;
     debian-13*)    base_image="debian:13";    pkg_format="deb"; libpython_pkg="libpython3.13"; numpy_version="2.1.0"; scipy_version="1.15.0" ;;
-    centos-9*)     base_image="quay.io/centos/centos:stream9";  pkg_format="rpm" ;;
+    centos-9*)     base_image="quay.io/centos/centos:stream9";  pkg_format="rpm"; networkx_version="3.2.1" ;;
     centos-10*)    base_image="quay.io/centos/centos:stream10"; pkg_format="rpm" ;;
-    rocky-9.3*)    base_image="rockylinux:9.3"; pkg_format="rpm" ;;
+    rocky-9.3*)    base_image="rockylinux:9.3"; pkg_format="rpm"; networkx_version="3.2.1" ;;
     rocky-10*)     base_image="rockylinux:10";  pkg_format="rpm" ;;
     fedora-38*)    base_image="fedora:38"; pkg_format="rpm" ;;
     fedora-39*)    base_image="fedora:39"; pkg_format="rpm" ;;
@@ -978,7 +980,7 @@ package_smoke_image() {
   # so it must be supplied as a pre-built wheel via --wheels-dir.
   local pip_packages="cryptography==46.0.7 PyJWT==2.12.1 requests==2.32.5 \
 ldap3==2.6 pyyaml==6.0.1 python3-saml==1.16.0 lxml==6.1.0 xmlsec==1.3.16 \
-gssapi==1.11.1 numpy==${numpy_version} scipy==${scipy_version} networkx==3.4.2 gensim==4.4.0"
+gssapi==1.11.1 numpy==${numpy_version} scipy==${scipy_version} networkx==${networkx_version} gensim==4.4.0"
 
   local build_dir
   build_dir=$(mktemp -d)
@@ -1031,8 +1033,13 @@ gssapi==1.11.1 numpy==${numpy_version} scipy==${scipy_version} networkx==3.4.2 g
     # dnf will resolve them. Add the runtime libs memgraph dlopens but which
     # aren't part of the declared Requires, then pip-install the Python
     # packages needed by bundled query modules.
+    #
+    # Fedora/CentOS/Rocky minimal docker images set tsflags=nodocs in
+    # /etc/dnf/dnf.conf, which strips memgraph's license files in
+    # /usr/share/doc/memgraph/. Override on the dnf install line so the
+    # smoke license check passes.
     install_cmd="export PIP_BREAK_SYSTEM_PACKAGES=1 && \
-      dnf install -y xmlsec1 libseccomp libatomic python3-libs python3-pip krb5-libs /pkg/$package_name && \
+      dnf install -y --setopt=tsflags='' xmlsec1 libseccomp libatomic python3-libs python3-pip krb5-libs /pkg/$package_name && \
       pip3 install --no-cache-dir ${pip_find_links} ${pip_packages} && \
       dnf clean all"
   fi

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -944,25 +944,27 @@ package_smoke_image() {
   local base_image=""
   local pkg_format=""
   local libpython_pkg=""
-  # numpy 1.26.4 has no prebuilt wheel for Python 3.13, and the source build
-  # fails inside the smoke image (no compiler/headers). Distros that ship
-  # Python 3.13 as the default (debian-13, fedora-41+) need numpy 2.1.0.
+  # numpy 1.26.4 / scipy 1.13.0 have no prebuilt wheels for Python 3.13, and
+  # the source builds fail inside the smoke image (no compiler/headers).
+  # Distros that ship Python 3.13 as the default (debian-13, fedora-41+) need
+  # numpy 2.1.0 / scipy 1.15.0.
   local numpy_version="1.26.4"
+  local scipy_version="1.13.0"
   case "$os" in
     ubuntu-24.04*) base_image="ubuntu:24.04"; pkg_format="deb"; libpython_pkg="libpython3.12" ;;
     ubuntu-22.04*) base_image="ubuntu:22.04"; pkg_format="deb"; libpython_pkg="libpython3.10" ;;
     ubuntu-20.04*) base_image="ubuntu:20.04"; pkg_format="deb"; libpython_pkg="libpython3.8" ;;
     debian-11*)    base_image="debian:11";    pkg_format="deb"; libpython_pkg="libpython3.9" ;;
     debian-12*)    base_image="debian:12";    pkg_format="deb"; libpython_pkg="libpython3.11" ;;
-    debian-13*)    base_image="debian:13";    pkg_format="deb"; libpython_pkg="libpython3.13"; numpy_version="2.1.0" ;;
+    debian-13*)    base_image="debian:13";    pkg_format="deb"; libpython_pkg="libpython3.13"; numpy_version="2.1.0"; scipy_version="1.15.0" ;;
     centos-9*)     base_image="quay.io/centos/centos:stream9";  pkg_format="rpm" ;;
     centos-10*)    base_image="quay.io/centos/centos:stream10"; pkg_format="rpm" ;;
     rocky-9.3*)    base_image="rockylinux:9.3"; pkg_format="rpm" ;;
     rocky-10*)     base_image="rockylinux:10";  pkg_format="rpm" ;;
     fedora-38*)    base_image="fedora:38"; pkg_format="rpm" ;;
     fedora-39*)    base_image="fedora:39"; pkg_format="rpm" ;;
-    fedora-41*)    base_image="fedora:41"; pkg_format="rpm"; numpy_version="2.1.0" ;;
-    fedora-42*)    base_image="fedora:42"; pkg_format="rpm"; numpy_version="2.1.0" ;;
+    fedora-41*)    base_image="fedora:41"; pkg_format="rpm"; numpy_version="2.1.0"; scipy_version="1.15.0" ;;
+    fedora-42*)    base_image="fedora:42"; pkg_format="rpm"; numpy_version="2.1.0"; scipy_version="1.15.0" ;;
     *)
       echo "Error: Unsupported OS for package-smoke-image: $os"
       exit 1
@@ -976,7 +978,7 @@ package_smoke_image() {
   # so it must be supplied as a pre-built wheel via --wheels-dir.
   local pip_packages="cryptography==46.0.7 PyJWT==2.12.1 requests==2.32.5 \
 ldap3==2.6 pyyaml==6.0.1 python3-saml==1.16.0 lxml==6.1.0 xmlsec==1.3.16 \
-gssapi==1.11.1 numpy==${numpy_version} scipy==1.13.0 networkx==3.4.2 gensim==4.3.3"
+gssapi==1.11.1 numpy==${numpy_version} scipy==${scipy_version} networkx==3.4.2 gensim==4.3.3"
 
   local build_dir
   build_dir=$(mktemp -d)

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -921,7 +921,7 @@ package_smoke_image() {
         shift 2
       ;;
       *)
-        echo "Error: Unknown flag '$1'"
+        echo "Error: Unknown flag '$1'" >&2
         print_help
         exit 1
       ;;
@@ -929,14 +929,14 @@ package_smoke_image() {
   done
 
   if [[ -z "$image_tag" ]]; then
-    echo "Error: --image-tag is required for package-smoke-image"
+    echo "Error: --image-tag is required for package-smoke-image" >&2
     exit 1
   fi
 
   local package_name
   package_name=$(cd "$package_dir" && ls -t memgraph* 2>/dev/null | head -1)
   if [[ -z "$package_name" ]]; then
-    echo "Error: No memgraph package found in $package_dir"
+    echo "Error: No memgraph package found in $package_dir" >&2
     exit 1
   fi
   echo "Building smoke image from package: $package_dir/$package_name"
@@ -955,20 +955,14 @@ package_smoke_image() {
   case "$os" in
     ubuntu-24.04*) base_image="ubuntu:24.04"; pkg_format="deb"; libpython_pkg="libpython3.12" ;;
     ubuntu-22.04*) base_image="ubuntu:22.04"; pkg_format="deb"; libpython_pkg="libpython3.10" ;;
-    ubuntu-20.04*) base_image="ubuntu:20.04"; pkg_format="deb"; libpython_pkg="libpython3.8" ;;
-    debian-11*)    base_image="debian:11";    pkg_format="deb"; libpython_pkg="libpython3.9"; networkx_version="3.2.1" ;;
     debian-12*)    base_image="debian:12";    pkg_format="deb"; libpython_pkg="libpython3.11" ;;
     debian-13*)    base_image="debian:13";    pkg_format="deb"; libpython_pkg="libpython3.13"; numpy_version="2.1.0"; scipy_version="1.15.0" ;;
     centos-9*)     base_image="quay.io/centos/centos:stream9";  pkg_format="rpm"; networkx_version="3.2.1" ;;
     centos-10*)    base_image="quay.io/centos/centos:stream10"; pkg_format="rpm" ;;
-    rocky-9.3*)    base_image="rockylinux:9.3"; pkg_format="rpm"; networkx_version="3.2.1" ;;
     rocky-10*)     base_image="rockylinux/rockylinux:10";  pkg_format="rpm" ;;
-    fedora-38*)    base_image="fedora:38"; pkg_format="rpm" ;;
-    fedora-39*)    base_image="fedora:39"; pkg_format="rpm" ;;
-    fedora-41*)    base_image="fedora:41"; pkg_format="rpm"; numpy_version="2.1.0"; scipy_version="1.15.0" ;;
     fedora-42*)    base_image="fedora:42"; pkg_format="rpm"; numpy_version="2.1.0"; scipy_version="1.15.0" ;;
     *)
-      echo "Error: Unsupported OS for package-smoke-image: $os"
+      echo "Error: Unsupported OS for package-smoke-image: $os" >&2
       exit 1
     ;;
   esac
@@ -997,17 +991,8 @@ gssapi==1.11.1 numpy==${numpy_version} scipy==${scipy_version} networkx==${netwo
     fi
   fi
 
-  # PIP_BREAK_SYSTEM_PACKAGES env var is honoured by pip on distros that
-  # ship the PEP 668 marker (e.g. Ubuntu 24.04, Debian 12+). Older pip
-  # versions (e.g. Ubuntu 22.04's) don't recognise the --break-system-packages
-  # CLI flag at all, but they ignore the env var so it's safe everywhere.
   local install_cmd
   if [[ "$pkg_format" == "deb" ]]; then
-    # Mirror release/docker/v7_deb.dockerfile runtime deps so the smoke image
-    # has the same package surface memgraph expects in production. libpython3.X
-    # provides libpython3.X.so which memgraph dlopens to embed Python; python3
-    # alone only pulls in libpython3.X-minimal.
-    #
     # Ubuntu Docker base images filter /usr/share/doc/* via
     # /etc/dpkg/dpkg.cfg.d/excludes, dropping memgraph's license files
     # (MEL.pdf/BSL.txt/APL.txt) which the smoke license check verifies.
@@ -1029,11 +1014,6 @@ gssapi==1.11.1 numpy==${numpy_version} scipy==${scipy_version} networkx==${netwo
       pip3 install --no-cache-dir ${pip_find_links} ${pip_packages} && \
       rm -rf /var/lib/apt/lists/*"
   else
-    # RPM declares Requires for openssl/curl/python3/logrotate/shadow-utils;
-    # dnf will resolve them. Add the runtime libs memgraph dlopens but which
-    # aren't part of the declared Requires, then pip-install the Python
-    # packages needed by bundled query modules.
-    #
     # Fedora/CentOS/Rocky minimal docker images set tsflags=nodocs in
     # /etc/dnf/dnf.conf, which strips memgraph's license files in
     # /usr/share/doc/memgraph/. Override on the dnf install line so the
@@ -1064,7 +1044,7 @@ EOF
   local rc=$?
   rm -rf "$build_dir"
   if [[ $rc -ne 0 ]]; then
-    echo "Error: docker build failed for memgraph/memgraph:$image_tag"
+    echo "Error: docker build failed for memgraph/memgraph:$image_tag" >&2
     exit $rc
   fi
   echo "Built smoke image: memgraph/memgraph:$image_tag"

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -978,7 +978,7 @@ package_smoke_image() {
   # so it must be supplied as a pre-built wheel via --wheels-dir.
   local pip_packages="cryptography==46.0.7 PyJWT==2.12.1 requests==2.32.5 \
 ldap3==2.6 pyyaml==6.0.1 python3-saml==1.16.0 lxml==6.1.0 xmlsec==1.3.16 \
-gssapi==1.11.1 numpy==${numpy_version} scipy==${scipy_version} networkx==3.4.2 gensim==4.3.3"
+gssapi==1.11.1 numpy==${numpy_version} scipy==${scipy_version} networkx==3.4.2 gensim==4.4.0"
 
   local build_dir
   build_dir=$(mktemp -d)

--- a/tools/ci/package_mage_setup.py
+++ b/tools/ci/package_mage_setup.py
@@ -98,7 +98,7 @@ class PackageMageSetup:
             "memgraph_download_link": "",
             "push_to_s3": False,
             "s3_dest_dir": "mage-unofficial",
-            "run_smoke_tests": False,
+            "run_smoke_tests": True,
             "run_tests": True,
             "package_deb": "default",
             "generate_sbom": False,

--- a/tools/ci/package_mage_setup.py
+++ b/tools/ci/package_mage_setup.py
@@ -5,55 +5,61 @@ import sys
 
 PR_BUILDS = ["amd", "arm", "cuda", "cugraph"]
 
+# Matrix values are emitted as JSON and consumed by package_mage.yaml via
+# `${{ matrix.X == 'true' }}` comparisons. GitHub Actions coerces operands to
+# numbers when comparing across types, so a Python bool `True` round-tripped
+# through json.dumps as JSON `true` does NOT equal the string `'true'`. Keep
+# every boolean-flavoured field as a string here so the workflow comparisons
+# resolve correctly.
 MATRIX_BUILDS = [
     {
         "arch": "amd",
         "build_type": "Release",
-        "cuda": False,
-        "cugraph": False,
-        "malloc": False,
+        "cuda": "false",
+        "cugraph": "false",
+        "malloc": "false",
     },
     {
         "arch": "arm",
         "build_type": "Release",
-        "cuda": False,
-        "cugraph": False,
-        "malloc": False,
+        "cuda": "false",
+        "cugraph": "false",
+        "malloc": "false",
     },
     {
         "arch": "amd",
         "build_type": "RelWithDebInfo",
-        "cuda": False,
-        "cugraph": False,
-        "malloc": False,
+        "cuda": "false",
+        "cugraph": "false",
+        "malloc": "false",
     },
     {
         "arch": "arm",
         "build_type": "RelWithDebInfo",
-        "cuda": False,
-        "cugraph": False,
-        "malloc": False,
+        "cuda": "false",
+        "cugraph": "false",
+        "malloc": "false",
     },
     {
         "arch": "amd",
         "build_type": "RelWithDebInfo",
-        "cuda": True,
-        "cugraph": False,
-        "malloc": False,
+        "cuda": "true",
+        "cugraph": "false",
+        "malloc": "false",
     },
     {
         "arch": "amd",
         "build_type": "Release",
-        "cuda": False,
-        "cugraph": False,
-        "malloc": True,
+        "cuda": "false",
+        "cugraph": "false",
+        "malloc": "true",
     },
     {
         "arch": "amd",
         "build_type": "Release",
-        "cuda": False,
-        "cugraph": True,
-        "malloc": False,
+        "cuda": "false",
+        "cugraph": "true",
+        "malloc": "false",
     },
 ]
 
@@ -94,14 +100,14 @@ class PackageMageSetup:
 
     def _check_pr_label(self, package: str, pr_labels: list) -> bool:
         default_args = {
-            "malloc": False,
+            "malloc": "false",
             "memgraph_download_link": "",
-            "push_to_s3": False,
+            "push_to_s3": "false",
             "s3_dest_dir": "mage-unofficial",
-            "run_smoke_tests": True,
-            "run_tests": True,
+            "run_smoke_tests": "true",
+            "run_tests": "true",
             "package_deb": "default",
-            "generate_sbom": False,
+            "generate_sbom": "false",
             "ref": "",
         }
         if f"CI -package=mage-{package}" in pr_labels:
@@ -109,8 +115,8 @@ class PackageMageSetup:
             out = {
                 "build_type": "Release",
                 "arch": "arm" if package == "arm" else "amd",
-                "cuda": package == "cuda",
-                "cugraph": package == "cugraph",
+                "cuda": "true" if package == "cuda" else "false",
+                "cugraph": "true" if package == "cugraph" else "false",
             }
             out.update(default_args)
             return out
@@ -131,20 +137,23 @@ class PackageMageSetup:
     def _check_workflow_input(self) -> bool:
         if self.workflow_inputs.get(f"matrix_build") == "true":
             return MATRIX_BUILDS
+        # GitHub passes workflow_dispatch/workflow_call inputs as strings
+        # ("true"/"false"); keep the fallbacks as strings too so the matrix
+        # always serialises booleans consistently — see MATRIX_BUILDS comment.
         return [
             {
                 "build_type": self.workflow_inputs.get("build_type", "Release"),
                 "arch": self.workflow_inputs.get("build_arch", "amd"),
-                "cuda": self.workflow_inputs.get("cuda", False),
-                "cugraph": self.workflow_inputs.get("cugraph", False),
-                "malloc": self.workflow_inputs.get("malloc", False),
+                "cuda": self.workflow_inputs.get("cuda", "false"),
+                "cugraph": self.workflow_inputs.get("cugraph", "false"),
+                "malloc": self.workflow_inputs.get("malloc", "false"),
                 "memgraph_download_link": self.workflow_inputs.get("memgraph_download_link", ""),
-                "push_to_s3": self.workflow_inputs.get("push_to_s3", False),
+                "push_to_s3": self.workflow_inputs.get("push_to_s3", "false"),
                 "s3_dest_dir": self.workflow_inputs.get("s3_dest_dir", "mage-unofficial"),
-                "run_smoke_tests": self.workflow_inputs.get("run_smoke_tests", False),
-                "run_tests": self.workflow_inputs.get("run_tests", False),
+                "run_smoke_tests": self.workflow_inputs.get("run_smoke_tests", "false"),
+                "run_tests": self.workflow_inputs.get("run_tests", "false"),
                 "package_deb": self.workflow_inputs.get("package_deb", "default"),
-                "generate_sbom": self.workflow_inputs.get("generate_sbom", False),
+                "generate_sbom": self.workflow_inputs.get("generate_sbom", "false"),
                 "ref": self.workflow_inputs.get("ref", ""),
             }
         ]

--- a/tools/ci/package_setup.py
+++ b/tools/ci/package_setup.py
@@ -87,12 +87,12 @@ class PackageSetup:
             # For pull_request events, return default values
             return {
                 "build_type": "Release",
-                "toolchain": "v6",
                 "push_to_s3": "false",
                 "s3_dest_dir": "",
                 "push_to_github": "false",
                 "malloc": "false",
                 "generate_sbom": "false",
+                "run_smoke_tests": "true",
             }
 
     def _setup_workflow_dispatch(self) -> None:

--- a/tools/ci/package_setup.py
+++ b/tools/ci/package_setup.py
@@ -114,18 +114,23 @@ class PackageSetup:
 
 
 def print_package_suite(packages: dict, workflow_inputs: dict, set_env_vars: bool = False) -> None:
-    for package, run in packages.items():
-        # Convert package names to valid GitHub output names (replace dots and hyphens with underscores)
-        output_name = package.replace(".", "_").replace("-", "_")
-        print(f"run_package_{output_name}={run}")
-        if set_env_vars:
-            os.popen(f"echo run_package_{output_name}={run} >> $GITHUB_OUTPUT")
+    gh_output = open(os.environ["GITHUB_OUTPUT"], "a") if set_env_vars else None
+    try:
+        for package, run in packages.items():
+            # Convert package names to valid GitHub output names (replace dots and hyphens with underscores)
+            output_name = package.replace(".", "_").replace("-", "_")
+            print(f"run_package_{output_name}={run}")
+            if gh_output:
+                gh_output.write(f"run_package_{output_name}={run}\n")
 
-    # Also output workflow inputs
-    for key, value in workflow_inputs.items():
-        print(f"workflow_input_{key}={value}")
-        if set_env_vars:
-            os.popen(f"echo workflow_input_{key}={value} >> $GITHUB_OUTPUT")
+        # Also output workflow inputs
+        for key, value in workflow_inputs.items():
+            print(f"workflow_input_{key}={value}")
+            if gh_output:
+                gh_output.write(f"workflow_input_{key}={value}\n")
+    finally:
+        if gh_output:
+            gh_output.close()
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
- Add smoke tests for packaged DEB/RPMs for distro builds - uses the same logic as the Docker builds by building a Docker image using the DEB/RPM.
- Run smoke tests by default when packaging Memgraph and MAGE.
- Fixed `package_memgraph.yaml` bug where it would ignore the workflow input for running smoke tests.
- Fix exit before error output on license check smoke test.
- Use `command -v` instead of `which` because minimal images sometimes do not contain it.



