### PR TITLE
Feature (Light Edges / 12) - feat(replication): unify replica edge-set-property via FindEdge, light-edge aware

### DIFF
--- a/src/dbms/inmemory/replication_handlers.cpp
+++ b/src/dbms/inmemory/replication_handlers.cpp
@@ -1087,9 +1087,6 @@ std::optional<storage::SingleTxnDeltasProcessingResult> InMemoryReplicationHandl
     storage::InMemoryStorage *storage, storage::durability::BaseDecoder *decoder, const uint64_t version,
     slk::Builder *res_builder, bool const two_phase_commit, bool const loading_wal, uint64_t deltas_batch_progress_size,
     uint32_t const start_batch_counter) {
-  auto edge_acc = storage->edges_.access();
-  auto vertex_acc = storage->vertices_.access();
-
   constexpr auto kSharedAccess = storage::StorageAccessType::WRITE;
   constexpr auto kUniqueAccess = storage::StorageAccessType::UNIQUE;
 
@@ -1345,24 +1342,56 @@ std::optional<storage::SingleTxnDeltasProcessingResult> InMemoryReplicationHandl
             return;
           }
 
-          std::optional<std::tuple<EdgeRef,
-                                   memgraph::storage::EdgeTypeId,
-                                   memgraph::storage::Vertex *,
-                                   memgraph::storage::Vertex *>>
-              edge_info;
+          // Resolve EdgeInfo using the best available WAL data (newest to oldest format).
+          // Edge is alive by WAL ordering — a SET_PROPERTY delta proves it was not GC-collectable
+          // at main-side commit.
+          // Case 1 (newest WAL): from_gid + to_gid + edge_type → type-filtered out_edges scan via
+          //                      transaction->FindEdge, fastest. Light and heavy edges both supported.
+          // Case 2:              from_gid only → storage->FindEdge(gid, from_gid) handles both light
+          //                      and heavy edges internally; no special-casing needed. O(log V + deg).
+          // Case 3 (oldest WAL): gid only → storage->FindEdge(gid) handles both light and heavy edges
+          //                      internally; no special-casing needed. Full scan fallback.
+          const auto cached_edge_info = std::invoke([&]() -> storage::EdgeInfo {
+            if (data.from_gid.has_value() && data.to_gid.has_value() && data.edge_type.has_value() &&
+                *data.to_gid != storage::kInvalidGid && !data.edge_type->empty()) {
+              auto to_v = transaction->FindVertex(*data.to_gid, View::NEW);
+              if (!to_v)
+                throw utils::BasicException("Failed to find to vertex {} when setting edge property.",
+                                            data.to_gid->AsUint());
+              auto from_v = transaction->FindVertex(*data.from_gid, View::NEW);
+              if (!from_v)
+                throw utils::BasicException("Failed to find from vertex {} when setting edge property.",
+                                            data.from_gid->AsUint());
+              auto const edge_type_id = transaction->NameToEdgeType(*data.edge_type);
+              auto found = transaction->FindEdge(data.gid, View::NEW, edge_type_id, &*from_v, &*to_v);
+              if (!found) {
+                throw utils::BasicException("Failed to find edge {} when setting edge property.", edge_gid);
+              }
+              return storage::EdgeInfo{
+                  std::in_place, found->edge_, found->edge_type_, found->from_vertex_, found->to_vertex_};
+            } else if (data.from_gid.has_value()) {
+              auto info = storage->FindEdge(data.gid, *data.from_gid);
+              if (!info)
+                throw utils::BasicException("Failed to find edge {} from vertex {} when setting edge property.",
+                                            edge_gid,
+                                            data.from_gid->AsUint());
+              return info;
+            } else {
+              auto info = storage->FindEdge(data.gid);
+              if (!info) throw utils::BasicException("Failed to find edge {} when setting edge property.", edge_gid);
+              return info;
+            }
+          });
 
-          // Slow path: resolve edge via edge_acc / FindEdge (WAL or legacy replication).
-          auto edge = edge_acc.find(data.gid);
-          if (edge == edge_acc.end()) {
-            throw utils::BasicException("Failed to find edge {} when setting property.", edge_gid);
-          }
+          auto const &[er, et, fv, tv] = *cached_edge_info;
+          auto *edge_raw = er.ptr;
           {
             bool is_visible = true;
             Delta *local_delta = nullptr;
             {
-              auto guard = std::shared_lock{edge->lock};
-              is_visible = !edge->deleted();
-              local_delta = edge->delta();
+              auto guard = std::shared_lock{edge_raw->lock};
+              is_visible = !edge_raw->deleted();
+              local_delta = edge_raw->delta();
             }
             ApplyDeltasForRead(
                 &transaction->GetTransaction(), local_delta, View::NEW, [&is_visible](const Delta &delta) {
@@ -1387,70 +1416,9 @@ std::optional<storage::SingleTxnDeltasProcessingResult> InMemoryReplicationHandl
                   }
                 });
             if (!is_visible) {
-              throw utils::BasicException("Edge {} isn't visible when setting property.", edge_gid);
+              throw utils::BasicException("Edge {} isn't visible when setting edge property.", edge_gid);
             }
           }
-
-          auto [edge_ref, edge_type, from_vertex, vertex_to] = std::invoke([&] {
-            if (data.from_gid.has_value()) {
-              // Faster path: use to vertex and edge type from WAL delta.
-              // Newer versions store to_gid and edge_type when needed, so we can use the faster path via FindEdge.
-              // NOTE: WAL edge deltas mix vertex and edge deltas. For efficiency, we don't record the to gid and
-              // edge type in case the edge was created in this transaction. We should either be using the cached
-              // edge accessor (from EdgeCreate - actually a vertex delta) or we should have valid to gid and edge
-              // type.
-              if (data.to_gid.has_value() && data.edge_type.has_value() && *data.to_gid != storage::kInvalidGid &&
-                  !data.edge_type->empty()) {
-                auto to_vertex = transaction->FindVertex(*data.to_gid, View::NEW);
-                if (!to_vertex)
-                  throw utils::BasicException("Failed to find to vertex {} when setting edge property.",
-                                              data.to_gid->AsUint());
-
-                auto from_vertex = transaction->FindVertex(*data.from_gid, View::NEW);
-                if (!from_vertex)
-                  throw utils::BasicException("Failed to find from vertex {} when setting edge property.",
-                                              data.from_gid->AsUint());
-
-                auto const edge_type_id = transaction->NameToEdgeType(*data.edge_type);
-                auto found_edge = transaction->FindEdge(data.gid, View::NEW, edge_type_id, &*from_vertex, &*to_vertex);
-                if (!found_edge) {
-                  constexpr auto src_loc{std::source_location()};
-                  throw utils::BasicException(
-                      "Invalid transaction! Please raise an issue, {}:{}", src_loc.file_name(), src_loc.line());
-                }
-                return std::tuple{
-                    found_edge->edge_, found_edge->edge_type_, found_edge->from_vertex_, found_edge->to_vertex_};
-              }
-
-              // Fallback path: resolve edge via vertex_acc / FindEdge (legacy replication).
-              auto vertex_acc = storage->vertices_.access();
-              auto from_vertex = vertex_acc.find(data.from_gid);
-              if (from_vertex == vertex_acc.end())
-                throw utils::BasicException("Failed to find from vertex {} when setting edge property.",
-                                            data.from_gid->AsUint());
-
-              auto found_edge = r::find_if(from_vertex->out_edges, [raw_edge_ref = EdgeRef(&*edge)](auto &in) {
-                return std::get<2>(in) == raw_edge_ref;
-              });
-              if (found_edge == from_vertex->out_edges.end()) {
-                throw utils::BasicException(
-                    "Couldn't find edge {} in vertex {}'s out edge collection.", edge_gid, from_vertex->gid.AsUint());
-              }
-              const auto &[edge_type, vertex_to, edge_ref] = *found_edge;
-              return std::tuple{edge_ref, edge_type, &*from_vertex, vertex_to};
-            }
-            auto found_edge = storage->FindEdge(edge->gid);
-            if (!found_edge) {
-              constexpr auto src_loc{std::source_location()};
-              throw utils::BasicException(
-                  "Invalid transaction! Please raise an issue, {}:{}", src_loc.file_name(), src_loc.line());
-            }
-            const auto &[edge_ref, edge_type, vertex_from, vertex_to] = *found_edge;
-            return std::tuple{edge_ref, edge_type, vertex_from, vertex_to};
-          });
-          edge_info.emplace(edge_ref, edge_type, from_vertex, vertex_to);
-
-          auto const &[er, et, fv, tv] = *edge_info;
           EdgeAccessor ea{er, et, fv, tv, storage, &transaction->GetTransaction()};
           edge_set_property_cache.emplace(cache_key, ea);  // Fast edge accessor lookup cache
           auto ret = ea.SetProperty(transaction->NameToProperty(data.property), ToPropertyValue(data.value, mapper));

--- a/tests/e2e/replication/CMakeLists.txt
+++ b/tests/e2e/replication/CMakeLists.txt
@@ -2,12 +2,15 @@ find_package(gflags REQUIRED)
 
 add_executable(memgraph__e2e__replication__constraints constraints.cpp)
 target_link_libraries(memgraph__e2e__replication__constraints gflags mgclient::mgclient mg-utils mg-io Threads::Threads)
+add_dependencies(memgraph__e2e memgraph__e2e__replication__constraints)
 
 add_executable(memgraph__e2e__replication__indices indices.cpp)
 target_link_libraries(memgraph__e2e__replication__indices gflags mgclient::mgclient mg-utils mg-io Threads::Threads)
+add_dependencies(memgraph__e2e memgraph__e2e__replication__indices)
 
 add_executable(memgraph__e2e__replication__read_write_benchmark read_write_benchmark.cpp)
 target_link_libraries(memgraph__e2e__replication__read_write_benchmark gflags nlohmann_json::nlohmann_json mgclient::mgclient mg-utils mg-io Threads::Threads)
+add_dependencies(memgraph__e2e memgraph__e2e__replication__read_write_benchmark)
 
 copy_e2e_python_files(replication common.py)
 copy_e2e_python_files(replication conftest.py)

--- a/tests/e2e/replication/edge_delete.py
+++ b/tests/e2e/replication/edge_delete.py
@@ -18,11 +18,14 @@ from mg_utils import mg_sleep_and_assert_collection
 
 
 # BUGFIX: for issue https://github.com/memgraph/memgraph/issues/1515
-def test_replication_handles_delete_when_multiple_edges_of_same_type(connection):
+def test_replication_handles_delete_when_multiple_edges_of_same_type(connection, pytestconfig):
     # Goal is to check the timestamp are correctly computed from the information we get from replicas.
     # 0/ Check original state of replicas.
     # 1/ Add nodes and edges to MAIN, then delete the edges.
     # 2/ Check state of replicas.
+
+    with_props = pytestconfig.getoption("with_props")
+    print("Running with properties: ", with_props)
 
     # 0/
     conn = connection(7687, "main")
@@ -49,7 +52,12 @@ def test_replication_handles_delete_when_multiple_edges_of_same_type(connection)
     assert all([x in actual_data for x in expected_data])
 
     # 1/
-    execute_and_fetch_all(cursor, "CREATE (a)-[r:X]->(b) CREATE (a)-[:X]->(b) DELETE r;")
+    if with_props:
+        execute_and_fetch_all(
+            cursor, "CREATE (a)-[r:X{p:1, str:'1234567890'}]->(b) CREATE (a)-[:X{p:2, str:'1234567890'}]->(b) DELETE r;"
+        )
+    else:
+        execute_and_fetch_all(cursor, "CREATE (a)-[r:X]->(b) CREATE (a)-[:X]->(b) DELETE r;")
 
     # 2/
     expected_data = [
@@ -77,4 +85,4 @@ def test_replication_handles_delete_when_multiple_edges_of_same_type(connection)
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__, "-rA"]))
+    sys.exit(pytest.main([__file__, "-rA"] + sys.argv[1:]))

--- a/tests/e2e/replication/workloads.yaml
+++ b/tests/e2e/replication/workloads.yaml
@@ -27,6 +27,45 @@ template_simple_cluster: &template_simple_cluster
           "REGISTER REPLICA replica_2 ASYNC TO '127.0.0.1:10002'",
         ]
 
+template_simple_cluster_light_edge: &template_simple_cluster_light_edge
+  cluster:
+    replica_1:
+      args: ["--bolt-port", "7688", "--log-level=TRACE", "--storage-light-edge", "--storage-properties-on-edges"]
+      log_file: "replication-e2e-replica1.log"
+      setup_queries: ["SET REPLICATION ROLE TO REPLICA WITH PORT 10001;"]
+    replica_2:
+      args: ["--bolt-port", "7689", "--log-level=TRACE", "--storage-light-edge", "--storage-properties-on-edges"]
+      log_file: "replication-e2e-replica2.log"
+      setup_queries: ["SET REPLICATION ROLE TO REPLICA WITH PORT 10002;"]
+    main:
+      args: ["--bolt-port", "7687", "--log-level=TRACE", "--storage-light-edge", "--storage-properties-on-edges"]
+      log_file: "replication-e2e-main.log"
+      setup_queries:
+        [
+          "REGISTER REPLICA replica_1 SYNC TO '127.0.0.1:10001'",
+          "REGISTER REPLICA replica_2 ASYNC TO '127.0.0.1:10002'",
+        ]
+
+template_simple_cluster_mixed_edge: &template_simple_cluster_mixed_edge
+  cluster:
+    replica_1:
+      args: ["--bolt-port", "7688", "--log-level=TRACE", "--storage-light-edge", "--storage-properties-on-edges"]
+      log_file: "replication-e2e-replica1.log"
+      setup_queries: ["SET REPLICATION ROLE TO REPLICA WITH PORT 10001;"]
+    replica_2:
+      args: ["--bolt-port", "7689", "--log-level=TRACE", "--nostorage-light-edge", "--storage-properties-on-edges"]
+      log_file: "replication-e2e-replica2.log"
+      setup_queries: ["SET REPLICATION ROLE TO REPLICA WITH PORT 10002;"]
+    main:
+      args: ["--bolt-port", "7687", "--log-level=TRACE", "--nostorage-light-edge", "--storage-properties-on-edges"]
+      log_file: "replication-e2e-main.log"
+      setup_queries:
+        [
+          "REGISTER REPLICA replica_1 SYNC TO '127.0.0.1:10001'",
+          "REGISTER REPLICA replica_2 ASYNC TO '127.0.0.1:10002'",
+        ]
+
+
 template_cluster: &template_cluster
   cluster:
     replica_1:
@@ -114,6 +153,11 @@ workloads:
     args: ["replication/replicate_periodic_commit.py"]
     <<: *template_simple_cluster
 
+  - name: "Replicate periodic commit (light-edge)"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["replication/replicate_periodic_commit.py"]
+    <<: *template_simple_cluster_light_edge
+
   - name: "Replicate spatial feature"
     binary: "tests/e2e/pytest_runner.sh"
     args: [ "replication/replicate_spatial_feature.py" ]
@@ -138,6 +182,16 @@ workloads:
     binary: "tests/e2e/pytest_runner.sh"
     args: ["replication/edge_delete.py"]
     <<: *template_simple_cluster
+
+  - name: "Delete edge replication (light-edge)"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["replication/edge_delete.py", "--with-props"]
+    <<: *template_simple_cluster_light_edge
+
+  - name: "Delete edge replication (mixed-edge)"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["replication/edge_delete.py", "--with-props"]
+    <<: *template_simple_cluster_mixed_edge
 
   - name: "Replication with property compression used"
     binary: "tests/e2e/pytest_runner.sh"

--- a/tests/unit/storage_v2_replication.cpp
+++ b/tests/unit/storage_v2_replication.cpp
@@ -1975,3 +1975,223 @@ TEST_F(ReplicationTest, EdgeMetadataRecoveredOnReplicaSnapshotTransfer) {
     ASSERT_TRUE(acc->FindEdge(e1_gid, View::OLD).has_value());
   }
 }
+
+// ---------------------------------------------------------------------------
+// Light-edge replication tests
+// ---------------------------------------------------------------------------
+
+class ReplicationTestLightEdge : public ::testing::Test {
+ protected:
+  std::filesystem::path storage_directory{std::filesystem::temp_directory_path() /
+                                          "MG_test_unit_storage_v2_replication_light_edge"};
+  std::filesystem::path repl_storage_directory{std::filesystem::temp_directory_path() /
+                                               "MG_test_unit_storage_v2_replication_light_edge_repl"};
+
+  void SetUp() override { Clear(); }
+
+  void TearDown() override { Clear(); }
+
+  Config MakeLightEdgeConfig(const std::filesystem::path &dir) const {
+    Config config{
+        .durability =
+            {
+                .root_data_directory = dir,
+                .snapshot_wal_mode = Config::Durability::SnapshotWalMode::PERIODIC_SNAPSHOT_WITH_WAL,
+            },
+        .salient.items = {.properties_on_edges = true, .storage_light_edge = true},
+    };
+    UpdatePaths(config, dir);
+    return config;
+  }
+
+  const std::string local_host = "127.0.0.1";
+  const uint16_t port = 10'100;
+  const std::string replica_name = "LIGHT_REPLICA";
+
+ private:
+  void Clear() {
+    if (std::filesystem::exists(storage_directory)) std::filesystem::remove_all(storage_directory);
+    if (std::filesystem::exists(repl_storage_directory)) std::filesystem::remove_all(repl_storage_directory);
+  }
+};
+
+/// Verify that edge create, edge set-property, and edge delete are all
+/// replicated correctly when storage_light_edge=true on both main and replica.
+TEST_F(ReplicationTestLightEdge, EdgeCrudReplicatedSynchronously) {
+  MinMemgraph main(MakeLightEdgeConfig(storage_directory));
+  MinMemgraph replica(MakeLightEdgeConfig(repl_storage_directory));
+
+  replica.repl_handler.TrySetReplicationRoleReplica(ReplicationServerConfig{.repl_server = Endpoint(local_host, port)});
+
+  ASSERT_TRUE(main.repl_handler
+                  .TryRegisterReplica(ReplicationClientConfig{
+                      .name = replica_name,
+                      .mode = ReplicationMode::SYNC,
+                      .repl_server_endpoint = Endpoint(local_host, port),
+                  })
+                  .has_value());
+
+  const auto *edge_type_name = "light_et";
+  const auto *edge_prop_name = "eprop";
+  const auto *edge_prop_value = "hello_light";
+
+  Gid v1_gid, v2_gid;
+  Gid edge_gid;
+
+  // Create two vertices + one edge with a property.
+  {
+    auto acc = main.db.Access(memgraph::storage::WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    v1_gid = v1.Gid();
+    v2_gid = v2.Gid();
+    auto edge_res = acc->CreateEdge(&v1, &v2, main.db.storage()->NameToEdgeType(edge_type_name));
+    ASSERT_TRUE(edge_res.has_value());
+    auto edge = edge_res.value();
+    edge_gid = edge.Gid();
+    ASSERT_TRUE(edge.SetProperty(main.db.storage()->NameToProperty(edge_prop_name), PropertyValue(edge_prop_value))
+                    .has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
+  }
+
+  // Replica should see the edge and its property.
+  {
+    auto acc = replica.db.Access(memgraph::storage::WRITE);
+    const auto v1 = acc->FindVertex(v1_gid, View::OLD);
+    ASSERT_TRUE(v1.has_value());
+    const auto out_edges = v1->OutEdges(View::OLD);
+    ASSERT_TRUE(out_edges.has_value());
+    ASSERT_EQ(out_edges->edges.size(), 1U);
+    const auto &edge = out_edges->edges[0];
+    ASSERT_EQ(edge.Gid(), edge_gid);
+    ASSERT_EQ(edge.EdgeType(), replica.db.storage()->NameToEdgeType(edge_type_name));
+    const auto props = edge.Properties(View::OLD);
+    ASSERT_TRUE(props.has_value());
+    ASSERT_EQ(props->size(), 1U);
+    ASSERT_EQ(props->at(replica.db.storage()->NameToProperty(edge_prop_name)), PropertyValue(edge_prop_value));
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Update edge property in a separate transaction (exercises WAL SET_PROPERTY for light edges).
+  const auto *updated_value = "updated_light";
+  {
+    auto acc = main.db.Access(memgraph::storage::WRITE);
+    auto v1 = acc->FindVertex(v1_gid, View::OLD).value();
+    auto out_edges = v1.OutEdges(View::OLD);
+    ASSERT_TRUE(out_edges.has_value());
+    auto edge = out_edges->edges[0];
+    ASSERT_TRUE(
+        edge.SetProperty(main.db.storage()->NameToProperty(edge_prop_name), PropertyValue(updated_value)).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
+  }
+
+  {
+    auto acc = replica.db.Access(memgraph::storage::WRITE);
+    const auto v1 = acc->FindVertex(v1_gid, View::OLD).value();
+    const auto out_edges = v1.OutEdges(View::OLD);
+    ASSERT_TRUE(out_edges.has_value());
+    const auto &edge = out_edges->edges[0];
+    const auto props = edge.Properties(View::OLD);
+    ASSERT_TRUE(props.has_value());
+    ASSERT_EQ(props->at(replica.db.storage()->NameToProperty(edge_prop_name)), PropertyValue(updated_value));
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete the edge.
+  {
+    auto acc = main.db.Access(memgraph::storage::WRITE);
+    auto v1 = acc->FindVertex(v1_gid, View::OLD).value();
+    auto out_edges = v1.OutEdges(View::OLD);
+    ASSERT_TRUE(out_edges.has_value());
+    auto edge = out_edges->edges[0];
+    ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
+  }
+
+  {
+    auto acc = replica.db.Access(memgraph::storage::WRITE);
+    const auto v1 = acc->FindVertex(v1_gid, View::OLD).value();
+    const auto out_edges = v1.OutEdges(View::OLD);
+    ASSERT_TRUE(out_edges.has_value());
+    ASSERT_TRUE(out_edges->edges.empty());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+}
+
+/// Verify that a replica recovers from snapshot+WAL written with light edges
+/// and then accepts live replication of further changes.
+TEST_F(ReplicationTestLightEdge, RecoveryProcess) {
+  Gid v1_gid, v2_gid, edge_gid;
+
+  // Phase 1: write data and snapshot to disk.
+  {
+    auto conf = MakeLightEdgeConfig(storage_directory);
+    conf.durability.snapshot_on_exit = true;
+    MinMemgraph main(conf);
+
+    auto acc = main.db.Access(memgraph::storage::WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    v1_gid = v1.Gid();
+    v2_gid = v2.Gid();
+    auto edge_res = acc->CreateEdge(&v1, &v2, main.db.storage()->NameToEdgeType("et"));
+    ASSERT_TRUE(edge_res.has_value());
+    edge_gid = edge_res->Gid();
+    ASSERT_TRUE(edge_res->SetProperty(main.db.storage()->NameToProperty("p"), PropertyValue(42)).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
+  }
+
+  // Phase 2: recover from snapshot, add a label, then register replica.
+  auto conf = MakeLightEdgeConfig(storage_directory);
+  conf.durability.recover_on_startup = true;
+  MinMemgraph main(conf);
+
+  // Verify recovery from snapshot restored the edge.
+  {
+    auto acc = main.db.Access(memgraph::storage::WRITE);
+    auto v1 = acc->FindVertex(v1_gid, View::OLD);
+    ASSERT_TRUE(v1.has_value());
+    auto out_edges = v1->OutEdges(View::OLD);
+    ASSERT_TRUE(out_edges.has_value());
+    ASSERT_EQ(out_edges->edges.size(), 1U);
+    ASSERT_EQ(out_edges->edges[0].Gid(), edge_gid);
+    ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
+  }
+
+  // Register replica (it will receive the snapshot for catch-up).
+  MinMemgraph replica(MakeLightEdgeConfig(repl_storage_directory));
+  replica.repl_handler.TrySetReplicationRoleReplica(ReplicationServerConfig{.repl_server = Endpoint(local_host, port)});
+  ASSERT_TRUE(main.repl_handler
+                  .TryRegisterReplica(ReplicationClientConfig{
+                      .name = replica_name,
+                      .mode = ReplicationMode::SYNC,
+                      .repl_server_endpoint = Endpoint(local_host, port),
+                  })
+                  .has_value());
+
+  while (main.db.storage()->GetReplicaState(replica_name) != ReplicaState::READY) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  // Send one more live transaction; replica must apply it.
+  {
+    auto acc = main.db.Access(memgraph::storage::WRITE);
+    auto v1 = acc->FindVertex(v1_gid, View::OLD).value();
+    ASSERT_TRUE(v1.AddLabel(main.db.storage()->NameToLabel("recovered")).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(MakeCommitArgs(main.db_acc)).has_value());
+  }
+
+  {
+    auto acc = replica.db.Access(memgraph::storage::WRITE);
+    const auto v1 = acc->FindVertex(v1_gid, View::OLD);
+    ASSERT_TRUE(v1.has_value());
+    const auto labels = v1->Labels(View::OLD);
+    ASSERT_TRUE(labels.has_value());
+    ASSERT_THAT(*labels, ::testing::Contains(replica.db.storage()->NameToLabel("recovered")));
+    // Edge must also be present on replica after recovery.
+    const auto out_edges = v1->OutEdges(View::OLD);
+    ASSERT_TRUE(out_edges.has_value());
+    ASSERT_EQ(out_edges->edges.size(), 1U);
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+}


### PR DESCRIPTION
Replace the replica WalEdgeSetProperty handler's edge_acc.find + manual out_edges scan with a single up-front storage->FindEdge resolution that dispatches heavy/light internally (self-gating on storage_light_edge), so the handler needs no explicit flag branch. Heavy mode is byte-equivalent to the prior path (logic-verifier: EQUIVALENT-WITH-CAVEATS; metadata-index from-vertex resolution matches existing master FindEdge semantics). Ships its tests in-PR: 2 ReplicationTestLightEdge unit tests (edge CRUD + recovery under the flag) plus light and mixed-edge e2e replication workloads. Existing heavy ReplicationTest coverage incl. the #4189 snapshot-transfer edge-metadata regression test is preserved. Drift-only files and the master-added replication_server tests untouched.