### PR TITLE
feat: add elementId function

### DIFF
--- a/src/query/interpret/awesome_memgraph_functions.cpp
+++ b/src/query/interpret/awesome_memgraph_functions.cpp
@@ -1196,9 +1196,7 @@ TypedValue Counter(const TypedValue *args, int64_t nargs, const FunctionContext 
   return TypedValue(value, context.memory);
 }
 
-TypedValue Id(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
-  FType<Or<Null, Vertex, Edge>>("id", args, nargs);
-  const auto &arg = args[0];
+TypedValue IdOf(const TypedValue &arg, const FunctionContext &ctx) {
   if (arg.IsNull()) {
     return TypedValue(ctx.memory);
   } else if (arg.IsVirtualNode()) {
@@ -1210,6 +1208,19 @@ TypedValue Id(const TypedValue *args, int64_t nargs, const FunctionContext &ctx)
   } else {
     return TypedValue(arg.ValueEdge().CypherId(), ctx.memory);
   }
+}
+
+TypedValue Id(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
+  FType<Or<Null, Vertex, Edge>>("id", args, nargs);
+  return IdOf(args[0], ctx);
+}
+
+// Returns the id as a string for compatibility with external integrations.
+TypedValue ElementId(const TypedValue *args, int64_t nargs, const FunctionContext &ctx) {
+  FType<Or<Null, Vertex, Edge>>("elementId", args, nargs);
+  auto id = IdOf(args[0], ctx);
+  if (id.IsNull()) return id;
+  return TypedValue(std::to_string(id.ValueInt()), ctx.memory);
 }
 
 // Conversion core shared by toString and toStringOrNull; nullopt iff the enum can't be resolved to a name.
@@ -1991,6 +2002,7 @@ auto const builtin_functions = absl::flat_hash_map<std::string, func_info>{
     {"ENDNODE", func_info{.func_ = EndNode, .is_pure_ = true}},
     {"HEAD", func_info{.func_ = Head, .is_pure_ = true}},
     {kId, func_info{.func_ = Id, .is_pure_ = true}},
+    {kElementId, func_info{.func_ = ElementId, .is_pure_ = true}},
     {"LAST", func_info{.func_ = Last, .is_pure_ = true}},
     {"PROPERTIES", func_info{.func_ = Properties, .is_pure_ = true}},
     {"RANDOMUUID", func_info{.func_ = RandomUuid, .is_pure_ = false}},

--- a/src/query/interpret/awesome_memgraph_functions.hpp
+++ b/src/query/interpret/awesome_memgraph_functions.hpp
@@ -30,6 +30,7 @@ const char kStartsWith[] = "STARTSWITH";
 const char kEndsWith[] = "ENDSWITH";
 const char kContains[] = "CONTAINS";
 const char kId[] = "ID";
+const char kElementId[] = "ELEMENTID";
 }  // namespace
 
 struct FunctionContext {

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -14,6 +14,7 @@
 #include "metrics/prometheus_metrics.hpp"
 
 #include <algorithm>
+#include <charconv>
 #include <cstdint>
 #include <execution>
 #include <functional>
@@ -1648,9 +1649,29 @@ std::unique_ptr<LogicalOperator> ScanAllByLabelProperties::Clone(AstStorage *sto
   return object;
 }
 
+namespace {
+// Extracts the looked-up id from an evaluated id()/elementId() comparison
+// value; nullopt if the value can't match any id.
+std::optional<int64_t> ExtractIdValue(const TypedValue &value, bool expects_string_id) {
+  if (expects_string_id) {
+    if (!value.IsString()) return std::nullopt;
+    const auto &str = value.ValueString();
+    int64_t id{};
+    const auto *end = str.data() + str.size();
+    auto [ptr, ec] = std::from_chars(str.data(), end, id);
+    if (ec != std::errc{} || ptr != end) return std::nullopt;
+    return id;
+  }
+  if (!value.IsNumeric()) return std::nullopt;
+  int64_t id = value.IsInt() ? value.ValueInt() : value.ValueDouble();
+  if (value.IsDouble() && id != value.ValueDouble()) return std::nullopt;
+  return id;
+}
+}  // namespace
+
 ScanAllById::ScanAllById(const std::shared_ptr<LogicalOperator> &input, Symbol output_symbol, Expression *expression,
-                         storage::View view)
-    : ScanAll(input, output_symbol, view), expression_(expression) {
+                         storage::View view, bool expects_string_id)
+    : ScanAll(input, output_symbol, view), expression_(expression), expects_string_id_(expects_string_id) {
   MG_ASSERT(expression);
 }
 
@@ -1672,10 +1693,9 @@ UniqueCursorPtr ScanAllById::MakeCursor(utils::MemoryResource *mem,
                                   context.user_or_role,
                                   context.triggering_user);
     auto value = expression_->Accept(evaluator);
-    if (!value.IsNumeric()) return std::nullopt;
-    int64_t id = value.IsInt() ? value.ValueInt() : value.ValueDouble();
-    if (value.IsDouble() && id != value.ValueDouble()) return std::nullopt;
-    auto maybe_vertex = db->FindVertex(storage::Gid::FromInt(id), view_);
+    auto id = ExtractIdValue(value, expects_string_id_);
+    if (!id) return std::nullopt;
+    auto maybe_vertex = db->FindVertex(storage::Gid::FromInt(*id), view_);
     if (!maybe_vertex) return std::nullopt;
     return std::vector<VertexAccessor>{*maybe_vertex};
   };
@@ -1691,13 +1711,16 @@ std::unique_ptr<LogicalOperator> ScanAllById::Clone(AstStorage *storage) const {
   object->output_symbol_ = output_symbol_;
   object->view_ = view_;
   object->expression_ = expression_ ? expression_->Clone(storage) : nullptr;
+  object->expects_string_id_ = expects_string_id_;
   return object;
 }
 
 ScanAllByEdgeId::ScanAllByEdgeId(const std::shared_ptr<LogicalOperator> &input, Symbol edge_symbol, Symbol node1_symbol,
                                  Symbol node2_symbol, EdgeAtom::Direction direction, Expression *expression,
-                                 storage::View view)
-    : ScanAllByEdge(input, edge_symbol, node1_symbol, node2_symbol, direction, {}, view), expression_(expression) {
+                                 storage::View view, bool expects_string_id)
+    : ScanAllByEdge(input, edge_symbol, node1_symbol, node2_symbol, direction, {}, view),
+      expression_(expression),
+      expects_string_id_(expects_string_id) {
   MG_ASSERT(expression);
 }
 
@@ -1719,10 +1742,9 @@ UniqueCursorPtr ScanAllByEdgeId::MakeCursor(utils::MemoryResource *mem,
                                   context.user_or_role,
                                   context.triggering_user);
     auto value = expression_->Accept(evaluator);
-    if (!value.IsNumeric()) return std::nullopt;
-    int64_t id = value.IsInt() ? value.ValueInt() : value.ValueDouble();
-    if (value.IsDouble() && id != value.ValueDouble()) return std::nullopt;
-    auto maybe_edge = db->FindEdge(storage::Gid::FromInt(id), view_);
+    auto id = ExtractIdValue(value, expects_string_id_);
+    if (!id) return std::nullopt;
+    auto maybe_edge = db->FindEdge(storage::Gid::FromInt(*id), view_);
     if (!maybe_edge) return std::nullopt;
     return std::vector<EdgeAccessor>{*maybe_edge};
   };
@@ -1740,6 +1762,7 @@ std::unique_ptr<LogicalOperator> ScanAllByEdgeId::Clone(AstStorage *storage) con
   object->common_ = common_;
   object->view_ = view_;
   object->expression_ = expression_ ? expression_->Clone(storage) : nullptr;
+  object->expects_string_id_ = expects_string_id_;
   return object;
 }
 

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -1660,6 +1660,8 @@ std::optional<int64_t> ExtractIdValue(const TypedValue &value, bool expects_stri
     const auto *end = str.data() + str.size();
     auto [ptr, ec] = std::from_chars(str.data(), end, id);
     if (ec != std::errc{} || ptr != end) return std::nullopt;
+    // Only the canonical form can match ("042" parses to 42 but "042" != elementId of 42).
+    if (std::to_string(id) != std::string_view{str}) return std::nullopt;
     return id;
   }
   if (!value.IsNumeric()) return std::nullopt;

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -4535,7 +4535,9 @@ std::string Filter::SingleFilterName(FilterInfo const &single_filter) {
           "{{{}.{}}}", single_filter.property_filter->symbol_.name(), single_filter.property_filter->property_ids_);
     }
     case Type::Id: {
-      return fmt::format("id({})", single_filter.id_filter->symbol_.name());
+      return fmt::format("{}({})",
+                         single_filter.id_filter->expects_string_id_ ? "elementId" : "id",
+                         single_filter.id_filter->symbol_.name());
     }
     case Type::Pattern: {
       return "Pattern";

--- a/src/query/plan/operator.cpp
+++ b/src/query/plan/operator.cpp
@@ -1665,8 +1665,11 @@ std::optional<int64_t> ExtractIdValue(const TypedValue &value, bool expects_stri
     return id;
   }
   if (!value.IsNumeric()) return std::nullopt;
-  int64_t id = value.IsInt() ? value.ValueInt() : value.ValueDouble();
-  if (value.IsDouble() && id != value.ValueDouble()) return std::nullopt;
+  if (value.IsInt()) return value.ValueInt();
+  const double d = value.ValueDouble();
+  const auto id = static_cast<int64_t>(d);
+  // Only doubles representing an exact integer can match.
+  if (static_cast<double>(id) != d) return std::nullopt;
   return id;
 }
 }  // namespace

--- a/src/query/plan/operator.hpp
+++ b/src/query/plan/operator.hpp
@@ -894,12 +894,14 @@ class ScanAllById : public memgraph::query::plan::ScanAll {
 
   ScanAllById() = default;
   ScanAllById(const std::shared_ptr<LogicalOperator> &input, Symbol output_symbol, Expression *expression,
-              storage::View view = storage::View::OLD);
+              storage::View view = storage::View::OLD, bool expects_string_id = false);
 
   bool Accept(HierarchicalLogicalOperatorVisitor &visitor) override;
   UniqueCursorPtr MakeCursor(utils::MemoryResource *, metrics::DatabaseMetricHandles &) const override;
 
   Expression *expression_;
+  /// True if the id value is a string (elementId) rather than a number (id).
+  bool expects_string_id_{false};
 
   std::string ToString() const override;
 
@@ -915,7 +917,7 @@ class ScanAllByEdgeId : public memgraph::query::plan::ScanAllByEdge {
   ScanAllByEdgeId() = default;
   ScanAllByEdgeId(const std::shared_ptr<LogicalOperator> &input, Symbol edge_symbol, Symbol node1_symbol,
                   Symbol node2_symbol, EdgeAtom::Direction direction, Expression *expression,
-                  storage::View view = storage::View::OLD);
+                  storage::View view = storage::View::OLD, bool expects_string_id = false);
   bool Accept(HierarchicalLogicalOperatorVisitor &visitor) override;
   UniqueCursorPtr MakeCursor(utils::MemoryResource *, metrics::DatabaseMetricHandles &) const override;
 
@@ -928,6 +930,8 @@ class ScanAllByEdgeId : public memgraph::query::plan::ScanAllByEdge {
   std::string ToString() const override;
 
   Expression *expression_;
+  /// True if the id value is a string (elementId) rather than a number (id).
+  bool expects_string_id_{false};
 
   std::unique_ptr<LogicalOperator> Clone(AstStorage *storage) const override;
 };

--- a/src/query/plan/preprocess.cpp
+++ b/src/query/plan/preprocess.cpp
@@ -273,8 +273,8 @@ PropertyFilter::PropertyFilter(Symbol symbol, PropertyIx property, Type type)
 PropertyFilter::PropertyFilter(Symbol symbol, PropertyIxPath properties, Type type)
     : symbol_(std::move(symbol)), property_ids_(std::move(properties)), type_(type) {}
 
-IdFilter::IdFilter(const SymbolTable &symbol_table, const Symbol &symbol, Expression *value)
-    : symbol_(symbol), value_(value) {
+IdFilter::IdFilter(const SymbolTable &symbol_table, const Symbol &symbol, Expression *value, bool expects_string_id)
+    : symbol_(symbol), value_(value), expects_string_id_(expects_string_id) {
   MG_ASSERT(value);
   UsedSymbolsCollector collector(symbol_table);
   value->Accept(collector);
@@ -739,12 +739,12 @@ void Filters::AnalyzeAndStoreFilter(Expression *expr, const SymbolTable &symbol_
   auto add_id_equal = [&](auto *maybe_id_fun, auto *val_expr) -> bool {
     auto *id_fun = utils::Downcast<Function>(maybe_id_fun);
     if (!id_fun) return false;
-    if (id_fun->function_name_ != kId) return false;
+    if (id_fun->function_name_ != kId && id_fun->function_name_ != kElementId) return false;
     if (id_fun->arguments_.size() != 1U) return false;
     auto *ident = utils::Downcast<Identifier>(id_fun->arguments_.front());
     if (!ident) return false;
     auto filter = make_filter(FilterInfo::Type::Id);
-    filter.id_filter.emplace(symbol_table, symbol_table.at(*ident), val_expr);
+    filter.id_filter.emplace(symbol_table, symbol_table.at(*ident), val_expr, id_fun->function_name_ == kElementId);
     all_filters_.emplace_back(filter);
     return true;
   };

--- a/src/query/plan/preprocess.hpp
+++ b/src/query/plan/preprocess.hpp
@@ -350,7 +350,7 @@ struct PointFilter {
 class IdFilter {
  public:
   /// Construct with Expression being the required value for ID.
-  IdFilter(const SymbolTable &, const Symbol &, Expression *);
+  IdFilter(const SymbolTable &, const Symbol &, Expression *, bool expects_string_id = false);
 
   /// Symbol whose id is looked up.
   Symbol symbol_;
@@ -358,6 +358,8 @@ class IdFilter {
   Expression *value_;
   /// True if the same symbol is used in expressions for value.
   bool is_symbol_in_value_{false};
+  /// True if the filter comes from elementId(), which compares against a string id.
+  bool expects_string_id_{false};
 };
 
 /// Stores additional information for a filter expression.

--- a/src/query/plan/pretty_print.cpp
+++ b/src/query/plan/pretty_print.cpp
@@ -675,6 +675,7 @@ bool PlanToJsonVisitor::PreVisit(ScanAllById &op) {
   json self;
   self["name"] = "ScanAllById";
   self["output_symbol"] = ToJson(op.output_symbol_);
+  self["expects_string_id"] = op.expects_string_id_;
   op.input_->Accept(*this);
   self["input"] = PopOutput();
   output_ = std::move(self);
@@ -797,6 +798,7 @@ bool PlanToJsonVisitor::PreVisit(ScanAllByEdgeId &op) {
   json self;
   self["name"] = "ScanAllByEdgeId";
   self["output_symbol"] = ToJson(op.common_.edge_symbol);
+  self["expects_string_id"] = op.expects_string_id_;
   op.input_->Accept(*this);
   self["input"] = PopOutput();
   output_ = std::move(self);

--- a/src/query/plan/rewrite/edge_index_lookup.hpp
+++ b/src/query/plan/rewrite/edge_index_lookup.hpp
@@ -963,8 +963,14 @@ class EdgeIndexRewriter final : public HierarchicalLogicalOperatorVisitor {
       auto *value = filter.id_filter->value_;
       filter_exprs_for_removal_.insert(filter.expression);
       filters_.EraseFilter(filter);
-      return std::make_unique<ScanAllByEdgeId>(
-          input, common.edge_symbol, common.node1_symbol, common.node2_symbol, common.direction, value, view);
+      return std::make_unique<ScanAllByEdgeId>(input,
+                                               common.edge_symbol,
+                                               common.node1_symbol,
+                                               common.node2_symbol,
+                                               common.direction,
+                                               value,
+                                               view,
+                                               filter.id_filter->expects_string_id_);
     }
 
     if (common.edge_types.size() > 1) {

--- a/src/query/plan/rewrite/index_lookup.hpp
+++ b/src/query/plan/rewrite/index_lookup.hpp
@@ -1627,7 +1627,9 @@ class IndexLookupRewriter final : public HierarchicalLogicalOperatorVisitor {
         auto *value = filter.id_filter->value_;
         metadata.filters_to_erase.push_back(filter);
         metadata.expressions_to_mark_for_removal.push_back(filter.expression);
-        return ScanByIndexResult{std::make_shared<ScanAllById>(input, node_symbol, value, view), std::move(metadata)};
+        return ScanByIndexResult{
+            std::make_shared<ScanAllById>(input, node_symbol, value, view, filter.id_filter->expects_string_id_),
+            std::move(metadata)};
       }
     }
     // Now try to see if we can use label+property index. If not, try to use

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -2572,6 +2572,21 @@ TYPED_TEST(FunctionTest, Id) {
   EXPECT_THROW(this->EvaluateFunction("ID", va, *ea), QueryRuntimeException);
 }
 
+TYPED_TEST(FunctionTest, ElementId) {
+  auto va = this->dba.InsertVertex();
+  auto ea = this->dba.InsertEdge(&va, &va, this->dba.NameToEdgeType("edge"));
+  ASSERT_TRUE(ea.has_value());
+  auto vb = this->dba.InsertVertex();
+  this->dba.AdvanceCommand();
+  EXPECT_TRUE(this->EvaluateFunction("ELEMENTID", TypedValue()).IsNull());
+  EXPECT_EQ(this->EvaluateFunction("ELEMENTID", va).ValueString(), "0");
+  EXPECT_EQ(this->EvaluateFunction("ELEMENTID", *ea).ValueString(), "0");
+  EXPECT_EQ(this->EvaluateFunction("ELEMENTID", vb).ValueString(), "1");
+  EXPECT_THROW(this->EvaluateFunction("ELEMENTID"), QueryRuntimeException);
+  EXPECT_THROW(this->EvaluateFunction("ELEMENTID", 0), QueryRuntimeException);
+  EXPECT_THROW(this->EvaluateFunction("ELEMENTID", va, *ea), QueryRuntimeException);
+}
+
 TYPED_TEST(FunctionTest, ToStringNull) { EXPECT_TRUE(this->EvaluateFunction("TOSTRING", TypedValue()).IsNull()); }
 
 TYPED_TEST(FunctionTest, ToStringString) {

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -31,6 +31,8 @@
 #include "query/path.hpp"
 #include "query/string_helpers.hpp"
 #include "query/typed_value.hpp"
+#include "query/virtual_edge.hpp"
+#include "query/virtual_node.hpp"
 #include "storage/v2/disk/storage.hpp"
 #include "storage/v2/enum.hpp"
 #include "storage/v2/inmemory/storage.hpp"
@@ -2585,6 +2587,21 @@ TYPED_TEST(FunctionTest, ElementId) {
   EXPECT_THROW(this->EvaluateFunction("ELEMENTID"), QueryRuntimeException);
   EXPECT_THROW(this->EvaluateFunction("ELEMENTID", 0), QueryRuntimeException);
   EXPECT_THROW(this->EvaluateFunction("ELEMENTID", va, *ea), QueryRuntimeException);
+}
+
+TYPED_TEST(FunctionTest, ElementIdVirtual) {
+  auto vn1 = std::make_shared<const memgraph::query::VirtualNode>(memgraph::query::VirtualNode({"L1"}, {}));
+  auto vn2 = std::make_shared<const memgraph::query::VirtualNode>(memgraph::query::VirtualNode({"L2"}, {}));
+  auto ve = memgraph::query::VirtualEdge(vn1, vn2, "ET");
+  // Virtual elements return their own (synthetic) gids, consistent with id().
+  EXPECT_EQ(this->EvaluateFunction("ELEMENTID", TypedValue(*vn1)).ValueString(),
+            std::to_string(vn1->CypherId()).c_str());
+  EXPECT_EQ(this->EvaluateFunction("ELEMENTID", TypedValue(*vn2)).ValueString(),
+            std::to_string(vn2->CypherId()).c_str());
+  EXPECT_EQ(this->EvaluateFunction("ELEMENTID", TypedValue(ve)).ValueString(),
+            std::to_string(ve.Gid().AsInt()).c_str());
+  EXPECT_EQ(this->EvaluateFunction("ID", TypedValue(*vn1)).ValueInt(), vn1->CypherId());
+  EXPECT_EQ(this->EvaluateFunction("ID", TypedValue(ve)).ValueInt(), ve.Gid().AsInt());
 }
 
 TYPED_TEST(FunctionTest, ToStringNull) { EXPECT_TRUE(this->EvaluateFunction("TOSTRING", TypedValue()).IsNull()); }

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -2399,7 +2399,7 @@ TYPED_TEST(TestPlanner, ScanAllByElementId) {
   // Test MATCH (n) WHERE elementId(n) = "42" RETURN n
   auto *query = QUERY(
       SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), WHERE(EQ(FN("elementId", IDENT("n")), LITERAL("42"))), RETURN("n")));
-  CheckPlan<TypeParam>(query, this->storage, ExpectScanAllById(), ExpectProduce());
+  CheckPlan<TypeParam>(query, this->storage, ExpectScanAllById(/* expects_string_id */ true), ExpectProduce());
 }
 
 TYPED_TEST(TestPlanner, ScanAllByEdgeElementId) {
@@ -2407,7 +2407,7 @@ TYPED_TEST(TestPlanner, ScanAllByEdgeElementId) {
   auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("anon1"), EDGE("r"), NODE("anon2"))),
                                    WHERE(EQ(FN("elementId", IDENT("r")), LITERAL("42"))),
                                    RETURN("r")));
-  CheckPlan<TypeParam>(query, this->storage, ExpectScanAllByEdgeId(), ExpectProduce());
+  CheckPlan<TypeParam>(query, this->storage, ExpectScanAllByEdgeId(/* expects_string_id */ true), ExpectProduce());
 }
 
 TYPED_TEST(TestPlanner, BfsToExisting) {

--- a/tests/unit/query_plan.cpp
+++ b/tests/unit/query_plan.cpp
@@ -2395,6 +2395,21 @@ TYPED_TEST(TestPlanner, ScanAllByEdgeId) {
   CheckPlan<TypeParam>(query, this->storage, ExpectScanAllByEdgeId(), ExpectProduce());
 }
 
+TYPED_TEST(TestPlanner, ScanAllByElementId) {
+  // Test MATCH (n) WHERE elementId(n) = "42" RETURN n
+  auto *query = QUERY(
+      SINGLE_QUERY(MATCH(PATTERN(NODE("n"))), WHERE(EQ(FN("elementId", IDENT("n")), LITERAL("42"))), RETURN("n")));
+  CheckPlan<TypeParam>(query, this->storage, ExpectScanAllById(), ExpectProduce());
+}
+
+TYPED_TEST(TestPlanner, ScanAllByEdgeElementId) {
+  // Test MATCH ()-[r]->() WHERE elementId(r) = "42" RETURN r
+  auto *query = QUERY(SINGLE_QUERY(MATCH(PATTERN(NODE("anon1"), EDGE("r"), NODE("anon2"))),
+                                   WHERE(EQ(FN("elementId", IDENT("r")), LITERAL("42"))),
+                                   RETURN("r")));
+  CheckPlan<TypeParam>(query, this->storage, ExpectScanAllByEdgeId(), ExpectProduce());
+}
+
 TYPED_TEST(TestPlanner, BfsToExisting) {
   // Test MATCH (n)-[r *bfs]-(m) WHERE id(m) = 42 RETURN r
   // Since the graph is empty its cheaper to use ScanAll

--- a/tests/unit/query_plan_checker.hpp
+++ b/tests/unit/query_plan_checker.hpp
@@ -266,8 +266,31 @@ using ExpectCreateExpand = OpChecker<CreateExpand>;
 using ExpectDelete = OpChecker<Delete>;
 using ExpectScanAll = OpChecker<ScanAll>;
 using ExpectScanAllByEdgeType = OpChecker<ScanAllByEdgeType>;
-using ExpectScanAllByEdgeId = OpChecker<ScanAllByEdgeId>;
-using ExpectScanAllById = OpChecker<ScanAllById>;
+
+class ExpectScanAllByEdgeId : public OpChecker<ScanAllByEdgeId> {
+ public:
+  explicit ExpectScanAllByEdgeId(bool expects_string_id = false) : expects_string_id_(expects_string_id) {}
+
+  void ExpectOp(ScanAllByEdgeId &scan_all, const SymbolTable &) override {
+    EXPECT_EQ(scan_all.expects_string_id_, expects_string_id_);
+  }
+
+ private:
+  bool expects_string_id_;
+};
+
+class ExpectScanAllById : public OpChecker<ScanAllById> {
+ public:
+  explicit ExpectScanAllById(bool expects_string_id = false) : expects_string_id_(expects_string_id) {}
+
+  void ExpectOp(ScanAllById &scan_all, const SymbolTable &) override {
+    EXPECT_EQ(scan_all.expects_string_id_, expects_string_id_);
+  }
+
+ private:
+  bool expects_string_id_;
+};
+
 using ExpectExpand = OpChecker<Expand>;
 using ExpectConstructNamedPath = OpChecker<ConstructNamedPath>;
 using ExpectProduce = OpChecker<Produce>;

--- a/tests/unit/query_plan_match_filter_return.cpp
+++ b/tests/unit/query_plan_match_filter_return.cpp
@@ -156,6 +156,9 @@ TYPED_TEST(MatchReturnFixture, ScanAllByIdString) {
   EXPECT_EQ(0, pull_count(LITERAL(vertex.Gid().AsInt()), true));   // number where string expected
   EXPECT_EQ(0, pull_count(LITERAL(id_str), false));                // string where number expected
   EXPECT_EQ(1, pull_count(LITERAL(vertex.Gid().AsInt()), false));  // id() path still works
+  const auto id_dbl = static_cast<double>(vertex.Gid().AsInt());
+  EXPECT_EQ(1, pull_count(LITERAL(id_dbl), false));        // exact-integer double matches
+  EXPECT_EQ(0, pull_count(LITERAL(id_dbl + 0.5), false));  // non-integer double matches nothing
 }
 
 TYPED_TEST(MatchReturnFixture, ScanAllByEdgeIdString) {

--- a/tests/unit/query_plan_match_filter_return.cpp
+++ b/tests/unit/query_plan_match_filter_return.cpp
@@ -131,6 +131,70 @@ TYPED_TEST(MatchReturnFixture, MatchReturnPath) {
   EXPECT_TRUE(std::is_permutation(expected_paths.begin(), expected_paths.end(), results.begin()));
 }
 
+TYPED_TEST(MatchReturnFixture, ScanAllByIdString) {
+  // elementId(n) lookups use ScanAllById with expects_string_id, which must
+  // match only the canonical decimal string of the id.
+  auto vertex = this->dba.InsertVertex();
+  this->dba.AdvanceCommand();
+  const auto id_str = std::to_string(vertex.Gid().AsInt());
+
+  auto pull_count = [&](Expression *expression, bool expects_string_id) {
+    auto sym = this->symbol_table.CreateSymbol("n", true);
+    auto scan =
+        std::make_shared<ScanAllById>(nullptr, sym, expression, memgraph::storage::View::OLD, expects_string_id);
+    auto output =
+        NEXPR("n", IDENT("n")->MapTo(sym))->MapTo(this->symbol_table.CreateSymbol("named_expression_1", true));
+    auto produce = MakeProduce(scan, output);
+    auto context = MakeContext(this->storage, this->symbol_table, &this->dba);
+    return PullAll(*produce, &context);
+  };
+
+  EXPECT_EQ(1, pull_count(LITERAL(id_str), true));
+  EXPECT_EQ(0, pull_count(LITERAL("0" + id_str), true));           // non-canonical form
+  EXPECT_EQ(0, pull_count(LITERAL(id_str + "abc"), true));         // trailing garbage
+  EXPECT_EQ(0, pull_count(LITERAL("abc"), true));                  // not a number
+  EXPECT_EQ(0, pull_count(LITERAL(vertex.Gid().AsInt()), true));   // number where string expected
+  EXPECT_EQ(0, pull_count(LITERAL(id_str), false));                // string where number expected
+  EXPECT_EQ(1, pull_count(LITERAL(vertex.Gid().AsInt()), false));  // id() path still works
+}
+
+TYPED_TEST(MatchReturnFixture, ScanAllByEdgeIdString) {
+  if (std::is_same_v<TypeParam, memgraph::storage::DiskStorage>) {
+    GTEST_SKIP() << "Id based edge lookup is not implemented for on-disk storage";
+  }
+  auto v1 = this->dba.InsertVertex();
+  auto v2 = this->dba.InsertVertex();
+  auto edge = this->dba.InsertEdge(&v1, &v2, this->dba.NameToEdgeType("Type"));
+  ASSERT_TRUE(edge.has_value());
+  this->dba.AdvanceCommand();
+  const auto id_str = std::to_string(edge->Gid().AsInt());
+
+  auto pull_count = [&](Expression *expression, bool expects_string_id) {
+    auto edge_sym = this->symbol_table.CreateSymbol("r", true);
+    auto node1_sym = this->symbol_table.CreateSymbol("n1", true);
+    auto node2_sym = this->symbol_table.CreateSymbol("n2", true);
+    auto scan = std::make_shared<ScanAllByEdgeId>(nullptr,
+                                                  edge_sym,
+                                                  node1_sym,
+                                                  node2_sym,
+                                                  EdgeAtom::Direction::OUT,
+                                                  expression,
+                                                  memgraph::storage::View::OLD,
+                                                  expects_string_id);
+    auto output =
+        NEXPR("r", IDENT("r")->MapTo(edge_sym))->MapTo(this->symbol_table.CreateSymbol("named_expression_1", true));
+    auto produce = MakeProduce(scan, output);
+    auto context = MakeContext(this->storage, this->symbol_table, &this->dba);
+    return PullAll(*produce, &context);
+  };
+
+  // String matching itself is covered by ScanAllByIdString; this only checks
+  // the flag is honored by the edge operator and the lookup works.
+  EXPECT_EQ(1, pull_count(LITERAL(id_str), true));
+  EXPECT_EQ(0, pull_count(LITERAL(edge->Gid().AsInt()), true));
+  EXPECT_EQ(1, pull_count(LITERAL(edge->Gid().AsInt()), false));
+}
+
 #ifdef MG_ENTERPRISE
 TYPED_TEST(MatchReturnFixture, ScanAllWithAuthChecker) {
   std::string labelName = "l1";


### PR DESCRIPTION
Adds the `elementId()` built-in function. It returns the element's GID as a string, for compatibility with external integrations (e.g. Spring Boot). Works for nodes, edges, and their virtual counterparts (synthetic gids, consistent with `id()`); returns `null` for `null` input, mirroring `id()` argument validation otherwise.

`WHERE elementId(n) = <string>` plans as `ScanAllById`/`ScanAllByEdgeId`, same as `id()`. The id filter and scan operators track whether a string or numeric id is expected, so comparison semantics stay exact: a string id matches only a fully numeric string, a numeric value never matches `elementId`, and `id()` behavior is unchanged.