### PR TITLE
Feature (Light Edges / 6) - feat(flags): add --storage-light-edge flag (default false, inert)

### DIFF
--- a/src/flags/general.cpp
+++ b/src/flags/general.cpp
@@ -170,6 +170,11 @@ DEFINE_bool(storage_enable_edges_metadata, false,
             "certain queries.");
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DEFINE_bool(storage_light_edge, false,
+            "Controls whether edges are stored as lightweight objects in order to reduce memory footprint; implies "
+            "--storage-properties-on-edges.");
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_bool(storage_delta_on_identical_property_update, true,
             "Controls whether updating a property with the same value should create a delta object.");
 

--- a/src/flags/general.hpp
+++ b/src/flags/general.hpp
@@ -100,6 +100,8 @@ DECLARE_bool(storage_automatic_edge_type_index_creation_enabled);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_bool(storage_enable_edges_metadata);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DECLARE_bool(storage_light_edge);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_bool(storage_delta_on_identical_property_update);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_bool(storage_backup_dir_enabled);

--- a/src/memgraph.cpp
+++ b/src/memgraph.cpp
@@ -547,17 +547,31 @@ int main(int argc, char **argv) {
                         .enable_label_index_auto_creation = FLAGS_storage_automatic_label_index_creation_enabled,
                         .enable_edge_type_index_auto_creation =
                             FLAGS_storage_automatic_edge_type_index_creation_enabled,  // NOLINT(misc-include-cleaner)
+                        .storage_light_edge = FLAGS_storage_light_edge,
                         .delta_on_identical_property_update = FLAGS_storage_delta_on_identical_property_update,
                         .property_store_compression_enabled = FLAGS_storage_property_store_compression_enabled},
       .salient.storage_mode = memgraph::flags::ParseStorageMode(),
       .salient.property_store_compression_level = memgraph::flags::ParseCompressionLevel(),
       .track_label_counts = FLAGS_telemetry_enabled};
+  // Light edges require properties on edges: coerce BEFORE any check that
+  // depends on properties_on_edges (the edge-type auto-index fatal below and
+  // the edges-metadata warning) so they all observe the effective value.
+  if (db_config.salient.items.storage_light_edge && !db_config.salient.items.properties_on_edges) {
+    spdlog::warn("Light edges require properties on edges. Forcing properties_on_edges to true.");
+    db_config.salient.items.properties_on_edges = true;
+    // enable_edges_metadata was derived from the raw flag at struct-init
+    // (false when properties_on_edges was off) — re-derive it from the user's
+    // request now that properties_on_edges is effectively on.
+    db_config.salient.items.enable_edges_metadata = FLAGS_storage_enable_edges_metadata;
+  }
   if (db_config.salient.items.enable_edge_type_index_auto_creation && !db_config.salient.items.properties_on_edges) {
     LOG_FATAL(
         "Automatic index creation on edge-types has been set but properties on edges are disabled. If you wish to use "
         "automatic edge-type index creation, enable properties on edges as well.");
   }
-  if (!FLAGS_storage_properties_on_edges && FLAGS_storage_enable_edges_metadata) {
+  // Read the POST-coercion config field so the warning reflects the effective
+  // value (light-edge coercion above may have forced properties_on_edges true).
+  if (!db_config.salient.items.properties_on_edges && FLAGS_storage_enable_edges_metadata) {
     spdlog::warn(
         "Properties on edges were not enabled, hence edges metadata will also be disabled. If you wish to utilize "
         "extra metadata on edges, enable properties on edges as well.");

--- a/src/storage/v2/config.cpp
+++ b/src/storage/v2/config.cpp
@@ -23,6 +23,7 @@ void to_json(nlohmann::json &data, SalientConfig::Items const &items) {
       {"enable_edges_metadata", items.enable_edges_metadata},
       {"enable_label_index_auto_creation", items.enable_label_index_auto_creation},
       {"enable_edge_type_index_auto_creation", items.enable_edge_type_index_auto_creation},
+      {"storage_light_edge", items.storage_light_edge},
       {"property_store_compression_enabled", items.property_store_compression_enabled},
   };
 }
@@ -34,6 +35,10 @@ void from_json(const nlohmann::json &data, SalientConfig::Items &items) {
   data.at("enable_schema_info").get_to(items.enable_schema_info);
   data.at("enable_label_index_auto_creation").get_to(items.enable_label_index_auto_creation);
   data.at("enable_edge_type_index_auto_creation").get_to(items.enable_edge_type_index_auto_creation);
+  // Single lookup; key may be absent in durability files written before the flag existed.
+  if (auto it = data.find("storage_light_edge"); it != data.end()) {
+    it->get_to(items.storage_light_edge);
+  }
   data.at("property_store_compression_enabled").get_to(items.property_store_compression_enabled);
 }
 

--- a/src/storage/v2/config.hpp
+++ b/src/storage/v2/config.hpp
@@ -50,6 +50,7 @@ struct SalientConfig {
     bool enable_schema_info{false};
     bool enable_label_index_auto_creation{false};
     bool enable_edge_type_index_auto_creation{false};
+    bool storage_light_edge{false};
     bool delta_on_identical_property_update{true};
     bool property_store_compression_enabled{false};
     friend bool operator==(const Items &lrh, const Items &rhs) = default;

--- a/tests/e2e/configuration/default_config.py
+++ b/tests/e2e/configuration/default_config.py
@@ -179,6 +179,11 @@ startup_config_dict = {
         "false",
         "Controls whether additional metadata should be stored about the edges in order to do faster traversals on certain queries.",
     ),
+    "storage_light_edge": (
+        "false",
+        "false",
+        "Controls whether edges are stored as lightweight objects in order to reduce memory footprint; implies --storage-properties-on-edges.",
+    ),
     "storage_property_store_compression_enabled": (
         "false",
         "false",

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -805,6 +805,11 @@ add_unit_test(storage_v2_schema_info
     LINK_TARGETS mg::storage
 )
 
+add_unit_test(storage_v2_config
+    SOURCES storage_v2_config.cpp
+    LINK_TARGETS mg::storage
+)
+
 add_unit_test(replication_server
     SOURCES replication_server.cpp
     LINK_TARGETS mg::storage Boost::filesystem

--- a/tests/unit/storage_v2_config.cpp
+++ b/tests/unit/storage_v2_config.cpp
@@ -1,0 +1,47 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "storage/v2/config.hpp"
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+using memgraph::storage::SalientConfig;
+
+TEST(StorageV2Config, Default) {
+  SalientConfig::Items items{};
+  EXPECT_FALSE(items.storage_light_edge);
+}
+
+TEST(StorageV2Config, RoundTrip) {
+  SalientConfig::Items items{};
+  items.storage_light_edge = true;
+
+  nlohmann::json j;
+  to_json(j, items);
+
+  SalientConfig::Items result{};
+  from_json(j, result);
+
+  EXPECT_TRUE(result.storage_light_edge);
+}
+
+TEST(StorageV2Config, BackCompatMissingKey) {
+  SalientConfig::Items items{};
+
+  nlohmann::json j;
+  to_json(j, items);
+  j.erase("storage_light_edge");
+
+  SalientConfig::Items result{};
+  EXPECT_NO_THROW(from_json(j, result));
+  EXPECT_FALSE(result.storage_light_edge);
+}


### PR DESCRIPTION
Introduce the opt-in storage_light_edge gflag, its SalientConfig::Items field with back-compat json (de)serialization, and the memgraph.cpp wiring (including the properties_on_edges implication). Default false; no storage code reads the field yet (first reader lands in the light create/find PR), so this is a wholly inert plumbing change that is safe to land mid-stack. A tiny storage_v2_config unit target proves default false, json round-trip, and the missing-key back-compat path.