### PR TITLE
fix: remove unnecessary sleep from mgps.await_indexes

### DIFF
--- a/query_modules/mgps.py
+++ b/query_modules/mgps.py
@@ -1,5 +1,3 @@
-import time
-
 import mgp
 
 
@@ -15,10 +13,10 @@ def components(
 
 @mgp.read_proc
 def await_indexes(context: mgp.ProcCtx, seconds: int):
-    # Nothing smart here
-    # This method exists only for compatibility with Neo4j's
-    # db.awaitIndexes, inside the Apache Spark Connector integration
-    time.sleep(1)
+    # No-op: index creation is synchronous, so there is nothing to await.
+    # This method exists only for compatibility with the Apache Spark
+    # Connector integration.
+    pass
 
 
 @mgp.function


### PR DESCRIPTION
Removes the hardcoded `time.sleep(1)` from `mgps.await_indexes`. Index creation is synchronous, so there is nothing to await — the sleep only added a flat 1s of latency to every Spark connector call. The procedure is kept as a no-op for compatibility.