### PR TITLE
Upgrade Python packages

### DIFF
--- a/init-dev
+++ b/init-dev
@@ -45,6 +45,6 @@ if [[ "$ci" == "false" ]]; then
   echo "Installing pre-commit hooks"
   export PIP_BREAK_SYSTEM_PACKAGES=1
   python3 -m pip install --upgrade pip
-  pip install pre-commit black==23.1.* isort==5.12.*
+  pip install pre-commit black==26.5.0 isort==5.12.*
   python3 -m pre_commit install
 fi

--- a/mage/python/requirements-gpu.txt
+++ b/mage/python/requirements-gpu.txt
@@ -26,4 +26,4 @@ setuptools==81.0.0  # maximum version that can be used until torchmetrics doesn'
 six==1.17.0
 torch==2.9.0
 torchmetrics==0.10.0
-litellm==1.83.7
+litellm==1.85.0

--- a/mage/python/requirements-gpu.txt
+++ b/mage/python/requirements-gpu.txt
@@ -3,7 +3,7 @@ boto3==1.36.23
 defusedxml==0.7.1
 duckdb==1.2.1
 elasticsearch==8.17.0
-filelock==3.19.1
+filelock==3.29.0
 gekko==1.2.1
 gensim==4.3.3
 gqlalchemy==1.8.0

--- a/mage/python/requirements.txt
+++ b/mage/python/requirements.txt
@@ -3,7 +3,7 @@ boto3==1.36.23
 defusedxml==0.7.1
 duckdb==1.2.1
 elasticsearch==8.17.0
-filelock==3.20.3
+filelock==3.29.0
 gekko==1.2.1
 gensim==4.3.3
 gqlalchemy==1.8.0

--- a/mage/python/requirements.txt
+++ b/mage/python/requirements.txt
@@ -28,4 +28,4 @@ six==1.17.0
 torch==2.9.0+cpu; platform_machine != "aarch64"
 torch==2.9.0; platform_machine == "aarch64"
 torchmetrics==0.10.0 # current implementation of node_classification module depends on version <= 0.10.0
-litellm==1.83.7
+litellm==1.85.0

--- a/mage/python/tests/requirements.txt
+++ b/mage/python/tests/requirements.txt
@@ -1,6 +1,6 @@
 pytest==8.3.4
 PyYAML==6.0.2
-black==24.10.0
+black==26.5.0
 flake8==7.1.1
 pymgclient==1.5.2
 pytest-pylint==0.21.0

--- a/mage/python/tests/requirements.txt
+++ b/mage/python/tests/requirements.txt
@@ -1,4 +1,4 @@
-pytest==8.3.4
+pytest==9.0.3
 PyYAML==6.0.2
 black==26.5.0
 flake8==7.1.1

--- a/src/auth/reference_modules/requirements.txt
+++ b/src/auth/reference_modules/requirements.txt
@@ -1,6 +1,6 @@
 cryptography==46.0.7
 PyJWT==2.12.1
-requests==2.32.5
+requests==2.34.2
 ldap3==2.6
 pyyaml==6.0.1
 python3-saml==1.16.0

--- a/tests/e2e/sso/test_self_signed_certificate.py
+++ b/tests/e2e/sso/test_self_signed_certificate.py
@@ -53,7 +53,9 @@ def generate_self_signed_cert():
         cert_path = os.path.join(tmpdir, "cert.pem")
         key_path = os.path.join(tmpdir, "key.pem")
 
-        # Generate self-signed certificate
+        # Generate self-signed certificate. The subjectAltName extension is
+        # required: urllib3 2.x no longer falls back to CommonName for
+        # hostname verification, so a cert with only CN=localhost is rejected.
         subprocess.run(
             [
                 "openssl",
@@ -70,6 +72,8 @@ def generate_self_signed_cert():
                 "-nodes",
                 "-subj",
                 "/CN=localhost",
+                "-addext",
+                "subjectAltName=DNS:localhost,IP:127.0.0.1",
             ],
             check=True,
             capture_output=True,

--- a/tests/query_modules/requirements.txt
+++ b/tests/query_modules/requirements.txt
@@ -1,6 +1,6 @@
 setuptools==80.9.0
 six==1.17.0
-pytest==7.3.2
+pytest==9.0.3
 numpy==1.26.4
 scipy==1.13.0
 networkx==2.5.1

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,7 +5,7 @@ cryptography==46.0.7
 faker==37.3.0
 gensim==4.3.3
 gqlalchemy==1.8.0
-idna==2.10
+idna==3.15
 kafka-python==2.0.2
 ldap3==2.6
 lxml==6.1.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -17,10 +17,10 @@ parse==1.18.0
 parse-type==0.5.2
 pulsar-client==3.5.0
 pyarrow==19.0.1
-PyJWT==2.10.1
+PyJWT==2.12.1
 pymgclient==1.5.2
 pyopenssl==26.0.0
-pytest==7.3.2
+pytest==9.0.3
 pytest-cov==6.0.0
 pytest-flake8==1.3.0
 python3-saml==1.16.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -26,7 +26,7 @@ pytest-flake8==1.3.0
 python3-saml==1.16.0
 pytz==2023.3
 pyyaml==6.0.1
-requests==2.32.2
+requests==2.34.2
 scipy==1.13.0
 setuptools==80.9.0
 six==1.17.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -30,5 +30,5 @@ requests==2.34.2
 scipy==1.13.0
 setuptools==80.9.0
 six==1.17.0
-urllib3==1.26.20
+urllib3==2.7.0
 xmlsec==1.3.16

--- a/tools/bench-graph-client/requirements.txt
+++ b/tools/bench-graph-client/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.25.1
+requests==2.34.2

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,6 +1,6 @@
 cycler==0.10.0
 matplotlib==2.0.2
-numpy==1.21
+numpy==1.22
 pyparsing==2.2.0
 python-dateutil==2.6.1
 pytz==2023.3


### PR DESCRIPTION
Upgraded some Python packages used during testing and in packaging. Added fix for OIDC test to set the SAN because the newer `urllib3` does not fallback to CN.
