### PR TITLE
fix: Forbid routing to data instances, enable bolt 4.4

### DIFF
--- a/src/communication/bolt/v1/constants.hpp
+++ b/src/communication/bolt/v1/constants.hpp
@@ -29,7 +29,7 @@ inline constexpr size_t kChunkWholeSize = kChunkHeaderSize + kChunkMaxDataSize;
  */
 inline constexpr size_t kHandshakeSize = 20;
 
-inline constexpr auto kSupportedVersions = std::array<uint16_t, 5>{0x0100, 0x0400, 0x0401, 0x0403, 0x0502};
+inline constexpr auto kSupportedVersions = std::array<uint16_t, 6>{0x0100, 0x0400, 0x0401, 0x0403, 0x0404, 0x0502};
 
 inline constexpr int kPullAll = -1;
 inline constexpr int kPullLast = -1;

--- a/src/communication/bolt/v1/states/executing.hpp
+++ b/src/communication/bolt/v1/states/executing.hpp
@@ -139,7 +139,10 @@ State StateExecutingRun(TSession &session, State state) {
       return RunHandlerV1(signature, session, state, marker);
     case 4: {
       memgraph::metrics::Metrics().global.bolt_messages->Increment();
-      if (session.version_.minor >= 3) {
+      if (session.version_.minor == 4) {
+        return RunHandlerV4<TSession, 4>(signature, session, state, marker);
+      }
+      if (session.version_.minor == 3) {
         return RunHandlerV4<TSession, 3>(signature, session, state, marker);
       }
       if (session.version_.minor >= 1) {

--- a/src/communication/bolt/v1/states/handlers.hpp
+++ b/src/communication/bolt/v1/states/handlers.hpp
@@ -513,7 +513,10 @@ State HandleGoodbye() {
 
 template <typename TSession, int bolt_major, int bolt_minor = 0>
 auto ReadDB(TSession &session) -> std::optional<std::string> {
-  if constexpr (bolt_major == 5) {
+  // The ROUTE message carries the database name differently across Bolt versions: 4.3 sends it as a standalone
+  // string field, while 4.4+ (and all of 5.x) moved it inside the trailing `extra` map. The third struct field
+  // must be consumed regardless so the decoder stays aligned, hence the explicit branch per layout.
+  if constexpr (bolt_major == 5 || (bolt_major == 4 && bolt_minor >= 4)) {
     Value extra;
     if (!session.decoder_.ReadValue(&extra, Value::Type::Map)) {
       spdlog::trace("Couldn't read extra field!");

--- a/src/communication/bolt/v1/states/handshake.hpp
+++ b/src/communication/bolt/v1/states/handshake.hpp
@@ -51,8 +51,8 @@ inline std::vector<std::string> StringifySupportedVersions(uint8_t *data) {
 }
 
 inline bool CopyProtocolInformationIfSupported(uint16_t version, uint8_t *protocol) {
-  const auto *supported_version = std::find(std::begin(kSupportedVersions), std::end(kSupportedVersions), version);
-  if (supported_version != std::end(kSupportedVersions)) {
+  const auto *supported_version = std::ranges::find(kSupportedVersions, version);
+  if (supported_version != std::ranges::end(kSupportedVersions)) {
     std::memcpy(protocol, &version, sizeof(version));
     return true;
   }

--- a/src/glue/SessionHL.cpp
+++ b/src/glue/SessionHL.cpp
@@ -447,19 +447,14 @@ std::pair<std::vector<std::string>, std::optional<int>> SessionHL::InterpretPrep
 }
 
 #ifdef MG_ENTERPRISE
-auto SessionHL::Route(bolt_map_t const &routing, std::vector<bolt_value_t> const & /*bookmarks*/,
+auto SessionHL::Route(bolt_map_t const & /*routing*/, std::vector<bolt_value_t> const & /*bookmarks*/,
                       std::optional<std::string> const &db, bolt_map_t const &
                       /*extra*/) -> bolt_map_t {
-  auto const routing_map =
-      ranges::views::transform(routing,
-                               [](auto const &pair) { return std::pair(pair.first, pair.second.ValueString()); }) |
-      ranges::to<std::map<std::string, std::string>>();
-
   if (db) {
     spdlog::trace("Handling routing request for the database: {}", *db);
   }
 
-  auto routing_table_res = interpreter_.Route(routing_map, db);
+  auto routing_table_res = interpreter_.Route(db);
 
   auto create_server = [](auto const &server_info) -> bolt_value_t {
     auto const &[addresses, role] = server_info;

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -9203,24 +9203,12 @@ void Interpreter::RollbackTransaction() {
 }
 
 #ifdef MG_ENTERPRISE
-auto Interpreter::Route(std::map<std::string, std::string> const &routing, std::optional<std::string> const &db)
-    -> RouteResult {
+auto Interpreter::Route(std::optional<std::string> const &db) -> RouteResult {
   if (!interpreter_context_->coordinator_state_) {
     throw QueryException("You cannot fetch routing table from an instance which is not part of a cluster.");
   }
   if (interpreter_context_->coordinator_state_ && interpreter_context_->coordinator_state_->IsDataInstance()) {
-    auto const &address = routing.find("address");
-    if (address == routing.end()) {
-      throw QueryException("Routing table must contain address field.");
-    }
-
-    auto result = RouteResult{};
-    if (interpreter_context_->repl_state->ReadLock()->IsMain()) {
-      result.servers.emplace_back(std::vector<std::string>{address->second}, "WRITE");
-    } else {
-      result.servers.emplace_back(std::vector<std::string>{address->second}, "READ");
-    }
-    return result;
+    throw QueryException("Cannot fetch routing table from a data instance!");
   }
 
   auto const db_name = db.has_value() ? *db : dbms::kDefaultDB;

--- a/src/query/interpreter.hpp
+++ b/src/query/interpreter.hpp
@@ -378,7 +378,7 @@ class Interpreter final {
   void CheckAuthorized(std::vector<AuthQuery::Privilege> const &privileges, std::optional<std::string> db = {});
 
 #ifdef MG_ENTERPRISE
-  auto Route(std::map<std::string, std::string> const &routing, std::optional<std::string> const &db) -> RouteResult;
+  auto Route(std::optional<std::string> const &db) -> RouteResult;
 #endif
 
   /**

--- a/tests/unit/bolt_session.cpp
+++ b/tests/unit/bolt_session.cpp
@@ -453,14 +453,14 @@ TEST(BoltSession, HandshakeWithVersionOffset) {
     ASSERT_EQ(session.version_.minor, 3);
     ASSERT_EQ(session.version_.major, 4);
   }
-  // This should pick 4.3 version since 4.4 and 4.5 are not existant
+  // This should pick 4.4 version since 4.5 is not existant
   {
     INIT_VARS;
     const uint8_t priority_request[] = {0x60, 0x60, 0xb0, 0x17, 0x00, 0x03, 0x05, 0x04, 0x00, 0x00,
                                         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-    const uint8_t priority_response[] = {0x00, 0x00, 0x03, 0x04};
+    const uint8_t priority_response[] = {0x00, 0x00, 0x04, 0x04};
     ExecuteHandshake(input_stream, session, output, priority_request, priority_response);
-    ASSERT_EQ(session.version_.minor, 3);
+    ASSERT_EQ(session.version_.minor, 4);
     ASSERT_EQ(session.version_.major, 4);
   }
   // With multiple offsets (added v5.2)
@@ -478,9 +478,9 @@ TEST(BoltSession, HandshakeWithVersionOffset) {
     INIT_VARS;
     const uint8_t priority_request[] = {0x60, 0x60, 0xb0, 0x17, 0x00, 0x07, 0x06, 0x04, 0x00, 0x00,
                                         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-    const uint8_t priority_response[] = {0x00, 0x00, 0x03, 0x04};
+    const uint8_t priority_response[] = {0x00, 0x00, 0x04, 0x04};
     ExecuteHandshake(input_stream, session, output, priority_request, priority_response);
-    ASSERT_EQ(session.version_.minor, 3);
+    ASSERT_EQ(session.version_.minor, 4);
     ASSERT_EQ(session.version_.major, 4);
   }
   // Using offset but no version supported


### PR DESCRIPTION
When bolt 4.4 was used, the db was always defaulted to false. Data instances were also incorrectly returning routing table although the proper behavior should be to drop such a request.