### PR TITLE
fix: DEB/RPM/Docker naming consistency on the daily build

### DIFF
--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -128,6 +128,7 @@ jobs:
       arch: ${{ matrix.arch }}
       build_type: RelWithDebInfo
       build_docker_image: ${{ matrix.build_docker_image || 'none' }}
+      daily_build: true
       push_to_github: 'false'
       push_to_s3: 'true'
       s3_dest_dir: "daily-build/memgraph${{ inputs.mock && '_mock' || '' }}/${{ needs.CurrentDateJob.outputs.current_date }}"
@@ -243,6 +244,7 @@ jobs:
       arch: ${{ matrix.build_arch }}
       build_type: RelWithDebInfo
       build_docker_image: ${{ matrix.build_docker_image }}
+      daily_build: true
       memgraph_download_link: >-
         ${{ format(
           'https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/daily-build/memgraph{0}/{1}/ubuntu-24.04{2}{3}/memgraph_{4}-1_{5}.deb',

--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -189,12 +189,11 @@ jobs:
       - name: Resolve memgraph version
         id: version
         run: |
-          # Daily version strings include "+" and "~" (e.g. 3.10.0+57~1935c004bd81)
-          # — both are legal in S3 keys and stored verbatim, but "+" needs to
-          # be percent-encoded in URL paths or HTTP clients treat it as a
-          # space. memgraph_version_url is the URL-safe form for download
-          # links; memgraph_version stays raw for any filename matching.
-          version="$(release/get_version.py --memgraph-root-dir "$(pwd)" '' '' --variant binary)"
+          # The version string includes "+" and "~" — both are legal in S3 keys and
+          # stored verbatim, but "+" must be percent-encoded in URL paths or HTTP
+          # clients treat it as a space. memgraph_version_url is the URL-safe form
+          # for download links; memgraph_version stays raw for any filename matching.
+          version="$(tools/ci/get_master_package_version.sh)"
           version_url="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$version")"
           echo "Resolved memgraph version: $version"
           echo "URL-safe version: $version_url"

--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -276,6 +276,7 @@ jobs:
       run_smoke_tests: ${{ !matrix.cugraph && !inputs.skip_smoke_tests }}
       run_tests: true
       package_deb: "default"
+      upload_debug_symbols: true
       generate_sbom: ${{ matrix.build_arch == 'amd' && !matrix.malloc && !matrix.cuda && !matrix.cugraph }}
     secrets: inherit
 

--- a/.github/workflows/package_mage.yaml
+++ b/.github/workflows/package_mage.yaml
@@ -148,6 +148,7 @@ jobs:
       cuda: ${{ matrix.cuda == 'true' }}
       cugraph: ${{ matrix.cugraph == 'true' }}
       push_to_s3: ${{ matrix.push_to_s3 == 'true' }}
+      upload_debug_symbols: ${{ matrix.push_to_s3 == 'true' }}
       malloc: ${{ matrix.malloc == 'true' }}
       run_smoke_tests: ${{ matrix.run_smoke_tests == 'true' }}
       run_tests: ${{ matrix.run_tests == 'true' }}

--- a/.github/workflows/reusable_package.yaml
+++ b/.github/workflows/reusable_package.yaml
@@ -499,35 +499,50 @@ jobs:
       - name: "Rename Package"
         if: github.ref == 'refs/heads/master' && !inputs.ref
         run: |
-          tag="$(tools/ci/get_latest_tag.sh)"
-          pr="$(git log --pretty=%B | grep -oP '(?<=\(#)\d+(?=\))' | head -n 1)"
-          commit="$(git rev-parse HEAD | cut -c1-12)"
+          # during testing, we will keep the default naming because it uses the
+          # previous tag + number of commits since and the current commit hash
+          # if on master, then store the latest PR number and the commit
 
+          old_debuginfo=""
+          new_debuginfo=""
           if [[ "$OS" == *"debian"* || "$OS" == *"ubuntu"* ]]; then
+            core="$(tools/ci/get_master_package_version.sh)"
             old_name="$(ls -1 $PACKAGE_ARTIFACT_DIR/memgraph_*.deb 2>/dev/null | head -n 1)"
-            new_name="memgraph_${tag}+pr${pr}~${commit}-1_${ARCH}64.deb"
+            new_name="memgraph_${core}-1_${ARCH}64.deb"
+            old_debuginfo="$(ls -1 $PACKAGE_ARTIFACT_DIR/memgraph-debuginfo_*.deb 2>/dev/null | head -n 1)"
+            new_debuginfo="memgraph-debuginfo_${core}-1_${ARCH}64.deb"
           else
+            core="$(tools/ci/get_master_package_version.sh rpm)"
             old_name="$(ls -1 $PACKAGE_ARTIFACT_DIR/memgraph-[0-9]*.rpm 2>/dev/null | head -n 1)"
             if [[ "$ARCH" == "amd" ]]; then
               arch_str="x86_64"
             else
               arch_str="aarch64"
             fi
-            new_name="memgraph-${tag}_0.pr${pr}.${commit}-1.${arch_str}.rpm"
+            new_name="memgraph-${core}-1.${arch_str}.rpm"
+            old_debuginfo="$(ls -1 $PACKAGE_ARTIFACT_DIR/memgraph-debuginfo-*.rpm 2>/dev/null | head -n 1)"
+            new_debuginfo="memgraph-debuginfo-${core}-1.${arch_str}.rpm"
           fi
           mv -v "$old_name" "$PACKAGE_ARTIFACT_DIR/$new_name"
+          # Sidecar only exists for split-debug (RelWithDebInfo) builds.
+          if [[ -n "$old_debuginfo" ]]; then
+            mv -v "$old_debuginfo" "$PACKAGE_ARTIFACT_DIR/$new_debuginfo"
+          fi
 
+          if [[ "$BUILD_DOCKER_IMAGE" != "none" ]]; then
+            docker_core="$(tools/ci/get_master_package_version.sh docker)"
+          fi
           if [[ "$BUILD_DOCKER_IMAGE" == "prod" || "$BUILD_DOCKER_IMAGE" == "both" ]]; then
             for old_name in "$DOCKER_PROD_ARTIFACT_DIR"/memgraph*-docker.tar.gz; do
               [ -e "$old_name" ] || continue
-              new_name="memgraph-${tag}_pr${pr}_${commit}-docker.tar.gz"
+              new_name="memgraph-${docker_core}-docker.tar.gz"
               mv -v "$old_name" "$DOCKER_PROD_ARTIFACT_DIR/$new_name"
             done
           fi
           if [[ "$BUILD_DOCKER_IMAGE" == "debug" || "$BUILD_DOCKER_IMAGE" == "both" ]]; then
             for old_name in "$DOCKER_DEBUG_ARTIFACT_DIR"/memgraph*-docker.tar.gz; do
               [ -e "$old_name" ] || continue
-              new_name="memgraph-${tag}_pr${pr}_${commit}-relwithdebinfo-docker.tar.gz"
+              new_name="memgraph-${docker_core}-relwithdebinfo-docker.tar.gz"
               mv -v "$old_name" "$DOCKER_DEBUG_ARTIFACT_DIR/$new_name"
             done
           fi

--- a/.github/workflows/reusable_package.yaml
+++ b/.github/workflows/reusable_package.yaml
@@ -39,6 +39,10 @@ on:
         type: string
         description: "Git ref to checkout. Default value is the current ref."
         default: ''
+      daily_build:
+        type: boolean
+        description: "Selects the daily/master PR-style package naming (<tag>+pr<pr>~<commit>) instead of using release/get_version.py."
+        default: false
       generate_sbom:
         type: boolean
         description: "Generate SBOM"
@@ -497,11 +501,11 @@ jobs:
             --last-image "memgraph/memgraph:${LAST_VERSION}"
 
       - name: "Rename Package"
-        if: github.ref == 'refs/heads/master' && !inputs.ref
+        if: ${{ inputs.daily_build }}
         run: |
-          # during testing, we will keep the default naming because it uses the
-          # previous tag + number of commits since and the current commit hash
-          # if on master, then store the latest PR number and the commit
+          # Daily builds rename to the PR-style scheme (latest released tag +
+          # PR number + commit). All non-daily callers keep get_version.py
+          # naming via the default (false).
 
           old_debuginfo=""
           new_debuginfo=""

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -198,14 +198,18 @@ jobs:
           fi
 
       - name: Get Memgraph version
+        env:
+          INPUT_REF: ${{ inputs.ref }}
         run: |
-          variant=binary
-          version="${VERSION}"
-          if [[ -n "$version" ]]; then
-            # strip "v" prefix if it exists
-            version="${version#v}"
+          # Match the MEMGRAPH_VERSION format with that used in reusable_package.yaml:
+          # If building on `master` (i.e. the scheduled daily build) then use the format
+          # "{tag}_pr{number}_commit{hash}"
+          # Otherwise use the format provided by get_version.py
+          if [[ -z "$VERSION" && -z "$INPUT_REF" && "$GITHUB_REF" == "refs/heads/master" ]]; then
+            version="$(tools/ci/get_master_package_version.sh)"
+          else
+            version="$(release/get_version.py --memgraph-root-dir "$(pwd)" "${VERSION#v}" '' --variant binary)"
           fi
-          version="$(release/get_version.py --memgraph-root-dir $(pwd) "$VERSION" '' --variant "$variant")"
           echo "MEMGRAPH_VERSION=${version}" >> $GITHUB_ENV
 
       - name: Create wheels directory and fetch wheels if available

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -99,9 +99,9 @@ env:
   ARCH: "${{ inputs.arch }}"
   DOCKER_REPOSITORY_NAME: memgraph/memgraph-mage
   BUILD_TYPE: "${{ inputs.build_type }}"
-  # Split-debug is implicit: always on for RelWithDebInfo packaging, the only
-  # build type CI uses. The MAGE deb build now requires the .debug sidecars
-  # the split produces; build-deb.sh errors out if they're missing.
+  # Split-debug is implicit: on for RelWithDebInfo packaging, the build type CI
+  # uses. When on, the MAGE deb build also emits a memgraph-mage-debuginfo deb
+  # from the .debug sidecars; when off, build-deb.sh skips that deb gracefully.
   SPLIT_DEBUG: "${{ inputs.build_type == 'RelWithDebInfo' && 'true' || 'false' }}"
   BUILD_DOCKER_IMAGE: "${{ inputs.build_docker_image }}"
   MALLOC: "${{ inputs.malloc }}"

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -87,6 +87,10 @@ on:
         type: string
         description: "Version to build"
         default: ''
+      daily_build:
+        type: boolean
+        description: "Selects the daily/master PR-style version (<tag>+pr<pr>~<commit>) instead of using release/get_version.py."
+        default: false
 
 run-name: "Build and test MAGE"
 
@@ -123,6 +127,7 @@ env:
   MEMGRAPH_DOWNLOAD_LINK: ${{ inputs.memgraph_download_link }}
   MEMGRAPH_DEBUGINFO_DOWNLOAD_LINK: ${{ inputs.memgraph_debuginfo_download_link }}
   VERSION: "${{ inputs.version }}"
+  DAILY_BUILD: "${{ inputs.daily_build }}"
   CI_BRANCH: "${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}"
   MONITORING_HOST: ${{ secrets.MONITORING_HOST }}
   MONITORING_USERNAME: ${{ secrets.MONITORING_USERNAME }}
@@ -198,14 +203,12 @@ jobs:
           fi
 
       - name: Get Memgraph version
-        env:
-          INPUT_REF: ${{ inputs.ref }}
         run: |
-          # Match the MEMGRAPH_VERSION format with that used in reusable_package.yaml:
-          # If building on `master` (i.e. the scheduled daily build) then use the format
-          # "{tag}_pr{number}_commit{hash}"
-          # Otherwise use the format provided by get_version.py
-          if [[ -z "$VERSION" && -z "$INPUT_REF" && "$GITHUB_REF" == "refs/heads/master" ]]; then
+          # Match the MEMGRAPH_VERSION format with that used in reusable_package.yaml,
+          # so MAGE artifacts are versioned like the memgraph package they bundle.
+          # Daily builds use the PR-style scheme "{tag}+pr{number}~{commit}"; everything
+          # else (RC/manual/diff) uses release/get_version.py.
+          if [[ "$DAILY_BUILD" == "true" ]]; then
             version="$(tools/ci/get_master_package_version.sh)"
           else
             version="$(release/get_version.py --memgraph-root-dir "$(pwd)" "${VERSION#v}" '' --variant binary)"

--- a/tools/ci/get_master_package_version.sh
+++ b/tools/ci/get_master_package_version.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Single source of truth for the version string of memgraph packages built
+# from master. These are NOT versioned by release/get_version.py — master/daily
+# packages are renamed to <latest-tag>+pr<pr>~<commit>. Both the "Rename Package"
+# step (reusable_package.yaml) and the MAGE download-link resolver
+# (daily_build.yml) consume this.
+set -euo pipefail
+# Which encoding of the (tag, pr, commit) tuple to emit. These mirror the
+# distinct version conventions of each artifact type (cf. release/get_version.py):
+#   binary|deb : tag+pr~commit         (memgraph_<v>-1_<arch>.deb)
+#   rpm        : tag_0.pr.commit        (memgraph-<v>-1.<arch>.rpm)
+#   docker     : tag_pr_commit          (memgraph-<v>[-relwithdebinfo]-docker.tar.gz)
+variant="${1:-binary}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+tag="$("$here/get_latest_tag.sh")"
+pr="$(git log --pretty=%B | grep -oP '(?<=\(#)\d+(?=\))' | head -n 1)"
+commit="$(git rev-parse HEAD | cut -c1-12)"
+case "$variant" in
+  rpm)    printf '%s_0.pr%s.%s' "$tag" "$pr" "$commit" ;;
+  docker) printf '%s_pr%s_%s'   "$tag" "$pr" "$commit" ;;
+  *)      printf '%s+pr%s~%s'   "$tag" "$pr" "$commit" ;;
+esac

--- a/tools/ci/get_master_package_version.sh
+++ b/tools/ci/get_master_package_version.sh
@@ -13,7 +13,8 @@ set -euo pipefail
 variant="${1:-binary}"
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 tag="$("$here/get_latest_tag.sh")"
-pr="$(git log --pretty=%B | grep -oP '(?<=\(#)\d+(?=\))' | head -n 1)"
+commit_log="$(git log --pretty=%B)"
+pr="$(grep -oPm1 '(?<=\(#)\d+(?=\))' <<<"$commit_log" || true)"
 commit="$(git rev-parse HEAD | cut -c1-12)"
 case "$variant" in
   rpm)    printf '%s_0.pr%s.%s' "$tag" "$pr" "$commit" ;;

--- a/tools/ci/mage-build/package/build-deb.sh
+++ b/tools/ci/mage-build/package/build-deb.sh
@@ -50,14 +50,33 @@ tar -xvzf $PACKAGE_DIR -C $SCRIPT_DIR/build/usr/lib/memgraph/
 DEBUG_PACKAGE_DIR="$(dirname "$PACKAGE_DIR")/mage-debug.tar.gz"
 DEBUGINFO_STAGE_ROOT="$SCRIPT_DIR/build-debuginfo/usr/lib/memgraph"
 mkdir -pv "$DEBUGINFO_STAGE_ROOT/query_modules"
-if [[ -f "$DEBUG_PACKAGE_DIR" ]] && \
-   tar -tzf "$DEBUG_PACKAGE_DIR" | grep -q '\.debug$'; then
-    HAS_DEBUGINFO=true
+
+# Diagnostic: who we are and which tarballs actually sit next to mage.tar.gz.
+# A missing or misdetected mage-debug.tar.gz is then obvious in the build log.
+echo "build-deb.sh: user=$(id -un) HOME=${HOME:-} PACKAGE_DIR=$PACKAGE_DIR"
+ls -la "$(dirname "$PACKAGE_DIR")"/*.tar.gz 2>&1 || true
+
+# Detect the split-debug sidecar. Read the listing into a variable before
+# grepping: `tar -tzf … | grep -q` lets grep close the pipe early, and the
+# resulting SIGPIPE on tar is fatal under `set -o pipefail`.
+HAS_DEBUGINFO=false
+if [[ -f "$DEBUG_PACKAGE_DIR" ]]; then
+    debug_listing="$(tar -tzf "$DEBUG_PACKAGE_DIR" 2>/dev/null || true)"
+    if grep -qm1 '\.debug$' <<<"$debug_listing"; then
+        HAS_DEBUGINFO=true
+    fi
+fi
+
+if [[ "$HAS_DEBUGINFO" == "true" ]]; then
     tar -xvzf "$DEBUG_PACKAGE_DIR" -C "$DEBUGINFO_STAGE_ROOT"
 else
-    HAS_DEBUGINFO=false
-    echo "::warning::No .debug sidecars at $DEBUG_PACKAGE_DIR — skipping memgraph-mage-debuginfo deb. Pass --split-debug to produce it."
-    awk 'BEGIN{RS=""; ORS="\n\n"} !/^Package: memgraph-mage-debuginfo$/' \
+    # No sidecars: build-mage ran without --split-debug (which stays optional
+    # for MAGE, as it is for Memgraph). Skip the debuginfo deb gracefully.
+    echo "::warning::No .debug sidecars at $DEBUG_PACKAGE_DIR — skipping memgraph-mage-debuginfo deb ($BUILD_TYPE build)."
+    # Drop the debuginfo stanza from debian/control. Paragraph mode (RS="")
+    # treats each stanza as one record; anchor on embedded newlines because
+    # plain ^/$ match the whole record, not the Package: line within it.
+    awk 'BEGIN{RS="";ORS="\n\n"} $0 !~ /(^|\n)Package: memgraph-mage-debuginfo(\n|$)/' \
         "$SCRIPT_DIR/debian/control" > "$SCRIPT_DIR/debian/control.tmp"
     mv "$SCRIPT_DIR/debian/control.tmp" "$SCRIPT_DIR/debian/control"
     # debhelper's dh_install processes every debian/<pkg>.install file it


### PR DESCRIPTION
Fix inconsistencies in the package naming used during the daily build.
- Bug since #4079 merged - DEB package URL to be downloaded by the MAGE workflow did not match the actual URL -> MAGE builds all fail.
- Longer lasting inconsistency between Memgraph and MAGE versions - when an RC with a new tag was built (e.g. `v3.11.0`), the MAGE packages would be named using the RC tag version (incorrectly), while the Memgraph packages would be using the previous release tag (e.g. `v3.10.1`) -> now both should use the same version.
- Previously, the reusable packaging workflows would use the daily build naming convention if they were detected to be running on the `master` branch - this is not reliable and means that testing the daily build on other branches results in the wrong naming format being used. Added a new `daily_build` input for consistency across branches.
- Add missing debug symbol packages to the daily build and to the package MAGE workflows.

