### PR TITLE
Feature (Light Edges / 11) - chore(e2e): pass extra args through pytest_runner 

### DIFF
--- a/tests/e2e/pytest_runner.sh
+++ b/tests/e2e/pytest_runner.sh
@@ -3,4 +3,4 @@
 # This workaround is necessary to run in the same virtualenv as the e2e runner.py
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-python3 "$DIR/$1"
+python3 "$DIR/$1" "${@:2}"

--- a/tests/e2e/replication/conftest.py
+++ b/tests/e2e/replication/conftest.py
@@ -10,8 +10,7 @@
 # licenses/APL.txt.
 
 import pytest
-
-from common import execute_and_fetch_all, connect
+from common import connect, execute_and_fetch_all
 
 
 # The fixture here is more complex because the connection has to be
@@ -42,3 +41,7 @@ def connection():
     if role_holder == "main":
         cursor = connection_holder.cursor()
         execute_and_fetch_all(cursor, "MATCH (n) DETACH DELETE n;")
+
+
+def pytest_addoption(parser):
+    parser.addoption("--with-props", action="store_true", default=False, help="Run tests with properties enabled")


### PR DESCRIPTION
Enables e2e workloads to forward additional arguments to pytest (pytest_runner.sh "${@:2}") and adds the --with-props pytest option to the replication conftest. Pure test-harness plumbing with no runtime logic; prerequisite for the light-edge replication e2e workloads.