### PR TITLE
fix(utils): make GetDirDiskUsage immune to filesystem races

### DIFF
--- a/src/utils/stat.hpp
+++ b/src/utils/stat.hpp
@@ -27,15 +27,74 @@ namespace memgraph::utils {
 
 static constexpr int64_t VM_MAX_MAP_COUNT_DEFAULT{-1};
 
+// Forward declaration so the per-entry helper below can recurse into
+// subdirectories.
+template <bool IgnoreSymlink = true>
+inline uint64_t GetDirDiskUsage(const std::filesystem::path &path);
+
+namespace detail {
+
+// Returns the on-disk byte size contributed by a single directory entry, or 0
+// if the entry should be skipped (a symlink when IgnoreSymlink, a vanished or
+// unreadable entry, a non-regular file). Uses its own error_code so a per-entry
+// failure never leaks out; recurses into real subdirectories.
+template <bool IgnoreSymlink>
+inline uint64_t DirEntryDiskUsage(const std::filesystem::directory_entry &dir_entry) {
+  static_assert(sizeof(std::uintmax_t) >= sizeof(uint64_t), "file_size() result may be narrowed");
+  std::error_code ec;
+
+  if constexpr (IgnoreSymlink) {
+    const bool is_symlink = dir_entry.is_symlink(ec);
+    if (ec) {
+      // Entry vanished or became unstattable mid-scan.
+      spdlog::trace("Skipping entry '{}' during disk usage scan: {}", dir_entry.path(), ec.message());
+      return 0;
+    }
+    if (is_symlink) {
+      return 0;  // expected skip — do not log
+    }
+  }
+
+  const bool entry_is_dir = dir_entry.is_directory(ec);
+  if (!ec && entry_is_dir) {
+    return GetDirDiskUsage<IgnoreSymlink>(dir_entry.path());
+  }
+
+  // Not a directory; only regular files contribute. ec set here means the entry
+  // vanished between iteration and stat — skip it.
+  const bool entry_is_file = dir_entry.is_regular_file(ec);
+  if (ec || !entry_is_file) {
+    return 0;
+  }
+
+  if (!utils::HasReadAccess(dir_entry.path())) {
+    spdlog::warn(
+        "Skipping file path on collecting directory disk usage '{}' because it is not readable, check file "
+        "ownership and read permissions!",
+        dir_entry.path());
+    return 0;
+  }
+
+  const auto fsize = dir_entry.file_size(ec);
+  if (ec) {
+    // The file vanished between is_regular_file and file_size (e.g. WAL
+    // rotation) — skip silently at trace level.
+    spdlog::trace("Skipping file '{}' during disk usage scan: {}", dir_entry.path(), ec.message());
+    return 0;
+  }
+  return static_cast<uint64_t>(fsize);
+}
+
+}  // namespace detail
+
 /// Returns the number of bytes a directory is using on disk. If the given path
 /// isn't a directory, zero will be returned. If there are some files with
 /// wrong permission, it will be skipped. Entries that vanish during the scan
 /// (e.g. WAL rotation, snapshot retention deletes) are skipped silently so
 /// that the function is non-throwing by construction even under filesystem
 /// races.
-template <bool IgnoreSymlink = true>
+template <bool IgnoreSymlink>
 inline uint64_t GetDirDiskUsage(const std::filesystem::path &path) {
-  static_assert(sizeof(std::uintmax_t) >= sizeof(uint64_t), "file_size() result may be narrowed");
   std::error_code ec;
 
   // Guard: path must be an existing directory (non-throwing). A vanished or
@@ -58,71 +117,34 @@ inline uint64_t GetDirDiskUsage(const std::filesystem::path &path) {
     return 0;
   }
 
-  // Construct iterator without throwing; warn and bail on error.
+  // Construct iterator without throwing. A directory that vanished between the
+  // is_directory check above and this open (e.g. snapshot retention) is an
+  // expected race — trace it, like a vanished file; other failures (permissions,
+  // I/O) warrant a warning.
   std::filesystem::directory_iterator it(path, ec);
   if (ec) {
-    spdlog::warn("Cannot open directory for disk usage scan '{}': {}", path, ec.message());
+    if (ec == std::errc::no_such_file_or_directory || ec == std::errc::not_a_directory) {
+      spdlog::trace("Skipping disk usage scan of '{}': directory vanished mid-scan: {}", path, ec.message());
+    } else {
+      spdlog::warn("Cannot open directory for disk usage scan '{}': {}", path, ec.message());
+    }
     return 0;
   }
 
   uint64_t size = 0;
+  // *it is dereferenced only when valid: the constructor produced the first
+  // entry (checked above), and after a successful increment the loop condition
+  // re-validates against end{}. A failed increment is reported and breaks
+  // before the iterator is touched again, so we never dereference past an error
+  // regardless of how the failed iterator compares to end{}.
+  for (const std::filesystem::directory_iterator end{}; it != end;) {
+    size += detail::DirEntryDiskUsage<IgnoreSymlink>(*it);
 
-  // Single increment site: std::filesystem::directory_iterator::increment(ec)
-  // sets the iterator to end on error, so the loop condition handles termination
-  // correctly. increment(ec) is the last operation before each loop exit and the
-  // error_code overloads clear ec on success ([fs.err.report]), so the post-loop
-  // check below is authoritative for the advance that actually failed — no manual
-  // reset of ec is needed inside the body.
-  for (const std::filesystem::directory_iterator end{}; it != end; it.increment(ec)) {
-    const auto &dir_entry = *it;
-
-    // All per-entry status queries use the error_code overloads so that a
-    // file disappearing mid-scan (e.g. WAL rename/delete) is silently skipped.
-    if constexpr (IgnoreSymlink) {
-      const bool is_symlink = dir_entry.is_symlink(ec);
-      if (ec) {
-        // Entry vanished or became unstattable mid-scan.
-        spdlog::trace("Skipping entry '{}' during disk usage scan: {}", dir_entry.path(), ec.message());
-        continue;
-      }
-      if (is_symlink) {
-        continue;  // expected skip — do not log
-      }
-    }
-
-    const bool entry_is_dir = dir_entry.is_directory(ec);
-    if (!ec && entry_is_dir) {
-      size += GetDirDiskUsage<IgnoreSymlink>(dir_entry.path());
-      continue;
-    }
-
-    // Not a directory; only regular files contribute. ec set here means the
-    // entry vanished between iteration and stat — skip it.
-    const bool entry_is_file = dir_entry.is_regular_file(ec);
-    if (ec || !entry_is_file) {
-      continue;
-    }
-
-    if (!utils::HasReadAccess(dir_entry.path())) {
-      spdlog::warn(
-          "Skipping file path on collecting directory disk usage '{}' because it is not readable, check file "
-          "ownership and read permissions!",
-          dir_entry.path());
-      continue;
-    }
-
-    const auto fsize = dir_entry.file_size(ec);
+    it.increment(ec);
     if (ec) {
-      // The file vanished between is_regular_file and file_size (e.g. WAL
-      // rotation) — skip silently at trace level.
-      spdlog::trace("Skipping file '{}' during disk usage scan: {}", dir_entry.path(), ec.message());
-      continue;
+      spdlog::warn("Error advancing directory iterator for '{}': {}", path, ec.message());
+      break;
     }
-    size += static_cast<uint64_t>(fsize);
-  }
-
-  if (ec) {
-    spdlog::warn("Error advancing directory iterator for '{}': {}", path, ec.message());
   }
 
   return size;

--- a/src/utils/stat.hpp
+++ b/src/utils/stat.hpp
@@ -35,11 +35,18 @@ static constexpr int64_t VM_MAX_MAP_COUNT_DEFAULT{-1};
 /// races.
 template <bool IgnoreSymlink = true>
 inline uint64_t GetDirDiskUsage(const std::filesystem::path &path) {
+  static_assert(sizeof(std::uintmax_t) >= sizeof(uint64_t), "file_size() result may be narrowed");
   std::error_code ec;
 
-  // Guard: path must be an existing directory (non-throwing).
+  // Guard: path must be an existing directory (non-throwing). A vanished or
+  // unstattable path is expected under filesystem races (e.g. a directory
+  // removed by snapshot retention), so trace rather than warn.
   const bool is_dir = std::filesystem::is_directory(path, ec);
-  if (ec || !is_dir) {
+  if (ec) {
+    spdlog::trace("Skipping disk usage scan of '{}': cannot stat path: {}", path, ec.message());
+    return 0;
+  }
+  if (!is_dir) {
     return 0;
   }
 
@@ -62,52 +69,56 @@ inline uint64_t GetDirDiskUsage(const std::filesystem::path &path) {
 
   // Single increment site: std::filesystem::directory_iterator::increment(ec)
   // sets the iterator to end on error, so the loop condition handles termination
-  // correctly.  We clear ec before every increment so the post-loop check is
-  // authoritative for the last advance that actually failed.
+  // correctly. increment(ec) is the last operation before each loop exit and the
+  // error_code overloads clear ec on success ([fs.err.report]), so the post-loop
+  // check below is authoritative for the advance that actually failed — no manual
+  // reset of ec is needed inside the body.
   for (const std::filesystem::directory_iterator end{}; it != end; it.increment(ec)) {
     const auto &dir_entry = *it;
 
     // All per-entry status queries use the error_code overloads so that a
     // file disappearing mid-scan (e.g. WAL rename/delete) is silently skipped.
     if constexpr (IgnoreSymlink) {
-      ec.clear();
       const bool is_symlink = dir_entry.is_symlink(ec);
-      if (ec || is_symlink) {
-        // Entry vanished, unreadable, or is a symlink we should skip.
-        ec.clear();
+      if (ec) {
+        // Entry vanished or became unstattable mid-scan.
+        spdlog::trace("Skipping entry '{}' during disk usage scan: {}", dir_entry.path(), ec.message());
         continue;
+      }
+      if (is_symlink) {
+        continue;  // expected skip — do not log
       }
     }
 
-    ec.clear();
     const bool entry_is_dir = dir_entry.is_directory(ec);
     if (!ec && entry_is_dir) {
       size += GetDirDiskUsage<IgnoreSymlink>(dir_entry.path());
-      ec.clear();
       continue;
     }
 
-    ec.clear();
+    // Not a directory; only regular files contribute. ec set here means the
+    // entry vanished between iteration and stat — skip it.
     const bool entry_is_file = dir_entry.is_regular_file(ec);
-    if (!ec && entry_is_file) {
-      if (!utils::HasReadAccess(dir_entry.path())) {
-        spdlog::warn(
-            "Skipping file path on collecting directory disk usage '{}' because it is not readable, check file "
-            "ownership and read permissions!",
-            dir_entry.path());
-        ec.clear();
-        continue;
-      }
-      ec.clear();
-      const auto fsize = dir_entry.file_size(ec);
-      if (!ec) {
-        size += fsize;
-      }
-      // If ec is set the file vanished between is_regular_file and file_size
-      // (e.g. WAL rotation) — skip silently.
+    if (ec || !entry_is_file) {
+      continue;
     }
-    // ec set by is_directory or is_regular_file: entry vanished — skip.
-    ec.clear();
+
+    if (!utils::HasReadAccess(dir_entry.path())) {
+      spdlog::warn(
+          "Skipping file path on collecting directory disk usage '{}' because it is not readable, check file "
+          "ownership and read permissions!",
+          dir_entry.path());
+      continue;
+    }
+
+    const auto fsize = dir_entry.file_size(ec);
+    if (ec) {
+      // The file vanished between is_regular_file and file_size (e.g. WAL
+      // rotation) — skip silently at trace level.
+      spdlog::trace("Skipping file '{}' during disk usage scan: {}", dir_entry.path(), ec.message());
+      continue;
+    }
+    size += static_cast<uint64_t>(fsize);
   }
 
   if (ec) {

--- a/src/utils/stat.hpp
+++ b/src/utils/stat.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -12,8 +12,10 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <filesystem>
 #include <optional>
+#include <system_error>
 
 #include <unistd.h>
 
@@ -27,10 +29,19 @@ static constexpr int64_t VM_MAX_MAP_COUNT_DEFAULT{-1};
 
 /// Returns the number of bytes a directory is using on disk. If the given path
 /// isn't a directory, zero will be returned. If there are some files with
-/// wrong permission, it will be skipped
+/// wrong permission, it will be skipped. Entries that vanish during the scan
+/// (e.g. WAL rotation, snapshot retention deletes) are skipped silently so
+/// that the function is non-throwing by construction even under filesystem
+/// races.
 template <bool IgnoreSymlink = true>
 inline uint64_t GetDirDiskUsage(const std::filesystem::path &path) {
-  if (!std::filesystem::is_directory(path)) return 0;
+  std::error_code ec;
+
+  // Guard: path must be an existing directory (non-throwing).
+  const bool is_dir = std::filesystem::is_directory(path, ec);
+  if (ec || !is_dir) {
+    return 0;
+  }
 
   if (!utils::HasReadAccess(path)) {
     spdlog::warn(
@@ -39,21 +50,68 @@ inline uint64_t GetDirDiskUsage(const std::filesystem::path &path) {
         path);
     return 0;
   }
+
+  // Construct iterator without throwing; warn and bail on error.
+  std::filesystem::directory_iterator it(path, ec);
+  if (ec) {
+    spdlog::warn("Cannot open directory for disk usage scan '{}': {}", path, ec.message());
+    return 0;
+  }
+
   uint64_t size = 0;
-  for (const auto &dir_entry : std::filesystem::directory_iterator(path)) {
-    if (IgnoreSymlink && std::filesystem::is_symlink(dir_entry)) continue;
-    if (std::filesystem::is_directory(dir_entry)) {
-      size += GetDirDiskUsage(dir_entry);
-    } else if (std::filesystem::is_regular_file(dir_entry)) {
-      if (!utils::HasReadAccess(dir_entry)) {
+
+  // Single increment site: std::filesystem::directory_iterator::increment(ec)
+  // sets the iterator to end on error, so the loop condition handles termination
+  // correctly.  We clear ec before every increment so the post-loop check is
+  // authoritative for the last advance that actually failed.
+  for (const std::filesystem::directory_iterator end{}; it != end; it.increment(ec)) {
+    const auto &dir_entry = *it;
+
+    // All per-entry status queries use the error_code overloads so that a
+    // file disappearing mid-scan (e.g. WAL rename/delete) is silently skipped.
+    if constexpr (IgnoreSymlink) {
+      ec.clear();
+      const bool is_symlink = dir_entry.is_symlink(ec);
+      if (ec || is_symlink) {
+        // Entry vanished, unreadable, or is a symlink we should skip.
+        ec.clear();
+        continue;
+      }
+    }
+
+    ec.clear();
+    const bool entry_is_dir = dir_entry.is_directory(ec);
+    if (!ec && entry_is_dir) {
+      size += GetDirDiskUsage<IgnoreSymlink>(dir_entry.path());
+      ec.clear();
+      continue;
+    }
+
+    ec.clear();
+    const bool entry_is_file = dir_entry.is_regular_file(ec);
+    if (!ec && entry_is_file) {
+      if (!utils::HasReadAccess(dir_entry.path())) {
         spdlog::warn(
             "Skipping file path on collecting directory disk usage '{}' because it is not readable, check file "
             "ownership and read permissions!",
             dir_entry.path());
+        ec.clear();
         continue;
       }
-      size += std::filesystem::file_size(dir_entry);
+      ec.clear();
+      const auto fsize = dir_entry.file_size(ec);
+      if (!ec) {
+        size += fsize;
+      }
+      // If ec is set the file vanished between is_regular_file and file_size
+      // (e.g. WAL rotation) — skip silently.
     }
+    // ec set by is_directory or is_regular_file: entry vanished — skip.
+    ec.clear();
+  }
+
+  if (ec) {
+    spdlog::warn("Error advancing directory iterator for '{}': {}", path, ec.message());
   }
 
   return size;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -436,6 +436,11 @@ add_unit_test(utils_file
     LINK_TARGETS mg-utils
 )
 
+add_unit_test(utils_stat
+    SOURCES utils_stat.cpp
+    LINK_TARGETS mg-utils
+)
+
 add_unit_test(utils_math
     SOURCES utils_math.cpp
     LINK_TARGETS mg-utils

--- a/tests/unit/utils_stat.cpp
+++ b/tests/unit/utils_stat.cpp
@@ -13,6 +13,8 @@
 #include <fstream>
 #include <string>
 
+#include <unistd.h>
+
 #include <gtest/gtest.h>
 
 #include "utils/stat.hpp"
@@ -22,7 +24,8 @@ namespace fs = std::filesystem;
 class GetDirDiskUsageTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    root_ = fs::temp_directory_path() / "MG_test_get_dir_disk_usage";
+    // Per-process unique root so parallel test binaries (ctest -j) don't collide.
+    root_ = fs::temp_directory_path() / ("MG_test_get_dir_disk_usage_" + std::to_string(::getpid()));
     fs::remove_all(root_);
     fs::create_directories(root_);
   }

--- a/tests/unit/utils_stat.cpp
+++ b/tests/unit/utils_stat.cpp
@@ -1,0 +1,78 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "utils/stat.hpp"
+
+namespace fs = std::filesystem;
+
+class GetDirDiskUsageTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    root_ = fs::temp_directory_path() / "MG_test_get_dir_disk_usage";
+    fs::remove_all(root_);
+    fs::create_directories(root_);
+  }
+
+  void TearDown() override { fs::remove_all(root_); }
+
+  // Creates a file with `size` bytes of content and returns its path.
+  fs::path MakeFile(const fs::path &path, size_t size) {
+    fs::create_directories(path.parent_path());
+    std::ofstream ofs(path, std::ios::binary | std::ios::trunc);
+    ofs << std::string(size, 'x');
+    ofs.close();
+    return path;
+  }
+
+  fs::path root_;
+};
+
+TEST_F(GetDirDiskUsageTest, NonExistentPathReturnsZero) {
+  EXPECT_EQ(memgraph::utils::GetDirDiskUsage(root_ / "does_not_exist"), 0U);
+}
+
+TEST_F(GetDirDiskUsageTest, RegularFileAsPathReturnsZero) {
+  // The function only operates on directories; a file path yields 0.
+  const auto file = MakeFile(root_ / "a.bin", 42);
+  EXPECT_EQ(memgraph::utils::GetDirDiskUsage(file), 0U);
+}
+
+TEST_F(GetDirDiskUsageTest, EmptyDirectoryReturnsZero) { EXPECT_EQ(memgraph::utils::GetDirDiskUsage(root_), 0U); }
+
+TEST_F(GetDirDiskUsageTest, SumsRegularFiles) {
+  MakeFile(root_ / "a.bin", 5);
+  MakeFile(root_ / "b.bin", 10);
+  EXPECT_EQ(memgraph::utils::GetDirDiskUsage(root_), 15U);
+}
+
+TEST_F(GetDirDiskUsageTest, RecursesIntoSubdirectories) {
+  MakeFile(root_ / "top.bin", 5);
+  MakeFile(root_ / "sub" / "nested.bin", 10);
+  MakeFile(root_ / "sub" / "deeper" / "leaf.bin", 20);
+  EXPECT_EQ(memgraph::utils::GetDirDiskUsage(root_), 35U);
+}
+
+TEST_F(GetDirDiskUsageTest, IgnoresSymlinksByDefault) {
+  // Default template parameter IgnoreSymlink == true: a symlink to a file is
+  // not counted, so the directory holding only the symlink measures 0.
+  const auto target = MakeFile(root_ / "external" / "target.bin", 7);
+  const auto scan_dir = root_ / "scan";
+  fs::create_directories(scan_dir);
+  fs::create_symlink(target, scan_dir / "link.bin");
+
+  EXPECT_EQ(memgraph::utils::GetDirDiskUsage(scan_dir), 0U);
+}


### PR DESCRIPTION
A CI stress run crashed with std::terminate:

  filesystem error: cannot get file size: No such file or directory
  [.../databases/memgraph/wal/<ts>_current]

GetDirDiskUsage (used by SHOW STORAGE INFO disk_usage, storage info and telemetry) scanned the live data directory with the THROWING std::filesystem overloads. WalFile::FinalizeWal renames the '<ts>_current' WAL file on finalize; when the rename lands between the is_regular_file() stat and the file_size() stat, file_size throws filesystem_error, which escaped to std::terminate and killed the server. Files vanishing mid-scan is normal (WAL rotation, snapshot retention), so the scan must be non-throwing by construction.

Rewrite the scan using the std::error_code overloads end to end: iterator construction, per-entry type queries, file_size, and a single increment site (increment(ec) sets the iterator to end() on failure, so the loop terminates cleanly and the post-loop check reports it). Entries that vanish during the scan are skipped; permission warnings are preserved.

Behavior note: recursion now propagates the IgnoreSymlink template parameter instead of always defaulting to true. For the only <false> caller (InMemoryStorage::GetBaseInfo) subdirectory symlinks are now treated consistently with the top level; durability directories do not normally contain symlinked subtrees, so reported numbers should not change in practice.