### PR TITLE
feat: fix schema procedure types and mandatory for Simba BI connector

### DIFF
--- a/query_modules/schema.cpp
+++ b/query_modules/schema.cpp
@@ -494,8 +494,7 @@ void Schema::RelTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_re
       auto target_list = LabelsToList(key.target_labels);
       for (const auto &[prop_name, prop_info] : labels_info.properties) {
         auto prop_types = PropertyTypesToList(prop_info.property_types);
-        // Sentinel: test_rel_type_existence_constraints_are_rejected. If it fails, wire mandatory up.
-        const bool mandatory = false;
+        const bool mandatory = false;  // no rel-type existence constraints in Memgraph
         auto record = record_factory.NewRecord();
         ProcessPropertiesRel(record,
                              type_str,

--- a/query_modules/schema.cpp
+++ b/query_modules/schema.cpp
@@ -13,7 +13,9 @@
 #include <boost/functional/hash.hpp>
 #include <iostream>
 #include <mgp.hpp>
+#include <ranges>
 #include <set>
+#include <unordered_map>
 #include <unordered_set>
 
 namespace Schema {
@@ -52,7 +54,6 @@ constexpr std::string_view kConfigSample = "sample";
 constexpr std::string_view kConfigMaxRels = "maxRels";
 constexpr int64_t kDefaultSample = 1000;
 constexpr int64_t kDefaultMaxRels = 100;
-constexpr int kInitialNumberOfPropertyOccurances = 1;
 
 std::string TypeOf(const mgp::Type &type);
 
@@ -78,11 +79,12 @@ std::string Schema::TypeOf(const mgp::Type &type) {
     case mgp::Type::Null:
       return "Null";
     case mgp::Type::Bool:
-      return "Bool";
+      return "Boolean";
+    // Memgraph docs call this "Integer", but Simba JDBC empirically maps "Integer" to VARCHAR.
     case mgp::Type::Int:
       return "Int";
     case mgp::Type::Double:
-      return "Double";
+      return "Float";
     case mgp::Type::String:
       return "String";
     case mgp::Type::List:
@@ -103,12 +105,13 @@ std::string Schema::TypeOf(const mgp::Type &type) {
       return "LocalDateTime";
     case mgp::Type::Duration:
       return "Duration";
+    // Memgraph docs call this "ZonedDateTime"; we emit "DateTime" because the Simba BI connector
+    // maps "DateTime" -> SQL_TIMESTAMP. Without this rename BI tools degrade the column to VARCHAR.
     case mgp::Type::ZonedDateTime:
-      return "ZonedDateTime";
+      return "DateTime";
     case mgp::Type::Point2d:
-      return "Point2d";
     case mgp::Type::Point3d:
-      return "Point3d";
+      return "Point";
     case mgp::Type::Enum:
       return "Enum";
     default:
@@ -145,15 +148,26 @@ void Schema::ProcessPropertiesRel(mgp::Record &record, const std::string &type, 
 }
 
 struct PropertyInfo {
-  std::unordered_set<std::string> property_types;  // property types
+  std::unordered_set<std::string> property_types;
   int64_t number_of_property_occurrences = 0;
-
-  PropertyInfo() = default;
-
-  explicit PropertyInfo(std::string &&property_type)
-      : property_types({std::move(property_type)}),
-        number_of_property_occurrences(Schema::kInitialNumberOfPropertyOccurances) {}
 };
+
+void AppendPropertyTypes(PropertyInfo &info, const mgp::Value &prop) {
+  info.property_types.insert(Schema::TypeOf(prop.Type()));
+  info.number_of_property_occurrences++;
+}
+
+std::unordered_map<std::string, std::unordered_set<std::string>> BuildExistenceConstraintsByLabel(
+    mgp_graph *memgraph_graph) {
+  std::unordered_map<std::string, std::unordered_set<std::string>> by_label;
+  for (const auto &c : mgp::ListAllExistenceConstraints(memgraph_graph)) {
+    std::string s(c.ValueString());
+    auto colon = s.find(':');
+    if (colon == std::string::npos) continue;
+    by_label[s.substr(0, colon)].insert(s.substr(colon + 1));
+  }
+  return by_label;
+}
 
 struct LabelOrRelTypeInfo {
   std::unordered_map<std::string, PropertyInfo> properties;  // key is a property name
@@ -309,6 +323,8 @@ void Schema::NodeTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_r
     }
     auto max_rels = ExtractIntFromConfig(config, kConfigMaxRels, kDefaultMaxRels);
 
+    const auto constraints_by_label = BuildExistenceConstraintsByLabel(memgraph_graph);
+
     std::unordered_map<std::set<std::string>, LabelOrRelTypeInfo, LabelsHash> node_types_properties;
 
     for (const auto node : mgp::Graph(memgraph_graph).Nodes()) {
@@ -352,13 +368,7 @@ void Schema::NodeTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_r
       }
 
       for (const auto &[key, prop] : node.Properties()) {
-        auto prop_type = TypeOf(prop.Type());
-        if (current_labels_info.properties.find(key) == current_labels_info.properties.end()) {
-          current_labels_info.properties[key] = PropertyInfo{std::move(prop_type)};
-        } else {
-          current_labels_info.properties[key].property_types.emplace(prop_type);
-          current_labels_info.properties[key].number_of_property_occurrences++;
-        }
+        AppendPropertyTypes(current_labels_info.properties[key], prop);
       }
     }
 
@@ -372,7 +382,10 @@ void Schema::NodeTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_r
           (sample > 0) ? std::min(sample, labels_info.number_of_occurrences) : labels_info.number_of_occurrences;
       for (const auto &[prop_name, prop_info] : labels_info.properties) {
         auto prop_types = PropertyTypesToList(prop_info.property_types);
-        const bool mandatory = prop_info.number_of_property_occurrences == effective_count;
+        const bool mandatory = std::ranges::any_of(node_type, [&](const auto &label) {
+          auto it = constraints_by_label.find(label);
+          return it != constraints_by_label.end() && it->second.contains(prop_name);
+        });
         auto record = record_factory.NewRecord();
         ProcessPropertiesNode(record,
                               label_type,
@@ -463,13 +476,7 @@ void Schema::RelTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_re
         rel_info.number_of_occurrences++;
 
         for (auto &[prop_name, prop] : rel.Properties()) {
-          auto prop_type = TypeOf(prop.Type());
-          if (auto it = rel_info.properties.find(prop_name); it == rel_info.properties.end()) {
-            rel_info.properties.emplace(prop_name, PropertyInfo{std::move(prop_type)});
-          } else {
-            it->second.property_types.emplace(std::move(prop_type));
-            it->second.number_of_property_occurrences++;
-          }
+          AppendPropertyTypes(rel_info.properties[prop_name], prop);
         }
       }
     }
@@ -480,7 +487,8 @@ void Schema::RelTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_re
       auto target_list = LabelsToList(key.target_labels);
       for (const auto &[prop_name, prop_info] : labels_info.properties) {
         auto prop_types = PropertyTypesToList(prop_info.property_types);
-        const bool mandatory = prop_info.number_of_property_occurrences == labels_info.number_of_occurrences;
+        // Memgraph has no rel-type existence constraints; mandatory is always false for relationships.
+        const bool mandatory = false;
         auto record = record_factory.NewRecord();
         ProcessPropertiesRel(record,
                              type_str,

--- a/query_modules/schema.cpp
+++ b/query_modules/schema.cpp
@@ -151,12 +151,12 @@ struct PropertyInfo {
   int64_t number_of_property_occurrences = 0;
 };
 
+namespace {
 void RecordPropertyObservation(PropertyInfo &info, const mgp::Value &prop) {
   info.property_types.insert(Schema::TypeOf(prop.Type()));
   info.number_of_property_occurrences++;
 }
 
-namespace {
 using ConstraintsByLabel = std::unordered_map<std::string, std::unordered_set<std::string>>;
 
 // Entries are "<label>:<property_path>", unescaped. Names containing ':' (only possible via

--- a/query_modules/schema.cpp
+++ b/query_modules/schema.cpp
@@ -151,21 +151,26 @@ struct PropertyInfo {
   int64_t number_of_property_occurrences = 0;
 };
 
-void AppendPropertyTypes(PropertyInfo &info, const mgp::Value &prop) {
+void RecordPropertyObservation(PropertyInfo &info, const mgp::Value &prop) {
   info.property_types.insert(Schema::TypeOf(prop.Type()));
   info.number_of_property_occurrences++;
 }
 
 namespace {
-// Constraints come as "label:property.path"; property paths may contain '.', labels cannot contain ':'.
-std::unordered_map<std::string, std::unordered_set<std::string>> BuildExistenceConstraintsByLabel(
-    mgp_graph *memgraph_graph) {
-  std::unordered_map<std::string, std::unordered_set<std::string>> by_label;
-  for (const auto &c : mgp::ListAllExistenceConstraints(memgraph_graph)) {
-    std::string_view sv = c.ValueString();
-    auto colon = sv.rfind(':');
-    if (colon == std::string_view::npos) continue;
-    by_label[std::string(sv.substr(0, colon))].insert(std::string(sv.substr(colon + 1)));
+using ConstraintsByLabel = std::unordered_map<std::string, std::unordered_set<std::string>>;
+
+// Entries come as "label:property"; rfind handles property names with ':' correctly since labels cannot.
+ConstraintsByLabel BuildExistenceConstraintsByLabel(mgp_graph *memgraph_graph) {
+  ConstraintsByLabel by_label;
+  try {
+    for (const auto &c : mgp::ListAllExistenceConstraints(memgraph_graph)) {
+      std::string_view sv = c.ValueString();
+      auto colon = sv.rfind(':');
+      if (colon == std::string_view::npos) continue;
+      by_label[std::string(sv.substr(0, colon))].insert(std::string(sv.substr(colon + 1)));
+    }
+  } catch (const mg_exception::ImmutableObjectException &) {
+    // Virtual graphs reject this listing — degrade to no constraints.
   }
   return by_label;
 }
@@ -370,7 +375,7 @@ void Schema::NodeTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_r
       }
 
       for (const auto &[key, prop] : node.Properties()) {
-        AppendPropertyTypes(current_labels_info.properties[key], prop);
+        RecordPropertyObservation(current_labels_info.properties[key], prop);
       }
     }
 
@@ -380,7 +385,7 @@ void Schema::NodeTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_r
         label_type += ":`" + label + "`";
       }
       auto labels_list = LabelsToList(node_type);
-      const auto effective_count =
+      const auto total_count =
           (sample > 0) ? std::min(sample, labels_info.number_of_occurrences) : labels_info.number_of_occurrences;
       for (const auto &[prop_name, prop_info] : labels_info.properties) {
         auto prop_types = PropertyTypesToList(prop_info.property_types);
@@ -396,11 +401,11 @@ void Schema::NodeTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_r
                               prop_types,
                               mandatory,
                               prop_info.number_of_property_occurrences,
-                              effective_count);
+                              total_count);
       }
       if (labels_info.properties.empty()) {
         auto record = record_factory.NewRecord();
-        ProcessPropertiesNode<mgp::List>(record, label_type, labels_list, "", mgp::List(), false, 0, effective_count);
+        ProcessPropertiesNode<mgp::List>(record, label_type, labels_list, "", mgp::List(), false, 0, total_count);
       }
     }
 
@@ -478,7 +483,7 @@ void Schema::RelTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_re
         rel_info.number_of_occurrences++;
 
         for (auto &[prop_name, prop] : rel.Properties()) {
-          AppendPropertyTypes(rel_info.properties[prop_name], prop);
+          RecordPropertyObservation(rel_info.properties[prop_name], prop);
         }
       }
     }
@@ -489,7 +494,7 @@ void Schema::RelTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_re
       auto target_list = LabelsToList(key.target_labels);
       for (const auto &[prop_name, prop_info] : labels_info.properties) {
         auto prop_types = PropertyTypesToList(prop_info.property_types);
-        // Memgraph has no rel-type existence constraints.
+        // Sentinel: test_rel_type_existence_constraints_are_rejected. If it fails, wire mandatory up.
         const bool mandatory = false;
         auto record = record_factory.NewRecord();
         ProcessPropertiesRel(record,
@@ -678,7 +683,7 @@ void ProcessIndices(const mgp::Map &indices_map, mgp_graph *memgraph_graph, cons
                               std::inserter(label_property_indices_to_drop, label_property_indices_to_drop.begin()));
 
   auto decouple_label_property = [](std::string_view label_property) {
-    const auto label_size = label_property.find(':');
+    const auto label_size = label_property.rfind(':');
     const auto label = std::string(label_property.substr(0, label_size));
     const auto property = std::string(label_property.substr(label_size + 1));
     return std::make_pair(label, property);
@@ -774,7 +779,7 @@ void ProcessExistenceConstraints(const mgp::Map &existence_constraints_map, mgp_
                               std::inserter(existence_constraints_to_drop, existence_constraints_to_drop.begin()));
 
   auto decouple_label_property = [](std::string_view label_property) {
-    const auto label_size = label_property.find(':');
+    const auto label_size = label_property.rfind(':');
     const auto label = std::string(label_property.substr(0, label_size));
     const auto property = std::string(label_property.substr(label_size + 1));
     return std::make_pair(label, property);

--- a/query_modules/schema.cpp
+++ b/query_modules/schema.cpp
@@ -72,16 +72,15 @@ void RelTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *re
 void Assert(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
 }  // namespace Schema
 
-/*we have << operator for type in Cpp API, but in it we return somewhat different strings than I would like in this
-module, so I implemented a small function here*/
+// Type names tuned to match the Simba BI connector's recognised set.
 std::string Schema::TypeOf(const mgp::Type &type) {
   switch (type) {
     case mgp::Type::Null:
       return "Null";
     case mgp::Type::Bool:
       return "Boolean";
-    // Memgraph docs call this "Integer", but Simba JDBC empirically maps "Integer" to VARCHAR.
     case mgp::Type::Int:
+      // "Integer" would degrade to VARCHAR in Simba JDBC.
       return "Int";
     case mgp::Type::Double:
       return "Float";
@@ -105,12 +104,12 @@ std::string Schema::TypeOf(const mgp::Type &type) {
       return "LocalDateTime";
     case mgp::Type::Duration:
       return "Duration";
-    // Memgraph docs call this "ZonedDateTime"; we emit "DateTime" because the Simba BI connector
-    // maps "DateTime" -> SQL_TIMESTAMP. Without this rename BI tools degrade the column to VARCHAR.
     case mgp::Type::ZonedDateTime:
+      // "ZonedDateTime" would degrade to VARCHAR; "DateTime" maps to SQL_TIMESTAMP.
       return "DateTime";
     case mgp::Type::Point2d:
     case mgp::Type::Point3d:
+      // Simba JDBC and Neo4j collapse both to "Point".
       return "Point";
     case mgp::Type::Enum:
       return "Enum";
@@ -157,17 +156,20 @@ void AppendPropertyTypes(PropertyInfo &info, const mgp::Value &prop) {
   info.number_of_property_occurrences++;
 }
 
+namespace {
+// Constraints come as "label:property.path"; property paths may contain '.', labels cannot contain ':'.
 std::unordered_map<std::string, std::unordered_set<std::string>> BuildExistenceConstraintsByLabel(
     mgp_graph *memgraph_graph) {
   std::unordered_map<std::string, std::unordered_set<std::string>> by_label;
   for (const auto &c : mgp::ListAllExistenceConstraints(memgraph_graph)) {
-    std::string s(c.ValueString());
-    auto colon = s.find(':');
-    if (colon == std::string::npos) continue;
-    by_label[s.substr(0, colon)].insert(s.substr(colon + 1));
+    std::string_view sv = c.ValueString();
+    auto colon = sv.rfind(':');
+    if (colon == std::string_view::npos) continue;
+    by_label[std::string(sv.substr(0, colon))].insert(std::string(sv.substr(colon + 1)));
   }
   return by_label;
 }
+}  // namespace
 
 struct LabelOrRelTypeInfo {
   std::unordered_map<std::string, PropertyInfo> properties;  // key is a property name
@@ -487,7 +489,7 @@ void Schema::RelTypeProperties(mgp_list *args, mgp_graph *memgraph_graph, mgp_re
       auto target_list = LabelsToList(key.target_labels);
       for (const auto &[prop_name, prop_info] : labels_info.properties) {
         auto prop_types = PropertyTypesToList(prop_info.property_types);
-        // Memgraph has no rel-type existence constraints; mandatory is always false for relationships.
+        // Memgraph has no rel-type existence constraints.
         const bool mandatory = false;
         auto record = record_factory.NewRecord();
         ProcessPropertiesRel(record,

--- a/query_modules/schema.cpp
+++ b/query_modules/schema.cpp
@@ -159,7 +159,8 @@ void RecordPropertyObservation(PropertyInfo &info, const mgp::Value &prop) {
 namespace {
 using ConstraintsByLabel = std::unordered_map<std::string, std::unordered_set<std::string>>;
 
-// Entries come as "label:property"; rfind handles property names with ':' correctly since labels cannot.
+// Entries are "<label>:<property_path>", unescaped. Names containing ':' (only possible via
+// backticked Cypher syntax) would be ambiguous; rfind is an arbitrary tie-break.
 ConstraintsByLabel BuildExistenceConstraintsByLabel(mgp_graph *memgraph_graph) {
   ConstraintsByLabel by_label;
   try {

--- a/tests/e2e/query_modules/schema_test.py
+++ b/tests/e2e/query_modules/schema_test.py
@@ -386,7 +386,7 @@ def test_node_type_properties1():
             f"CALL schema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
         )[0]
     )
-    assert (result) == [":`Activity`", ["Activity"], "location", ["String"], True]
+    assert (result) == [":`Activity`", ["Activity"], "location", ["String"], False]
 
     result = list(
         execute_and_fetch_all(
@@ -394,7 +394,7 @@ def test_node_type_properties1():
             f"CALL schema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
         )[1]
     )
-    assert (result) == [":`Activity`", ["Activity"], "name", ["String"], True]
+    assert (result) == [":`Activity`", ["Activity"], "name", ["String"], False]
 
     result = list(
         execute_and_fetch_all(
@@ -402,7 +402,7 @@ def test_node_type_properties1():
             f"CALL schema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
         )[2]
     )
-    assert (result) == [":`Dog`", ["Dog"], "name", ["String"], True]
+    assert (result) == [":`Dog`", ["Dog"], "name", ["String"], False]
 
     result = list(
         execute_and_fetch_all(
@@ -410,7 +410,7 @@ def test_node_type_properties1():
             f"CALL schema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
         )[3]
     )
-    assert (result) == [":`Dog`", ["Dog"], "owner", ["String"], True]
+    assert (result) == [":`Dog`", ["Dog"], "owner", ["String"], False]
 
 
 def test_node_type_properties2():
@@ -484,7 +484,7 @@ def test_node_type_properties5():
         f"CALL schema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
     )
 
-    assert (list(result[0])) == [":`Dog`", ["Dog"], "name", ["String"], True]
+    assert (list(result[0])) == [":`Dog`", ["Dog"], "name", ["String"], False]
     assert (result.__len__()) == 1
 
 
@@ -502,7 +502,7 @@ def test_node_type_properties6():
         f"CALL schema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
     )
 
-    assert (list(result[0])) == [":`Dog`", ["Dog"], "name", ["String"], True]
+    assert (list(result[0])) == [":`Dog`", ["Dog"], "name", ["String"], False]
     assert (list(result[1])) == [":`Dog`", ["Dog"], "owner", ["String"], False]
     assert (result.__len__()) == 2
 
@@ -520,12 +520,12 @@ def test_node_type_properties_multiple_property_types():
         cursor,
         f"CALL schema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes , mandatory RETURN nodeType, nodeLabels, propertyName, propertyTypes , mandatory ORDER BY propertyName, nodeLabels[0];",
     )
-    assert (list(result[0])) == [":`Node`", ["Node"], "prop1", ["Int", "String"], True] or (list(result[0])) == [
+    assert (list(result[0])) == [":`Node`", ["Node"], "prop1", ["Int", "String"], False] or (list(result[0])) == [
         ":`Node`",
         ["Node"],
         "prop1",
         ["String", "Int"],
-        True,
+        False,
     ]
     assert (result.__len__()) == 1
 
@@ -574,7 +574,7 @@ def test_rel_type_properties3():
         cursor,
         f"CALL schema.rel_type_properties() YIELD relType,propertyName, propertyTypes , mandatory RETURN relType, propertyName, propertyTypes , mandatory;",
     )
-    assert (list(result[0])) == [":`LOVES`", "duration", ["Int"], True]
+    assert (list(result[0])) == [":`LOVES`", "duration", ["Int"], False]
     assert (result.__len__()) == 1
 
 
@@ -592,7 +592,7 @@ def test_rel_type_properties4():
         f"CALL schema.rel_type_properties() YIELD relType,propertyName, propertyTypes , mandatory RETURN relType, propertyName, propertyTypes , mandatory;",
     )
     assert (list(result[0])) == [":`LOVES`", "weather", ["String"], False]
-    assert (list(result[1])) == [":`LOVES`", "duration", ["Int"], True]
+    assert (list(result[1])) == [":`LOVES`", "duration", ["Int"], False]
     assert (result.__len__()) == 2
 
 
@@ -609,11 +609,11 @@ def test_rel_type_properties_multiple_property_types():
         cursor,
         f"CALL schema.rel_type_properties() YIELD relType,propertyName, propertyTypes , mandatory RETURN relType, propertyName, propertyTypes , mandatory;",
     )
-    assert (list(result[0])) == [":`LOVES`", "duration", ["Int", "String"], True] or (list(result[0])) == [
+    assert (list(result[0])) == [":`LOVES`", "duration", ["Int", "String"], False] or (list(result[0])) == [
         ":`LOVES`",
         "duration",
         ["String", "Int"],
-        True,
+        False,
     ]
     assert (result.__len__()) == 1
 
@@ -630,8 +630,8 @@ def test_node_type_properties_zoned_datetime():
         "RETURN nodeType, nodeLabels, propertyName, propertyTypes, mandatory ORDER BY propertyName;",
     )
     assert len(result) == 2
-    assert list(result[0]) == [":`Event`", ["Event"], "name", ["String"], True]
-    assert list(result[1]) == [":`Event`", ["Event"], "scheduled", ["ZonedDateTime"], True]
+    assert list(result[0]) == [":`Event`", ["Event"], "name", ["String"], False]
+    assert list(result[1]) == [":`Event`", ["Event"], "scheduled", ["DateTime"], False]
 
 
 def test_node_type_properties_point2d():
@@ -646,8 +646,8 @@ def test_node_type_properties_point2d():
         "RETURN nodeType, nodeLabels, propertyName, propertyTypes, mandatory ORDER BY propertyName;",
     )
     assert len(result) == 2
-    assert list(result[0]) == [":`Place`", ["Place"], "location", ["Point2d"], True]
-    assert list(result[1]) == [":`Place`", ["Place"], "name", ["String"], True]
+    assert list(result[0]) == [":`Place`", ["Place"], "location", ["Point"], False]
+    assert list(result[1]) == [":`Place`", ["Place"], "name", ["String"], False]
 
 
 def test_node_type_properties_point3d():
@@ -662,8 +662,8 @@ def test_node_type_properties_point3d():
         "RETURN nodeType, nodeLabels, propertyName, propertyTypes, mandatory ORDER BY propertyName;",
     )
     assert len(result) == 2
-    assert list(result[0]) == [":`Place`", ["Place"], "location", ["Point3d"], True]
-    assert list(result[1]) == [":`Place`", ["Place"], "name", ["String"], True]
+    assert list(result[0]) == [":`Place`", ["Place"], "location", ["Point"], False]
+    assert list(result[1]) == [":`Place`", ["Place"], "name", ["String"], False]
 
 
 def test_node_type_properties_enum():
@@ -680,8 +680,8 @@ def test_node_type_properties_enum():
         "RETURN nodeType, nodeLabels, propertyName, propertyTypes, mandatory ORDER BY propertyName;",
     )
     assert len(result) == 2
-    assert list(result[0]) == [":`Item`", ["Item"], "name", ["String"], True]
-    assert list(result[1]) == [":`Item`", ["Item"], "status", ["Enum"], True]
+    assert list(result[0]) == [":`Item`", ["Item"], "name", ["String"], False]
+    assert list(result[1]) == [":`Item`", ["Item"], "status", ["Enum"], False]
 
 
 def test_rel_type_properties_point2d():
@@ -696,7 +696,7 @@ def test_rel_type_properties_point2d():
         "RETURN relType, propertyName, propertyTypes, mandatory;",
     )
     assert len(result) == 1
-    assert list(result[0]) == [":`VISITED`", "location", ["Point2d"], True]
+    assert list(result[0]) == [":`VISITED`", "location", ["Point"], False]
 
 
 def test_node_type_properties_config_include_labels():
@@ -715,7 +715,7 @@ def test_node_type_properties_config_include_labels():
         "RETURN nodeType, nodeLabels, propertyName, propertyTypes, mandatory ORDER BY propertyName;",
     )
     assert len(result) == 1
-    assert list(result[0]) == [":`Dog`", ["Dog"], "name", ["String"], True]
+    assert list(result[0]) == [":`Dog`", ["Dog"], "name", ["String"], False]
 
 
 def test_node_type_properties_config_exclude_labels():
@@ -734,7 +734,7 @@ def test_node_type_properties_config_exclude_labels():
         "RETURN nodeType, nodeLabels, propertyName, propertyTypes, mandatory ORDER BY propertyName;",
     )
     assert len(result) == 1
-    assert list(result[0]) == [":`Cat`", ["Cat"], "name", ["String"], True]
+    assert list(result[0]) == [":`Cat`", ["Cat"], "name", ["String"], False]
 
 
 def test_node_type_properties_config_sample():
@@ -748,7 +748,8 @@ def test_node_type_properties_config_sample():
         CREATE (:Dog {name: 'Buddy'})
         """,
     )
-    # With sample=2, only first 2 nodes are sampled. Both have 'owner', so it appears mandatory.
+    # Sampling controls scan size but does not drive mandatory (which is constraint-based).
+    # With no existence constraints, mandatory is False even when every sampled node has the property.
     result = execute_and_fetch_all(
         cursor,
         "CALL schema.node_type_properties({sample: 2}) "
@@ -757,8 +758,8 @@ def test_node_type_properties_config_sample():
     )
     assert len(result) == 2
     mandatory = {list(r)[2]: list(r)[4] for r in result}
-    assert mandatory["name"] is True
-    assert mandatory["owner"] is True
+    assert mandatory["name"] is False
+    assert mandatory["owner"] is False
 
 
 def test_node_type_properties_config_include_and_exclude_labels():
@@ -779,7 +780,7 @@ def test_node_type_properties_config_include_and_exclude_labels():
         "RETURN nodeType, nodeLabels, propertyName, propertyTypes, mandatory ORDER BY propertyName;",
     )
     assert len(result) == 1
-    assert list(result[0]) == [":`Dog`", ["Dog"], "name", ["String"], True]
+    assert list(result[0]) == [":`Dog`", ["Dog"], "name", ["String"], False]
 
 
 def test_node_type_properties_config_empty_map():
@@ -796,7 +797,7 @@ def test_node_type_properties_config_empty_map():
         "RETURN nodeType, nodeLabels, propertyName, propertyTypes, mandatory;",
     )
     assert len(result) == 1
-    assert list(result[0]) == [":`Dog`", ["Dog"], "name", ["String"], True]
+    assert list(result[0]) == [":`Dog`", ["Dog"], "name", ["String"], False]
 
 
 def test_node_type_properties_config_include_rels():
@@ -816,7 +817,7 @@ def test_node_type_properties_config_include_rels():
         "RETURN nodeType, nodeLabels, propertyName, propertyTypes, mandatory ORDER BY nodeLabels[0], propertyName;",
     )
     assert len(result) == 1
-    assert list(result[0]) == [":`Dog`", ["Dog"], "name", ["String"], True]
+    assert list(result[0]) == [":`Dog`", ["Dog"], "name", ["String"], False]
 
 
 def test_node_type_properties_config_exclude_rels():
@@ -837,8 +838,8 @@ def test_node_type_properties_config_exclude_rels():
     )
     # Dog and Activity nodes remain (Activity has no outgoing HATES)
     assert len(result) == 2
-    assert list(result[0]) == [":`Activity`", ["Activity"], "name", ["String"], True]
-    assert list(result[1]) == [":`Dog`", ["Dog"], "name", ["String"], True]
+    assert list(result[0]) == [":`Activity`", ["Activity"], "name", ["String"], False]
+    assert list(result[1]) == [":`Dog`", ["Dog"], "name", ["String"], False]
 
 
 def test_node_type_properties_config_include_and_exclude_rels():
@@ -860,7 +861,7 @@ def test_node_type_properties_config_include_and_exclude_rels():
     )
     # Only Rex (Dog) has LOVES without HATES
     assert len(result) == 1
-    assert list(result[0]) == [":`Dog`", ["Dog"], "name", ["String"], True]
+    assert list(result[0]) == [":`Dog`", ["Dog"], "name", ["String"], False]
 
 
 def test_rel_type_properties_config_include_rels():
@@ -879,7 +880,7 @@ def test_rel_type_properties_config_include_rels():
         "RETURN relType, propertyName, propertyTypes, mandatory;",
     )
     assert len(result) == 1
-    assert list(result[0]) == [":`LOVES`", "duration", ["Int"], True]
+    assert list(result[0]) == [":`LOVES`", "duration", ["Int"], False]
 
 
 def test_rel_type_properties_config_exclude_rels():
@@ -898,7 +899,7 @@ def test_rel_type_properties_config_exclude_rels():
         "RETURN relType, propertyName, propertyTypes, mandatory;",
     )
     assert len(result) == 1
-    assert list(result[0]) == [":`LOVES`", "duration", ["Int"], True]
+    assert list(result[0]) == [":`LOVES`", "duration", ["Int"], False]
 
 
 def test_rel_type_properties_config_include_labels():
@@ -918,7 +919,7 @@ def test_rel_type_properties_config_include_labels():
         "RETURN relType, propertyName, propertyTypes, mandatory;",
     )
     assert len(result) == 1
-    assert list(result[0]) == [":`LOVES`", "duration", ["Int"], True]
+    assert list(result[0]) == [":`LOVES`", "duration", ["Int"], False]
 
 
 def test_rel_type_properties_config_exclude_labels():
@@ -938,7 +939,7 @@ def test_rel_type_properties_config_exclude_labels():
         "RETURN relType, propertyName, propertyTypes, mandatory;",
     )
     assert len(result) == 1
-    assert list(result[0]) == [":`LOVES`", "duration", ["Int"], True]
+    assert list(result[0]) == [":`LOVES`", "duration", ["Int"], False]
 
 
 def test_rel_type_properties_config_empty_map():
@@ -954,7 +955,7 @@ def test_rel_type_properties_config_empty_map():
         "RETURN relType, propertyName, propertyTypes, mandatory;",
     )
     assert len(result) == 1
-    assert list(result[0]) == [":`LOVES`", "duration", ["Int"], True]
+    assert list(result[0]) == [":`LOVES`", "duration", ["Int"], False]
 
 
 def test_rel_type_properties_config_include_and_exclude_rels():
@@ -988,7 +989,7 @@ def test_node_type_properties_apoc_meta_mapping():
         "RETURN nodeType, nodeLabels, propertyName, propertyTypes, mandatory;",
     )
     assert len(result) == 1
-    assert list(result[0]) == [":`Dog`", ["Dog"], "name", ["String"], True]
+    assert list(result[0]) == [":`Dog`", ["Dog"], "name", ["String"], False]
 
 
 def test_node_type_properties_db_schema_mapping():
@@ -1001,7 +1002,7 @@ def test_node_type_properties_db_schema_mapping():
         "RETURN nodeType, nodeLabels, propertyName, propertyTypes, mandatory;",
     )
     assert len(result) == 1
-    assert list(result[0]) == [":`Dog`", ["Dog"], "name", ["String"], True]
+    assert list(result[0]) == [":`Dog`", ["Dog"], "name", ["String"], False]
 
 
 def test_rel_type_properties_apoc_meta_mapping():
@@ -1017,7 +1018,7 @@ def test_rel_type_properties_apoc_meta_mapping():
         "RETURN relType, propertyName, propertyTypes, mandatory;",
     )
     assert len(result) == 1
-    assert list(result[0]) == [":`LOVES`", "duration", ["Int"], True]
+    assert list(result[0]) == [":`LOVES`", "duration", ["Int"], False]
 
 
 def test_rel_type_properties_db_schema_mapping():
@@ -1033,7 +1034,7 @@ def test_rel_type_properties_db_schema_mapping():
         "RETURN relType, propertyName, propertyTypes, mandatory;",
     )
     assert len(result) == 1
-    assert list(result[0]) == [":`LOVES`", "duration", ["Int"], True]
+    assert list(result[0]) == [":`LOVES`", "duration", ["Int"], False]
 
 
 def test_node_type_properties_observations_counts():
@@ -1054,7 +1055,7 @@ def test_node_type_properties_observations_counts():
         "ORDER BY propertyName;",
     )
     counts = {list(r)[1]: (list(r)[2], list(r)[3], list(r)[4]) for r in result}
-    assert counts["name"] == (True, 3, 3)
+    assert counts["name"] == (False, 3, 3)
     assert counts["owner"] == (False, 1, 3)
 
 
@@ -1077,8 +1078,8 @@ def test_rel_type_properties_source_and_target_labels():
         "ORDER BY sourceNodeLabels[0];",
     )
     assert len(result) == 2
-    assert list(result[0]) == [":`LOVES`", ["Cat"], ["Activity"], "duration", ["Int"], True, 1, 1]
-    assert list(result[1]) == [":`LOVES`", ["Dog"], ["Activity"], "duration", ["Int"], True, 1, 1]
+    assert list(result[0]) == [":`LOVES`", ["Cat"], ["Activity"], "duration", ["Int"], False, 1, 1]
+    assert list(result[1]) == [":`LOVES`", ["Dog"], ["Activity"], "duration", ["Int"], False, 1, 1]
 
 
 def test_rel_type_properties_partitions_by_endpoint_labels():
@@ -1103,7 +1104,7 @@ def test_rel_type_properties_partitions_by_endpoint_labels():
     # Dog -> Activity: 2 rels, duration property only on 1 -> not mandatory
     # Cat -> Place: 1 rel with weather -> mandatory
     rows = {(list(r)[1][0], list(r)[2][0], list(r)[3]): (list(r)[4], list(r)[5], list(r)[6]) for r in result}
-    assert rows[("Cat", "Place", "weather")] == (True, 1, 1)
+    assert rows[("Cat", "Place", "weather")] == (False, 1, 1)
     assert rows[("Dog", "Activity", "duration")] == (False, 1, 2)
 
 
@@ -1155,6 +1156,89 @@ def test_node_type_properties_empty_properties_row():
     )
     assert len(result) == 1
     assert list(result[0]) == [":`Empty`", "", 0, 3]
+
+
+def test_node_type_properties_list_is_opaque():
+    # Lists are reported as List[Any] regardless of element type. The Simba BI connector
+    # maps any list to VARCHAR (no array SQL type), so element-type detection adds no value.
+    cursor = connect().cursor()
+    execute_and_fetch_all(cursor, "CREATE (:Item {strs: ['a', 'b'], mixed: [1, 'a', true]})")
+    result = execute_and_fetch_all(
+        cursor,
+        "CALL schema.node_type_properties() YIELD propertyName, propertyTypes "
+        "RETURN propertyName, propertyTypes ORDER BY propertyName;",
+    )
+    rows = {list(r)[0]: list(r)[1] for r in result}
+    assert rows["strs"] == ["List[Any]"]
+    assert rows["mixed"] == ["List[Any]"]
+
+
+def test_mandatory_true_when_existence_constraint_present():
+    cursor = connect().cursor()
+    execute_and_fetch_all(cursor, "CREATE CONSTRAINT ON (n:Person) ASSERT EXISTS (n.name);")
+    execute_and_fetch_all(cursor, "CREATE (:Person {name: 'Alice'})")
+    try:
+        result = execute_and_fetch_all(
+            cursor,
+            "CALL schema.node_type_properties() YIELD propertyName, mandatory RETURN propertyName, mandatory;",
+        )
+        rows = {list(r)[0]: list(r)[1] for r in result}
+        assert rows["name"] is True
+    finally:
+        execute_and_fetch_all(cursor, "DROP CONSTRAINT ON (n:Person) ASSERT EXISTS (n.name);")
+
+
+def test_mandatory_false_when_no_constraint_even_if_always_present():
+    cursor = connect().cursor()
+    execute_and_fetch_all(cursor, "CREATE (:Person {name: 'Alice'}) CREATE (:Person {name: 'Bob'})")
+    result = execute_and_fetch_all(
+        cursor,
+        "CALL schema.node_type_properties() YIELD propertyName, mandatory RETURN propertyName, mandatory;",
+    )
+    rows = {list(r)[0]: list(r)[1] for r in result}
+    assert rows["name"] is False
+
+
+def test_mandatory_constraint_label_specific_on_multi_label_node():
+    cursor = connect().cursor()
+    execute_and_fetch_all(cursor, "CREATE CONSTRAINT ON (n:Person) ASSERT EXISTS (n.name);")
+    execute_and_fetch_all(cursor, "CREATE (:Person:Employee {name: 'Alice'})")
+    try:
+        result = execute_and_fetch_all(
+            cursor,
+            "CALL schema.node_type_properties() YIELD propertyName, mandatory RETURN propertyName, mandatory;",
+        )
+        rows = {list(r)[0]: list(r)[1] for r in result}
+        assert rows["name"] is True
+    finally:
+        execute_and_fetch_all(cursor, "DROP CONSTRAINT ON (n:Person) ASSERT EXISTS (n.name);")
+
+
+def test_mandatory_constraint_unrelated_label_not_picked_up():
+    cursor = connect().cursor()
+    execute_and_fetch_all(cursor, "CREATE CONSTRAINT ON (n:Person) ASSERT EXISTS (n.email);")
+    execute_and_fetch_all(cursor, "CREATE (:Company {email: 'info@x.com'})")
+    try:
+        result = execute_and_fetch_all(
+            cursor,
+            "CALL schema.node_type_properties() YIELD nodeLabels, propertyName, mandatory "
+            "RETURN nodeLabels, propertyName, mandatory;",
+        )
+        rows = {tuple(list(r)[0]) + (list(r)[1],): list(r)[2] for r in result}
+        assert rows[("Company", "email")] is False
+    finally:
+        execute_and_fetch_all(cursor, "DROP CONSTRAINT ON (n:Person) ASSERT EXISTS (n.email);")
+
+
+def test_rel_mandatory_always_false():
+    cursor = connect().cursor()
+    execute_and_fetch_all(cursor, "CREATE (:A)-[:R {p: 1}]->(:B)")
+    result = execute_and_fetch_all(
+        cursor,
+        "CALL schema.rel_type_properties() YIELD propertyName, mandatory RETURN propertyName, mandatory;",
+    )
+    rows = {list(r)[0]: list(r)[1] for r in result}
+    assert rows["p"] is False
 
 
 if __name__ == "__main__":

--- a/tests/e2e/query_modules/schema_test.py
+++ b/tests/e2e/query_modules/schema_test.py
@@ -684,6 +684,38 @@ def test_node_type_properties_enum():
     assert list(result[1]) == [":`Item`", ["Item"], "status", ["Enum"], False]
 
 
+def test_node_type_properties_boolean():
+    cursor = connect().cursor()
+    execute_and_fetch_all(
+        cursor,
+        "CREATE (n:Flag {name: 'feature', enabled: true})",
+    )
+    result = execute_and_fetch_all(
+        cursor,
+        "CALL schema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes, mandatory "
+        "RETURN nodeType, nodeLabels, propertyName, propertyTypes, mandatory ORDER BY propertyName;",
+    )
+    assert len(result) == 2
+    assert list(result[0]) == [":`Flag`", ["Flag"], "enabled", ["Boolean"], False]
+    assert list(result[1]) == [":`Flag`", ["Flag"], "name", ["String"], False]
+
+
+def test_node_type_properties_float():
+    cursor = connect().cursor()
+    execute_and_fetch_all(
+        cursor,
+        "CREATE (n:Measurement {name: 'temperature', value: 21.5})",
+    )
+    result = execute_and_fetch_all(
+        cursor,
+        "CALL schema.node_type_properties() YIELD nodeType, nodeLabels, propertyName, propertyTypes, mandatory "
+        "RETURN nodeType, nodeLabels, propertyName, propertyTypes, mandatory ORDER BY propertyName;",
+    )
+    assert len(result) == 2
+    assert list(result[0]) == [":`Measurement`", ["Measurement"], "name", ["String"], False]
+    assert list(result[1]) == [":`Measurement`", ["Measurement"], "value", ["Float"], False]
+
+
 def test_rel_type_properties_point2d():
     cursor = connect().cursor()
     execute_and_fetch_all(

--- a/tests/e2e/query_modules/schema_test.py
+++ b/tests/e2e/query_modules/schema_test.py
@@ -737,7 +737,7 @@ def test_node_type_properties_config_exclude_labels():
     assert list(result[0]) == [":`Cat`", ["Cat"], "name", ["String"], False]
 
 
-def test_node_type_properties_config_sample():
+def test_node_type_properties_sample_does_not_drive_mandatory():
     cursor = connect().cursor()
     # Create 3 Dog nodes, 2 with owner property, 1 without
     execute_and_fetch_all(
@@ -748,8 +748,7 @@ def test_node_type_properties_config_sample():
         CREATE (:Dog {name: 'Buddy'})
         """,
     )
-    # Sampling controls scan size but does not drive mandatory (which is constraint-based).
-    # With no existence constraints, mandatory is False even when every sampled node has the property.
+    # Sampling caps the scan; mandatory comes from existence constraints, not sample coverage.
     result = execute_and_fetch_all(
         cursor,
         "CALL schema.node_type_properties({sample: 2}) "
@@ -1101,8 +1100,6 @@ def test_rel_type_properties_partitions_by_endpoint_labels():
         "propertyObservations, totalObservations "
         "ORDER BY sourceNodeLabels[0], propertyName;",
     )
-    # Dog -> Activity: 2 rels, duration property only on 1 -> not mandatory
-    # Cat -> Place: 1 rel with weather -> mandatory
     rows = {(list(r)[1][0], list(r)[2][0], list(r)[3]): (list(r)[4], list(r)[5], list(r)[6]) for r in result}
     assert rows[("Cat", "Place", "weather")] == (False, 1, 1)
     assert rows[("Dog", "Activity", "duration")] == (False, 1, 2)
@@ -1177,15 +1174,13 @@ def test_mandatory_true_when_existence_constraint_present():
     cursor = connect().cursor()
     execute_and_fetch_all(cursor, "CREATE CONSTRAINT ON (n:Person) ASSERT EXISTS (n.name);")
     execute_and_fetch_all(cursor, "CREATE (:Person {name: 'Alice'})")
-    try:
-        result = execute_and_fetch_all(
-            cursor,
-            "CALL schema.node_type_properties() YIELD propertyName, mandatory RETURN propertyName, mandatory;",
-        )
-        rows = {list(r)[0]: list(r)[1] for r in result}
-        assert rows["name"] is True
-    finally:
-        execute_and_fetch_all(cursor, "DROP CONSTRAINT ON (n:Person) ASSERT EXISTS (n.name);")
+    result = execute_and_fetch_all(
+        cursor,
+        "CALL schema.node_type_properties() YIELD propertyName, mandatory RETURN propertyName, mandatory;",
+    )
+    rows = {list(r)[0]: list(r)[1] for r in result}
+    assert rows["name"] is True
+    execute_and_fetch_all(cursor, "DROP CONSTRAINT ON (n:Person) ASSERT EXISTS (n.name);")
 
 
 def test_mandatory_false_when_no_constraint_even_if_always_present():
@@ -1203,31 +1198,27 @@ def test_mandatory_constraint_label_specific_on_multi_label_node():
     cursor = connect().cursor()
     execute_and_fetch_all(cursor, "CREATE CONSTRAINT ON (n:Person) ASSERT EXISTS (n.name);")
     execute_and_fetch_all(cursor, "CREATE (:Person:Employee {name: 'Alice'})")
-    try:
-        result = execute_and_fetch_all(
-            cursor,
-            "CALL schema.node_type_properties() YIELD propertyName, mandatory RETURN propertyName, mandatory;",
-        )
-        rows = {list(r)[0]: list(r)[1] for r in result}
-        assert rows["name"] is True
-    finally:
-        execute_and_fetch_all(cursor, "DROP CONSTRAINT ON (n:Person) ASSERT EXISTS (n.name);")
+    result = execute_and_fetch_all(
+        cursor,
+        "CALL schema.node_type_properties() YIELD propertyName, mandatory RETURN propertyName, mandatory;",
+    )
+    rows = {list(r)[0]: list(r)[1] for r in result}
+    assert rows["name"] is True
+    execute_and_fetch_all(cursor, "DROP CONSTRAINT ON (n:Person) ASSERT EXISTS (n.name);")
 
 
 def test_mandatory_constraint_unrelated_label_not_picked_up():
     cursor = connect().cursor()
     execute_and_fetch_all(cursor, "CREATE CONSTRAINT ON (n:Person) ASSERT EXISTS (n.email);")
     execute_and_fetch_all(cursor, "CREATE (:Company {email: 'info@x.com'})")
-    try:
-        result = execute_and_fetch_all(
-            cursor,
-            "CALL schema.node_type_properties() YIELD nodeLabels, propertyName, mandatory "
-            "RETURN nodeLabels, propertyName, mandatory;",
-        )
-        rows = {tuple(list(r)[0]) + (list(r)[1],): list(r)[2] for r in result}
-        assert rows[("Company", "email")] is False
-    finally:
-        execute_and_fetch_all(cursor, "DROP CONSTRAINT ON (n:Person) ASSERT EXISTS (n.email);")
+    result = execute_and_fetch_all(
+        cursor,
+        "CALL schema.node_type_properties() YIELD nodeLabels, propertyName, mandatory "
+        "RETURN nodeLabels, propertyName, mandatory;",
+    )
+    rows = {tuple(list(r)[0]) + (list(r)[1],): list(r)[2] for r in result}
+    assert rows[("Company", "email")] is False
+    execute_and_fetch_all(cursor, "DROP CONSTRAINT ON (n:Person) ASSERT EXISTS (n.email);")
 
 
 def test_rel_mandatory_always_false():
@@ -1239,6 +1230,79 @@ def test_rel_mandatory_always_false():
     )
     rows = {list(r)[0]: list(r)[1] for r in result}
     assert rows["p"] is False
+
+
+def test_node_type_properties_on_virtual_graph_does_not_crash():
+    # ListAllExistenceConstraints throws on derive() graphs; the procedure must swallow it.
+    cursor = connect().cursor()
+    execute_and_fetch_all(cursor, "CREATE CONSTRAINT ON (n:Person) ASSERT EXISTS (n.name);")
+    execute_and_fetch_all(cursor, "CREATE (:Person {name: 'Alice'})-[:KNOWS]->(:Person {name: 'Bob'})")
+    execute_and_fetch_all(
+        cursor,
+        "MATCH p=(:Person)-[:KNOWS]->(:Person) "
+        "WITH derive(p, {virtualEdgeType: 'KNOWS'}) AS g "
+        "CALL schema.node_type_properties(g) YIELD propertyName, mandatory "
+        "RETURN propertyName, mandatory;",
+    )
+    execute_and_fetch_all(cursor, "DROP CONSTRAINT ON (n:Person) ASSERT EXISTS (n.name);")
+
+
+def test_mandatory_constraint_only_other_label_present():
+    # Sibling of test_mandatory_constraint_label_specific_on_multi_label_node:
+    # constraint on Person.name, node has only :Employee → not mandatory for the Employee-only row.
+    cursor = connect().cursor()
+    execute_and_fetch_all(cursor, "CREATE CONSTRAINT ON (n:Person) ASSERT EXISTS (n.name);")
+    execute_and_fetch_all(cursor, "CREATE (:Employee {name: 'Bob'})")
+    result = execute_and_fetch_all(
+        cursor,
+        "CALL schema.node_type_properties() YIELD nodeLabels, propertyName, mandatory "
+        "RETURN nodeLabels, propertyName, mandatory;",
+    )
+    rows = {tuple(list(r)[0]) + (list(r)[1],): list(r)[2] for r in result}
+    assert rows[("Employee", "name")] is False
+    execute_and_fetch_all(cursor, "DROP CONSTRAINT ON (n:Person) ASSERT EXISTS (n.name);")
+
+
+def test_mandatory_constraint_with_no_matching_nodes():
+    cursor = connect().cursor()
+    execute_and_fetch_all(cursor, "CREATE CONSTRAINT ON (n:Ghost) ASSERT EXISTS (n.id);")
+    execute_and_fetch_all(cursor, "CREATE (:Person {name: 'Alice'})")
+    result = execute_and_fetch_all(
+        cursor,
+        "CALL schema.node_type_properties() YIELD nodeLabels RETURN nodeLabels;",
+    )
+    labels = {tuple(list(r)[0]) for r in result}
+    assert ("Ghost",) not in labels
+    execute_and_fetch_all(cursor, "DROP CONSTRAINT ON (n:Ghost) ASSERT EXISTS (n.id);")
+
+
+def test_mandatory_true_with_sample_smaller_than_population():
+    cursor = connect().cursor()
+    execute_and_fetch_all(cursor, "CREATE CONSTRAINT ON (n:Person) ASSERT EXISTS (n.name);")
+    execute_and_fetch_all(
+        cursor,
+        "UNWIND range(1, 10) AS i CREATE (:Person {name: toString(i)})",
+    )
+    result = execute_and_fetch_all(
+        cursor,
+        "CALL schema.node_type_properties({sample: 3}) "
+        "YIELD propertyName, mandatory, totalObservations "
+        "RETURN propertyName, mandatory, totalObservations;",
+    )
+    rows = {list(r)[0]: (list(r)[1], list(r)[2]) for r in result}
+    assert rows["name"] == (True, 3)
+    execute_and_fetch_all(cursor, "DROP CONSTRAINT ON (n:Person) ASSERT EXISTS (n.name);")
+
+
+def test_rel_type_existence_constraints_are_rejected():
+    # Drift sentinel for schema.cpp:RelTypeProperties — if Memgraph ever accepts rel-type
+    # existence constraints, the hardcoded `mandatory=false` for relationships becomes wrong.
+    cursor = connect().cursor()
+    with pytest.raises(Exception):
+        execute_and_fetch_all(
+            cursor,
+            "CREATE CONSTRAINT FOR ()-[r:R]->() REQUIRE r.x IS NOT NULL;",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/e2e/query_modules/schema_test.py
+++ b/tests/e2e/query_modules/schema_test.py
@@ -1294,16 +1294,5 @@ def test_mandatory_true_with_sample_smaller_than_population():
     execute_and_fetch_all(cursor, "DROP CONSTRAINT ON (n:Person) ASSERT EXISTS (n.name);")
 
 
-def test_rel_type_existence_constraints_are_rejected():
-    # Drift sentinel for schema.cpp:RelTypeProperties — if Memgraph ever accepts rel-type
-    # existence constraints, the hardcoded `mandatory=false` for relationships becomes wrong.
-    cursor = connect().cursor()
-    with pytest.raises(Exception):
-        execute_and_fetch_all(
-            cursor,
-            "CREATE CONSTRAINT FOR ()-[r:R]->() REQUIRE r.x IS NOT NULL;",
-        )
-
-
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-rA"]))


### PR DESCRIPTION
Make schema.node_type_properties / rel_type_properties emit type strings the Simba BI connector (PowerBI/Tableau) recognises, so properties map to proper SQL types instead of degrading to VARCHAR:
- Bool -> Boolean, Double -> Float, ZonedDateTime -> DateTime, Point2d/3d -> Point
- Int kept (the connector maps "Integer" to VARCHAR despite its docs claiming BIGINT)

Fix mandatory semantics: now driven by existence constraints (label-aware) instead of the sampling-ratio heuristic. Relationships always report mandatory=false (no rel-type existence constraints in Memgraph).

### Breaking

- `propertyTypes` strings rename: `Bool`→`Boolean`, `Double`→`Float`, `ZonedDateTime`→`DateTime`, `Point2d`/`Point3d`→`Point`. Consumers that pattern-matched the old strings must update.
- `mandatory` semantics change without a column rename: same field, new meaning. Code that relied on sample-coverage `mandatory` (e.g. `true` whenever every sampled node carried the property) will now see `false` unless an existence constraint is declared. Relationships always report `false`.