### PR TITLE
fix: Rebind default db UUID when data instance joins cluster

### DIFF
--- a/src/dbms/dbms_handler.hpp
+++ b/src/dbms/dbms_handler.hpp
@@ -207,7 +207,9 @@ class DbmsHandler {
       }
       spdlog::debug("Updated default db's UUID");
       // Default db cannot be deleted and remade, have to just update the UUID
+      auto const old_uuid = storage->config_.salient.uuid;
       storage->config_.salient.uuid = config.uuid;
+      metrics::Metrics().RebindDatabaseUUID(old_uuid, config.uuid);
       UpdateDurability(storage->config_, ".");
       return db;
     }

--- a/src/dbms/dbms_handler.hpp
+++ b/src/dbms/dbms_handler.hpp
@@ -207,9 +207,8 @@ class DbmsHandler {
       }
       spdlog::debug("Updated default db's UUID");
       // Default db cannot be deleted and remade, have to just update the UUID
-      auto const old_uuid = storage->config_.salient.uuid;
       storage->config_.salient.uuid = config.uuid;
-      metrics::Metrics().RebindDatabaseUUID(old_uuid, config.uuid);
+      metrics::Metrics().RebindDefaultDatabaseUUID(config.uuid);
       UpdateDurability(storage->config_, ".");
       return db;
     }

--- a/src/metrics/prometheus_metrics.cpp
+++ b/src/metrics/prometheus_metrics.cpp
@@ -1114,7 +1114,7 @@ void PrometheusMetrics::RemoveDatabase(utils::UUID const &uuid) {
 
 void PrometheusMetrics::RebindDefaultDatabaseUUID(utils::UUID const &new_uuid) {
   std::lock_guard const lock{databases_.mutex};
-  MG_ASSERT(default_db_uuid_, "RebindDefaultDatabaseUUID: no default database registered");
+  if (!default_db_uuid_) return;  // metrics not registered for the default DB
   auto const &old_uuid = *default_db_uuid_;
   auto it = r::find_if(databases_.entries, [&old_uuid](auto const &e) { return e.uuid == old_uuid; });
   MG_ASSERT(it != databases_.entries.end(), "RebindDefaultDatabaseUUID: default UUID not found in metrics registry");

--- a/src/metrics/prometheus_metrics.cpp
+++ b/src/metrics/prometheus_metrics.cpp
@@ -1112,6 +1112,16 @@ void PrometheusMetrics::RemoveDatabase(utils::UUID const &uuid) {
   databases_.entries.erase(it);
 }
 
+void PrometheusMetrics::RebindDatabaseUUID(utils::UUID const &old_uuid, utils::UUID const &new_uuid) {
+  std::lock_guard const lock{databases_.mutex};
+  auto it = r::find_if(databases_.entries, [&old_uuid](auto const &e) { return e.uuid == old_uuid; });
+  if (it == databases_.entries.end()) return;
+  it->uuid = new_uuid;
+  if (default_db_uuid_ && *default_db_uuid_ == old_uuid) {
+    default_db_uuid_ = new_uuid;
+  }
+}
+
 void PrometheusMetrics::UpdateGauges() {
   std::vector<utils::UUID> db_uuids;
   {

--- a/src/metrics/prometheus_metrics.cpp
+++ b/src/metrics/prometheus_metrics.cpp
@@ -1112,14 +1112,14 @@ void PrometheusMetrics::RemoveDatabase(utils::UUID const &uuid) {
   databases_.entries.erase(it);
 }
 
-void PrometheusMetrics::RebindDatabaseUUID(utils::UUID const &old_uuid, utils::UUID const &new_uuid) {
+void PrometheusMetrics::RebindDefaultDatabaseUUID(utils::UUID const &new_uuid) {
   std::lock_guard const lock{databases_.mutex};
+  MG_ASSERT(default_db_uuid_, "RebindDefaultDatabaseUUID: no default database registered");
+  auto const &old_uuid = *default_db_uuid_;
   auto it = r::find_if(databases_.entries, [&old_uuid](auto const &e) { return e.uuid == old_uuid; });
-  if (it == databases_.entries.end()) return;
+  MG_ASSERT(it != databases_.entries.end(), "RebindDefaultDatabaseUUID: default UUID not found in metrics registry");
   it->uuid = new_uuid;
-  if (default_db_uuid_ && *default_db_uuid_ == old_uuid) {
-    default_db_uuid_ = new_uuid;
-  }
+  default_db_uuid_ = new_uuid;
 }
 
 void PrometheusMetrics::UpdateGauges() {

--- a/src/metrics/prometheus_metrics.hpp
+++ b/src/metrics/prometheus_metrics.hpp
@@ -346,6 +346,7 @@ class PrometheusMetrics {
 
   DatabaseMetricHandles AddDatabase(utils::UUID const &uuid, std::string_view name);
   void RemoveDatabase(utils::UUID const &uuid);
+  void RebindDatabaseUUID(utils::UUID const &old_uuid, utils::UUID const &new_uuid);
   void UpdateGauges();
 
   void SetStorageSnapshotResolver(StorageSnapshotResolver resolver);

--- a/src/metrics/prometheus_metrics.hpp
+++ b/src/metrics/prometheus_metrics.hpp
@@ -346,7 +346,7 @@ class PrometheusMetrics {
 
   DatabaseMetricHandles AddDatabase(utils::UUID const &uuid, std::string_view name);
   void RemoveDatabase(utils::UUID const &uuid);
-  void RebindDatabaseUUID(utils::UUID const &old_uuid, utils::UUID const &new_uuid);
+  void RebindDefaultDatabaseUUID(utils::UUID const &new_uuid);
   void UpdateGauges();
 
   void SetStorageSnapshotResolver(StorageSnapshotResolver resolver);

--- a/tests/unit/prometheus_metrics.cpp
+++ b/tests/unit/prometheus_metrics.cpp
@@ -147,18 +147,21 @@ TEST(PrometheusMetrics, UpdateGaugesReturnsZeroAfterDefaultDbUuidChange) {
 
   memgraph::metrics::StorageSnapshot const snapshot{.vertex_count = 42, .edge_count = 10, .disk_usage = 2048};
 
-  // Resolver only knows uuid_b — simulates storage having been re-keyed.
+  // Snapshot resolver will simulate return returning "stale" settings if
+  // requesting any database with a uuid other than the HA cluster's default
+  // db uuid.
   pm.SetStorageSnapshotResolver(
       [&](memgraph::utils::UUID const &uuid) -> std::optional<memgraph::metrics::StorageSnapshot> {
         if (uuid == uuid_b) return snapshot;
         return std::nullopt;
       });
 
-  // Metrics registered with original uuid_a (as happens at startup).
+  // Metrics registered with original uuid_a, as happens at startup
   pm.AddDatabase(uuid_a, "memgraph");
 
-  // Simulate HA UUID realignment: storage now answers to uuid_b.
-  pm.RebindDatabaseUUID(uuid_a, uuid_b);
+  // Simulate HA UUID realignment on joining cluster: storage now answers to
+  // uuid_b
+  pm.RebindDefaultDatabaseUUID(uuid_b);
 
   pm.UpdateGauges();
 

--- a/tests/unit/prometheus_metrics.cpp
+++ b/tests/unit/prometheus_metrics.cpp
@@ -137,6 +137,37 @@ TEST(DatabaseMetrics, SwitchToOnDiskUpdatesSnapshotCallback) {
   disk_test_utils::RemoveRocksDbDirs("SwitchToOnDiskMetrics");
 }
 
+TEST(PrometheusMetrics, UpdateGaugesReturnsZeroAfterDefaultDbUuidChange) {
+  FLAGS_metrics_format = "OpenMetrics";
+  memgraph::metrics::PrometheusMetrics pm;
+
+  memgraph::utils::UUID const uuid_a{};
+  memgraph::utils::UUID const uuid_b{};
+  ASSERT_NE(uuid_a, uuid_b);
+
+  memgraph::metrics::StorageSnapshot const snapshot{.vertex_count = 42, .edge_count = 10, .disk_usage = 2048};
+
+  // Resolver only knows uuid_b — simulates storage having been re-keyed.
+  pm.SetStorageSnapshotResolver(
+      [&](memgraph::utils::UUID const &uuid) -> std::optional<memgraph::metrics::StorageSnapshot> {
+        if (uuid == uuid_b) return snapshot;
+        return std::nullopt;
+      });
+
+  // Metrics registered with original uuid_a (as happens at startup).
+  pm.AddDatabase(uuid_a, "memgraph");
+
+  // Simulate HA UUID realignment: storage now answers to uuid_b.
+  pm.RebindDatabaseUUID(uuid_a, uuid_b);
+
+  pm.UpdateGauges();
+
+  auto const families = pm.registry().Collect();
+  EXPECT_EQ(FindSample(families, "memgraph_vertex_count", "memgraph"), 42.0);
+  EXPECT_EQ(FindSample(families, "memgraph_edge_count", "memgraph"), 10.0);
+  EXPECT_EQ(FindSample(families, "memgraph_disk_usage_bytes", "memgraph"), 2048.0);
+}
+
 TEST(MetricHandles, GaugeHandleNullSafety) {
   memgraph::metrics::GaugeHandle h{};
   EXPECT_NO_FATAL_FAILURE(h.Increment());


### PR DESCRIPTION
Rebind the default database UUID in the metrics collector after a data instance joins a HA cluster. Fixes an issue where vertex counts, etc, on the newly-connected data instance are collected using the stale UUID.