### PR TITLE
fix: UAF on Database drop

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -65,15 +65,15 @@ class Memgraph(ConanFile):
         "jemalloc/*:enable_fill": False,
         "jemalloc/*:lg_page": "12",
         "jemalloc/*:lg_hugepage": "21",
-        # NOTE: percpu_arena is intentionally DISABLED (not :percpu). With percpu_arena,
-        # jemalloc picks a thread's arena from sched_getcpu() with no clamp
-        # (percpu_arena_choose, jemalloc_internal_inlines_a.h); on hosts where a CPU id
-        # can exceed jemalloc's ncpus (offline/sparse online CPU sets, cgroups, NUMA -- see
-        # jemalloc#2054), a thread binds its tcache to a per-DB arena created via
-        # arenas.create, causing a shutdown use-after-free (tantivy worker threads vs the
-        # per-DB MemoryTracker). With percpu disabled, arena_choose() ranges only over the
-        # auto arenas and never selects a created arena. See tantivy_arena_uaf_*.md.
-        "jemalloc/*:malloc_conf": "retain:false,percpu_arena:disabled,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000",
+        # NOTE: with percpu_arena, jemalloc picks a thread's arena from sched_getcpu()
+        # with no clamp (percpu_arena_choose, jemalloc_internal_inlines_a.h); on hosts
+        # where a CPU id can exceed jemalloc's ncpus (offline/sparse online CPU sets,
+        # cgroups, NUMA -- see jemalloc#2054) a thread would bind its tcache to a per-DB
+        # arena created via arenas.create, causing a shutdown use-after-free. Memgraph
+        # guards this at runtime: EnsureCpuArenaCoverage() (src/memory/db_arena.cpp)
+        # creates sacrificial arenas so every possible CPU id resolves below the first
+        # per-DB arena index. See tantivy_arena_uaf_*.md.
+        "jemalloc/*:malloc_conf": "retain:false,percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000",
         "rapidcheck/*:enable_gtest": True,
         "rapidcheck/*:enable_gmock": True,
         "gflags/*:nothreads": False,

--- a/conanfile.py
+++ b/conanfile.py
@@ -65,14 +65,8 @@ class Memgraph(ConanFile):
         "jemalloc/*:enable_fill": False,
         "jemalloc/*:lg_page": "12",
         "jemalloc/*:lg_hugepage": "21",
-        # NOTE: with percpu_arena, jemalloc picks a thread's arena from sched_getcpu()
-        # with no clamp (percpu_arena_choose, jemalloc_internal_inlines_a.h); on hosts
-        # where a CPU id can exceed jemalloc's ncpus (offline/sparse online CPU sets,
-        # cgroups, NUMA -- see jemalloc#2054) a thread would bind its tcache to a per-DB
-        # arena created via arenas.create, causing a shutdown use-after-free. Memgraph
-        # guards this at runtime: EnsureCpuArenaCoverage() (src/memory/db_arena.cpp)
-        # creates sacrificial arenas so every possible CPU id resolves below the first
-        # per-DB arena index. See tantivy_arena_uaf_*.md.
+        # NOTE: percpu_arena can bind threads to per-DB arenas on hosts with sparse CPU
+        # sets (jemalloc#2054); guarded at runtime by EnsureCpuArenaCoverage() (db_arena.hpp).
         "jemalloc/*:malloc_conf": "retain:false,percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000",
         "rapidcheck/*:enable_gtest": True,
         "rapidcheck/*:enable_gmock": True,

--- a/conanfile.py
+++ b/conanfile.py
@@ -65,7 +65,15 @@ class Memgraph(ConanFile):
         "jemalloc/*:enable_fill": False,
         "jemalloc/*:lg_page": "12",
         "jemalloc/*:lg_hugepage": "21",
-        "jemalloc/*:malloc_conf": "retain:false,percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000",
+        # NOTE: percpu_arena is intentionally DISABLED (not :percpu). With percpu_arena,
+        # jemalloc picks a thread's arena from sched_getcpu() with no clamp
+        # (percpu_arena_choose, jemalloc_internal_inlines_a.h); on hosts where a CPU id
+        # can exceed jemalloc's ncpus (offline/sparse online CPU sets, cgroups, NUMA -- see
+        # jemalloc#2054), a thread binds its tcache to a per-DB arena created via
+        # arenas.create, causing a shutdown use-after-free (tantivy worker threads vs the
+        # per-DB MemoryTracker). With percpu disabled, arena_choose() ranges only over the
+        # auto arenas and never selects a created arena. See tantivy_arena_uaf_*.md.
+        "jemalloc/*:malloc_conf": "retain:false,percpu_arena:disabled,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000",
         "rapidcheck/*:enable_gtest": True,
         "rapidcheck/*:enable_gmock": True,
         "gflags/*:nothreads": False,

--- a/mgcxx/text_search/src/lib.rs
+++ b/mgcxx/text_search/src/lib.rs
@@ -215,8 +215,18 @@ pub struct TantivyContext {
     pub index_path: std::path::PathBuf,
     pub schema: Schema,
     pub index: Index,
-    pub index_writer: IndexWriter,
+    pub index_writer: Option<IndexWriter>,
     pub index_reader: IndexReader,
+}
+
+impl Drop for TantivyContext {
+    fn drop(&mut self) {
+        if let Some(writer) = self.index_writer.take() {
+            if let Err(e) = writer.wait_merging_threads() {
+                log::warn!("wait_merging_threads failed during TantivyContext drop: {:?}", e);
+            }
+        }
+    }
 }
 
 fn init(_log_level: &String) -> Result<(), std::io::Error> {
@@ -467,7 +477,7 @@ fn create_index(path: &String, config: &ffi::IndexConfig) -> Result<ffi::Context
             index_path: path,
             schema,
             index,
-            index_writer,
+            index_writer: Some(index_writer),
             index_reader,
         }),
     })
@@ -492,7 +502,7 @@ fn add_document(
             ));
         }
     };
-    let index_writer = &mut context.tantivyContext.index_writer;
+    let index_writer = context.tantivyContext.index_writer.as_mut().expect("index_writer present");
     match index_writer.add_document(document) {
         Ok(_) => {
             if skip_commit {
@@ -532,7 +542,7 @@ fn delete_document(
             ));
         }
     };
-    let index_writer = &mut context.tantivyContext.index_writer;
+    let index_writer = context.tantivyContext.index_writer.as_mut().expect("index_writer present");
     match index_writer.delete_query(query) {
         Ok(_) => {
             if skip_commit {
@@ -555,7 +565,7 @@ fn delete_document(
 
 fn commit(context: &mut ffi::Context) -> Result<(), std::io::Error> {
     let index_path = &context.tantivyContext.index_path;
-    match context.tantivyContext.index_writer.commit() {
+    match context.tantivyContext.index_writer.as_mut().expect("index_writer present").commit() {
         Ok(_) => {
             // Explicitly reload the index reader to see the new changes
             if let Err(e) = context.tantivyContext.index_reader.reload() {
@@ -583,7 +593,7 @@ fn commit(context: &mut ffi::Context) -> Result<(), std::io::Error> {
 
 fn rollback(context: &mut ffi::Context) -> Result<(), std::io::Error> {
     let index_path = &context.tantivyContext.index_path;
-    match context.tantivyContext.index_writer.rollback() {
+    match context.tantivyContext.index_writer.as_mut().expect("index_writer present").rollback() {
         Ok(_) => {
             return Ok(());
         }
@@ -1073,18 +1083,11 @@ fn get_num_docs(context: &mut ffi::Context) -> Result<u64, std::io::Error> {
 /// This will remove the entire directory and all its contents.
 /// NOTE: This function takes ownership of the context.
 fn drop_index(context: ffi::Context) -> Result<(), std::io::Error> {
-    let TantivyContext {
-        index_path,
-        schema: _,
-        index,
-        index_writer,
-        index_reader,
-    } = *context.tantivyContext;
+    let index_path = context.tantivyContext.index_path.clone();
 
-    // Drop Tantivy resources to release file handles
-    drop(index_reader);
-    drop(index_writer);
-    drop(index);
+    // Dropping context triggers TantivyContext::drop, which calls wait_merging_threads
+    // before releasing the writer, then drops index_reader and index via field drop.
+    drop(context);
 
     // Now safe to remove the directory
     if index_path.exists() {

--- a/mgcxx/text_search/src/lib.rs
+++ b/mgcxx/text_search/src/lib.rs
@@ -211,12 +211,14 @@ mod tests {
     }
 }
 
+// Field order is load-bearing: Rust drops fields in declaration order;
+// index_reader must drop before index.
 pub struct TantivyContext {
     pub index_path: std::path::PathBuf,
     pub schema: Schema,
-    pub index: Index,
     pub index_writer: Option<IndexWriter>,
     pub index_reader: IndexReader,
+    pub index: Index,
 }
 
 impl Drop for TantivyContext {

--- a/mgcxx/text_search/src/lib.rs
+++ b/mgcxx/text_search/src/lib.rs
@@ -221,11 +221,21 @@ pub struct TantivyContext {
     pub index: Index,
 }
 
+impl TantivyContext {
+    fn writer_mut(&mut self) -> &mut IndexWriter {
+        self.index_writer.as_mut().expect("BUG: index_writer consumed before Drop")
+    }
+}
+
 impl Drop for TantivyContext {
     fn drop(&mut self) {
         if let Some(writer) = self.index_writer.take() {
             if let Err(e) = writer.wait_merging_threads() {
-                log::warn!("wait_merging_threads failed during TantivyContext drop: {:?}", e);
+                log::warn!(
+                    "wait_merging_threads failed during TantivyContext drop for {:?}: {:?}",
+                    self.index_path,
+                    e
+                );
             }
         }
     }
@@ -504,8 +514,7 @@ fn add_document(
             ));
         }
     };
-    let index_writer = context.tantivyContext.index_writer.as_mut().expect("index_writer present");
-    match index_writer.add_document(document) {
+    match context.tantivyContext.writer_mut().add_document(document) {
         Ok(_) => {
             if skip_commit {
                 return Ok(());
@@ -527,25 +536,26 @@ fn delete_document(
     input: &ffi::SearchInput,
     skip_commit: bool,
 ) -> Result<(), std::io::Error> {
-    let index_path = &context.tantivyContext.index_path;
-    let index = &context.tantivyContext.index;
-    let schema = &context.tantivyContext.schema;
-    let search_fields = search_get_fields(&input.search_fields, schema, index_path)?;
-    let query_parser = QueryParser::for_index(index, search_fields);
-    let query = match query_parser.parse_query(&input.search_query) {
-        Ok(q) => q,
-        Err(e) => {
-            return Err(Error::new(
-                ErrorKind::Other,
-                format!(
-                    "Unable to create search query for {:?} text search index -> {}",
-                    index_path, e
-                ),
-            ));
+    let query = {
+        let index_path = &context.tantivyContext.index_path;
+        let index = &context.tantivyContext.index;
+        let schema = &context.tantivyContext.schema;
+        let search_fields = search_get_fields(&input.search_fields, schema, index_path)?;
+        let query_parser = QueryParser::for_index(index, search_fields);
+        match query_parser.parse_query(&input.search_query) {
+            Ok(q) => q,
+            Err(e) => {
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    format!(
+                        "Unable to create search query for {:?} text search index -> {}",
+                        index_path, e
+                    ),
+                ));
+            }
         }
     };
-    let index_writer = context.tantivyContext.index_writer.as_mut().expect("index_writer present");
-    match index_writer.delete_query(query) {
+    match context.tantivyContext.writer_mut().delete_query(query) {
         Ok(_) => {
             if skip_commit {
                 return Ok(());
@@ -554,6 +564,7 @@ fn delete_document(
             }
         }
         Err(e) => {
+            let index_path = &context.tantivyContext.index_path;
             return Err(Error::new(
                 ErrorKind::Other,
                 format!(
@@ -566,10 +577,10 @@ fn delete_document(
 }
 
 fn commit(context: &mut ffi::Context) -> Result<(), std::io::Error> {
-    let index_path = &context.tantivyContext.index_path;
-    match context.tantivyContext.index_writer.as_mut().expect("index_writer present").commit() {
+    match context.tantivyContext.writer_mut().commit() {
         Ok(_) => {
             // Explicitly reload the index reader to see the new changes
+            let index_path = &context.tantivyContext.index_path;
             if let Err(e) = context.tantivyContext.index_reader.reload() {
                 return Err(Error::new(
                     ErrorKind::Other,
@@ -582,6 +593,7 @@ fn commit(context: &mut ffi::Context) -> Result<(), std::io::Error> {
             return Ok(());
         }
         Err(e) => {
+            let index_path = &context.tantivyContext.index_path;
             return Err(Error::new(
                 ErrorKind::Other,
                 format!(
@@ -594,12 +606,12 @@ fn commit(context: &mut ffi::Context) -> Result<(), std::io::Error> {
 }
 
 fn rollback(context: &mut ffi::Context) -> Result<(), std::io::Error> {
-    let index_path = &context.tantivyContext.index_path;
-    match context.tantivyContext.index_writer.as_mut().expect("index_writer present").rollback() {
+    match context.tantivyContext.writer_mut().rollback() {
         Ok(_) => {
             return Ok(());
         }
         Err(e) => {
+            let index_path = &context.tantivyContext.index_path;
             return Err(Error::new(
                 ErrorKind::Other,
                 format!(
@@ -1085,6 +1097,7 @@ fn get_num_docs(context: &mut ffi::Context) -> Result<u64, std::io::Error> {
 /// This will remove the entire directory and all its contents.
 /// NOTE: This function takes ownership of the context.
 fn drop_index(context: ffi::Context) -> Result<(), std::io::Error> {
+    // Clone (not mem::take) so TantivyContext::drop can still log the path on failure.
     let index_path = context.tantivyContext.index_path.clone();
 
     // Dropping context triggers TantivyContext::drop, which calls wait_merging_threads

--- a/mgcxx/text_search/src/lib.rs
+++ b/mgcxx/text_search/src/lib.rs
@@ -478,9 +478,9 @@ fn create_index(path: &String, config: &ffi::IndexConfig) -> Result<ffi::Context
         tantivyContext: Box::new(TantivyContext {
             index_path: path,
             schema,
-            index,
             index_writer: Some(index_writer),
             index_reader,
+            index,
         }),
     })
 }

--- a/src/memory/db_arena.cpp
+++ b/src/memory/db_arena.cpp
@@ -312,7 +312,9 @@ ArenaPool::~ArenaPool() noexcept {
             "ArenaPool {}: failed to restore default hooks (err={}); hooks_ may outlive arena", arena_idx, err);
         spdlog::error("ArenaPool {}: leaking arena from GlobalArenaPool reuse after failed hook restore", arena_idx);
         hooks_->tracker = nullptr;
-        (void)hooks_.release();
+        // Intentional leak: keep hooks alive so the orphaned arena (which we failed to restore to
+        // default hooks) does not call back into freed memory on subsequent allocations.
+        (void)hooks_.release();  // NOLINT(bugprone-unused-return-value)
         continue;
       }
 

--- a/src/memory/db_arena.cpp
+++ b/src/memory/db_arena.cpp
@@ -54,25 +54,27 @@ bool ConsumeFailureInjection(testing::ArenaPoolFailureInjection failure) {
 void *db_arena_alloc(extent_hooks_t *hooks, void *new_addr, size_t size, size_t alignment, bool *zero, bool *commit,
                      unsigned arena_ind) {
   auto *dh = reinterpret_cast<DbArenaHooks *>(hooks);
+  // tracker is null only for a hooks struct leaked on the (unreachable in
+  // practice) hook-restore-failure path; in that case skip tracking but still
+  // proxy to the base jemalloc hooks.
+  auto *tracker = dh->tracker;
   const bool requested_commit = *commit;
-  // tracker may be null on an abandoned arena whose ArenaPool failed to restore default hooks;
-  // in that case we skip tracking but still proxy to the base jemalloc hooks.
   // Pre-track if commit was requested (mandatory — base hook must return committed or fail).
   if (requested_commit) {
-    if (dh->tracker && !dh->tracker->Alloc(static_cast<int64_t>(size))) {
+    if (tracker && !tracker->Alloc(static_cast<int64_t>(size))) {
       return nullptr;
     }
   }
   void *ptr = dh->base_hooks->alloc(dh->base_hooks, new_addr, size, alignment, zero, commit, arena_ind);
   if (ptr == nullptr) {
-    if (requested_commit && dh->tracker) dh->tracker->Free(static_cast<int64_t>(size));
+    if (requested_commit && tracker) tracker->Free(static_cast<int64_t>(size));
     return nullptr;
   }
   // *commit is an out-parameter: the base hook may have committed pages even if we didn't ask.
   if (*commit && !requested_commit) {
-    if (dh->tracker) {
+    if (tracker) {
       const utils::MemoryTracker::OutOfMemoryExceptionBlocker blocker;
-      dh->tracker->Alloc(static_cast<int64_t>(size));
+      tracker->Alloc(static_cast<int64_t>(size));
     }
   }
   return ptr;
@@ -80,32 +82,35 @@ void *db_arena_alloc(extent_hooks_t *hooks, void *new_addr, size_t size, size_t 
 
 bool db_arena_dalloc(extent_hooks_t *hooks, void *addr, size_t size, bool committed, unsigned arena_ind) {
   auto *dh = reinterpret_cast<DbArenaHooks *>(hooks);
+  auto *tracker = dh->tracker;
   const bool err = dh->base_hooks->dalloc(dh->base_hooks, addr, size, committed, arena_ind);
   if (!err && committed) {
-    if (dh->tracker) dh->tracker->Free(static_cast<int64_t>(size));
+    if (tracker) tracker->Free(static_cast<int64_t>(size));
   }
   return err;
 }
 
 void db_arena_destroy(extent_hooks_t *hooks, void *addr, size_t size, bool committed, unsigned arena_ind) {
   auto *dh = reinterpret_cast<DbArenaHooks *>(hooks);
+  auto *tracker = dh->tracker;
   if (committed) {
-    if (dh->tracker) dh->tracker->Free(static_cast<int64_t>(size));
+    if (tracker) tracker->Free(static_cast<int64_t>(size));
   }
   dh->base_hooks->destroy(dh->base_hooks, addr, size, committed, arena_ind);
 }
 
 bool db_arena_commit(extent_hooks_t *hooks, void *addr, size_t size, size_t offset, size_t length, unsigned arena_ind) {
   auto *dh = reinterpret_cast<DbArenaHooks *>(hooks);
+  auto *tracker = dh->tracker;
   const bool err = dh->base_hooks->commit(dh->base_hooks, addr, size, offset, length, arena_ind);
   if (!err) {
-    if (dh->tracker) {
+    if (tracker) {
       // Pages are already committed by the OS — we cannot undo the commit here.
       // OutOfMemoryExceptionBlocker makes MemoryTrackerCanThrow() return false on this thread,
       // which means Alloc() will never enter its rollback path: the fetch_add is permanent and
       // the entire tracker chain returns true unconditionally. Tracking is therefore guaranteed.
       const utils::MemoryTracker::OutOfMemoryExceptionBlocker blocker;
-      dh->tracker->Alloc(static_cast<int64_t>(length));
+      tracker->Alloc(static_cast<int64_t>(length));
     }
   }
   return err;
@@ -114,9 +119,10 @@ bool db_arena_commit(extent_hooks_t *hooks, void *addr, size_t size, size_t offs
 bool db_arena_decommit(extent_hooks_t *hooks, void *addr, size_t size, size_t offset, size_t length,
                        unsigned arena_ind) {
   auto *dh = reinterpret_cast<DbArenaHooks *>(hooks);
+  auto *tracker = dh->tracker;
   const bool err = dh->base_hooks->decommit(dh->base_hooks, addr, size, offset, length, arena_ind);
   if (!err) {
-    if (dh->tracker) dh->tracker->Free(static_cast<int64_t>(length));
+    if (tracker) tracker->Free(static_cast<int64_t>(length));
   }
   return err;
 }
@@ -124,10 +130,11 @@ bool db_arena_decommit(extent_hooks_t *hooks, void *addr, size_t size, size_t of
 bool db_arena_purge_forced(extent_hooks_t *hooks, void *addr, size_t size, size_t offset, size_t length,
                            unsigned arena_ind) {
   auto *dh = reinterpret_cast<DbArenaHooks *>(hooks);
+  auto *tracker = dh->tracker;
   if (dh->base_hooks->purge_forced == nullptr) return true;
   const bool err = dh->base_hooks->purge_forced(dh->base_hooks, addr, size, offset, length, arena_ind);
   if (!err) {
-    if (dh->tracker) dh->tracker->Free(static_cast<int64_t>(length));
+    if (tracker) tracker->Free(static_cast<int64_t>(length));
   }
   return err;
 }
@@ -135,6 +142,8 @@ bool db_arena_purge_forced(extent_hooks_t *hooks, void *addr, size_t size, size_
 }  // namespace
 
 void InitDbArenaHooks(DbArenaHooks &h, utils::MemoryTracker *tracker, extent_hooks_t *base_hooks) {
+  // Runs before the hooks are installed (published) via je_mallctl, whose arena
+  // mutexes order this write before any callback can read it.
   h.tracker = tracker;
   h.base_hooks = base_hooks;
   h.hooks = extent_hooks_t{
@@ -195,31 +204,18 @@ bool InstallDbArenaHooks(unsigned arena_idx, DbArenaHooks &hooks, std::string_vi
   return true;
 }
 
-// RAII helper to ensure arena release and hook restoration on failure.
+// RAII guard: returns the arena index to the GlobalArenaPool unless Commit()ed.
+// Note this guard never needs to restore extent hooks: both call sites are
+// structured so that no statement between a successful hook install and
+// Commit() can throw (vector capacity is reserved up front), and a failed
+// install mallctl never publishes the hooks to jemalloc in the first place.
 class PendingArena {
  public:
   explicit PendingArena(unsigned arena_idx) noexcept : arena_idx_(arena_idx) {}
 
   ~PendingArena() noexcept {
+    if (arena_idx_ == 0) return;
     try {
-      if (arena_idx_ == 0) return;
-
-      if (hooks_installed_ && base_hooks_) {
-        const std::string hooks_key = "arena." + std::to_string(arena_idx_) + ".extent_hooks";
-        const extent_hooks_t *base = base_hooks_;
-        const int err = je_mallctl(hooks_key.c_str(),
-                                   nullptr,
-                                   nullptr,
-                                   static_cast<void *>(const_cast<extent_hooks_t **>(&base)),
-                                   sizeof(extent_hooks_t *));
-        if (err != 0) {
-          LogDestructorCleanupFailure("PendingArena",
-                                      arena_idx_,
-                                      "restore hooks",
-                                      fmt::format("err={} (arena leaked from GlobalArenaPool reuse)", err));
-          return;
-        }
-      }
       GlobalArenaPool::Instance().Release(arena_idx_);
     } catch (const std::exception &e) {
       LogDestructorCleanupFailure("PendingArena", arena_idx_, "release", e.what());
@@ -228,17 +224,10 @@ class PendingArena {
     }
   }
 
-  void MarkHooksInstalled(extent_hooks_t *base) noexcept {
-    hooks_installed_ = true;
-    base_hooks_ = base;
-  }
-
   void Commit() noexcept { arena_idx_ = 0; }
 
  private:
   unsigned arena_idx_{0};
-  extent_hooks_t *base_hooks_{nullptr};
-  bool hooks_installed_{false};
 };
 
 }  // namespace
@@ -248,6 +237,14 @@ ArenaPool::ArenaPool(utils::MemoryTracker *tracker) {
 
   first_arena_idx_ = GlobalArenaPool::Instance().Acquire();
   PendingArena pending(first_arena_idx_);
+
+  // Everything that can throw must happen BEFORE the hook install below, so a
+  // constructor failure never has to un-install hooks (see PendingArena).
+  arenas_.reserve(1);
+
+  if (ConsumeFailureInjection(testing::ArenaPoolFailureInjection::ConstructorPublish)) {
+    throw std::runtime_error("Injected ArenaPool constructor publish failure");
+  }
 
   const std::string arena_key = "arena." + std::to_string(first_arena_idx_);
   const std::string hooks_key = arena_key + ".extent_hooks";
@@ -268,15 +265,12 @@ ArenaPool::ArenaPool(utils::MemoryTracker *tracker) {
                            static_cast<void *>(const_cast<extent_hooks_t **>(&new_hooks)),
                            sizeof(extent_hooks_t *));
       err != 0) {
+    // A failed mallctl write never installs the hooks, so letting hooks_ die
+    // during unwinding is safe — jemalloc holds no reference to it.
     throw std::runtime_error(fmt::format("Failed to install hooks for arena {} (err={})", first_arena_idx_, err));
   }
 
-  pending.MarkHooksInstalled(base_hooks);
-
-  if (ConsumeFailureInjection(testing::ArenaPoolFailureInjection::ConstructorPublish)) {
-    throw std::runtime_error("Injected ArenaPool constructor publish failure");
-  }
-
+  // No-throw from here on (capacity reserved above).
   arenas_.push_back(first_arena_idx_);
   free_count_ = arenas_.size();
   pending.Commit();
@@ -290,6 +284,12 @@ ArenaPool::~ArenaPool() noexcept {
     // First release all the tcached memory back to the arenas, then purge them
     DestroyAllTcaches();
 
+    // All arenas in the pool share the single `hooks_` struct. If restoring the
+    // default hooks fails for ANY arena, that arena keeps these hooks installed,
+    // so the struct must outlive the pool. Defer the leak until AFTER the loop:
+    // releasing `hooks_` mid-loop would null it and crash the next iteration's
+    // `hooks_->base_hooks` read.
+    bool restore_failed = false;
     for (const auto arena_idx : arenas_) {
       const std::string arena_key = "arena." + std::to_string(arena_idx);
 
@@ -309,12 +309,13 @@ ArenaPool::~ArenaPool() noexcept {
                            sizeof(extent_hooks_t *));
       if (err != 0) {
         spdlog::error(
-            "ArenaPool {}: failed to restore default hooks (err={}); hooks_ may outlive arena", arena_idx, err);
-        spdlog::error("ArenaPool {}: leaking arena from GlobalArenaPool reuse after failed hook restore", arena_idx);
-        hooks_->tracker = nullptr;
-        // Intentional leak: keep hooks alive so the orphaned arena (which we failed to restore to
-        // default hooks) does not call back into freed memory on subsequent allocations.
-        (void)hooks_.release();  // NOLINT(bugprone-unused-return-value)
+            "ArenaPool {}: failed to restore default hooks (err={}); leaking hooks_ and the arena to "
+            "avoid a use-after-free on this orphaned arena",
+            arena_idx,
+            err);
+        restore_failed = true;
+        // Do NOT release the arena back to GlobalArenaPool: it still has our hooks
+        // installed, so reusing the index would install a second hooks struct on top.
         continue;
       }
 
@@ -324,6 +325,20 @@ ArenaPool::~ArenaPool() noexcept {
         LogDestructorCleanupFailure("ArenaPool", arena_idx, "release", e.what());
       } catch (...) {
         LogDestructorCleanupFailure("ArenaPool", arena_idx, "release", "unknown exception");
+      }
+    }
+
+    if (restore_failed) {
+      // Defense in depth for a path that cannot occur in practice: restoring
+      // hooks is a mallctl write on a live arena index, which jemalloc only
+      // rejects for an invalid/unknown index. If it ever does fail, the arena
+      // keeps these hooks installed, so keep the struct alive (intentional
+      // leak) and null the tracker best-effort so late background-thread
+      // callbacks become no-ops instead of touching the tracker after the
+      // Database (which owns it) is destroyed.
+      if (hooks_) {
+        hooks_->tracker = nullptr;
+        (void)hooks_.release();  // NOLINT(bugprone-unused-return-value)
       }
     }
   } catch (const std::exception &e) {
@@ -363,7 +378,7 @@ unsigned ArenaPool::Acquire() {
     return first_arena_idx_;
   }
 
-  // 4. Install hooks with RAII protection
+  // 4. Install hooks; pending releases new_idx if the install fails
   PendingArena pending(new_idx);
   if (!InstallDbArenaHooks(new_idx, *hooks_, "per-thread")) {
     spdlog::trace("Failed to install hooks on arena. Fallback to first arena...");
@@ -371,7 +386,7 @@ unsigned ArenaPool::Acquire() {
     return first_arena_idx_;  // pending dtor releases new_idx
   }
 
-  pending.MarkHooksInstalled(hooks_->base_hooks);
+  // No-throw from here on (capacity reserved above).
   arenas_.push_back(new_idx);
   pending.Commit();
   return new_idx;

--- a/src/memory/db_arena.cpp
+++ b/src/memory/db_arena.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cerrno>
 #include <exception>
 #include <mutex>
 #include <stdexcept>
@@ -364,11 +365,16 @@ ArenaPool::~ArenaPool() noexcept {
 
       // Restore the default hooks AFTER purging
       const extent_hooks_t *base = hooks_->base_hooks;
-      int err = je_mallctl(fmt::format("arena.{}.extent_hooks", arena_idx).c_str(),
-                           nullptr,
-                           nullptr,
-                           static_cast<void *>(const_cast<extent_hooks_t **>(&base)),
-                           sizeof(extent_hooks_t *));
+      int err = 0;
+      if (ConsumeFailureInjection(testing::ArenaPoolFailureInjection::DestructorRestore)) {
+        err = EFAULT;  // simulate arenas[ind] nulled by arena.<i>.destroy
+      } else {
+        err = je_mallctl(fmt::format("arena.{}.extent_hooks", arena_idx).c_str(),
+                         nullptr,
+                         nullptr,
+                         static_cast<void *>(const_cast<extent_hooks_t **>(&base)),
+                         sizeof(extent_hooks_t *));
+      }
       if (err != 0) {
         spdlog::error(
             "ArenaPool {}: failed to restore default hooks (err={}); leaking hooks_ and the arena to "

--- a/src/memory/db_arena.cpp
+++ b/src/memory/db_arena.cpp
@@ -144,8 +144,7 @@ bool db_arena_purge_forced(extent_hooks_t *hooks, void *addr, size_t size, size_
 }  // namespace
 
 const std::vector<unsigned> &EnsureCpuArenaCoverage() {
-  // Magic static: thread-safe, the first caller does the work, later callers
-  // (and re-entrant ones) just get the cached result.
+  // Magic static: thread-safe; the first caller does the work, later callers get the cached result.
   static const std::vector<unsigned> coverage = [] {
     std::vector<unsigned> created;
 

--- a/src/memory/db_arena.cpp
+++ b/src/memory/db_arena.cpp
@@ -11,12 +11,15 @@
 
 #include "db_arena.hpp"
 
+#include <unistd.h>
+
 #include <algorithm>
 #include <atomic>
 #include <exception>
 #include <mutex>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "utils/logging.hpp"
@@ -140,6 +143,71 @@ bool db_arena_purge_forced(extent_hooks_t *hooks, void *addr, size_t size, size_
 }
 
 }  // namespace
+
+const std::vector<unsigned> &EnsureCpuArenaCoverage() {
+  // Magic static: thread-safe, the first caller does the work, later callers
+  // (and re-entrant ones) just get the cached result.
+  static const std::vector<unsigned> coverage = [] {
+    std::vector<unsigned> created;
+
+    // Only relevant under percpu_arena: without it arena_choose() never ranges
+    // past the automatic arenas, so no CPU id can select a per-DB arena.
+    const char *percpu_mode = nullptr;
+    size_t sz = sizeof(percpu_mode);
+    if (je_mallctl("opt.percpu_arena", static_cast<void *>(&percpu_mode), &sz, nullptr, 0) != 0 ||
+        percpu_mode == nullptr || std::string_view{percpu_mode} == "disabled") {
+      return created;
+    }
+
+    // Possible (boot-time configured) CPUs bound every id sched_getcpu() can
+    // return, including CPUs that are currently offline or may be hotplugged.
+    const long n_conf = sysconf(_SC_NPROCESSORS_CONF);
+    if (n_conf <= 0) {
+      spdlog::warn("CPU arena coverage: sysconf(_SC_NPROCESSORS_CONF) failed; skipping");
+      return created;
+    }
+    const auto max_cpu_id = static_cast<unsigned>(n_conf) - 1;
+
+    unsigned narenas = 0;
+    sz = sizeof(narenas);
+    if (je_mallctl("arenas.narenas", &narenas, &sz, nullptr, 0) != 0) {
+      spdlog::warn("CPU arena coverage: failed to read arenas.narenas; skipping");
+      return created;
+    }
+
+    // arenas.create appends at the previous total, so indices come back
+    // strictly increasing; stop once the index space covers max_cpu_id (or on
+    // error, e.g. at MALLOCX_ARENA_LIMIT).
+    while (narenas <= max_cpu_id) {
+      unsigned idx = 0;
+      size_t isz = sizeof(idx);
+      if (const int err = je_mallctl("arenas.create", &idx, &isz, nullptr, 0); err != 0) {
+        spdlog::error("CPU arena coverage: arenas.create failed (err={}) at {} arenas; CPU ids {}..{} stay uncovered",
+                      err,
+                      narenas,
+                      narenas,
+                      max_cpu_id);
+        break;
+      }
+      created.push_back(idx);
+      narenas = idx + 1;
+    }
+
+    if (!created.empty()) {
+      spdlog::info(
+          "Created {} sacrificial jemalloc arenas ({}..{}) so threads on CPU ids up to {} can never bind a per-DB "
+          "arena (online CPU count {} < possible CPU count {})",
+          created.size(),
+          created.front(),
+          created.back(),
+          max_cpu_id,
+          sysconf(_SC_NPROCESSORS_ONLN),
+          n_conf);
+    }
+    return created;
+  }();
+  return coverage;
+}
 
 void InitDbArenaHooks(DbArenaHooks &h, utils::MemoryTracker *tracker, extent_hooks_t *base_hooks) {
   // Runs before the hooks are installed (published) via je_mallctl, whose arena

--- a/src/memory/db_arena.cpp
+++ b/src/memory/db_arena.cpp
@@ -55,21 +55,25 @@ void *db_arena_alloc(extent_hooks_t *hooks, void *new_addr, size_t size, size_t 
                      unsigned arena_ind) {
   auto *dh = reinterpret_cast<DbArenaHooks *>(hooks);
   const bool requested_commit = *commit;
+  // tracker may be null on an abandoned arena whose ArenaPool failed to restore default hooks;
+  // in that case we skip tracking but still proxy to the base jemalloc hooks.
   // Pre-track if commit was requested (mandatory — base hook must return committed or fail).
   if (requested_commit) {
-    if (!dh->tracker->Alloc(static_cast<int64_t>(size))) {
+    if (dh->tracker && !dh->tracker->Alloc(static_cast<int64_t>(size))) {
       return nullptr;
     }
   }
   void *ptr = dh->base_hooks->alloc(dh->base_hooks, new_addr, size, alignment, zero, commit, arena_ind);
   if (ptr == nullptr) {
-    if (requested_commit) dh->tracker->Free(static_cast<int64_t>(size));
+    if (requested_commit && dh->tracker) dh->tracker->Free(static_cast<int64_t>(size));
     return nullptr;
   }
   // *commit is an out-parameter: the base hook may have committed pages even if we didn't ask.
   if (*commit && !requested_commit) {
-    const utils::MemoryTracker::OutOfMemoryExceptionBlocker blocker;
-    dh->tracker->Alloc(static_cast<int64_t>(size));
+    if (dh->tracker) {
+      const utils::MemoryTracker::OutOfMemoryExceptionBlocker blocker;
+      dh->tracker->Alloc(static_cast<int64_t>(size));
+    }
   }
   return ptr;
 }
@@ -78,7 +82,7 @@ bool db_arena_dalloc(extent_hooks_t *hooks, void *addr, size_t size, bool commit
   auto *dh = reinterpret_cast<DbArenaHooks *>(hooks);
   const bool err = dh->base_hooks->dalloc(dh->base_hooks, addr, size, committed, arena_ind);
   if (!err && committed) {
-    dh->tracker->Free(static_cast<int64_t>(size));
+    if (dh->tracker) dh->tracker->Free(static_cast<int64_t>(size));
   }
   return err;
 }
@@ -86,7 +90,7 @@ bool db_arena_dalloc(extent_hooks_t *hooks, void *addr, size_t size, bool commit
 void db_arena_destroy(extent_hooks_t *hooks, void *addr, size_t size, bool committed, unsigned arena_ind) {
   auto *dh = reinterpret_cast<DbArenaHooks *>(hooks);
   if (committed) {
-    dh->tracker->Free(static_cast<int64_t>(size));
+    if (dh->tracker) dh->tracker->Free(static_cast<int64_t>(size));
   }
   dh->base_hooks->destroy(dh->base_hooks, addr, size, committed, arena_ind);
 }
@@ -95,12 +99,14 @@ bool db_arena_commit(extent_hooks_t *hooks, void *addr, size_t size, size_t offs
   auto *dh = reinterpret_cast<DbArenaHooks *>(hooks);
   const bool err = dh->base_hooks->commit(dh->base_hooks, addr, size, offset, length, arena_ind);
   if (!err) {
-    // Pages are already committed by the OS — we cannot undo the commit here.
-    // OutOfMemoryExceptionBlocker makes MemoryTrackerCanThrow() return false on this thread,
-    // which means Alloc() will never enter its rollback path: the fetch_add is permanent and
-    // the entire tracker chain returns true unconditionally. Tracking is therefore guaranteed.
-    const utils::MemoryTracker::OutOfMemoryExceptionBlocker blocker;
-    dh->tracker->Alloc(static_cast<int64_t>(length));
+    if (dh->tracker) {
+      // Pages are already committed by the OS — we cannot undo the commit here.
+      // OutOfMemoryExceptionBlocker makes MemoryTrackerCanThrow() return false on this thread,
+      // which means Alloc() will never enter its rollback path: the fetch_add is permanent and
+      // the entire tracker chain returns true unconditionally. Tracking is therefore guaranteed.
+      const utils::MemoryTracker::OutOfMemoryExceptionBlocker blocker;
+      dh->tracker->Alloc(static_cast<int64_t>(length));
+    }
   }
   return err;
 }
@@ -110,7 +116,7 @@ bool db_arena_decommit(extent_hooks_t *hooks, void *addr, size_t size, size_t of
   auto *dh = reinterpret_cast<DbArenaHooks *>(hooks);
   const bool err = dh->base_hooks->decommit(dh->base_hooks, addr, size, offset, length, arena_ind);
   if (!err) {
-    dh->tracker->Free(static_cast<int64_t>(length));
+    if (dh->tracker) dh->tracker->Free(static_cast<int64_t>(length));
   }
   return err;
 }
@@ -121,7 +127,7 @@ bool db_arena_purge_forced(extent_hooks_t *hooks, void *addr, size_t size, size_
   if (dh->base_hooks->purge_forced == nullptr) return true;
   const bool err = dh->base_hooks->purge_forced(dh->base_hooks, addr, size, offset, length, arena_ind);
   if (!err) {
-    dh->tracker->Free(static_cast<int64_t>(length));
+    if (dh->tracker) dh->tracker->Free(static_cast<int64_t>(length));
   }
   return err;
 }
@@ -253,8 +259,9 @@ ArenaPool::ArenaPool(utils::MemoryTracker *tracker) {
     throw std::runtime_error(fmt::format("Failed to read default hooks for arena {} (err={})", first_arena_idx_, err));
   }
 
-  InitDbArenaHooks(hooks_, tracker, base_hooks);
-  const extent_hooks_t *new_hooks = &hooks_.hooks;
+  hooks_ = std::make_unique<DbArenaHooks>();
+  InitDbArenaHooks(*hooks_, tracker, base_hooks);
+  const extent_hooks_t *new_hooks = &hooks_->hooks;
   if (int err = je_mallctl(hooks_key.c_str(),
                            nullptr,
                            nullptr,
@@ -294,7 +301,7 @@ ArenaPool::~ArenaPool() noexcept {
       }
 
       // Restore the default hooks AFTER purging
-      const extent_hooks_t *base = hooks_.base_hooks;
+      const extent_hooks_t *base = hooks_->base_hooks;
       int err = je_mallctl((arena_key + ".extent_hooks").c_str(),
                            nullptr,
                            nullptr,
@@ -304,6 +311,8 @@ ArenaPool::~ArenaPool() noexcept {
         spdlog::error(
             "ArenaPool {}: failed to restore default hooks (err={}); hooks_ may outlive arena", arena_idx, err);
         spdlog::error("ArenaPool {}: leaking arena from GlobalArenaPool reuse after failed hook restore", arena_idx);
+        hooks_->tracker = nullptr;
+        (void)hooks_.release();
         continue;
       }
 
@@ -354,13 +363,13 @@ unsigned ArenaPool::Acquire() {
 
   // 4. Install hooks with RAII protection
   PendingArena pending(new_idx);
-  if (!InstallDbArenaHooks(new_idx, hooks_, "per-thread")) {
+  if (!InstallDbArenaHooks(new_idx, *hooks_, "per-thread")) {
     spdlog::trace("Failed to install hooks on arena. Fallback to first arena...");
     ++first_arena_use_count_;
     return first_arena_idx_;  // pending dtor releases new_idx
   }
 
-  pending.MarkHooksInstalled(hooks_.base_hooks);
+  pending.MarkHooksInstalled(hooks_->base_hooks);
   arenas_.push_back(new_idx);
   pending.Commit();
   return new_idx;

--- a/src/memory/db_arena.cpp
+++ b/src/memory/db_arena.cpp
@@ -307,7 +307,7 @@ ArenaPool::ArenaPool(utils::MemoryTracker *tracker) {
   // constructor failure never has to un-install hooks (see PendingArena).
   arenas_.reserve(1);
 
-  if (ConsumeFailureInjection(testing::ArenaPoolFailureInjection::ConstructorPublish)) {
+  if (ConsumeFailureInjection(testing::ArenaPoolFailureInjection::ConstructorThrow)) {
     throw std::runtime_error("Injected ArenaPool constructor publish failure");
   }
 

--- a/src/memory/db_arena.cpp
+++ b/src/memory/db_arena.cpp
@@ -57,10 +57,8 @@ bool ConsumeFailureInjection(testing::ArenaPoolFailureInjection failure) {
 void *db_arena_alloc(extent_hooks_t *hooks, void *new_addr, size_t size, size_t alignment, bool *zero, bool *commit,
                      unsigned arena_ind) {
   auto *dh = reinterpret_cast<DbArenaHooks *>(hooks);
-  // tracker is null only for a hooks struct leaked on the (unreachable in
-  // practice) hook-restore-failure path; in that case skip tracking but still
-  // proxy to the base jemalloc hooks.
-  auto *tracker = dh->tracker;
+  // null only if hooks_ was leaked on the hook-restore-failure path; skip tracking, still proxy to base hooks.
+  auto *tracker = dh->tracker.load(std::memory_order_relaxed);
   const bool requested_commit = *commit;
   // Pre-track if commit was requested (mandatory — base hook must return committed or fail).
   if (requested_commit) {
@@ -85,7 +83,7 @@ void *db_arena_alloc(extent_hooks_t *hooks, void *new_addr, size_t size, size_t 
 
 bool db_arena_dalloc(extent_hooks_t *hooks, void *addr, size_t size, bool committed, unsigned arena_ind) {
   auto *dh = reinterpret_cast<DbArenaHooks *>(hooks);
-  auto *tracker = dh->tracker;
+  auto *tracker = dh->tracker.load(std::memory_order_relaxed);
   const bool err = dh->base_hooks->dalloc(dh->base_hooks, addr, size, committed, arena_ind);
   if (!err && committed) {
     if (tracker) tracker->Free(static_cast<int64_t>(size));
@@ -95,7 +93,7 @@ bool db_arena_dalloc(extent_hooks_t *hooks, void *addr, size_t size, bool commit
 
 void db_arena_destroy(extent_hooks_t *hooks, void *addr, size_t size, bool committed, unsigned arena_ind) {
   auto *dh = reinterpret_cast<DbArenaHooks *>(hooks);
-  auto *tracker = dh->tracker;
+  auto *tracker = dh->tracker.load(std::memory_order_relaxed);
   if (committed) {
     if (tracker) tracker->Free(static_cast<int64_t>(size));
   }
@@ -104,7 +102,7 @@ void db_arena_destroy(extent_hooks_t *hooks, void *addr, size_t size, bool commi
 
 bool db_arena_commit(extent_hooks_t *hooks, void *addr, size_t size, size_t offset, size_t length, unsigned arena_ind) {
   auto *dh = reinterpret_cast<DbArenaHooks *>(hooks);
-  auto *tracker = dh->tracker;
+  auto *tracker = dh->tracker.load(std::memory_order_relaxed);
   const bool err = dh->base_hooks->commit(dh->base_hooks, addr, size, offset, length, arena_ind);
   if (!err) {
     if (tracker) {
@@ -122,7 +120,7 @@ bool db_arena_commit(extent_hooks_t *hooks, void *addr, size_t size, size_t offs
 bool db_arena_decommit(extent_hooks_t *hooks, void *addr, size_t size, size_t offset, size_t length,
                        unsigned arena_ind) {
   auto *dh = reinterpret_cast<DbArenaHooks *>(hooks);
-  auto *tracker = dh->tracker;
+  auto *tracker = dh->tracker.load(std::memory_order_relaxed);
   const bool err = dh->base_hooks->decommit(dh->base_hooks, addr, size, offset, length, arena_ind);
   if (!err) {
     if (tracker) tracker->Free(static_cast<int64_t>(length));
@@ -133,7 +131,7 @@ bool db_arena_decommit(extent_hooks_t *hooks, void *addr, size_t size, size_t of
 bool db_arena_purge_forced(extent_hooks_t *hooks, void *addr, size_t size, size_t offset, size_t length,
                            unsigned arena_ind) {
   auto *dh = reinterpret_cast<DbArenaHooks *>(hooks);
-  auto *tracker = dh->tracker;
+  auto *tracker = dh->tracker.load(std::memory_order_relaxed);
   if (dh->base_hooks->purge_forced == nullptr) return true;
   const bool err = dh->base_hooks->purge_forced(dh->base_hooks, addr, size, offset, length, arena_ind);
   if (!err) {
@@ -210,9 +208,8 @@ const std::vector<unsigned> &EnsureCpuArenaCoverage() {
 }
 
 void InitDbArenaHooks(DbArenaHooks &h, utils::MemoryTracker *tracker, extent_hooks_t *base_hooks) {
-  // Runs before the hooks are installed (published) via je_mallctl, whose arena
-  // mutexes order this write before any callback can read it.
-  h.tracker = tracker;
+  // Publish ordering comes from jemalloc's RELEASE store of extent_hooks at mallctl install time.
+  h.tracker.store(tracker, std::memory_order_relaxed);
   h.base_hooks = base_hooks;
   h.hooks = extent_hooks_t{
       .alloc = &db_arena_alloc,
@@ -244,8 +241,7 @@ void LogDestructorCleanupFailure(std::string_view owner, unsigned arena_idx, std
 }
 
 bool InstallDbArenaHooks(unsigned arena_idx, DbArenaHooks &hooks, std::string_view error_context) {
-  const std::string arena_key = "arena." + std::to_string(arena_idx);
-  const std::string hooks_key = arena_key + ".extent_hooks";
+  const std::string hooks_key = fmt::format("arena.{}.extent_hooks", arena_idx);
 
   extent_hooks_t *base_hooks = nullptr;
   size_t hooks_sz = sizeof(extent_hooks_t *);
@@ -314,8 +310,7 @@ ArenaPool::ArenaPool(utils::MemoryTracker *tracker) {
     throw std::runtime_error("Injected ArenaPool constructor publish failure");
   }
 
-  const std::string arena_key = "arena." + std::to_string(first_arena_idx_);
-  const std::string hooks_key = arena_key + ".extent_hooks";
+  const std::string hooks_key = fmt::format("arena.{}.extent_hooks", first_arena_idx_);
 
   extent_hooks_t *base_hooks = nullptr;
   size_t hooks_sz = sizeof(extent_hooks_t *);
@@ -359,18 +354,17 @@ ArenaPool::~ArenaPool() noexcept {
     // `hooks_->base_hooks` read.
     bool restore_failed = false;
     for (const auto arena_idx : arenas_) {
-      const std::string arena_key = "arena." + std::to_string(arena_idx);
-
       // Purge all dirty/muzzy pages back to the OS FIRST, while our custom hooks are
       // still installed.
-      if (int perr = je_mallctl((arena_key + ".purge").c_str(), nullptr, nullptr, nullptr, 0); perr != 0) {
+      if (int perr = je_mallctl(fmt::format("arena.{}.purge", arena_idx).c_str(), nullptr, nullptr, nullptr, 0);
+          perr != 0) {
         spdlog::error(
             "ArenaPool {}: purge failed (err={}); MemoryTracker may drift before hook restore", arena_idx, perr);
       }
 
       // Restore the default hooks AFTER purging
       const extent_hooks_t *base = hooks_->base_hooks;
-      int err = je_mallctl((arena_key + ".extent_hooks").c_str(),
+      int err = je_mallctl(fmt::format("arena.{}.extent_hooks", arena_idx).c_str(),
                            nullptr,
                            nullptr,
                            static_cast<void *>(const_cast<extent_hooks_t **>(&base)),
@@ -397,16 +391,14 @@ ArenaPool::~ArenaPool() noexcept {
     }
 
     if (restore_failed) {
-      // Defense in depth for a path that cannot occur in practice: restoring
-      // hooks is a mallctl write on a live arena index, which jemalloc only
-      // rejects for an invalid/unknown index. If it ever does fail, the arena
-      // keeps these hooks installed, so keep the struct alive (intentional
-      // leak) and null the tracker best-effort so late background-thread
-      // callbacks become no-ops instead of touching the tracker after the
-      // Database (which owns it) is destroyed.
+      // Defense in depth: the only realistic trigger is arenas[ind] nulled by arena.<i>.destroy
+      // (jemalloc 5.2.1 ctl.c) — Memgraph never calls it. If it ever fires, the arena keeps our
+      // hooks, so leak
+      // hooks_ (~64 B) and null the tracker so late background-thread callbacks no-op instead of
+      // touching the destroyed Database's tracker.
       if (hooks_) {
-        hooks_->tracker = nullptr;
-        (void)hooks_.release();  // NOLINT(bugprone-unused-return-value)
+        hooks_->tracker.store(nullptr, std::memory_order_relaxed);
+        [[maybe_unused]] auto *leaked = hooks_.release();
       }
     }
   } catch (const std::exception &e) {
@@ -497,13 +489,12 @@ void ArenaPool::PurgeAllArenas() const {
   std::vector<unsigned> arena_indices;
   {
     const std::lock_guard<std::mutex> lock(arena_mux_);
-    arena_indices.reserve(arenas_.size());
     arena_indices = arenas_;
   }
 
   for (const auto arena_idx : arena_indices) {
     if (arena_idx == 0) continue;
-    je_mallctl(("arena." + std::to_string(arena_idx) + ".purge").c_str(), nullptr, nullptr, nullptr, 0);
+    je_mallctl(fmt::format("arena.{}.purge", arena_idx).c_str(), nullptr, nullptr, nullptr, 0);
   }
 }
 

--- a/src/memory/db_arena.cpp
+++ b/src/memory/db_arena.cpp
@@ -274,6 +274,9 @@ bool InstallDbArenaHooks(unsigned arena_idx, DbArenaHooks &hooks, std::string_vi
 // structured so that no statement between a successful hook install and
 // Commit() can throw (vector capacity is reserved up front), and a failed
 // install mallctl never publishes the hooks to jemalloc in the first place.
+// INVARIANT for future edits: do NOT insert any allocating/throwing statement
+// between the hook-install mallctl write and Commit() at either call site —
+// that would release an arena with live custom hooks into the global pool.
 class PendingArena {
  public:
   explicit PendingArena(unsigned arena_idx) noexcept : arena_idx_(arena_idx) {}

--- a/src/memory/db_arena.hpp
+++ b/src/memory/db_arena.hpp
@@ -124,6 +124,28 @@ class ArenaPool {
 
 #if USE_JEMALLOC
 
+// Ensure every CPU id that sched_getcpu() can return resolves to an arena that
+// is NOT a per-DB arena.
+//
+// Under percpu_arena, jemalloc binds a thread to arenas[sched_getcpu()] with no
+// clamp (percpu_arena_choose). jemalloc sizes the automatic range from the
+// number of ONLINE CPUs, but sched_getcpu() can return any id below the number
+// of POSSIBLE CPUs (sparse online sets: offlined cores, cgroups, NUMA, VM
+// hotplug headroom; cf. jemalloc#2054). A thread on such an overflow CPU would
+// bind to whatever arena owns that index — which is exactly where per-DB
+// arenas (arenas.create) live — and later free through the per-DB extent hooks
+// after the owning Database is destroyed (shutdown use-after-free).
+//
+// Fix: before any per-DB arena is created, append plain "sacrificial" arenas
+// (default hooks, never destroyed, process lifetime) until the arena index
+// space covers every possible CPU id. Overflow CPUs then get a dedicated
+// 1:1 arena, and per-DB arenas land at indices no CPU id can ever reach.
+//
+// Returns the indices of the sacrificial arenas created (empty when the
+// automatic range already covers all possible CPU ids, or percpu_arena is
+// disabled). Thread-safe and idempotent; the first caller does the work.
+const std::vector<unsigned> &EnsureCpuArenaCoverage();
+
 // Populate a DbArenaHooks struct so it can be installed on any jemalloc arena.
 // `tracker`    – receives Alloc/Free calls for that arena.
 // `base_hooks` – jemalloc's default hooks; the callbacks call through to these.
@@ -164,6 +186,10 @@ class GlobalArenaPool {
         return idx;
       }
     }
+    // Safety net: per-DB arena indices must stay above every reachable CPU id,
+    // so the sacrificial coverage arenas (normally created at startup by
+    // SetHooks) must exist before we append the first per-DB arena.
+    EnsureCpuArenaCoverage();
     unsigned arena_idx = 0;
     size_t sz = sizeof(arena_idx);
     const int err = je_mallctl("arenas.create", &arena_idx, &sz, nullptr, 0);

--- a/src/memory/db_arena.hpp
+++ b/src/memory/db_arena.hpp
@@ -64,7 +64,7 @@ class ArenaPool {
   unsigned idx() const noexcept;
 
   // Acquire an arena for DB-owned thread work.
-  unsigned Acquire();
+  [[nodiscard]] unsigned Acquire();
 
   // Return an arena acquired from this pool so a future Acquire() can reuse it.
   void Release(unsigned arena_idx) noexcept;
@@ -77,7 +77,7 @@ class ArenaPool {
   void PurgeAllArenas() const;
 
   // Acquire an explicit tcache for DB-owned thread work.
-  unsigned AcquireTcache();
+  [[nodiscard]] unsigned AcquireTcache();
 
   // Return a tcache acquired from this pool so a future AcquireTcache() can reuse it.
   void ReleaseTcache(unsigned tcache_id) noexcept;
@@ -153,7 +153,7 @@ class GlobalArenaPool {
   // concurrently; each gets a distinct valid index. This is benign: je_mallctl is
   // thread-safe and neither index is lost. At most N-1 extra arenas are created versus
   // serialising the slow path, which is acceptable for an infrequent operation.
-  unsigned Acquire() {
+  [[nodiscard]] unsigned Acquire() {
     {
       std::lock_guard<std::mutex> lock(mux_);
       if (!pool_.empty()) {

--- a/src/memory/db_arena.hpp
+++ b/src/memory/db_arena.hpp
@@ -207,7 +207,7 @@ namespace testing {
 
 enum class ArenaPoolFailureInjection {
   None,
-  ConstructorPublish,
+  ConstructorThrow,
   AcquireArenaCreate,
   DestructorRestore,
 };

--- a/src/memory/db_arena.hpp
+++ b/src/memory/db_arena.hpp
@@ -209,6 +209,7 @@ enum class ArenaPoolFailureInjection {
   None,
   ConstructorPublish,
   AcquireArenaCreate,
+  DestructorRestore,
 };
 
 void SetArenaPoolFailureInjection(ArenaPoolFailureInjection failure);

--- a/src/memory/db_arena.hpp
+++ b/src/memory/db_arena.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <memory>
 #include <mutex>
 #include <stdexcept>
 #include <utility>
@@ -81,7 +82,19 @@ class ArenaPool {
 
  private:
 #if USE_JEMALLOC
-  DbArenaHooks hooks_{};
+  // Heap-allocated so its address is stable for jemalloc and, critically,
+  // so that it can outlive ~ArenaPool() on the unhook-failure path. We
+  // install `&hooks_->hooks` on each jemalloc arena via mallctl; jemalloc
+  // can still invoke this hook from tcache flush / decay long after
+  // ~ArenaPool() returns. On the happy path the unique_ptr destructs
+  // normally — by then we've already restored the default extent hooks on
+  // every arena, so no callback can reach this struct. On the failure path
+  // (mallctl fails to swap hooks back), ~ArenaPool() calls
+  // `(void)hooks_.release()` to intentionally leak this struct (~64 B per
+  // failed restore) so any retained jemalloc reference stays valid for the
+  // process lifetime. The arena is also abandoned (not returned to
+  // GlobalArenaPool), so this leak is bounded.
+  std::unique_ptr<DbArenaHooks> hooks_;
 
   // Protects arenas_, free_count_, and first_arena_use_count_.
   mutable std::mutex arena_mux_;

--- a/src/memory/db_arena.hpp
+++ b/src/memory/db_arena.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
@@ -33,14 +34,12 @@ namespace memgraph::memory {
 // that extent hook callbacks can cast `extent_hooks_t *` → `DbArenaHooks *`.
 struct DbArenaHooks {
   extent_hooks_t hooks;  // must be first
-  // Per-DB tracker, fed by extent events. A plain pointer is sufficient: it is
-  // written exactly once (InitDbArenaHooks) before the hooks are published to
-  // jemalloc via mallctl, and is only read from extent callbacks while the
-  // hooks are installed on some arena. Teardown is serialised by jemalloc
-  // itself: extent_hooks_set swaps hooks under the arena's background-thread
-  // mutex — the same mutex the background thread holds while invoking hooks —
-  // so after a successful restore no thread can be executing these callbacks.
-  utils::MemoryTracker *tracker;
+  // Written once (relaxed) before hooks are published via mallctl; jemalloc's
+  // RELEASE store of extent_hooks orders it against callback loads, so relaxed
+  // suffices for the success path. Nulled (relaxed) only on the hook-restore-
+  // failure path in ~ArenaPool where no jemalloc mutex serialises — atomic only
+  // to keep that defensive store race-free, never a synchronisation point.
+  std::atomic<utils::MemoryTracker *> tracker;
   extent_hooks_t *base_hooks;  // default jemalloc hooks (called through)
 };
 
@@ -88,18 +87,9 @@ class ArenaPool {
 
  private:
 #if USE_JEMALLOC
-  // Heap-allocated so its address is stable for jemalloc and, critically,
-  // so that it can outlive ~ArenaPool() on the unhook-failure path. We
-  // install `&hooks_->hooks` on each jemalloc arena via mallctl; jemalloc
-  // can still invoke this hook from tcache flush / decay long after
-  // ~ArenaPool() returns. On the happy path the unique_ptr destructs
-  // normally — by then we've already restored the default extent hooks on
-  // every arena, so no callback can reach this struct. On the failure path
-  // (mallctl fails to swap hooks back), ~ArenaPool() calls
-  // `(void)hooks_.release()` to intentionally leak this struct (~64 B per
-  // failed restore) so any retained jemalloc reference stays valid for the
-  // process lifetime. The arena is also abandoned (not returned to
-  // GlobalArenaPool), so this leak is bounded.
+  // Heap-allocated for stable address; &hooks_->hooks is installed on jemalloc arenas via mallctl.
+  // On failed hook restore, ~ArenaPool leaks this struct (~64 B) so any retained jemalloc reference
+  // stays valid for the process lifetime. The arena is abandoned, so the leak is bounded.
   std::unique_ptr<DbArenaHooks> hooks_;
 
   // Protects arenas_, free_count_, and first_arena_use_count_.
@@ -124,26 +114,12 @@ class ArenaPool {
 
 #if USE_JEMALLOC
 
-// Ensure every CPU id that sched_getcpu() can return resolves to an arena that
-// is NOT a per-DB arena.
-//
-// Under percpu_arena, jemalloc binds a thread to arenas[sched_getcpu()] with no
-// clamp (percpu_arena_choose). jemalloc sizes the automatic range from the
-// number of ONLINE CPUs, but sched_getcpu() can return any id below the number
-// of POSSIBLE CPUs (sparse online sets: offlined cores, cgroups, NUMA, VM
-// hotplug headroom; cf. jemalloc#2054). A thread on such an overflow CPU would
-// bind to whatever arena owns that index — which is exactly where per-DB
-// arenas (arenas.create) live — and later free through the per-DB extent hooks
-// after the owning Database is destroyed (shutdown use-after-free).
-//
-// Fix: before any per-DB arena is created, append plain "sacrificial" arenas
-// (default hooks, never destroyed, process lifetime) until the arena index
-// space covers every possible CPU id. Overflow CPUs then get a dedicated
-// 1:1 arena, and per-DB arenas land at indices no CPU id can ever reach.
-//
-// Returns the indices of the sacrificial arenas created (empty when the
-// automatic range already covers all possible CPU ids, or percpu_arena is
-// disabled). Thread-safe and idempotent; the first caller does the work.
+// Ensure every CPU id sched_getcpu() can return resolves to an arena that is NOT a per-DB arena.
+// percpu_arena binds threads to arenas[sched_getcpu()] with no clamp; sched_getcpu can return ids
+// above the online-CPU-derived automatic range (jemalloc#2054). A thread on an overflow CPU would
+// bind a per-DB arena → shutdown UAF. Fix: create sacrificial arenas (default hooks, process
+// lifetime) until per-DB indices exceed every possible CPU id. Idempotent, thread-safe.
+// Returns the sacrificial arena indices created (empty if percpu_arena is disabled or already covered).
 const std::vector<unsigned> &EnsureCpuArenaCoverage();
 
 // Populate a DbArenaHooks struct so it can be installed on any jemalloc arena.

--- a/src/memory/db_arena.hpp
+++ b/src/memory/db_arena.hpp
@@ -32,10 +32,16 @@ namespace memgraph::memory {
 // Internal layout for per-DB extent hooks. The `hooks` field MUST be first so
 // that extent hook callbacks can cast `extent_hooks_t *` → `DbArenaHooks *`.
 struct DbArenaHooks {
-  extent_hooks_t hooks;           // must be first
-  utils::MemoryTracker *tracker;  // per-DB tracker, fed by extent events
-  extent_hooks_t *base_hooks;     // default jemalloc hooks (called through)
-  // TODO: Think about a failsafe in case unhooking failed
+  extent_hooks_t hooks;  // must be first
+  // Per-DB tracker, fed by extent events. A plain pointer is sufficient: it is
+  // written exactly once (InitDbArenaHooks) before the hooks are published to
+  // jemalloc via mallctl, and is only read from extent callbacks while the
+  // hooks are installed on some arena. Teardown is serialised by jemalloc
+  // itself: extent_hooks_set swaps hooks under the arena's background-thread
+  // mutex — the same mutex the background thread holds while invoking hooks —
+  // so after a successful restore no thread can be executing these callbacks.
+  utils::MemoryTracker *tracker;
+  extent_hooks_t *base_hooks;  // default jemalloc hooks (called through)
 };
 
 #endif

--- a/src/memory/global_memory_control.cpp
+++ b/src/memory/global_memory_control.cpp
@@ -54,13 +54,13 @@ const std::vector<unsigned> &GlobalHookArenaIds() {
   static const std::vector<unsigned> ids = [] {
     unsigned n_arenas = 0;
     size_t sz = sizeof(n_arenas);
-    if (je_mallctl("opt.narenas", (void *)&n_arenas, &sz, nullptr, 0)) {
+    if (je_mallctl("opt.narenas", static_cast<void *>(&n_arenas), &sz, nullptr, 0)) {
       LOG_FATAL("Error getting number of jemalloc arenas");
     }
     std::vector<unsigned> result(n_arenas);
     std::ranges::iota(result, 0U);
     const auto &coverage = EnsureCpuArenaCoverage();
-    result.insert(result.end(), coverage.begin(), coverage.end());
+    result.append_range(coverage);
     return result;
   }();
   return ids;
@@ -86,7 +86,7 @@ void SetHooks() {
     extent_hooks_t *current_old_hooks = nullptr;
     size_t hooks_len = sizeof(extent_hooks_t *);
 
-    err = je_mallctl(func_name.c_str(), (void *)&current_old_hooks, &hooks_len, nullptr, 0);
+    err = je_mallctl(func_name.c_str(), static_cast<void *>(&current_old_hooks), &hooks_len, nullptr, 0);
     if (err) {
       LOG_FATAL("Error getting hooks for jemalloc arena {}", i);
     }
@@ -112,14 +112,14 @@ void SetHooks() {
 
     // Due to the way jemalloc works, we need first to set their hooks
     // which will trigger creating arena, then we can set our custom hook wrappers
-    err = je_mallctl(func_name.c_str(), nullptr, nullptr, (void *)&old_hooks, sizeof(extent_hooks_t *));
+    err = je_mallctl(func_name.c_str(), nullptr, nullptr, static_cast<void *>(&old_hooks), sizeof(extent_hooks_t *));
     if (err) {
       LOG_FATAL("Error setting jemalloc hooks for jemalloc arena {}", i);
     }
 
     // Install tracker hooks.
     const extent_hooks_t *new_hooks = &global_graph_arena_hooks.hooks;
-    err = je_mallctl(func_name.c_str(), nullptr, nullptr, (void *)&new_hooks, sizeof(extent_hooks_t *));
+    err = je_mallctl(func_name.c_str(), nullptr, nullptr, static_cast<void *>(&new_hooks), sizeof(extent_hooks_t *));
     if (err) {
       LOG_FATAL("Error setting custom hooks for jemalloc arena {}", i);
     }
@@ -133,20 +133,10 @@ void UnsetHooks() {
     return;
   }
 
-  MG_ASSERT(old_hooks);
-  MG_ASSERT(old_hooks->alloc);
-  MG_ASSERT(old_hooks->dalloc);
-  MG_ASSERT(old_hooks->destroy);
-  MG_ASSERT(old_hooks->commit);
-  MG_ASSERT(old_hooks->decommit);
-  MG_ASSERT(old_hooks->purge_forced);
-  MG_ASSERT(old_hooks->purge_lazy);
-  MG_ASSERT(old_hooks->split);
-  MG_ASSERT(old_hooks->merge);
-
   for (const unsigned i : GlobalHookArenaIds()) {
     const auto func_name = fmt::format("arena.{}.extent_hooks", i);
-    const int err = je_mallctl(func_name.c_str(), nullptr, nullptr, (void *)&old_hooks, sizeof(extent_hooks_t *));
+    const int err =
+        je_mallctl(func_name.c_str(), nullptr, nullptr, static_cast<void *>(&old_hooks), sizeof(extent_hooks_t *));
     if (err) {
       LOG_FATAL("Error setting default hooks for jemalloc arena {}", i);
     }

--- a/src/memory/global_memory_control.cpp
+++ b/src/memory/global_memory_control.cpp
@@ -48,8 +48,8 @@ DbArenaHooks global_graph_arena_hooks{};
 extent_hooks_t *old_hooks = nullptr;
 
 // Arenas for global graph hooks: automatic arenas [0, opt.narenas) plus the
-// sacrificial CPU-coverage arenas (overflow CPUs bind to these and must be
-// tracked identically). Invariant after startup — cached as magic static.
+// sacrificial CPU-coverage arenas lazily created by EnsureCpuArenaCoverage().
+// Invariant after startup — cached as magic static.
 const std::vector<unsigned> &GlobalHookArenaIds() {
   static const std::vector<unsigned> ids = [] {
     unsigned n_arenas = 0;
@@ -58,7 +58,7 @@ const std::vector<unsigned> &GlobalHookArenaIds() {
       LOG_FATAL("Error getting number of jemalloc arenas");
     }
     std::vector<unsigned> result(n_arenas);
-    std::iota(result.begin(), result.end(), 0U);
+    std::ranges::iota(result, 0U);
     const auto &coverage = EnsureCpuArenaCoverage();
     result.insert(result.end(), coverage.begin(), coverage.end());
     return result;
@@ -79,6 +79,7 @@ void SetHooks() {
   int err = 0;
   // Create the sacrificial CPU-coverage arenas BEFORE installing the global
   // tracking hooks so they are covered too (see GlobalHookArenaIds).
+  EnsureCpuArenaCoverage();
   for (const unsigned i : GlobalHookArenaIds()) {
     const auto func_name = fmt::format("arena.{}.extent_hooks", i);
 

--- a/src/memory/global_memory_control.cpp
+++ b/src/memory/global_memory_control.cpp
@@ -12,7 +12,9 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <numeric>
 #include <string>
+#include <vector>
 
 #include "db_arena.hpp"
 #include "global_memory_control.hpp"
@@ -44,6 +46,23 @@ namespace {
 DbArenaHooks global_graph_arena_hooks{};
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extent_hooks_t *old_hooks = nullptr;
+
+// All arenas the global graph hooks are (to be) installed on: the automatic
+// arenas [0, opt.narenas) plus the sacrificial CPU-coverage arenas. Threads on
+// overflow CPU ids (sched_getcpu() >= narenas_auto) bind to the coverage
+// arenas, so those must be tracked exactly like the automatic ones.
+std::vector<unsigned> GlobalHookArenaIds() {
+  unsigned n_arenas = 0;
+  size_t sz = sizeof(n_arenas);
+  if (je_mallctl("opt.narenas", (void *)&n_arenas, &sz, nullptr, 0)) {
+    LOG_FATAL("Error getting number of jemalloc arenas");
+  }
+  std::vector<unsigned> ids(n_arenas);
+  std::iota(ids.begin(), ids.end(), 0U);
+  const auto &coverage = EnsureCpuArenaCoverage();
+  ids.insert(ids.end(), coverage.begin(), coverage.end());
+  return ids;
+}
 }  // namespace
 
 #endif
@@ -55,14 +74,10 @@ void SetHooks() {
     return;
   }
 
-  unsigned n_arenas = 0;
-  size_t sz = sizeof(n_arenas);
-  int err = je_mallctl("opt.narenas", (void *)&n_arenas, &sz, nullptr, 0);
-  if (err) {
-    LOG_FATAL("Error getting number of jemalloc arenas");
-  }
-
-  for (unsigned i = 0; i < n_arenas; i++) {
+  int err = 0;
+  // Create the sacrificial CPU-coverage arenas BEFORE installing the global
+  // tracking hooks so they are covered too (see GlobalHookArenaIds).
+  for (const unsigned i : GlobalHookArenaIds()) {
     std::string func_name = "arena." + std::to_string(i) + ".extent_hooks";
 
     extent_hooks_t *current_old_hooks = nullptr;
@@ -126,16 +141,9 @@ void UnsetHooks() {
   MG_ASSERT(old_hooks->split);
   MG_ASSERT(old_hooks->merge);
 
-  unsigned n_arenas{0};
-  size_t sz = sizeof(n_arenas);
-  int err = je_mallctl("opt.narenas", (void *)&n_arenas, &sz, nullptr, 0);
-  if (err) {
-    LOG_FATAL("Error getting number of jemalloc arenas");
-  }
-
-  for (unsigned i = 0; i < n_arenas; i++) {
+  for (const unsigned i : GlobalHookArenaIds()) {
     std::string func_name = "arena." + std::to_string(i) + ".extent_hooks";
-    err = je_mallctl(func_name.c_str(), nullptr, nullptr, (void *)&old_hooks, sizeof(extent_hooks_t *));
+    const int err = je_mallctl(func_name.c_str(), nullptr, nullptr, (void *)&old_hooks, sizeof(extent_hooks_t *));
     if (err) {
       LOG_FATAL("Error setting default hooks for jemalloc arena {}", i);
     }

--- a/src/memory/global_memory_control.cpp
+++ b/src/memory/global_memory_control.cpp
@@ -47,20 +47,22 @@ DbArenaHooks global_graph_arena_hooks{};
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extent_hooks_t *old_hooks = nullptr;
 
-// All arenas the global graph hooks are (to be) installed on: the automatic
-// arenas [0, opt.narenas) plus the sacrificial CPU-coverage arenas. Threads on
-// overflow CPU ids (sched_getcpu() >= narenas_auto) bind to the coverage
-// arenas, so those must be tracked exactly like the automatic ones.
-std::vector<unsigned> GlobalHookArenaIds() {
-  unsigned n_arenas = 0;
-  size_t sz = sizeof(n_arenas);
-  if (je_mallctl("opt.narenas", (void *)&n_arenas, &sz, nullptr, 0)) {
-    LOG_FATAL("Error getting number of jemalloc arenas");
-  }
-  std::vector<unsigned> ids(n_arenas);
-  std::iota(ids.begin(), ids.end(), 0U);
-  const auto &coverage = EnsureCpuArenaCoverage();
-  ids.insert(ids.end(), coverage.begin(), coverage.end());
+// Arenas for global graph hooks: automatic arenas [0, opt.narenas) plus the
+// sacrificial CPU-coverage arenas (overflow CPUs bind to these and must be
+// tracked identically). Invariant after startup — cached as magic static.
+const std::vector<unsigned> &GlobalHookArenaIds() {
+  static const std::vector<unsigned> ids = [] {
+    unsigned n_arenas = 0;
+    size_t sz = sizeof(n_arenas);
+    if (je_mallctl("opt.narenas", (void *)&n_arenas, &sz, nullptr, 0)) {
+      LOG_FATAL("Error getting number of jemalloc arenas");
+    }
+    std::vector<unsigned> result(n_arenas);
+    std::iota(result.begin(), result.end(), 0U);
+    const auto &coverage = EnsureCpuArenaCoverage();
+    result.insert(result.end(), coverage.begin(), coverage.end());
+    return result;
+  }();
   return ids;
 }
 }  // namespace
@@ -78,7 +80,7 @@ void SetHooks() {
   // Create the sacrificial CPU-coverage arenas BEFORE installing the global
   // tracking hooks so they are covered too (see GlobalHookArenaIds).
   for (const unsigned i : GlobalHookArenaIds()) {
-    std::string func_name = "arena." + std::to_string(i) + ".extent_hooks";
+    const auto func_name = fmt::format("arena.{}.extent_hooks", i);
 
     extent_hooks_t *current_old_hooks = nullptr;
     size_t hooks_len = sizeof(extent_hooks_t *);
@@ -142,12 +144,13 @@ void UnsetHooks() {
   MG_ASSERT(old_hooks->merge);
 
   for (const unsigned i : GlobalHookArenaIds()) {
-    std::string func_name = "arena." + std::to_string(i) + ".extent_hooks";
+    const auto func_name = fmt::format("arena.{}.extent_hooks", i);
     const int err = je_mallctl(func_name.c_str(), nullptr, nullptr, (void *)&old_hooks, sizeof(extent_hooks_t *));
     if (err) {
       LOG_FATAL("Error setting default hooks for jemalloc arena {}", i);
     }
   }
+  old_hooks = nullptr;
 #endif
 }
 

--- a/tests/unit/db_memory_tracking.cpp
+++ b/tests/unit/db_memory_tracking.cpp
@@ -11,6 +11,7 @@
 
 #include <gtest/gtest.h>
 
+#include <unistd.h>
 #include <cstddef>
 #include <cstring>
 #include <filesystem>
@@ -1222,6 +1223,66 @@ TEST_F(DbMemoryTrackingTest, MixedAllocators_ConsistentAttribution) {
   EXPECT_GT(after, before + static_cast<int64_t>(1024 * 1024))
       << "Mixed allocator usage should consistently attribute to DB tracker. "
       << "before=" << before << " after=" << after;
+}
+
+// ---------------------------------------------------------------------------
+// 15. (continued) Destructor restore failure leaks hooks and abandons arena
+// ---------------------------------------------------------------------------
+TEST_F(DbMemoryTrackingTest, ArenaPool_DestructorRestoreFailureLeaksHooksAndAbandonsArena) {
+  memgraph::memory::GlobalArenaPool::Instance().Drain();
+
+  unsigned abandoned = 0;
+  {
+    memgraph::utils::MemoryTracker tracker;
+    memgraph::memory::ArenaPool pool{&tracker};
+    abandoned = pool.idx();
+    memgraph::memory::testing::SetArenaPoolFailureInjection(
+        memgraph::memory::testing::ArenaPoolFailureInjection::DestructorRestore);
+  }  // dtor consumes injection; tracker destroyed at scope exit
+
+  ASSERT_NE(abandoned, 0U);
+
+  {
+    memgraph::utils::MemoryTracker t2;
+    memgraph::memory::ArenaPool pool2{&t2};
+    EXPECT_NE(pool2.idx(), abandoned) << "abandoned arena must not be recycled into GlobalArenaPool";
+  }
+
+  // The abandoned arena still has the leaked hooks installed with tracker == nullptr
+  // and the MemoryTracker already destroyed; under ASan this regression-tests that
+  // callbacks no-op instead of UAF.
+  void *p = je_mallocx(2 * 1024 * 1024, MALLOCX_ARENA(abandoned) | MALLOCX_TCACHE_NONE);
+  EXPECT_NE(p, nullptr);
+  je_dallocx(p, MALLOCX_TCACHE_NONE);
+  const std::string purge_key = "arena." + std::to_string(abandoned) + ".purge";
+  je_mallctl(purge_key.c_str(), nullptr, nullptr, nullptr, 0);
+
+  memgraph::memory::testing::SetArenaPoolFailureInjection(memgraph::memory::testing::ArenaPoolFailureInjection::None);
+}
+
+// ---------------------------------------------------------------------------
+// 15. (continued) Per-DB arena indices must exceed every possible CPU id
+// ---------------------------------------------------------------------------
+TEST_F(DbMemoryTrackingTest, ArenaPool_PerDbArenaIndicesAboveEveryPossibleCpuId) {
+  const char *mode = nullptr;
+  size_t sz = sizeof(mode);
+  if (je_mallctl("opt.percpu_arena", &mode, &sz, nullptr, 0) != 0 || mode == nullptr ||
+      std::string{mode} == "disabled") {
+    GTEST_SKIP() << "percpu_arena disabled";
+  }
+
+  const long n_conf = sysconf(_SC_NPROCESSORS_CONF);
+  ASSERT_GT(n_conf, 0);
+  const auto max_cpu_id = static_cast<unsigned>(n_conf) - 1;
+
+  memgraph::memory::EnsureCpuArenaCoverage();
+
+  EXPECT_GT(JemallocArenaCount(), max_cpu_id) << "arena index space must cover every possible CPU id";
+
+  memgraph::memory::GlobalArenaPool::Instance().Drain();
+  const unsigned idx = memgraph::memory::GlobalArenaPool::Instance().Acquire();
+  EXPECT_GT(idx, max_cpu_id) << "per-DB arenas must be unreachable by percpu binding";
+  memgraph::memory::GlobalArenaPool::Instance().Release(idx);
 }
 
 #endif  // USE_JEMALLOC

--- a/tests/unit/db_memory_tracking.cpp
+++ b/tests/unit/db_memory_tracking.cpp
@@ -799,13 +799,15 @@ TEST_F(DbMemoryTrackingTest, ArenaPool_BaseArenaVsAcquireRelease) {
 // ---------------------------------------------------------------------------
 TEST_F(DbMemoryTrackingTest, ArenaPool_ConstructorFailureReleasesPendingArena) {
   memgraph::memory::GlobalArenaPool::Instance().Drain();
+  // Pre-warm CPU coverage so Acquire() below creates exactly one arena.
+  memgraph::memory::EnsureCpuArenaCoverage();
 
   memgraph::utils::MemoryTracker tracker1;
   memgraph::utils::MemoryTracker tracker2;
 
   const auto arena_count_before = JemallocArenaCount();
   memgraph::memory::testing::SetArenaPoolFailureInjection(
-      memgraph::memory::testing::ArenaPoolFailureInjection::ConstructorPublish);
+      memgraph::memory::testing::ArenaPoolFailureInjection::ConstructorThrow);
   EXPECT_THROW((memgraph::memory::ArenaPool{&tracker1}), std::runtime_error);
 
   const auto arena_count_after_failure = JemallocArenaCount();


### PR DESCRIPTION
Two root causes, both fixed:
- Text index drop did not join tantivy's background merge threads; they could outlive the Database and free through its arena hooks. TantivyContext now joins them on drop (wait_merging_threads).
- jemalloc percpu_arena binds a thread to arenas[sched_getcpu()] with no clamp; on hosts with sparse online CPU sets (jemalloc#2054) a high CPU id lands on a per-DB arena index, binding an unrelated thread's tcache to a Database-owned arena. EnsureCpuArenaCoverage() now creates sacrificial arenas at startup so per-DB arena indices are unreachable by any possible CPU id.

Also hardened ArenaPool teardown: if restoring default extent hooks ever fails, the hooks struct is intentionally leaked and the arena abandoned instead of recycled; the tracker pointer is a relaxed atomic so late callbacks no-op.

Verified by offlining CPUs to recreate the sparse-CPU condition: the original failing test (DurabilityTest.SnapshotOnExit) crashes 3/50 on master, 0/150 with this fix. Unit tests cover the hook-restore failure path and the CPU-coverage invariant.

Notes on choices:
- Leads with the user-visible symptom, then the two root causes — review confirmed both legs are load-bearing, so neither is framed as secondary.
- The hardening paragraph stays because it's real behavior change reviewers/git-archaeologists will encounter (relaxed atomic, intentional leak).
- Kept the empirical numbers in one line — they're the strongest signal in the whole PR and cost two lines.