### PR TITLE
fix: rebuild edge metadata after WAL recovery

### DIFF
--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -666,7 +666,7 @@ void InMemoryReplicationHandlers::SnapshotHandler(rpc::FileReplicationHandler co
           dst_snapshot_file,
           &storage->vertices_,
           &storage->edges_,
-          &storage->edges_metadata_,
+          storage->edges_metadata_index_ ? &*storage->edges_metadata_index_ : nullptr,
           &storage->repl_storage_state_.history,
           storage->name_id_mapper_.get(),
           &storage->edge_count_,
@@ -691,16 +691,18 @@ void InMemoryReplicationHandlers::SnapshotHandler(rpc::FileReplicationHandler co
       // We are the only active transaction, so mark everything up to the next timestamp
       if (storage->timestamp_ > 0) storage->commit_log_->MarkFinishedInRange(0, storage->timestamp_ - 1);
 
-      RecoverIndicesStatsAndConstraints(&storage->vertices_,
-                                        storage->name_id_mapper_.get(),
-                                        &storage->indices_,
-                                        &storage->constraints_,
-                                        storage->config_,
-                                        recovery_info,
-                                        storage->DbArenaPool(),
-                                        indices_constraints,
-                                        storage->config_.salient.items.properties_on_edges,
-                                        snapshot_observer_info);
+      RecoverDerivedState(&storage->vertices_,
+                          &storage->edges_,
+                          storage->name_id_mapper_.get(),
+                          &storage->indices_,
+                          &storage->constraints_,
+                          storage->config_,
+                          recovery_info,
+                          storage->DbArenaPool(),
+                          indices_constraints,
+                          storage->edges_metadata_index_ ? &*storage->edges_metadata_index_ : nullptr,
+                          storage->config_.salient.items.properties_on_edges,
+                          snapshot_observer_info);
     } catch (const storage::durability::RecoveryFailure &e) {
       spdlog::error(
           "Couldn't load the snapshot from {} because of: {}. Storage will be cleared. Snapshot and WAL files are "

--- a/src/storage/v2/CMakeLists.txt
+++ b/src/storage/v2/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(mg-storage-v2
         durability/snapshot.cpp
         durability/wal.cpp
         edge_accessor.cpp
+        edge_metadata_index.cpp
         edge_ref.cpp
         edges_iterable.cpp
         id_types.cpp

--- a/src/storage/v2/durability/durability.cpp
+++ b/src/storage/v2/durability/durability.cpp
@@ -30,6 +30,8 @@
 #include "storage/v2/durability/metadata.hpp"
 #include "storage/v2/durability/snapshot.hpp"
 #include "storage/v2/durability/wal.hpp"
+#include "storage/v2/edge.hpp"
+#include "storage/v2/edge_metadata_index.hpp"
 #include "storage/v2/indices/active_indices_updater.hpp"
 #include "storage/v2/inmemory/edge_property_index.hpp"
 #include "storage/v2/inmemory/edge_type_index.hpp"
@@ -221,6 +223,19 @@ std::optional<std::vector<WalDurabilityInfo>> GetWalFiles(const std::filesystem:
 // indices and constraints must be recovered after the data recovery is done
 // to ensure that the indices and constraints are consistent at the end of the
 // recovery process.
+
+namespace {
+void RecoverExistenceConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &, Constraints *,
+                                 utils::SkipListDb<Vertex> *, NameIdMapper *,
+                                 const std::optional<ParallelizedSchemaCreationInfo> &,
+                                 std::optional<SnapshotObserverInfo> const &);
+void RecoverUniqueConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &, Constraints *,
+                              utils::SkipListDb<Vertex> *, NameIdMapper *,
+                              const std::optional<ParallelizedSchemaCreationInfo> &,
+                              std::optional<SnapshotObserverInfo> const &);
+void RecoverTypeConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &, Constraints *,
+                            utils::SkipListDb<Vertex> *, const std::optional<ParallelizedSchemaCreationInfo> &,
+                            std::optional<SnapshotObserverInfo> const &);
 
 void RecoverConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &constraints_metadata,
                         Constraints *constraints, utils::SkipListDb<Vertex> *vertices, NameIdMapper *name_id_mapper,
@@ -513,12 +528,23 @@ void RecoverTypeConstraints(const RecoveredIndicesAndConstraints::ConstraintsMet
 
   spdlog::info("Type constraints are recreated from metadata.");
 }
+}  // namespace
 
-void RecoverIndicesStatsAndConstraints(utils::SkipListDb<Vertex> *vertices, NameIdMapper *name_id_mapper,
-                                       Indices *indices, Constraints *constraints, Config const &config,
-                                       RecoveryInfo const &recovery_info, memory::ArenaPool *db_arena_pool,
-                                       RecoveredIndicesAndConstraints &indices_constraints, bool properties_on_edges,
-                                       std::optional<SnapshotObserverInfo> const &snapshot_info) {
+void RecoverDerivedState(utils::SkipListDb<Vertex> *vertices, [[maybe_unused]] utils::SkipListDb<Edge> *edges,
+                         NameIdMapper *name_id_mapper, Indices *indices, Constraints *constraints, Config const &config,
+                         RecoveryInfo const &recovery_info, memory::ArenaPool *db_arena_pool,
+                         RecoveredIndicesAndConstraints &indices_constraints, EdgeMetadataIndex *edges_metadata,
+                         bool properties_on_edges, std::optional<SnapshotObserverInfo> const &snapshot_info) {
+  // Rebuild the edge metadata index from the fully recovered adjacency before any
+  // other derived structure observes it.
+  if (edges_metadata) {
+    edges_metadata->RebuildFrom(*vertices, GetParallelExecInfo(recovery_info, config, db_arena_pool));
+    // Every recovered edge must have an edge-metadata entry; fail at recovery rather
+    // than later in GC or via lookups.
+    DMG_ASSERT(edges_metadata->size() == edges->size(),
+               "Edge metadata count does not match edge count after recovery!");
+  }
+
   RecoverIndicesAndStats(indices_constraints.indices,
                          indices,
                          vertices,
@@ -547,7 +573,7 @@ std::optional<ParallelizedSchemaCreationInfo> GetParallelExecInfo(const Recovery
 
 std::optional<RecoveryInfo> Recovery::RecoverData(
     utils::UUID &uuid, ReplicationStorageState &repl_storage_state, utils::SkipListDb<Vertex> *vertices,
-    utils::SkipListDb<Edge> *edges, utils::SkipListDb<EdgeMetadata> *edges_metadata, std::atomic<uint64_t> *edge_count,
+    utils::SkipListDb<Edge> *edges, EdgeMetadataIndex *edges_metadata, std::atomic<uint64_t> *edge_count,
     NameIdMapper *name_id_mapper, Indices *indices, Constraints *constraints, Config const &config,
     memory::ArenaPool *db_arena_pool, uint64_t *wal_seq_num, EnumStore *enum_store, SharedSchemaTracking *schema_info,
     std::function<std::optional<std::tuple<EdgeRef, EdgeTypeId, Vertex *, Vertex *>>(Gid)> find_edge,
@@ -782,15 +808,17 @@ std::optional<RecoveryInfo> Recovery::RecoverData(
   }
 
   // Apply meta structures now after all graph data has been loaded
-  RecoverIndicesStatsAndConstraints(vertices,
-                                    name_id_mapper,
-                                    indices,
-                                    constraints,
-                                    config,
-                                    recovery_info,
-                                    db_arena_pool,
-                                    indices_constraints,
-                                    config.salient.items.properties_on_edges);
+  RecoverDerivedState(vertices,
+                      edges,
+                      name_id_mapper,
+                      indices,
+                      constraints,
+                      config,
+                      recovery_info,
+                      db_arena_pool,
+                      indices_constraints,
+                      edges_metadata,
+                      config.salient.items.properties_on_edges);
 
   spdlog::trace("Epoch id: {}. Last durable commit timestamp: {}.",
                 std::string(repl_storage_state.epoch_.id()),

--- a/src/storage/v2/durability/durability.hpp
+++ b/src/storage/v2/durability/durability.hpp
@@ -30,6 +30,10 @@
 #include "storage/v2/vertex.hpp"
 #include "utils/skip_list.hpp"
 
+namespace memgraph::storage {
+class EdgeMetadataIndex;
+}
+
 namespace memgraph::storage::durability {
 
 /// Verifies that the owner of the storage directory is the same user that
@@ -95,52 +99,23 @@ std::optional<std::vector<WalDurabilityInfo>> GetWalFiles(const std::filesystem:
 
 bool ValidateDurabilityFile(std::filesystem::directory_entry const &dir_entry);
 
-// Helper function used to recover all discovered indices. The
-// indices must be recovered after the data recovery is done
-// to ensure that the indices consistent at the end of the
-// recovery process.
+// Rebuild every piece of derived state from the recovered adjacency
+// (vertices + edges). This is the single seam called by every recovery
+// route - snapshot load, WAL replay, replica snapshot RPC - so anything
+// that is a pure function of the final adjacency (indices, constraints,
+// edge-metadata index, ...) belongs here, never inlined into a single
+// version loader.
 /// @throw RecoveryFailure
-void RecoverIndicesAndStats(RecoveredIndicesAndConstraints::IndicesMetadata &indices_metadata, Indices *indices,
-                            utils::SkipListDb<Vertex> *vertices,
-                            NameIdMapper *name_id_mapper, bool properties_on_edges,
-                            const std::optional<ParallelizedSchemaCreationInfo> &parallel_exec_info = std::nullopt,
-                            std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
-
-// Helper function used to recover all discovered constraints. The
-// constraints must be recovered after the data recovery is done
-// to ensure that the constraints are consistent at the end of the
-// recovery process.
-/// @throw RecoveryFailure
-void RecoverConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &constraints_metadata,
-                        Constraints *constraints, utils::SkipListDb<Vertex> *vertices,
-                        NameIdMapper *name_id_mapper,
-                        const std::optional<ParallelizedSchemaCreationInfo> &parallel_exec_info = std::nullopt,
-                        std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
-
-void RecoverIndicesStatsAndConstraints(utils::SkipListDb<Vertex> *vertices,
-                                       NameIdMapper *name_id_mapper, Indices *indices, Constraints *constraints,
-                                       Config const &config, RecoveryInfo const &recovery_info,
-                                       memory::ArenaPool *db_arena_pool,
-                                       RecoveredIndicesAndConstraints &indices_constraints, bool properties_on_edges,
-                                       std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
+void RecoverDerivedState(utils::SkipListDb<Vertex> *vertices, utils::SkipListDb<Edge> *edges,
+                         NameIdMapper *name_id_mapper, Indices *indices, Constraints *constraints, Config const &config,
+                         RecoveryInfo const &recovery_info, memory::ArenaPool *db_arena_pool,
+                         RecoveredIndicesAndConstraints &indices_constraints, EdgeMetadataIndex *edges_metadata,
+                         bool properties_on_edges,
+                         std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
 std::optional<ParallelizedSchemaCreationInfo> GetParallelExecInfo(const RecoveryInfo &recovery_info,
                                                                   const Config &config,
                                                                   memory::ArenaPool *db_arena_pool);
-
-void RecoverExistenceConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &, Constraints *,
-                                 utils::SkipListDb<Vertex> *, NameIdMapper *,
-                                 const std::optional<ParallelizedSchemaCreationInfo> &,
-                                 std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
-
-void RecoverUniqueConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &, Constraints *,
-                              utils::SkipListDb<Vertex> *, NameIdMapper *,
-                              const std::optional<ParallelizedSchemaCreationInfo> &,
-                              std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
-void RecoverTypeConstraints(const RecoveredIndicesAndConstraints::ConstraintsMetadata &, Constraints *,
-                            utils::SkipListDb<Vertex> *,
-                            const std::optional<ParallelizedSchemaCreationInfo> &,
-                            std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt);
 
 struct Recovery {
  public:
@@ -148,10 +123,8 @@ struct Recovery {
   /// @throw RecoveryFailure
   /// @throw std::bad_alloc
   std::optional<RecoveryInfo> RecoverData(
-      utils::UUID &uuid, ReplicationStorageState &repl_storage_state,
-      utils::SkipListDb<Vertex> *vertices,
-      utils::SkipListDb<Edge> *edges,
-      utils::SkipListDb<EdgeMetadata> *edges_metadata, std::atomic<uint64_t> *edge_count,
+      utils::UUID &uuid, ReplicationStorageState &repl_storage_state, utils::SkipListDb<Vertex> *vertices,
+      utils::SkipListDb<Edge> *edges, EdgeMetadataIndex *edges_metadata, std::atomic<uint64_t> *edge_count,
       NameIdMapper *name_id_mapper, Indices *indices, Constraints *constraints, Config const &config,
       memory::ArenaPool *db_arena_pool, uint64_t *wal_seq_num, EnumStore *enum_store, SharedSchemaTracking *schema_info,
       std::function<std::optional<std::tuple<EdgeRef, EdgeTypeId, Vertex *, Vertex *>>(Gid)> find_edge,

--- a/src/storage/v2/durability/snapshot.cpp
+++ b/src/storage/v2/durability/snapshot.cpp
@@ -200,6 +200,44 @@ using task_results_t = std::vector<std::pair<SnapshotPartialRes, std::promise<bo
 
 namespace {
 
+// Rolls back partially-loaded recovery state on destruction unless Commit()
+// was called.
+class RecoveryRollbackGuard {
+ public:
+  RecoveryRollbackGuard(utils::SkipListDb<Vertex> *vertices, utils::SkipListDb<Edge> *edges,
+                        EdgeMetadataIndex *edges_metadata, std::deque<std::pair<std::string, uint64_t>> *epoch_history,
+                        EnumStore *enum_store = nullptr)
+      : vertices_(vertices),
+        edges_(edges),
+        edges_metadata_(edges_metadata),
+        epoch_history_(epoch_history),
+        enum_store_(enum_store) {}
+
+  ~RecoveryRollbackGuard() {
+    if (committed_) return;
+    edges_->clear();
+    vertices_->clear();
+    if (edges_metadata_) edges_metadata_->Clear();
+    epoch_history_->clear();
+    if (enum_store_) enum_store_->clear();
+  }
+
+  RecoveryRollbackGuard(RecoveryRollbackGuard const &) = delete;
+  RecoveryRollbackGuard &operator=(RecoveryRollbackGuard const &) = delete;
+  RecoveryRollbackGuard(RecoveryRollbackGuard &&) = delete;
+  RecoveryRollbackGuard &operator=(RecoveryRollbackGuard &&) = delete;
+
+  void Commit() noexcept { committed_ = true; }
+
+ private:
+  utils::SkipListDb<Vertex> *vertices_;
+  utils::SkipListDb<Edge> *edges_;
+  EdgeMetadataIndex *edges_metadata_;
+  std::deque<std::pair<std::string, uint64_t>> *epoch_history_;
+  EnumStore *enum_store_;
+  bool committed_ = false;
+};
+
 bool WaitAndCombine(task_results_t &partial_results, SnapshotEncoder &snapshot_encoder, uint64_t &element_count,
                     std::vector<BatchInfo> &batch_infos, std::unordered_set<uint64_t> &used_ids,
                     auto &&snapshot_aborted) {
@@ -932,9 +970,8 @@ struct LoadPartialConnectivityResult {
 template <typename TEdgeTypeFromIdFunc>
 LoadPartialConnectivityResult LoadPartialConnectivity(
     const std::filesystem::path &path, utils::SkipListDb<Vertex> &vertices, utils::SkipListDb<Edge> &edges,
-    utils::SkipListDb<EdgeMetadata> &edges_metadata, SharedSchemaTracking *schema_info, const uint64_t from_offset,
-    const uint64_t vertices_count, const SalientConfig::Items items, const bool snapshot_has_edges,
-    TEdgeTypeFromIdFunc get_edge_type_from_id,
+    SharedSchemaTracking *schema_info, const uint64_t from_offset, const uint64_t vertices_count,
+    const SalientConfig::Items items, const bool snapshot_has_edges, TEdgeTypeFromIdFunc get_edge_type_from_id,
     std::optional<SnapshotObserverInfo> const &snapshot_info = std::nullopt) {
   Decoder snapshot;
   snapshot.Initialize(path, kSnapshotMagic);
@@ -943,7 +980,6 @@ LoadPartialConnectivityResult LoadPartialConnectivity(
 
   auto vertex_acc = vertices.access();
   auto edge_acc = edges.access();
-  auto edge_metadata_acc = edges_metadata.access();
 
   // Read the first gid to find the necessary iterator in vertices
   const auto first_vertex_gid = std::invoke([&]() mutable {
@@ -1090,9 +1126,6 @@ LoadPartialConnectivityResult LoadPartialConnectivity(
             auto [edge, inserted] = edge_acc.insert(Edge{Gid::FromUint(*edge_gid), nullptr});
             edge_ref = EdgeRef(&*edge);
           }
-          if (items.enable_edges_metadata) {
-            edge_metadata_acc.insert(EdgeMetadata{Gid::FromUint(*edge_gid), &vertex});
-          }
         }
         vertex.out_edges.emplace_back(get_edge_type_from_id(*edge_type), &*to_vertex, edge_ref);
         // Increment edge count. We only increment the count here because the
@@ -1149,23 +1182,14 @@ void RecoverOnMultipleThreads(size_t thread_count, const TFunc &func, const std:
 
 RecoveredSnapshot LoadSnapshotVersion14(Decoder &snapshot, const std::filesystem::path &path,
                                         utils::SkipListDb<Vertex> *vertices, utils::SkipListDb<Edge> *edges,
-                                        utils::SkipListDb<EdgeMetadata> *edges_metadata,
+                                        EdgeMetadataIndex *edges_metadata,
                                         std::deque<std::pair<std::string, uint64_t>> *epoch_history,
                                         NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count,
                                         SharedSchemaTracking *schema_info, SalientConfig::Items items) {
   RecoveryInfo ret;
   RecoveredIndicesAndConstraints indices_constraints;
 
-  // Cleanup of loaded data in case of failure.
-  bool success = false;
-  const utils::OnScopeExit cleanup([&] {
-    if (!success) {
-      edges->clear();
-      vertices->clear();
-      edges_metadata->clear();
-      epoch_history->clear();
-    }
-  });
+  RecoveryRollbackGuard rollback{vertices, edges, edges_metadata, epoch_history};
 
   // Read snapshot info.
   const auto info = ReadSnapshotInfo(path);
@@ -1627,31 +1651,21 @@ RecoveredSnapshot LoadSnapshotVersion14(Decoder &snapshot, const std::filesystem
   // Recover timestamp.
   ret.next_timestamp = info.start_timestamp + 1;
 
-  // Set success flag (to disable cleanup).
-  success = true;
+  rollback.Commit();
 
   return {info, ret, std::move(indices_constraints)};
 }
 
 RecoveredSnapshot LoadSnapshotVersion15(Decoder &snapshot, const std::filesystem::path &path,
                                         utils::SkipListDb<Vertex> *vertices, utils::SkipListDb<Edge> *edges,
-                                        utils::SkipListDb<EdgeMetadata> *edges_metadata,
+                                        EdgeMetadataIndex *edges_metadata,
                                         std::deque<std::pair<std::string, uint64_t>> *epoch_history,
                                         NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count,
                                         SharedSchemaTracking *schema_info, const Config &config) {
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
 
-  // Cleanup of loaded data in case of failure.
-  bool success = false;
-  const utils::OnScopeExit cleanup([&] {
-    if (!success) {
-      edges->clear();
-      vertices->clear();
-      edges_metadata->clear();
-      epoch_history->clear();
-    }
-  });
+  RecoveryRollbackGuard rollback{vertices, edges, edges_metadata, epoch_history};
 
   // Read snapshot info.
   const auto info = ReadSnapshotInfo(path);
@@ -1772,7 +1786,6 @@ RecoveredSnapshot LoadSnapshotVersion15(Decoder &snapshot, const std::filesystem
         [path,
          vertices,
          edges,
-         edges_metadata,
          schema_info,
          edge_count,
          items = config.salient.items,
@@ -1783,7 +1796,6 @@ RecoveredSnapshot LoadSnapshotVersion15(Decoder &snapshot, const std::filesystem
           const auto result = LoadPartialConnectivity(path,
                                                       *vertices,
                                                       *edges,
-                                                      *edges_metadata,
                                                       schema_info,
                                                       batch.offset,
                                                       batch.count,
@@ -1939,31 +1951,21 @@ RecoveredSnapshot LoadSnapshotVersion15(Decoder &snapshot, const std::filesystem
   // Recover timestamp.
   recovery_info.next_timestamp = info.start_timestamp + 1;
 
-  // Set success flag (to disable cleanup).
-  success = true;
+  rollback.Commit();
 
   return {.snapshot_info = info, .recovery_info = recovery_info, .indices_constraints = std::move(indices_constraints)};
 }
 
 RecoveredSnapshot LoadSnapshotVersion16(Decoder &snapshot, const std::filesystem::path &path,
                                         utils::SkipListDb<Vertex> *vertices, utils::SkipListDb<Edge> *edges,
-                                        utils::SkipListDb<EdgeMetadata> *edges_metadata,
+                                        EdgeMetadataIndex *edges_metadata,
                                         std::deque<std::pair<std::string, uint64_t>> *epoch_history,
                                         NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count,
                                         SharedSchemaTracking *schema_info, const Config &config) {
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
 
-  // Cleanup of loaded data in case of failure.
-  bool success = false;
-  const utils::OnScopeExit cleanup([&] {
-    if (!success) {
-      edges->clear();
-      vertices->clear();
-      edges_metadata->clear();
-      epoch_history->clear();
-    }
-  });
+  RecoveryRollbackGuard rollback{vertices, edges, edges_metadata, epoch_history};
 
   // Read snapshot info.
   const auto info = ReadSnapshotInfo(path);
@@ -2084,7 +2086,6 @@ RecoveredSnapshot LoadSnapshotVersion16(Decoder &snapshot, const std::filesystem
         [path,
          vertices,
          edges,
-         edges_metadata,
          schema_info,
          edge_count,
          items = config.salient.items,
@@ -2095,7 +2096,6 @@ RecoveredSnapshot LoadSnapshotVersion16(Decoder &snapshot, const std::filesystem
           const auto result = LoadPartialConnectivity(path,
                                                       *vertices,
                                                       *edges,
-                                                      *edges_metadata,
                                                       schema_info,
                                                       batch.offset,
                                                       batch.count,
@@ -2313,31 +2313,21 @@ RecoveredSnapshot LoadSnapshotVersion16(Decoder &snapshot, const std::filesystem
   // Recover timestamp.
   recovery_info.next_timestamp = info.start_timestamp + 1;
 
-  // Set success flag (to disable cleanup).
-  success = true;
+  rollback.Commit();
 
   return {.snapshot_info = info, .recovery_info = recovery_info, .indices_constraints = std::move(indices_constraints)};
 }
 
 RecoveredSnapshot LoadSnapshotVersion17(Decoder &snapshot, const std::filesystem::path &path,
                                         utils::SkipListDb<Vertex> *vertices, utils::SkipListDb<Edge> *edges,
-                                        utils::SkipListDb<EdgeMetadata> *edges_metadata,
+                                        EdgeMetadataIndex *edges_metadata,
                                         std::deque<std::pair<std::string, uint64_t>> *epoch_history,
                                         NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count,
                                         SharedSchemaTracking *schema_info, const Config &config) {
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
 
-  // Cleanup of loaded data in case of failure.
-  bool success = false;
-  const utils::OnScopeExit cleanup([&] {
-    if (!success) {
-      edges->clear();
-      vertices->clear();
-      edges_metadata->clear();
-      epoch_history->clear();
-    }
-  });
+  RecoveryRollbackGuard rollback{vertices, edges, edges_metadata, epoch_history};
 
   // Read snapshot info.
   const auto info = ReadSnapshotInfo(path);
@@ -2458,7 +2448,6 @@ RecoveredSnapshot LoadSnapshotVersion17(Decoder &snapshot, const std::filesystem
         [path,
          vertices,
          edges,
-         edges_metadata,
          schema_info,
          edge_count,
          items = config.salient.items,
@@ -2469,7 +2458,6 @@ RecoveredSnapshot LoadSnapshotVersion17(Decoder &snapshot, const std::filesystem
           const auto result = LoadPartialConnectivity(path,
                                                       *vertices,
                                                       *edges,
-                                                      *edges_metadata,
                                                       schema_info,
                                                       batch.offset,
                                                       batch.count,
@@ -2732,8 +2720,7 @@ RecoveredSnapshot LoadSnapshotVersion17(Decoder &snapshot, const std::filesystem
   // Recover timestamp.
   recovery_info.next_timestamp = info.start_timestamp + 1;
 
-  // Set success flag (to disable cleanup).
-  success = true;
+  rollback.Commit();
 
   return {.snapshot_info = info, .recovery_info = recovery_info, .indices_constraints = std::move(indices_constraints)};
 }
@@ -2742,7 +2729,7 @@ RecoveredSnapshot LoadSnapshotVersion17(Decoder &snapshot, const std::filesystem
 /// hence same load for 18 will work for 19
 RecoveredSnapshot LoadSnapshotVersion18or19(Decoder &snapshot, const std::filesystem::path &path,
                                             utils::SkipListDb<Vertex> *vertices, utils::SkipListDb<Edge> *edges,
-                                            utils::SkipListDb<EdgeMetadata> *edges_metadata,
+                                            EdgeMetadataIndex *edges_metadata,
                                             std::deque<std::pair<std::string, uint64_t>> *epoch_history,
                                             NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count,
                                             SharedSchemaTracking *schema_info, const Config &config,
@@ -2750,17 +2737,7 @@ RecoveredSnapshot LoadSnapshotVersion18or19(Decoder &snapshot, const std::filesy
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
 
-  // Cleanup of loaded data in case of failure.
-  bool success = false;
-  auto const cleanup = utils::OnScopeExit([&] {
-    if (!success) {
-      edges->clear();
-      vertices->clear();
-      edges_metadata->clear();
-      epoch_history->clear();
-      enum_store->clear();
-    }
-  });
+  RecoveryRollbackGuard rollback{vertices, edges, edges_metadata, epoch_history, enum_store};
 
   // Read snapshot info.
   const auto info = ReadSnapshotInfo(path);
@@ -2919,7 +2896,6 @@ RecoveredSnapshot LoadSnapshotVersion18or19(Decoder &snapshot, const std::filesy
         [path,
          vertices,
          edges,
-         edges_metadata,
          edge_count,
          items = config.salient.items,
          snapshot_has_edges,
@@ -2930,7 +2906,6 @@ RecoveredSnapshot LoadSnapshotVersion18or19(Decoder &snapshot, const std::filesy
           const auto result = LoadPartialConnectivity(path,
                                                       *vertices,
                                                       *edges,
-                                                      *edges_metadata,
                                                       schema_info,
                                                       batch.offset,
                                                       batch.count,
@@ -3212,15 +3187,14 @@ RecoveredSnapshot LoadSnapshotVersion18or19(Decoder &snapshot, const std::filesy
   // Recover timestamp.
   recovery_info.next_timestamp = info.start_timestamp + 1;
 
-  // Set success flag (to disable cleanup).
-  success = true;
+  rollback.Commit();
 
   return {.snapshot_info = info, .recovery_info = recovery_info, .indices_constraints = std::move(indices_constraints)};
 }
 
 RecoveredSnapshot LoadSnapshotVersion20or21(Decoder &snapshot, const std::filesystem::path &path,
                                             utils::SkipListDb<Vertex> *vertices, utils::SkipListDb<Edge> *edges,
-                                            utils::SkipListDb<EdgeMetadata> *edges_metadata,
+                                            EdgeMetadataIndex *edges_metadata,
                                             std::deque<std::pair<std::string, uint64_t>> *epoch_history,
                                             NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count,
                                             SharedSchemaTracking *schema_info, const Config &config,
@@ -3228,17 +3202,7 @@ RecoveredSnapshot LoadSnapshotVersion20or21(Decoder &snapshot, const std::filesy
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
 
-  // Cleanup of loaded data in case of failure.
-  bool success = false;
-  auto const cleanup = utils::OnScopeExit([&] {
-    if (!success) {
-      edges->clear();
-      vertices->clear();
-      edges_metadata->clear();
-      epoch_history->clear();
-      enum_store->clear();
-    }
-  });
+  RecoveryRollbackGuard rollback{vertices, edges, edges_metadata, epoch_history, enum_store};
 
   // Read snapshot info.
   const auto info = ReadSnapshotInfo(path);
@@ -3397,7 +3361,6 @@ RecoveredSnapshot LoadSnapshotVersion20or21(Decoder &snapshot, const std::filesy
         [path,
          vertices,
          edges,
-         edges_metadata,
          schema_info,
          edge_count,
          items = config.salient.items,
@@ -3408,7 +3371,6 @@ RecoveredSnapshot LoadSnapshotVersion20or21(Decoder &snapshot, const std::filesy
           const auto result = LoadPartialConnectivity(path,
                                                       *vertices,
                                                       *edges,
-                                                      *edges_metadata,
                                                       schema_info,
                                                       batch.offset,
                                                       batch.count,
@@ -3739,15 +3701,14 @@ RecoveredSnapshot LoadSnapshotVersion20or21(Decoder &snapshot, const std::filesy
   // Recover timestamp.
   recovery_info.next_timestamp = info.start_timestamp + 1;
 
-  // Set success flag (to disable cleanup).
-  success = true;
+  rollback.Commit();
 
   return {.snapshot_info = info, .recovery_info = recovery_info, .indices_constraints = std::move(indices_constraints)};
 }
 
 RecoveredSnapshot LoadSnapshotVersion22or23(Decoder &snapshot, const std::filesystem::path &path,
                                             utils::SkipListDb<Vertex> *vertices, utils::SkipListDb<Edge> *edges,
-                                            utils::SkipListDb<EdgeMetadata> *edges_metadata,
+                                            EdgeMetadataIndex *edges_metadata,
                                             std::deque<std::pair<std::string, uint64_t>> *epoch_history,
                                             NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count,
                                             const Config &config, memgraph::storage::EnumStore *enum_store,
@@ -3756,17 +3717,7 @@ RecoveredSnapshot LoadSnapshotVersion22or23(Decoder &snapshot, const std::filesy
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
 
-  // Cleanup of loaded data in case of failure.
-  bool success = false;
-  const utils::OnScopeExit cleanup([&] {
-    if (!success) {
-      edges->clear();
-      vertices->clear();
-      edges_metadata->clear();
-      epoch_history->clear();
-      enum_store->clear();
-    }
-  });
+  RecoveryRollbackGuard rollback{vertices, edges, edges_metadata, epoch_history, enum_store};
 
   // Read snapshot info.
   const auto info = ReadSnapshotInfo(path);
@@ -3928,7 +3879,6 @@ RecoveredSnapshot LoadSnapshotVersion22or23(Decoder &snapshot, const std::filesy
         [path,
          vertices,
          edges,
-         edges_metadata,
          schema_info,
          edge_count,
          items = config.salient.items,
@@ -3940,7 +3890,6 @@ RecoveredSnapshot LoadSnapshotVersion22or23(Decoder &snapshot, const std::filesy
           const auto result = LoadPartialConnectivity(path,
                                                       *vertices,
                                                       *edges,
-                                                      *edges_metadata,
                                                       schema_info,
                                                       batch.offset,
                                                       batch.count,
@@ -4319,15 +4268,14 @@ RecoveredSnapshot LoadSnapshotVersion22or23(Decoder &snapshot, const std::filesy
   // Recover timestamp.
   recovery_info.next_timestamp = info.start_timestamp + 1;
 
-  // Set success flag (to disable cleanup).
-  success = true;
+  rollback.Commit();
 
   return {.snapshot_info = info, .recovery_info = recovery_info, .indices_constraints = std::move(indices_constraints)};
 }
 
 RecoveredSnapshot LoadSnapshotVersion24(Decoder &snapshot, std::filesystem::path const &path,
                                         utils::SkipListDb<Vertex> *vertices, utils::SkipListDb<Edge> *edges,
-                                        utils::SkipListDb<EdgeMetadata> *edges_metadata,
+                                        EdgeMetadataIndex *edges_metadata,
                                         std::deque<std::pair<std::string, uint64_t>> *epoch_history,
                                         NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count,
                                         Config const &config, EnumStore *enum_store, SharedSchemaTracking *schema_info,
@@ -4337,16 +4285,7 @@ RecoveredSnapshot LoadSnapshotVersion24(Decoder &snapshot, std::filesystem::path
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
 
-  bool success = false;
-  auto const cleanup = utils::OnScopeExit([&] {
-    if (!success) {
-      edges->clear();
-      vertices->clear();
-      edges_metadata->clear();
-      epoch_history->clear();
-      enum_store->clear();
-    }
-  });
+  RecoveryRollbackGuard rollback{vertices, edges, edges_metadata, epoch_history, enum_store};
 
   // Read snapshot info.
   const auto info = ReadSnapshotInfo(path);
@@ -4513,7 +4452,6 @@ RecoveredSnapshot LoadSnapshotVersion24(Decoder &snapshot, std::filesystem::path
           [path,
            vertices,
            edges,
-           edges_metadata,
            schema_info,
            edge_count,
            items = config.salient.items,
@@ -4525,7 +4463,6 @@ RecoveredSnapshot LoadSnapshotVersion24(Decoder &snapshot, std::filesystem::path
             const auto result = LoadPartialConnectivity(path,
                                                         *vertices,
                                                         *edges,
-                                                        *edges_metadata,
                                                         schema_info,
                                                         batch.offset,
                                                         batch.count,
@@ -4949,15 +4886,14 @@ RecoveredSnapshot LoadSnapshotVersion24(Decoder &snapshot, std::filesystem::path
   // Recover timestamp.
   recovery_info.next_timestamp = info.start_timestamp + 1;
 
-  // Set success flag (to disable cleanup).
-  success = true;
+  rollback.Commit();
 
   return {.snapshot_info = info, .recovery_info = recovery_info, .indices_constraints = std::move(indices_constraints)};
 }
 
 RecoveredSnapshot LoadSnapshotVersion25(Decoder &snapshot, std::filesystem::path const &path,
                                         utils::SkipListDb<Vertex> *vertices, utils::SkipListDb<Edge> *edges,
-                                        utils::SkipListDb<EdgeMetadata> *edges_metadata,
+                                        EdgeMetadataIndex *edges_metadata,
                                         std::deque<std::pair<std::string, uint64_t>> *epoch_history,
                                         NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count,
                                         Config const &config, EnumStore *enum_store, SharedSchemaTracking *schema_info,
@@ -4967,16 +4903,7 @@ RecoveredSnapshot LoadSnapshotVersion25(Decoder &snapshot, std::filesystem::path
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
 
-  bool success = false;
-  auto const cleanup = utils::OnScopeExit([&] {
-    if (!success) {
-      edges->clear();
-      vertices->clear();
-      edges_metadata->clear();
-      epoch_history->clear();
-      enum_store->clear();
-    }
-  });
+  RecoveryRollbackGuard rollback{vertices, edges, edges_metadata, epoch_history, enum_store};
 
   // Read snapshot info.
   const auto info = ReadSnapshotInfo(path);
@@ -5162,7 +5089,6 @@ RecoveredSnapshot LoadSnapshotVersion25(Decoder &snapshot, std::filesystem::path
           [path,
            vertices,
            edges,
-           edges_metadata,
            schema_info,
            edge_count,
            items = config.salient.items,
@@ -5174,7 +5100,6 @@ RecoveredSnapshot LoadSnapshotVersion25(Decoder &snapshot, std::filesystem::path
             const auto result = LoadPartialConnectivity(path,
                                                         *vertices,
                                                         *edges,
-                                                        *edges_metadata,
                                                         schema_info,
                                                         batch.offset,
                                                         batch.count,
@@ -5571,15 +5496,14 @@ RecoveredSnapshot LoadSnapshotVersion25(Decoder &snapshot, std::filesystem::path
   // Recover timestamp.
   recovery_info.next_timestamp = info.start_timestamp + 1;
 
-  // Set success flag (to disable cleanup).
-  success = true;
+  rollback.Commit();
 
   return {.snapshot_info = info, .recovery_info = recovery_info, .indices_constraints = std::move(indices_constraints)};
 }
 
 RecoveredSnapshot LoadSnapshotVersion26(Decoder &snapshot, std::filesystem::path const &path,
                                         utils::SkipListDb<Vertex> *vertices, utils::SkipListDb<Edge> *edges,
-                                        utils::SkipListDb<EdgeMetadata> *edges_metadata,
+                                        EdgeMetadataIndex *edges_metadata,
                                         std::deque<std::pair<std::string, uint64_t>> *epoch_history,
                                         NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count,
                                         Config const &config, EnumStore *enum_store, SharedSchemaTracking *schema_info,
@@ -5589,16 +5513,7 @@ RecoveredSnapshot LoadSnapshotVersion26(Decoder &snapshot, std::filesystem::path
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
 
-  bool success = false;
-  auto const cleanup = utils::OnScopeExit([&] {
-    if (!success) {
-      edges->clear();
-      vertices->clear();
-      edges_metadata->clear();
-      epoch_history->clear();
-      enum_store->clear();
-    }
-  });
+  RecoveryRollbackGuard rollback{vertices, edges, edges_metadata, epoch_history, enum_store};
 
   // Read snapshot info.
   const auto info = ReadSnapshotInfo(path);
@@ -5784,7 +5699,6 @@ RecoveredSnapshot LoadSnapshotVersion26(Decoder &snapshot, std::filesystem::path
           [path,
            vertices,
            edges,
-           edges_metadata,
            schema_info,
            edge_count,
            items = config.salient.items,
@@ -5796,7 +5710,6 @@ RecoveredSnapshot LoadSnapshotVersion26(Decoder &snapshot, std::filesystem::path
             const auto result = LoadPartialConnectivity(path,
                                                         *vertices,
                                                         *edges,
-                                                        *edges_metadata,
                                                         schema_info,
                                                         batch.offset,
                                                         batch.count,
@@ -6195,15 +6108,14 @@ RecoveredSnapshot LoadSnapshotVersion26(Decoder &snapshot, std::filesystem::path
   // Recover timestamp.
   recovery_info.next_timestamp = info.start_timestamp + 1;
 
-  // Set success flag (to disable cleanup).
-  success = true;
+  rollback.Commit();
 
   return {.snapshot_info = info, .recovery_info = recovery_info, .indices_constraints = std::move(indices_constraints)};
 }
 
 RecoveredSnapshot LoadSnapshotVersion27or28(Decoder &snapshot, std::filesystem::path const &path,
                                             utils::SkipListDb<Vertex> *vertices, utils::SkipListDb<Edge> *edges,
-                                            utils::SkipListDb<EdgeMetadata> *edges_metadata,
+                                            EdgeMetadataIndex *edges_metadata,
                                             std::deque<std::pair<std::string, uint64_t>> *epoch_history,
                                             NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count,
                                             Config const &config, EnumStore *enum_store,
@@ -6213,16 +6125,7 @@ RecoveredSnapshot LoadSnapshotVersion27or28(Decoder &snapshot, std::filesystem::
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
 
-  bool success = false;
-  auto const cleanup = utils::OnScopeExit([&] {
-    if (!success) {
-      edges->clear();
-      vertices->clear();
-      edges_metadata->clear();
-      epoch_history->clear();
-      enum_store->clear();
-    }
-  });
+  RecoveryRollbackGuard rollback{vertices, edges, edges_metadata, epoch_history, enum_store};
 
   // Read snapshot info.
   const auto info = ReadSnapshotInfo(path);
@@ -6408,7 +6311,6 @@ RecoveredSnapshot LoadSnapshotVersion27or28(Decoder &snapshot, std::filesystem::
           [path,
            vertices,
            edges,
-           edges_metadata,
            schema_info,
            edge_count,
            items = config.salient.items,
@@ -6420,7 +6322,6 @@ RecoveredSnapshot LoadSnapshotVersion27or28(Decoder &snapshot, std::filesystem::
             const auto result = LoadPartialConnectivity(path,
                                                         *vertices,
                                                         *edges,
-                                                        *edges_metadata,
                                                         schema_info,
                                                         batch.offset,
                                                         batch.count,
@@ -6873,15 +6774,14 @@ RecoveredSnapshot LoadSnapshotVersion27or28(Decoder &snapshot, std::filesystem::
   // Recover timestamp.
   recovery_info.next_timestamp = info.start_timestamp + 1;
 
-  // Set success flag (to disable cleanup).
-  success = true;
+  rollback.Commit();
 
   return {.snapshot_info = info, .recovery_info = recovery_info, .indices_constraints = std::move(indices_constraints)};
 }
 
 RecoveredSnapshot LoadSnapshotVersion29(Decoder &snapshot, std::filesystem::path const &path,
                                         utils::SkipListDb<Vertex> *vertices, utils::SkipListDb<Edge> *edges,
-                                        utils::SkipListDb<EdgeMetadata> *edges_metadata,
+                                        EdgeMetadataIndex *edges_metadata,
                                         std::deque<std::pair<std::string, uint64_t>> *epoch_history,
                                         NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count,
                                         Config const &config, EnumStore *enum_store, SharedSchemaTracking *schema_info,
@@ -6891,16 +6791,7 @@ RecoveredSnapshot LoadSnapshotVersion29(Decoder &snapshot, std::filesystem::path
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
 
-  bool success = false;
-  auto const cleanup = utils::OnScopeExit([&] {
-    if (!success) {
-      edges->clear();
-      vertices->clear();
-      edges_metadata->clear();
-      epoch_history->clear();
-      enum_store->clear();
-    }
-  });
+  RecoveryRollbackGuard rollback{vertices, edges, edges_metadata, epoch_history, enum_store};
 
   // Read snapshot info.
   const auto info = ReadSnapshotInfo(path);
@@ -7086,7 +6977,6 @@ RecoveredSnapshot LoadSnapshotVersion29(Decoder &snapshot, std::filesystem::path
           [path,
            vertices,
            edges,
-           edges_metadata,
            schema_info,
            edge_count,
            items = config.salient.items,
@@ -7098,7 +6988,6 @@ RecoveredSnapshot LoadSnapshotVersion29(Decoder &snapshot, std::filesystem::path
             const auto result = LoadPartialConnectivity(path,
                                                         *vertices,
                                                         *edges,
-                                                        *edges_metadata,
                                                         schema_info,
                                                         batch.offset,
                                                         batch.count,
@@ -7561,15 +7450,14 @@ RecoveredSnapshot LoadSnapshotVersion29(Decoder &snapshot, std::filesystem::path
   // Recover timestamp.
   recovery_info.next_timestamp = info.start_timestamp + 1;
 
-  // Set success flag (to disable cleanup).
-  success = true;
+  rollback.Commit();
 
   return {.snapshot_info = info, .recovery_info = recovery_info, .indices_constraints = std::move(indices_constraints)};
 }
 
 RecoveredSnapshot LoadSnapshotVersion30(Decoder &snapshot, std::filesystem::path const &path,
                                         utils::SkipListDb<Vertex> *vertices, utils::SkipListDb<Edge> *edges,
-                                        utils::SkipListDb<EdgeMetadata> *edges_metadata,
+                                        EdgeMetadataIndex *edges_metadata,
                                         std::deque<std::pair<std::string, uint64_t>> *epoch_history,
                                         NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count,
                                         Config const &config, EnumStore *enum_store, SharedSchemaTracking *schema_info,
@@ -7580,16 +7468,7 @@ RecoveredSnapshot LoadSnapshotVersion30(Decoder &snapshot, std::filesystem::path
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
 
-  bool success = false;
-  auto const cleanup = utils::OnScopeExit([&] {
-    if (!success) {
-      edges->clear();
-      vertices->clear();
-      edges_metadata->clear();
-      epoch_history->clear();
-      enum_store->clear();
-    }
-  });
+  RecoveryRollbackGuard rollback{vertices, edges, edges_metadata, epoch_history, enum_store};
 
   // Read snapshot info.
   const auto info = ReadSnapshotInfo(path);
@@ -7775,7 +7654,6 @@ RecoveredSnapshot LoadSnapshotVersion30(Decoder &snapshot, std::filesystem::path
           [path,
            vertices,
            edges,
-           edges_metadata,
            schema_info,
            edge_count,
            items = config.salient.items,
@@ -7787,7 +7665,6 @@ RecoveredSnapshot LoadSnapshotVersion30(Decoder &snapshot, std::filesystem::path
             const auto result = LoadPartialConnectivity(path,
                                                         *vertices,
                                                         *edges,
-                                                        *edges_metadata,
                                                         schema_info,
                                                         batch.offset,
                                                         batch.count,
@@ -8314,15 +8191,14 @@ RecoveredSnapshot LoadSnapshotVersion30(Decoder &snapshot, std::filesystem::path
   recovery_info.next_timestamp = info.start_timestamp + 1;
   recovery_info.num_committed_txns = info.num_committed_txns;
 
-  // Set success flag (to disable cleanup).
-  success = true;
+  rollback.Commit();
 
   return {.snapshot_info = info, .recovery_info = recovery_info, .indices_constraints = std::move(indices_constraints)};
 }
 
 RecoveredSnapshot LoadSnapshotVersion31(Decoder &snapshot, std::filesystem::path const &path,
                                         utils::SkipListDb<Vertex> *vertices, utils::SkipListDb<Edge> *edges,
-                                        utils::SkipListDb<EdgeMetadata> *edges_metadata,
+                                        EdgeMetadataIndex *edges_metadata,
                                         std::deque<std::pair<std::string, uint64_t>> *epoch_history,
                                         NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count,
                                         Config const &config, EnumStore *enum_store, SharedSchemaTracking *schema_info,
@@ -8333,16 +8209,7 @@ RecoveredSnapshot LoadSnapshotVersion31(Decoder &snapshot, std::filesystem::path
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
 
-  bool success = false;
-  auto const cleanup = utils::OnScopeExit([&] {
-    if (!success) {
-      edges->clear();
-      vertices->clear();
-      edges_metadata->clear();
-      epoch_history->clear();
-      enum_store->clear();
-    }
-  });
+  RecoveryRollbackGuard rollback{vertices, edges, edges_metadata, epoch_history, enum_store};
 
   // Read snapshot info.
   const auto info = ReadSnapshotInfo(path);
@@ -8528,7 +8395,6 @@ RecoveredSnapshot LoadSnapshotVersion31(Decoder &snapshot, std::filesystem::path
           [path,
            vertices,
            edges,
-           edges_metadata,
            schema_info,
            edge_count,
            items = config.salient.items,
@@ -8540,7 +8406,6 @@ RecoveredSnapshot LoadSnapshotVersion31(Decoder &snapshot, std::filesystem::path
             const auto result = LoadPartialConnectivity(path,
                                                         *vertices,
                                                         *edges,
-                                                        *edges_metadata,
                                                         schema_info,
                                                         batch.offset,
                                                         batch.count,
@@ -9105,8 +8970,7 @@ RecoveredSnapshot LoadSnapshotVersion31(Decoder &snapshot, std::filesystem::path
   recovery_info.next_timestamp = info.start_timestamp + 1;
   recovery_info.num_committed_txns = info.num_committed_txns;
 
-  // Set success flag (to disable cleanup).
-  success = true;
+  rollback.Commit();
 
   return {.snapshot_info = info, .recovery_info = recovery_info, .indices_constraints = std::move(indices_constraints)};
 }
@@ -9114,7 +8978,7 @@ RecoveredSnapshot LoadSnapshotVersion31(Decoder &snapshot, std::filesystem::path
 // NOLINTNEXTLINE(readability-function-size)
 RecoveredSnapshot LoadSnapshotVersion33(Decoder &snapshot, std::filesystem::path const &path,
                                         utils::SkipListDb<Vertex> *vertices, utils::SkipListDb<Edge> *edges,
-                                        utils::SkipListDb<EdgeMetadata> *edges_metadata,
+                                        EdgeMetadataIndex *edges_metadata,
                                         std::deque<std::pair<std::string, uint64_t>> *epoch_history,
                                         NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count,
                                         Config const &config, EnumStore *enum_store, SharedSchemaTracking *schema_info,
@@ -9125,16 +8989,7 @@ RecoveredSnapshot LoadSnapshotVersion33(Decoder &snapshot, std::filesystem::path
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
 
-  bool success = false;
-  auto const cleanup = utils::OnScopeExit([&] {
-    if (!success) {
-      edges->clear();
-      vertices->clear();
-      edges_metadata->clear();
-      epoch_history->clear();
-      enum_store->clear();
-    }
-  });
+  RecoveryRollbackGuard rollback{vertices, edges, edges_metadata, epoch_history, enum_store};
 
   // Read snapshot info.
   const auto info = ReadSnapshotInfo(path);
@@ -9320,7 +9175,6 @@ RecoveredSnapshot LoadSnapshotVersion33(Decoder &snapshot, std::filesystem::path
           [path,
            vertices,
            edges,
-           edges_metadata,
            schema_info,
            edge_count,
            items = config.salient.items,
@@ -9332,7 +9186,6 @@ RecoveredSnapshot LoadSnapshotVersion33(Decoder &snapshot, std::filesystem::path
             const auto result = LoadPartialConnectivity(path,
                                                         *vertices,
                                                         *edges,
-                                                        *edges_metadata,
                                                         schema_info,
                                                         batch.offset,
                                                         batch.count,
@@ -9904,8 +9757,7 @@ RecoveredSnapshot LoadSnapshotVersion33(Decoder &snapshot, std::filesystem::path
   recovery_info.next_timestamp = info.start_timestamp + 1;
   recovery_info.num_committed_txns = info.num_committed_txns;
 
-  // Set success flag (to disable cleanup).
-  success = true;
+  rollback.Commit();
 
   return {.snapshot_info = info, .recovery_info = recovery_info, .indices_constraints = std::move(indices_constraints)};
 }
@@ -10000,7 +9852,7 @@ void RecoverDescriptionStore(Decoder &snapshot, SnapshotInfo const &info, NameId
 // NOLINTNEXTLINE(readability-function-size)
 RecoveredSnapshot LoadCurrentVersionSnapshot(
     Decoder &snapshot, std::filesystem::path const &path, utils::SkipListDb<Vertex> *vertices,
-    utils::SkipListDb<Edge> *edges, utils::SkipListDb<EdgeMetadata> *edges_metadata,
+    utils::SkipListDb<Edge> *edges, EdgeMetadataIndex *edges_metadata,
     std::deque<std::pair<std::string, uint64_t>> *epoch_history, NameIdMapper *name_id_mapper,
     std::atomic<uint64_t> *edge_count, Config const &config, EnumStore *enum_store, SharedSchemaTracking *schema_info,
     memgraph::storage::ttl::TTL *ttl, memgraph::storage::DescriptionStore *description_store,
@@ -10010,16 +9862,7 @@ RecoveredSnapshot LoadCurrentVersionSnapshot(
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
 
-  bool success = false;
-  auto const cleanup = utils::OnScopeExit([&] {
-    if (!success) {
-      edges->clear();
-      vertices->clear();
-      edges_metadata->clear();
-      epoch_history->clear();
-      enum_store->clear();
-    }
-  });
+  RecoveryRollbackGuard rollback{vertices, edges, edges_metadata, epoch_history, enum_store};
 
   // Read snapshot info.
   const auto info = ReadSnapshotInfo(path);
@@ -10205,7 +10048,6 @@ RecoveredSnapshot LoadCurrentVersionSnapshot(
           [path,
            vertices,
            edges,
-           edges_metadata,
            schema_info,
            edge_count,
            items = config.salient.items,
@@ -10217,7 +10059,6 @@ RecoveredSnapshot LoadCurrentVersionSnapshot(
             const auto result = LoadPartialConnectivity(path,
                                                         *vertices,
                                                         *edges,
-                                                        *edges_metadata,
                                                         schema_info,
                                                         batch.offset,
                                                         batch.count,
@@ -10858,15 +10699,14 @@ RecoveredSnapshot LoadCurrentVersionSnapshot(
   recovery_info.next_timestamp = info.start_timestamp + 1;
   recovery_info.num_committed_txns = info.num_committed_txns;
 
-  // Set success flag (to disable cleanup).
-  success = true;
+  rollback.Commit();
 
   return {.snapshot_info = info, .recovery_info = recovery_info, .indices_constraints = std::move(indices_constraints)};
 }
 
 RecoveredSnapshot LoadSnapshotVersion34(Decoder &snapshot, std::filesystem::path const &path,
                                         utils::SkipListDb<Vertex> *vertices, utils::SkipListDb<Edge> *edges,
-                                        utils::SkipListDb<EdgeMetadata> *edges_metadata,
+                                        EdgeMetadataIndex *edges_metadata,
                                         std::deque<std::pair<std::string, uint64_t>> *epoch_history,
                                         NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count,
                                         Config const &config, EnumStore *enum_store, SharedSchemaTracking *schema_info,
@@ -10878,16 +10718,7 @@ RecoveredSnapshot LoadSnapshotVersion34(Decoder &snapshot, std::filesystem::path
   RecoveryInfo recovery_info;
   RecoveredIndicesAndConstraints indices_constraints;
 
-  bool success = false;
-  auto const cleanup = utils::OnScopeExit([&] {
-    if (!success) {
-      edges->clear();
-      vertices->clear();
-      edges_metadata->clear();
-      epoch_history->clear();
-      enum_store->clear();
-    }
-  });
+  RecoveryRollbackGuard rollback{vertices, edges, edges_metadata, epoch_history, enum_store};
 
   // Read snapshot info.
   const auto info = ReadSnapshotInfo(path);
@@ -11073,7 +10904,6 @@ RecoveredSnapshot LoadSnapshotVersion34(Decoder &snapshot, std::filesystem::path
           [path,
            vertices,
            edges,
-           edges_metadata,
            schema_info,
            edge_count,
            items = config.salient.items,
@@ -11085,7 +10915,6 @@ RecoveredSnapshot LoadSnapshotVersion34(Decoder &snapshot, std::filesystem::path
             const auto result = LoadPartialConnectivity(path,
                                                         *vertices,
                                                         *edges,
-                                                        *edges_metadata,
                                                         schema_info,
                                                         batch.offset,
                                                         batch.count,
@@ -11696,8 +11525,7 @@ RecoveredSnapshot LoadSnapshotVersion34(Decoder &snapshot, std::filesystem::path
   recovery_info.next_timestamp = info.start_timestamp + 1;
   recovery_info.num_committed_txns = info.num_committed_txns;
 
-  // Set success flag (to disable cleanup).
-  success = true;
+  rollback.Commit();
 
   return {.snapshot_info = info, .recovery_info = recovery_info, .indices_constraints = std::move(indices_constraints)};
 }
@@ -11705,7 +11533,7 @@ RecoveredSnapshot LoadSnapshotVersion34(Decoder &snapshot, std::filesystem::path
 }  // namespace
 
 RecoveredSnapshot LoadSnapshot(const std::filesystem::path &path, utils::SkipListDb<Vertex> *vertices,
-                               utils::SkipListDb<Edge> *edges, utils::SkipListDb<EdgeMetadata> *edges_metadata,
+                               utils::SkipListDb<Edge> *edges, EdgeMetadataIndex *edges_metadata,
                                std::deque<std::pair<std::string, uint64_t>> *epoch_history,
                                NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count, const Config &config,
                                memgraph::storage::EnumStore *enum_store, SharedSchemaTracking *schema_info,

--- a/src/storage/v2/durability/snapshot.hpp
+++ b/src/storage/v2/durability/snapshot.hpp
@@ -20,6 +20,7 @@
 #include "storage/v2/description_store.hpp"
 #include "storage/v2/durability/metadata.hpp"
 #include "storage/v2/edge.hpp"
+#include "storage/v2/edge_metadata_index.hpp"
 #include "storage/v2/enum_store.hpp"
 #include "storage/v2/indices/indices.hpp"
 #include "storage/v2/name_id_mapper.hpp"
@@ -80,7 +81,7 @@ bool OverwriteSnapshotUUID(std::filesystem::path const &path, utils::UUID const 
 /// Function used to load the snapshot data into the storage.
 /// @throw RecoveryFailure
 RecoveredSnapshot LoadSnapshot(std::filesystem::path const &path, utils::SkipListDb<Vertex> *vertices,
-                               utils::SkipListDb<Edge> *edges, utils::SkipListDb<EdgeMetadata> *edges_metadata,
+                               utils::SkipListDb<Edge> *edges, EdgeMetadataIndex *edges_metadata,
                                std::deque<std::pair<std::string, uint64_t>> *epoch_history,
                                NameIdMapper *name_id_mapper, std::atomic<uint64_t> *edge_count, Config const &config,
                                memgraph::storage::EnumStore *enum_store,

--- a/src/storage/v2/edge_metadata_index.cpp
+++ b/src/storage/v2/edge_metadata_index.cpp
@@ -1,0 +1,40 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "storage/v2/edge_metadata_index.hpp"
+
+#include "storage/v2/indices/indices_utils.hpp"
+#include "utils/logging.hpp"
+
+namespace memgraph::storage {
+
+void EdgeMetadataIndex::RebuildFrom(
+    utils::SkipListDb<Vertex> &vertices,
+    std::optional<durability::ParallelizedSchemaCreationInfo> const &parallel_exec_info) {
+  data_.clear();
+  auto vertex_acc = vertices.access();
+  PopulateIndexDispatch(
+      vertex_acc,
+      [this]() { return data_.access(); },
+      [](Vertex &vertex, auto &metadata_acc) {
+        for (auto const &[edge_type, to_vertex, edge_ref] : vertex.out_edges) {
+          auto *edge = edge_ref.ptr;
+          // NOLINTBEGIN(clang-analyzer-core.NullDereference)
+          auto [_, inserted] = metadata_acc.insert(EdgeMetadata{edge->gid, &vertex});
+          MG_ASSERT(inserted, "Edge metadata entry already existed for gid {}!", edge->gid.AsUint());
+          // NOLINTEND(clang-analyzer-core.NullDereference)
+        }
+      },
+      []() { return false; },
+      parallel_exec_info);
+}
+
+}  // namespace memgraph::storage

--- a/src/storage/v2/edge_metadata_index.hpp
+++ b/src/storage/v2/edge_metadata_index.hpp
@@ -1,0 +1,86 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <optional>
+#include <ranges>
+
+#include "storage/v2/durability/recovery_type.hpp"
+#include "storage/v2/edge.hpp"
+#include "storage/v2/id_types.hpp"
+#include "storage/v2/vertex.hpp"
+#include "utils/skip_list.hpp"
+
+namespace memgraph::storage {
+
+// Denormalised gid -> from-vertex map used to answer edge-by-gid lookups in
+// O(log N) without scanning vertex adjacency. Derived from vertex out_edges;
+// never loaded from durability files. Presence on `InMemoryStorage` is gated by
+// the salient flag `enable_edges_metadata` (which requires `properties_on_edges`).
+//
+// Invariant: when the index exists, `size() == edges_.size()` at every
+// quiescent point (post-recovery, post-GC). The index is populated during
+// recovery by a single post-recovery rebuild from the final adjacency, not
+// inlined into any particular recovery route.
+class EdgeMetadataIndex {
+ public:
+  EdgeMetadataIndex() = default;
+  EdgeMetadataIndex(EdgeMetadataIndex const &) = delete;
+  EdgeMetadataIndex &operator=(EdgeMetadataIndex const &) = delete;
+  EdgeMetadataIndex(EdgeMetadataIndex &&) = delete;
+  EdgeMetadataIndex &operator=(EdgeMetadataIndex &&) = delete;
+  ~EdgeMetadataIndex() = default;
+
+  void OnEdgeCreated(Gid gid, Vertex *from_vertex) {
+    auto acc = data_.access();
+    auto [_, inserted] = acc.insert(EdgeMetadata{gid, from_vertex});
+    MG_ASSERT(inserted, "Edge metadata entry already existed for gid {}!", gid.AsUint());
+  }
+
+  void OnEdgeDeleted(Gid gid) {
+    auto acc = data_.access();
+    MG_ASSERT(acc.remove(gid), "Edge metadata entry missing for deleted edge {}!", gid.AsUint());
+  }
+
+  template <std::ranges::input_range R>
+    requires std::same_as<std::ranges::range_value_t<R>, Gid>
+  void OnEdgesDeleted(R const &gids) {
+    auto acc = data_.access();
+    for (auto gid : gids) {
+      MG_ASSERT(acc.remove(gid), "Edge metadata entry missing for deleted edge {}!", gid.AsUint());
+    }
+  }
+
+  // Returns the `from_vertex` recorded for `edge_gid`. Hard-asserts on miss:
+  // every Edge in `edges_` has a metadata entry when the index is enabled.
+  Vertex *FromVertexOf(Gid edge_gid) const {
+    auto acc = data_.access();
+    auto it = acc.find(edge_gid);
+    MG_ASSERT(it != acc.end(), "Edge metadata missing for gid {}!", edge_gid.AsUint());
+    return it->from_vertex;
+  }
+
+  // The only path that populates the index during recovery.
+  void RebuildFrom(utils::SkipListDb<Vertex> &vertices,
+                   std::optional<durability::ParallelizedSchemaCreationInfo> const &parallel_exec_info);
+
+  void Clear() { data_.clear(); }
+
+  void RunGc() { data_.run_gc(); }
+
+  std::uint64_t size() const { return data_.size(); }
+
+ private:
+  utils::SkipListDb<EdgeMetadata> data_;
+};
+
+}  // namespace memgraph::storage

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -315,7 +315,9 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
       db_arena_(db_arena),
       vertices_{},
       edges_{},
-      edges_metadata_{},
+      edges_metadata_index_{(config.salient.items.properties_on_edges && config.salient.items.enable_edges_metadata)
+                                ? std::optional<EdgeMetadataIndex>{std::in_place}
+                                : std::nullopt},
       recovery_{.snapshot_directory_ = config.durability.storage_directory / durability::kSnapshotDirectory,
                 .wal_directory_ = config.durability.storage_directory / durability::kWalDirectory},
       lock_file_path_(config.durability.storage_directory / durability::kLockFile),
@@ -361,7 +363,7 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
         repl_storage_state_,
         &vertices_,
         &edges_,
-        &edges_metadata_,
+        edges_metadata_index_ ? &*edges_metadata_index_ : nullptr,
         &edge_count_,
         name_id_mapper_.get(),
         &indices_,
@@ -449,7 +451,9 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
       static_cast<InMemoryUniqueConstraints *>(constraints_.unique_constraints_.get())->RunGC();
 
       // SkipList is already threadsafe
-      edges_metadata_.run_gc();
+      if (edges_metadata_index_) {
+        edges_metadata_index_->RunGc();
+      }
       vertices_.run_gc();
       edges_.run_gc();
 
@@ -683,7 +687,6 @@ Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdge(VertexAccesso
   // It's important to destruct accessors after we unlock the vertices to avoid expensive skip list gc while we hold the
   // locks
   std::optional<utils::SkipListDb<Edge>::Accessor> edge_acc;
-  std::optional<utils::SkipListDb<EdgeMetadata>::Accessor> edge_metadata_acc;
 
   auto *from_vertex = from->vertex_;
   auto *to_vertex = to->vertex_;
@@ -738,10 +741,8 @@ Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdge(VertexAccesso
     if (delta) {
       delta->prev.Set(&*it);
     }
-    if (config_.enable_edges_metadata) {
-      edge_metadata_acc = mem_storage->edges_metadata_.access();
-      auto [_, inserted] = edge_metadata_acc->insert(EdgeMetadata(gid, from->vertex_));
-      MG_ASSERT(inserted, "The edge must be inserted here!");
+    if (auto &idx = mem_storage->edges_metadata_index_) {
+      idx->OnEdgeCreated(gid, from->vertex_);
     }
   }
 
@@ -810,7 +811,6 @@ Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdgeEx(VertexAcces
   // It's important to destruct accessors after we unlock the vertices to avoid expensive skip list gc while we hold the
   // locks
   std::optional<utils::SkipListDb<Edge>::Accessor> edge_acc;
-  std::optional<utils::SkipListDb<EdgeMetadata>::Accessor> edge_metadata_acc;
 
   auto *from_vertex = from->vertex_;
   auto *to_vertex = to->vertex_;
@@ -870,10 +870,8 @@ Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdgeEx(VertexAcces
     if (delta) {
       delta->prev.Set(&*it);
     }
-    if (config_.enable_edges_metadata) {
-      edge_metadata_acc = mem_storage->edges_metadata_.access();
-      auto [_, inserted] = edge_metadata_acc->insert(EdgeMetadata(gid, from->vertex_));
-      MG_ASSERT(inserted, "The edge must be inserted here!");
+    if (auto &idx = mem_storage->edges_metadata_index_) {
+      idx->OnEdgeCreated(gid, from->vertex_);
     }
   }
 
@@ -903,15 +901,6 @@ Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdgeEx(VertexAcces
   });
 
   return EdgeAccessor(edge, edge_type, from_vertex, to_vertex, storage_, &transaction_);
-}
-
-void InMemoryStorage::UpdateEdgesMetadataOnModification(Edge *edge, Vertex *from_vertex) {
-  auto edge_metadata_acc = edges_metadata_.access();
-  auto edge_to_modify = edge_metadata_acc.find(edge->gid);
-  if (edge_to_modify == edge_metadata_acc.end()) {
-    throw utils::BasicException("Invalid transaction! Please raise an issue, {}:{}", __FILE__, __LINE__);
-  }
-  edge_to_modify->from_vertex = from_vertex;
 }
 
 std::expected<void, ConstraintViolation> InMemoryStorage::InMemoryAccessor::ExistenceConstraintsViolation() const {
@@ -1688,10 +1677,9 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
                                   transaction_.start_timestamp,
                                   mem_storage->name_id_mapper_.get());
     // EDGES METADATA (has ptr to Vertices, must be before removing verticies)
-    if (!my_deleted_edges.empty() && mem_storage->config_.salient.items.enable_edges_metadata) {
-      auto edges_metadata_acc = mem_storage->edges_metadata_.access();
-      for (auto gid : my_deleted_edges) {
-        edges_metadata_acc.remove(gid);
+    if (!my_deleted_edges.empty()) {
+      if (auto &idx = mem_storage->edges_metadata_index_) {
+        idx->OnEdgesDeleted(my_deleted_edges);
       }
     }
 
@@ -3224,10 +3212,9 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
   }
 
   // EDGES METADATA (has ptr to Vertices, must be before removing vertices)
-  if (!current_deleted_edges.empty() && config_.salient.items.enable_edges_metadata) {
-    auto edge_metadata_acc = edges_metadata_.access();
-    for (auto edge : current_deleted_edges) {
-      MG_ASSERT(edge_metadata_acc.remove(edge), "Invalid database state!");
+  if (!current_deleted_edges.empty()) {
+    if (auto &idx = edges_metadata_index_) {
+      idx->OnEdgesDeleted(current_deleted_edges);
     }
   }
 
@@ -3337,11 +3324,11 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
       }
     }
 
-    auto edge_metadata_acc = edges_metadata_.access();
+    auto *idx = edges_metadata_index_ ? &*edges_metadata_index_ : nullptr;
     for (auto &edge : edge_acc) {
       if (edge.delta() == nullptr && edge.deleted()) {
+        if (idx) idx->OnEdgeDeleted(edge.gid);
         edge_acc.remove(edge);
-        edge_metadata_acc.remove(edge.gid);
       }
     }
   }
@@ -4170,7 +4157,7 @@ std::expected<void, InMemoryStorage::RecoverSnapshotError> InMemoryStorage::Reco
         storage::durability::LoadSnapshot(local_path,
                                           &vertices_,
                                           &edges_,
-                                          &edges_metadata_,
+                                          edges_metadata_index_ ? &*edges_metadata_index_ : nullptr,
                                           &repl_storage_state_.history,
                                           name_id_mapper_.get(),
                                           &edge_count_,
@@ -4200,16 +4187,18 @@ std::expected<void, InMemoryStorage::RecoverSnapshotError> InMemoryStorage::Reco
     // We are the only active transaction, so mark everything up to the next timestamp
     if (timestamp_ > 0) commit_log_->MarkFinishedInRange(0, timestamp_ - 1);
 
-    spdlog::trace("Recovering indices and constraints from snapshot.");
-    storage::durability::RecoverIndicesStatsAndConstraints(&vertices_,
-                                                           name_id_mapper_.get(),
-                                                           &indices_,
-                                                           &constraints_,
-                                                           config_,
-                                                           recovery_info,
-                                                           db_arena_,
-                                                           recovered_snapshot.indices_constraints,
-                                                           config_.salient.items.properties_on_edges);
+    spdlog::trace("Recovering derived state from snapshot.");
+    storage::durability::RecoverDerivedState(&vertices_,
+                                             &edges_,
+                                             name_id_mapper_.get(),
+                                             &indices_,
+                                             &constraints_,
+                                             config_,
+                                             recovery_info,
+                                             db_arena_,
+                                             recovered_snapshot.indices_constraints,
+                                             edges_metadata_index_ ? &*edges_metadata_index_ : nullptr,
+                                             config_.salient.items.properties_on_edges);
     spdlog::trace("Successfully recovered from snapshot {}", local_path);
 
     // Destroying current wal file
@@ -4477,25 +4466,21 @@ EdgeInfo ExtractEdgeInfo(Vertex *from_vertex, const Edge *edge_ptr) {
   return std::nullopt;
 }
 
-EdgeInfo InMemoryStorage::FindEdgeFromMetadata(Gid gid, const Edge *edge_ptr) {
-  auto edge_metadata_acc = edges_metadata_.access();
-  auto edge_metadata_it = edge_metadata_acc.find(gid);
-  MG_ASSERT(edge_metadata_it != edge_metadata_acc.end(), "Invalid database state!");
-  return ExtractEdgeInfo(edge_metadata_it->from_vertex, edge_ptr);
-}
-
-EdgeInfo InMemoryStorage::FindEdge(Gid gid) {
+EdgeInfo InMemoryStorage::FindEdge(Gid edge_gid) {
   auto edge_acc = edges_.access();
-  auto edge_it = edge_acc.find(gid);
+  auto edge_it = edge_acc.find(edge_gid);
   if (edge_it == edge_acc.end()) {
     return std::nullopt;
   }
 
   auto *edge_ptr = &(*edge_it);
 
+  // Pin vertices_ for the duration of the ExtractEdgeInfo scan. The Vertex*
+  // returned by the index points into this skip list; without the accessor,
+  // GC could reclaim the node mid-scan.
   auto vertices_acc = vertices_.access();
-  if (config_.salient.items.enable_edges_metadata) {
-    return FindEdgeFromMetadata(gid, edge_ptr);
+  if (edges_metadata_index_) {
+    return ExtractEdgeInfo(edges_metadata_index_->FromVertexOf(edge_gid), edge_ptr);
   }
 
   for (auto &from_vertex : vertices_acc) {
@@ -4515,9 +4500,10 @@ EdgeInfo InMemoryStorage::FindEdge(Gid edge_gid, Gid from_vertex_gid) {
 
   auto *edge_ptr = &(*edge_it);
 
+  // Pin vertices_ for ExtractEdgeInfo (see FindEdge(Gid) above).
   auto vertices_acc = vertices_.access();
-  if (config_.salient.items.enable_edges_metadata) {
-    return FindEdgeFromMetadata(edge_gid, edge_ptr);
+  if (edges_metadata_index_) {
+    return ExtractEdgeInfo(edges_metadata_index_->FromVertexOf(edge_gid), edge_ptr);
   }
 
   auto vertex_it = vertices_acc.find(from_vertex_gid);
@@ -4580,8 +4566,10 @@ void InMemoryStorage::Clear() {
   indices_.DropGraphClearIndices();
   constraints_.DropGraphClearConstraints();
 
-  edges_metadata_.clear();
-  edges_metadata_.run_gc();
+  if (edges_metadata_index_) {
+    edges_metadata_index_->Clear();
+    edges_metadata_index_->RunGc();
+  }
   stored_node_labels_.clear();
   stored_edge_types_.clear();
 

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -13,11 +13,13 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string_view>
 #include <utility>
 #include "memory/db_arena_fwd.hpp"
 #include "replication_coordination_glue/role.hpp"
 #include "storage/v2/commit_log.hpp"
+#include "storage/v2/edge_metadata_index.hpp"
 #include "storage/v2/edge_ref.hpp"
 #include "storage/v2/indices/label_index_stats.hpp"
 #include "storage/v2/inmemory/edge_type_index.hpp"
@@ -797,13 +799,9 @@ class InMemoryStorage final : public Storage {
 
   void PrepareForNewEpoch() override;
 
-  void UpdateEdgesMetadataOnModification(Edge *edge, Vertex *from_vertex);
-
-  EdgeInfo FindEdge(Gid gid);
+  EdgeInfo FindEdge(Gid edge_gid);
 
   EdgeInfo FindEdge(Gid edge_gid, Gid from_vertex_gid);
-
-  EdgeInfo FindEdgeFromMetadata(Gid gid, const Edge *edge_ptr);
 
   // Database-owned arena pool for per-thread arena management.
   // Database must outlive Storage; Database member declaration order guarantees that.
@@ -814,7 +812,8 @@ class InMemoryStorage final : public Storage {
   // the appropriate execution boundary.
   utils::SkipListDb<Vertex> vertices_;
   utils::SkipListDb<Edge> edges_;
-  utils::SkipListDb<EdgeMetadata> edges_metadata_;
+  // Present iff salient.items.enable_edges_metadata && salient.items.properties_on_edges.
+  std::optional<EdgeMetadataIndex> edges_metadata_index_;
 
   // Durability
   durability::Recovery recovery_;

--- a/tests/unit/storage_v2_durability_inmemory.cpp
+++ b/tests/unit/storage_v2_durability_inmemory.cpp
@@ -46,6 +46,7 @@
 #include "storage/v2/durability/version.hpp"
 #include "storage/v2/durability/wal.hpp"
 #include "storage/v2/edge_accessor.hpp"
+#include "storage/v2/edge_metadata_index.hpp"
 #include "storage/v2/id_types.hpp"
 #include "storage/v2/indices/label_index_stats.hpp"
 #include "storage/v2/indices/text_index_utils.hpp"
@@ -3707,7 +3708,12 @@ TEST_P(DurabilityTest, ConstraintsRecoveryFunctionSetting) {
   config.durability.snapshot_on_exit = false;
   memgraph::utils::SkipListDb<memgraph::storage::Vertex> vertices;
   memgraph::utils::SkipListDb<memgraph::storage::Edge> edges;
-  memgraph::utils::SkipListDb<memgraph::storage::EdgeMetadata> edges_metadata;
+  // Mirror InMemoryStorage: the metadata index only exists when both
+  // properties_on_edges and enable_edges_metadata are set.
+  std::optional<memgraph::storage::EdgeMetadataIndex> edges_metadata{
+      (config.salient.items.properties_on_edges && config.salient.items.enable_edges_metadata)
+          ? std::optional<memgraph::storage::EdgeMetadataIndex>{std::in_place}
+          : std::nullopt};
   std::unique_ptr<memgraph::storage::NameIdMapper> name_id_mapper = std::make_unique<memgraph::storage::NameIdMapper>();
   std::atomic<uint64_t> edge_count{0};
   uint64_t wal_seq_num{0};
@@ -3728,7 +3734,7 @@ TEST_P(DurabilityTest, ConstraintsRecoveryFunctionSetting) {
       repl_storage_state,
       &vertices,
       &edges,
-      &edges_metadata,
+      edges_metadata ? &*edges_metadata : nullptr,
       &edge_count,
       name_id_mapper.get(),
       &indices,
@@ -3965,6 +3971,87 @@ TEST_P(DurabilityTest, EdgeMetadataRecovered) {
     ASSERT_FALSE(edge.has_value());
 
     ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Every recovered edge has a metadata entry, so delete + GC succeeds.
+  {
+    auto acc = db.Access(memgraph::storage::WRITE);
+    for (auto i{0U}; i < 5U; ++i) {
+      auto edge = acc->FindEdge(memgraph::storage::Gid::FromUint(i), memgraph::storage::View::OLD);
+      ASSERT_TRUE(edge.has_value());
+      ASSERT_TRUE(acc->DeleteEdge(&*edge).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  db.storage()->FreeMemory();
+  {
+    auto acc = db.Access(memgraph::storage::READ);
+    for (auto i{0U}; i < 5U; ++i) {
+      ASSERT_FALSE(acc->FindEdge(memgraph::storage::Gid::FromUint(i), memgraph::storage::View::OLD).has_value());
+    }
+  }
+}
+
+// Edges recovered from WAL (no snapshot) are registered in edge metadata, so they
+// resolve by id and are deletable.
+TEST_P(DurabilityTest, EdgeMetadataRecoveredFromWal) {
+  if (!GetParam()) {
+    return;
+  }
+  // Create dataset, persisted to WAL only (no snapshot).
+  {
+    memgraph::storage::Config config{
+        .durability = {.storage_directory = storage_directory,
+                       .snapshot_wal_mode =
+                           memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
+                       .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
+                       .wal_file_flush_every_n_tx = kFlushWalEvery},
+        .salient.items = {.properties_on_edges = GetParam(), .enable_schema_info = false}};
+    memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+    CreateBaseDataset(db.storage(), GetParam());
+    VerifyDataset(db.storage(), DatasetType::ONLY_BASE, GetParam(), config.salient.items.enable_schema_info);
+  }
+
+  ASSERT_EQ(GetSnapshotsList().size(), 0);
+  ASSERT_GE(GetWalsList().size(), 1);
+
+  // Recover from WAL with edge metadata enabled.
+  memgraph::storage::Config config{
+      .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
+      .salient.items = {.properties_on_edges = GetParam(), .enable_edges_metadata = true, .enable_schema_info = false}};
+  memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+  VerifyDataset(db.storage(), DatasetType::ONLY_BASE, GetParam(), config.salient.items.enable_schema_info);
+
+  // Every WAL-recovered edge is resolvable by id via metadata.
+  {
+    auto acc = db.Access(memgraph::storage::WRITE);
+    for (auto i{0U}; i < kNumBaseEdges; ++i) {
+      auto edge = acc->FindEdge(memgraph::storage::Gid::FromUint(i), memgraph::storage::View::OLD);
+      ASSERT_TRUE(edge.has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete + GC of WAL-recovered edges succeeds.
+  {
+    auto acc = db.Access(memgraph::storage::WRITE);
+    for (auto i{0U}; i < 5U; ++i) {
+      auto edge = acc->FindEdge(memgraph::storage::Gid::FromUint(i), memgraph::storage::View::OLD);
+      ASSERT_TRUE(edge.has_value());
+      ASSERT_TRUE(acc->DeleteEdge(&*edge).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  db.storage()->FreeMemory();
+
+  // The deleted edges are now gone from both the edge store and the edge metadata index.
+  {
+    auto acc = db.Access(memgraph::storage::READ);
+    for (auto i{0U}; i < 5U; ++i) {
+      ASSERT_FALSE(acc->FindEdge(memgraph::storage::Gid::FromUint(i), memgraph::storage::View::OLD).has_value());
+    }
   }
 }
 
@@ -4756,4 +4843,177 @@ TEST_P(DurabilityTest, DescriptionsRecoveredFromWal) {
     ASSERT_EQ(acc->GetEdgeTypePatternDescription(person_labels, "KNOWS", person_labels), "Person knows person");
     ASSERT_EQ(acc->GetAllDescriptions().size(), 5);
   }
+}
+
+// An edge present only in adjacency after one recovery cycle becomes fully
+// addressable (resolvable by id, deletable, GC-safe) after a snapshot-on-exit
+// round-trip, because the post-recovery rebuild repopulates its metadata from
+// the snapshot's adjacency. Phases: (1) create edge, persist to WAL only;
+// (2) recover from WAL, exit writing a snapshot-on-exit; (3) recover from that
+// snapshot.
+TEST_F(DurabilityTest, EdgeMetadataHealedByCleanRestart) {
+  memgraph::storage::Gid from_gid{memgraph::storage::Gid::FromUint(0)};
+  memgraph::storage::Gid edge_gid{memgraph::storage::Gid::FromUint(0)};
+
+  // Phase 1: create the edge, persisted to WAL only.
+  {
+    memgraph::storage::Config config{
+        .durability = {.storage_directory = storage_directory,
+                       .snapshot_wal_mode =
+                           memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
+                       .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
+                       .wal_file_flush_every_n_tx = kFlushWalEvery},
+        .salient = {.items = {.properties_on_edges = true, .enable_edges_metadata = true}},
+    };
+    memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+    auto acc = db.Access(memgraph::storage::WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    from_gid = v1.Gid();
+    auto edge = acc->CreateEdge(&v1, &v2, db.storage()->NameToEdgeType("et"));
+    ASSERT_TRUE(edge.has_value());
+    edge_gid = edge->Gid();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  ASSERT_EQ(GetSnapshotsList().size(), 0);
+  ASSERT_GE(GetWalsList().size(), 1);
+
+  // Phase 2: recover from WAL (edge is metadata-less here - do NOT fetch by id),
+  // then exit writing a snapshot that captures it from adjacency.
+  {
+    memgraph::storage::Config config{
+        .durability = {.storage_directory = storage_directory, .recover_on_startup = true, .snapshot_on_exit = true},
+        .salient = {.items = {.properties_on_edges = true, .enable_edges_metadata = true}},
+    };
+    memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+    // Confirm the edge actually survived WAL recovery via adjacency (a vertex
+    // out-edge scan, which does not consult the edge metadata index).
+    auto acc = db.Access(memgraph::storage::READ);
+    auto v1 = acc->FindVertex(from_gid, memgraph::storage::View::OLD);
+    ASSERT_TRUE(v1);
+    auto out_edges = v1->OutEdges(memgraph::storage::View::OLD);
+    ASSERT_TRUE(out_edges.has_value());
+    ASSERT_EQ(out_edges->edges.size(), 1U);
+    ASSERT_EQ(out_edges->edges[0].Gid(), edge_gid);
+  }
+  ASSERT_GE(GetSnapshotsList().size(), 1);
+
+  // Phase 3: recover from the snapshot - metadata is rebuilt, so the edge is safe.
+  memgraph::storage::Config config{
+      .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
+      .salient = {.items = {.properties_on_edges = true, .enable_edges_metadata = true}},
+  };
+  memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+
+  {
+    auto acc = db.Access(memgraph::storage::READ);
+    auto edge = acc->FindEdge(edge_gid, memgraph::storage::View::OLD);
+    ASSERT_TRUE(edge.has_value());
+  }
+  {
+    auto acc = db.Access(memgraph::storage::WRITE);
+    auto v1 = acc->FindVertex(from_gid, memgraph::storage::View::OLD);
+    ASSERT_TRUE(v1);
+    auto out_edges = v1->OutEdges(memgraph::storage::View::OLD);
+    ASSERT_TRUE(out_edges.has_value());
+    ASSERT_EQ(out_edges->edges.size(), 1U);
+    auto edge = out_edges->edges[0];
+    ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  db.storage()->FreeMemory();
+}
+
+// Snapshot holds an edge, a WAL-tail delta DELETES it, then recovery + GC.
+// Because metadata is rebuilt from final adjacency (and WAL delete removes the
+// edge from both edges_ and adjacency together), the deleted edge ends up in
+// neither edges_ nor edge metadata - no stale entry, no "metadata not found".
+// The surviving edge must still be fully usable.
+TEST_F(DurabilityTest, EdgeMetadataConsistentAfterSnapshotThenWalDelete) {
+  memgraph::storage::Gid v1_gid{memgraph::storage::Gid::FromUint(0)};
+  memgraph::storage::Gid deleted_edge_gid{memgraph::storage::Gid::FromUint(0)};
+  memgraph::storage::Gid surviving_edge_gid{memgraph::storage::Gid::FromUint(0)};
+
+  // Phase 1: create two edges, snapshot them, then delete one (delete goes to WAL
+  // AFTER the snapshot).
+  {
+    memgraph::storage::Config config{
+        .durability = {.storage_directory = storage_directory,
+                       .snapshot_wal_mode =
+                           memgraph::storage::Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
+                       .snapshot_interval = memgraph::utils::SchedulerInterval{std::chrono::minutes(20)},
+                       .wal_file_flush_every_n_tx = kFlushWalEvery},
+        .salient = {.items = {.properties_on_edges = true, .enable_edges_metadata = true}},
+    };
+    memgraph::dbms::Database db{config};
+    const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+
+    {
+      auto acc = db.Access(memgraph::storage::WRITE);
+      auto v1 = acc->CreateVertex();
+      auto v2 = acc->CreateVertex();
+      auto v3 = acc->CreateVertex();
+      v1_gid = v1.Gid();
+      auto e1 = acc->CreateEdge(&v1, &v2, db.storage()->NameToEdgeType("et"));
+      auto e2 = acc->CreateEdge(&v1, &v3, db.storage()->NameToEdgeType("et"));
+      ASSERT_TRUE(e1.has_value() && e2.has_value());
+      deleted_edge_gid = e1->Gid();
+      surviving_edge_gid = e2->Gid();
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    // Snapshot now contains both edges.
+    ASSERT_TRUE(static_cast<memgraph::storage::InMemoryStorage *>(db.storage())->CreateSnapshot(true).has_value());
+
+    // Delete one edge AFTER the snapshot -> recorded in the WAL tail.
+    {
+      auto acc = db.Access(memgraph::storage::WRITE);
+      auto v1 = acc->FindVertex(v1_gid, memgraph::storage::View::OLD);
+      ASSERT_TRUE(v1);
+      auto out_edges = v1->OutEdges(memgraph::storage::View::OLD);
+      ASSERT_TRUE(out_edges.has_value());
+      ASSERT_EQ(out_edges->edges.size(), 2U);
+      auto to_delete =
+          std::ranges::find_if(out_edges->edges, [&](auto const &e) { return e.Gid() == deleted_edge_gid; });
+      ASSERT_NE(to_delete, out_edges->edges.end());
+      ASSERT_TRUE(acc->DeleteEdge(&*to_delete).has_value());
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+  }
+
+  ASSERT_GE(GetSnapshotsList().size(), 1);
+  ASSERT_GE(GetWalsList().size(), 1);
+
+  // Phase 2: recover (snapshot + WAL delete), then exercise both edges and GC.
+  memgraph::storage::Config config{
+      .durability = {.storage_directory = storage_directory, .recover_on_startup = true},
+      .salient = {.items = {.properties_on_edges = true, .enable_edges_metadata = true}},
+  };
+  memgraph::dbms::Database db{config};
+  const memgraph::memory::DbArenaScope arena_scope{&db.Arena()};
+
+  {
+    auto acc = db.Access(memgraph::storage::READ);
+    // Deleted edge: gone from edges_ -> nullopt (never reaches metadata).
+    ASSERT_FALSE(acc->FindEdge(deleted_edge_gid, memgraph::storage::View::OLD).has_value());
+    // Surviving edge: present and resolvable via metadata.
+    ASSERT_TRUE(acc->FindEdge(surviving_edge_gid, memgraph::storage::View::OLD).has_value());
+  }
+  {
+    // The surviving edge is deletable and GC-safe.
+    auto acc = db.Access(memgraph::storage::WRITE);
+    auto v1 = acc->FindVertex(v1_gid, memgraph::storage::View::OLD);
+    ASSERT_TRUE(v1);
+    auto out_edges = v1->OutEdges(memgraph::storage::View::OLD);
+    ASSERT_TRUE(out_edges.has_value());
+    ASSERT_EQ(out_edges->edges.size(), 1U);
+    auto edge = out_edges->edges[0];
+    ASSERT_EQ(edge.Gid(), surviving_edge_gid);
+    ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  db.storage()->FreeMemory();
 }

--- a/tests/unit/storage_v2_replication.cpp
+++ b/tests/unit/storage_v2_replication.cpp
@@ -1897,3 +1897,81 @@ TEST_F(ReplicationTest, GetTelemetryJson) {
   auto const expected_json = nlohmann::json({{"async", 1}, {"sync", 1}, {"strict_sync", 0}});
   ASSERT_EQ(main_json.value(), expected_json);
 }
+
+// A replica recovered via snapshot transfer must end up with edge metadata, so
+// a later (replicated) delete + GC on the replica does not hit "metadata not
+// found". Exercises the snapshot-recovery path on the replica.
+TEST_F(ReplicationTest, EdgeMetadataRecoveredOnReplicaSnapshotTransfer) {
+  main_conf.salient.items.enable_edges_metadata = true;
+  repl_conf.salient.items.enable_edges_metadata = true;
+
+  Gid e0_gid{Gid::FromUint(0)};
+  Gid e1_gid{Gid::FromUint(0)};
+
+  MinMemgraph main(main_conf);
+
+  // Create a couple of edges on main.
+  {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
+    auto acc = main.db.Access(memgraph::storage::WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    auto v3 = acc->CreateVertex();
+    auto e0 = acc->CreateEdge(&v1, &v2, main.db.storage()->NameToEdgeType("et"));
+    auto e1 = acc->CreateEdge(&v1, &v3, main.db.storage()->NameToEdgeType("et"));
+    ASSERT_TRUE(e0.has_value() && e1.has_value());
+    e0_gid = e0->Gid();
+    e1_gid = e1->Gid();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
+  }
+
+  // Force a snapshot. With no finalized WAL yet, registering a fresh replica makes
+  // GetRecoverySteps ship the SNAPSHOT (not WAL), exercising the snapshot-recovery
+  // metadata rebuild on the replica.
+  ASSERT_TRUE(static_cast<InMemoryStorage *>(main.db.storage())->CreateSnapshot(true).has_value());
+
+  MinMemgraph replica(repl_conf);
+  auto replica_store_handler = replica.repl_handler;
+  replica_store_handler.TrySetReplicationRoleReplica(
+      ReplicationServerConfig{.repl_server = Endpoint(local_host, ports[0])});
+  ASSERT_TRUE(main.repl_handler
+                  .TryRegisterReplica(ReplicationClientConfig{
+                      .name = replicas[0],
+                      .mode = ReplicationMode::SYNC,
+                      .repl_server_endpoint = Endpoint(local_host, ports[0]),
+                  })
+                  .has_value());
+  while (main.db.storage()->GetReplicaState(replicas[0]) != ReplicaState::READY) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  // Replica recovered via snapshot transfer must resolve both edges by id (metadata).
+  {
+    auto acc = replica.db.Access(memgraph::storage::READ);
+    ASSERT_TRUE(acc->FindEdge(e0_gid, View::OLD).has_value());
+    ASSERT_TRUE(acc->FindEdge(e1_gid, View::OLD).has_value());
+  }
+
+  // Delete one edge on main; SYNC replication applies it on the replica.
+  {
+    const memgraph::memory::DbArenaScope arena_scope{&main.db.Arena()};
+    auto acc = main.db.Access(memgraph::storage::WRITE);
+    auto e = acc->FindEdge(e0_gid, View::OLD);
+    ASSERT_TRUE(e.has_value());
+    ASSERT_TRUE(acc->DeleteEdge(&*e).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
+  }
+  while (main.db.storage()->GetReplicaState(replicas[0]) != ReplicaState::READY) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  // Replica GC removes the deleted edge's metadata cleanly.
+  replica.db.storage()->FreeMemory();
+
+  // Deleted edge gone on replica; surviving edge intact.
+  {
+    auto acc = replica.db.Access(memgraph::storage::READ);
+    ASSERT_FALSE(acc->FindEdge(e0_gid, View::OLD).has_value());
+    ASSERT_TRUE(acc->FindEdge(e1_gid, View::OLD).has_value());
+  }
+}


### PR DESCRIPTION
WAL replay did not populate the edge metadata index; a later delete of a WAL-recovered edge tripped the GC assertion and edge-by-id lookups returned wrong results.

Rebuild the index once from the final recovered adjacency in the post-recovery derived-structure pass, so snapshot load, WAL replay, and replica snapshot transfer all converge on the same state.

Encapsulate the gid -> from-vertex map as EdgeMetadataIndex, replacing ad-hoc SkipListDb access sites in storage, durability, and replication. Rename the post-recovery hook to RecoverDerivedState; demote its private helpers to an anonymous namespace.

Pin vertices_ in InMemoryStorage::FindEdge before the index fast-path (GC could otherwise reclaim the returned Vertex* mid-scan).