### PR TITLE
Feature (Light Edges / 8) - feat(storage): light-edge delete + graveyard GC routing

### DIFF
--- a/docs/design/light_edges/PR-07b-i-graveyard-delete.md
+++ b/docs/design/light_edges/PR-07b-i-graveyard-delete.md
@@ -1,0 +1,131 @@
+# PR7b-i — Light-edge delete lifecycle + graveyard GC routing (gated)
+
+## What this PR implements
+
+Adds the deferred-free path for **deleted light edges**. Light edges are
+pool-allocated `Edge*` (introduced in PR7a) rather than skip-list nodes, so they
+cannot be reclaimed by `edges_.run_gc()` like heavy edges. This PR routes a
+deleted light `Edge*` into a per-storage **graveyard** at GC/commit/abort time
+and frees it from a dedicated drain (`DrainLightEdgeGraveyard`) that runs each GC
+cycle. Everything is gated by `config_.salient.items.storage_light_edge`; with
+the flag off the storage is byte-behaviour-identical to PR7a.
+
+This is the first half of the original PR7b. The second half (PR7b-ii) adds the
+`EpochTracker`-backed iterable guard, the gated light `MakeEdgePin`, the
+`LightEdgeIterable` analytical full-scan path, and the epoch-gated (`IsSafeToFree`)
+drain. PR7b-i deliberately ships an **unconditional** drain (see "How").
+
+## Why
+
+PR7a made light-edge create/find work but left deletion unrealized: a deleted
+light edge's `Edge*` was leaked because it is not a skip-list node. The graveyard
+is the deferred-reclamation structure that lets GC hand off deleted light `Edge*`
+for safe freeing after MVCC visibility has passed. Source intent and the two
+locked danger-zone decisions are recorded in
+`~/workspace/opencode-work/light_edges/pr-07b-graveyard-gc.md` (§I user
+decisions): the GC edge-removal **ordering inversion is NOT ported** (gate-only
+reconcile, heavy ordering preserved) and the dead `[[maybe_unused]]
+transaction_id` param is **dropped**.
+
+## How
+
+### Data structures (storage.hpp)
+- `struct LightEdgeGraveyardEntry { uint64_t guard_epoch; std::vector<Edge*,
+  DbAwareAllocator<Edge*>> edges; };` — `guard_epoch` is reserved for the
+  PR7b-ii epoch-gated drain; in PR7b-i it is a sentinel (`0`).
+- `utils::Synchronized<std::list<LightEdgeGraveyardEntry>, utils::SpinLock>
+  light_edge_graveyard_;` — per-storage queue, sibling of `deleted_edges_`.
+- `LightEdgeGraveyardSizeForTest()` test helper; `DrainLightEdgeGraveyard()` decl.
+
+### GC/commit/abort routing (storage.cpp) — gate-only reconcile
+Three edge-removal blocks are wrapped as `if (light) { push to graveyard } else {
+ORIGINAL heavy block, verbatim, in its original position }`:
+1. `CollectGarbage` `// EDGES / LIGHT EDGES` — the light arm runs an
+   **unconditional** light-only vector-edge-index cleanup before the push (the
+   heavy arm only cleans when no vertices were deleted; the light `Edge*` and
+   their `Vertex*` outlive the push, so the cleanup must always run). The heavy
+   `else` arm is character-for-character identical to PR7a, **after** the VERTICES
+   block — no ordering inversion.
+2. `InMemoryAccessor::Abort` `// EDGES / LIGHT EDGES` — additive gate; ordering
+   already metadata→vertices→edges on PR7a, unchanged.
+3. `InMemoryAccessor::FastDiscardOfDeltas` — light arm pushes to graveyard, heavy
+   arm keeps the original `deleted_edges_.insert`.
+
+`Abort`'s `my_deleted_edges` local changed allocator from `std::vector<Edge*>` to
+`std::vector<Edge*, DbAwareAllocator<Edge*>>` to enable `std::move` into the
+graveyard entry — behaviour-neutral for heavy (transient local; allocator does
+not affect skip-list removal).
+
+### Drain (storage.cpp)
+`DrainLightEdgeGraveyard()` early-returns when the flag is off, else swaps the
+graveyard out under lock and frees every queued `Edge*` (via the
+`edges_metadata_index_` **wrapper** `OnEdgeDeleted` + `DeleteLightEdge`).
+Called in the ctor `free_memory_func_` lambda immediately after `edges_.run_gc()`.
+
+### Why the unconditional drain is UAF-safe in PR7b-i (degenerate-safe invariant)
+In PR7b-i **nothing pins light edges** — `MakeEdgePin` is still the heavy-only
+`return edges_.access();` form, so no edge-index iterable holds a light `Edge*`
+across a yield. The only readers are MVCC adjacency readers, and they are
+protected by the standard MVCC GC gate: an `Edge*` is collected into
+`current_deleted_edges`/`my_deleted_edges` only when its delete's
+`unlinkable_timestamp < oldest_active_start_timestamp` (`storage.cpp:2949`),
+which guarantees every concurrently active transaction has `start_ts > T_delete`
+and therefore sees the edge as already-deleted under `View::OLD` — it can never
+obtain the `Edge*` via adjacency delta reconstruction. The push and the
+same-GC-cycle drain leave no gap (push in `CollectGarbage`, drain a few lines
+later in the same lambda). Abort/FastDiscard are safe by stronger exclusion
+arguments (aborted creations are visible only to the aborting txn; FastDiscard
+runs only when the committing txn is the sole active transaction).
+**Verified SAFE by logic-verifier** (2026-06-03). When PR7b-ii adds pinning
+readers, the epoch tracker replaces this unconditional drain with `IsSafeToFree`.
+
+### Teardown (storage.cpp)
+`ClearLightEdges` (PR7a freed only live adjacency) now also drains and frees the
+graveyard. The dtor / `Clear` / `DropGraph` already call `ClearLightEdges`
+(gated, PR7a), so graveyard teardown is covered without a new call site.
+
+## What changes (file map)
+| File | Change |
+|---|---|
+| `src/storage/v2/inmemory/storage.hpp` | +`LightEdgeGraveyardEntry`, `light_edge_graveyard_`, `LightEdgeGraveyardSizeForTest`, `DrainLightEdgeGraveyard` decl (+26) |
+| `src/storage/v2/inmemory/storage.cpp` | gated push at CollectGarbage/Abort/FastDiscard; `DrainLightEdgeGraveyard` def + ctor call; `ClearLightEdges` graveyard loop; `my_deleted_edges` allocator (+75/-17) |
+| `tests/unit/storage_v2_light_edges.cpp` | +9 cases (delete/abort-delete/MVCC-delete/non-concurrent graveyard/graveyard-teardown) |
+| `tests/unit/storage_v2_gc.cpp` | +`StorageV2GcLightEdge.{Sanity, ConcurrentEdgeOperationsAbortDeleteRepeat}` + helper |
+
+## What does NOT change
+- Heavy mode (flag off): proven byte-behaviour-identical to PR7a by VER-1
+  (logic-verifier PASS) — same metadata→vertices→edges ordering, identical heavy
+  else-arms, no `transaction_id` param, drain early-returns.
+- `MakeEdgePin` is untouched (still heavy-only — light branch is PR7b-ii).
+- `edges_metadata_` flattening stays DROPPED — the `EdgeMetadataIndex` wrapper
+  (#4189) is used everywhere (`OnEdgeDeleted`).
+- No durability (PR8) or replication (PR10) code; no `EpochTracker` /
+  `LightEdgeIterable` / iterable-tracker construct (PR7b-ii).
+
+## Test plan
+- `storage_v2_light_edges`: 21/21 PASS (incl. 9 new 7b-i cases).
+- `storage_v2_gc`: 26/26 PASS (24 heavy + 2 new light) — the heavy baseline is
+  the in-practice GC-ordering regression net.
+- Heavy regression net: `storage_v2_edge_inmemory` 45/45, `storage_v2_indices`
+  116 passed / 0 failed (73 pre-existing disk-param skips).
+- Deferred to PR7b-ii: reader-pin / partial-drain / analytical-full-scan /
+  concurrent-CRUD-with-indices cases (need the epoch tracker).
+
+## Dependencies
+- Base: PR7a `light_edges-07a-storage-core` (`4d11a06d8`). Predecessor design
+  doc: `docs/design/light_edges/PR-07a-*.md`.
+
+## Follow-ups
+- PR7b-ii `light-edge-iterable-guard-tracker` (base 7b-i): `EpochTracker`
+  member, gated `MakeEdgePin`, `LightEdgeIterable` + analytical full-scan,
+  epoch-gated drain (`guard_epoch = CurrentEpoch()` / `IsSafeToFree`).
+- PR8 durability, PR10 replication.
+
+## References
+- Original messy branch: `light_edges` HEAD `222030a78` (source of truth for the
+  copied test bodies and the reconciled hunks).
+- Split plan: `~/workspace/opencode-work/light_edges/split-plan.md`.
+- Reconcile + user decisions: `~/workspace/opencode-work/light_edges/pr-07b-graveyard-gc.md` (§0, §I, §J).
+- EdgeMetadataIndex wrapper #4189.
+- Verifications (2026-06-03): VER-1 heavy GC-ordering equivalence PASS;
+  UAF-safety of unconditional drain SAFE (both logic-verifier).

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -460,6 +460,7 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
       }
       vertices_.run_gc();
       edges_.run_gc();
+      DrainLightEdgeGraveyard();
 
       // Auto-indexer also has a skiplist
       async_indexer_.RunGC();
@@ -669,6 +670,25 @@ InMemoryStorage::InMemoryAccessor::DetachDelete(std::vector<VertexAccessor *> no
     if (!deleted_edges.empty() && transaction_.storage_mode == StorageMode::IN_MEMORY_ANALYTICAL) {
       auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
       mem_storage->gc_full_scan_edges_delete_.store(true, std::memory_order_release);
+
+      // PR7b-i leak fix: in analytical mode the edge is pop_back'd from vertex
+      // adjacency at delete time (storage.cpp DeleteEdge ~528), so the GC full-scan
+      // light arm (which iterates over LIVE adjacency) can never find these light
+      // Edge* -> they would be unreachable and leak (heavy works because its node
+      // persists in the edges_ skip-list scanned by the heavy full-scan arm). Route
+      // the deleted LIGHT Edge* into deleted_edges_, exactly like the transactional
+      // FastDiscard path. CollectGarbage swaps deleted_edges_ into
+      // current_deleted_edges and the light arm pushes them to the graveyard with
+      // guard_epoch = 0U (snapped at collection time). The full-scan light arm then
+      // finds nothing for these (not in adjacency) -> no double-push.
+      // Heavy mode keeps the skip-list full-scan path byte-identical.
+      if (config_.storage_light_edge) {
+        mem_storage->deleted_edges_.WithLock([&](auto &storage_deleted_edges) {
+          for (auto const &edge : deleted_edges) {
+            storage_deleted_edges.push_back(edge.edge_.ptr);
+          }
+        });
+      }
     }
   }};
 
@@ -1312,6 +1332,13 @@ void InMemoryStorage::InMemoryAccessor::FastDiscardOfDeltas(std::unique_lock<std
         [&](auto &deleted_vertices) { deleted_vertices.splice(deleted_vertices.end(), current_deleted_vertices); });
   }
   if (!current_deleted_edges.empty()) {
+    // Both heavy and light edges defer to deleted_edges_ here. Light edges must
+    // NOT be pushed to the light_edge_graveyard_ at commit time: the graveyard
+    // watermark (guard_epoch) is snapped at GC-COLLECTION time so that any
+    // post-commit reader is ordered before it. Riding deleted_edges_ into
+    // CollectGarbage also runs the index cleanup (OnEdgesDeleted +
+    // RemoveEdgesFromVectorEdgeIndices) before the graveyard push, exactly like
+    // heavy. Heavy behaviour is unchanged.
     mem_storage->deleted_edges_.WithLock([&](auto &deleted_edges) {
       deleted_edges.insert(deleted_edges.end(), current_deleted_edges.begin(), current_deleted_edges.end());
     });
@@ -1359,7 +1386,7 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
     // then remove them directly from the skiplists and transfer ownership
     // to the GC in one locked batch, instead of acquiring the lock once per element.
     std::vector<Gid> my_deleted_vertices;
-    std::vector<Edge *> my_deleted_edges;
+    std::vector<Edge *, memory::DbAwareAllocator<Edge *>> my_deleted_edges;
 
     // TWO passes needed here
     // Abort will modify objects to restore state to how they were before this txn
@@ -1661,8 +1688,14 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
                                   *transaction_.active_indices_,
                                   transaction_.start_timestamp,
                                   mem_storage->name_id_mapper_.get());
-    // EDGES METADATA (has ptr to Vertices, must be before removing verticies)
-    if (!my_deleted_edges.empty()) {
+    // EDGES METADATA (has ptr to Vertices, must be before removing verticies).
+    // Heavy edges are removed from the edges_ skiplist below and never re-enter
+    // GC, so abort is their single metadata-removal site. Light edges instead
+    // ride deleted_edges_ into CollectGarbage, which is THEIR single removal site
+    // (OnEdgesDeleted at the transactional GC light arm) — calling OnEdgesDeleted
+    // here too would double-remove the gid and trip the MG_ASSERT in
+    // EdgeMetadataIndex::OnEdgesDeleted. So gate this to heavy only.
+    if (!my_deleted_edges.empty() && !mem_storage->config_.salient.items.storage_light_edge) {
       if (auto &idx = mem_storage->edges_metadata_index_) {
         idx->OnEdgesDeleted(my_deleted_edges | std::ranges::views::transform(&Edge::gid));
       }
@@ -1676,11 +1709,28 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
       }
     }
 
-    // EDGES
+    // EDGES / LIGHT EDGES
+    // Both heavy and light edges defer to deleted_edges_ here. Light edges must
+    // NOT be pushed to the light_edge_graveyard_ at abort time: the graveyard
+    // watermark (guard_epoch) is snapped at GC-COLLECTION time so that any
+    // post-abort reader is ordered before it. Riding deleted_edges_ into
+    // CollectGarbage also runs the index cleanup (OnEdgesDeleted +
+    // RemoveEdgesFromVectorEdgeIndices) before the graveyard push, exactly like
+    // heavy. Light edges have no skiplist node, so the heavy edges_acc.remove
+    // call is skipped for them; only the deleted_edges_ routing applies.
+    // Heavy behaviour is unchanged.
     if (!my_deleted_edges.empty()) {
-      auto edges_acc = mem_storage->edges_.access();
-      for (auto *edge : my_deleted_edges) {
-        edges_acc.remove(edge->gid);
+      if (mem_storage->config_.salient.items.storage_light_edge) {
+        // Watermark snapped at GC-collection time; index cleanup runs in
+        // CollectGarbage before the graveyard push — see FastDiscard above.
+        mem_storage->deleted_edges_.WithLock([&](auto &deleted_edges) {
+          deleted_edges.insert(deleted_edges.end(), my_deleted_edges.begin(), my_deleted_edges.end());
+        });
+      } else {
+        auto edges_acc = mem_storage->edges_.access();
+        for (auto *edge : my_deleted_edges) {
+          edges_acc.remove(edge->gid);
+        }
       }
     }
   }
@@ -3183,16 +3233,31 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
     }
   }
 
-  // EDGES
+  // EDGES / LIGHT EDGES
   if (!current_deleted_edges.empty()) {
-    auto edge_acc = edges_.access();
+    if (config_.salient.items.storage_light_edge) {
+      // Light edges are not skiplist nodes; route them to the graveyard for
+      // deferred free. Clean the vector edge index first (unconditionally —
+      // unlike the heavy arm below which only does so when no vertices were
+      // deleted — because the light Edge* and their Vertex* outlive the push).
+      if (!indices_.vector_edge_index_.Empty()) {
+        indices_.RemoveEdgesFromVectorEdgeIndices(current_deleted_edges);
+      }
+      light_edge_graveyard_.WithLock([&](auto &graveyard) {
+        // guard_epoch defaults to 0 (epoch gating snapped at drain time in 7b-ii)
+        LightEdgeGraveyardEntry entry{.edges = std::move(current_deleted_edges)};
+        graveyard.push_back(std::move(entry));
+      });
+    } else {
+      auto edge_acc = edges_.access();
 
-    if (current_deleted_vertices.empty() && !indices_.vector_edge_index_.Empty()) {
-      indices_.RemoveEdgesFromVectorEdgeIndices(current_deleted_edges);
-    }
+      if (current_deleted_vertices.empty() && !indices_.vector_edge_index_.Empty()) {
+        indices_.RemoveEdgesFromVectorEdgeIndices(current_deleted_edges);
+      }
 
-    for (auto *edge : current_deleted_edges) {
-      MG_ASSERT(edge_acc.remove(edge->gid), "Invalid database state!");
+      for (auto *edge : current_deleted_edges) {
+        MG_ASSERT(edge_acc.remove(edge->gid), "Invalid database state!");
+      }
     }
   }
 
@@ -3253,6 +3318,45 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
         if (idx) idx->OnEdgeDeleted(edge.gid);
         edge_acc.remove(edge);
       }
+    }
+
+    // PR7b-i light-edge analytical arm: analytically-deleted light edges do NOT
+    // appear in the edges_ skip-list (they live in vertex adjacency and are
+    // removed at delete time), so there are no entries to find here via edge_acc.
+    // Instead, inform_gc_edge_deletion routes deleted light Edge* directly into
+    // deleted_edges_ so they arrive in current_deleted_edges and are handled by
+    // the transactional light arm above (OnEdgesDeleted + graveyard push with
+    // guard_epoch = 0U). PR7b-ii upgrades this to an adjacency full-scan via
+    // LightEdgeIterable once that iterator exists and epoch tracking is wired.
+  }
+}
+
+void InMemoryStorage::DrainLightEdgeGraveyard() {
+  if (!config_.salient.items.storage_light_edge) return;
+  // PR7b-i: no edge-index iterable pins light edges yet (MakeEdgePin is still the
+  // heavy-only form; the iterable tracker/guard land in PR7b-ii). Therefore no
+  // reader can race the free and we drain the whole graveyard unconditionally
+  // here. The epoch-gated (IsSafeToFree) drain is wired in PR7b-ii.
+  //
+  // The ONLY push site for this graveyard is CollectGarbage at GC-collection
+  // time (storage.cpp EDGES / LIGHT EDGES block, ~line 3221). Both the
+  // commit (FastDiscard) and abort light arms route deleted Edge* through
+  // deleted_edges_ so that CollectGarbage snaps the guard_epoch watermark
+  // AFTER all readers are ordered. Invariant: metadata + vector-index entries
+  // are already removed at GC-collect time before the push happens.
+  std::list<LightEdgeGraveyardEntry, memory::DbAwareAllocator<LightEdgeGraveyardEntry>> local_graveyard;
+  light_edge_graveyard_.WithLock([&](auto &graveyard) { local_graveyard.swap(graveyard); });
+  if (local_graveyard.empty()) return;
+
+  // The edge-metadata entry for every graveyarded edge was already removed at
+  // GC-collection time (CollectGarbage OnEdgesDeleted at ~line 3188 and
+  // RemoveEdgesFromVectorEdgeIndices at ~line 3228) BEFORE the Edge* was
+  // routed here. The graveyard exists solely to defer the *memory free*; it
+  // must NOT touch edges_metadata_index_ again, otherwise it would
+  // double-remove the entry and trip the `acc.remove` assert in OnEdgeDeleted.
+  for (auto &entry : local_graveyard) {
+    for (auto *edge : entry.edges) {
+      DestroyLightEdge(edge);
     }
   }
 }
@@ -4538,6 +4642,37 @@ void InMemoryStorage::ClearLightEdges() {
       DestroyLightEdge(edge_ref.ptr);
     }
   }
+
+  // PR7b-i: also free any deleted light edges still queued in the graveyard.
+  // Swap out under lock, then free without holding the SpinLock (mirrors
+  // DrainLightEdgeGraveyard's swap-out-then-free pattern).
+  std::list<LightEdgeGraveyardEntry, memory::DbAwareAllocator<LightEdgeGraveyardEntry>> pending_graveyard;
+  light_edge_graveyard_.WithLock([&](auto &graveyard) { pending_graveyard.swap(graveyard); });
+  for (auto &entry : pending_graveyard) {
+    for (auto *edge : entry.edges) {
+      DestroyLightEdge(edge);
+    }
+  }
+
+  // PR7b-i: free any deleted light edges still queued in deleted_edges_ that
+  // never reached the graveyard (i.e. were deleted but GC has not yet collected
+  // them — see the commit (FastDiscard) / abort routing at the deleted_edges_
+  // inserts and the CollectGarbage swap that drains them into the graveyard).
+  // These pool-allocated Edge* are owned by no skip-list, so without this drain
+  // they leak at teardown/Clear/DropGraph. The three sets (live adjacency,
+  // deleted_edges_, graveyard) are disjoint: CollectGarbage swaps deleted_edges_
+  // empty BEFORE moving the edges into a graveyard entry, and an edge is removed
+  // from vertex adjacency in the same delta-processing step that later routes its
+  // Edge* into deleted_edges_ — so no Edge* freed here is double-freed by the
+  // loops above. Heavy mode never reaches this function (all callers gate on
+  // storage_light_edge); heavy deleted_edges_ Edge* live in the edges_ skip-list
+  // and are freed by it, so they must NOT be DestroyLightEdge'd.
+  deleted_edges_.WithLock([&](auto &deleted_edges) {
+    for (auto *edge : deleted_edges) {
+      DestroyLightEdge(edge);
+    }
+    deleted_edges.clear();
+  });
 }
 
 void InMemoryStorage::Clear() {

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -831,6 +831,11 @@ class InMemoryStorage final : public Storage {
   // Light-edge teardown (frees pool-allocated Edge* still live in vertex
   // adjacency). Gated at every call site by salient.items.storage_light_edge.
   void ClearLightEdges();
+  // Drain the light-edge graveyard: free queued Edge* (PR7b-i frees
+  // unconditionally — no reader pins light edges yet; epoch gating arrives in
+  // PR7b-ii). Called from FreeMemory after edges_.run_gc(); early-returns when
+  // the storage_light_edge flag is off.
+  void DrainLightEdgeGraveyard();
 
   // Database-owned arena pool for per-thread arena management.
   // Database must outlive Storage; Database member declaration order guarantees that.
@@ -840,6 +845,26 @@ class InMemoryStorage final : public Storage {
   // current DB TLS scope, while long-lived DB work establishes that scope at
   // the appropriate execution boundary.
   utils::SkipListDb<Vertex> vertices_;
+
+  // Graveyard for deleted light edges (PR7b-i). Deleted light Edge* are pushed
+  // here ONLY at CollectGarbage time (after metadata + vector-index entries are
+  // already removed). The commit (FastDiscard) and abort light arms route
+  // deleted Edge* through deleted_edges_ so that the guard_epoch watermark is
+  // snapped only after all concurrent readers are ordered. The drain frees them
+  // later. guard_epoch is reserved for the epoch-gated drain wired in PR7b-ii;
+  // in PR7b-i no reader pins light edges so the drain frees unconditionally and
+  // the field is a sentinel (0).
+  struct LightEdgeGraveyardEntry {
+    uint64_t guard_epoch{0};
+    std::vector<Edge *, memory::DbAwareAllocator<Edge *>> edges;
+  };
+
+  // Test helper: number of entries currently sitting in the light-edge graveyard.
+  std::size_t LightEdgeGraveyardSizeForTest() {
+    std::size_t n = 0;
+    light_edge_graveyard_.WithLock([&](auto &graveyard) { n = graveyard.size(); });
+    return n;
+  }
 
   // Returns a pin that keeps edge-index iterables' underlying Edge memory alive
   // for the lifetime of the iterable. Heavy mode pins the edges_ skip-list
@@ -919,6 +944,11 @@ class InMemoryStorage final : public Storage {
   // Edges that are logically deleted and wait to be removed from the main
   // storage.
   utils::Synchronized<std::vector<Edge *, memory::DbAwareAllocator<Edge *>>, utils::SpinLock> deleted_edges_;
+
+  // Deleted light edges awaiting deferred free (see DrainLightEdgeGraveyard).
+  utils::Synchronized<std::list<LightEdgeGraveyardEntry, memory::DbAwareAllocator<LightEdgeGraveyardEntry>>,
+                      utils::SpinLock>
+      light_edge_graveyard_;
 
   std::atomic<bool> gc_index_cleanup_vertex_performance_ = false;
   std::atomic<bool> gc_index_cleanup_edge_performance_ = false;

--- a/tests/unit/storage_v2_gc.cpp
+++ b/tests/unit/storage_v2_gc.cpp
@@ -1497,3 +1497,169 @@ TEST(StorageV2Gc, ClearDrainsWaitingGcDeltas) {
     ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
   }
 }
+
+// PR7b-i: light-edge GC routing tests (storage_light_edge=true).
+
+namespace {
+auto MakeLightEdgeGcStorage() {
+  return std::make_unique<ms::InMemoryStorage>(
+      ms::Config{.gc = {.type = ms::Config::Gc::Type::PERIODIC, .interval = std::chrono::milliseconds(100)},
+                 .salient = {.items = {.properties_on_edges = true, .storage_light_edge = true}}});
+}
+}  // namespace
+
+// Mirrors StorageV2Gc/Sanity: GC running while a transaction is still alive must not free live data.
+// NOLINTNEXTLINE(hicpp-special-member-functions)
+TEST(StorageV2GcLightEdge, Sanity) {
+  auto storage = MakeLightEdgeGcStorage();
+
+  ms::Gid v1_gid, v2_gid;
+  {
+    auto acc = storage->Access(memgraph::storage::WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    v1_gid = v1.Gid();
+    v2_gid = v2.Gid();
+    ASSERT_TRUE(acc->CreateEdge(&v1, &v2, acc->NameToEdgeType("e")).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Reader keeps an open transaction.
+  auto reader = storage->Access(memgraph::storage::WRITE);
+
+  {
+    // Delete the edge in a second transaction while reader is alive.
+    auto writer = storage->Access(memgraph::storage::WRITE);
+    auto v1 = writer->FindVertex(v1_gid, ms::View::OLD).value();
+    auto edges = v1.OutEdges(ms::View::OLD);
+    ASSERT_TRUE(edges.has_value());
+    ASSERT_EQ(edges->edges.size(), 1U);
+    auto edge = edges->edges[0];
+    ASSERT_TRUE(writer->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(writer->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Let GC run while reader is still alive — it must NOT free the edge yet.
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+  // Reader still sees the edge via View::OLD.
+  {
+    auto v1 = reader->FindVertex(v1_gid, ms::View::OLD).value();
+    auto edges = v1.OutEdges(ms::View::OLD);
+    ASSERT_TRUE(edges.has_value());
+    ASSERT_EQ(edges->edges.size(), 1U);
+  }
+
+  reader->Abort();
+
+  // After reader closes, GC must eventually collect the graveyard.
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  // Storage destructor runs without crash — graveyard fully drained.
+}
+
+// Mirrors StorageV2Gc/ConcurrentEdgeOperationsAbortDeleteRepeat:
+// two transactions each create an edge, both abort; GC must not crash.
+// NOLINTNEXTLINE(hicpp-special-member-functions)
+TEST(StorageV2GcLightEdge, ConcurrentEdgeOperationsAbortDeleteRepeat) {
+  auto storage = MakeLightEdgeGcStorage();
+
+  ms::Gid v1_gid, v2_gid;
+  {
+    auto acc = storage->Access(memgraph::storage::WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    v1_gid = v1.Gid();
+    v2_gid = v2.Gid();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  auto tx1 = storage->Access(memgraph::storage::WRITE);
+  auto tx2 = storage->Access(memgraph::storage::WRITE);
+
+  {
+    auto v1 = tx1->FindVertex(v1_gid, ms::View::OLD).value();
+    auto v2 = tx1->FindVertex(v2_gid, ms::View::OLD).value();
+    ASSERT_TRUE(tx1->CreateEdge(&v1, &v2, tx1->NameToEdgeType("Edge1")).has_value());
+  }
+  {
+    auto v1 = tx2->FindVertex(v1_gid, ms::View::OLD).value();
+    auto v2 = tx2->FindVertex(v2_gid, ms::View::OLD).value();
+    ASSERT_TRUE(tx2->CreateEdge(&v1, &v2, tx2->NameToEdgeType("Edge2")).has_value());
+  }
+
+  tx1->Abort();
+  tx2->Abort();
+
+  // GC runs; aborted light-edge creations must have been freed inline (not via graveyard).
+  std::this_thread::sleep_for(std::chrono::milliseconds(400));
+
+  {
+    auto reader = storage->Access(memgraph::storage::WRITE);
+    auto v1 = reader->FindVertex(v1_gid, ms::View::OLD);
+    if (v1.has_value()) {
+      auto edges = v1->OutEdges(ms::View::OLD);
+      ASSERT_TRUE(edges.has_value());
+      ASSERT_EQ(edges->edges.size(), 0U);
+    }
+  }
+}
+
+// Regression test: light edges deleted in analytical mode must be put in the graveyard
+// and freed by GC, not leaked.  Verifies that:
+//   - the storage destructor does not crash (no double-free / use-after-free)
+//   - ~Edge() is called (catches PropertyStore heap-allocation leak under ASan)
+//   - graveyard is drained correctly after mode switch back to transactional
+// NOLINTNEXTLINE(hicpp-special-member-functions)
+TEST(StorageV2GcLightEdge, AnalyticalModeDeleteGoesToGraveyard) {
+  auto storage = MakeLightEdgeGcStorage();
+  auto *mem_storage = static_cast<ms::InMemoryStorage *>(storage.get());
+
+  ms::Gid v1_gid, v2_gid;
+  {
+    auto acc = storage->Access(memgraph::storage::WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    v1_gid = v1.Gid();
+    v2_gid = v2.Gid();
+    auto edge_res = acc->CreateEdge(&v1, &v2, acc->NameToEdgeType("e"));
+    ASSERT_TRUE(edge_res.has_value());
+    // Set a property so the PropertyStore has a heap allocation — caught by ASan if ~Edge() is skipped.
+    ASSERT_TRUE(edge_res->SetProperty(acc->NameToProperty("key"), ms::PropertyValue{"value"}).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Switch to analytical mode and delete the edge there.
+  mem_storage->SetStorageMode(ms::StorageMode::IN_MEMORY_ANALYTICAL);
+  {
+    auto acc = storage->Access(memgraph::storage::WRITE);
+    auto v1 = acc->FindVertex(v1_gid, ms::View::OLD);
+    ASSERT_TRUE(v1.has_value());
+    auto edges = v1->OutEdges(ms::View::OLD);
+    ASSERT_TRUE(edges.has_value());
+    ASSERT_EQ(edges->edges.size(), 1U);
+    auto edge = edges->edges[0];
+    ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Switch back — this triggers a FreeMemory/GC pass which must not crash.
+  mem_storage->SetStorageMode(ms::StorageMode::IN_MEMORY_TRANSACTIONAL);
+
+  // Run GC explicitly a second time to drain the graveyard.
+  {
+    auto main_guard = std::unique_lock{mem_storage->main_lock_};
+    mem_storage->FreeMemory(std::move(main_guard), false);
+  }
+
+  // Verify the edge is gone and the two vertices are still intact.
+  {
+    auto acc = storage->Access(memgraph::storage::READ);
+    auto v1 = acc->FindVertex(v1_gid, ms::View::OLD);
+    ASSERT_TRUE(v1.has_value());
+    auto edges = v1->OutEdges(ms::View::OLD);
+    ASSERT_TRUE(edges.has_value());
+    EXPECT_TRUE(edges->edges.empty());
+    EXPECT_TRUE(acc->FindVertex(v2_gid, ms::View::OLD).has_value());
+  }
+  // storage destructor runs here — must not crash or report sanitizer errors.
+}

--- a/tests/unit/storage_v2_light_edges.cpp
+++ b/tests/unit/storage_v2_light_edges.cpp
@@ -425,3 +425,603 @@ TEST(LightEdgesCleanup, DropGraphFreesEdgesAndPool) {
     ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
   }
 }
+
+// PR7b-i: light-edge delete lifecycle + graveyard GC routing
+
+// ===========================================================================
+// 4. DeleteEdge
+// ===========================================================================
+
+TEST(LightEdgesDeleteEdge, BasicDeleteAndCommit) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create edge
+  Gid edge_gid = Gid::FromUint(0);
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("REL");
+    auto res = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(res.has_value());
+    edge_gid = res->Gid();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete edge
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    ASSERT_TRUE(vf);
+    auto edge = vf->OutEdges(View::NEW).value().edges[0];
+
+    auto del = acc->DeleteEdge(&edge);
+    ASSERT_TRUE(del.has_value());
+
+    // After delete: NEW shows 0 edges, OLD shows 1
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 0);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 1);
+
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // After commit: edge gone
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+TEST(LightEdgesDeleteEdge, DetachDeleteVertex) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create edge
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("REL");
+    ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Detach delete from_vertex
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    ASSERT_TRUE(vf);
+    auto del = acc->DetachDeleteVertex(&*vf);
+    ASSERT_TRUE(del.has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // to_vertex should have no in_edges
+  {
+    auto acc = store->Access(WRITE);
+    auto vt = acc->FindVertex(gid_to, View::OLD);
+    ASSERT_TRUE(vt);
+    ASSERT_EQ(vt->InEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+// ===========================================================================
+// 5. Abort Handling
+// ===========================================================================
+
+TEST(LightEdgesAbort, AbortCreation) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create edge then abort (don't commit)
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("TEMP");
+    auto res = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(res.has_value());
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 1);
+    // Accessor destructor will abort
+  }
+
+  // Edge should not exist
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 0);
+  }
+}
+
+// Regression: with enable_edges_metadata + light edges, CREATING an edge then
+// ABORTING the transaction must not double-remove the metadata entry. Abort
+// routes the aborted-created light Edge* into deleted_edges_ (the heal), so the
+// single metadata OnEdgesDeleted must happen at CollectGarbage time, NOT also at
+// abort time. Before the fix, OnEdgesDeleted fired at abort AND again in GC,
+// tripping MG_ASSERT(acc.remove(gid)) in EdgeMetadataIndex on the second pass.
+TEST(LightEdgesAbort, AbortCreationWithMetadataNoDoubleRemove) {
+  auto store = MakeLightEdgeStorageWithMetadata();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create edge then abort (don't commit).
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("TEMP");
+    ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    // Accessor destructor aborts; metadata entry for the aborted edge is removed
+    // exactly once (at GC), not here.
+  }
+
+  // GC processes the abort-routed Edge* in deleted_edges_: OnEdgesDeleted removes
+  // its metadata entry. Pre-fix this MG_ASSERT-aborts (entry already removed at
+  // abort time). Call twice to drain every batch.
+  store->FreeMemory();
+  store->FreeMemory();
+
+  // Edge must not exist and the storage must be consistent (no crash above).
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+TEST(LightEdgesAbort, AbortDeletion) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create edge
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("PERM");
+    ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete edge then abort
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto edge = vf->OutEdges(View::NEW).value().edges[0];
+    auto del = acc->DeleteEdge(&edge);
+    ASSERT_TRUE(del.has_value());
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 0);
+    // Don't commit - abort
+  }
+
+  // Edge should still exist
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 1);
+  }
+}
+
+TEST(LightEdgesAbort, AbortCreateAndDeleteInSameTxn) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create + delete in same txn, then abort
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("EPHEMERAL");
+    auto res = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(res.has_value());
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 1);
+
+    auto del = acc->DeleteEdge(&*res);
+    ASSERT_TRUE(del.has_value());
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 0);
+    // Abort
+  }
+
+  // Nothing should exist
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+// ===========================================================================
+// 6. MVCC + GC (graveyard)
+// ===========================================================================
+
+TEST(LightEdgesMVCC, ConcurrentTxnSeesDeletedEdge) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create edge
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("REL");
+    auto res = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(res.has_value());
+
+    // Set a property so we can verify the Edge* is valid
+    auto prop = acc->NameToProperty("val");
+    ASSERT_TRUE(res->SetProperty(prop, PropertyValue(42)).has_value());
+
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Start reader txn BEFORE the delete
+  auto reader = store->Access(WRITE);
+  auto vf_reader = reader->FindVertex(gid_from, View::OLD);
+  ASSERT_TRUE(vf_reader);
+  ASSERT_EQ(vf_reader->OutEdges(View::OLD)->edges.size(), 1);
+
+  // Delete edge in a separate txn
+  {
+    auto writer = store->Access(WRITE);
+    auto vf = writer->FindVertex(gid_from, View::NEW);
+    auto edge = vf->OutEdges(View::NEW).value().edges[0];
+    ASSERT_TRUE(writer->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(writer->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // GC runs but reader is still active -> graveyard shouldn't drain
+  store->FreeMemory();
+
+  // Reader should still see the edge with correct properties
+  {
+    auto out = vf_reader->OutEdges(View::OLD);
+    ASSERT_EQ(out->edges.size(), 1);
+    auto prop = reader->NameToProperty("val");
+    auto val = out->edges[0].GetProperty(prop, View::OLD);
+    ASSERT_TRUE(val.has_value());
+    ASSERT_EQ(val->ValueInt(), 42);
+  }
+
+  // Close reader
+  reader.reset();
+
+  // Now GC should drain the graveyard
+  store->FreeMemory();
+
+  // Edge is gone for new transactions
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+TEST(LightEdgesMVCC, GCDrainsGraveyardAfterAllReadersGone) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create and delete multiple edges
+  constexpr int kEdges = 10;
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("MULTI");
+    for (int i = 0; i < kEdges; ++i) {
+      ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete all edges
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    for (int i = 0; i < kEdges; ++i) {
+      auto edge = vf->OutEdges(View::NEW).value().edges[0];
+      ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    }
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 0);
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Run GC
+  store->FreeMemory();
+
+  // Verify edges are gone
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+// ===========================================================================
+// 6b. Graveyard-specific tests
+// ===========================================================================
+
+// Regression: with enable_edges_metadata + light edges, deleting an edge and
+// running GC routes the Edge* through CollectGarbage (which removes the
+// edges-metadata entry via OnEdgesDeleted) and then through
+// DrainLightEdgeGraveyard in the SAME FreeMemory() cycle. Before the fix the
+// drain re-called OnEdgeDeleted(gid) on the already-removed entry, tripping the
+// `MG_ASSERT(acc.remove(gid))` in edge_metadata_index.hpp (double-remove abort).
+// After the fix the drain only frees memory and the test runs clean; we also
+// create+delete a second edge afterwards to prove the metadata index stays
+// consistent (a stale double-removed entry would corrupt later inserts).
+TEST(LightEdgesGraveyard, EdgesMetadataConsistentThroughDeleteAndDrain) {
+  auto store = MakeLightEdgeStorageWithMetadata();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create + commit a batch of edges.
+  constexpr int kEdges = 5;
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("META");
+    for (int i = 0; i < kEdges; ++i) {
+      ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete + commit all of them.
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    for (int i = 0; i < kEdges; ++i) {
+      auto edge = vf->OutEdges(View::NEW).value().edges[0];
+      ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    }
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 0);
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // GC collects the deleted light edges: CollectGarbage removes their metadata
+  // entries and pushes the Edge* to the graveyard, then DrainLightEdgeGraveyard
+  // frees them in the same cycle. Without the fix this MG_ASSERT-aborts on the
+  // double OnEdgeDeleted. Call twice to be sure every batch drains.
+  store->FreeMemory();
+  store->FreeMemory();
+
+  // Edge is gone.
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+
+  // Subsequent create/delete/GC must still work: a corrupted metadata index
+  // (from a stale double-removed entry) would surface as an abort or a wrong
+  // edge view here.
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("META2");
+    ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 1);
+    auto edge = vf->OutEdges(View::NEW).value().edges[0];
+    ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  store->FreeMemory();
+  store->FreeMemory();
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+TEST(LightEdgesGraveyard, MultipleBatchesAccumulateAndDrain) {
+  // Delete edges across many separate transactions, each creating a graveyard batch.
+  // Verify all batches drain after all readers are gone.
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  constexpr int kEdges = 20;
+
+  // Create edges
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("BATCH");
+    auto prop = acc->NameToProperty("idx");
+    for (int i = 0; i < kEdges; ++i) {
+      auto res = acc->CreateEdge(&*vf, &*vt, et);
+      ASSERT_TRUE(res.has_value());
+      ASSERT_TRUE(res->SetProperty(prop, PropertyValue(i)).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete edges one-by-one in separate transactions -> one graveyard batch each
+  for (int i = 0; i < kEdges; ++i) {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto out = vf->OutEdges(View::NEW);
+    ASSERT_TRUE(out.has_value());
+    ASSERT_FALSE(out->edges.empty());
+    auto edge = out->edges[0];
+    ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // All edges deleted, verify vertex shows 0
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+
+  // GC drains all batches (call twice for good measure)
+  store->FreeMemory();
+  store->FreeMemory();
+
+  // Verify no crash on final state
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+// FastDiscard path: create+commit then delete+commit with no overlapping
+// transaction (FastDiscard fires on the delete commit). Verify that after
+// FreeMemory() the metadata index has no stale entry and FindEdge returns
+// nullopt cleanly (no crash / UAF).
+TEST(LightEdgesGraveyard, FastDiscardRouteKeepsMetadataConsistent) {
+  auto store = MakeLightEdgeStorageWithMetadata();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  Gid edge_gid = Gid::FromUint(std::numeric_limits<uint64_t>::max());
+
+  // Step 1: create + commit the edge (no concurrent reader -> FastDiscard eligible).
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("FD");
+    auto res = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(res.has_value());
+    edge_gid = res->Gid();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Verify edge is visible.
+  {
+    auto acc = store->Access(READ);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 1);
+    // FindEdge via accessor must succeed while edge is live.
+    ASSERT_TRUE(acc->FindEdge(edge_gid, View::OLD).has_value());
+  }
+
+  // Step 2: delete + commit (no concurrent reader -> FastDiscard fires, Edge*
+  // routed through deleted_edges_ into CollectGarbage, NOT directly to graveyard).
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    ASSERT_TRUE(vf);
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 1);
+    auto edge = vf->OutEdges(View::NEW).value().edges[0];
+    ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 0);
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Step 3: run GC twice — CollectGarbage picks up deleted_edges_, removes
+  // metadata entry, pushes to graveyard; DrainLightEdgeGraveyard frees.
+  // Two FreeMemory() calls ensure every GC phase completes.
+  store->FreeMemory();
+  store->FreeMemory();
+
+  // Step 4: verify no stale metadata entry and no crash (no UAF).
+  {
+    auto acc = store->Access(READ);
+    // Vertex must see zero edges.
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+    // FindEdge must return nullopt cleanly — stale metadata entry would either
+    // abort (double-remove assert) or return a dangling pointer.
+    ASSERT_FALSE(acc->FindEdge(edge_gid, View::OLD).has_value());
+  }
+}
+
+// ===========================================================================
+// 10. Storage Cleanup
+// ===========================================================================
+
+TEST(LightEdgesCleanup, DestructorFreesGraveyardEdges) {
+  // Verify no crash when edges are in the graveyard at destruction time
+  {
+    auto store = MakeLightEdgeStorage();
+    auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+    // Create edges
+    {
+      auto acc = store->Access(WRITE);
+      auto vf = acc->FindVertex(gid_from, View::NEW);
+      auto vt = acc->FindVertex(gid_to, View::NEW);
+      auto et = acc->NameToEdgeType("GRAVE");
+      for (int i = 0; i < 50; ++i) {
+        ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+      }
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    // Delete all edges (they go to graveyard)
+    {
+      auto acc = store->Access(WRITE);
+      auto vf = acc->FindVertex(gid_from, View::NEW);
+      for (int i = 0; i < 50; ++i) {
+        auto edge = vf->OutEdges(View::NEW).value().edges[0];
+        ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+      }
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    // DON'T run GC - leave edges in graveyard
+    // Store destruction should clean them up
+  }
+  // If we get here without errors, graveyard cleanup worked
+}
+
+// ===========================================================================
+// 12. DropGraph tests
+// ===========================================================================
+
+// DropGraph with edges in the graveyard (deleted but not yet GC'd).
+TEST(LightEdgesCleanup, DropGraphWithGraveyardEdges) {
+  auto store = MakeLightEdgeStorage();
+  auto *mem_storage = static_cast<InMemoryStorage *>(store.get());
+
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create and then delete edges so they sit in the graveyard.
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto etype = acc->NameToEdgeType("T");
+    for (int idx = 0; idx < 50; ++idx) {
+      ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, etype).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    while (true) {
+      auto out = vf->OutEdges(View::NEW);
+      if (!out.has_value() || out->edges.empty()) break;
+      auto edge = out->edges[0];
+      ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  // Deliberately skip GC so edges remain in graveyard.
+
+  mem_storage->SetStorageMode(StorageMode::IN_MEMORY_ANALYTICAL);
+  {
+    auto acc = store->UniqueAccess();
+    acc->DropGraph();
+    // No crash / ASAN error = graveyard was drained and pool reclaimed.
+  }
+}


### PR DESCRIPTION
Route deleted light Edge* into a per-storage graveyard at GC/commit/abort time and free them from DrainLightEdgeGraveyard each GC cycle. Light edges are pool-allocated (not skip-list nodes) so edges_.run_gc() cannot reclaim them; the graveyard is the deferred-free path.

Gate-only reconcile: the heavy CollectGarbage/Abort/FastDiscard edge-removal blocks are wrapped as 'if (light) push; else { original block verbatim }' in their original position. No ordering inversion is ported; the dead [[maybe_unused]] transaction_id param is dropped. Heavy mode (flag off) is byte-behaviour-identical to PR7a (logic-verifier VER-1 PASS).

The PR7b-i drain is unconditional (degenerate-safe): nothing pins light edges yet (MakeEdgePin stays heavy-only), so MVCC visibility alone guarantees a deleted Edge* is unreachable by every active txn before it is freed (logic-verifier UAF-safety SAFE). The EpochTracker-gated drain, gated MakeEdgePin, and LightEdgeIterable land in PR7b-ii.

Base: PR7a light_edges-07a-storage-core (4d11a06d8).
