### PR TITLE
fix: prevent infinite loop/OOM in replace() with empty search string

### DIFF
--- a/src/utils/string.hpp
+++ b/src/utils/string.hpp
@@ -186,6 +186,16 @@ template <class TAllocator>
 std::basic_string<char, std::char_traits<char>, TAllocator> *Replace(
     std::basic_string<char, std::char_traits<char>, TAllocator> *out, const std::string_view src,
     const std::string_view match, const std::string_view replacement) {
+  if (match.empty()) {  // empty match inserts replacement at every byte boundary, matching std::regex_replace
+    out->clear();
+    out->reserve(src.size() + (src.size() + 1) * replacement.size());
+    out->append(replacement);
+    for (const char c : src) {
+      out->push_back(c);
+      out->append(replacement);
+    }
+    return out;
+  }
   // TODO: This could be implemented much more efficiently.
   *out = src;
   for (size_t pos = out->find(match); pos != std::string::npos; pos = out->find(match, pos + replacement.size())) {

--- a/tests/unit/query_expression_evaluator.cpp
+++ b/tests/unit/query_expression_evaluator.cpp
@@ -2884,6 +2884,10 @@ TYPED_TEST(FunctionTest, Replace) {
   EXPECT_TRUE(this->EvaluateFunction("REPLACE", "hello", TypedValue(), "w").IsNull());
   EXPECT_TRUE(this->EvaluateFunction("REPLACE", "hello", "l", TypedValue()).IsNull());
   EXPECT_EQ(this->EvaluateFunction("REPLACE", "hello", "l", "w").ValueString(), "hewwo");
+  EXPECT_EQ(this->EvaluateFunction("REPLACE", "A", "", "B").ValueString(), "BAB");
+  EXPECT_EQ(this->EvaluateFunction("REPLACE", "abc", "", "-").ValueString(), "-a-b-c-");
+  EXPECT_EQ(this->EvaluateFunction("REPLACE", "", "", "a").ValueString(), "a");
+  EXPECT_EQ(this->EvaluateFunction("REPLACE", "A", "", "").ValueString(), "A");
 
   EXPECT_THROW(this->EvaluateFunction("REPLACE", 1, "l", "w"), QueryRuntimeException);
   EXPECT_THROW(this->EvaluateFunction("REPLACE", "hello", 1, "w"), QueryRuntimeException);

--- a/tests/unit/utils_string.cpp
+++ b/tests/unit/utils_string.cpp
@@ -67,6 +67,12 @@ TEST(String, Replace) {
   EXPECT_EQ(Replace("ababccab.", "ab", ""), "cc.");
   EXPECT_EQ(Replace("aabb", "ab", ""), "ab");
   EXPECT_EQ(Replace("ababcab.", "ab", "abab"), "ababababcabab.");
+  // Empty match inserts the replacement at every byte boundary (like std::regex_replace).
+  EXPECT_EQ(Replace("abc", "", "-"), "-a-b-c-");
+  EXPECT_EQ(Replace("A", "", "B"), "BAB");
+  EXPECT_EQ(Replace("", "", "a"), "a");
+  EXPECT_EQ(Replace("abc", "", ""), "abc");
+  EXPECT_EQ(Replace("", "", ""), "");
 }
 
 TEST(String, SplitNoLimit) {


### PR DESCRIPTION
### Description

Fixes #4266.

`replace(original, search, replacement)` crashed the server (infinite loop → OOM) whenever `search` was an empty string, e.g. `RETURN replace("A", "", "B")`. In `utils::Replace`, `find("")` matches at every position and the loop never advances, so it appends the replacement indefinitely until the process exhausts memory.

### Fix

Special-case an empty `match`: insert the replacement at every byte boundary in a single pass with an exact `reserve()`, matching `std::regex_replace`. So `replace("A", "", "B")` → `"BAB"` and `replace("abc", "", "-")` → `"-a-b-c-"`. This converts an unbounded loop into a bounded, single allocation.