### PR TITLE
Feature (Light Edges / 1) - refactor(storage): thread EdgeRef through edge-type-index abort path

### DIFF
--- a/src/storage/v2/edge_ref.hpp
+++ b/src/storage/v2/edge_ref.hpp
@@ -24,9 +24,11 @@ struct EdgeRef {
 
   explicit EdgeRef(Edge *ptr) : ptr(ptr) {}
 
-  friend bool operator==(const EdgeRef &a, const EdgeRef &b) noexcept { return a.gid == b.gid; }
+  friend bool operator==(const EdgeRef &lhs, const EdgeRef &rhs) noexcept { return lhs.gid == rhs.gid; }
 
-  friend bool operator<(const EdgeRef &first, const EdgeRef &second) { return first.gid < second.gid; }
+  friend std::strong_ordering operator<=>(const EdgeRef &lhs, const EdgeRef &rhs) noexcept {
+    return lhs.gid <=> rhs.gid;
+  }
 
   union {
     Gid gid;

--- a/src/storage/v2/indices/edge_type_index.cpp
+++ b/src/storage/v2/indices/edge_type_index.cpp
@@ -15,7 +15,7 @@
 
 namespace memgraph::storage {
 void EdgeTypeIndexAbortProcessor::CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex *from_vertex, Vertex *to_vertex,
-                                                       Edge *edge) {
+                                                       EdgeRef edge) {
   auto it = cleanup_collection_.find(edge_type);
   if (it == cleanup_collection_.end()) return;
   it->second.emplace_back(from_vertex, to_vertex, edge);

--- a/src/storage/v2/indices/edge_type_index.hpp
+++ b/src/storage/v2/indices/edge_type_index.hpp
@@ -31,7 +31,7 @@ struct Vertex;
 
 struct EdgeTypeIndexActiveIndices;
 struct EdgeTypeIndexAbortProcessor;
-using EdgeTypeIndexAbortableInfo = std::map<EdgeTypeId, std::vector<std::tuple<Vertex *, Vertex *, Edge *>>>;
+using EdgeTypeIndexAbortableInfo = std::map<EdgeTypeId, std::vector<std::tuple<Vertex *, Vertex *, EdgeRef>>>;
 
 class EdgeTypeIndex {
  public:
@@ -56,7 +56,7 @@ class EdgeTypeIndex {
 struct EdgeTypeIndexAbortProcessor {
   explicit EdgeTypeIndexAbortProcessor(std::span<EdgeTypeId const> edge_types);
 
-  void CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex *from_vertex, Vertex *to_vertex, Edge *edge);
+  void CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex *from_vertex, Vertex *to_vertex, EdgeRef edge);
 
   EdgeTypeIndexAbortableInfo cleanup_collection_;
 };

--- a/src/storage/v2/indices/indices.cpp
+++ b/src/storage/v2/indices/indices.cpp
@@ -183,7 +183,7 @@ Indices::AbortProcessor Indices::GetAbortProcessor(ActiveIndices const &active_i
 }
 
 void Indices::AbortProcessor::CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex *from_vertex, Vertex *to_vertex,
-                                                   Edge *edge) {
+                                                   EdgeRef edge) {
   edge_type_.CollectOnEdgeRemoval(edge_type, from_vertex, to_vertex, edge);
 }
 

--- a/src/storage/v2/indices/indices.hpp
+++ b/src/storage/v2/indices/indices.hpp
@@ -78,7 +78,7 @@ struct Indices {
     VectorIndex::AbortProcessor vector_;
     VectorEdgeIndex::AbortProcessor vector_edge_;
 
-    void CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex *from_vertex, Vertex *to_vertex, Edge *edge);
+    void CollectOnEdgeRemoval(EdgeTypeId edge_type, Vertex *from_vertex, Vertex *to_vertex, EdgeRef edge);
     void CollectOnLabelRemoval(LabelId labelId, Vertex *vertex);
     void CollectOnLabelAddition(LabelId labelId, Vertex *vertex);
     void CollectOnPropertyChange(PropertyId propId, const PropertyValue &old_value, Vertex *vertex);

--- a/src/storage/v2/inmemory/edge_type_index.cpp
+++ b/src/storage/v2/inmemory/edge_type_index.cpp
@@ -317,7 +317,8 @@ void InMemoryEdgeTypeIndex::ActiveIndices::AbortEntries(EdgeTypeIndex::Abortable
     auto &index_storage = it->second;
     auto acc = index_storage->skip_list_.access();
     for (const auto &[from_vertex, to_vertex, edge] : edges) {
-      acc.remove(Entry{from_vertex, to_vertex, edge, exact_start_timestamp});
+      acc.remove(Entry{
+          .from_vertex = from_vertex, .to_vertex = to_vertex, .edge = edge.ptr, .timestamp = exact_start_timestamp});
     }
   }
 }

--- a/src/storage/v2/inmemory/edge_type_index.hpp
+++ b/src/storage/v2/inmemory/edge_type_index.hpp
@@ -36,7 +36,9 @@ class InMemoryEdgeTypeIndex : public storage::EdgeTypeIndex {
     Vertex *from_vertex;
     Vertex *to_vertex;
 
-    Edge *edge;  // TODO: Generalise to EdgeRef?
+    Edge *edge;  // Stays Edge* deliberately: the upstream abort tuple now carries EdgeRef,
+                 // but this index is only populated when properties_on_edges=true, where
+                 // the edge object is always materialised and a raw pointer is valid.
 
     uint64_t timestamp;
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -1539,11 +1539,10 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
             // properties are disabled.
             storage_->edge_count_.fetch_add(-1, std::memory_order_acq_rel);
 
-            // TODO: Change edge type index to work with EdgeRef rather than Edge *
             if (!mem_storage->config_.salient.items.properties_on_edges) break;
 
             auto const &[_, edge_type, to_vertex, edge] = current->vertex_edge;
-            index_abort_processor.CollectOnEdgeRemoval(edge_type, vertex, to_vertex.Get(), edge.ptr);
+            index_abort_processor.CollectOnEdgeRemoval(edge_type, vertex, to_vertex.Get(), edge);
             // TODO: ensure collector also processeses for edge_type+property index
 
             break;


### PR DESCRIPTION
The edge-type-index abort path collected raw Edge* for cleanup. Threading EdgeRef instead lets the same abort machinery describe both heavy (skiplist-resident) and light (pool-allocated) edges by gid-or-pointer, which a later light-edge PR requires. In isolation this is behaviour-preserving: the abort collection is a std::vector iterated linearly, never sorted or keyed on EdgeRef, so EdgeRef's gid-based comparators are never exercised; every EdgeRef originates from an Edge* so .ptr is the active union member end-to-end, and the index consumer extracts .edge = edge.ptr exactly as before.