### PR TITLE
feat: Add MAGE offline build

### DIFF
--- a/.github/workflows/build_rc.yml
+++ b/.github/workflows/build_rc.yml
@@ -300,6 +300,7 @@ jobs:
       run_tests: true
       package_deb: "default"
       generate_sbom: ${{ matrix.build_arch == 'amd' && matrix.build_type == 'Release' && !matrix.malloc && !matrix.cuda && !matrix.cugraph }}
+      build_offline_installer: ${{ matrix.build_arch == 'amd' && matrix.build_type == 'RelWithDebInfo' && !matrix.malloc && !matrix.cuda && !matrix.cugraph }}
       ref: ${{ needs.PrepareReleaseBranch.outputs.tag_name }}
       version: ${{ inputs.version }}
     secrets: inherit

--- a/.github/workflows/package_mage.yaml
+++ b/.github/workflows/package_mage.yaml
@@ -50,6 +50,10 @@ on:
         type: boolean
         description: "Run smoke tests on images after building (tests against previous tagged image)"
         default: false
+      build_offline_installer:
+        type: boolean
+        description: "Build offline installer (.run) for Ubuntu 24.04"
+        default: false
       generate_sbom:
         type: boolean
         description: "Generate SBOM for the image"
@@ -100,6 +104,10 @@ on:
       run_smoke_tests:
         type: boolean
         description: "Run smoke tests on images after building (tests against previous tagged image)"
+        default: false
+      build_offline_installer:
+        type: boolean
+        description: "Build offline installer (.run) for Ubuntu 24.04"
         default: false
       generate_sbom:
         type: boolean
@@ -156,5 +164,6 @@ jobs:
       run_tests: ${{ matrix.run_tests == 'true' }}
       package_deb: ${{ matrix.package_deb }}
       generate_sbom: ${{ matrix.generate_sbom == 'true' }}
+      build_offline_installer: ${{ inputs.build_offline_installer == true }}
       ref: ${{ matrix.ref }}
     secrets: inherit

--- a/.github/workflows/promote_rc_release.yml
+++ b/.github/workflows/promote_rc_release.yml
@@ -532,13 +532,6 @@ jobs:
           echo "Copied Ubuntu 24.04 MAGE packages to s3://${release_bucket}/${mage_release_dir}/ubuntu-24.04/"
 
       - name: Setup offline installer paths
-        # The .run filename encodes both the arch and the variant suffix
-        # (matches matrix.image_ext) so each matrix slot probes amd64 + arm64
-        # independently. Today only the bare "-relwithdebinfo" / amd64 slot
-        # finds a file (per build_offline_installer gating in build_rc.yml
-        # and the amd64-only build script); other slots no-op cleanly. Arm
-        # support drops in when the build side allows it — no promote change
-        # needed.
         run: |
           offline_run_amd="memgraph-mage-offline-${RELEASE_VERSION}-amd64${{ matrix.image_ext }}.run"
           offline_run_arm="memgraph-mage-offline-${RELEASE_VERSION}-arm64${{ matrix.image_ext }}.run"

--- a/.github/workflows/promote_rc_release.yml
+++ b/.github/workflows/promote_rc_release.yml
@@ -531,6 +531,76 @@ jobs:
           aws s3 cp "s3://${rc_bucket}/${mage_rc_dir}/" "s3://${release_bucket}/${mage_release_dir}/ubuntu-24.04/" --recursive --exclude "*" --include "memgraph-mage_${RELEASE_VERSION}-1_*.deb"
           echo "Copied Ubuntu 24.04 MAGE packages to s3://${release_bucket}/${mage_release_dir}/ubuntu-24.04/"
 
+      - name: Setup offline installer paths
+        # The .run filename encodes both the arch and the variant suffix
+        # (matches matrix.image_ext) so each matrix slot probes amd64 + arm64
+        # independently. Today only the bare "-relwithdebinfo" / amd64 slot
+        # finds a file (per build_offline_installer gating in build_rc.yml
+        # and the amd64-only build script); other slots no-op cleanly. Arm
+        # support drops in when the build side allows it — no promote change
+        # needed.
+        run: |
+          offline_run_amd="memgraph-mage-offline-${RELEASE_VERSION}-amd64${{ matrix.image_ext }}.run"
+          offline_run_arm="memgraph-mage-offline-${RELEASE_VERSION}-arm64${{ matrix.image_ext }}.run"
+          echo "offline_run_amd=${offline_run_amd}" >> $GITHUB_ENV
+          echo "offline_run_arm=${offline_run_arm}" >> $GITHUB_ENV
+          echo "s3_input_offline_amd=s3://${rc_bucket}/${mage_rc_dir}/${offline_run_amd}" >> $GITHUB_ENV
+          echo "s3_input_offline_arm=s3://${rc_bucket}/${mage_rc_dir}/${offline_run_arm}" >> $GITHUB_ENV
+          if [[ "${{ github.event.inputs.test }}" == "true" ]]; then
+            offline_dest_root="offline-installer-test"
+          else
+            offline_dest_root="offline-installer"
+          fi
+          echo "s3_output_offline_amd=s3://${rc_bucket}/${offline_dest_root}/v${RELEASE_VERSION}/${offline_run_amd}" >> $GITHUB_ENV
+          echo "s3_output_offline_arm=s3://${rc_bucket}/${offline_dest_root}/v${RELEASE_VERSION}/${offline_run_arm}" >> $GITHUB_ENV
+
+      - name: Check if RC offline installers for this build exist
+        run: |
+          if aws s3 ls "${s3_input_offline_amd}" &> /dev/null; then
+            echo "has_rc_offline_amd=true" >> $GITHUB_ENV
+            echo "Found amd64 RC offline installer at ${s3_input_offline_amd}"
+          else
+            echo "has_rc_offline_amd=false" >> $GITHUB_ENV
+            echo "No amd64 RC offline installer at ${s3_input_offline_amd}"
+          fi
+          if aws s3 ls "${s3_input_offline_arm}" &> /dev/null; then
+            echo "has_rc_offline_arm=true" >> $GITHUB_ENV
+            echo "Found arm64 RC offline installer at ${s3_input_offline_arm}"
+          else
+            echo "has_rc_offline_arm=false" >> $GITHUB_ENV
+            echo "No arm64 RC offline installer at ${s3_input_offline_arm}"
+          fi
+
+      - name: Check if release offline installers for this build already exist
+        run: |
+          if [[ "${has_rc_offline_amd}" == "true" ]] && aws s3 ls "${s3_output_offline_amd}" &> /dev/null; then
+            echo "Release amd64 offline installer already exists at ${s3_output_offline_amd}"
+            if [[ "$FORCE_PROMOTE" != "true" ]]; then
+              echo "Set force_promote to true to override existing release!"
+              exit 1
+            fi
+            echo "Forcing promotion of existing amd64 offline installer ..."
+          fi
+          if [[ "${has_rc_offline_arm}" == "true" ]] && aws s3 ls "${s3_output_offline_arm}" &> /dev/null; then
+            echo "Release arm64 offline installer already exists at ${s3_output_offline_arm}"
+            if [[ "$FORCE_PROMOTE" != "true" ]]; then
+              echo "Set force_promote to true to override existing release!"
+              exit 1
+            fi
+            echo "Forcing promotion of existing arm64 offline installer ..."
+          fi
+
+      - name: Promote offline installers to release bucket
+        run: |
+          if [[ "${has_rc_offline_amd}" == "true" ]]; then
+            aws s3 cp "${s3_input_offline_amd}" "${s3_output_offline_amd}"
+            echo "Copied amd64 offline installer to ${s3_output_offline_amd}"
+          fi
+          if [[ "${has_rc_offline_arm}" == "true" ]]; then
+            aws s3 cp "${s3_input_offline_arm}" "${s3_output_offline_arm}"
+            echo "Copied arm64 offline installer to ${s3_output_offline_arm}"
+          fi
+
       - name: Log in to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -398,9 +398,21 @@ jobs:
       - name: Build offline installer (.run) for Ubuntu 24.04
         # CPU-only amd64 today; the build script rejects other arch/cuda combos.
         # Drops the .run into output/ so the existing S3 sync picks it up.
+        # The filename encodes the variant suffix (-relwithdebinfo/-malloc/
+        # -cuda/-cugraph) so future per-variant .run builds don't collide in
+        # S3 and the promote workflow can probe each matrix variant.
         if: ${{ inputs.build_offline_installer && env.PACKAGE_DEB == 'true' }}
         run: |
-          OFFLINE_RUN="output/memgraph-mage-offline-${MEMGRAPH_VERSION}-amd64.run"
+          SUFFIX=""
+          [[ "$BUILD_TYPE" == "RelWithDebInfo" ]] && SUFFIX="${SUFFIX}-relwithdebinfo"
+          [[ "$MALLOC" == "true" ]]               && SUFFIX="${SUFFIX}-malloc"
+          [[ "$CUDA" == "true" ]]                 && SUFFIX="${SUFFIX}-cuda"
+          [[ "$CUGRAPH" == "true" ]]              && SUFFIX="${SUFFIX}-cugraph"
+          # ARCH is "amd"/"arm" → dpkg arch "amd64"/"arm64"; the build script
+          # currently rejects non-amd64, but using $ARCH64 here means once arm
+          # support lands the filename automatically picks up arm64 and the
+          # promote workflow doesn't need a second pass of changes.
+          OFFLINE_RUN="output/memgraph-mage-offline-${MEMGRAPH_VERSION}-${ARCH}64${SUFFIX}.run"
           ./release/package/mgbuild.sh \
             --toolchain $TOOLCHAIN \
             --os "$OS" \

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -396,12 +396,6 @@ jobs:
           echo "DEB_PACKAGE=${DEB_PACKAGE}" >> $GITHUB_ENV
 
       - name: Build offline installer (.run) for Ubuntu 24.04
-        # Drops the .run into output/ so the existing S3 sync picks it up.
-        # The filename encodes the variant suffix (-relwithdebinfo/-malloc/
-        # -cuda or -cugraph) — must match matrix.image_ext in
-        # promote_rc_release.yml so the promote step finds it. -cuda and
-        # -cugraph are mutually exclusive (cugraph implies cuda but only the
-        # "cugraph" tag shows in image_ext).
         if: ${{ inputs.build_offline_installer && env.PACKAGE_DEB == 'true' }}
         run: |
           SUFFIX=""

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -396,32 +396,38 @@ jobs:
           echo "DEB_PACKAGE=${DEB_PACKAGE}" >> $GITHUB_ENV
 
       - name: Build offline installer (.run) for Ubuntu 24.04
-        # CPU-only amd64 today; the build script rejects other arch/cuda combos.
         # Drops the .run into output/ so the existing S3 sync picks it up.
         # The filename encodes the variant suffix (-relwithdebinfo/-malloc/
-        # -cuda/-cugraph) so future per-variant .run builds don't collide in
-        # S3 and the promote workflow can probe each matrix variant.
+        # -cuda or -cugraph) — must match matrix.image_ext in
+        # promote_rc_release.yml so the promote step finds it. -cuda and
+        # -cugraph are mutually exclusive (cugraph implies cuda but only the
+        # "cugraph" tag shows in image_ext).
         if: ${{ inputs.build_offline_installer && env.PACKAGE_DEB == 'true' }}
         run: |
           SUFFIX=""
           [[ "$BUILD_TYPE" == "RelWithDebInfo" ]] && SUFFIX="${SUFFIX}-relwithdebinfo"
           [[ "$MALLOC" == "true" ]]               && SUFFIX="${SUFFIX}-malloc"
-          [[ "$CUDA" == "true" ]]                 && SUFFIX="${SUFFIX}-cuda"
-          [[ "$CUGRAPH" == "true" ]]              && SUFFIX="${SUFFIX}-cugraph"
-          # ARCH is "amd"/"arm" → dpkg arch "amd64"/"arm64"; the build script
-          # currently rejects non-amd64, but using $ARCH64 here means once arm
-          # support lands the filename automatically picks up arm64 and the
-          # promote workflow doesn't need a second pass of changes.
+          if [[ "$CUGRAPH" == "true" ]]; then
+            SUFFIX="${SUFFIX}-cugraph"
+          elif [[ "$CUDA" == "true" ]]; then
+            SUFFIX="${SUFFIX}-cuda"
+          fi
+          # ARCH is "amd"/"arm" → dpkg arch "amd64"/"arm64".
           OFFLINE_RUN="output/memgraph-mage-offline-${MEMGRAPH_VERSION}-${ARCH}64${SUFFIX}.run"
+          PACKAGE_ARGS=()
+          [[ "$MALLOC" == "true" ]] && PACKAGE_ARGS+=(--malloc)
+          [[ "$CUDA" == "true" ]]   && PACKAGE_ARGS+=(--cuda)
           ./release/package/mgbuild.sh \
             --toolchain $TOOLCHAIN \
             --os "$OS" \
             --arch $ARCH \
             --build-type $BUILD_TYPE \
+            --cugraph $CUGRAPH \
             package-mage-offline-installer \
             --memgraph-deb mage/memgraph.deb \
             --mage-deb "$DEB_PACKAGE" \
-            --output "$OFFLINE_RUN"
+            --output "$OFFLINE_RUN" \
+            "${PACKAGE_ARGS[@]}"
           echo "OFFLINE_INSTALLER=${OFFLINE_RUN}" >> $GITHUB_ENV
 
       - name: Smoke test offline installer
@@ -429,8 +435,10 @@ jobs:
         # network access, then verifies memgraph reaches Bolt readiness using
         # tools/ci/wait_for_memgraph_bolt.sh (mgconsole is part of the
         # memgraph .deb that the installer lays down, so it's on $PATH after
-        # the installer finishes).
-        if: ${{ inputs.run_smoke_tests && env.OFFLINE_INSTALLER != '' }}
+        # the installer finishes). Skipped only for the cugraph variant —
+        # cugraph needs an Nvidia GPU at startup, which CI runners don't
+        # have. CUDA-built memgraph starts fine without a GPU.
+        if: ${{ inputs.run_smoke_tests && env.OFFLINE_INSTALLER != '' && !inputs.cugraph }}
         run: |
           set -euo pipefail
           docker run --rm \

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -408,6 +408,29 @@ jobs:
             --output "$OFFLINE_RUN"
           echo "OFFLINE_INSTALLER=${OFFLINE_RUN}" >> $GITHUB_ENV
 
+      - name: Smoke test offline installer
+        # Runs the built .run inside a fresh ubuntu:24.04 container with no
+        # network access, then verifies memgraph reaches Bolt readiness using
+        # tools/ci/wait_for_memgraph_bolt.sh (mgconsole is part of the
+        # memgraph .deb that the installer lays down, so it's on $PATH after
+        # the installer finishes).
+        if: ${{ inputs.run_smoke_tests && env.OFFLINE_INSTALLER != '' }}
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --network none \
+            -v "$PWD/${OFFLINE_INSTALLER}:/installer.run:ro" \
+            -v "$PWD/tools/ci/wait_for_memgraph_bolt.sh:/wait_for_memgraph_bolt.sh:ro" \
+            ubuntu:24.04 \
+            bash -euxo pipefail -c '
+              /installer.run
+              su - memgraph -c "/usr/lib/memgraph/memgraph --also-log-to-stderr" \
+                > /tmp/memgraph.log 2>&1 &
+              MG_PID=$!
+              trap "kill $MG_PID 2>/dev/null || true; wait $MG_PID 2>/dev/null || true" EXIT
+              bash /wait_for_memgraph_bolt.sh 127.0.0.1 7687 60 1
+            '
+
       - name: Run tests
         if: ${{ inputs.run_tests == true }}
         run: |

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -391,6 +391,23 @@ jobs:
           DEB_PACKAGE="$(ls output/memgraph-mage*.deb)"
           echo "DEB_PACKAGE=${DEB_PACKAGE}" >> $GITHUB_ENV
 
+      - name: Build offline installer (.run) for Ubuntu 24.04
+        # CPU-only amd64 today; the build script rejects other arch/cuda combos.
+        # Drops the .run into output/ so the existing S3 sync picks it up.
+        if: ${{ (inputs.push_to_github || inputs.push_to_s3) && env.PACKAGE_DEB == 'true' && inputs.arch == 'amd' && !inputs.cuda && !inputs.cugraph }}
+        run: |
+          OFFLINE_RUN="output/memgraph-mage-offline-${MEMGRAPH_VERSION}-amd64.run"
+          ./release/package/mgbuild.sh \
+            --toolchain $TOOLCHAIN \
+            --os "$OS" \
+            --arch $ARCH \
+            --build-type $BUILD_TYPE \
+            package-mage-offline-installer \
+            --memgraph-deb mage/memgraph.deb \
+            --mage-deb "$DEB_PACKAGE" \
+            --output "$OFFLINE_RUN"
+          echo "OFFLINE_INSTALLER=${OFFLINE_RUN}" >> $GITHUB_ENV
+
       - name: Run tests
         if: ${{ inputs.run_tests == true }}
         run: |

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -107,7 +107,7 @@ jobs:
   BuildAndPush:
     name: "Build and Test MAGE"
     runs-on: [self-hosted, DockerMgBuild, Linux, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
-    timeout-minutes: ${{ (inputs.cugraph || inputs.cuda) && 45 || 35 }}
+    timeout-minutes: ${{ (inputs.cugraph || inputs.cuda || (inputs.build_type == 'Release' && inputs.arch == 'amd' && inputs.run_smoke_tests)) && 45 || 35 }}
     outputs:
       s3_package_url: ${{ steps.output-url.outputs.s3_url }}
     steps:

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -59,6 +59,10 @@ on:
         description: "Build deb package (true|false|default)"
         # default is build only for Release/RelWithDebInfo + amd64/arm64 (other combinations are not actually different)
         default: default
+      build_offline_installer:
+        type: boolean
+        description: "Build offline installer (.run) for Ubuntu 24.04"
+        default: false
       generate_sbom:
         type: boolean
         description: "Generate SBOM"
@@ -107,7 +111,7 @@ jobs:
   BuildAndPush:
     name: "Build and Test MAGE"
     runs-on: [self-hosted, DockerMgBuild, Linux, "${{ inputs.arch == 'arm' && 'ARM64' || 'X64' }}"]
-    timeout-minutes: ${{ (inputs.cugraph || inputs.cuda || (inputs.build_type == 'Release' && inputs.arch == 'amd' && inputs.run_smoke_tests)) && 45 || 35 }}
+    timeout-minutes: ${{ (inputs.cugraph || inputs.cuda || inputs.build_offline_installer) && 45 || 35 }}
     outputs:
       s3_package_url: ${{ steps.output-url.outputs.s3_url }}
     steps:
@@ -394,7 +398,7 @@ jobs:
       - name: Build offline installer (.run) for Ubuntu 24.04
         # CPU-only amd64 today; the build script rejects other arch/cuda combos.
         # Drops the .run into output/ so the existing S3 sync picks it up.
-        if: ${{ (inputs.push_to_github || inputs.push_to_s3) && env.PACKAGE_DEB == 'true' && inputs.arch == 'amd' && !inputs.cuda && !inputs.cugraph }}
+        if: ${{ inputs.build_offline_installer && env.PACKAGE_DEB == 'true' }}
         run: |
           OFFLINE_RUN="output/memgraph-mage-offline-${MEMGRAPH_VERSION}-amd64.run"
           ./release/package/mgbuild.sh \

--- a/mage/install_python_requirements.sh
+++ b/mage/install_python_requirements.sh
@@ -113,9 +113,7 @@ if [ "$ARCH" = "arm64" ]; then
     } || {
       python3 -m pip install --no-cache-dir torch-sparse torch-cluster torch-spline-conv torch-geometric torch-scatter -f https://data.pyg.org/whl/torch-2.9.0+cpu.html
     }
-    curl -o dgl-2.5-cp312-cp312-linux_aarch64.whl https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/wheels/arm64/dgl-2.5-cp312-cp312-linux_aarch64.whl
-    python3 -m pip install --no-cache-dir $DGL
-    rm dgl-2.5-cp312-cp312-linux_aarch64.whl
+    python3 -m pip install --no-cache-dir "$DGL"
   fi
 else
   if [ "$CACHE_PRESENT" = "true" ]; then
@@ -132,9 +130,7 @@ else
         python3 -m pip install --no-cache-dir torch-sparse torch-cluster torch-spline-conv torch-geometric torch-scatter -f https://data.pyg.org/whl/torch-2.9.0+cpu.html
       fi
     }
-    curl -o dgl-2.5-cp312-cp312-linux_x86_64.whl https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/wheels/amd64/dgl-2.5-cp312-cp312-linux_x86_64.whl
-    python3 -m pip install --no-cache-dir $DGL
-    rm dgl-2.5-cp312-cp312-linux_x86_64.whl
+    python3 -m pip install --no-cache-dir "$DGL"
   fi
 fi
 rm -fr /home/memgraph/.cache/pip

--- a/mage/install_python_requirements.sh
+++ b/mage/install_python_requirements.sh
@@ -79,6 +79,14 @@ else
 fi
 
 # custom package links TODO(matt): use official binaries when available
+#
+# IMPORTANT: the PyG/DGL versions baked into the URLs below must stay in sync
+# with the *_VERSION variables in
+# tools/ci/mage-build/offline-installer/download-wheels.sh. These wheels are
+# custom-built and hosted in our S3 bucket (not on PyPI), so both scripts have
+# to agree on which version to fetch — there's no upstream registry to derive
+# a single answer from. Any version bump here must be mirrored there and vice
+# versa.
 BASE_URL="https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/wheels"
 if [[ "$ARCH" == "arm64" ]]; then
   BASE_URL="${BASE_URL}/arm64"

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -94,6 +94,7 @@ print_help () {
   echo -e "  package-smoke-image [OPTIONS]      Build a Docker image with the .deb/.rpm package installed (for smoke tests)"
   echo -e "  package-mage-deb [OPTIONS]         Create MAGE DEB package"
   echo -e "  package-mage-docker [OPTIONS]      Create MAGE docker image"
+  echo -e "  package-mage-offline-installer [OPTIONS]  Build a self-contained .run installer for Memgraph + MAGE on Ubuntu 24.04"
   echo -e "  pull                               Pull mgbuild image from dockerhub"
   echo -e "  push [OPTIONS]                     Push mgbuild image to dockerhub"
   echo -e "  run [OPTIONS]                      Run mgbuild container"
@@ -189,6 +190,12 @@ print_help () {
 
   echo -e "\ngenerate-mage-image-sbom options:"
   echo -e "  --image-name string           Specify the image name (required)"
+
+  echo -e "\npackage-mage-offline-installer options:"
+  echo -e "  --memgraph-deb PATH           Path to the memgraph .deb (required)"
+  echo -e "  --mage-deb PATH               Path to the memgraph-mage .deb (required)"
+  echo -e "  --output PATH                 Output path for the .run file (default: ./memgraph-mage-offline-<version>-<arch>.run)"
+  echo -e "  --wheels-dir PATH             Directory of pre-built host wheels to bundle (default: \"\$PROJECT_ROOT/mage/wheels\")"
 
   echo -e "\nToolchain v4 supported OSs:"
   echo -e "  \"${SUPPORTED_OS_V4[*]}\""
@@ -1814,6 +1821,62 @@ package_mage_docker() {
   echo -e "${GREEN_BOLD}Docker image packaged successfully${RESET}"
 }
 
+package_mage_offline_installer() {
+
+  echo -e "${GREEN_BOLD}Building MAGE offline installer (.run)${RESET}"
+
+  local memgraph_deb=""
+  local mage_deb=""
+  local output=""
+  local wheels_dir="$PROJECT_ROOT/mage/wheels"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --memgraph-deb)
+        memgraph_deb=$2
+        shift 2
+      ;;
+      --mage-deb)
+        mage_deb=$2
+        shift 2
+      ;;
+      --output)
+        output=$2
+        shift 2
+      ;;
+      --wheels-dir)
+        wheels_dir=$2
+        shift 2
+      ;;
+      *)
+        echo "Error: Unknown flag '$1'"
+        print_help
+        exit 1
+      ;;
+    esac
+  done
+
+  if [[ -z "$memgraph_deb" || -z "$mage_deb" ]]; then
+    echo -e "${RED_BOLD}Error: package-mage-offline-installer requires --memgraph-deb and --mage-deb${RESET}"
+    exit 1
+  fi
+
+  # The mgbuild --arch values are amd/arm; the offline installer script speaks
+  # debian/dpkg arch (amd64/arm64).
+  local dpkg_arch="${arch}64"
+
+  local build_args=(
+    --memgraph-deb "$memgraph_deb"
+    --mage-deb "$mage_deb"
+    --arch "$dpkg_arch"
+    --wheels-dir "$wheels_dir"
+  )
+  if [[ -n "$output" ]]; then
+    build_args+=(--output "$output")
+  fi
+
+  "$PROJECT_ROOT/tools/ci/mage-build/build-offline-installer.sh" "${build_args[@]}"
+}
+
 test_mage() {
   # TODO: move other tests into this function like the test_memgraph function
 
@@ -2618,6 +2681,9 @@ case $command in
     ;;
     package-mage-docker)
       package_mage_docker $@
+    ;;
+    package-mage-offline-installer)
+      package_mage_offline_installer $@
     ;;
     test-mage)
       test_mage $@

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -194,8 +194,12 @@ print_help () {
   echo -e "\npackage-mage-offline-installer options:"
   echo -e "  --memgraph-deb PATH           Path to the memgraph .deb (required)"
   echo -e "  --mage-deb PATH               Path to the memgraph-mage .deb (required)"
-  echo -e "  --output PATH                 Output path for the .run file (default: ./memgraph-mage-offline-<version>-<arch>.run)"
+  echo -e "  --output PATH                 Output path for the .run file (default: ./memgraph-mage-offline-<version>-<arch><variant>.run)"
   echo -e "  --wheels-dir PATH             Directory of pre-built host wheels to bundle (default: \"\$PROJECT_ROOT/mage/wheels\")"
+  echo -e "  --malloc                      Variant flag — affects the output filename only"
+  echo -e "  --cuda                        Bundle CUDA-flavoured Python wheels (requires --arch amd)"
+  echo -e "  --cuda-version X.Y            CUDA version for the S3 wheel path (default \"13.0\")"
+  echo -e "                                Build-type and cugraph come from the global --build-type / --cugraph flags."
 
   echo -e "\nToolchain v4 supported OSs:"
   echo -e "  \"${SUPPORTED_OS_V4[*]}\""
@@ -1829,6 +1833,9 @@ package_mage_offline_installer() {
   local mage_deb=""
   local output=""
   local wheels_dir="$PROJECT_ROOT/mage/wheels"
+  local malloc=false
+  local cuda=false
+  local cuda_version="13.0"
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --memgraph-deb)
@@ -1847,6 +1854,18 @@ package_mage_offline_installer() {
         wheels_dir=$2
         shift 2
       ;;
+      --malloc)
+        malloc=true
+        shift 1
+      ;;
+      --cuda)
+        cuda=true
+        shift 1
+      ;;
+      --cuda-version)
+        cuda_version=$2
+        shift 2
+      ;;
       *)
         echo "Error: Unknown flag '$1'"
         print_help
@@ -1860,6 +1879,12 @@ package_mage_offline_installer() {
     exit 1
   fi
 
+  # cugraph is a global mgbuild flag (parallel with package_mage_deb / docker);
+  # it implies cuda for wheel selection.
+  if [[ "$cugraph" = true ]]; then
+    cuda=true
+  fi
+
   # The mgbuild --arch values are amd/arm; the offline installer script speaks
   # debian/dpkg arch (amd64/arm64).
   local dpkg_arch="${arch}64"
@@ -1868,6 +1893,11 @@ package_mage_offline_installer() {
     --memgraph-deb "$memgraph_deb"
     --mage-deb "$mage_deb"
     --arch "$dpkg_arch"
+    --build-type "$build_type"
+    --cuda "$cuda"
+    --cuda-version "$cuda_version"
+    --malloc "$malloc"
+    --cugraph "$cugraph"
     --wheels-dir "$wheels_dir"
   )
   if [[ -n "$output" ]]; then

--- a/tools/ci/mage-build/build-offline-installer.sh
+++ b/tools/ci/mage-build/build-offline-installer.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 # The output is a single executable file containing:
 #   - memgraph .deb + memgraph-mage .deb
 #   - every apt dependency .deb needed on a vanilla Ubuntu 24.04 host
-#   - every Python wheel needed by mage and the auth modules
+#   - every Python wheel needed by mage and the auth modules (CPU or CUDA
+#     variant, depending on --cuda)
 #   - install.sh (offline installer logic)
 #
 # Build steps:
@@ -18,8 +19,9 @@ set -euo pipefail
 #      install.sh script into the staging tree.
 #   4. tar the staging tree and prepend a tiny self-extracting shell preamble.
 #
-# Currently amd64 / CPU-only; --arch and --cuda are wired through for the
-# future but not yet validated.
+# Variant flags (--build-type/--malloc/--cuda/--cugraph) feed into the output
+# filename and, for --cuda/--cugraph, also select GPU-flavoured Python wheels
+# so the cache matches what the memgraph-mage .deb's postinst expects.
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PROJECT_ROOT="$SCRIPT_DIR/../../.."
@@ -28,7 +30,11 @@ OFFLINE_DIR="$SCRIPT_DIR/offline-installer"
 MEMGRAPH_DEB=""
 MAGE_DEB=""
 ARCH="amd64"
+BUILD_TYPE="Release"
 CUDA="false"
+CUDA_VERSION="13.0"
+MALLOC="false"
+CUGRAPH="false"
 OUTPUT=""
 WHEELS_PREBUILT_DIR="$PROJECT_ROOT/mage/wheels"
 
@@ -37,15 +43,19 @@ usage() {
 Usage: $0 --memgraph-deb PATH --mage-deb PATH [options]
 
 Required:
-  --memgraph-deb PATH     Path to memgraph_*.deb
-  --mage-deb PATH         Path to memgraph-mage_*.deb
+  --memgraph-deb PATH       Path to memgraph_*.deb
+  --mage-deb PATH           Path to memgraph-mage_*.deb
 
 Options:
-  --arch amd64            Target architecture (only amd64 supported today)
-  --cuda true|false       Bundle GPU wheels (not supported yet; must be false)
-  --output PATH           Output .run file (default: memgraph-mage-offline-<version>-<arch>.run)
-  --wheels-dir PATH       Directory of pre-built host wheels to include
-                          (default: $PROJECT_ROOT/mage/wheels)
+  --arch amd64|arm64        Target dpkg arch (default amd64)
+  --build-type STR          Release|RelWithDebInfo (default Release)
+  --cuda true|false         Bundle CUDA wheels (requires --arch amd64)
+  --cuda-version X.Y        CUDA version for S3 wheel path (default 13.0)
+  --malloc true|false       Variant flag — for output filename only
+  --cugraph true|false      Variant flag — implies --cuda true
+  --output PATH             Output .run file
+                            (default: memgraph-mage-offline-<version>-<arch><suffix>.run)
+  --wheels-dir PATH         Pre-built host wheels to bundle (default: \$PROJECT_ROOT/mage/wheels)
 EOF
 }
 
@@ -54,13 +64,22 @@ while [[ $# -gt 0 ]]; do
     --memgraph-deb) MEMGRAPH_DEB="$2"; shift 2 ;;
     --mage-deb)     MAGE_DEB="$2";     shift 2 ;;
     --arch)         ARCH="$2";         shift 2 ;;
+    --build-type)   BUILD_TYPE="$2";   shift 2 ;;
     --cuda)         CUDA="$2";         shift 2 ;;
+    --cuda-version) CUDA_VERSION="$2"; shift 2 ;;
+    --malloc)       MALLOC="$2";       shift 2 ;;
+    --cugraph)      CUGRAPH="$2";      shift 2 ;;
     --output)       OUTPUT="$2";       shift 2 ;;
     --wheels-dir)   WHEELS_PREBUILT_DIR="$2"; shift 2 ;;
     -h|--help)      usage; exit 0 ;;
     *)              echo "Unknown option: $1" >&2; usage; exit 1 ;;
   esac
 done
+
+# cugraph implies cuda — mirrors release/package/mgbuild.sh::package_mage_deb.
+if [[ "$CUGRAPH" == "true" ]]; then
+  CUDA="true"
+fi
 
 if [[ -z "$MEMGRAPH_DEB" || -z "$MAGE_DEB" ]]; then
   echo "Error: --memgraph-deb and --mage-deb are required." >&2
@@ -75,22 +94,37 @@ if [[ ! -f "$MAGE_DEB" ]]; then
   echo "Error: mage deb not found at $MAGE_DEB" >&2
   exit 1
 fi
-if [[ "$ARCH" != "amd64" ]]; then
-  echo "Error: only amd64 is supported in this version of the offline installer." >&2
-  exit 1
-fi
-if [[ "$CUDA" != "false" ]]; then
-  echo "Error: CUDA bundles are not supported yet (got --cuda $CUDA)." >&2
+case "$ARCH" in
+  amd64|arm64) ;;
+  *) echo "Error: --arch must be amd64 or arm64 (got $ARCH)" >&2; exit 1 ;;
+esac
+case "$BUILD_TYPE" in
+  Release|RelWithDebInfo) ;;
+  *) echo "Error: --build-type must be Release or RelWithDebInfo (got $BUILD_TYPE)" >&2; exit 1 ;;
+esac
+if [[ "$CUDA" == "true" && "$ARCH" != "amd64" ]]; then
+  echo "Error: --cuda true requires --arch amd64 (no CUDA wheels published for arm64)" >&2
   exit 1
 fi
 
-# Derive a default output filename from the memgraph deb version.
+# Build the variant suffix. Must match matrix.image_ext in
+# .github/workflows/promote_rc_release.yml so the promote step can find the
+# .run file by predictable name.
+SUFFIX=""
+[[ "$BUILD_TYPE" == "RelWithDebInfo" ]] && SUFFIX="${SUFFIX}-relwithdebinfo"
+[[ "$MALLOC" == "true" ]]                && SUFFIX="${SUFFIX}-malloc"
+[[ "$CUDA" == "true" && "$CUGRAPH" != "true" ]] && SUFFIX="${SUFFIX}-cuda"
+[[ "$CUGRAPH" == "true" ]]               && SUFFIX="${SUFFIX}-cugraph"
+
 if [[ -z "$OUTPUT" ]]; then
   base=$(basename "$MEMGRAPH_DEB")
   # memgraph_<version>_<arch>.deb -> <version>
   version=$(echo "$base" | sed -E 's/^memgraph_(.+)_[a-z0-9]+\.deb$/\1/')
-  OUTPUT="$PWD/memgraph-mage-offline-${version}-${ARCH}.run"
+  OUTPUT="$PWD/memgraph-mage-offline-${version}-${ARCH}${SUFFIX}.run"
 fi
+
+echo "==> Build config: arch=$ARCH build_type=$BUILD_TYPE cuda=$CUDA malloc=$MALLOC cugraph=$CUGRAPH"
+echo "==> Output: $OUTPUT"
 
 STAGING=$(mktemp -d -t mg-offline-build-XXXXXX)
 trap 'rm -rf "$STAGING"' EXIT
@@ -102,18 +136,26 @@ mkdir -p "$STAGING/bundle/debs" "$STAGING/bundle/wheels" "$STAGING/bundle/requir
 cp -v "$MEMGRAPH_DEB" "$STAGING/bundle/debs/"
 cp -v "$MAGE_DEB" "$STAGING/bundle/debs/"
 
-# Bundle the requirements files install.sh will pass to `pip install -r`.
-# These are the same files we feed to `pip download` in the wheels pass.
-cp -v "$PROJECT_ROOT/mage/python/requirements.txt" \
-  "$STAGING/bundle/requirements/mage-requirements.txt"
+# The mage .deb's postinst will run install_python_requirements.sh, which
+# reads /usr/lib/memgraph/mage-requirements.txt (packaged inside the deb based
+# on the deb's own --cuda flag at deb-build time). Our install.sh's step 3
+# pip-installs from the .run's bundled requirements file. To keep the version
+# pins consistent, we mirror the deb's choice here: CUDA build → -gpu file.
+if [[ "$CUDA" == "true" ]]; then
+  MAGE_REQ_SRC="$PROJECT_ROOT/mage/python/requirements-gpu.txt"
+else
+  MAGE_REQ_SRC="$PROJECT_ROOT/mage/python/requirements.txt"
+fi
+
+cp -v "$MAGE_REQ_SRC" "$STAGING/bundle/requirements/mage-requirements.txt"
 cp -v "$PROJECT_ROOT/src/auth/reference_modules/requirements.txt" \
   "$STAGING/bundle/requirements/auth-module-requirements.txt"
 
-# Stage the input for the wheels container: requirements files + any prebuilt
-# wheels the caller wants us to include.
+# Stage inputs for the wheels container.
 mkdir -p "$STAGING/wheels-input/wheels-prebuilt"
-cp -v "$PROJECT_ROOT/mage/python/requirements.txt" "$STAGING/wheels-input/requirements.txt"
-cp -v "$PROJECT_ROOT/src/auth/reference_modules/requirements.txt" "$STAGING/wheels-input/auth-module-requirements.txt"
+cp -v "$MAGE_REQ_SRC" "$STAGING/wheels-input/requirements.txt"
+cp -v "$PROJECT_ROOT/src/auth/reference_modules/requirements.txt" \
+  "$STAGING/wheels-input/auth-module-requirements.txt"
 if [[ -d "$WHEELS_PREBUILT_DIR" ]]; then
   shopt -s nullglob
   for whl in "$WHEELS_PREBUILT_DIR"/*.whl; do
@@ -139,6 +181,9 @@ docker run --rm \
 echo "==> Downloading Python wheels (fresh ubuntu:24.04 container)"
 docker run --rm \
   --platform "linux/$ARCH" \
+  -e ARCH="$ARCH" \
+  -e CUDA="$CUDA" \
+  -e CUDA_VERSION="$CUDA_VERSION" \
   -v "$OFFLINE_DIR/download-wheels.sh:/usr/local/bin/download-wheels.sh:ro" \
   -v "$STAGING/wheels-input:/input:ro" \
   -v "$STAGING/bundle/wheels:/output/wheels" \
@@ -154,12 +199,8 @@ chmod +x "$STAGING/bundle/install.sh"
 # ---------------------------------------------------------------------------
 echo "==> Packing bundle into $OUTPUT"
 
-# Tar the bundle.
 tar -C "$STAGING/bundle" -czf "$STAGING/payload.tar.gz" .
 
-# Shell preamble. tail finds the line immediately after __PAYLOAD_BELOW__ and
-# pipes the rest of the file into tar. We exec install.sh from the extract dir
-# and exit before bash would parse the appended binary.
 PREAMBLE="$STAGING/preamble.sh"
 cat > "$PREAMBLE" <<'PREAMBLE_EOF'
 #!/bin/bash

--- a/tools/ci/mage-build/build-offline-installer.sh
+++ b/tools/ci/mage-build/build-offline-installer.sh
@@ -96,11 +96,18 @@ STAGING=$(mktemp -d -t mg-offline-build-XXXXXX)
 trap 'rm -rf "$STAGING"' EXIT
 
 echo "==> Staging bundle in $STAGING"
-mkdir -p "$STAGING/bundle/debs" "$STAGING/bundle/wheels"
+mkdir -p "$STAGING/bundle/debs" "$STAGING/bundle/wheels" "$STAGING/bundle/requirements"
 
 # Copy memgraph + mage debs into the bundle.
 cp -v "$MEMGRAPH_DEB" "$STAGING/bundle/debs/"
 cp -v "$MAGE_DEB" "$STAGING/bundle/debs/"
+
+# Bundle the requirements files install.sh will pass to `pip install -r`.
+# These are the same files we feed to `pip download` in the wheels pass.
+cp -v "$PROJECT_ROOT/mage/python/requirements.txt" \
+  "$STAGING/bundle/requirements/mage-requirements.txt"
+cp -v "$PROJECT_ROOT/src/auth/reference_modules/requirements.txt" \
+  "$STAGING/bundle/requirements/auth-module-requirements.txt"
 
 # Stage the input for the wheels container: requirements files + any prebuilt
 # wheels the caller wants us to include.

--- a/tools/ci/mage-build/build-offline-installer.sh
+++ b/tools/ci/mage-build/build-offline-installer.sh
@@ -117,9 +117,19 @@ SUFFIX=""
 [[ "$CUGRAPH" == "true" ]]               && SUFFIX="${SUFFIX}-cugraph"
 
 if [[ -z "$OUTPUT" ]]; then
-  base=$(basename "$MEMGRAPH_DEB")
-  # memgraph_<version>_<arch>.deb -> <version>
-  version=$(echo "$base" | sed -E 's/^memgraph_(.+)_[a-z0-9]+\.deb$/\1/')
+  if ! command -v dpkg-deb >/dev/null 2>&1; then
+    echo "Error: dpkg-deb not found on PATH; pass --output explicitly." >&2
+    exit 1
+  fi
+  version=$(dpkg-deb -f "$MEMGRAPH_DEB" Version)
+  if [[ -z "$version" ]]; then
+    echo "Error: could not read Version from $MEMGRAPH_DEB; pass --output explicitly." >&2
+    exit 1
+  fi
+  # The control file's Version is `<upstream>-<debian-revision>` (e.g.
+  # 3.10.2-1). Strip the trailing `-<revision>` to match the CI naming
+  # convention which uses just the upstream version.
+  version="${version%-*}"
   OUTPUT="$PWD/memgraph-mage-offline-${version}-${ARCH}${SUFFIX}.run"
 fi
 

--- a/tools/ci/mage-build/build-offline-installer.sh
+++ b/tools/ci/mage-build/build-offline-installer.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+set -euo pipefail
+# Build a self-contained .run installer for memgraph + MAGE on Ubuntu 24.04.
+#
+# The output is a single executable file containing:
+#   - memgraph .deb + memgraph-mage .deb
+#   - every apt dependency .deb needed on a vanilla Ubuntu 24.04 host
+#   - every Python wheel needed by mage and the auth modules
+#   - install.sh (offline installer logic)
+#
+# Build steps:
+#   1. Spin up a fresh ubuntu:24.04 container and run download-debs.sh to
+#      harvest .debs into a host-side staging dir.
+#   2. Spin up another fresh ubuntu:24.04 container and run download-wheels.sh
+#      to populate the wheels/ staging dir from PyPI + our S3 bucket + any
+#      pre-built wheels under mage/wheels (e.g. gssapi).
+#   3. Drop the two input .deb files (memgraph + memgraph-mage) and the
+#      install.sh script into the staging tree.
+#   4. tar the staging tree and prepend a tiny self-extracting shell preamble.
+#
+# Currently amd64 / CPU-only; --arch and --cuda are wired through for the
+# future but not yet validated.
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJECT_ROOT="$SCRIPT_DIR/../../.."
+OFFLINE_DIR="$SCRIPT_DIR/offline-installer"
+
+MEMGRAPH_DEB=""
+MAGE_DEB=""
+ARCH="amd64"
+CUDA="false"
+OUTPUT=""
+WHEELS_PREBUILT_DIR="$PROJECT_ROOT/mage/wheels"
+
+usage() {
+  cat <<EOF
+Usage: $0 --memgraph-deb PATH --mage-deb PATH [options]
+
+Required:
+  --memgraph-deb PATH     Path to memgraph_*.deb
+  --mage-deb PATH         Path to memgraph-mage_*.deb
+
+Options:
+  --arch amd64            Target architecture (only amd64 supported today)
+  --cuda true|false       Bundle GPU wheels (not supported yet; must be false)
+  --output PATH           Output .run file (default: memgraph-mage-offline-<version>-<arch>.run)
+  --wheels-dir PATH       Directory of pre-built host wheels to include
+                          (default: $PROJECT_ROOT/mage/wheels)
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --memgraph-deb) MEMGRAPH_DEB="$2"; shift 2 ;;
+    --mage-deb)     MAGE_DEB="$2";     shift 2 ;;
+    --arch)         ARCH="$2";         shift 2 ;;
+    --cuda)         CUDA="$2";         shift 2 ;;
+    --output)       OUTPUT="$2";       shift 2 ;;
+    --wheels-dir)   WHEELS_PREBUILT_DIR="$2"; shift 2 ;;
+    -h|--help)      usage; exit 0 ;;
+    *)              echo "Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [[ -z "$MEMGRAPH_DEB" || -z "$MAGE_DEB" ]]; then
+  echo "Error: --memgraph-deb and --mage-deb are required." >&2
+  usage
+  exit 1
+fi
+if [[ ! -f "$MEMGRAPH_DEB" ]]; then
+  echo "Error: memgraph deb not found at $MEMGRAPH_DEB" >&2
+  exit 1
+fi
+if [[ ! -f "$MAGE_DEB" ]]; then
+  echo "Error: mage deb not found at $MAGE_DEB" >&2
+  exit 1
+fi
+if [[ "$ARCH" != "amd64" ]]; then
+  echo "Error: only amd64 is supported in this version of the offline installer." >&2
+  exit 1
+fi
+if [[ "$CUDA" != "false" ]]; then
+  echo "Error: CUDA bundles are not supported yet (got --cuda $CUDA)." >&2
+  exit 1
+fi
+
+# Derive a default output filename from the memgraph deb version.
+if [[ -z "$OUTPUT" ]]; then
+  base=$(basename "$MEMGRAPH_DEB")
+  # memgraph_<version>_<arch>.deb -> <version>
+  version=$(echo "$base" | sed -E 's/^memgraph_(.+)_[a-z0-9]+\.deb$/\1/')
+  OUTPUT="$PWD/memgraph-mage-offline-${version}-${ARCH}.run"
+fi
+
+STAGING=$(mktemp -d -t mg-offline-build-XXXXXX)
+trap 'rm -rf "$STAGING"' EXIT
+
+echo "==> Staging bundle in $STAGING"
+mkdir -p "$STAGING/bundle/debs" "$STAGING/bundle/wheels"
+
+# Copy memgraph + mage debs into the bundle.
+cp -v "$MEMGRAPH_DEB" "$STAGING/bundle/debs/"
+cp -v "$MAGE_DEB" "$STAGING/bundle/debs/"
+
+# Stage the input for the wheels container: requirements files + any prebuilt
+# wheels the caller wants us to include.
+mkdir -p "$STAGING/wheels-input/wheels-prebuilt"
+cp -v "$PROJECT_ROOT/mage/python/requirements.txt" "$STAGING/wheels-input/requirements.txt"
+cp -v "$PROJECT_ROOT/src/auth/reference_modules/requirements.txt" "$STAGING/wheels-input/auth-module-requirements.txt"
+if [[ -d "$WHEELS_PREBUILT_DIR" ]]; then
+  shopt -s nullglob
+  for whl in "$WHEELS_PREBUILT_DIR"/*.whl; do
+    cp -v "$whl" "$STAGING/wheels-input/wheels-prebuilt/"
+  done
+  shopt -u nullglob
+fi
+
+# ---------------------------------------------------------------------------
+# Pass 1: download apt deps in a fresh ubuntu:24.04 container.
+# ---------------------------------------------------------------------------
+echo "==> Downloading apt dependencies (fresh ubuntu:24.04 container)"
+docker run --rm \
+  --platform "linux/$ARCH" \
+  -v "$OFFLINE_DIR/download-debs.sh:/usr/local/bin/download-debs.sh:ro" \
+  -v "$STAGING/bundle/debs:/output/debs" \
+  ubuntu:24.04 \
+  bash /usr/local/bin/download-debs.sh
+
+# ---------------------------------------------------------------------------
+# Pass 2: download python wheels in a fresh ubuntu:24.04 container.
+# ---------------------------------------------------------------------------
+echo "==> Downloading Python wheels (fresh ubuntu:24.04 container)"
+docker run --rm \
+  --platform "linux/$ARCH" \
+  -v "$OFFLINE_DIR/download-wheels.sh:/usr/local/bin/download-wheels.sh:ro" \
+  -v "$STAGING/wheels-input:/input:ro" \
+  -v "$STAGING/bundle/wheels:/output/wheels" \
+  ubuntu:24.04 \
+  bash /usr/local/bin/download-wheels.sh
+
+# Drop the installer script into the bundle root.
+cp -v "$OFFLINE_DIR/install.sh" "$STAGING/bundle/install.sh"
+chmod +x "$STAGING/bundle/install.sh"
+
+# ---------------------------------------------------------------------------
+# Assemble the self-extracting .run.
+# ---------------------------------------------------------------------------
+echo "==> Packing bundle into $OUTPUT"
+
+# Tar the bundle.
+tar -C "$STAGING/bundle" -czf "$STAGING/payload.tar.gz" .
+
+# Shell preamble. tail finds the line immediately after __PAYLOAD_BELOW__ and
+# pipes the rest of the file into tar. We exec install.sh from the extract dir
+# and exit before bash would parse the appended binary.
+PREAMBLE="$STAGING/preamble.sh"
+cat > "$PREAMBLE" <<'PREAMBLE_EOF'
+#!/bin/bash
+set -euo pipefail
+# Self-extracting installer for memgraph + MAGE on Ubuntu 24.04.
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "Error: this installer must be run as root (try: sudo $0)" >&2
+  exit 1
+fi
+
+EXTRACT_DIR=$(mktemp -d -t mg-offline-XXXXXX)
+trap 'rm -rf "$EXTRACT_DIR"' EXIT
+
+echo "==> Extracting bundle to $EXTRACT_DIR"
+ARCHIVE_LINE=$(awk '/^__PAYLOAD_BELOW__$/{print NR + 1; exit 0}' "$0")
+tail -n +"$ARCHIVE_LINE" "$0" | tar xz -C "$EXTRACT_DIR"
+
+BUNDLE_DIR="$EXTRACT_DIR" bash "$EXTRACT_DIR/install.sh" "$@"
+exit $?
+__PAYLOAD_BELOW__
+PREAMBLE_EOF
+
+cat "$PREAMBLE" "$STAGING/payload.tar.gz" > "$OUTPUT"
+chmod +x "$OUTPUT"
+
+size=$(du -h "$OUTPUT" | cut -f1)
+echo
+echo "Built offline installer: $OUTPUT ($size)"
+echo "Run on target: sudo $OUTPUT"

--- a/tools/ci/mage-build/offline-installer/download-debs.sh
+++ b/tools/ci/mage-build/offline-installer/download-debs.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -euo pipefail
+# Run me inside a clean ubuntu:24.04 container as root.
+# Downloads (without installing) every .deb required to bring a vanilla
+# ubuntu:24.04 host up to the level of dependencies that memgraph + MAGE need,
+# plus dpkg-dev so the installer can build a tiny local apt repo on the target.
+# Output: /output/debs/*.deb
+
+OUTPUT_DIR=${OUTPUT_DIR:-/output/debs}
+
+# Packages required at runtime by memgraph + MAGE on Ubuntu 24.04.
+# Sourced from:
+#   - mage/install_runtime_requirements.sh
+#   - tools/ci/mage-build/package/debian/control (memgraph-mage Depends)
+#   - release/CMakeLists.txt (memgraph CPACK_DEBIAN_PACKAGE_DEPENDS + shlibdeps)
+RUNTIME_PACKAGES=(
+  libcurl4
+  libpython3.12
+  openssl
+  python3
+  python3-pip
+  python3-setuptools
+  adduser
+  libgomp1
+  libaio1t64
+  libatomic1
+  libkrb5-3
+  libseccomp2
+  libxmlsec1
+  ca-certificates
+)
+
+# msodbcsql18 comes from the Microsoft apt source. Pull it in too so the
+# pyodbc-based modules work offline.
+MSSQL_PACKAGES=(
+  msodbcsql18
+  unixodbc-dev
+)
+
+# dpkg-dev gives us dpkg-scanpackages on the target so install.sh can build
+# a local apt repo from the bundled debs without needing network access.
+INSTALLER_TOOLS=(
+  dpkg-dev
+)
+
+mkdir -p "$OUTPUT_DIR"
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+
+# Microsoft repo for msodbcsql18.
+apt-get install -y --no-install-recommends curl gnupg
+curl -sSL -O https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb
+dpkg -i packages-microsoft-prod.deb
+rm -f packages-microsoft-prod.deb
+apt-get update
+
+# Pre-accept the EULA for msodbcsql18 so we can resolve it.
+echo "msodbcsql18 msodbcsql/ACCEPT_EULA boolean true" | debconf-set-selections
+
+# --download-only places .debs into /var/cache/apt/archives/. --reinstall makes
+# it also download already-installed base packages, which is what we want so
+# the bundle works on minimal hosts that may be missing some of them.
+apt-get clean
+apt-get install -y --no-install-recommends --download-only --reinstall \
+  "${RUNTIME_PACKAGES[@]}" \
+  "${MSSQL_PACKAGES[@]}" \
+  "${INSTALLER_TOOLS[@]}"
+
+cp -v /var/cache/apt/archives/*.deb "$OUTPUT_DIR/"
+
+echo "Downloaded $(ls "$OUTPUT_DIR" | wc -l) .deb files to $OUTPUT_DIR"

--- a/tools/ci/mage-build/offline-installer/download-debs.sh
+++ b/tools/ci/mage-build/offline-installer/download-debs.sh
@@ -31,6 +31,11 @@ RUNTIME_PACKAGES=(
   libseccomp2
   libxmlsec1
   ca-certificates
+  # libdw-dev is listed in memgraph-mage's debian control Depends. It pulls
+  # in libdw1 + headers; arguably the control file should depend on libdw1
+  # alone, but until that's fixed we have to ship the -dev package or
+  # memgraph-mage refuses to configure.
+  libdw-dev
 )
 
 # msodbcsql18 comes from the Microsoft apt source. Pull it in too so the

--- a/tools/ci/mage-build/offline-installer/download-debs.sh
+++ b/tools/ci/mage-build/offline-installer/download-debs.sh
@@ -31,13 +31,6 @@ RUNTIME_PACKAGES=(
   libseccomp2
   libxmlsec1
   ca-certificates
-  # libdw1t64 (the t64 transition rename of libdw1) is what memgraph-mage
-  # actually needs at runtime — the symbol lookup happens against
-  # /lib/.../libdw.so.1. The previous libdw-dev choice pulled the whole
-  # build toolchain (libc6-dev, zlib1g-dev, linux-libc-dev, libelf-dev,
-  # rpcsvc-proto, ...), and several of those have strict-version Depends on
-  # libc6/gcc-14-base, which caused offline installs to fail on hosts whose
-  # base image was slightly behind the build container.
   libdw1t64
 )
 

--- a/tools/ci/mage-build/offline-installer/download-debs.sh
+++ b/tools/ci/mage-build/offline-installer/download-debs.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 # Run me inside a clean ubuntu:24.04 container as root.
-# Downloads (without installing) every .deb required to bring a vanilla
-# ubuntu:24.04 host up to the level of dependencies that memgraph + MAGE need,
-# plus dpkg-dev so the installer can build a tiny local apt repo on the target.
+# Downloads (without installing on the target) every .deb required to bring a
+# vanilla ubuntu:24.04 host up to the level of dependencies that memgraph +
+# MAGE need. Strategy: snapshot installed packages before/after `apt install`,
+# then download .debs for the delta — that's the exact closure of packages
+# that need to ship in the bundle, including transitive deps that were
+# pre-installed in the build container and would otherwise be missing.
 # Output: /output/debs/*.deb
 
 OUTPUT_DIR=${OUTPUT_DIR:-/output/debs}
@@ -41,28 +44,48 @@ mkdir -p "$OUTPUT_DIR"
 
 export DEBIAN_FRONTEND=noninteractive
 
+# Snapshot the base ubuntu:24.04 package set BEFORE we install anything. The
+# delta after install is the exact set of packages a fresh ubuntu:24.04 host
+# is missing, which is what the offline installer must ship.
+BASE_PKGS=$(mktemp)
+dpkg-query -W -f '${Package}\n' | sort -u > "$BASE_PKGS"
+
 apt-get update
 
-# Microsoft repo for msodbcsql18. ca-certificates is required so curl can
-# verify the HTTPS cert on packages.microsoft.com — the ubuntu:24.04 base
-# image does not ship one.
-apt-get install -y --no-install-recommends curl gnupg ca-certificates
+# bootstrap deps that the script itself needs (not the target):
+#   - curl, gnupg, ca-certificates: fetch the microsoft apt source
+#   - apt-utils: silences the "delaying package configuration" debconf noise
+# These get rolled into the install closure; we strip them back out at the end.
+apt-get install -y --no-install-recommends curl gnupg ca-certificates apt-utils
+
+# Microsoft repo for msodbcsql18.
 curl -sSL -O https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb
 dpkg -i packages-microsoft-prod.deb
 rm -f packages-microsoft-prod.deb
 apt-get update
 
-# Pre-accept the EULA for msodbcsql18 so we can resolve it.
+# Pre-accept the EULA for msodbcsql18 so its postinst doesn't block.
 echo "msodbcsql18 msodbcsql/ACCEPT_EULA boolean true" | debconf-set-selections
+export ACCEPT_EULA=Y
 
-# --download-only places .debs into /var/cache/apt/archives/. --reinstall makes
-# it also download already-installed base packages, which is what we want so
-# the bundle works on minimal hosts that may be missing some of them.
-apt-get clean
-apt-get install -y --no-install-recommends --download-only --reinstall \
+# Actually install (not just download) so apt resolves the entire transitive
+# dependency closure. We collect the resulting deltas in a moment.
+apt-get install -y --no-install-recommends \
   "${RUNTIME_PACKAGES[@]}" \
   "${MSSQL_PACKAGES[@]}"
 
-cp -v /var/cache/apt/archives/*.deb "$OUTPUT_DIR/"
+# Compute the delta: packages installed *because of* our request, minus the
+# base image set. Exclude bootstrap packages (curl/gnupg/etc.) that we only
+# needed in this container; they're not required on the target.
+ALL_PKGS=$(mktemp)
+DELTA_PKGS=$(mktemp)
+EXCLUDE=$(mktemp)
+dpkg-query -W -f '${Package}\n' | sort -u > "$ALL_PKGS"
+printf '%s\n' curl gnupg apt-utils | sort -u > "$EXCLUDE"
+comm -23 <(comm -13 "$BASE_PKGS" "$ALL_PKGS") "$EXCLUDE" > "$DELTA_PKGS"
 
-echo "Downloaded $(ls "$OUTPUT_DIR" | wc -l) .deb files to $OUTPUT_DIR"
+echo "Downloading $(wc -l < "$DELTA_PKGS") packages to $OUTPUT_DIR"
+cd "$OUTPUT_DIR"
+xargs -a "$DELTA_PKGS" -n1 apt-get download
+
+echo "Downloaded $(ls "$OUTPUT_DIR" | wc -l) .deb files"

--- a/tools/ci/mage-build/offline-installer/download-debs.sh
+++ b/tools/ci/mage-build/offline-installer/download-debs.sh
@@ -49,8 +49,10 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 
-# Microsoft repo for msodbcsql18.
-apt-get install -y --no-install-recommends curl gnupg
+# Microsoft repo for msodbcsql18. ca-certificates is required so curl can
+# verify the HTTPS cert on packages.microsoft.com — the ubuntu:24.04 base
+# image does not ship one.
+apt-get install -y --no-install-recommends curl gnupg ca-certificates
 curl -sSL -O https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb
 dpkg -i packages-microsoft-prod.deb
 rm -f packages-microsoft-prod.deb

--- a/tools/ci/mage-build/offline-installer/download-debs.sh
+++ b/tools/ci/mage-build/offline-installer/download-debs.sh
@@ -31,11 +31,14 @@ RUNTIME_PACKAGES=(
   libseccomp2
   libxmlsec1
   ca-certificates
-  # libdw-dev is listed in memgraph-mage's debian control Depends. It pulls
-  # in libdw1 + headers; arguably the control file should depend on libdw1
-  # alone, but until that's fixed we have to ship the -dev package or
-  # memgraph-mage refuses to configure.
-  libdw-dev
+  # libdw1t64 (the t64 transition rename of libdw1) is what memgraph-mage
+  # actually needs at runtime — the symbol lookup happens against
+  # /lib/.../libdw.so.1. The previous libdw-dev choice pulled the whole
+  # build toolchain (libc6-dev, zlib1g-dev, linux-libc-dev, libelf-dev,
+  # rpcsvc-proto, ...), and several of those have strict-version Depends on
+  # libc6/gcc-14-base, which caused offline installs to fail on hosts whose
+  # base image was slightly behind the build container.
+  libdw1t64
 )
 
 # msodbcsql18 comes from the Microsoft apt source. Pull it in too so the
@@ -89,8 +92,36 @@ dpkg-query -W -f '${Package}\n' | sort -u > "$ALL_PKGS"
 printf '%s\n' curl gnupg apt-utils | sort -u > "$EXCLUDE"
 comm -23 <(comm -13 "$BASE_PKGS" "$ALL_PKGS") "$EXCLUDE" > "$DELTA_PKGS"
 
-echo "Downloading $(wc -l < "$DELTA_PKGS") packages to $OUTPUT_DIR"
+# The snapshot-diff captures packages that are *new* on the target relative
+# to ubuntu:24.04 base. But several debs in the delta carry strict-version
+# Depends on base packages (e.g. libatomic1 requires `gcc-14-base (= X.Y)`,
+# libc6-dev requires `libc6 (= X.Y)`). If the target's base image is a patch
+# release older than ours, those strict deps fail. Walk the strict-version
+# Depends/Pre-Depends of the delta — and any newly-added base packages —
+# until we reach a fixed point, then download everything we found.
+TO_SHIP=$(mktemp)
+PREV=$(mktemp)
+sort -u "$DELTA_PKGS" > "$TO_SHIP"
+while true; do
+  cp "$TO_SHIP" "$PREV"
+  # `dpkg-query -W -f 'Pre-Depends:\nDepends:'` returns both fields per pkg.
+  # Split on commas, keep only `(= version)` constraints (strict pins —
+  # the ones that fail when the target's base packages are slightly older),
+  # and extract the package name.
+  STRICT=$(xargs -a "$TO_SHIP" -r dpkg-query -W \
+             -f '${Pre-Depends}\n${Depends}\n' 2>/dev/null \
+           | tr ',' '\n' \
+           | grep -E '\([[:space:]]*=' \
+           | sed -E 's/^[[:space:]]*([A-Za-z0-9._+-]+).*/\1/' \
+           | sort -u)
+  printf '%s\n' "$STRICT" | sort -u | grep -v '^$' \
+    | cat - "$TO_SHIP" | sort -u > "$TO_SHIP.new"
+  mv "$TO_SHIP.new" "$TO_SHIP"
+  cmp -s "$PREV" "$TO_SHIP" && break
+done
+
+echo "Downloading $(wc -l < "$TO_SHIP") packages to $OUTPUT_DIR (incl. strict-version base deps)"
 cd "$OUTPUT_DIR"
-xargs -a "$DELTA_PKGS" -n1 apt-get download
+xargs -a "$TO_SHIP" -n1 apt-get download
 
 echo "Downloaded $(ls "$OUTPUT_DIR" | wc -l) .deb files"

--- a/tools/ci/mage-build/offline-installer/download-debs.sh
+++ b/tools/ci/mage-build/offline-installer/download-debs.sh
@@ -37,12 +37,6 @@ MSSQL_PACKAGES=(
   unixodbc-dev
 )
 
-# dpkg-dev gives us dpkg-scanpackages on the target so install.sh can build
-# a local apt repo from the bundled debs without needing network access.
-INSTALLER_TOOLS=(
-  dpkg-dev
-)
-
 mkdir -p "$OUTPUT_DIR"
 
 export DEBIAN_FRONTEND=noninteractive
@@ -67,8 +61,7 @@ echo "msodbcsql18 msodbcsql/ACCEPT_EULA boolean true" | debconf-set-selections
 apt-get clean
 apt-get install -y --no-install-recommends --download-only --reinstall \
   "${RUNTIME_PACKAGES[@]}" \
-  "${MSSQL_PACKAGES[@]}" \
-  "${INSTALLER_TOOLS[@]}"
+  "${MSSQL_PACKAGES[@]}"
 
 cp -v /var/cache/apt/archives/*.deb "$OUTPUT_DIR/"
 

--- a/tools/ci/mage-build/offline-installer/download-wheels.sh
+++ b/tools/ci/mage-build/offline-installer/download-wheels.sh
@@ -27,6 +27,20 @@ apt-get install -y --no-install-recommends \
 
 export PIP_BREAK_SYSTEM_PACKAGES=1
 
+# Copy any prebuilt wheels supplied by the host (gssapi is built by the
+# build-gssapi mgbuild subcommand and lives in mage/wheels/). They must land
+# in $OUTPUT_DIR *before* pip download runs — pip checks the dest dir for an
+# existing wheel that satisfies the requirement and skips fetching it, which
+# is how we avoid pip trying to build gssapi from its sdist (it has no PyPI
+# wheel and the build needs krb5-config + libkrb5-dev).
+if [[ -d "$INPUT_DIR/wheels-prebuilt" ]]; then
+  shopt -s nullglob
+  for whl in "$INPUT_DIR/wheels-prebuilt"/*.whl; do
+    cp -v "$whl" "$OUTPUT_DIR/"
+  done
+  shopt -u nullglob
+fi
+
 # --prefer-binary biases pip toward wheels over sdists so we don't bundle
 # anything that would need a compiler at install time on the target.
 PIP_FLAGS=(--dest "$OUTPUT_DIR" --prefer-binary)
@@ -58,15 +72,5 @@ for wheel in "${S3_WHEELS[@]}"; do
   echo "Fetching $wheel"
   curl -fsSL -o "$OUTPUT_DIR/$wheel" "$BASE_URL/$wheel"
 done
-
-# Copy any prebuilt wheels supplied by the host (gssapi is built by the
-# build-gssapi mgbuild subcommand and lives in mage/wheels/).
-if [[ -d "$INPUT_DIR/wheels-prebuilt" ]]; then
-  shopt -s nullglob
-  for whl in "$INPUT_DIR/wheels-prebuilt"/*.whl; do
-    cp -v "$whl" "$OUTPUT_DIR/"
-  done
-  shopt -u nullglob
-fi
 
 echo "Downloaded $(ls "$OUTPUT_DIR" | wc -l) wheels to $OUTPUT_DIR"

--- a/tools/ci/mage-build/offline-installer/download-wheels.sh
+++ b/tools/ci/mage-build/offline-installer/download-wheels.sh
@@ -41,30 +41,12 @@ if [[ -d "$INPUT_DIR/wheels-prebuilt" ]]; then
   shopt -u nullglob
 fi
 
-# --prefer-binary biases pip toward wheels over sdists so we don't bundle
-# anything that would need a compiler at install time on the target.
-# --find-links=$OUTPUT_DIR makes pip *resolve* against wheels we've already
-# placed there (e.g. the prebuilt gssapi wheel). Without it, pip only looks
-# at $OUTPUT_DIR to detect "already downloaded" by exact filename — which
-# fails for gssapi because PyPI ships only an sdist (gssapi-1.11.1.tar.gz)
-# whereas our prebuilt is gssapi-1.11.1-cp311-abi3-linux_x86_64.whl, and pip
-# would otherwise grab the sdist and try to build it (krb5-config missing).
-PIP_FLAGS=(--dest "$OUTPUT_DIR" --find-links "$OUTPUT_DIR" --prefer-binary)
-
-# Resolve mage's runtime requirements + transitive deps.
-python3 -m pip download \
-  "${PIP_FLAGS[@]}" \
-  --requirement "$INPUT_DIR/requirements.txt"
-
-# Resolve auth module requirements + transitive deps. Some overlap with the
-# above is fine — pip download just rewrites identical filenames.
-python3 -m pip download \
-  "${PIP_FLAGS[@]}" \
-  --requirement "$INPUT_DIR/auth-module-requirements.txt"
-
-# Special wheels hosted in our S3 bucket (PyG ecosystem + DGL). install_python_
-# requirements.sh fetches these as a fallback layer after the requirements.txt
-# pass — we bundle them directly so the offline target never reaches out.
+# Special wheels hosted in our S3 bucket (PyG ecosystem + DGL).
+# install_python_requirements.sh fetches these as a fallback layer after the
+# requirements.txt pass. We pull them down *before* `pip download` runs so
+# subsequent download passes can resolve their transitive deps too — e.g.
+# torch-geometric needs pyparsing, which is otherwise never pulled into the
+# wheel cache and bites at install time on the target.
 BASE_URL="https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/wheels/amd64"
 S3_WHEELS=(
   "torch_cluster-1.6.3-cp312-cp312-linux_x86_64.whl"
@@ -78,5 +60,35 @@ for wheel in "${S3_WHEELS[@]}"; do
   echo "Fetching $wheel"
   curl -fsSL -o "$OUTPUT_DIR/$wheel" "$BASE_URL/$wheel"
 done
+
+# --prefer-binary biases pip toward wheels over sdists so we don't bundle
+# anything that would need a compiler at install time on the target.
+# --find-links=$OUTPUT_DIR makes pip *resolve* against wheels we've already
+# placed there (e.g. the prebuilt gssapi + S3 PyG wheels). Without it, pip
+# only looks at $OUTPUT_DIR to detect "already downloaded" by exact filename
+# — which fails for gssapi because PyPI ships only an sdist
+# (gssapi-1.11.1.tar.gz) whereas our prebuilt is
+# gssapi-1.11.1-cp311-abi3-linux_x86_64.whl, and pip would otherwise grab the
+# sdist and try to build it (krb5-config missing).
+PIP_FLAGS=(--dest "$OUTPUT_DIR" --find-links "$OUTPUT_DIR" --prefer-binary)
+
+# Resolve mage's runtime requirements + transitive deps.
+python3 -m pip download \
+  "${PIP_FLAGS[@]}" \
+  --requirement "$INPUT_DIR/requirements.txt"
+
+# Resolve auth module requirements + transitive deps. Some overlap with the
+# above is fine — pip download just rewrites identical filenames.
+python3 -m pip download \
+  "${PIP_FLAGS[@]}" \
+  --requirement "$INPUT_DIR/auth-module-requirements.txt"
+
+# Explicitly resolve the PyG/DGL extras now so their transitive deps land in
+# the cache. They're already in $OUTPUT_DIR from the curl loop above, so pip
+# picks those wheels via --find-links and only downloads anything missing
+# (pyparsing for torch-geometric, etc.).
+python3 -m pip download \
+  "${PIP_FLAGS[@]}" \
+  torch-cluster torch-geometric torch-scatter torch-sparse torch-spline-conv dgl
 
 echo "Downloaded $(ls "$OUTPUT_DIR" | wc -l) wheels to $OUTPUT_DIR"

--- a/tools/ci/mage-build/offline-installer/download-wheels.sh
+++ b/tools/ci/mage-build/offline-installer/download-wheels.sh
@@ -2,21 +2,37 @@
 set -euo pipefail
 # Run me inside a clean ubuntu:24.04 container as root.
 # Downloads every Python wheel needed by MAGE + the memgraph auth module into
-# /output/wheels/. amd64 / CPU-only.
+# /output/wheels/. Mirrors the wheel-selection logic in
+# mage/install_python_requirements.sh.
 #
-# Inputs (bind-mounted into the container):
-#   /input/requirements.txt           — mage/python/requirements.txt
+# Inputs (env vars):
+#   ARCH         amd64 or arm64 (default amd64)
+#   CUDA         true|false (default false; CUDA only valid for amd64)
+#   CUDA_VERSION CUDA version for the S3 wheel path (default 13.0)
+#
+# Inputs (bind-mounted):
+#   /input/requirements.txt              — mage's requirements file
+#                                          (gpu file when CUDA=true, else cpu)
 #   /input/auth-module-requirements.txt — src/auth/reference_modules/requirements.txt
-#   /input/wheels-prebuilt/           — wheels already produced on the host
-#                                       (gssapi etc., copied through verbatim)
+#   /input/wheels-prebuilt/             — wheels already produced on the host
+#                                         (gssapi etc., copied through verbatim)
 # Output:
 #   /output/wheels/*.whl
-#
-# Mirrors the CPU/amd64 branch of mage/install_python_requirements.sh — same
-# torch / torch_geometric / dgl wheels from S3, same auth-module requirements.
 
 OUTPUT_DIR=${OUTPUT_DIR:-/output/wheels}
 INPUT_DIR=${INPUT_DIR:-/input}
+ARCH=${ARCH:-amd64}
+CUDA=${CUDA:-false}
+CUDA_VERSION=${CUDA_VERSION:-13.0}
+
+case "$ARCH" in
+  amd64|arm64) ;;
+  *) echo "Error: ARCH must be amd64 or arm64 (got $ARCH)" >&2; exit 1 ;;
+esac
+if [[ "$CUDA" == "true" && "$ARCH" != "amd64" ]]; then
+  echo "Error: CUDA wheels are only published for amd64 (got ARCH=$ARCH)" >&2
+  exit 1
+fi
 
 mkdir -p "$OUTPUT_DIR"
 
@@ -27,9 +43,8 @@ apt-get install -y --no-install-recommends \
 
 export PIP_BREAK_SYSTEM_PACKAGES=1
 
-# Copy any prebuilt wheels supplied by the host (gssapi is built by the
-# build-gssapi mgbuild subcommand and lives in mage/wheels/). They must land
-# in $OUTPUT_DIR *before* pip download runs — pip checks the dest dir for an
+# Copy prebuilt host wheels first (gssapi etc.). They must land in
+# $OUTPUT_DIR before `pip download` runs — pip checks the dest dir for an
 # existing wheel that satisfies the requirement and skips fetching it, which
 # is how we avoid pip trying to build gssapi from its sdist (it has no PyPI
 # wheel and the build needs krb5-config + libkrb5-dev).
@@ -41,23 +56,37 @@ if [[ -d "$INPUT_DIR/wheels-prebuilt" ]]; then
   shopt -u nullglob
 fi
 
-# Special wheels hosted in our S3 bucket (PyG ecosystem + DGL).
-# install_python_requirements.sh fetches these as a fallback layer after the
-# requirements.txt pass. We pull them down *before* `pip download` runs so
-# subsequent download passes can resolve their transitive deps too — e.g.
-# torch-geometric needs pyparsing, which is otherwise never pulled into the
-# wheel cache and bites at install time on the target.
-BASE_URL="https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/wheels/amd64"
+# S3 wheel paths and filename suffixes mirror mage/install_python_requirements.sh:
+#   arm64                 -> wheels/arm64/                   + linux_aarch64 tag
+#   amd64 + CUDA=false    -> wheels/amd64/                   + linux_x86_64 tag
+#   amd64 + CUDA=true     -> wheels/cuda-${CUDA_VERSION}/    + linux_x86_64 tag
+BASE_URL="https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/wheels"
+if [[ "$ARCH" == "arm64" ]]; then
+  BASE_URL="${BASE_URL}/arm64"
+  TORCH_TAG="linux_aarch64"
+  DGL_TAG="linux_aarch64"
+elif [[ "$CUDA" == "true" ]]; then
+  BASE_URL="${BASE_URL}/cuda-${CUDA_VERSION}"
+  TORCH_TAG="linux_x86_64"
+  DGL_TAG="linux_x86_64"
+else
+  BASE_URL="${BASE_URL}/amd64"
+  TORCH_TAG="linux_x86_64"
+  DGL_TAG="linux_x86_64"
+fi
+
+# Pull S3 wheels down first so subsequent `pip download` passes can resolve
+# their transitive deps too (e.g. torch-geometric needs pyparsing).
 S3_WHEELS=(
-  "torch_cluster-1.6.3-cp312-cp312-linux_x86_64.whl"
+  "torch_cluster-1.6.3-cp312-cp312-${TORCH_TAG}.whl"
   "torch_geometric-2.8.0-py3-none-any.whl"
-  "torch_scatter-2.1.2-cp312-cp312-linux_x86_64.whl"
-  "torch_sparse-0.6.18-cp312-cp312-linux_x86_64.whl"
-  "torch_spline_conv-1.2.2-cp312-cp312-linux_x86_64.whl"
-  "dgl-2.5-cp312-cp312-linux_x86_64.whl"
+  "torch_scatter-2.1.2-cp312-cp312-${TORCH_TAG}.whl"
+  "torch_sparse-0.6.18-cp312-cp312-${TORCH_TAG}.whl"
+  "torch_spline_conv-1.2.2-cp312-cp312-${TORCH_TAG}.whl"
+  "dgl-2.5-cp312-cp312-${DGL_TAG}.whl"
 )
 for wheel in "${S3_WHEELS[@]}"; do
-  echo "Fetching $wheel"
+  echo "Fetching $BASE_URL/$wheel"
   curl -fsSL -o "$OUTPUT_DIR/$wheel" "$BASE_URL/$wheel"
 done
 

--- a/tools/ci/mage-build/offline-installer/download-wheels.sh
+++ b/tools/ci/mage-build/offline-installer/download-wheels.sh
@@ -79,6 +79,12 @@ fi
 # pass below so we never end up with two versions of the same package in the
 # cache (e.g. pip preferring a newer PyPI wheel and `pip install` later
 # picking that over the S3 one we tested with).
+#
+# IMPORTANT: keep these in sync with the URLs in
+# mage/install_python_requirements.sh. The custom PyG/DGL wheels are hosted in
+# our S3 bucket (not on PyPI), so both scripts have to agree on which version
+# to fetch — there's no upstream registry to derive a single answer from. Any
+# version bump here must be mirrored there and vice versa.
 TORCH_CLUSTER_VERSION="1.6.3"
 TORCH_GEOMETRIC_VERSION="2.8.0"
 TORCH_SCATTER_VERSION="2.1.2"

--- a/tools/ci/mage-build/offline-installer/download-wheels.sh
+++ b/tools/ci/mage-build/offline-installer/download-wheels.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -euo pipefail
+# Run me inside a clean ubuntu:24.04 container as root.
+# Downloads every Python wheel needed by MAGE + the memgraph auth module into
+# /output/wheels/. amd64 / CPU-only.
+#
+# Inputs (bind-mounted into the container):
+#   /input/requirements.txt           — mage/python/requirements.txt
+#   /input/auth-module-requirements.txt — src/auth/reference_modules/requirements.txt
+#   /input/wheels-prebuilt/           — wheels already produced on the host
+#                                       (gssapi etc., copied through verbatim)
+# Output:
+#   /output/wheels/*.whl
+#
+# Mirrors the CPU/amd64 branch of mage/install_python_requirements.sh — same
+# torch / torch_geometric / dgl wheels from S3, same auth-module requirements.
+
+OUTPUT_DIR=${OUTPUT_DIR:-/output/wheels}
+INPUT_DIR=${INPUT_DIR:-/input}
+
+mkdir -p "$OUTPUT_DIR"
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y --no-install-recommends \
+  python3 python3-pip curl ca-certificates
+
+export PIP_BREAK_SYSTEM_PACKAGES=1
+
+# --prefer-binary biases pip toward wheels over sdists so we don't bundle
+# anything that would need a compiler at install time on the target.
+PIP_FLAGS=(--dest "$OUTPUT_DIR" --prefer-binary)
+
+# Resolve mage's runtime requirements + transitive deps.
+python3 -m pip download \
+  "${PIP_FLAGS[@]}" \
+  --requirement "$INPUT_DIR/requirements.txt"
+
+# Resolve auth module requirements + transitive deps. Some overlap with the
+# above is fine — pip download just rewrites identical filenames.
+python3 -m pip download \
+  "${PIP_FLAGS[@]}" \
+  --requirement "$INPUT_DIR/auth-module-requirements.txt"
+
+# Special wheels hosted in our S3 bucket (PyG ecosystem + DGL). install_python_
+# requirements.sh fetches these as a fallback layer after the requirements.txt
+# pass — we bundle them directly so the offline target never reaches out.
+BASE_URL="https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/wheels/amd64"
+S3_WHEELS=(
+  "torch_cluster-1.6.3-cp312-cp312-linux_x86_64.whl"
+  "torch_geometric-2.8.0-py3-none-any.whl"
+  "torch_scatter-2.1.2-cp312-cp312-linux_x86_64.whl"
+  "torch_sparse-0.6.18-cp312-cp312-linux_x86_64.whl"
+  "torch_spline_conv-1.2.2-cp312-cp312-linux_x86_64.whl"
+  "dgl-2.5-cp312-cp312-linux_x86_64.whl"
+)
+for wheel in "${S3_WHEELS[@]}"; do
+  echo "Fetching $wheel"
+  curl -fsSL -o "$OUTPUT_DIR/$wheel" "$BASE_URL/$wheel"
+done
+
+# Copy any prebuilt wheels supplied by the host (gssapi is built by the
+# build-gssapi mgbuild subcommand and lives in mage/wheels/).
+if [[ -d "$INPUT_DIR/wheels-prebuilt" ]]; then
+  shopt -s nullglob
+  for whl in "$INPUT_DIR/wheels-prebuilt"/*.whl; do
+    cp -v "$whl" "$OUTPUT_DIR/"
+  done
+  shopt -u nullglob
+fi
+
+echo "Downloaded $(ls "$OUTPUT_DIR" | wc -l) wheels to $OUTPUT_DIR"

--- a/tools/ci/mage-build/offline-installer/download-wheels.sh
+++ b/tools/ci/mage-build/offline-installer/download-wheels.sh
@@ -75,15 +75,26 @@ else
   DGL_TAG="linux_x86_64"
 fi
 
+# Pinned PyG/DGL versions — shared between the S3 fetch and the `pip download`
+# pass below so we never end up with two versions of the same package in the
+# cache (e.g. pip preferring a newer PyPI wheel and `pip install` later
+# picking that over the S3 one we tested with).
+TORCH_CLUSTER_VERSION="1.6.3"
+TORCH_GEOMETRIC_VERSION="2.8.0"
+TORCH_SCATTER_VERSION="2.1.2"
+TORCH_SPARSE_VERSION="0.6.18"
+TORCH_SPLINE_CONV_VERSION="1.2.2"
+DGL_VERSION="2.5"
+
 # Pull S3 wheels down first so subsequent `pip download` passes can resolve
 # their transitive deps too (e.g. torch-geometric needs pyparsing).
 S3_WHEELS=(
-  "torch_cluster-1.6.3-cp312-cp312-${TORCH_TAG}.whl"
-  "torch_geometric-2.8.0-py3-none-any.whl"
-  "torch_scatter-2.1.2-cp312-cp312-${TORCH_TAG}.whl"
-  "torch_sparse-0.6.18-cp312-cp312-${TORCH_TAG}.whl"
-  "torch_spline_conv-1.2.2-cp312-cp312-${TORCH_TAG}.whl"
-  "dgl-2.5-cp312-cp312-${DGL_TAG}.whl"
+  "torch_cluster-${TORCH_CLUSTER_VERSION}-cp312-cp312-${TORCH_TAG}.whl"
+  "torch_geometric-${TORCH_GEOMETRIC_VERSION}-py3-none-any.whl"
+  "torch_scatter-${TORCH_SCATTER_VERSION}-cp312-cp312-${TORCH_TAG}.whl"
+  "torch_sparse-${TORCH_SPARSE_VERSION}-cp312-cp312-${TORCH_TAG}.whl"
+  "torch_spline_conv-${TORCH_SPLINE_CONV_VERSION}-cp312-cp312-${TORCH_TAG}.whl"
+  "dgl-${DGL_VERSION}-cp312-cp312-${DGL_TAG}.whl"
 )
 for wheel in "${S3_WHEELS[@]}"; do
   echo "Fetching $BASE_URL/$wheel"
@@ -113,11 +124,17 @@ python3 -m pip download \
   --requirement "$INPUT_DIR/auth-module-requirements.txt"
 
 # Explicitly resolve the PyG/DGL extras now so their transitive deps land in
-# the cache. They're already in $OUTPUT_DIR from the curl loop above, so pip
-# picks those wheels via --find-links and only downloads anything missing
-# (pyparsing for torch-geometric, etc.).
+# the cache. They're already in $OUTPUT_DIR from the curl loop above; the
+# version pins here guarantee pip picks our exact S3 wheel rather than
+# downloading a newer PyPI wheel, which would leave two versions in the
+# cache and let `pip install` later choose the wrong one.
 python3 -m pip download \
   "${PIP_FLAGS[@]}" \
-  torch-cluster torch-geometric torch-scatter torch-sparse torch-spline-conv dgl
+  "torch-cluster==${TORCH_CLUSTER_VERSION}" \
+  "torch-geometric==${TORCH_GEOMETRIC_VERSION}" \
+  "torch-scatter==${TORCH_SCATTER_VERSION}" \
+  "torch-sparse==${TORCH_SPARSE_VERSION}" \
+  "torch-spline-conv==${TORCH_SPLINE_CONV_VERSION}" \
+  "dgl==${DGL_VERSION}"
 
 echo "Downloaded $(ls "$OUTPUT_DIR" | wc -l) wheels to $OUTPUT_DIR"

--- a/tools/ci/mage-build/offline-installer/download-wheels.sh
+++ b/tools/ci/mage-build/offline-installer/download-wheels.sh
@@ -43,7 +43,13 @@ fi
 
 # --prefer-binary biases pip toward wheels over sdists so we don't bundle
 # anything that would need a compiler at install time on the target.
-PIP_FLAGS=(--dest "$OUTPUT_DIR" --prefer-binary)
+# --find-links=$OUTPUT_DIR makes pip *resolve* against wheels we've already
+# placed there (e.g. the prebuilt gssapi wheel). Without it, pip only looks
+# at $OUTPUT_DIR to detect "already downloaded" by exact filename — which
+# fails for gssapi because PyPI ships only an sdist (gssapi-1.11.1.tar.gz)
+# whereas our prebuilt is gssapi-1.11.1-cp311-abi3-linux_x86_64.whl, and pip
+# would otherwise grab the sdist and try to build it (krb5-config missing).
+PIP_FLAGS=(--dest "$OUTPUT_DIR" --find-links "$OUTPUT_DIR" --prefer-binary)
 
 # Resolve mage's runtime requirements + transitive deps.
 python3 -m pip download \

--- a/tools/ci/mage-build/offline-installer/install.sh
+++ b/tools/ci/mage-build/offline-installer/install.sh
@@ -47,6 +47,10 @@ export ACCEPT_EULA=Y
 # -> memgraph.deb in reusable_package_mage.yaml so the Dockerfile build
 # context can find it at a stable path). memgraph-mage keeps its versioned
 # filename. Exclude both forms here — they install in step 4.
+# nullglob makes the loop body skip entirely when the glob doesn't match
+# (instead of bash's default of iterating once with the literal pattern,
+# which would feed dpkg a bogus path).
+shopt -s nullglob
 APT_DEBS=()
 for deb in "$DEBS_DIR"/*.deb; do
   case "$(basename "$deb")" in
@@ -54,6 +58,12 @@ for deb in "$DEBS_DIR"/*.deb; do
     *) APT_DEBS+=("$deb") ;;
   esac
 done
+shopt -u nullglob
+
+if [[ ${#APT_DEBS[@]} -eq 0 ]]; then
+  echo "Error: no apt-dep .debs found in $DEBS_DIR — bundle is incomplete." >&2
+  exit 1
+fi
 
 for attempt in 1 2 3; do
   if dpkg -i "${APT_DEBS[@]}"; then

--- a/tools/ci/mage-build/offline-installer/install.sh
+++ b/tools/ci/mage-build/offline-installer/install.sh
@@ -43,10 +43,14 @@ export ACCEPT_EULA=Y
 # packages (notably python3) carry Pre-Depends that require their prereq to
 # be *configured*, not merely unpacked, before unpack can proceed. The
 # configure-then-retry loop converges within two or three rounds.
+# memgraph.deb arrives renamed by the workflow (mv memgraph_x.y.z_amd64.deb
+# -> memgraph.deb in reusable_package_mage.yaml so the Dockerfile build
+# context can find it at a stable path). memgraph-mage keeps its versioned
+# filename. Exclude both forms here — they install in step 4.
 APT_DEBS=()
 for deb in "$DEBS_DIR"/*.deb; do
   case "$(basename "$deb")" in
-    memgraph_*.deb|memgraph-mage_*.deb) continue ;;
+    memgraph.deb|memgraph_*.deb|memgraph-mage.deb|memgraph-mage_*.deb) continue ;;
     *) APT_DEBS+=("$deb") ;;
   esac
 done
@@ -132,15 +136,22 @@ su - memgraph -c "python3 -m pip install --no-cache-dir \
 # ---------------------------------------------------------------------------
 echo "==> Installing memgraph + memgraph-mage"
 
-MEMGRAPH_DEB=$(ls "$DEBS_DIR"/memgraph_*.deb 2>/dev/null | head -1 || true)
-MAGE_DEB=$(ls "$DEBS_DIR"/memgraph-mage_*.deb 2>/dev/null | head -1 || true)
+# Accept both filename forms (see step-1 comment).
+MEMGRAPH_DEB=""
+for candidate in "$DEBS_DIR"/memgraph.deb "$DEBS_DIR"/memgraph_*.deb; do
+  if [[ -f "$candidate" ]]; then MEMGRAPH_DEB="$candidate"; break; fi
+done
+MAGE_DEB=""
+for candidate in "$DEBS_DIR"/memgraph-mage.deb "$DEBS_DIR"/memgraph-mage_*.deb; do
+  if [[ -f "$candidate" ]]; then MAGE_DEB="$candidate"; break; fi
+done
 
 if [[ -z "$MEMGRAPH_DEB" ]]; then
-  echo "Error: no memgraph_*.deb found in $DEBS_DIR" >&2
+  echo "Error: no memgraph .deb found in $DEBS_DIR (expected memgraph.deb or memgraph_*.deb)" >&2
   exit 1
 fi
 if [[ -z "$MAGE_DEB" ]]; then
-  echo "Error: no memgraph-mage_*.deb found in $DEBS_DIR" >&2
+  echo "Error: no memgraph-mage .deb found in $DEBS_DIR (expected memgraph-mage.deb or memgraph-mage_*.deb)" >&2
   exit 1
 fi
 

--- a/tools/ci/mage-build/offline-installer/install.sh
+++ b/tools/ci/mage-build/offline-installer/install.sh
@@ -55,7 +55,12 @@ for attempt in 1 2 3; do
     break
   fi
   echo "==> dpkg pass $attempt left packages half-installed, running --configure -a"
-  dpkg --configure -a
+  # `|| true` is critical here: the configure pass *will* fail until enough
+  # packages are unpacked (e.g. python3-pip can't configure until python3 is
+  # there). We need to let the loop iterate so the next dpkg -i can unpack
+  # the packages whose Pre-Depends are now satisfied. set -euo pipefail would
+  # otherwise kill the script after this line.
+  dpkg --configure -a || true
 done
 # Final verification: any half-configured package here is a real bug, not an
 # ordering glitch, so let the script die.
@@ -133,7 +138,7 @@ for attempt in 1 2 3; do
   if dpkg -i "$MEMGRAPH_DEB" "$MAGE_DEB"; then
     break
   fi
-  dpkg --configure -a
+  dpkg --configure -a || true
 done
 dpkg --configure -a
 

--- a/tools/ci/mage-build/offline-installer/install.sh
+++ b/tools/ci/mage-build/offline-installer/install.sh
@@ -155,6 +155,14 @@ if [[ -z "$MAGE_DEB" ]]; then
   exit 1
 fi
 
+# MEMGRAPH_OFFLINE_INSTALL=1 propagates into the postinst environment and
+# tells it to tolerate install_python_requirements.sh failing (it tries to
+# curl/pip-install from the internet, which doesn't work offline — but the
+# wheels are already installed by step 3). Without this env var the postinst
+# treats the failure as hard so normal online apt/dpkg installs don't
+# silently leave MAGE broken.
+export MEMGRAPH_OFFLINE_INSTALL=1
+
 # All Depends: from these debs (openssl, python3, libcurl4, etc.) were
 # already installed and configured in step 1. memgraph-mage Depends: memgraph
 # so install order matters; loop with --configure -a between passes in case

--- a/tools/ci/mage-build/offline-installer/install.sh
+++ b/tools/ci/mage-build/offline-installer/install.sh
@@ -27,66 +27,29 @@ fi
 export DEBIAN_FRONTEND=noninteractive
 
 # ---------------------------------------------------------------------------
-# 1. Install apt dependencies from a temporary local apt repository.
+# 1. Install apt dependencies directly from the bundled .deb files.
 # ---------------------------------------------------------------------------
 echo "==> Installing apt dependencies from bundled .deb files"
 
-# dpkg-scanpackages lives in dpkg-dev; we bundle dpkg-dev itself. Install it
-# with dpkg first so we can scan the rest into a local Packages index.
-# (Two passes — dpkg doesn't topo-sort across a single -i call.)
-dpkg -i "$DEBS_DIR"/dpkg-dev*.deb "$DEBS_DIR"/libdpkg-perl*.deb 2>/dev/null || true
-dpkg -i "$DEBS_DIR"/dpkg-dev*.deb "$DEBS_DIR"/libdpkg-perl*.deb
-
-# Build the local repo index inside the bundle directory.
-(
-  cd "$DEBS_DIR"
-  dpkg-scanpackages --multiversion . /dev/null > Packages
-  gzip -9kf Packages
-)
-
-# Point apt at the local repo and only the local repo for the duration of the
-# install — this is how we guarantee zero network use. Save existing sources
-# so we can restore them when we're done.
-SOURCES_BACKUP="/etc/apt/sources.list.memgraph-offline.bak"
-SOURCES_D_BACKUP="/etc/apt/sources.list.d.memgraph-offline.bak"
-[[ -f /etc/apt/sources.list ]] && mv /etc/apt/sources.list "$SOURCES_BACKUP" || true
-[[ -d /etc/apt/sources.list.d ]] && mv /etc/apt/sources.list.d "$SOURCES_D_BACKUP" || true
-mkdir -p /etc/apt/sources.list.d
-echo "deb [trusted=yes] file:$DEBS_DIR ./" > /etc/apt/sources.list.d/memgraph-offline.list
-
-restore_apt_sources() {
-  rm -f /etc/apt/sources.list.d/memgraph-offline.list
-  rmdir /etc/apt/sources.list.d 2>/dev/null || true
-  [[ -d "$SOURCES_D_BACKUP" ]] && mv "$SOURCES_D_BACKUP" /etc/apt/sources.list.d || true
-  [[ -f "$SOURCES_BACKUP" ]] && mv "$SOURCES_BACKUP" /etc/apt/sources.list || true
-}
-trap restore_apt_sources EXIT
-
-apt-get -o Acquire::Check-Valid-Until=false update
-
-# Order matches mage/install_runtime_requirements.sh + the runtime control deps.
-# Don't list dpkg-dev again (already installed); list everything else.
-RUNTIME_PACKAGES=(
-  libcurl4
-  libpython3.12
-  openssl
-  python3
-  python3-pip
-  python3-setuptools
-  adduser
-  libgomp1
-  libaio1t64
-  libatomic1
-  libkrb5-3
-  libseccomp2
-  libxmlsec1
-  ca-certificates
-  msodbcsql18
-  unixodbc-dev
-)
-
+# Pre-accept the msodbcsql18 EULA before its postinst runs.
 echo "msodbcsql18 msodbcsql/ACCEPT_EULA boolean true" | debconf-set-selections
-ACCEPT_EULA=Y apt-get install -y --no-install-recommends "${RUNTIME_PACKAGES[@]}"
+export ACCEPT_EULA=Y
+
+# Install every apt dep deb in a single dpkg call so dpkg can resolve all
+# in-batch dependencies. We exclude the memgraph + memgraph-mage debs here —
+# they get installed in step 4 once the python wheels are in place. Two
+# passes settle any ordering issues (dpkg unpacks all then configures, but
+# transient configure failures clear once all packages are unpacked).
+APT_DEBS=()
+for deb in "$DEBS_DIR"/*.deb; do
+  case "$(basename "$deb")" in
+    memgraph_*.deb|memgraph-mage_*.deb) continue ;;
+    *) APT_DEBS+=("$deb") ;;
+  esac
+done
+
+dpkg -i "${APT_DEBS[@]}" 2>/dev/null || true
+dpkg -i "${APT_DEBS[@]}"
 
 # Match install_runtime_requirements.sh: provide the libaio.so.1 symlink some
 # of the python modules link against.
@@ -128,8 +91,7 @@ restore_pip_conf() {
   [[ -f "$PIP_CONF_BACKUP" ]] && mv "$PIP_CONF_BACKUP" /etc/pip.conf || true
 }
 
-# Compose with the apt restore trap.
-trap 'restore_pip_conf; restore_apt_sources' EXIT
+trap restore_pip_conf EXIT
 
 # Install every wheel in one shot. pip resolves the dep graph using the wheels
 # in $WHEELS_DIR and never reaches out to PyPI because of pip.conf above.
@@ -153,9 +115,11 @@ if [[ -z "$MAGE_DEB" ]]; then
   exit 1
 fi
 
-# Use the local apt repo so the memgraph + mage debs' Depends: lines resolve
-# without touching the network.
-apt-get install -y --no-install-recommends "$MEMGRAPH_DEB" "$MAGE_DEB"
+# All Depends: from these debs (openssl, python3, libcurl4, etc.) were
+# already installed in step 1, so dpkg has everything it needs in-batch.
+# Two passes for safety — memgraph-mage Depends: memgraph, so order matters.
+dpkg -i "$MEMGRAPH_DEB" "$MAGE_DEB" 2>/dev/null || true
+dpkg -i "$MEMGRAPH_DEB" "$MAGE_DEB"
 
 echo
 echo "Memgraph + MAGE installed successfully."

--- a/tools/ci/mage-build/offline-installer/install.sh
+++ b/tools/ci/mage-build/offline-installer/install.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 BUNDLE_DIR=${BUNDLE_DIR:-"$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"}
 DEBS_DIR="$BUNDLE_DIR/debs"
 WHEELS_DIR="$BUNDLE_DIR/wheels"
+REQS_DIR="$BUNDLE_DIR/requirements"
 
 if [[ "${EUID}" -ne 0 ]]; then
   echo "Error: install.sh must run as root (try: sudo ./memgraph-mage-offline.run)" >&2
@@ -108,10 +109,23 @@ restore_pip_conf() {
 
 trap restore_pip_conf EXIT
 
-# Install every wheel in one shot. pip resolves the dep graph using the wheels
-# in $WHEELS_DIR and never reaches out to PyPI because of pip.conf above.
-chown -R memgraph:memgraph "$WHEELS_DIR"
-su - memgraph -c "python3 -m pip install --no-cache-dir $WHEELS_DIR/*.whl"
+chown -R memgraph:memgraph "$WHEELS_DIR" "$REQS_DIR"
+
+# Install via the bundled requirements files (the same ones we used for
+# `pip download` at build time). pip resolves to one version per package
+# using the pins in these files; passing wheels directly via `pip install
+# *.whl` instead would fail because the wheel cache contains multiple
+# versions of some packages (e.g. cryptography 46 from auth-module pin +
+# cryptography 48 from oracledb's looser >=3.2.1 constraint).
+su - memgraph -c "python3 -m pip install --no-cache-dir \
+  -r $REQS_DIR/mage-requirements.txt \
+  -r $REQS_DIR/auth-module-requirements.txt"
+
+# Now the PyG / DGL extras that don't appear in any requirements file
+# (install_python_requirements.sh installs them by S3 URL). Resolved by
+# name from the wheel cache via pip.conf's find-links.
+su - memgraph -c "python3 -m pip install --no-cache-dir \
+  torch-cluster torch-geometric torch-scatter torch-sparse torch-spline-conv dgl"
 
 # ---------------------------------------------------------------------------
 # 4. Install memgraph and memgraph-mage debs.

--- a/tools/ci/mage-build/offline-installer/install.sh
+++ b/tools/ci/mage-build/offline-installer/install.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+set -euo pipefail
+# Installs Memgraph + MAGE on a vanilla Ubuntu 24.04 host with no network
+# access. Run as root after the self-extracting .run file has expanded the
+# bundle into BUNDLE_DIR.
+#
+# Bundle layout:
+#   debs/                — every .deb needed: apt deps, dpkg-dev, memgraph, memgraph-mage
+#   wheels/              — every .whl needed by mage + auth modules
+#   install.sh           — this script
+
+BUNDLE_DIR=${BUNDLE_DIR:-"$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"}
+DEBS_DIR="$BUNDLE_DIR/debs"
+WHEELS_DIR="$BUNDLE_DIR/wheels"
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "Error: install.sh must run as root (try: sudo ./memgraph-mage-offline.run)" >&2
+  exit 1
+fi
+
+. /etc/os-release 2>/dev/null || true
+if [[ "${ID:-}" != "ubuntu" || "${VERSION_ID:-}" != "24.04" ]]; then
+  echo "Warning: this installer targets Ubuntu 24.04, found ${ID:-unknown} ${VERSION_ID:-unknown}." >&2
+  echo "         Continuing, but results are unsupported." >&2
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+# ---------------------------------------------------------------------------
+# 1. Install apt dependencies from a temporary local apt repository.
+# ---------------------------------------------------------------------------
+echo "==> Installing apt dependencies from bundled .deb files"
+
+# dpkg-scanpackages lives in dpkg-dev; we bundle dpkg-dev itself. Install it
+# with dpkg first so we can scan the rest into a local Packages index.
+# (Two passes — dpkg doesn't topo-sort across a single -i call.)
+dpkg -i "$DEBS_DIR"/dpkg-dev*.deb "$DEBS_DIR"/libdpkg-perl*.deb 2>/dev/null || true
+dpkg -i "$DEBS_DIR"/dpkg-dev*.deb "$DEBS_DIR"/libdpkg-perl*.deb
+
+# Build the local repo index inside the bundle directory.
+(
+  cd "$DEBS_DIR"
+  dpkg-scanpackages --multiversion . /dev/null > Packages
+  gzip -9kf Packages
+)
+
+# Point apt at the local repo and only the local repo for the duration of the
+# install — this is how we guarantee zero network use. Save existing sources
+# so we can restore them when we're done.
+SOURCES_BACKUP="/etc/apt/sources.list.memgraph-offline.bak"
+SOURCES_D_BACKUP="/etc/apt/sources.list.d.memgraph-offline.bak"
+[[ -f /etc/apt/sources.list ]] && mv /etc/apt/sources.list "$SOURCES_BACKUP" || true
+[[ -d /etc/apt/sources.list.d ]] && mv /etc/apt/sources.list.d "$SOURCES_D_BACKUP" || true
+mkdir -p /etc/apt/sources.list.d
+echo "deb [trusted=yes] file:$DEBS_DIR ./" > /etc/apt/sources.list.d/memgraph-offline.list
+
+restore_apt_sources() {
+  rm -f /etc/apt/sources.list.d/memgraph-offline.list
+  rmdir /etc/apt/sources.list.d 2>/dev/null || true
+  [[ -d "$SOURCES_D_BACKUP" ]] && mv "$SOURCES_D_BACKUP" /etc/apt/sources.list.d || true
+  [[ -f "$SOURCES_BACKUP" ]] && mv "$SOURCES_BACKUP" /etc/apt/sources.list || true
+}
+trap restore_apt_sources EXIT
+
+apt-get -o Acquire::Check-Valid-Until=false update
+
+# Order matches mage/install_runtime_requirements.sh + the runtime control deps.
+# Don't list dpkg-dev again (already installed); list everything else.
+RUNTIME_PACKAGES=(
+  libcurl4
+  libpython3.12
+  openssl
+  python3
+  python3-pip
+  python3-setuptools
+  adduser
+  libgomp1
+  libaio1t64
+  libatomic1
+  libkrb5-3
+  libseccomp2
+  libxmlsec1
+  ca-certificates
+  msodbcsql18
+  unixodbc-dev
+)
+
+echo "msodbcsql18 msodbcsql/ACCEPT_EULA boolean true" | debconf-set-selections
+ACCEPT_EULA=Y apt-get install -y --no-install-recommends "${RUNTIME_PACKAGES[@]}"
+
+# Match install_runtime_requirements.sh: provide the libaio.so.1 symlink some
+# of the python modules link against.
+if [[ ! -e /usr/lib/x86_64-linux-gnu/libaio.so.1 \
+   && -e /usr/lib/x86_64-linux-gnu/libaio.so.1t64 ]]; then
+  ln -sv /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Create the memgraph user (mirrors Dockerfile.release).
+# ---------------------------------------------------------------------------
+echo "==> Creating memgraph user"
+if ! getent group memgraph >/dev/null; then
+  groupadd -g 103 memgraph
+fi
+if ! id memgraph >/dev/null 2>&1; then
+  useradd -u 101 -g memgraph -m -d /home/memgraph -s /bin/bash memgraph
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Install all Python wheels as the memgraph user, offline.
+# ---------------------------------------------------------------------------
+echo "==> Installing Python wheels into /home/memgraph/.local"
+
+# pip.conf locks pip into our local wheel directory for every user on the box
+# for the duration of step 3 + step 4 (the memgraph-mage postinst runs pip
+# install too — see mage/install_python_requirements.sh --deb-package).
+PIP_CONF_BACKUP="/etc/pip.conf.memgraph-offline.bak"
+[[ -f /etc/pip.conf ]] && mv /etc/pip.conf "$PIP_CONF_BACKUP" || true
+cat > /etc/pip.conf <<EOF
+[global]
+no-index = true
+find-links = $WHEELS_DIR
+break-system-packages = true
+EOF
+
+restore_pip_conf() {
+  rm -f /etc/pip.conf
+  [[ -f "$PIP_CONF_BACKUP" ]] && mv "$PIP_CONF_BACKUP" /etc/pip.conf || true
+}
+
+# Compose with the apt restore trap.
+trap 'restore_pip_conf; restore_apt_sources' EXIT
+
+# Install every wheel in one shot. pip resolves the dep graph using the wheels
+# in $WHEELS_DIR and never reaches out to PyPI because of pip.conf above.
+chown -R memgraph:memgraph "$WHEELS_DIR"
+su - memgraph -c "python3 -m pip install --no-cache-dir $WHEELS_DIR/*.whl"
+
+# ---------------------------------------------------------------------------
+# 4. Install memgraph and memgraph-mage debs.
+# ---------------------------------------------------------------------------
+echo "==> Installing memgraph + memgraph-mage"
+
+MEMGRAPH_DEB=$(ls "$DEBS_DIR"/memgraph_*.deb 2>/dev/null | head -1 || true)
+MAGE_DEB=$(ls "$DEBS_DIR"/memgraph-mage_*.deb 2>/dev/null | head -1 || true)
+
+if [[ -z "$MEMGRAPH_DEB" ]]; then
+  echo "Error: no memgraph_*.deb found in $DEBS_DIR" >&2
+  exit 1
+fi
+if [[ -z "$MAGE_DEB" ]]; then
+  echo "Error: no memgraph-mage_*.deb found in $DEBS_DIR" >&2
+  exit 1
+fi
+
+# Use the local apt repo so the memgraph + mage debs' Depends: lines resolve
+# without touching the network.
+apt-get install -y --no-install-recommends "$MEMGRAPH_DEB" "$MAGE_DEB"
+
+echo
+echo "Memgraph + MAGE installed successfully."
+echo "Start with: systemctl start memgraph"

--- a/tools/ci/mage-build/offline-installer/install.sh
+++ b/tools/ci/mage-build/offline-installer/install.sh
@@ -37,9 +37,11 @@ export ACCEPT_EULA=Y
 
 # Install every apt dep deb in a single dpkg call so dpkg can resolve all
 # in-batch dependencies. We exclude the memgraph + memgraph-mage debs here —
-# they get installed in step 4 once the python wheels are in place. Two
-# passes settle any ordering issues (dpkg unpacks all then configures, but
-# transient configure failures clear once all packages are unpacked).
+# they get installed in step 4 once the python wheels are in place. Multiple
+# passes with `dpkg --configure -a` between them are needed because some
+# packages (notably python3) carry Pre-Depends that require their prereq to
+# be *configured*, not merely unpacked, before unpack can proceed. The
+# configure-then-retry loop converges within two or three rounds.
 APT_DEBS=()
 for deb in "$DEBS_DIR"/*.deb; do
   case "$(basename "$deb")" in
@@ -48,8 +50,16 @@ for deb in "$DEBS_DIR"/*.deb; do
   esac
 done
 
-dpkg -i "${APT_DEBS[@]}" 2>/dev/null || true
-dpkg -i "${APT_DEBS[@]}"
+for attempt in 1 2 3; do
+  if dpkg -i "${APT_DEBS[@]}"; then
+    break
+  fi
+  echo "==> dpkg pass $attempt left packages half-installed, running --configure -a"
+  dpkg --configure -a
+done
+# Final verification: any half-configured package here is a real bug, not an
+# ordering glitch, so let the script die.
+dpkg --configure -a
 
 # Match install_runtime_requirements.sh: provide the libaio.so.1 symlink some
 # of the python modules link against.
@@ -116,10 +126,16 @@ if [[ -z "$MAGE_DEB" ]]; then
 fi
 
 # All Depends: from these debs (openssl, python3, libcurl4, etc.) were
-# already installed in step 1, so dpkg has everything it needs in-batch.
-# Two passes for safety — memgraph-mage Depends: memgraph, so order matters.
-dpkg -i "$MEMGRAPH_DEB" "$MAGE_DEB" 2>/dev/null || true
-dpkg -i "$MEMGRAPH_DEB" "$MAGE_DEB"
+# already installed and configured in step 1. memgraph-mage Depends: memgraph
+# so install order matters; loop with --configure -a between passes in case
+# of any Pre-Depends/ordering quirks (same pattern as step 1).
+for attempt in 1 2 3; do
+  if dpkg -i "$MEMGRAPH_DEB" "$MAGE_DEB"; then
+    break
+  fi
+  dpkg --configure -a
+done
+dpkg --configure -a
 
 echo
 echo "Memgraph + MAGE installed successfully."

--- a/tools/ci/mage-build/package/debian/control
+++ b/tools/ci/mage-build/package/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 4.6.0
 Package: memgraph-mage
 Architecture: @ARCH@
 Replaces: memgraph
-Depends: ${misc:Depends}, memgraph, libcurl4, libpython3.12, openssl, python3, python3-pip, python3-setuptools, adduser, libgomp1, libaio1t64, libatomic1, libdw-dev
+Depends: ${misc:Depends}, memgraph, libcurl4, libpython3.12, openssl, python3, python3-pip, python3-setuptools, adduser, libgomp1, libaio1t64, libatomic1, libdw1t64 | libdw1
 Description: Extra query modules for Memgraph
  Additional query modules for Memgraph, installed under
  /usr/lib/memgraph/query_modules/.

--- a/tools/ci/mage-build/package/debian/postinst
+++ b/tools/ci/mage-build/package/debian/postinst
@@ -7,17 +7,24 @@ case "$1" in
         CUDA=@CUDA@
         ARCH=@ARCH@
         # install_python_requirements.sh attempts to fetch torch/PyG/DGL wheels
-        # from the internet. In an offline install scenario the wheels are
-        # already on disk from the .run installer's wheel-install pass, so the
-        # network access fails (and `curl` may not even be present). Treat the
-        # script's failure as a warning so the deb still configures cleanly —
-        # the python deps are already installed, the script just can't verify
-        # them without network.
+        # from the internet. During an offline install (i.e. via the .run
+        # installer) the wheels are already on disk and the network call fails
+        # — but the python deps are still in place, so we want the postinst
+        # to succeed. The offline installer sets MEMGRAPH_OFFLINE_INSTALL=1
+        # before invoking dpkg, which propagates into the postinst env; in
+        # that mode we treat failure as a warning. For normal apt/dpkg
+        # installs the env var is unset and the failure remains hard so a
+        # genuine network/pip error doesn't silently leave MAGE broken.
         if ! su - memgraph -c "/usr/lib/memgraph/install_python_requirements.sh --deb-package --cuda $CUDA --arch $ARCH"; then
-            echo "WARNING: install_python_requirements.sh exited non-zero." >&2
-            echo "         This is expected during an offline install — the python deps were" >&2
-            echo "         installed by the offline installer. If you ran apt/dpkg directly," >&2
-            echo "         re-run with network access or ensure the wheels are pre-installed." >&2
+            if [ "${MEMGRAPH_OFFLINE_INSTALL:-}" = "1" ]; then
+                echo "WARNING: install_python_requirements.sh exited non-zero." >&2
+                echo "         Tolerated because MEMGRAPH_OFFLINE_INSTALL=1 — the python deps" >&2
+                echo "         were installed by the offline installer's wheel pass." >&2
+            else
+                echo "ERROR: install_python_requirements.sh failed." >&2
+                echo "       Check network connectivity and pip configuration, then retry." >&2
+                exit 1
+            fi
         fi
         # Only restart memgraph if systemd is actually running. /run/systemd/system
         # exists iff systemd is the active init system; it's absent in containers,

--- a/tools/ci/mage-build/package/debian/postinst
+++ b/tools/ci/mage-build/package/debian/postinst
@@ -6,7 +6,19 @@ case "$1" in
         # install requirements as user memgraph
         CUDA=@CUDA@
         ARCH=@ARCH@
-        su - memgraph -c "/usr/lib/memgraph/install_python_requirements.sh --deb-package --cuda $CUDA --arch $ARCH"
+        # install_python_requirements.sh attempts to fetch torch/PyG/DGL wheels
+        # from the internet. In an offline install scenario the wheels are
+        # already on disk from the .run installer's wheel-install pass, so the
+        # network access fails (and `curl` may not even be present). Treat the
+        # script's failure as a warning so the deb still configures cleanly —
+        # the python deps are already installed, the script just can't verify
+        # them without network.
+        if ! su - memgraph -c "/usr/lib/memgraph/install_python_requirements.sh --deb-package --cuda $CUDA --arch $ARCH"; then
+            echo "WARNING: install_python_requirements.sh exited non-zero." >&2
+            echo "         This is expected during an offline install — the python deps were" >&2
+            echo "         installed by the offline installer. If you ran apt/dpkg directly," >&2
+            echo "         re-run with network access or ensure the wheels are pre-installed." >&2
+        fi
         systemctl restart memgraph.service
     ;;
 esac

--- a/tools/ci/mage-build/package/debian/postinst
+++ b/tools/ci/mage-build/package/debian/postinst
@@ -19,7 +19,15 @@ case "$1" in
             echo "         installed by the offline installer. If you ran apt/dpkg directly," >&2
             echo "         re-run with network access or ensure the wheels are pre-installed." >&2
         fi
-        systemctl restart memgraph.service
+        # Only restart memgraph if systemd is actually running. /run/systemd/system
+        # exists iff systemd is the active init system; it's absent in containers,
+        # chroots, and minimal images. Without this check, `systemctl restart`
+        # exits 127 (command not found) on systemd-less hosts and the postinst
+        # fails, leaving the package half-configured. The user can restart
+        # memgraph by hand in those environments.
+        if [ -d /run/systemd/system ]; then
+            systemctl restart memgraph.service
+        fi
     ;;
 esac
 


### PR DESCRIPTION
Added an offline installer build for Memgraph + MAGE. 

The new build code should work for all existing variants of MAGE, but will only be used during the RC build for RelWithDebInfo on x86_64.

The resulting package is a `.run` file which contains all of the required DEB packages and Python wheels used by Memgraph +  MAGE on Ubuntu 24.04. To install, make it executable and run as root, e.g.

```bash
chmod +x memgraph-mage-offline-v3.10.1.run
sudo ./memgraph-mage-offline-v3.10.1.run
```

