### PR TITLE
Feature (Light Edges / 7+8) - feat(storage): light-edge create/find/delete core

### DIFF
--- a/src/storage/v2/edge.hpp
+++ b/src/storage/v2/edge.hpp
@@ -23,7 +23,7 @@ namespace memgraph::storage {
 struct Vertex;
 
 struct Edge {
-  Edge(Gid gid, Delta *delta) : gid(gid), delta_(delta) {
+  Edge(Gid gid, Delta *delta) noexcept : gid(gid), delta_(delta) {
     MG_ASSERT(delta == nullptr || delta->action == Delta::Action::DELETE_OBJECT ||
                   delta->action == Delta::Action::DELETE_DESERIALIZED_OBJECT,
               "Edge must be created with an initial DELETE_OBJECT delta!");

--- a/src/storage/v2/edge_metadata_index.hpp
+++ b/src/storage/v2/edge_metadata_index.hpp
@@ -69,6 +69,15 @@ class EdgeMetadataIndex {
     return it->from_vertex;
   }
 
+  // Soft-miss variant of FromVertexOf used by the gated light-edge find path:
+  // returns nullptr when no metadata entry exists for edge_gid (a light edge
+  // deleted from adjacency has no entry) instead of hard-asserting.
+  Vertex *TryFromVertexOf(Gid edge_gid) const {
+    auto acc = data_.access();
+    auto it = acc.find(edge_gid);
+    return it == acc.end() ? nullptr : it->from_vertex;
+  }
+
   // The only path that populates the index during recovery.
   void RebuildFrom(utils::SkipListDb<Vertex> &vertices,
                    std::optional<durability::ParallelizedSchemaCreationInfo> const &parallel_exec_info);

--- a/src/storage/v2/inmemory/storage.cpp
+++ b/src/storage/v2/inmemory/storage.cpp
@@ -59,6 +59,7 @@
 #include "storage/v2/storage_mode.hpp"
 #include "utils/atomic_memory_block.hpp"
 #include "utils/atomic_utils.hpp"
+#include "utils/db_aware_allocator.hpp"
 #include "utils/exceptions.hpp"
 #include "utils/file.hpp"
 #include "utils/memory_tracker.hpp"
@@ -325,6 +326,9 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
       global_locker_(file_retainer_.AddLocker()) {
   MG_ASSERT(config.salient.storage_mode != StorageMode::ON_DISK_TRANSACTIONAL,
             "Invalid storage mode sent to InMemoryStorage constructor!");
+  MG_ASSERT(!config_.salient.items.storage_light_edge || config_.salient.items.properties_on_edges,
+            "Light edges require properties on edges (--storage-light-edge implies "
+            "--storage-properties-on-edges=true).");
   if (config_.durability.snapshot_wal_mode != Config::Durability::SnapshotWalMode::DISABLED ||
       config_.durability.snapshot_on_exit || config_.durability.recover_on_startup) {
     // Create the directory initially to crash the database in case of
@@ -456,6 +460,7 @@ InMemoryStorage::InMemoryStorage(Config config, std::optional<free_mem_fn> free_
       }
       vertices_.run_gc();
       edges_.run_gc();
+      DrainLightEdgeGraveyard();
 
       // Auto-indexer also has a skiplist
       async_indexer_.RunGC();
@@ -522,6 +527,11 @@ InMemoryStorage::~InMemoryStorage() {
     create_snapshot_handler("exit");
   }
   committed_transactions_.WithLock([](auto &transactions) { transactions.clear(); });
+  // Free live light edges (pool-allocated Edge*) before teardown. Gated: heavy
+  // edges live in edges_ and are freed by the skip-list, not here.
+  if (config_.salient.items.storage_light_edge) {
+    ClearLightEdges();
+  }
 }
 
 void InMemoryStorage::UpdateLabelCount(LabelId const label, int64_t const change) {
@@ -660,6 +670,25 @@ InMemoryStorage::InMemoryAccessor::DetachDelete(std::vector<VertexAccessor *> no
     if (!deleted_edges.empty() && transaction_.storage_mode == StorageMode::IN_MEMORY_ANALYTICAL) {
       auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
       mem_storage->gc_full_scan_edges_delete_.store(true, std::memory_order_release);
+
+      // Analytical-mode leak fix: in analytical mode the edge is pop_back'd from
+      // vertex adjacency at delete time, so the GC full-scan light arm (which
+      // iterates over LIVE adjacency) can never find these light Edge* -> they
+      // would be unreachable and leak (heavy works because its node persists in
+      // the edges_ skip-list scanned by the heavy full-scan arm). Route the
+      // deleted LIGHT Edge* into deleted_edges_, exactly like the transactional
+      // FastDiscard path. CollectGarbage swaps deleted_edges_ into
+      // current_deleted_edges and the light arm pushes them to the graveyard with
+      // guard_epoch snapped at collection time. The full-scan light arm then finds
+      // nothing for these (not in adjacency) -> no double-push. Heavy mode keeps
+      // the skip-list full-scan path byte-identical.
+      if (config_.storage_light_edge) {
+        mem_storage->deleted_edges_.WithLock([&](auto &storage_deleted_edges) {
+          for (auto const &edge : deleted_edges) {
+            storage_deleted_edges.push_back(edge.edge_.ptr);
+          }
+        });
+      }
     }
   }};
 
@@ -675,74 +704,33 @@ InMemoryStorage::InMemoryAccessor::DetachDelete(std::vector<VertexAccessor *> no
   return maybe_result;
 }
 
-Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdge(VertexAccessor *from, VertexAccessor *to,
-                                                                   EdgeTypeId edge_type) {
-  MG_ASSERT(from->transaction_ == to->transaction_,
-            "VertexAccessors must be from the same transaction when creating "
-            "an edge!");
-  MG_ASSERT(from->transaction_ == &transaction_,
-            "VertexAccessors must be from the same transaction in when "
-            "creating an edge!");
-
-  // It's important to destruct accessors after we unlock the vertices to avoid expensive skip list gc while we hold the
-  // locks
-  std::optional<utils::SkipListDb<Edge>::Accessor> edge_acc;
-
-  auto *from_vertex = from->vertex_;
-  auto *to_vertex = to->vertex_;
-
-  // This has to be called before any object gets locked
-  auto schema_acc = SchemaInfoAccessor(storage_, &transaction_);
-  // Obtain the locks by `gid` order to avoid lock cycles.
-  auto guard_from = std::unique_lock{from_vertex->lock, std::defer_lock};
-  auto guard_to = std::unique_lock{to_vertex->lock, std::defer_lock};
-  if (from_vertex->gid < to_vertex->gid) {
-    guard_from.lock();
-    guard_to.lock();
-  } else if (from_vertex->gid > to_vertex->gid) {
-    guard_to.lock();
-    guard_from.lock();
-  } else {
-    // The vertices are the same vertex, only lock one.
-    guard_from.lock();
-  }
-
-  transaction_.async_index_helper_.Track(edge_type);
-
-  auto const from_result = PrepareForNonSequentialWrite(&transaction_, from_vertex, Delta::Action::ADD_OUT_EDGE);
-  if (from_result == WriteResult::SERIALIZATION_ERROR) return std::unexpected{Error::SERIALIZATION_ERROR};
-  if (from_vertex->deleted()) return std::unexpected{Error::DELETED_OBJECT};
-  DeltaChainState const from_state =
-      ComputeDeltaChainState(ShouldSetNonSequentialBlockerUpstreamFlag(&transaction_, from_vertex), from_result);
-
-  // If to and from are the same we need to ensure to_result is the same as from_result
-  DeltaChainState to_state = from_state;
-  if (to_vertex != from_vertex) {
-    WriteResult const to_result = PrepareForNonSequentialWrite(&transaction_, to_vertex, Delta::Action::ADD_IN_EDGE);
-    if (to_result == WriteResult::SERIALIZATION_ERROR) return std::unexpected{Error::SERIALIZATION_ERROR};
-    if (to_vertex->deleted()) return std::unexpected{Error::DELETED_OBJECT};
-    to_state = ComputeDeltaChainState(ShouldSetNonSequentialBlockerUpstreamFlag(&transaction_, to_vertex), to_result);
-  }
-
-  if (storage_->config_.salient.items.enable_schema_metadata) {
-    storage_->stored_edge_types_.try_insert(edge_type);
-  }
+std::optional<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdgeInternal(
+    Vertex *from_vertex, Vertex *to_vertex, EdgeTypeId edge_type, DeltaChainState from_state, DeltaChainState to_state,
+    storage::Gid gid, std::optional<SchemaInfo::ModifyingAccessor> &schema_acc,
+    std::optional<utils::SkipListDb<Edge>::Accessor> &edge_acc) {
   auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
-  auto gid = storage::Gid::FromUint(mem_storage->edge_id_.fetch_add(1, std::memory_order_acq_rel));
+
   EdgeRef edge(gid);
   if (config_.properties_on_edges) {
-    // SchemaInfo handles edge creation via vertices; add collector here if that evert changes
-    edge_acc = mem_storage->edges_.access();
+    // SchemaInfo handles edge creation via vertices; add collector here if that ever changes
+    Edge *edge_ptr = nullptr;
     auto *delta = CreateDeleteObjectDelta(&transaction_);
-    auto [it, inserted] = edge_acc->insert(Edge(gid, delta));
-    MG_ASSERT(inserted, "The edge must be inserted here!");
-    MG_ASSERT(it != edge_acc->end(), "Invalid Edge accessor!");
-    edge = EdgeRef(&*it);
-    if (delta) {
-      delta->prev.Set(&*it);
+    if (config_.storage_light_edge) {
+      // Create throws on OOM (propagated to abort the txn), never returns null.
+      edge_ptr = InMemoryStorage::LightEdgePool::Create(gid, delta);
+    } else {
+      edge_acc = mem_storage->edges_.access();
+      auto [it, inserted] = edge_acc->insert(Edge(gid, delta));
+      MG_ASSERT(inserted, "The edge must be inserted here!");
+      MG_ASSERT(it != edge_acc->end(), "Invalid Edge accessor!");
+      edge_ptr = &*it;
     }
+    if (delta) {
+      delta->prev.Set(edge_ptr);
+    }
+    edge = EdgeRef(edge_ptr);
     if (auto &idx = mem_storage->edges_metadata_index_) {
-      idx->OnEdgeCreated(gid, from->vertex_);
+      idx->OnEdgeCreated(gid, from_vertex);
     }
   }
 
@@ -781,6 +769,64 @@ Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdge(VertexAccesso
   return EdgeAccessor(edge, edge_type, from_vertex, to_vertex, storage_, &transaction_);
 }
 
+Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdge(VertexAccessor *from, VertexAccessor *to,
+                                                                   EdgeTypeId edge_type) {
+  MG_ASSERT(from->transaction_ == to->transaction_,
+            "VertexAccessors must be from the same transaction when creating "
+            "an edge!");
+  MG_ASSERT(from->transaction_ == &transaction_,
+            "VertexAccessors must be from the same transaction in when "
+            "creating an edge!");
+
+  // It's important to destruct the accessor after we unlock the vertices to avoid expensive skip list gc while we hold
+  // the locks
+  std::optional<utils::SkipListDb<Edge>::Accessor> edge_acc;
+  auto *from_vertex = from->vertex_;
+  auto *to_vertex = to->vertex_;
+
+  // This has to be called before any object gets locked
+  auto schema_acc = SchemaInfoAccessor(storage_, &transaction_);
+  // Obtain the locks by `gid` order to avoid lock cycles.
+  auto guard_from = std::unique_lock{from_vertex->lock, std::defer_lock};
+  auto guard_to = std::unique_lock{to_vertex->lock, std::defer_lock};
+  if (from_vertex->gid < to_vertex->gid) {
+    guard_from.lock();
+    guard_to.lock();
+  } else if (from_vertex->gid > to_vertex->gid) {
+    guard_to.lock();
+    guard_from.lock();
+  } else {
+    // The vertices are the same vertex, only lock one.
+    guard_from.lock();
+  }
+
+  transaction_.async_index_helper_.Track(edge_type);
+  auto const from_result = PrepareForNonSequentialWrite(&transaction_, from_vertex, Delta::Action::ADD_OUT_EDGE);
+  if (from_result == WriteResult::SERIALIZATION_ERROR) return std::unexpected{Error::SERIALIZATION_ERROR};
+  if (from_vertex->deleted()) return std::unexpected{Error::DELETED_OBJECT};
+  DeltaChainState const from_state =
+      ComputeDeltaChainState(ShouldSetNonSequentialBlockerUpstreamFlag(&transaction_, from_vertex), from_result);
+
+  // If to and from are the same we need to ensure to_result is the same as from_result
+  DeltaChainState to_state = from_state;
+  if (to_vertex != from_vertex) {
+    WriteResult const to_result = PrepareForNonSequentialWrite(&transaction_, to_vertex, Delta::Action::ADD_IN_EDGE);
+    if (to_result == WriteResult::SERIALIZATION_ERROR) return std::unexpected{Error::SERIALIZATION_ERROR};
+    if (to_vertex->deleted()) return std::unexpected{Error::DELETED_OBJECT};
+    to_state = ComputeDeltaChainState(ShouldSetNonSequentialBlockerUpstreamFlag(&transaction_, to_vertex), to_result);
+  }
+
+  if (storage_->config_.salient.items.enable_schema_metadata) {
+    storage_->stored_edge_types_.try_insert(edge_type);
+  }
+  auto *mem_storage = static_cast<InMemoryStorage *>(storage_);
+  auto gid = storage::Gid::FromUint(mem_storage->edge_id_.fetch_add(1, std::memory_order_acq_rel));
+
+  auto result = CreateEdgeInternal(from_vertex, to_vertex, edge_type, from_state, to_state, gid, schema_acc, edge_acc);
+  MG_ASSERT(result.has_value(), "CreateEdgeInternal must not fail when called from CreateEdge");
+  return *result;
+}
+
 std::optional<EdgeAccessor> InMemoryStorage::InMemoryAccessor::FindEdge(Gid gid, const View view, EdgeTypeId edge_type,
                                                                         VertexAccessor *from_vertex,
                                                                         VertexAccessor *to_vertex) {
@@ -808,10 +854,9 @@ Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdgeEx(VertexAcces
             "VertexAccessors must be from the same transaction in when "
             "creating an edge!");
 
-  // It's important to destruct accessors after we unlock the vertices to avoid expensive skip list gc while we hold the
-  // locks
+  // It's important to destruct the accessor after we unlock the vertices to avoid expensive skip list gc while we hold
+  // the locks
   std::optional<utils::SkipListDb<Edge>::Accessor> edge_acc;
-
   auto *from_vertex = from->vertex_;
   auto *to_vertex = to->vertex_;
 
@@ -858,49 +903,9 @@ Result<EdgeAccessor> InMemoryStorage::InMemoryAccessor::CreateEdgeEx(VertexAcces
   // possible.
   atomic_fetch_max_explicit(&mem_storage->edge_id_, gid.AsUint() + 1, std::memory_order_acq_rel);
 
-  EdgeRef edge(gid);
-  if (config_.properties_on_edges) {
-    // SchemaInfo handles edge creation via vertices; add collector here if that evert changes
-    edge_acc = mem_storage->edges_.access();
-    auto *delta = CreateDeleteObjectDelta(&transaction_);
-    auto [it, inserted] = edge_acc->insert(Edge(gid, delta));
-    MG_ASSERT(inserted, "The edge must be inserted here!");
-    MG_ASSERT(it != edge_acc->end(), "Invalid Edge accessor!");
-    edge = EdgeRef(&*it);
-    if (delta) {
-      delta->prev.Set(&*it);
-    }
-    if (auto &idx = mem_storage->edges_metadata_index_) {
-      idx->OnEdgeCreated(gid, from->vertex_);
-    }
-  }
-
-  utils::AtomicMemoryBlock([this, edge, from_vertex, edge_type, to_vertex, &schema_acc, from_state, to_state]() {
-    CreateAndLinkDelta(&transaction_, from_vertex, Delta::RemoveOutEdgeTag(), edge_type, to_vertex, edge, from_state);
-    from_vertex->out_edges.emplace_back(edge_type, to_vertex, edge);
-
-    CreateAndLinkDelta(&transaction_, to_vertex, Delta::RemoveInEdgeTag(), edge_type, from_vertex, edge, to_state);
-    to_vertex->in_edges.emplace_back(edge_type, from_vertex, edge);
-
-    transaction_.manyDeltasCache.Invalidate(from_vertex, edge_type, EdgeDirection::OUT);
-    transaction_.manyDeltasCache.Invalidate(to_vertex, edge_type, EdgeDirection::IN);
-
-    // Update indices if they exist.
-    Indices::UpdateOnEdgeCreation(from_vertex, to_vertex, edge, edge_type, transaction_);
-
-    // Increment edge count.
-    storage_->edge_count_.fetch_add(1, std::memory_order_acq_rel);
-
-    if (schema_acc) {
-      std::visit(utils::Overloaded{[&](SchemaInfo::VertexModifyingAccessor &acc) {
-                                     acc.CreateEdge(from_vertex, to_vertex, edge_type);
-                                   },
-                                   [](auto & /* unused */) { DMG_ASSERT(false, "Using the wrong accessor"); }},
-                 *schema_acc);
-    }
-  });
-
-  return EdgeAccessor(edge, edge_type, from_vertex, to_vertex, storage_, &transaction_);
+  auto result = CreateEdgeInternal(from_vertex, to_vertex, edge_type, from_state, to_state, gid, schema_acc, edge_acc);
+  MG_ASSERT(result.has_value(), "CreateEdgeInternal must not fail when called from CreateEdgeEx");
+  return *result;
 }
 
 std::expected<void, ConstraintViolation> InMemoryStorage::InMemoryAccessor::ExistenceConstraintsViolation() const {
@@ -1327,6 +1332,13 @@ void InMemoryStorage::InMemoryAccessor::FastDiscardOfDeltas(std::unique_lock<std
         [&](auto &deleted_vertices) { deleted_vertices.splice(deleted_vertices.end(), current_deleted_vertices); });
   }
   if (!current_deleted_edges.empty()) {
+    // Both heavy and light edges defer to deleted_edges_ here. Light edges must
+    // NOT be pushed to the light_edge_graveyard_ at commit time: the graveyard
+    // watermark (guard_epoch) is snapped at GC-COLLECTION time so that any
+    // post-commit reader is ordered before it. Riding deleted_edges_ into
+    // CollectGarbage also runs the index cleanup (OnEdgesDeleted +
+    // RemoveEdgesFromVectorEdgeIndices) before the graveyard push, exactly like
+    // heavy. Heavy behaviour is unchanged.
     // O(1) splice under the SpinLock — never an O(batch) copy while locked.
     mem_storage->deleted_edges_.WithLock(
         [&](auto &deleted_edges) { deleted_edges.splice(deleted_edges.end(), current_deleted_edges); });
@@ -1374,7 +1386,9 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
     // then remove them directly from the skiplists and transfer ownership
     // to the GC in one locked batch, instead of acquiring the lock once per element.
     std::vector<Gid> my_deleted_vertices;
-    std::vector<Edge *> my_deleted_edges;
+    // std::list so the light-edge abort handover into deleted_edges_ is an O(1)
+    // splice under the SpinLock (see below); heavy arm only iterates it.
+    std::list<Edge *, memory::DbAwareAllocator<Edge *>> my_deleted_edges;
 
     // TWO passes needed here
     // Abort will modify objects to restore state to how they were before this txn
@@ -1676,10 +1690,16 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
                                   *transaction_.active_indices_,
                                   transaction_.start_timestamp,
                                   mem_storage->name_id_mapper_.get());
-    // EDGES METADATA (has ptr to Vertices, must be before removing verticies)
+    // EDGES METADATA (has ptr to Vertices, must be before removing verticies).
+    // Heavy edges are removed from the edges_ skiplist below and never re-enter
+    // GC, so abort is their single metadata-removal site. Light edges instead
+    // ride deleted_edges_ into CollectGarbage, which is THEIR single removal site
+    // (OnEdgesDeleted at the transactional GC light arm) — calling OnEdgesDeleted
+    // here too would double-remove the gid and trip the MG_ASSERT in
+    // EdgeMetadataIndex::OnEdgesDeleted. So gate this to heavy only.
     // my_deleted_edges holds Edge* for edges this aborting txn created (abort-of-create);
     // they remain in `edges_` until the remove loop below, so reading ->gid here is safe.
-    if (!my_deleted_edges.empty()) {
+    if (!my_deleted_edges.empty() && !mem_storage->config_.salient.items.storage_light_edge) {
       if (auto &idx = mem_storage->edges_metadata_index_) {
         idx->OnEdgesDeleted(my_deleted_edges | std::ranges::views::transform(&Edge::gid));
       }
@@ -1693,11 +1713,28 @@ void InMemoryStorage::InMemoryAccessor::Abort() {
       }
     }
 
-    // EDGES
+    // EDGES / LIGHT EDGES
+    // Both heavy and light edges defer to deleted_edges_ here. Light edges must
+    // NOT be pushed to the light_edge_graveyard_ at abort time: the graveyard
+    // watermark (guard_epoch) is snapped at GC-COLLECTION time so that any
+    // post-abort reader is ordered before it. Riding deleted_edges_ into
+    // CollectGarbage also runs the index cleanup (OnEdgesDeleted +
+    // RemoveEdgesFromVectorEdgeIndices) before the graveyard push, exactly like
+    // heavy. Light edges have no skiplist node, so the heavy edges_acc.remove
+    // call is skipped for them; only the deleted_edges_ routing applies.
+    // Heavy behaviour is unchanged.
     if (!my_deleted_edges.empty()) {
-      auto edges_acc = mem_storage->edges_.access();
-      for (auto *edge : my_deleted_edges) {
-        edges_acc.remove(edge->gid);
+      if (mem_storage->config_.salient.items.storage_light_edge) {
+        // Watermark snapped at GC-collection time; index cleanup runs in
+        // CollectGarbage before the graveyard push — see FastDiscard above.
+        // O(1) splice under the SpinLock — never an O(batch) copy while locked.
+        mem_storage->deleted_edges_.WithLock(
+            [&](auto &deleted_edges) { deleted_edges.splice(deleted_edges.end(), my_deleted_edges); });
+      } else {
+        auto edges_acc = mem_storage->edges_.access();
+        for (auto *edge : my_deleted_edges) {
+          edges_acc.remove(edge->gid);
+        }
       }
     }
   }
@@ -3213,18 +3250,36 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
     }
   }
 
-  // EDGES
+  // EDGES / LIGHT EDGES
   if (!current_deleted_edges.empty()) {
-    auto edge_acc = edges_.access();
+    if (config_.salient.items.storage_light_edge) {
+      // Light edges are not skiplist nodes; route them to the graveyard for
+      // deferred free. Clean the vector edge index first (unconditionally —
+      // unlike the heavy arm below which only does so when no vertices were
+      // deleted — because the light Edge* and their Vertex* outlive the push).
+      if (!indices_.vector_edge_index_.Empty()) {
+        // std::list -> contiguous temp vector for the std::span API (off-lock).
+        std::vector<Edge *> const edges_to_remove(current_deleted_edges.begin(), current_deleted_edges.end());
+        indices_.RemoveEdgesFromVectorEdgeIndices(edges_to_remove);
+      }
+      light_edge_graveyard_.WithLock([&](auto &graveyard) {
+        // guard_epoch defaults to 0 (epoch gating snapped at drain time in 7b-ii)
+        // std::move is an O(1) list move (entry.edges is a std::list) under the lock.
+        LightEdgeGraveyardEntry entry{.edges = std::move(current_deleted_edges)};
+        graveyard.push_back(std::move(entry));
+      });
+    } else {
+      auto edge_acc = edges_.access();
 
-    if (current_deleted_vertices.empty() && !indices_.vector_edge_index_.Empty()) {
-      // std::list -> contiguous temp vector for the std::span API (off-lock; see above).
-      std::vector<Edge *> const edges_to_remove(current_deleted_edges.begin(), current_deleted_edges.end());
-      indices_.RemoveEdgesFromVectorEdgeIndices(edges_to_remove);
-    }
+      if (current_deleted_vertices.empty() && !indices_.vector_edge_index_.Empty()) {
+        // std::list -> contiguous temp vector for the std::span API (off-lock; see above).
+        std::vector<Edge *> const edges_to_remove(current_deleted_edges.begin(), current_deleted_edges.end());
+        indices_.RemoveEdgesFromVectorEdgeIndices(edges_to_remove);
+      }
 
-    for (auto *edge : current_deleted_edges) {
-      MG_ASSERT(edge_acc.remove(edge->gid), "Invalid database state!");
+      for (auto *edge : current_deleted_edges) {
+        MG_ASSERT(edge_acc.remove(edge->gid), "Invalid database state!");
+      }
     }
   }
 
@@ -3285,6 +3340,41 @@ void InMemoryStorage::CollectGarbage(std::unique_lock<utils::ResourceLock> main_
         if (idx) idx->OnEdgeDeleted(edge.gid);
         edge_acc.remove(edge);
       }
+    }
+
+    // Light-edge analytical arm: analytically-deleted light edges do NOT appear
+    // in the edges_ skip-list (they live in vertex adjacency and are removed at
+    // delete time), so there are no entries to find here via edge_acc. Instead,
+    // inform_gc_edge_deletion routes deleted light Edge* directly into
+    // deleted_edges_ so they arrive in current_deleted_edges and are handled by
+    // the transactional light arm above (OnEdgesDeleted + graveyard push).
+  }
+}
+
+void InMemoryStorage::DrainLightEdgeGraveyard() {
+  if (!config_.salient.items.storage_light_edge) return;
+  // No edge-index iterable pins light edges yet (MakeEdgePin is still the
+  // heavy-only form), so no reader can race the free and we drain the whole
+  // graveyard unconditionally here.
+  //
+  // The ONLY push site for this graveyard is CollectGarbage at GC-collection
+  // time. Both the commit (FastDiscard) and abort light arms route deleted Edge*
+  // through deleted_edges_ so that CollectGarbage snaps the guard_epoch watermark
+  // AFTER all readers are ordered. Invariant: metadata + vector-index entries are
+  // already removed at GC-collect time before the push happens.
+  std::list<LightEdgeGraveyardEntry, memory::DbAwareAllocator<LightEdgeGraveyardEntry>> local_graveyard;
+  light_edge_graveyard_.WithLock([&](auto &graveyard) { local_graveyard.swap(graveyard); });
+  if (local_graveyard.empty()) return;
+
+  // The edge-metadata entry for every graveyarded edge was already removed at
+  // GC-collection time (CollectGarbage OnEdgesDeleted and
+  // RemoveEdgesFromVectorEdgeIndices) BEFORE the Edge* was routed here. The
+  // graveyard exists solely to defer the *memory free*; it must NOT touch
+  // edges_metadata_index_ again, otherwise it would double-remove the entry and
+  // trip the `acc.remove` assert in OnEdgeDeleted.
+  for (auto &entry : local_graveyard) {
+    for (auto *edge : entry.edges) {
+      InMemoryStorage::LightEdgePool::Destroy(edge);
     }
   }
 }
@@ -4422,7 +4512,21 @@ EdgeInfo ExtractEdgeInfo(Vertex *from_vertex, const Edge *edge_ptr) {
   return std::nullopt;
 }
 
-EdgeInfo InMemoryStorage::FindEdge(Gid edge_gid) {
+// Scan from_vertex->out_edges for the light edge with the given GID.
+// Acquires from_vertex->lock (shared) for the scan, mirroring ExtractEdgeInfo.
+namespace {
+EdgeInfo ScanOutEdgesForGid(Vertex *from_vertex, Gid edge_gid) {
+  std::shared_lock const guard{from_vertex->lock};
+  for (const auto &[edge_type, to_vertex, edge_ref] : from_vertex->out_edges) {
+    if (edge_ref.ptr->gid == edge_gid) {
+      return std::tuple(edge_ref, edge_type, from_vertex, to_vertex);
+    }
+  }
+  return std::nullopt;
+}
+}  // namespace
+
+EdgeInfo InMemoryStorage::FindHeavyEdge(Gid edge_gid) {
   auto edge_acc = edges_.access();
   auto edge_it = edge_acc.find(edge_gid);
   if (edge_it == edge_acc.end()) {
@@ -4447,7 +4551,53 @@ EdgeInfo InMemoryStorage::FindEdge(Gid edge_gid) {
   return std::nullopt;
 }
 
+EdgeInfo InMemoryStorage::FindLightEdgeFromMetadata(Gid edge_gid) {
+  // Light edges are not in edges_; resolve from_vertex via the metadata index
+  // (soft-miss: a deleted light edge has no entry) then rescan its out_edges.
+  if (!edges_metadata_index_) return std::nullopt;
+  // Pin vertices_ BEFORE calling TryFromVertexOf so that GC cannot reclaim the
+  // Vertex node between the index lookup and the point we lock/scan it. This
+  // mirrors FindHeavyEdge, which also pins before the index consultation.
+  auto vertices_acc = vertices_.access();
+  auto *from_vertex = edges_metadata_index_->TryFromVertexOf(edge_gid);
+  if (from_vertex == nullptr) return std::nullopt;
+  return ScanOutEdgesForGid(from_vertex, edge_gid);
+}
+
+EdgeInfo InMemoryStorage::FindLightEdgeByScan(Gid edge_gid) {
+  // No metadata index: scan all vertices' out_edges for the gid.
+  auto vertices_acc = vertices_.access();
+  for (auto &from_vertex : vertices_acc) {
+    if (auto maybe_info = ScanOutEdgesForGid(&from_vertex, edge_gid)) {
+      return maybe_info;
+    }
+  }
+  return std::nullopt;
+}
+
+EdgeInfo InMemoryStorage::FindEdge(Gid edge_gid) {
+  if (config_.salient.items.storage_light_edge) {  // GATE
+    if (edges_metadata_index_) return FindLightEdgeFromMetadata(edge_gid);
+    return FindLightEdgeByScan(edge_gid);
+  }
+  return FindHeavyEdge(edge_gid);
+}
+
 EdgeInfo InMemoryStorage::FindEdge(Gid edge_gid, Gid from_vertex_gid) {
+  if (config_.salient.items.storage_light_edge) {  // GATE — light edges not in edges_
+    auto vertices_acc = vertices_.access();
+    auto vertex_it = vertices_acc.find(from_vertex_gid);
+    // Soft-miss on an absent from_vertex: the heavy arm (and the public
+    // optional-returning FindEdge wrapper) return nullopt for a not-found edge,
+    // and callers (e.g. the mgp C-API edge lookup) treat that as "no such edge"
+    // rather than an error. A stale/deleted from_vertex_gid means the edge is
+    // gone, so return nullopt instead of throwing across the query boundary.
+    if (vertex_it == vertices_acc.end()) {
+      return std::nullopt;
+    }
+    auto *from_vertex = &(*vertex_it);
+    return ScanOutEdgesForGid(from_vertex, edge_gid);
+  }
   auto edge_acc = edges_.access();
   auto edge_it = edge_acc.find(edge_gid);
   if (edge_it == edge_acc.end()) {
@@ -4469,6 +4619,78 @@ EdgeInfo InMemoryStorage::FindEdge(Gid edge_gid, Gid from_vertex_gid) {
   return ExtractEdgeInfo(&(*vertex_it), edge_ptr);
 }
 
+Edge *InMemoryStorage::LightEdgePool::Create(Gid gid, Delta *delta) {
+  // Allocation failure is propagated, NOT swallowed: an over-limit allocation
+  // throws utils::OutOfMemoryException (derived from BasicException, NOT
+  // std::bad_alloc) and a genuine OOM throws std::bad_alloc. Both must reach the
+  // query layer so the transaction aborts with an error — exactly as the heavy
+  // path does when edges_.insert() allocates a skip-list node. Catching only
+  // std::bad_alloc here (in a noexcept function) would let OutOfMemoryException
+  // cross the noexcept boundary -> std::terminate, turning a recoverable
+  // memory-limit hit into a server crash. Edge(Gid, Delta*) is nothrow (asserted
+  // below), so only the allocation can throw; it does so before any edge is
+  // constructed or linked, so propagation is exception-safe — the caller's delta
+  // is unwound by the transaction abort, identical to the heavy OOM path.
+  static_assert(std::is_nothrow_constructible_v<Edge, Gid, Delta *>,
+                "Edge(Gid, Delta*) must be nothrow; otherwise a throwing "
+                "construct_at would leak the allocation made just above it.");
+  memory::DbAwareAllocator<Edge> alloc;
+  Edge *edge_ptr = std::allocator_traits<decltype(alloc)>::allocate(alloc, 1);
+  std::construct_at(edge_ptr, gid, delta);
+  return edge_ptr;
+}
+
+void InMemoryStorage::LightEdgePool::Destroy(Edge *p) noexcept {
+  if (p == nullptr) return;
+  memory::DbAwareAllocator<Edge> alloc;
+  std::destroy_at(p);
+  std::allocator_traits<decltype(alloc)>::deallocate(alloc, p, 1);
+}
+
+void InMemoryStorage::ClearLightEdges() {
+  // Free ONLY live light edges held in vertex adjacency. Each edge appears
+  // exactly once across all out_edges (a self-loop has a single source-vertex
+  // entry), so no deduplication is needed. Deleted light edges still queued in
+  // the graveyard are freed by the loop below.
+  auto vertex_acc = vertices_.access();
+  for (auto &vertex : vertex_acc) {
+    for (auto const &[edge_type, to_vertex, edge_ref] : vertex.out_edges) {
+      InMemoryStorage::LightEdgePool::Destroy(edge_ref.ptr);
+    }
+  }
+
+  // Also free any deleted light edges still queued in the graveyard. Swap out
+  // under lock, then free without holding the SpinLock (mirrors
+  // DrainLightEdgeGraveyard's swap-out-then-free pattern).
+  std::list<LightEdgeGraveyardEntry, memory::DbAwareAllocator<LightEdgeGraveyardEntry>> pending_graveyard;
+  light_edge_graveyard_.WithLock([&](auto &graveyard) { pending_graveyard.swap(graveyard); });
+  for (auto &entry : pending_graveyard) {
+    for (auto *edge : entry.edges) {
+      InMemoryStorage::LightEdgePool::Destroy(edge);
+    }
+  }
+
+  // Free any deleted light edges still queued in deleted_edges_ that never
+  // reached the graveyard (i.e. were deleted but GC has not yet collected them —
+  // the commit (FastDiscard) / abort paths route them into deleted_edges_, and
+  // the CollectGarbage swap later drains them into the graveyard). These
+  // pool-allocated Edge* are owned by no skip-list, so without this drain they
+  // leak at teardown/Clear/DropGraph. The three sets (live adjacency,
+  // deleted_edges_, graveyard) are disjoint: CollectGarbage swaps deleted_edges_
+  // empty BEFORE moving the edges into a graveyard entry, and an edge is removed
+  // from vertex adjacency in the same delta-processing step that later routes its
+  // Edge* into deleted_edges_ — so no Edge* freed here is double-freed by the
+  // loops above. Heavy mode never reaches this function (all callers gate on
+  // storage_light_edge); heavy deleted_edges_ Edge* live in the edges_ skip-list
+  // and are freed by it, so they must NOT be freed as light edges.
+  deleted_edges_.WithLock([&](auto &deleted_edges) {
+    for (auto *edge : deleted_edges) {
+      InMemoryStorage::LightEdgePool::Destroy(edge);
+    }
+    deleted_edges.clear();
+  });
+}
+
 void InMemoryStorage::Clear() {
   // NOTE: Make sure this function is called while exclusively holding on to the main lock
   // When creating a snapshot, we first lock the snapshot, then create the accessor
@@ -4485,6 +4707,11 @@ void InMemoryStorage::Clear() {
     last_processed_commit_ts_ = kTimestampInitialId;
   }
   schema_info_.Clear();
+  // Free live light edges before clearing vertices (their adjacency lists are
+  // the only handle to the pool-allocated Edge*).
+  if (config_.salient.items.storage_light_edge) {
+    ClearLightEdges();
+  }
 
   // Clear main memory
   vertices_.clear();
@@ -4669,6 +4896,10 @@ void InMemoryStorage::InMemoryAccessor::DropGraph() {
   mem_storage->constraints_.DropGraphClearConstraints();
 
   if (mem_storage->config_.salient.items.enable_schema_info) mem_storage->schema_info_.Clear();
+  // Free live light edges before clearing vertices (analytical DROP GRAPH).
+  if (mem_storage->config_.salient.items.storage_light_edge) {
+    mem_storage->ClearLightEdges();
+  }
 
   mem_storage->vertices_.clear();
   mem_storage->waiting_gc_deltas_->clear();

--- a/src/storage/v2/inmemory/storage.hpp
+++ b/src/storage/v2/inmemory/storage.hpp
@@ -125,6 +125,18 @@ class InMemoryStorage final : public Storage {
 
  public:
   using free_mem_fn = std::function<void(std::unique_lock<utils::ResourceLock>, bool)>;
+
+  /// Light-weight wrapper around DbAwareAllocator<Edge> for light-edge
+  /// allocation and destruction. DbAwareAllocator is stateless (reads the
+  /// thread-local arena at each call), so Create/Destroy are safe to call
+  /// from any thread with an active DbArenaScope.
+  struct LightEdgePool {
+    // Throws (utils::OutOfMemoryException / std::bad_alloc) on allocation
+    // failure, like the heavy edges_.insert path — never returns nullptr.
+    static Edge *Create(Gid gid, Delta *delta);
+    static void Destroy(Edge *p) noexcept;
+  };
+
   enum class CreateSnapshotError : uint8_t { ReachedMaxNumTries, AbortSnapshot, AlreadyRunning, NothingNewToWrite };
 
   static const char *CreateSnapshotErrorToString(CreateSnapshotError error) {
@@ -188,6 +200,12 @@ class InMemoryStorage final : public Storage {
     std::expected<void, ConstraintViolation> UniqueConstraintsViolation() const;
 
     void CheckForFastDiscardOfDeltas();
+
+    std::optional<EdgeAccessor> CreateEdgeInternal(Vertex *from_vertex, Vertex *to_vertex, EdgeTypeId edge_type,
+                                                   DeltaChainState from_state, DeltaChainState to_state,
+                                                   storage::Gid gid,
+                                                   std::optional<SchemaInfo::ModifyingAccessor> &schema_acc,
+                                                   std::optional<utils::SkipListDb<Edge>::Accessor> &edge_acc);
 
     [[nodiscard]] auto HandleDurabilityAndReplicate(uint64_t durability_commit_timestamp,
                                                     TransactionReplication &replicating_txn,
@@ -814,6 +832,20 @@ class InMemoryStorage final : public Storage {
 
   EdgeInfo FindEdge(Gid edge_gid, Gid from_vertex_gid);
 
+  // Light-edge find helpers (gated by salient.items.storage_light_edge). The
+  // heavy path remains FindHeavyEdge (== prior FindEdge(Gid) body).
+  EdgeInfo FindLightEdgeFromMetadata(Gid edge_gid);
+  EdgeInfo FindLightEdgeByScan(Gid edge_gid);
+  EdgeInfo FindHeavyEdge(Gid edge_gid);
+
+  // Light-edge teardown (frees pool-allocated Edge* still live in vertex
+  // adjacency). Gated at every call site by salient.items.storage_light_edge.
+  void ClearLightEdges();
+  // Drain the light-edge graveyard: free the queued deleted Edge*. The drain is
+  // unconditional (no reader pins light edges yet). Called from FreeMemory after
+  // edges_.run_gc(); early-returns when the storage_light_edge flag is off.
+  void DrainLightEdgeGraveyard();
+
   // Database-owned arena pool for per-thread arena management.
   // Database must outlive Storage; Database member declaration order guarantees that.
   memgraph::memory::ArenaPool *db_arena_{nullptr};
@@ -822,6 +854,21 @@ class InMemoryStorage final : public Storage {
   // current DB TLS scope, while long-lived DB work establishes that scope at
   // the appropriate execution boundary.
   utils::SkipListDb<Vertex> vertices_;
+
+  // Graveyard for deleted light edges. Deleted light Edge* are pushed here ONLY
+  // at CollectGarbage time (after metadata + vector-index entries are already
+  // removed). The commit (FastDiscard) and abort light arms route deleted Edge*
+  // through deleted_edges_ so the guard_epoch watermark is snapped only after all
+  // concurrent readers are ordered; the drain frees them later. guard_epoch is a
+  // sentinel (0) here — the drain frees unconditionally, as no reader pins light
+  // edges.
+  struct LightEdgeGraveyardEntry {
+    uint64_t guard_epoch{0};
+    // std::list (not vector): current_deleted_edges is std::move'd in under the
+    // light_edge_graveyard_ lock, so the transfer must be an O(1) list move, not
+    // an O(batch) copy. The drain iterates it once, off the lock.
+    std::list<Edge *, memory::DbAwareAllocator<Edge *>> edges;
+  };
 
   // Returns a pin that keeps edge-index iterables' underlying Edge memory alive
   // for the lifetime of the iterable. Heavy mode pins the edges_ skip-list
@@ -906,6 +953,11 @@ class InMemoryStorage final : public Storage {
   // splice: the FastDiscard/Abort critical sections must not do O(batch) work
   // while holding this SpinLock. The GC consume side runs off the lock.
   utils::Synchronized<std::list<Edge *, memory::DbAwareAllocator<Edge *>>, utils::SpinLock> deleted_edges_;
+
+  // Deleted light edges awaiting deferred free (see DrainLightEdgeGraveyard).
+  utils::Synchronized<std::list<LightEdgeGraveyardEntry, memory::DbAwareAllocator<LightEdgeGraveyardEntry>>,
+                      utils::SpinLock>
+      light_edge_graveyard_;
 
   std::atomic<bool> gc_index_cleanup_vertex_performance_ = false;
   std::atomic<bool> gc_index_cleanup_edge_performance_ = false;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -724,6 +724,11 @@ add_unit_test(storage_v2_edge_inmemory
     LINK_TARGETS mg::storage
 )
 
+add_unit_test(storage_v2_light_edges
+    SOURCES storage_v2_light_edges.cpp
+    LINK_TARGETS mg::storage mg-dbms
+)
+
 add_unit_test(storage_v2_edge_ondisk
     SOURCES storage_v2_edge_ondisk.cpp
     LINK_TARGETS mg::storage disk_test_utils

--- a/tests/unit/storage_v2_gc.cpp
+++ b/tests/unit/storage_v2_gc.cpp
@@ -1532,3 +1532,176 @@ TEST(StorageV2Gc, ClearDrainsWaitingGcDeltas) {
     ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
   }
 }
+
+// Light-edge GC routing tests (storage_light_edge=true).
+
+namespace {
+auto MakeLightEdgeGcStorage() {
+  return std::make_unique<ms::InMemoryStorage>(
+      ms::Config{.gc = {.type = ms::Config::Gc::Type::PERIODIC, .interval = std::chrono::milliseconds(100)},
+                 .salient = {.items = {.properties_on_edges = true, .storage_light_edge = true}}});
+}
+}  // namespace
+
+// Mirrors StorageV2Gc/Sanity: GC running while a transaction is still alive must not free live data.
+// NOLINTNEXTLINE(hicpp-special-member-functions)
+TEST(StorageV2GcLightEdge, Sanity) {
+  auto storage = MakeLightEdgeGcStorage();
+
+  ms::Gid v1_gid, v2_gid;
+  {
+    auto acc = storage->Access(memgraph::storage::WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    v1_gid = v1.Gid();
+    v2_gid = v2.Gid();
+    ASSERT_TRUE(acc->CreateEdge(&v1, &v2, acc->NameToEdgeType("e")).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Reader keeps an open transaction.
+  auto reader = storage->Access(memgraph::storage::WRITE);
+
+  {
+    // Delete the edge in a second transaction while reader is alive.
+    auto writer = storage->Access(memgraph::storage::WRITE);
+    auto v1 = writer->FindVertex(v1_gid, ms::View::OLD).value();
+    auto edges = v1.OutEdges(ms::View::OLD);
+    ASSERT_TRUE(edges.has_value());
+    ASSERT_EQ(edges->edges.size(), 1U);
+    auto edge = edges->edges[0];
+    ASSERT_TRUE(writer->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(writer->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Let GC run while reader is still alive — it must NOT free the edge yet.
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+  // Reader still sees the edge via View::OLD.
+  {
+    auto v1 = reader->FindVertex(v1_gid, ms::View::OLD).value();
+    auto edges = v1.OutEdges(ms::View::OLD);
+    ASSERT_TRUE(edges.has_value());
+    ASSERT_EQ(edges->edges.size(), 1U);
+  }
+
+  reader->Abort();
+
+  // After the reader closes, GC eventually collects the graveyard. A fresh
+  // transaction must no longer see the deleted edge.
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  {
+    auto checker = storage->Access(memgraph::storage::WRITE);
+    auto v1 = checker->FindVertex(v1_gid, ms::View::NEW).value();
+    auto edges = v1.OutEdges(ms::View::NEW);
+    ASSERT_TRUE(edges.has_value());
+    EXPECT_EQ(edges->edges.size(), 0U) << "deleted light edge must no longer be visible";
+  }
+}
+
+// Mirrors StorageV2Gc/ConcurrentEdgeOperationsAbortDeleteRepeat:
+// two transactions each create an edge, both abort; GC must not crash.
+// NOLINTNEXTLINE(hicpp-special-member-functions)
+TEST(StorageV2GcLightEdge, ConcurrentEdgeOperationsAbortDeleteRepeat) {
+  auto storage = MakeLightEdgeGcStorage();
+
+  ms::Gid v1_gid, v2_gid;
+  {
+    auto acc = storage->Access(memgraph::storage::WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    v1_gid = v1.Gid();
+    v2_gid = v2.Gid();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  auto tx1 = storage->Access(memgraph::storage::WRITE);
+  auto tx2 = storage->Access(memgraph::storage::WRITE);
+
+  {
+    auto v1 = tx1->FindVertex(v1_gid, ms::View::OLD).value();
+    auto v2 = tx1->FindVertex(v2_gid, ms::View::OLD).value();
+    ASSERT_TRUE(tx1->CreateEdge(&v1, &v2, tx1->NameToEdgeType("Edge1")).has_value());
+  }
+  {
+    auto v1 = tx2->FindVertex(v1_gid, ms::View::OLD).value();
+    auto v2 = tx2->FindVertex(v2_gid, ms::View::OLD).value();
+    ASSERT_TRUE(tx2->CreateEdge(&v1, &v2, tx2->NameToEdgeType("Edge2")).has_value());
+  }
+
+  tx1->Abort();
+  tx2->Abort();
+
+  // GC runs; aborted light-edge creations must have been freed inline (not via graveyard).
+  std::this_thread::sleep_for(std::chrono::milliseconds(400));
+
+  {
+    auto reader = storage->Access(memgraph::storage::WRITE);
+    auto v1 = reader->FindVertex(v1_gid, ms::View::OLD);
+    if (v1.has_value()) {
+      auto edges = v1->OutEdges(ms::View::OLD);
+      ASSERT_TRUE(edges.has_value());
+      ASSERT_EQ(edges->edges.size(), 0U);
+    }
+  }
+}
+
+// Regression test: light edges deleted in analytical mode must be put in the graveyard
+// and freed by GC, not leaked.  Verifies that:
+//   - the storage destructor does not crash (no double-free / use-after-free)
+//   - ~Edge() is called (catches PropertyStore heap-allocation leak under ASan)
+//   - graveyard is drained correctly after mode switch back to transactional
+// NOLINTNEXTLINE(hicpp-special-member-functions)
+TEST(StorageV2GcLightEdge, AnalyticalModeDeleteGoesToGraveyard) {
+  auto storage = MakeLightEdgeGcStorage();
+  auto *mem_storage = static_cast<ms::InMemoryStorage *>(storage.get());
+
+  ms::Gid v1_gid, v2_gid;
+  {
+    auto acc = storage->Access(memgraph::storage::WRITE);
+    auto v1 = acc->CreateVertex();
+    auto v2 = acc->CreateVertex();
+    v1_gid = v1.Gid();
+    v2_gid = v2.Gid();
+    auto edge_res = acc->CreateEdge(&v1, &v2, acc->NameToEdgeType("e"));
+    ASSERT_TRUE(edge_res.has_value());
+    // Set a property so the PropertyStore has a heap allocation — caught by ASan if ~Edge() is skipped.
+    ASSERT_TRUE(edge_res->SetProperty(acc->NameToProperty("key"), ms::PropertyValue{"value"}).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Switch to analytical mode and delete the edge there.
+  mem_storage->SetStorageMode(ms::StorageMode::IN_MEMORY_ANALYTICAL);
+  {
+    auto acc = storage->Access(memgraph::storage::WRITE);
+    auto v1 = acc->FindVertex(v1_gid, ms::View::OLD);
+    ASSERT_TRUE(v1.has_value());
+    auto edges = v1->OutEdges(ms::View::OLD);
+    ASSERT_TRUE(edges.has_value());
+    ASSERT_EQ(edges->edges.size(), 1U);
+    auto edge = edges->edges[0];
+    ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Switch back — this triggers a FreeMemory/GC pass which must not crash.
+  mem_storage->SetStorageMode(ms::StorageMode::IN_MEMORY_TRANSACTIONAL);
+
+  // Run GC explicitly a second time to drain the graveyard.
+  {
+    auto main_guard = std::unique_lock{mem_storage->main_lock_};
+    mem_storage->FreeMemory(std::move(main_guard), false);
+  }
+
+  // Verify the edge is gone and the two vertices are still intact.
+  {
+    auto acc = storage->Access(memgraph::storage::READ);
+    auto v1 = acc->FindVertex(v1_gid, ms::View::OLD);
+    ASSERT_TRUE(v1.has_value());
+    auto edges = v1->OutEdges(ms::View::OLD);
+    ASSERT_TRUE(edges.has_value());
+    EXPECT_TRUE(edges->edges.empty());
+    EXPECT_TRUE(acc->FindVertex(v2_gid, ms::View::OLD).has_value());
+  }
+  // storage destructor runs here — must not crash or report sanitizer errors.
+}

--- a/tests/unit/storage_v2_light_edges.cpp
+++ b/tests/unit/storage_v2_light_edges.cpp
@@ -1,0 +1,1025 @@
+// Copyright 2026 Memgraph Ltd.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+// License, and you may not use this file except in compliance with the Business Source License.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "dbms/database.hpp"
+#include "storage/v2/config.hpp"
+#include "storage/v2/inmemory/storage.hpp"
+#include "storage/v2/storage.hpp"
+#include "tests/test_commit_args_helper.hpp"
+
+using namespace memgraph::storage;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// Create an InMemoryStorage with light edges enabled.
+auto MakeLightEdgeStorage() -> std::unique_ptr<Storage> {
+  return std::make_unique<InMemoryStorage>(
+      Config{.salient = {.items = {.properties_on_edges = true, .storage_light_edge = true}}});
+}
+
+/// Create an InMemoryStorage with light edges + edges_metadata enabled.
+auto MakeLightEdgeStorageWithMetadata() -> std::unique_ptr<Storage> {
+  return std::make_unique<InMemoryStorage>(Config{
+      .salient = {.items = {.properties_on_edges = true, .enable_edges_metadata = true, .storage_light_edge = true}}});
+}
+
+/// Helper: create two vertices and return their Gids.
+auto CreateTwoVertices(Storage *store) -> std::pair<Gid, Gid> {
+  auto acc = store->Access(WRITE);
+  auto v1 = acc->CreateVertex();
+  auto v2 = acc->CreateVertex();
+  auto gid1 = v1.Gid();
+  auto gid2 = v2.Gid();
+  EXPECT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  return {gid1, gid2};
+}
+
+}  // namespace
+
+// ===========================================================================
+// 1. Config Validation
+// ===========================================================================
+
+TEST(LightEdgesConfig, LightEdgeWithPropertiesOnEdges) {
+  // Light edges require properties_on_edges=true.
+  // Verify the combination works: edges get full property support.
+  auto store = MakeLightEdgeStorage();
+  auto acc = store->Access(WRITE);
+  auto v1 = acc->CreateVertex();
+  auto v2 = acc->CreateVertex();
+  auto et = acc->NameToEdgeType("ET");
+  auto edge_res = acc->CreateEdge(&v1, &v2, et);
+  ASSERT_TRUE(edge_res.has_value());
+
+  // Set a property on the edge to verify properties work
+  auto prop = acc->NameToProperty("key");
+  auto set_res = edge_res->SetProperty(prop, PropertyValue(42));
+  ASSERT_TRUE(set_res.has_value());
+
+  auto props = edge_res->Properties(View::NEW);
+  ASSERT_TRUE(props.has_value());
+  ASSERT_EQ(props->size(), 1);
+  ASSERT_EQ(props->at(prop).ValueInt(), 42);
+
+  ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+}
+
+// ===========================================================================
+// 3. CreateEdge
+// ===========================================================================
+
+TEST(LightEdgesCreateEdge, BasicCreateAndCommit) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create edge
+  Gid edge_gid = Gid::FromUint(std::numeric_limits<uint64_t>::max());
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    ASSERT_TRUE(vf);
+    ASSERT_TRUE(vt);
+
+    auto et = acc->NameToEdgeType("KNOWS");
+    auto res = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(res.has_value());
+    edge_gid = res->Gid();
+
+    // Before commit: NEW shows edge, OLD doesn't
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 1);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+    ASSERT_EQ(vt->InEdges(View::NEW)->edges.size(), 1);
+    ASSERT_EQ(vt->InEdges(View::OLD)->edges.size(), 0);
+
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // After commit: both views show the edge
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    auto out = vf->OutEdges(View::OLD);
+    ASSERT_TRUE(out.has_value());
+    ASSERT_EQ(out->edges.size(), 1);
+    ASSERT_EQ(out->edges[0].Gid(), edge_gid);
+  }
+}
+
+TEST(LightEdgesCreateEdge, EdgeWithProperties) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("HAS");
+    auto res = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(res.has_value());
+
+    auto prop_weight = acc->NameToProperty("weight");
+    auto prop_name = acc->NameToProperty("name");
+
+    ASSERT_TRUE(res->SetProperty(prop_weight, PropertyValue(3.14)).has_value());
+    ASSERT_TRUE(res->SetProperty(prop_name, PropertyValue("test")).has_value());
+
+    auto props = res->Properties(View::NEW);
+    ASSERT_TRUE(props.has_value());
+    ASSERT_EQ(props->size(), 2);
+    ASSERT_DOUBLE_EQ(props->at(prop_weight).ValueDouble(), 3.14);
+    ASSERT_EQ(props->at(prop_name).ValueString(), "test");
+
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Verify properties after commit
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    auto out = vf->OutEdges(View::OLD);
+    ASSERT_EQ(out->edges.size(), 1);
+    auto props = out->edges[0].Properties(View::OLD);
+    ASSERT_TRUE(props.has_value());
+    ASSERT_EQ(props->size(), 2);
+  }
+}
+
+TEST(LightEdgesCreateEdge, SelfLoop) {
+  auto store = MakeLightEdgeStorage();
+
+  Gid gid;
+  {
+    auto acc = store->Access(WRITE);
+    auto v = acc->CreateVertex();
+    gid = v.Gid();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  {
+    auto acc = store->Access(WRITE);
+    auto v = acc->FindVertex(gid, View::NEW);
+    ASSERT_TRUE(v);
+    auto et = acc->NameToEdgeType("SELF");
+    auto res = acc->CreateEdge(&*v, &*v, et);
+    ASSERT_TRUE(res.has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  {
+    auto acc = store->Access(WRITE);
+    auto v = acc->FindVertex(gid, View::OLD);
+    ASSERT_TRUE(v);
+    ASSERT_EQ(v->OutEdges(View::OLD)->edges.size(), 1);
+    ASSERT_EQ(v->InEdges(View::OLD)->edges.size(), 1);
+    ASSERT_EQ(*v->OutDegree(View::OLD), 1);
+    ASSERT_EQ(*v->InDegree(View::OLD), 1);
+  }
+}
+
+TEST(LightEdgesCreateEdge, MultipleEdgesBetweenSameVertices) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et1 = acc->NameToEdgeType("KNOWS");
+    auto et2 = acc->NameToEdgeType("LIKES");
+
+    auto r1 = acc->CreateEdge(&*vf, &*vt, et1);
+    ASSERT_TRUE(r1.has_value());
+    auto r2 = acc->CreateEdge(&*vf, &*vt, et2);
+    ASSERT_TRUE(r2.has_value());
+    auto r3 = acc->CreateEdge(&*vf, &*vt, et1);
+    ASSERT_TRUE(r3.has_value());
+
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 3);
+    ASSERT_EQ(vt->InEdges(View::NEW)->edges.size(), 3);
+
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 3);
+  }
+}
+
+// ===========================================================================
+// 7. FindEdge
+// ===========================================================================
+
+// FindEdge is a private method tested indirectly through WAL recovery,
+// snapshot recovery, and replication. We test the public edge-lookup behavior
+// here (via OutEdges/InEdges on vertices).
+
+TEST(LightEdgesFindEdge, EdgeAccessibleViaVertexWithMetadata) {
+  auto store = MakeLightEdgeStorageWithMetadata();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  Gid edge_gid = Gid::FromUint(0);
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("FOUND");
+    auto res = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(res.has_value());
+    edge_gid = res->Gid();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Edge should be findable via vertex out_edges
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    auto out = vf->OutEdges(View::OLD);
+    ASSERT_EQ(out->edges.size(), 1);
+    ASSERT_EQ(out->edges[0].Gid(), edge_gid);
+  }
+}
+
+// Two-arg FindEdge(edge_gid, from_vertex_gid) with a stale/absent from_vertex
+// must SOFT-MISS (return nullopt), matching the heavy arm and the optional
+// contract of the public wrapper — not throw across the query boundary.
+TEST(LightEdgesFindEdge, FindEdgeWithStaleFromVertexSoftMisses) {
+  auto store = MakeLightEdgeStorageWithMetadata();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  Gid edge_gid = Gid::FromUint(0);
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("FOUND");
+    auto res = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(res.has_value());
+    edge_gid = res->Gid();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  {
+    auto acc = store->Access(WRITE);
+    // A from_vertex_gid that never existed: must return nullopt, not throw.
+    auto never = Gid::FromUint(999999);
+    std::optional<EdgeAccessor> found;
+    ASSERT_NO_THROW({ found = acc->FindEdge(edge_gid, never, View::OLD); });
+    ASSERT_FALSE(found.has_value());
+    // And the real (gid, from) still resolves.
+    auto real = acc->FindEdge(edge_gid, gid_from, View::OLD);
+    ASSERT_TRUE(real.has_value());
+    ASSERT_EQ(real->Gid(), edge_gid);
+  }
+}
+
+TEST(LightEdgesFindEdge, EdgeAccessibleViaVertexWithoutMetadata) {
+  auto store = MakeLightEdgeStorage();  // no edges_metadata
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  Gid edge_gid = Gid::FromUint(0);
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("FOUND");
+    auto res = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(res.has_value());
+    edge_gid = res->Gid();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    auto out = vf->OutEdges(View::OLD);
+    ASSERT_EQ(out->edges.size(), 1);
+    ASSERT_EQ(out->edges[0].Gid(), edge_gid);
+  }
+}
+
+TEST(LightEdgesFindEdge, NoEdgesOnEmptyVertex) {
+  auto store = MakeLightEdgeStorageWithMetadata();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  auto acc = store->Access(WRITE);
+  auto vf = acc->FindVertex(gid_from, View::OLD);
+  ASSERT_TRUE(vf);
+  auto out = vf->OutEdges(View::OLD);
+  ASSERT_EQ(out->edges.size(), 0);
+}
+
+// ===========================================================================
+// 10. Storage Cleanup
+// ===========================================================================
+
+TEST(LightEdgesCleanup, DestructorFreesAllEdges) {
+  // Simply verifies no crash / ASAN errors on destruction with edges alive
+  {
+    auto store = MakeLightEdgeStorage();
+    auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("ALIVE");
+    for (int i = 0; i < 100; ++i) {
+      ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    // Accessor drops, then store destroys -> should free all 100 edges from pool
+  }
+  // If we get here without ASAN/MSAN errors, cleanup worked
+}
+
+TEST(LightEdgesCleanup, DestroyAndRecreateStorage) {
+  // Verify that destroying a storage with edges and creating a new one works
+  // without memory issues (tests pool allocator recycling).
+  for (int round = 0; round < 3; ++round) {
+    auto store = MakeLightEdgeStorage();
+    auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("CYCLE");
+    for (int i = 0; i < 50; ++i) {
+      ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    // store destructor frees everything, next iteration creates fresh storage
+  }
+}
+
+// ===========================================================================
+// 12. DropGraph tests
+// ===========================================================================
+
+// DropGraph on a light-edge storage must free all edges (no
+// ASAN/MSAN errors), leave the storage empty, and leave the pool reusable.
+TEST(LightEdgesCleanup, DropGraphFreesEdgesAndPool) {
+  auto store = MakeLightEdgeStorage();
+  auto *mem_storage = static_cast<InMemoryStorage *>(store.get());
+
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create enough edges to span multiple pool chunks.
+  constexpr int kEdges = 500;
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto etype = acc->NameToEdgeType("T");
+    for (int idx = 0; idx < kEdges; ++idx) {
+      ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, etype).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // DropGraph requires IN_MEMORY_ANALYTICAL mode.
+  mem_storage->SetStorageMode(StorageMode::IN_MEMORY_ANALYTICAL);
+  {
+    auto acc = store->UniqueAccess();
+    acc->DropGraph();
+  }
+
+  // Verify storage is empty.
+  mem_storage->SetStorageMode(StorageMode::IN_MEMORY_TRANSACTIONAL);
+  {
+    auto acc = store->Access(READ);
+    int edge_count = 0;
+    for (auto vertex : acc->Vertices(View::OLD)) {
+      auto out = vertex.OutEdges(View::OLD);
+      if (out.has_value()) edge_count += static_cast<int>(out->edges.size());
+    }
+    EXPECT_EQ(edge_count, 0);
+  }
+
+  // Pool must still be usable after DropGraph + Reclaim.
+  auto [gf2, gt2] = CreateTwoVertices(store.get());
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gf2, View::NEW);
+    auto vt = acc->FindVertex(gt2, View::NEW);
+    ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, acc->NameToEdgeType("NEW")).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+}
+
+// ===========================================================================
+// 4. DeleteEdge
+// ===========================================================================
+
+TEST(LightEdgesDeleteEdge, BasicDeleteAndCommit) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create edge
+  Gid edge_gid = Gid::FromUint(0);
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("REL");
+    auto res = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(res.has_value());
+    edge_gid = res->Gid();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete edge
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    ASSERT_TRUE(vf);
+    auto edge = vf->OutEdges(View::NEW).value().edges[0];
+
+    auto del = acc->DeleteEdge(&edge);
+    ASSERT_TRUE(del.has_value());
+
+    // After delete: NEW shows 0 edges, OLD shows 1
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 0);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 1);
+
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // After commit: edge gone
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+TEST(LightEdgesDeleteEdge, DetachDeleteVertex) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create edge
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("REL");
+    ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Detach delete from_vertex
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    ASSERT_TRUE(vf);
+    auto del = acc->DetachDeleteVertex(&*vf);
+    ASSERT_TRUE(del.has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // to_vertex should have no in_edges
+  {
+    auto acc = store->Access(WRITE);
+    auto vt = acc->FindVertex(gid_to, View::OLD);
+    ASSERT_TRUE(vt);
+    ASSERT_EQ(vt->InEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+// ===========================================================================
+// 5. Abort Handling
+// ===========================================================================
+
+TEST(LightEdgesAbort, AbortCreation) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create edge then abort (don't commit)
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("TEMP");
+    auto res = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(res.has_value());
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 1);
+    // Accessor destructor will abort
+  }
+
+  // Edge should not exist
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 0);
+  }
+}
+
+// Regression: with enable_edges_metadata + light edges, CREATING an edge then
+// ABORTING the transaction must not double-remove the metadata entry. Abort
+// routes the aborted-created light Edge* into deleted_edges_ (the heal), so the
+// single metadata OnEdgesDeleted must happen at CollectGarbage time, NOT also at
+// abort time. Before the fix, OnEdgesDeleted fired at abort AND again in GC,
+// tripping MG_ASSERT(acc.remove(gid)) in EdgeMetadataIndex on the second pass.
+TEST(LightEdgesAbort, AbortCreationWithMetadataNoDoubleRemove) {
+  auto store = MakeLightEdgeStorageWithMetadata();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create edge then abort (don't commit).
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("TEMP");
+    ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    // Accessor destructor aborts; metadata entry for the aborted edge is removed
+    // exactly once (at GC), not here.
+  }
+
+  // GC processes the abort-routed Edge* in deleted_edges_: OnEdgesDeleted removes
+  // its metadata entry. Pre-fix this MG_ASSERT-aborts (entry already removed at
+  // abort time). Call twice to drain every batch.
+  store->FreeMemory();
+  store->FreeMemory();
+
+  // Edge must not exist and the storage must be consistent (no crash above).
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+TEST(LightEdgesAbort, AbortDeletion) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create edge
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("PERM");
+    ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete edge then abort
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto edge = vf->OutEdges(View::NEW).value().edges[0];
+    auto del = acc->DeleteEdge(&edge);
+    ASSERT_TRUE(del.has_value());
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 0);
+    // Don't commit - abort
+  }
+
+  // Edge should still exist
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 1);
+  }
+}
+
+TEST(LightEdgesAbort, AbortCreateAndDeleteInSameTxn) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create + delete in same txn, then abort
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("EPHEMERAL");
+    auto res = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(res.has_value());
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 1);
+
+    auto del = acc->DeleteEdge(&*res);
+    ASSERT_TRUE(del.has_value());
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 0);
+    // Abort
+  }
+
+  // Nothing should exist
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+// ===========================================================================
+// 6. MVCC + GC (graveyard)
+// ===========================================================================
+
+TEST(LightEdgesMVCC, ConcurrentTxnSeesDeletedEdge) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create edge
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("REL");
+    auto res = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(res.has_value());
+
+    // Set a property so we can verify the Edge* is valid
+    auto prop = acc->NameToProperty("val");
+    ASSERT_TRUE(res->SetProperty(prop, PropertyValue(42)).has_value());
+
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Start reader txn BEFORE the delete
+  auto reader = store->Access(WRITE);
+  auto vf_reader = reader->FindVertex(gid_from, View::OLD);
+  ASSERT_TRUE(vf_reader);
+  ASSERT_EQ(vf_reader->OutEdges(View::OLD)->edges.size(), 1);
+
+  // Delete edge in a separate txn
+  {
+    auto writer = store->Access(WRITE);
+    auto vf = writer->FindVertex(gid_from, View::NEW);
+    auto edge = vf->OutEdges(View::NEW).value().edges[0];
+    ASSERT_TRUE(writer->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(writer->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // GC runs but reader is still active -> graveyard shouldn't drain
+  store->FreeMemory();
+
+  // Reader should still see the edge with correct properties
+  {
+    auto out = vf_reader->OutEdges(View::OLD);
+    ASSERT_EQ(out->edges.size(), 1);
+    auto prop = reader->NameToProperty("val");
+    auto val = out->edges[0].GetProperty(prop, View::OLD);
+    ASSERT_TRUE(val.has_value());
+    ASSERT_EQ(val->ValueInt(), 42);
+  }
+
+  // Close reader
+  reader.reset();
+
+  // Now GC should drain the graveyard
+  store->FreeMemory();
+
+  // Edge is gone for new transactions
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+TEST(LightEdgesMVCC, GCDrainsGraveyardAfterAllReadersGone) {
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create and delete multiple edges
+  constexpr int kEdges = 10;
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("MULTI");
+    for (int i = 0; i < kEdges; ++i) {
+      ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete all edges
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    for (int i = 0; i < kEdges; ++i) {
+      auto edge = vf->OutEdges(View::NEW).value().edges[0];
+      ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    }
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 0);
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Run GC
+  store->FreeMemory();
+
+  // Verify edges are gone
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+// ===========================================================================
+// 6b. Graveyard-specific tests
+// ===========================================================================
+
+// Regression: with enable_edges_metadata + light edges, deleting an edge and
+// running GC routes the Edge* through CollectGarbage (which removes the
+// edges-metadata entry via OnEdgesDeleted) and then through
+// DrainLightEdgeGraveyard in the SAME FreeMemory() cycle. Before the fix the
+// drain re-called OnEdgeDeleted(gid) on the already-removed entry, tripping the
+// `MG_ASSERT(acc.remove(gid))` in edge_metadata_index.hpp (double-remove abort).
+// After the fix the drain only frees memory and the test runs clean; we also
+// create+delete a second edge afterwards to prove the metadata index stays
+// consistent (a stale double-removed entry would corrupt later inserts).
+TEST(LightEdgesGraveyard, EdgesMetadataConsistentThroughDeleteAndDrain) {
+  auto store = MakeLightEdgeStorageWithMetadata();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create + commit a batch of edges.
+  constexpr int kEdges = 5;
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("META");
+    for (int i = 0; i < kEdges; ++i) {
+      ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete + commit all of them.
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    for (int i = 0; i < kEdges; ++i) {
+      auto edge = vf->OutEdges(View::NEW).value().edges[0];
+      ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    }
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 0);
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // GC collects the deleted light edges: CollectGarbage removes their metadata
+  // entries and pushes the Edge* to the graveyard, then DrainLightEdgeGraveyard
+  // frees them in the same cycle. Without the fix this MG_ASSERT-aborts on the
+  // double OnEdgeDeleted. Call twice to be sure every batch drains.
+  store->FreeMemory();
+  store->FreeMemory();
+
+  // Edge is gone.
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+
+  // Subsequent create/delete/GC must still work: a corrupted metadata index
+  // (from a stale double-removed entry) would surface as an abort or a wrong
+  // edge view here.
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("META2");
+    ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 1);
+    auto edge = vf->OutEdges(View::NEW).value().edges[0];
+    ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  store->FreeMemory();
+  store->FreeMemory();
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+TEST(LightEdgesGraveyard, MultipleBatchesAccumulateAndDrain) {
+  // Delete edges across many separate transactions, each creating a graveyard batch.
+  // Verify all batches drain after all readers are gone.
+  auto store = MakeLightEdgeStorage();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  constexpr int kEdges = 20;
+
+  // Create edges
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("BATCH");
+    auto prop = acc->NameToProperty("idx");
+    for (int i = 0; i < kEdges; ++i) {
+      auto res = acc->CreateEdge(&*vf, &*vt, et);
+      ASSERT_TRUE(res.has_value());
+      ASSERT_TRUE(res->SetProperty(prop, PropertyValue(i)).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Delete edges one-by-one in separate transactions -> one graveyard batch each
+  for (int i = 0; i < kEdges; ++i) {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto out = vf->OutEdges(View::NEW);
+    ASSERT_TRUE(out.has_value());
+    ASSERT_FALSE(out->edges.empty());
+    auto edge = out->edges[0];
+    ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // All edges deleted, verify vertex shows 0
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+
+  // GC drains all batches (call twice for good measure)
+  store->FreeMemory();
+  store->FreeMemory();
+
+  // Verify no crash on final state
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+  }
+}
+
+// FastDiscard path: create+commit then delete+commit with no overlapping
+// transaction (FastDiscard fires on the delete commit). Verify that after
+// FreeMemory() the metadata index has no stale entry and FindEdge returns
+// nullopt cleanly (no crash / UAF).
+TEST(LightEdgesGraveyard, FastDiscardRouteKeepsMetadataConsistent) {
+  auto store = MakeLightEdgeStorageWithMetadata();
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  Gid edge_gid = Gid::FromUint(std::numeric_limits<uint64_t>::max());
+
+  // Step 1: create + commit the edge (no concurrent reader -> FastDiscard eligible).
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto et = acc->NameToEdgeType("FD");
+    auto res = acc->CreateEdge(&*vf, &*vt, et);
+    ASSERT_TRUE(res.has_value());
+    edge_gid = res->Gid();
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Verify edge is visible.
+  {
+    auto acc = store->Access(READ);
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 1);
+    // FindEdge via accessor must succeed while edge is live.
+    ASSERT_TRUE(acc->FindEdge(edge_gid, View::OLD).has_value());
+  }
+
+  // Step 2: delete + commit (no concurrent reader -> FastDiscard fires, Edge*
+  // routed through deleted_edges_ into CollectGarbage, NOT directly to graveyard).
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    ASSERT_TRUE(vf);
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 1);
+    auto edge = vf->OutEdges(View::NEW).value().edges[0];
+    ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    ASSERT_EQ(vf->OutEdges(View::NEW)->edges.size(), 0);
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+
+  // Step 3: run GC twice — CollectGarbage picks up deleted_edges_, removes
+  // metadata entry, pushes to graveyard; DrainLightEdgeGraveyard frees.
+  // Two FreeMemory() calls ensure every GC phase completes.
+  store->FreeMemory();
+  store->FreeMemory();
+
+  // Step 4: verify no stale metadata entry and no crash (no UAF).
+  {
+    auto acc = store->Access(READ);
+    // Vertex must see zero edges.
+    auto vf = acc->FindVertex(gid_from, View::OLD);
+    ASSERT_TRUE(vf);
+    ASSERT_EQ(vf->OutEdges(View::OLD)->edges.size(), 0);
+    // FindEdge must return nullopt cleanly — stale metadata entry would either
+    // abort (double-remove assert) or return a dangling pointer.
+    ASSERT_FALSE(acc->FindEdge(edge_gid, View::OLD).has_value());
+  }
+}
+
+// ===========================================================================
+// 10. Storage Cleanup
+// ===========================================================================
+
+TEST(LightEdgesCleanup, DestructorFreesGraveyardEdges) {
+  // Verify no crash when edges are in the graveyard at destruction time
+  {
+    auto store = MakeLightEdgeStorage();
+    auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+    // Create edges
+    {
+      auto acc = store->Access(WRITE);
+      auto vf = acc->FindVertex(gid_from, View::NEW);
+      auto vt = acc->FindVertex(gid_to, View::NEW);
+      auto et = acc->NameToEdgeType("GRAVE");
+      for (int i = 0; i < 50; ++i) {
+        ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, et).has_value());
+      }
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    // Delete all edges (they go to graveyard)
+    {
+      auto acc = store->Access(WRITE);
+      auto vf = acc->FindVertex(gid_from, View::NEW);
+      for (int i = 0; i < 50; ++i) {
+        auto edge = vf->OutEdges(View::NEW).value().edges[0];
+        ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+      }
+      ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+    }
+
+    // DON'T run GC - leave edges in graveyard
+    // Store destruction should clean them up
+  }
+  // If we get here without errors, graveyard cleanup worked
+}
+
+// ===========================================================================
+// 12. DropGraph tests
+// ===========================================================================
+
+// DropGraph with edges in the graveyard (deleted but not yet GC'd).
+TEST(LightEdgesCleanup, DropGraphWithGraveyardEdges) {
+  auto store = MakeLightEdgeStorage();
+  auto *mem_storage = static_cast<InMemoryStorage *>(store.get());
+
+  auto [gid_from, gid_to] = CreateTwoVertices(store.get());
+
+  // Create and then delete edges so they sit in the graveyard.
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    auto vt = acc->FindVertex(gid_to, View::NEW);
+    auto etype = acc->NameToEdgeType("T");
+    for (int idx = 0; idx < 50; ++idx) {
+      ASSERT_TRUE(acc->CreateEdge(&*vf, &*vt, etype).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  {
+    auto acc = store->Access(WRITE);
+    auto vf = acc->FindVertex(gid_from, View::NEW);
+    while (true) {
+      auto out = vf->OutEdges(View::NEW);
+      if (!out.has_value() || out->edges.empty()) break;
+      auto edge = out->edges[0];
+      ASSERT_TRUE(acc->DeleteEdge(&edge).has_value());
+    }
+    ASSERT_TRUE(acc->PrepareForCommitPhase(memgraph::tests::MakeMainCommitArgs()).has_value());
+  }
+  // Deliberately skip GC so edges remain in graveyard.
+
+  mem_storage->SetStorageMode(StorageMode::IN_MEMORY_ANALYTICAL);
+  {
+    auto acc = store->UniqueAccess();
+    acc->DropGraph();
+    // No crash / ASAN error = graveyard was drained and pool reclaimed.
+  }
+}


### PR DESCRIPTION
Create/find:
- LightEdgePool::Create/Destroy over memory::DbAwareAllocator<Edge>. Create propagates allocation failure (OutOfMemoryException / std::bad_alloc) so the txn aborts, exactly like edges_.insert; never returns nullptr.
- Unify CreateEdge/CreateEdgeEx into CreateEdgeInternal (heavy arm byte-equivalent).
- Split FindEdge into FindHeavyEdge + gated FindLightEdgeFromMetadata / FindLightEdgeByScan; EdgeMetadataIndex::TryFromVertexOf soft-miss helper.
- ScanOutEdgesForGid now acquires from_vertex->lock itself (mirrors ExtractEdgeInfo), so the find paths no longer each lock before calling it.

Delete/reclaim:
- light_edge_graveyard_ + LightEdgeGraveyardEntry; deleted light Edge* route to the graveyard at GC-collection time and are freed by the drain. guard_epoch is a sentinel (0) here; the epoch-gated drain is wired in 7b-ii.
- FastDiscard/Abort light arms splice the deleted light Edge* into deleted_edges_ (O(1) under the SpinLock) instead of edge_acc.remove.
- ClearLightEdges / DropGraph / ~InMemoryStorage drain live adjacency + graveyard.

Cleanup: dropped the CreateLightEdge/DestroyLightEdge free-function shims — every caller (storage.cpp, and later snapshot.cpp/wal.cpp) includes the full InMemoryStorage definition, so the shims were pure indirection; callers use InMemoryStorage::LightEdgePool::Create/Destroy directly.