### PR TITLE
feat: search-as-you-type fuzzy prefix for text search

### DIFF
--- a/mgcxx/text_search/src/lib.rs
+++ b/mgcxx/text_search/src/lib.rs
@@ -17,7 +17,7 @@ use tantivy::aggregation::agg_result::AggregationResults;
 use tantivy::aggregation::AggregationCollector;
 use tantivy::collector::TopDocs;
 use tantivy::directory::MmapDirectory;
-use tantivy::query::{QueryParser, RegexQuery};
+use tantivy::query::{BooleanQuery, FuzzyTermQuery, Occur, Query, QueryParser, RegexQuery};
 use tantivy::schema::*;
 use tantivy::{Index, IndexReader, IndexWriter, ReloadPolicy, TantivyDocument};
 
@@ -180,6 +180,149 @@ fn apply_fuzzy_config(
     Ok(())
 }
 
+// As-you-type prefix search only supports a single field and plain terms; boolean
+// operators / multiple field clauses are intentionally rejected rather than mis-parsed.
+fn has_unsupported_prefix_syntax(terms: &str) -> bool {
+    terms.contains(':')
+        || terms.contains('(')
+        || terms.contains(')')
+        || terms.starts_with('+')
+        || terms.starts_with('-')
+        || terms
+            .split_whitespace()
+            .any(|w| w == "AND" || w == "OR" || w == "NOT")
+}
+
+// Splits the search query into (field_name, json_path, terms) for the two fuzzy-capable modes.
+// SPECIFIED_PROPERTIES uses fuzzy_field == "data" with a `data.<path>:<terms>` query; ALL_PROPERTIES
+// uses fuzzy_field == "all" with a bare `<terms>` query on the text field.
+fn split_field_and_terms(
+    input: &ffi::SearchInput,
+) -> Result<(String, Option<String>, String), std::io::Error> {
+    let form_err = || {
+        Error::new(
+            ErrorKind::Other,
+            format!(
+                "fuzzy_prefix search on 'data' requires 'data.<property>:<terms>' form, got: {}",
+                input.search_query
+            ),
+        )
+    };
+    let (field_name, json_path, terms) = match input.fuzzy_field.as_str() {
+        "all" => ("all".to_string(), None, input.search_query.trim().to_string()),
+        "data" => {
+            let (lhs, rhs) = input.search_query.split_once(':').ok_or_else(form_err)?;
+            let (prefix, path) = lhs.split_once('.').ok_or_else(form_err)?;
+            if prefix.trim() != "data" {
+                return Err(form_err());
+            }
+            ("data".to_string(), Some(path.trim().to_string()), rhs.trim().to_string())
+        }
+        other => {
+            return Err(Error::new(
+                ErrorKind::Other,
+                format!("fuzzy_prefix search unsupported for field '{}'", other),
+            ));
+        }
+    };
+    if has_unsupported_prefix_syntax(&terms) {
+        return Err(Error::new(
+            ErrorKind::Other,
+            "fuzzy_prefix mode does not support boolean operators or multiple field clauses".to_string(),
+        ));
+    }
+    Ok((field_name, json_path, terms))
+}
+
+// Builds a "search as you type" query: leading tokens matched whole, the last token matched as a
+// prefix, all tolerating fuzzy_distance typos, combined with AND. This is the per-term prefix
+// control that QueryParser cannot express (its fuzzy setting is per-field, not per-term).
+fn build_as_you_type_query(
+    index: &Index,
+    schema: &Schema,
+    input: &ffi::SearchInput,
+    index_path: &std::path::PathBuf,
+) -> Result<Box<dyn Query>, std::io::Error> {
+    let (field_name, json_path, terms) = split_field_and_terms(input)?;
+    let field = schema.get_field(&field_name).map_err(|e| {
+        Error::new(
+            ErrorKind::Other,
+            format!("fuzzy_prefix field '{}' not found in {:?} -> {}", field_name, index_path, e),
+        )
+    })?;
+
+    let mut analyzer = index.tokenizer_for_field(field).map_err(|e| {
+        Error::new(
+            ErrorKind::Other,
+            format!("Unable to get tokenizer for '{}' in {:?} -> {}", field_name, index_path, e),
+        )
+    })?;
+    let mut tokens: Vec<String> = Vec::new();
+    {
+        let mut stream = analyzer.token_stream(&terms);
+        while stream.advance() {
+            tokens.push(stream.token().text.clone());
+        }
+    }
+    if tokens.is_empty() {
+        return Err(Error::new(
+            ErrorKind::Other,
+            format!("fuzzy_prefix query '{}' produced no searchable tokens", terms),
+        ));
+    }
+
+    // distance is passed through unclamped so distance > 2 surfaces the same InvalidArgument
+    // error as the non-prefix path (tantivy supports 0..=2), rather than silently clamping.
+    let distance = input.fuzzy_distance;
+    let transpositions = input.fuzzy_transpositions;
+    let last = tokens.len() - 1;
+    let clauses: Vec<(Occur, Box<dyn Query>)> = tokens
+        .iter()
+        .enumerate()
+        .map(|(i, tok)| {
+            let term = match &json_path {
+                // expand_dots stays false to match how the `data` field is indexed.
+                Some(path) => {
+                    let mut t = Term::from_field_json_path(field, path, false);
+                    t.append_type_and_str(tok);
+                    t
+                }
+                None => Term::from_field_text(field, tok),
+            };
+            let fq = if i == last {
+                FuzzyTermQuery::new_prefix(term, distance, transpositions)
+            } else {
+                FuzzyTermQuery::new(term, distance, transpositions)
+            };
+            (Occur::Must, Box::new(fq) as Box<dyn Query>)
+        })
+        .collect();
+
+    Ok(Box::new(BooleanQuery::new(clauses)))
+}
+
+// Shared query construction for the gid-search entry points: as-you-type prefix builder when
+// fuzzy_prefix is set, otherwise the standard QueryParser path.
+fn build_search_query(
+    index: &Index,
+    schema: &Schema,
+    input: &ffi::SearchInput,
+    index_path: &std::path::PathBuf,
+) -> Result<Box<dyn Query>, std::io::Error> {
+    if input.fuzzy_prefix {
+        return build_as_you_type_query(index, schema, input, index_path);
+    }
+    let search_fields = search_get_fields(&input.search_fields, schema, index_path)?;
+    let mut query_parser = QueryParser::for_index(index, search_fields);
+    apply_fuzzy_config(&mut query_parser, schema, input)?;
+    query_parser.parse_query(&input.search_query).map_err(|e| {
+        Error::new(
+            ErrorKind::Other,
+            format!("Unable to create search query for {:?} -> {}", index_path, e),
+        )
+    })
+}
+
 fn owned_value_to_json(val: OwnedValue) -> serde_json::Value {
     match val {
         OwnedValue::Null => serde_json::Value::Null,
@@ -235,6 +378,88 @@ mod tests {
             owned_value_to_json(doc),
             json!({"name": "test", "count": -3, "tags": [true, 42u64], "nested": {"x": 1.5}, "empty": null})
         );
+    }
+
+    fn json_data_index(bodies: &[(&str, serde_json::Value)]) -> (Index, Schema) {
+        let mappings: serde_json::Map<String, Value> = serde_json::from_value(json!({
+            "properties": {"data": {"type": "json", "fast": true, "stored": true, "text": true}}
+        }))
+        .unwrap();
+        let schema = create_index_schema(&mappings).unwrap();
+        let index = Index::create_in_ram(schema.clone());
+        let mut writer: IndexWriter = index.writer(50_000_000).unwrap();
+        for (prop, value) in bodies {
+            let mut inner = serde_json::Map::new();
+            inner.insert((*prop).to_string(), value.clone());
+            let mut outer = serde_json::Map::new();
+            outer.insert("data".to_string(), Value::Object(inner));
+            let doc = TantivyDocument::parse_json(&schema, &Value::Object(outer).to_string()).unwrap();
+            writer.add_document(doc).unwrap();
+        }
+        writer.commit().unwrap();
+        (index, schema)
+    }
+
+    fn prefix_input(query: &str, distance: u8) -> ffi::SearchInput {
+        ffi::SearchInput {
+            search_fields: vec![],
+            search_query: query.to_string(),
+            return_fields: vec![],
+            aggregation_query: String::new(),
+            limit: 10,
+            fuzzy_distance: distance,
+            fuzzy_prefix: true,
+            fuzzy_transpositions: true,
+            fuzzy_field: "data".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_as_you_type_last_token_is_prefix_on_json_field() {
+        use tantivy::collector::Count;
+        let (index, schema) = json_data_index(&[
+            ("title", json!("lucky luke")),
+            ("title", json!("lucky lucy")),
+            ("title", json!("luckydog kennel")),
+            ("title", json!("lumber yard")),
+        ]);
+        let searcher = index.reader().unwrap().searcher();
+        let path = std::path::PathBuf::from("test");
+        let count = |q: &str, d: u8| {
+            let query = build_as_you_type_query(&index, &schema, &prefix_input(q, d), &path).unwrap();
+            searcher.search(&query, &Count).unwrap()
+        };
+        // leading "lucky" whole, last "lu" prefix => lucky luke + lucky lucy; NOT luckydog (leading
+        // is not a prefix) and NOT lumber.
+        assert_eq!(count("data.title:lucky lu", 0), 2);
+        // single token is treated as a prefix
+        assert_eq!(count("data.title:luc", 0), 3);
+        // typo in the whole leading word tolerated at distance 1
+        assert_eq!(count("data.title:lucki lu", 1), 2);
+    }
+
+    #[test]
+    fn test_as_you_type_numeric_property_matches_nothing() {
+        use tantivy::collector::Count;
+        let (index, schema) = json_data_index(&[("age", json!(30))]);
+        let searcher = index.reader().unwrap().searcher();
+        let query =
+            build_as_you_type_query(&index, &schema, &prefix_input("data.age:3", 0), &std::path::PathBuf::from("test"))
+                .unwrap();
+        // the query builds a string-typed json-path term; a numeric property has no string terms.
+        assert_eq!(searcher.search(&query, &Count).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_as_you_type_rejects_malformed_and_boolean_queries() {
+        let (index, schema) = json_data_index(&[("title", json!("lucky luke"))]);
+        let path = std::path::PathBuf::from("test");
+        // missing 'data.<prop>:' form
+        assert!(build_as_you_type_query(&index, &schema, &prefix_input("lucky", 0), &path).is_err());
+        // boolean operator
+        assert!(build_as_you_type_query(&index, &schema, &prefix_input("data.title:lucky AND luke", 0), &path).is_err());
+        // empty terms produce no tokens
+        assert!(build_as_you_type_query(&index, &schema, &prefix_input("data.title:", 0), &path).is_err());
     }
 }
 
@@ -861,15 +1086,7 @@ fn search_gids_pinned(
     let index = &context.tantivyContext.index;
     let schema = &context.tantivyContext.schema;
 
-    let search_fields = search_get_fields(&input.search_fields, schema, index_path)?;
-    let mut query_parser = QueryParser::for_index(index, search_fields);
-    apply_fuzzy_config(&mut query_parser, schema, input)?;
-    let query = query_parser.parse_query(&input.search_query).map_err(|e| {
-        Error::new(
-            ErrorKind::Other,
-            format!("Unable to create search query for {:?} -> {}", index_path, e),
-        )
-    })?;
+    let query = build_search_query(index, schema, input, index_path)?;
 
     let top_docs = searcher_ctx
         .searcher
@@ -952,15 +1169,7 @@ fn search_edge_gids_pinned(
     let index = &context.tantivyContext.index;
     let schema = &context.tantivyContext.schema;
 
-    let search_fields = search_get_fields(&input.search_fields, schema, index_path)?;
-    let mut query_parser = QueryParser::for_index(index, search_fields);
-    apply_fuzzy_config(&mut query_parser, schema, input)?;
-    let query = query_parser.parse_query(&input.search_query).map_err(|e| {
-        Error::new(
-            ErrorKind::Other,
-            format!("Unable to create search query for {:?} -> {}", index_path, e),
-        )
-    })?;
+    let query = build_search_query(index, schema, input, index_path)?;
 
     let top_docs = searcher_ctx
         .searcher

--- a/tests/gql_behave/tests/memgraph_V1/features/text_edge_search.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/text_edge_search.feature
@@ -504,3 +504,26 @@ Feature: Text edge search related features
             | title       |
             | 'memgrap'   |
             | 'memgraph'  |
+
+    Scenario: Fuzzy prefix on edges treats only the last word as a prefix
+        Given an empty graph
+        And having executed
+            """
+            CREATE TEXT EDGE INDEX asYouTypeEdge ON :RELATES_TO
+            """
+        And having executed
+            """
+            CREATE (a:Document)-[:RELATES_TO {title: 'lucky luke'}]->(b:Document)
+            CREATE (c:Document)-[:RELATES_TO {title: 'lucky lucy'}]->(d:Document)
+            CREATE (e:Document)-[:RELATES_TO {title: 'luckydog kennel'}]->(f:Document)
+            """
+        When executing query:
+            """
+            CALL text_search.search_edges('asYouTypeEdge', 'data.title:lucky lu', {fuzzy_prefix: true}) YIELD edge
+            RETURN edge.title AS title
+            ORDER BY title ASC
+            """
+        Then the result should be:
+            | title          |
+            | 'lucky lucy'   |
+            | 'lucky luke'   |

--- a/tests/gql_behave/tests/memgraph_V1/features/text_search.feature
+++ b/tests/gql_behave/tests/memgraph_V1/features/text_search.feature
@@ -549,6 +549,49 @@ Feature: Text search related features
             | title       |
             | 'memgraph'  |
 
+    Scenario: Fuzzy prefix treats only the last word as a prefix
+        Given an empty graph
+        And having executed
+            """
+            CREATE TEXT INDEX asYouType ON :Document
+            """
+        And having executed
+            """
+            CREATE (:Document {title: 'lucky luke'})
+            CREATE (:Document {title: 'lucky lucy'})
+            CREATE (:Document {title: 'luckydog kennel'})
+            """
+        When executing query:
+            """
+            CALL text_search.search('asYouType', 'data.title:lucky lu', {fuzzy_prefix: true}) YIELD node
+            RETURN node.title AS title
+            ORDER BY title ASC
+            """
+        Then the result should be:
+            | title          |
+            | 'lucky lucy'   |
+            | 'lucky luke'   |
+
+    Scenario: Fuzzy prefix combines a typo in the leading word with a last-word prefix
+        Given an empty graph
+        And having executed
+            """
+            CREATE TEXT INDEX asYouTypeTypo ON :Document
+            """
+        And having executed
+            """
+            CREATE (:Document {title: 'lucky luke'})
+            CREATE (:Document {title: 'coffee break'})
+            """
+        When executing query:
+            """
+            CALL text_search.search('asYouTypeTypo', 'data.title:lucki lu', {fuzzy_distance: 1, fuzzy_prefix: true}) YIELD node
+            RETURN node.title AS title
+            """
+        Then the result should be:
+            | title         |
+            | 'lucky luke'  |
+
     Scenario: Fuzzy search_all combines fuzzy with all-properties mode
         Given an empty graph
         And having executed

--- a/tests/unit/cpp_api.cpp
+++ b/tests/unit/cpp_api.cpp
@@ -1599,6 +1599,57 @@ TYPED_TEST(CppApiTestFixture, TestTextIndexFuzzySearch) {
   }
 }
 
+TYPED_TEST(CppApiTestFixture, TestTextIndexFuzzyPrefixSearch) {
+  constexpr auto index_name = "fuzzy_prefix_node_text_index";
+  constexpr auto label_name = "Document";
+  constexpr auto property_name = "content";
+  constexpr std::size_t text_search_limit = 10;
+  {
+    auto storage_acc = this->storage->UniqueAccess();
+    auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
+    auto label = db_acc->NameToLabel(label_name);
+    auto property = db_acc->NameToProperty(property_name);
+    auto text_index_spec =
+        memgraph::storage::TextIndexSpec{.index_name = index_name, .label = label, .properties = {property}};
+    ASSERT_TRUE(db_acc->CreateTextIndex(text_index_spec).has_value());
+    ASSERT_TRUE(db_acc->Commit(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  {
+    auto storage_acc = this->storage->UniqueAccess();
+    auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
+    mgp_graph raw_graph = this->CreateGraph(db_acc.get());
+    auto graph = mgp::Graph(&raw_graph);
+    for (const auto *content : {"lucky luke", "lucky lucy", "luckydog kennel"}) {
+      auto node = graph.CreateNode();
+      node.AddLabel(label_name);
+      node.SetProperty(property_name, mgp::Value(content));
+    }
+    ASSERT_TRUE(db_acc->Commit(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  {
+    auto storage_acc = this->storage->Access(memgraph::storage::StorageAccessType::READ);
+    auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
+    mgp_graph raw_graph = this->CreateGraph(db_acc.get());
+    // last word "lu" is a prefix, leading "lucky" is matched whole => lucky luke + lucky lucy,
+    // not luckydog.
+    auto as_you_type = mgp::SearchTextIndex(&raw_graph,
+                                            index_name,
+                                            "data.content:lucky lu",
+                                            text_search_mode::SPECIFIED_PROPERTIES,
+                                            mgp::TextSearchConfig{.limit = text_search_limit, .fuzzy_prefix = true});
+    EXPECT_EQ(as_you_type.Size(), 2);
+  }
+
+  {
+    auto storage_acc = this->storage->UniqueAccess();
+    auto db_acc = std::make_unique<memgraph::query::DbAccessor>(storage_acc.get());
+    ASSERT_TRUE(db_acc->DropTextIndex(index_name).has_value());
+    ASSERT_TRUE(db_acc->Commit(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+}
+
 TYPED_TEST(CppApiTestFixture, TestTextIndexOnEdges) {
   if constexpr (!std::is_same<TypeParam, memgraph::storage::InMemoryStorage>::value) {
     GTEST_SKIP() << "TestTextIndexOnEdges runs only on InMemoryStorage.";

--- a/tests/unit/text_index.cpp
+++ b/tests/unit/text_index.cpp
@@ -399,3 +399,33 @@ TEST_F(TextIndexTest, FuzzyDistanceAboveTwoThrows) {
                  memgraph::query::TextSearchException);
   }
 }
+
+TEST_F(TextIndexTest, FuzzyPrefixTreatsLastTokenAsPrefix) {
+  this->CreateIndex();
+  {
+    auto acc = this->storage->Access(memgraph::storage::WRITE);
+    this->CreateVertex(acc.get(), "lucky luke", "");
+    this->CreateVertex(acc.get(), "lucky lucy", "");
+    this->CreateVertex(acc.get(), "luckydog kennel", "");
+    this->CreateVertex(acc.get(), "lumber yard", "");
+    ASSERT_NO_ERROR(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()));
+  }
+  {
+    auto acc = this->storage->Access(memgraph::storage::WRITE);
+    constexpr TextSearchConfig prefix_config{.limit = 10, .fuzzy_prefix = true};
+    // last word "lu" is a prefix, leading "lucky" is matched whole => lucky luke + lucky lucy,
+    // not luckydog (leading word is not a prefix) and not lumber.
+    auto as_you_type = acc->TextIndexSearch(
+        test_index.data(), "data.title:lucky lu", text_search_mode::SPECIFIED_PROPERTIES, prefix_config);
+    EXPECT_EQ(as_you_type.size(), 2);
+
+    auto single = acc->TextIndexSearch(
+        test_index.data(), "data.title:luc", text_search_mode::SPECIFIED_PROPERTIES, prefix_config);
+    EXPECT_EQ(single.size(), 3);
+
+    constexpr TextSearchConfig typo_config{.limit = 10, .fuzzy_distance = 1, .fuzzy_prefix = true};
+    auto with_typo = acc->TextIndexSearch(
+        test_index.data(), "data.title:lucki lu", text_search_mode::SPECIFIED_PROPERTIES, typo_config);
+    EXPECT_EQ(with_typo.size(), 2);
+  }
+}


### PR DESCRIPTION
## Summary

Redefines the `fuzzy_prefix` text-search config flag to mean **"treat my input as a prefix"** — delivering proper *search-as-you-type* autocomplete. The **last** word is matched as a (fuzzy) prefix, leading words are matched whole, all words tolerate `fuzzy_distance` typos, and the words are combined with **AND**.

### Why

- The documented Tantivy phrase-prefix syntax (`data.name:"name some"*`) is **silently dropped on JSON fields** — our per-property search is backed by a JSON `data` field, where Tantivy never implemented phrase-prefix (unlike `FuzzyTermQuery`, which *is* JSON-path-aware). So `"…"*` degrades to an exact phrase.
- The old `fuzzy_prefix: true` made **every** word a prefix (so `lucky` matched `luckydog`), which floods results — not "search as you type".
- Tantivy's `QueryParser` can't make only the *last* term a prefix: its fuzzy setting is keyed per-field, applied to every term. So the query has to be built by hand.

### Behavior

| `fuzzy_prefix` | behavior |
|---|---|
| `false` (default) | every word matched whole (fuzzy if `fuzzy_distance > 0`) — **unchanged** |
| `true` | **last word = prefix, leading words whole**; all tolerate `fuzzy_distance` typos; works at distance 0 (exact prefix) |

The previous "all words are prefixes" behavior of `fuzzy_prefix: true` is removed in favor of last-word-only.

## Implementation

All changes are in the Tantivy bridge `mgcxx/text_search/src/lib.rs` — **no C ABI or config-key change** (`fuzzy_prefix` already flows end-to-end):

- `build_as_you_type_query` — tokenizes with the field's analyzer, builds `FuzzyTermQuery::new` for leading tokens and `FuzzyTermQuery::new_prefix` for the last, using JSON-path-aware terms (`Term::from_field_json_path` for `data`, `from_field_text` for `all`), combined into a `BooleanQuery` with `Occur::Must`.
- `split_field_and_terms` — parses `data.<property>:<terms>` (SPECIFIED_PROPERTIES) or a bare `<terms>` query on the `all` text field (ALL_PROPERTIES); rejects boolean operators / multi-field clauses in prefix mode.
- `build_search_query` — shared entry point used by both `search_gids_pinned` and `search_edge_gids_pinned`.

## Usage

```cypher
// types "lucky lu" -> matches "lucky luke", "lucky lucy" (not "luckydog")
CALL text_search.search('people', 'data.name:lucky lu', {fuzzy_prefix: true})
YIELD node RETURN node.name;

// with a typo: "lucki lu" still matches via fuzzy_distance
CALL text_search.search('people', 'data.name:lucki lu', {fuzzy_distance: 1, fuzzy_prefix: true})
YIELD node RETURN node.name;

// edges behave the same
CALL text_search.search_edges('rels', 'data.name:lucky lu', {fuzzy_prefix: true})
YIELD edge RETURN edge.name;
```

## Caveat

Words are combined with `BooleanQuery` AND, which does **not** enforce word order/adjacency (e.g. `lucky lu` can also match a value like `lu… lucky…`). Strict ordering would require a phrase-prefix query, which can't host fuzzy terms in Tantivy. 