### PR TITLE
infra: Use OpenMetrics for monitoring CI

### DIFF
--- a/.github/workflows/issu_test.yaml
+++ b/.github/workflows/issu_test.yaml
@@ -25,6 +25,11 @@ on:
         description: Check for flakiness by running every selected job multiple times. Enter a number between 2 and 20.
         required: false
         default: 1
+      helm_charts_branch:
+        type: string
+        description: helm-charts repo branch to install the HA chart from (enables direct OpenMetrics scraping). Empty = pinned published chart version.
+        required: false
+        default: ''
 
 jobs:
   single_test:
@@ -35,6 +40,7 @@ jobs:
       last_image: ${{ inputs.prev_image }}
       next_image: ${{ inputs.next_image }}
       arch: ${{ inputs.arch }}
+      helm_charts_branch: ${{ inputs.helm_charts_branch }}
     secrets: inherit
 
   prepare_flakiness_matrix:
@@ -76,4 +82,5 @@ jobs:
       next_image: ${{ inputs.next_image }}
       arch: ${{ inputs.arch }}
       run_id: "${{ matrix.run_no }}"
+      helm_charts_branch: ${{ inputs.helm_charts_branch }}
     secrets: inherit

--- a/.github/workflows/reusable_issu_test.yaml
+++ b/.github/workflows/reusable_issu_test.yaml
@@ -26,6 +26,11 @@ on:
         required: false
         type: string
         default: ''
+      helm_charts_branch:
+        description: 'helm-charts repo branch to install the HA chart from (enables direct OpenMetrics scraping). Empty = pinned published chart version (default).'
+        required: false
+        type: string
+        default: ''
 
 env:
   MEMGRAPH_ENTERPRISE_LICENSE: ${{ secrets.MEMGRAPH_ENTERPRISE_LICENSE }}
@@ -115,6 +120,8 @@ jobs:
           echo "MEMGRAPH_NEXT_TAG=${NEXT_TAG}" >> $GITHUB_ENV
 
       - name: Run ISSU Test
+        env:
+          HELM_CHARTS_BRANCH: ${{ inputs.helm_charts_branch }}
         run: |
           cd tests/issu
           ./test_upgrade.sh ${{ env.MEMGRAPH_LAST_TAG }} ${{ env.MEMGRAPH_NEXT_TAG }} --test-routing=false --debug=false

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -558,7 +558,8 @@ jobs:
             -e OPENAI_API_KEY=$OPENAI_API_KEY \
             ${DOCKER_REPOSITORY_NAME}:$IMAGE_TAG \
             --telemetry-enabled=False \
-            --log-level=INFO
+            --log-level=INFO \
+            --metrics-format=OpenMetrics
 
       - name: Run end-to-end tests
         if: ${{ inputs.run_tests == true && inputs.cugraph == false }}

--- a/tests/drivers/run.sh
+++ b/tests/drivers/run.sh
@@ -26,6 +26,7 @@ mg_binary_dir="$DIR/../../build"
 
 # Start memgraph.
 $mg_binary_dir/memgraph \
+    --metrics-format=OpenMetrics \
     --cartesian-product-enabled=false \
     --data-directory=$tmpdir \
     --query-execution-timeout-sec=5 \

--- a/tests/drivers/run_cluster.sh
+++ b/tests/drivers/run_cluster.sh
@@ -52,6 +52,7 @@ mg_binary_dir="$DIR/../../build"
 # Start instance_1
 check_ports_unused 7687 10011
 $mg_binary_dir/memgraph \
+    --metrics-format=OpenMetrics \
     --bolt-port=7687 \
     --data-directory=$tmpdir/instance_1/ \
     --bolt-server-name-for-init="Neo4j/1.1" \
@@ -69,6 +70,7 @@ pids+=($pid_instance_1)
 # Start instance_2
 check_ports_unused 7688 10012
 $mg_binary_dir/memgraph \
+    --metrics-format=OpenMetrics \
     --bolt-port=7688 \
     --data-directory=$tmpdir/instance_2 \
     --bolt-server-name-for-init="Neo4j/1.1" \
@@ -86,6 +88,7 @@ pids+=($pid_instance_2)
 # Start instance_3
 check_ports_unused 7689 10013
 $mg_binary_dir/memgraph \
+    --metrics-format=OpenMetrics \
     --bolt-port=7689 \
     --data-directory=$tmpdir/instance_3 \
     --bolt-server-name-for-init="Neo4j/1.1" \
@@ -104,6 +107,7 @@ pids+=($pid_instance_3)
 # Start coordinator_1
 check_ports_unused 7690 10121 10111
 $mg_binary_dir/memgraph \
+    --metrics-format=OpenMetrics \
     --bolt-port=7690 \
     --data-directory=$tmpdir/coordinator_1 \
     --bolt-server-name-for-init="Neo4j/1.1" \
@@ -123,6 +127,7 @@ pids+=($pid_coordinator_1)
 # Start coordinator_2
 check_ports_unused 7691 10122 10112
 $mg_binary_dir/memgraph \
+    --metrics-format=OpenMetrics \
     --bolt-port=7691 \
     --data-directory=$tmpdir/coordinator_2 \
     --bolt-server-name-for-init="Neo4j/1.1" \
@@ -142,6 +147,7 @@ pids+=($pid_coordinator_2)
 # Start coordinator_3
 check_ports_unused 7692 10123 10113
 $mg_binary_dir/memgraph \
+    --metrics-format=OpenMetrics \
     --bolt-port=7692 \
     --data-directory=$tmpdir/coordinator_3 \
     --bolt-server-name-for-init="Neo4j/1.1" \

--- a/tests/e2e/configuration/workloads.yaml
+++ b/tests/e2e/configuration/workloads.yaml
@@ -4,6 +4,10 @@ args: &args
   - "--storage-snapshot-interval-sec"
   - "300"
   - "--storage-wal-enabled=True"
+  # configuration_check.py asserts SHOW CONFIG matches the compiled defaults, so pin
+  # metrics-format to the default (JSON) — otherwise the e2e harness injects
+  # --metrics-format=OpenMetrics and the current-value check fails.
+  - "--metrics-format=JSON"
 
 snap_args: &snap_args
   - "--log-level=TRACE"

--- a/tests/e2e/memgraph.py
+++ b/tests/e2e/memgraph.py
@@ -220,14 +220,20 @@ class MemgraphInstanceRunner:
         self.args = [replace_paths(arg) for arg in self.args]
 
         storage_snapshot_on_exit = "true" if storage_snapshot_on_exit else "false"
-        args_mg = [
+        default_args = [
             self.binary_path,
             "--storage-wal-enabled",
             "--storage-snapshot-interval-sec",
             "300",
             "--storage-properties-on-edges",
             f"--storage-snapshot-on-exit={storage_snapshot_on_exit}",
-        ] + self.args
+        ]
+        # Default the metrics endpoint to OpenMetrics unless the workload opts out
+        # (e.g. tests that exercise the deprecated JSON format set --metrics-format
+        # explicitly, in which case their value wins).
+        if not any(arg.startswith("--metrics-format") for arg in self.args):
+            default_args.append("--metrics-format=OpenMetrics")
+        args_mg = default_args + self.args
 
         if bolt_port:
             self.bolt_port = bolt_port

--- a/tests/e2e/show_metrics/workloads.yaml
+++ b/tests/e2e/show_metrics/workloads.yaml
@@ -9,7 +9,7 @@ show_metrics_cluster: &show_metrics_cluster
 show_metrics_json_cluster: &show_metrics_json_cluster
   cluster:
     main:
-      args: ["--bolt-port", "7687", "--log-level=TRACE", "--metrics-port=9091"]
+      args: ["--bolt-port", "7687", "--log-level=TRACE", "--metrics-port=9091", "--metrics-format=JSON"]
       log_file: "show_metrics_json_values.log"
       setup_queries: []
       validation_queries: []

--- a/tests/gql_behave/continuous_integration
+++ b/tests/gql_behave/continuous_integration
@@ -179,6 +179,7 @@ class MemgraphRunner:
             LOG_LEVEL,
             "--query-modules-directory",
             str(os.path.join(BUILD_DIR, "query_modules")),
+            "--metrics-format=OpenMetrics",
         ]
         self.proc_mg = subprocess.Popen(args_mg + self.args)
         wait_for_server(7687, self.proc_mg, 1)

--- a/tests/integration/audit/runner.py
+++ b/tests/integration/audit/runner.py
@@ -95,6 +95,7 @@ def execute_test(memgraph_binary, tester_binary):
         "--audit-enabled",
         "--log-file=memgraph.log",
         "--log-level=TRACE",
+        "--metrics-format=OpenMetrics",
     ]
 
     # Start the memgraph binary

--- a/tests/integration/auth/runner.py
+++ b/tests/integration/auth/runner.py
@@ -146,7 +146,7 @@ def check_permissions(query_perms, user_perms):
 
 def execute_test(memgraph_binary, tester_binary, checker_binary):
     storage_directory = tempfile.TemporaryDirectory()
-    memgraph_args = [memgraph_binary, "--data-directory", storage_directory.name]
+    memgraph_args = [memgraph_binary, "--data-directory", storage_directory.name, "--metrics-format=OpenMetrics"]
 
     def execute_admin_queries(queries, should_fail=False):
         return execute_tester(

--- a/tests/integration/durability/memgraph_server_context.py
+++ b/tests/integration/durability/memgraph_server_context.py
@@ -50,6 +50,7 @@ def memgraph_server(memgraph, data_dir: Path, port, logger, extra_args=None, tim
         "--also-log-to-stderr",
         f"--bolt-port={port}",
         f"--data-directory={data_dir.resolve()}",
+        "--metrics-format=OpenMetrics",
     ] + (extra_args if extra_args else [])
 
     logger.info("Starting Memgraph server...")

--- a/tests/integration/env_variable_check/runner.py
+++ b/tests/integration/env_variable_check/runner.py
@@ -112,7 +112,7 @@ def test_with_passfile_env_variable(storage_directory: tempfile.TemporaryDirecto
 
 def execute_test(memgraph_binary: str, tester_binary: str) -> None:
     storage_directory = tempfile.TemporaryDirectory()
-    memgraph_args = [memgraph_binary, "--data-directory", storage_directory.name]
+    memgraph_args = [memgraph_binary, "--data-directory", storage_directory.name, "--metrics-format=OpenMetrics"]
 
     return_to_prev_state = {}
     if "MEMGRAPH_USER" in os.environ:

--- a/tests/integration/fine_grained_access/runner.py
+++ b/tests/integration/fine_grained_access/runner.py
@@ -61,7 +61,7 @@ def execute_filtering(
 
 def execute_test(memgraph_binary: str, tester_binary: str, filtering_binary: str) -> None:
     storage_directory = tempfile.TemporaryDirectory()
-    memgraph_args = [memgraph_binary, "--data-directory", storage_directory.name]
+    memgraph_args = [memgraph_binary, "--data-directory", storage_directory.name, "--metrics-format=OpenMetrics"]
 
     def execute_admin_queries(queries):
         return execute_tester(

--- a/tests/integration/flag_check/runner.py
+++ b/tests/integration/flag_check/runner.py
@@ -124,7 +124,7 @@ def test_init_and_init_data_file(flag_checker_binary: str, tester_binary: str, m
 
 def execute_test(memgraph_binary: str, tester_binary: str, flag_checker_binary: str) -> None:
     storage_directory = tempfile.TemporaryDirectory()
-    memgraph_args = [memgraph_binary, "--data-directory", storage_directory.name]
+    memgraph_args = [memgraph_binary, "--data-directory", storage_directory.name, "--metrics-format=OpenMetrics"]
 
     # Start the memgraph binary
     with open(os.path.join(os.getcwd(), "dummy_init_file.cypherl"), "w") as temp_file:

--- a/tests/integration/init_file/runner.py
+++ b/tests/integration/init_file/runner.py
@@ -20,6 +20,8 @@ def wait_for_server(port, delay=0.1):
 
 
 def prepare_memgraph(memgraph_args):
+    if "--metrics-format=OpenMetrics" not in memgraph_args:
+        memgraph_args = memgraph_args + ["--metrics-format=OpenMetrics"]
     memgraph = subprocess.Popen(list(map(str, memgraph_args)))
     time.sleep(0.1)
     assert memgraph.poll() is None, "Memgraph process died prematurely!"

--- a/tests/integration/ldap/runner.py
+++ b/tests/integration/ldap/runner.py
@@ -112,6 +112,7 @@ class Memgraph:
             self._binary,
             "--data-directory",
             self._storage_directory.name,
+            "--metrics-format=OpenMetrics",
         ]
         module_path = kwargs.pop("module_executable", self._auth_module)
         if module_path:

--- a/tests/integration/run_time_settings/runner.py
+++ b/tests/integration/run_time_settings/runner.py
@@ -220,7 +220,7 @@ def execute_test(
     memgraph_binary: str, tester_binary: str, flag_tester_binary: str, executor_binary: str, test_config_binary: str
 ) -> None:
     storage_directory = tempfile.TemporaryDirectory()
-    memgraph_args = [memgraph_binary, "--data-directory", storage_directory.name]
+    memgraph_args = [memgraph_binary, "--data-directory", storage_directory.name, "--metrics-format=OpenMetrics"]
 
     print("\033[1;36m~~ Starting run-time settings check test ~~\033[0m")
 

--- a/tests/integration/storage_mode/runner.py
+++ b/tests/integration/storage_mode/runner.py
@@ -34,6 +34,8 @@ def wait_for_server(port, delay=0.1):
 
 def prepare_memgraph(memgraph_args):
     # Start the memgraph binary
+    if "--metrics-format=OpenMetrics" not in memgraph_args:
+        memgraph_args = memgraph_args + ["--metrics-format=OpenMetrics"]
     memgraph = subprocess.Popen(list(map(str, memgraph_args)))
     time.sleep(0.1)
     assert memgraph.poll() is None, "Memgraph process died prematurely!"

--- a/tests/integration/transactions/runner.sh
+++ b/tests/integration/transactions/runner.sh
@@ -6,7 +6,7 @@ cd "$DIR"
 binary_dir="$DIR/../../../build"
 
 # Start the memgraph process.
-$binary_dir/memgraph &
+$binary_dir/memgraph --metrics-format=OpenMetrics &
 pid=$!
 
 # Wait for the database to start up.

--- a/tests/integration/triggers/memgraph_server_context.py
+++ b/tests/integration/triggers/memgraph_server_context.py
@@ -50,6 +50,7 @@ def memgraph_server(memgraph, data_dir: Path, port, logger, extra_args=None, tim
         "--also-log-to-stderr",
         f"--bolt-port={port}",
         f"--data-directory={data_dir.resolve()}",
+        "--metrics-format=OpenMetrics",
     ] + (extra_args if extra_args else [])
 
     logger.info("Starting Memgraph server...")

--- a/tests/issu/test_upgrade.sh
+++ b/tests/issu/test_upgrade.sh
@@ -200,9 +200,13 @@ supports_openmetrics() {
   local tag_commit
   tag_commit="$(extract_commit_from_tag "$tag")"
   if [[ -n "$tag_commit" ]]; then
-    # tag carries a commit: does it contain the OpenMetrics commit?
-    git merge-base --is-ancestor "$OPENMETRICS_CUTOFF_COMMIT" "$tag_commit" 2>/dev/null
-    return
+    # tag carries a commit: does it contain the OpenMetrics commit? Guard with an
+    # `if` so a non-zero/128 exit (commit not in a shallow checkout, etc.) doesn't
+    # trip `set -e`; an unknown commit is treated as "not supported".
+    if git merge-base --is-ancestor "$OPENMETRICS_CUTOFF_COMMIT" "$tag_commit" 2>/dev/null; then
+      return 0
+    fi
+    return 1
   fi
   # otherwise fall back to a version compare
   local v

--- a/tests/issu/test_upgrade.sh
+++ b/tests/issu/test_upgrade.sh
@@ -602,8 +602,8 @@ kubectl create secret generic memgraph-secrets --from-literal=MEMGRAPH_ENTERPRIS
 HELM_CHARTS_BRANCH="${HELM_CHARTS_BRANCH:-}"
 HELM_CHARTS_REPO_URL="${HELM_CHARTS_REPO_URL:-https://github.com/memgraph/helm-charts}"
 # TODO(matt): bump CHART_VERSION to the published chart release that includes
-# vmagentRemote.scrapeMemgraphDirectly (chart > 1.1.0) so the default path uses
-# direct OpenMetrics scraping instead of falling back to the mg-exporter.
+# scrapeMemgraphDirectly (chart > 1.1.0) so the default path uses direct OpenMetrics
+# scraping instead of falling back to the mg-exporter.
 CHART_VERSION="${CHART_VERSION:-1.0.1}"
 
 if [[ -n "$HELM_CHARTS_BRANCH" ]]; then
@@ -619,7 +619,7 @@ else
   helm repo update memgraph
   HA_CHART="memgraph/memgraph-high-availability"
   CHART_VERSION_ARGS=(--version "$CHART_VERSION")
-  # The published chart only exposes vmagentRemote.scrapeMemgraphDirectly after 1.1.0.
+  # The published chart only exposes scrapeMemgraphDirectly after 1.1.0.
   if version_gt "$CHART_VERSION" "1.1.0"; then
     CHART_SUPPORTS_DIRECT_SCRAPE=true
   else
@@ -680,7 +680,7 @@ if [[ "${REMOTE_MONITORING_ENABLED}" == "true" ]]; then
     echo -e "${GREEN}Monitoring: scraping Memgraph OpenMetrics directly (chart supports it; start tag ${LAST_TAG} supports --metrics-format).${NC}"
     helm_install_args+=(
       --set prometheus.enabled=false
-      --set vmagentRemote.scrapeMemgraphDirectly=true
+      --set scrapeMemgraphDirectly=true
     )
   else
     echo -e "${YELLOW}Monitoring: using mg-exporter (Prometheus) path — OpenMetrics unavailable (chart_supports=${CHART_SUPPORTS_DIRECT_SCRAPE}, start tag ${LAST_TAG}).${NC}"

--- a/tests/issu/test_upgrade.sh
+++ b/tests/issu/test_upgrade.sh
@@ -130,6 +130,11 @@ version_gte() {
   ! version_lt "$a" "$b"
 }
 
+# return 0 if $1 > $2
+version_gt() {
+  version_lt "$2" "$1"
+}
+
 HA_39_MIGRATION_CUTOFF_VERSION="3.9.0"
 
 requires_ha_39_migration() {
@@ -182,6 +187,27 @@ behavior_for_tag() {
   else
     echo "auth_pre_upgrade.cypherl"   # 3.7.0 or later
   fi
+}
+
+# --- OpenMetrics support detection ---
+# Memgraph gained the --metrics-format flag / OpenMetrics endpoint in #3911.
+OPENMETRICS_CUTOFF_COMMIT="dbf744fd9b107a8e2ea24f8e1d46166b7f1bb2ff"
+OPENMETRICS_CUTOFF_VERSION="3.11.0"
+
+# return 0 if the Memgraph identified by $1 (tag/commit) supports --metrics-format=OpenMetrics
+supports_openmetrics() {
+  local tag="$1"
+  local tag_commit
+  tag_commit="$(extract_commit_from_tag "$tag")"
+  if [[ -n "$tag_commit" ]]; then
+    # tag carries a commit: does it contain the OpenMetrics commit?
+    git merge-base --is-ancestor "$OPENMETRICS_CUTOFF_COMMIT" "$tag_commit" 2>/dev/null
+    return
+  fi
+  # otherwise fall back to a version compare
+  local v
+  v="$(extract_version_from_tag "$tag")"
+  [[ -n "$v" ]] && version_gte "$v" "$OPENMETRICS_CUTOFF_VERSION"
 }
 
 auth_pre_upgrade_file=$(behavior_for_tag "$LAST_TAG")
@@ -571,6 +597,9 @@ kubectl create secret generic memgraph-secrets --from-literal=MEMGRAPH_ENTERPRIS
 # repo instead (cloned locally; no --version pin).
 HELM_CHARTS_BRANCH="${HELM_CHARTS_BRANCH:-}"
 HELM_CHARTS_REPO_URL="${HELM_CHARTS_REPO_URL:-https://github.com/memgraph/helm-charts}"
+# TODO(matt): bump CHART_VERSION to the published chart release that includes
+# vmagentRemote.scrapeMemgraphDirectly (chart > 1.1.0) so the default path uses
+# direct OpenMetrics scraping instead of falling back to the mg-exporter.
 CHART_VERSION="${CHART_VERSION:-1.0.1}"
 
 if [[ -n "$HELM_CHARTS_BRANCH" ]]; then
@@ -579,11 +608,19 @@ if [[ -n "$HELM_CHARTS_BRANCH" ]]; then
   git clone --depth 1 --branch "$HELM_CHARTS_BRANCH" "$HELM_CHARTS_REPO_URL" helm-charts
   HA_CHART="helm-charts/charts/memgraph-high-availability"
   CHART_VERSION_ARGS=()
+  # A branch is assumed to support direct OpenMetrics scraping (it's where the feature lives).
+  CHART_SUPPORTS_DIRECT_SCRAPE=true
 else
   helm repo add memgraph https://memgraph.github.io/helm-charts >/dev/null 2>&1 || true
   helm repo update memgraph
   HA_CHART="memgraph/memgraph-high-availability"
   CHART_VERSION_ARGS=(--version "$CHART_VERSION")
+  # The published chart only exposes vmagentRemote.scrapeMemgraphDirectly after 1.1.0.
+  if version_gt "$CHART_VERSION" "1.1.0"; then
+    CHART_SUPPORTS_DIRECT_SCRAPE=true
+  else
+    CHART_SUPPORTS_DIRECT_SCRAPE=false
+  fi
 fi
 
 MEMGRAPH_NAMESPACE="${MEMGRAPH_NAMESPACE:-default}"
@@ -630,13 +667,26 @@ if [[ "${REMOTE_MONITORING_ENABLED}" == "true" ]]; then
     --from-literal=password="${MONITORING_PASSWORD}" \
     --dry-run=client -o yaml | kubectl apply -f -
 
-  # Always scrape Memgraph's OpenMetrics endpoint directly (no mg-exporter). The
-  # chart appends --metrics-format=OpenMetrics to each instance automatically.
-  # Requires a chart that supports vmagentRemote.scrapeMemgraphDirectly (use
-  # HELM_CHARTS_BRANCH until that chart version is published).
+  # Scrape Memgraph's OpenMetrics endpoint directly only when both the chart and the
+  # starting Memgraph version support it; the chart then appends
+  # --metrics-format=OpenMetrics to each instance. Otherwise fall back to the
+  # mg-exporter (Prometheus) path, which reads Memgraph's legacy JSON metrics and
+  # works with older Memgraph versions.
+  if [[ "$CHART_SUPPORTS_DIRECT_SCRAPE" == "true" ]] && supports_openmetrics "$LAST_TAG"; then
+    echo -e "${GREEN}Monitoring: scraping Memgraph OpenMetrics directly (chart supports it; start tag ${LAST_TAG} supports --metrics-format).${NC}"
+    helm_install_args+=(
+      --set prometheus.enabled=false
+      --set vmagentRemote.scrapeMemgraphDirectly=true
+    )
+  else
+    echo -e "${YELLOW}Monitoring: using mg-exporter (Prometheus) path — OpenMetrics unavailable (chart_supports=${CHART_SUPPORTS_DIRECT_SCRAPE}, start tag ${LAST_TAG}).${NC}"
+    helm_install_args+=(
+      --set prometheus.enabled=true
+      --set "prometheus.namespace=${MONITORING_NAMESPACE}"
+      --set prometheus.serviceMonitor.enabled=false
+    )
+  fi
   helm_install_args+=(
-    --set prometheus.enabled=false
-    --set vmagentRemote.scrapeMemgraphDirectly=true
     --set vmagentRemote.enabled=true
     --set "vmagentRemote.namespace=${MONITORING_NAMESPACE}"
     --set "vmagentRemote.remoteWrite.url=${REMOTE_WRITE_URL}"

--- a/tests/issu/test_upgrade.sh
+++ b/tests/issu/test_upgrade.sh
@@ -566,8 +566,25 @@ echo -e "${YELLOW} Creating secret with license details"
 kubectl create secret generic memgraph-secrets --from-literal=MEMGRAPH_ENTERPRISE_LICENSE=${ENTERPRISE_LICENSE} --from-literal=MEMGRAPH_ORGANIZATION_NAME=${ORGANIZATION_NAME}
 
 # --- Helm chart prep ---
-helm repo add memgraph https://memgraph.github.io/helm-charts >/dev/null 2>&1 || true
-helm repo update memgraph
+# By default install the published chart pinned to a specific version. Optionally,
+# set HELM_CHARTS_BRANCH to install the HA chart from a branch of the helm-charts
+# repo instead (cloned locally; no --version pin).
+HELM_CHARTS_BRANCH="${HELM_CHARTS_BRANCH:-}"
+HELM_CHARTS_REPO_URL="${HELM_CHARTS_REPO_URL:-https://github.com/memgraph/helm-charts}"
+CHART_VERSION="${CHART_VERSION:-1.0.1}"
+
+if [[ -n "$HELM_CHARTS_BRANCH" ]]; then
+  echo -e "${GREEN}Using helm-charts branch '${HELM_CHARTS_BRANCH}' from ${HELM_CHARTS_REPO_URL}${NC}"
+  rm -rf helm-charts
+  git clone --depth 1 --branch "$HELM_CHARTS_BRANCH" "$HELM_CHARTS_REPO_URL" helm-charts
+  HA_CHART="helm-charts/charts/memgraph-high-availability"
+  CHART_VERSION_ARGS=()
+else
+  helm repo add memgraph https://memgraph.github.io/helm-charts >/dev/null 2>&1 || true
+  helm repo update memgraph
+  HA_CHART="memgraph/memgraph-high-availability"
+  CHART_VERSION_ARGS=(--version "$CHART_VERSION")
+fi
 
 MEMGRAPH_NAMESPACE="${MEMGRAPH_NAMESPACE:-default}"
 MONITORING_NAMESPACE="${MONITORING_NAMESPACE:-monitoring}"
@@ -588,8 +605,8 @@ fi
 
 helm_install_args=(
   install "$RELEASE"
-  memgraph/memgraph-high-availability
-  --version 1.0.1
+  "$HA_CHART"
+  "${CHART_VERSION_ARGS[@]}"
   -f old_values.yaml
   --timeout 120s
   --wait
@@ -613,10 +630,13 @@ if [[ "${REMOTE_MONITORING_ENABLED}" == "true" ]]; then
     --from-literal=password="${MONITORING_PASSWORD}" \
     --dry-run=client -o yaml | kubectl apply -f -
 
+  # Always scrape Memgraph's OpenMetrics endpoint directly (no mg-exporter). The
+  # chart appends --metrics-format=OpenMetrics to each instance automatically.
+  # Requires a chart that supports vmagentRemote.scrapeMemgraphDirectly (use
+  # HELM_CHARTS_BRANCH until that chart version is published).
   helm_install_args+=(
-    --set prometheus.enabled=true
-    --set "prometheus.namespace=${MONITORING_NAMESPACE}"
-    --set prometheus.serviceMonitor.enabled=false
+    --set prometheus.enabled=false
+    --set vmagentRemote.scrapeMemgraphDirectly=true
     --set vmagentRemote.enabled=true
     --set "vmagentRemote.namespace=${MONITORING_NAMESPACE}"
     --set "vmagentRemote.remoteWrite.url=${REMOTE_WRITE_URL}"
@@ -776,7 +796,7 @@ kubectl exec memgraph-data-0-0 -- bash -c "mgconsole < /var/lib/memgraph/pre_upg
 echo "Run test queries on old version"
 
 # --- Upgrade chart values ---
-helm upgrade "$RELEASE" memgraph/memgraph-high-availability --version 1.0.1 -f new_values.yaml
+helm upgrade "$RELEASE" "$HA_CHART" "${CHART_VERSION_ARGS[@]}" -f new_values.yaml
 echo "Updated versions"
 
 

--- a/tests/issu/values_template.yaml
+++ b/tests/issu/values_template.yaml
@@ -365,6 +365,9 @@ data:
   - id: "0"
     restoreDataFromSnapshot: false
     volumeSnapshotName: data-0-snap # Used only if restoreDataFromSnapshot is set to true
+    tls:
+      bolt:
+        enabled: false
     internalAccessAnnotations: {} # Per-instance annotations for internal ClusterIP service
     externalAccessAnnotations: {} # Per-instance annotations for external access service (merged with externalAccessConfig.dataInstance.annotations, per-instance takes precedence)
     # Example
@@ -382,6 +385,9 @@ data:
   - id: "1"
     restoreDataFromSnapshot: false
     volumeSnapshotName: data-1-snap
+    tls:
+      bolt:
+        enabled: false
     internalAccessAnnotations: {}
     externalAccessAnnotations: {}
     args:
@@ -395,6 +401,9 @@ coordinators:
   - id: "1"
     restoreDataFromSnapshot: false
     volumeSnapshotName: coord-1-snap
+    tls:
+      bolt:
+        enabled: false
     internalAccessAnnotations: {}
     externalAccessAnnotations: {}
     args:
@@ -406,6 +415,9 @@ coordinators:
   - id: "2"
     restoreDataFromSnapshot: false
     volumeSnapshotName: coord-2-snap
+    tls:
+      bolt:
+        enabled: false
     internalAccessAnnotations: {}
     externalAccessAnnotations: {}
     args:
@@ -417,6 +429,9 @@ coordinators:
   - id: "3"
     restoreDataFromSnapshot: false
     volumeSnapshotName: coord-3-snap
+    tls:
+      bolt:
+        enabled: false
     internalAccessAnnotations: {}
     externalAccessAnnotations: {}
     args:

--- a/tests/issu/values_template.yaml
+++ b/tests/issu/values_template.yaml
@@ -378,6 +378,7 @@ data:
       - "--telemetry-enabled=false"
       - "--monitoring-port=7444"
       - "--monitoring-address=0.0.0.0"
+      - "--metrics-format=OpenMetrics"
   - id: "1"
     restoreDataFromSnapshot: false
     volumeSnapshotName: data-1-snap
@@ -388,6 +389,7 @@ data:
       - "--telemetry-enabled=false"
       - "--monitoring-port=7444"
       - "--monitoring-address=0.0.0.0"
+      - "--metrics-format=OpenMetrics"
 
 coordinators:
   - id: "1"
@@ -399,6 +401,7 @@ coordinators:
       - "--telemetry-enabled=false"
       - "--monitoring-port=7444"
       - "--monitoring-address=0.0.0.0"
+      - "--metrics-format=OpenMetrics"
 
   - id: "2"
     restoreDataFromSnapshot: false
@@ -409,6 +412,7 @@ coordinators:
       - "--telemetry-enabled=false"
       - "--monitoring-port=7444"
       - "--monitoring-address=0.0.0.0"
+      - "--metrics-format=OpenMetrics"
 
   - id: "3"
     restoreDataFromSnapshot: false
@@ -419,6 +423,7 @@ coordinators:
       - "--telemetry-enabled=false"
       - "--monitoring-port=7444"
       - "--monitoring-address=0.0.0.0"
+      - "--metrics-format=OpenMetrics"
 
 userContainers:
   data: []

--- a/tests/issu/values_template.yaml
+++ b/tests/issu/values_template.yaml
@@ -381,7 +381,6 @@ data:
       - "--telemetry-enabled=false"
       - "--monitoring-port=7444"
       - "--monitoring-address=0.0.0.0"
-      - "--metrics-format=OpenMetrics"
   - id: "1"
     restoreDataFromSnapshot: false
     volumeSnapshotName: data-1-snap
@@ -395,7 +394,6 @@ data:
       - "--telemetry-enabled=false"
       - "--monitoring-port=7444"
       - "--monitoring-address=0.0.0.0"
-      - "--metrics-format=OpenMetrics"
 
 coordinators:
   - id: "1"
@@ -410,7 +408,6 @@ coordinators:
       - "--telemetry-enabled=false"
       - "--monitoring-port=7444"
       - "--monitoring-address=0.0.0.0"
-      - "--metrics-format=OpenMetrics"
 
   - id: "2"
     restoreDataFromSnapshot: false
@@ -424,7 +421,6 @@ coordinators:
       - "--telemetry-enabled=false"
       - "--monitoring-port=7444"
       - "--monitoring-address=0.0.0.0"
-      - "--metrics-format=OpenMetrics"
 
   - id: "3"
     restoreDataFromSnapshot: false
@@ -438,7 +434,6 @@ coordinators:
       - "--telemetry-enabled=false"
       - "--monitoring-port=7444"
       - "--monitoring-address=0.0.0.0"
-      - "--metrics-format=OpenMetrics"
 
 userContainers:
   data: []

--- a/tests/jepsen/src/memgraph/support.clj
+++ b/tests/jepsen/src/memgraph/support.clj
@@ -48,6 +48,7 @@
            (str "--storage-backup-dir-enabled=" @storage-backup-dir-enabled)
            (str "--storage-wal-file-flush-every-n-tx=" @sync-after-n-txn)
            "--telemetry-enabled=false"
+           "--metrics-format=OpenMetrics"
            :--storage-properties-on-edges]
           (tls-flags))))
 
@@ -66,6 +67,7 @@
            :--storage-properties-on-edges
            "--storage-snapshot-interval-sec=300"
            "--telemetry-enabled=false"
+           "--metrics-format=OpenMetrics"
            "--log-level=TRACE"
            (str "--storage-backup-dir-enabled=" @storage-backup-dir-enabled)
            :--coordinator-id (get node-config :coordinator-id)
@@ -88,6 +90,7 @@
            "--log-level=TRACE"
            (str "--storage-backup-dir-enabled=" @storage-backup-dir-enabled)
            "--telemetry-enabled=false"
+           "--metrics-format=OpenMetrics"
            :--replication-restore-state-on-startup
            :--data-recovery-on-startup
            :--storage-properties-on-edges

--- a/tests/macro_benchmark/databases.py
+++ b/tests/macro_benchmark/databases.py
@@ -76,6 +76,7 @@ class Memgraph:
         # SHOW SCHEMA INFO has to enable edge metadata (or edge index); otherwise it is unusable
         database_args += ["--storage-properties-on-edges"]
         database_args += ["--storage-enable-edges-metadata"]
+        database_args += ["--metrics-format", "OpenMetrics"]
 
         # find executable path
         runner_bin = self.args.runner_bin

--- a/tests/mgbench/runners.py
+++ b/tests/mgbench/runners.py
@@ -638,6 +638,7 @@ class Memgraph(BaseRunner):
         kwargs["data_directory"] = data_directory
         kwargs["storage_properties_on_edges"] = True
         kwargs["bolt_num_workers"] = self._bolt_num_workers
+        kwargs["metrics_format"] = "OpenMetrics"
         for key, value in self._vendor_args.items():
             kwargs[key] = value
         return _convert_args_to_flags(self._memgraph_binary, **kwargs)

--- a/tests/stress/durability
+++ b/tests/stress/durability
@@ -56,6 +56,7 @@ cmd = [
     "--query-execution-timeout-sec=600",
     "--bolt-server-name-for-init=Neo4j/v5.11.0 compatible graph database server - Memgraph",
     "--log-level=TRACE",
+    "--metrics-format=OpenMetrics",
 ]
 if not args.verbose:
     cmd += ["--log-level", "WARNING"]

--- a/tests/stress/ha/docker/deployment/deployment.sh
+++ b/tests/stress/ha/docker/deployment/deployment.sh
@@ -36,12 +36,14 @@ DEFAULT_DATA_FLAGS=(
     "--query-execution-timeout-sec=0"
     "--log-level=TRACE"
     "--also-log-to-stderr=true"
+    "--metrics-format=OpenMetrics"
 )
 
 # Default flags for Memgraph Coordinator Nodes
 DEFAULT_COORD_FLAGS=(
     "--log-level=TRACE"
     "--also-log-to-stderr=true"
+    "--metrics-format=OpenMetrics"
 )
 
 # Data node configurations: name, bolt_port, management_port, monitoring_port, metrics_port

--- a/tests/stress/ha/eks/deployment/values.yaml
+++ b/tests/stress/ha/eks/deployment/values.yaml
@@ -371,6 +371,7 @@ data:
       - "--metrics-port=9091"
       - "--monitoring-port=7444"
       - "--monitoring-address=0.0.0.0"
+      - "--metrics-format=OpenMetrics"
 
   - id: "1"
     restoreDataFromSnapshot: false
@@ -384,6 +385,7 @@ data:
       - "--metrics-port=9091"
       - "--monitoring-port=7444"
       - "--monitoring-address=0.0.0.0"
+      - "--metrics-format=OpenMetrics"
 
 coordinators:
   - id: "1"
@@ -397,6 +399,7 @@ coordinators:
       - "--metrics-port=9091"
       - "--monitoring-port=7444"
       - "--monitoring-address=0.0.0.0"
+      - "--metrics-format=OpenMetrics"
 
   - id: "2"
     restoreDataFromSnapshot: false
@@ -409,6 +412,7 @@ coordinators:
       - "--metrics-port=9091"
       - "--monitoring-port=7444"
       - "--monitoring-address=0.0.0.0"
+      - "--metrics-format=OpenMetrics"
 
 
   - id: "3"
@@ -422,6 +426,7 @@ coordinators:
       - "--metrics-port=9091"
       - "--monitoring-port=7444"
       - "--monitoring-address=0.0.0.0"
+      - "--metrics-format=OpenMetrics"
 
 userContainers:
   data: []

--- a/tests/stress/ha/native/deployment/deployment.sh
+++ b/tests/stress/ha/native/deployment/deployment.sh
@@ -47,6 +47,7 @@ DEFAULT_DATA_FLAGS=(
     "--storage-snapshot-on-exit=false"
     "--telemetry-enabled=false"
     "--query-execution-timeout-sec=1200"
+    "--metrics-format=OpenMetrics"
 )
 
 # Default flags for Memgraph Coordinator Nodes
@@ -56,6 +57,7 @@ DEFAULT_COORD_FLAGS=(
     "--log-file="
     "--log-level=TRACE"
     "--telemetry-enabled=false"
+    "--metrics-format=OpenMetrics"
 )
 
 # Configuration for Data Nodes

--- a/tests/stress/standalone/native/deployment/deployment.sh
+++ b/tests/stress/standalone/native/deployment/deployment.sh
@@ -32,6 +32,7 @@ DEFAULT_FLAGS=(
     "--storage-wal-enabled=true"
     "--storage-snapshot-on-exit=false"
     "--telemetry-enabled=false"
+    "--metrics-format=OpenMetrics"
 )
 
 is_memgraph_running() {

--- a/tools/ci/monitoring/README.md
+++ b/tools/ci/monitoring/README.md
@@ -2,12 +2,14 @@
 
 This bundle reuses the same remote monitoring flow as `victoria-cluster`, but for Memgraph processes running inside mgbuild containers.
 
-- Metrics: `Memgraph -> mg-exporter -> vmagent -> VictoriaMetrics`
+- Metrics: `Memgraph (OpenMetrics, port 9091) -> vmagent -> VictoriaMetrics`
 - Logs: `Memgraph websocket (port 7444) -> vector -> VictoriaLogs`
+
+`vmagent` scrapes Memgraph's metrics endpoint directly; the standalone
+`mg-exporter` is no longer used.
 
 ## What this starts
 
-- `mg-exporter` (`memgraph/prometheus-exporter:0.2.3`)
 - `vmagent` (`victoriametrics/vmagent:v1.139.0`)
 - `vector` (`timberio/vector:0.49.0-debian`)
 
@@ -17,6 +19,8 @@ This bundle reuses the same remote monitoring flow as `victoria-cluster`, but fo
 - `envsubst`
 - mgbuild services started from `release/package/*-builders-v7.yml`
 - `mgbuild_network` Docker network exists
+- Memgraph instances started with `--metrics-format=OpenMetrics` so the metrics
+  port (`9091`) serves Prometheus/OpenMetrics text instead of the legacy JSON
 - Memgraph instances expose websocket logs on port `7444`
 
 ## Endpoint configuration
@@ -40,7 +44,7 @@ or host + optional ports/schemes:
 - `CLUSTER_ENV` (default: `ci-standalone-victoria`)
 - `MEMGRAPH_METRICS_HOST` (default: `host.docker.internal`)
 - `MEMGRAPH_METRICS_PORT` (default: `9091`)
-- `MEMGRAPH_METRICS_TARGETS` (comma-separated, e.g. `mgbuild_v7_ubuntu-24.04:9091,mgbuild_v7_debian-12:9091`; enables multi-instance exporter mode)
+- `MEMGRAPH_METRICS_TARGETS` (comma-separated, e.g. `mgbuild_v7_ubuntu-24.04:9091,mgbuild_v7_debian-12:9091`; enables multi-instance scraping)
 - `MEMGRAPH_LOG_WS_PORT` (default: `7444`)
 - `MEMGRAPH_LOG_WS_TARGETS` (comma-separated websocket targets; accepts `host`, `host:port`, or full `ws://...`; defaults to `MEMGRAPH_METRICS_TARGETS` when present)
 - `MONITORING_USERNAME` / `MONITORING_PASSWORD` (optional basic auth for both VictoriaMetrics remote write and VictoriaLogs push; also supports `CI_MONITORING_USER` / `CI_MONITORING_PASSWORD`)
@@ -48,8 +52,7 @@ or host + optional ports/schemes:
 
 ## Multi-instance notes
 
-- One `mg-exporter` can scrape multiple Memgraph instances using `MEMGRAPH_METRICS_TARGETS`.
-- One `vmagent` is enough because it scrapes only `mg-exporter`.
+- One `vmagent` can scrape multiple Memgraph instances directly using `MEMGRAPH_METRICS_TARGETS`.
 - One `vector` is enough because it can connect to multiple websocket targets.
 - For parallel monitoring stacks, use different `COMPOSE_PROJECT_NAME` values.
 
@@ -80,6 +83,5 @@ cd tools/ci/monitoring
 
 `up.sh` renders runtime files in `generated/`:
 
-- `generated/mg-exporter.yaml`
 - `generated/vmagent-scrape.yml`
 - `generated/vector.yaml`

--- a/tools/ci/monitoring/docker-compose.host-network.yml
+++ b/tools/ci/monitoring/docker-compose.host-network.yml
@@ -1,22 +1,9 @@
 services:
-  mg-exporter:
-    image: memgraph/prometheus-exporter:0.2.3
-    container_name: ${COMPOSE_PROJECT_NAME}-mg-exporter
-    restart: unless-stopped
-    network_mode: host
-    volumes:
-      - ./generated/mg-exporter.yaml:/etc/mg-exporter/config.yaml:ro
-    environment:
-      - DEPLOYMENT_TYPE=${MG_EXPORTER_DEPLOYMENT_TYPE}
-      - CONFIG_FILE=/etc/mg-exporter/config.yaml
-
   vmagent:
     image: victoriametrics/vmagent:v1.139.0
     container_name: ${COMPOSE_PROJECT_NAME}-vmagent
     restart: unless-stopped
     network_mode: host
-    depends_on:
-      - mg-exporter
     volumes:
       - ./generated/vmagent-scrape.yml:/etc/vmagent/scrape.yml:ro
       - vmagent_tmp:/tmpData

--- a/tools/ci/monitoring/docker-compose.yml
+++ b/tools/ci/monitoring/docker-compose.yml
@@ -1,25 +1,13 @@
 services:
-  mg-exporter:
-    image: memgraph/prometheus-exporter:0.2.3
-    container_name: ${COMPOSE_PROJECT_NAME}-mg-exporter
+  vmagent:
+    image: victoriametrics/vmagent:v1.139.0
+    container_name: ${COMPOSE_PROJECT_NAME}-vmagent
     restart: unless-stopped
     extra_hosts:
       - "host.docker.internal:host-gateway"
     networks:
       - default
       - target_network
-    volumes:
-      - ./generated/mg-exporter.yaml:/etc/mg-exporter/config.yaml:ro
-    environment:
-      - DEPLOYMENT_TYPE=${MG_EXPORTER_DEPLOYMENT_TYPE}
-      - CONFIG_FILE=/etc/mg-exporter/config.yaml
-
-  vmagent:
-    image: victoriametrics/vmagent:v1.139.0
-    container_name: ${COMPOSE_PROJECT_NAME}-vmagent
-    restart: unless-stopped
-    depends_on:
-      - mg-exporter
     volumes:
       - ./generated/vmagent-scrape.yml:/etc/vmagent/scrape.yml:ro
       - vmagent_tmp:/tmpData

--- a/tools/ci/monitoring/down.sh
+++ b/tools/ci/monitoring/down.sh
@@ -10,7 +10,6 @@ COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yml"
 HOST_NETWORK_COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.host-network.yml"
 MONITORING_USE_HOST_NETWORK="${MONITORING_USE_HOST_NETWORK:-false}"
 REMOTE_WRITE_URL="${REMOTE_WRITE_URL:-http://127.0.0.1:8428/api/v1/write}"
-MG_EXPORTER_DEPLOYMENT_TYPE="${MG_EXPORTER_DEPLOYMENT_TYPE:-standalone}"
 VMAGENT_AUTH_ARGS="${VMAGENT_AUTH_ARGS:-}"
 docker compose version >/dev/null 2>&1 || {
   echo "error: Docker Compose plugin was not found. Install and use 'docker compose'." >&2
@@ -22,7 +21,7 @@ if [[ "${MONITORING_USE_HOST_NETWORK}" == "true" ]]; then
   COMPOSE_FILES=(-f "${HOST_NETWORK_COMPOSE_FILE}")
 fi
 
-export COMPOSE_PROJECT_NAME REMOTE_WRITE_URL MG_EXPORTER_DEPLOYMENT_TYPE VMAGENT_AUTH_ARGS
+export COMPOSE_PROJECT_NAME REMOTE_WRITE_URL VMAGENT_AUTH_ARGS
 
 echo "==> Stopping monitoring stack (${COMPOSE_PROJECT_NAME})"
 "${COMPOSE_CMD[@]}" \

--- a/tools/ci/monitoring/manifests/mg-exporter-ha.yaml.tmpl
+++ b/tools/ci/monitoring/manifests/mg-exporter-ha.yaml.tmpl
@@ -1,5 +1,0 @@
-exporter:
-  port: 9115
-  pull_frequency_seconds: 5
-instances:
-${MEMGRAPH_INSTANCES_BLOCK}

--- a/tools/ci/monitoring/manifests/mg-exporter-standalone.yaml.tmpl
+++ b/tools/ci/monitoring/manifests/mg-exporter-standalone.yaml.tmpl
@@ -1,7 +1,0 @@
-exporter:
-  port: 9115
-memgraph:
-  endpoint_url: http://${MEMGRAPH_METRICS_HOST}
-  port: ${MEMGRAPH_METRICS_PORT}
-general:
-  pull_frequency_seconds: 5

--- a/tools/ci/monitoring/manifests/vmagent-scrape.yml.tmpl
+++ b/tools/ci/monitoring/manifests/vmagent-scrape.yml.tmpl
@@ -6,7 +6,10 @@ global:
     cluster_env: "${CLUSTER_ENV}"
 
 scrape_configs:
-  - job_name: memgraph-exporter
+  # Memgraph exposes Prometheus/OpenMetrics directly on the metrics port
+  # (requires the instance to run with --metrics-format=OpenMetrics).
+  - job_name: memgraph
+    metrics_path: /metrics
     static_configs:
       - targets:
-          - ${MG_EXPORTER_SCRAPE_TARGET}
+${MEMGRAPH_SCRAPE_TARGETS_BLOCK}

--- a/tools/ci/monitoring/up.sh
+++ b/tools/ci/monitoring/up.sh
@@ -64,21 +64,18 @@ COMPOSE_CMD=(docker compose)
 COMPOSE_FILES=(-f "${COMPOSE_FILE}")
 if [[ "${MONITORING_USE_HOST_NETWORK}" == "true" ]]; then
   COMPOSE_FILES=(-f "${HOST_NETWORK_COMPOSE_FILE}")
-  MG_EXPORTER_SCRAPE_TARGET="127.0.0.1:9115"
-else
-  MG_EXPORTER_SCRAPE_TARGET="mg-exporter:9115"
 fi
 
-MG_EXPORTER_CONFIG="${GENERATED_DIR}/mg-exporter.yaml"
 VMAGENT_SCRAPE_CONFIG="${GENERATED_DIR}/vmagent-scrape.yml"
 VECTOR_CONFIG="${GENERATED_DIR}/vector.yaml"
 
 export MEMGRAPH_METRICS_HOST MEMGRAPH_METRICS_PORT
 
+# vmagent scrapes Memgraph's OpenMetrics endpoint directly (no mg-exporter in
+# between). Each instance must run with --metrics-format=OpenMetrics so that the
+# metrics port serves Prometheus/OpenMetrics text instead of the legacy JSON.
+MEMGRAPH_SCRAPE_TARGETS_BLOCK=""
 if [[ -n "${MEMGRAPH_METRICS_TARGETS}" ]]; then
-  MG_EXPORTER_DEPLOYMENT_TYPE="HA"
-  MEMGRAPH_INSTANCES_BLOCK=""
-  target_index=1
   IFS=',' read -r -a metrics_targets <<< "${MEMGRAPH_METRICS_TARGETS}"
   for target in "${metrics_targets[@]}"; do
     trimmed_target="$(echo "${target}" | xargs)"
@@ -89,23 +86,16 @@ if [[ -n "${MEMGRAPH_METRICS_TARGETS}" ]]; then
     target_port="${trimmed_target##*:}"
     if [[ "${target_host}" == "${target_port}" ]]; then
       target_host="${trimmed_target}"
-      target_port="9091"
+      target_port="${MEMGRAPH_METRICS_PORT}"
     fi
-    MEMGRAPH_INSTANCES_BLOCK+=$'  - name: memgraph'"${target_index}"$'\n'
-    MEMGRAPH_INSTANCES_BLOCK+=$'    url: http://'"${target_host}"$'\n'
-    MEMGRAPH_INSTANCES_BLOCK+=$'    port: '"${target_port}"$'\n'
-    MEMGRAPH_INSTANCES_BLOCK+=$'    type: data_instance\n'
-    target_index=$((target_index + 1))
+    MEMGRAPH_SCRAPE_TARGETS_BLOCK+=$'          - '"${target_host}:${target_port}"$'\n'
   done
-  if [[ -z "${MEMGRAPH_INSTANCES_BLOCK}" ]]; then
+  if [[ -z "${MEMGRAPH_SCRAPE_TARGETS_BLOCK}" ]]; then
     echo "error: MEMGRAPH_METRICS_TARGETS was provided, but no valid targets were parsed." >&2
     exit 2
   fi
-  export MEMGRAPH_INSTANCES_BLOCK
-  envsubst < "${MANIFESTS_DIR}/mg-exporter-ha.yaml.tmpl" > "${MG_EXPORTER_CONFIG}"
 else
-  MG_EXPORTER_DEPLOYMENT_TYPE="standalone"
-  envsubst < "${MANIFESTS_DIR}/mg-exporter-standalone.yaml.tmpl" > "${MG_EXPORTER_CONFIG}"
+  MEMGRAPH_SCRAPE_TARGETS_BLOCK+=$'          - '"${MEMGRAPH_METRICS_HOST}:${MEMGRAPH_METRICS_PORT}"$'\n'
 fi
 
 if [[ -z "${MEMGRAPH_LOG_WS_TARGETS}" ]]; then
@@ -214,10 +204,10 @@ if [[ -z "${VECTOR_ENRICH_INPUTS}" ]]; then
   exit 2
 fi
 
-export COMPOSE_PROJECT_NAME REMOTE_WRITE_URL VLOGS_INSERT_ENDPOINT MG_EXPORTER_DEPLOYMENT_TYPE
+export COMPOSE_PROJECT_NAME REMOTE_WRITE_URL VLOGS_INSERT_ENDPOINT
 export MEMGRAPH_METRICS_HOST MEMGRAPH_METRICS_PORT CLUSTER_ID CLUSTER_ENV SERVICE_NAME
 export VECTOR_SOURCES_BLOCK VECTOR_PREPROCESS_BLOCK VECTOR_ENRICH_INPUTS
-export VMAGENT_AUTH_ARGS VLOGS_AUTH_BLOCK MG_EXPORTER_SCRAPE_TARGET
+export VMAGENT_AUTH_ARGS VLOGS_AUTH_BLOCK MEMGRAPH_SCRAPE_TARGETS_BLOCK
 
 envsubst < "${MANIFESTS_DIR}/vmagent-scrape.yml.tmpl" > "${VMAGENT_SCRAPE_CONFIG}"
 envsubst < "${MANIFESTS_DIR}/vector.yaml.tmpl" > "${VECTOR_CONFIG}"
@@ -284,7 +274,6 @@ else
 fi
 echo
 echo "Generated files:"
-echo "  ${MG_EXPORTER_CONFIG}"
 echo "  ${VMAGENT_SCRAPE_CONFIG}"
 echo "  ${VECTOR_CONFIG}"
 echo

--- a/tools/ci/monitoring/up.sh
+++ b/tools/ci/monitoring/up.sh
@@ -64,6 +64,12 @@ COMPOSE_CMD=(docker compose)
 COMPOSE_FILES=(-f "${COMPOSE_FILE}")
 if [[ "${MONITORING_USE_HOST_NETWORK}" == "true" ]]; then
   COMPOSE_FILES=(-f "${HOST_NETWORK_COMPOSE_FILE}")
+  # In host-network mode there is no extra_hosts mapping for host.docker.internal,
+  # so the default standalone scrape target would be unreachable. Fall back to
+  # 127.0.0.1 (an explicit MEMGRAPH_METRICS_HOST override is left untouched).
+  if [[ "${MEMGRAPH_METRICS_HOST}" == "host.docker.internal" ]]; then
+    MEMGRAPH_METRICS_HOST="127.0.0.1"
+  fi
 fi
 
 VMAGENT_SCRAPE_CONFIG="${GENERATED_DIR}/vmagent-scrape.yml"


### PR DESCRIPTION
Switch to OpenMetrics format in CI monitoring.

Added the launch argument to all test runners which we already monitor to include `--metrics-format=OpenMetrics`.

Added missing tls values required by the new charts for ISSU to work.

Added optional `helm_charts_branch` input to the ISSU test to allow testing against a specific branch, rather than the fixed version hard-coded into the `test_upgrade.sh` script. 

The new monitoring scraping method required both the new chart release (assumed >1.1.0) and a build of memgraph which supports the `--metrics-format` flag - so it falls back to `mg-exporter` where not supported.

The following tests were checked against the new dashboard provided by https://github.com/memgraph/infra/pull/504 :

- [x] Diff debug core
- [x] Diff debug integration
- [x] Diff release core
- [x] Diff release stress
- [x] Diff release e2e
- [x] Diff Jepsen
- [x] Stress Jepsen
- [x] Stress standalone
- [x] Stress Native HA
- [x] Stress Docker HA
- [x] Stress EKS HA
- [x] ISSU

