### PR TITLE
feat: add per-phase logging to snapshot creation

### DIFF
--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -310,9 +310,8 @@ void InMemoryReplicationHandlers::Register(
 auto InMemoryReplicationHandlers::TakeSnapshotLock(auto &snapshot_guard, storage::InMemoryStorage *storage) -> bool {
   if (snapshot_guard.try_lock()) return true;
 
-  spdlog::trace(
-      "Couldn't obtain the snapshot lock because there is an ongoing snapshot creation. Trying to abort snapshot "
-      "creation.");
+  spdlog::info(
+      "[snapshot] couldn't obtain the snapshot lock because there is an ongoing snapshot creation, trying to abort");
 
   // abort_snapshot_ will be reset to false in CreateSnapshot in storage.cpp at the end of its execution with
   // OnScopeExit block

--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -310,8 +310,7 @@ void InMemoryReplicationHandlers::Register(
 auto InMemoryReplicationHandlers::TakeSnapshotLock(auto &snapshot_guard, storage::InMemoryStorage *storage) -> bool {
   if (snapshot_guard.try_lock()) return true;
 
-  spdlog::info(
-      "[snapshot] couldn't obtain the snapshot lock because there is an ongoing snapshot creation, trying to abort");
+  spdlog::info("snapshot lock contention: another snapshot is in progress, requesting abort");
 
   // abort_snapshot_ will be reset to false in CreateSnapshot in storage.cpp at the end of its execution with
   // OnScopeExit block

--- a/src/dbms/inmemory/storage_helper.hpp
+++ b/src/dbms/inmemory/storage_helper.hpp
@@ -25,18 +25,22 @@ inline std::unique_ptr<storage::Storage> CreateInMemoryStorage(
     std::function<storage::DatabaseProtectorPtr()> database_protector_factory = nullptr,
     memgraph::memory::ArenaPool *db_arena = nullptr, utils::MemoryTracker *db_embedding_memory_tracker = nullptr) {
   // Use default safe factory from Storage constructor for basic usage
-  auto storage = std::make_unique<storage::InMemoryStorage>(
-      std::move(config), std::nullopt, std::move(invalidator), std::move(metric_handles),
-      std::move(database_protector_factory), db_arena, db_embedding_memory_tracker);
+  auto storage = std::make_unique<storage::InMemoryStorage>(std::move(config),
+                                                            std::nullopt,
+                                                            std::move(invalidator),
+                                                            std::move(metric_handles),
+                                                            std::move(database_protector_factory),
+                                                            db_arena,
+                                                            db_embedding_memory_tracker);
 
-  storage->CreateSnapshotHandler(
-      [storage = storage.get()]() -> std::expected<void, storage::InMemoryStorage::CreateSnapshotError> {
-        auto result = storage->CreateSnapshot();
-        if (!result) {
-          return std::unexpected(result.error());
-        }
-        return {};
-      });
+  storage->CreateSnapshotHandler([storage = storage.get()](std::string_view trigger)
+                                     -> std::expected<void, storage::InMemoryStorage::CreateSnapshotError> {
+    auto result = storage->CreateSnapshot(false, trigger);
+    if (!result) {
+      return std::unexpected(result.error());
+    }
+    return {};
+  });
   return storage;
 }
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -5980,7 +5980,7 @@ PreparedQuery PrepareCreateSnapshotQuery(ParsedQuery parsed_query, bool in_expli
     if (!maybe_path) {
       switch (maybe_path.error()) {
         case storage::InMemoryStorage::CreateSnapshotError::ReachedMaxNumTries:
-          spdlog::warn("Failed to create snapshot. {}. Please contact support.",
+          spdlog::warn("snapshot failed: {}. Please contact support.",
                        storage::InMemoryStorage::CreateSnapshotErrorToString(maybe_path.error()));
           break;
         case storage::InMemoryStorage::CreateSnapshotError::AbortSnapshot:

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -5976,7 +5976,7 @@ PreparedQuery PrepareCreateSnapshotQuery(ParsedQuery parsed_query, bool in_expli
   callback.fn = [storage]() mutable -> std::vector<std::vector<TypedValue>> {
     auto *mem_storage = static_cast<storage::InMemoryStorage *>(storage);
     constexpr bool kForce = true;
-    const auto maybe_path = mem_storage->CreateSnapshot(kForce);
+    const auto maybe_path = mem_storage->CreateSnapshot(kForce, "manual");
     if (!maybe_path) {
       switch (maybe_path.error()) {
         case storage::InMemoryStorage::CreateSnapshotError::ReachedMaxNumTries:

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -12032,7 +12032,9 @@ void EnsureNecessaryWalFilesExist(const std::filesystem::path &wal_directory, co
   // handles the edge case when that one file is the current WAL file that
   if (it != wal_files.begin()) {
     auto const num_to_delete = static_cast<size_t>(std::distance(wal_files.begin(), std::prev(it)));
-    spdlog::info("snapshot retention: deleting {} old WAL file(s), keeping from ts {}", num_to_delete, old_durable_ts);
+    spdlog::info("snapshot retention: deleting {} pre-snapshot WAL file(s) (oldest retained snapshot ts={})",
+                 num_to_delete,
+                 old_durable_ts);
     std::for_each(wal_files.begin(), std::prev(it), [file_retainer](auto const &wal_info) {
       file_retainer->DeleteFile(wal_info.path);
     });

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -12087,14 +12087,12 @@ void DeleteOldSnapshotFiles(OldSnapshotFiles &old_snapshot_files, uint64_t const
   old_snapshot_files.erase(old_snapshot_files.begin(), old_snapshot_files.begin() + num_to_erase);
 }
 
-std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transaction *transaction,
-                                                    const std::filesystem::path &snapshot_directory,
-                                                    const std::filesystem::path &wal_directory,
-                                                    utils::SkipListDb<Vertex> *vertices, utils::SkipListDb<Edge> *edges,
-                                                    utils::UUID const &uuid, std::string_view const epoch_id,
-                                                    const std::deque<std::pair<std::string, uint64_t>> &epoch_history,
-                                                    utils::FileRetainer *file_retainer,
-                                                    std::atomic_bool *abort_snapshot, SnapshotProgress *progress) {
+std::optional<std::filesystem::path> CreateSnapshot(
+    Storage *storage, Transaction *transaction, const std::filesystem::path &snapshot_directory,
+    const std::filesystem::path &wal_directory, utils::SkipListDb<Vertex> *vertices, utils::SkipListDb<Edge> *edges,
+    utils::UUID const &uuid, std::string_view const epoch_id,
+    const std::deque<std::pair<std::string, uint64_t>> &epoch_history, utils::FileRetainer *file_retainer,
+    std::atomic_bool *abort_snapshot, SnapshotProgress *progress, std::string_view trigger) {
   utils::Timer timer;
 
   // Ensure that the storage directory exists.
@@ -12112,10 +12110,11 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
       return false;
     }
     file_retainer->DeleteFile(path);
+    spdlog::info("[snapshot] aborted");
     return true;
   };
 
-  spdlog::info("Starting snapshot creation to {}", path);
+  spdlog::info("[snapshot] starting {} snapshot creation to {}", trigger, path);
   SnapshotEncoder snapshot;
   if (!snapshot.Initialize(path, kSnapshotMagic, kVersion)) {
     spdlog::warn(
@@ -12408,6 +12407,7 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
   std::vector<BatchInfo> vertex_batch_infos;
 
   if (storage->config_.durability.allow_parallel_snapshot_creation) {
+    spdlog::info("[snapshot] writing edges and vertices");
     auto *edge_ptr = storage->config_.salient.items.properties_on_edges ? edges : nullptr;
     if (!MultiThreadedWorkflow(edge_ptr,
                                vertices,
@@ -12436,6 +12436,7 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
     }
   } else {
     if (storage->config_.salient.items.properties_on_edges) {
+      spdlog::info("[snapshot] writing edges");
       if (progress) progress->SetPhase(SnapshotProgress::Phase::EDGES, edges->size());
       offset_edges = snapshot.GetPosition();  // Global edge offset
       // Handle edges
@@ -12447,6 +12448,7 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
     if (snapshot_aborted()) {
       return std::nullopt;
     }
+    spdlog::info("[snapshot] writing vertices");
     if (progress) progress->SetPhase(SnapshotProgress::Phase::VERTICES, vertices->size());
     {
       offset_vertices = snapshot.GetPosition();  // Global vertex offset
@@ -12469,6 +12471,7 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
 
     // Write label indices.
     {
+      spdlog::info("[snapshot] writing label indices");
       auto label = transaction->active_indices_->label_->ListIndices(transaction->start_timestamp);
       snapshot.WriteUint(label.size());
       for (const auto &item : label) {
@@ -12570,6 +12573,7 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
     auto asc_indices = inmem_active_indices->ListIndices(transaction->start_timestamp, IndexOrder::ASC);
     auto desc_indices = inmem_active_indices->ListIndices(transaction->start_timestamp, IndexOrder::DESC);
 
+    spdlog::info("[snapshot] writing label-property indices");
     // Write ASC label+properties indices.
     {
       write_label_property_indices(asc_indices);
@@ -12592,6 +12596,7 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
     offset_edge_indices = snapshot.GetPosition();
     snapshot.WriteMarker(Marker::SECTION_EDGE_INDICES);
     {
+      spdlog::info("[snapshot] writing edge-type indices");
       auto edge_type = transaction->active_indices_->edge_type_->ListIndices(transaction->start_timestamp);
       snapshot.WriteUint(edge_type.size());
       for (const auto &item : edge_type) {
@@ -12604,6 +12609,7 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
 
     // Write edge-type + property indices.
     {
+      spdlog::info("[snapshot] writing edge-type-property indices");
       auto edge_type = transaction->active_indices_->edge_type_properties_->ListIndices(transaction->start_timestamp);
       snapshot.WriteUint(edge_type.size());
       for (const auto &item : edge_type) {
@@ -12617,6 +12623,7 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
 
     // Write global edge property indices.
     {
+      spdlog::info("[snapshot] writing edge-property indices");
       auto indices = transaction->active_indices_->edge_property_->ListIndices(transaction->start_timestamp);
       snapshot.WriteUint(indices.size());
       for (const auto &property : indices) {
@@ -12626,6 +12633,7 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
 
     // Write point indices.
     {
+      spdlog::info("[snapshot] writing point indices");
       auto point_keys = storage->indices_.point_index_.ListIndices();
       snapshot.WriteUint(point_keys.size());
       for (const auto &[label, property] : point_keys) {
@@ -12639,6 +12647,7 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
 
     // Write vector indices
     {
+      spdlog::info("[snapshot] writing vector indices");
       storage->indices_.vector_index_.SerializeAllVectorIndices(&snapshot, used_ids);
       if (snapshot_aborted()) {
         return std::nullopt;
@@ -12647,6 +12656,7 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
 
     // Write vector edge indices
     {
+      spdlog::info("[snapshot] writing vector edge indices");
       storage->indices_.vector_edge_index_.SerializeAllVectorEdgeIndices(&snapshot, used_ids);
       if (snapshot_aborted()) {
         return std::nullopt;
@@ -12657,6 +12667,7 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
     {
       // Text indices on nodes
       {
+        spdlog::info("[snapshot] writing text node indices");
         const auto text_indices = storage->indices_.text_index_.ListIndices();
         snapshot.WriteUint(text_indices.size());
         for (const auto &[index_name, label, properties] : text_indices) {
@@ -12673,6 +12684,7 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
       }
       // Text indices on edges
       {
+        spdlog::info("[snapshot] writing text edge indices");
         const auto text_edge_indices = storage->indices_.text_edge_index_.ListIndices();
         snapshot.WriteUint(text_edge_indices.size());
         for (const auto &[index_name, edge_type, properties] : text_edge_indices) {
@@ -12691,6 +12703,7 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
   }
 
   // Write constraints.
+  spdlog::info("[snapshot] writing constraints");
   if (progress) progress->SetPhase(SnapshotProgress::Phase::CONSTRAINTS, 0);
   {
     offset_constraints = snapshot.GetPosition();
@@ -12740,6 +12753,7 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
   }
 
   // Write mapper data, enums, metadata, batch info, TTL.
+  spdlog::info("[snapshot] finalizing");
   if (progress) progress->SetPhase(SnapshotProgress::Phase::FINALIZING, 0);
   {
     offset_mapper = snapshot.GetPosition();
@@ -12952,10 +12966,8 @@ std::optional<std::filesystem::path> CreateSnapshot(Storage *storage, Transactio
     return std::nullopt;
   }
 
-  // Finalize snapshot file.
-  spdlog::trace("Finalizing snapshot file!");
   snapshot.Finalize();
-  spdlog::info("Snapshot creation successful!");
+  spdlog::info("[snapshot] creation successful");
 
   auto const old_snapshot_files =
       EnsureRetentionCountSnapshotsExist(snapshot_directory, uuid_str, path, file_retainer, storage);

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -12974,8 +12974,8 @@ std::optional<std::filesystem::path> CreateSnapshot(
     return std::nullopt;
   }
 
-  auto const snapshot_size = snapshot.GetSize();
   snapshot.Finalize();
+  auto const snapshot_size = std::filesystem::file_size(path);
   spdlog::info("snapshot complete: {} ({} vertices, {} edges, {:.1f} MiB, {:.2f}s)",
                path,
                vertices_count,

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -12031,6 +12031,8 @@ void EnsureNecessaryWalFilesExist(const std::filesystem::path &wal_directory, co
   // one WAL file that contains deltas before the snapshot, this correctly
   // handles the edge case when that one file is the current WAL file that
   if (it != wal_files.begin()) {
+    auto const num_to_delete = static_cast<size_t>(std::distance(wal_files.begin(), std::prev(it)));
+    spdlog::info("snapshot retention: deleting {} old WAL file(s), keeping from ts {}", num_to_delete, old_durable_ts);
     std::for_each(wal_files.begin(), std::prev(it), [file_retainer](auto const &wal_info) {
       file_retainer->DeleteFile(wal_info.path);
     });
@@ -12079,6 +12081,9 @@ void DeleteOldSnapshotFiles(OldSnapshotFiles &old_snapshot_files, uint64_t const
 
   // -1 because the current snapshot path has been skipped
   const uint32_t num_to_erase = old_snapshot_files.size() - (snapshot_retention_count - 1);
+  spdlog::info("snapshot retention: deleting {} old snapshot file(s), retention_count={}",
+               num_to_erase,
+               snapshot_retention_count);
   for (size_t i = 0; i < num_to_erase; ++i) {
     const auto &[_, snapshot_path] = old_snapshot_files[i];
     file_retainer->DeleteFile(snapshot_path);
@@ -12110,11 +12115,11 @@ std::optional<std::filesystem::path> CreateSnapshot(
       return false;
     }
     file_retainer->DeleteFile(path);
-    spdlog::info("[snapshot] aborted");
+    spdlog::info("snapshot aborted");
     return true;
   };
 
-  spdlog::info("[snapshot] starting {} snapshot creation to {}", trigger, path);
+  spdlog::info("snapshot starting: {} (trigger={})", path, trigger);
   SnapshotEncoder snapshot;
   if (!snapshot.Initialize(path, kSnapshotMagic, kVersion)) {
     spdlog::warn(
@@ -12407,7 +12412,8 @@ std::optional<std::filesystem::path> CreateSnapshot(
   std::vector<BatchInfo> vertex_batch_infos;
 
   if (storage->config_.durability.allow_parallel_snapshot_creation) {
-    spdlog::info("[snapshot] writing edges and vertices");
+    spdlog::info("snapshot writing edges and vertices (parallel, {} threads)",
+                 storage->config_.durability.snapshot_thread_count);
     auto *edge_ptr = storage->config_.salient.items.properties_on_edges ? edges : nullptr;
     if (!MultiThreadedWorkflow(edge_ptr,
                                vertices,
@@ -12436,7 +12442,7 @@ std::optional<std::filesystem::path> CreateSnapshot(
     }
   } else {
     if (storage->config_.salient.items.properties_on_edges) {
-      spdlog::info("[snapshot] writing edges");
+      spdlog::info("snapshot writing edges");
       if (progress) progress->SetPhase(SnapshotProgress::Phase::EDGES, edges->size());
       offset_edges = snapshot.GetPosition();  // Global edge offset
       // Handle edges
@@ -12448,7 +12454,7 @@ std::optional<std::filesystem::path> CreateSnapshot(
     if (snapshot_aborted()) {
       return std::nullopt;
     }
-    spdlog::info("[snapshot] writing vertices");
+    spdlog::info("snapshot writing vertices");
     if (progress) progress->SetPhase(SnapshotProgress::Phase::VERTICES, vertices->size());
     {
       offset_vertices = snapshot.GetPosition();  // Global vertex offset
@@ -12471,7 +12477,7 @@ std::optional<std::filesystem::path> CreateSnapshot(
 
     // Write label indices.
     {
-      spdlog::info("[snapshot] writing label indices");
+      spdlog::info("snapshot writing label indices");
       auto label = transaction->active_indices_->label_->ListIndices(transaction->start_timestamp);
       snapshot.WriteUint(label.size());
       for (const auto &item : label) {
@@ -12573,7 +12579,7 @@ std::optional<std::filesystem::path> CreateSnapshot(
     auto asc_indices = inmem_active_indices->ListIndices(transaction->start_timestamp, IndexOrder::ASC);
     auto desc_indices = inmem_active_indices->ListIndices(transaction->start_timestamp, IndexOrder::DESC);
 
-    spdlog::info("[snapshot] writing label-property indices");
+    spdlog::info("snapshot writing label-property indices");
     // Write ASC label+properties indices.
     {
       write_label_property_indices(asc_indices);
@@ -12596,7 +12602,7 @@ std::optional<std::filesystem::path> CreateSnapshot(
     offset_edge_indices = snapshot.GetPosition();
     snapshot.WriteMarker(Marker::SECTION_EDGE_INDICES);
     {
-      spdlog::info("[snapshot] writing edge-type indices");
+      spdlog::info("snapshot writing edge-type indices");
       auto edge_type = transaction->active_indices_->edge_type_->ListIndices(transaction->start_timestamp);
       snapshot.WriteUint(edge_type.size());
       for (const auto &item : edge_type) {
@@ -12609,7 +12615,7 @@ std::optional<std::filesystem::path> CreateSnapshot(
 
     // Write edge-type + property indices.
     {
-      spdlog::info("[snapshot] writing edge-type-property indices");
+      spdlog::info("snapshot writing edge-type-property indices");
       auto edge_type = transaction->active_indices_->edge_type_properties_->ListIndices(transaction->start_timestamp);
       snapshot.WriteUint(edge_type.size());
       for (const auto &item : edge_type) {
@@ -12623,7 +12629,7 @@ std::optional<std::filesystem::path> CreateSnapshot(
 
     // Write global edge property indices.
     {
-      spdlog::info("[snapshot] writing edge-property indices");
+      spdlog::info("snapshot writing edge-property indices");
       auto indices = transaction->active_indices_->edge_property_->ListIndices(transaction->start_timestamp);
       snapshot.WriteUint(indices.size());
       for (const auto &property : indices) {
@@ -12633,7 +12639,7 @@ std::optional<std::filesystem::path> CreateSnapshot(
 
     // Write point indices.
     {
-      spdlog::info("[snapshot] writing point indices");
+      spdlog::info("snapshot writing point indices");
       auto point_keys = storage->indices_.point_index_.ListIndices();
       snapshot.WriteUint(point_keys.size());
       for (const auto &[label, property] : point_keys) {
@@ -12647,7 +12653,7 @@ std::optional<std::filesystem::path> CreateSnapshot(
 
     // Write vector indices
     {
-      spdlog::info("[snapshot] writing vector indices");
+      spdlog::info("snapshot writing vector indices");
       storage->indices_.vector_index_.SerializeAllVectorIndices(&snapshot, used_ids);
       if (snapshot_aborted()) {
         return std::nullopt;
@@ -12656,7 +12662,7 @@ std::optional<std::filesystem::path> CreateSnapshot(
 
     // Write vector edge indices
     {
-      spdlog::info("[snapshot] writing vector edge indices");
+      spdlog::info("snapshot writing vector edge indices");
       storage->indices_.vector_edge_index_.SerializeAllVectorEdgeIndices(&snapshot, used_ids);
       if (snapshot_aborted()) {
         return std::nullopt;
@@ -12667,7 +12673,7 @@ std::optional<std::filesystem::path> CreateSnapshot(
     {
       // Text indices on nodes
       {
-        spdlog::info("[snapshot] writing text node indices");
+        spdlog::info("snapshot writing text node indices");
         const auto text_indices = storage->indices_.text_index_.ListIndices();
         snapshot.WriteUint(text_indices.size());
         for (const auto &[index_name, label, properties] : text_indices) {
@@ -12684,7 +12690,7 @@ std::optional<std::filesystem::path> CreateSnapshot(
       }
       // Text indices on edges
       {
-        spdlog::info("[snapshot] writing text edge indices");
+        spdlog::info("snapshot writing text edge indices");
         const auto text_edge_indices = storage->indices_.text_edge_index_.ListIndices();
         snapshot.WriteUint(text_edge_indices.size());
         for (const auto &[index_name, edge_type, properties] : text_edge_indices) {
@@ -12703,7 +12709,7 @@ std::optional<std::filesystem::path> CreateSnapshot(
   }
 
   // Write constraints.
-  spdlog::info("[snapshot] writing constraints");
+  spdlog::info("snapshot writing constraints");
   if (progress) progress->SetPhase(SnapshotProgress::Phase::CONSTRAINTS, 0);
   {
     offset_constraints = snapshot.GetPosition();
@@ -12753,7 +12759,7 @@ std::optional<std::filesystem::path> CreateSnapshot(
   }
 
   // Write mapper data, enums, metadata, batch info, TTL.
-  spdlog::info("[snapshot] finalizing");
+  spdlog::info("snapshot finalizing");
   if (progress) progress->SetPhase(SnapshotProgress::Phase::FINALIZING, 0);
   {
     offset_mapper = snapshot.GetPosition();
@@ -12966,8 +12972,14 @@ std::optional<std::filesystem::path> CreateSnapshot(
     return std::nullopt;
   }
 
+  auto const snapshot_size = snapshot.GetSize();
   snapshot.Finalize();
-  spdlog::info("[snapshot] creation successful");
+  spdlog::info("snapshot complete: {} ({} vertices, {} edges, {:.1f} MiB, {:.2f}s)",
+               path,
+               vertices_count,
+               edges_count,
+               static_cast<double>(snapshot_size) / (1024.0 * 1024.0),
+               std::chrono::duration<double>(timer.Elapsed()).count());
 
   auto const old_snapshot_files =
       EnsureRetentionCountSnapshotsExist(snapshot_directory, uuid_str, path, file_retainer, storage);

--- a/src/storage/v2/durability/snapshot.hpp
+++ b/src/storage/v2/durability/snapshot.hpp
@@ -106,6 +106,7 @@ std::optional<std::filesystem::path> CreateSnapshot(
     const std::filesystem::path &wal_directory, utils::SkipListDb<Vertex> *vertices, utils::SkipListDb<Edge> *edges,
     utils::UUID const &uuid, std::string_view epoch_id,
     const std::deque<std::pair<std::string, uint64_t>> &epoch_history, utils::FileRetainer *file_retainer,
-    std::atomic_bool *abort_snapshot = nullptr, SnapshotProgress *progress = nullptr);
+    std::atomic_bool *abort_snapshot = nullptr, SnapshotProgress *progress = nullptr,
+    std::string_view trigger = "periodic");
 
 }  // namespace memgraph::storage::durability

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -508,7 +508,7 @@ InMemoryStorage::~InMemoryStorage() {
   // will figure out that there are no changes.
   if (!config_.durability.snapshot_on_exit) {
     if (snapshot_running_.load(std::memory_order_acquire)) {
-      spdlog::info("[snapshot] aborting: storage is shutting down");
+      spdlog::info("snapshot aborting: storage is shutting down");
     }
     abort_snapshot_.store(true, std::memory_order_release);
   }
@@ -4428,15 +4428,15 @@ void InMemoryStorage::CreateSnapshotHandler(
     if (auto maybe_error = cb(); !maybe_error.has_value()) {
       switch (maybe_error.error()) {
         case CreateSnapshotError::ReachedMaxNumTries:
-          spdlog::warn("Failed to create snapshot. {}. Please contact support.",
+          spdlog::warn("snapshot failed: {}. Please contact support.",
                        CreateSnapshotErrorToString(maybe_error.error()));
           break;
         case CreateSnapshotError::AbortSnapshot:
-          spdlog::warn("Failed to create snapshot. {}.", CreateSnapshotErrorToString(maybe_error.error()));
+          spdlog::warn("snapshot failed: {}", CreateSnapshotErrorToString(maybe_error.error()));
           break;
         case CreateSnapshotError::AlreadyRunning:
         case CreateSnapshotError::NothingNewToWrite:
-          spdlog::info("Skipping snapshot creation. {}.", CreateSnapshotErrorToString(maybe_error.error()));
+          spdlog::info("snapshot skipped: {}", CreateSnapshotErrorToString(maybe_error.error()));
           break;
       }
     }

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -507,6 +507,9 @@ InMemoryStorage::~InMemoryStorage() {
   // If snapshot on exit is set to true then create_snapshot_handler() will just skip snapshot creation because it
   // will figure out that there are no changes.
   if (!config_.durability.snapshot_on_exit) {
+    if (snapshot_running_.load(std::memory_order_acquire)) {
+      spdlog::info("[snapshot] aborting: storage is shutting down");
+    }
     abort_snapshot_.store(true, std::memory_order_release);
   }
 
@@ -2776,7 +2779,8 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
                                                             repl_storage_state_.history,
                                                             &file_retainer_,
                                                             &abort_snapshot_,
-                                                            &snapshot_progress_);
+                                                            &snapshot_progress_,
+                                                            "storage mode change");
       snapshot_runner_.Resume();
     }
     storage_mode_ = new_storage_mode;
@@ -3968,7 +3972,8 @@ auto InMemoryStorage::InMemoryAccessor::HandleDurabilityAndReplicate(uint64_t du
   return replicating_txn.ShipDeltas(durability_commit_timestamp, commit_args);
 }
 
-std::expected<std::filesystem::path, InMemoryStorage::CreateSnapshotError> InMemoryStorage::CreateSnapshot(bool force) {
+std::expected<std::filesystem::path, InMemoryStorage::CreateSnapshotError> InMemoryStorage::CreateSnapshot(
+    bool force, std::string_view trigger) {
   auto abort_reset = utils::OnScopeExit([this]() mutable {
     // Abort is a one shot, reset it to false every time
     abort_snapshot_.store(false, std::memory_order_release);
@@ -4034,7 +4039,8 @@ std::expected<std::filesystem::path, InMemoryStorage::CreateSnapshotError> InMem
                                                         epochHistory,
                                                         &file_retainer_,
                                                         &abort_snapshot_,
-                                                        &snapshot_progress_);
+                                                        &snapshot_progress_,
+                                                        trigger);
   if (!snapshot_path) {
     return std::unexpected{CreateSnapshotError::AbortSnapshot};
   }

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -515,7 +515,7 @@ InMemoryStorage::~InMemoryStorage() {
 
   snapshot_runner_.Stop();
   if (config_.durability.snapshot_on_exit && this->create_snapshot_handler) {
-    create_snapshot_handler();
+    create_snapshot_handler("exit");
   }
   committed_transactions_.WithLock([](auto &transactions) { transactions.clear(); });
 }
@@ -4423,9 +4423,9 @@ std::unique_ptr<Storage::Accessor> InMemoryStorage::ReadOnlyAccess(
 }
 
 void InMemoryStorage::CreateSnapshotHandler(
-    std::function<std::expected<void, InMemoryStorage::CreateSnapshotError>()> cb) {
-  create_snapshot_handler = [cb = std::move(cb)] {
-    if (auto maybe_error = cb(); !maybe_error.has_value()) {
+    std::function<std::expected<void, InMemoryStorage::CreateSnapshotError>(std::string_view)> cb) {
+  create_snapshot_handler = [cb = std::move(cb)](std::string_view trigger) {
+    if (auto maybe_error = cb(trigger); !maybe_error.has_value()) {
       switch (maybe_error.error()) {
         case CreateSnapshotError::ReachedMaxNumTries:
           spdlog::warn("snapshot failed: {}. Please contact support.",
@@ -4450,7 +4450,7 @@ void InMemoryStorage::CreateSnapshotHandler(
   snapshot_runner_.Run("Snapshot", [this, token = stop_source.get_token()]() {
     const memory::DbArenaScope db_arena_scope{db_arena_};
     if (!token.stop_requested()) {
-      this->create_snapshot_handler();
+      this->create_snapshot_handler("periodic");
     }
   });
 }

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2780,7 +2780,7 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
                                                             &file_retainer_,
                                                             &abort_snapshot_,
                                                             &snapshot_progress_,
-                                                            "storage mode change");
+                                                            "storage_mode_change");
       snapshot_runner_.Resume();
     }
     storage_mode_ = new_storage_mode;

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -752,7 +752,8 @@ class InMemoryStorage final : public Storage {
             .start_steady_ms = snapshot_progress_.start_steady_ms.load(std::memory_order_acquire)};
   }
 
-  void CreateSnapshotHandler(std::function<std::expected<void, InMemoryStorage::CreateSnapshotError>()> cb);
+  void CreateSnapshotHandler(
+      std::function<std::expected<void, InMemoryStorage::CreateSnapshotError>(std::string_view)> cb);
 
   Transaction CreateTransaction(IsolationLevel isolation_level, StorageMode storage_mode) override;
 
@@ -895,7 +896,7 @@ class InMemoryStorage final : public Storage {
   free_mem_fn free_memory_func_;
 
   // Moved the create snapshot to a user defined handler so we can remove the global replication state from the storage
-  std::function<void()> create_snapshot_handler{};
+  std::function<void(std::string_view)> create_snapshot_handler{};
 
   // Snapshot digest is the minimal meta info of a snapshot
   // Used to figure out if the current snapshot should be written or not

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -13,6 +13,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <string_view>
 #include <utility>
 #include "memory/db_arena_fwd.hpp"
 #include "replication_coordination_glue/role.hpp"
@@ -730,7 +731,8 @@ class InMemoryStorage final : public Storage {
   utils::FileRetainer::FileLockerAccessor::ret_type LockPath();
   utils::FileRetainer::FileLockerAccessor::ret_type UnlockPath();
 
-  std::expected<std::filesystem::path, InMemoryStorage::CreateSnapshotError> CreateSnapshot(bool force = false);
+  std::expected<std::filesystem::path, InMemoryStorage::CreateSnapshotError> CreateSnapshot(
+      bool force = false, std::string_view trigger = "periodic");
 
   std::expected<void, InMemoryStorage::RecoverSnapshotError> RecoverSnapshot(
       std::filesystem::path uri, bool force, memgraph::replication_coordination_glue::ReplicationRole replication_role,


### PR DESCRIPTION
Snapshot creation previously logged only start and end, so it was impossible to tell which phase a stalled snapshot was stuck in. This PR adds per-phase info logs (edges, vertices, each index sub-phase, constraints, finalize); enriches the start line with trigger and path, the parallel-write line with thread count, and the completion line with vertices/edges/size/elapsed; logs how many old snapshot/WAL files retention reaps; and logs a reason when the abort flag is set so aborted snapshots are distinguishable from stuck ones.