### PR TITLE
fix: cross database module failing when using PERIODIC COMMIT

### DIFF
--- a/include/_mgp.hpp
+++ b/include/_mgp.hpp
@@ -330,8 +330,8 @@ inline bool graph_is_transactional(mgp_graph *graph) { return MgInvoke<int>(mgp_
 
 inline bool graph_is_mutable(mgp_graph *graph) { return MgInvoke<int>(mgp_graph_is_mutable, graph); }
 
-inline int64_t graph_get_transaction_id(mgp_graph *graph) {
-  return MgInvoke<int64_t>(mgp_graph_get_transaction_id, graph);
+inline int64_t graph_get_start_timestamp(mgp_graph *graph) {
+  return MgInvoke<int64_t>(mgp_graph_get_start_timestamp, graph);
 }
 
 inline mgp_vertex *graph_create_vertex(mgp_graph *graph, mgp_memory *memory) {

--- a/include/_mgp_mock.py
+++ b/include/_mgp_mock.py
@@ -43,7 +43,9 @@ class EdgeConstants(Enum):
 class Graph:
     """Wrapper around a NetworkX MultiDiGraph instance."""
 
-    __slots__ = ("nx", "_highest_vertex_id", "_highest_edge_id", "_valid")
+    __slots__ = ("nx", "_highest_vertex_id", "_highest_edge_id", "_valid", "start_timestamp")
+
+    _next_start_timestamp = 0
 
     def __init__(self, graph: nx.MultiDiGraph) -> None:
         if not isinstance(graph, nx.MultiDiGraph):
@@ -53,6 +55,10 @@ class Graph:
         self._highest_vertex_id = None
         self._highest_edge_id = None
         self._valid = True
+        # Mirror the real Storage::Accessor::GetStartTimestamp contract: a value
+        # that is stable for the lifetime of this Graph instance.
+        Graph._next_start_timestamp += 1
+        self.start_timestamp = Graph._next_start_timestamp
 
     @property
     def vertex_ids(self):

--- a/include/mg_procedure.h
+++ b/include/mg_procedure.h
@@ -1119,10 +1119,9 @@ enum mgp_error mgp_graph_is_mutable(struct mgp_graph *graph, int *result);
 /// Current implementation always returns without errors.
 enum mgp_error mgp_graph_is_transactional(struct mgp_graph *graph, int *result);
 
-/// Get the transaction ID associated with the current graph access.
-/// The result is set to the transaction ID associated with the active transaction.
-/// Current implementation always returns without errors.
-enum mgp_error mgp_graph_get_transaction_id(struct mgp_graph *graph, int64_t *result);
+/// Stable per-query id; preserved across `USING PERIODIC COMMIT`.
+/// Use as a cache key in batched procedures.
+enum mgp_error mgp_graph_get_start_timestamp(struct mgp_graph *graph, int64_t *result);
 
 /// Add a new vertex to the graph.
 /// Resulting vertex must be freed using mgp_vertex_destroy.

--- a/include/mgp.py
+++ b/include/mgp.py
@@ -1261,22 +1261,25 @@ class Graph:
         return self._graph.is_mutable()
 
     @property
-    def transaction_id(self) -> int:
+    def start_timestamp(self) -> int:
         """
-        Get the transaction ID associated with the current graph access.
+        Get a stable identifier for the current logical query, preserved across
+        `USING PERIODIC COMMIT` boundaries. Backed by the start_timestamp of the
+        original transaction at query start. Useful as a cache key in batched
+        procedures whose state must survive periodic commits.
 
         Returns:
-            An `int` representing the transaction ID.
+            An `int` that is stable for the duration of one logical query.
 
         Raises:
             InvalidContextError: If context is invalid.
 
         Examples:
-            ```graph.transaction_id```
+            ```graph.start_timestamp```
         """
         if not self.is_valid():
             raise InvalidContextError()
-        return self._graph.get_transaction_id()
+        return self._graph.get_start_timestamp()
 
     def create_vertex(self) -> Vertex:
         """

--- a/include/mgp_mock.py
+++ b/include/mgp_mock.py
@@ -1203,22 +1203,23 @@ class Graph:
         return not self._graph.is_immutable()
 
     @property
-    def transaction_id(self) -> int:
+    def start_timestamp(self) -> int:
         """
-        Get the transaction ID associated with the current graph access.
+        Get a stable identifier for the current logical query, preserved across
+        `USING PERIODIC COMMIT` boundaries.
 
         Returns:
-            An `int` representing the transaction ID.
+            An `int` that is stable for the duration of one logical query.
 
         Raises:
             InvalidContextError: If the graph is not in a valid context.
 
         Examples:
-            ```graph.transaction_id```
+            ```graph.start_timestamp```
         """
         if not self.is_valid():
             raise InvalidContextError()
-        return self._graph.transaction_id
+        return self._graph.start_timestamp
 
     def create_vertex(self) -> Vertex:
         """

--- a/mage/python/cross_database.py
+++ b/mage/python/cross_database.py
@@ -53,19 +53,8 @@ class Constants:
 # ---------------------------------------------------------------------------
 
 
-def _get_cache_key(tx_id: int, query: str, config: mgp.Map, params: mgp.Nullable[mgp.Any] = None) -> str:
-    """
-    Create a cache key from the transaction ID, query, config, and params.
-
-    The transaction ID isolates concurrent transactions so they don't interfere
-    with each other's connections or cursors. The query/config/params hash
-    distinguishes multiple cross-database calls within the same transaction.
-
-    :param tx_id: Memgraph transaction ID (unique per transaction)
-    :param query: The query string (or table name, endpoint, file path, etc.)
-    :param config: Configuration map
-    :param params: Optional query parameters
-    """
+def _get_cache_key(start_ts: int, query: str, config: mgp.Map, params: mgp.Nullable[mgp.Any] = None) -> str:
+    """Cache key from per-query start_timestamp (stable across PERIODIC COMMIT) + query/config/params hash."""
     config_dict = dict(config)
     config_str = json.dumps(config_dict, sort_keys=True, default=str)
 
@@ -78,7 +67,7 @@ def _get_cache_key(tx_id: int, query: str, config: mgp.Map, params: mgp.Nullable
         else:
             params_str = str(params)
 
-    hash_input = f"{tx_id}|{query}|{config_str}|{params_str}"
+    hash_input = f"{start_ts}|{query}|{config_str}|{params_str}"
     return hashlib.sha256(hash_input.encode("utf-8")).hexdigest()
 
 
@@ -251,7 +240,7 @@ def _build_uri(config: mgp.Map) -> str:
 
 def _bolt_init_state(
     state_dict: dict,
-    tx_id: int,
+    start_ts: int,
     label_or_rel_or_query: str,
     config: mgp.Map,
     config_path: str,
@@ -263,7 +252,7 @@ def _bolt_init_state(
         config = _combine_config(config=config, config_path=config_path)
 
     query = _formulate_cypher_query(label_or_rel_or_query)
-    cache_key = _get_cache_key(tx_id, query, config, params)
+    cache_key = _get_cache_key(start_ts, query, config, params)
 
     if cache_key in state_dict:
         raise RuntimeError(Constants.ALREADY_RUNNING_ERROR)
@@ -292,7 +281,7 @@ def _bolt_init_state(
 
 def _bolt_fetch_batch(
     state_dict: dict,
-    tx_id: int,
+    start_ts: int,
     label_or_rel_or_query: str,
     config: mgp.Map,
     config_path: str,
@@ -302,7 +291,7 @@ def _bolt_fetch_batch(
         config = _combine_config(config=config, config_path=config_path)
 
     query = _formulate_cypher_query(label_or_rel_or_query)
-    cache_key = _get_cache_key(tx_id, query, config, params)
+    cache_key = _get_cache_key(start_ts, query, config, params)
     result = state_dict[cache_key][Constants.RESULT]
 
     batch = []
@@ -342,7 +331,7 @@ def _init_bolt(
     config_path: str = "",
     params: mgp.Nullable[mgp.Any] = None,
 ):
-    _bolt_init_state(_bolt_state, ctx.graph.transaction_id, label_or_rel_or_query, config, config_path, params)
+    _bolt_init_state(_bolt_state, ctx.graph.start_timestamp, label_or_rel_or_query, config, config_path, params)
 
 
 def bolt(
@@ -361,7 +350,7 @@ def bolt(
     :param params: Optional query parameters
     :return: Stream of rows from the remote database
     """
-    return _bolt_fetch_batch(_bolt_state, ctx.graph.transaction_id, label_or_rel_or_query, config, config_path, params)
+    return _bolt_fetch_batch(_bolt_state, ctx.graph.start_timestamp, label_or_rel_or_query, config, config_path, params)
 
 
 def _cleanup_bolt():
@@ -388,7 +377,7 @@ def _init_neo4j(
 ):
     _bolt_init_state(
         _neo4j_state,
-        ctx.graph.transaction_id,
+        ctx.graph.start_timestamp,
         label_or_rel_or_query,
         config,
         config_path,
@@ -414,7 +403,9 @@ def neo4j(
     :param params: Optional query parameters
     :return: Stream of rows from Neo4j
     """
-    return _bolt_fetch_batch(_neo4j_state, ctx.graph.transaction_id, label_or_rel_or_query, config, config_path, params)
+    return _bolt_fetch_batch(
+        _neo4j_state, ctx.graph.start_timestamp, label_or_rel_or_query, config, config_path, params
+    )
 
 
 def _cleanup_neo4j():
@@ -449,7 +440,7 @@ def init_migrate_mysql(
     if _query_is_table(table_or_sql):
         table_or_sql = f"SELECT * FROM {table_or_sql};"
 
-    cache_key = _get_cache_key(ctx.graph.transaction_id, table_or_sql, config, params)
+    cache_key = _get_cache_key(ctx.graph.start_timestamp, table_or_sql, config, params)
 
     if cache_key in mysql_dict:
         raise RuntimeError(Constants.ALREADY_RUNNING_ERROR)
@@ -496,7 +487,7 @@ def mysql(
     if _query_is_table(table_or_sql):
         table_or_sql = f"SELECT * FROM {table_or_sql};"
 
-    cache_key = _get_cache_key(ctx.graph.transaction_id, table_or_sql, config, params)
+    cache_key = _get_cache_key(ctx.graph.start_timestamp, table_or_sql, config, params)
     cursor = mysql_dict[cache_key][Constants.CURSOR]
     column_names = mysql_dict[cache_key][Constants.COLUMN_NAMES]
 
@@ -557,7 +548,7 @@ def init_migrate_sql_server(
     if _query_is_table(table_or_sql):
         table_or_sql = f"SELECT * FROM {table_or_sql};"
 
-    cache_key = _get_cache_key(ctx.graph.transaction_id, table_or_sql, config, params)
+    cache_key = _get_cache_key(ctx.graph.start_timestamp, table_or_sql, config, params)
 
     if cache_key in sql_server_dict:
         raise RuntimeError(Constants.ALREADY_RUNNING_ERROR)
@@ -608,7 +599,7 @@ def sql_server(
     if _query_is_table(table_or_sql):
         table_or_sql = f"SELECT * FROM {table_or_sql};"
 
-    cache_key = _get_cache_key(ctx.graph.transaction_id, table_or_sql, config, params)
+    cache_key = _get_cache_key(ctx.graph.start_timestamp, table_or_sql, config, params)
     cursor = sql_server_dict[cache_key][Constants.CURSOR]
     column_names = sql_server_dict[cache_key][Constants.COLUMN_NAMES]
     rows = cursor.fetchmany(Constants.BATCH_SIZE)
@@ -671,7 +662,7 @@ def init_migrate_oracle_db(
 
     config["disable_oob"] = True
 
-    cache_key = _get_cache_key(ctx.graph.transaction_id, table_or_sql, config, params)
+    cache_key = _get_cache_key(ctx.graph.start_timestamp, table_or_sql, config, params)
 
     if cache_key in oracle_db_dict:
         raise RuntimeError(Constants.ALREADY_RUNNING_ERROR)
@@ -729,7 +720,7 @@ def oracle_db(
         config = {}
     config["disable_oob"] = True
 
-    cache_key = _get_cache_key(ctx.graph.transaction_id, table_or_sql, config, params)
+    cache_key = _get_cache_key(ctx.graph.start_timestamp, table_or_sql, config, params)
     cursor = oracle_db_dict[cache_key][Constants.CURSOR]
     column_names = oracle_db_dict[cache_key][Constants.COLUMN_NAMES]
     rows = cursor.fetchmany(Constants.BATCH_SIZE)
@@ -789,7 +780,7 @@ def init_migrate_postgresql(
     if _query_is_table(table_or_sql):
         table_or_sql = f"SELECT * FROM {table_or_sql};"
 
-    cache_key = _get_cache_key(ctx.graph.transaction_id, table_or_sql, config, params)
+    cache_key = _get_cache_key(ctx.graph.start_timestamp, table_or_sql, config, params)
 
     if cache_key in postgres_dict:
         raise RuntimeError(Constants.ALREADY_RUNNING_ERROR)
@@ -838,7 +829,7 @@ def postgresql(
     if _query_is_table(table_or_sql):
         table_or_sql = f"SELECT * FROM {table_or_sql};"
 
-    cache_key = _get_cache_key(ctx.graph.transaction_id, table_or_sql, config, params)
+    cache_key = _get_cache_key(ctx.graph.start_timestamp, table_or_sql, config, params)
     cursor = postgres_dict[cache_key][Constants.CURSOR]
     column_names = postgres_dict[cache_key][Constants.COLUMN_NAMES]
 
@@ -906,7 +897,7 @@ def init_migrate_s3(
     bucket_name, *key_parts = file_path_no_protocol.split("/")
     s3_key = "/".join(key_parts)
 
-    cache_key = _get_cache_key(ctx.graph.transaction_id, file_path, config)
+    cache_key = _get_cache_key(ctx.graph.start_timestamp, file_path, config)
 
     if cache_key in s3_dict:
         raise RuntimeError(Constants.ALREADY_RUNNING_ERROR)
@@ -950,7 +941,7 @@ def s3(
     if len(config_path) > 0:
         config = _combine_config(config=config, config_path=config_path)
 
-    cache_key = _get_cache_key(ctx.graph.transaction_id, file_path, config)
+    cache_key = _get_cache_key(ctx.graph.start_timestamp, file_path, config)
     csv_reader = s3_dict[cache_key][Constants.CURSOR]
     column_names = s3_dict[cache_key][Constants.COLUMN_NAMES]
 
@@ -1001,7 +992,7 @@ def init_migrate_arrow_flight(
     if len(config_path) > 0:
         config = _combine_config(config=config, config_path=config_path)
 
-    cache_key = _get_cache_key(ctx.graph.transaction_id, query, config)
+    cache_key = _get_cache_key(ctx.graph.start_timestamp, query, config)
 
     if cache_key in flight_dict:
         raise RuntimeError(Constants.ALREADY_RUNNING_ERROR)
@@ -1056,7 +1047,7 @@ def arrow_flight(
     if len(config_path) > 0:
         config = _combine_config(config=config, config_path=config_path)
 
-    cache_key = _get_cache_key(ctx.graph.transaction_id, query, config)
+    cache_key = _get_cache_key(ctx.graph.start_timestamp, query, config)
     cursor = flight_dict[cache_key][Constants.CURSOR]
     batch = []
     for _ in range(Constants.BATCH_SIZE):
@@ -1104,7 +1095,7 @@ def init_migrate_duckdb(ctx: mgp.ProcCtx, query: str, setup_queries: mgp.Nullabl
     global duckdb_dict
 
     setup_queries_str = json.dumps(setup_queries, sort_keys=False) if setup_queries else ""
-    cache_key = _get_cache_key(ctx.graph.transaction_id, query, {}, setup_queries_str)
+    cache_key = _get_cache_key(ctx.graph.start_timestamp, query, {}, setup_queries_str)
 
     if cache_key in duckdb_dict:
         raise RuntimeError(Constants.ALREADY_RUNNING_ERROR)
@@ -1134,7 +1125,7 @@ def duckdb(ctx: mgp.ProcCtx, query: str, setup_queries: mgp.Nullable[List[str]] 
     global duckdb_dict
 
     setup_queries_str = json.dumps(setup_queries, sort_keys=False) if setup_queries else ""
-    cache_key = _get_cache_key(ctx.graph.transaction_id, query, {}, setup_queries_str)
+    cache_key = _get_cache_key(ctx.graph.start_timestamp, query, {}, setup_queries_str)
     cursor = duckdb_dict[cache_key][Constants.CURSOR]
     column_names = duckdb_dict[cache_key][Constants.COLUMN_NAMES]
 
@@ -1191,7 +1182,7 @@ def init_migrate_servicenow(
     if len(config_path) > 0:
         config = _combine_config(config=config, config_path=config_path)
 
-    cache_key = _get_cache_key(ctx.graph.transaction_id, endpoint, config, params)
+    cache_key = _get_cache_key(ctx.graph.start_timestamp, endpoint, config, params)
 
     if cache_key in servicenow_dict:
         raise RuntimeError(Constants.ALREADY_RUNNING_ERROR)
@@ -1231,7 +1222,7 @@ def servicenow(
     if len(config_path) > 0:
         config = _combine_config(config=config, config_path=config_path)
 
-    cache_key = _get_cache_key(ctx.graph.transaction_id, endpoint, config, params)
+    cache_key = _get_cache_key(ctx.graph.start_timestamp, endpoint, config, params)
     data_iter = servicenow_dict[cache_key][Constants.CURSOR]
 
     batch_rows = []

--- a/mage/tests/e2e_migration/test_memgraph/test/successful/periodic_commit_test.yml
+++ b/mage/tests/e2e_migration/test_memgraph/test/successful/periodic_commit_test.yml
@@ -6,5 +6,7 @@ query: |
   )
   YIELD row
   MERGE (v:PCTestNode {n: row.n})
+  RETURN count(row) AS cnt
 
-output: []
+output:
+  - cnt: 200

--- a/mage/tests/e2e_migration/test_memgraph/test/successful/periodic_commit_test.yml
+++ b/mage/tests/e2e_migration/test_memgraph/test/successful/periodic_commit_test.yml
@@ -1,0 +1,10 @@
+query: |
+  USING PERIODIC COMMIT 30
+  CALL cross_database.bolt(
+      'UNWIND range(0, 199) AS n RETURN n',
+      {host: 'localhost', port: 7687}
+  )
+  YIELD row
+  MERGE (v:PCTestNode {n: row.n})
+
+output: []

--- a/mage/tests/run_e2e_migration_tests.sh
+++ b/mage/tests/run_e2e_migration_tests.sh
@@ -142,6 +142,7 @@ run_memgraph_tests() {
     echo "Cleaning up Memgraph test data..."
     docker exec -i "$MAGE_CONTAINER" mgconsole <<< "MATCH (n:DummyNode) DETACH DELETE n;"
     docker exec -i "$MAGE_CONTAINER" mgconsole <<< "MATCH (n:DummyNode2) DETACH DELETE n;"
+    docker exec -i "$MAGE_CONTAINER" mgconsole <<< "MATCH (n:PCTestNode) DETACH DELETE n;"
 }
 
 # Main execution

--- a/mage/tests/run_e2e_migration_tests.sh
+++ b/mage/tests/run_e2e_migration_tests.sh
@@ -140,9 +140,7 @@ run_memgraph_tests() {
     python3 -m pytest e2e_migration/test_migration.py -v -k memgraph
 
     echo "Cleaning up Memgraph test data..."
-    docker exec -i "$MAGE_CONTAINER" mgconsole <<< "MATCH (n:DummyNode) DETACH DELETE n;"
-    docker exec -i "$MAGE_CONTAINER" mgconsole <<< "MATCH (n:DummyNode2) DETACH DELETE n;"
-    docker exec -i "$MAGE_CONTAINER" mgconsole <<< "MATCH (n:PCTestNode) DETACH DELETE n;"
+    docker exec -i "$MAGE_CONTAINER" mgconsole <<< "MATCH (n) DETACH DELETE n;"
 }
 
 # Main execution

--- a/src/query/db_accessor.hpp
+++ b/src/query/db_accessor.hpp
@@ -429,7 +429,7 @@ class DbAccessor final {
 
   auto &GetTransactionMemoryTracker() { return accessor_->GetTransactionMemoryTracker(); }
 
-  auto GetTransactionId() { return accessor_->GetTransactionId(); }
+  auto GetStartTimestamp() { return accessor_->GetStartTimestamp(); }
 
   bool TransactionHasSerializationError() const { return accessor_->TransactionHasSerializationError(); }
 

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -7738,7 +7738,7 @@ namespace {
 void CallCustomProcedure(const std::string_view fully_qualified_procedure_name, const mgp_proc &proc,
                          const std::vector<Expression *> &args, mgp_graph &graph, ExpressionEvaluator *evaluator,
                          utils::MemoryResource *memory, std::optional<size_t> memory_limit, mgp_result *result,
-                         int64_t procedure_id, uint64_t transaction_id, const bool call_initializer = false) {
+                         int64_t procedure_id, const bool call_initializer = false) {
   static_assert(std::uses_allocator_v<mgp_value, utils::Allocator<mgp_value>>,
                 "Expected mgp_value to use custom allocator and makes STL "
                 "containers aware of that");
@@ -7946,8 +7946,6 @@ class CallProcedureCursor : public Cursor {
       auto *memory = context.evaluation_context.memory;
       auto memory_limit = EvaluateMemoryLimit(evaluator, self_->memory_limit_, self_->memory_scale_);
       auto graph = mgp_graph::WritableGraph(*context.db_accessor, graph_view, context);
-      const auto transaction_id = context.db_accessor->GetTransactionId();
-      MG_ASSERT(transaction_id);
       CallCustomProcedure(self_->procedure_name_,
                           *proc_,
                           self_->arguments_,
@@ -7957,7 +7955,6 @@ class CallProcedureCursor : public Cursor {
                           memory_limit,
                           &result_,
                           self_->procedure_id_,
-                          transaction_id.value(),
                           call_initializer);
 
       if (call_initializer) call_initializer = false;

--- a/src/query/procedure/mg_procedure_impl.cpp
+++ b/src/query/procedure/mg_procedure_impl.cpp
@@ -3689,11 +3689,11 @@ mgp_error mgp_graph_is_mutable(mgp_graph *graph, int *result) {
   return mgp_error::MGP_ERROR_NO_ERROR;
 };
 
-mgp_error mgp_graph_get_transaction_id(mgp_graph *graph, int64_t *result) {
+mgp_error mgp_graph_get_start_timestamp(mgp_graph *graph, int64_t *result) {
   return WrapExceptions([graph, result] {
-    auto maybe_tx_id = graph->getImpl()->GetTransactionId();
-    DMG_ASSERT(maybe_tx_id, "Procedure must be called within an active transaction");
-    *result = static_cast<int64_t>(*maybe_tx_id);
+    auto maybe_ts = graph->getImpl()->GetStartTimestamp();
+    DMG_ASSERT(maybe_ts, "Procedure must be called within an active transaction");
+    *result = static_cast<int64_t>(*maybe_ts);
   });
 }
 

--- a/src/query/procedure/py_module.cpp
+++ b/src/query/procedure/py_module.cpp
@@ -379,13 +379,13 @@ PyObject *PyGraphIsMutable(PyGraph *self, PyObject *Py_UNUSED(ignored)) {
 }
 
 namespace {
-PyObject *PyGraphGetTransactionId(PyGraph *self, PyObject *Py_UNUSED(ignored)) {
+PyObject *PyGraphGetStartTimestamp(PyGraph *self, PyObject *Py_UNUSED(ignored)) {
   MG_ASSERT(PyGraphIsValidImpl(*self));
-  int64_t tx_id{0};
-  if (RaiseExceptionFromErrorCode(mgp_graph_get_transaction_id(self->graph, &tx_id))) {
+  int64_t start_ts{0};
+  if (RaiseExceptionFromErrorCode(mgp_graph_get_start_timestamp(self->graph, &start_ts))) {
     return nullptr;
   }
-  return PyLong_FromLongLong(tx_id);
+  return PyLong_FromLongLong(start_ts);
 }
 }  // namespace
 
@@ -469,10 +469,10 @@ static PyMethodDef PyGraphMethods[] = {
      reinterpret_cast<PyCFunction>(PyGraphIsMutable),
      METH_NOARGS,
      "Return True if Graph is mutable and can be used to modify vertices and edges."},
-    {"get_transaction_id",
-     reinterpret_cast<PyCFunction>(PyGraphGetTransactionId),
+    {"get_start_timestamp",
+     reinterpret_cast<PyCFunction>(PyGraphGetStartTimestamp),
      METH_NOARGS,
-     "Return the transaction ID associated with the current graph access."},
+     "Return a stable per-query identifier (the start_timestamp of the original transaction)."},
     {"get_vertex_by_id",
      reinterpret_cast<PyCFunction>(PyGraphGetVertexById),
      METH_VARARGS,

--- a/src/storage/v2/indices/indices_utils.hpp
+++ b/src/storage/v2/indices/indices_utils.hpp
@@ -412,7 +412,7 @@ inline void CreateIndexOnMultipleThreads(TVerticesAccessor &vertices, TSKiplistI
 inline bool CanSeeEntityWithTimestamp(uint64_t insertion_timestamp, Transaction *transaction, View view) {
   // Not enough information, need to rely on MVCC to fully check entry
   if (transaction->command_id != 0) return true;
-  auto const original_start_timestamp = transaction->original_start_timestamp.value_or(transaction->start_timestamp);
+  auto const original_start_timestamp = transaction->original_start_timestamp;
   if (view == View::OLD) {
     return insertion_timestamp < original_start_timestamp;
   }

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1273,15 +1273,14 @@ std::expected<void, StorageManipulationError> InMemoryStorage::InMemoryAccessor:
 
   FinalizeTransaction();
 
-  auto original_start_timestamp = transaction_.original_start_timestamp.value_or(transaction_.start_timestamp);
-
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
 
   auto new_transaction = mem_storage->CreateTransaction(transaction_.isolation_level, transaction_.storage_mode);
   transaction_.start_timestamp = new_transaction.start_timestamp;
   transaction_.transaction_id = new_transaction.transaction_id;
   transaction_.commit_info.reset();
-  transaction_.original_start_timestamp = original_start_timestamp;
+  // Do NOT touch `original_start_timestamp` — it must remain stable per-query
+  // (procedures use it as a cache key across PERIODIC COMMIT).
 
   is_transaction_active_ = true;
 

--- a/src/storage/v2/storage.cpp
+++ b/src/storage/v2/storage.cpp
@@ -206,9 +206,9 @@ std::vector<LabelId> Storage::ListAllPossiblyPresentVertexLabels() const { retur
 
 StorageMode Storage::Accessor::GetCreationStorageMode() const noexcept { return creation_storage_mode_; }
 
-std::optional<uint64_t> Storage::Accessor::GetTransactionId() const {
+std::optional<uint64_t> Storage::Accessor::GetStartTimestamp() const {
   if (is_transaction_active_) {
-    return transaction_.transaction_id;
+    return transaction_.original_start_timestamp;
   }
   return {};
 }

--- a/src/storage/v2/storage.hpp
+++ b/src/storage/v2/storage.hpp
@@ -667,7 +667,8 @@ class Accessor {
 
   virtual void FinalizeTransaction() = 0;
 
-  std::optional<uint64_t> GetTransactionId() const;
+  // Stable per-query id; preserved across PERIODIC COMMIT.
+  std::optional<uint64_t> GetStartTimestamp() const;
 
   utils::QueryMemoryTracker &GetTransactionMemoryTracker();
 

--- a/src/storage/v2/transaction.hpp
+++ b/src/storage/v2/transaction.hpp
@@ -137,6 +137,7 @@ struct Transaction {
               metrics::GaugeHandle unreleased_delta_gauge = {})
       : transaction_id(transaction_id),
         start_timestamp(start_timestamp),
+        original_start_timestamp(start_timestamp),
         command_id(0),
         deltas(unreleased_delta_gauge),
         md_deltas(utils::NewDeleteResource()),
@@ -220,7 +221,8 @@ struct Transaction {
 
   uint64_t transaction_id{};
   uint64_t start_timestamp{};
-  std::optional<uint64_t> original_start_timestamp{};
+  // Set at construction; never reassigned. Stable across PeriodicCommit.
+  uint64_t original_start_timestamp{};
   // The `Transaction` object is stack allocated, but the `commit_info`
   // must be heap allocated because `Delta`s have a pointer to it, and that
   // pointer must stay valid after the `Transaction` is moved into

--- a/tests/unit/query_procedures_mgp_graph.cpp
+++ b/tests/unit/query_procedures_mgp_graph.cpp
@@ -704,11 +704,13 @@ TYPED_TEST(MgpGraphTest, EdgeSetPropertyWithImmutableGraph) {
   EXPECT_EQ(mgp_edge_set_property(edge.get(), "property", value.get()), mgp_error::MGP_ERROR_IMMUTABLE_OBJECT);
 }
 
-TYPED_TEST(MgpGraphTest, GetTransactionId) {
+TYPED_TEST(MgpGraphTest, GetStartTimestamp) {
   mgp_graph graph = this->CreateGraph();
-  int64_t tx_id{0};
-  EXPECT_SUCCESS(mgp_graph_get_transaction_id(&graph, &tx_id));
-  // The first transaction on a fresh storage starts at kTransactionInitialId
-  // (1ULL << 63, used to disambiguate transaction IDs from commit timestamps).
-  EXPECT_EQ(tx_id, static_cast<int64_t>(memgraph::storage::kTransactionInitialId));
+  int64_t start_ts{0};
+  EXPECT_SUCCESS(mgp_graph_get_start_timestamp(&graph, &start_ts));
+  // Repeated calls must return the same value — the per-query identifier is
+  // stable for the lifetime of the accessor.
+  int64_t start_ts_again{0};
+  EXPECT_SUCCESS(mgp_graph_get_start_timestamp(&graph, &start_ts_again));
+  EXPECT_EQ(start_ts, start_ts_again);
 }


### PR DESCRIPTION
## Problem

Batched procs in `cross_database.py` keyed cached state on `ctx.graph.transaction_id`. `USING PERIODIC COMMIT` rotates `transaction_id` per batch, so the cache lookup `KeyError`'d mid-stream and broke `migrate.duckdb` ingestion.

## Fix

Expose a per-query identifier stable across PERIODIC COMMIT.

- `ctx.graph.transaction_id` → `ctx.graph.start_timestamp`, backed by `Transaction::original_start_timestamp`.
- `original_start_timestamp` is now set in the `Transaction` constructor and never reassigned — `PeriodicCommit` leaves it alone by design.
- Dropped `std::optional` wrapping; every caller already collapsed it via `.value_or(start_timestamp)`.
- Migrated 20 call sites in `cross_database.py`; removed unused `transaction_id` param from `CallCustomProcedure`.

The procedure-facing `transaction_id` API was added in #3832 and never released — clean rename, no compat layer needed.