### PR TITLE
fix: trim leading whitespace before stripping EXPLAIN/PROFILE prefix to avoid crash

### DIFF
--- a/src/query/cypher_query_interpreter.cpp
+++ b/src/query/cypher_query_interpreter.cpp
@@ -27,6 +27,7 @@
 #include "query/plan/used_index_checker.hpp"
 #include "query/plan/vertex_count_cache.hpp"
 #include "utils/flag_validation.hpp"
+#include "utils/string.hpp"
 
 #include "parameters/parameters.hpp"
 #include "query/plan_v2/frontend/ast_converter.hpp"
@@ -69,9 +70,13 @@ auto PrepareQueryParameters(frontend::StrippedQuery const &stripped_query, UserP
   return parameters;
 }
 
-ParsedQuery ParseQuery(const std::string &query_string, UserParameters const &user_parameters,
+ParsedQuery ParseQuery(const std::string &raw_query_string, UserParameters const &user_parameters,
                        utils::SkipList<QueryCacheEntry> *cache, const InterpreterConfig::Query &query_config,
                        std::string_view database_uuid, parameters::Parameters const *server_parameters) {
+  // Drop leading whitespace so prefix-stripping consumers (EXPLAIN, PROFILE)
+  // can rely on the query starting with its first significant character.
+  std::string query_string{utils::LTrim(raw_query_string)};
+
   // Strip the query for caching purposes. The process of stripping a query
   // "normalizes" it by replacing any literals with new parameters. This
   // results in just the *structure* of the query being taken into account for
@@ -159,7 +164,7 @@ ParsedQuery ParseQuery(const std::string &query_string, UserParameters const &us
   }
 
   return ParsedQuery{
-      .query_string = query_string,
+      .query_string = std::move(query_string),
       .stripped_query = std::move(stripped_query),
       .ast_storage = std::move(result.ast_storage),
       .query = result.query,

--- a/tests/gql_behave/steps/database.py
+++ b/tests/gql_behave/steps/database.py
@@ -32,16 +32,23 @@ def query(q, context, params={}):
 
     is_on_disk = storage_mode == "ON_DISK_TRANSACTIONAL"
 
-    # Prepend USING PARALLEL EXECUTION to data queries (those with RETURN) when flag is set
-    # and storage mode is not ON_DISK_TRANSACTIONAL
+    # Add USING PARALLEL EXECUTION to data queries (those with RETURN) when flag is set
+    # and storage mode is not ON_DISK_TRANSACTIONAL.
+    # Per the grammar, the directive lives inside cypherQuery, which EXPLAIN/PROFILE wrap
+    # (explainQuery: EXPLAIN cypherQuery), so for those it must go *after* the keyword, e.g.
+    # "EXPLAIN USING PARALLEL EXECUTION RETURN 1" -- not before, which is a parse error.
     if parallel_execution and not is_on_disk:
         if "RETURN" in q.upper():
-            if q.strip().upper().startswith("USING"):
-                import re
+            import re
 
-                q = re.sub(r"(?i)^(\s*USING\s+)", r"\1PARALLEL EXECUTION, ", q)
+            # Split off a leading EXPLAIN/PROFILE keyword (the directive goes after it).
+            match = re.match(r"(?is)^(\s*(?:EXPLAIN|PROFILE)\s+)(.*)$", q)
+            prefix, body = (match.group(1), match.group(2)) if match else ("", q)
+            if body.strip().upper().startswith("USING"):
+                body = re.sub(r"(?i)^(\s*USING\s+)", r"\1PARALLEL EXECUTION, ", body)
             else:
-                q = "USING PARALLEL EXECUTION " + q
+                body = "USING PARALLEL EXECUTION " + body
+            q = prefix + body
 
     # Store the actual query being executed (for logging and validation purposes)
     context.last_executed_query = q

--- a/tests/gql_behave/steps/database.py
+++ b/tests/gql_behave/steps/database.py
@@ -11,6 +11,8 @@
 
 # -*- coding: utf-8 -*-
 
+import re
+
 
 def query(q, context, params={}):
     """
@@ -39,8 +41,6 @@ def query(q, context, params={}):
     # "EXPLAIN USING PARALLEL EXECUTION RETURN 1" -- not before, which is a parse error.
     if parallel_execution and not is_on_disk:
         if "RETURN" in q.upper():
-            import re
-
             # Split off a leading EXPLAIN/PROFILE keyword (the directive goes after it).
             match = re.match(r"(?is)^(\s*(?:EXPLAIN|PROFILE)\s+)(.*)$", q)
             prefix, body = (match.group(1), match.group(2)) if match else ("", q)

--- a/tests/gql_behave/tests/memgraph_V1/features/memgraph.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/memgraph.feature
@@ -224,3 +224,30 @@ Feature: Memgraph only tests (queries in which we choose to be incompatible with
             DROP ENUM Status;
             """
         Then an error should be raised
+
+    Scenario: EXPLAIN tolerates leading whitespace
+        Given an empty graph
+        When executing query:
+            """
+
+                EXPLAIN RETURN 1
+            """
+        Then the result should be:
+            | QUERY PLAN        |
+            | ' * Produce {0}'  |
+            | ' * Once'         |
+
+    Scenario: PROFILE tolerates leading whitespace
+        Given an empty graph
+        When executing query:
+            """
+
+                PROFILE RETURN 1
+            """
+        When executing query:
+            """
+            RETURN 1 AS n
+            """
+        Then the result should be:
+            | n |
+            | 1 |


### PR DESCRIPTION
PrepareExplainQuery and PrepareProfileQuery stripped the keyword via query_string.substr(8) on the raw query. When the query had leading whitespace before EXPLAIN/PROFILE, this sliced into the inner query instead of removing the keyword — either failing the MG_ASSERT that expects a CypherQuery, or producing a Cypher parse error.

LTrim the raw query before the substr so the prefix is removed correctly regardless of leading whitespace.
