### PR TITLE
feat: richer output for schema node/rel type-properties procedures

### DIFF
--- a/query_modules/schema.cpp
+++ b/query_modules/schema.cpp
@@ -237,13 +237,41 @@ struct RelKey {
   bool operator==(const RelKey &) const = default;
 };
 
+struct RelKeyView {
+  std::string_view rel_type;
+  const std::set<std::string> &source_labels;
+  const std::set<std::string> &target_labels;
+};
+
 struct RelKeyHash {
-  std::size_t operator()(const RelKey &k) const noexcept {
-    std::size_t seed = std::hash<std::string>{}(k.rel_type);
-    boost::hash_combine(seed, boost::hash_range(k.source_labels.begin(), k.source_labels.end()));
-    boost::hash_combine(seed, boost::hash_range(k.target_labels.begin(), k.target_labels.end()));
+  using is_transparent = void;
+
+  std::size_t operator()(const RelKey &k) const noexcept { return Hash(k.rel_type, k.source_labels, k.target_labels); }
+
+  std::size_t operator()(const RelKeyView &k) const noexcept {
+    return Hash(k.rel_type, k.source_labels, k.target_labels);
+  }
+
+ private:
+  static std::size_t Hash(std::string_view rt, const std::set<std::string> &s,
+                          const std::set<std::string> &t) noexcept {
+    std::size_t seed = std::hash<std::string_view>{}(rt);
+    boost::hash_combine(seed, boost::hash_range(s.begin(), s.end()));
+    boost::hash_combine(seed, boost::hash_range(t.begin(), t.end()));
     return seed;
   }
+};
+
+struct RelKeyEqual {
+  using is_transparent = void;
+
+  bool operator()(const RelKey &a, const RelKey &b) const noexcept { return a == b; }
+
+  bool operator()(const RelKey &a, const RelKeyView &b) const noexcept {
+    return a.rel_type == b.rel_type && a.source_labels == b.source_labels && a.target_labels == b.target_labels;
+  }
+
+  bool operator()(const RelKeyView &a, const RelKey &b) const noexcept { return (*this)(b, a); }
 };
 
 mgp::List LabelsToList(const std::set<std::string> &labels) {
@@ -323,10 +351,6 @@ void Schema::NodeTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_r
         continue;
       }
 
-      if (node.Properties().empty()) {
-        continue;
-      }
-
       for (const auto &[key, prop] : node.Properties()) {
         auto prop_type = TypeOf(prop.Type());
         if (current_labels_info.properties.find(key) == current_labels_info.properties.end()) {
@@ -374,7 +398,7 @@ void Schema::NodeTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_r
 void Schema::RelTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory) {
   mgp::MemoryDispatcherGuard guard{memory};
 
-  std::unordered_map<RelKey, LabelOrRelTypeInfo, RelKeyHash> rel_types_properties;
+  std::unordered_map<RelKey, LabelOrRelTypeInfo, RelKeyHash, RelKeyEqual> rel_types_properties;
   const auto record_factory = mgp::RecordFactory(result);
   try {
     auto arguments = mgp::List(args);
@@ -426,16 +450,17 @@ void Schema::RelTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_re
           target_labels.emplace(label);
         }
 
-        // source_labels is reused across this node's edges, so it must be copied (not moved).
-        RelKey key{.rel_type = std::string(rel_type_view),
-                   .source_labels = source_labels,
-                   .target_labels = std::move(target_labels)};
-        auto &rel_info = rel_types_properties[std::move(key)];
-        rel_info.number_of_occurrences++;
-
-        if (rel.Properties().empty()) {
-          continue;
+        const RelKeyView probe{rel_type_view, source_labels, target_labels};
+        auto it = rel_types_properties.find(probe);
+        if (it == rel_types_properties.end()) {
+          // source_labels is reused across this node's edges, so it must be copied (not moved).
+          RelKey key{.rel_type = std::string(rel_type_view),
+                     .source_labels = source_labels,
+                     .target_labels = std::move(target_labels)};
+          it = rel_types_properties.emplace(std::move(key), LabelOrRelTypeInfo{}).first;
         }
+        auto &rel_info = it->second;
+        rel_info.number_of_occurrences++;
 
         for (auto &[prop_name, prop] : rel.Properties()) {
           auto prop_type = TypeOf(prop.Type());

--- a/query_modules/schema.cpp
+++ b/query_modules/schema.cpp
@@ -160,8 +160,24 @@ struct LabelOrRelTypeInfo {
   int64_t number_of_occurrences = 0;
 };
 
-std::unordered_set<std::string> ExtractStringSetFromConfig(const mgp::Map &config, const std::string_view key) {
-  std::unordered_set<std::string> result;
+struct StringHash {
+  using is_transparent = void;
+
+  std::size_t operator()(std::string_view s) const noexcept { return std::hash<std::string_view>{}(s); }
+
+  std::size_t operator()(const std::string &s) const noexcept { return std::hash<std::string_view>{}(s); }
+};
+
+struct StringEqual {
+  using is_transparent = void;
+
+  bool operator()(std::string_view a, std::string_view b) const noexcept { return a == b; }
+};
+
+using StringSet = std::unordered_set<std::string, StringHash, StringEqual>;
+
+StringSet ExtractStringSetFromConfig(const mgp::Map &config, const std::string_view key) {
+  StringSet result;
   if (!config.KeyExists(key)) {
     return result;
   }
@@ -177,8 +193,8 @@ std::unordered_set<std::string> ExtractStringSetFromConfig(const mgp::Map &confi
   return result;
 }
 
-bool ShouldIncludeLabels(const std::set<std::string> &labels, const std::unordered_set<std::string> &include_labels,
-                         const std::unordered_set<std::string> &exclude_labels) {
+bool ShouldIncludeLabels(const std::set<std::string> &labels, const StringSet &include_labels,
+                         const StringSet &exclude_labels) {
   if (!include_labels.empty()) {
     if (!std::ranges::any_of(labels, [&](const auto &label) { return include_labels.contains(label); })) return false;
   }
@@ -199,8 +215,7 @@ int64_t ExtractIntFromConfig(const mgp::Map &config, const std::string_view key,
   return val.ValueInt();
 }
 
-bool ShouldIncludeRelType(const std::string &rel_type, const std::unordered_set<std::string> &include_rels,
-                          const std::unordered_set<std::string> &exclude_rels) {
+bool ShouldIncludeRelType(std::string_view rel_type, const StringSet &include_rels, const StringSet &exclude_rels) {
   if (!include_rels.empty() && !include_rels.contains(rel_type)) {
     return false;
   }
@@ -210,12 +225,9 @@ bool ShouldIncludeRelType(const std::string &rel_type, const std::unordered_set<
   return true;
 }
 
+namespace {
 struct LabelsHash {
   std::size_t operator()(const std::set<std::string> &s) const { return boost::hash_range(s.begin(), s.end()); }
-};
-
-struct LabelsComparator {
-  bool operator()(const std::set<std::string> &lhs, const std::set<std::string> &rhs) const { return lhs == rhs; }
 };
 
 struct RelKey {
@@ -234,7 +246,6 @@ struct RelKeyHash {
   }
 };
 
-namespace {
 mgp::List LabelsToList(const std::set<std::string> &labels) {
   auto list = mgp::List();
   list.Reserve(labels.size());
@@ -270,7 +281,7 @@ void Schema::NodeTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_r
     }
     auto max_rels = ExtractIntFromConfig(config, kConfigMaxRels, kDefaultMaxRels);
 
-    std::unordered_map<std::set<std::string>, LabelOrRelTypeInfo, LabelsHash, LabelsComparator> node_types_properties;
+    std::unordered_map<std::set<std::string>, LabelOrRelTypeInfo, LabelsHash> node_types_properties;
 
     for (const auto node : mgp::Graph(memgraph_graph).Nodes()) {
       std::set<std::string> labels_set = {};
@@ -403,9 +414,8 @@ void Schema::RelTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_re
           break;
         }
 
-        std::string rel_type{rel.Type()};
-
-        if (!ShouldIncludeRelType(rel_type, include_rels, exclude_rels)) {
+        const std::string_view rel_type_view = rel.Type();
+        if (!ShouldIncludeRelType(rel_type_view, include_rels, exclude_rels)) {
           continue;
         }
 
@@ -416,7 +426,10 @@ void Schema::RelTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_re
           target_labels.emplace(label);
         }
 
-        RelKey key{std::move(rel_type), source_labels, std::move(target_labels)};
+        // source_labels is reused across this node's edges, so it must be copied (not moved).
+        RelKey key{.rel_type = std::string(rel_type_view),
+                   .source_labels = source_labels,
+                   .target_labels = std::move(target_labels)};
         auto &rel_info = rel_types_properties[std::move(key)];
         rel_info.number_of_occurrences++;
 

--- a/query_modules/schema.cpp
+++ b/query_modules/schema.cpp
@@ -27,9 +27,13 @@ constexpr std::string_view kProcedureRelType = "rel_type_properties";
 constexpr std::string_view kProcedureAssert = "assert";
 constexpr std::string_view kReturnLabels = "nodeLabels";
 constexpr std::string_view kReturnRelType = "relType";
+constexpr std::string_view kReturnSourceNodeLabels = "sourceNodeLabels";
+constexpr std::string_view kReturnTargetNodeLabels = "targetNodeLabels";
 constexpr std::string_view kReturnPropertyName = "propertyName";
 constexpr std::string_view kReturnPropertyType = "propertyTypes";
 constexpr std::string_view kReturnMandatory = "mandatory";
+constexpr std::string_view kReturnPropertyObservations = "propertyObservations";
+constexpr std::string_view kReturnTotalObservations = "totalObservations";
 constexpr std::string_view kReturnLabel = "label";
 constexpr std::string_view kReturnKey = "key";
 constexpr std::string_view kReturnKeys = "keys";
@@ -54,11 +58,13 @@ std::string TypeOf(const mgp::Type &type);
 
 template <typename T>
 void ProcessPropertiesNode(mgp::Record &record, const std::string &type, const mgp::List &labels,
-                           const std::string &propertyName, const T &propertyType, const bool &mandatory);
+                           const std::string &propertyName, const T &propertyType, bool mandatory,
+                           int64_t property_observations, int64_t total_observations);
 
 template <typename T>
-void ProcessPropertiesRel(mgp::Record &record, const std::string_view &type, const std::string &propertyName,
-                          const T &propertyType, const bool &mandatory);
+void ProcessPropertiesRel(mgp::Record &record, const std::string &type, const mgp::List &source_labels,
+                          const mgp::List &target_labels, const std::string &propertyName, const T &propertyType,
+                          bool mandatory, int64_t property_observations, int64_t total_observations);
 
 void NodeTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
 void RelTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
@@ -112,21 +118,30 @@ std::string Schema::TypeOf(const mgp::Type &type) {
 
 template <typename T>
 void Schema::ProcessPropertiesNode(mgp::Record &record, const std::string &type, const mgp::List &labels,
-                                   const std::string &propertyName, const T &propertyType, const bool &mandatory) {
+                                   const std::string &propertyName, const T &propertyType, bool mandatory,
+                                   int64_t property_observations, int64_t total_observations) {
   record.Insert(std::string(kReturnNodeType).c_str(), type);
   record.Insert(std::string(kReturnLabels).c_str(), labels);
   record.Insert(std::string(kReturnPropertyName).c_str(), propertyName);
   record.Insert(std::string(kReturnPropertyType).c_str(), propertyType);
   record.Insert(std::string(kReturnMandatory).c_str(), mandatory);
+  record.Insert(std::string(kReturnPropertyObservations).c_str(), property_observations);
+  record.Insert(std::string(kReturnTotalObservations).c_str(), total_observations);
 }
 
 template <typename T>
-void Schema::ProcessPropertiesRel(mgp::Record &record, const std::string_view &type, const std::string &propertyName,
-                                  const T &propertyType, const bool &mandatory) {
+void Schema::ProcessPropertiesRel(mgp::Record &record, const std::string &type, const mgp::List &source_labels,
+                                  const mgp::List &target_labels, const std::string &propertyName,
+                                  const T &propertyType, bool mandatory, int64_t property_observations,
+                                  int64_t total_observations) {
   record.Insert(std::string(kReturnRelType).c_str(), type);
+  record.Insert(std::string(kReturnSourceNodeLabels).c_str(), source_labels);
+  record.Insert(std::string(kReturnTargetNodeLabels).c_str(), target_labels);
   record.Insert(std::string(kReturnPropertyName).c_str(), propertyName);
   record.Insert(std::string(kReturnPropertyType).c_str(), propertyType);
   record.Insert(std::string(kReturnMandatory).c_str(), mandatory);
+  record.Insert(std::string(kReturnPropertyObservations).c_str(), property_observations);
+  record.Insert(std::string(kReturnTotalObservations).c_str(), total_observations);
 }
 
 struct PropertyInfo {
@@ -203,6 +218,42 @@ struct LabelsComparator {
   bool operator()(const std::set<std::string> &lhs, const std::set<std::string> &rhs) const { return lhs == rhs; }
 };
 
+struct RelKey {
+  std::string rel_type;
+  std::set<std::string> source_labels;
+  std::set<std::string> target_labels;
+  bool operator==(const RelKey &) const = default;
+};
+
+struct RelKeyHash {
+  std::size_t operator()(const RelKey &k) const noexcept {
+    std::size_t seed = std::hash<std::string>{}(k.rel_type);
+    boost::hash_combine(seed, boost::hash_range(k.source_labels.begin(), k.source_labels.end()));
+    boost::hash_combine(seed, boost::hash_range(k.target_labels.begin(), k.target_labels.end()));
+    return seed;
+  }
+};
+
+namespace {
+mgp::List LabelsToList(const std::set<std::string> &labels) {
+  auto list = mgp::List();
+  list.Reserve(labels.size());
+  for (const auto &label : labels) {
+    list.AppendExtend(mgp::Value(label));
+  }
+  return list;
+}
+
+mgp::List PropertyTypesToList(const std::unordered_set<std::string> &types) {
+  auto list = mgp::List();
+  list.Reserve(types.size());
+  for (const auto &t : types) {
+    list.AppendExtend(mgp::Value(t));
+  }
+  return list;
+}
+}  // namespace
+
 void Schema::NodeTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory) {
   mgp::MemoryDispatcherGuard guard{memory};
   const auto record_factory = mgp::RecordFactory(result);
@@ -278,25 +329,28 @@ void Schema::NodeTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_r
 
     for (auto &[node_type, labels_info] : node_types_properties) {  // node type is a set of labels
       std::string label_type;
-      auto labels_list = mgp::List();
       for (const auto &label : node_type) {
-        label_type += ":`" + std::string(label) + "`";
-        labels_list.AppendExtend(mgp::Value(label));
+        label_type += ":`" + label + "`";
       }
-      auto effective_count =
+      auto labels_list = LabelsToList(node_type);
+      const auto effective_count =
           (sample > 0) ? std::min(sample, labels_info.number_of_occurrences) : labels_info.number_of_occurrences;
-      for (const auto &prop : labels_info.properties) {
-        auto prop_types = mgp::List();
-        for (const auto &prop_type : prop.second.property_types) {
-          prop_types.AppendExtend(mgp::Value(prop_type));
-        }
-        bool mandatory = prop.second.number_of_property_occurrences == effective_count;
+      for (const auto &[prop_name, prop_info] : labels_info.properties) {
+        auto prop_types = PropertyTypesToList(prop_info.property_types);
+        const bool mandatory = prop_info.number_of_property_occurrences == effective_count;
         auto record = record_factory.NewRecord();
-        ProcessPropertiesNode(record, label_type, labels_list, prop.first, prop_types, mandatory);
+        ProcessPropertiesNode(record,
+                              label_type,
+                              labels_list,
+                              prop_name,
+                              prop_types,
+                              mandatory,
+                              prop_info.number_of_property_occurrences,
+                              effective_count);
       }
       if (labels_info.properties.empty()) {
         auto record = record_factory.NewRecord();
-        ProcessPropertiesNode<mgp::List>(record, label_type, labels_list, "", mgp::List(), false);
+        ProcessPropertiesNode<mgp::List>(record, label_type, labels_list, "", mgp::List(), false, 0, effective_count);
       }
     }
 
@@ -309,7 +363,7 @@ void Schema::NodeTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_r
 void Schema::RelTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory) {
   mgp::MemoryDispatcherGuard guard{memory};
 
-  std::unordered_map<std::string, LabelOrRelTypeInfo> rel_types_properties;
+  std::unordered_map<RelKey, LabelOrRelTypeInfo, RelKeyHash> rel_types_properties;
   const auto record_factory = mgp::RecordFactory(result);
   try {
     auto arguments = mgp::List(args);
@@ -332,12 +386,12 @@ void Schema::RelTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_re
         break;
       }
 
-      std::set<std::string> node_labels;
+      std::set<std::string> source_labels;
       for (const auto label : node.Labels()) {
-        node_labels.emplace(label);
+        source_labels.emplace(label);
       }
 
-      if (!ShouldIncludeLabels(node_labels, include_labels, exclude_labels)) {
+      if (!ShouldIncludeLabels(source_labels, include_labels, exclude_labels)) {
         continue;
       }
 
@@ -349,7 +403,7 @@ void Schema::RelTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_re
           break;
         }
 
-        std::string rel_type = std::string(rel.Type());
+        std::string rel_type{rel.Type()};
 
         if (!ShouldIncludeRelType(rel_type, include_rels, exclude_rels)) {
           continue;
@@ -357,39 +411,53 @@ void Schema::RelTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_re
 
         rels_read++;
 
-        auto &rel_info = rel_types_properties[rel_type];
+        std::set<std::string> target_labels;
+        for (const auto label : rel.To().Labels()) {
+          target_labels.emplace(label);
+        }
+
+        RelKey key{std::move(rel_type), source_labels, std::move(target_labels)};
+        auto &rel_info = rel_types_properties[std::move(key)];
         rel_info.number_of_occurrences++;
 
         if (rel.Properties().empty()) {
           continue;
         }
 
-        for (auto &[key, prop] : rel.Properties()) {
+        for (auto &[prop_name, prop] : rel.Properties()) {
           auto prop_type = TypeOf(prop.Type());
-          if (rel_info.properties.find(key) == rel_info.properties.end()) {
-            rel_info.properties[key] = PropertyInfo{std::move(prop_type)};
+          if (auto it = rel_info.properties.find(prop_name); it == rel_info.properties.end()) {
+            rel_info.properties.emplace(prop_name, PropertyInfo{std::move(prop_type)});
           } else {
-            rel_info.properties[key].property_types.emplace(prop_type);
-            rel_info.properties[key].number_of_property_occurrences++;
+            it->second.property_types.emplace(std::move(prop_type));
+            it->second.number_of_property_occurrences++;
           }
         }
       }
     }
 
-    for (auto &[rel_type, labels_info] : rel_types_properties) {
-      std::string type_str = ":`" + std::string(rel_type) + "`";
-      for (const auto &prop : labels_info.properties) {
-        auto prop_types = mgp::List();
-        for (const auto &prop_type : prop.second.property_types) {
-          prop_types.AppendExtend(mgp::Value(prop_type));
-        }
-        bool mandatory = prop.second.number_of_property_occurrences == labels_info.number_of_occurrences;
+    for (auto &[key, labels_info] : rel_types_properties) {
+      const std::string type_str = ":`" + key.rel_type + "`";
+      auto source_list = LabelsToList(key.source_labels);
+      auto target_list = LabelsToList(key.target_labels);
+      for (const auto &[prop_name, prop_info] : labels_info.properties) {
+        auto prop_types = PropertyTypesToList(prop_info.property_types);
+        const bool mandatory = prop_info.number_of_property_occurrences == labels_info.number_of_occurrences;
         auto record = record_factory.NewRecord();
-        ProcessPropertiesRel(record, type_str, prop.first, prop_types, mandatory);
+        ProcessPropertiesRel(record,
+                             type_str,
+                             source_list,
+                             target_list,
+                             prop_name,
+                             prop_types,
+                             mandatory,
+                             prop_info.number_of_property_occurrences,
+                             labels_info.number_of_occurrences);
       }
       if (labels_info.properties.empty()) {
         auto record = record_factory.NewRecord();
-        ProcessPropertiesRel<mgp::List>(record, type_str, "", mgp::List(), false);
+        ProcessPropertiesRel<mgp::List>(
+            record, type_str, source_list, target_list, "", mgp::List(), false, 0, labels_info.number_of_occurrences);
       }
     }
 
@@ -838,8 +906,10 @@ extern "C" int mgp_init_module(struct mgp_module *module, struct mgp_memory *mem
                  {mgp::Return(Schema::kReturnNodeType, mgp::Type::String),
                   mgp::Return(Schema::kReturnLabels, {mgp::Type::List, mgp::Type::String}),
                   mgp::Return(Schema::kReturnPropertyName, mgp::Type::String),
-                  mgp::Return(Schema::kReturnPropertyType, mgp::Type::Any),
-                  mgp::Return(Schema::kReturnMandatory, mgp::Type::Bool)},
+                  mgp::Return(Schema::kReturnPropertyType, {mgp::Type::List, mgp::Type::String}),
+                  mgp::Return(Schema::kReturnMandatory, mgp::Type::Bool),
+                  mgp::Return(Schema::kReturnPropertyObservations, mgp::Type::Int),
+                  mgp::Return(Schema::kReturnTotalObservations, mgp::Type::Int)},
                  module,
                  memory);
 
@@ -848,9 +918,13 @@ extern "C" int mgp_init_module(struct mgp_module *module, struct mgp_memory *mem
                  mgp::ProcedureType::Read,
                  {mgp::Parameter(Schema::kParameterConfig, {mgp::Type::Map, mgp::Type::Any}, mgp::Value(mgp::Map{}))},
                  {mgp::Return(Schema::kReturnRelType, mgp::Type::String),
+                  mgp::Return(Schema::kReturnSourceNodeLabels, {mgp::Type::List, mgp::Type::String}),
+                  mgp::Return(Schema::kReturnTargetNodeLabels, {mgp::Type::List, mgp::Type::String}),
                   mgp::Return(Schema::kReturnPropertyName, mgp::Type::String),
-                  mgp::Return(Schema::kReturnPropertyType, mgp::Type::Any),
-                  mgp::Return(Schema::kReturnMandatory, mgp::Type::Bool)},
+                  mgp::Return(Schema::kReturnPropertyType, {mgp::Type::List, mgp::Type::String}),
+                  mgp::Return(Schema::kReturnMandatory, mgp::Type::Bool),
+                  mgp::Return(Schema::kReturnPropertyObservations, mgp::Type::Int),
+                  mgp::Return(Schema::kReturnTotalObservations, mgp::Type::Int)},
                  module,
                  memory);
     AddProcedure(

--- a/query_modules/schema.cpp
+++ b/query_modules/schema.cpp
@@ -176,7 +176,7 @@ struct StringEqual {
 
 using StringSet = std::unordered_set<std::string, StringHash, StringEqual>;
 
-StringSet ExtractStringSetFromConfig(const mgp::Map &config, const std::string_view key) {
+StringSet ExtractStringSetFromConfig(const mgp::Map &config, std::string_view key) {
   StringSet result;
   if (!config.KeyExists(key)) {
     return result;
@@ -204,7 +204,7 @@ bool ShouldIncludeLabels(const std::set<std::string> &labels, const StringSet &i
   return true;
 }
 
-int64_t ExtractIntFromConfig(const mgp::Map &config, const std::string_view key, int64_t default_value) {
+int64_t ExtractIntFromConfig(const mgp::Map &config, std::string_view key, int64_t default_value) {
   if (!config.KeyExists(key)) {
     return default_value;
   }
@@ -414,7 +414,7 @@ void Schema::RelTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_re
           break;
         }
 
-        const std::string_view rel_type_view = rel.Type();
+        std::string_view rel_type_view = rel.Type();
         if (!ShouldIncludeRelType(rel_type_view, include_rels, exclude_rels)) {
           continue;
         }
@@ -480,8 +480,7 @@ void Schema::RelTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_re
   }
 }
 
-void InsertRecordForLabelIndex(const auto &record_factory, const std::string_view label,
-                               const std::string_view status) {
+void InsertRecordForLabelIndex(const auto &record_factory, std::string_view label, std::string_view status) {
   auto record = record_factory.NewRecord();
   record.Insert(std::string(Schema::kReturnLabel).c_str(), label);
   record.Insert(std::string(Schema::kReturnKey).c_str(), "");
@@ -490,8 +489,8 @@ void InsertRecordForLabelIndex(const auto &record_factory, const std::string_vie
   record.Insert(std::string(Schema::kReturnAction).c_str(), status);
 }
 
-void InsertRecordForUniqueConstraint(const auto &record_factory, const std::string_view label,
-                                     const mgp::List &properties, const std::string_view status) {
+void InsertRecordForUniqueConstraint(const auto &record_factory, std::string_view label, const mgp::List &properties,
+                                     std::string_view status) {
   auto record = record_factory.NewRecord();
   record.Insert(std::string(Schema::kReturnLabel).c_str(), label);
   record.Insert(std::string(Schema::kReturnKey).c_str(), properties.ToString());
@@ -500,9 +499,8 @@ void InsertRecordForUniqueConstraint(const auto &record_factory, const std::stri
   record.Insert(std::string(Schema::kReturnAction).c_str(), status);
 }
 
-void InsertRecordForLabelPropertyIndexAndExistenceConstraint(const auto &record_factory, const std::string_view label,
-                                                             const std::string_view property,
-                                                             const std::string_view status) {
+void InsertRecordForLabelPropertyIndexAndExistenceConstraint(const auto &record_factory, std::string_view label,
+                                                             std::string_view property, std::string_view status) {
   auto record = record_factory.NewRecord();
   record.Insert(std::string(Schema::kReturnLabel).c_str(), label);
   record.Insert(std::string(Schema::kReturnKey).c_str(), property);
@@ -511,7 +509,7 @@ void InsertRecordForLabelPropertyIndexAndExistenceConstraint(const auto &record_
   record.Insert(std::string(Schema::kReturnAction).c_str(), status);
 }
 
-void ProcessCreatingLabelIndex(const std::string_view label, const std::set<std::string_view> &existing_label_indices,
+void ProcessCreatingLabelIndex(std::string_view label, const std::set<std::string_view> &existing_label_indices,
                                mgp_graph *memgraph_graph, const auto &record_factory) {
   if (existing_label_indices.contains(label)) {
     InsertRecordForLabelIndex(record_factory, label, Schema::kStatusKept);
@@ -521,8 +519,7 @@ void ProcessCreatingLabelIndex(const std::string_view label, const std::set<std:
 }
 
 template <typename TFunc>
-void ProcessCreatingLabelPropertyIndexAndExistenceConstraint(const std::string_view label,
-                                                             const std::string_view property,
+void ProcessCreatingLabelPropertyIndexAndExistenceConstraint(std::string_view label, std::string_view property,
                                                              const std::set<std::string_view> &existing_collection,
                                                              const TFunc &func_creation, mgp_graph *memgraph_graph,
                                                              const auto &record_factory) {
@@ -537,7 +534,7 @@ void ProcessCreatingLabelPropertyIndexAndExistenceConstraint(const std::string_v
 /// We collect properties for which index was created.
 using AssertedIndices = std::set<std::string, std::less<>>;
 
-AssertedIndices CreateIndicesForLabel(const std::string_view label, const mgp::Value &properties_val,
+AssertedIndices CreateIndicesForLabel(std::string_view label, const mgp::Value &properties_val,
                                       mgp_graph *memgraph_graph, const auto &record_factory,
                                       const std::set<std::string_view> &existing_label_indices,
                                       const std::set<std::string_view> &existing_label_property_indices) {
@@ -604,7 +601,7 @@ void ProcessIndices(const mgp::Map &indices_map, mgp_graph *memgraph_graph, cons
   };
 
   for (const auto &index : indices_map) {
-    const std::string_view label = index.key;
+    std::string_view label = index.key;
     const mgp::Value &properties_val = index.value;
 
     AssertedIndices asserted_indices_new = CreateIndicesForLabel(
@@ -634,7 +631,7 @@ void ProcessIndices(const mgp::Map &indices_map, mgp_graph *memgraph_graph, cons
                               asserted_label_indices,
                               std::inserter(label_indices_to_drop, label_indices_to_drop.begin()));
 
-  std::ranges::for_each(label_indices_to_drop, [memgraph_graph, &record_factory](const std::string_view label) {
+  std::ranges::for_each(label_indices_to_drop, [memgraph_graph, &record_factory](std::string_view label) {
     if (mgp::DropLabelIndex(memgraph_graph, label)) {
       InsertRecordForLabelIndex(record_factory, label, Schema::kStatusDropped);
     }
@@ -645,29 +642,28 @@ void ProcessIndices(const mgp::Map &indices_map, mgp_graph *memgraph_graph, cons
                               asserted_label_property_indices,
                               std::inserter(label_property_indices_to_drop, label_property_indices_to_drop.begin()));
 
-  auto decouple_label_property = [](const std::string_view label_property) {
+  auto decouple_label_property = [](std::string_view label_property) {
     const auto label_size = label_property.find(':');
     const auto label = std::string(label_property.substr(0, label_size));
     const auto property = std::string(label_property.substr(label_size + 1));
     return std::make_pair(label, property);
   };
 
-  std::ranges::for_each(
-      label_property_indices_to_drop,
-      [memgraph_graph, &record_factory, decouple_label_property](const std::string_view label_property) {
-        const auto [label, property] = decouple_label_property(label_property);
-        if (mgp::DropLabelPropertyIndex(memgraph_graph, label, property)) {
-          InsertRecordForLabelPropertyIndexAndExistenceConstraint(
-              record_factory, label, property, Schema::kStatusDropped);
-        }
-      });
+  std::ranges::for_each(label_property_indices_to_drop,
+                        [memgraph_graph, &record_factory, decouple_label_property](std::string_view label_property) {
+                          const auto [label, property] = decouple_label_property(label_property);
+                          if (mgp::DropLabelPropertyIndex(memgraph_graph, label, property)) {
+                            InsertRecordForLabelPropertyIndexAndExistenceConstraint(
+                                record_factory, label, property, Schema::kStatusDropped);
+                          }
+                        });
 }
 
 using ExistenceConstraintsStorage = std::set<std::string_view>;
 
 ExistenceConstraintsStorage CreateExistenceConstraintsForLabel(
-    const std::string_view label, const mgp::Value &properties_val, mgp_graph *memgraph_graph,
-    const auto &record_factory, const std::set<std::string_view> &existing_existence_constraints) {
+    std::string_view label, const mgp::Value &properties_val, mgp_graph *memgraph_graph, const auto &record_factory,
+    const std::set<std::string_view> &existing_existence_constraints) {
   ExistenceConstraintsStorage asserted_existence_constraints;
   if (!properties_val.IsList()) {
     return asserted_existence_constraints;
@@ -689,7 +685,7 @@ ExistenceConstraintsStorage CreateExistenceConstraintsForLabel(
                   if (!validate_property(property)) {
                     return;
                   }
-                  const std::string_view property_str = property.ValueString();
+                  std::string_view property_str = property.ValueString();
                   asserted_existence_constraints.emplace(property_str);
                   ProcessCreatingLabelPropertyIndexAndExistenceConstraint(label,
                                                                           property_str,
@@ -710,7 +706,7 @@ void ProcessExistenceConstraints(const mgp::Map &existence_constraints_map, mgp_
                  std::inserter(existing_existence_constraints, existing_existence_constraints.begin()),
                  [](const mgp::Value &constraint) { return constraint.ValueString(); });
 
-  auto merge_label_property = [](const std::string_view label, const std::string_view property) {
+  auto merge_label_property = [](std::string_view label, std::string_view property) {
     auto str = std::string(label) + ":";
     str += property;
     return str;
@@ -719,7 +715,7 @@ void ProcessExistenceConstraints(const mgp::Map &existence_constraints_map, mgp_
   ExistenceConstraintsStorage asserted_existence_constraints;
 
   for (const auto &existing_constraint : existence_constraints_map) {
-    const std::string_view label = existing_constraint.key;
+    std::string_view label = existing_constraint.key;
     const mgp::Value &properties_val = existing_constraint.value;
     auto asserted_existence_constraints_new = CreateExistenceConstraintsForLabel(
         label, properties_val, memgraph_graph, record_factory, existing_existence_constraints);
@@ -727,11 +723,10 @@ void ProcessExistenceConstraints(const mgp::Map &existence_constraints_map, mgp_
       continue;
     }
 
-    std::ranges::for_each(
-        asserted_existence_constraints_new,
-        [&asserted_existence_constraints, &merge_label_property, label](const std::string_view property) {
-          asserted_existence_constraints.emplace(merge_label_property(label, property));
-        });
+    std::ranges::for_each(asserted_existence_constraints_new,
+                          [&asserted_existence_constraints, &merge_label_property, label](std::string_view property) {
+                            asserted_existence_constraints.emplace(merge_label_property(label, property));
+                          });
   }
 
   if (!drop_existing) {
@@ -743,14 +738,14 @@ void ProcessExistenceConstraints(const mgp::Map &existence_constraints_map, mgp_
                               asserted_existence_constraints,
                               std::inserter(existence_constraints_to_drop, existence_constraints_to_drop.begin()));
 
-  auto decouple_label_property = [](const std::string_view label_property) {
+  auto decouple_label_property = [](std::string_view label_property) {
     const auto label_size = label_property.find(':');
     const auto label = std::string(label_property.substr(0, label_size));
     const auto property = std::string(label_property.substr(label_size + 1));
     return std::make_pair(label, property);
   };
 
-  std::ranges::for_each(existence_constraints_to_drop, [&](const std::string_view label_property) {
+  std::ranges::for_each(existence_constraints_to_drop, [&](std::string_view label_property) {
     const auto [label, property] = decouple_label_property(label_property);
     if (mgp::DropExistenceConstraint(memgraph_graph, label, property)) {
       InsertRecordForLabelPropertyIndexAndExistenceConstraint(record_factory, label, property, Schema::kStatusDropped);
@@ -761,7 +756,7 @@ void ProcessExistenceConstraints(const mgp::Map &existence_constraints_map, mgp_
 using AssertedUniqueConstraintsStorage = std::set<std::set<std::string_view>>;
 
 AssertedUniqueConstraintsStorage CreateUniqueConstraintsForLabel(
-    const std::string_view label, const mgp::Value &unique_props_nested,
+    std::string_view label, const mgp::Value &unique_props_nested,
     const std::map<std::string_view, AssertedUniqueConstraintsStorage> &existing_unique_constraints,
     mgp_graph *memgraph_graph, const auto &record_factory) {
   AssertedUniqueConstraintsStorage asserted_unique_constraints;
@@ -783,7 +778,7 @@ AssertedUniqueConstraintsStorage CreateUniqueConstraintsForLabel(
   };
 
   auto unique_constraint_exists =
-      [](const std::string_view label,
+      [](std::string_view label,
          const std::set<std::string_view> &properties,
          const std::map<std::string_view, AssertedUniqueConstraintsStorage> &existing_unique_constraints) -> bool {
     auto iter = existing_unique_constraints.find(label);
@@ -826,7 +821,7 @@ void ProcessUniqueConstraints(const mgp::Map &unique_constraints_map, mgp_graph 
     for (int i = 1; i < constraint_list.Size(); i++) {
       properties.emplace(constraint_list[i].ValueString());
     }
-    const std::string_view label = constraint_list[0].ValueString();
+    std::string_view label = constraint_list[0].ValueString();
     auto [it, inserted] = existing_unique_constraints.try_emplace(label, AssertedUniqueConstraintsStorage{properties});
     if (!inserted) {
       it->second.emplace(std::move(properties));
@@ -884,7 +879,7 @@ void ProcessUniqueConstraints(const mgp::Map &unique_constraints_map, mgp_graph 
         const auto &[label, unique_constraint] = label_unique_constraint;
 
         auto unique_constraint_list = mgp::List();
-        std::ranges::for_each(unique_constraint, [&unique_constraint_list](const std::string_view &property) {
+        std::ranges::for_each(unique_constraint, [&unique_constraint_list](std::string_view property) {
           unique_constraint_list.AppendExtend(mgp::Value(property));
         });
 

--- a/tests/e2e/query_modules/schema_test.py
+++ b/tests/e2e/query_modules/schema_test.py
@@ -1036,5 +1036,76 @@ def test_rel_type_properties_db_schema_mapping():
     assert list(result[0]) == [":`LOVES`", "duration", ["Int"], True]
 
 
+def test_node_type_properties_observations_counts():
+    cursor = connect().cursor()
+    execute_and_fetch_all(
+        cursor,
+        """
+        CREATE (:Dog {name: 'Rex', owner: 'Carl'})
+        CREATE (:Dog {name: 'Simba'})
+        CREATE (:Dog {name: 'Buddy'})
+        """,
+    )
+    result = execute_and_fetch_all(
+        cursor,
+        "CALL schema.node_type_properties() "
+        "YIELD nodeType, propertyName, mandatory, propertyObservations, totalObservations "
+        "RETURN nodeType, propertyName, mandatory, propertyObservations, totalObservations "
+        "ORDER BY propertyName;",
+    )
+    counts = {list(r)[1]: (list(r)[2], list(r)[3], list(r)[4]) for r in result}
+    assert counts["name"] == (True, 3, 3)
+    assert counts["owner"] == (False, 1, 3)
+
+
+def test_rel_type_properties_source_and_target_labels():
+    cursor = connect().cursor()
+    execute_and_fetch_all(
+        cursor,
+        """
+        CREATE (:Dog {name: 'Rex'})-[:LOVES {duration: 30}]->(:Activity {name: 'Running'})
+        CREATE (:Cat {name: 'Whiskers'})-[:LOVES {duration: 10}]->(:Activity {name: 'Sleeping'})
+        """,
+    )
+    result = execute_and_fetch_all(
+        cursor,
+        "CALL schema.rel_type_properties() "
+        "YIELD relType, sourceNodeLabels, targetNodeLabels, propertyName, propertyTypes, mandatory, "
+        "propertyObservations, totalObservations "
+        "RETURN relType, sourceNodeLabels, targetNodeLabels, propertyName, propertyTypes, mandatory, "
+        "propertyObservations, totalObservations "
+        "ORDER BY sourceNodeLabels[0];",
+    )
+    assert len(result) == 2
+    assert list(result[0]) == [":`LOVES`", ["Cat"], ["Activity"], "duration", ["Int"], True, 1, 1]
+    assert list(result[1]) == [":`LOVES`", ["Dog"], ["Activity"], "duration", ["Int"], True, 1, 1]
+
+
+def test_rel_type_properties_partitions_by_endpoint_labels():
+    cursor = connect().cursor()
+    execute_and_fetch_all(
+        cursor,
+        """
+        CREATE (:Dog)-[:LOVES {duration: 30}]->(:Activity)
+        CREATE (:Dog)-[:LOVES]->(:Activity)
+        CREATE (:Cat)-[:LOVES {weather: 'sunny'}]->(:Place)
+        """,
+    )
+    result = execute_and_fetch_all(
+        cursor,
+        "CALL schema.rel_type_properties() "
+        "YIELD relType, sourceNodeLabels, targetNodeLabels, propertyName, mandatory, "
+        "propertyObservations, totalObservations "
+        "RETURN relType, sourceNodeLabels, targetNodeLabels, propertyName, mandatory, "
+        "propertyObservations, totalObservations "
+        "ORDER BY sourceNodeLabels[0], propertyName;",
+    )
+    # Dog -> Activity: 2 rels, duration property only on 1 -> not mandatory
+    # Cat -> Place: 1 rel with weather -> mandatory
+    rows = {(list(r)[1][0], list(r)[2][0], list(r)[3]): (list(r)[4], list(r)[5], list(r)[6]) for r in result}
+    assert rows[("Cat", "Place", "weather")] == (True, 1, 1)
+    assert rows[("Dog", "Activity", "duration")] == (False, 1, 2)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/query_modules/schema_test.py
+++ b/tests/e2e/query_modules/schema_test.py
@@ -1119,13 +1119,7 @@ def test_rel_type_properties_unlabeled_endpoints():
         "propertyObservations, totalObservations;",
     )
     assert len(result) == 1
-    row = list(result[0])
-    assert row[0] == ":`KNOWS`"
-    assert row[1] == []
-    assert row[2] == []
-    assert row[3] == ""
-    assert row[4] == 0
-    assert row[5] == 1
+    assert list(result[0]) == [":`KNOWS`", [], [], "", 0, 1]
 
 
 def test_rel_type_properties_multi_label_endpoints():
@@ -1138,10 +1132,8 @@ def test_rel_type_properties_multi_label_endpoints():
         "RETURN relType, sourceNodeLabels, targetNodeLabels;",
     )
     assert len(result) == 1
-    row = list(result[0])
-    assert row[0] == ":`OWNS`"
-    assert set(row[1]) == {"Dog", "Pet"}
-    assert set(row[2]) == {"Object", "Toy"}
+    rel_type, source_labels, target_labels = result[0]
+    assert (rel_type, sorted(source_labels), sorted(target_labels)) == (":`OWNS`", ["Dog", "Pet"], ["Object", "Toy"])
 
 
 def test_node_type_properties_empty_properties_row():
@@ -1162,10 +1154,7 @@ def test_node_type_properties_empty_properties_row():
         "RETURN nodeType, propertyName, propertyObservations, totalObservations;",
     )
     assert len(result) == 1
-    row = list(result[0])
-    assert row[1] == ""
-    assert row[2] == 0
-    assert row[3] == 3
+    assert list(result[0]) == [":`Empty`", "", 0, 3]
 
 
 if __name__ == "__main__":

--- a/tests/e2e/query_modules/schema_test.py
+++ b/tests/e2e/query_modules/schema_test.py
@@ -1107,5 +1107,66 @@ def test_rel_type_properties_partitions_by_endpoint_labels():
     assert rows[("Dog", "Activity", "duration")] == (False, 1, 2)
 
 
+def test_rel_type_properties_unlabeled_endpoints():
+    cursor = connect().cursor()
+    execute_and_fetch_all(cursor, "CREATE ()-[:KNOWS]->()")
+    result = execute_and_fetch_all(
+        cursor,
+        "CALL schema.rel_type_properties() "
+        "YIELD relType, sourceNodeLabels, targetNodeLabels, propertyName, "
+        "propertyObservations, totalObservations "
+        "RETURN relType, sourceNodeLabels, targetNodeLabels, propertyName, "
+        "propertyObservations, totalObservations;",
+    )
+    assert len(result) == 1
+    row = list(result[0])
+    assert row[0] == ":`KNOWS`"
+    assert row[1] == []
+    assert row[2] == []
+    assert row[3] == ""
+    assert row[4] == 0
+    assert row[5] == 1
+
+
+def test_rel_type_properties_multi_label_endpoints():
+    cursor = connect().cursor()
+    execute_and_fetch_all(cursor, "CREATE (:Dog:Pet {name: 'Rex'})-[:OWNS]->(:Toy:Object {name: 'Ball'})")
+    result = execute_and_fetch_all(
+        cursor,
+        "CALL schema.rel_type_properties() "
+        "YIELD relType, sourceNodeLabels, targetNodeLabels "
+        "RETURN relType, sourceNodeLabels, targetNodeLabels;",
+    )
+    assert len(result) == 1
+    row = list(result[0])
+    assert row[0] == ":`OWNS`"
+    assert set(row[1]) == {"Dog", "Pet"}
+    assert set(row[2]) == {"Object", "Toy"}
+
+
+def test_node_type_properties_empty_properties_row():
+    cursor = connect().cursor()
+    execute_and_fetch_all(
+        cursor,
+        """
+        CREATE (:Empty)
+        CREATE (:Empty)
+        CREATE (:Empty)
+        """,
+    )
+    result = execute_and_fetch_all(
+        cursor,
+        "CALL schema.node_type_properties() "
+        "YIELD nodeType, propertyName, propertyObservations, totalObservations "
+        "WHERE nodeType = ':`Empty`' "
+        "RETURN nodeType, propertyName, propertyObservations, totalObservations;",
+    )
+    assert len(result) == 1
+    row = list(result[0])
+    assert row[1] == ""
+    assert row[2] == 0
+    assert row[3] == 3
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-rA"]))


### PR DESCRIPTION
## Summary

Enriches the output of `schema.node_type_properties()` and `schema.rel_type_properties()` so consumers get a more complete picture of the graph's shape.

### Output changes

**`rel_type_properties()`** now emits one row per `(relType, sourceNodeLabels, targetNodeLabels, propertyName)` instead of one row per `(relType, propertyName)`. The same edge type connecting different endpoint label sets produces separate rows. New columns:

- `sourceNodeLabels: LIST<STRING>`, `targetNodeLabels: LIST<STRING>` — labels on the start / end node of edges in the partition.
- `propertyObservations: INTEGER` — edges in the partition that carried this property.
- `totalObservations: INTEGER` — edges in the partition that were examined.

**`node_type_properties()`** keeps its `(nodeType, propertyName)` row granularity and gains `propertyObservations` / `totalObservations` with the analogous meaning for nodes.

`propertyTypes` is now declared `LIST<STRING>` on both procedures (was `Any`).

### Implementation notes

- New `RelKey { rel_type, source_labels, target_labels }` keys the rel-properties scan, hashed via `boost::hash_combine` over the sorted label sets.
- Filter lookups now use a transparent `StringSet`, so `includeRels`/`excludeRels`/`includeLabels`/`excludeLabels` take `std::string_view` without per-call allocations; `rel.Type()` is materialised into a `std::string` only after the filter accepts it.
- `RelKey`, `RelKeyHash`, and `LabelsHash` moved into the file's anonymous namespace; dead `LabelsComparator` removed.

## BREAKING

The output schemas of `schema.node_type_properties()` and `schema.rel_type_properties()` are not backwards-compatible:

1. **New columns** — `CALL ... YIELD *` returns extra fields. Code that binds positionally or asserts column counts will break; use explicit `YIELD <names>`.
2. **Row granularity for `rel_type_properties` changed** — a relationship type connecting multiple endpoint-label combinations now produces one row per `(sourceLabels, targetLabels, property)` rather than one per `(relType, property)`. Row counts and per-row `mandatory` / count values can differ.
3. **`propertyTypes` declared type narrowed** from `Any` to `LIST<STRING>` — clients binding by declared type will see a schema change.