### PR TITLE
fix: Forbid usage of analytical mode on data instances

### DIFF
--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -572,6 +572,10 @@ int main(int argc, char **argv) {
   }
 
 #ifdef MG_ENTERPRISE
+  MG_ASSERT(!(coordination_setup.IsDataInstanceManagedByCoordinator() &&
+              db_config.salient.storage_mode == IN_MEMORY_ANALYTICAL),
+            "Data instances cannot use analytical mode!");
+
   if (coordination_setup.IsDataInstanceManagedByCoordinator() &&
       db_config.salient.storage_mode == IN_MEMORY_TRANSACTIONAL) {
     MG_ASSERT(db_config.durability.snapshot_wal_mode == PERIODIC_SNAPSHOT_WITH_WAL,
@@ -587,6 +591,7 @@ int main(int argc, char **argv) {
     MG_ASSERT(FLAGS_init_data_file.empty(),
               "Coordinator instances don't support --init-data-file flag. Please restart the instance by removing this "
               "flag.");
+    spdlog::warn("All storage-related flags are ignored since coordinators don't have storage.");
   }
 
   if (coordination_setup.IsDataInstanceManagedByCoordinator()) {

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -5897,10 +5897,12 @@ PreparedQuery PrepareStorageModeQuery(ParsedQuery parsed_query, const bool in_ex
 
   std::function<void()> callback;
 
-  if (interpreter_context->coordinator_state_->IsDataInstance() &&
+#ifdef MG_ENTERPRISE
+  if (interpreter_context->coordinator_state_ && interpreter_context->coordinator_state_->IsDataInstance() &&
       requested_mode == storage::StorageMode::IN_MEMORY_ANALYTICAL) {
     throw QueryRuntimeException("Data instances cannot use analytical mode");
   }
+#endif
 
   if (current_mode == storage::StorageMode::ON_DISK_TRANSACTIONAL ||
       requested_mode == storage::StorageMode::ON_DISK_TRANSACTIONAL) {

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -5897,6 +5897,11 @@ PreparedQuery PrepareStorageModeQuery(ParsedQuery parsed_query, const bool in_ex
 
   std::function<void()> callback;
 
+  if (interpreter_context->coordinator_state_->IsDataInstance() &&
+      requested_mode == storage::StorageMode::IN_MEMORY_ANALYTICAL) {
+    throw QueryRuntimeException("Data instances cannot use analytical mode");
+  }
+
   if (current_mode == storage::StorageMode::ON_DISK_TRANSACTIONAL ||
       requested_mode == storage::StorageMode::ON_DISK_TRANSACTIONAL) {
     callback = SwitchMemoryDevice(current_mode, requested_mode, db_acc).fn;

--- a/tests/e2e/analytical_mode/CMakeLists.txt
+++ b/tests/e2e/analytical_mode/CMakeLists.txt
@@ -4,5 +4,6 @@ endfunction()
 
 copy_analytical_mode_e2e_python_files(common.py)
 copy_analytical_mode_e2e_python_files(free_memory.py)
+copy_analytical_mode_e2e_python_files(analytical_data_instance.py)
 
 copy_e2e_files(analytical_mode workloads.yaml)

--- a/tests/e2e/analytical_mode/analytical_data_instance.py
+++ b/tests/e2e/analytical_mode/analytical_data_instance.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+import sys
+
+import mgclient
+import pytest
+from common import execute_and_fetch_all
+
+
+def test_data_instance_cannot_switch_analytical():
+    connection = mgclient.connect(host="localhost", port=7687)
+    connection.autocommit = True
+    cursor = connection.cursor()
+    with pytest.raises(mgclient.DatabaseError) as e:
+        execute_and_fetch_all(cursor, "STORAGE MODE IN_MEMORY_ANALYTICAL")
+    assert "Data instances cannot use analytical mode" in str(e.value)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/analytical_mode/workloads.yaml
+++ b/tests/e2e/analytical_mode/workloads.yaml
@@ -6,9 +6,22 @@ analytical_mode_cluster: &analytical_mode_cluster
       setup_queries: []
       validation_queries: []
 
+analytical_mode_data_instance: &analytical_mode_data_instance
+  cluster:
+    main:
+      args: ["--bolt-port=7687", "--log-level=TRACE", "--management-port=10000"]
+      log_file: "analytical_data_instance.log"
+      setup_queries: []
+      validation_queries: []
+
 
 workloads:
   - name: "Analytical mode checks"
     binary: "tests/e2e/pytest_runner.sh"
     args: ["analytical_mode/free_memory.py"]
     <<: *analytical_mode_cluster
+
+  - name: "Analytical mode data instance"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["analytical_mode/analytical_data_instance.py"]
+    <<: *analytical_mode_data_instance

--- a/tests/e2e/high_availability/coordinator.py
+++ b/tests/e2e/high_availability/coordinator.py
@@ -203,5 +203,11 @@ def test_main_and_replicas_cannot_register_coord_server(test_name):
         assert str(e.value) == "Only coordinator can register coordinator server!"
 
 
+def test_coord_cannot_change_storage_mode(test_name):
+    cursor = setup_test(test_name=test_name)
+    with pytest.raises(Exception) as e:
+        execute_and_fetch_all(cursor, "storage mode in_memory_analytical")
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/high_availability/coordinator.py
+++ b/tests/e2e/high_availability/coordinator.py
@@ -14,6 +14,7 @@ import sys
 from functools import partial
 
 import interactive_mg_runner
+import mgclient
 import pytest
 from common import connect, execute_and_fetch_all, get_data_path, get_logs_path, show_instances
 from mg_utils import mg_sleep_and_assert
@@ -205,8 +206,9 @@ def test_main_and_replicas_cannot_register_coord_server(test_name):
 
 def test_coord_cannot_change_storage_mode(test_name):
     cursor = setup_test(test_name=test_name)
-    with pytest.raises(Exception) as e:
+    with pytest.raises(mgclient.DatabaseError) as e:
         execute_and_fetch_all(cursor, "storage mode in_memory_analytical")
+    assert "Coordinator can run only coordinator queries!" in str(e.value)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Data instances cannot use analytical mode. Forbid starting such instances and using query for changing storage mode.