### PR TITLE
fix: Increse timeout on stress tests and use process groups

### DIFF
--- a/tests/stress/continuous_integration
+++ b/tests/stress/continuous_integration
@@ -13,6 +13,7 @@ Usage:
 import argparse
 import multiprocessing
 import os
+import signal
 import subprocess
 import sys
 import time
@@ -363,10 +364,27 @@ def run_workload_script(workload: Dict[str, Any], args: Args, timeout_sec: int, 
     run_env["PYTHONPATH"] = f"{ha_dir}:{script_dir}:{SCRIPT_DIR}:{existing}".rstrip(":")
 
     print(f"Executing workload script: {' '.join(cmd)}")
-    result = subprocess.run(cmd, cwd=SCRIPT_DIR, timeout=timeout_sec, env=run_env)
 
-    if result.returncode != 0:
-        raise Exception(f"Workload script returned non-zero ({result.returncode})!")
+    # start_new_session puts the workload in its own process group so a timeout
+    # can SIGKILL the whole tree (the workload's multiprocessing.Pool workers
+    # would otherwise be orphaned and keep hitting the cluster as it shuts down,
+    # polluting logs with confusing post-mortem SYNC replica errors).
+    process = subprocess.Popen(cmd, cwd=SCRIPT_DIR, env=run_env, start_new_session=True)
+    try:
+        returncode = process.wait(timeout=timeout_sec)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        process.wait()
+        raise Exception(
+            f"Workload script timed out after {timeout_sec} seconds "
+            f"({timeout_sec // 60} min). Increase timeout_min or reduce workload size."
+        )
+
+    if returncode != 0:
+        raise Exception(f"Workload script returned non-zero ({returncode})!")
 
 
 def run_custom_workloads(config: Config, args: Args) -> Dict[str, Any]:

--- a/tests/stress/ha/ha_common.py
+++ b/tests/stress/ha/ha_common.py
@@ -16,7 +16,7 @@ from enum import Enum
 from typing import Any, Callable, Iterable, TypeVar
 
 from neo4j import GraphDatabase
-from neo4j.exceptions import ServiceUnavailable, TransientError
+from neo4j.exceptions import ServiceUnavailable, SessionExpired, TransientError
 
 # Suppress neo4j driver noise (connection pool chatter, retry warnings, etc.)
 # so they don't drown out workload and monitor output.
@@ -257,7 +257,7 @@ def _run_query(
             if SYNC_REPLICA_ERROR in str(e):
                 print(f"\nWARN: Sync replica error (instance={instance_name}, query={query!r}): {e}")
                 return None
-            if isinstance(e, ServiceUnavailable) or WRITE_ON_REPLICA_ERROR in str(e):
+            if isinstance(e, (ServiceUnavailable, SessionExpired)) or WRITE_ON_REPLICA_ERROR in str(e):
                 connection_attempt += 1
                 pid = os.getpid()
                 key = (pid, instance_name, protocol.value, auth[0], auth[1])
@@ -356,10 +356,12 @@ def _run_with_manual_retries(
                 # should investigate the replica to understand why it lagged.
                 print(f"\nWARN: SYNC_REPLICA_ERROR (instance={instance_name}, query={query!r}): {e}")
                 return fallback
-            retriable = isinstance(e, (TransientError, ServiceUnavailable)) or WRITE_ON_REPLICA_ERROR in str(e)
+            retriable = isinstance(
+                e, (TransientError, ServiceUnavailable, SessionExpired)
+            ) or WRITE_ON_REPLICA_ERROR in str(e)
             if not retriable:
                 raise
-            if isinstance(e, ServiceUnavailable) or WRITE_ON_REPLICA_ERROR in str(e):
+            if isinstance(e, (ServiceUnavailable, SessionExpired)) or WRITE_ON_REPLICA_ERROR in str(e):
                 pid = os.getpid()
                 key = (pid, instance_name, protocol.value, auth[0], auth[1])
                 _driver_cache.pop(key, None)

--- a/tests/stress/ha/workloads/concurrent_edge_creation_on_supernode/workload.yaml
+++ b/tests/stress/ha/workloads/concurrent_edge_creation_on_supernode/workload.yaml
@@ -2,4 +2,4 @@ customWorkloads:
   tests:
     - name: concurrent-edge-creation-on-supernode
       script: "ha/workloads/concurrent_edge_creation_on_supernode/workload.py"
-      timeout_min: 30
+      timeout_min: 60


### PR DESCRIPTION
Increase timeout for stress tests.
Use a process group to make process destruction easier. By using process group, the main process becomes a session leader and all of children inherit PGID so with `os.killpg(process.pid, SIGKILL)` we kill all processes.