### PR TITLE
Feature (Light Edges / 3) - chore(tools): suppress libpython3.13 leak

### DIFF
--- a/tools/lsan.supp
+++ b/tools/lsan.supp
@@ -9,4 +9,9 @@ leak:void std::vector<std::shared_ptr<antlr4::atn::ATNConfig>, std::allocator<st
 leak:antlr4::atn::ATNConfigSet::add(std::shared_ptr<antlr4::atn::ATNConfig> const&, std::map<std::pair<std::shared_ptr<antlr4::atn::PredictionContext>, std::shared_ptr<antlr4::atn::PredictionContext> >, std::shared_ptr<antlr4::atn::PredictionContext>, std::less<std::pair<std::shared_ptr<antlr4::atn::PredictionContext>, std::shared_ptr<antlr4::atn::PredictionContext> > >, std::allocator<std::pair<std::pair<std::shared_ptr<antlr4::atn::PredictionContext>, std::shared_ptr<antlr4::atn::PredictionContext> > const, std::shared_ptr<antlr4::atn::PredictionContext> > > >*)
 leak:antlr4::atn::ParserATNSimulator::getEpsilonTarget(std::shared_ptr<antlr4::atn::ATNConfig> const&, antlr4::atn::Transition*, bool, bool, bool, bool)
 leak:antlr4::atn::PredictionContext::mergeArrays(std::shared_ptr<antlr4::atn::ArrayPredictionContext> const&, std::shared_ptr<antlr4::atn::ArrayPredictionContext> const&, bool, std::map<std::pair<std::shared_ptr<antlr4::atn::PredictionContext>, std::shared_ptr<antlr4::atn::PredictionContext> >, std::shared_ptr<antlr4::atn::PredictionContext>, std::less<std::pair<std::shared_ptr<antlr4::atn::PredictionContext>, std::shared_ptr<antlr4::atn::PredictionContext> > >, std::allocator<std::pair<std::pair<std::shared_ptr<antlr4::atn::PredictionContext>, std::shared_ptr<antlr4::atn::PredictionContext> > const, std::shared_ptr<antlr4::atn::PredictionContext> > > >*)
-leak:/lib/x86_64-linux-gnu/libpython3.
+# query_procedure_py_module test intentionally skips Py_Finalize() due to Python bug bpo-42969.
+# This causes all Python runtime allocations to be reported as leaks.
+# See tests/unit/query_procedure_py_module.cpp main() for details.
+# Version-agnostic (matches any libpython3.x soname or path) so a toolchain
+# Python upgrade does not silently resurface the intentional leaks.
+leak:libpython3.


### PR DESCRIPTION
The query_procedure_py_module unit test intentionally skips Py_Finalize() in its main() to work around CPython bug bpo-42969. As a result every CPython runtime allocation is still live at process exit and LeakSanitizer reports it as a leak, drowning real findings. Suppress the libpython3.13.so allocation origin so ASan/LSan builds of the unit-test suite stay green without masking genuine Memgraph leaks.