### PR TITLE
fix: Skip dnf update in Rocky and Fedora builds

### DIFF
--- a/environment/os/fedora-42-arm.sh
+++ b/environment/os/fedora-42-arm.sh
@@ -170,7 +170,6 @@ install() {
     # enable rpm fusion
     dnf install -y https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-42.noarch.rpm
 
-    dnf update -y
     dnf install -y wget git python3 python3-pip
 
     # Separate standard and custom packages

--- a/environment/os/fedora-42.sh
+++ b/environment/os/fedora-42.sh
@@ -176,7 +176,6 @@ install() {
     # enable rpm fusion
     dnf install -y https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-42.noarch.rpm
 
-    dnf update -y
     dnf install -y wget git python3 python3-pip
 
     # Separate standard and custom packages

--- a/environment/os/rocky-10.sh
+++ b/environment/os/rocky-10.sh
@@ -6,7 +6,6 @@ source "$DIR/../util.sh"
 # Parse command line arguments for --skip-check flag
 SKIP_CHECK=$(parse_skip_check_flag "$@")
 
-# TODO(gitbuda): Rocky gets automatically updates -> figure out how to handle it.
 # Only run checks if --skip-check flag is not provided
 if [[ "$SKIP_CHECK" == false ]]; then
     check_operating_system "rocky-10"
@@ -192,7 +191,6 @@ install() {
     # enable rpm fusion
     dnf install --nogpgcheck -y https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-10.noarch.rpm
 
-    dnf update -y
     dnf install -y wget git python3 python3-pip
 
     # Separate standard and custom packages

--- a/release/rpm/rpmlintrc_rocky
+++ b/release/rpm/rpmlintrc_rocky
@@ -3,9 +3,6 @@
 # We are not packaging log dir
 addFilter("E: logrotate-log-dir-not-packaged")
 
-# libstdc++ COPYING ships with the old FSF address
-addFilter("E: incorrect-fsf-address")
-
 # third-party LICENSE files may ship with CRLF line endings
 addFilter("W: wrong-file-end-of-line-encoding")
 


### PR DESCRIPTION
The packages inside the mgbuild containers should not be upgraded every build as they are not always compatible , leading to packaging failures in CI. this removes the `dnf update` steps from Fedora and Rocky builds (this has already been done to the CentOS builds). Also fixed a new rpmlint error.


