### PR TITLE
Feature (Light Edges / 9) - feat(storage): epoch-gated light-edge iterable drain + tracker

### DIFF
--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -157,6 +157,86 @@ DeltaChainState ComputeDeltaChainState(bool has_blocker, WriteResult result) {
   return DeltaChainState::SEQUENTIAL;
 }
 
+// Flattens a vertex skip-list accessor into a range of Edge references
+// by walking every vertex's out_edges. Only safe while the vertex
+// accessor (and therefore all vertices) remain alive. Used by the light-edge
+// analytical full-scan paths to enumerate deleted light edges.
+class LightEdgeIterable {
+ public:
+  using VertexIterator = utils::SkipListDb<Vertex>::Accessor::iterator;
+
+  class Iterator {
+   public:
+    using value_type = Edge;
+    using reference = Edge &;
+    using pointer = Edge *;
+    using difference_type = std::ptrdiff_t;
+    using iterator_category = std::forward_iterator_tag;
+
+    Iterator() = default;
+
+    Iterator(VertexIterator vertex_it, VertexIterator vertex_end) : vertex_it_(vertex_it), vertex_end_(vertex_end) {
+      AdvanceToNextEdge();
+    }
+
+    reference operator*() const { return *std::get<2>(*edge_it_).ptr; }
+
+    pointer operator->() const { return std::get<2>(*edge_it_).ptr; }
+
+    Iterator &operator++() {
+      ++edge_it_;
+      if (edge_it_ == edge_end_) {
+        ++vertex_it_;
+        AdvanceToNextEdge();
+      }
+      return *this;
+    }
+
+    friend bool operator==(Iterator const &lhs, Iterator const &rhs) {
+      // Both iterators are at end when their vertex_it_ values agree AND one of
+      // them is at its own vertex_end_ (past-the-end iterators compare equal
+      // regardless of edge_it_, which is default-initialised for end()). When
+      // neither is at end, edge_it_ must also agree for equality.
+      if (lhs.vertex_it_ != rhs.vertex_it_) return false;
+      if (lhs.vertex_it_ == lhs.vertex_end_ || rhs.vertex_it_ == rhs.vertex_end_) return true;
+      return lhs.edge_it_ == rhs.edge_it_;
+    }
+
+   private:
+    void AdvanceToNextEdge() {
+      for (; vertex_it_ != vertex_end_; ++vertex_it_) {
+        auto &out_edges = vertex_it_->out_edges;
+        if (!out_edges.empty()) {
+          edge_it_ = out_edges.begin();
+          edge_end_ = out_edges.end();
+          return;
+        }
+      }
+    }
+
+    VertexIterator vertex_it_{};
+    VertexIterator vertex_end_{};
+    Edges::iterator edge_it_{};
+    Edges::iterator edge_end_{};
+  };
+
+  explicit LightEdgeIterable(utils::SkipListDb<Vertex>::Accessor &vertex_acc) {
+    // Cache end() once: the accessor is valid for the lifetime of this
+    // iterable, and repeated calls to end() are O(1) but redundant.
+    auto end_it = vertex_acc.end();
+    begin_ = Iterator{vertex_acc.begin(), end_it};
+    end_ = Iterator{end_it, end_it};
+  }
+
+  Iterator begin() const { return begin_; }
+
+  Iterator end() const { return end_; }
+
+ private:
+  Iterator begin_;
+  Iterator end_;
+};
+
 class PeriodicSnapshotObserver : public memgraph::utils::Observer<memgraph::utils::SchedulerInterval> {
  public:
   explicit PeriodicSnapshotObserver(memgraph::utils::Scheduler &scheduler) : scheduler_{&scheduler} {}
@@ -526,6 +606,19 @@ InMemoryStorage::~InMemoryStorage() {
   if (config_.durability.snapshot_on_exit && this->create_snapshot_handler) {
     create_snapshot_handler("exit");
   }
+  // Leak fix: a deleted light edge whose delta chain was never GC-unlinked
+  // (an older txn was active at delete time) is referenced ONLY by an un-GC'd
+  // RECREATE_OBJECT delta in committed_transactions_/waiting_gc_deltas_. The
+  // clear() below frees those deltas but NOT the pool-allocated Edge*, and
+  // ClearLightEdges only drains {adjacency, graveyard, deleted_edges_} -> the
+  // Edge* would leak. A forced CollectGarbage here would work but is NOT noexcept
+  // (allocations, logging) and a throw in a dtor calls std::terminate. Instead
+  // run a noexcept harvester that frees exactly those delta-chain-only light
+  // edges (disjoint from the three sets ClearLightEdges drains, so no double
+  // free). Gated: heavy Edge* live in edges_ and are freed by the skiplist.
+  if (config_.salient.items.storage_light_edge) {
+    HarvestDeltaChainOnlyLightEdges();
+  }
   committed_transactions_.WithLock([](auto &transactions) { transactions.clear(); });
   // Free live light edges (pool-allocated Edge*) before teardown. Gated: heavy
   // edges live in edges_ and are freed by the skip-list, not here.
@@ -673,20 +766,25 @@ InMemoryStorage::InMemoryAccessor::DetachDelete(std::vector<VertexAccessor *> no
 
       // Analytical-mode leak fix: in analytical mode the edge is pop_back'd from
       // vertex adjacency at delete time, so the GC full-scan light arm (which
-      // iterates over LIVE adjacency) can never find these light Edge* -> they
-      // would be unreachable and leak (heavy works because its node persists in
-      // the edges_ skip-list scanned by the heavy full-scan arm). Route the
-      // deleted LIGHT Edge* into deleted_edges_, exactly like the transactional
+      // iterates LightEdgeIterable over LIVE adjacency) can never find these light
+      // Edge* -> they would be unreachable and leak (heavy works because its node
+      // persists in the edges_ skip-list scanned by the heavy full-scan arm). Route
+      // the deleted LIGHT Edge* into deleted_edges_, exactly like the transactional
       // FastDiscard path. CollectGarbage swaps deleted_edges_ into
       // current_deleted_edges and the light arm pushes them to the graveyard with
-      // guard_epoch snapped at collection time. The full-scan light arm then finds
-      // nothing for these (not in adjacency) -> no double-push. Heavy mode keeps
-      // the skip-list full-scan path byte-identical.
+      // guard_epoch snapped at COLLECTION time, preserving the epoch-gated drain
+      // invariant. The full-scan light arm then finds nothing for these (not in
+      // adjacency) -> no double-push. Heavy mode keeps the skip-list full-scan path
+      // byte-identical.
       if (config_.storage_light_edge) {
+        // Collect the Edge* off-lock, then splice in O(1) under the SpinLock — the
+        // critical section must not do O(batch) node allocation while locked.
+        std::list<Edge *, memory::DbAwareAllocator<Edge *>> light_edges;
+        for (auto const &edge : deleted_edges) {
+          light_edges.push_back(edge.edge_.ptr);
+        }
         mem_storage->deleted_edges_.WithLock([&](auto &storage_deleted_edges) {
-          for (auto const &edge : deleted_edges) {
-            storage_deleted_edges.push_back(edge.edge_.ptr);
-          }
+          storage_deleted_edges.splice(storage_deleted_edges.end(), light_edges);
         });
       }
     }
@@ -1332,13 +1430,8 @@ void InMemoryStorage::InMemoryAccessor::FastDiscardOfDeltas(std::unique_lock<std
         [&](auto &deleted_vertices) { deleted_vertices.splice(deleted_vertices.end(), current_deleted_vertices); });
   }
   if (!current_deleted_edges.empty()) {
-    // Both heavy and light edges defer to deleted_edges_ here. Light edges must
-    // NOT be pushed to the light_edge_graveyard_ at commit time: the graveyard
-    // watermark (guard_epoch) is snapped at GC-COLLECTION time so that any
-    // post-commit reader is ordered before it. Riding deleted_edges_ into
-    // CollectGarbage also runs the index cleanup (OnEdgesDeleted +
-    // RemoveEdgesFromVectorEdgeIndices) before the graveyard push, exactly like
-    // heavy. Heavy behaviour is unchanged.
+    // Both heavy and light edges defer to deleted_edges_ here; light edges are
+    // pushed to the graveyard later, at GC-collection time.
     // O(1) splice under the SpinLock — never an O(batch) copy while locked.
     mem_storage->deleted_edges_.WithLock(
         [&](auto &deleted_edges) { deleted_edges.splice(deleted_edges.end(), current_deleted_edges); });
@@ -1725,8 +1818,13 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
     // Heavy behaviour is unchanged.
     if (!my_deleted_edges.empty()) {
       if (mem_storage->config_.salient.items.storage_light_edge) {
-        // Watermark snapped at GC-collection time; index cleanup runs in
-        // CollectGarbage before the graveyard push — see FastDiscard above.
+        // Do NOT push to light_edge_graveyard_ here: snapping guard_epoch at abort
+        // time, before any post-commit index iterable opens, would let
+        // DrainLightEdgeGraveyard free the Edge* under a live iterable (UAF). Mirror
+        // the heavy deferral (the skiplist GC frees a marked node only once its
+        // accessor watermark clears) by routing light edges through deleted_edges_
+        // into CollectGarbage, which snaps the graveyard watermark at GC-collection
+        // time.
         // O(1) splice under the SpinLock — never an O(batch) copy while locked.
         mem_storage->deleted_edges_.WithLock(
             [&](auto &deleted_edges) { deleted_edges.splice(deleted_edges.end(), my_deleted_edges); });
@@ -3262,11 +3360,10 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
         std::vector<Edge *> const edges_to_remove(current_deleted_edges.begin(), current_deleted_edges.end());
         indices_.RemoveEdgesFromVectorEdgeIndices(edges_to_remove);
       }
+      auto const guard_epoch = light_edge_iterable_tracker_.CurrentEpoch();
       light_edge_graveyard_.WithLock([&](auto &graveyard) {
-        // guard_epoch defaults to 0 (epoch gating snapped at drain time in 7b-ii)
         // std::move is an O(1) list move (entry.edges is a std::list) under the lock.
-        LightEdgeGraveyardEntry entry{.edges = std::move(current_deleted_edges)};
-        graveyard.push_back(std::move(entry));
+        graveyard.emplace_back(guard_epoch, std::move(current_deleted_edges));
       });
     } else {
       auto edge_acc = edges_.access();
@@ -3304,9 +3401,16 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
     // Remove edges from vector edge index BEFORE vertex skip-list removal.
     if (!indices_.vector_edge_index_.Empty()) {
       auto edge_acc = edges_.access();
-      auto const analytical_deleted_edges =
+      auto analytical_deleted_edges =
           edge_acc | std::ranges::views::filter([](auto const &e) { return e.delta() == nullptr && e.deleted(); }) |
           std::ranges::views::transform([](auto &e) { return &e; }) | std::ranges::to<std::vector>();
+
+      // Light edges live in vertices_ adjacency, not edges_; collect deleted ones too.
+      if (config_.salient.items.storage_light_edge) {
+        for (auto &e : LightEdgeIterable{vertex_acc}) {
+          if (e.delta() == nullptr && e.deleted()) analytical_deleted_edges.push_back(&e);
+        }
+      }
 
       if (!analytical_deleted_edges.empty()) {
         indices_.RemoveEdgesFromVectorEdgeIndices(analytical_deleted_edges);
@@ -3325,9 +3429,16 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
     auto edge_acc = edges_.access();
 
     if (!need_full_scan_vertices && !indices_.vector_edge_index_.Empty()) {
-      auto const analytical_deleted_edges =
+      auto analytical_deleted_edges =
           edge_acc | std::ranges::views::filter([](auto const &e) { return e.delta() == nullptr && e.deleted(); }) |
           std::ranges::views::transform([](auto &e) { return &e; }) | std::ranges::to<std::vector>();
+
+      if (config_.salient.items.storage_light_edge) {
+        auto vertex_acc = vertices_.access();
+        for (auto &e : LightEdgeIterable{vertex_acc}) {
+          if (e.delta() == nullptr && e.deleted()) analytical_deleted_edges.push_back(&e);
+        }
+      }
 
       if (!analytical_deleted_edges.empty()) {
         indices_.RemoveEdgesFromVectorEdgeIndices(analytical_deleted_edges);
@@ -3342,40 +3453,67 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
       }
     }
 
-    // Light-edge analytical arm: analytically-deleted light edges do NOT appear
-    // in the edges_ skip-list (they live in vertex adjacency and are removed at
-    // delete time), so there are no entries to find here via edge_acc. Instead,
-    // inform_gc_edge_deletion routes deleted light Edge* directly into
-    // deleted_edges_ so they arrive in current_deleted_edges and are handled by
-    // the transactional light arm above (OnEdgesDeleted + graveyard push).
+    if (config_.salient.items.storage_light_edge) {
+      auto vertex_acc = vertices_.access();
+      // std::list (not vector): it is std::move'd into the graveyard entry under
+      // the lock below (O(1)), matching LightEdgeGraveyardEntry::edges.
+      std::list<Edge *, memory::DbAwareAllocator<Edge *>> analytical_deleted_light_edges;
+      for (auto &e : LightEdgeIterable{vertex_acc}) {
+        if (e.delta() == nullptr && e.deleted()) {
+          if (idx) idx->OnEdgeDeleted(e.gid);
+          analytical_deleted_light_edges.push_back(&e);
+        }
+      }
+      if (!analytical_deleted_light_edges.empty()) {
+        auto const guard_epoch = light_edge_iterable_tracker_.CurrentEpoch();
+        light_edge_graveyard_.WithLock(
+            [&](auto &graveyard) { graveyard.emplace_back(guard_epoch, std::move(analytical_deleted_light_edges)); });
+      }
+    }
   }
 }
 
 void InMemoryStorage::DrainLightEdgeGraveyard() {
   if (!config_.salient.items.storage_light_edge) return;
-  // No edge-index iterable pins light edges yet (MakeEdgePin is still the
-  // heavy-only form), so no reader can race the free and we drain the whole
-  // graveyard unconditionally here.
+  // Light edges may be pinned by edge-index iterables (MakeEdgePin now returns a
+  // LightEdgeIterableGuard that Acquires an epoch). A graveyard entry recorded
+  // guard_epoch = CurrentEpoch() at delete time; we may only free its edges once
+  // IsSafeToFree(guard_epoch) confirms every reader that existed before the delete
+  // has Released. Swap the graveyard out under the lock, free the safe entries
+  // lock-free, and splice the not-yet-safe survivors back for a later drain.
   //
-  // The ONLY push site for this graveyard is CollectGarbage at GC-collection
-  // time. Both the commit (FastDiscard) and abort light arms route deleted Edge*
-  // through deleted_edges_ so that CollectGarbage snaps the guard_epoch watermark
-  // AFTER all readers are ordered. Invariant: metadata + vector-index entries are
-  // already removed at GC-collect time before the push happens.
+  // Pushes happen ONLY at GC-collection time (CollectGarbage transactional arm and
+  // the analytical arm) — commit (FastDiscard) and abort route deleted Edge*
+  // through deleted_edges_ first, so guard_epoch is snapped AFTER index cleanup and
+  // after all pre-existing readers are ordered.
   std::list<LightEdgeGraveyardEntry, memory::DbAwareAllocator<LightEdgeGraveyardEntry>> local_graveyard;
   light_edge_graveyard_.WithLock([&](auto &graveyard) { local_graveyard.swap(graveyard); });
   if (local_graveyard.empty()) return;
 
-  // The edge-metadata entry for every graveyarded edge was already removed at
-  // GC-collection time (CollectGarbage OnEdgesDeleted and
-  // RemoveEdgesFromVectorEdgeIndices) BEFORE the Edge* was routed here. The
-  // graveyard exists solely to defer the *memory free*; it must NOT touch
-  // edges_metadata_index_ again, otherwise it would double-remove the entry and
-  // trip the `acc.remove` assert in OnEdgeDeleted.
-  for (auto &entry : local_graveyard) {
-    for (auto *edge : entry.edges) {
-      InMemoryStorage::LightEdgePool::Destroy(edge);
+  // GC-collection time (CollectGarbage transactional arm OnEdgesDeleted, and the
+  // analytical arm OnEdgeDeleted) BEFORE the Edge* was routed here. The graveyard
+  // exists solely to defer the *memory free* until live edge-index iterables have
+  // drained; it must NOT touch edges_metadata_index_ again, otherwise it would
+  // double-remove the entry and trip the `acc.remove` assert in OnEdgeDeleted.
+  // Snapshot the dead-prefix watermark once for the whole sweep: the dead prefix
+  // is monotonic, so a single O(blocks) scan plus an O(1) check per entry beats
+  // re-scanning the tracker for every entry. An entry not yet freeable under this
+  // snapshot is simply spliced back and retried on the next drain, never freed early.
+  const uint64_t watermark = light_edge_iterable_tracker_.DeadPrefixWatermark();
+  for (auto it = local_graveyard.begin(); it != local_graveyard.end();) {
+    if (utils::EpochTracker::IsSafeToFree(it->guard_epoch, watermark)) {
+      for (auto *edge : it->edges) {
+        InMemoryStorage::LightEdgePool::Destroy(edge);
+      }
+      it = local_graveyard.erase(it);
+    } else {
+      ++it;
     }
+  }
+  // Splice the not-yet-safe survivors back for a future drain (skip the lock
+  // acquisition entirely when all entries were freed this pass).
+  if (!local_graveyard.empty()) {
+    light_edge_graveyard_.WithLock([&](auto &graveyard) { graveyard.splice(graveyard.end(), local_graveyard); });
   }
 }
 
@@ -4647,7 +4785,30 @@ void InMemoryStorage::LightEdgePool::Destroy(Edge *p) noexcept {
   std::allocator_traits<decltype(alloc)>::deallocate(alloc, p, 1);
 }
 
-void InMemoryStorage::ClearLightEdges() {
+void InMemoryStorage::HarvestDeltaChainOnlyLightEdges() noexcept {
+  // Walk both containers under their respective locks. All background tasks are
+  // stopped before this runs (single-threaded dtor path), so no concurrency on
+  // the delta chains — atomic reads of prev/delta/deleted suffice; no edge lock
+  // needed. The edge->delta()==&delta guard is the chain-head dedup used by the
+  // GC loop (storage.cpp:3135) and UnlinkAndRemoveDeltas (:303-310): it ensures
+  // each deleted light Edge* is freed EXACTLY ONCE across the whole walk.
+  auto harvest = [](auto &transactions) noexcept {
+    for (auto &entry : transactions) {
+      for (Delta &delta : entry.deltas_) {
+        auto prev = delta.prev.Get();
+        if (prev.type != PreviousPtr::Type::EDGE) continue;
+        Edge *edge = prev.edge;
+        if (!edge->deleted()) continue;
+        if (edge->delta() != &delta) continue;
+        InMemoryStorage::LightEdgePool::Destroy(edge);
+      }
+    }
+  };
+  committed_transactions_.WithLock(harvest);
+  waiting_gc_deltas_.WithLock(harvest);
+}
+
+void InMemoryStorage::ClearLightEdges() noexcept {
   // Free ONLY live light edges held in vertex adjacency. Each edge appears
   // exactly once across all out_edges (a self-loop has a single source-vertex
   // entry), so no deduplication is needed. Deleted light edges still queued in
@@ -4707,6 +4868,17 @@ void InMemoryStorage::Clear() {
     last_processed_commit_ts_ = kTimestampInitialId;
   }
   schema_info_.Clear();
+  // Leak fix (mirrors dtor ordering): a deleted light edge whose delta chain was
+  // never GC-unlinked is referenced ONLY by a RECREATE_OBJECT delta in
+  // committed_transactions_/waiting_gc_deltas_. The clear() below frees those
+  // deltas but NOT the pool-allocated Edge*, and ClearLightEdges only drains
+  // {adjacency, graveyard, deleted_edges_} -> the Edge* would leak. Harvest BEFORE
+  // ClearLightEdges (and before committed_transactions_ is cleared) so the delta
+  // chains are still reachable. Gated: heavy Edge* live in edges_ and are freed by
+  // the skip-list, not here.
+  if (config_.salient.items.storage_light_edge) {
+    HarvestDeltaChainOnlyLightEdges();
+  }
   // Free live light edges before clearing vertices (their adjacency lists are
   // the only handle to the pool-allocated Edge*).
   if (config_.salient.items.storage_light_edge) {
@@ -4887,6 +5059,14 @@ void InMemoryStorage::InMemoryAccessor::DropGraph() {
   // we take the control from the GC to clear any deltas
   auto gc_guard = std::unique_lock{mem_storage->gc_lock_};
   mem_storage->garbage_undo_buffers_.WithLock([&](auto &garbage_undo_buffers) { garbage_undo_buffers.clear(); });
+  // Free deleted light Edge* referenced only by un-GC'd RECREATE_OBJECT
+  // deltas before clearing committed_transactions_/waiting_gc_deltas_ (which hold
+  // those delta chains). Mirrors Clear()'s harvest call; ClearLightEdges below
+  // only drains {adjacency, graveyard, deleted_edges_} — delta-chain-only edges
+  // are disjoint from those three sets and would leak without this harvest.
+  if (mem_storage->config_.salient.items.storage_light_edge) {
+    mem_storage->HarvestDeltaChainOnlyLightEdges();
+  }
   mem_storage->committed_transactions_.WithLock([&](auto &committed_transactions) { committed_transactions.clear(); });
 
   mem_storage->async_indexer_.Clear();

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -840,10 +840,23 @@ class InMemoryStorage final : public Storage {
 
   // Light-edge teardown (frees pool-allocated Edge* still live in vertex
   // adjacency). Gated at every call site by salient.items.storage_light_edge.
-  void ClearLightEdges();
-  // Drain the light-edge graveyard: free the queued deleted Edge*. The drain is
-  // unconditional (no reader pins light edges yet). Called from FreeMemory after
-  // edges_.run_gc(); early-returns when the storage_light_edge flag is off.
+  // noexcept: body only calls LightEdgePool::Destroy (noexcept), SpinLock acquire
+  // (noexcept via MG_ASSERT), std::list::swap (noexcept), and clear(); the
+  // vertices_.access() ctor calls SkipList::gc_.AllocateId() which is a plain
+  // atomic fetch_add — no heap allocation, no throw.
+  void ClearLightEdges() noexcept;
+  // Free deleted light Edge* referenced ONLY by un-GC'd RECREATE_OBJECT deltas in
+  // committed_transactions_/waiting_gc_deltas_ at teardown (GC never unlinked them
+  // because an older txn was active at delete time). noexcept: the walk only reads
+  // lock-free delta prev pointers and calls the noexcept LightEdgePool::Destroy; no
+  // allocation. Disjoint from adjacency/deleted_edges_/graveyard by construction,
+  // so each edge is freed exactly once. Gated by the caller on
+  // salient.items.storage_light_edge.
+  void HarvestDeltaChainOnlyLightEdges() noexcept;
+  // Drain the light-edge graveyard: free each queued deleted Edge* once its
+  // guard_epoch watermark confirms every reader that existed before the delete has
+  // released its epoch. Called from FreeMemory after edges_.run_gc(); early-returns
+  // when the storage_light_edge flag is off.
   void DrainLightEdgeGraveyard();
 
   // Database-owned arena pool for per-thread arena management.
@@ -859,9 +872,8 @@ class InMemoryStorage final : public Storage {
   // at CollectGarbage time (after metadata + vector-index entries are already
   // removed). The commit (FastDiscard) and abort light arms route deleted Edge*
   // through deleted_edges_ so the guard_epoch watermark is snapped only after all
-  // concurrent readers are ordered; the drain frees them later. guard_epoch is a
-  // sentinel (0) here — the drain frees unconditionally, as no reader pins light
-  // edges.
+  // concurrent readers are ordered; the drain then frees each entry once its
+  // guard_epoch confirms every pre-existing reader has released its epoch.
   struct LightEdgeGraveyardEntry {
     uint64_t guard_epoch{0};
     // std::list (not vector): current_deleted_edges is std::move'd in under the
@@ -872,12 +884,26 @@ class InMemoryStorage final : public Storage {
 
   // Returns a pin that keeps edge-index iterables' underlying Edge memory alive
   // for the lifetime of the iterable. Heavy mode pins the edges_ skip-list
-  // ConstAccessor (the first alternative of the EdgePin variant).
-  [[nodiscard]] EdgePin MakeEdgePin() const { return edges_.access(); }
+  // ConstAccessor (the first alternative of the EdgePin variant). Light mode
+  // acquires an epoch from light_edge_iterable_tracker_ so the graveyard drain
+  // can determine when it is safe to free deleted Edge objects.
+  [[nodiscard]] EdgePin MakeEdgePin() const {
+    if (config_.salient.items.storage_light_edge) [[unlikely]] {
+      return LightEdgeIterableGuard{&light_edge_iterable_tracker_};
+    }
+    return edges_.access();
+  }
 
   utils::SkipListDb<Edge> edges_;
   // Present iff salient.items.enable_edges_metadata && salient.items.properties_on_edges.
   std::optional<EdgeMetadataIndex> edges_metadata_index_;
+
+  // Epoch tracker for light-edge edge-index iterables. Readers (edge-index
+  // iterables) Acquire an epoch ID via MakeEdgePin()->LightEdgeIterableGuard;
+  // the graveyard drain frees a deleted light Edge* only once IsSafeToFree(guard_epoch)
+  // confirms every reader that existed before the delete has Released. mutable
+  // because MakeEdgePin() const calls Acquire() (mutating) on it.
+  mutable utils::EpochTracker light_edge_iterable_tracker_;
 
   // Durability
   durability::Recovery recovery_;

--- a/tests/unit/storage_v2_edge_inmemory.cpp
+++ b/tests/unit/storage_v2_edge_inmemory.cpp
@@ -20,15 +20,25 @@
 
 using testing::UnorderedElementsAre;
 
-class StorageEdgeTest : public ::testing::TestWithParam<bool> {};
+struct StorageEdgeConfig {
+  bool properties_on_edges{true};
+  bool light_edge{false};
+};
 
-INSTANTIATE_TEST_SUITE_P(EdgesWithProperties, StorageEdgeTest, ::testing::Values(true));
-INSTANTIATE_TEST_SUITE_P(EdgesWithoutProperties, StorageEdgeTest, ::testing::Values(false));
+class StorageEdgeTest : public ::testing::TestWithParam<StorageEdgeConfig> {};
+
+INSTANTIATE_TEST_SUITE_P(EdgesWithProperties, StorageEdgeTest,
+                         ::testing::Values(StorageEdgeConfig{.properties_on_edges = true}));
+INSTANTIATE_TEST_SUITE_P(EdgesWithoutProperties, StorageEdgeTest,
+                         ::testing::Values(StorageEdgeConfig{.properties_on_edges = false}));
+INSTANTIATE_TEST_SUITE_P(LightEdges, StorageEdgeTest,
+                         ::testing::Values(StorageEdgeConfig{.properties_on_edges = true, .light_edge = true}));
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeCreateFromSmallerCommit) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_from = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_to = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -218,8 +228,9 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSmallerCommit) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeCreateFromLargerCommit) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_from = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_to = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -391,8 +402,9 @@ TEST_P(StorageEdgeTest, EdgeCreateFromLargerCommit) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeCreateFromSameCommit) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_vertex = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
   // Create vertex
@@ -537,8 +549,9 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSameCommit) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeCreateFromSmallerAbort) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_from = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_to = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -807,8 +820,9 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSmallerAbort) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeCreateFromLargerAbort) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_from = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_to = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -1077,8 +1091,9 @@ TEST_P(StorageEdgeTest, EdgeCreateFromLargerAbort) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeCreateFromSameAbort) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_vertex = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
   // Create vertex
@@ -1304,8 +1319,9 @@ TEST_P(StorageEdgeTest, EdgeCreateFromSameAbort) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerCommit) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_from = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_to = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -1573,8 +1589,9 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerCommit) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeDeleteFromLargerCommit) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_from = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_to = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -1842,8 +1859,9 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerCommit) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeDeleteFromSameCommit) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_vertex = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
   // Create vertex
@@ -2068,8 +2086,9 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameCommit) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerAbort) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_from = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_to = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -2491,8 +2510,9 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSmallerAbort) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeDeleteFromLargerAbort) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_from = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_to = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -2915,8 +2935,9 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromLargerAbort) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, EdgeDeleteFromSameAbort) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_vertex = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
   // Create vertex
@@ -3275,8 +3296,9 @@ TEST_P(StorageEdgeTest, EdgeDeleteFromSameAbort) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, VertexDetachDeleteSingleCommit) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_from = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_to = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -3414,8 +3436,9 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteSingleCommit) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, VertexDetachDeleteMultipleCommit) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_vertex1 = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_vertex2 = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -3744,8 +3767,9 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteMultipleCommit) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, VertexDetachDeleteSingleAbort) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_from = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_to = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -3987,8 +4011,9 @@ TEST_P(StorageEdgeTest, VertexDetachDeleteSingleAbort) {
 
 // NOLINTNEXTLINE(hicpp-special-member-functions)
 TEST_P(StorageEdgeTest, VertexDetachDeleteMultipleAbort) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_vertex1 = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
   memgraph::storage::Gid gid_vertex2 = memgraph::storage::Gid::FromUint(std::numeric_limits<uint64_t>::max());
 
@@ -5413,8 +5438,9 @@ TEST(StorageWithProperties, EdgeNonexistentPropertyAPI) {
 }
 
 TEST_P(StorageEdgeTest, ConcurrentTransactionsCanCreateNonSequentialOperations) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_v1, gid_v2;
 
   {
@@ -5453,8 +5479,9 @@ TEST_P(StorageEdgeTest, ConcurrentTransactionsCanCreateNonSequentialOperations) 
 }
 
 TEST_P(StorageEdgeTest, NonSequentialOperationsOnCurrentTransactionsAreSerializationErrors) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_v1, gid_v2;
 
   {
@@ -5483,8 +5510,9 @@ TEST_P(StorageEdgeTest, NonSequentialOperationsOnCurrentTransactionsAreSerializa
 }
 
 TEST_P(StorageEdgeTest, OnlyNonSequentialOperationsCanBePerformedWhenHeadOperationIsNonSequential) {
-  std::unique_ptr<memgraph::storage::Storage> store(
-      new memgraph::storage::InMemoryStorage({.salient = {.items = {.properties_on_edges = GetParam()}}}));
+  std::unique_ptr<memgraph::storage::Storage> store(new memgraph::storage::InMemoryStorage(
+      {.salient = {.items = {.properties_on_edges = GetParam().properties_on_edges,
+                             .storage_light_edge = GetParam().light_edge}}}));
   memgraph::storage::Gid gid_v1, gid_v2, gid_v3;
 
   {

--- a/tests/unit/storage_v2_gc.cpp
+++ b/tests/unit/storage_v2_gc.cpp
@@ -13,6 +13,7 @@
 #include <gtest/gtest.h>
 
 #include <optional>
+#include <set>
 #include <string_view>
 
 #include "flags/general.hpp"
@@ -1643,6 +1644,56 @@ TEST(StorageV2GcLightEdge, ConcurrentEdgeOperationsAbortDeleteRepeat) {
       ASSERT_TRUE(edges.has_value());
       ASSERT_EQ(edges->edges.size(), 0U);
     }
+  }
+}
+
+// Mirrors StorageV2Gc/Indices: index GC correctness with light edges.
+// NOLINTNEXTLINE(hicpp-special-member-functions)
+TEST(StorageV2GcLightEdge, Indices) {
+  auto storage = MakeLightEdgeGcStorage();
+
+  {
+    auto unique_acc = storage->UniqueAccess();
+    ASSERT_TRUE(unique_acc->CreateIndex(storage->NameToLabel("label")).has_value());
+    ASSERT_TRUE(unique_acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  ms::Gid v1_gid, v2_gid;
+  {
+    auto acc = storage->Access(memgraph::storage::WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    ASSERT_TRUE(*v1.AddLabel(acc->NameToLabel("label")));
+    ASSERT_TRUE(*v2.AddLabel(acc->NameToLabel("label")));
+    v1_gid = v1.Gid();
+    v2_gid = v2.Gid();
+    ASSERT_TRUE(acc->CreateEdge(&v1, &v2, acc->NameToEdgeType("e")).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  {
+    auto acc1 = storage->Access(memgraph::storage::WRITE);
+
+    auto acc2 = storage->Access(memgraph::storage::WRITE);
+    auto v1 = acc2->FindVertex(v1_gid, ms::View::OLD).value();
+    auto v2 = acc2->FindVertex(v2_gid, ms::View::OLD).value();
+    auto edges = v1.OutEdges(ms::View::OLD);
+    ASSERT_TRUE(edges.has_value());
+    ASSERT_EQ(edges->edges.size(), 1U);
+    auto edge = edges->edges[0];
+    ASSERT_TRUE(acc2->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(*v1.RemoveLabel(acc2->NameToLabel("label")));
+    ASSERT_TRUE(*v2.RemoveLabel(acc2->NameToLabel("label")));
+    ASSERT_TRUE(acc2->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+
+    // GC runs while acc1 still holds a snapshot — must not collect index entries visible to acc1.
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+    std::set<ms::Gid> gids;
+    for (auto vertex : acc1->Vertices(acc1->NameToLabel("label"), ms::View::OLD)) {
+      gids.insert(vertex.Gid());
+    }
+    EXPECT_EQ(gids.size(), 2U);
   }
 }
 

--- a/tests/unit/storage_v2_indices.cpp
+++ b/tests/unit/storage_v2_indices.cpp
@@ -72,6 +72,9 @@ auto MakeMap(Ts &&...values) -> PropertyValue
        std::forward<std::tuple_element_t<1, std::decay_t<Ts>>>(std::get<1>(std::forward<Ts>(values)))}...}};
 };
 
+/// Tag type: run IndexTest with InMemoryStorage + storage_light_edge=true.
+struct InMemoryStorageLightEdge {};
+
 template <typename StorageType>
 class IndexTest : public testing::Test {
  protected:
@@ -79,7 +82,12 @@ class IndexTest : public testing::Test {
     FLAGS_storage_properties_on_edges = true;
     config_.salient.items.properties_on_edges = true;
     config_ = disk_test_utils::GenerateOnDiskConfig(testSuite);
-    this->storage = std::make_unique<StorageType>(config_);
+    if constexpr (std::is_same_v<StorageType, InMemoryStorageLightEdge>) {
+      config_.salient.items.storage_light_edge = true;
+      this->storage = std::make_unique<memgraph::storage::InMemoryStorage>(config_);
+    } else {
+      this->storage = std::make_unique<StorageType>(config_);
+    }
     auto acc = this->storage->Access(memgraph::storage::WRITE);
     this->prop_id = acc->NameToProperty("id");
     this->prop_val = acc->NameToProperty("val");
@@ -97,7 +105,7 @@ class IndexTest : public testing::Test {
   }
 
   void TearDown() override {
-    if (std::is_same<StorageType, memgraph::storage::DiskStorage>::value) {
+    if constexpr (std::is_same_v<StorageType, memgraph::storage::DiskStorage>) {
       disk_test_utils::RemoveRocksDbDirs(testSuite);
     }
     this->storage.reset(nullptr);
@@ -111,7 +119,8 @@ class IndexTest : public testing::Test {
   std::unique_ptr<memgraph::storage::Storage> storage;
 
   auto CreateIndexAccessor() -> std::unique_ptr<memgraph::storage::Storage::Accessor> {
-    if constexpr (std::is_same_v<StorageType, memgraph::storage::InMemoryStorage>) {
+    if constexpr (std::is_same_v<StorageType, memgraph::storage::InMemoryStorage> ||
+                  std::is_same_v<StorageType, InMemoryStorageLightEdge>) {
       return this->storage->ReadOnlyAccess();
     } else {
       return this->storage->UniqueAccess();
@@ -119,7 +128,8 @@ class IndexTest : public testing::Test {
   }
 
   auto DropIndexAccessor() -> std::unique_ptr<memgraph::storage::Storage::Accessor> {
-    if constexpr (std::is_same_v<StorageType, memgraph::storage::InMemoryStorage>) {
+    if constexpr (std::is_same_v<StorageType, memgraph::storage::InMemoryStorage> ||
+                  std::is_same_v<StorageType, InMemoryStorageLightEdge>) {
       return this->storage->Access(memgraph::storage::StorageAccessType::READ);
     } else {
       return this->storage->UniqueAccess();
@@ -171,7 +181,8 @@ class IndexTest : public testing::Test {
   int vertex_id;
 };
 
-using StorageTypes = ::testing::Types<memgraph::storage::InMemoryStorage, memgraph::storage::DiskStorage>;
+using StorageTypes =
+    ::testing::Types<memgraph::storage::InMemoryStorage, memgraph::storage::DiskStorage, InMemoryStorageLightEdge>;
 
 TYPED_TEST_SUITE(IndexTest, StorageTypes);
 

--- a/tests/unit/storage_v2_light_edges.cpp
+++ b/tests/unit/storage_v2_light_edges.cpp
@@ -12,8 +12,14 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <random>
+#include <thread>
+#include <vector>
+
 #include "dbms/database.hpp"
 #include "storage/v2/config.hpp"
+#include "storage/v2/indices/vector_edge_index.hpp"
 #include "storage/v2/inmemory/storage.hpp"
 #include "storage/v2/storage.hpp"
 #include "tests/test_commit_args_helper.hpp"
@@ -981,6 +987,94 @@ TEST(LightEdgesCleanup, DestructorFreesGraveyardEdges) {
   // If we get here without errors, graveyard cleanup worked
 }
 
+// Regression: with the collection-time routing, a DELETE+commit (without any
+// subsequent GC/FreeMemory) leaves the deleted light Edge* sitting in
+// deleted_edges_ — they are NOT pushed to the graveyard until a GC cycle swaps
+// deleted_edges_ and snaps the graveyard watermark. ClearLightEdges() (run from
+// ~InMemoryStorage) must drain deleted_edges_ via LightEdgePool::Destroy or those
+// pool-allocated Edge* leak. Under ASan this test fails on the leak if the drain
+// is missing; under RelWithDebInfo it at least exercises the teardown path.
+TEST(LightEdgesCleanup, DeletedButNotGCedEdgesFreedAtTeardown) {
+  {
+    auto store = MakeLightEdgeStorage();
+    auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+    // Create + commit edges.
+    {
+      auto acc = store->Access(WRITE);
+      auto vf = acc->FindVertex(gid_from, View::NEW);
+      auto vt = acc->FindVertex(gid_to, View::NEW);
+      auto et = acc->NameToEdgeType("LEAK");
+      for (int i = 0; i < 100; ++i) {
+        ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+      }
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    // DELETE + commit all edges. These go to deleted_edges_, NOT the graveyard.
+    {
+      auto acc = store->Access(WRITE);
+      auto vf = acc->FindVertex(gid_from, View::NEW);
+      while (true) {
+        auto out = vf->OutEdges(View::NEW);
+        if (!out.has_value() || out->edges.empty()) break;
+        auto edge = out->edges[0];
+        ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+      }
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    // Deliberately DO NOT run GC/FreeMemory: the deleted Edge* stay in
+    // deleted_edges_ and never reach the graveyard. Store destruction
+    // (~InMemoryStorage -> ClearLightEdges) must free them.
+  }
+  // If we get here without ASan leak/UAF errors, the deleted_edges_ drain worked.
+}
+
+// Regression, Clear() path: same scenario as above but the deleted
+// light edges are reclaimed through InMemoryStorage::Clear() (reachable in
+// analytical mode via the storage clearing path) rather than the destructor.
+TEST(LightEdgesCleanup, DeletedButNotGCedEdgesFreedAtClear) {
+  auto store = MakeLightEdgeStorage();
+  auto *mem_storage = static_cast<InMemoryStorage *>(store.get());
+
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create + commit edges.
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("LEAKC");
+    for (int i = 0; i < 100; ++i) {
+      ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // DELETE + commit all edges -> deleted_edges_ (not graveyard, no GC run).
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    while (true) {
+      auto out = vf->OutEdges(View::NEW);
+      if (!out.has_value() || out->edges.empty()) break;
+      auto edge = out->edges[0];
+      ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // DropGraph routes through ClearLightEdges (analytical). Use it as the
+  // reachable Clear()-family path: it must drain deleted_edges_.
+  mem_storage->SetStorageMode(StorageMode::IN_MEMORY_ANALYTICAL);
+  {
+    auto acc = store->UniqueAccess();
+    acc->DropGraph();
+    // No ASan leak/UAF = deleted_edges_ drained on the clear path.
+  }
+}
+
 // ===========================================================================
 // 12. DropGraph tests
 // ===========================================================================
@@ -1021,5 +1115,919 @@ TEST(LightEdgesCleanup, DropGraphWithGraveyardEdges) {
     auto acc = store->UniqueAccess();
     acc->DropGraph();
     // No crash / ASAN error = graveyard was drained and pool reclaimed.
+  }
+}
+
+TEST(LightEdgesGraveyard, PartialDrainMultipleBatches) {
+  // Create edges in separate transactions so they get different graveyard timestamps.
+  // Hold a reader between the two deletes so only the first batch drains.
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create 2 edges in separate txns
+  Gid edge1_gid, edge2_gid;
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("GY");
+    auto r1 = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(r1.has_value());
+    edge1_gid = r1->Gid();
+    auto r2 = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(r2.has_value());
+    edge2_gid = r2->Gid();
+
+    auto prop = acc->NameToProperty("batch");
+    ASSERT_TRUE(r1->SetProperty(prop, PropertyValue(1)).has_value());
+    ASSERT_TRUE(r2->SetProperty(prop, PropertyValue(2)).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete edge1 in txn A (graveyard batch 1)
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto out = vf->OutEdges(View::NEW);
+    // Find edge1 specifically
+    for (auto &e : out->edges) {
+      if (e.Gid() == edge1_gid) {
+        ASSERT_TRUE(acc->DeleteEdge(&e).has_value());
+        break;
+      }
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // GC to advance timestamps and drain batch 1
+  store->FreeMemory();
+
+  // Now open a reader that pins current state (edge2 still alive)
+  auto reader = store->Access(WRITE);
+
+  // Delete edge2 in txn B (graveyard batch 2)
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto out = vf->OutEdges(View::NEW);
+    ASSERT_TRUE(!out->edges.empty());
+    auto edge = out->edges[0];
+    ASSERT_EQ(edge.Gid(), edge2_gid);
+    ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // GC: batch 2 should NOT drain because reader is still active
+  store->FreeMemory();
+
+  // Reader should still see edge2 with valid properties
+  {
+    auto vf = reader->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    auto out = vf->OutEdges(View::OLD);
+    ASSERT_TRUE(out.has_value());
+    // Reader started after edge1 was deleted but before edge2 was deleted,
+    // so it sees only edge2
+    ASSERT_EQ(out->edges.size(), 1);
+    ASSERT_EQ(out->edges[0].Gid(), edge2_gid);
+    auto prop = reader->NameToProperty("batch");
+    auto val = out->edges[0].GetProperty(prop, View::OLD);
+    ASSERT_TRUE(val.has_value());
+    ASSERT_EQ(val->ValueInt(), 2);
+  }
+
+  // Close reader, GC should now drain batch 2
+  reader.reset();
+  store->FreeMemory();
+
+  // Both edges gone
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+TEST(LightEdgesGraveyard, ConcurrentDeleteAndGC) {
+  // Multiple threads delete edges while GC runs concurrently.
+  // Verify no crash and final state is consistent.
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  constexpr int kEdges = 100;
+
+  // Create many edges
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("CONC");
+    for (int i = 0; i < kEdges; ++i) {
+      ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete edges from multiple threads while GC runs
+  std::atomic<bool> gc_running{true};
+  std::atomic<uint64_t> total_deleted{0};
+
+  std::thread gc_thread([&]() {
+    while (gc_running.load()) {
+      store->FreeMemory();
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    store->FreeMemory();
+    store->FreeMemory();
+  });
+
+  constexpr int kDeleteThreads = 4;
+  std::vector<std::thread> deleters;
+  deleters.reserve(kDeleteThreads);
+  for (int t = 0; t < kDeleteThreads; ++t) {
+    deleters.emplace_back([&]() {
+      while (true) {
+        auto acc = store->Access(WRITE);
+        auto vf = acc->FindVertex(gid_from, View::NEW);
+        if (!vf) break;
+        auto out = vf->OutEdges(View::NEW);
+        if (!out.has_value() || out->edges.empty()) break;
+
+        auto edge = out->edges[0];
+        auto del = acc->DeleteEdge(&edge);
+        if (!del.has_value()) continue;  // serialization conflict, retry
+
+        if (acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value()) {
+          total_deleted.fetch_add(1);
+        }
+      }
+    });
+  }
+
+  for (auto &d : deleters) d.join();
+  gc_running.store(false);
+  gc_thread.join();
+
+  // All edges should be deleted
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+  EXPECT_EQ(total_deleted.load(), kEdges);
+}
+
+TEST(LightEdgesGraveyard, ReaderPinsMultipleGraveyardBatches) {
+  // A long-lived reader pins all graveyard batches. After the reader closes,
+  // GC drains everything in one pass.
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  constexpr int kEdges = 5;
+
+  // Create edges
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("PIN");
+    auto prop = acc->NameToProperty("val");
+    for (int i = 0; i < kEdges; ++i) {
+      auto res = acc->CreateEdge(&*vf, &*vt, et);
+      ASSERT_TRUE(res.has_value());
+      ASSERT_TRUE(res->SetProperty(prop, PropertyValue(i * 10)).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Open a reader that sees all edges
+  auto reader = store->Access(WRITE);
+  {
+    auto vf = reader->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), kEdges);
+  }
+
+  // Delete all edges in separate txns (creates separate graveyard batches)
+  for (int i = 0; i < kEdges; ++i) {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto out = vf->OutEdges(View::NEW);
+    ASSERT_FALSE(out->edges.empty());
+    auto edge = out->edges[0];
+    ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // GC multiple times - nothing should drain because reader is active
+  for (int i = 0; i < 3; ++i) {
+    store->FreeMemory();
+  }
+
+  // Reader still sees all edges with valid properties
+  {
+    auto vf = reader->FindVertex(gid_from, View::OLD);
+    auto out = vf->OutEdges(View::OLD);
+    ASSERT_EQ(out->edges.size(), kEdges);
+    auto prop = reader->NameToProperty("val");
+    for (const auto &e : out->edges) {
+      auto val = e.GetProperty(prop, View::OLD);
+      ASSERT_TRUE(val.has_value());
+      // Just verify the property is readable (value is an int multiple of 10)
+      ASSERT_TRUE(val->IsInt());
+    }
+  }
+
+  // Close reader, GC drains all batches
+  reader.reset();
+  store->FreeMemory();
+
+  // All edges gone
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+TEST(LightEdgesGraveyard, PostCommitIndexIterableBlocksDrain) {
+  // Regression test for collection-time graveyard watermark.
+  //
+  // The bug: a deleted light edge's guard_epoch used to be snapped at COMMIT
+  // time (in FastDiscard) / ABORT time, before any post-commit index iterable
+  // could exist — so guard_epoch was 0. A reader that then started an index
+  // iterable (epoch id 0) was NOT >= guard_epoch, so the graveyard drained on
+  // the next GC and freed the Edge* out from under the live iterable (UAF).
+  //
+  // The fix: light edges no longer push to the graveyard at commit/abort time.
+  // They defer through deleted_edges_ into CollectGarbage, which snaps
+  // guard_epoch = CurrentEpoch() at GC-COLLECTION time — after
+  // RemoveObsoleteEdgeEntries removed the stale index entry, and after any
+  // post-commit reader has Acquired its epoch. The collection-time watermark is
+  // therefore > the iterable's epoch id, so IsSafeToFree stays false until the
+  // iterable is destroyed. (This mirrors heavy edges, whose skiplist-collection
+  // watermark is likewise always >= any iterable opened since the commit.)
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create edge type index.
+  EdgeTypeId et;
+  {
+    auto acc = store->UniqueAccess();
+    et = acc->NameToEdgeType("REL");
+    ASSERT_TRUE(acc->CreateIndex(et).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Create edge.
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete the edge — defers the Edge* into deleted_edges_ (no graveyard push
+  // yet; the graveyard watermark is snapped later at GC-collection time).
+  {
+    auto writer = store->Access(WRITE);
+    auto vf = writer->FindVertex(gid_from, View::NEW);
+    auto edge = vf->OutEdges(View::NEW).value().edges[0];
+    ASSERT_TRUE(writer->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(writer->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Start a post-commit reader.  It acquires epoch id e_R (the delete has not
+  // been collected yet, so no graveyard watermark exists for it).
+  auto reader = store->Access(WRITE);
+  // Constructing the iterable acquires epoch e_R from light_edge_iterable_tracker_.
+  // The iterable is kept alive for the rest of the test to hold the epoch guard.
+  auto iterable = std::make_optional(reader->Edges(et, View::OLD));
+
+  // GC cycle 1: CollectGarbage swaps the edge out of deleted_edges_,
+  // RemoveObsoleteEdgeEntries removes the stale index entry, then the
+  // collection-time light arm snaps guard_epoch = CurrentEpoch() > e_R, so
+  // IsSafeToFree(guard_epoch) stays false while e_R is live and the Edge* is NOT
+  // freed. Iterating the index iterable and dereferencing each Edge would be a
+  // use-after-free (ASan abort) had the drain freed it prematurely.
+  auto probe_iterable = [&] {
+    for (auto edge : *iterable) {
+      (void)edge.Gid();
+      (void)edge.EdgeType();
+    }
+  };
+  store->FreeMemory();
+  probe_iterable();
+
+  // A second GC cycle must also leave the Edge* alive.
+  store->FreeMemory();
+  probe_iterable();
+
+  // Destroying the iterable releases e_R, so the graveyard may now drain.
+  iterable.reset();  // Note: Result<Iterable> — reset the optional
+  reader.reset();
+  store->FreeMemory();
+
+  // The deleted edge must no longer be visible to a fresh transaction.
+  {
+    auto checker = store->Access(WRITE);
+    auto vf = checker->FindVertex(gid_from, View::NEW);
+    ASSERT_TRUE(vf.has_value());
+    auto out = vf->OutEdges(View::NEW);
+    ASSERT_TRUE(out.has_value());
+    EXPECT_EQ(out->edges.size(), 0U) << "deleted light edge must no longer be visible after drain";
+  }
+}
+
+// UAF realization test for the commit fast-path (FastDiscard).
+//
+// It ITERATES the post-commit index iterable AFTER a FreeMemory drain and
+// dereferences each Edge (via .Gid(), which reads edge_.ptr->gid). With the old
+// commit-time guard_epoch snap (guard_epoch == 0) the drain would free the Edge*
+// here, so this iteration would be a use-after-free that ASan catches. With the
+// collection-time watermark the Edge* is kept alive, so the iteration is valid.
+TEST(LightEdgesGraveyard, PostCommitIterateAfterDrainNoUseAfterFreeFastDiscard) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  EdgeTypeId et;
+  {
+    auto acc = store->UniqueAccess();
+    et = acc->NameToEdgeType("REL");
+    ASSERT_TRUE(acc->CreateIndex(et).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  Gid edge_gid{};
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto e = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(e.has_value());
+    edge_gid = e->Gid();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete + commit. The commit fast-path (FastDiscard) defers the Edge* to
+  // deleted_edges_; no graveyard push happens yet, so no early guard_epoch == 0.
+  {
+    auto writer = store->Access(WRITE);
+    auto vf = writer->FindVertex(gid_from, View::NEW);
+    auto edge = vf->OutEdges(View::NEW).value().edges[0];
+    ASSERT_TRUE(writer->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(writer->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Post-commit reader: opens an edge-type-index iterable that still references
+  // the deleted-but-not-yet-collected Edge*. Its epoch guard must block the free.
+  auto reader = store->Access(WRITE);
+  auto iterable = std::make_optional(reader->Edges(et, View::OLD));
+
+  // Drain attempt. With the early-snap bug this frees the Edge* now (guard_epoch
+  // was 0). With the fix, the collection-time watermark keeps it alive.
+  store->FreeMemory();
+
+  // ITERATE and dereference every Edge in the iterable. If the Edge* were freed
+  // by the drain above, .Gid() would be a use-after-free (ASan abort). We accept
+  // any gid value; the point is that the dereference must touch live memory.
+  std::size_t seen = 0;
+  for (auto edge : *iterable) {
+    (void)edge.Gid();
+    (void)edge.EdgeType();
+    ++seen;
+  }
+  // The deleted edge may or may not pass the OLD-view filter; either way the
+  // iteration must not crash. Touch is what matters for the UAF probe.
+  (void)seen;
+
+  // Release the reader; now the graveyard may drain.
+  iterable.reset();
+  reader.reset();
+  store->FreeMemory();
+
+  // The deleted edge must no longer be visible to a fresh transaction.
+  {
+    auto checker = store->Access(WRITE);
+    auto vf = checker->FindVertex(gid_from, View::NEW);
+    ASSERT_TRUE(vf.has_value());
+    auto out = vf->OutEdges(View::NEW);
+    ASSERT_TRUE(out.has_value());
+    EXPECT_EQ(out->edges.size(), 0U) << "deleted light edge must no longer be visible after drain";
+  }
+}
+
+// ===========================================================================
+// 7. FindEdge
+// ===========================================================================
+
+// FindEdge is a private method tested indirectly through WAL recovery,
+// snapshot recovery, and replication. We test the public edge-lookup behavior
+// here (via OutEdges/InEdges on vertices).
+
+TEST(LightEdgesStress, ConcurrentCrudWithIndices) {
+  constexpr int kVertices = 100;
+  constexpr int kWriterThreads = 4;
+  constexpr int kReaderThreads = 4;
+  constexpr int kWriterIterations = 200;
+
+  auto store = MakeLightEdgeStorage();
+
+  // --- Setup: create vertices ---
+  std::vector<Gid> vertex_gids;
+  vertex_gids.reserve(kVertices);
+  {
+    auto acc = store->Access(WRITE);
+    for (int i = 0; i < kVertices; ++i) {
+      auto v = acc->CreateVertex();
+      vertex_gids.push_back(v.Gid());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // --- Setup: create edge indices (requires UniqueAccess, single-threaded) ---
+
+  EdgeTypeId stress_et;
+  PropertyId weight_prop;
+
+  // Edge type index on STRESS_ET
+  {
+    auto acc = store->UniqueAccess();
+    stress_et = acc->NameToEdgeType("STRESS_ET");
+    ASSERT_TRUE(acc->CreateIndex(stress_et).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Edge type + property index on (STRESS_ET, weight)
+  {
+    auto acc = store->UniqueAccess();
+    stress_et = acc->NameToEdgeType("STRESS_ET");
+    weight_prop = acc->NameToProperty("weight");
+    ASSERT_TRUE(acc->CreateIndex(stress_et, weight_prop).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Global edge property index on weight
+  {
+    auto acc = store->UniqueAccess();
+    weight_prop = acc->NameToProperty("weight");
+    ASSERT_TRUE(acc->CreateGlobalEdgeIndex(weight_prop).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Vector edge index on (VEC_ET, embedding) with dimension=4
+  EdgeTypeId vec_et;
+  PropertyId embedding_prop;
+  {
+    auto acc = store->UniqueAccess();
+    vec_et = acc->NameToEdgeType("VEC_ET");
+    embedding_prop = acc->NameToProperty("embedding");
+    VectorEdgeIndexSpec spec{
+        .index_name = "stress_vec_idx",
+        .edge_type_filter =
+            memgraph::storage::VectorEdgeTypeFilter{memgraph::storage::VectorMatchMode::SINGLE, {vec_et}},
+        .property = embedding_prop,
+        .metric_kind = unum::usearch::metric_kind_t::l2sq_k,
+        .dimension = 4,
+        .resize_coefficient = 2,
+        .capacity = static_cast<std::size_t>(kWriterThreads * kWriterIterations),
+        .scalar_kind = unum::usearch::scalar_kind_t::f32_k};
+    ASSERT_TRUE(acc->CreateVectorEdgeIndex(spec).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // --- Concurrent phase ---
+  std::atomic<bool> running{true};
+  std::atomic<int> writers_done{0};
+  std::atomic<uint64_t> total_creates{0};
+  std::atomic<uint64_t> total_deletes{0};
+  std::atomic<uint64_t> total_updates{0};
+
+  // Writer threads
+  std::vector<std::thread> writers;
+  writers.reserve(kWriterThreads);
+  for (int t = 0; t < kWriterThreads; ++t) {
+    writers.emplace_back([&, t]() {
+      std::mt19937 rng(42 + t);
+      std::uniform_int_distribution<int> vertex_dist(0, kVertices - 1);
+      std::uniform_int_distribution<int> op_dist(0, 2);  // 0=create, 1=delete, 2=update
+      std::uniform_int_distribution<int> weight_dist(1, 10000);
+      std::uniform_real_distribution<float> float_dist(-1.0f, 1.0f);
+
+      for (int i = 0; i < kWriterIterations; ++i) {
+        int op = op_dist(rng);
+
+        if (op == 0) {
+          // CREATE edge with STRESS_ET + weight property
+          auto acc = store->Access(WRITE);
+          int from_idx = vertex_dist(rng);
+          int to_idx = vertex_dist(rng);
+          auto vf = acc->FindVertex(vertex_gids[from_idx], View::NEW);
+          auto vt = acc->FindVertex(vertex_gids[to_idx], View::NEW);
+          if (!vf || !vt) continue;
+
+          auto et = acc->NameToEdgeType("STRESS_ET");
+          auto res = acc->CreateEdge(&*vf, &*vt, et);
+          if (!res.has_value()) continue;
+
+          auto wp = acc->NameToProperty("weight");
+          res->SetProperty(wp, PropertyValue(weight_dist(rng)));
+
+          if (acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value()) {
+            total_creates.fetch_add(1);
+          }
+        } else if (op == 1) {
+          // DELETE an edge from a random vertex
+          auto acc = store->Access(WRITE);
+          int from_idx = vertex_dist(rng);
+          auto vf = acc->FindVertex(vertex_gids[from_idx], View::NEW);
+          if (!vf) continue;
+
+          auto out = vf->OutEdges(View::NEW);
+          if (!out.has_value() || out->edges.empty()) continue;
+
+          auto edge = out->edges[0];
+          auto del = acc->DeleteEdge(&edge);
+          if (!del.has_value()) continue;
+
+          if (acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value()) {
+            total_deletes.fetch_add(1);
+          }
+        } else {
+          // UPDATE property on an existing STRESS_ET edge
+          auto acc = store->Access(WRITE);
+          int from_idx = vertex_dist(rng);
+          auto vf = acc->FindVertex(vertex_gids[from_idx], View::NEW);
+          if (!vf) continue;
+
+          auto et = acc->NameToEdgeType("STRESS_ET");
+          auto out = vf->OutEdges(View::NEW, {et});
+          if (!out.has_value() || out->edges.empty()) continue;
+
+          auto edge = out->edges[0];
+          auto wp = acc->NameToProperty("weight");
+          auto set_res = edge.SetProperty(wp, PropertyValue(weight_dist(rng)));
+          if (!set_res.has_value()) continue;
+
+          if (acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value()) {
+            total_updates.fetch_add(1);
+          }
+        }
+      }
+
+      // Also create some edges with VEC_ET + embedding property for vector index
+      for (int i = 0; i < 10; ++i) {
+        auto acc = store->Access(WRITE);
+        int from_idx = vertex_dist(rng);
+        int to_idx = vertex_dist(rng);
+        auto vf = acc->FindVertex(vertex_gids[from_idx], View::NEW);
+        auto vt = acc->FindVertex(vertex_gids[to_idx], View::NEW);
+        if (!vf || !vt) continue;
+
+        auto et = acc->NameToEdgeType("VEC_ET");
+        auto res = acc->CreateEdge(&*vf, &*vt, et);
+        if (!res.has_value()) continue;
+
+        auto ep = acc->NameToProperty("embedding");
+        std::vector<PropertyValue> vec_vals;
+        vec_vals.reserve(4);
+        for (int d = 0; d < 4; ++d) {
+          vec_vals.emplace_back(static_cast<double>(float_dist(rng)));
+        }
+        res->SetProperty(ep, PropertyValue(std::move(vec_vals)));
+
+        acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs());
+      }
+
+      if (writers_done.fetch_add(1) + 1 == kWriterThreads) {
+        running.store(false);
+      }
+    });
+  }
+
+  // Reader threads
+  std::vector<std::thread> readers;
+  readers.reserve(kReaderThreads);
+  for (int t = 0; t < kReaderThreads; ++t) {
+    readers.emplace_back([&, t]() {
+      std::mt19937 rng(1000 + t);
+      std::uniform_int_distribution<int> vertex_dist(0, kVertices - 1);
+      std::uniform_int_distribution<int> query_dist(0, 3);
+      std::uniform_real_distribution<float> float_dist(-1.0f, 1.0f);
+
+      while (running.load()) {
+        int query = query_dist(rng);
+
+        if (query == 0) {
+          // Vertex scan: pick a random vertex, read its out-edges and properties
+          auto acc = store->Access(WRITE);
+          int idx = vertex_dist(rng);
+          auto vf = acc->FindVertex(vertex_gids[idx], View::NEW);
+          if (!vf) continue;
+          auto out = vf->OutEdges(View::NEW);
+          if (!out.has_value()) continue;
+          for (const auto &edge : out->edges) {
+            // Read properties to exercise Edge* dereferencing
+            [[maybe_unused]] auto props = edge.Properties(View::NEW);
+          }
+        } else if (query == 1) {
+          // Edge type index query
+          auto acc = store->Access(WRITE);
+          auto et = acc->NameToEdgeType("STRESS_ET");
+          auto edges = acc->Edges(et, View::NEW);
+          uint64_t count = 0;
+          for ([[maybe_unused]] const auto &e : edges) {
+            ++count;
+          }
+          // Just verify iteration works without crash
+          (void)count;
+        } else if (query == 2) {
+          // Edge type + property index query
+          auto acc = store->Access(WRITE);
+          auto et = acc->NameToEdgeType("STRESS_ET");
+          auto wp = acc->NameToProperty("weight");
+          auto edges = acc->Edges(et, wp, View::NEW);
+          uint64_t count = 0;
+          for ([[maybe_unused]] const auto &e : edges) {
+            ++count;
+          }
+          (void)count;
+        } else {
+          // Global edge property index query
+          auto acc = store->Access(WRITE);
+          auto wp = acc->NameToProperty("weight");
+          auto edges = acc->Edges(wp, View::NEW);
+          uint64_t count = 0;
+          for ([[maybe_unused]] const auto &e : edges) {
+            ++count;
+          }
+          (void)count;
+        }
+      }
+    });
+  }
+
+  // GC thread
+  std::thread gc_thread([&]() {
+    while (running.load()) {
+      store->FreeMemory();
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    // Final GC passes
+    store->FreeMemory();
+    store->FreeMemory();
+  });
+
+  // Join all threads
+  for (auto &w : writers) w.join();
+  for (auto &r : readers) r.join();
+  gc_thread.join();
+
+  // --- Verification ---
+  // Count edges via vertex scan
+  uint64_t vertex_scan_count = 0;
+  {
+    auto acc = store->Access(WRITE);
+    for (const auto &gid : vertex_gids) {
+      auto v = acc->FindVertex(gid, View::OLD);
+      if (!v) continue;
+      auto out = v->OutEdges(View::OLD);
+      if (out.has_value()) {
+        vertex_scan_count += out->edges.size();
+      }
+    }
+  }
+
+  // Count edges via edge type index
+  uint64_t stress_et_index_count = 0;
+  {
+    auto acc = store->Access(WRITE);
+    auto et = acc->NameToEdgeType("STRESS_ET");
+    auto edges = acc->Edges(et, View::OLD);
+    for ([[maybe_unused]] const auto &e : edges) {
+      ++stress_et_index_count;
+    }
+  }
+
+  // Count edges via edge type + property index
+  uint64_t stress_et_prop_index_count = 0;
+  {
+    auto acc = store->Access(WRITE);
+    auto et = acc->NameToEdgeType("STRESS_ET");
+    auto wp = acc->NameToProperty("weight");
+    auto edges = acc->Edges(et, wp, View::OLD);
+    for ([[maybe_unused]] const auto &e : edges) {
+      ++stress_et_prop_index_count;
+    }
+  }
+
+  // Count edges via global edge property index
+  uint64_t global_prop_index_count = 0;
+  {
+    auto acc = store->Access(WRITE);
+    auto wp = acc->NameToProperty("weight");
+    auto edges = acc->Edges(wp, View::OLD);
+    for ([[maybe_unused]] const auto &e : edges) {
+      ++global_prop_index_count;
+    }
+  }
+
+  // Count VEC_ET edges via vertex scan
+  uint64_t vec_et_count = 0;
+  {
+    auto acc = store->Access(WRITE);
+    auto vet = acc->NameToEdgeType("VEC_ET");
+    for (const auto &gid : vertex_gids) {
+      auto v = acc->FindVertex(gid, View::OLD);
+      if (!v) continue;
+      auto out = v->OutEdges(View::OLD);
+      if (!out.has_value()) continue;
+      for (const auto &e : out->edges) {
+        if (e.EdgeType() == vet) ++vec_et_count;
+      }
+    }
+  }
+
+  // Vector index search (just verify no crash, don't assert exact counts)
+  {
+    auto acc = store->Access(WRITE);
+    std::vector<float> query_vec{0.1f, 0.2f, 0.3f, 0.4f};
+    auto results = acc->VectorIndexSearchOnEdges("stress_vec_idx", 5, query_vec);
+    // Results may be empty if all VEC_ET edges were deleted
+    (void)results;
+  }
+
+  // Verify counts are consistent
+  // stress_et_index_count should match STRESS_ET edges from vertex scan
+  uint64_t stress_et_from_vertex_scan = vertex_scan_count - vec_et_count;
+  EXPECT_EQ(stress_et_index_count, stress_et_from_vertex_scan);
+
+  // edge type+property index count should equal edge type index count
+  // (all STRESS_ET edges have the weight property set)
+  EXPECT_EQ(stress_et_prop_index_count, stress_et_index_count);
+
+  // global edge property index count should equal edge type+property index count
+  // (only STRESS_ET edges have the weight property, VEC_ET edges have embedding)
+  EXPECT_EQ(global_prop_index_count, stress_et_prop_index_count);
+
+  // Sanity: we should have done some creates and deletes
+  EXPECT_GT(total_creates.load(), 0u);
+  EXPECT_GT(total_deletes.load(), 0u);
+  EXPECT_GT(total_updates.load(), 0u);
+
+  // Run final GC and verify no crash during cleanup
+  store->FreeMemory();
+  store->FreeMemory();
+}
+
+// ===========================================================================
+// 12. DropGraph tests
+// ===========================================================================
+
+// DropGraph on a light-edge storage must free all edges (no
+// ASAN/MSAN errors), leave the storage empty, and leave the pool reusable.
+
+// A light edge created AND deleted in the same committed transaction, never GC'd.
+// When this is the only transaction in flight, FastDiscardOfDeltas fires at
+// commit time (no older/newer transactions), which routes the deleted Edge* into
+// deleted_edges_; ClearLightEdges then drains it. This test verifies the basic
+// DropGraph + ClearLightEdges path for the single-transaction case. The
+// concurrent-transaction variant (FastDiscard blocked) is covered by
+// DropGraphFreesDeltaChainOnlyEdgesWithConcurrentTxn below.
+// NOTE: DropGraph does NOT call Clear() — it calls ClearLightEdges directly plus
+// HarvestDeltaChainOnlyLightEdges.
+TEST(LightEdgesCleanup, DropGraphFreesDeltaChainOnlyEdges) {
+  auto store = MakeLightEdgeStorage();
+  auto *mem_storage = static_cast<InMemoryStorage *>(store.get());
+
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // In ONE transaction: create an edge and immediately delete it, then commit.
+  // FastDiscard fires (only transaction), so the Edge* lands in deleted_edges_
+  // after commit — ClearLightEdges drains it.
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto etype = acc->NameToEdgeType("EPHEMERAL");
+    auto edge_res = acc->CreateEdge(&*vf, &*vt, etype);
+    ASSERT_TRUE(edge_res.has_value());
+    // Delete the edge in the same transaction before committing.
+    ASSERT_TRUE(acc->DeleteEdge(&*edge_res).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Deliberately do NOT call FreeMemory — GC must NOT have collected the delta
+  // chain. In the single-txn case the edge is in deleted_edges_ (not the
+  // graveyard), so ClearLightEdges will drain it.
+
+  mem_storage->SetStorageMode(StorageMode::IN_MEMORY_ANALYTICAL);
+  {
+    auto acc = store->UniqueAccess();
+    acc->DropGraph();
+    // No ASan leak = ClearLightEdges drained deleted_edges_ (single-txn path).
+  }
+
+  // Storage must be fully empty and the pool reusable after DropGraph.
+  mem_storage->SetStorageMode(StorageMode::IN_MEMORY_TRANSACTIONAL);
+  {
+    auto acc = store->Access(READ);
+    int edge_count = 0;
+    for (auto vertex : acc->Vertices(View::OLD)) {
+      auto out = vertex.OutEdges(View::OLD);
+      if (out.has_value()) edge_count += static_cast<int>(out->edges.size());
+    }
+    EXPECT_EQ(edge_count, 0);
+  }
+
+  // Pool must still be usable after DropGraph + Reclaim.
+  auto [gf2, gt2] = CreateTwoVertices(store.get());
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gf2, View::NEW);
+    auto vt = acc->FindVertex(gt2, View::NEW);
+    ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, acc->NameToEdgeType("NEW")).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+}
+
+// DropGraph must free delta-chain-only light edges even when FastDiscardOfDeltas
+// was blocked by a concurrent older transaction.
+//
+// FastDiscardOfDeltas only fires when ALL of the following hold at txn B's
+// commit time:
+//   (a) OldestActive() == commit_ts_B  — B is the oldest still-active entry
+//   (b) transaction_id_  == B.id + 1  — no newer transaction was ever opened
+// Opening txn A BEFORE txn B ensures A's start_timestamp < B's commit_ts, so
+// condition (a) fails: OldestActive() returns A's start_ts, not commit_ts_B.
+// FastDiscard is blocked. B's deleted Edge* therefore stays in
+// committed_transactions_ as a RECREATE_OBJECT delta (delta-chain-only).
+// Without the HarvestDeltaChainOnlyLightEdges() call in DropGraph,
+// committed_transactions_.clear() destroys the delta and loses the only handle
+// to the pool-allocated Edge* — a memory leak. Under ASan this test reports a
+// leak without the fix and is clean with it.
+TEST(LightEdgesCleanup, DropGraphFreesDeltaChainOnlyEdgesWithConcurrentTxn) {
+  auto store = MakeLightEdgeStorage();
+  auto *mem_storage = static_cast<InMemoryStorage *>(store.get());
+
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Open txn A first so its start_timestamp is registered in the commit log as
+  // the oldest active entry. A does no writes — it only pins the commit log.
+  auto acc_a = store->Access(WRITE);
+
+  // Txn B: create and immediately delete an edge, then commit.
+  // FastDiscard is blocked (see above), so the Edge* stays in
+  // committed_transactions_ as a RECREATE_OBJECT delta-chain-only reference.
+  {
+    auto acc_b = store->Access(WRITE);
+    auto vf = acc_b->FindVertex(gid_from, View::NEW);
+    auto vt = acc_b->FindVertex(gid_to, View::NEW);
+    auto etype = acc_b->NameToEdgeType("EPHEMERAL_CONCURRENT");
+    auto edge_res = acc_b->CreateEdge(&*vf, &*vt, etype);
+    ASSERT_TRUE(edge_res.has_value());
+    ASSERT_TRUE(acc_b->DeleteEdge(&*edge_res).has_value());
+    ASSERT_TRUE(acc_b->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Abort txn A WITHOUT calling FreeMemory so committed_transactions_ still
+  // holds B's delta chain (the only owner of the deleted Edge*). Because GC never
+  // ran, the edge is still a delta-chain-only reference — it never reached the
+  // graveyard.
+  acc_a->Abort();
+  acc_a.reset();
+
+  // DropGraph on the analytical accessor. Without
+  // HarvestDeltaChainOnlyLightEdges (before committed_transactions_.clear()),
+  // ASan reports a pool-allocated Edge* leak here.
+  mem_storage->SetStorageMode(StorageMode::IN_MEMORY_ANALYTICAL);
+  {
+    auto acc = store->UniqueAccess();
+    acc->DropGraph();
+    // No ASan leak = HarvestDeltaChainOnlyLightEdges() ran before
+    // committed_transactions_->clear() inside DropGraph (F2 fix).
+  }
+
+  // Storage must be fully empty after DropGraph.
+  mem_storage->SetStorageMode(StorageMode::IN_MEMORY_TRANSACTIONAL);
+  {
+    auto acc = store->Access(READ);
+    int edge_count = 0;
+    for (auto vertex : acc->Vertices(View::OLD)) {
+      auto out = vertex.OutEdges(View::OLD);
+      if (out.has_value()) edge_count += static_cast<int>(out->edges.size());
+    }
+    EXPECT_EQ(edge_count, 0);
+  }
+
+  // Pool must still be usable after DropGraph + Reclaim.
+  auto [gf3, gt3] = CreateTwoVertices(store.get());
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gf3, View::NEW);
+    auto vt = acc->FindVertex(gt3, View::NEW);
+    ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, acc->NameToEdgeType("NEW")).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
   }
 }


### PR DESCRIPTION
Adds the per-storage light_edge_iterable_tracker_ (EpochTracker-backed), the gated light branch of MakeEdgePin (LightEdgeIterableGuard), the LightEdgeIterable forward iterator, and the epoch-gated graveyard drain.

Deleted light edges follow the heavy-edge path: FastDiscard/Abort route Edge* into deleted_edges_, and the graveyard push + guard_epoch snapshot (= CurrentEpoch()) happens only at GC-collection time, after RemoveObsoleteEdgeEntries, so a post-commit index iterable blocks the drain until it releases. ClearLightEdges drains deleted_edges_ at teardown to avoid leaking deleted-but-not-GCed light edges.