### PR TITLE
fix: drain async indexer before unique lock in SetStorageMode

### DIFF
--- a/src/storage/v2/async_indexer.cpp
+++ b/src/storage/v2/async_indexer.cpp
@@ -51,13 +51,7 @@ void AsyncIndexer::Clear() {
 }
 
 bool AsyncIndexer::IsIdle() const {
-  std::lock_guard const lock(mutex_);
-  // no work to pickup and not currently working
-  // OR we have stopped the worker thread
-  return IsIdle_();
-}
-
-bool AsyncIndexer::IsIdle_() const {
+  // Lock-free; safe under any other lock (including storage main_lock_ UNIQUE).
   return (request_queue_.size() == 0 && !is_processing_.load()) || HasThreadStopped();
 }
 
@@ -93,8 +87,8 @@ void AsyncIndexer::Start(std::stop_token stop_token, Storage *storage) {
           // Mark as processing when we have work to do
           is_processing_ = true;
           auto processing_exit = utils::OnScopeExit{[this] {
-            // Mark as not processing when done with current batch
             is_processing_ = false;
+            cv_.notify_all();  // wake CompleteRemaining waiters
           }};
 
           for (auto it = access.begin(); it != it_end;) {
@@ -121,7 +115,8 @@ void AsyncIndexer::Start(std::stop_token stop_token, Storage *storage) {
                     [[maybe_unused]] auto result = storage_acc->CreateIndex(edge_type, cancel_check);
                   },
                   [&](LabelProperties &lp) {
-                    [[maybe_unused]] auto result = storage_acc->CreateIndex(lp.label, lp.properties, IndexOrder::ASC, cancel_check);
+                    [[maybe_unused]] auto result =
+                        storage_acc->CreateIndex(lp.label, lp.properties, IndexOrder::ASC, cancel_check);
                   },
                   [&](PropertyId property) {
                     [[maybe_unused]] auto result = storage_acc->CreateGlobalEdgeIndex(property, cancel_check);
@@ -159,7 +154,7 @@ void AsyncIndexer::Shutdown() {
 
 void AsyncIndexer::CompleteRemaining() {
   auto guard = std::unique_lock{mutex_};
-  cv_.wait(guard, [this] { return IsIdle_(); });
+  cv_.wait(guard, [this] { return IsIdle(); });
 }
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/async_indexer.cpp
+++ b/src/storage/v2/async_indexer.cpp
@@ -51,7 +51,6 @@ void AsyncIndexer::Clear() {
 }
 
 bool AsyncIndexer::IsIdle() const {
-  // Lock-free.
   return (request_queue_.size() == 0 && !is_processing_.load()) || HasThreadStopped();
 }
 

--- a/src/storage/v2/async_indexer.cpp
+++ b/src/storage/v2/async_indexer.cpp
@@ -51,7 +51,7 @@ void AsyncIndexer::Clear() {
 }
 
 bool AsyncIndexer::IsIdle() const {
-  // Lock-free; safe under any other lock (including storage main_lock_ UNIQUE).
+  // Lock-free.
   return (request_queue_.size() == 0 && !is_processing_.load()) || HasThreadStopped();
 }
 

--- a/src/storage/v2/async_indexer.hpp
+++ b/src/storage/v2/async_indexer.hpp
@@ -40,8 +40,9 @@ struct AsyncIndexer {
 
   void Clear();
 
+  /// Lock-free.
   /// @return true if no work is queued and thread is waiting, false otherwise
-  bool IsIdle() const;  // lock-free
+  bool IsIdle() const;
 
   /// Check if the async indexer thread has stopped (due to null protector or stop request)
   /// @return true if the background thread is no longer running, false otherwise

--- a/src/storage/v2/async_indexer.hpp
+++ b/src/storage/v2/async_indexer.hpp
@@ -40,6 +40,7 @@ struct AsyncIndexer {
 
   void Clear();
 
+  /// @return true if no work is queued and thread is waiting, false otherwise
   bool IsIdle() const;  // lock-free
 
   /// Check if the async indexer thread has stopped (due to null protector or stop request)

--- a/src/storage/v2/async_indexer.hpp
+++ b/src/storage/v2/async_indexer.hpp
@@ -40,9 +40,7 @@ struct AsyncIndexer {
 
   void Clear();
 
-  /// Check if the async indexer is idle (no pending work)
-  /// @return true if no work is queued and thread is waiting, false otherwise
-  bool IsIdle() const;
+  bool IsIdle() const;  // lock-free
 
   /// Check if the async indexer thread has stopped (due to null protector or stop request)
   /// @return true if the background thread is no longer running, false otherwise
@@ -56,8 +54,6 @@ struct AsyncIndexer {
   void CompleteRemaining();
 
  private:
-  bool IsIdle_() const;
-
   struct LabelProperties {
     LabelId label;
     PropertiesPaths properties;

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2741,6 +2741,15 @@ Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, S
 }
 
 void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
+  // Drain pending async index work BEFORE taking main_lock_ as UNIQUE.
+  // The worker holds AsyncIndexer::mutex_ while it tries to acquire main_lock_
+  // for each item it processes; draining under the unique lock would deadlock.
+  if (new_storage_mode == StorageMode::IN_MEMORY_ANALYTICAL && storage_mode_ == StorageMode::IN_MEMORY_TRANSACTIONAL) {
+    spdlog::info("SetStorageMode: draining async indexer before transition to IN_MEMORY_ANALYTICAL");
+    async_indexer_.CompleteRemaining();
+    spdlog::info("SetStorageMode: async indexer drained");
+  }
+
   auto unique_accessor = UniqueAccess();
   MG_ASSERT(
       (storage_mode_ == StorageMode::IN_MEMORY_ANALYTICAL || storage_mode_ == StorageMode::IN_MEMORY_TRANSACTIONAL) &&
@@ -2756,8 +2765,14 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
             "Constraints are not supported in analytical storage mode. Please drop them before "
             "changing storage mode to analytical or use transactional mode.");
       }
-      // Ensure all pending work has been completed before changing to IN_MEMORY_ANALYTICAL
-      async_indexer_.CompleteRemaining();
+      // Drain happened before the unique lock; if anything slipped into the
+      // queue in between we cannot drain here without risking deadlock.
+      if (!async_indexer_.IsIdle()) {
+        throw utils::BasicException(
+            "Cannot switch to IN_MEMORY_ANALYTICAL: async index creation tasks were enqueued "
+            "concurrently with the storage mode change. Wait for pending CREATE INDEX requests "
+            "to finish and retry.");
+      }
       snapshot_runner_.Pause();
     } else {
       // No need to resume async indexer, it is always running.

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2741,9 +2741,8 @@ Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, S
 }
 
 void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
-  // Drain pending async index work BEFORE taking main_lock_ as UNIQUE.
-  // The worker holds AsyncIndexer::mutex_ while it tries to acquire main_lock_
-  // for each item it processes; draining under the unique lock would deadlock.
+  // Drain async indexer before UNIQUE: the worker holds AsyncIndexer::mutex_
+  // while waiting on main_lock_, so draining under UNIQUE would deadlock.
   if (new_storage_mode == StorageMode::IN_MEMORY_ANALYTICAL && storage_mode_ == StorageMode::IN_MEMORY_TRANSACTIONAL) {
     spdlog::info("SetStorageMode: draining async indexer before transition to IN_MEMORY_ANALYTICAL");
     async_indexer_.CompleteRemaining();
@@ -2765,8 +2764,8 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
             "Constraints are not supported in analytical storage mode. Please drop them before "
             "changing storage mode to analytical or use transactional mode.");
       }
-      // Drain happened before the unique lock; if anything slipped into the
-      // queue in between we cannot drain here without risking deadlock.
+      // Anything enqueued between the pre-UNIQUE drain and here cannot be
+      // drained under UNIQUE without deadlocking.
       if (!async_indexer_.IsIdle()) {
         throw utils::BasicException(
             "Cannot switch to IN_MEMORY_ANALYTICAL: async index creation tasks were enqueued "

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2741,8 +2741,8 @@ Transaction InMemoryStorage::CreateTransaction(IsolationLevel isolation_level, S
 }
 
 void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
-  // Drain async indexer before UNIQUE: the worker holds AsyncIndexer::mutex_
-  // while waiting on main_lock_, so draining under UNIQUE would deadlock.
+  // Drain before UNIQUE: worker holds AsyncIndexer::mutex_ while waiting on
+  // main_lock_, so draining under UNIQUE would deadlock.
   if (new_storage_mode == StorageMode::IN_MEMORY_ANALYTICAL && storage_mode_ == StorageMode::IN_MEMORY_TRANSACTIONAL) {
     spdlog::info("SetStorageMode: draining async indexer before transition to IN_MEMORY_ANALYTICAL");
     async_indexer_.CompleteRemaining();
@@ -2764,13 +2764,12 @@ void InMemoryStorage::SetStorageMode(StorageMode new_storage_mode) {
             "Constraints are not supported in analytical storage mode. Please drop them before "
             "changing storage mode to analytical or use transactional mode.");
       }
-      // Anything enqueued between the pre-UNIQUE drain and here cannot be
-      // drained under UNIQUE without deadlocking.
+      // Anything enqueued in the gap between drain and UNIQUE can't be drained here without deadlock.
       if (!async_indexer_.IsIdle()) {
         throw utils::BasicException(
-            "Cannot switch to IN_MEMORY_ANALYTICAL: async index creation tasks were enqueued "
-            "concurrently with the storage mode change. Wait for pending CREATE INDEX requests "
-            "to finish and retry.");
+            "Cannot switch to IN_MEMORY_ANALYTICAL: an async index creation task (from CREATE INDEX "
+            "or ENABLE TTL) was enqueued concurrently with the storage mode change. Wait for pending "
+            "index creation to finish and retry.");
       }
       snapshot_runner_.Pause();
     } else {

--- a/tests/unit/storage_v2_storage_mode.cpp
+++ b/tests/unit/storage_v2_storage_mode.cpp
@@ -11,6 +11,8 @@
 
 #include <gtest/gtest.h>
 #include <chrono>
+#include <future>
+#include <memory>
 #include <stop_token>
 #include <string>
 #include <string_view>
@@ -178,4 +180,43 @@ TEST_F(StorageModeMultiTxTest, ErrorChangeIsolationLevel) {
 
   ASSERT_THROW(running_interpreter.Interpret("SET GLOBAL TRANSACTION ISOLATION LEVEL READ COMMITTED;"),
                memgraph::query::IsolationLevelModificationInAnalyticsException);
+}
+
+// Regression: SetStorageMode(ANALYTICAL) used to take main_lock_ UNIQUE first
+// and *then* call CompleteRemaining(), which waits on AsyncIndexer::mutex_ —
+// held by the indexer worker, whose ReadOnlyAccess in turn times out forever
+// on the UNIQUE state. Real trigger: ENABLE TTL queues a label+property index
+// task (src/storage/v2/ttl.cpp:219) right before a STORAGE MODE change.
+//
+// We trigger it deterministically by holding UNIQUE ourselves and releasing
+// it during the worker's catch-handler sleep_for window (not its
+// ReadOnlyAccess cv.wait_for), so SetStorageMode reliably wins the UNIQUE
+// race — the exact ordering that produced the deadlock.
+TEST(StorageModeAsyncIndexerDeadlock, EnableTtlStyleEnqueueThenAnalytical) {
+  using namespace memgraph::storage;
+  using namespace std::chrono_literals;
+
+  auto storage = std::make_unique<InMemoryStorage>(Config{});
+  auto label = storage->NameToLabel("TTL");
+  auto prop = storage->NameToProperty("ttl");
+
+  storage->GetAsyncIndexer().Enqueue(label, std::vector{PropertyPath{prop}});
+  auto unique_holder = storage->UniqueAccess();
+
+  std::promise<void> done;
+  auto done_fut = done.get_future();
+  std::thread([&, p = std::move(done)]() mutable {
+    storage->SetStorageMode(StorageMode::IN_MEMORY_ANALYTICAL);
+    p.set_value();
+  }).detach();
+
+  // Worker cycle while UNIQUE is held: ~1 s ReadOnlyAccess timeout, then
+  // ~100 ms sleep_for backoff (×1.5 each iter). Land in the 2nd sleep window
+  // [2100, 2250] ms so SetStorageMode is the sole main_lock_ waiter at release.
+  std::this_thread::sleep_for(2175ms);
+  unique_holder.reset();
+
+  ASSERT_EQ(done_fut.wait_for(3s), std::future_status::ready)
+      << "SetStorageMode hung — AsyncIndexer / main_lock_ deadlock is back";
+  EXPECT_EQ(storage->GetStorageMode(), StorageMode::IN_MEMORY_ANALYTICAL);
 }

--- a/tests/unit/storage_v2_storage_mode.cpp
+++ b/tests/unit/storage_v2_storage_mode.cpp
@@ -182,41 +182,40 @@ TEST_F(StorageModeMultiTxTest, ErrorChangeIsolationLevel) {
                memgraph::query::IsolationLevelModificationInAnalyticsException);
 }
 
-// Regression: SetStorageMode(ANALYTICAL) used to take main_lock_ UNIQUE first
-// and *then* call CompleteRemaining(), which waits on AsyncIndexer::mutex_ —
-// held by the indexer worker, whose ReadOnlyAccess in turn times out forever
-// on the UNIQUE state. Real trigger: ENABLE TTL queues a label+property index
-// task (src/storage/v2/ttl.cpp:219) right before a STORAGE MODE change.
-//
-// We trigger it deterministically by holding UNIQUE ourselves and releasing
-// it during the worker's catch-handler sleep_for window (not its
-// ReadOnlyAccess cv.wait_for), so SetStorageMode reliably wins the UNIQUE
-// race — the exact ordering that produced the deadlock.
+// Regression: SetStorageMode(ANALYTICAL) used to drain the async indexer while
+// holding main_lock_ UNIQUE, deadlocking against the worker's ReadOnlyAccess.
 TEST(StorageModeAsyncIndexerDeadlock, EnableTtlStyleEnqueueThenAnalytical) {
   using namespace memgraph::storage;
   using namespace std::chrono_literals;
 
-  auto storage = std::make_unique<InMemoryStorage>(Config{});
+  // Heap-allocated: on regression the worker is stuck and joining hangs the
+  // test binary, so we leak instead.
+  auto *storage = new InMemoryStorage{Config{}};
   auto label = storage->NameToLabel("TTL");
   auto prop = storage->NameToProperty("ttl");
 
-  storage->GetAsyncIndexer().Enqueue(label, std::vector{PropertyPath{prop}});
+  // UNIQUE before Enqueue: prevents the worker from draining the queue early.
   auto unique_holder = storage->UniqueAccess();
+  storage->GetAsyncIndexer().Enqueue(label, std::vector{PropertyPath{prop}});
 
   std::promise<void> done;
   auto done_fut = done.get_future();
-  std::thread([&, p = std::move(done)]() mutable {
+  std::thread setter([&] {
     storage->SetStorageMode(StorageMode::IN_MEMORY_ANALYTICAL);
-    p.set_value();
-  }).detach();
+    done.set_value();
+  });
 
-  // Worker cycle while UNIQUE is held: ~1 s ReadOnlyAccess timeout, then
-  // ~100 ms sleep_for backoff (×1.5 each iter). Land in the 2nd sleep window
-  // [2100, 2250] ms so SetStorageMode is the sole main_lock_ waiter at release.
+  // Release UNIQUE during the worker's 2nd backoff sleep [2100–2250 ms] so
+  // SetStorageMode wins the UNIQUE race uncontested.
   std::this_thread::sleep_for(2175ms);
   unique_holder.reset();
 
-  ASSERT_EQ(done_fut.wait_for(3s), std::future_status::ready)
-      << "SetStorageMode hung — AsyncIndexer / main_lock_ deadlock is back";
+  if (done_fut.wait_for(5s) != std::future_status::ready) {
+    setter.detach();
+    FAIL() << "SetStorageMode hung — AsyncIndexer / main_lock_ deadlock is back";
+    return;
+  }
   EXPECT_EQ(storage->GetStorageMode(), StorageMode::IN_MEMORY_ANALYTICAL);
+  setter.join();
+  delete storage;
 }

--- a/tests/unit/storage_v2_storage_mode.cpp
+++ b/tests/unit/storage_v2_storage_mode.cpp
@@ -188,8 +188,7 @@ TEST(StorageModeAsyncIndexerDeadlock, EnableTtlStyleEnqueueThenAnalytical) {
   using namespace memgraph::storage;
   using namespace std::chrono_literals;
 
-  // Heap-allocated: on regression the worker is stuck and joining hangs the
-  // test binary, so we leak instead.
+  // Heap-allocated so we can leak on regression — destructor would hang.
   auto *storage = new InMemoryStorage{Config{}};
   auto label = storage->NameToLabel("TTL");
   auto prop = storage->NameToProperty("ttl");
@@ -198,11 +197,13 @@ TEST(StorageModeAsyncIndexerDeadlock, EnableTtlStyleEnqueueThenAnalytical) {
   auto unique_holder = storage->UniqueAccess();
   storage->GetAsyncIndexer().Enqueue(label, std::vector{PropertyPath{prop}});
 
-  std::promise<void> done;
-  auto done_fut = done.get_future();
-  std::thread setter([&] {
+  // Heap-owned promise: on the detach path we leak it along with storage so
+  // a delayed (non-permanent) deadlock can't write through a dangling ref.
+  auto *done = new std::promise<void>{};
+  auto done_fut = done->get_future();
+  std::thread setter([storage, done] {
     storage->SetStorageMode(StorageMode::IN_MEMORY_ANALYTICAL);
-    done.set_value();
+    done->set_value();
   });
 
   // Release UNIQUE during the worker's 2nd backoff sleep [2100–2250 ms] so
@@ -211,11 +212,12 @@ TEST(StorageModeAsyncIndexerDeadlock, EnableTtlStyleEnqueueThenAnalytical) {
   unique_holder.reset();
 
   if (done_fut.wait_for(5s) != std::future_status::ready) {
-    setter.detach();
+    setter.detach();  // leak storage + promise; can't join without hanging.
     FAIL() << "SetStorageMode hung — AsyncIndexer / main_lock_ deadlock is back";
     return;
   }
   EXPECT_EQ(storage->GetStorageMode(), StorageMode::IN_MEMORY_ANALYTICAL);
   setter.join();
+  delete done;
   delete storage;
 }

--- a/tests/unit/storage_v2_storage_mode.cpp
+++ b/tests/unit/storage_v2_storage_mode.cpp
@@ -11,8 +11,6 @@
 
 #include <gtest/gtest.h>
 #include <chrono>
-#include <future>
-#include <memory>
 #include <stop_token>
 #include <string>
 #include <string_view>
@@ -180,44 +178,4 @@ TEST_F(StorageModeMultiTxTest, ErrorChangeIsolationLevel) {
 
   ASSERT_THROW(running_interpreter.Interpret("SET GLOBAL TRANSACTION ISOLATION LEVEL READ COMMITTED;"),
                memgraph::query::IsolationLevelModificationInAnalyticsException);
-}
-
-// Regression: SetStorageMode(ANALYTICAL) used to drain the async indexer while
-// holding main_lock_ UNIQUE, deadlocking against the worker's ReadOnlyAccess.
-TEST(StorageModeAsyncIndexerDeadlock, EnableTtlStyleEnqueueThenAnalytical) {
-  using namespace memgraph::storage;
-  using namespace std::chrono_literals;
-
-  // Heap-allocated so we can leak on regression — destructor would hang.
-  auto *storage = new InMemoryStorage{Config{}};
-  auto label = storage->NameToLabel("TTL");
-  auto prop = storage->NameToProperty("ttl");
-
-  // UNIQUE before Enqueue: prevents the worker from draining the queue early.
-  auto unique_holder = storage->UniqueAccess();
-  storage->GetAsyncIndexer().Enqueue(label, std::vector{PropertyPath{prop}});
-
-  // Heap-owned promise: on the detach path we leak it along with storage so
-  // a delayed (non-permanent) deadlock can't write through a dangling ref.
-  auto *done = new std::promise<void>{};
-  auto done_fut = done->get_future();
-  std::thread setter([storage, done] {
-    storage->SetStorageMode(StorageMode::IN_MEMORY_ANALYTICAL);
-    done->set_value();
-  });
-
-  // Release UNIQUE during the worker's 2nd backoff sleep [2100–2250 ms] so
-  // SetStorageMode wins the UNIQUE race uncontested.
-  std::this_thread::sleep_for(2175ms);
-  unique_holder.reset();
-
-  if (done_fut.wait_for(5s) != std::future_status::ready) {
-    setter.detach();  // leak storage + promise; can't join without hanging.
-    FAIL() << "SetStorageMode hung — AsyncIndexer / main_lock_ deadlock is back";
-    return;
-  }
-  EXPECT_EQ(storage->GetStorageMode(), StorageMode::IN_MEMORY_ANALYTICAL);
-  setter.join();
-  delete done;
-  delete storage;
 }


### PR DESCRIPTION
## Bug

`SetStorageMode(ANALYTICAL)` took `main_lock_` UNIQUE and then called `async_indexer_.CompleteRemaining()`, which waits on `AsyncIndexer::mutex_`. The indexer worker holds that mutex across its `ReadOnlyAccess` retry loop; under UNIQUE the `ReadOnlyAccess` times out forever — a two-lock cycle.

Real-world trigger: `ENABLE TTL` queues a label+property index task (`ttl.cpp:219`) right before a `STORAGE MODE` change.

## Fix

- Call `CompleteRemaining()` *before* `UniqueAccess()`.
- After taking UNIQUE, if anything slipped into the queue in the gap, throw a descriptive `BasicException` rather than draining under the lock.