### PR TITLE
feat: SHOW STORAGE INFO query refinement

### DIFF
--- a/src/license/license.cpp
+++ b/src/license/license.cpp
@@ -90,16 +90,16 @@ LicenseCheckResult IsValidLicenseInternal(const License &license, std::string_vi
 std::string LicenseTypeToString(const LicenseType license_type) {
   switch (license_type) {
     case LicenseType::ENTERPRISE: {
-      return "enterprise";
+      return std::string{kLicenseTypeEnterprise};
     }
     case LicenseType::OEM_COMMUNITY: {
-      return "oem_community";
+      return std::string{kLicenseTypeOemCommunity};
     }
     case LicenseType::AI_PLATFORM: {
-      return "ai_platform";
+      return std::string{kLicenseTypeAiPlatform};
     }
     case LicenseType::OEM: {
-      return "oem";
+      return std::string{kLicenseTypeOem};
     }
   }
   std::unreachable();

--- a/src/license/license.hpp
+++ b/src/license/license.hpp
@@ -40,6 +40,11 @@ constexpr bool IsEnterpriseTier(LicenseType type) noexcept {
 
 std::string LicenseTypeToString(LicenseType license_type);
 
+inline constexpr std::string_view kLicenseTypeEnterprise = "enterprise";
+inline constexpr std::string_view kLicenseTypeOem = "oem";
+inline constexpr std::string_view kLicenseTypeOemCommunity = "oem_community";
+inline constexpr std::string_view kLicenseTypeAiPlatform = "ai_platform";
+
 struct License {
   License() = default;
 

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -386,7 +386,7 @@ int main(int argc, char **argv) {
               "Running out of available RAM, only {} MB left.", *free_ram / 1024, "https://memgr.ph/ram"));
 
         auto memory_res = memgraph::utils::GetMemoryRES();
-        peak_gauge->Set(std::max(static_cast<double>(memory_res), peak_gauge->Value()));
+        memgraph::metrics::Metrics().UpdateAndGetPeakMemoryRes(memory_res);
       });
     } else {
       // Kernel version for the `MemAvailable` value is from: man procfs

--- a/src/metrics/prometheus_metrics.cpp
+++ b/src/metrics/prometheus_metrics.cpp
@@ -1211,6 +1211,15 @@ void PrometheusMetrics::UpdateGauges() {
 #endif
 }
 
+uint64_t PrometheusMetrics::UpdateAndGetPeakMemoryRes(uint64_t const current) const {
+  static std::mutex mtx;
+  std::lock_guard const lock{mtx};
+  auto const peak = static_cast<uint64_t>(global.peak_memory_res_bytes->Value());
+  auto const new_peak = std::max(current, peak);
+  global.peak_memory_res_bytes->Set(static_cast<double>(new_peak));
+  return new_peak;
+}
+
 namespace {
 
 // Compute percentile from a prometheus histogram's cumulative bucket data.

--- a/src/metrics/prometheus_metrics.cpp
+++ b/src/metrics/prometheus_metrics.cpp
@@ -857,6 +857,9 @@ PrometheusMetrics::PrometheusMetrics()
   global.update_data_instance_config_rpc_seconds =
       &update_data_instance_config_rpc_histogram_family_.Add(no_labels, kLatencyBuckets);
   global.get_histories_seconds = &get_histories_family_.Add(no_labels, kLatencyBuckets);
+
+  // StorageInfo global/system level (no-db fallback, same family as per-db)
+  global.show_storage_info = &show_storage_info_family_.Add(no_labels);
 }
 
 void PrometheusMetrics::SetStorageSnapshotResolver(StorageSnapshotResolver resolver) {
@@ -1875,8 +1878,10 @@ std::vector<MetricInfo> PrometheusMetrics::GetGlobalMetricsInfoForJson() {
   // SchemaInfo
   out.push_back({"ShowSchema", "SchemaInfo", "Counter", total_show_schema});
 
-  // StorageInfo
+  // StorageInfo — per-db total (sum across all databases)
   out.push_back({"ShowStorageInfoOnDatabase", "StorageInfo", "Counter", total_show_storage_info});
+  // StorageInfo — global/system-level counter
+  out.push_back({"ShowStorageInfo", "StorageInfo", "Counter", static_cast<int64_t>(global.show_storage_info->Value())});
 
   // Query
   AppendMergedHistogramPercentiles(out, "QueryExecutionLatency", "Query", query_exec_hdatas);
@@ -2080,6 +2085,9 @@ std::vector<MetricInfo> PrometheusMetrics::GetGlobalMetricsInfo() const {
   AppendHistogramPercentiles(
       out, "UpdateDataInstanceConfigRpc", "HighAvailability", *global.update_data_instance_config_rpc_seconds);
   AppendHistogramPercentiles(out, "GetHistories", "HighAvailability", *global.get_histories_seconds);
+
+  // StorageInfo global/system level (no-db SHOW STORAGE INFO)
+  out.push_back({"ShowStorageInfo", "StorageInfo", "Counter", static_cast<int64_t>(global.show_storage_info->Value())});
 
   return out;
 }
@@ -2377,6 +2385,7 @@ nlohmann::json PrometheusMetrics::GetTelemetryCounters() const {
     {"DeletedEdges", deleted_edges},
     {"ShowSchema", show_schema},
     {"ShowStorageInfoOnDatabase", show_storage_info},
+    {"ShowStorageInfo", static_cast<int64_t>(global.show_storage_info->Value())},
     {"SuccessfulFailovers", static_cast<int64_t>(global.successful_failovers->Value())},
     {"RaftFailedFailovers", static_cast<int64_t>(global.raft_failed_failovers->Value())},
     {"NoAliveInstanceFailedFailovers", static_cast<int64_t>(global.no_alive_instance_failed_failovers->Value())},

--- a/src/metrics/prometheus_metrics.cpp
+++ b/src/metrics/prometheus_metrics.cpp
@@ -1889,8 +1889,6 @@ std::vector<MetricInfo> PrometheusMetrics::GetGlobalMetricsInfoForJson() {
 
   // StorageInfo — per-db total (sum across all databases)
   out.push_back({"ShowStorageInfoOnDatabase", "StorageInfo", "Counter", total_show_storage_info});
-  // StorageInfo — global/system-level counter
-  out.push_back({"ShowStorageInfo", "StorageInfo", "Counter", static_cast<int64_t>(global.show_storage_info->Value())});
 
   // Query
   AppendMergedHistogramPercentiles(out, "QueryExecutionLatency", "Query", query_exec_hdatas);

--- a/src/metrics/prometheus_metrics.hpp
+++ b/src/metrics/prometheus_metrics.hpp
@@ -352,6 +352,10 @@ class PrometheusMetrics {
   void RebindDefaultDatabaseUUID(utils::UUID const &new_uuid);
   void UpdateGauges();
 
+  /// Thread-safe update of the global peak_memory_res_bytes gauge.
+  /// Sets the gauge to max(current, previous) and returns the new peak.
+  uint64_t UpdateAndGetPeakMemoryRes(uint64_t current) const;
+
   void SetStorageSnapshotResolver(StorageSnapshotResolver resolver);
 #ifdef MG_ENTERPRISE
   void SetInstanceStatusResolver(InstanceStatusResolver resolver);

--- a/src/metrics/prometheus_metrics.hpp
+++ b/src/metrics/prometheus_metrics.hpp
@@ -240,7 +240,7 @@ struct DatabaseMetricHandles {
   // SchemaInfo
   CounterHandle show_schema;
 
-  // StorageInfo
+  // StorageInfo database specific
   CounterHandle show_storage_info;
 
   // Histograms
@@ -332,6 +332,9 @@ struct GlobalMetricHandles {
   prometheus::Histogram *system_recovery_rpc_seconds;
   prometheus::Histogram *update_data_instance_config_rpc_seconds;
   prometheus::Histogram *get_histories_seconds;
+
+  // StorageInfo global/system level
+  prometheus::Counter *show_storage_info;
 };
 
 class PrometheusMetrics {

--- a/src/query/frontend/ast/ast.hpp
+++ b/src/query/frontend/ast/ast.hpp
@@ -3130,11 +3130,13 @@ class SystemInfoQuery : public memgraph::query::Query {
 
   memgraph::query::SystemInfoQuery::InfoType info_type_;
   std::optional<std::string> database_;
+  bool is_current_database_{false};
 
   SystemInfoQuery *Clone(AstStorage *storage) const override {
     SystemInfoQuery *object = storage->Create<SystemInfoQuery>();
     object->info_type_ = info_type_;
     object->database_ = database_;
+    object->is_current_database_ = is_current_database_;
     return object;
   }
 };

--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -188,8 +188,12 @@ antlrcpp::Any CypherMainVisitor::visitSystemInfoQuery(MemgraphCypher::SystemInfo
   query_ = info_query;
   if (ctx->storageInfo()) {
     info_query->info_type_ = SystemInfoQuery::InfoType::STORAGE;
-    if (ctx->storageInfo()->db) {
-      info_query->database_ = std::any_cast<std::string>(ctx->storageInfo()->db->accept(this));
+    if (ctx->storageInfo()->ON()) {
+      if (ctx->storageInfo()->db) {
+        info_query->database_ = std::any_cast<std::string>(ctx->storageInfo()->db->accept(this));
+      } else if (ctx->storageInfo()->CURRENT()) {
+        info_query->is_current_database_ = true;
+      }
     }
     return info_query;
   }

--- a/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
+++ b/src/query/frontend/opencypher/grammar/MemgraphCypher.g4
@@ -992,10 +992,10 @@ showDescriptions
     : SHOW DESCRIPTIONS
     ;
 
-// Overrides Cypher.g4: storageInfo adds an optional 'ON DATABASE <name>' clause.
+// Overrides Cypher.g4: storageInfo adds an optional 'ON DATABASE <name>' or 'ON CURRENT DATABASE' clause.
 // systemInfoQuery is re-listed so it dispatches to the overridden storageInfo above.
 systemInfoQuery : SHOW ( storageInfo | buildInfo | activeUsersInfo | licenseInfo ) ;
-storageInfo : STORAGE INFO ( ON DATABASE db=symbolicName )? ;
+storageInfo : STORAGE INFO ( ON ( DATABASE db=symbolicName | CURRENT DATABASE ) )? ;
 
 edgeTypePatternNode
     : '(' ( ':' labelName )+ ')'

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -50,7 +50,10 @@
 #include "dbms/dbms_handler.hpp"
 #include "dbms/global.hpp"
 #include "flags/experimental.hpp"
+#include "flags/general.hpp"
+#include "flags/isolation_level.hpp"
 #include "flags/run_time_configurable.hpp"
+#include "flags/storage_mode.hpp"
 #include "frontend/ast/query/tenant_profile.hpp"
 #include "frontend/ast/query/user_profile.hpp"
 #include "frontend/semantic/rw_checker.hpp"
@@ -114,6 +117,9 @@
 #include "utils/algorithm.hpp"
 #include "utils/build_info.hpp"
 #include "utils/compile_time.hpp"
+#include "utils/event_counter.hpp"
+#include "utils/event_gauge.hpp"
+#include "utils/event_histogram.hpp"
 #include "utils/exceptions.hpp"
 #include "utils/functional.hpp"
 #include "utils/likely.hpp"
@@ -143,11 +149,32 @@ import memgraph.utils.aws;
 namespace r = ranges;
 namespace rv = ranges::views;
 
+namespace memgraph::metrics {
+extern const Event PeakMemoryRes;
+}  // namespace memgraph::metrics
+
 namespace {
 
 using memgraph::query::Expression;
 using memgraph::query::ExpressionVisitor;
 using memgraph::query::TypedValue;
+
+struct InstanceStorageInfo {
+  uint64_t memory_res;
+  uint64_t peak_memory_res;
+  uint64_t disk_usage;
+  int64_t vm_max_map_count;
+};
+
+InstanceStorageInfo GetInstanceStorageInfo() {
+  const auto memory_res = memgraph::utils::GetMemoryRES();
+  memgraph::metrics::SetGaugeValue(memgraph::metrics::PeakMemoryRes, memory_res);
+  const auto peak_memory_res = memgraph::metrics::GetGaugeValue(memgraph::metrics::PeakMemoryRes);
+  const int64_t vm_max_map_count =
+      memgraph::utils::GetVmMaxMapCount().value_or(memgraph::utils::VM_MAX_MAP_COUNT_DEFAULT);
+  const auto disk_usage = memgraph::utils::GetDirDiskUsage(FLAGS_data_directory);
+  return {memory_res, peak_memory_res, disk_usage, vm_max_map_count};
+}
 
 auto ParseConfigMap(std::unordered_map<Expression *, Expression *> const &config_map,
                     ExpressionVisitor<TypedValue> &evaluator)
@@ -7164,19 +7191,25 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
       } else {
         MG_ASSERT(current_db.db_acc_, "System storage info query expects a current DB");
         handler = [storage = current_db.db_acc_->get()->storage(),
+                   db = current_db.db_acc_->get(),
+                   interpreter_context,
                    interpreter_isolation_level,
                    next_transaction_isolation_level] {
-          auto info = storage->GetBaseInfo();
-          const int64_t vm_max_map_count_storage_info =
-              utils::GetVmMaxMapCount().value_or(memgraph::utils::VM_MAX_MAP_COUNT_DEFAULT);
-          const auto disk_usage = utils::GetDirDiskUsage(storage->config_.durability.root_data_directory);
-
+          const auto instance_info = GetInstanceStorageInfo();
+          int64_t global_query_memory = 0;
+          if (interpreter_context->dbms_handler) {
+            global_query_memory = 0;
+            interpreter_context->dbms_handler->ForEach(
+                [&global_query_memory](auto db_acc) { global_query_memory += db_acc->DbQueryMemoryUsage(); });
+          }
           const std::vector<std::vector<TypedValue>> results{
-              {TypedValue("vm_max_map_count"), TypedValue(vm_max_map_count_storage_info)},
-              {TypedValue("memory_res"), TypedValue(utils::GetReadableSize(static_cast<double>(info.memory_res)))},
+              {TypedValue("vm_max_map_count"), TypedValue(instance_info.vm_max_map_count)},
+              {TypedValue("memory_res"),
+               TypedValue(utils::GetReadableSize(static_cast<double>(instance_info.memory_res)))},
               {TypedValue("peak_memory_res"),
-               TypedValue(utils::GetReadableSize(static_cast<double>(info.peak_memory_res)))},
-              {TypedValue("disk_usage"), TypedValue(utils::GetReadableSize(static_cast<double>(disk_usage)))},
+               TypedValue(utils::GetReadableSize(static_cast<double>(instance_info.peak_memory_res)))},
+              {TypedValue("disk_usage"),
+               TypedValue(utils::GetReadableSize(static_cast<double>(instance_info.disk_usage)))},
               {TypedValue("memory_tracked"),
                TypedValue(utils::GetReadableSize(static_cast<double>(utils::total_memory_tracker.Amount())))},
               {TypedValue("runtime_allocation_limit"),
@@ -7186,11 +7219,17 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
                  const int64_t limit = info->has_value() ? (*info)->license.memory_limit : 0;
                  return limit > 0 ? utils::GetReadableSize(static_cast<double>(limit)) : std::string("unlimited");
                }))},
-              {TypedValue("isolation_level"), TypedValue(IsolationLevelToString(storage->GetIsolationLevel()))},
+              {TypedValue("graph_memory_tracked"),
+               TypedValue(utils::GetReadableSize(static_cast<double>(utils::graph_memory_tracker.Amount())))},
+              {TypedValue("vector_index_memory_tracked"),
+               TypedValue(utils::GetReadableSize(static_cast<double>(utils::vector_index_memory_tracker.Amount())))},
+              {TypedValue("query_memory_tracked"),
+               TypedValue(utils::GetReadableSize(static_cast<double>(global_query_memory)))},
+              {TypedValue("storage_isolation_level"), TypedValue(IsolationLevelToString(flags::ParseIsolationLevel()))},
               {TypedValue("session_isolation_level"), TypedValue(IsolationLevelToString(interpreter_isolation_level))},
               {TypedValue("next_session_isolation_level"),
                TypedValue(IsolationLevelToString(next_transaction_isolation_level))},
-              {TypedValue("storage_mode"), TypedValue(StorageModeToString(storage->GetStorageMode()))}};
+              {TypedValue("storage_mode"), TypedValue(StorageModeToString(flags::ParseStorageMode()))}};
           return std::pair{results, QueryHandlerResult::NOTHING};
         };
       }

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -7146,6 +7146,8 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
           const auto db_storage_memory = static_cast<double>(db->DbStorageMemoryUsage());
           const auto db_embedding_memory = static_cast<double>(db->DbEmbeddingMemoryUsage());
           const auto db_query_memory = static_cast<double>(db->DbQueryMemoryUsage());
+          const auto global_disk = utils::GetDirDiskUsage(storage->config_.durability.root_data_directory);
+
           const std::vector<std::vector<TypedValue>> results{
               {TypedValue("name"), TypedValue(storage->name())},
               {TypedValue("database_uuid"), TypedValue(static_cast<std::string>(storage->uuid()))},
@@ -7157,8 +7159,8 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
               {TypedValue("peak_memory_res"),
                TypedValue(utils::GetReadableSize(static_cast<double>(info.peak_memory_res)))},
               {TypedValue("unreleased_delta_objects"), TypedValue(static_cast<int64_t>(info.unreleased_delta_objects))},
-              {TypedValue("global_disk_usage"),
-               TypedValue(utils::GetReadableSize(static_cast<double>(info.disk_usage)))},
+              {TypedValue("db_disk_usage"), TypedValue(utils::GetReadableSize(static_cast<double>(info.disk_usage)))},
+              {TypedValue("global_disk_usage"), TypedValue(utils::GetReadableSize(static_cast<double>(global_disk)))},
               {TypedValue("global_memory_tracked"),
                TypedValue(utils::GetReadableSize(static_cast<double>(utils::total_memory_tracker.Amount())))},
               {TypedValue("global_runtime_allocation_limit"),

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -7190,18 +7190,8 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
         };
       } else {
         MG_ASSERT(current_db.db_acc_, "System storage info query expects a current DB");
-        handler = [storage = current_db.db_acc_->get()->storage(),
-                   db = current_db.db_acc_->get(),
-                   interpreter_context,
-                   interpreter_isolation_level,
-                   next_transaction_isolation_level] {
+        handler = [interpreter_context, interpreter_isolation_level, next_transaction_isolation_level] {
           const auto instance_info = GetInstanceStorageInfo();
-          int64_t global_query_memory = 0;
-          if (interpreter_context->dbms_handler) {
-            global_query_memory = 0;
-            interpreter_context->dbms_handler->ForEach(
-                [&global_query_memory](auto db_acc) { global_query_memory += db_acc->DbQueryMemoryUsage(); });
-          }
           const std::vector<std::vector<TypedValue>> results{
               {TypedValue("vm_max_map_count"), TypedValue(instance_info.vm_max_map_count)},
               {TypedValue("memory_res"),
@@ -7212,19 +7202,17 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
                TypedValue(utils::GetReadableSize(static_cast<double>(instance_info.disk_usage)))},
               {TypedValue("memory_tracked"),
                TypedValue(utils::GetReadableSize(static_cast<double>(utils::total_memory_tracker.Amount())))},
-              {TypedValue("runtime_allocation_limit"),
+              {TypedValue("memory_limit"),
                TypedValue(utils::GetReadableSize(static_cast<double>(utils::total_memory_tracker.MaximumHardLimit())))},
-              {TypedValue("license_allocation_limit"), TypedValue(std::invoke([] {
+              {TypedValue("license_memory_limit"), TypedValue(std::invoke([] {
                  auto info = license::global_license_checker.GetLicenseInfo().Lock();
                  const int64_t limit = info->has_value() ? (*info)->license.memory_limit : 0;
                  return limit > 0 ? utils::GetReadableSize(static_cast<double>(limit)) : std::string("unlimited");
                }))},
-              {TypedValue("graph_memory_tracked"),
+              {TypedValue("query_graph_memory_tracked"),
                TypedValue(utils::GetReadableSize(static_cast<double>(utils::graph_memory_tracker.Amount())))},
               {TypedValue("vector_index_memory_tracked"),
                TypedValue(utils::GetReadableSize(static_cast<double>(utils::vector_index_memory_tracker.Amount())))},
-              {TypedValue("query_memory_tracked"),
-               TypedValue(utils::GetReadableSize(static_cast<double>(global_query_memory)))},
               {TypedValue("storage_isolation_level"), TypedValue(IsolationLevelToString(flags::ParseIsolationLevel()))},
               {TypedValue("session_isolation_level"), TypedValue(IsolationLevelToString(interpreter_isolation_level))},
               {TypedValue("next_session_isolation_level"),
@@ -7257,9 +7245,14 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
       header = {"license info", "value"};
       handler = [] {
         const auto license_info = license::global_license_checker.GetDetailedLicenseInfo();
-        const auto memory_limit = license_info.memory_limit != 0
-                                      ? utils::GetReadableSize(static_cast<double>(license_info.memory_limit))
-                                      : "UNLIMITED";
+        std::string memory_limit_policy = "Memory usage is not limited.";
+        std::string memory_limit = "UNLIMITED";
+        if (license_info.memory_limit != 0) {
+          memory_limit = utils::GetReadableSize(static_cast<double>(license_info.memory_limit));
+          memory_limit_policy = license_info.license_type == license::kLicenseTypeAiPlatform
+                                    ? "Graph and query memory are limited. Vector index memory is not limited."
+                                    : "All memory usage is limited.";
+        }
 
         const std::vector<std::vector<TypedValue>> results{
             {TypedValue("organization_name"), TypedValue(license_info.organization_name)},
@@ -7267,8 +7260,9 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
             {TypedValue("is_valid"), TypedValue(license_info.is_valid)},
             {TypedValue("license_type"), TypedValue(license_info.license_type)},
             {TypedValue("valid_until"), TypedValue(license_info.valid_until)},
-            {TypedValue("memory_limit"), TypedValue(memory_limit)},
+            {TypedValue("memory_limit"), TypedValue(std::move(memory_limit))},
             {TypedValue("status"), TypedValue(license_info.status)},
+            {TypedValue("memory_limit_policy"), TypedValue(std::move(memory_limit_policy))},
         };
 
         return std::pair{results, QueryHandlerResult::NOTHING};

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -173,7 +173,10 @@ InstanceStorageInfo GetInstanceStorageInfo() {
   const int64_t vm_max_map_count =
       memgraph::utils::GetVmMaxMapCount().value_or(memgraph::utils::VM_MAX_MAP_COUNT_DEFAULT);
   const auto disk_usage = memgraph::utils::GetDirDiskUsage(FLAGS_data_directory);
-  return {memory_res, peak_memory_res, disk_usage, vm_max_map_count};
+  return {.memory_res = memory_res,
+          .peak_memory_res = peak_memory_res,
+          .disk_usage = disk_usage,
+          .vm_max_map_count = vm_max_map_count};
 }
 
 auto ParseConfigMap(std::unordered_map<Expression *, Expression *> const &config_map,

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -7112,28 +7112,32 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
       }
 #endif
       auto *dbms_handler = interpreter_context->dbms_handler;
-      std::optional<dbms::DatabaseAccess> database{};
-
-      if (info_query->database_) {
-        const auto &db_name = *info_query->database_;
-        if (!license::global_license_checker.IsEnterpriseValidFast() && db_name != dbms::kDefaultDB) {
-          throw QueryRuntimeException(
-              license::LicenseCheckErrorToString(license::LicenseCheckError::NOT_ENTERPRISE_LICENSE, "multi-tenancy"));
-        }
+      auto resolve_database = [&]() -> std::optional<dbms::DatabaseAccess> {
+        if (info_query->database_) {
+          const auto &db_name = *info_query->database_;
+          if (!license::global_license_checker.IsEnterpriseValidFast() && db_name != dbms::kDefaultDB) {
+            throw QueryRuntimeException(license::LicenseCheckErrorToString(
+                license::LicenseCheckError::NOT_ENTERPRISE_LICENSE, "multi-tenancy"));
+          }
 #ifdef MG_ENTERPRISE
-        database = dbms_handler->Get(*info_query->database_);
+          auto db = dbms_handler->Get(db_name);
 #else
-        database = dbms_handler->Get();
+          auto db = dbms_handler->Get();
 #endif
-        if (!database) {
-          throw QueryRuntimeException("Database '{}' was not found.", *info_query->database_);
+          if (!db) {
+            throw QueryRuntimeException("Database '{}' was not found.", db_name);
+          }
+          return db;
         }
-      } else if (info_query->is_current_database_) {
-        if (!current_db.db_acc_) {
-          throw QueryRuntimeException("No current database for the session.");
+        if (info_query->is_current_database_) {
+          if (!current_db.db_acc_) {
+            throw QueryRuntimeException("No current database for the session.");
+          }
+          return current_db.db_acc_;
         }
-        database = current_db.db_acc_;
-      }
+        return std::nullopt;
+      };
+      auto database = resolve_database();
 
       if (database) {
         handler = [db_acc = std::move(
@@ -7196,11 +7200,11 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
                TypedValue(utils::GetReadableSize(static_cast<double>(utils::graph_memory_tracker.Amount())))},
               {TypedValue("vector_index_memory_tracked"),
                TypedValue(utils::GetReadableSize(static_cast<double>(utils::vector_index_memory_tracker.Amount())))},
-              {TypedValue("storage_isolation_level"), TypedValue(IsolationLevelToString(flags::ParseIsolationLevel()))},
+              {TypedValue("global_isolation_level"), TypedValue(IsolationLevelToString(flags::ParseIsolationLevel()))},
               {TypedValue("session_isolation_level"), TypedValue(IsolationLevelToString(interpreter_isolation_level))},
               {TypedValue("next_session_isolation_level"),
                TypedValue(IsolationLevelToString(next_transaction_isolation_level))},
-              {TypedValue("storage_mode"), TypedValue(StorageModeToString(flags::ParseStorageMode()))}};
+              {TypedValue("global_storage_mode"), TypedValue(StorageModeToString(flags::ParseStorageMode()))}};
           return std::pair{results, QueryHandlerResult::NOTHING};
         };
       }

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -7089,93 +7089,104 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
         throw QueryRuntimeException("Coordinators don't have storage!");
       }
 #endif
+      // Helper lambda to build database-specific results (used by ON DATABASE and ON CURRENT DATABASE)
+      auto build_db_results = [](auto *storage, auto *db) {
+        auto info = storage->GetBaseInfo();
+        const auto db_storage_memory = static_cast<double>(db->DbStorageMemoryUsage());
+        const auto db_embedding_memory = static_cast<double>(db->DbEmbeddingMemoryUsage());
+        const auto db_query_memory = static_cast<double>(db->DbQueryMemoryUsage());
+        const auto db_total_memory = static_cast<double>(db->DbMemoryUsage());
+        const auto db_peak_memory = static_cast<double>(db->DbPeakMemoryUsage());
+        const auto tenant_limit = db->TenantMemoryLimit();
+
+        const std::vector<std::vector<TypedValue>> results{
+            {TypedValue("name"), TypedValue(storage->name())},
+            {TypedValue("database_uuid"), TypedValue(static_cast<std::string>(storage->uuid()))},
+            {TypedValue("storage_mode"), TypedValue(StorageModeToString(storage->GetStorageMode()))},
+            {TypedValue("vertex_count"), TypedValue(static_cast<int64_t>(info.vertex_count))},
+            {TypedValue("edge_count"), TypedValue(static_cast<int64_t>(info.edge_count))},
+            {TypedValue("average_degree"), TypedValue(info.average_degree)},
+            {TypedValue("unreleased_delta_objects"), TypedValue(static_cast<int64_t>(info.unreleased_delta_objects))},
+            {TypedValue("disk_usage"), TypedValue(utils::GetReadableSize(static_cast<double>(info.disk_usage)))},
+            {TypedValue("graph_memory_tracked"), TypedValue(utils::GetReadableSize(db_storage_memory))},
+            {TypedValue("query_memory_tracked"), TypedValue(utils::GetReadableSize(db_query_memory))},
+            {TypedValue("vector_index_memory_tracked"), TypedValue(utils::GetReadableSize(db_embedding_memory))},
+            {TypedValue("tenant_memory_tracked"), TypedValue(utils::GetReadableSize(db_total_memory))},
+            {TypedValue("tenant_peak_memory_tracked"), TypedValue(utils::GetReadableSize(db_peak_memory))},
+            {TypedValue("tenant_memory_limit"),
+             TypedValue(tenant_limit > 0 ? utils::GetReadableSize(static_cast<double>(tenant_limit))
+                                         : std::string("unlimited"))},
+            {TypedValue("storage_isolation_level"), TypedValue(IsolationLevelToString(storage->GetIsolationLevel()))},
+        };
+        return std::pair{results, QueryHandlerResult::NOTHING};
+      };
+
       if (info_query->database_) {
 #ifdef MG_ENTERPRISE
-        handler = [db_name = *info_query->database_, db_handler = interpreter_context->dbms_handler]
-            -> std::pair<std::vector<std::vector<TypedValue>>, QueryHandlerResult> {
-          if (!db_handler) {
-            throw QueryRuntimeException("Database handler is not available");
-          }
-          auto db_acc = db_handler->Get(db_name);
-          auto *db = db_acc.get();
-          if (!db) throw QueryRuntimeException("Database '{}' was dropped during query execution.", db_name);
-          if (auto *mh = db->metric_handles()) mh->show_storage_info.Increment();
-          auto *storage = db->storage();
-          auto info = storage->GetBaseInfo();
-
-          const auto db_storage_memory = static_cast<double>(db->DbStorageMemoryUsage());
-          const auto db_embedding_memory = static_cast<double>(db->DbEmbeddingMemoryUsage());
-          const auto db_query_memory = static_cast<double>(db->DbQueryMemoryUsage());
-          const auto db_total_memory = static_cast<double>(db->DbMemoryUsage());
-          const auto db_peak_memory = static_cast<double>(db->DbPeakMemoryUsage());
-          const auto tenant_limit = db->TenantMemoryLimit();
-
-          const std::vector<std::vector<TypedValue>> results{
-              {TypedValue("name"), TypedValue(storage->name())},
-              {TypedValue("database_uuid"), TypedValue(static_cast<std::string>(storage->uuid()))},
-              {TypedValue("storage_mode"), TypedValue(StorageModeToString(storage->GetStorageMode()))},
-              {TypedValue("vertex_count"), TypedValue(static_cast<int64_t>(info.vertex_count))},
-              {TypedValue("edge_count"), TypedValue(static_cast<int64_t>(info.edge_count))},
-              {TypedValue("average_degree"), TypedValue(info.average_degree)},
-              {TypedValue("unreleased_delta_objects"), TypedValue(static_cast<int64_t>(info.unreleased_delta_objects))},
-              {TypedValue("disk_usage"), TypedValue(utils::GetReadableSize(static_cast<double>(info.disk_usage)))},
-              {TypedValue("graph_memory_tracked"), TypedValue(utils::GetReadableSize(db_storage_memory))},
-              {TypedValue("query_memory_tracked"), TypedValue(utils::GetReadableSize(db_query_memory))},
-              {TypedValue("vector_index_memory_tracked"), TypedValue(utils::GetReadableSize(db_embedding_memory))},
-              {TypedValue("tenant_memory_tracked"), TypedValue(utils::GetReadableSize(db_total_memory))},
-              {TypedValue("tenant_peak_memory_tracked"), TypedValue(utils::GetReadableSize(db_peak_memory))},
-              {TypedValue("tenant_memory_limit"),
-               TypedValue(tenant_limit > 0 ? utils::GetReadableSize(static_cast<double>(tenant_limit))
-                                           : std::string("unlimited"))},
-              {TypedValue("storage_isolation_level"), TypedValue(IsolationLevelToString(storage->GetIsolationLevel()))},
+        if (interpreter_context->dbms_handler) {
+          handler = [db_name = *info_query->database_,
+                     db_handler = interpreter_context->dbms_handler,
+                     build_db_results] -> std::pair<std::vector<std::vector<TypedValue>>, QueryHandlerResult> {
+            if (!db_handler) {
+              throw QueryRuntimeException("Database handler is not available");
+            }
+            memgraph::metrics::IncrementCounter(memgraph::metrics::ShowStorageInfoOnDatabase);
+            auto db_acc = db_handler->Get(db_name);
+            auto *db = db_acc.get();
+            if (!db) throw QueryRuntimeException("Database '{}' was dropped during query execution.", db_name);
+            if (auto *mh = db->metric_handles()) mh->show_storage_info.Increment();
+            return build_db_results(db->storage(), db);
           };
-          return std::pair{results, QueryHandlerResult::NOTHING};
-        };
-#else
-        throw QueryRuntimeException("SHOW STORAGE INFO ON DATABASE is only available in the enterprise edition.");
+        } else
 #endif
-      } else {
+        {
+          // Community path or when dbms_handler is null
+          MG_ASSERT(current_db.db_acc_, "System storage info query expects a current DB");
+          if (current_db.name() == *info_query->database_) {
+            handler = [storage = current_db.db_acc_->get()->storage(),
+                       db = current_db.db_acc_->get(),
+                       build_db_results] -> std::pair<std::vector<std::vector<TypedValue>>, QueryHandlerResult> {
+              memgraph::metrics::IncrementCounter(memgraph::metrics::ShowStorageInfoOnDatabase);
+              return build_db_results(storage, db);
+            };
+          } else {
+            throw QueryRuntimeException("SHOW STORAGE INFO ON DATABASE is only available in the enterprise edition.");
+          }
+        }
+      } else if (info_query->is_current_database_) {
         MG_ASSERT(current_db.db_acc_, "System storage info query expects a current DB");
         handler = [storage = current_db.db_acc_->get()->storage(),
                    db = current_db.db_acc_->get(),
+                   build_db_results] -> std::pair<std::vector<std::vector<TypedValue>>, QueryHandlerResult> {
+          memgraph::metrics::IncrementCounter(memgraph::metrics::ShowStorageInfoOnDatabase);
+          return build_db_results(storage, db);
+        };
+      } else {
+        MG_ASSERT(current_db.db_acc_, "System storage info query expects a current DB");
+        handler = [storage = current_db.db_acc_->get()->storage(),
                    interpreter_isolation_level,
                    next_transaction_isolation_level] {
           auto info = storage->GetBaseInfo();
           const int64_t vm_max_map_count_storage_info =
               utils::GetVmMaxMapCount().value_or(memgraph::utils::VM_MAX_MAP_COUNT_DEFAULT);
-          const auto db_storage_memory = static_cast<double>(db->DbStorageMemoryUsage());
-          const auto db_embedding_memory = static_cast<double>(db->DbEmbeddingMemoryUsage());
-          const auto db_query_memory = static_cast<double>(db->DbQueryMemoryUsage());
-          const auto global_disk = utils::GetDirDiskUsage(storage->config_.durability.root_data_directory);
+          const auto disk_usage = utils::GetDirDiskUsage(storage->config_.durability.root_data_directory);
 
           const std::vector<std::vector<TypedValue>> results{
-              {TypedValue("name"), TypedValue(storage->name())},
-              {TypedValue("database_uuid"), TypedValue(static_cast<std::string>(storage->uuid()))},
-              {TypedValue("vertex_count"), TypedValue(static_cast<int64_t>(info.vertex_count))},
-              {TypedValue("edge_count"), TypedValue(static_cast<int64_t>(info.edge_count))},
-              {TypedValue("average_degree"), TypedValue(info.average_degree)},
               {TypedValue("vm_max_map_count"), TypedValue(vm_max_map_count_storage_info)},
               {TypedValue("memory_res"), TypedValue(utils::GetReadableSize(static_cast<double>(info.memory_res)))},
               {TypedValue("peak_memory_res"),
                TypedValue(utils::GetReadableSize(static_cast<double>(info.peak_memory_res)))},
-              {TypedValue("unreleased_delta_objects"), TypedValue(static_cast<int64_t>(info.unreleased_delta_objects))},
-              {TypedValue("db_disk_usage"), TypedValue(utils::GetReadableSize(static_cast<double>(info.disk_usage)))},
-              {TypedValue("global_disk_usage"), TypedValue(utils::GetReadableSize(static_cast<double>(global_disk)))},
-              {TypedValue("global_memory_tracked"),
+              {TypedValue("disk_usage"), TypedValue(utils::GetReadableSize(static_cast<double>(disk_usage)))},
+              {TypedValue("memory_tracked"),
                TypedValue(utils::GetReadableSize(static_cast<double>(utils::total_memory_tracker.Amount())))},
-              {TypedValue("global_runtime_allocation_limit"),
+              {TypedValue("runtime_allocation_limit"),
                TypedValue(utils::GetReadableSize(static_cast<double>(utils::total_memory_tracker.MaximumHardLimit())))},
-              {TypedValue("global_license_allocation_limit"), TypedValue(std::invoke([] {
+              {TypedValue("license_allocation_limit"), TypedValue(std::invoke([] {
                  auto info = license::global_license_checker.GetLicenseInfo().Lock();
                  const int64_t limit = info->has_value() ? (*info)->license.memory_limit : 0;
                  return limit > 0 ? utils::GetReadableSize(static_cast<double>(limit)) : std::string("unlimited");
                }))},
-              {TypedValue("db_memory_tracked"),
-               TypedValue(utils::GetReadableSize(db_storage_memory + db_embedding_memory + db_query_memory))},
-              {TypedValue("db_storage_memory_tracked"), TypedValue(utils::GetReadableSize(db_storage_memory))},
-              {TypedValue("db_embedding_memory_tracked"), TypedValue(utils::GetReadableSize(db_embedding_memory))},
-              {TypedValue("db_query_memory_tracked"), TypedValue(utils::GetReadableSize(db_query_memory))},
-              {TypedValue("global_isolation_level"), TypedValue(IsolationLevelToString(storage->GetIsolationLevel()))},
+              {TypedValue("isolation_level"), TypedValue(IsolationLevelToString(storage->GetIsolationLevel()))},
               {TypedValue("session_isolation_level"), TypedValue(IsolationLevelToString(interpreter_isolation_level))},
               {TypedValue("next_session_isolation_level"),
                TypedValue(IsolationLevelToString(next_transaction_isolation_level))},

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -161,10 +161,7 @@ struct InstanceStorageInfo {
 
 InstanceStorageInfo GetInstanceStorageInfo() {
   const auto memory_res = memgraph::utils::GetMemoryRES();
-  memgraph::metrics::Metrics().global.peak_memory_res_bytes->Set(
-      std::max(static_cast<double>(memory_res), memgraph::metrics::Metrics().global.peak_memory_res_bytes->Value()));
-  const auto peak_memory_res =
-      static_cast<uint64_t>(memgraph::metrics::Metrics().global.peak_memory_res_bytes->Value());
+  const auto peak_memory_res = memgraph::metrics::Metrics().UpdateAndGetPeakMemoryRes(memory_res);
   const int64_t vm_max_map_count =
       memgraph::utils::GetVmMaxMapCount().value_or(memgraph::utils::VM_MAX_MAP_COUNT_DEFAULT);
   const auto disk_usage = memgraph::utils::GetDirDiskUsage(FLAGS_data_directory);
@@ -7142,7 +7139,7 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
         handler = [db_acc = std::move(
                        *database)] mutable -> std::pair<std::vector<std::vector<TypedValue>>, QueryHandlerResult> {
           auto *db = db_acc.get();
-          if (!db) throw QueryRuntimeException("Database '{}' was dropped during query execution.", db->name());
+          if (!db) throw QueryRuntimeException("Database was dropped during query execution.");
           if (auto *mh = db->metric_handles()) mh->show_storage_info.Increment();
           auto *storage = db->storage();
           auto info = storage->GetBaseInfo();
@@ -7175,7 +7172,6 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
           return std::pair{results, QueryHandlerResult::NOTHING};
         };
       } else {
-        MG_ASSERT(current_db.db_acc_, "System storage info query expects a current DB");
         handler = [interpreter_isolation_level, next_transaction_isolation_level] {
           metrics::Metrics().global.show_storage_info->Increment();
           const auto instance_info = GetInstanceStorageInfo();
@@ -7191,11 +7187,11 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
                TypedValue(utils::GetReadableSize(static_cast<double>(utils::total_memory_tracker.Amount())))},
               {TypedValue("memory_limit"),
                TypedValue(utils::GetReadableSize(static_cast<double>(utils::total_memory_tracker.MaximumHardLimit())))},
-              {TypedValue("license_memory_limit"), TypedValue(std::invoke([] {
+              {TypedValue("license_memory_limit"), TypedValue([] {
                  auto info = license::global_license_checker.GetLicenseInfo().Lock();
                  const int64_t limit = info->has_value() ? (*info)->license.memory_limit : 0;
                  return limit > 0 ? utils::GetReadableSize(static_cast<double>(limit)) : std::string("unlimited");
-               }))},
+               }())},
               {TypedValue("query+graph_memory_tracked"),
                TypedValue(utils::GetReadableSize(static_cast<double>(utils::graph_memory_tracker.Amount())))},
               {TypedValue("vector_index_memory_tracked"),

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -7248,8 +7248,8 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
       header = {"license info", "value"};
       handler = [] {
         const auto license_info = license::global_license_checker.GetDetailedLicenseInfo();
-        std::string memory_limit_policy = "Memory usage is not limited.";
         std::string memory_limit = "UNLIMITED";
+        std::string memory_limit_policy = "Memory usage is not limited.";
         if (license_info.memory_limit != 0) {
           memory_limit = utils::GetReadableSize(static_cast<double>(license_info.memory_limit));
           memory_limit_policy = license_info.license_type == license::kLicenseTypeAiPlatform
@@ -7263,9 +7263,9 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
             {TypedValue("is_valid"), TypedValue(license_info.is_valid)},
             {TypedValue("license_type"), TypedValue(license_info.license_type)},
             {TypedValue("valid_until"), TypedValue(license_info.valid_until)},
-            {TypedValue("memory_limit"), TypedValue(std::move(memory_limit))},
+            {TypedValue("memory_limit"), TypedValue(memory_limit)},
             {TypedValue("status"), TypedValue(license_info.status)},
-            {TypedValue("memory_limit_policy"), TypedValue(std::move(memory_limit_policy))},
+            {TypedValue("memory_limit_policy"), TypedValue(memory_limit_policy)},
         };
 
         return std::pair{results, QueryHandlerResult::NOTHING};

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -117,9 +117,6 @@
 #include "utils/algorithm.hpp"
 #include "utils/build_info.hpp"
 #include "utils/compile_time.hpp"
-#include "utils/event_counter.hpp"
-#include "utils/event_gauge.hpp"
-#include "utils/event_histogram.hpp"
 #include "utils/exceptions.hpp"
 #include "utils/functional.hpp"
 #include "utils/likely.hpp"
@@ -149,10 +146,6 @@ import memgraph.utils.aws;
 namespace r = ranges;
 namespace rv = ranges::views;
 
-namespace memgraph::metrics {
-extern const Event PeakMemoryRes;
-}  // namespace memgraph::metrics
-
 namespace {
 
 using memgraph::query::Expression;
@@ -168,8 +161,10 @@ struct InstanceStorageInfo {
 
 InstanceStorageInfo GetInstanceStorageInfo() {
   const auto memory_res = memgraph::utils::GetMemoryRES();
-  memgraph::metrics::SetGaugeValue(memgraph::metrics::PeakMemoryRes, memory_res);
-  const auto peak_memory_res = memgraph::metrics::GetGaugeValue(memgraph::metrics::PeakMemoryRes);
+  memgraph::metrics::Metrics().global.peak_memory_res_bytes->Set(
+      std::max(static_cast<double>(memory_res), memgraph::metrics::Metrics().global.peak_memory_res_bytes->Value()));
+  const auto peak_memory_res =
+      static_cast<uint64_t>(memgraph::metrics::Metrics().global.peak_memory_res_bytes->Value());
   const int64_t vm_max_map_count =
       memgraph::utils::GetVmMaxMapCount().value_or(memgraph::utils::VM_MAX_MAP_COUNT_DEFAULT);
   const auto disk_usage = memgraph::utils::GetDirDiskUsage(FLAGS_data_directory);
@@ -7119,81 +7114,70 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
         throw QueryRuntimeException("Coordinators don't have storage!");
       }
 #endif
-      // Helper lambda to build database-specific results (used by ON DATABASE and ON CURRENT DATABASE)
-      auto build_db_results = [](auto *storage, auto *db) {
-        auto info = storage->GetBaseInfo();
-        const auto db_storage_memory = static_cast<double>(db->DbStorageMemoryUsage());
-        const auto db_embedding_memory = static_cast<double>(db->DbEmbeddingMemoryUsage());
-        const auto db_query_memory = static_cast<double>(db->DbQueryMemoryUsage());
-        const auto db_total_memory = static_cast<double>(db->DbMemoryUsage());
-        const auto db_peak_memory = static_cast<double>(db->DbPeakMemoryUsage());
-        const auto tenant_limit = db->TenantMemoryLimit();
-
-        const std::vector<std::vector<TypedValue>> results{
-            {TypedValue("name"), TypedValue(storage->name())},
-            {TypedValue("database_uuid"), TypedValue(static_cast<std::string>(storage->uuid()))},
-            {TypedValue("storage_mode"), TypedValue(StorageModeToString(storage->GetStorageMode()))},
-            {TypedValue("vertex_count"), TypedValue(static_cast<int64_t>(info.vertex_count))},
-            {TypedValue("edge_count"), TypedValue(static_cast<int64_t>(info.edge_count))},
-            {TypedValue("average_degree"), TypedValue(info.average_degree)},
-            {TypedValue("unreleased_delta_objects"), TypedValue(static_cast<int64_t>(info.unreleased_delta_objects))},
-            {TypedValue("disk_usage"), TypedValue(utils::GetReadableSize(static_cast<double>(info.disk_usage)))},
-            {TypedValue("graph_memory_tracked"), TypedValue(utils::GetReadableSize(db_storage_memory))},
-            {TypedValue("query_memory_tracked"), TypedValue(utils::GetReadableSize(db_query_memory))},
-            {TypedValue("vector_index_memory_tracked"), TypedValue(utils::GetReadableSize(db_embedding_memory))},
-            {TypedValue("tenant_memory_tracked"), TypedValue(utils::GetReadableSize(db_total_memory))},
-            {TypedValue("tenant_peak_memory_tracked"), TypedValue(utils::GetReadableSize(db_peak_memory))},
-            {TypedValue("tenant_memory_limit"),
-             TypedValue(tenant_limit > 0 ? utils::GetReadableSize(static_cast<double>(tenant_limit))
-                                         : std::string("unlimited"))},
-            {TypedValue("storage_isolation_level"), TypedValue(IsolationLevelToString(storage->GetIsolationLevel()))},
-        };
-        return std::pair{results, QueryHandlerResult::NOTHING};
-      };
+      auto *dbms_handler = interpreter_context->dbms_handler;
+      std::optional<dbms::DatabaseAccess> database{};
 
       if (info_query->database_) {
+        const auto &db_name = *info_query->database_;
+        if (!license::global_license_checker.IsEnterpriseValidFast() && db_name != dbms::kDefaultDB) {
+          throw QueryRuntimeException(
+              license::LicenseCheckErrorToString(license::LicenseCheckError::NOT_ENTERPRISE_LICENSE, "multi-tenancy"));
+        }
 #ifdef MG_ENTERPRISE
-        if (interpreter_context->dbms_handler) {
-          handler = [db_name = *info_query->database_,
-                     db_handler = interpreter_context->dbms_handler,
-                     build_db_results] -> std::pair<std::vector<std::vector<TypedValue>>, QueryHandlerResult> {
-            if (!db_handler) {
-              throw QueryRuntimeException("Database handler is not available");
-            }
-            memgraph::metrics::IncrementCounter(memgraph::metrics::ShowStorageInfoOnDatabase);
-            auto db_acc = db_handler->Get(db_name);
-            auto *db = db_acc.get();
-            if (!db) throw QueryRuntimeException("Database '{}' was dropped during query execution.", db_name);
-            if (auto *mh = db->metric_handles()) mh->show_storage_info.Increment();
-            return build_db_results(db->storage(), db);
-          };
-        } else
+        database = dbms_handler->Get(*info_query->database_);
+#else
+        database = dbms_handler->Get();
 #endif
-        {
-          // Community path or when dbms_handler is null
-          MG_ASSERT(current_db.db_acc_, "System storage info query expects a current DB");
-          if (current_db.name() == *info_query->database_) {
-            handler = [storage = current_db.db_acc_->get()->storage(),
-                       db = current_db.db_acc_->get(),
-                       build_db_results] -> std::pair<std::vector<std::vector<TypedValue>>, QueryHandlerResult> {
-              memgraph::metrics::IncrementCounter(memgraph::metrics::ShowStorageInfoOnDatabase);
-              return build_db_results(storage, db);
-            };
-          } else {
-            throw QueryRuntimeException("SHOW STORAGE INFO ON DATABASE is only available in the enterprise edition.");
-          }
+        if (!database) {
+          throw QueryRuntimeException("Database '{}' was not found.", *info_query->database_);
         }
       } else if (info_query->is_current_database_) {
-        MG_ASSERT(current_db.db_acc_, "System storage info query expects a current DB");
-        handler = [storage = current_db.db_acc_->get()->storage(),
-                   db = current_db.db_acc_->get(),
-                   build_db_results] -> std::pair<std::vector<std::vector<TypedValue>>, QueryHandlerResult> {
-          memgraph::metrics::IncrementCounter(memgraph::metrics::ShowStorageInfoOnDatabase);
-          return build_db_results(storage, db);
+        if (!current_db.db_acc_) {
+          throw QueryRuntimeException("No current database for the session.");
+        }
+        database = current_db.db_acc_;
+      }
+
+      if (database) {
+        handler = [db_acc = std::move(
+                       *database)] mutable -> std::pair<std::vector<std::vector<TypedValue>>, QueryHandlerResult> {
+          auto *db = db_acc.get();
+          if (!db) throw QueryRuntimeException("Database '{}' was dropped during query execution.", db->name());
+          if (auto *mh = db->metric_handles()) mh->show_storage_info.Increment();
+          auto *storage = db->storage();
+          auto info = storage->GetBaseInfo();
+          const auto db_storage_memory = static_cast<double>(db->DbStorageMemoryUsage());
+          const auto db_embedding_memory = static_cast<double>(db->DbEmbeddingMemoryUsage());
+          const auto db_query_memory = static_cast<double>(db->DbQueryMemoryUsage());
+          const auto db_total_memory = static_cast<double>(db->DbMemoryUsage());
+          const auto db_peak_memory = static_cast<double>(db->DbPeakMemoryUsage());
+          const auto tenant_limit = db->TenantMemoryLimit();
+
+          const std::vector<std::vector<TypedValue>> results{
+              {TypedValue("name"), TypedValue(storage->name())},
+              {TypedValue("database_uuid"), TypedValue(static_cast<std::string>(storage->uuid()))},
+              {TypedValue("storage_mode"), TypedValue(StorageModeToString(storage->GetStorageMode()))},
+              {TypedValue("vertex_count"), TypedValue(static_cast<int64_t>(info.vertex_count))},
+              {TypedValue("edge_count"), TypedValue(static_cast<int64_t>(info.edge_count))},
+              {TypedValue("average_degree"), TypedValue(info.average_degree)},
+              {TypedValue("unreleased_delta_objects"), TypedValue(static_cast<int64_t>(info.unreleased_delta_objects))},
+              {TypedValue("disk_usage"), TypedValue(utils::GetReadableSize(static_cast<double>(info.disk_usage)))},
+              {TypedValue("graph_memory_tracked"), TypedValue(utils::GetReadableSize(db_storage_memory))},
+              {TypedValue("query_memory_tracked"), TypedValue(utils::GetReadableSize(db_query_memory))},
+              {TypedValue("vector_index_memory_tracked"), TypedValue(utils::GetReadableSize(db_embedding_memory))},
+              {TypedValue("tenant_memory_tracked"), TypedValue(utils::GetReadableSize(db_total_memory))},
+              {TypedValue("tenant_peak_memory_tracked"), TypedValue(utils::GetReadableSize(db_peak_memory))},
+              {TypedValue("tenant_memory_limit"),
+               TypedValue(tenant_limit > 0 ? utils::GetReadableSize(static_cast<double>(tenant_limit))
+                                           : std::string("unlimited"))},
+              {TypedValue("storage_isolation_level"), TypedValue(IsolationLevelToString(storage->GetIsolationLevel()))},
+          };
+          return std::pair{results, QueryHandlerResult::NOTHING};
         };
       } else {
         MG_ASSERT(current_db.db_acc_, "System storage info query expects a current DB");
-        handler = [interpreter_context, interpreter_isolation_level, next_transaction_isolation_level] {
+        handler = [interpreter_isolation_level, next_transaction_isolation_level] {
+          metrics::Metrics().global.show_storage_info->Increment();
           const auto instance_info = GetInstanceStorageInfo();
           const std::vector<std::vector<TypedValue>> results{
               {TypedValue("vm_max_map_count"), TypedValue(instance_info.vm_max_map_count)},
@@ -7212,7 +7196,7 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
                  const int64_t limit = info->has_value() ? (*info)->license.memory_limit : 0;
                  return limit > 0 ? utils::GetReadableSize(static_cast<double>(limit)) : std::string("unlimited");
                }))},
-              {TypedValue("query_graph_memory_tracked"),
+              {TypedValue("query+graph_memory_tracked"),
                TypedValue(utils::GetReadableSize(static_cast<double>(utils::graph_memory_tracker.Amount())))},
               {TypedValue("vector_index_memory_tracked"),
                TypedValue(utils::GetReadableSize(static_cast<double>(utils::vector_index_memory_tracker.Amount())))},

--- a/src/storage/v2/disk/storage.cpp
+++ b/src/storage/v2/disk/storage.cpp
@@ -942,9 +942,7 @@ StorageInfo DiskStorage::GetBaseInfo() {
     info.average_degree = 2.0 * static_cast<double>(info.edge_count) / info.vertex_count;
   }
   info.memory_res = utils::GetMemoryRES();
-  metrics::Metrics().global.peak_memory_res_bytes->Set(
-      std::max(static_cast<double>(info.memory_res), metrics::Metrics().global.peak_memory_res_bytes->Value()));
-  info.peak_memory_res = static_cast<uint64_t>(metrics::Metrics().global.peak_memory_res_bytes->Value());
+  info.peak_memory_res = metrics::Metrics().UpdateAndGetPeakMemoryRes(info.memory_res);
   info.unreleased_delta_objects = static_cast<uint64_t>(metric_handles_.unreleased_delta_objects.Value());
 
   info.disk_usage = GetDiskSpaceUsage();

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -3339,9 +3339,7 @@ StorageInfo InMemoryStorage::GetBaseInfo() {
     info.average_degree = 2.0 * static_cast<double>(info.edge_count) / info.vertex_count;
   }
   info.memory_res = utils::GetMemoryRES();
-  metrics::Metrics().global.peak_memory_res_bytes->Set(
-      std::max(static_cast<double>(info.memory_res), metrics::Metrics().global.peak_memory_res_bytes->Value()));
-  info.peak_memory_res = static_cast<uint64_t>(metrics::Metrics().global.peak_memory_res_bytes->Value());
+  info.peak_memory_res = metrics::Metrics().UpdateAndGetPeakMemoryRes(info.memory_res);
   info.unreleased_delta_objects = static_cast<uint64_t>(metric_handles_.unreleased_delta_objects.Value());
 
   // Special case for the default database

--- a/tests/e2e/analytical_mode/free_memory.py
+++ b/tests/e2e/analytical_mode/free_memory.py
@@ -16,7 +16,7 @@ from common import connect, execute_and_fetch_all
 
 
 def check_storage_info(cursor, expected_values):
-    cursor.execute("SHOW STORAGE INFO")
+    cursor.execute("SHOW STORAGE INFO ON CURRENT DATABASE")
     config = cursor.fetchall()
 
     for conf in config:

--- a/tests/e2e/configuration/storage_info.py
+++ b/tests/e2e/configuration/storage_info.py
@@ -21,11 +21,9 @@ default_storage_info_dict = {
     "peak_memory_res": "",  # machine dependent
     "disk_usage": "",  # machine dependent
     "memory_tracked": "",  # machine dependent
-    "runtime_allocation_limit": "",  # machine dependent
-    "license_allocation_limit": "",  # license dependent
-    "graph_memory_tracked": "",  # machine dependent
+    "memory_limit": "",  # machine dependent
+    "license_memory_limit": "",  # license dependent
     "vector_index_memory_tracked": "",  # machine dependent
-    "query_memory_tracked": "",  # machine dependent
     "storage_isolation_level": "SNAPSHOT_ISOLATION",
     "session_isolation_level": "",
     "next_session_isolation_level": "",
@@ -60,12 +58,10 @@ def test_does_default_config_match():
         "peak_memory_res",
         "disk_usage",
         "memory_tracked",
-        "runtime_allocation_limit",
-        "license_allocation_limit",
+        "memory_limit",
+        "license_memory_limit",
         "vm_max_map_count",
-        "graph_memory_tracked",
         "vector_index_memory_tracked",
-        "query_memory_tracked",
     ]
     # Number of different data-points returned by SHOW STORAGE INFO
     assert len(config) == len(default_storage_info_dict)

--- a/tests/e2e/configuration/storage_info.py
+++ b/tests/e2e/configuration/storage_info.py
@@ -16,28 +16,17 @@ import mgclient
 import pytest
 
 default_storage_info_dict = {
-    "name": "memgraph",
-    "database_uuid": "abcd",
-    "vertex_count": 0,
-    "edge_count": 0,
-    "average_degree": 0,
     "vm_max_map_count": 0,  # machine dependent
     "memory_res": "",  # machine dependent
     "peak_memory_res": "",  # machine dependent
-    "unreleased_delta_objects": 0,
-    "db_disk_usage": "",  # machine dependent
-    "global_disk_usage": "",  # machine dependent
-    "global_memory_tracked": "",  # machine dependent
-    "global_runtime_allocation_limit": "",  # machine dependent
-    "global_license_allocation_limit": "",  # license dependent
-    "global_isolation_level": "SNAPSHOT_ISOLATION",
+    "disk_usage": "",  # machine dependent
+    "memory_tracked": "",  # machine dependent
+    "runtime_allocation_limit": "",  # machine dependent
+    "license_allocation_limit": "",  # license dependent
+    "isolation_level": "SNAPSHOT_ISOLATION",
     "session_isolation_level": "",
     "next_session_isolation_level": "",
     "storage_mode": "IN_MEMORY_TRANSACTIONAL",
-    "db_memory_tracked": "",  # machine dependent
-    "db_storage_memory_tracked": "",  # machine dependent
-    "db_embedding_memory_tracked": "",  # machine dependent
-    "db_query_memory_tracked": "",  # machine dependent
 }
 
 
@@ -64,18 +53,12 @@ def test_does_default_config_match():
 
     # The default value of these is dependent on the given machine.
     machine_dependent_configurations = [
-        "database_uuid",
         "memory_res",
         "peak_memory_res",
-        "db_disk_usage",
-        "global_disk_usage",
-        "global_memory_tracked",
-        "global_runtime_allocation_limit",
-        "global_license_allocation_limit",
-        "db_memory_tracked",
-        "db_storage_memory_tracked",
-        "db_embedding_memory_tracked",
-        "db_query_memory_tracked",
+        "disk_usage",
+        "memory_tracked",
+        "runtime_allocation_limit",
+        "license_allocation_limit",
         "vm_max_map_count",
     ]
     # Number of different data-points returned by SHOW STORAGE INFO
@@ -114,7 +97,7 @@ def test_info_change():
     ]
 
     expected_values = {
-        "global_isolation_level": "READ_UNCOMMITTED",
+        "isolation_level": "READ_UNCOMMITTED",
         "session_isolation_level": "READ_COMMITTED",
         "next_session_isolation_level": "READ_COMMITTED",
     }
@@ -161,7 +144,7 @@ def test_show_storage_info_on_database():
     # Session-level fields must NOT be present.
     assert "session_isolation_level" not in config
     assert "next_session_isolation_level" not in config
-    assert "global_memory_tracked" not in config
+    assert "memory_tracked" not in config
 
     assert config["name"] == "memgraph"
     assert config["storage_mode"] in ("IN_MEMORY_TRANSACTIONAL", "IN_MEMORY_ANALYTICAL")

--- a/tests/e2e/configuration/storage_info.py
+++ b/tests/e2e/configuration/storage_info.py
@@ -23,6 +23,7 @@ default_storage_info_dict = {
     "memory_tracked": "",  # machine dependent
     "memory_limit": "",  # machine dependent
     "license_memory_limit": "",  # license dependent
+    "query+graph_memory_tracked": "",  # machine dependent
     "vector_index_memory_tracked": "",  # machine dependent
     "storage_isolation_level": "SNAPSHOT_ISOLATION",
     "session_isolation_level": "",
@@ -61,6 +62,7 @@ def test_does_default_config_match():
         "memory_limit",
         "license_memory_limit",
         "vm_max_map_count",
+        "query+graph_memory_tracked",
         "vector_index_memory_tracked",
     ]
     # Number of different data-points returned by SHOW STORAGE INFO
@@ -151,6 +153,36 @@ def test_show_storage_info_on_database():
     assert config["name"] == "memgraph"
     assert config["storage_mode"] in ("IN_MEMORY_TRANSACTIONAL", "IN_MEMORY_ANALYTICAL")
     assert config["tenant_memory_limit"] != "unlimited"
+
+
+def test_show_storage_info_bare_vs_on_current_database():
+    connection = mgclient.connect(host="localhost", port=7687)
+    connection.autocommit = True
+    cursor = connection.cursor()
+
+    cursor.execute("SHOW STORAGE INFO")
+    bare = {row[0]: row[1] for row in cursor.fetchall()}
+
+    cursor.execute("SHOW STORAGE INFO ON CURRENT DATABASE")
+    current = {row[0]: row[1] for row in cursor.fetchall()}
+
+    # Bare/global variant must contain instance-level fields
+    assert "memory_tracked" in bare
+    assert "vm_max_map_count" in bare
+    assert "query+graph_memory_tracked" in bare
+
+    # ON CURRENT DATABASE variant must contain DB-level fields
+    assert "name" in current
+    assert "vertex_count" in current
+    assert "edge_count" in current
+    assert "graph_memory_tracked" in current
+    assert "query_memory_tracked" in current
+
+    # They must NOT contain each other's exclusive fields
+    assert "vertex_count" not in bare
+    assert "name" not in bare
+    assert "memory_tracked" not in current
+    assert "vm_max_map_count" not in current
 
 
 if __name__ == "__main__":

--- a/tests/e2e/configuration/storage_info.py
+++ b/tests/e2e/configuration/storage_info.py
@@ -32,19 +32,6 @@ default_storage_info_dict = {
 }
 
 
-def apply_queries_and_check_for_storage_info(cursor, setup_query_list, expected_values):
-    for query in setup_query_list:
-        cursor.execute(query)
-
-    cursor.execute("SHOW STORAGE INFO")
-    config = cursor.fetchall()
-
-    for conf in config:
-        conf_name = conf[0]
-        if conf_name in expected_values:
-            assert expected_values[conf_name] == conf[1]
-
-
 def test_does_default_config_match():
     connection = mgclient.connect(host="localhost", port=7687)
     connection.autocommit = True
@@ -81,39 +68,46 @@ def test_info_change():
 
     cursor = connection.cursor()
 
-    # Check for vertex and edge changes
+    # Check for vertex and edge changes (DB-specific fields)
     setup_query_list = [
         "CREATE(n{id: 1}),(m{id: 2})",
         "MATCH(n),(m) WHERE n.id = 1 AND m.id = 2 CREATE (n)-[r:relation]->(m)",
     ]
-    expected_values = {
-        "vertex_count": 2,
-        "edge_count": 1,
-    }
+    for query in setup_query_list:
+        cursor.execute(query)
 
-    apply_queries_and_check_for_storage_info(cursor, setup_query_list, expected_values)
+    cursor.execute("SHOW STORAGE INFO ON CURRENT DATABASE")
+    config = cursor.fetchall()
+    db_values = {row[0]: row[1] for row in config}
+    assert db_values.get("vertex_count") == 2
+    assert db_values.get("edge_count") == 1
 
-    # Check for isolation level changes
-    setup_query_list = [
+    # Check for isolation level changes (DB-scoped mutations)
+    for query in [
         "SET GLOBAL TRANSACTION ISOLATION LEVEL READ UNCOMMITTED",
         "SET NEXT TRANSACTION ISOLATION LEVEL READ COMMITTED",
         "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED",
-    ]
+    ]:
+        cursor.execute(query)
 
-    expected_values = {
-        "storage_isolation_level": "READ_UNCOMMITTED",
-        "session_isolation_level": "READ_COMMITTED",
-        "next_session_isolation_level": "READ_COMMITTED",
-    }
+    cursor.execute("SHOW STORAGE INFO ON CURRENT DATABASE")
+    config = cursor.fetchall()
+    db_values = {row[0]: row[1] for row in config}
+    assert db_values.get("storage_isolation_level") == "READ_UNCOMMITTED"
 
-    apply_queries_and_check_for_storage_info(cursor, setup_query_list, expected_values)
+    # session and next_session isolation levels are returned by the bare query only,
+    # so fetch them separately.
+    cursor.execute("SHOW STORAGE INFO")
+    global_values = {row[0]: row[1] for row in cursor.fetchall()}
+    assert global_values.get("session_isolation_level") == "READ_COMMITTED"
+    assert global_values.get("next_session_isolation_level") == "READ_COMMITTED"
 
-    # Check for storage mode change
-    setup_query_list = ["STORAGE MODE IN_MEMORY_ANALYTICAL"]
-
-    expected_values = {"storage_mode": "IN_MEMORY_ANALYTICAL"}
-
-    apply_queries_and_check_for_storage_info(cursor, setup_query_list, expected_values)
+    # Check for storage mode change (DB-scoped mutation)
+    cursor.execute("STORAGE MODE IN_MEMORY_ANALYTICAL")
+    cursor.execute("SHOW STORAGE INFO ON CURRENT DATABASE")
+    config = cursor.fetchall()
+    db_values = {row[0]: row[1] for row in config}
+    assert db_values.get("storage_mode") == "IN_MEMORY_ANALYTICAL"
 
 
 def test_show_storage_info_on_database():

--- a/tests/e2e/configuration/storage_info.py
+++ b/tests/e2e/configuration/storage_info.py
@@ -23,7 +23,10 @@ default_storage_info_dict = {
     "memory_tracked": "",  # machine dependent
     "runtime_allocation_limit": "",  # machine dependent
     "license_allocation_limit": "",  # license dependent
-    "isolation_level": "SNAPSHOT_ISOLATION",
+    "graph_memory_tracked": "",  # machine dependent
+    "vector_index_memory_tracked": "",  # machine dependent
+    "query_memory_tracked": "",  # machine dependent
+    "storage_isolation_level": "SNAPSHOT_ISOLATION",
     "session_isolation_level": "",
     "next_session_isolation_level": "",
     "storage_mode": "IN_MEMORY_TRANSACTIONAL",
@@ -60,6 +63,9 @@ def test_does_default_config_match():
         "runtime_allocation_limit",
         "license_allocation_limit",
         "vm_max_map_count",
+        "graph_memory_tracked",
+        "vector_index_memory_tracked",
+        "query_memory_tracked",
     ]
     # Number of different data-points returned by SHOW STORAGE INFO
     assert len(config) == len(default_storage_info_dict)
@@ -97,7 +103,7 @@ def test_info_change():
     ]
 
     expected_values = {
-        "isolation_level": "READ_UNCOMMITTED",
+        "storage_isolation_level": "READ_UNCOMMITTED",
         "session_isolation_level": "READ_COMMITTED",
         "next_session_isolation_level": "READ_COMMITTED",
     }

--- a/tests/e2e/configuration/storage_info.py
+++ b/tests/e2e/configuration/storage_info.py
@@ -25,10 +25,10 @@ default_storage_info_dict = {
     "license_memory_limit": "",  # license dependent
     "query+graph_memory_tracked": "",  # machine dependent
     "vector_index_memory_tracked": "",  # machine dependent
-    "storage_isolation_level": "SNAPSHOT_ISOLATION",
+    "global_isolation_level": "SNAPSHOT_ISOLATION",
     "session_isolation_level": "",
     "next_session_isolation_level": "",
-    "storage_mode": "IN_MEMORY_TRANSACTIONAL",
+    "global_storage_mode": "IN_MEMORY_TRANSACTIONAL",
 }
 
 

--- a/tests/e2e/configuration/storage_info.py
+++ b/tests/e2e/configuration/storage_info.py
@@ -25,6 +25,7 @@ default_storage_info_dict = {
     "memory_res": "",  # machine dependent
     "peak_memory_res": "",  # machine dependent
     "unreleased_delta_objects": 0,
+    "db_disk_usage": "",  # machine dependent
     "global_disk_usage": "",  # machine dependent
     "global_memory_tracked": "",  # machine dependent
     "global_runtime_allocation_limit": "",  # machine dependent
@@ -66,6 +67,7 @@ def test_does_default_config_match():
         "database_uuid",
         "memory_res",
         "peak_memory_res",
+        "db_disk_usage",
         "global_disk_usage",
         "global_memory_tracked",
         "global_runtime_allocation_limit",

--- a/tests/e2e/configuration/tenant_profiles.py
+++ b/tests/e2e/configuration/tenant_profiles.py
@@ -143,7 +143,7 @@ def test_error_paths():
 
 
 def test_attach_lifecycle_propagates_limit():
-    """SET surfaces the limit in SHOW STORAGE INFO; ALTER updates it; REMOVE falls back
+    """SET surfaces the limit in SHOW STORAGE INFO ON DATABASE; ALTER updates it; REMOVE falls back
     to the global --memory-limit."""
     conn = connect()
     cur = conn.cursor()

--- a/tests/e2e/constraints/constraints_validation.py
+++ b/tests/e2e/constraints/constraints_validation.py
@@ -285,7 +285,7 @@ def test_delta_release_on_unique_constraint_error(memgraph):
 
     memgraph.execute("FREE MEMORY;")
 
-    results = list(memgraph.execute_and_fetch("SHOW STORAGE INFO;"))
+    results = list(memgraph.execute_and_fetch("SHOW STORAGE INFO ON CURRENT DATABASE;"))
     unreleased_delta_objects_actual = [x for x in results if x["storage info"] == "unreleased_delta_objects"][0][
         "value"
     ]

--- a/tests/e2e/disk_storage/storage_info.py
+++ b/tests/e2e/disk_storage/storage_info.py
@@ -18,7 +18,7 @@ from common import connect, execute_and_fetch_all
 def test_empty_show_storage_info(connect):
     cursor = connect.cursor()
     execute_and_fetch_all(cursor, "STORAGE MODE ON_DISK_TRANSACTIONAL")
-    results = execute_and_fetch_all(cursor, "SHOW STORAGE INFO")
+    results = execute_and_fetch_all(cursor, "SHOW STORAGE INFO ON CURRENT DATABASE")
     results = dict(map(lambda pair: (pair[0], pair[1]), results))
     assert results["vertex_count"] == 0
     assert results["edge_count"] == 0
@@ -30,7 +30,7 @@ def test_show_storage_info_after_initialization(connect):
     execute_and_fetch_all(cursor, "CREATE (n:User {id: 1})")
     execute_and_fetch_all(cursor, "CREATE (n:User {id: 2})")
     execute_and_fetch_all(cursor, "MATCH (n:User {id: 1}), (m:User {id: 2}) CREATE (n)-[r:FRIEND {id: 1}]->(m)")
-    results = execute_and_fetch_all(cursor, "SHOW STORAGE INFO")
+    results = execute_and_fetch_all(cursor, "SHOW STORAGE INFO ON CURRENT DATABASE")
     results = dict(map(lambda pair: (pair[0], pair[1]), results))
     assert results["vertex_count"] == 2
     assert results["edge_count"] == 1
@@ -44,7 +44,7 @@ def test_show_storage_info_detach_delete_vertex(connect):
     execute_and_fetch_all(cursor, "CREATE (n:User {id: 2})")
     execute_and_fetch_all(cursor, "MATCH (n:User {id: 1}), (m:User {id: 2}) CREATE (n)-[r:FRIEND {id: 1}]->(m)")
     execute_and_fetch_all(cursor, "MATCH (n:User {id: 1}) DETACH DELETE n;")
-    results = execute_and_fetch_all(cursor, "SHOW STORAGE INFO")
+    results = execute_and_fetch_all(cursor, "SHOW STORAGE INFO ON CURRENT DATABASE")
     results = dict(map(lambda pair: (pair[0], pair[1]), results))
     assert results["vertex_count"] == 1
     assert results["edge_count"] == 0
@@ -58,7 +58,7 @@ def test_show_storage_info_delete_edge(connect):
     execute_and_fetch_all(cursor, "CREATE (n:User {id: 2})")
     execute_and_fetch_all(cursor, "MATCH (n:User {id: 1}), (m:User {id: 2}) CREATE (n)-[r:FRIEND {id: 1}]->(m)")
     execute_and_fetch_all(cursor, "MATCH (n:User {id: 1})-[r]->(m:User {id: 2}) DELETE r;")
-    results = execute_and_fetch_all(cursor, "SHOW STORAGE INFO")
+    results = execute_and_fetch_all(cursor, "SHOW STORAGE INFO ON CURRENT DATABASE")
     results = dict(map(lambda pair: (pair[0], pair[1]), results))
     assert results["vertex_count"] == 2
     assert results["edge_count"] == 0

--- a/tests/e2e/drop_queries/drop_graph.py
+++ b/tests/e2e/drop_queries/drop_graph.py
@@ -40,7 +40,7 @@ def test_create_everything_then_drop_graph(memgraph):
     assert get_results_length(memgraph, "SHOW INDEX INFO") == 0
     assert get_results_length(memgraph, "SHOW TRIGGERS") == 0
 
-    storage_info = list(memgraph.execute_and_fetch("SHOW STORAGE INFO"))
+    storage_info = list(memgraph.execute_and_fetch("SHOW STORAGE INFO ON CURRENT DATABASE"))
     print(storage_info)
     vertex_count = [x for x in storage_info if x["storage info"] == "vertex_count"][0]
     edge_count = [x for x in storage_info if x["storage info"] == "edge_count"][0]

--- a/tests/e2e/durability/snapshot_recovery.py
+++ b/tests/e2e/durability/snapshot_recovery.py
@@ -599,7 +599,7 @@ def test_marked_commits_after_snapshot(test_name):
     # 6
     execute_and_fetch_all(cursor, "FREE MEMORY")
     execute_and_fetch_all(cursor, "FREE MEMORY")
-    info = execute_and_fetch_all(cursor, "SHOW STORAGE INFO")
+    info = execute_and_fetch_all(cursor, "SHOW STORAGE INFO ON CURRENT DATABASE")
     unreleased_deltas = None
     for [key, val] in info:
         if key == "unreleased_delta_objects":
@@ -780,11 +780,11 @@ def test_snapshot_on_mode_change_analytical_to_transactional(test_name):
     interactive_mg_runner.kill_all()
 
 
-def _get_db_memory_tracked_bytes(cursor):
-    """Return the db_memory_tracked field from SHOW STORAGE INFO as bytes."""
-    info = execute_and_fetch_all(cursor, "SHOW STORAGE INFO")
+def _get_tenant_memory_tracked_bytes(cursor):
+    """Return the tenant_memory_tracked field from SHOW STORAGE INFO as bytes."""
+    info = execute_and_fetch_all(cursor, "SHOW STORAGE INFO ON CURRENT DATABASE")
     info_dict = {row[0]: row[1] for row in info}
-    return _parse_size_bytes(info_dict.get("db_memory_tracked", "0B"))
+    return _parse_size_bytes(info_dict.get("tenant_memory_tracked", "0B"))
 
 
 def _parse_size_bytes(size_str):
@@ -798,13 +798,13 @@ def _parse_size_bytes(size_str):
     return int(float(m.group(1)) * units[m.group(2)])
 
 
-def test_db_memory_tracked_after_recover_snapshot(test_name):
+def test_tenant_memory_tracked_after_recover_snapshot(test_name):
     """
-    After RECOVER SNAPSHOT, db_memory_tracked must be non-zero.
+    After RECOVER SNAPSHOT, tenant_memory_tracked must be non-zero.
 
     The snapshot recovery path runs on threads that are fully pinned to the DB arena via
     je_mallctl (GC/scheduler threads), so all recovered vertices and edges are attributed
-    to db_memory_tracked.
+    to tenant_memory_tracked.
     """
     data_directory = get_data_path("snapshot_recovery", test_name)
     interactive_mg_runner.start(memgraph_instances(data_directory), "default")
@@ -820,8 +820,8 @@ def test_db_memory_tracked_after_recover_snapshot(test_name):
     )
 
     # Capture memory before snapshot (data is loaded in-memory)
-    before_snapshot = _get_db_memory_tracked_bytes(cursor)
-    assert before_snapshot > 0, "db_memory_tracked should be non-zero after creating dataset"
+    before_snapshot = _get_tenant_memory_tracked_bytes(cursor)
+    assert before_snapshot > 0, "tenant_memory_tracked should be non-zero after creating dataset"
 
     # Take a snapshot of the current state
     result = execute_and_fetch_all(cursor, "CREATE SNAPSHOT")
@@ -831,17 +831,17 @@ def test_db_memory_tracked_after_recover_snapshot(test_name):
     # Recover from the snapshot — this replaces in-memory state by re-loading from disk
     execute_and_fetch_all(cursor, f"RECOVER SNAPSHOT '{snapshot_path}' FORCE")
 
-    after_recovery = _get_db_memory_tracked_bytes(cursor)
+    after_recovery = _get_tenant_memory_tracked_bytes(cursor)
 
     interactive_mg_runner.kill_all()
 
     assert after_recovery > 0, (
-        f"db_memory_tracked must be non-zero after RECOVER SNAPSHOT. "
+        f"tenant_memory_tracked must be non-zero after RECOVER SNAPSHOT. "
         f"before_snapshot={before_snapshot} after_recovery={after_recovery}"
     )
 
 
-def test_db_memory_tracked_recover_snapshot_into_correct_db(test_name):
+def test_tenant_memory_tracked_recover_snapshot_into_correct_db(test_name):
     """
     RECOVER SNAPSHOT executed while USE DATABASE other_db is active must attribute
     memory to other_db, not to the default memgraph database.
@@ -863,7 +863,7 @@ def test_db_memory_tracked_recover_snapshot_into_correct_db(test_name):
 
     # Clean up the default DB so we can confirm cross-DB attribution
     execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n")
-    baseline_memgraph = _get_db_memory_tracked_bytes(cursor)
+    baseline_memgraph = _get_tenant_memory_tracked_bytes(cursor)
 
     # Create a second database and recover the snapshot there (enterprise feature)
     try:
@@ -875,25 +875,25 @@ def test_db_memory_tracked_recover_snapshot_into_correct_db(test_name):
 
     # Switch to snapshot_target_db and recover
     other_cursor = mt_cursor(connection, "snapshot_target_db")
-    baseline_other = _get_db_memory_tracked_bytes(other_cursor)
+    baseline_other = _get_tenant_memory_tracked_bytes(other_cursor)
 
     execute_and_fetch_all(other_cursor, f"RECOVER SNAPSHOT '{snapshot_path}' FORCE")
 
-    after_other = _get_db_memory_tracked_bytes(other_cursor)
+    after_other = _get_tenant_memory_tracked_bytes(other_cursor)
 
     # Switch back to memgraph and verify it did NOT grow
     cursor2 = mt_cursor(connection, "memgraph")
-    after_memgraph = _get_db_memory_tracked_bytes(cursor2)
+    after_memgraph = _get_tenant_memory_tracked_bytes(cursor2)
 
     interactive_mg_runner.kill_all()
 
     assert after_other > baseline_other, (
-        f"snapshot_target_db db_memory_tracked should grow after RECOVER SNAPSHOT. "
+        f"snapshot_target_db tenant_memory_tracked should grow after RECOVER SNAPSHOT. "
         f"baseline={baseline_other} after={after_other}"
     )
     # Allow 512 KiB noise for background threads
     assert after_memgraph <= baseline_memgraph + 512 * 1024, (
-        f"memgraph db_memory_tracked should NOT grow when recovering into snapshot_target_db. "
+        f"memgraph tenant_memory_tracked should NOT grow when recovering into snapshot_target_db. "
         f"baseline_memgraph={baseline_memgraph} after_memgraph={after_memgraph}"
     )
 

--- a/tests/e2e/high_availability/strict_sync.py
+++ b/tests/e2e/high_availability/strict_sync.py
@@ -289,10 +289,10 @@ def test_commit_works(test_name):
     # Create data on MAIN
     instance3_cursor = connect(host="localhost", port=7689).cursor()
     execute_and_fetch_all(instance3_cursor, "CREATE (n:Node)")
-    res = dict(execute_and_fetch_all(instance3_cursor, "show storage info"))
+    res = dict(execute_and_fetch_all(instance3_cursor, "show storage info on current database"))
 
     def get_unreleased_delta_obj(instance_cursor):
-        res = dict(execute_and_fetch_all(instance_cursor, "show storage info"))
+        res = dict(execute_and_fetch_all(instance_cursor, "show storage info on current database"))
         return res["unreleased_delta_objects"]
 
     mg_sleep_and_assert(0, partial(get_unreleased_delta_obj, instance3_cursor))

--- a/tests/e2e/isolation_levels/isolation_levels.cpp
+++ b/tests/e2e/isolation_levels/isolation_levels.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -45,7 +45,7 @@ auto GetVertexCount(std::unique_ptr<mg::Client> &client) {
 }
 
 bool IsDiskStorageMode(std::unique_ptr<mg::Client> &client) {
-  MG_ASSERT(client->Execute("SHOW STORAGE INFO"));
+  MG_ASSERT(client->Execute("SHOW STORAGE INFO ON CURRENT DATABASE"));
   auto maybe_rows = client->FetchAll();
   MG_ASSERT(maybe_rows, "Failed to fetch storage info");
 
@@ -115,7 +115,8 @@ void TestSnapshotIsolation(std::unique_ptr<mg::Client> &client) {
               "Invalid number of vertices found for SNAPSHOT ISOLATION (found {}, expected {}). Read vertices from a "
               "transaction which started "
               "at a later point.",
-              current_vertex_count, 0);
+              current_vertex_count,
+              0);
   }
 
   MG_ASSERT(creator->CommitTransaction());
@@ -125,7 +126,8 @@ void TestSnapshotIsolation(std::unique_ptr<mg::Client> &client) {
             "Invalid number of vertices found for SNAPSHOT ISOLATION (found {}, expected {}). Read vertices from a "
             "transaction which started "
             "at a later point.",
-            current_vertex_count, 0);
+            current_vertex_count,
+            0);
   MG_ASSERT(client->CommitTransaction());
   CleanDatabase(creator);
 }
@@ -149,7 +151,8 @@ void TestReadCommitted(std::unique_ptr<mg::Client> &client) {
               "Invalid number of vertices found for READ COMMITTED (found {}, expected {}. Read vertices from a "
               "transaction which is not "
               "committed.",
-              current_vertex_count, 0);
+              current_vertex_count,
+              0);
   }
 
   MG_ASSERT(creator->CommitTransaction());
@@ -158,7 +161,8 @@ void TestReadCommitted(std::unique_ptr<mg::Client> &client) {
   MG_ASSERT(current_vertex_count == vertex_count,
             "Invalid number of vertices found for READ COMMITTED (found {}, expected {}). Failed to read vertices "
             "from a committed transaction",
-            current_vertex_count, vertex_count);
+            current_vertex_count,
+            vertex_count);
   MG_ASSERT(client->CommitTransaction());
   CleanDatabase(creator);
 }
@@ -181,7 +185,8 @@ void TestReadUncommitted(std::unique_ptr<mg::Client> &client) {
     MG_ASSERT(current_vertex_count == i,
               "Invalid number of vertices found for READ UNCOMMITTED (found {}, expected {}). Failed to read vertices "
               "from a different transaction.",
-              current_vertex_count, i);
+              current_vertex_count,
+              i);
   }
 
   MG_ASSERT(creator->CommitTransaction());
@@ -190,7 +195,8 @@ void TestReadUncommitted(std::unique_ptr<mg::Client> &client) {
   MG_ASSERT(current_vertex_count == vertex_count,
             "Invalid number of vertices found for READ UNCOMMITTED (found {}, expected {}). Failed to read vertices "
             "from a different transaction",
-            current_vertex_count, vertex_count);
+            current_vertex_count,
+            vertex_count);
   MG_ASSERT(client->CommitTransaction());
   CleanDatabase(creator);
 }

--- a/tests/e2e/memory/db_memory_tracking.py
+++ b/tests/e2e/memory/db_memory_tracking.py
@@ -73,6 +73,10 @@ def fetch_all(cursor, query, params=None):
 
 
 def get_storage_info(cursor):
+    return {row[0]: row[1] for row in fetch_all(cursor, "SHOW STORAGE INFO ON CURRENT DATABASE")}
+
+
+def get_global_storage_info(cursor):
     return {row[0]: row[1] for row in fetch_all(cursor, "SHOW STORAGE INFO")}
 
 
@@ -162,12 +166,14 @@ def drop_all_triggers(cursor):
 
 def metric_triplet(cursor):
     info = get_storage_info(cursor)
+    graph = parse_size_bytes(info["graph_memory_tracked"])
+    vector = parse_size_bytes(info["vector_index_memory_tracked"])
+    query = parse_size_bytes(info["query_memory_tracked"])
     return {
-        "db_memory_tracked": parse_size_bytes(info["db_memory_tracked"]),
-        "db_storage_memory_tracked": parse_size_bytes(info["db_storage_memory_tracked"]),
-        "db_embedding_memory_tracked": parse_size_bytes(info["db_embedding_memory_tracked"]),
-        "db_query_memory_tracked": parse_size_bytes(info["db_query_memory_tracked"]),
-        "global_memory_tracked": parse_size_bytes(info["global_memory_tracked"]),
+        "db_memory_tracked": graph + vector + query,
+        "db_storage_memory_tracked": graph,
+        "db_embedding_memory_tracked": vector,
+        "db_query_memory_tracked": query,
     }
 
 
@@ -287,11 +293,9 @@ def test_show_storage_info_contains_db_split_fields():
     conn.close()
 
     required = {
-        "db_memory_tracked",
-        "db_storage_memory_tracked",
-        "db_embedding_memory_tracked",
-        "db_query_memory_tracked",
-        "global_memory_tracked",
+        "graph_memory_tracked",
+        "vector_index_memory_tracked",
+        "query_memory_tracked",
     }
     assert required.issubset(set(info.keys())), f"Missing keys: {required - set(info.keys())}"
 
@@ -1004,8 +1008,9 @@ def test_drop_database_releases_global_memory():
     memgraph_cursor = memgraph_conn.cursor()
     execute(memgraph_cursor, "FREE MEMORY")
     execute(memgraph_cursor, "FREE MEMORY")
-    baseline = metric_triplet(memgraph_cursor)
-    debug_log(f"drop-db baseline db={db_name} metrics={baseline}")
+    global_info = get_global_storage_info(memgraph_cursor)
+    baseline_global = parse_size_bytes(global_info.get("memory_tracked", "0B"))
+    debug_log(f"drop-db baseline db={db_name} global_memory_tracked={baseline_global}")
 
     db_conn = connect(db_name)
     db_cursor = db_conn.cursor()
@@ -1013,9 +1018,10 @@ def test_drop_database_releases_global_memory():
     execute(db_cursor, "CREATE INDEX ON :DropNode;")
     execute(db_cursor, "FREE MEMORY")
     execute(db_cursor, "FREE MEMORY")
-    db_after_alloc = metric_triplet(memgraph_cursor)
-    debug_log(f"drop-db after alloc db={db_name} metrics={db_after_alloc}")
-    assert db_after_alloc["global_memory_tracked"] > baseline["global_memory_tracked"]
+    global_info = get_global_storage_info(memgraph_cursor)
+    db_after_alloc_global = parse_size_bytes(global_info.get("memory_tracked", "0B"))
+    debug_log(f"drop-db after alloc db={db_name} global_memory_tracked={db_after_alloc_global}")
+    assert db_after_alloc_global > baseline_global
 
     db_conn.close()
     drop_database(admin_cursor, db_name)
@@ -1023,18 +1029,19 @@ def test_drop_database_releases_global_memory():
     execute(memgraph_cursor, "FREE MEMORY")
     assert_metric_returns_near_baseline(
         memgraph_cursor,
-        "global_memory_tracked",
-        baseline["global_memory_tracked"],
+        "memory_tracked",
+        baseline_global,
         1024 * 1024,
         message="total memory tracker did not return near baseline after database drop",
     )
-    after_drop = metric_triplet(memgraph_cursor)
-    debug_log(f"drop-db after drop db={db_name} metrics={after_drop}")
+    global_info = get_global_storage_info(memgraph_cursor)
+    after_drop_global = parse_size_bytes(global_info.get("memory_tracked", "0B"))
+    debug_log(f"drop-db after drop db={db_name} global_memory_tracked={after_drop_global}")
 
     memgraph_conn.close()
     admin.close()
 
-    assert after_drop["global_memory_tracked"] <= baseline["global_memory_tracked"] + 1024 * 1024
+    assert after_drop_global <= baseline_global + 1024 * 1024
 
 
 if __name__ == "__main__":

--- a/tests/e2e/memory/db_memory_tracking.py
+++ b/tests/e2e/memory/db_memory_tracking.py
@@ -90,10 +90,6 @@ def parse_size_bytes(size_str):
     return int(float(match.group(1)) * units[match.group(2)])
 
 
-def storage_metric_bytes(cursor, key):
-    return parse_size_bytes(get_storage_info(cursor)[key])
-
-
 def wait_until(predicate, timeout=15.0, interval=0.2, message="condition not met"):
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -165,6 +161,9 @@ def drop_all_triggers(cursor):
 
 
 def metric_triplet(cursor):
+    # Internal legacy key names (db_*) intentionally retained; they predate the
+    # SHOW STORAGE INFO split. The on-the-wire field names from SHOW STORAGE INFO
+    # ON CURRENT DATABASE are graph/query/vector_index_memory_tracked (+ tenant_*).
     info = get_storage_info(cursor)
     graph = parse_size_bytes(info["graph_memory_tracked"])
     vector = parse_size_bytes(info["vector_index_memory_tracked"])
@@ -306,6 +305,9 @@ def test_show_storage_info_contains_db_split_fields():
         "graph_memory_tracked",
         "vector_index_memory_tracked",
         "query_memory_tracked",
+        "tenant_memory_tracked",
+        "tenant_peak_memory_tracked",
+        "tenant_memory_limit",
     }
     assert required.issubset(set(info.keys())), f"Missing keys: {required - set(info.keys())}"
 
@@ -313,12 +315,17 @@ def test_show_storage_info_contains_db_split_fields():
 def test_db_total_equals_storage_plus_embedding_plus_query():
     conn = connect()
     cursor = conn.cursor()
-    info = metric_triplet(cursor)
+    info = get_storage_info(cursor)
     conn.close()
 
+    graph = parse_size_bytes(info["graph_memory_tracked"])
+    vector = parse_size_bytes(info["vector_index_memory_tracked"])
+    query = parse_size_bytes(info["query_memory_tracked"])
+    tenant_total = parse_size_bytes(info["tenant_memory_tracked"])
+
     assert_metrics_close(
-        info["db_memory_tracked"],
-        info["db_storage_memory_tracked"] + info["db_embedding_memory_tracked"] + info["db_query_memory_tracked"],
+        tenant_total,
+        graph + vector + query,
         64 * 1024,
         "db total should match storage+embedding+query within readable-size rounding tolerance",
     )

--- a/tests/e2e/memory/db_memory_tracking.py
+++ b/tests/e2e/memory/db_memory_tracking.py
@@ -197,6 +197,16 @@ def assert_metric_returns_near_baseline(cursor, key, baseline, tolerance_bytes, 
     )
 
 
+def assert_global_metric_returns_near_baseline(cursor, key, baseline, tolerance_bytes, timeout=20.0, message=None):
+    if message is None:
+        message = f"global {key} did not return near baseline"
+    wait_until(
+        lambda: parse_size_bytes(get_global_storage_info(cursor).get(key, "0B")) <= baseline + tolerance_bytes,
+        timeout=timeout,
+        message=message,
+    )
+
+
 def release_query_memory_hold(cursor, signal_id):
     debug_log(f"release proc start signal_id={signal_id}")
     rows = fetch_all(
@@ -1027,7 +1037,7 @@ def test_drop_database_releases_global_memory():
     drop_database(admin_cursor, db_name)
     execute(memgraph_cursor, "FREE MEMORY")
     execute(memgraph_cursor, "FREE MEMORY")
-    assert_metric_returns_near_baseline(
+    assert_global_metric_returns_near_baseline(
         memgraph_cursor,
         "memory_tracked",
         baseline_global,

--- a/tests/e2e/memory/vector_index_memory.py
+++ b/tests/e2e/memory/vector_index_memory.py
@@ -53,6 +53,11 @@ def cleanup_after_test():
 
 
 def get_storage_info(cursor):
+    rows = execute_and_fetch_all(cursor, "SHOW STORAGE INFO ON CURRENT DATABASE")
+    return {row[0]: row[1] for row in rows}
+
+
+def get_global_storage_info(cursor):
     rows = execute_and_fetch_all(cursor, "SHOW STORAGE INFO")
     return {row[0]: row[1] for row in rows}
 
@@ -94,8 +99,8 @@ def setup_index_and_data(cursor):
 
 def test_db_storage_and_embedding_sum_to_db_total():
     """
-    db_storage_memory_tracked + db_embedding_memory_tracked must approximately
-    equal db_memory_tracked (the per-DB total tracker).
+    graph_memory_tracked + vector_index_memory_tracked must approximately
+    equal db_memory_tracked (the per-DB total tracker, computed as sum of components).
 
     Also checks that the RSS–tracked gap observed at startup does not grow
     significantly after inserting vectors, meaning the tracker stays honest
@@ -104,8 +109,8 @@ def test_db_storage_and_embedding_sum_to_db_total():
     interactive_mg_runner.start_all(INSTANCE_200MB)
     cursor = connect(host="localhost", port=BOLT_PORT).cursor()
 
-    baseline = get_storage_info(cursor)
-    baseline_gap = parse_mib(baseline["memory_res"]) - parse_mib(baseline["global_memory_tracked"])
+    global_info = get_global_storage_info(cursor)
+    baseline_gap = parse_mib(global_info["memory_res"]) - parse_mib(global_info["memory_tracked"])
     execute_and_fetch_all(
         cursor,
         f"CREATE VECTOR INDEX emb_idx ON :Embedding(vec) "
@@ -115,18 +120,20 @@ def test_db_storage_and_embedding_sum_to_db_total():
     insert_vectors(cursor, INDEX_VECTOR_COUNT, DIMENSION)
 
     info = get_storage_info(cursor)
-    total = parse_mib(info["global_memory_tracked"])
-    db_storage = parse_mib(info["db_storage_memory_tracked"])
-    db_embedding = parse_mib(info["db_embedding_memory_tracked"])
-    db_total = parse_mib(info["db_memory_tracked"])
-    rss = parse_mib(info["memory_res"])
+    global_info = get_global_storage_info(cursor)
+    total = parse_mib(global_info["memory_tracked"])
+    graph = parse_mib(info["graph_memory_tracked"])
+    vector = parse_mib(info["vector_index_memory_tracked"])
+    query = parse_mib(info["query_memory_tracked"])
+    db_total = graph + vector + query
+    rss = parse_mib(global_info["memory_res"])
 
-    assert db_embedding > 0, "db_embedding_memory_tracked should be non-zero after vector insertions"
-    assert db_storage > 0, "db_storage_memory_tracked should be non-zero"
+    assert vector > 0, "vector_index_memory_tracked should be non-zero after vector insertions"
+    assert graph > 0, "graph_memory_tracked should be non-zero"
 
-    assert abs((db_storage + db_embedding) - db_total) < TOLERANCE_MIB, (
-        f"db_storage ({db_storage:.2f} MiB) + db_embedding ({db_embedding:.2f} MiB) = {db_storage + db_embedding:.2f} MiB "
-        f"but db_memory_tracked = {db_total:.2f} MiB (diff > {TOLERANCE_MIB} MiB)"
+    assert abs((graph + vector) - db_total) < TOLERANCE_MIB, (
+        f"graph ({graph:.2f} MiB) + vector_index ({vector:.2f} MiB) = {graph + vector:.2f} MiB "
+        f"but db_total = {db_total:.2f} MiB (diff > {TOLERANCE_MIB} MiB)"
     )
 
     post_gap = rss - total
@@ -169,14 +176,14 @@ def test_remove_vector_property_vector_index_unchanged():
     cursor = connect(host="localhost", port=BOLT_PORT).cursor()
     setup_index_and_data(cursor)
 
-    vi_before = parse_mib(get_storage_info(cursor)["db_embedding_memory_tracked"])
-    assert vi_before > 0, "db_embedding_memory_tracked should be non-zero after setup"
+    vi_before = parse_mib(get_storage_info(cursor)["vector_index_memory_tracked"])
+    assert vi_before > 0, "vector_index_memory_tracked should be non-zero after setup"
 
     execute_and_fetch_all(cursor, "MATCH (n:Embedding) REMOVE n.vec")
 
-    vi_after = parse_mib(get_storage_info(cursor)["db_embedding_memory_tracked"])
+    vi_after = parse_mib(get_storage_info(cursor)["vector_index_memory_tracked"])
     assert vi_after == vi_before, (
-        f"db_embedding_memory_tracked changed after removing vec property: "
+        f"vector_index_memory_tracked changed after removing vec property: "
         f"before={vi_before:.2f} MiB, after={vi_after:.2f} MiB"
     )
 
@@ -191,22 +198,22 @@ def test_delete_vertices_graph_down_vector_index_unchanged():
     setup_index_and_data(cursor)
 
     info_before = get_storage_info(cursor)
-    graph_before = parse_mib(info_before["db_storage_memory_tracked"])
-    vi_before = parse_mib(info_before["db_embedding_memory_tracked"])
+    graph_before = parse_mib(info_before["graph_memory_tracked"])
+    vi_before = parse_mib(info_before["vector_index_memory_tracked"])
 
     execute_and_fetch_all(cursor, "MATCH (n:Embedding) DETACH DELETE n")
     execute_and_fetch_all(cursor, "FREE MEMORY")
 
     info_after = get_storage_info(cursor)
-    graph_after = parse_mib(info_after["db_storage_memory_tracked"])
-    vi_after = parse_mib(info_after["db_embedding_memory_tracked"])
+    graph_after = parse_mib(info_after["graph_memory_tracked"])
+    vi_after = parse_mib(info_after["vector_index_memory_tracked"])
 
     assert vi_after == vi_before, (
-        f"db_embedding_memory_tracked changed after deleting vertices: "
+        f"vector_index_memory_tracked changed after deleting vertices: "
         f"before={vi_before:.2f} MiB, after={vi_after:.2f} MiB"
     )
     assert graph_after < graph_before, (
-        f"db_storage_memory_tracked should decrease after deleting vertices: "
+        f"graph_memory_tracked should decrease after deleting vertices: "
         f"before={graph_before:.2f} MiB, after={graph_after:.2f} MiB"
     )
 
@@ -221,13 +228,13 @@ def test_drop_index_vector_index_zero():
     cursor = connect(host="localhost", port=BOLT_PORT).cursor()
     setup_index_and_data(cursor)
 
-    vi_before = parse_mib(get_storage_info(cursor)["db_embedding_memory_tracked"])
-    assert vi_before > 0, "db_embedding_memory_tracked should be non-zero before drop"
+    vi_before = parse_mib(get_storage_info(cursor)["vector_index_memory_tracked"])
+    assert vi_before > 0, "vector_index_memory_tracked should be non-zero before drop"
 
     execute_and_fetch_all(cursor, "DROP VECTOR INDEX emb_idx")
 
-    vi_after = parse_mib(get_storage_info(cursor)["db_embedding_memory_tracked"])
-    assert vi_after < 1.0, f"db_embedding_memory_tracked should be ~0 after dropping index, got {vi_after:.2f} MiB"
+    vi_after = parse_mib(get_storage_info(cursor)["vector_index_memory_tracked"])
+    assert vi_after < 1.0, f"vector_index_memory_tracked should be ~0 after dropping index, got {vi_after:.2f} MiB"
 
 
 if __name__ == "__main__":

--- a/tests/e2e/memory/vector_index_memory.py
+++ b/tests/e2e/memory/vector_index_memory.py
@@ -99,8 +99,9 @@ def setup_index_and_data(cursor):
 
 def test_db_storage_and_embedding_sum_to_db_total():
     """
-    graph_memory_tracked + vector_index_memory_tracked must approximately
-    equal db_memory_tracked (the per-DB total tracker, computed as sum of components).
+    graph_memory_tracked + vector_index_memory_tracked + query_memory_tracked must
+    approximately equal tenant_memory_tracked (the per-DB total tracker, computed
+    as sum of components).
 
     Also checks that the RSS–tracked gap observed at startup does not grow
     significantly after inserting vectors, meaning the tracker stays honest
@@ -125,15 +126,15 @@ def test_db_storage_and_embedding_sum_to_db_total():
     graph = parse_mib(info["graph_memory_tracked"])
     vector = parse_mib(info["vector_index_memory_tracked"])
     query = parse_mib(info["query_memory_tracked"])
-    db_total = graph + vector + query
+    tenant_total = parse_mib(info["tenant_memory_tracked"])
     rss = parse_mib(global_info["memory_res"])
 
     assert vector > 0, "vector_index_memory_tracked should be non-zero after vector insertions"
     assert graph > 0, "graph_memory_tracked should be non-zero"
 
-    assert abs((graph + vector) - db_total) < TOLERANCE_MIB, (
-        f"graph ({graph:.2f} MiB) + vector_index ({vector:.2f} MiB) = {graph + vector:.2f} MiB "
-        f"but db_total = {db_total:.2f} MiB (diff > {TOLERANCE_MIB} MiB)"
+    assert abs((graph + vector + query) - tenant_total) < TOLERANCE_MIB, (
+        f"graph ({graph:.2f} MiB) + vector_index ({vector:.2f} MiB) + query ({query:.2f} MiB) = {graph + vector + query:.2f} MiB "
+        f"but tenant_total = {tenant_total:.2f} MiB (diff > {TOLERANCE_MIB} MiB)"
     )
 
     post_gap = rss - total

--- a/tests/e2e/observe_current_amount_of_deltas/observe_current_amount_of_deltas.py
+++ b/tests/e2e/observe_current_amount_of_deltas/observe_current_amount_of_deltas.py
@@ -19,7 +19,7 @@ def get_current_amount_of_deltas():
     storage_info_connection = connect_with_autocommit()
 
     storage_cursor = storage_info_connection.cursor()
-    result = execute_and_fetch_all(storage_cursor, "SHOW STORAGE INFO")
+    result = execute_and_fetch_all(storage_cursor, "SHOW STORAGE INFO ON CURRENT DATABASE")
 
     result = [x for x in result if x[0] == "unreleased_delta_objects"][0][1]
 

--- a/tests/e2e/replication/read_write_benchmark.cpp
+++ b/tests/e2e/replication/read_write_benchmark.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -89,7 +89,7 @@ int main(int argc, char **argv) {
       auto now = std::chrono::steady_clock::now();
       while (now - start < TIMEOUT) {
         auto client = mg::e2e::replication::Connect(database_endpoint);
-        client->Execute("SHOW STORAGE INFO;");
+        client->Execute("SHOW STORAGE INFO ON CURRENT DATABASE;");
         auto maybe_rows = client->FetchAll();
         if (!maybe_rows) {
           LOG_FATAL("Failed to fetch storage info from {}", database_endpoint.SocketAddress());

--- a/tests/e2e/show_license_info/test_show_license_info.py
+++ b/tests/e2e/show_license_info/test_show_license_info.py
@@ -19,14 +19,41 @@ def get_license_info_by_key(results, key):
     return [x["value"] for x in results if x["license info"] == key][0]
 
 
+def expected_memory_limit_policy(license_type: str, memory_limit: str) -> str:
+    # Mirrors src/query/interpreter.cpp SHOW LICENSE INFO handler.
+    if memory_limit == "UNLIMITED":
+        return "Memory usage is not limited."
+    if license_type == "ai_platform":
+        return "Graph and query memory are limited. Vector index memory is not limited."
+    return "All memory usage is limited."
+
+
 def test_empty_show_active_users_info(memgraph):
     results = list(memgraph.execute_and_fetch("SHOW LICENSE INFO"))
     assert len(results) == 8
+
+    expected_keys = {
+        "organization_name",
+        "license_key",
+        "is_valid",
+        "license_type",
+        "valid_until",
+        "memory_limit",
+        "status",
+        "memory_limit_policy",
+    }
+    assert {row["license info"] for row in results} == expected_keys
+
     assert get_license_info_by_key(results, "organization_name") == "Memgraph"
     assert get_license_info_by_key(results, "is_valid") is True
     assert get_license_info_by_key(results, "status") == "You are running a valid Memgraph Enterprise License."
-    # Enterprise license (non-AI-Platform) should report the standard policy
-    assert get_license_info_by_key(results, "memory_limit_policy") == "All memory usage is limited."
+
+    license_type = get_license_info_by_key(results, "license_type")
+    memory_limit = get_license_info_by_key(results, "memory_limit")
+    assert license_type in {"enterprise", "oem", "ai_platform", "oem_community"}
+
+    policy = get_license_info_by_key(results, "memory_limit_policy")
+    assert policy == expected_memory_limit_policy(license_type, memory_limit)
 
 
 if __name__ == "__main__":

--- a/tests/e2e/show_license_info/test_show_license_info.py
+++ b/tests/e2e/show_license_info/test_show_license_info.py
@@ -21,7 +21,7 @@ def get_license_info_by_key(results, key):
 
 def test_empty_show_active_users_info(memgraph):
     results = list(memgraph.execute_and_fetch("SHOW LICENSE INFO"))
-    assert len(results) == 7
+    assert len(results) == 8
     assert get_license_info_by_key(results, "organization_name") == "Memgraph"
     assert get_license_info_by_key(results, "is_valid") is True
     assert get_license_info_by_key(results, "status") == "You are running a valid Memgraph Enterprise License."

--- a/tests/e2e/show_license_info/test_show_license_info.py
+++ b/tests/e2e/show_license_info/test_show_license_info.py
@@ -21,10 +21,12 @@ def get_license_info_by_key(results, key):
 
 def test_empty_show_active_users_info(memgraph):
     results = list(memgraph.execute_and_fetch("SHOW LICENSE INFO"))
-    assert len(results) == 8
+    assert len(results) == 9
     assert get_license_info_by_key(results, "organization_name") == "Memgraph"
     assert get_license_info_by_key(results, "is_valid") is True
     assert get_license_info_by_key(results, "status") == "You are running a valid Memgraph Enterprise License."
+    # Enterprise license (non-AI-Platform) should report the standard policy
+    assert get_license_info_by_key(results, "memory_limit_policy") == "All memory usage is limited."
 
 
 if __name__ == "__main__":

--- a/tests/e2e/show_license_info/test_show_license_info.py
+++ b/tests/e2e/show_license_info/test_show_license_info.py
@@ -21,7 +21,7 @@ def get_license_info_by_key(results, key):
 
 def test_empty_show_active_users_info(memgraph):
     results = list(memgraph.execute_and_fetch("SHOW LICENSE INFO"))
-    assert len(results) == 9
+    assert len(results) == 8
     assert get_license_info_by_key(results, "organization_name") == "Memgraph"
     assert get_license_info_by_key(results, "is_valid") is True
     assert get_license_info_by_key(results, "status") == "You are running a valid Memgraph Enterprise License."

--- a/tests/e2e/show_metrics/show_metrics.py
+++ b/tests/e2e/show_metrics/show_metrics.py
@@ -235,6 +235,7 @@ def test_all_show_metrics_info_values_are_present(memgraph):
         {"name": "SnapshotRecoveryLatency_us_50p", "type": "Snapshot", "metric type": "Histogram"},
         {"name": "SnapshotRecoveryLatency_us_90p", "type": "Snapshot", "metric type": "Histogram"},
         {"name": "SnapshotRecoveryLatency_us_99p", "type": "Snapshot", "metric type": "Histogram"},
+        {"name": "ShowStorageInfo", "type": "StorageInfo", "metric type": "Counter"},
         {"name": "ShowStorageInfoOnDatabase", "type": "StorageInfo", "metric type": "Counter"},
         # Stream
         {"name": "MessagesConsumed", "type": "Stream", "metric type": "Counter"},

--- a/tests/e2e/show_metrics/show_metrics_json_values.py
+++ b/tests/e2e/show_metrics/show_metrics_json_values.py
@@ -272,6 +272,7 @@ EXPECTED_JSON_METRICS = {
     },
     "StorageInfo": {
         "ShowStorageInfoOnDatabase",
+        "ShowStorageInfo",
     },
 }
 

--- a/tests/e2e/streams/kafka_streams_tests.py
+++ b/tests/e2e/streams/kafka_streams_tests.py
@@ -24,7 +24,7 @@ from mg_utils import mg_sleep_and_assert
 
 
 def _get_storage_info(cursor):
-    cursor.execute("SHOW STORAGE INFO")
+    cursor.execute("SHOW STORAGE INFO ON CURRENT DATABASE")
     return {row[0]: row[1] for row in cursor.fetchall()}
 
 
@@ -539,7 +539,7 @@ def test_db_memory_grows_from_kafka_stream_ingestion(kafka_producer, kafka_topic
     common.create_stream(cursor, stream_name, topic, "kafka_transform.simple")
     common.start_stream(cursor, stream_name)
 
-    before = _parse_size_bytes(_get_storage_info(cursor).get("db_memory_tracked", "0B"))
+    before = _parse_size_bytes(_get_storage_info(cursor).get("tenant_memory_tracked", "0B"))
 
     # Send enough messages to trigger arena extent allocations (each message creates
     # one :MESSAGE node with topic + payload properties via kafka_transform.simple).
@@ -550,7 +550,7 @@ def test_db_memory_grows_from_kafka_stream_ingestion(kafka_producer, kafka_topic
     # Wait for the last message to be ingested before measuring.
     common.kafka_check_vertex_exists_with_topic_and_payload(cursor, topic, common.SIMPLE_MSG)
 
-    after = _parse_size_bytes(_get_storage_info(cursor).get("db_memory_tracked", "0B"))
+    after = _parse_size_bytes(_get_storage_info(cursor).get("tenant_memory_tracked", "0B"))
 
     # Cleanup
     common.stop_stream(cursor, stream_name)
@@ -558,7 +558,8 @@ def test_db_memory_grows_from_kafka_stream_ingestion(kafka_producer, kafka_topic
     cursor.execute("MATCH (n:MESSAGE) DETACH DELETE n")
 
     assert after > before, (
-        f"db_memory_tracked must grow after Kafka consumer creates {msg_count} nodes. " f"before={before} after={after}"
+        f"tenant_memory_tracked must grow after Kafka consumer creates {msg_count} nodes. "
+        f"before={before} after={after}"
     )
 
 

--- a/tests/e2e/streams/kafka_streams_tests.py
+++ b/tests/e2e/streams/kafka_streams_tests.py
@@ -524,12 +524,12 @@ def test_check_stream_with_batch_limit_with_invalid_batch_limit(kafka_topics, co
 
 def test_db_memory_grows_from_kafka_stream_ingestion(kafka_producer, kafka_topics, connection):
     """
-    Objects created by Kafka consumer ingestion must be attributed to db_memory_tracked.
+    Objects created by Kafka consumer ingestion must be attributed to tenant_memory_tracked.
 
     The Kafka consumer thread is fully pinned to the DB jemalloc arena via je_mallctl
     (kafka/consumer.cpp). Every vertex/edge created by the transformation Cypher query
-    goes through the DB arena extent hooks and is reflected in SHOW STORAGE INFO →
-    db_memory_tracked.
+    goes through the DB arena extent hooks and is reflected in
+    SHOW STORAGE INFO ON CURRENT DATABASE → tenant_memory_tracked.
     """
     assert len(kafka_topics) > 0
     cursor = connection.cursor()

--- a/tests/e2e/system_replication/multitenancy.py
+++ b/tests/e2e/system_replication/multitenancy.py
@@ -1905,10 +1905,10 @@ def _parse_size_bytes_mt(size_str):
 
 
 def _get_db_memory_bytes_mt(cursor):
-    """Return db_memory_tracked from SHOW STORAGE INFO as bytes."""
-    info = execute_and_fetch_all(cursor, "SHOW STORAGE INFO")
+    """Return tenant_memory_tracked from SHOW STORAGE INFO as bytes."""
+    info = execute_and_fetch_all(cursor, "SHOW STORAGE INFO ON CURRENT DATABASE")
     info_dict = {row[0]: row[1] for row in info}
-    return _parse_size_bytes_mt(info_dict.get("db_memory_tracked", "0B"))
+    return _parse_size_bytes_mt(info_dict.get("tenant_memory_tracked", "0B"))
 
 
 def test_db_memory_tracking_cross_db_replication_isolation(connection, test_name):
@@ -1916,8 +1916,8 @@ def test_db_memory_tracking_cross_db_replication_isolation(connection, test_name
     Per-DB memory tracking must be isolated across replicated databases.
 
     Write 5000 nodes to database A on MAIN. Verify on replica_1 (SYNC):
-      - Database A's db_memory_tracked grew.
-      - Database B's db_memory_tracked did NOT grow significantly.
+      - Database A's tenant_memory_tracked grew.
+      - Database B's tenant_memory_tracked did NOT grow significantly.
 
     This validates that replication deltas are attributed to the correct DB arena on
     the replica, not leaked into unrelated databases.
@@ -1980,13 +1980,13 @@ def test_db_memory_tracking_cross_db_replication_isolation(connection, test_name
     after_b = _get_db_memory_bytes_mt(replica_cursor2)
 
     assert after_a > baseline_a, (
-        f"replica_1 database A db_memory_tracked should grow after replicating 5000 nodes. "
+        f"replica_1 database A tenant_memory_tracked should grow after replicating 5000 nodes. "
         f"baseline_a={baseline_a} after_a={after_a}"
     )
 
     # Allow up to 512 KiB noise for background threads / jemalloc rounding
     assert after_b <= baseline_b + 512 * 1024, (
-        f"replica_1 database B db_memory_tracked must NOT grow when only writing to A. "
+        f"replica_1 database B tenant_memory_tracked must NOT grow when only writing to A. "
         f"baseline_b={baseline_b} after_b={after_b}"
     )
 

--- a/tests/gql_behave/steps/graph.py
+++ b/tests/gql_behave/steps/graph.py
@@ -18,7 +18,7 @@ from behave import given
 
 
 def clear_graph(context):
-    result = database.query("SHOW STORAGE INFO", context)
+    result = database.query("SHOW STORAGE INFO ON CURRENT DATABASE", context)
     storage_mode = next(record["value"] for record in result if record["storage info"] == "storage_mode")
     if storage_mode == "ON_DISK_TRANSACTIONAL":
         database.query("MATCH (n) DETACH DELETE n", context)

--- a/tests/integration/license_info/client.cpp
+++ b/tests/integration/license_info/client.cpp
@@ -29,16 +29,16 @@ DEFINE_int64(interval, 1, "Interval used for reporting telemetry in seconds.");
 DEFINE_int64(duration, 10, "Duration of the test in seconds.");
 
 memgraph::license::LicenseType StringToLicenseType(const std::string_view license_type) {
-  if (license_type == "enterprise") {
+  if (license_type == memgraph::license::kLicenseTypeEnterprise) {
     return memgraph::license::LicenseType::ENTERPRISE;
   }
-  if (license_type == "oem_community") {
+  if (license_type == memgraph::license::kLicenseTypeOemCommunity) {
     return memgraph::license::LicenseType::OEM_COMMUNITY;
   }
-  if (license_type == "ai_platform") {
+  if (license_type == memgraph::license::kLicenseTypeAiPlatform) {
     return memgraph::license::LicenseType::AI_PLATFORM;
   }
-  if (license_type == "oem") {
+  if (license_type == memgraph::license::kLicenseTypeOem) {
     return memgraph::license::LicenseType::OEM;
   }
   spdlog::critical("Invalid license type!");

--- a/tests/integration/telemetry/field_validator.py
+++ b/tests/integration/telemetry/field_validator.py
@@ -293,6 +293,7 @@ EXPECTED_EVENT_COUNTERS = {
     "ShowInstances",
     "ShowSchema",
     "ShowStorageInfoOnDatabase",
+    "ShowStorageInfo",
     "SkipOperator",
     "StateCheckRpcFail",
     "StateCheckRpcSuccess",

--- a/tests/manual/test_isolation_level.py
+++ b/tests/manual/test_isolation_level.py
@@ -700,7 +700,7 @@ if __name__ == "__main__":
     info_cursor = info_conn.cursor()
     res = execute_and_fetch_all(info_cursor, "show storage info")
     res = {r[0]: r[1] for r in res}
-    global_isolation_level = res["isolation_level"]
+    global_isolation_level = res["storage_isolation_level"]
     print(f"Database started with global isolation level set to: {global_isolation_level}")
     info_conn.close()
 

--- a/tests/manual/test_isolation_level.py
+++ b/tests/manual/test_isolation_level.py
@@ -700,7 +700,7 @@ if __name__ == "__main__":
     info_cursor = info_conn.cursor()
     res = execute_and_fetch_all(info_cursor, "show storage info")
     res = {r[0]: r[1] for r in res}
-    global_isolation_level = res["global_isolation_level"]
+    global_isolation_level = res["isolation_level"]
     print(f"Database started with global isolation level set to: {global_isolation_level}")
     info_conn.close()
 

--- a/tests/manual/test_isolation_level.py
+++ b/tests/manual/test_isolation_level.py
@@ -700,7 +700,7 @@ if __name__ == "__main__":
     info_cursor = info_conn.cursor()
     res = execute_and_fetch_all(info_cursor, "show storage info")
     res = {r[0]: r[1] for r in res}
-    global_isolation_level = res["storage_isolation_level"]
+    global_isolation_level = res["global_isolation_level"]
     print(f"Database started with global isolation level set to: {global_isolation_level}")
     info_conn.close()
 

--- a/tests/stress/ha/cluster_monitor.py
+++ b/tests/stress/ha/cluster_monitor.py
@@ -27,7 +27,7 @@ class ClusterMonitor:
             show_replicas=True,
             show_instances=True,
             verify_up=True,
-            storage_info=["vertex_count", "edge_count", "memory_res"],
+            storage_info=["vertex_count", "edge_count", "memory_res", "memory_limit"],
             interval=5,
         )
         with monitor:
@@ -178,6 +178,11 @@ class ClusterMonitor:
             try:
                 coord, rows = self._query("SHOW STORAGE INFO;")
                 info = {row["storage info"]: row["value"] for row in rows if "storage info" in row}
+                # Per-DB fields (vertex_count, edge_count, ...) live in the per-DB variant only.
+                _, db_rows = self._query("SHOW STORAGE INFO ON CURRENT DATABASE;")
+                for row in db_rows:
+                    if "storage info" in row:
+                        info[row["storage info"]] = row["value"]
                 parts = [f"{f}={info.get(f, '?')}" for f in self._storage_fields]
                 print(f"\n[STORAGE INFO @ {time.strftime('%H:%M:%S')} via {coord}] {' '.join(parts)}")
             except Exception as e:

--- a/tests/stress/ha/workloads/concurrent_edge_creation_on_supernode/workload.py
+++ b/tests/stress/ha/workloads/concurrent_edge_creation_on_supernode/workload.py
@@ -149,7 +149,7 @@ def main():
         coordinators=COORDINATORS,
         show_replicas=True,
         verify_up=True,
-        storage_info=["memory_res", "runtime_allocation_limit"],
+        storage_info=["memory_res", "memory_limit"],
         metrics_info=["FailedQuery", "TransientErrors"],
         interval=2,
     )

--- a/tests/stress/ha/workloads/concurrent_edge_creation_on_supernode/workload.py
+++ b/tests/stress/ha/workloads/concurrent_edge_creation_on_supernode/workload.py
@@ -149,7 +149,7 @@ def main():
         coordinators=COORDINATORS,
         show_replicas=True,
         verify_up=True,
-        storage_info=["vertex_count", "edge_count", "memory_res", "global_runtime_allocation_limit"],
+        storage_info=["memory_res", "runtime_allocation_limit"],
         metrics_info=["FailedQuery", "TransientErrors"],
         interval=2,
     )

--- a/tests/stress/ha/workloads/concurrent_edge_write/workload.py
+++ b/tests/stress/ha/workloads/concurrent_edge_write/workload.py
@@ -81,7 +81,7 @@ def main():
         coordinators=COORDINATORS,
         show_replicas=True,
         verify_up=True,
-        storage_info=["vertex_count", "edge_count", "memory_res", "global_runtime_allocation_limit"],
+        storage_info=["memory_res", "runtime_allocation_limit"],
         interval=5,
     )
 

--- a/tests/stress/ha/workloads/concurrent_edge_write/workload.py
+++ b/tests/stress/ha/workloads/concurrent_edge_write/workload.py
@@ -81,7 +81,7 @@ def main():
         coordinators=COORDINATORS,
         show_replicas=True,
         verify_up=True,
-        storage_info=["memory_res", "runtime_allocation_limit"],
+        storage_info=["memory_res", "memory_limit"],
         interval=5,
     )
 

--- a/tests/stress/ha/workloads/concurrent_index_creation/workload.py
+++ b/tests/stress/ha/workloads/concurrent_index_creation/workload.py
@@ -234,7 +234,7 @@ def main():
         coordinators=COORDINATORS,
         show_replicas=True,
         verify_up=True,
-        storage_info=["vertex_count", "memory_res", "global_runtime_allocation_limit"],
+        storage_info=["memory_res", "runtime_allocation_limit"],
         metrics_info=["FailedQuery", "TransientErrors"],
         interval=2,
     )

--- a/tests/stress/ha/workloads/concurrent_index_creation/workload.py
+++ b/tests/stress/ha/workloads/concurrent_index_creation/workload.py
@@ -234,7 +234,7 @@ def main():
         coordinators=COORDINATORS,
         show_replicas=True,
         verify_up=True,
-        storage_info=["memory_res", "runtime_allocation_limit"],
+        storage_info=["memory_res", "memory_limit"],
         metrics_info=["FailedQuery", "TransientErrors"],
         interval=2,
     )

--- a/tests/stress/ha/workloads/publications/workload.py
+++ b/tests/stress/ha/workloads/publications/workload.py
@@ -447,7 +447,7 @@ def main():
         coordinators=COORDINATORS,
         show_replicas=True,
         verify_up=True,
-        storage_info=["vertex_count", "edge_count", "memory_res", "global_runtime_allocation_limit"],
+        storage_info=["memory_res", "runtime_allocation_limit"],
         interval=5,
     )
 

--- a/tests/stress/ha/workloads/publications/workload.py
+++ b/tests/stress/ha/workloads/publications/workload.py
@@ -447,7 +447,7 @@ def main():
         coordinators=COORDINATORS,
         show_replicas=True,
         verify_up=True,
-        storage_info=["memory_res", "runtime_allocation_limit"],
+        storage_info=["memory_res", "memory_limit"],
         interval=5,
     )
 

--- a/tests/stress/ha/workloads/rag/workload.py
+++ b/tests/stress/ha/workloads/rag/workload.py
@@ -117,7 +117,7 @@ def main():
         coordinators=COORDINATORS,
         show_replicas=True,
         verify_up=False,
-        storage_info=["memory_res", "runtime_allocation_limit"],
+        storage_info=["memory_res", "memory_limit"],
         interval=10,
     )
 

--- a/tests/stress/ha/workloads/rag/workload.py
+++ b/tests/stress/ha/workloads/rag/workload.py
@@ -117,7 +117,7 @@ def main():
         coordinators=COORDINATORS,
         show_replicas=True,
         verify_up=False,
-        storage_info=["vertex_count", "edge_count", "memory_res", "global_runtime_allocation_limit"],
+        storage_info=["memory_res", "runtime_allocation_limit"],
         interval=10,
     )
 

--- a/tests/stress/ha/workloads/responsive_reads/workload.py
+++ b/tests/stress/ha/workloads/responsive_reads/workload.py
@@ -229,7 +229,7 @@ def main():
         coordinators=COORDINATORS,
         show_replicas=True,
         verify_up=True,
-        storage_info=["vertex_count", "memory_res", "global_runtime_allocation_limit"],
+        storage_info=["memory_res", "runtime_allocation_limit"],
         interval=2,
         auth=AUTH,
     )

--- a/tests/stress/ha/workloads/responsive_reads/workload.py
+++ b/tests/stress/ha/workloads/responsive_reads/workload.py
@@ -229,7 +229,7 @@ def main():
         coordinators=COORDINATORS,
         show_replicas=True,
         verify_up=True,
-        storage_info=["memory_res", "runtime_allocation_limit"],
+        storage_info=["memory_res", "memory_limit"],
         interval=2,
         auth=AUTH,
     )

--- a/tests/stress/ha/workloads/restarting_instances/workload.py
+++ b/tests/stress/ha/workloads/restarting_instances/workload.py
@@ -286,7 +286,7 @@ def main():
         coordinators=COORDINATORS,
         show_replicas=True,
         verify_up=False,
-        storage_info=["vertex_count", "edge_count", "memory_res", "global_runtime_allocation_limit"],
+        storage_info=["memory_res", "runtime_allocation_limit"],
         interval=10,
     )
 

--- a/tests/stress/ha/workloads/restarting_instances/workload.py
+++ b/tests/stress/ha/workloads/restarting_instances/workload.py
@@ -286,7 +286,7 @@ def main():
         coordinators=COORDINATORS,
         show_replicas=True,
         verify_up=False,
-        storage_info=["memory_res", "runtime_allocation_limit"],
+        storage_info=["memory_res", "memory_limit"],
         interval=10,
     )
 

--- a/tests/stress/memory_limit.py
+++ b/tests/stress/memory_limit.py
@@ -146,7 +146,7 @@ def get_tracker_data(session) -> Optional[float]:
 
     try:
         data, _ = try_execute(session, f"SHOW STORAGE INFO")
-        memory_tracker_data = isolate_value(data, "global_memory_tracked")
+        memory_tracker_data = isolate_value(data, "memory_tracked")
 
         return parse_data(memory_tracker_data)
 

--- a/tests/stress/memory_tracker.py
+++ b/tests/stress/memory_tracker.py
@@ -215,7 +215,7 @@ def get_storage_data(session) -> Tuple[float, float]:
     try:
         data = execute_till_success(session, f"SHOW STORAGE INFO")[0]
         res_data = isolate_value(data, "memory_res")
-        memory_tracker_data = isolate_value(data, "global_memory_tracked")
+        memory_tracker_data = isolate_value(data, "memory_tracked")
         log.info(
             f"Worker {Constants.MONITOR_CLEANUP_FUNCTION} logged memory: memory tracker {memory_tracker_data} vs res data {res_data}"
         )

--- a/tests/stress/standalone/native/workloads/analytical_memory/workload.py
+++ b/tests/stress/standalone/native/workloads/analytical_memory/workload.py
@@ -21,7 +21,7 @@ ITERATIONS = 10
 TOTAL_NODES = 50_000_000
 TOTAL_EDGES = 25_000_000
 
-MONITOR_FIELDS = ["vertex_count", "edge_count", "memory_res", "global_memory_tracked"]
+MONITOR_FIELDS = ["memory_res", "memory_tracked"]
 
 
 def main():

--- a/tests/stress/standalone_monitor.py
+++ b/tests/stress/standalone_monitor.py
@@ -20,7 +20,7 @@ class StandaloneMonitor:
         monitor = StandaloneMonitor(
             host="127.0.0.1",
             port=7687,
-            storage_info=["vertex_count", "edge_count", "memory_res"],
+            storage_info=["vertex_count", "edge_count", "memory_res", "memory_limit"],
             interval=10,
         )
         with monitor:
@@ -47,10 +47,16 @@ class StandaloneMonitor:
         self._driver = GraphDatabase.driver(f"bolt://{host}:{port}", auth=("", ""))
 
     def get_storage_info(self) -> dict[str, Any]:
-        """One-shot: query SHOW STORAGE INFO and return as dict."""
+        """One-shot: query both global and per-DB SHOW STORAGE INFO and return the merged dict.
+
+        Per-DB fields (e.g. vertex_count, edge_count) are scoped to the default
+        database. Per-DB fields take precedence over global ones on key collision.
+        """
         with self._driver.session() as session:
-            result = session.run("SHOW STORAGE INFO;")
-            return {row["storage info"]: row["value"] for row in result}
+            merged: dict[str, Any] = {row["storage info"]: row["value"] for row in session.run("SHOW STORAGE INFO;")}
+            for row in session.run("SHOW STORAGE INFO ON CURRENT DATABASE;"):
+                merged[row["storage info"]] = row["value"]
+            return merged
 
     def log_storage_info(self, label: str = "") -> dict[str, Any]:
         """Fetch and print storage info. Returns the info dict."""

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -4871,9 +4871,28 @@ TEST_P(CypherMainVisitorTest, TestProfileAuthQuery) {
 
 TEST_P(CypherMainVisitorTest, TestShowStorageInfo) {
   auto &ast_generator = *GetParam();
-  auto *query = dynamic_cast<SystemInfoQuery *>(ast_generator.ParseQuery("SHOW STORAGE INFO"));
-  ASSERT_TRUE(query);
-  EXPECT_EQ(query->info_type_, SystemInfoQuery::InfoType::STORAGE);
+  {
+    auto *query = dynamic_cast<SystemInfoQuery *>(ast_generator.ParseQuery("SHOW STORAGE INFO"));
+    ASSERT_TRUE(query);
+    EXPECT_EQ(query->info_type_, SystemInfoQuery::InfoType::STORAGE);
+    EXPECT_FALSE(query->database_.has_value());
+    EXPECT_FALSE(query->is_current_database_);
+  }
+  {
+    auto *query = dynamic_cast<SystemInfoQuery *>(ast_generator.ParseQuery("SHOW STORAGE INFO ON DATABASE memgraph"));
+    ASSERT_TRUE(query);
+    EXPECT_EQ(query->info_type_, SystemInfoQuery::InfoType::STORAGE);
+    ASSERT_TRUE(query->database_.has_value());
+    EXPECT_EQ(*query->database_, "memgraph");
+    EXPECT_FALSE(query->is_current_database_);
+  }
+  {
+    auto *query = dynamic_cast<SystemInfoQuery *>(ast_generator.ParseQuery("SHOW STORAGE INFO ON CURRENT DATABASE"));
+    ASSERT_TRUE(query);
+    EXPECT_EQ(query->info_type_, SystemInfoQuery::InfoType::STORAGE);
+    EXPECT_FALSE(query->database_.has_value());
+    EXPECT_TRUE(query->is_current_database_);
+  }
 }
 
 TEST_P(CypherMainVisitorTest, TestShowIndexInfo) {

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -629,9 +629,11 @@ TYPED_TEST(InterpreterTest, ShowStorageInfoIncludesQueryTrackingFields) {
   EXPECT_TRUE(values.contains("memory_limit"));
   EXPECT_TRUE(values.contains("license_memory_limit"));
   EXPECT_TRUE(values.contains("disk_usage"));
+  EXPECT_TRUE(values.contains("query+graph_memory_tracked"));
 
   EXPECT_TRUE(values.at("memory_tracked").IsString());
   EXPECT_TRUE(values.at("license_memory_limit").IsString());
+  EXPECT_TRUE(values.at("query+graph_memory_tracked").IsString());
 }
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -626,12 +626,12 @@ TYPED_TEST(InterpreterTest, ShowStorageInfoIncludesQueryTrackingFields) {
   }
 
   EXPECT_TRUE(values.contains("memory_tracked"));
-  EXPECT_TRUE(values.contains("runtime_allocation_limit"));
-  EXPECT_TRUE(values.contains("license_allocation_limit"));
+  EXPECT_TRUE(values.contains("memory_limit"));
+  EXPECT_TRUE(values.contains("license_memory_limit"));
   EXPECT_TRUE(values.contains("disk_usage"));
 
   EXPECT_TRUE(values.at("memory_tracked").IsString());
-  EXPECT_TRUE(values.at("license_allocation_limit").IsString());
+  EXPECT_TRUE(values.at("license_memory_limit").IsString());
 }
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -625,21 +625,13 @@ TYPED_TEST(InterpreterTest, ShowStorageInfoIncludesQueryTrackingFields) {
     values.emplace(row[0].ValueString(), row[1]);
   }
 
-  EXPECT_TRUE(values.contains("global_memory_tracked"));
-  EXPECT_TRUE(values.contains("global_runtime_allocation_limit"));
-  EXPECT_TRUE(values.contains("global_license_allocation_limit"));
-  EXPECT_TRUE(values.contains("db_memory_tracked"));
-  EXPECT_TRUE(values.contains("db_storage_memory_tracked"));
-  EXPECT_TRUE(values.contains("db_embedding_memory_tracked"));
-  EXPECT_TRUE(values.contains("db_query_memory_tracked"));
-  EXPECT_TRUE(values.contains("db_disk_usage"));
-  EXPECT_TRUE(values.contains("global_disk_usage"));
+  EXPECT_TRUE(values.contains("memory_tracked"));
+  EXPECT_TRUE(values.contains("runtime_allocation_limit"));
+  EXPECT_TRUE(values.contains("license_allocation_limit"));
+  EXPECT_TRUE(values.contains("disk_usage"));
 
-  EXPECT_TRUE(values.at("global_memory_tracked").IsString());
-  EXPECT_TRUE(values.at("db_memory_tracked").IsString());
-  EXPECT_TRUE(values.at("db_storage_memory_tracked").IsString());
-  EXPECT_TRUE(values.at("db_embedding_memory_tracked").IsString());
-  EXPECT_TRUE(values.at("db_query_memory_tracked").IsString());
+  EXPECT_TRUE(values.at("memory_tracked").IsString());
+  EXPECT_TRUE(values.at("license_allocation_limit").IsString());
 }
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -632,6 +632,8 @@ TYPED_TEST(InterpreterTest, ShowStorageInfoIncludesQueryTrackingFields) {
   EXPECT_TRUE(values.contains("db_storage_memory_tracked"));
   EXPECT_TRUE(values.contains("db_embedding_memory_tracked"));
   EXPECT_TRUE(values.contains("db_query_memory_tracked"));
+  EXPECT_TRUE(values.contains("db_disk_usage"));
+  EXPECT_TRUE(values.contains("global_disk_usage"));
 
   EXPECT_TRUE(values.at("global_memory_tracked").IsString());
   EXPECT_TRUE(values.at("db_memory_tracked").IsString());

--- a/tests/unit/license.cpp
+++ b/tests/unit/license.cpp
@@ -186,7 +186,7 @@ TEST_F(LicenseTest, DetailedLicenseInfo_Enterprise) {
   auto detailed_license_info = license_checker->GetDetailedLicenseInfo();
   ASSERT_EQ(detailed_license_info.organization_name, "Memgraph");
   ASSERT_TRUE(detailed_license_info.is_valid);
-  ASSERT_EQ(detailed_license_info.license_type, "enterprise");
+  ASSERT_EQ(detailed_license_info.license_type, memgraph::license::kLicenseTypeEnterprise);
   ASSERT_EQ(detailed_license_info.valid_until, "FOREVER");
   ASSERT_EQ(detailed_license_info.memory_limit, 0);
   ASSERT_EQ(detailed_license_info.status, "You are running a valid Memgraph Enterprise License.");
@@ -211,7 +211,7 @@ TEST_F(LicenseTest, DetailedLicenseInfo_OemCommunityNonExpiredIsInvalid) {
   license_checker->SetCliLicense(license_key, organization_name, *settings);
   auto detailed_license_info = license_checker->GetDetailedLicenseInfo();
   ASSERT_FALSE(detailed_license_info.is_valid);
-  ASSERT_EQ(detailed_license_info.license_type, "oem_community");
+  ASSERT_EQ(detailed_license_info.license_type, memgraph::license::kLicenseTypeOemCommunity);
   ASSERT_EQ(detailed_license_info.status,
             "You are running a valid Memgraph OEM Community License. Enterprise features are not enabled.");
 }
@@ -467,7 +467,7 @@ TEST_F(LicenseTest, AiPlatform_DetailedLicenseInfo) {
   license_checker->SetCliLicense(key, org, *settings);
   auto info = license_checker->GetDetailedLicenseInfo();
   ASSERT_TRUE(info.is_valid);
-  ASSERT_EQ(info.license_type, "ai_platform");
+  ASSERT_EQ(info.license_type, memgraph::license::kLicenseTypeAiPlatform);
   ASSERT_EQ(info.memory_limit, 512);
   ASSERT_EQ(info.status, "You are running a valid Memgraph AI Platform License.");
 }
@@ -539,7 +539,7 @@ TEST_F(LicenseTest, Oem_DetailedLicenseInfo) {
   license_checker->SetCliLicense(key, org, *settings);
   auto info = license_checker->GetDetailedLicenseInfo();
   ASSERT_TRUE(info.is_valid);
-  ASSERT_EQ(info.license_type, "oem");
+  ASSERT_EQ(info.license_type, memgraph::license::kLicenseTypeOem);
   ASSERT_EQ(info.valid_until, "FOREVER");
   ASSERT_EQ(info.status, "You are running a valid Memgraph OEM License.");
 }


### PR DESCRIPTION
## SHOW STORAGE INFO Variants

The `SHOW STORAGE INFO` command is refactored into three distinct query variants to cleanly separate instance-level (global) system telemetry from per-database performance metrics.

### Query Syntax

* `SHOW STORAGE INFO`
  * **Scope:** Instance-level metrics (process-wide).
  * **Status:** Semantics changed — previously returned a mix of process-wide and per-DB fields; now strictly process-wide.
* `SHOW STORAGE INFO ON DATABASE <name>`
  * **Scope:** Per-database metrics.
  * **Status:** Pre-existing syntax; result schema updated to the per-DB schema below.
  * *Note: Accessing non-default databases via this command is enterprise-gated.*
* `SHOW STORAGE INFO ON CURRENT DATABASE`
  * **Scope:** Per-database metrics targeting the session's currently-selected database.
  * **Status:** New in this PR.

### Schema & Field Split

#### Global Handler Returns

When executing the bare `SHOW STORAGE INFO` query, the following global fields are returned:

| Field Name | Type / Category | Description |
| :--- | :--- | :--- |
| `vm_max_map_count` | System Info | Operating system memory map area limit (`vm.max_map_count`). |
| `memory_res` | Memory Metric | Resident set size (RSS) currently used by the process. |
| `peak_memory_res` | Memory Metric | Peak resident set size observed during runtime. |
| `disk_usage` | Storage | Disk usage of the configured data directory (`--data-directory`). |
| `memory_tracked` | Memory Metric | Total engine-tracked internal allocations (`total_memory_tracker`). |
| `memory_limit` | Memory Metric | Active runtime memory limit (`total_memory_tracker` hard limit). |
| `license_memory_limit` | Memory Metric | Memory cap enforced by the current license, or `unlimited` if none. |
| `query+graph_memory_tracked` | Component Memory | Value of `graph_memory_tracker` — the global graph-arena tracker which captures all default-`new` allocations (both graph data and query-execution heap allocations). |
| `vector_index_memory_tracked` | Component Memory | Process-wide memory tracked by `vector_index_memory_tracker`. |
| `global_isolation_level` | Isolation | **Startup-default** isolation level (`--isolation-level`). Does **not** reflect runtime `SET GLOBAL TRANSACTION ISOLATION LEVEL` mutations — those only affect a single DB's storage and are visible via the per-DB variant's `storage_isolation_level`. |
| `session_isolation_level` | Isolation | Isolation level currently applied to the calling session. |
| `next_session_isolation_level` | Isolation | Isolation level designated to take effect on the next transaction in the session. |
| `global_storage_mode` | Storage | **Startup-default** storage mode (`--storage-mode`). Does **not** reflect runtime `STORAGE MODE …` mutations — those are visible via the per-DB variant's `storage_mode`. |

#### Per-DB Handler Returns

When executing either the `ON DATABASE <name>` or `ON CURRENT DATABASE` variants, the following schema is returned:

| Field Name | Category | Description |
| :--- | :--- | :--- |
| `name` | Metadata | Name of the database. |
| `database_uuid` | Metadata | Universally unique identifier for the database. |
| `storage_mode` | Storage | Current storage engine mode for this database (reflects runtime `STORAGE MODE …` changes). |
| `vertex_count` | Graph Metrics | Total number of vertices currently stored. |
| `edge_count` | Graph Metrics | Total number of edges currently stored. |
| `average_degree` | Graph Metrics | Average vertex degree. |
| `unreleased_delta_objects` | Graph Metrics | Number of delta objects awaiting garbage collection. |
| `disk_usage` | Storage | Disk usage of this database's storage directory (data + WAL + snapshots). |
| `graph_memory_tracked` | Component Memory | Per-DB graph allocations (`db_memory_tracker_`). |
| `query_memory_tracked` | Component Memory | Tracked allocations attributed to query execution contexts for this database. |
| `vector_index_memory_tracked` | Component Memory | Per-DB embedding tracker (`db_embedding_memory_tracker_`) — covers embeddings and vector indexes for this database. |
| `tenant_memory_tracked` | Tenant Memory | Total memory tracked for this database (`DbMemoryUsage`). |
| `tenant_peak_memory_tracked` | Tenant Memory | Highest recorded memory usage for this database. |
| `tenant_memory_limit` | Tenant Memory | Configured allocation ceiling for this database/tenant, or `unlimited`. |
| `storage_isolation_level` | Isolation | Active isolation level for this database (reflects runtime `SET GLOBAL TRANSACTION ISOLATION LEVEL` mutations). |

---

## SHOW LICENSE INFO Extension

To clearly differentiate behavioral enforcement policies between the standard Enterprise/OEM tiers and the managed AI Platform licensing tier, a new row `memory_limit_policy` has been introduced.

### Row Evaluation Matrix

The value of `memory_limit_policy` is determined by `license_type` **and** whether the license carries a non-zero `memory_limit`:

| License type | `memory_limit` | `memory_limit_policy` |
| :--- | :--- | :--- |
| AI Platform | `> 0` | `"Graph and query memory are limited. Vector index memory is not limited."` |
| Enterprise / OEM / other | `> 0` | `"All memory usage is limited."` |
| Any license type (incl. AI Platform) | `== 0` | `"Memory usage is not limited."` |
| No / invalid license | n/a | `"Memory usage is not limited."` |

Note: an AI Platform license with `memory_limit == 0` reports the unlimited string, not the AI Platform policy string.

---

## Metrics Updates (`src/metrics/prometheus_metrics.*`)

* **New Global Telemetry Counter:** Added a new `global.show_storage_info` counter tracking invocations of the no-DB `SHOW STORAGE INFO` variant. This counter is exposed in tandem with the existing per-DB counter (`ShowStorageInfoOnDatabase`).
* **JSON View Comment:** The existing per-DB counter `ShowStorageInfoOnDatabase` retains its name. A clarifying comment now identifies it as the per-DB total (sum across all databases) to distinguish it from the new global counter in code review and diagnostics inspection. *(No metric was renamed; only the comment was updated.)*
* **Peak Tracking Consolidation:** Replaced ad-hoc inline peak-RES gauge updates with a single unified helper: `PrometheusMetrics::UpdateAndGetPeakMemoryRes()`.

---

## Breaking Changes

### 1. Schema Separation

The bare `SHOW STORAGE INFO` statement **no longer yields database-level metrics**. Clients reading columns such as `vertex_count`, `edge_count`, `storage_mode`, `storage_isolation_level`, `db_memory_tracked`, etc., will find those columns absent from the result set. Applications must explicitly switch to the per-DB variant:

* `SHOW STORAGE INFO ON CURRENT DATABASE` (replaces the previous per-DB portion of the bare query for the current session DB), or
* `SHOW STORAGE INFO ON DATABASE <name>` (enterprise-gated for non-default DBs).

Per-DB fields **removed** from bare `SHOW STORAGE INFO`:
`name`, `database_uuid`, `vertex_count`, `edge_count`, `average_degree`, `unreleased_delta_objects`, `db_memory_tracked`, `db_storage_memory_tracked`, `db_embedding_memory_tracked`, `db_query_memory_tracked`.

Global fields **added** to bare `SHOW STORAGE INFO`:
`query+graph_memory_tracked`, `vector_index_memory_tracked`.

### 2. Global Field Renames

Several instance-level fields in the bare query response have been renamed:

| Old Name | New Name |
| :--- | :--- |
| `global_memory_tracked` | `memory_tracked` |
| `global_runtime_allocation_limit` | `memory_limit` |
| `global_license_allocation_limit` | `license_memory_limit` |
| `global_disk_usage` | `disk_usage` |
| `storage_mode` | `global_storage_mode` |

`global_isolation_level` retains its name but its **semantics changed**: it now reports the startup-default (`--isolation-level` flag) instead of the current DB's runtime isolation level. To observe runtime isolation-level changes made via `SET GLOBAL TRANSACTION ISOLATION LEVEL`, query `SHOW STORAGE INFO ON CURRENT DATABASE` and read `storage_isolation_level`.

The same applies to `global_storage_mode` (renamed from `storage_mode`): it reflects the startup-default `--storage-mode`, not runtime `STORAGE MODE …` mutations. For the live per-DB value, read `storage_mode` from the per-DB variant.