### PR TITLE
perf(utils): cache EpochTracker dead-prefix watermark across rescans

### DIFF
--- a/src/utils/epoch_tracker.hpp
+++ b/src/utils/epoch_tracker.hpp
@@ -48,6 +48,26 @@ namespace memgraph::utils {
 /// live id) before the tracker is destroyed or Clear()ed. Destroying with live
 /// readers is undefined behaviour (a subsequent Release() would touch freed
 /// memory).
+///
+/// Dead-prefix watermark cache (amortized O(1) rescan):
+///   The dead prefix is monotonic — bits in field[] are only ever set (never
+///   cleared) until Clear().  ComputeLastDead() caches (cached_last_dead_,
+///   scan_resume_) so subsequent calls resume from the stall point instead of
+///   re-walking the entire block list from tail_.  The cache is NOT thread-safe
+///   under *concurrent* IsSafeToFree() / ComputeLastDead() calls: it is a
+///   multi-step read-modify of two non-atomic fields, so callers must serialise
+///   these two methods externally.  The only caller is the light-edge graveyard
+///   drain (DrainLightEdgeGraveyard); note it does NOT run on a single dedicated
+///   thread — FreeMemory reaches it from the periodic GC runner, a FREE MEMORY
+///   query, and SetStorageMode.  Serialisation there is provided not by a thread
+///   identity but by the drain itself: it swaps the whole graveyard into a
+///   thread-local list under a lock, so a second concurrent caller swaps an empty
+///   list and returns before ever touching the tracker — at most one thread
+///   executes the scan at a time.  (Cross-drain visibility of the cache fields
+///   comes from that same graveyard mutex; and even a stale read would be benign
+///   because the dead prefix is monotonic — resuming earlier only re-scans, never
+///   frees prematurely.)  Do NOT add an IsSafeToFree call site outside that
+///   swap-serialised drain without adding your own external serialisation.
 
 // TODO This is just the skiplist allocator's epoch tracker. Can we move the skiplist's out and use this there as well?
 // Audit to make sure the logic is EXACTLY the same.
@@ -147,7 +167,10 @@ class EpochTracker {
   }
 
   /// Returns true if all readers with id < guard_epoch have called Release().
-  /// Safe to call from any thread.
+  ///
+  /// NOT thread-safe vs concurrent IsSafeToFree() calls (see class-level doc).
+  /// Sole caller is the swap-serialised light-edge graveyard drain
+  /// (DrainLightEdgeGraveyard), which guarantees at most one thread scans at a time.
   bool IsSafeToFree(uint64_t guard_epoch) const noexcept {
     if (guard_epoch == 0) return true;  // no readers existed before the guard was recorded
     uint64_t last_dead = ComputeLastDead();
@@ -165,14 +188,44 @@ class EpochTracker {
   /// Returns the highest ID N such that all IDs in [0, N] have been released,
   /// or kNoDeadPrefix if no contiguous dead prefix has been established yet
   /// (i.e., ID 0 has not been released, or nothing has been released at all).
+  ///
+  /// Resume optimisation: the dead prefix is monotonically non-decreasing
+  /// (bits in field[] are set, never cleared, until Clear()).  We cache the
+  /// stall point (scan_resume_, cached_last_dead_) so the scan restarts from
+  /// the block where the prefix last stalled rather than from tail_ each time.
+  /// This makes repeated calls amortized O(newly-freed IDs) instead of O(all
+  /// freed IDs).  Resume granularity is one Block: all fields within the resume
+  /// block are re-examined (some may have been partially filled since the last
+  /// call) — this is safe and simpler than tracking per-field position.
+  ///
+  /// NOT thread-safe vs concurrent calls (see class-level doc and IsSafeToFree).
   uint64_t ComputeLastDead() const noexcept {
-    Block *block = tail_.load(std::memory_order_acquire);
-    uint64_t last_dead = kNoDeadPrefix;  // sentinel: no dead prefix yet
+    // Determine where to start scanning.
+    // If scan_resume_ is set, the prefix up to cached_last_dead_ is proven dead
+    // forever (bits only grow); resume from the stalled block.  Otherwise start
+    // from the oldest block (tail_).
+    Block *block;
+    uint64_t last_dead;
+    if (scan_resume_ != nullptr) {
+      block = scan_resume_;
+      last_dead = cached_last_dead_;
+    } else {
+      block = tail_.load(std::memory_order_acquire);
+      last_dead = kNoDeadPrefix;  // sentinel: no dead prefix yet
+    }
+
     while (block != nullptr) {
       for (uint64_t pos = 0; pos < kBlockFields; ++pos) {
         uint64_t bits = block->field[pos].load(std::memory_order_acquire);
         if (bits != kFieldFull) {
-          if (bits == 0) return last_dead;  // no IDs in this field are dead
+          if (bits == 0) {
+            // No IDs in this field are dead; the dead prefix stalls here.
+            // Update the resume cache to this block (re-scanning its fields next
+            // time is cheap and correct — partial fields may advance further).
+            scan_resume_ = block;
+            cached_last_dead_ = last_dead;
+            return last_dead;
+          }
           // Partial field: first still-alive id = first zero bit of bits =
           // countr_zero(~bits).  ~bits != 0 here: bits is neither 0 (caught
           // above) nor all-ones (caught by kFieldFull check), so at least one
@@ -181,12 +234,23 @@ class EpochTracker {
           uint64_t base = block->first_id + pos * kIdsInField;
           // base + where_alive - 1: when where_alive==0 and base==0 this wraps to
           // kNoDeadPrefix, which correctly signals "no dead prefix" (bit 0 is alive).
-          return base + where_alive - 1;
+          uint64_t result = base + where_alive - 1;
+          // Stall point is inside this block; cache it so next call re-scans
+          // from here (the partial field may fill further).
+          scan_resume_ = block;
+          cached_last_dead_ = last_dead;
+          return result;
         }
         // Full field: all 64 IDs in this field are dead.
         last_dead = block->first_id + (pos + 1) * kIdsInField - 1;
       }
-      block = block->succ.load(std::memory_order_acquire);
+      // Entire block is dead; advance to successor and update the cache.
+      Block *next = block->succ.load(std::memory_order_acquire);
+      // The resume pointer moves to the next block (or stays on the last one if
+      // next==nullptr, meaning the entire tracked range is dead so far).
+      scan_resume_ = (next != nullptr) ? next : block;
+      cached_last_dead_ = last_dead;
+      block = next;
     }
     return last_dead;
   }
@@ -204,6 +268,11 @@ class EpochTracker {
     head_.store(nullptr, std::memory_order_relaxed);
     tail_.store(nullptr, std::memory_order_relaxed);
     last_id_ = 0;
+    // CRITICAL: reset the watermark cache.  scan_resume_ points into a Block
+    // that is now freed; leaving it set would cause a dangling-pointer
+    // dereference on the next ComputeLastDead() call.
+    cached_last_dead_ = kNoDeadPrefix;
+    scan_resume_ = nullptr;
   }
 
   RWSpinLock lock_;
@@ -213,6 +282,23 @@ class EpochTracker {
   std::atomic<Block *> head_{nullptr};
   std::atomic<Block *> tail_{nullptr};
   uint64_t last_id_{0};
+
+  // Dead-prefix watermark cache (see ComputeLastDead() doc).
+  //
+  // These are NOT atomic.  Thread-safety relies on external serialisation of
+  // IsSafeToFree / ComputeLastDead: the sole caller is the light-edge graveyard
+  // drain, which swaps the graveyard out under a lock so only one thread ever
+  // executes the scan at a time (see class-level doc — the drain is NOT a single
+  // dedicated thread).  Making these atomic would add RMW overhead on every GC
+  // call and would not be sufficient on its own (ComputeLastDead performs a
+  // multi-step read-modify of both fields, which requires external serialisation
+  // regardless).
+  //
+  // Lifecycle: initialized to "no cache" state; updated by ComputeLastDead();
+  // MUST be reset to "no cache" state in Clear() because scan_resume_ points
+  // into a Block that Clear() deallocates (dangling pointer otherwise).
+  mutable uint64_t cached_last_dead_{kNoDeadPrefix};
+  mutable Block *scan_resume_{nullptr};
 };
 
 }  // namespace memgraph::utils

--- a/tests/unit/utils_epoch_tracker.cpp
+++ b/tests/unit/utils_epoch_tracker.cpp
@@ -375,6 +375,136 @@ TEST(EpochTrackerStress, ConcurrentReleaseRacesBlockAllocation) {
       << "IsSafeToFree(" << kTotal << ") must be true after all " << kTotal << " ids released";
 }
 
+// ---------------------------------------------------------------------------
+// Watermark cache tests
+// ---------------------------------------------------------------------------
+
+// WatermarkCacheAdvancesAndStalls: verify that the resume cache correctly
+// advances across block boundaries and stalls at partial fields, and that
+// IsSafeToFree returns identical results to a fresh oracle tracker performing
+// the same operations.
+//
+// Layout (kIdsInField==64, kIdsInBlock==4096):
+//   Phase A: release ids 0..62 (partial first field of block 0) → stall inside block 0.
+//   Phase B: release id 63 (first field of block 0 now full) → stall still inside block 0.
+//   Phase C: release ids 64..4095 (rest of block 0, all fields full) → prefix advances
+//            through block 0; stall at start of block 1.
+//   Phase D: release ids 4096..4158 (first two partial fields of block 1) → stall
+//            inside block 1.
+//   Phase E: release ids 4159..8191 (rest of block 1 minus id 8192 which stays live)
+//            → prefix advances through block 1; stall at block 2 (first field not full).
+//
+// After each phase, IsSafeToFree is compared against a hand-computed expected
+// last_dead derived from the same logic as ComputeLastDead.
+TEST(EpochTracker, WatermarkCacheAdvancesAndStalls) {
+  using namespace memgraph::utils;
+
+  // kIdsInField and kIdsInBlock are private; use the values documented in the
+  // header (64 and 4096 respectively) — the BlockBoundary64 and
+  // BlockAllocationAcross4096 tests already verify these constants.
+  constexpr uint64_t kField = 64;
+  constexpr uint64_t kBlock = 4096;
+
+  // Acquire enough ids to span 3 blocks (ids 0 .. 3*kBlock-1 = 12287) plus one
+  // extra live id that stays unreleased throughout to pin the stall point.
+  constexpr uint64_t kTotal = 3 * kBlock + 1;  // 12289
+  EpochTracker tracker;
+  for (uint64_t i = 0; i < kTotal; ++i) (void)tracker.Acquire();
+
+  // --- Phase A: release ids 0..62 (partial first field of block 0) ---
+  // Expected last_dead: 62 (where_alive=63 in the partial field; bit 63 still alive).
+  // IsSafeToFree(63) → last_dead(62) >= 62 → true.
+  // IsSafeToFree(64) → last_dead(62) >= 63 → false.
+  for (uint64_t i = 0; i <= 62; ++i) tracker.Release(i);
+  EXPECT_TRUE(tracker.IsSafeToFree(63)) << "Phase A: guard 63 should be safe";
+  EXPECT_FALSE(tracker.IsSafeToFree(64)) << "Phase A: guard 64 should not be safe";
+
+  // --- Phase B: release id 63 → first field now full ---
+  // Expected last_dead: 63 (stall at second field of block 0, which is empty).
+  // IsSafeToFree(64) → 63 >= 63 → true.
+  // IsSafeToFree(65) → 63 >= 64 → false.
+  tracker.Release(63);
+  EXPECT_TRUE(tracker.IsSafeToFree(64)) << "Phase B: guard 64 should be safe after id 63 released";
+  EXPECT_FALSE(tracker.IsSafeToFree(65)) << "Phase B: guard 65 should not be safe";
+
+  // --- Phase C: release ids 64..4095 (complete rest of block 0) ---
+  // Expected last_dead: 4095; stall at block 1 field 0 (all zero).
+  // IsSafeToFree(4096) → 4095 >= 4095 → true.
+  // IsSafeToFree(4097) → 4095 >= 4096 → false.
+  for (uint64_t i = 64; i <= 4095; ++i) tracker.Release(i);
+  EXPECT_TRUE(tracker.IsSafeToFree(4096)) << "Phase C: guard 4096 should be safe";
+  EXPECT_FALSE(tracker.IsSafeToFree(4097)) << "Phase C: guard 4097 should not be safe";
+
+  // --- Phase D: release ids 4096..4095+2*kField-1 = 4096..4223 (two partial fields of block 1) ---
+  // All 128 bits of fields 0 and 1 of block 1 are set; field 2 is empty.
+  // Expected last_dead: 4095 + 2*kField = 4095 + 128 = 4223.
+  // IsSafeToFree(4224) → 4223 >= 4223 → true.
+  // IsSafeToFree(4225) → 4223 >= 4224 → false.
+  for (uint64_t i = 4096; i <= 4095 + 2 * kField; ++i) tracker.Release(i);
+  EXPECT_TRUE(tracker.IsSafeToFree(4224)) << "Phase D: guard 4224 should be safe";
+  EXPECT_FALSE(tracker.IsSafeToFree(4225)) << "Phase D: guard 4225 should not be safe";
+
+  // --- Phase E: release ids 4224..8191 (rest of block 1 through last id 8191) ---
+  // id 8192 (first of block 2) is still live.
+  // Expected last_dead: 8191 (stall at block 2 field 0, bit 0 not set).
+  // IsSafeToFree(8192) → 8191 >= 8191 → true.
+  // IsSafeToFree(8193) → 8191 >= 8192 → false.
+  for (uint64_t i = 4224; i <= 8191; ++i) tracker.Release(i);
+  EXPECT_TRUE(tracker.IsSafeToFree(8192)) << "Phase E: guard 8192 should be safe";
+  EXPECT_FALSE(tracker.IsSafeToFree(8193)) << "Phase E: guard 8193 should not be safe";
+
+  // Release remaining live ids so the destructor assertion holds.
+  for (uint64_t i = 8192; i < kTotal; ++i) tracker.Release(i);
+}
+
+// ClearResetsWatermarkCache: verify that destroying an EpochTracker with a warm
+// cache and recreating a fresh one produces correct, stale-free results.
+//
+// Round 1: fill tracker, warm the cache (IsSafeToFree returns true), then
+// destroy the tracker.  Any dangling scan_resume_ would manifest as a
+// use-after-free on the next ComputeLastDead call if the cache were carried
+// into round 2 — Clear() is called by the destructor.
+//
+// Round 2: a brand-new EpochTracker starting from a clean state is used to
+// re-verify that a fresh instance works correctly with no leftover state.
+// (Because Clear() is private and only called by the destructor, we exercise
+// it through destruction+recreation rather than calling it directly.)
+TEST(EpochTracker, ClearResetsWatermarkCache) {
+  using namespace memgraph::utils;
+
+  constexpr uint64_t kBlock = 4096;
+  // Use 2.5 blocks worth of ids to ensure at least 2 full blocks are committed
+  // to the cache (warm: scan_resume_ points into a Block that will be freed).
+  constexpr uint64_t kRound1Ids = 2 * kBlock + 128;
+
+  // --- Round 1: warm the cache then destroy ---
+  {
+    EpochTracker t1;
+    for (uint64_t i = 0; i < kRound1Ids; ++i) (void)t1.Acquire();
+    for (uint64_t i = 0; i < kRound1Ids; ++i) t1.Release(i);
+    // Warm the cache: IsSafeToFree walks all blocks, sets scan_resume_.
+    EXPECT_TRUE(t1.IsSafeToFree(kRound1Ids)) << "Round 1: all ids released, must be safe";
+    // t1 goes out of scope here; ~EpochTracker() calls Clear(), which must
+    // reset scan_resume_=nullptr and cached_last_dead_=kNoDeadPrefix.
+    // If the reset is missing, t2 (a fresh placement in the same stack region
+    // on many compilers) or a subsequent EpochTracker created at the same
+    // address would inherit a dangling pointer — caught by ASan.
+  }
+
+  // --- Round 2: fresh tracker, verify clean state ---
+  {
+    EpochTracker t2;
+    // Fresh tracker: no ids acquired, no cache.
+    EXPECT_FALSE(t2.IsSafeToFree(1)) << "Round 2: fresh tracker, guard 1 must not be safe";
+    EXPECT_TRUE(t2.IsSafeToFree(0)) << "Round 2: guard 0 always safe";
+
+    constexpr uint64_t kRound2Ids = kBlock + 1;
+    for (uint64_t i = 0; i < kRound2Ids; ++i) (void)t2.Acquire();
+    for (uint64_t i = 0; i < kRound2Ids; ++i) t2.Release(i);
+    EXPECT_TRUE(t2.IsSafeToFree(kRound2Ids)) << "Round 2: all ids released, must be safe";
+  }
+}
+
 // Acquire/Release churn with interleaved threads: N threads each loop k times,
 // calling Acquire() immediately followed by Release() with an occasional yield.
 // Ids from different threads interleave in the epoch counter, so partial
@@ -382,6 +512,12 @@ TEST(EpochTrackerStress, ConcurrentReleaseRacesBlockAllocation) {
 //
 // After all threads join, IsSafeToFree(CurrentEpoch()) must hold because every
 // Acquire()d id was immediately Release()d.
+//
+// Note on watermark cache + concurrency: IsSafeToFree / ComputeLastDead are
+// called ONLY from the checker thread in SafetyContractUnderConcurrency, which
+// satisfies the single-caller contract (see class-level doc).  This test does
+// NOT call IsSafeToFree from multiple threads concurrently; the post-join
+// IsSafeToFree call below is made single-threaded after all workers have exited.
 // EXPECT_* is issued only by main after all threads have joined.
 TEST(EpochTrackerStress, AcquireReleaseChurn) {
   using namespace memgraph::utils;


### PR DESCRIPTION
ComputeLastDead rescanned the whole block list from tail_ on every IsSafeToFree call. The dead prefix is monotonic (bits only ever set, never cleared, until Clear()), so the scan can resume from the block where the prefix last stalled instead of re-walking the entire list from tail_ — bounded by the blocks touched since the last stall rather than the total block count.

The cache members are deliberately non-atomic. IsSafeToFree / ComputeLastDead require external serialisation (each is a multi-step read-modify of two non-atomic fields); the sole caller is the light-edge graveyard drain, which serialises them by swapping the graveyard out under a lock so only one thread ever runs the scan at a time. Note the drain is NOT a single dedicated thread — FreeMemory reaches it from the periodic GC runner, a FREE MEMORY query, and SetStorageMode — so the safety rests on the swap, not on thread identity. Reader threads only touch the field[] bitmap. Clear() resets the cache (scan_resume_ would otherwise dangle across the block frees).

Tests: WatermarkCacheAdvancesAndStalls (stall/advance/stall across block boundaries against hand-computed oracles), ClearResetsWatermarkCache (no stale state across teardown).

Git commit description, explain the changes you made here

---
__*Leave above in PR description, copy the below into a comment*__
___

### Tracking
- [ ] **[Link to Epic/Issue]**

### Standard development
- [ ] Update unit/E2E tests
- [ ] Compare the [benchmarking results](https://bench-graph.memgraph.com/) between the master branch this branch

### CI Testing Labels
- [ ] Select the appropriate CI test labels _(CI -build=**build-name** -test=**test-suite**)_

### Documentation checklist
- [ ] Add the documentation label
- [ ] Add the bug / feature label
- [ ] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - What has changed? What does it mean for a user? What should a user do with it? [#{{PR_number}}]({{link to the PR}})
- [ ] **[ Documentation PR link memgraph/documentation#XXXX ]**
    - [ ] Is back linked to this development PR
