### PR TITLE
fix(query): bind IS NULL and string predicates looser than arithmetic

### DIFF
--- a/src/query/frontend/ast/cypher_main_visitor.cpp
+++ b/src/query/frontend/ast/cypher_main_visitor.cpp
@@ -3543,34 +3543,9 @@ antlrcpp::Any CypherMainVisitor::visitPartialComparisonExpression(
   return 0;
 }
 
-// Addition and subtraction.
-antlrcpp::Any CypherMainVisitor::visitExpression7(MemgraphCypher::Expression7Context *ctx) {
-  return LeftAssociativeOperatorExpression(
-      ctx->expression6(), ctx->children, {MemgraphCypher::PLUS, MemgraphCypher::MINUS});
-}
-
-// Multiplication, division, modding.
-antlrcpp::Any CypherMainVisitor::visitExpression6(MemgraphCypher::Expression6Context *ctx) {
-  return LeftAssociativeOperatorExpression(
-      ctx->expression5(), ctx->children, {MemgraphCypher::ASTERISK, MemgraphCypher::SLASH, MemgraphCypher::PERCENT});
-}
-
-// Exponentiation.
-antlrcpp::Any CypherMainVisitor::visitExpression5(MemgraphCypher::Expression5Context *ctx) {
-  if (ctx->expression4().size() > 1U) {
-    return LeftAssociativeOperatorExpression(ctx->expression4(), ctx->children, {MemgraphCypher::CARET});
-  }
-  return visitChildren(ctx);
-}
-
-// Unary minus and plus.
-antlrcpp::Any CypherMainVisitor::visitExpression4(MemgraphCypher::Expression4Context *ctx) {
-  return PrefixUnaryOperator(ctx->expression3a(), ctx->children, {MemgraphCypher::PLUS, MemgraphCypher::MINUS});
-}
-
 // IS NULL, IS NOT NULL, STARTS WITH, ..
-antlrcpp::Any CypherMainVisitor::visitExpression3a(MemgraphCypher::Expression3aContext *ctx) {
-  auto *expression = std::any_cast<Expression *>(ctx->expression2a()->accept(this));
+antlrcpp::Any CypherMainVisitor::visitExpression7(MemgraphCypher::Expression7Context *ctx) {
+  auto *expression = std::any_cast<Expression *>(ctx->expression6()->accept(this));
 
   for (auto *op : ctx->stringAndNullOperators()) {
     if (op->IS() && op->NOT() && op->CYPHERNULL()) {
@@ -3580,11 +3555,11 @@ antlrcpp::Any CypherMainVisitor::visitExpression3a(MemgraphCypher::Expression3aC
       expression = static_cast<Expression *>(storage_->Create<IsNullOperator>(expression));
     } else if (op->IN()) {
       expression = static_cast<Expression *>(
-          storage_->Create<InListOperator>(expression, std::any_cast<Expression *>(op->expression2a()->accept(this))));
+          storage_->Create<InListOperator>(expression, std::any_cast<Expression *>(op->expression6()->accept(this))));
     } else if (utils::StartsWith(op->getText(), "=~")) {
       auto *regex_match = storage_->Create<RegexMatch>();
       regex_match->string_expr_ = expression;
-      regex_match->regex_ = std::any_cast<Expression *>(op->expression2a()->accept(this));
+      regex_match->regex_ = std::any_cast<Expression *>(op->expression6()->accept(this));
       expression = regex_match;
     } else {
       std::string function_name;
@@ -3597,12 +3572,37 @@ antlrcpp::Any CypherMainVisitor::visitExpression3a(MemgraphCypher::Expression3aC
       } else {
         throw utils::NotYetImplemented("function '{}'", op->getText());
       }
-      auto *expression2 = std::any_cast<Expression *>(op->expression2a()->accept(this));
+      auto *expression2 = std::any_cast<Expression *>(op->expression6()->accept(this));
       std::vector<Expression *> args = {expression, expression2};
       expression = static_cast<Expression *>(storage_->Create<Function>(function_name, args));
     }
   }
   return expression;
+}
+
+// Addition and subtraction.
+antlrcpp::Any CypherMainVisitor::visitExpression6(MemgraphCypher::Expression6Context *ctx) {
+  return LeftAssociativeOperatorExpression(
+      ctx->expression5(), ctx->children, {MemgraphCypher::PLUS, MemgraphCypher::MINUS});
+}
+
+// Multiplication, division, modding.
+antlrcpp::Any CypherMainVisitor::visitExpression5(MemgraphCypher::Expression5Context *ctx) {
+  return LeftAssociativeOperatorExpression(
+      ctx->expression4(), ctx->children, {MemgraphCypher::ASTERISK, MemgraphCypher::SLASH, MemgraphCypher::PERCENT});
+}
+
+// Exponentiation.
+antlrcpp::Any CypherMainVisitor::visitExpression4(MemgraphCypher::Expression4Context *ctx) {
+  if (ctx->expression3().size() > 1U) {
+    return LeftAssociativeOperatorExpression(ctx->expression3(), ctx->children, {MemgraphCypher::CARET});
+  }
+  return visitChildren(ctx);
+}
+
+// Unary minus and plus.
+antlrcpp::Any CypherMainVisitor::visitExpression3(MemgraphCypher::Expression3Context *ctx) {
+  return PrefixUnaryOperator(ctx->expression2a(), ctx->children, {MemgraphCypher::PLUS, MemgraphCypher::MINUS});
 }
 
 antlrcpp::Any CypherMainVisitor::visitStringAndNullOperators(MemgraphCypher::StringAndNullOperatorsContext *) {

--- a/src/query/frontend/ast/cypher_main_visitor.hpp
+++ b/src/query/frontend/ast/cypher_main_visitor.hpp
@@ -65,8 +65,8 @@ class CypherMainVisitor : public antlropencypher::MemgraphCypherBaseVisitor {
    * Convert opencypher's n-ary production to ast binary operators.
    *
    * @param _expressions Subexpressions of child for which we construct ast
-   * operators, for example expression6 if we want to create ast nodes for
-   * expression7.
+   * operators, for example expression5 if we want to create ast nodes for
+   * expression6.
    */
   template <typename TExpression>
   Expression *LeftAssociativeOperatorExpression(std::vector<TExpression *> _expressions,
@@ -1025,42 +1025,42 @@ class CypherMainVisitor : public antlropencypher::MemgraphCypherBaseVisitor {
   antlrcpp::Any visitPartialComparisonExpression(MemgraphCypher::PartialComparisonExpressionContext *ctx) override;
 
   /**
-   * Addition and subtraction.
+   * IS NULL, IS NOT NULL, STARTS WITH, ENDS WITH, =~, ...
    *
    * @return Expression*
    */
   antlrcpp::Any visitExpression7(MemgraphCypher::Expression7Context *ctx) override;
 
   /**
-   * Multiplication, division, modding.
+   * Addition and subtraction.
    *
    * @return Expression*
    */
   antlrcpp::Any visitExpression6(MemgraphCypher::Expression6Context *ctx) override;
 
   /**
-   * Exponentiation.
+   * Multiplication, division, modding.
    *
    * @return Expression*
    */
   antlrcpp::Any visitExpression5(MemgraphCypher::Expression5Context *ctx) override;
 
   /**
-   * Unary minus and plus.
+   * Exponentiation.
    *
    * @return Expression*
    */
   antlrcpp::Any visitExpression4(MemgraphCypher::Expression4Context *ctx) override;
 
   /**
-   * IS NULL, IS NOT NULL, STARTS WITH, END WITH, =~, ...
+   * Unary minus and plus.
    *
    * @return Expression*
    */
-  antlrcpp::Any visitExpression3a(MemgraphCypher::Expression3aContext *ctx) override;
+  antlrcpp::Any visitExpression3(MemgraphCypher::Expression3Context *ctx) override;
 
   /**
-   * Does nothing, everything is done in visitExpression3a.
+   * Does nothing, everything is done in visitExpression7.
    *
    * @return Expression*
    */

--- a/src/query/frontend/opencypher/grammar/Cypher.g4
+++ b/src/query/frontend/opencypher/grammar/Cypher.g4
@@ -227,17 +227,20 @@ expression9 : ( NOT )* expression8 ;
 
 expression8 : expression7 ( partialComparisonExpression )* ;
 
-expression7 : expression6 ( ( '+' expression6 ) | ( '-' expression6 ) )* ;
+// String, list and null predicates (IS NULL, IN, STARTS WITH, ...) bind looser
+// than arithmetic but tighter than comparison: a predicate applies to the whole
+// arithmetic expression to its left, not just the right-most operand.
+expression7 : expression6 ( stringAndNullOperators )* ;
 
-expression6 : expression5 ( ( '*' expression5 ) | ( '/' expression5 ) | ( '%' expression5 ) )* ;
+expression6 : expression5 ( ( '+' expression5 ) | ( '-' expression5 ) )* ;
 
-expression5 : expression4 ( '^' expression4 )* ;
+expression5 : expression4 ( ( '*' expression4 ) | ( '/' expression4 ) | ( '%' expression4 ) )* ;
 
-expression4 : ( ( '+' | '-' ) )* expression3a ;
+expression4 : expression3 ( '^' expression3 )* ;
 
-expression3a : expression2a ( stringAndNullOperators )* ;
+expression3 : ( ( '+' | '-' ) )* expression2a ;
 
-stringAndNullOperators : ( ( ( ( '=~' ) | ( IN ) | ( STARTS WITH ) | ( ENDS WITH ) | ( CONTAINS ) ) expression2a) | ( IS CYPHERNULL ) | ( IS NOT CYPHERNULL ) ) ;
+stringAndNullOperators : ( ( ( ( '=~' ) | ( IN ) | ( STARTS WITH ) | ( ENDS WITH ) | ( CONTAINS ) ) expression6) | ( IS CYPHERNULL ) | ( IS NOT CYPHERNULL ) ) ;
 
 expression2a : expression2b ( nodeLabels )? ;
 

--- a/tests/gql_behave/tests/memgraph_V1/features/expressions.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/expressions.feature
@@ -131,3 +131,13 @@ Feature: Expressions
         Then the result should be:
             |   n   |
             | false |
+
+    Scenario: Test IS NULL binds looser than arithmetic
+        Given an empty graph
+        When executing query:
+            """
+            RETURN (null + 1) * 1 IS NULL AS result
+            """
+        Then the result should be:
+            | result |
+            | true   |

--- a/tests/gql_behave/tests/memgraph_V1_on_disk/features/expressions.feature
+++ b/tests/gql_behave/tests/memgraph_V1_on_disk/features/expressions.feature
@@ -131,3 +131,13 @@ Feature: Expressions
         Then the result should be:
             |   n   |
             | false |
+
+    Scenario: Test IS NULL binds looser than arithmetic
+        Given an empty graph
+        When executing query:
+            """
+            RETURN (null + 1) * 1 IS NULL AS result
+            """
+        Then the result should be:
+            | result |
+            | true   |

--- a/tests/unit/cypher_main_visitor.cpp
+++ b/tests/unit/cypher_main_visitor.cpp
@@ -924,6 +924,84 @@ TEST_P(CypherMainVisitorTest, IsNotNull) {
   CheckRWType(query, kRead);
 }
 
+TEST_P(CypherMainVisitorTest, IsNullBindsLooserThanArithmetic) {
+  // `IS NULL` applies to the whole arithmetic expression, not just its
+  // right-most operand. `(null + 1) * 1 IS NULL` parses as
+  // `((null + 1) * 1) IS NULL`, i.e. IsNullOperator wrapping the
+  // MultiplicationOperator, not MultiplicationOperator wrapping IsNullOperator.
+  auto &ast_generator = *GetParam();
+  auto *query = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("RETURN (null + 1) * 1 IS NULL"));
+  ASSERT_TRUE(query);
+  ASSERT_TRUE(query->single_query_);
+  auto *single_query = query->single_query_;
+  auto *return_clause = dynamic_cast<Return *>(single_query->clauses_[0]);
+  auto *is_null = dynamic_cast<IsNullOperator *>(return_clause->body_.named_expressions[0]->expression_);
+  ASSERT_TRUE(is_null);
+  auto *mult = dynamic_cast<MultiplicationOperator *>(is_null->expression_);
+  ASSERT_TRUE(mult);
+  CheckRWType(query, kRead);
+}
+
+TEST_P(CypherMainVisitorTest, IsNullBindsLooserThanAddition) {
+  // `1 + 2 IS NULL` must parse as `(1 + 2) IS NULL`.
+  auto &ast_generator = *GetParam();
+  auto *query = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("RETURN 1 + 2 IS NULL"));
+  ASSERT_TRUE(query);
+  auto *return_clause = dynamic_cast<Return *>(query->single_query_->clauses_[0]);
+  auto *is_null = dynamic_cast<IsNullOperator *>(return_clause->body_.named_expressions[0]->expression_);
+  ASSERT_TRUE(is_null);
+  auto *add = dynamic_cast<AdditionOperator *>(is_null->expression_);
+  ASSERT_TRUE(add);
+  ast_generator.CheckLiteral(add->expression1_, 1);
+  ast_generator.CheckLiteral(add->expression2_, 2);
+  CheckRWType(query, kRead);
+}
+
+TEST_P(CypherMainVisitorTest, ComparisonBindsLooserThanIsNull) {
+  // Comparison is looser than IS NULL: `1 = 2 IS NULL` parses as
+  // `1 = (2 IS NULL)`, so EqualOperator wraps IsNullOperator on its right side.
+  auto &ast_generator = *GetParam();
+  auto *query = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("RETURN 1 = 2 IS NULL"));
+  ASSERT_TRUE(query);
+  auto *return_clause = dynamic_cast<Return *>(query->single_query_->clauses_[0]);
+  auto *eq = dynamic_cast<EqualOperator *>(return_clause->body_.named_expressions[0]->expression_);
+  ASSERT_TRUE(eq);
+  ast_generator.CheckLiteral(eq->expression1_, 1);
+  auto *is_null = dynamic_cast<IsNullOperator *>(eq->expression2_);
+  ASSERT_TRUE(is_null);
+  ast_generator.CheckLiteral(is_null->expression_, 2);
+  CheckRWType(query, kRead);
+}
+
+TEST_P(CypherMainVisitorTest, StringPredicateOperandsBindArithmetic) {
+  // Both sides of STARTS WITH bind the full arithmetic expression:
+  // `'a' + 'b' STARTS WITH 'a' + 'c'` -> startsWith(('a'+'b'), ('a'+'c')).
+  auto &ast_generator = *GetParam();
+  auto *query = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("RETURN 'a' + 'b' STARTS WITH 'a' + 'c'"));
+  ASSERT_TRUE(query);
+  auto *return_clause = dynamic_cast<Return *>(query->single_query_->clauses_[0]);
+  auto *function = dynamic_cast<Function *>(return_clause->body_.named_expressions[0]->expression_);
+  ASSERT_TRUE(function);
+  ASSERT_EQ(function->arguments_.size(), 2U);
+  ASSERT_TRUE(dynamic_cast<AdditionOperator *>(function->arguments_[0]));
+  ASSERT_TRUE(dynamic_cast<AdditionOperator *>(function->arguments_[1]));
+  CheckRWType(query, kRead);
+}
+
+TEST_P(CypherMainVisitorTest, InRightOperandBindsArithmetic) {
+  // The right operand of IN binds the full arithmetic expression:
+  // `1 IN [2] + [1]` -> 1 IN ([2] + [1]).
+  auto &ast_generator = *GetParam();
+  auto *query = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("RETURN 1 IN [2] + [1]"));
+  ASSERT_TRUE(query);
+  auto *return_clause = dynamic_cast<Return *>(query->single_query_->clauses_[0]);
+  auto *in_list = dynamic_cast<InListOperator *>(return_clause->body_.named_expressions[0]->expression_);
+  ASSERT_TRUE(in_list);
+  ast_generator.CheckLiteral(in_list->expression1_, 1);
+  ASSERT_TRUE(dynamic_cast<AdditionOperator *>(in_list->expression2_));
+  CheckRWType(query, kRead);
+}
+
 TEST_P(CypherMainVisitorTest, NotOperator) {
   auto &ast_generator = *GetParam();
   auto *query = dynamic_cast<CypherQuery *>(ast_generator.ParseQuery("RETURN not true"));


### PR DESCRIPTION
The string, list and null predicates (IS NULL, IS NOT NULL, IN, STARTS WITH, ENDS WITH, CONTAINS, =~) now bind looser than the arithmetic operators (* / + -) and tighter than comparison, so a predicate applies to the whole arithmetic expression on each side.

Previously these predicates bound tighter than arithmetic, so `(null + 1) * 1 IS NULL` parsed as `(null + 1) * (1 IS NULL)`. It now parses as `((null + 1) * 1) IS NULL`.