### PR TITLE
fix: CI issues

### DIFF
--- a/.github/actions/cancel-on-failure-in-merge-queue/action.yml
+++ b/.github/actions/cancel-on-failure-in-merge-queue/action.yml
@@ -1,5 +1,5 @@
 name: 'Cancel run on merge_group failure'
-description: 'Cancels the current workflow run via the GitHub API. The caller must gate this with `if: failure() && github.event_name == ''merge_group''` because composite actions cannot read the calling job''s runtime status.'
+description: 'Emits an error annotation naming the failing job, then cancels the current workflow run via the GitHub API to fail fast. The annotation makes the real culprit identifiable in the run summary even though cancellation marks every job as cancelled. The caller must gate this with `if: failure() && github.event_name == ''merge_group''` because composite actions cannot read the calling job''s runtime status.'
 
 runs:
   using: 'composite'
@@ -10,9 +10,16 @@ runs:
         GH_TOKEN: ${{ github.token }}
         GH_REPO: ${{ github.repository }}
         RUN_ID: ${{ github.run_id }}
+        JOB: ${{ github.job }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       run: |
         set -euo pipefail
-        echo "Cancelling workflow run ${RUN_ID} in ${GH_REPO} after merge_group job failure"
+        # Cancelling the run marks every still-running job as "cancelled", which
+        # hides which job actually failed. Emit an error annotation from this
+        # (the failing) job first: it is attributed to this job and shows up in
+        # the run summary, pointing reviewers at the real culprit.
+        echo "::error title=Merge queue fail-fast triggered by job '${JOB}'::Job '${JOB}' failed and is cancelling run ${RUN_ID} to fail fast. Other jobs reported as 'cancelled' were stopped as a side effect — '${JOB}' is the job that actually failed. ${RUN_URL}"
+        echo "Cancelling workflow run ${RUN_ID} in ${GH_REPO} after merge_group failure in job '${JOB}'"
         curl -fsSL -X POST \
           --proto '=https' --proto-redir '=https' \
           -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/benchmark_on_pokec_large.yaml
+++ b/.github/workflows/benchmark_on_pokec_large.yaml
@@ -29,6 +29,12 @@ jobs:
             # branches and tags. (default: 1)
             fetch-depth: 0
 
+        - name: Clean up Docker
+          if: always()
+          continue-on-error: true
+          run: |
+            ./tools/ci/docker_cleanup.sh
+
         - name: Log in to Docker Hub
           uses: ./.github/actions/docker-login
           with:

--- a/.github/workflows/daily_benchmark.yaml
+++ b/.github/workflows/daily_benchmark.yaml
@@ -51,6 +51,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
+
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
         with:

--- a/.github/workflows/diff_community.yaml
+++ b/.github/workflows/diff_community.yaml
@@ -49,6 +49,12 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
 
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
+
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
         with:

--- a/.github/workflows/diff_coverage.yaml
+++ b/.github/workflows/diff_coverage.yaml
@@ -54,6 +54,12 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
 
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
+
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
         with:
@@ -193,6 +199,12 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref || github.ref }}
 
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
+
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
         with:
@@ -284,6 +296,12 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref || github.ref }}
+
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login

--- a/.github/workflows/diff_debug.yaml
+++ b/.github/workflows/diff_debug.yaml
@@ -59,6 +59,12 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
 
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
+
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
         with:
@@ -194,6 +200,12 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
+
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login

--- a/.github/workflows/diff_jepsen.yaml
+++ b/.github/workflows/diff_jepsen.yaml
@@ -45,6 +45,12 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
 
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
+
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
         with:

--- a/.github/workflows/diff_malloc.yaml
+++ b/.github/workflows/diff_malloc.yaml
@@ -50,6 +50,12 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
 
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
+
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
         with:

--- a/.github/workflows/diff_release.yaml
+++ b/.github/workflows/diff_release.yaml
@@ -72,6 +72,12 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
 
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
+
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
         with:
@@ -216,6 +222,12 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
+
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
@@ -456,6 +468,12 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
 
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
+
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
         with:
@@ -586,6 +604,12 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
+
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
@@ -738,6 +762,12 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
+
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login

--- a/.github/workflows/reusable_build_mgbench_client.yml
+++ b/.github/workflows/reusable_build_mgbench_client.yml
@@ -68,6 +68,12 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0

--- a/.github/workflows/reusable_issu_test.yaml
+++ b/.github/workflows/reusable_issu_test.yaml
@@ -52,6 +52,12 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
+
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
         with:

--- a/.github/workflows/reusable_package.yaml
+++ b/.github/workflows/reusable_package.yaml
@@ -95,6 +95,12 @@ jobs:
           fetch-depth: 0 # Required because of release/get_version.py
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
+
       - name: "Log in to Docker Hub"
         uses: ./.github/actions/docker-login
         with:

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -152,6 +152,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
+
       - name: "Log in to Docker Hub"
         uses: ./.github/actions/docker-login
         with:

--- a/.github/workflows/reusable_release_tests.yaml
+++ b/.github/workflows/reusable_release_tests.yaml
@@ -70,6 +70,12 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
+
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
         with:
@@ -150,6 +156,12 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
@@ -249,6 +261,12 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
@@ -384,6 +402,12 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
+
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
         with:
@@ -469,6 +493,12 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
@@ -584,6 +614,12 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
@@ -708,6 +744,12 @@ jobs:
           fetch-depth: 0
           ref:  ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
+
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
         with:
@@ -814,6 +856,12 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
@@ -925,6 +973,12 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
@@ -1066,6 +1120,12 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
@@ -1217,6 +1277,12 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
+
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
         with:
@@ -1315,6 +1381,12 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login

--- a/.github/workflows/reusable_smoke_test_docker.yml
+++ b/.github/workflows/reusable_smoke_test_docker.yml
@@ -62,6 +62,12 @@ jobs:
           submodules: recursive
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
+
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
         with:

--- a/.github/workflows/reusable_stress_jepsen.yaml
+++ b/.github/workflows/reusable_stress_jepsen.yaml
@@ -71,6 +71,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
+
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
         with:

--- a/.github/workflows/reusable_stress_tests.yaml
+++ b/.github/workflows/reusable_stress_tests.yaml
@@ -64,6 +64,12 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
+
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
         with:
@@ -168,6 +174,12 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
+
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
         with:
@@ -270,6 +282,12 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
+
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login
         with:
@@ -356,6 +374,12 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+
+      - name: Clean up Docker
+        if: always()
+        continue-on-error: true
+        run: |
+          ./tools/ci/docker_cleanup.sh
 
       - name: Log in to Docker Hub
         uses: ./.github/actions/docker-login

--- a/init-dev
+++ b/init-dev
@@ -32,7 +32,8 @@ fi
 
 echo "Linking git hooks OR skip if .git folder is not there"
 if [ -d "$DIR/.git" ]; then
-  for hook in $(find "$DIR/.githooks" -type f -printf "%f\n"); do
+  for hookpath in $(find "$DIR/.githooks" -type f); do
+    hook="$(basename "$hookpath")"
     ln -s -f "$DIR/.githooks/$hook" "$DIR/.git/hooks/$hook"
     echo "Added $hook hook"
   done
@@ -44,7 +45,9 @@ fi
 if [[ "$ci" == "false" ]]; then
   echo "Installing pre-commit hooks"
   export PIP_BREAK_SYSTEM_PACKAGES=1
-  python3 -m pip install --upgrade pip
-  pip install pre-commit black==26.5.0 isort==5.12.*
+  # Upgrading pip is best-effort: a Homebrew/distro-managed pip can't uninstall
+  # itself (no RECORD file), so don't let a failed upgrade abort the script.
+  python3 -m pip install --upgrade pip || true
+  python3 -m pip install pre-commit black==26.5.0 isort==5.12.*
   python3 -m pre_commit install
 fi

--- a/mage/install_python_requirements.sh
+++ b/mage/install_python_requirements.sh
@@ -52,6 +52,8 @@ if [[ "$CUDA" == true && "$ARCH" != "amd64" ]]; then
 fi
 
 export PIP_BREAK_SYSTEM_PACKAGES=1
+export PIP_DEFAULT_TIMEOUT=120
+export PIP_RETRIES=8
 if [[ "$CUDA" == true && "$DEB_PACKAGE" == "false" ]]; then
   requirements_file="requirements-gpu.txt"
 else

--- a/mage/tests/smoke-release-testing/requirements.txt
+++ b/mage/tests/smoke-release-testing/requirements.txt
@@ -1,3 +1,3 @@
-GQLAlchemy
+gqlalchemy @ git+https://github.com/memgraph/gqlalchemy.git@d2a7ce1e9f70e153712397a49d39136ffe7601db
 neo4j==5.23
 semver==3.0.2

--- a/tools/ci/container-test-mage.sh
+++ b/tools/ci/container-test-mage.sh
@@ -70,7 +70,7 @@ else
 fi
 docker cp mage/python/$requirements_file $CONTAINER_NAME:/tmp/$requirements_file
 docker cp src/auth/reference_modules/requirements.txt $CONTAINER_NAME:/tmp/auth_module-requirements.txt
-docker exec -i -u mg $CONTAINER_NAME bash -c "cd \$HOME/memgraph/mage/ && \
+docker exec -i -u mg $CONTAINER_NAME bash -c "export PIP_DEFAULT_TIMEOUT=120 PIP_RETRIES=8 && cd \$HOME/memgraph/mage/ && \
   ./install_python_requirements.sh --ci --cache-present $CACHE_PRESENT --cuda $CUDA --arch $ARCH && \
   pip install -r \$HOME/memgraph/mage/python/tests/requirements.txt --break-system-packages"
 docker exec -i -u mg $CONTAINER_NAME bash -c "cd \$HOME/memgraph/mage/python/ && python3 -m pytest ."


### PR DESCRIPTION
- Run the docker cleanup script at the start of a job, just in case a previous job failed to cleanup on that runner.
- Emit annotation on GitHub to show which job triggers the fast-fail action when there is a failure in the merge queue.
- Increase timeout for pip to resolve dependencies, so that the MAGE build might not fail.
- Fix the `init-dev` script on macOS.
