### PR TITLE
fix(plan): prevent server crash on label disjunctions over many indexed labels

### DIFF
--- a/src/query/cypher_query_interpreter.cpp
+++ b/src/query/cypher_query_interpreter.cpp
@@ -27,6 +27,7 @@
 #include "query/plan/used_index_checker.hpp"
 #include "query/plan/vertex_count_cache.hpp"
 #include "utils/flag_validation.hpp"
+#include "utils/memory_tracker.hpp"
 #include "utils/string.hpp"
 
 #include "parameters/parameters.hpp"
@@ -224,6 +225,13 @@ std::shared_ptr<PlanWrapper> CypherQueryToPlan(frontend::StrippedQuery const &st
                                                PlanCacheLRU *plan_cache, DbAccessor *db_accessor,
                                                plan::v2::QueryPlannerContext &planner_context,
                                                const std::vector<Identifier *> &predefined_identifiers) {
+  // Enforce the global memory limit during query preparation. Without this,
+  // MemoryTrackerCanThrow() is false here (the per-cursor
+  // OutOfMemoryExceptionEnablers only cover execution), so a runaway allocation
+  // while planning would bypass --memory-limit and let the kernel OOM-kill the
+  // whole server instead of aborting just the query.
+  utils::MemoryTracker::OutOfMemoryExceptionEnabler const oom_exception_enabler;
+
   // Skip plan cache when using experimental v2 planner - plans may change as v2 evolves
   const bool use_plan_cache = plan_cache && !flags::AreExperimentsEnabled(flags::Experiments::PLANNER_V2);
   if (use_plan_cache) {

--- a/src/query/plan/rewrite/balanced_union.hpp
+++ b/src/query/plan/rewrite/balanced_union.hpp
@@ -1,0 +1,88 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+/// @file
+/// Lowering for an indexed disjunction over a single node: fold N index scans
+/// into a balanced `Union` tree topped by a single `Distinct`.
+
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "query/frontend/semantic/symbol.hpp"
+#include "query/plan/operator.hpp"
+#include "utils/logging.hpp"
+
+namespace memgraph::query::plan {
+
+/// Fold per-symbol index `scans` into a balanced binary `Union` tree topped by a
+/// single deduplicating `Distinct`, and return the root.
+///
+/// Preconditions (all hold for an indexed label or edge-type disjunction over
+/// one node, and are exactly what make the balancing + single `Distinct` valid):
+///   - every scan produces the same single output symbol `node_symbol`, so the
+///     symbol mapping is identical at every level of the tree;
+///   - the branches combine by pure set-union (`Union` concatenates), so one
+///     global `Distinct` is equivalent to deduplicating at every level;
+///   - the combine operator (`Union`) is order-independent in cost --
+///     `Union(A, B)` costs the same as `Union(B, A)`, and the total cardinality
+///     is the sum of the branches regardless of how they nest -- so the pairing
+///     and nesting are free to optimize for depth. Note this does NOT require
+///     the branches to be equal-cost: they routinely are not (one label may hit
+///     a handful of vertices and another millions), and they are paired by
+///     index order, not by cost.
+///
+/// Do NOT reuse this for query-level `UNION` (per-combinator symbols, `UNION
+/// ALL`) or `Cartesian` (left/right order is the cost decision): those violate
+/// the preconditions, and balancing would change semantics or cost.
+///
+/// Balancing keeps the operator-tree depth at O(log N) in the number of scans
+/// instead of the O(N) of a left-deep chain, which otherwise overflows the
+/// executor thread stack at large N. Balancing trades nothing in logical
+/// (cardinality) cost; what it bounds is the executor stack depth. The single
+/// top `Distinct` removes the duplicates a vertex matching several labels would
+/// otherwise produce.
+///
+/// `scans` must be non-empty. With a single scan the result is that scan
+/// unchanged (no `Union`, no `Distinct`).
+inline std::unique_ptr<LogicalOperator> BalancedDisjunctionUnion(std::vector<std::unique_ptr<LogicalOperator>> scans,
+                                                                 const Symbol &node_symbol) {
+  MG_ASSERT(!scans.empty(), "BalancedDisjunctionUnion requires at least one scan");
+  // More than one branch means a vertex can match several of them, so the
+  // combined output needs deduplicating exactly once at the top.
+  const bool needs_distinct = scans.size() > 1;
+  // Combine adjacent pairs each round; an odd one out is carried over unchanged.
+  while (scans.size() > 1) {
+    std::vector<std::unique_ptr<LogicalOperator>> combined;
+    combined.reserve((scans.size() + 1) / 2);
+    for (std::size_t i = 0; i < scans.size(); i += 2) {
+      if (i + 1 < scans.size()) {
+        combined.push_back(std::make_unique<Union>(std::move(scans[i]),
+                                                   std::move(scans[i + 1]),
+                                                   std::vector<Symbol>{node_symbol},
+                                                   std::vector<Symbol>{node_symbol},
+                                                   std::vector<Symbol>{node_symbol}));
+      } else {
+        combined.push_back(std::move(scans[i]));
+      }
+    }
+    scans = std::move(combined);
+  }
+  auto root = std::move(scans.front());
+  if (needs_distinct) {
+    root = std::make_unique<Distinct>(std::move(root), std::vector<Symbol>{node_symbol});
+  }
+  return root;
+}
+
+}  // namespace memgraph::query::plan

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -36,6 +36,7 @@
 #include "frontend/ast/ast_storage.hpp"
 #include "query/plan/operator.hpp"
 #include "query/plan/preprocess.hpp"
+#include "query/plan/rewrite/balanced_union.hpp"
 #include "query/plan/rewrite/general.hpp"
 #include "query/plan/rewrite/order_by_elimination.hpp"
 #include "storage/v2/id_types.hpp"
@@ -1786,35 +1787,8 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
             scans.push_back(std::move(label_property_index_scan));
           }
         }
-        // Fold the per-label scans into a balanced binary Union tree by combining
-        // adjacent pairs each round. This keeps the operator-tree depth at
-        // O(log N) in the number of labels instead of the O(N) of a left-deep
-        // chain, which otherwise overflows the executor thread stack (#4238).
-        while (scans.size() > 1) {
-          std::vector<std::unique_ptr<LogicalOperator>> combined;
-          combined.reserve((scans.size() + 1) / 2);
-          for (std::size_t i = 0; i < scans.size(); i += 2) {
-            if (i + 1 < scans.size()) {
-              combined.push_back(std::make_unique<Union>(std::move(scans[i]),
-                                                         std::move(scans[i + 1]),
-                                                         std::vector<Symbol>{node_symbol},
-                                                         std::vector<Symbol>{node_symbol},
-                                                         std::vector<Symbol>{node_symbol}));
-            } else {
-              // Odd one out this round is carried over unchanged.
-              combined.push_back(std::move(scans[i]));
-            }
-          }
-          scans = std::move(combined);
-        }
-        auto prev = std::move(scans.front());
-        // Deduplicate the combined disjunction exactly once at the top (a vertex
-        // matching several of the labels would otherwise appear multiple times).
-        if (best_group.indices.size() > 1) {
-          prev = std::make_unique<Distinct>(std::move(prev), std::vector<Symbol>{node_symbol});
-        }
         metadata.is_or_label_filter = true;
-        return ScanByIndexResult{std::move(prev), std::move(metadata)};
+        return ScanByIndexResult{BalancedDisjunctionUnion(std::move(scans), node_symbol), std::move(metadata)};
       }
     }
     return std::nullopt;

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1740,7 +1740,10 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
       // If we satisfy max_vertex_count and if there is a group for which we can find an index let's use it and chain
       // it in unions
       if ((!max_vertex_count || best_group.vertex_count <= *max_vertex_count) && !best_group.indices.empty()) {
-        std::unique_ptr<LogicalOperator> prev;
+        // Collect one index scan per disjoined label, then fold them into a
+        // balanced Union tree with a single deduplicating Distinct on top.
+        std::vector<std::unique_ptr<LogicalOperator>> scans;
+        scans.reserve(best_group.indices.size());
         metadata.labels_to_erase.reserve(best_group.indices.size());
         std::optional<std::vector<storage::PropertyPath>>
             filtered_property_ids;  // Used to check if all indices uses the same filter
@@ -1750,17 +1753,8 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
           if (std::holds_alternative<LabelIx>(index)) {
             metadata.all_property_filters_same = false;
             metadata.labels_to_erase.push_back(std::get<LabelIx>(index));
-            auto scan = std::make_unique<ScanAllByLabel>(input, node_symbol, GetLabel(std::get<LabelIx>(index)), view);
-            if (prev) {
-              auto union_op = std::make_unique<Union>(std::move(prev),
-                                                      std::move(scan),
-                                                      std::vector<Symbol>{node_symbol},
-                                                      std::vector<Symbol>{node_symbol},
-                                                      std::vector<Symbol>{node_symbol});
-              prev = std::make_unique<Distinct>(std::move(union_op), std::vector<Symbol>{node_symbol});
-            } else {
-              prev = std::move(scan);
-            }
+            scans.push_back(
+                std::make_unique<ScanAllByLabel>(input, node_symbol, GetLabel(std::get<LabelIx>(index)), view));
           } else {
             auto &label_property_index = std::get<LabelPropertyIndex>(index);
             metadata.labels_to_erase.push_back(label_property_index.label);
@@ -1789,17 +1783,35 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
                                                            std::move(expr_ranges),
                                                            view);
             label_property_index_scan->index_order_ = label_property_index.order;
-            if (prev) {
-              auto union_op = std::make_unique<Union>(std::move(prev),
-                                                      std::move(label_property_index_scan),
-                                                      std::vector<Symbol>{node_symbol},
-                                                      std::vector<Symbol>{node_symbol},
-                                                      std::vector<Symbol>{node_symbol});
-              prev = std::make_unique<Distinct>(std::move(union_op), std::vector<Symbol>{node_symbol});
+            scans.push_back(std::move(label_property_index_scan));
+          }
+        }
+        // Fold the per-label scans into a balanced binary Union tree by combining
+        // adjacent pairs each round. This keeps the operator-tree depth at
+        // O(log N) in the number of labels instead of the O(N) of a left-deep
+        // chain, which otherwise overflows the executor thread stack (#4238).
+        while (scans.size() > 1) {
+          std::vector<std::unique_ptr<LogicalOperator>> combined;
+          combined.reserve((scans.size() + 1) / 2);
+          for (std::size_t i = 0; i < scans.size(); i += 2) {
+            if (i + 1 < scans.size()) {
+              combined.push_back(std::make_unique<Union>(std::move(scans[i]),
+                                                         std::move(scans[i + 1]),
+                                                         std::vector<Symbol>{node_symbol},
+                                                         std::vector<Symbol>{node_symbol},
+                                                         std::vector<Symbol>{node_symbol}));
             } else {
-              prev = std::move(label_property_index_scan);
+              // Odd one out this round is carried over unchanged.
+              combined.push_back(std::move(scans[i]));
             }
           }
+          scans = std::move(combined);
+        }
+        auto prev = std::move(scans.front());
+        // Deduplicate the combined disjunction exactly once at the top (a vertex
+        // matching several of the labels would otherwise appear multiple times).
+        if (best_group.indices.size() > 1) {
+          prev = std::make_unique<Distinct>(std::move(prev), std::vector<Symbol>{node_symbol});
         }
         metadata.is_or_label_filter = true;
         return ScanByIndexResult{std::move(prev), std::move(metadata)};

--- a/src/query/plan/used_index_checker.cpp
+++ b/src/query/plan/used_index_checker.cpp
@@ -91,11 +91,13 @@ PRE_VISIT(EdgeUniquenessFilter)
 PRE_VISIT(Merge)
 PRE_VISIT(Optional)
 
-bool UsedIndexChecker::PreVisit(Cartesian &op) {
-  op.left_op_->Accept(*this);
-  op.right_op_->Accept(*this);
-  return true;
-}
+// NOTE: For composite operators we intentionally return `true` WITHOUT
+// traversing children here. The operator's own `Accept` already descends into
+// every branch when `PreVisit` returns true. Traversing manually AND returning
+// true makes `Accept` re-traverse, which doubles the work at each binary node
+// and becomes exponential (2^N) over deeply nested operators such as the
+// Union/Distinct chain produced by a label disjunction over indexed labels.
+PRE_VISIT(Cartesian)
 
 PRE_VISIT(EmptyResult)
 PRE_VISIT(Produce)
@@ -107,11 +109,7 @@ PRE_VISIT(OrderBy)
 PRE_VISIT(Distinct)
 PRE_VISIT(PeriodicCommit)
 
-bool UsedIndexChecker::PreVisit(Union &op) {
-  op.left_op_->Accept(*this);
-  op.right_op_->Accept(*this);
-  return true;
-}
+PRE_VISIT(Union)
 
 PRE_VISIT(Unwind)
 
@@ -124,35 +122,15 @@ bool UsedIndexChecker::PreVisit(CallProcedure &op) {
 
 bool UsedIndexChecker::PreVisit([[maybe_unused]] Foreach &op) { return true; }
 
-bool UsedIndexChecker::PreVisit(Apply &op) {
-  op.input_->Accept(*this);
-  op.subquery_->Accept(*this);
-  return true;
-}
+PRE_VISIT(Apply)
 
-bool UsedIndexChecker::PreVisit(IndexedJoin &op) {
-  op.main_branch_->Accept(*this);
-  op.sub_branch_->Accept(*this);
-  return true;
-}
+PRE_VISIT(IndexedJoin)
 
-bool UsedIndexChecker::PreVisit(HashJoin &op) {
-  op.left_op_->Accept(*this);
-  op.right_op_->Accept(*this);
-  return true;
-}
+PRE_VISIT(HashJoin)
 
-bool UsedIndexChecker::PreVisit(PeriodicSubquery &op) {
-  op.input_->Accept(*this);
-  op.subquery_->Accept(*this);
-  return true;
-}
+PRE_VISIT(PeriodicSubquery)
 
-bool UsedIndexChecker::PreVisit(RollUpApply &op) {
-  op.input_->Accept(*this);
-  op.list_collection_branch_->Accept(*this);
-  return true;
-}
+PRE_VISIT(RollUpApply)
 
 #undef PRE_VISIT
 

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -11,6 +11,7 @@
 
 #include "query_plan_checker.hpp"
 
+#include <cmath>
 #include <iostream>
 #include <list>
 #include <memory>
@@ -32,6 +33,8 @@
 #include "query/frontend/semantic/symbol_table.hpp"
 #include "query/plan/operator.hpp"
 #include "query/plan/planner.hpp"
+#include "query/plan/rewrite/balanced_union.hpp"
+#include "query/plan/used_index_checker.hpp"
 
 #include "query_common.hpp"
 #include "utils/bound.hpp"
@@ -3948,6 +3951,8 @@ struct UnionPlanShape : public memgraph::query::plan::HierarchicalLogicalOperato
   using HierarchicalLogicalOperatorVisitor::Visit;
 
   int distinct_count = 0;
+  int union_count = 0;
+  int once_count = 0;
   int cur_union_depth = 0;
   int max_union_depth = 0;
 
@@ -3957,6 +3962,7 @@ struct UnionPlanShape : public memgraph::query::plan::HierarchicalLogicalOperato
   }
 
   bool PreVisit(memgraph::query::plan::Union & /*unused*/) override {
+    ++union_count;
     ++cur_union_depth;
     max_union_depth = std::max(max_union_depth, cur_union_depth);
     return true;
@@ -3967,7 +3973,10 @@ struct UnionPlanShape : public memgraph::query::plan::HierarchicalLogicalOperato
     return true;
   }
 
-  bool Visit(memgraph::query::plan::Once & /*unused*/) override { return true; }
+  bool Visit(memgraph::query::plan::Once & /*unused*/) override {
+    ++once_count;
+    return true;
+  }
 };
 
 TYPED_TEST(TestPlanner, ORLabelExpressionBalancedUnionTree) {
@@ -3994,6 +4003,83 @@ TYPED_TEST(TestPlanner, ORLabelExpressionBalancedUnionTree) {
   planner.plan().Accept(shape);
   EXPECT_EQ(shape.distinct_count, 1);
   EXPECT_EQ(shape.max_union_depth, 3);
+}
+
+// Direct unit test of the disjunction-lowering fold, independent of the planner:
+// feed it N synthetic leaf scans and assert the shape of the tree it builds.
+TEST(BalancedDisjunctionUnion, ShapeByScanCount) {
+  using memgraph::query::plan::BalancedDisjunctionUnion;
+  using memgraph::query::plan::LogicalOperator;
+  using memgraph::query::plan::Once;
+  const memgraph::query::Symbol node_symbol{"n", 0, /*user_declared=*/false};
+
+  auto make_scans = [](int n) {
+    std::vector<std::unique_ptr<LogicalOperator>> scans;
+    scans.reserve(n);
+    for (int i = 0; i < n; ++i) scans.push_back(std::make_unique<Once>());
+    return scans;
+  };
+
+  // A single scan is returned unchanged: no Union, no Distinct.
+  {
+    auto root = BalancedDisjunctionUnion(make_scans(1), node_symbol);
+    UnionPlanShape shape;
+    root->Accept(shape);
+    EXPECT_EQ(shape.distinct_count, 0);
+    EXPECT_EQ(shape.union_count, 0);
+    EXPECT_EQ(shape.max_union_depth, 0);
+    EXPECT_EQ(shape.once_count, 1);
+  }
+
+  // For N > 1: exactly one top Distinct, N-1 Unions, N leaves preserved, and the
+  // tree is balanced so its Union-nesting depth is ceil(log2(N)) rather than the
+  // N-1 of a left-deep chain (the property that keeps the executor stack safe).
+  for (int n : {2, 3, 4, 5, 8, 13, 36}) {
+    auto root = BalancedDisjunctionUnion(make_scans(n), node_symbol);
+    UnionPlanShape shape;
+    root->Accept(shape);
+    EXPECT_EQ(shape.distinct_count, 1) << "n=" << n;
+    EXPECT_EQ(shape.union_count, n - 1) << "n=" << n;
+    EXPECT_EQ(shape.once_count, n) << "n=" << n;
+    const int expected_depth = static_cast<int>(std::ceil(std::log2(n)));
+    EXPECT_EQ(shape.max_union_depth, expected_depth) << "n=" << n;
+  }
+}
+
+// UsedIndexChecker validates a cached plan by collecting the indices it relies
+// on, then checking they are all still ready. For composite operators it relies
+// on Accept to descend into every branch (it must not traverse manually). This
+// asserts that contract holds across a balanced Union tree: every label scan, on
+// both sides at every level, must be collected. A skipped branch would drop a
+// label, letting a stale plan that references a since-dropped index survive
+// validation -- the crash this guards against.
+TEST(UsedIndexChecker, CollectsEveryBranchOfDisjunctionUnion) {
+  using memgraph::query::plan::BalancedDisjunctionUnion;
+  using memgraph::query::plan::LogicalOperator;
+  using memgraph::query::plan::Once;
+  using memgraph::query::plan::ScanAllByLabel;
+  using memgraph::query::plan::UsedIndexChecker;
+
+  FakeDbAccessor dba;
+  const memgraph::query::Symbol node_symbol{"n", 0, /*user_declared=*/false};
+  const std::shared_ptr<LogicalOperator> input = std::make_shared<Once>();
+
+  // Four labels => a depth-2 balanced Union tree, so both branches at both
+  // levels must be traversed for all labels to be collected.
+  std::vector<memgraph::storage::LabelId> labels;
+  std::vector<std::unique_ptr<LogicalOperator>> scans;
+  for (const auto *name : {"L0", "L1", "L2", "L3"}) {
+    auto label = dba.Label(name);
+    labels.push_back(label);
+    scans.push_back(std::make_unique<ScanAllByLabel>(input, node_symbol, label));
+  }
+
+  auto root = BalancedDisjunctionUnion(std::move(scans), node_symbol);
+
+  UsedIndexChecker checker;
+  root->Accept(checker);
+
+  EXPECT_THAT(checker.required_indices_.label_, ::testing::UnorderedElementsAreArray(labels));
 }
 
 TYPED_TEST(TestPlanner, ORLabelExpressionMatchWhereCombination) {

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -3849,8 +3849,9 @@ TYPED_TEST(TestPlanner, ORLabelExpressionWithMultipleLabels) {
   // expect union of union and scan all by label
   std::list<BaseOpChecker *> left_subquery_part{new ExpectScanAllByLabel()};
   std::list<BaseOpChecker *> right_subquery_part{new ExpectScanAllByLabel()};
-  std::list<BaseOpChecker *> first_subquery_plan{new ExpectUnion(left_subquery_part, right_subquery_part),
-                                                 new ExpectDistinct()};
+  // Single deduplicating Distinct sits at the top of the whole Union tree; the
+  // intermediate Union has no Distinct of its own.
+  std::list<BaseOpChecker *> first_subquery_plan{new ExpectUnion(left_subquery_part, right_subquery_part)};
   std::list<BaseOpChecker *> second_subquery_plan{new ExpectScanAllByLabel()};
 
   CheckPlan(planner.plan(),
@@ -3922,8 +3923,9 @@ TYPED_TEST(TestPlanner, ORLabelExpressionWhereClauseMultipleLabels) {
 
   std::list<BaseOpChecker *> left_subquery_part{new ExpectScanAllByLabel()};
   std::list<BaseOpChecker *> right_subquery_part{new ExpectScanAllByLabel()};
-  std::list<BaseOpChecker *> first_subquery_plan{new ExpectUnion(left_subquery_part, right_subquery_part),
-                                                 new ExpectDistinct()};
+  // Single deduplicating Distinct sits at the top of the whole Union tree; the
+  // intermediate Union has no Distinct of its own.
+  std::list<BaseOpChecker *> first_subquery_plan{new ExpectUnion(left_subquery_part, right_subquery_part)};
   std::list<BaseOpChecker *> second_subquery_plan{new ExpectScanAllByLabel()};
 
   CheckPlan(planner.plan(),
@@ -3936,6 +3938,62 @@ TYPED_TEST(TestPlanner, ORLabelExpressionWhereClauseMultipleLabels) {
   DeleteListContent(&second_subquery_plan);
   DeleteListContent(&left_subquery_part);
   DeleteListContent(&right_subquery_part);
+}
+
+// Collects the shape of an index-disjunction plan: how many Distinct operators
+// it contains and the maximum nesting depth of Union operators along any path.
+struct UnionPlanShape : public memgraph::query::plan::HierarchicalLogicalOperatorVisitor {
+  using HierarchicalLogicalOperatorVisitor::PostVisit;
+  using HierarchicalLogicalOperatorVisitor::PreVisit;
+  using HierarchicalLogicalOperatorVisitor::Visit;
+
+  int distinct_count = 0;
+  int cur_union_depth = 0;
+  int max_union_depth = 0;
+
+  bool PreVisit(memgraph::query::plan::Distinct & /*unused*/) override {
+    ++distinct_count;
+    return true;
+  }
+
+  bool PreVisit(memgraph::query::plan::Union & /*unused*/) override {
+    ++cur_union_depth;
+    max_union_depth = std::max(max_union_depth, cur_union_depth);
+    return true;
+  }
+
+  bool PostVisit(memgraph::query::plan::Union & /*unused*/) override {
+    --cur_union_depth;
+    return true;
+  }
+
+  bool Visit(memgraph::query::plan::Once & /*unused*/) override { return true; }
+};
+
+TYPED_TEST(TestPlanner, ORLabelExpressionBalancedUnionTree) {
+  // MATCH (n) WHERE n:L0 OR n:L1 OR ... OR n:L7 RETURN n, all labels indexed.
+  // The disjunction compiles to a single Distinct over a balanced Union tree,
+  // so its depth is O(log N) (ceil(log2(8)) == 3), not the N-1 == 7 of a
+  // left-deep chain. Deep left-deep trees overflow the executor stack.
+  FakeDbAccessor dba;
+  constexpr int kLabels = 8;
+  auto node_identifier = IDENT("n");
+  memgraph::query::Expression *or_expr = nullptr;
+  for (int i = 0; i < kLabels; ++i) {
+    const auto name = "L" + std::to_string(i);
+    dba.SetIndexCount(dba.Label(name), 1);
+    auto label_ix = std::vector<memgraph::query::LabelIx>{this->storage.GetLabelIx(name)};
+    memgraph::query::Expression *test = LABELS_TEST(node_identifier, label_ix);
+    or_expr = or_expr ? static_cast<memgraph::query::Expression *>(OR(or_expr, test)) : test;
+  }
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), WHERE(or_expr), RETURN("n")));
+  auto symbol_table = memgraph::query::MakeSymbolTable(query);
+  auto planner = MakePlanner<TypeParam>(&dba, this->storage, symbol_table, query);
+
+  UnionPlanShape shape;
+  planner.plan().Accept(shape);
+  EXPECT_EQ(shape.distinct_count, 1);
+  EXPECT_EQ(shape.max_union_depth, 3);
 }
 
 TYPED_TEST(TestPlanner, ORLabelExpressionMatchWhereCombination) {


### PR DESCRIPTION
A query like `MATCH (n) WHERE n:L0 OR ... OR n:Ln RETURN n` (all labels indexed) could crash the whole server (OOM-killed or stack-overflow segfault), scaling with the number of labels. 

Three fixes:

1. **Exponential index validation (OOM).** `UsedIndexChecker`'s composite-operator `PreVisit`s were traversing children manually *and* returned `true`, hence `Accept` re-traversed every branch, causing 2^N over the deep Union chain. I've dropped the manual traversal so each branch is visited only once.

2. **Linear tree depth (stack overflow).** The disjunction compiled to a left-deep `Union`+`Distinct` chain, depth linear in N. Now folds into a balanced `Union` tree (depth `ceil(log2 N)`) with a single top `Distinct`.

3. **Memory limit bypassed while planning.** `MemoryTrackerCanThrow()` was false during preparation, so the runaway allocation skipped `--memory-limit`. Added an `OutOfMemoryExceptionEnabler` around `CypherQueryToPlan`; a runaway now aborts the query instead of killing the server.

No behaviour change for valid queries: the plan is set-equivalent, and the union-fold is still only used when every disjoined label is indexed.
