### PR TITLE
Shutdown forces telemetry/license updates to abort

### DIFF
--- a/src/license/license_sender.cpp
+++ b/src/license/license_sender.cpp
@@ -55,7 +55,12 @@ LicenseInfoSender::LicenseInfoSender(std::string url, std::string uuid, std::str
       });
 }
 
-LicenseInfoSender::~LicenseInfoSender() { scheduler_.Stop(); }
+LicenseInfoSender::~LicenseInfoSender() { Stop(); }
+
+void LicenseInfoSender::Stop() {
+  abort_.store(true, std::memory_order_relaxed);
+  scheduler_.Stop();
+}
 
 void LicenseInfoSender::SendData() {
   nlohmann::json data = nlohmann::json::object();
@@ -85,7 +90,8 @@ void LicenseInfoSender::SendData() {
   }
   if (!requests::RequestPostJson(url_,
                                  data,
-                                 /* timeout_in_seconds = */ 2 * 60)) {
+                                 /* timeout_in_seconds = */ 2 * 60,
+                                 &abort_)) {
     spdlog::trace("Cannot send license information, enable {} availability!", url_);
   }
 }

--- a/src/license/license_sender.hpp
+++ b/src/license/license_sender.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <nlohmann/json_fwd.hpp>
@@ -36,6 +37,12 @@ class LicenseInfoSender final {
   LicenseInfoSender &operator=(LicenseInfoSender &&) noexcept = delete;
   ~LicenseInfoSender();
 
+  /**
+   * Signal the license sender to stop immediately.
+   * Call this during shutdown to prevent blocking.
+   */
+  void Stop();
+
  private:
   void SendData();
 
@@ -46,6 +53,8 @@ class LicenseInfoSender final {
 
   utils::Synchronized<std::optional<LicenseInfo>, utils::SpinLock> &license_info_;
   utils::Scheduler scheduler_;
+
+  std::atomic<bool> abort_{false};
 };
 
 }  // namespace memgraph::license

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -929,12 +929,11 @@ int main(int argc, char **argv) {
     telemetry->AddExceptionCollector();
     telemetry->Start();
   }
-  memgraph::license::LicenseInfoSender const license_info_sender(
-      telemetry_server,
-      memgraph::glue::run_id_,
-      machine_id,
-      memory_limit,
-      memgraph::license::global_license_checker.GetLicenseInfo());
+  memgraph::license::LicenseInfoSender license_info_sender(telemetry_server,
+                                                           memgraph::glue::run_id_,
+                                                           machine_id,
+                                                           memory_limit,
+                                                           memgraph::license::global_license_checker.GetLicenseInfo());
 
   memgraph::communication::websocket::SafeAuth websocket_auth{auth_.get()};
   memgraph::communication::websocket::Server websocket_server{
@@ -969,10 +968,23 @@ int main(int argc, char **argv) {
                       &interpreter_context_,
                       &dbms_handler,
                       &repl_state,
-                      &worker_pool_] {
+                      &worker_pool_,
+                      &license_info_sender,
+                      &telemetry] {
     // Server needs to be shutdown first and then the database. This prevents
     // a race condition when a transaction is accepted during server shutdown.
     spdlog::trace("Shutting down handler!");
+
+    // STOP LICENSE SENDER IMMEDIATELY
+    // Prevents blocking on license HTTP requests during shutdown
+    license_info_sender.Stop();
+
+    // STOP TELEMETRY IMMEDIATELY
+    // Prevents blocking on telemetry HTTP requests during shutdown
+    if (telemetry) {
+      telemetry->Stop();
+    }
+
     spdlog::info("Workers shutting down.");
     if (worker_pool_) worker_pool_->ShutDown();  // Workers can enqueue io tasks, so they need to be stopped first
     // Shutdown communication server

--- a/src/requests/requests.cpp
+++ b/src/requests/requests.cpp
@@ -87,11 +87,22 @@ auto DownloadProgressCb(void *clientp, curl_off_t dltotal, curl_off_t dlnow, cur
 
 size_t CurlWriteCallback(char * /*ptr*/, size_t /*size*/, size_t nmemb, void * /*userdata*/) { return nmemb; }
 
+// Progress callback for POST requests - checks per-request abort flag
+auto PostProgressCallback(void *clientp, curl_off_t /*dltotal*/, curl_off_t /*dlnow*/, curl_off_t /*ultotal*/,
+                          curl_off_t /*ulnow*/) -> int {
+  auto const *abort_flag = static_cast<std::atomic<bool> const *>(clientp);
+  if (abort_flag && abort_flag->load(std::memory_order_relaxed)) {
+    return 1;  // Return non-zero to abort transfer
+  }
+  return 0;  // Continue transfer
+}
+
 }  // namespace
 
 void Init() { curl_global_init(CURL_GLOBAL_ALL); }
 
-bool RequestPostJson(const std::string &url, const nlohmann::json &data, int timeout_in_seconds) {
+bool RequestPostJson(const std::string &url, const nlohmann::json &data, int timeout_in_seconds,
+                     std::atomic<bool> const *abort_flag) {
   CURL *curl = nullptr;
   CURLcode res = CURLE_UNSUPPORTED_PROTOCOL;
 
@@ -117,6 +128,11 @@ bool RequestPostJson(const std::string &url, const nlohmann::json &data, int tim
   curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 10);
   curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
   curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_in_seconds);
+
+  // Enable progress callback so an in-flight transfer can be aborted
+  curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+  curl_easy_setopt(curl, CURLOPT_XFERINFODATA, abort_flag);
+  curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, PostProgressCallback);
 
   res = curl_easy_perform(curl);
   curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);

--- a/src/requests/requests.hpp
+++ b/src/requests/requests.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <nlohmann/json_fwd.hpp>
@@ -37,9 +38,12 @@ void Init();
  * @param url url to which to send the request
  * @param data json payload
  * @param timeout the timeout that should be used when making the request
+ * @param abort_flag optional pointer to an atomic flag. If set and true, the
+ *        in-progress transfer will be aborted via the progress callback.
  * @return bool true if the request was successful, false otherwise.
  */
-bool RequestPostJson(const std::string &url, const nlohmann::json &data, int timeout_in_seconds = 10);
+bool RequestPostJson(const std::string &url, const nlohmann::json &data, int timeout_in_seconds = 10,
+                     std::atomic<bool> const *abort_flag = nullptr);
 
 /**
  * This functions sends a GET request to the given `url` and writes the response

--- a/src/telemetry/telemetry.cpp
+++ b/src/telemetry/telemetry.cpp
@@ -104,7 +104,8 @@ Telemetry::~Telemetry() noexcept {
     // would be aborted immediately because the flag is still set.
     abort_.store(false, std::memory_order_relaxed);
     CollectData(kEventShutdown);
-  } catch (...) {
+  } catch (const std::exception &e) {
+    spdlog::warn("Telemetry shutdown failure: {}", e.what());
   }
 }
 

--- a/src/telemetry/telemetry.cpp
+++ b/src/telemetry/telemetry.cpp
@@ -104,8 +104,8 @@ Telemetry::~Telemetry() noexcept {
     // would be aborted immediately because the flag is still set.
     abort_.store(false, std::memory_order_relaxed);
     CollectData(kEventShutdown);
-  } catch (const std::exception &e) {
-    spdlog::warn("Telemetry shutdown failure: {}", e.what());
+  } catch (...) {
+    (void)0;  // clang-tidy
   }
 }
 

--- a/src/telemetry/telemetry.cpp
+++ b/src/telemetry/telemetry.cpp
@@ -37,6 +37,8 @@
 
 namespace {
 constexpr auto kFirstShotAfter = std::chrono::seconds{60};
+constexpr auto kEventStartup = "startup";
+constexpr auto kEventShutdown = "shutdown";
 }  // namespace
 
 namespace memgraph::telemetry {
@@ -52,7 +54,7 @@ Telemetry::Telemetry(std::string url, std::filesystem::path storage_directory, s
       ssl_(ssl),
       send_every_n_(send_every_n),
       storage_(std::move(storage_directory)) {
-  StoreData("startup", utils::GetSystemInfo());
+  StoreData(kEventStartup, utils::GetSystemInfo());
   AddCollector("resources", [&, root_directory = std::move(root_directory)]() -> nlohmann::json {
     return GetResourceUsage(root_directory);
   });
@@ -101,7 +103,7 @@ Telemetry::~Telemetry() noexcept {
     // data (with the 10s timeout). Without this, the in-flight curl transfer
     // would be aborted immediately because the flag is still set.
     abort_.store(false, std::memory_order_relaxed);
-    CollectData("shutdown");
+    CollectData(kEventShutdown);
   } catch (...) {
   }
 }
@@ -168,9 +170,9 @@ void Telemetry::CollectData(const std::string &event) {
   } else {
     StoreData(event, data);
   }
-  if (num_ % send_every_n_ == 0 || event == "shutdown") {
+  if (num_ % send_every_n_ == 0 || event == kEventShutdown) {
     // Use shorter timeout for shutdown event
-    int const timeout = (event == "shutdown") ? 10 : (2 * 60);
+    int const timeout = (event == kEventShutdown) ? 10 : (2 * 60);
     SendData(timeout);
   }
 }

--- a/src/telemetry/telemetry.cpp
+++ b/src/telemetry/telemetry.cpp
@@ -89,8 +89,17 @@ void Telemetry::AddCollector(std::string name, FuncSig func) {
   collectors_.emplace_back(std::move(name), std::move(func));
 }
 
-Telemetry::~Telemetry() {
+void Telemetry::Stop() {
+  abort_.store(true, std::memory_order_relaxed);
   scheduler_.Stop();
+}
+
+Telemetry::~Telemetry() {
+  Stop();
+  // Clear the abort flag so the final shutdown collection can actually send
+  // data (with the 10s timeout). Without this, the in-flight curl transfer
+  // would be aborted immediately because the flag is still set.
+  abort_.store(false, std::memory_order_relaxed);
   CollectData("shutdown");
 }
 
@@ -106,7 +115,7 @@ void Telemetry::StoreData(const nlohmann::json &event, const nlohmann::json &dat
   storage_.Put(fmt::format("{}:{}", uuid_, event.dump()), payload.dump());
 }
 
-void Telemetry::SendData() {
+void Telemetry::SendData(int timeout_seconds) {
   std::vector<std::string> keys;
   nlohmann::json payload = nlohmann::json::array();
 
@@ -122,7 +131,8 @@ void Telemetry::SendData() {
 
   if (requests::RequestPostJson(url_,
                                 payload,
-                                /* timeout_in_seconds = */ 2 * 60)) {
+                                /* timeout_in_seconds = */ timeout_seconds,
+                                &abort_)) {
     for (const auto &key : keys) {
       if (!storage_.Delete(key)) {
         SPDLOG_WARN(
@@ -156,7 +166,9 @@ void Telemetry::CollectData(const std::string &event) {
     StoreData(event, data);
   }
   if (num_ % send_every_n_ == 0 || event == "shutdown") {
-    SendData();
+    // Use shorter timeout for shutdown event
+    int timeout = (event == "shutdown") ? 10 : (2 * 60);
+    SendData(timeout);
   }
 }
 

--- a/src/telemetry/telemetry.cpp
+++ b/src/telemetry/telemetry.cpp
@@ -94,13 +94,16 @@ void Telemetry::Stop() {
   scheduler_.Stop();
 }
 
-Telemetry::~Telemetry() {
-  Stop();
-  // Clear the abort flag so the final shutdown collection can actually send
-  // data (with the 10s timeout). Without this, the in-flight curl transfer
-  // would be aborted immediately because the flag is still set.
-  abort_.store(false, std::memory_order_relaxed);
-  CollectData("shutdown");
+Telemetry::~Telemetry() noexcept {
+  try {
+    Stop();
+    // Clear the abort flag so the final shutdown collection can actually send
+    // data (with the 10s timeout). Without this, the in-flight curl transfer
+    // would be aborted immediately because the flag is still set.
+    abort_.store(false, std::memory_order_relaxed);
+    CollectData("shutdown");
+  } catch (...) {
+  }
 }
 
 void Telemetry::StoreData(const nlohmann::json &event, const nlohmann::json &data) {
@@ -167,7 +170,7 @@ void Telemetry::CollectData(const std::string &event) {
   }
   if (num_ % send_every_n_ == 0 || event == "shutdown") {
     // Use shorter timeout for shutdown event
-    int timeout = (event == "shutdown") ? 10 : (2 * 60);
+    int const timeout = (event == "shutdown") ? 10 : (2 * 60);
     SendData(timeout);
   }
 }

--- a/src/telemetry/telemetry.hpp
+++ b/src/telemetry/telemetry.hpp
@@ -64,7 +64,7 @@ class Telemetry final {
   void AddExceptionCollector();
   void AddReplicationCollector(utils::Synchronized<replication::ReplicationState, utils::RWSpinLock> const &repl_state);
 
-  ~Telemetry();
+  ~Telemetry() noexcept;
 
   Telemetry(const Telemetry &) = delete;
   Telemetry(Telemetry &&) = delete;

--- a/src/telemetry/telemetry.hpp
+++ b/src/telemetry/telemetry.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <mutex>
 #include <string>
 
@@ -72,9 +73,15 @@ class Telemetry final {
 
   void Start();
 
+  /**
+   * Signal the telemetry service to stop immediately.
+   * Call this during shutdown to prevent blocking on in-flight HTTP requests.
+   */
+  void Stop();
+
  private:
   void StoreData(const nlohmann::json &event, const nlohmann::json &data);
-  void SendData();
+  void SendData(int timeout_seconds = 2 * 60);
   /// Iterates over all collectors and calls associated functions synchronously.
   void CollectData(const std::string &event = "");
 
@@ -94,6 +101,8 @@ class Telemetry final {
   std::vector<std::pair<std::string, FuncSig>> collectors_;
 
   kvstore::KVStore storage_;
+
+  std::atomic<bool> abort_{false};
 };
 
 }  // namespace memgraph::telemetry

--- a/tests/integration/telemetry/runner.py
+++ b/tests/integration/telemetry/runner.py
@@ -90,7 +90,6 @@ TESTS = [
     {"redirect": True},
     {"no_response_count": 2},
     {"wrong_code_count": 2},
-    {"hang": True, "duration": 0},
     {"path": "/nonexistant/", "no_check": True},
     {"endpoint": "http://127.0.0.1:9000/nonexistant/", "no_check": True},
     {"start_server": False},


### PR DESCRIPTION
Telemetry data requests are aborted, while shutdown request has a lower 10 second timeout.
License requests are simply aborted during shutdown.