### PR TITLE
feat: derive() inherits origin node labels and properties when options omitted

### DIFF
--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -6672,7 +6672,8 @@ class AggregateCursor : public Cursor {
     }
   }
 
-  VirtualNode BuildDerivedNode(std::string_view labels_key, std::string_view props_key, const TypedValue::TMap &options,
+  VirtualNode BuildDerivedNode(const VertexAccessor &real_vertex, std::string_view labels_key,
+                               std::string_view props_key, const TypedValue::TMap &options,
                                VirtualNode::allocator_type alloc) const {
     VirtualNode::label_list labels{alloc};
     if (const auto labels_it = options.find(labels_key); labels_it != options.end()) {
@@ -6685,11 +6686,29 @@ class AggregateCursor : public Cursor {
         }
         labels.emplace_back(label.ValueString());
       }
+    } else if (db_accessor_) {
+      // no labels option -> inherit every label from the original vertex
+      auto maybe_labels = real_vertex.Labels(storage::View::NEW);
+      if (!maybe_labels) throw QueryRuntimeException("derive() could not read labels of a path vertex.");
+      for (const auto label_id : *maybe_labels) {
+        const auto &name = db_accessor_->LabelToName(label_id);
+        labels.emplace_back(name.data(), name.size());
+      }
     }
+
     VirtualNode::property_map properties{alloc};
-    ApplyPropertyMap(options, props_key, [&](storage::PropertyId id, storage::PropertyValue pv) {
-      properties.insert_or_assign(id, std::move(pv));
-    });
+    if (options.contains(props_key)) {
+      ApplyPropertyMap(options, props_key, [&](storage::PropertyId id, storage::PropertyValue pv) {
+        properties.insert_or_assign(id, std::move(pv));
+      });
+    } else if (db_accessor_) {
+      // no properties option -> inherit every property from the original vertex
+      auto maybe_props = real_vertex.Properties(storage::View::NEW);
+      if (!maybe_props) throw QueryRuntimeException("derive() could not read properties of a path vertex.");
+      for (auto &[id, pv] : *maybe_props) {
+        properties.insert_or_assign(id, std::move(pv));
+      }
+    }
     return {std::move(labels), std::move(properties), alloc};
   }
 
@@ -6748,7 +6767,7 @@ class AggregateCursor : public Cursor {
       if (const auto it = dedup.find(real_gid); it != dedup.end()) {
         return projected_graph.FindNode(it->second);
       }
-      auto new_node = BuildDerivedNode(labels_key, props_key, options, alloc);
+      auto new_node = BuildDerivedNode(real_vertex, labels_key, props_key, options, alloc);
       const auto synth_gid = new_node.Gid();
       dedup[real_gid] = synth_gid;
       projected_graph.InsertNode(std::move(new_node));

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -6404,6 +6404,7 @@ class AggregateCursor : public Cursor {
    */
   bool ProcessAll(Frame *frame, ExecutionContext *context) {
     db_accessor_ = context->db_accessor;
+    MG_ASSERT(db_accessor_, "Aggregation expects a current DB transaction");
     ExpressionEvaluator evaluator(frame,
                                   context->symbol_table,
                                   context->evaluation_context,
@@ -6686,7 +6687,7 @@ class AggregateCursor : public Cursor {
         }
         labels.emplace_back(label.ValueString());
       }
-    } else if (db_accessor_) {
+    } else {
       // no labels option -> inherit every label from the original vertex
       auto maybe_labels = real_vertex.Labels(storage::View::NEW);
       if (!maybe_labels) throw QueryRuntimeException("derive() could not read labels of a path vertex.");
@@ -6697,11 +6698,11 @@ class AggregateCursor : public Cursor {
     }
 
     VirtualNode::property_map properties{alloc};
-    if (options.contains(props_key)) {
+    if (options.find(props_key) != options.end()) {
       ApplyPropertyMap(options, props_key, [&](storage::PropertyId id, storage::PropertyValue pv) {
         properties.insert_or_assign(id, std::move(pv));
       });
-    } else if (db_accessor_) {
+    } else {
       // no properties option -> inherit every property from the original vertex
       auto maybe_props = real_vertex.Properties(storage::View::NEW);
       if (!maybe_props) throw QueryRuntimeException("derive() could not read properties of a path vertex.");

--- a/tests/gql_behave/tests/memgraph_V1/features/aggregations.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/aggregations.feature
@@ -798,6 +798,34 @@ Feature: Aggregations
             | s_lbl | s_score | t_lbl | t_rank |
             | true  | 99      | true  | 7      |
 
+    Scenario: derive inherits all labels and properties from origin nodes when options are omitted
+        Given an empty graph
+        And having executed
+            """
+            CREATE (a:Person:Admin {name: 'Alice', age: 30})-[:R]->(b:City {name: 'NYC', pop: 8000000})
+            """
+        When executing query:
+            """
+            MATCH p=(:Person {name: 'Alice'})-[:R]->(:City) WITH derive(p, {virtualEdgeType: 'V'}) AS graph UNWIND graph.edges AS e RETURN 'Person' IN labels(startNode(e)) AND 'Admin' IN labels(startNode(e)) AS s_lbls, startNode(e).name AS s_name, startNode(e).age AS s_age, 'City' IN labels(endNode(e)) AS t_lbl, endNode(e).pop AS t_pop
+            """
+        Then the result should be:
+            | s_lbls | s_name  | s_age | t_lbl | t_pop   |
+            | true   | 'Alice' | 30    | true  | 8000000 |
+
+    Scenario: derive inherits per key - explicit source labels override but source properties still inherited
+        Given an empty graph
+        And having executed
+            """
+            CREATE (a:Person {name: 'Alice', age: 30})-[:R]->(b:City {name: 'NYC'})
+            """
+        When executing query:
+            """
+            MATCH p=(:Person)-[:R]->(:City) WITH derive(p, {virtualEdgeType: 'V', sourceNodeLabels: ['Renamed']}) AS graph UNWIND graph.edges AS e RETURN labels(startNode(e)) AS s_lbls, startNode(e).name AS s_name, startNode(e).age AS s_age, 'City' IN labels(endNode(e)) AS t_lbl, endNode(e).name AS t_name
+            """
+        Then the result should be:
+            | s_lbls      | s_name  | s_age | t_lbl | t_name |
+            | ['Renamed'] | 'Alice' | 30    | true  | 'NYC'  |
+
     Scenario: undirectedEdgeTypes doubles the virtual edge between distinct endpoints
         Given an empty graph
         And having executed


### PR DESCRIPTION
When the `sourceNode`/`targetNode` label or property options are absent from the `derive()` map, the synthetic endpoint now copies all labels and properties from the original path endpoint instead of being created empty.