### PR TITLE
feat: Split OEM license into OEM and OEM_COMMUNITY tiers

### DIFF
--- a/src/license/license.cpp
+++ b/src/license/license.cpp
@@ -27,6 +27,7 @@
 #include <optional>
 #include <stdexcept>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "slk/serialization.hpp"
@@ -91,11 +92,14 @@ std::string LicenseTypeToString(const LicenseType license_type) {
     case LicenseType::ENTERPRISE: {
       return "enterprise";
     }
-    case LicenseType::OEM: {
-      return "oem";
+    case LicenseType::OEM_COMMUNITY: {
+      return "oem_community";
     }
     case LicenseType::AI_PLATFORM: {
       return "ai_platform";
+    }
+    case LicenseType::OEM: {
+      return "oem";
     }
   }
 }
@@ -313,7 +317,7 @@ std::string LicenseCheckErrorToString(LicenseCheckError error, const std::string
           feature);
     case LicenseCheckError::NOT_ENTERPRISE_LICENSE:
       return fmt::format(
-          "Your license has an invalid type. To use {} you need to have an enterprise or ai_platform license.\n",
+          "Your license has an invalid type. To use {} you need to have an enterprise, ai_platform, or oem license.\n",
           feature);
   }
 }
@@ -333,11 +337,18 @@ LicenseCheckResult LicenseChecker::IsEnterpriseValid(std::string_view license_ke
   if (!maybe_license) {
     return std::unexpected{LicenseCheckError::INVALID_LICENSE_KEY_STRING};
   }
-  if (maybe_license->type != LicenseType::ENTERPRISE && maybe_license->type != LicenseType::AI_PLATFORM) {
-    return std::unexpected{LicenseCheckError::NOT_ENTERPRISE_LICENSE};
+
+  if (auto basic = IsValidLicenseInternal(*maybe_license, organization_name); !basic) {
+    return basic;
   }
 
-  return IsValidLicenseInternal(*maybe_license, organization_name);
+  const bool is_enterprise_tier = maybe_license->type == LicenseType::ENTERPRISE ||
+                                  maybe_license->type == LicenseType::AI_PLATFORM ||
+                                  maybe_license->type == LicenseType::OEM;
+  if (!is_enterprise_tier) {
+    return std::unexpected{LicenseCheckError::NOT_ENTERPRISE_LICENSE};
+  }
+  return {};
 }
 
 LicenseCheckResult LicenseChecker::IsEnterpriseValid() const {
@@ -413,19 +424,33 @@ DetailedLicenseInfo LicenseChecker::GetDetailedLicenseInfo() {
   }
 
   // Use the same validation logic as enterprise feature checks to ensure is_valid is consistent.
-  // IsEnterpriseValid(key, org) validates: decodeable key + ENTERPRISE type + org name match + not expired.
   // NOTE: this overload does not re-acquire previous_license_info_ lock, so no deadlock.
   const auto license_check_result = IsEnterpriseValid(info.license_key, info.organization_name);
   if (!license_check_result) {
     info.is_valid = false;
-    info.status = LicenseCheckErrorToString(license_check_result.error(), "Memgraph Enterprise");
+    if (license_check_result.error() == LicenseCheckError::NOT_ENTERPRISE_LICENSE &&
+        maybe_license->type == LicenseType::OEM_COMMUNITY) {
+      info.status = "You are running a valid Memgraph OEM Community License. Enterprise features are not enabled.";
+    } else {
+      info.status = LicenseCheckErrorToString(license_check_result.error(), "Memgraph Enterprise");
+    }
     return info;
   }
 
   info.is_valid = true;
-  info.status = maybe_license->type == LicenseType::AI_PLATFORM
-                    ? "You are running a valid Memgraph AI Platform License."
-                    : "You are running a valid Memgraph Enterprise License.";
+  switch (maybe_license->type) {
+    case LicenseType::ENTERPRISE:
+      info.status = "You are running a valid Memgraph Enterprise License.";
+      break;
+    case LicenseType::AI_PLATFORM:
+      info.status = "You are running a valid Memgraph AI Platform License.";
+      break;
+    case LicenseType::OEM:
+      info.status = "You are running a valid Memgraph OEM License.";
+      break;
+    case LicenseType::OEM_COMMUNITY:
+      std::unreachable();
+  }
   return info;
 }
 
@@ -434,7 +459,8 @@ bool LicenseChecker::IsEnterpriseValidFast() const {
   // This ensures we see the license_type_ write that precedes those release stores,
   // avoiding a data race on the non-atomic license_type_.
   return is_valid_.load(std::memory_order_acquire) &&
-         (license_type_ == LicenseType::ENTERPRISE || license_type_ == LicenseType::AI_PLATFORM);
+         (license_type_ == LicenseType::ENTERPRISE || license_type_ == LicenseType::AI_PLATFORM ||
+          license_type_ == LicenseType::OEM);
 }
 
 std::string Encode(const License &license) {

--- a/src/license/license.cpp
+++ b/src/license/license.cpp
@@ -102,6 +102,7 @@ std::string LicenseTypeToString(const LicenseType license_type) {
       return "oem";
     }
   }
+  std::unreachable();
 }
 
 void RegisterLicenseSettings(LicenseChecker &license_checker, utils::Settings &settings) {
@@ -509,6 +510,15 @@ std::optional<License> Decode(std::string_view license_key) {
     slk::Load(&memory_limit, &reader);
     std::underlying_type_t<LicenseType> license_type{0};
     slk::Load(&license_type, &reader);
+    switch (license_type) {
+      case std::to_underlying(LicenseType::ENTERPRISE):
+      case std::to_underlying(LicenseType::OEM_COMMUNITY):
+      case std::to_underlying(LicenseType::AI_PLATFORM):
+      case std::to_underlying(LicenseType::OEM):
+        break;
+      default:
+        return std::nullopt;
+    }
     return {License{organization_name, valid_until, memory_limit, LicenseType(license_type)}};
   } catch (const slk::SlkReaderException &e) {
     return std::nullopt;

--- a/src/license/license.cpp
+++ b/src/license/license.cpp
@@ -343,10 +343,7 @@ LicenseCheckResult LicenseChecker::IsEnterpriseValid(std::string_view license_ke
     return basic;
   }
 
-  const bool is_enterprise_tier = maybe_license->type == LicenseType::ENTERPRISE ||
-                                  maybe_license->type == LicenseType::AI_PLATFORM ||
-                                  maybe_license->type == LicenseType::OEM;
-  if (!is_enterprise_tier) {
+  if (!IsEnterpriseTier(maybe_license->type)) {
     return std::unexpected{LicenseCheckError::NOT_ENTERPRISE_LICENSE};
   }
   return {};
@@ -459,9 +456,7 @@ bool LicenseChecker::IsEnterpriseValidFast() const {
   // Acquire synchronizes with release stores in RevalidateLicense/EnableTesting.
   // This ensures we see the license_type_ write that precedes those release stores,
   // avoiding a data race on the non-atomic license_type_.
-  return is_valid_.load(std::memory_order_acquire) &&
-         (license_type_ == LicenseType::ENTERPRISE || license_type_ == LicenseType::AI_PLATFORM ||
-          license_type_ == LicenseType::OEM);
+  return is_valid_.load(std::memory_order_acquire) && IsEnterpriseTier(license_type_);
 }
 
 std::string Encode(const License &license) {
@@ -510,16 +505,15 @@ std::optional<License> Decode(std::string_view license_key) {
     slk::Load(&memory_limit, &reader);
     std::underlying_type_t<LicenseType> license_type{0};
     slk::Load(&license_type, &reader);
-    switch (license_type) {
-      case std::to_underlying(LicenseType::ENTERPRISE):
-      case std::to_underlying(LicenseType::OEM_COMMUNITY):
-      case std::to_underlying(LicenseType::AI_PLATFORM):
-      case std::to_underlying(LicenseType::OEM):
-        break;
-      default:
-        return std::nullopt;
+    const auto typed = static_cast<LicenseType>(license_type);
+    switch (typed) {
+      case LicenseType::ENTERPRISE:
+      case LicenseType::OEM_COMMUNITY:
+      case LicenseType::AI_PLATFORM:
+      case LicenseType::OEM:
+        return License{organization_name, valid_until, memory_limit, typed};
     }
-    return {License{organization_name, valid_until, memory_limit, LicenseType(license_type)}};
+    return std::nullopt;
   } catch (const slk::SlkReaderException &e) {
     return std::nullopt;
   }

--- a/src/license/license.cpp
+++ b/src/license/license.cpp
@@ -317,9 +317,7 @@ std::string LicenseCheckErrorToString(LicenseCheckError error, const std::string
           "SET DATABASE SETTING \"enterprise.license\" TO \"your-license-key\"",
           feature);
     case LicenseCheckError::NOT_ENTERPRISE_LICENSE:
-      return fmt::format(
-          "Your license has an invalid type. To use {} you need to have an enterprise, ai_platform, or oem license.\n",
-          feature);
+      return fmt::format("Access to {} requires an enterprise, ai_platform, or oem license.", feature);
   }
 }
 

--- a/src/license/license.hpp
+++ b/src/license/license.hpp
@@ -27,7 +27,12 @@
 
 namespace memgraph::license {
 
-enum class LicenseType : uint8_t { ENTERPRISE, OEM, AI_PLATFORM };
+enum class LicenseType : uint8_t {
+  ENTERPRISE = 0,
+  OEM_COMMUNITY = 1,
+  AI_PLATFORM = 2,
+  OEM = 3,
+};
 
 std::string LicenseTypeToString(LicenseType license_type);
 

--- a/src/license/license.hpp
+++ b/src/license/license.hpp
@@ -29,9 +29,9 @@ namespace memgraph::license {
 
 enum class LicenseType : uint8_t {
   ENTERPRISE = 0,
-  OEM_COMMUNITY = 1,
+  OEM = 1,
   AI_PLATFORM = 2,
-  OEM = 3,
+  OEM_COMMUNITY = 3,
 };
 
 constexpr bool IsEnterpriseTier(LicenseType type) noexcept {

--- a/src/license/license.hpp
+++ b/src/license/license.hpp
@@ -34,6 +34,10 @@ enum class LicenseType : uint8_t {
   OEM = 3,
 };
 
+constexpr bool IsEnterpriseTier(LicenseType type) noexcept {
+  return type == LicenseType::ENTERPRISE || type == LicenseType::AI_PLATFORM || type == LicenseType::OEM;
+}
+
 std::string LicenseTypeToString(LicenseType license_type);
 
 struct License {

--- a/tests/integration/license_info/client.cpp
+++ b/tests/integration/license_info/client.cpp
@@ -24,7 +24,7 @@
 #include "utils/uuid.hpp"
 
 DEFINE_string(endpoint, "http://127.0.0.1:5500/", "Endpoint that should be used for the test.");
-DEFINE_string(license_type, "enterprise", "License type; can be enterprise, oem, or ai_platform.");
+DEFINE_string(license_type, "enterprise", "License type; can be enterprise, oem, oem_community, or ai_platform.");
 DEFINE_int64(interval, 1, "Interval used for reporting telemetry in seconds.");
 DEFINE_int64(duration, 10, "Duration of the test in seconds.");
 
@@ -32,11 +32,14 @@ memgraph::license::LicenseType StringToLicenseType(const std::string_view licens
   if (license_type == "enterprise") {
     return memgraph::license::LicenseType::ENTERPRISE;
   }
-  if (license_type == "oem") {
-    return memgraph::license::LicenseType::OEM;
+  if (license_type == "oem_community") {
+    return memgraph::license::LicenseType::OEM_COMMUNITY;
   }
   if (license_type == "ai_platform") {
     return memgraph::license::LicenseType::AI_PLATFORM;
+  }
+  if (license_type == "oem") {
+    return memgraph::license::LicenseType::OEM;
   }
   spdlog::critical("Invalid license type!");
   std::terminate();

--- a/tests/unit/license.cpp
+++ b/tests/unit/license.cpp
@@ -581,3 +581,9 @@ TEST_F(LicenseTest, BackwardCompat_WireValue1RoundTripsAsOemCommunity) {
   EXPECT_EQ(static_cast<uint8_t>(decoded->type), 1);
   EXPECT_EQ(decoded->organization_name, "FixtureOrg");
 }
+
+TEST_F(LicenseTest, Decode_RejectsUnknownLicenseTypeByte) {
+  const auto crafted = memgraph::license::License{"Memgraph", 0, 0, static_cast<memgraph::license::LicenseType>(0xFF)};
+  const auto encoded = memgraph::license::Encode(crafted);
+  EXPECT_FALSE(memgraph::license::Decode(encoded).has_value());
+}

--- a/tests/unit/license.cpp
+++ b/tests/unit/license.cpp
@@ -569,15 +569,15 @@ TEST_F(LicenseTest, Oem_MemoryLimitTreatedAsTotal) {
 }
 
 // ===========================================================================
-// Wire-format compat for existing OEM Community license keys
+// Wire-format compat for existing OEM license keys
 // ===========================================================================
 
-TEST_F(LicenseTest, BackwardCompat_WireValue1RoundTripsAsOemCommunity) {
+TEST_F(LicenseTest, BackwardCompat_WireValue1RoundTripsAsOem) {
   const auto fixture = memgraph::license::License{"FixtureOrg", 0, 0, static_cast<memgraph::license::LicenseType>(1)};
   const auto encoded = memgraph::license::Encode(fixture);
   const auto decoded = memgraph::license::Decode(encoded);
   ASSERT_TRUE(decoded.has_value());
-  EXPECT_EQ(decoded->type, memgraph::license::LicenseType::OEM_COMMUNITY);
+  EXPECT_EQ(decoded->type, memgraph::license::LicenseType::OEM);
   EXPECT_EQ(static_cast<uint8_t>(decoded->type), 1);
   EXPECT_EQ(decoded->organization_name, "FixtureOrg");
 }

--- a/tests/unit/license.cpp
+++ b/tests/unit/license.cpp
@@ -45,7 +45,7 @@ class LicenseTest : public ::testing::Test {
 
 TEST_F(LicenseTest, EncodeDecode) {
   const std::array licenses = {
-      memgraph::license::License{"Organization", 1, 2, memgraph::license::LicenseType::OEM},
+      memgraph::license::License{"Organization", 1, 2, memgraph::license::LicenseType::OEM_COMMUNITY},
       memgraph::license::License{"", -1, 0, memgraph::license::LicenseType::ENTERPRISE},
       memgraph::license::License{
           "Some very long name for the organization Ltd", -999, -9999, memgraph::license::LicenseType::ENTERPRISE},
@@ -153,7 +153,7 @@ TEST_F(LicenseTest, LicenseType) {
     CheckLicenseValidity(true);
   }
   {
-    memgraph::license::License license_oem{organization_name, 0, 0, memgraph::license::LicenseType::OEM};
+    memgraph::license::License license_oem{organization_name, 0, 0, memgraph::license::LicenseType::OEM_COMMUNITY};
     const std::string license_key = memgraph::license::Encode(license_oem);
     license_checker->SetCliLicense(license_key, organization_name, *settings);
     CheckLicenseValidity(false);
@@ -162,7 +162,7 @@ TEST_F(LicenseTest, LicenseType) {
     memgraph::license::License license_oem{organization_name,
                                            std::numeric_limits<int64_t>::min(),
                                            std::numeric_limits<int64_t>::max(),
-                                           memgraph::license::LicenseType::OEM};
+                                           memgraph::license::LicenseType::OEM_COMMUNITY};
     const std::string license_key = memgraph::license::Encode(license_oem);
     license_checker->SetCliLicense(license_key, organization_name, *settings);
     CheckLicenseValidity(false);
@@ -171,7 +171,7 @@ TEST_F(LicenseTest, LicenseType) {
     memgraph::license::License license_oem{organization_name,
                                            std::numeric_limits<int64_t>::max(),
                                            std::numeric_limits<int64_t>::min(),
-                                           memgraph::license::LicenseType::OEM};
+                                           memgraph::license::LicenseType::OEM_COMMUNITY};
     const std::string license_key = memgraph::license::Encode(license_oem);
     license_checker->SetCliLicense(license_key, organization_name, *settings);
     CheckLicenseValidity(false);
@@ -192,26 +192,28 @@ TEST_F(LicenseTest, DetailedLicenseInfo_Enterprise) {
   ASSERT_EQ(detailed_license_info.status, "You are running a valid Memgraph Enterprise License.");
 }
 
-TEST_F(LicenseTest, DetailedLicenseInfo_OemExpired) {
-  // An expired OEM key produces no valid candidate; previous_license_info_ is reset.
+TEST_F(LicenseTest, DetailedLicenseInfo_OemCommunityExpired) {
+  // An expired OEM Community key produces no valid candidate; previous_license_info_ is reset.
   // GetDetailedLicenseInfo returns is_valid=false with no license details.
   const std::string organization_name{"Memgraph"};
-  memgraph::license::License license_oem{organization_name, 1, 6, memgraph::license::LicenseType::OEM};
+  memgraph::license::License license_oem{organization_name, 1, 6, memgraph::license::LicenseType::OEM_COMMUNITY};
   const std::string license_key = memgraph::license::Encode(license_oem);
   license_checker->SetCliLicense(license_key, organization_name, *settings);
   auto detailed_license_info = license_checker->GetDetailedLicenseInfo();
   ASSERT_FALSE(detailed_license_info.is_valid);
 }
 
-TEST_F(LicenseTest, DetailedLicenseInfo_OemNonExpiredIsInvalid) {
-  SCOPED_TRACE("Valid non-expired OEM license must report is_valid=false (not enterprise type)");
+TEST_F(LicenseTest, DetailedLicenseInfo_OemCommunityNonExpiredIsInvalid) {
+  SCOPED_TRACE("Valid non-expired OEM Community license must report is_valid=false (not enterprise tier)");
   const std::string organization_name{"Memgraph"};
-  memgraph::license::License license_oem{organization_name, 0, 0, memgraph::license::LicenseType::OEM};
+  memgraph::license::License license_oem{organization_name, 0, 0, memgraph::license::LicenseType::OEM_COMMUNITY};
   const std::string license_key = memgraph::license::Encode(license_oem);
   license_checker->SetCliLicense(license_key, organization_name, *settings);
   auto detailed_license_info = license_checker->GetDetailedLicenseInfo();
   ASSERT_FALSE(detailed_license_info.is_valid);
-  ASSERT_EQ(detailed_license_info.license_type, "oem");
+  ASSERT_EQ(detailed_license_info.license_type, "oem_community");
+  ASSERT_EQ(detailed_license_info.status,
+            "You are running a valid Memgraph OEM Community License. Enterprise features are not enabled.");
 }
 
 TEST_F(LicenseTest, DetailedLicenseInfo_MismatchedOrgName) {
@@ -516,4 +518,66 @@ TEST_F(LicenseTest, AiPlatform_SwitchToEnterpriseClearsGraphLimit) {
 TEST_F(LicenseTest, AiPlatform_TestingFlag) {
   license_checker->EnableTesting(memgraph::license::LicenseType::AI_PLATFORM);
   CheckLicenseValidity(true);
+}
+
+// ===========================================================================
+// OEM license type (enterprise-equivalent, wire value 3)
+// ===========================================================================
+
+TEST_F(LicenseTest, Oem_EnterpriseValidation) {
+  const std::string org{"Memgraph"};
+  memgraph::license::License lic{org, 0, 0, memgraph::license::LicenseType::OEM};
+  const auto key = memgraph::license::Encode(lic);
+  license_checker->SetCliLicense(key, org, *settings);
+  CheckLicenseValidity(true);
+}
+
+TEST_F(LicenseTest, Oem_DetailedLicenseInfo) {
+  const std::string org{"Memgraph"};
+  memgraph::license::License lic{org, 0, 0, memgraph::license::LicenseType::OEM};
+  const auto key = memgraph::license::Encode(lic);
+  license_checker->SetCliLicense(key, org, *settings);
+  auto info = license_checker->GetDetailedLicenseInfo();
+  ASSERT_TRUE(info.is_valid);
+  ASSERT_EQ(info.license_type, "oem");
+  ASSERT_EQ(info.valid_until, "FOREVER");
+  ASSERT_EQ(info.status, "You are running a valid Memgraph OEM License.");
+}
+
+TEST_F(LicenseTest, Oem_IsEnterpriseValidFastReturnsTrue) {
+  const std::string org{"Memgraph"};
+  memgraph::license::License lic{org, 0, 0, memgraph::license::LicenseType::OEM};
+  license_checker->SetCliLicense(memgraph::license::Encode(lic), org, *settings);
+  ASSERT_TRUE(license_checker->IsEnterpriseValidFast());
+}
+
+TEST_F(LicenseTest, Oem_MemoryLimitTreatedAsTotal) {
+  constexpr int64_t system_limit = 1'000'000'000;
+  memgraph::utils::total_memory_tracker.SetMaximumHardLimit(system_limit);
+  memgraph::utils::total_memory_tracker.SetHardLimit(system_limit);
+
+  const std::string org{"Memgraph"};
+  constexpr int64_t license_limit = 500'000'000;
+  memgraph::license::License lic{org, 0, license_limit, memgraph::license::LicenseType::OEM};
+  license_checker->SetCliLicense(memgraph::license::Encode(lic), org, *settings);
+
+  ASSERT_EQ(memgraph::utils::total_memory_tracker.HardLimit(), license_limit);
+  ASSERT_EQ(memgraph::utils::graph_memory_tracker.HardLimit(), 0);
+
+  memgraph::utils::graph_memory_tracker.ResetLimit();
+  memgraph::utils::total_memory_tracker.ResetTrackings();
+}
+
+// ===========================================================================
+// Wire-format compat for existing OEM Community license keys
+// ===========================================================================
+
+TEST_F(LicenseTest, BackwardCompat_WireValue1RoundTripsAsOemCommunity) {
+  const auto fixture = memgraph::license::License{"FixtureOrg", 0, 0, static_cast<memgraph::license::LicenseType>(1)};
+  const auto encoded = memgraph::license::Encode(fixture);
+  const auto decoded = memgraph::license::Decode(encoded);
+  ASSERT_TRUE(decoded.has_value());
+  EXPECT_EQ(decoded->type, memgraph::license::LicenseType::OEM_COMMUNITY);
+  EXPECT_EQ(static_cast<uint8_t>(decoded->type), 1);
+  EXPECT_EQ(decoded->organization_name, "FixtureOrg");
 }


### PR DESCRIPTION
Splits the OEM license tier into two: `OEM` (enterprise-equivalent, wire value 1) for OEM Platform/Enterprise deals, and `OEM_COMMUNITY` (tracking-only, wire value 3) for distributed Community licenses. Existing OEM keys in the wild decode to the new enterprise-equivalent OEM tier on upgrade; customers needing community-tier tracking must be re-issued with the new wire value. 