### PR TITLE
fix: removed empty CMD argument from dockerfiles

### DIFF
--- a/.github/workflows/reusable_package.yaml
+++ b/.github/workflows/reusable_package.yaml
@@ -286,6 +286,18 @@ jobs:
           echo "IMAGE_TAG=$image_tag" >> $GITHUB_ENV
           echo "Resolved IMAGE_TAG=$image_tag"
 
+      - name: "Bolt smoke test (no-arg startup)"
+        if: ${{ env.FOR_DOCKER == 'true' }}
+        run: |
+          image="memgraph/memgraph:${IMAGE_TAG}"
+          # --keep-image-loaded is only true when run_smoke_tests is set, so
+          # load from the tarball when needed.
+          if ! docker image inspect "$image" >/dev/null 2>&1; then
+            image_archive="$(ls -1t "$DOCKER_ARTIFACT_DIR"/memgraph*-docker.tar.gz 2>/dev/null | head -n 1)"
+            docker load -i "$image_archive"
+          fi
+          ./tools/ci/smoke_test_docker_image.sh "$image"
+
       - name: "Generate Build SBOM"
         if: ${{ env.GENERATE_SBOM == 'true'  && env.FOR_DOCKER != 'true' }}
         run: |

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -444,6 +444,12 @@ jobs:
             --custom-mirror true \
             --cuda $CUDA
 
+      - name: "Bolt smoke test (no-arg startup)"
+        # cugraph/cuda images need an Nvidia GPU and can't start on CI runners.
+        if: ${{ !inputs.cugraph && !inputs.cuda }}
+        run: |
+          ./tools/ci/smoke_test_docker_image.sh "${DOCKER_REPOSITORY_NAME}:${IMAGE_TAG}"
+
       - name: Generate SBOM
         if: ${{ inputs.generate_sbom == true }}
         run: |

--- a/mage/Dockerfile.cugraph
+++ b/mage/Dockerfile.cugraph
@@ -128,4 +128,4 @@ COPY --from=python-base --chown=memgraph:memgraph /home/memgraph/.local /home/me
 EXPOSE 7687
 
 ENTRYPOINT ["/usr/lib/memgraph/memgraph"]
-CMD [""]
+CMD []

--- a/mage/Dockerfile.release
+++ b/mage/Dockerfile.release
@@ -114,7 +114,7 @@ USER memgraph
 EXPOSE 7687
 
 ENTRYPOINT ["/usr/lib/memgraph/memgraph"]
-CMD [""]
+CMD []
 
 
 FROM base AS relwithdebinfo
@@ -163,4 +163,4 @@ USER memgraph
 EXPOSE 7687
 
 ENTRYPOINT ["/usr/lib/memgraph/memgraph"]
-CMD [""]
+CMD []

--- a/release/docker/v7_deb.dockerfile
+++ b/release/docker/v7_deb.dockerfile
@@ -83,4 +83,4 @@ USER memgraph
 WORKDIR /usr/lib/memgraph
 
 ENTRYPOINT ["/usr/lib/memgraph/memgraph"]
-CMD [""]
+CMD []

--- a/release/docker/v7_deb_relwithdebinfo.dockerfile
+++ b/release/docker/v7_deb_relwithdebinfo.dockerfile
@@ -89,4 +89,4 @@ USER memgraph
 WORKDIR /usr/lib/memgraph
 
 ENTRYPOINT ["/usr/lib/memgraph/memgraph"]
-CMD [""]
+CMD []

--- a/tools/ci/smoke_test_docker_image.sh
+++ b/tools/ci/smoke_test_docker_image.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Quick smoke test for a Memgraph (or MAGE) Docker image.
+#
+# Runs the image with no arguments and verifies that the container accepts
+# Bolt connections. Catches regressions where the image can't start at all
+# (for example, a Dockerfile with `CMD [""]` that passes an empty argument
+# to the memgraph entrypoint).
+#
+# Usage: smoke_test_docker_image.sh <image_tag>
+#   e.g. smoke_test_docker_image.sh memgraph/memgraph-mage:1.30.0
+
+set -euo pipefail
+
+if [[ $# -lt 1 || -z "${1:-}" ]]; then
+  echo "Usage: $0 <image_tag>" >&2
+  exit 1
+fi
+
+IMAGE="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WAIT_SCRIPT="$SCRIPT_DIR/wait_for_memgraph_bolt.sh"
+
+if [[ ! -f "$WAIT_SCRIPT" ]]; then
+  echo "Error: cannot find $WAIT_SCRIPT" >&2
+  exit 1
+fi
+
+CONTAINER_NAME="memgraph-bolt-smoke-$$"
+
+cleanup() {
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+echo "Starting container $CONTAINER_NAME from $IMAGE (no arguments)..."
+docker run -d --name "$CONTAINER_NAME" "$IMAGE" >/dev/null
+
+# Give the entrypoint a moment to fail fast (e.g. bad args) before we exec.
+sleep 1
+status="$(docker inspect -f '{{.State.Status}}' "$CONTAINER_NAME" 2>/dev/null || echo missing)"
+if [[ "$status" != "running" ]]; then
+  echo "Smoke test FAILED for $IMAGE: container is not running (status=$status)." >&2
+  echo "--- container logs ---" >&2
+  docker logs "$CONTAINER_NAME" 2>&1 || true
+  echo "----------------------" >&2
+  exit 1
+fi
+
+# Copy the bolt wait helper into the container so we use the in-container
+# mgconsole binary instead of requiring one on the runner host.
+docker cp "$WAIT_SCRIPT" "$CONTAINER_NAME:/tmp/wait_for_memgraph_bolt.sh"
+
+if ! docker exec "$CONTAINER_NAME" bash /tmp/wait_for_memgraph_bolt.sh 127.0.0.1 7687 30 1; then
+  echo "Smoke test FAILED for $IMAGE: container did not accept Bolt connections." >&2
+  echo "--- container logs ---" >&2
+  docker logs "$CONTAINER_NAME" 2>&1 || true
+  echo "----------------------" >&2
+  exit 1
+fi
+
+echo "Smoke test PASSED for $IMAGE."


### PR DESCRIPTION
Fixes the bug where Memgraph and MAGE containers do not start with no arguments. The cause: an empty argument is passed the Memgraph by default with `CMD [""]`.
