### PR TITLE
feat: add toBooleanOrNull, toFloatOrNull, toIntegerOrNull, toStringList

### DIFF
--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -605,9 +605,8 @@ TypedValue OutDegree(const TypedValue *args, int64_t nargs, const FunctionContex
 
 // Type-set shared by each strict to* and its *OrNull variant: strict throws on a rejected type, *OrNull
 // returns null; a parse failure on an accepted type returns null in both.
-using ToBooleanTypes = Or<Null, Bool, Integer, String>;
-using ToFloatTypes = Or<Null, Bool, Number, String>;
-using ToIntegerTypes = Or<Null, Bool, Number, String>;
+using ToBooleanTypes = Or<Null, Bool, Integer, String>;  // Integer, not Number: toBoolean rejects floats.
+using ToNumericTypes = Or<Null, Bool, Number, String>;   // shared by toFloat and toInteger.
 using ToStringTypes =
     Or<Null, String, Number, Date, LocalTime, LocalDateTime, Duration, ZonedDateTime, Bool, Enum, Point2d, Point3d>;
 
@@ -631,7 +630,7 @@ TypedValue ToBoolean(const TypedValue *args, int64_t nargs, const FunctionContex
 }
 
 TypedValue ToFloat(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
-  FType<ToFloatTypes>("toFloat", args, nargs);
+  FType<ToNumericTypes>("toFloat", args, nargs);
   const auto &value = args[0];
   if (value.IsNull()) {
     return TypedValue(ctx.memory);
@@ -651,7 +650,7 @@ TypedValue ToFloat(const TypedValue *args, int64_t nargs, const FunctionContext 
 }
 
 TypedValue ToInteger(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
-  FType<ToIntegerTypes>("toInteger", args, nargs);
+  FType<ToNumericTypes>("toInteger", args, nargs);
   const auto &value = args[0];
   if (value.IsNull()) {
     return TypedValue(ctx.memory);
@@ -685,11 +684,11 @@ TypedValue ToBooleanOrNull(const TypedValue *args, int64_t nargs, const Function
 }
 
 TypedValue ToFloatOrNull(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
-  return ConvertOrNull<ToFloatTypes, ToFloat>("toFloatOrNull", args, nargs, ctx);
+  return ConvertOrNull<ToNumericTypes, ToFloat>("toFloatOrNull", args, nargs, ctx);
 }
 
 TypedValue ToIntegerOrNull(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
-  return ConvertOrNull<ToIntegerTypes, ToInteger>("toIntegerOrNull", args, nargs, ctx);
+  return ConvertOrNull<ToNumericTypes, ToInteger>("toIntegerOrNull", args, nargs, ctx);
 }
 
 TypedValue ToBooleanList(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
@@ -1284,7 +1283,6 @@ TypedValue ToString(const TypedValue *args, int64_t nargs, const FunctionContext
     case VirtualGraph:
     case Function: {
       MG_ASSERT(false, "unexpected TypedValue::Type");
-      std::unreachable();
     }
   }
 }

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -603,11 +603,13 @@ TypedValue OutDegree(const TypedValue *args, int64_t nargs, const FunctionContex
   return TypedValue(static_cast<int64_t>(out_degree), ctx.memory);
 }
 
-// Each strict to* conversion and its *OrNull variant share one type-set: the strict form throws
-// on a rejected type, the *OrNull form returns null.
+// Type-set shared by each strict to* and its *OrNull variant: strict throws on a rejected type, *OrNull
+// returns null; a parse failure on an accepted type returns null in both.
 using ToBooleanTypes = Or<Null, Bool, Integer, String>;
 using ToFloatTypes = Or<Null, Bool, Number, String>;
 using ToIntegerTypes = Or<Null, Bool, Number, String>;
+using ToStringTypes =
+    Or<Null, String, Number, Date, LocalTime, LocalDateTime, Duration, ZonedDateTime, Bool, Enum, Point2d, Point3d>;
 
 TypedValue ToBoolean(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
   FType<ToBooleanTypes>("toBoolean", args, nargs);
@@ -670,22 +672,24 @@ TypedValue ToInteger(const TypedValue *args, int64_t nargs, const FunctionContex
   }
 }
 
+// Null-on-rejected-type wrapper: accepted types delegate to the strict fn (still null on parse failure), rest -> null.
+template <typename Types, TypedValue (*StrictFn)(const TypedValue *, int64_t, const FunctionContext &)>
+TypedValue ConvertOrNull(const char *name, const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
+  if (nargs != 1) throw QueryRuntimeException("'{}' requires exactly 1 argument.", name);
+  if (!Types::Check(args[0])) return TypedValue(ctx.memory);
+  return StrictFn(args, nargs, ctx);
+}
+
 TypedValue ToBooleanOrNull(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
-  if (nargs != 1) throw QueryRuntimeException("'toBooleanOrNull' requires exactly 1 argument.");
-  if (!ToBooleanTypes::Check(args[0])) return TypedValue(ctx.memory);
-  return ToBoolean(args, nargs, ctx);
+  return ConvertOrNull<ToBooleanTypes, ToBoolean>("toBooleanOrNull", args, nargs, ctx);
 }
 
 TypedValue ToFloatOrNull(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
-  if (nargs != 1) throw QueryRuntimeException("'toFloatOrNull' requires exactly 1 argument.");
-  if (!ToFloatTypes::Check(args[0])) return TypedValue(ctx.memory);
-  return ToFloat(args, nargs, ctx);
+  return ConvertOrNull<ToFloatTypes, ToFloat>("toFloatOrNull", args, nargs, ctx);
 }
 
 TypedValue ToIntegerOrNull(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
-  if (nargs != 1) throw QueryRuntimeException("'toIntegerOrNull' requires exactly 1 argument.");
-  if (!ToIntegerTypes::Check(args[0])) return TypedValue(ctx.memory);
-  return ToInteger(args, nargs, ctx);
+  return ConvertOrNull<ToIntegerTypes, ToInteger>("toIntegerOrNull", args, nargs, ctx);
 }
 
 TypedValue ToBooleanList(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
@@ -1209,9 +1213,7 @@ TypedValue Id(const TypedValue *args, int64_t nargs, const FunctionContext &ctx)
 }
 
 TypedValue ToString(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
-  FType<
-      Or<Null, String, Number, Date, LocalTime, LocalDateTime, Duration, ZonedDateTime, Bool, Enum, Point2d, Point3d>>(
-      "toString", args, nargs);
+  FType<ToStringTypes>("toString", args, nargs);
   const auto &arg = args[0];
   using enum TypedValue::Type;
   switch (arg.type()) {
@@ -1282,6 +1284,7 @@ TypedValue ToString(const TypedValue *args, int64_t nargs, const FunctionContext
     case VirtualGraph:
     case Function: {
       MG_ASSERT(false, "unexpected TypedValue::Type");
+      std::unreachable();
     }
   }
 }
@@ -1290,75 +1293,11 @@ TypedValue ToStringOrNull(const TypedValue *args, int64_t nargs, const FunctionC
   if (nargs != 1) {
     throw QueryRuntimeException("'toStringOrNull' requires exactly 1 argument.");
   }
-
   const auto &arg = args[0];
-  using enum TypedValue::Type;
-  switch (arg.type()) {
-    case String: {
-      return {arg, ctx.memory};
-    }
-
-    case Int: {
-      // TODO: This is making a pointless copy of std::string, we may want to
-      // use a different conversion to string
-      return TypedValue(std::to_string(arg.ValueInt()), ctx.memory);
-    }
-
-    case Double: {
-      return TypedValue(memgraph::utils::DoubleToString(arg.ValueDouble()), ctx.memory);
-    }
-
-    case Date: {
-      return TypedValue(arg.ValueDate().ToString(), ctx.memory);
-    }
-
-    case LocalTime: {
-      return TypedValue(arg.ValueLocalTime().ToString(), ctx.memory);
-    }
-
-    case LocalDateTime: {
-      return TypedValue(arg.ValueLocalDateTime().ToString(), ctx.memory);
-    }
-
-    case Duration: {
-      return TypedValue(arg.ValueDuration().ToString(), ctx.memory);
-    }
-    case ZonedDateTime: {
-      return TypedValue(arg.ValueZonedDateTime().ToString(), ctx.memory);
-    }
-
-    case Enum: {
-      auto opt_str = ctx.db_accessor->EnumToName(arg.ValueEnum());
-      if (!opt_str) return TypedValue(ctx.memory);  // unresolvable enum -> null
-      return TypedValue(*opt_str, ctx.memory);
-    }
-
-    case Bool: {
-      return TypedValue(arg.ValueBool() ? "true" : "false", ctx.memory);
-    }
-
-    case Point2d: {
-      return TypedValue(CypherConstructionFor(arg.ValuePoint2d()), ctx.memory);
-    }
-
-    case Point3d: {
-      return TypedValue(CypherConstructionFor(arg.ValuePoint3d()), ctx.memory);
-    }
-
-    case Null:
-    case List:
-    case Map:
-    case Vertex:
-    case Edge:
-    case VirtualEdge:
-    case VirtualNode:
-    case Path:
-    case Graph:
-    case VirtualGraph:
-    case Function: {
-      return TypedValue(ctx.memory);
-    }
-  }
+  // Rejected type -> null. Unresolvable enum is the one accepted type whose strict conversion throws, so null it too.
+  if (!ToStringTypes::Check(arg)) return TypedValue(ctx.memory);
+  if (arg.IsEnum() && !ctx.db_accessor->EnumToName(arg.ValueEnum())) return TypedValue(ctx.memory);
+  return ToString(args, nargs, ctx);
 }
 
 TypedValue ToStringList(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -663,6 +663,36 @@ TypedValue ToInteger(const TypedValue *args, int64_t nargs, const FunctionContex
   }
 }
 
+TypedValue ToBooleanOrNull(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
+  if (nargs != 1) throw QueryRuntimeException("'toBooleanOrNull' requires exactly 1 argument.");
+  const auto &value = args[0];
+  // keep in sync with ToBoolean's FType
+  if (!(value.IsNull() || value.IsBool() || value.IsInt() || value.IsString())) {
+    return TypedValue(ctx.memory);
+  }
+  return ToBoolean(args, nargs, ctx);
+}
+
+TypedValue ToFloatOrNull(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
+  if (nargs != 1) throw QueryRuntimeException("'toFloatOrNull' requires exactly 1 argument.");
+  const auto &value = args[0];
+  // keep in sync with ToFloat's FType
+  if (!(value.IsNull() || value.IsBool() || value.IsInt() || value.IsDouble() || value.IsString())) {
+    return TypedValue(ctx.memory);
+  }
+  return ToFloat(args, nargs, ctx);
+}
+
+TypedValue ToIntegerOrNull(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
+  if (nargs != 1) throw QueryRuntimeException("'toIntegerOrNull' requires exactly 1 argument.");
+  const auto &value = args[0];
+  // keep in sync with ToInteger's FType
+  if (!(value.IsNull() || value.IsBool() || value.IsInt() || value.IsDouble() || value.IsString())) {
+    return TypedValue(ctx.memory);
+  }
+  return ToInteger(args, nargs, ctx);
+}
+
 TypedValue ToBooleanList(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
   FType<Or<Null, List>>("toBooleanList", args, nargs);
   const auto &value = args[0];
@@ -699,6 +729,23 @@ TypedValue ToIntegerList(const TypedValue *args, int64_t nargs, const FunctionCo
   TypedValue::TVector values(ctx.memory);
   values.reserve(list.size());
   for (const auto &element : list) values.emplace_back(ToInteger(&element, 1, ctx));
+  return TypedValue(std::move(values));
+}
+
+// Defined below, used by ToStringList for per-element conversion.
+TypedValue ToStringOrNull(const TypedValue *args, int64_t nargs, const FunctionContext &ctx);
+
+TypedValue ToStringList(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
+  FType<Or<Null, List>>("toStringList", args, nargs);
+  const auto &value = args[0];
+  if (value.IsNull()) {
+    return TypedValue(ctx.memory);
+  }
+  const auto &list = value.ValueList();
+  TypedValue::TVector values(ctx.memory);
+  values.reserve(list.size());
+  // ToStringOrNull, not ToString: bad elements -> null; ToString aborts on non-stringifiable types.
+  for (const auto &element : list) values.emplace_back(ToStringOrNull(&element, 1, ctx));
   return TypedValue(std::move(values));
 }
 
@@ -1297,7 +1344,7 @@ TypedValue ToStringOrNull(const TypedValue *args, int64_t nargs, const FunctionC
 
     case Enum: {
       auto opt_str = ctx.db_accessor->EnumToName(arg.ValueEnum());
-      if (!opt_str) throw QueryRuntimeException("'toString' the given enum can't be converted to a string");
+      if (!opt_str) return TypedValue(ctx.memory);  // OrNull: unconvertible enum -> null
       return TypedValue(*opt_str, ctx.memory);
     }
 
@@ -2007,9 +2054,13 @@ auto const builtin_functions = absl::flat_hash_map<std::string, func_info>{
     {"TOBOOLEAN", func_info{.func_ = ToBoolean, .is_pure_ = true}},
     {"TOFLOAT", func_info{.func_ = ToFloat, .is_pure_ = true}},
     {"TOINTEGER", func_info{.func_ = ToInteger, .is_pure_ = true}},
+    {"TOBOOLEANORNULL", func_info{.func_ = ToBooleanOrNull, .is_pure_ = true}},
+    {"TOFLOATORNULL", func_info{.func_ = ToFloatOrNull, .is_pure_ = true}},
+    {"TOINTEGERORNULL", func_info{.func_ = ToIntegerOrNull, .is_pure_ = true}},
     {"TOBOOLEANLIST", func_info{.func_ = ToBooleanList, .is_pure_ = true}},
     {"TOFLOATLIST", func_info{.func_ = ToFloatList, .is_pure_ = true}},
     {"TOINTEGERLIST", func_info{.func_ = ToIntegerList, .is_pure_ = true}},
+    {"TOSTRINGLIST", func_info{.func_ = ToStringList, .is_pure_ = true}},
     {"TYPE", func_info{.func_ = Type, .is_pure_ = true}},
     {"VALUETYPE", func_info{.func_ = ValueType, .is_pure_ = true}},
 

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -29,6 +29,7 @@
 #include "query/procedure/mg_procedure_impl.hpp"
 #include "query/procedure/module.hpp"
 #include "query/query_user.hpp"
+#include "query/string_helpers.hpp"
 #include "query/typed_value.hpp"
 #include "storage/v2/point_functions.hpp"
 #include "utils/case_insensitve_set.hpp"
@@ -602,8 +603,14 @@ TypedValue OutDegree(const TypedValue *args, int64_t nargs, const FunctionContex
   return TypedValue(static_cast<int64_t>(out_degree), ctx.memory);
 }
 
+// Each strict to* conversion and its *OrNull variant share one type-set: the strict form throws
+// on a rejected type, the *OrNull form returns null.
+using ToBooleanTypes = Or<Null, Bool, Integer, String>;
+using ToFloatTypes = Or<Null, Bool, Number, String>;
+using ToIntegerTypes = Or<Null, Bool, Number, String>;
+
 TypedValue ToBoolean(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
-  FType<Or<Null, Bool, Integer, String>>("toBoolean", args, nargs);
+  FType<ToBooleanTypes>("toBoolean", args, nargs);
   const auto &value = args[0];
   if (value.IsNull()) {
     return TypedValue(ctx.memory);
@@ -622,7 +629,7 @@ TypedValue ToBoolean(const TypedValue *args, int64_t nargs, const FunctionContex
 }
 
 TypedValue ToFloat(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
-  FType<Or<Null, Bool, Number, String>>("toFloat", args, nargs);
+  FType<ToFloatTypes>("toFloat", args, nargs);
   const auto &value = args[0];
   if (value.IsNull()) {
     return TypedValue(ctx.memory);
@@ -642,7 +649,7 @@ TypedValue ToFloat(const TypedValue *args, int64_t nargs, const FunctionContext 
 }
 
 TypedValue ToInteger(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
-  FType<Or<Null, Bool, Number, String>>("toInteger", args, nargs);
+  FType<ToIntegerTypes>("toInteger", args, nargs);
   const auto &value = args[0];
   if (value.IsNull()) {
     return TypedValue(ctx.memory);
@@ -665,31 +672,19 @@ TypedValue ToInteger(const TypedValue *args, int64_t nargs, const FunctionContex
 
 TypedValue ToBooleanOrNull(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
   if (nargs != 1) throw QueryRuntimeException("'toBooleanOrNull' requires exactly 1 argument.");
-  const auto &value = args[0];
-  // keep in sync with ToBoolean's FType
-  if (!(value.IsNull() || value.IsBool() || value.IsInt() || value.IsString())) {
-    return TypedValue(ctx.memory);
-  }
+  if (!ToBooleanTypes::Check(args[0])) return TypedValue(ctx.memory);
   return ToBoolean(args, nargs, ctx);
 }
 
 TypedValue ToFloatOrNull(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
   if (nargs != 1) throw QueryRuntimeException("'toFloatOrNull' requires exactly 1 argument.");
-  const auto &value = args[0];
-  // keep in sync with ToFloat's FType
-  if (!(value.IsNull() || value.IsBool() || value.IsInt() || value.IsDouble() || value.IsString())) {
-    return TypedValue(ctx.memory);
-  }
+  if (!ToFloatTypes::Check(args[0])) return TypedValue(ctx.memory);
   return ToFloat(args, nargs, ctx);
 }
 
 TypedValue ToIntegerOrNull(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
   if (nargs != 1) throw QueryRuntimeException("'toIntegerOrNull' requires exactly 1 argument.");
-  const auto &value = args[0];
-  // keep in sync with ToInteger's FType
-  if (!(value.IsNull() || value.IsBool() || value.IsInt() || value.IsDouble() || value.IsString())) {
-    return TypedValue(ctx.memory);
-  }
+  if (!ToIntegerTypes::Check(args[0])) return TypedValue(ctx.memory);
   return ToInteger(args, nargs, ctx);
 }
 
@@ -702,7 +697,7 @@ TypedValue ToBooleanList(const TypedValue *args, int64_t nargs, const FunctionCo
   const auto &list = value.ValueList();
   TypedValue::TVector values(ctx.memory);
   values.reserve(list.size());
-  for (const auto &element : list) values.emplace_back(ToBoolean(&element, 1, ctx));
+  for (const auto &element : list) values.emplace_back(ToBooleanOrNull(&element, 1, ctx));
   return TypedValue(std::move(values));
 }
 
@@ -715,7 +710,7 @@ TypedValue ToFloatList(const TypedValue *args, int64_t nargs, const FunctionCont
   const auto &list = value.ValueList();
   TypedValue::TVector values(ctx.memory);
   values.reserve(list.size());
-  for (const auto &element : list) values.emplace_back(ToFloat(&element, 1, ctx));
+  for (const auto &element : list) values.emplace_back(ToFloatOrNull(&element, 1, ctx));
   return TypedValue(std::move(values));
 }
 
@@ -728,24 +723,7 @@ TypedValue ToIntegerList(const TypedValue *args, int64_t nargs, const FunctionCo
   const auto &list = value.ValueList();
   TypedValue::TVector values(ctx.memory);
   values.reserve(list.size());
-  for (const auto &element : list) values.emplace_back(ToInteger(&element, 1, ctx));
-  return TypedValue(std::move(values));
-}
-
-// Defined below, used by ToStringList for per-element conversion.
-TypedValue ToStringOrNull(const TypedValue *args, int64_t nargs, const FunctionContext &ctx);
-
-TypedValue ToStringList(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
-  FType<Or<Null, List>>("toStringList", args, nargs);
-  const auto &value = args[0];
-  if (value.IsNull()) {
-    return TypedValue(ctx.memory);
-  }
-  const auto &list = value.ValueList();
-  TypedValue::TVector values(ctx.memory);
-  values.reserve(list.size());
-  // ToStringOrNull, not ToString: bad elements -> null; ToString aborts on non-stringifiable types.
-  for (const auto &element : list) values.emplace_back(ToStringOrNull(&element, 1, ctx));
+  for (const auto &element : list) values.emplace_back(ToIntegerOrNull(&element, 1, ctx));
   return TypedValue(std::move(values));
 }
 
@@ -1231,7 +1209,8 @@ TypedValue Id(const TypedValue *args, int64_t nargs, const FunctionContext &ctx)
 }
 
 TypedValue ToString(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
-  FType<Or<Null, String, Number, Date, LocalTime, LocalDateTime, Duration, ZonedDateTime, Bool, Enum>>(
+  FType<
+      Or<Null, String, Number, Date, LocalTime, LocalDateTime, Duration, ZonedDateTime, Bool, Enum, Point2d, Point3d>>(
       "toString", args, nargs);
   const auto &arg = args[0];
   using enum TypedValue::Type;
@@ -1284,6 +1263,14 @@ TypedValue ToString(const TypedValue *args, int64_t nargs, const FunctionContext
       return TypedValue(arg.ValueBool() ? "true" : "false", ctx.memory);
     }
 
+    case Point2d: {
+      return TypedValue(CypherConstructionFor(arg.ValuePoint2d()), ctx.memory);
+    }
+
+    case Point3d: {
+      return TypedValue(CypherConstructionFor(arg.ValuePoint3d()), ctx.memory);
+    }
+
     case List:
     case Map:
     case Vertex:
@@ -1293,9 +1280,7 @@ TypedValue ToString(const TypedValue *args, int64_t nargs, const FunctionContext
     case Path:
     case Graph:
     case VirtualGraph:
-    case Function:
-    case Point2d:
-    case Point3d: {
+    case Function: {
       MG_ASSERT(false, "unexpected TypedValue::Type");
     }
   }
@@ -1344,12 +1329,20 @@ TypedValue ToStringOrNull(const TypedValue *args, int64_t nargs, const FunctionC
 
     case Enum: {
       auto opt_str = ctx.db_accessor->EnumToName(arg.ValueEnum());
-      if (!opt_str) return TypedValue(ctx.memory);  // OrNull: unconvertible enum -> null
+      if (!opt_str) return TypedValue(ctx.memory);  // unresolvable enum -> null
       return TypedValue(*opt_str, ctx.memory);
     }
 
     case Bool: {
       return TypedValue(arg.ValueBool() ? "true" : "false", ctx.memory);
+    }
+
+    case Point2d: {
+      return TypedValue(CypherConstructionFor(arg.ValuePoint2d()), ctx.memory);
+    }
+
+    case Point3d: {
+      return TypedValue(CypherConstructionFor(arg.ValuePoint3d()), ctx.memory);
     }
 
     case Null:
@@ -1362,12 +1355,24 @@ TypedValue ToStringOrNull(const TypedValue *args, int64_t nargs, const FunctionC
     case Path:
     case Graph:
     case VirtualGraph:
-    case Function:
-    case Point2d:
-    case Point3d: {
+    case Function: {
       return TypedValue(ctx.memory);
     }
   }
+}
+
+TypedValue ToStringList(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
+  FType<Or<Null, List>>("toStringList", args, nargs);
+  const auto &value = args[0];
+  if (value.IsNull()) {
+    return TypedValue(ctx.memory);
+  }
+  const auto &list = value.ValueList();
+  TypedValue::TVector values(ctx.memory);
+  values.reserve(list.size());
+  // Per-element via ToStringOrNull (not ToString): non-stringifiable elements become null.
+  for (const auto &element : list) values.emplace_back(ToStringOrNull(&element, 1, ctx));
+  return TypedValue(std::move(values));
 }
 
 TypedValue Timestamp(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
@@ -2060,7 +2065,6 @@ auto const builtin_functions = absl::flat_hash_map<std::string, func_info>{
     {"TOBOOLEANLIST", func_info{.func_ = ToBooleanList, .is_pure_ = true}},
     {"TOFLOATLIST", func_info{.func_ = ToFloatList, .is_pure_ = true}},
     {"TOINTEGERLIST", func_info{.func_ = ToIntegerList, .is_pure_ = true}},
-    {"TOSTRINGLIST", func_info{.func_ = ToStringList, .is_pure_ = true}},
     {"TYPE", func_info{.func_ = Type, .is_pure_ = true}},
     {"VALUETYPE", func_info{.func_ = ValueType, .is_pure_ = true}},
 
@@ -2115,6 +2119,7 @@ auto const builtin_functions = absl::flat_hash_map<std::string, func_info>{
     {"TOLOWER", func_info{.func_ = ToLower, .is_pure_ = true}},
     {"TOSTRING", func_info{.func_ = ToString, .is_pure_ = true}},
     {"TOSTRINGORNULL", func_info{.func_ = ToStringOrNull, .is_pure_ = true}},
+    {"TOSTRINGLIST", func_info{.func_ = ToStringList, .is_pure_ = true}},
     {"TOUPPER", func_info{.func_ = ToUpper, .is_pure_ = true}},
     {"TRIM", func_info{.func_ = Trim, .is_pure_ = true}},
 

--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -18,6 +18,7 @@
 #include <cstdlib>
 #include <functional>
 #include <iterator>
+#include <optional>
 #include <random>
 #include <string_view>
 #include <type_traits>
@@ -1211,9 +1212,8 @@ TypedValue Id(const TypedValue *args, int64_t nargs, const FunctionContext &ctx)
   }
 }
 
-TypedValue ToString(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
-  FType<ToStringTypes>("toString", args, nargs);
-  const auto &arg = args[0];
+// Conversion core shared by toString and toStringOrNull; nullopt iff the enum can't be resolved to a name.
+std::optional<TypedValue> TryToString(const TypedValue &arg, const FunctionContext &ctx) {
   using enum TypedValue::Type;
   switch (arg.type()) {
     case Null: {
@@ -1221,7 +1221,7 @@ TypedValue ToString(const TypedValue *args, int64_t nargs, const FunctionContext
     }
 
     case String: {
-      return {arg, ctx.memory};
+      return TypedValue(arg, ctx.memory);
     }
 
     case Int: {
@@ -1256,7 +1256,7 @@ TypedValue ToString(const TypedValue *args, int64_t nargs, const FunctionContext
 
     case Enum: {
       auto opt_str = ctx.db_accessor->EnumToName(arg.ValueEnum());
-      if (!opt_str) throw QueryRuntimeException("'toString' the given enum can't be converted to a string");
+      if (!opt_str) return std::nullopt;
       return TypedValue(*opt_str, ctx.memory);
     }
 
@@ -1287,15 +1287,21 @@ TypedValue ToString(const TypedValue *args, int64_t nargs, const FunctionContext
   }
 }
 
+TypedValue ToString(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
+  FType<ToStringTypes>("toString", args, nargs);
+  auto converted = TryToString(args[0], ctx);
+  if (!converted) throw QueryRuntimeException("'toString' the given enum can't be converted to a string");
+  return *std::move(converted);
+}
+
 TypedValue ToStringOrNull(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
   if (nargs != 1) {
     throw QueryRuntimeException("'toStringOrNull' requires exactly 1 argument.");
   }
-  const auto &arg = args[0];
-  // Rejected type -> null. Unresolvable enum is the one accepted type whose strict conversion throws, so null it too.
-  if (!ToStringTypes::Check(arg)) return TypedValue(ctx.memory);
-  if (arg.IsEnum() && !ctx.db_accessor->EnumToName(arg.ValueEnum())) return TypedValue(ctx.memory);
-  return ToString(args, nargs, ctx);
+  // Rejected type or unconvertible value -> null.
+  if (!ToStringTypes::Check(args[0])) return TypedValue(ctx.memory);
+  auto converted = TryToString(args[0], ctx);
+  return converted ? *std::move(converted) : TypedValue(ctx.memory);
 }
 
 TypedValue ToStringList(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {

--- a/src/query/string_helpers.hpp
+++ b/src/query/string_helpers.hpp
@@ -14,11 +14,11 @@
 #include "storage/v2/point.hpp"
 
 namespace memgraph::query {
-inline auto CypherConstructionFor(storage::Point2d const &value) -> std::string {
+[[nodiscard]] inline auto CypherConstructionFor(storage::Point2d const &value) -> std::string {
   return fmt::format("POINT({{ x:{}, y:{}, srid: {} }})", value.x(), value.y(), CrsToSrid(value.crs()).value_of());
 }
 
-inline auto CypherConstructionFor(storage::Point3d const &value) -> std::string {
+[[nodiscard]] inline auto CypherConstructionFor(storage::Point3d const &value) -> std::string {
   return fmt::format(
       "POINT({{ x:{}, y:{}, z:{}, srid: {} }})", value.x(), value.y(), value.z(), CrsToSrid(value.crs()).value_of());
 }

--- a/tests/gql_behave/tests/memgraph_V1/features/functions.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/functions.feature
@@ -151,6 +151,46 @@ Feature: Functions
             | 1.2   |
             | 1.9   |
 
+    Scenario: ToBooleanOrNull returns null for unconvertible values instead of erroring:
+        Given an empty graph
+        When executing query:
+            """
+            RETURN toBooleanOrNull('true') AS a, toBooleanOrNull('nope') AS b, toBooleanOrNull(null) AS c, toBooleanOrNull([1, 2]) AS d
+            """
+        Then the result should be:
+            | a    | b    | c    | d    |
+            | true | null | null | null |
+
+    Scenario: ToIntegerOrNull returns null for unconvertible values instead of erroring:
+        Given an empty graph
+        When executing query:
+            """
+            RETURN toIntegerOrNull('42') AS a, toIntegerOrNull('nope') AS b, toIntegerOrNull(null) AS c, toIntegerOrNull([1, 2]) AS d
+            """
+        Then the result should be:
+            | a  | b    | c    | d    |
+            | 42 | null | null | null |
+
+    Scenario: ToFloatOrNull returns null for unconvertible values instead of erroring:
+        Given an empty graph
+        When executing query:
+            """
+            RETURN toFloatOrNull('1.5') AS a, toFloatOrNull('nope') AS b, toFloatOrNull(null) AS c, toFloatOrNull([1, 2]) AS d
+            """
+        Then the result should be:
+            | a   | b    | c    | d    |
+            | 1.5 | null | null | null |
+
+    Scenario: ToStringList converts each element and nulls unconvertible ones:
+        Given an empty graph
+        When executing query:
+            """
+            RETURN toStringList([1, true, 'x', [2]]) AS n
+            """
+        Then the result should be:
+            | n                        |
+            | ['1', 'true', 'x', null] |
+
 
     Scenario: Abs test 01:
         Given an empty graph

--- a/tests/gql_behave/tests/memgraph_V1/features/functions.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/functions.feature
@@ -155,11 +155,11 @@ Feature: Functions
         Given an empty graph
         When executing query:
             """
-            RETURN toBooleanOrNull('true') AS a, toBooleanOrNull('nope') AS b, toBooleanOrNull(null) AS c, toBooleanOrNull([1, 2]) AS d
+            RETURN toBooleanOrNull('true') AS a, toBooleanOrNull('nope') AS b, toBooleanOrNull(null) AS c, toBooleanOrNull([1, 2]) AS d, toBooleanOrNull(1) AS e
             """
         Then the result should be:
-            | a    | b    | c    | d    |
-            | true | null | null | null |
+            | a    | b    | c    | d    | e    |
+            | true | null | null | null | true |
 
     Scenario: ToIntegerOrNull returns null for unconvertible values instead of erroring:
         Given an empty graph
@@ -191,6 +191,15 @@ Feature: Functions
             | n                        |
             | ['1', 'true', 'x', null] |
 
+    Scenario: ToIntegerList nulls non-convertible elements instead of erroring:
+        Given an empty graph
+        When executing query:
+            """
+            RETURN toIntegerList([1, [2], '3', 'x']) AS n
+            """
+        Then the result should be:
+            | n                  |
+            | [1, null, 3, null] |
 
     Scenario: Abs test 01:
         Given an empty graph

--- a/tests/gql_behave/tests/memgraph_V1/features/functions.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/functions.feature
@@ -201,6 +201,26 @@ Feature: Functions
             | n                  |
             | [1, null, 3, null] |
 
+    Scenario: ToBooleanList nulls non-convertible elements instead of erroring:
+        Given an empty graph
+        When executing query:
+            """
+            RETURN toBooleanList([true, [2], 'true', 3.5]) AS n
+            """
+        Then the result should be:
+            | n                          |
+            | [true, null, true, null]   |
+
+    Scenario: ToFloatList nulls non-convertible elements instead of erroring:
+        Given an empty graph
+        When executing query:
+            """
+            RETURN toFloatList([1.5, [2], '3', 'x']) AS n
+            """
+        Then the result should be:
+            | n                    |
+            | [1.5, null, 3.0, null] |
+
     Scenario: Abs test 01:
         Given an empty graph
         And having executed

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -2049,6 +2049,11 @@ TYPED_TEST(FunctionTest, ToBoolean) {
   ASSERT_TRUE(this->EvaluateFunction("TOBOOLEAN", "\n\tFALSEA ").IsNull());
   ASSERT_EQ(this->EvaluateFunction("TOBOOLEAN", true).ValueBool(), true);
   ASSERT_EQ(this->EvaluateFunction("TOBOOLEAN", false).ValueBool(), false);
+  // Rejected types throw (this is the distinction from TOBOOLEANORNULL, which returns null).
+  ASSERT_THROW(this->EvaluateFunction("TOBOOLEAN", 3.5), QueryRuntimeException);
+  ASSERT_THROW(this->EvaluateFunction("TOBOOLEAN", MakeTypedValueList(1, 2, 3)), QueryRuntimeException);
+  ASSERT_THROW(this->EvaluateFunction("TOBOOLEAN", TypedValue(std::map<std::string, TypedValue>{})),
+               QueryRuntimeException);
 }
 
 TYPED_TEST(FunctionTest, ToFloat) {
@@ -2061,6 +2066,10 @@ TYPED_TEST(FunctionTest, ToFloat) {
   ASSERT_EQ(this->EvaluateFunction("TOFLOAT", -3).ValueDouble(), -3.0);
   ASSERT_EQ(this->EvaluateFunction("TOFLOAT", true).ValueDouble(), 1.0);
   ASSERT_EQ(this->EvaluateFunction("TOFLOAT", false).ValueDouble(), 0.0);
+  // Rejected types throw (this is the distinction from TOFLOATORNULL, which returns null).
+  ASSERT_THROW(this->EvaluateFunction("TOFLOAT", MakeTypedValueList(1, 2, 3)), QueryRuntimeException);
+  ASSERT_THROW(this->EvaluateFunction("TOFLOAT", TypedValue(std::map<std::string, TypedValue>{})),
+               QueryRuntimeException);
 }
 
 TYPED_TEST(FunctionTest, ToInteger) {
@@ -2073,6 +2082,10 @@ TYPED_TEST(FunctionTest, ToInteger) {
   ASSERT_TRUE(this->EvaluateFunction("TOINTEGER", "\n\t3X ").IsNull());
   ASSERT_EQ(this->EvaluateFunction("TOINTEGER", -3.5).ValueInt(), -3);
   ASSERT_EQ(this->EvaluateFunction("TOINTEGER", 3.5).ValueInt(), 3);
+  // Rejected types throw (the distinction from TOINTEGERORNULL, which returns null).
+  ASSERT_THROW(this->EvaluateFunction("TOINTEGER", MakeTypedValueList(1, 2, 3)), QueryRuntimeException);
+  ASSERT_THROW(this->EvaluateFunction("TOINTEGER", TypedValue(std::map<std::string, TypedValue>{})),
+               QueryRuntimeException);
 }
 
 TYPED_TEST(FunctionTest, ToBooleanOrNull) {
@@ -2702,14 +2715,29 @@ TYPED_TEST(FunctionTest, ToStringPoint) {
   using enum memgraph::storage::CoordinateReferenceSystem;
   const auto p2 = Point2d(Cartesian_2d, 1, 2);
   const auto p3 = Point3d(Cartesian_3d, 1, 2, 3);
-  // a point stringifies to Memgraph's standard point representation.
+  // Pin the exact format; the rest of the cases assert agreement with the canonical representation.
+  EXPECT_EQ(this->EvaluateFunction("TOSTRING", TypedValue(p2)).ValueString(), "POINT({ x:1, y:2, srid: 7203 })");
+  EXPECT_EQ(this->EvaluateFunction("TOSTRING", TypedValue(p3)).ValueString(), "POINT({ x:1, y:2, z:3, srid: 9157 })");
   EXPECT_EQ(this->EvaluateFunction("TOSTRING", TypedValue(p2)).ValueString(),
             memgraph::query::CypherConstructionFor(p2).c_str());
   EXPECT_EQ(this->EvaluateFunction("TOSTRING", TypedValue(p3)).ValueString(),
             memgraph::query::CypherConstructionFor(p3).c_str());
+}
+
+TYPED_TEST(FunctionTest, ToStringOrNullPoint) {
+  using memgraph::storage::Point2d;
+  using enum memgraph::storage::CoordinateReferenceSystem;
+  const auto p2 = Point2d(Cartesian_2d, 1, 2);
   EXPECT_EQ(this->EvaluateFunction("TOSTRINGORNULL", TypedValue(p2)).ValueString(),
             memgraph::query::CypherConstructionFor(p2).c_str());
-  // points flow through toStringList too (it delegates to toStringOrNull).
+}
+
+TYPED_TEST(FunctionTest, ToStringListPoint) {
+  using memgraph::storage::Point2d;
+  using memgraph::storage::Point3d;
+  using enum memgraph::storage::CoordinateReferenceSystem;
+  const auto p2 = Point2d(Cartesian_2d, 1, 2);
+  const auto p3 = Point3d(Cartesian_3d, 1, 2, 3);
   CompareList(
       this->EvaluateFunction("TOSTRINGLIST", MakeTypedValueList(TypedValue(p2), TypedValue(p3))),
       MakeTypedValueList(memgraph::query::CypherConstructionFor(p2), memgraph::query::CypherConstructionFor(p3)));

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -1852,6 +1852,8 @@ static void CompareList(const TypedValue &lhs, const TypedValue &rhs) {
       ASSERT_EQ(l.ValueInt(), r.ValueInt());
     } else if (l.IsDouble()) {
       ASSERT_EQ(l.ValueDouble(), r.ValueDouble());
+    } else if (l.IsString()) {
+      ASSERT_EQ(l.ValueString(), r.ValueString());
     } else {
       ASSERT_TRUE(false);
     }
@@ -2072,6 +2074,42 @@ TYPED_TEST(FunctionTest, ToInteger) {
   ASSERT_EQ(this->EvaluateFunction("TOINTEGER", 3.5).ValueInt(), 3);
 }
 
+TYPED_TEST(FunctionTest, ToBooleanOrNull) {
+  ASSERT_THROW(this->EvaluateFunction("TOBOOLEANORNULL"), QueryRuntimeException);
+  ASSERT_TRUE(this->EvaluateFunction("TOBOOLEANORNULL", TypedValue()).IsNull());
+  ASSERT_EQ(this->EvaluateFunction("TOBOOLEANORNULL", 123).ValueBool(), true);
+  ASSERT_EQ(this->EvaluateFunction("TOBOOLEANORNULL", 0).ValueBool(), false);
+  ASSERT_EQ(this->EvaluateFunction("TOBOOLEANORNULL", " trUE \n\t").ValueBool(), true);
+  ASSERT_TRUE(this->EvaluateFunction("TOBOOLEANORNULL", "not a bool").IsNull());
+  ASSERT_EQ(this->EvaluateFunction("TOBOOLEANORNULL", true).ValueBool(), true);
+  // unsupported types -> null (strict TOBOOLEAN throws)
+  ASSERT_TRUE(this->EvaluateFunction("TOBOOLEANORNULL", 3.5).IsNull());
+  ASSERT_TRUE(this->EvaluateFunction("TOBOOLEANORNULL", MakeTypedValueList(1, 2, 3)).IsNull());
+}
+
+TYPED_TEST(FunctionTest, ToFloatOrNull) {
+  ASSERT_THROW(this->EvaluateFunction("TOFLOATORNULL"), QueryRuntimeException);
+  ASSERT_TRUE(this->EvaluateFunction("TOFLOATORNULL", TypedValue()).IsNull());
+  ASSERT_EQ(this->EvaluateFunction("TOFLOATORNULL", " -3.5 \n\t").ValueDouble(), -3.5);
+  ASSERT_TRUE(this->EvaluateFunction("TOFLOATORNULL", "\n\t3.4e-3X ").IsNull());
+  ASSERT_EQ(this->EvaluateFunction("TOFLOATORNULL", -3).ValueDouble(), -3.0);
+  ASSERT_EQ(this->EvaluateFunction("TOFLOATORNULL", true).ValueDouble(), 1.0);
+  // unsupported types -> null (strict TOFLOAT throws)
+  ASSERT_TRUE(this->EvaluateFunction("TOFLOATORNULL", MakeTypedValueList(1, 2, 3)).IsNull());
+}
+
+TYPED_TEST(FunctionTest, ToIntegerOrNull) {
+  ASSERT_THROW(this->EvaluateFunction("TOINTEGERORNULL"), QueryRuntimeException);
+  ASSERT_TRUE(this->EvaluateFunction("TOINTEGERORNULL", TypedValue()).IsNull());
+  ASSERT_EQ(this->EvaluateFunction("TOINTEGERORNULL", true).ValueInt(), 1);
+  ASSERT_EQ(this->EvaluateFunction("TOINTEGERORNULL", "\n\t3").ValueInt(), 3);
+  ASSERT_EQ(this->EvaluateFunction("TOINTEGERORNULL", " -3.5 \n\t").ValueInt(), -3);
+  ASSERT_TRUE(this->EvaluateFunction("TOINTEGERORNULL", "\n\t3X ").IsNull());
+  ASSERT_EQ(this->EvaluateFunction("TOINTEGERORNULL", 3.5).ValueInt(), 3);
+  // unsupported types -> null (strict TOINTEGER throws)
+  ASSERT_TRUE(this->EvaluateFunction("TOINTEGERORNULL", MakeTypedValueList(1, 2, 3)).IsNull());
+}
+
 TYPED_TEST(FunctionTest, ToBooleanList) {
   ASSERT_THROW(this->EvaluateFunction("TOBOOLEANLIST"), QueryRuntimeException);
   CompareList(this->EvaluateFunction("TOBOOLEANLIST", MakeTypedValueList(TypedValue())),
@@ -2144,6 +2182,23 @@ TYPED_TEST(FunctionTest, ToIntegerList) {
   ASSERT_THROW(this->EvaluateFunction("TOINTEGERLIST", TypedValue("string")), QueryRuntimeException);
   ASSERT_THROW(this->EvaluateFunction("TOINTEGERLIST", TypedValue(42)), QueryRuntimeException);
   ASSERT_THROW(this->EvaluateFunction("TOINTEGERLIST", TypedValue(true)), QueryRuntimeException);
+}
+
+TYPED_TEST(FunctionTest, ToStringList) {
+  ASSERT_THROW(this->EvaluateFunction("TOSTRINGLIST"), QueryRuntimeException);
+  CompareList(this->EvaluateFunction("TOSTRINGLIST", MakeTypedValueList(TypedValue())),
+              MakeTypedValueList(TypedValue()));
+  CompareList(this->EvaluateFunction("TOSTRINGLIST", MakeTypedValueList(1, true, "x")),
+              MakeTypedValueList("1", "true", "x"));
+  // non-convertible element -> null, no throw (unlike the other *List functions)
+  CompareList(this->EvaluateFunction("TOSTRINGLIST", MakeTypedValueList(MakeTypedValueList(2))),
+              MakeTypedValueList(TypedValue()));
+  // Test empty list
+  auto empty_list = TypedValue(std::vector<TypedValue>{});
+  CompareList(this->EvaluateFunction("TOSTRINGLIST", empty_list), empty_list);
+  // Test non-list types
+  ASSERT_THROW(this->EvaluateFunction("TOSTRINGLIST", TypedValue("string")), QueryRuntimeException);
+  ASSERT_THROW(this->EvaluateFunction("TOSTRINGLIST", TypedValue(42)), QueryRuntimeException);
 }
 
 TYPED_TEST(FunctionTest, Type) {

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -29,6 +29,7 @@
 #include "query/interpret/eval.hpp"
 #include "query/interpret/frame.hpp"
 #include "query/path.hpp"
+#include "query/string_helpers.hpp"
 #include "query/typed_value.hpp"
 #include "storage/v2/disk/storage.hpp"
 #include "storage/v2/enum.hpp"
@@ -2085,6 +2086,7 @@ TYPED_TEST(FunctionTest, ToBooleanOrNull) {
   // unsupported types -> null (strict TOBOOLEAN throws)
   ASSERT_TRUE(this->EvaluateFunction("TOBOOLEANORNULL", 3.5).IsNull());
   ASSERT_TRUE(this->EvaluateFunction("TOBOOLEANORNULL", MakeTypedValueList(1, 2, 3)).IsNull());
+  ASSERT_TRUE(this->EvaluateFunction("TOBOOLEANORNULL", TypedValue(std::map<std::string, TypedValue>{})).IsNull());
 }
 
 TYPED_TEST(FunctionTest, ToFloatOrNull) {
@@ -2096,6 +2098,7 @@ TYPED_TEST(FunctionTest, ToFloatOrNull) {
   ASSERT_EQ(this->EvaluateFunction("TOFLOATORNULL", true).ValueDouble(), 1.0);
   // unsupported types -> null (strict TOFLOAT throws)
   ASSERT_TRUE(this->EvaluateFunction("TOFLOATORNULL", MakeTypedValueList(1, 2, 3)).IsNull());
+  ASSERT_TRUE(this->EvaluateFunction("TOFLOATORNULL", TypedValue(std::map<std::string, TypedValue>{})).IsNull());
 }
 
 TYPED_TEST(FunctionTest, ToIntegerOrNull) {
@@ -2108,6 +2111,7 @@ TYPED_TEST(FunctionTest, ToIntegerOrNull) {
   ASSERT_EQ(this->EvaluateFunction("TOINTEGERORNULL", 3.5).ValueInt(), 3);
   // unsupported types -> null (strict TOINTEGER throws)
   ASSERT_TRUE(this->EvaluateFunction("TOINTEGERORNULL", MakeTypedValueList(1, 2, 3)).IsNull());
+  ASSERT_TRUE(this->EvaluateFunction("TOINTEGERORNULL", TypedValue(std::map<std::string, TypedValue>{})).IsNull());
 }
 
 TYPED_TEST(FunctionTest, ToBooleanList) {
@@ -2125,6 +2129,11 @@ TYPED_TEST(FunctionTest, ToBooleanList) {
   CompareList(this->EvaluateFunction("TOBOOLEANLIST", MakeTypedValueList(false)), MakeTypedValueList(false));
   CompareList(this->EvaluateFunction("TOBOOLEANLIST", MakeTypedValueList(false, true, false)),
               MakeTypedValueList(false, true, false));
+  // non-convertible element type -> null, no throw
+  CompareList(this->EvaluateFunction("TOBOOLEANLIST", MakeTypedValueList(true, MakeTypedValueList(2), 0)),
+              MakeTypedValueList(true, TypedValue(), false));
+  CompareList(this->EvaluateFunction("TOBOOLEANLIST", MakeTypedValueList(3.5, true, 0)),
+              MakeTypedValueList(TypedValue(), true, false));
   // Test empty list
   auto empty_list = TypedValue(std::vector<TypedValue>{});
   CompareList(this->EvaluateFunction("TOBOOLEANLIST", empty_list), empty_list);
@@ -2150,6 +2159,9 @@ TYPED_TEST(FunctionTest, ToFloatList) {
               MakeTypedValueList(-3.0, 3.5, 5.6));
   CompareList(this->EvaluateFunction("TOFLOATLIST", MakeTypedValueList(true)), MakeTypedValueList(1.0));
   CompareList(this->EvaluateFunction("TOFLOATLIST", MakeTypedValueList(false)), MakeTypedValueList(0.0));
+  // non-convertible element type -> null, no throw
+  CompareList(this->EvaluateFunction("TOFLOATLIST", MakeTypedValueList(1.5, MakeTypedValueList(2))),
+              MakeTypedValueList(1.5, TypedValue()));
   // Test empty list
   auto empty_list = TypedValue(std::vector<TypedValue>{});
   CompareList(this->EvaluateFunction("TOFLOATLIST", empty_list), empty_list);
@@ -2173,6 +2185,9 @@ TYPED_TEST(FunctionTest, ToIntegerList) {
   CompareList(this->EvaluateFunction("TOINTEGERLIST", MakeTypedValueList(-3.5)), MakeTypedValueList(-3));
   CompareList(this->EvaluateFunction("TOINTEGERLIST", MakeTypedValueList(3.5)), MakeTypedValueList(3));
   CompareList(this->EvaluateFunction("TOINTEGERLIST", MakeTypedValueList(-3, 3.5, 5.6)), MakeTypedValueList(-3, 3, 5));
+  // non-convertible element type -> null, no throw
+  CompareList(this->EvaluateFunction("TOINTEGERLIST", MakeTypedValueList(3, MakeTypedValueList(2))),
+              MakeTypedValueList(3, TypedValue()));
   // Test empty list
   auto empty_list = TypedValue(std::vector<TypedValue>{});
   CompareList(this->EvaluateFunction("TOINTEGERLIST", empty_list), empty_list);
@@ -2186,11 +2201,13 @@ TYPED_TEST(FunctionTest, ToIntegerList) {
 
 TYPED_TEST(FunctionTest, ToStringList) {
   ASSERT_THROW(this->EvaluateFunction("TOSTRINGLIST"), QueryRuntimeException);
+  // whole-arg null -> null (not a list containing null)
+  ASSERT_TRUE(this->EvaluateFunction("TOSTRINGLIST", TypedValue()).IsNull());
   CompareList(this->EvaluateFunction("TOSTRINGLIST", MakeTypedValueList(TypedValue())),
               MakeTypedValueList(TypedValue()));
   CompareList(this->EvaluateFunction("TOSTRINGLIST", MakeTypedValueList(1, true, "x")),
               MakeTypedValueList("1", "true", "x"));
-  // non-convertible element -> null, no throw (unlike the other *List functions)
+  // non-convertible element -> null, no throw
   CompareList(this->EvaluateFunction("TOSTRINGLIST", MakeTypedValueList(MakeTypedValueList(2))),
               MakeTypedValueList(TypedValue()));
   // Test empty list
@@ -2669,6 +2686,33 @@ TYPED_TEST(FunctionTest, ToStringOrNullZonedDateTime) {
 
 TYPED_TEST(FunctionTest, ToStringOrNullUnstringifiableType) {
   EXPECT_TRUE(this->EvaluateFunction("TOSTRINGORNULL", MakeTypedValueList(1, 2, 3)).IsNull());
+}
+
+TYPED_TEST(FunctionTest, ToStringOrNullUnconvertibleEnum) {
+  // Enum id not in the store -> toStringOrNull returns null (strict toString throws).
+  using memgraph::storage::Enum;
+  using memgraph::storage::EnumTypeId;
+  using memgraph::storage::EnumValueId;
+  EXPECT_TRUE(this->EvaluateFunction("TOSTRINGORNULL", TypedValue(Enum{EnumTypeId{0}, EnumValueId{0}})).IsNull());
+}
+
+TYPED_TEST(FunctionTest, ToStringPoint) {
+  using memgraph::storage::Point2d;
+  using memgraph::storage::Point3d;
+  using enum memgraph::storage::CoordinateReferenceSystem;
+  const auto p2 = Point2d(Cartesian_2d, 1, 2);
+  const auto p3 = Point3d(Cartesian_3d, 1, 2, 3);
+  // a point stringifies to Memgraph's standard point representation.
+  EXPECT_EQ(this->EvaluateFunction("TOSTRING", TypedValue(p2)).ValueString(),
+            memgraph::query::CypherConstructionFor(p2).c_str());
+  EXPECT_EQ(this->EvaluateFunction("TOSTRING", TypedValue(p3)).ValueString(),
+            memgraph::query::CypherConstructionFor(p3).c_str());
+  EXPECT_EQ(this->EvaluateFunction("TOSTRINGORNULL", TypedValue(p2)).ValueString(),
+            memgraph::query::CypherConstructionFor(p2).c_str());
+  // points flow through toStringList too (it delegates to toStringOrNull).
+  CompareList(
+      this->EvaluateFunction("TOSTRINGLIST", MakeTypedValueList(TypedValue(p2), TypedValue(p3))),
+      MakeTypedValueList(memgraph::query::CypherConstructionFor(p2), memgraph::query::CypherConstructionFor(p3)));
 }
 
 TYPED_TEST(FunctionTest, TimestampVoid) {


### PR DESCRIPTION
Add the missing OrNull scalar conversion functions and the toStringList list converter. The OrNull variants return null for unsupported argument types instead of throwing, delegating to the existing strict conversion functions for the supported types. toStringList converts each element via toStringOrNull so non-stringifiable elements become null rather than aborting.

### Behavior changes

- **BREAKING: `toBooleanList` / `toFloatList` / `toIntegerList` no longer throw on a non-convertible element** — the offending element becomes `null` in the returned list, matching the documented casting semantics ("if any values are not convertible they will be `null` in the returned list"). Previously these aborted the whole query. Each now routes its per-element conversion through the corresponding `*OrNull` variant.
- **`toString` / `toStringOrNull` now stringify points** (`POINT({ x:.., y:.., srid:.. })`) via the shared canonical point representation used by Bolt output, dump, and audit.
- **`toStringOrNull` returns null (not throw)** when an enum value cannot be converted to a string, matching the OrNull contract.

### Notes

- The strict scalar conversions (`toBoolean` / `toFloat` / `toInteger`) keep throwing on a rejected argument type; the `*OrNull` variants return null. A parse failure on an accepted type (e.g. `toInteger("abc")`) returns null in both forms.
- The three scalar `*OrNull` wrappers now share a `ConvertOrNull` helper. `toString` and `toStringOrNull` share a `ToStringTypes` alias, and `toStringOrNull` delegates to `toString` (with the unresolvable-enum case still returning null) rather than duplicating its switch.
- Extend the CompareList unit-test helper to handle string elements.