### PR TITLE
test: Fix collision in e2e with with `CREATE SNAPSHOT`

### DIFF
--- a/tests/e2e/show_metrics/workloads.yaml
+++ b/tests/e2e/show_metrics/workloads.yaml
@@ -17,7 +17,7 @@ show_metrics_json_cluster: &show_metrics_json_cluster
 show_metrics_snapshot_cluster: &show_metrics_snapshot_cluster
   cluster:
     main:
-      args: ["--bolt-port", "7687", "--log-level=TRACE", "--storage-snapshot-interval-sec=1"]
+      args: ["--bolt-port", "7687", "--log-level=TRACE", "--storage-snapshot-interval-sec=0", "--storage-wal-enabled=false"]
       log_file: "show_metrics_snapshot.log"
       setup_queries: []
       validation_queries: []


### PR DESCRIPTION
`show_metrics` test has both a 1 second periodic snapshot and a manually trigged `CREATE SNAPSHOT`. This flakes, because the latter occasionally collides with the former.

Fixed by disabling periodic snapshots (and wal, which will not work when snapshot interval is 0.)