### PR TITLE
fix: use the correct conan profile when generating the SBOM

### DIFF
--- a/tools/ci/sbom/build-sbom.sh
+++ b/tools/ci/sbom/build-sbom.sh
@@ -50,7 +50,7 @@ elif [[ ! -f "$SOURCE_DIR/build/generators/sbom/memgraph-sbom.cdx.json" && -n "$
   MG_TOOLCHAIN_ROOT=/opt/toolchain-v7 conan install \
     . \
     --build=missing \
-    -pr:h memgraph_template_profile \
+    -pr:h memgraph_toolchain_v7 \
     -pr:b memgraph_build_profile \
     -s build_type="$BUILD_TYPE" \
     -s:a os=Linux \


### PR DESCRIPTION
The template profile for `conan` was previously renamed from `memgraph_template_profile` to `memgraph_toolchain_v7`. The SBOM generation code was using the old name still - this was fine on runners which still had the old config installed, but not on those whose `conan` configs had been cleared. Bug surfaced when the SBOM for MAGE was generated on a runner which had recently been cleaned.

