### PR TITLE
feat: show garbage collector in SHOW TRANSACTIONS

### DIFF
--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -6672,8 +6672,8 @@ std::vector<TypedValue> BuildBackgroundTaskRow(std::string_view transaction_id, 
   std::vector<TypedValue> row;
   row.reserve(7);
   row.emplace_back("");
-  row.emplace_back(std::string{transaction_id});
-  row.emplace_back(std::vector<TypedValue>{TypedValue(std::string{query_text})});
+  row.emplace_back(transaction_id);
+  row.emplace_back(std::vector<TypedValue>{TypedValue(query_text)});
   row.emplace_back("running");
   row.emplace_back(std::move(metadata));
   row.emplace_back(std::move(start_tv));

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -6734,8 +6734,8 @@ Callback HandleTransactionQueueQuery(TransactionQueueQuery *transaction_query,
             auto *storage = db_acc->storage();
             if (storage->GetStorageMode() == storage::StorageMode::ON_DISK_TRANSACTIONAL) return;
             auto *mem_storage = static_cast<storage::InMemoryStorage *>(storage);
-            if (mem_storage->IsSnapshotRunning()) {
-              results.emplace_back(BuildSnapshotTransactionRow(mem_storage->GetSnapshotProgress(), db_acc->name()));
+            if (auto snapshot_progress = mem_storage->TryGetSnapshotProgress()) {
+              results.emplace_back(BuildSnapshotTransactionRow(*snapshot_progress, db_acc->name()));
             }
             if (auto gc_info = mem_storage->TryGetGcRunInfo()) {
               results.emplace_back(BuildGcTransactionRow(*gc_info, db_acc->name()));

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -6657,26 +6657,24 @@ auto ShowTransactions(const std::unordered_set<Interpreter *> &interpreters, Que
   return results;
 }
 
-std::vector<TypedValue> BuildSnapshotTransactionRow(storage::SnapshotProgressView const &progress,
-                                                    std::string_view db_name) {
-  std::map<std::string, TypedValue> metadata;
-  metadata.emplace("phase", storage::SnapshotProgress::PhaseToString(progress.phase));
-  metadata.emplace("items_done", static_cast<int64_t>(progress.items_done));
-  metadata.emplace("items_total", static_cast<int64_t>(progress.items_total));
-  metadata.emplace("db_name", std::string{db_name});
-  TypedValue start_tv{};
-  int64_t elapsed_ms = 0;
-  if (progress.start_time_us > 0) {
-    auto const start_tp = std::chrono::system_clock::time_point{std::chrono::microseconds{progress.start_time_us}};
-    auto const steady_start =
-        std::chrono::steady_clock::time_point{std::chrono::milliseconds{progress.start_steady_ms}};
-    std::tie(start_tv, elapsed_ms) = StartTimeAndElapsedMs(start_tp, steady_start);
-  }
+// Builds a synthetic SHOW TRANSACTIONS row for a running background task
+// (snapshot, GC). They share the same 7-column shape and "running" status;
+// only the transaction_id, the query text, and the metadata differ.
+std::vector<TypedValue> BuildBackgroundTaskRow(std::string_view transaction_id, std::string_view query_text,
+                                               std::map<std::string, TypedValue> metadata, int64_t start_time_us,
+                                               int64_t start_steady_ms) {
+  // start_time_us == 0 means "not started yet": leave start_time null, elapsed 0.
+  auto [start_tv, elapsed_ms] = [&]() -> std::pair<TypedValue, int64_t> {
+    if (start_time_us <= 0) return {TypedValue{}, 0};
+    auto const start_tp = std::chrono::system_clock::time_point{std::chrono::microseconds{start_time_us}};
+    auto const steady_start = std::chrono::steady_clock::time_point{std::chrono::milliseconds{start_steady_ms}};
+    return StartTimeAndElapsedMs(start_tp, steady_start);
+  }();
   std::vector<TypedValue> row;
   row.reserve(7);
   row.emplace_back("");
-  row.emplace_back("snapshot");
-  row.emplace_back(std::vector<TypedValue>{TypedValue("CREATE SNAPSHOT")});
+  row.emplace_back(std::string{transaction_id});
+  row.emplace_back(std::vector<TypedValue>{TypedValue(std::string{query_text})});
   row.emplace_back("running");
   row.emplace_back(std::move(metadata));
   row.emplace_back(std::move(start_tv));
@@ -6684,29 +6682,25 @@ std::vector<TypedValue> BuildSnapshotTransactionRow(storage::SnapshotProgressVie
   return row;
 }
 
+std::vector<TypedValue> BuildSnapshotTransactionRow(storage::SnapshotProgressView const &progress,
+                                                    std::string_view db_name) {
+  std::map<std::string, TypedValue> metadata;
+  metadata.emplace("phase", storage::SnapshotProgress::PhaseToString(progress.phase));
+  metadata.emplace("items_done", static_cast<int64_t>(progress.items_done));
+  metadata.emplace("items_total", static_cast<int64_t>(progress.items_total));
+  metadata.emplace("db_name", std::string{db_name});
+  return BuildBackgroundTaskRow(
+      "snapshot", "CREATE SNAPSHOT", std::move(metadata), progress.start_time_us, progress.start_steady_ms);
+}
+
 std::vector<TypedValue> BuildGcTransactionRow(storage::GcRunInfoView const &info, std::string_view db_name) {
   std::map<std::string, TypedValue> metadata;
-  metadata.emplace("phase", storage::GcPhaseToString(info.phase));
+  metadata.emplace("phase", storage::GcProgress::PhaseToString(info.phase));
   metadata.emplace("trigger", info.periodic ? "periodic" : "forced");
   metadata.emplace("exclusive_lock", TypedValue(info.exclusive_lock));
   metadata.emplace("db_name", std::string{db_name});
-  TypedValue start_tv{};
-  int64_t elapsed_ms = 0;
-  if (info.start_time_us > 0) {
-    auto const start_tp = std::chrono::system_clock::time_point{std::chrono::microseconds{info.start_time_us}};
-    auto const steady_start = std::chrono::steady_clock::time_point{std::chrono::milliseconds{info.start_steady_ms}};
-    std::tie(start_tv, elapsed_ms) = StartTimeAndElapsedMs(start_tp, steady_start);
-  }
-  std::vector<TypedValue> row;
-  row.reserve(7);
-  row.emplace_back("");
-  row.emplace_back("gc");
-  row.emplace_back(std::vector<TypedValue>{TypedValue("GARBAGE COLLECTION")});
-  row.emplace_back("running");
-  row.emplace_back(std::move(metadata));
-  row.emplace_back(std::move(start_tv));
-  row.emplace_back(elapsed_ms);
-  return row;
+  return BuildBackgroundTaskRow(
+      "gc", "GARBAGE COLLECTION", std::move(metadata), info.start_time_us, info.start_steady_ms);
 }
 
 Callback HandleTransactionQueueQuery(TransactionQueueQuery *transaction_query,
@@ -6727,15 +6721,15 @@ Callback HandleTransactionQueueQuery(TransactionQueueQuery *transaction_query,
         return ShowTransactions(interpreters, user_or_role.get(), privilege_checker, status_filter);
       };
       callback.header = {"username", "transaction_id", "query", "status", "metadata", "start_time", "elapsed_ms"};
-      // Snapshot rows always have status "running"; skip them entirely if the filter
-      // is active and RUNNING is not among the requested statuses.
-      const bool include_snapshots =
+      // Background-task rows (snapshot, GC) always have status "running"; skip them
+      // entirely if the filter is active and RUNNING is not among the requested statuses.
+      const bool include_background_tasks =
           transaction_query->status_filter_.empty() ||
           std::ranges::contains(transaction_query->status_filter_, TransactionQueueQuery::StatusFilter::RUNNING);
-      callback.fn = [interpreter_context, show_transactions = std::move(show_transactions), include_snapshots] {
+      callback.fn = [interpreter_context, show_transactions = std::move(show_transactions), include_background_tasks] {
         auto results = interpreter_context->interpreters.WithLock(show_transactions);
-        // Append synthetic rows for running background tasks (snapshot, GC)
-        if (include_snapshots && interpreter_context->dbms_handler) {
+        // Append synthetic rows for running background tasks (snapshot, GC).
+        if (include_background_tasks && interpreter_context->dbms_handler) {
           interpreter_context->dbms_handler->ForEach([&results](auto db_acc) {
             auto *storage = db_acc->storage();
             if (storage->GetStorageMode() == storage::StorageMode::ON_DISK_TRANSACTIONAL) return;
@@ -6743,8 +6737,8 @@ Callback HandleTransactionQueueQuery(TransactionQueueQuery *transaction_query,
             if (mem_storage->IsSnapshotRunning()) {
               results.emplace_back(BuildSnapshotTransactionRow(mem_storage->GetSnapshotProgress(), db_acc->name()));
             }
-            if (mem_storage->IsGcRunning()) {
-              results.emplace_back(BuildGcTransactionRow(mem_storage->GetGcRunInfo(), db_acc->name()));
+            if (auto gc_info = mem_storage->TryGetGcRunInfo()) {
+              results.emplace_back(BuildGcTransactionRow(*gc_info, db_acc->name()));
             }
           });
         }

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -6684,6 +6684,31 @@ std::vector<TypedValue> BuildSnapshotTransactionRow(storage::SnapshotProgressVie
   return row;
 }
 
+std::vector<TypedValue> BuildGcTransactionRow(storage::GcRunInfoView const &info, std::string_view db_name) {
+  std::map<std::string, TypedValue> metadata;
+  metadata.emplace("phase", storage::GcPhaseToString(info.phase));
+  metadata.emplace("trigger", info.periodic ? "periodic" : "forced");
+  metadata.emplace("exclusive_lock", TypedValue(info.exclusive_lock));
+  metadata.emplace("db_name", std::string{db_name});
+  TypedValue start_tv{};
+  int64_t elapsed_ms = 0;
+  if (info.start_time_us > 0) {
+    auto const start_tp = std::chrono::system_clock::time_point{std::chrono::microseconds{info.start_time_us}};
+    auto const steady_start = std::chrono::steady_clock::time_point{std::chrono::milliseconds{info.start_steady_ms}};
+    std::tie(start_tv, elapsed_ms) = StartTimeAndElapsedMs(start_tp, steady_start);
+  }
+  std::vector<TypedValue> row;
+  row.reserve(7);
+  row.emplace_back("");
+  row.emplace_back("gc");
+  row.emplace_back(std::vector<TypedValue>{TypedValue("GARBAGE COLLECTION")});
+  row.emplace_back("running");
+  row.emplace_back(std::move(metadata));
+  row.emplace_back(std::move(start_tv));
+  row.emplace_back(elapsed_ms);
+  return row;
+}
+
 Callback HandleTransactionQueueQuery(TransactionQueueQuery *transaction_query,
                                      std::shared_ptr<QueryUserOrRole> user_or_role, const Parameters &parameters,
                                      InterpreterContext *interpreter_context) {
@@ -6709,14 +6734,18 @@ Callback HandleTransactionQueueQuery(TransactionQueueQuery *transaction_query,
           std::ranges::contains(transaction_query->status_filter_, TransactionQueueQuery::StatusFilter::RUNNING);
       callback.fn = [interpreter_context, show_transactions = std::move(show_transactions), include_snapshots] {
         auto results = interpreter_context->interpreters.WithLock(show_transactions);
-        // Append synthetic rows for running snapshots (background/periodic/exit)
+        // Append synthetic rows for running background tasks (snapshot, GC)
         if (include_snapshots && interpreter_context->dbms_handler) {
           interpreter_context->dbms_handler->ForEach([&results](auto db_acc) {
             auto *storage = db_acc->storage();
             if (storage->GetStorageMode() == storage::StorageMode::ON_DISK_TRANSACTIONAL) return;
             auto *mem_storage = static_cast<storage::InMemoryStorage *>(storage);
-            if (!mem_storage->IsSnapshotRunning()) return;
-            results.emplace_back(BuildSnapshotTransactionRow(mem_storage->GetSnapshotProgress(), db_acc->name()));
+            if (mem_storage->IsSnapshotRunning()) {
+              results.emplace_back(BuildSnapshotTransactionRow(mem_storage->GetSnapshotProgress(), db_acc->name()));
+            }
+            if (mem_storage->IsGcRunning()) {
+              results.emplace_back(BuildGcTransactionRow(mem_storage->GetGcRunInfo(), db_acc->name()));
+            }
           });
         }
         return results;

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -6657,9 +6657,8 @@ auto ShowTransactions(const std::unordered_set<Interpreter *> &interpreters, Que
   return results;
 }
 
-// Builds a synthetic SHOW TRANSACTIONS row for a running background task
-// (snapshot, GC). They share the same 7-column shape and "running" status;
-// only the transaction_id, the query text, and the metadata differ.
+// Synthetic SHOW TRANSACTIONS row for a background task (snapshot, GC): same
+// 7-column "running" shape, differing only in id, query text, and metadata.
 std::vector<TypedValue> BuildBackgroundTaskRow(std::string_view transaction_id, std::string_view query_text,
                                                std::map<std::string, TypedValue> metadata, int64_t start_time_us,
                                                int64_t start_steady_ms) {
@@ -6721,14 +6720,13 @@ Callback HandleTransactionQueueQuery(TransactionQueueQuery *transaction_query,
         return ShowTransactions(interpreters, user_or_role.get(), privilege_checker, status_filter);
       };
       callback.header = {"username", "transaction_id", "query", "status", "metadata", "start_time", "elapsed_ms"};
-      // Background-task rows (snapshot, GC) always have status "running"; skip them
-      // entirely if the filter is active and RUNNING is not among the requested statuses.
+      // Background-task rows are always "running"; skip them when a status filter
+      // excludes RUNNING.
       const bool include_background_tasks =
           transaction_query->status_filter_.empty() ||
           std::ranges::contains(transaction_query->status_filter_, TransactionQueueQuery::StatusFilter::RUNNING);
       callback.fn = [interpreter_context, show_transactions = std::move(show_transactions), include_background_tasks] {
         auto results = interpreter_context->interpreters.WithLock(show_transactions);
-        // Append synthetic rows for running background tasks (snapshot, GC).
         if (include_background_tasks && interpreter_context->dbms_handler) {
           interpreter_context->dbms_handler->ForEach([&results](auto db_acc) {
             auto *storage = db_acc->storage();

--- a/src/storage/v2/CMakeLists.txt
+++ b/src/storage/v2/CMakeLists.txt
@@ -70,6 +70,7 @@ target_sources(mg-storage-v2
         replication/rpc.cpp
         replication/serialization.cpp
         replication/slk.cpp
+        gc_status.cpp
         schema_info.cpp
         snapshot_progress.cpp
         storage.cpp

--- a/src/storage/v2/gc_status.cpp
+++ b/src/storage/v2/gc_status.cpp
@@ -13,19 +13,20 @@
 
 namespace memgraph::storage {
 
-const char *GcProgress::PhaseToString(GcPhase phase) {
+std::string_view GcProgress::PhaseToString(GcPhase phase) {
+  using namespace std::string_view_literals;
   switch (phase) {
     using enum GcPhase;
     case IDLE:
-      return "idle";
+      return "idle"sv;
     case UNLINK:
-      return "unlink";
+      return "unlink"sv;
     case INDEX_CLEANUP:
-      return "index_cleanup";
+      return "index_cleanup"sv;
     case DELETE:
-      return "delete";
+      return "delete"sv;
   }
-  return "unknown";
+  return "unknown"sv;
 }
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/gc_status.cpp
+++ b/src/storage/v2/gc_status.cpp
@@ -1,0 +1,31 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "storage/v2/gc_status.hpp"
+
+namespace memgraph::storage {
+
+const char *GcPhaseToString(GcPhase phase) {
+  switch (phase) {
+    using enum GcPhase;
+    case IDLE:
+      return "idle";
+    case UNLINK:
+      return "unlink";
+    case INDEX_CLEANUP:
+      return "index_cleanup";
+    case DELETE:
+      return "delete";
+  }
+  return "unknown";
+}
+
+}  // namespace memgraph::storage

--- a/src/storage/v2/gc_status.cpp
+++ b/src/storage/v2/gc_status.cpp
@@ -15,19 +15,17 @@
 
 namespace memgraph::storage {
 
-bool GcProgress::IsRunning() const { return running.load(std::memory_order_acquire); }
-
 void GcProgress::Start(bool is_periodic, bool is_exclusive) {
   start_steady_ms.store(
       std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch())
           .count(),
-      std::memory_order_relaxed);
+      std::memory_order_release);
   start_time_us.store(
       std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch())
           .count(),
-      std::memory_order_relaxed);
-  periodic.store(is_periodic, std::memory_order_relaxed);
-  exclusive_lock.store(is_exclusive, std::memory_order_relaxed);
+      std::memory_order_release);
+  periodic.store(is_periodic, std::memory_order_release);
+  exclusive_lock.store(is_exclusive, std::memory_order_release);
   phase.store(GcPhase::UNLINK, std::memory_order_release);
   running.store(true, std::memory_order_release);
 }
@@ -35,21 +33,23 @@ void GcProgress::Start(bool is_periodic, bool is_exclusive) {
 void GcProgress::SetPhase(GcPhase p) { phase.store(p, std::memory_order_release); }
 
 void GcProgress::Reset() {
+  // Clear `running` first so readers stop trusting the fields before they are wiped.
   running.store(false, std::memory_order_release);
-  phase.store(GcPhase::IDLE, std::memory_order_relaxed);
-  exclusive_lock.store(false, std::memory_order_relaxed);
-  periodic.store(false, std::memory_order_relaxed);
-  start_time_us.store(0, std::memory_order_relaxed);
-  start_steady_ms.store(0, std::memory_order_relaxed);
+  phase.store(GcPhase::IDLE, std::memory_order_release);
+  exclusive_lock.store(false, std::memory_order_release);
+  periodic.store(false, std::memory_order_release);
+  start_time_us.store(0, std::memory_order_release);
+  start_steady_ms.store(0, std::memory_order_release);
 }
 
 std::optional<GcRunInfoView> GcProgress::TryGetRunInfo() const {
-  if (!running.load(std::memory_order_acquire)) return std::nullopt;
   GcRunInfoView info{.phase = phase.load(std::memory_order_acquire),
-                     .exclusive_lock = exclusive_lock.load(std::memory_order_relaxed),
-                     .periodic = periodic.load(std::memory_order_relaxed),
-                     .start_time_us = start_time_us.load(std::memory_order_relaxed),
-                     .start_steady_ms = start_steady_ms.load(std::memory_order_relaxed)};
+                     .exclusive_lock = exclusive_lock.load(std::memory_order_acquire),
+                     .periodic = periodic.load(std::memory_order_acquire),
+                     .start_time_us = start_time_us.load(std::memory_order_acquire),
+                     .start_steady_ms = start_steady_ms.load(std::memory_order_acquire)};
+  // Check `running` after reading the fields so a run ending mid-read reads as
+  // not-running, never a torn row.
   if (!running.load(std::memory_order_acquire)) return std::nullopt;
   return info;
 }

--- a/src/storage/v2/gc_status.cpp
+++ b/src/storage/v2/gc_status.cpp
@@ -13,7 +13,7 @@
 
 namespace memgraph::storage {
 
-const char *GcPhaseToString(GcPhase phase) {
+const char *GcProgress::PhaseToString(GcPhase phase) {
   switch (phase) {
     using enum GcPhase;
     case IDLE:

--- a/src/storage/v2/gc_status.cpp
+++ b/src/storage/v2/gc_status.cpp
@@ -11,7 +11,48 @@
 
 #include "storage/v2/gc_status.hpp"
 
+#include <chrono>
+
 namespace memgraph::storage {
+
+bool GcProgress::IsRunning() const { return running.load(std::memory_order_acquire); }
+
+void GcProgress::Start(bool is_periodic, bool is_exclusive) {
+  start_steady_ms.store(
+      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch())
+          .count(),
+      std::memory_order_relaxed);
+  start_time_us.store(
+      std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch())
+          .count(),
+      std::memory_order_relaxed);
+  periodic.store(is_periodic, std::memory_order_relaxed);
+  exclusive_lock.store(is_exclusive, std::memory_order_relaxed);
+  phase.store(GcPhase::UNLINK, std::memory_order_release);
+  running.store(true, std::memory_order_release);
+}
+
+void GcProgress::SetPhase(GcPhase p) { phase.store(p, std::memory_order_release); }
+
+void GcProgress::Reset() {
+  running.store(false, std::memory_order_release);
+  phase.store(GcPhase::IDLE, std::memory_order_relaxed);
+  exclusive_lock.store(false, std::memory_order_relaxed);
+  periodic.store(false, std::memory_order_relaxed);
+  start_time_us.store(0, std::memory_order_relaxed);
+  start_steady_ms.store(0, std::memory_order_relaxed);
+}
+
+std::optional<GcRunInfoView> GcProgress::TryGetRunInfo() const {
+  if (!running.load(std::memory_order_acquire)) return std::nullopt;
+  GcRunInfoView info{.phase = phase.load(std::memory_order_acquire),
+                     .exclusive_lock = exclusive_lock.load(std::memory_order_relaxed),
+                     .periodic = periodic.load(std::memory_order_relaxed),
+                     .start_time_us = start_time_us.load(std::memory_order_relaxed),
+                     .start_steady_ms = start_steady_ms.load(std::memory_order_relaxed)};
+  if (!running.load(std::memory_order_acquire)) return std::nullopt;
+  return info;
+}
 
 std::string_view GcProgress::PhaseToString(GcPhase phase) {
   using namespace std::string_view_literals;

--- a/src/storage/v2/gc_status.hpp
+++ b/src/storage/v2/gc_status.hpp
@@ -20,7 +20,7 @@ namespace memgraph::storage {
 
 enum class GcPhase : uint8_t { IDLE, UNLINK, INDEX_CLEANUP, DELETE };
 
-// Plain-value snapshot of a running GC for display in SHOW TRANSACTIONS.
+// Point-in-time copy of GC run-state, for SHOW TRANSACTIONS.
 struct GcRunInfoView {
   GcPhase phase;
   bool exclusive_lock;  // GC holds main_lock_ exclusively (blocks all transactions)
@@ -29,30 +29,22 @@ struct GcRunInfoView {
   int64_t start_steady_ms;
 };
 
-// Run-state of the storage garbage collector, published for SHOW TRANSACTIONS.
-//
-// There is a single writer (the GC thread, which holds gc_lock_) and many
-// readers. Publication is a release/acquire handshake on `running`: Start()
-// writes the descriptive fields with relaxed stores and releases `running`
-// last, so any reader that acquire-observes running == true is guaranteed to
-// also observe coherent descriptive fields. This guarantee holds on every
-// architecture by the C++ memory model — it does not rely on x86 store
-// ordering. The descriptive loads can therefore stay relaxed; only `running`
-// (the handshake) and `phase` (advanced mid-run) carry ordering.
+// GC run-state for SHOW TRANSACTIONS. One writer (the GC thread, under gc_lock_),
+// many readers. `running` is the publish handshake: Start() fills the fields
+// (relaxed) then releases `running` last, so a reader seeing running == true also
+// sees coherent fields. This holds on any architecture, so the field loads stay
+// relaxed; only `running` and `phase` (advanced mid-run) carry ordering.
 struct GcProgress {
   std::atomic_bool running{false};
   std::atomic<GcPhase> phase{GcPhase::IDLE};
   std::atomic_bool exclusive_lock{false};
   std::atomic_bool periodic{false};
-  // system_clock us since epoch (display); 0 means "not started". steady_clock ms
-  // since epoch (for elapsed_ms) is only meaningful when start_time_us != 0.
+  // Epoch us / ms; start_time_us == 0 means "not started".
   std::atomic<int64_t> start_time_us{0};
   std::atomic<int64_t> start_steady_ms{0};
 
   bool IsRunning() const { return running.load(std::memory_order_acquire); }
 
-  // Begin a run. Descriptive fields are relaxed; `running` is released last and
-  // is the single synchronization point that publishes them to readers.
   void Start(bool is_periodic, bool is_exclusive) {
     start_steady_ms.store(
         std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch())
@@ -68,11 +60,9 @@ struct GcProgress {
     running.store(true, std::memory_order_release);
   }
 
-  // Advance the phase mid-run (release-stored so a reader re-reading sees it).
   void SetPhase(GcPhase p) { phase.store(p, std::memory_order_release); }
 
-  // End a run. `running` is cleared first (and seen first by readers) so the
-  // rest is wiped only after readers have stopped trusting the fields.
+  // Clears `running` first, then the rest, so readers never see half-reset fields.
   void Reset() {
     running.store(false, std::memory_order_release);
     phase.store(GcPhase::IDLE, std::memory_order_relaxed);
@@ -82,9 +72,8 @@ struct GcProgress {
     start_steady_ms.store(0, std::memory_order_relaxed);
   }
 
-  // Coherent read for display: nullopt when no GC is running. `running` is
-  // re-checked after the fields are read, so a run that ends mid-read is
-  // reported as "not running" rather than as a torn / half-reset row.
+  // Coherent read: nullopt unless running. Re-checks `running` after the fields
+  // so a run ending mid-read reads as not-running, never a torn row.
   std::optional<GcRunInfoView> TryGetRunInfo() const {
     if (!running.load(std::memory_order_acquire)) return std::nullopt;
     GcRunInfoView info{.phase = phase.load(std::memory_order_acquire),

--- a/src/storage/v2/gc_status.hpp
+++ b/src/storage/v2/gc_status.hpp
@@ -11,21 +11,92 @@
 
 #pragma once
 
+#include <atomic>
+#include <chrono>
 #include <cstdint>
+#include <optional>
 
 namespace memgraph::storage {
 
 enum class GcPhase : uint8_t { IDLE, UNLINK, INDEX_CLEANUP, DELETE };
 
-const char *GcPhaseToString(GcPhase phase);
-
-// Snapshot of a running GC for display in SHOW TRANSACTIONS.
+// Plain-value snapshot of a running GC for display in SHOW TRANSACTIONS.
 struct GcRunInfoView {
   GcPhase phase;
   bool exclusive_lock;  // GC holds main_lock_ exclusively (blocks all transactions)
   bool periodic;        // periodic scheduler vs forced (FREE MEMORY / storage-mode switch)
   int64_t start_time_us;
   int64_t start_steady_ms;
+};
+
+// Run-state of the storage garbage collector, published for SHOW TRANSACTIONS.
+//
+// There is a single writer (the GC thread, which holds gc_lock_) and many
+// readers. Publication is a release/acquire handshake on `running`: Start()
+// writes the descriptive fields with relaxed stores and releases `running`
+// last, so any reader that acquire-observes running == true is guaranteed to
+// also observe coherent descriptive fields. This guarantee holds on every
+// architecture by the C++ memory model — it does not rely on x86 store
+// ordering. The descriptive loads can therefore stay relaxed; only `running`
+// (the handshake) and `phase` (advanced mid-run) carry ordering.
+struct GcProgress {
+  std::atomic_bool running{false};
+  std::atomic<GcPhase> phase{GcPhase::IDLE};
+  std::atomic_bool exclusive_lock{false};
+  std::atomic_bool periodic{false};
+  // system_clock us since epoch (display); 0 means "not started". steady_clock ms
+  // since epoch (for elapsed_ms) is only meaningful when start_time_us != 0.
+  std::atomic<int64_t> start_time_us{0};
+  std::atomic<int64_t> start_steady_ms{0};
+
+  bool IsRunning() const { return running.load(std::memory_order_acquire); }
+
+  // Begin a run. Descriptive fields are relaxed; `running` is released last and
+  // is the single synchronization point that publishes them to readers.
+  void Start(bool is_periodic, bool is_exclusive) {
+    start_steady_ms.store(
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch())
+            .count(),
+        std::memory_order_relaxed);
+    start_time_us.store(
+        std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch())
+            .count(),
+        std::memory_order_relaxed);
+    periodic.store(is_periodic, std::memory_order_relaxed);
+    exclusive_lock.store(is_exclusive, std::memory_order_relaxed);
+    phase.store(GcPhase::UNLINK, std::memory_order_release);
+    running.store(true, std::memory_order_release);
+  }
+
+  // Advance the phase mid-run (release-stored so a reader re-reading sees it).
+  void SetPhase(GcPhase p) { phase.store(p, std::memory_order_release); }
+
+  // End a run. `running` is cleared first (and seen first by readers) so the
+  // rest is wiped only after readers have stopped trusting the fields.
+  void Reset() {
+    running.store(false, std::memory_order_release);
+    phase.store(GcPhase::IDLE, std::memory_order_relaxed);
+    exclusive_lock.store(false, std::memory_order_relaxed);
+    periodic.store(false, std::memory_order_relaxed);
+    start_time_us.store(0, std::memory_order_relaxed);
+    start_steady_ms.store(0, std::memory_order_relaxed);
+  }
+
+  // Coherent read for display: nullopt when no GC is running. `running` is
+  // re-checked after the fields are read, so a run that ends mid-read is
+  // reported as "not running" rather than as a torn / half-reset row.
+  std::optional<GcRunInfoView> TryGetRunInfo() const {
+    if (!running.load(std::memory_order_acquire)) return std::nullopt;
+    GcRunInfoView info{.phase = phase.load(std::memory_order_acquire),
+                       .exclusive_lock = exclusive_lock.load(std::memory_order_relaxed),
+                       .periodic = periodic.load(std::memory_order_relaxed),
+                       .start_time_us = start_time_us.load(std::memory_order_relaxed),
+                       .start_steady_ms = start_steady_ms.load(std::memory_order_relaxed)};
+    if (!running.load(std::memory_order_acquire)) return std::nullopt;
+    return info;
+  }
+
+  static const char *PhaseToString(GcPhase phase);
 };
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/gc_status.hpp
+++ b/src/storage/v2/gc_status.hpp
@@ -1,0 +1,31 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#pragma once
+
+#include <cstdint>
+
+namespace memgraph::storage {
+
+enum class GcPhase : uint8_t { IDLE, UNLINK, INDEX_CLEANUP, DELETE };
+
+const char *GcPhaseToString(GcPhase phase);
+
+// Snapshot of a running GC for display in SHOW TRANSACTIONS.
+struct GcRunInfoView {
+  GcPhase phase;
+  bool exclusive_lock;  // GC holds main_lock_ exclusively (blocks all transactions)
+  bool periodic;        // periodic scheduler vs forced (FREE MEMORY / storage-mode switch)
+  int64_t start_time_us;
+  int64_t start_steady_ms;
+};
+
+}  // namespace memgraph::storage

--- a/src/storage/v2/gc_status.hpp
+++ b/src/storage/v2/gc_status.hpp
@@ -30,10 +30,10 @@ struct GcRunInfoView {
 };
 
 // GC run-state for SHOW TRANSACTIONS. One writer (the GC thread, under gc_lock_),
-// many readers. `running` is the publish handshake: Start() fills the fields
-// (relaxed) then releases `running` last, so a reader seeing running == true also
-// sees coherent fields. This holds on any architecture, so the field loads stay
-// relaxed; only `running` and `phase` (advanced mid-run) carry ordering.
+// many readers. Mirrors SnapshotProgress: every field is release-stored /
+// acquire-loaded, so each is independently synchronized, and `running` gates the
+// read (see TryGetRunInfo). `running` is cleared first on Reset so readers stop
+// trusting the fields before they are wiped.
 struct GcProgress {
   std::atomic_bool running{false};
   std::atomic<GcPhase> phase{GcPhase::IDLE};
@@ -43,15 +43,14 @@ struct GcProgress {
   std::atomic<int64_t> start_time_us{0};
   std::atomic<int64_t> start_steady_ms{0};
 
-  bool IsRunning() const;
   void Start(bool is_periodic, bool is_exclusive);
   void SetPhase(GcPhase p);
 
   // Clears `running` first, then the rest, so readers never see half-reset fields.
   void Reset();
 
-  // Coherent read: nullopt unless running. Re-checks `running` after the fields
-  // so a run ending mid-read reads as not-running, never a torn row.
+  // Coherent read: reads the fields, then checks `running` last, so a run ending
+  // mid-read reads as not-running, never a torn row.
   std::optional<GcRunInfoView> TryGetRunInfo() const;
 
   static std::string_view PhaseToString(GcPhase phase);

--- a/src/storage/v2/gc_status.hpp
+++ b/src/storage/v2/gc_status.hpp
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <cstdint>
 #include <optional>
+#include <string_view>
 
 namespace memgraph::storage {
 
@@ -85,7 +86,7 @@ struct GcProgress {
     return info;
   }
 
-  static const char *PhaseToString(GcPhase phase);
+  static std::string_view PhaseToString(GcPhase phase);
 };
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/gc_status.hpp
+++ b/src/storage/v2/gc_status.hpp
@@ -12,7 +12,6 @@
 #pragma once
 
 #include <atomic>
-#include <chrono>
 #include <cstdint>
 #include <optional>
 #include <string_view>
@@ -44,47 +43,16 @@ struct GcProgress {
   std::atomic<int64_t> start_time_us{0};
   std::atomic<int64_t> start_steady_ms{0};
 
-  bool IsRunning() const { return running.load(std::memory_order_acquire); }
-
-  void Start(bool is_periodic, bool is_exclusive) {
-    start_steady_ms.store(
-        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch())
-            .count(),
-        std::memory_order_relaxed);
-    start_time_us.store(
-        std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch())
-            .count(),
-        std::memory_order_relaxed);
-    periodic.store(is_periodic, std::memory_order_relaxed);
-    exclusive_lock.store(is_exclusive, std::memory_order_relaxed);
-    phase.store(GcPhase::UNLINK, std::memory_order_release);
-    running.store(true, std::memory_order_release);
-  }
-
-  void SetPhase(GcPhase p) { phase.store(p, std::memory_order_release); }
+  bool IsRunning() const;
+  void Start(bool is_periodic, bool is_exclusive);
+  void SetPhase(GcPhase p);
 
   // Clears `running` first, then the rest, so readers never see half-reset fields.
-  void Reset() {
-    running.store(false, std::memory_order_release);
-    phase.store(GcPhase::IDLE, std::memory_order_relaxed);
-    exclusive_lock.store(false, std::memory_order_relaxed);
-    periodic.store(false, std::memory_order_relaxed);
-    start_time_us.store(0, std::memory_order_relaxed);
-    start_steady_ms.store(0, std::memory_order_relaxed);
-  }
+  void Reset();
 
   // Coherent read: nullopt unless running. Re-checks `running` after the fields
   // so a run ending mid-read reads as not-running, never a torn row.
-  std::optional<GcRunInfoView> TryGetRunInfo() const {
-    if (!running.load(std::memory_order_acquire)) return std::nullopt;
-    GcRunInfoView info{.phase = phase.load(std::memory_order_acquire),
-                       .exclusive_lock = exclusive_lock.load(std::memory_order_relaxed),
-                       .periodic = periodic.load(std::memory_order_relaxed),
-                       .start_time_us = start_time_us.load(std::memory_order_relaxed),
-                       .start_steady_ms = start_steady_ms.load(std::memory_order_relaxed)};
-    if (!running.load(std::memory_order_acquire)) return std::nullopt;
-    return info;
-  }
+  std::optional<GcRunInfoView> TryGetRunInfo() const;
 
   static std::string_view PhaseToString(GcPhase phase);
 };

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -3997,8 +3997,9 @@ std::expected<std::filesystem::path, InMemoryStorage::CreateSnapshotError> InMem
   }
   snapshot_progress_.Start();
   auto const clear_snapshot_running_on_exit = utils::OnScopeExit{[&] {
-    snapshot_progress_.Reset();
+    // Clear `running` first so readers stop trusting the fields before they are wiped.
     snapshot_running_.store(false, std::memory_order_release);
+    snapshot_progress_.Reset();
   }};
 
   // This is to make sure SHOW SNAPSHOTS, CREATE SNAPSHOT, and some replication

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2826,6 +2826,26 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
     return;
   }
 
+  // Publish run-state for SHOW TRANSACTIONS; gc_running_ set last, reset on exit.
+  gc_start_steady_ms_.store(
+      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch())
+          .count(),
+      std::memory_order_release);
+  gc_start_time_us_.store(
+      std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch())
+          .count(),
+      std::memory_order_release);
+  gc_periodic_.store(periodic, std::memory_order_release);
+  gc_exclusive_.store(main_guard.owns_lock(), std::memory_order_release);
+  gc_phase_.store(GcPhase::UNLINK, std::memory_order_release);
+  gc_running_.store(true, std::memory_order_release);
+  utils::OnScopeExit gc_run_state_reset{[&] {
+    gc_running_.store(false, std::memory_order_release);
+    gc_phase_.store(GcPhase::IDLE, std::memory_order_release);
+    gc_start_time_us_.store(0, std::memory_order_release);
+    gc_start_steady_ms_.store(0, std::memory_order_release);
+  }};
+
   // Diagnostic trace
   const utils::Timer timer;
   spdlog::trace("Storage GC on '{}' started [{}]", name(), periodic ? "periodic" : "forced");
@@ -3170,6 +3190,7 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
   // after the last currently active transaction is finished.
   // This operation is very expensive as it traverses through all of the items
   // in every index every time.
+  gc_phase_.store(GcPhase::INDEX_CLEANUP, std::memory_order_release);
   if (auto token = stop_source.get_token(); !token.stop_requested()) {
     if (index_cleanup_vertex_needed || index_cleanup_vertex_performance) {
       indices_.RemoveObsoleteVertexEntries(oldest_active_start_timestamp, token);
@@ -3184,6 +3205,8 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
     auto skiplist_elapsed = std::chrono::duration<double>(skiplist_cleanup_timer.Elapsed());
     metric_handles_.gc_skiplist_cleanup_latency_seconds.Observe(skiplist_elapsed.count());
   }
+
+  gc_phase_.store(GcPhase::DELETE, std::memory_order_release);
 
   {
     auto guard = std::unique_lock{engine_lock_};

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2826,25 +2826,10 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
     return;
   }
 
-  // Publish run-state for SHOW TRANSACTIONS; gc_running_ set last, reset on exit.
-  gc_start_steady_ms_.store(
-      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch())
-          .count(),
-      std::memory_order_release);
-  gc_start_time_us_.store(
-      std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch())
-          .count(),
-      std::memory_order_release);
-  gc_periodic_.store(periodic, std::memory_order_release);
-  gc_exclusive_.store(main_guard.owns_lock(), std::memory_order_release);
-  gc_phase_.store(GcPhase::UNLINK, std::memory_order_release);
-  gc_running_.store(true, std::memory_order_release);
-  utils::OnScopeExit gc_run_state_reset{[&] {
-    gc_running_.store(false, std::memory_order_release);
-    gc_phase_.store(GcPhase::IDLE, std::memory_order_release);
-    gc_start_time_us_.store(0, std::memory_order_release);
-    gc_start_steady_ms_.store(0, std::memory_order_release);
-  }};
+  // Publish run-state for SHOW TRANSACTIONS; Start() releases `running` last and
+  // Reset() clears every field on exit (see GcProgress).
+  gc_progress_.Start(periodic, main_guard.owns_lock());
+  utils::OnScopeExit gc_run_state_reset{[&] { gc_progress_.Reset(); }};
 
   // Diagnostic trace
   const utils::Timer timer;
@@ -3190,7 +3175,7 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
   // after the last currently active transaction is finished.
   // This operation is very expensive as it traverses through all of the items
   // in every index every time.
-  gc_phase_.store(GcPhase::INDEX_CLEANUP, std::memory_order_release);
+  gc_progress_.SetPhase(GcPhase::INDEX_CLEANUP);
   if (auto token = stop_source.get_token(); !token.stop_requested()) {
     if (index_cleanup_vertex_needed || index_cleanup_vertex_performance) {
       indices_.RemoveObsoleteVertexEntries(oldest_active_start_timestamp, token);
@@ -3206,7 +3191,7 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
     metric_handles_.gc_skiplist_cleanup_latency_seconds.Observe(skiplist_elapsed.count());
   }
 
-  gc_phase_.store(GcPhase::DELETE, std::memory_order_release);
+  gc_progress_.SetPhase(GcPhase::DELETE);
 
   {
     auto guard = std::unique_lock{engine_lock_};

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2826,8 +2826,7 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
     return;
   }
 
-  // Publish run-state for SHOW TRANSACTIONS; Start() releases `running` last and
-  // Reset() clears every field on exit (see GcProgress).
+  // Publish run-state for SHOW TRANSACTIONS; cleared on scope exit (see GcProgress).
   gc_progress_.Start(periodic, main_guard.owns_lock());
   utils::OnScopeExit gc_run_state_reset{[&] { gc_progress_.Reset(); }};
 

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -2828,7 +2828,7 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
 
   // Publish run-state for SHOW TRANSACTIONS; cleared on scope exit (see GcProgress).
   gc_progress_.Start(periodic, main_guard.owns_lock());
-  utils::OnScopeExit gc_run_state_reset{[&] { gc_progress_.Reset(); }};
+  const utils::OnScopeExit gc_run_state_reset{[&] { gc_progress_.Reset(); }};
 
   // Diagnostic trace
   const utils::Timer timer;

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -755,15 +755,9 @@ class InMemoryStorage final : public Storage {
             .start_steady_ms = snapshot_progress_.start_steady_ms.load(std::memory_order_acquire)};
   }
 
-  bool IsGcRunning() const { return gc_running_.load(std::memory_order_acquire); }
+  bool IsGcRunning() const { return gc_progress_.IsRunning(); }
 
-  GcRunInfoView GetGcRunInfo() const {
-    return {.phase = gc_phase_.load(std::memory_order_acquire),
-            .exclusive_lock = gc_exclusive_.load(std::memory_order_acquire),
-            .periodic = gc_periodic_.load(std::memory_order_acquire),
-            .start_time_us = gc_start_time_us_.load(std::memory_order_acquire),
-            .start_steady_ms = gc_start_steady_ms_.load(std::memory_order_acquire)};
-  }
+  std::optional<GcRunInfoView> TryGetGcRunInfo() const { return gc_progress_.TryGetRunInfo(); }
 
   void CreateSnapshotHandler(
       std::function<std::expected<void, InMemoryStorage::CreateSnapshotError>(std::string_view)> cb);
@@ -860,14 +854,9 @@ class InMemoryStorage final : public Storage {
   utils::Scheduler gc_runner_;
   std::mutex gc_lock_;
 
-  // GC run-state exposed via SHOW TRANSACTIONS. Descriptive fields are written
-  // before gc_running_ is set, so a reader seeing "running" sees coherent data.
-  std::atomic_bool gc_running_{false};
-  std::atomic<GcPhase> gc_phase_{GcPhase::IDLE};
-  std::atomic_bool gc_exclusive_{false};
-  std::atomic_bool gc_periodic_{false};
-  std::atomic<int64_t> gc_start_time_us_{0};
-  std::atomic<int64_t> gc_start_steady_ms_{0};
+  // GC run-state exposed via SHOW TRANSACTIONS. Written only by the GC thread
+  // (which holds gc_lock_); see GcProgress for the publication protocol.
+  GcProgress gc_progress_;
 
   struct GCDeltas {
     GCDeltas(uint64_t mark_timestamp, delta_container deltas, std::unique_ptr<CommitInfo> commit_info,

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -745,8 +745,6 @@ class InMemoryStorage final : public Storage {
 
   std::optional<SnapshotFileInfo> ShowNextSnapshot();
 
-  bool IsSnapshotRunning() const { return snapshot_running_.load(std::memory_order_acquire); }
-
   SnapshotProgressView GetSnapshotProgress() const {
     return {.phase = snapshot_progress_.phase.load(std::memory_order_acquire),
             .items_done = snapshot_progress_.items_done.load(std::memory_order_acquire),
@@ -755,16 +753,14 @@ class InMemoryStorage final : public Storage {
             .start_steady_ms = snapshot_progress_.start_steady_ms.load(std::memory_order_acquire)};
   }
 
-  // Coherent read: nullopt unless a snapshot is running. Re-checks the flag after
-  // the fields so a snapshot ending mid-read reads as not-running, never a torn row.
+  // Coherent read: nullopt unless a snapshot is running. Checks the flag after
+  // reading the fields so a snapshot ending mid-read reads as not-running, never
+  // a torn row.
   std::optional<SnapshotProgressView> TryGetSnapshotProgress() const {
-    if (!snapshot_running_.load(std::memory_order_acquire)) return std::nullopt;
     SnapshotProgressView progress = GetSnapshotProgress();
     if (!snapshot_running_.load(std::memory_order_acquire)) return std::nullopt;
     return progress;
   }
-
-  bool IsGcRunning() const { return gc_progress_.IsRunning(); }
 
   std::optional<GcRunInfoView> TryGetGcRunInfo() const { return gc_progress_.TryGetRunInfo(); }
 

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -755,9 +755,8 @@ class InMemoryStorage final : public Storage {
             .start_steady_ms = snapshot_progress_.start_steady_ms.load(std::memory_order_acquire)};
   }
 
-  // Coherent read for display: nullopt when no snapshot is running. snapshot_running_
-  // is re-checked after the fields are read, so a snapshot that ends mid-read is
-  // reported as not-running rather than as a torn / half-reset row.
+  // Coherent read: nullopt unless a snapshot is running. Re-checks the flag after
+  // the fields so a snapshot ending mid-read reads as not-running, never a torn row.
   std::optional<SnapshotProgressView> TryGetSnapshotProgress() const {
     if (!snapshot_running_.load(std::memory_order_acquire)) return std::nullopt;
     SnapshotProgressView progress = GetSnapshotProgress();
@@ -864,8 +863,7 @@ class InMemoryStorage final : public Storage {
   utils::Scheduler gc_runner_;
   std::mutex gc_lock_;
 
-  // GC run-state exposed via SHOW TRANSACTIONS. Written only by the GC thread
-  // (which holds gc_lock_); see GcProgress for the publication protocol.
+  // GC run-state for SHOW TRANSACTIONS; see GcProgress.
   GcProgress gc_progress_;
 
   struct GCDeltas {

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -755,6 +755,16 @@ class InMemoryStorage final : public Storage {
             .start_steady_ms = snapshot_progress_.start_steady_ms.load(std::memory_order_acquire)};
   }
 
+  // Coherent read for display: nullopt when no snapshot is running. snapshot_running_
+  // is re-checked after the fields are read, so a snapshot that ends mid-read is
+  // reported as not-running rather than as a torn / half-reset row.
+  std::optional<SnapshotProgressView> TryGetSnapshotProgress() const {
+    if (!snapshot_running_.load(std::memory_order_acquire)) return std::nullopt;
+    SnapshotProgressView progress = GetSnapshotProgress();
+    if (!snapshot_running_.load(std::memory_order_acquire)) return std::nullopt;
+    return progress;
+  }
+
   bool IsGcRunning() const { return gc_progress_.IsRunning(); }
 
   std::optional<GcRunInfoView> TryGetGcRunInfo() const { return gc_progress_.TryGetRunInfo(); }

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -21,6 +21,7 @@
 #include "storage/v2/commit_log.hpp"
 #include "storage/v2/edge_metadata_index.hpp"
 #include "storage/v2/edge_ref.hpp"
+#include "storage/v2/gc_status.hpp"
 #include "storage/v2/indices/label_index_stats.hpp"
 #include "storage/v2/inmemory/edge_type_index.hpp"
 #include "storage/v2/inmemory/label_index.hpp"
@@ -754,6 +755,16 @@ class InMemoryStorage final : public Storage {
             .start_steady_ms = snapshot_progress_.start_steady_ms.load(std::memory_order_acquire)};
   }
 
+  bool IsGcRunning() const { return gc_running_.load(std::memory_order_acquire); }
+
+  GcRunInfoView GetGcRunInfo() const {
+    return {.phase = gc_phase_.load(std::memory_order_acquire),
+            .exclusive_lock = gc_exclusive_.load(std::memory_order_acquire),
+            .periodic = gc_periodic_.load(std::memory_order_acquire),
+            .start_time_us = gc_start_time_us_.load(std::memory_order_acquire),
+            .start_steady_ms = gc_start_steady_ms_.load(std::memory_order_acquire)};
+  }
+
   void CreateSnapshotHandler(
       std::function<std::expected<void, InMemoryStorage::CreateSnapshotError>(std::string_view)> cb);
 
@@ -848,6 +859,15 @@ class InMemoryStorage final : public Storage {
 
   utils::Scheduler gc_runner_;
   std::mutex gc_lock_;
+
+  // GC run-state exposed via SHOW TRANSACTIONS. Descriptive fields are written
+  // before gc_running_ is set, so a reader seeing "running" sees coherent data.
+  std::atomic_bool gc_running_{false};
+  std::atomic<GcPhase> gc_phase_{GcPhase::IDLE};
+  std::atomic_bool gc_exclusive_{false};
+  std::atomic_bool gc_periodic_{false};
+  std::atomic<int64_t> gc_start_time_us_{0};
+  std::atomic<int64_t> gc_start_steady_ms_{0};
 
   struct GCDeltas {
     GCDeltas(uint64_t mark_timestamp, delta_container deltas, std::unique_ptr<CommitInfo> commit_info,

--- a/src/storage/v2/snapshot_progress.cpp
+++ b/src/storage/v2/snapshot_progress.cpp
@@ -13,23 +13,24 @@
 
 namespace memgraph::storage {
 
-const char *SnapshotProgress::PhaseToString(Phase phase) {
+std::string_view SnapshotProgress::PhaseToString(Phase phase) {
+  using namespace std::string_view_literals;
   switch (phase) {
     using enum Phase;
     case IDLE:
-      return "idle";
+      return "idle"sv;
     case EDGES:
-      return "edges";
+      return "edges"sv;
     case VERTICES:
-      return "vertices";
+      return "vertices"sv;
     case INDICES:
-      return "indices";
+      return "indices"sv;
     case CONSTRAINTS:
-      return "constraints";
+      return "constraints"sv;
     case FINALIZING:
-      return "finalizing";
+      return "finalizing"sv;
   }
-  return "unknown";
+  return "unknown"sv;
 }
 
 }  // namespace memgraph::storage

--- a/src/storage/v2/snapshot_progress.hpp
+++ b/src/storage/v2/snapshot_progress.hpp
@@ -14,6 +14,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <string_view>
 
 namespace memgraph::storage {
 
@@ -55,7 +56,7 @@ struct SnapshotProgress {
     start_steady_ms.store(0, std::memory_order_release);
   }
 
-  static const char *PhaseToString(Phase phase);
+  static std::string_view PhaseToString(Phase phase);
 };
 
 struct SnapshotProgressView {

--- a/tests/unit/snapshot_progress.cpp
+++ b/tests/unit/snapshot_progress.cpp
@@ -79,12 +79,12 @@ TEST(SnapshotProgressTest, ResetClearsAllFields) {
 }
 
 TEST(SnapshotProgressTest, PhaseToStringAllValues) {
-  EXPECT_STREQ(SnapshotProgress::PhaseToString(SnapshotProgress::Phase::IDLE), "idle");
-  EXPECT_STREQ(SnapshotProgress::PhaseToString(SnapshotProgress::Phase::EDGES), "edges");
-  EXPECT_STREQ(SnapshotProgress::PhaseToString(SnapshotProgress::Phase::VERTICES), "vertices");
-  EXPECT_STREQ(SnapshotProgress::PhaseToString(SnapshotProgress::Phase::INDICES), "indices");
-  EXPECT_STREQ(SnapshotProgress::PhaseToString(SnapshotProgress::Phase::CONSTRAINTS), "constraints");
-  EXPECT_STREQ(SnapshotProgress::PhaseToString(SnapshotProgress::Phase::FINALIZING), "finalizing");
+  EXPECT_EQ(SnapshotProgress::PhaseToString(SnapshotProgress::Phase::IDLE), "idle");
+  EXPECT_EQ(SnapshotProgress::PhaseToString(SnapshotProgress::Phase::EDGES), "edges");
+  EXPECT_EQ(SnapshotProgress::PhaseToString(SnapshotProgress::Phase::VERTICES), "vertices");
+  EXPECT_EQ(SnapshotProgress::PhaseToString(SnapshotProgress::Phase::INDICES), "indices");
+  EXPECT_EQ(SnapshotProgress::PhaseToString(SnapshotProgress::Phase::CONSTRAINTS), "constraints");
+  EXPECT_EQ(SnapshotProgress::PhaseToString(SnapshotProgress::Phase::FINALIZING), "finalizing");
 }
 
 TEST(SnapshotProgressTest, PhaseTransitionsFullLifecycle) {

--- a/tests/unit/storage_v2_gc.cpp
+++ b/tests/unit/storage_v2_gc.cpp
@@ -147,8 +147,7 @@ TEST(StorageV2GcStatus, ResetClearsAllFields) {
 
   EXPECT_FALSE(gc.IsRunning());
   EXPECT_FALSE(gc.TryGetRunInfo().has_value());
-  // Every field is cleared, not just `running` — a subsequent run must not
-  // inherit stale phase/trigger/exclusive/timing values.
+  // All fields cleared, not just `running`, so the next run can't inherit stale state.
   EXPECT_EQ(gc.phase.load(), ms::GcPhase::IDLE);
   EXPECT_FALSE(gc.exclusive_lock.load());
   EXPECT_FALSE(gc.periodic.load());

--- a/tests/unit/storage_v2_gc.cpp
+++ b/tests/unit/storage_v2_gc.cpp
@@ -88,66 +88,25 @@ TEST(StorageV2GcStatus, PhaseToString) {
   EXPECT_EQ(ms::GcProgress::PhaseToString(GcPhase::DELETE), "delete");
 }
 
-TEST(StorageV2GcStatus, NotRunningWhenIdle) {
-  // Long interval so the periodic runner never fires during the test.
-  auto storage = std::make_unique<ms::InMemoryStorage>(
-      ms::Config{.gc = {.type = ms::Config::Gc::Type::PERIODIC, .interval = std::chrono::seconds(3600)}});
-  EXPECT_FALSE(storage->IsGcRunning());
-}
-
-TEST(StorageV2GcStatus, TryGetRunInfoEmptyWhenNotRunning) {
+// Start publishes run-state, SetPhase advances it, Reset clears every field.
+// The Reset check is the regression guard: it once cleared only some fields.
+TEST(StorageV2GcStatus, RunStateLifecycle) {
   ms::GcProgress gc;
-  EXPECT_FALSE(gc.IsRunning());
   EXPECT_FALSE(gc.TryGetRunInfo().has_value());
-}
 
-TEST(StorageV2GcStatus, PublishesPeriodicRunInfo) {
-  ms::GcProgress gc;
-  gc.Start(/*is_periodic=*/true, /*is_exclusive=*/false);
-
-  EXPECT_TRUE(gc.IsRunning());
+  gc.Start(/*is_periodic=*/false, /*is_exclusive=*/true);
   auto info = gc.TryGetRunInfo();
   ASSERT_TRUE(info.has_value());
   EXPECT_EQ(info->phase, ms::GcPhase::UNLINK);
-  EXPECT_TRUE(info->periodic);
-  EXPECT_FALSE(info->exclusive_lock);
-  EXPECT_GT(info->start_time_us, 0);
-  EXPECT_GT(info->start_steady_ms, 0);
-}
-
-TEST(StorageV2GcStatus, PublishesForcedExclusiveRunInfo) {
-  ms::GcProgress gc;
-  gc.Start(/*is_periodic=*/false, /*is_exclusive=*/true);
-
-  auto info = gc.TryGetRunInfo();
-  ASSERT_TRUE(info.has_value());
   EXPECT_FALSE(info->periodic);
   EXPECT_TRUE(info->exclusive_lock);
-}
-
-TEST(StorageV2GcStatus, PhaseAdvancesWhileRunning) {
-  ms::GcProgress gc;
-  gc.Start(/*is_periodic=*/true, /*is_exclusive=*/false);
-  EXPECT_EQ(gc.TryGetRunInfo()->phase, ms::GcPhase::UNLINK);
+  EXPECT_GT(info->start_time_us, 0);
 
   gc.SetPhase(ms::GcPhase::INDEX_CLEANUP);
   EXPECT_EQ(gc.TryGetRunInfo()->phase, ms::GcPhase::INDEX_CLEANUP);
 
-  gc.SetPhase(ms::GcPhase::DELETE);
-  EXPECT_EQ(gc.TryGetRunInfo()->phase, ms::GcPhase::DELETE);
-}
-
-TEST(StorageV2GcStatus, ResetClearsAllFields) {
-  ms::GcProgress gc;
-  gc.Start(/*is_periodic=*/true, /*is_exclusive=*/true);
-  gc.SetPhase(ms::GcPhase::INDEX_CLEANUP);
-  ASSERT_TRUE(gc.IsRunning());
-
   gc.Reset();
-
-  EXPECT_FALSE(gc.IsRunning());
   EXPECT_FALSE(gc.TryGetRunInfo().has_value());
-  // All fields cleared, not just `running`, so the next run can't inherit stale state.
   EXPECT_EQ(gc.phase.load(), ms::GcPhase::IDLE);
   EXPECT_FALSE(gc.exclusive_lock.load());
   EXPECT_FALSE(gc.periodic.load());

--- a/tests/unit/storage_v2_gc.cpp
+++ b/tests/unit/storage_v2_gc.cpp
@@ -79,6 +79,21 @@ class StorageV2GcMetricsTest : public testing::Test {
   std::string db_name_;
 };
 
+TEST(StorageV2GcStatus, PhaseToString) {
+  using ms::GcPhase;
+  EXPECT_STREQ(ms::GcPhaseToString(GcPhase::IDLE), "idle");
+  EXPECT_STREQ(ms::GcPhaseToString(GcPhase::UNLINK), "unlink");
+  EXPECT_STREQ(ms::GcPhaseToString(GcPhase::INDEX_CLEANUP), "index_cleanup");
+  EXPECT_STREQ(ms::GcPhaseToString(GcPhase::DELETE), "delete");
+}
+
+TEST(StorageV2GcStatus, NotRunningWhenIdle) {
+  // Long interval so the periodic runner never fires during the test.
+  auto storage = std::make_unique<ms::InMemoryStorage>(
+      ms::Config{.gc = {.type = ms::Config::Gc::Type::PERIODIC, .interval = std::chrono::seconds(3600)}});
+  EXPECT_FALSE(storage->IsGcRunning());
+}
+
 // TODO: The point of these is not to test GC fully, these are just simple
 // sanity checks. These will be superseded by a more sophisticated stress test
 // which will verify that GC is working properly in a multithreaded environment.

--- a/tests/unit/storage_v2_gc.cpp
+++ b/tests/unit/storage_v2_gc.cpp
@@ -17,6 +17,7 @@
 
 #include "flags/general.hpp"
 #include "metrics/prometheus_metrics.hpp"
+#include "storage/v2/gc_status.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "tests/test_commit_args_helper.hpp"
 
@@ -81,10 +82,10 @@ class StorageV2GcMetricsTest : public testing::Test {
 
 TEST(StorageV2GcStatus, PhaseToString) {
   using ms::GcPhase;
-  EXPECT_STREQ(ms::GcPhaseToString(GcPhase::IDLE), "idle");
-  EXPECT_STREQ(ms::GcPhaseToString(GcPhase::UNLINK), "unlink");
-  EXPECT_STREQ(ms::GcPhaseToString(GcPhase::INDEX_CLEANUP), "index_cleanup");
-  EXPECT_STREQ(ms::GcPhaseToString(GcPhase::DELETE), "delete");
+  EXPECT_STREQ(ms::GcProgress::PhaseToString(GcPhase::IDLE), "idle");
+  EXPECT_STREQ(ms::GcProgress::PhaseToString(GcPhase::UNLINK), "unlink");
+  EXPECT_STREQ(ms::GcProgress::PhaseToString(GcPhase::INDEX_CLEANUP), "index_cleanup");
+  EXPECT_STREQ(ms::GcProgress::PhaseToString(GcPhase::DELETE), "delete");
 }
 
 TEST(StorageV2GcStatus, NotRunningWhenIdle) {
@@ -92,6 +93,67 @@ TEST(StorageV2GcStatus, NotRunningWhenIdle) {
   auto storage = std::make_unique<ms::InMemoryStorage>(
       ms::Config{.gc = {.type = ms::Config::Gc::Type::PERIODIC, .interval = std::chrono::seconds(3600)}});
   EXPECT_FALSE(storage->IsGcRunning());
+}
+
+TEST(StorageV2GcStatus, TryGetRunInfoEmptyWhenNotRunning) {
+  ms::GcProgress gc;
+  EXPECT_FALSE(gc.IsRunning());
+  EXPECT_FALSE(gc.TryGetRunInfo().has_value());
+}
+
+TEST(StorageV2GcStatus, PublishesPeriodicRunInfo) {
+  ms::GcProgress gc;
+  gc.Start(/*is_periodic=*/true, /*is_exclusive=*/false);
+
+  EXPECT_TRUE(gc.IsRunning());
+  auto info = gc.TryGetRunInfo();
+  ASSERT_TRUE(info.has_value());
+  EXPECT_EQ(info->phase, ms::GcPhase::UNLINK);
+  EXPECT_TRUE(info->periodic);
+  EXPECT_FALSE(info->exclusive_lock);
+  EXPECT_GT(info->start_time_us, 0);
+  EXPECT_GT(info->start_steady_ms, 0);
+}
+
+TEST(StorageV2GcStatus, PublishesForcedExclusiveRunInfo) {
+  ms::GcProgress gc;
+  gc.Start(/*is_periodic=*/false, /*is_exclusive=*/true);
+
+  auto info = gc.TryGetRunInfo();
+  ASSERT_TRUE(info.has_value());
+  EXPECT_FALSE(info->periodic);
+  EXPECT_TRUE(info->exclusive_lock);
+}
+
+TEST(StorageV2GcStatus, PhaseAdvancesWhileRunning) {
+  ms::GcProgress gc;
+  gc.Start(/*is_periodic=*/true, /*is_exclusive=*/false);
+  EXPECT_EQ(gc.TryGetRunInfo()->phase, ms::GcPhase::UNLINK);
+
+  gc.SetPhase(ms::GcPhase::INDEX_CLEANUP);
+  EXPECT_EQ(gc.TryGetRunInfo()->phase, ms::GcPhase::INDEX_CLEANUP);
+
+  gc.SetPhase(ms::GcPhase::DELETE);
+  EXPECT_EQ(gc.TryGetRunInfo()->phase, ms::GcPhase::DELETE);
+}
+
+TEST(StorageV2GcStatus, ResetClearsAllFields) {
+  ms::GcProgress gc;
+  gc.Start(/*is_periodic=*/true, /*is_exclusive=*/true);
+  gc.SetPhase(ms::GcPhase::INDEX_CLEANUP);
+  ASSERT_TRUE(gc.IsRunning());
+
+  gc.Reset();
+
+  EXPECT_FALSE(gc.IsRunning());
+  EXPECT_FALSE(gc.TryGetRunInfo().has_value());
+  // Every field is cleared, not just `running` — a subsequent run must not
+  // inherit stale phase/trigger/exclusive/timing values.
+  EXPECT_EQ(gc.phase.load(), ms::GcPhase::IDLE);
+  EXPECT_FALSE(gc.exclusive_lock.load());
+  EXPECT_FALSE(gc.periodic.load());
+  EXPECT_EQ(gc.start_time_us.load(), 0);
+  EXPECT_EQ(gc.start_steady_ms.load(), 0);
 }
 
 // TODO: The point of these is not to test GC fully, these are just simple

--- a/tests/unit/storage_v2_gc.cpp
+++ b/tests/unit/storage_v2_gc.cpp
@@ -82,10 +82,10 @@ class StorageV2GcMetricsTest : public testing::Test {
 
 TEST(StorageV2GcStatus, PhaseToString) {
   using ms::GcPhase;
-  EXPECT_STREQ(ms::GcProgress::PhaseToString(GcPhase::IDLE), "idle");
-  EXPECT_STREQ(ms::GcProgress::PhaseToString(GcPhase::UNLINK), "unlink");
-  EXPECT_STREQ(ms::GcProgress::PhaseToString(GcPhase::INDEX_CLEANUP), "index_cleanup");
-  EXPECT_STREQ(ms::GcProgress::PhaseToString(GcPhase::DELETE), "delete");
+  EXPECT_EQ(ms::GcProgress::PhaseToString(GcPhase::IDLE), "idle");
+  EXPECT_EQ(ms::GcProgress::PhaseToString(GcPhase::UNLINK), "unlink");
+  EXPECT_EQ(ms::GcProgress::PhaseToString(GcPhase::INDEX_CLEANUP), "index_cleanup");
+  EXPECT_EQ(ms::GcProgress::PhaseToString(GcPhase::DELETE), "delete");
 }
 
 TEST(StorageV2GcStatus, NotRunningWhenIdle) {


### PR DESCRIPTION
## Overview

`SHOW TRANSACTIONS` now reports an in-progress storage **garbage collection** as a synthetic transaction, the same way a running periodic snapshot already appears. This gives operators visibility into GC activity that was previously invisible.

## Motivation

Garbage collection runs continuously in the background. When it is healthy it completes in well under a millisecond and nobody needs to think about it. But when GC becomes a problem — a large backlog, very long version chains, or aggressive mode where it holds the storage lock and blocks all transactions — there was no way to observe it from a query. Operators had to infer a misbehaving GC indirectly.

This feature makes a slow, stuck, or blocking GC **directly observable**: it shows up in `SHOW TRANSACTIONS` exactly when it is running long enough to matter.

## Behavior

While a GC is actively running, `SHOW TRANSACTIONS` includes an extra row alongside the real client transactions:

| Column | Value |
|---|---|
| `username` | *(empty)* |
| `transaction_id` | `gc` |
| `query` | `["GARBAGE COLLECTION"]` |
| `status` | `running` |
| `start_time` | when this GC run started |
| `elapsed_ms` | how long it has been running — the key signal for a stuck GC |
| `metadata` | see below |

The `metadata` map carries the diagnostic detail:

- **`db_name`** — the database the GC is running on.
- **`phase`** — which stage of the GC cycle is currently running (see below). Helps answer "stuck where?".
- **`trigger`** — `periodic` (the background cycle) or `forced` (a `FREE MEMORY` query or a storage-mode switch).
- **`exclusive_lock`** — `true` when GC is holding the storage lock exclusively and therefore blocking all transactions. The clearest "GC is freezing the database" signal.

### GC phases

A GC run moves through these stages in order; the `phase` value tells you which one it is in right now:

- **`unlink`** — GC walks the obsolete record versions left behind by committed/aborted transactions and detaches the ones no active transaction can still see. This is also where the initial bookkeeping for the run happens.
- **`index_cleanup`** — stale entries for deleted objects are removed from indexes and constraints. This is typically the **most expensive** stage, since it scans index structures; a GC that appears stuck is most often sitting here.
- **`delete`** — the final reclamation: the unlinked versions are freed and deleted vertices/edges are removed from storage.

### Notes

- One `gc` row per database that currently has a GC running; multiple databases can each show their own.
- The row appears only while GC is actively working. A healthy fast GC will rarely be caught — that is expected; the value is in catching a pathological one.
- No change to the result schema: the existing 7 columns are reused, exactly like the snapshot row. Existing clients and drivers are unaffected.
- During a `FREE MEMORY` query, both the user's own transaction and the synthetic `gc` row may be visible at once, distinguished by `trigger`.

## Example

```
SHOW TRANSACTIONS;
```

```
username | transaction_id | query                  | status  | metadata                                                                                 | start_time           | elapsed_ms
---------+----------------+------------------------+---------+------------------------------------------------------------------------------------------+----------------------+-----------
         | gc             | ["GARBAGE COLLECTION"] | running | {db_name: "memgraph", phase: "index_cleanup", trigger: "periodic", exclusive_lock: true} | 2026-06-03T09:48:... | 395
```