### PR TITLE
feat: add unindexed-scan query counter

### DIFF
--- a/src/metrics/prometheus_metrics.cpp
+++ b/src/metrics/prometheus_metrics.cpp
@@ -168,7 +168,8 @@ PrometheusMetrics::PrometheusMetrics()
       query_no_index_lookup_family_{
           prometheus::BuildCounter()
               .Name("memgraph_query_no_index_lookup_total")
-              .Help("Queries planned with ScanAll+Filter where an index could have served them")
+              .Help("Query executions whose plan had a ScanAll+Filter an index could have served (counts once "
+                    "per query)")
               .Register(registry_)},
       // Operators
       once_operator_family_{prometheus::BuildCounter()
@@ -1964,6 +1965,7 @@ std::vector<MetricInfo> PrometheusMetrics::GetGlobalMetricsInfoForJson() {
   out.push_back({"ShowStorageInfoOnDatabase", "StorageInfo", "Counter", total_show_storage_info});
 
   // Query
+  // QueryNoIndexLookup is OpenMetrics / SHOW METRICS INFO only; not aggregated into the deprecated JSON endpoint.
   AppendMergedHistogramPercentiles(out, "QueryExecutionLatency", "Query", query_exec_hdatas);
 
   // Snapshot

--- a/src/metrics/prometheus_metrics.cpp
+++ b/src/metrics/prometheus_metrics.cpp
@@ -165,9 +165,9 @@ PrometheusMetrics::PrometheusMetrics()
                                    .Name("memgraph_read_write_queries_total")
                                    .Help("Total number of read-write queries")
                                    .Register(registry_)},
-      query_no_index_lookup_family_{
+      unindexed_scan_queries_family_{
           prometheus::BuildCounter()
-              .Name("memgraph_query_no_index_lookup_total")
+              .Name("memgraph_unindexed_scan_queries_total")
               .Help("Query executions whose plan had a ScanAll+Filter an index could have served (counts once "
                     "per query)")
               .Register(registry_)},
@@ -1026,7 +1026,7 @@ DatabaseMetricHandles PrometheusMetrics::AddDatabase(utils::UUID const &uuid, st
                   .read_query = {&read_query_family_.Add(labels)},
                   .write_query = {&write_query_family_.Add(labels)},
                   .read_write_query = {&read_write_query_family_.Add(labels)},
-                  .query_no_index_lookup = {&query_no_index_lookup_family_.Add(labels)},
+                  .unindexed_scan_queries = {&unindexed_scan_queries_family_.Add(labels)},
                   .deleted_nodes = {&deleted_nodes_family_.Add(labels)},
                   .deleted_edges = {&deleted_edges_family_.Add(labels)},
                   .show_schema = {&show_schema_family_.Add(labels)},
@@ -1140,7 +1140,7 @@ void PrometheusMetrics::RemoveDatabase(utils::UUID const &uuid) {
   read_query_family_.Remove(h.read_query.get());
   write_query_family_.Remove(h.write_query.get());
   read_write_query_family_.Remove(h.read_write_query.get());
-  query_no_index_lookup_family_.Remove(h.query_no_index_lookup.get());
+  unindexed_scan_queries_family_.Remove(h.unindexed_scan_queries.get());
   deleted_nodes_family_.Remove(h.deleted_nodes.get());
   deleted_edges_family_.Remove(h.deleted_edges.get());
   show_schema_family_.Remove(h.show_schema.get());
@@ -1579,7 +1579,7 @@ std::expected<std::vector<MetricInfo>, std::string> PrometheusMetrics::GetDbMetr
   out.push_back({"ReadWriteQuery", "QueryType", "Counter", static_cast<int64_t>(h.read_write_query.Value())});
 
   // Query (planner-level signals)
-  out.push_back({"QueryNoIndexLookup", "Query", "Counter", static_cast<int64_t>(h.query_no_index_lookup.Value())});
+  out.push_back({"UnindexedScanQueries", "Query", "Counter", static_cast<int64_t>(h.unindexed_scan_queries.Value())});
 
   // TTL
   out.push_back({"DeletedNodes", "TTL", "Counter", static_cast<int64_t>(h.deleted_nodes.Value())});
@@ -1965,7 +1965,7 @@ std::vector<MetricInfo> PrometheusMetrics::GetGlobalMetricsInfoForJson() {
   out.push_back({"ShowStorageInfoOnDatabase", "StorageInfo", "Counter", total_show_storage_info});
 
   // Query
-  // QueryNoIndexLookup is OpenMetrics / SHOW METRICS INFO only; not aggregated into the deprecated JSON endpoint.
+  // UnindexedScanQueries is OpenMetrics / SHOW METRICS INFO only; not aggregated into the deprecated JSON endpoint.
   AppendMergedHistogramPercentiles(out, "QueryExecutionLatency", "Query", query_exec_hdatas);
 
   // Snapshot

--- a/src/metrics/prometheus_metrics.cpp
+++ b/src/metrics/prometheus_metrics.cpp
@@ -168,9 +168,8 @@ PrometheusMetrics::PrometheusMetrics()
       unindexed_scan_queries_family_{
           prometheus::BuildCounter()
               .Name("memgraph_unindexed_scan_queries_total")
-              .Help("Queries planned with a sequential node scan (ScanAll) whose label or label+property filter a "
-                    "label or label-property index could have served. Counts once per query, not per scan; "
-                    "excludes scans already using a label index and label-less property filters")
+              .Help("Queries planned with a full node scan (ScanAll or its parallel-execution rewrite) that a "
+                    "label or label-property index could have served; counted once per query, not per scan")
               .Register(registry_)},
       // Operators
       once_operator_family_{prometheus::BuildCounter()

--- a/src/metrics/prometheus_metrics.cpp
+++ b/src/metrics/prometheus_metrics.cpp
@@ -165,6 +165,11 @@ PrometheusMetrics::PrometheusMetrics()
                                    .Name("memgraph_read_write_queries_total")
                                    .Help("Total number of read-write queries")
                                    .Register(registry_)},
+      query_no_index_lookup_family_{
+          prometheus::BuildCounter()
+              .Name("memgraph_query_no_index_lookup_total")
+              .Help("Queries planned with ScanAll+Filter where an index could have served them")
+              .Register(registry_)},
       // Operators
       once_operator_family_{prometheus::BuildCounter()
                                 .Name("memgraph_once_operator_total")
@@ -1020,6 +1025,7 @@ DatabaseMetricHandles PrometheusMetrics::AddDatabase(utils::UUID const &uuid, st
                   .read_query = {&read_query_family_.Add(labels)},
                   .write_query = {&write_query_family_.Add(labels)},
                   .read_write_query = {&read_write_query_family_.Add(labels)},
+                  .query_no_index_lookup = {&query_no_index_lookup_family_.Add(labels)},
                   .deleted_nodes = {&deleted_nodes_family_.Add(labels)},
                   .deleted_edges = {&deleted_edges_family_.Add(labels)},
                   .show_schema = {&show_schema_family_.Add(labels)},
@@ -1133,6 +1139,7 @@ void PrometheusMetrics::RemoveDatabase(utils::UUID const &uuid) {
   read_query_family_.Remove(h.read_query.get());
   write_query_family_.Remove(h.write_query.get());
   read_write_query_family_.Remove(h.read_write_query.get());
+  query_no_index_lookup_family_.Remove(h.query_no_index_lookup.get());
   deleted_nodes_family_.Remove(h.deleted_nodes.get());
   deleted_edges_family_.Remove(h.deleted_edges.get());
   show_schema_family_.Remove(h.show_schema.get());
@@ -1569,6 +1576,9 @@ std::expected<std::vector<MetricInfo>, std::string> PrometheusMetrics::GetDbMetr
   out.push_back({"ReadQuery", "QueryType", "Counter", static_cast<int64_t>(h.read_query.Value())});
   out.push_back({"WriteQuery", "QueryType", "Counter", static_cast<int64_t>(h.write_query.Value())});
   out.push_back({"ReadWriteQuery", "QueryType", "Counter", static_cast<int64_t>(h.read_write_query.Value())});
+
+  // Query (planner-level signals)
+  out.push_back({"QueryNoIndexLookup", "Query", "Counter", static_cast<int64_t>(h.query_no_index_lookup.Value())});
 
   // TTL
   out.push_back({"DeletedNodes", "TTL", "Counter", static_cast<int64_t>(h.deleted_nodes.Value())});

--- a/src/metrics/prometheus_metrics.cpp
+++ b/src/metrics/prometheus_metrics.cpp
@@ -168,7 +168,7 @@ PrometheusMetrics::PrometheusMetrics()
       unindexed_scan_queries_family_{
           prometheus::BuildCounter()
               .Name("memgraph_unindexed_scan_queries_total")
-              .Help("Query executions whose plan had a ScanAll+Filter an index could have served (counts once "
+              .Help("Planned queries whose plan had a ScanAll+Filter an index could have served (counts once "
                     "per query)")
               .Register(registry_)},
       // Operators
@@ -1578,7 +1578,7 @@ std::expected<std::vector<MetricInfo>, std::string> PrometheusMetrics::GetDbMetr
   out.push_back({"WriteQuery", "QueryType", "Counter", static_cast<int64_t>(h.write_query.Value())});
   out.push_back({"ReadWriteQuery", "QueryType", "Counter", static_cast<int64_t>(h.read_write_query.Value())});
 
-  // Query (planner-level signals)
+  // Query — planner-level signals
   out.push_back({"UnindexedScanQueries", "Query", "Counter", static_cast<int64_t>(h.unindexed_scan_queries.Value())});
 
   // TTL
@@ -1592,7 +1592,7 @@ std::expected<std::vector<MetricInfo>, std::string> PrometheusMetrics::GetDbMetr
   out.push_back(
       {"ShowStorageInfoOnDatabase", "StorageInfo", "Counter", static_cast<int64_t>(h.show_storage_info.Value())});
 
-  // Query
+  // Query — latency
   AppendHistogramPercentiles(out, "QueryExecutionLatency", "Query", *h.query_execution_latency_seconds.get());
 
   // Snapshot
@@ -1965,7 +1965,7 @@ std::vector<MetricInfo> PrometheusMetrics::GetGlobalMetricsInfoForJson() {
   out.push_back({"ShowStorageInfoOnDatabase", "StorageInfo", "Counter", total_show_storage_info});
 
   // Query
-  // UnindexedScanQueries is OpenMetrics / SHOW METRICS INFO only; not aggregated into the deprecated JSON endpoint.
+  // NOTE: UnindexedScanQueries is OpenMetrics / SHOW METRICS INFO only; deliberately not aggregated here.
   AppendMergedHistogramPercentiles(out, "QueryExecutionLatency", "Query", query_exec_hdatas);
 
   // Snapshot

--- a/src/metrics/prometheus_metrics.cpp
+++ b/src/metrics/prometheus_metrics.cpp
@@ -168,8 +168,9 @@ PrometheusMetrics::PrometheusMetrics()
       unindexed_scan_queries_family_{
           prometheus::BuildCounter()
               .Name("memgraph_unindexed_scan_queries_total")
-              .Help("Planned queries whose plan had a ScanAll+Filter an index could have served (counts once "
-                    "per query)")
+              .Help("Queries planned with a sequential node scan (ScanAll) whose label or label+property filter a "
+                    "label or label-property index could have served. Counts once per query, not per scan; "
+                    "excludes scans already using a label index and label-less property filters")
               .Register(registry_)},
       // Operators
       once_operator_family_{prometheus::BuildCounter()

--- a/src/metrics/prometheus_metrics.hpp
+++ b/src/metrics/prometheus_metrics.hpp
@@ -249,7 +249,7 @@ struct DatabaseMetricHandles {
   CounterHandle read_write_query;
 
   // Planner
-  CounterHandle query_no_index_lookup;
+  CounterHandle unindexed_scan_queries;
 
   // TTL
   CounterHandle deleted_nodes;
@@ -449,7 +449,7 @@ class PrometheusMetrics {
   prometheus::Family<prometheus::Counter> &read_write_query_family_;
 
   // Per-database metric families — planner
-  prometheus::Family<prometheus::Counter> &query_no_index_lookup_family_;
+  prometheus::Family<prometheus::Counter> &unindexed_scan_queries_family_;
 
   // Per-database metric families — operators
   prometheus::Family<prometheus::Counter> &once_operator_family_;

--- a/src/metrics/prometheus_metrics.hpp
+++ b/src/metrics/prometheus_metrics.hpp
@@ -248,7 +248,7 @@ struct DatabaseMetricHandles {
   CounterHandle write_query;
   CounterHandle read_write_query;
 
-  // Planner
+  // Query (planner-level signals); emitted under the "Query" category.
   // OpenMetrics / SHOW METRICS INFO only — intentionally not aggregated into the deprecated
   // global JSON endpoint (see GetGlobalMetricsInfoForJson).
   CounterHandle unindexed_scan_queries;
@@ -450,7 +450,7 @@ class PrometheusMetrics {
   prometheus::Family<prometheus::Counter> &write_query_family_;
   prometheus::Family<prometheus::Counter> &read_write_query_family_;
 
-  // Per-database metric families — planner
+  // Per-database metric families — query (planner-level signals)
   prometheus::Family<prometheus::Counter> &unindexed_scan_queries_family_;
 
   // Per-database metric families — operators

--- a/src/metrics/prometheus_metrics.hpp
+++ b/src/metrics/prometheus_metrics.hpp
@@ -248,9 +248,8 @@ struct DatabaseMetricHandles {
   CounterHandle write_query;
   CounterHandle read_write_query;
 
-  // Query (planner-level signals); emitted under the "Query" category.
-  // OpenMetrics / SHOW METRICS INFO only — intentionally not aggregated into the deprecated
-  // global JSON endpoint (see GetGlobalMetricsInfoForJson).
+  // Planner-level signal. Exposed via OpenMetrics + SHOW METRICS INFO; not aggregated into the
+  // deprecated global JSON endpoint (see GetGlobalMetricsInfoForJson).
   CounterHandle unindexed_scan_queries;
 
   // TTL

--- a/src/metrics/prometheus_metrics.hpp
+++ b/src/metrics/prometheus_metrics.hpp
@@ -248,8 +248,7 @@ struct DatabaseMetricHandles {
   CounterHandle write_query;
   CounterHandle read_write_query;
 
-  // Planner-level signal. Exposed via OpenMetrics + SHOW METRICS INFO; not aggregated into the
-  // deprecated global JSON endpoint (see GetGlobalMetricsInfoForJson).
+  // Planner-level signal; per-DB only, not aggregated into the global JSON endpoint (see GetGlobalMetricsInfoForJson).
   CounterHandle unindexed_scan_queries;
 
   // TTL

--- a/src/metrics/prometheus_metrics.hpp
+++ b/src/metrics/prometheus_metrics.hpp
@@ -248,6 +248,9 @@ struct DatabaseMetricHandles {
   CounterHandle write_query;
   CounterHandle read_write_query;
 
+  // Planner
+  CounterHandle query_no_index_lookup;
+
   // TTL
   CounterHandle deleted_nodes;
   CounterHandle deleted_edges;
@@ -444,6 +447,9 @@ class PrometheusMetrics {
   prometheus::Family<prometheus::Counter> &read_query_family_;
   prometheus::Family<prometheus::Counter> &write_query_family_;
   prometheus::Family<prometheus::Counter> &read_write_query_family_;
+
+  // Per-database metric families — planner
+  prometheus::Family<prometheus::Counter> &query_no_index_lookup_family_;
 
   // Per-database metric families — operators
   prometheus::Family<prometheus::Counter> &once_operator_family_;

--- a/src/metrics/prometheus_metrics.hpp
+++ b/src/metrics/prometheus_metrics.hpp
@@ -249,6 +249,8 @@ struct DatabaseMetricHandles {
   CounterHandle read_write_query;
 
   // Planner
+  // OpenMetrics / SHOW METRICS INFO only — intentionally not aggregated into the deprecated
+  // global JSON endpoint (see GetGlobalMetricsInfoForJson).
   CounterHandle unindexed_scan_queries;
 
   // TTL

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3372,7 +3372,7 @@ void AccessorCompliance(PlanWrapper &plan, DbAccessor &dba) {
   }
 }
 
-// Emits plan hints as notifications + session-trace events; the counter is bumped only by the regular path.
+// Emits plan hints as notifications + session-trace events (no metric side effects).
 void EmitPlanHints(const plan::PlanHintsResult &hints, std::vector<Notification> *notifications) {
   for (const auto &hint : hints.hints) {
     notifications->emplace_back(SeverityLevel::INFO, NotificationCode::PLAN_HINTING, hint);

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3372,9 +3372,8 @@ void AccessorCompliance(PlanWrapper &plan, DbAccessor &dba) {
   }
 }
 
-// Emits the planner's plan hints as notifications and session-trace events. Shared by the
-// regular/EXPLAIN/PROFILE prepare paths; only regular execution additionally increments the
-// unindexed-scan counter, so that step stays at its call site rather than living here.
+// Emits plan hints as notifications and session-trace events. Shared by the regular/EXPLAIN/PROFILE
+// paths; the unindexed-scan counter is bumped only by the regular path, at its call site.
 void EmitPlanHints(const plan::PlanHintsResult &hints, std::vector<Notification> *notifications) {
   for (const auto &hint : hints.hints) {
     notifications->emplace_back(SeverityLevel::INFO, NotificationCode::PLAN_HINTING, hint);
@@ -3601,9 +3600,8 @@ PreparedQuery PrepareCypherQuery(ParsedQuery parsed_query, std::map<std::string,
 
   auto hints = plan::ProvidePlanHints(&plan->plan(), plan->symbol_table());
   EmitPlanHints(hints, notifications);
-  // Per-query signal: count once even if the plan has several qualifying scans. Counted here
-  // (before AccessorCompliance below) so it reflects every query the planner produced an
-  // unindexed scan for, even one later rejected for a read-only-tx mismatch.
+  // Count once per planned query (not per scan), before AccessorCompliance below, so a query the
+  // planner left unindexed is counted even if later rejected for a read-only-tx mismatch.
   if (hints.has_unindexed_scan) {
     (*current_db.db_acc_)->metric_handles()->unindexed_scan_queries.Increment();
   }
@@ -3734,7 +3732,7 @@ PreparedQuery PrepareExplainQuery(ParsedQuery parsed_query, std::vector<Notifica
                                              interpreter.query_planner_context());
 
   auto hints = plan::ProvidePlanHints(&cypher_query_plan->plan(), cypher_query_plan->symbol_table());
-  // EXPLAIN does not execute the query, so it must not increment the unindexed-scan counter.
+  // EXPLAIN does not execute the query: emit hints only, no counter.
   EmitPlanHints(hints, notifications);
 
   std::stringstream printed_plan;
@@ -3848,8 +3846,7 @@ PreparedQuery PrepareProfileQuery(ParsedQuery parsed_query, bool in_explicit_tra
   PrepareCaching(cypher_query_plan->ast_storage(), frame_change_collector);
 
   auto hints = plan::ProvidePlanHints(&cypher_query_plan->plan(), cypher_query_plan->symbol_table());
-  // PROFILE is a diagnostic run, not a production execution, so it must not increment the
-  // unindexed-scan counter.
+  // PROFILE is a diagnostic run, not a production execution: emit hints only, no counter.
   EmitPlanHints(hints, notifications);
   AccessorCompliance(*cypher_query_plan, *dba);
   const auto rw_type = cypher_query_plan->rw_type();

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3372,11 +3372,17 @@ void AccessorCompliance(PlanWrapper &plan, DbAccessor &dba) {
   }
 }
 
-// Emits plan hints as notifications + session-trace events (no metric side effects).
-void EmitPlanHints(const plan::PlanHintsResult &hints, std::vector<Notification> *notifications) {
+// Emits plan hints as notifications + session-trace events. When `metric_handles` is non-null and the
+// plan has an unindexed scan, also bumps the per-query counter (once per query). Diagnostic runs that
+// must not count (EXPLAIN/PROFILE) pass nullptr, so the count decision is explicit at every call site.
+void EmitPlanHints(const plan::PlanHintsResult &hints, std::vector<Notification> *notifications,
+                   metrics::DatabaseMetricHandles *metric_handles) {
   for (const auto &hint : hints.hints) {
     notifications->emplace_back(SeverityLevel::INFO, NotificationCode::PLAN_HINTING, hint);
     memgraph::logging::EmitSessionTraceEvent(hint);
+  }
+  if (metric_handles != nullptr && hints.has_unindexed_scan) {
+    metric_handles->unindexed_scan_queries.Increment();
   }
 }
 
@@ -3598,12 +3604,9 @@ PreparedQuery PrepareCypherQuery(ParsedQuery parsed_query, std::map<std::string,
                                 interpreter.query_planner_context());
 
   auto hints = plan::ProvidePlanHints(&plan->plan(), plan->symbol_table());
-  EmitPlanHints(hints, notifications);
   // Count once per planned query (not per scan), before AccessorCompliance so a read-only-tx
   // rejection still counts the unindexed plan.
-  if (hints.has_unindexed_scan) {
-    (*current_db.db_acc_)->metric_handles()->unindexed_scan_queries.Increment();
-  }
+  EmitPlanHints(hints, notifications, (*current_db.db_acc_)->metric_handles());
 
   if (memgraph::logging::IsSessionTraceEnabled()) {
     std::stringstream printed_plan;
@@ -3731,8 +3734,8 @@ PreparedQuery PrepareExplainQuery(ParsedQuery parsed_query, std::vector<Notifica
                                              interpreter.query_planner_context());
 
   auto hints = plan::ProvidePlanHints(&cypher_query_plan->plan(), cypher_query_plan->symbol_table());
-  // EXPLAIN does not execute the query: emit hints only, no counter.
-  EmitPlanHints(hints, notifications);
+  // EXPLAIN does not execute the query: emit hints only, no counter (nullptr).
+  EmitPlanHints(hints, notifications, nullptr);
 
   std::stringstream printed_plan;
   plan::PrettyPrint(*dba, &cypher_query_plan->plan(), &printed_plan);
@@ -3845,8 +3848,8 @@ PreparedQuery PrepareProfileQuery(ParsedQuery parsed_query, bool in_explicit_tra
   PrepareCaching(cypher_query_plan->ast_storage(), frame_change_collector);
 
   auto hints = plan::ProvidePlanHints(&cypher_query_plan->plan(), cypher_query_plan->symbol_table());
-  // PROFILE is a diagnostic run, not a production execution: emit hints only, no counter.
-  EmitPlanHints(hints, notifications);
+  // PROFILE is a diagnostic run, not a production execution: emit hints only, no counter (nullptr).
+  EmitPlanHints(hints, notifications, nullptr);
   AccessorCompliance(*cypher_query_plan, *dba);
   const auto rw_type = cypher_query_plan->rw_type();
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3594,10 +3594,9 @@ PreparedQuery PrepareCypherQuery(ParsedQuery parsed_query, std::map<std::string,
     notifications->emplace_back(SeverityLevel::INFO, NotificationCode::PLAN_HINTING, hint);
     memgraph::logging::EmitSessionTraceEvent(hint);
   }
+  // Per-query signal: count once even if the plan has several qualifying scans.
   if (hints.no_index_lookup_count > 0) {
-    (*current_db.db_acc_)
-        ->metric_handles()
-        ->query_no_index_lookup.Increment(static_cast<double>(hints.no_index_lookup_count));
+    (*current_db.db_acc_)->metric_handles()->query_no_index_lookup.Increment(1.0);
   }
 
   if (memgraph::logging::IsSessionTraceEnabled()) {

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3595,8 +3595,8 @@ PreparedQuery PrepareCypherQuery(ParsedQuery parsed_query, std::map<std::string,
     memgraph::logging::EmitSessionTraceEvent(hint);
   }
   // Per-query signal: count once even if the plan has several qualifying scans.
-  if (hints.has_no_index_lookup) {
-    (*current_db.db_acc_)->metric_handles()->query_no_index_lookup.Increment(1.0);
+  if (hints.has_unindexed_scan) {
+    (*current_db.db_acc_)->metric_handles()->unindexed_scan_queries.Increment(1.0);
   }
 
   if (memgraph::logging::IsSessionTraceEnabled()) {

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3595,7 +3595,7 @@ PreparedQuery PrepareCypherQuery(ParsedQuery parsed_query, std::map<std::string,
     memgraph::logging::EmitSessionTraceEvent(hint);
   }
   // Per-query signal: count once even if the plan has several qualifying scans.
-  if (hints.no_index_lookup_count > 0) {
+  if (hints.has_no_index_lookup) {
     (*current_db.db_acc_)->metric_handles()->query_no_index_lookup.Increment(1.0);
   }
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3590,9 +3590,14 @@ PreparedQuery PrepareCypherQuery(ParsedQuery parsed_query, std::map<std::string,
                                 interpreter.query_planner_context());
 
   auto hints = plan::ProvidePlanHints(&plan->plan(), plan->symbol_table());
-  for (const auto &hint : hints) {
+  for (const auto &hint : hints.hints) {
     notifications->emplace_back(SeverityLevel::INFO, NotificationCode::PLAN_HINTING, hint);
     memgraph::logging::EmitSessionTraceEvent(hint);
+  }
+  if (hints.no_index_lookup_count > 0) {
+    (*current_db.db_acc_)
+        ->metric_handles()
+        ->query_no_index_lookup.Increment(static_cast<double>(hints.no_index_lookup_count));
   }
 
   if (memgraph::logging::IsSessionTraceEnabled()) {
@@ -3721,7 +3726,7 @@ PreparedQuery PrepareExplainQuery(ParsedQuery parsed_query, std::vector<Notifica
                                              interpreter.query_planner_context());
 
   auto hints = plan::ProvidePlanHints(&cypher_query_plan->plan(), cypher_query_plan->symbol_table());
-  for (const auto &hint : hints) {
+  for (const auto &hint : hints.hints) {
     notifications->emplace_back(SeverityLevel::INFO, NotificationCode::PLAN_HINTING, hint);
     memgraph::logging::EmitSessionTraceEvent(hint);
   }
@@ -3837,7 +3842,7 @@ PreparedQuery PrepareProfileQuery(ParsedQuery parsed_query, bool in_explicit_tra
   PrepareCaching(cypher_query_plan->ast_storage(), frame_change_collector);
 
   auto hints = plan::ProvidePlanHints(&cypher_query_plan->plan(), cypher_query_plan->symbol_table());
-  for (const auto &hint : hints) {
+  for (const auto &hint : hints.hints) {
     notifications->emplace_back(SeverityLevel::INFO, NotificationCode::PLAN_HINTING, hint);
     memgraph::logging::EmitSessionTraceEvent(hint);
   }

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3372,8 +3372,7 @@ void AccessorCompliance(PlanWrapper &plan, DbAccessor &dba) {
   }
 }
 
-// Emits plan hints as notifications and session-trace events. Shared by the regular/EXPLAIN/PROFILE
-// paths; the unindexed-scan counter is bumped only by the regular path, at its call site.
+// Emits plan hints as notifications + session-trace events; the counter is bumped only by the regular path.
 void EmitPlanHints(const plan::PlanHintsResult &hints, std::vector<Notification> *notifications) {
   for (const auto &hint : hints.hints) {
     notifications->emplace_back(SeverityLevel::INFO, NotificationCode::PLAN_HINTING, hint);
@@ -3600,8 +3599,8 @@ PreparedQuery PrepareCypherQuery(ParsedQuery parsed_query, std::map<std::string,
 
   auto hints = plan::ProvidePlanHints(&plan->plan(), plan->symbol_table());
   EmitPlanHints(hints, notifications);
-  // Count once per planned query (not per scan), before AccessorCompliance below, so a query the
-  // planner left unindexed is counted even if later rejected for a read-only-tx mismatch.
+  // Count once per planned query (not per scan), before AccessorCompliance so a read-only-tx
+  // rejection still counts the unindexed plan.
   if (hints.has_unindexed_scan) {
     (*current_db.db_acc_)->metric_handles()->unindexed_scan_queries.Increment();
   }

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -3372,6 +3372,16 @@ void AccessorCompliance(PlanWrapper &plan, DbAccessor &dba) {
   }
 }
 
+// Emits the planner's plan hints as notifications and session-trace events. Shared by the
+// regular/EXPLAIN/PROFILE prepare paths; only regular execution additionally increments the
+// unindexed-scan counter, so that step stays at its call site rather than living here.
+void EmitPlanHints(const plan::PlanHintsResult &hints, std::vector<Notification> *notifications) {
+  for (const auto &hint : hints.hints) {
+    notifications->emplace_back(SeverityLevel::INFO, NotificationCode::PLAN_HINTING, hint);
+    memgraph::logging::EmitSessionTraceEvent(hint);
+  }
+}
+
 }  // namespace
 
 Interpreter::Interpreter(InterpreterContext *interpreter_context) : interpreter_context_(interpreter_context) {
@@ -3590,13 +3600,12 @@ PreparedQuery PrepareCypherQuery(ParsedQuery parsed_query, std::map<std::string,
                                 interpreter.query_planner_context());
 
   auto hints = plan::ProvidePlanHints(&plan->plan(), plan->symbol_table());
-  for (const auto &hint : hints.hints) {
-    notifications->emplace_back(SeverityLevel::INFO, NotificationCode::PLAN_HINTING, hint);
-    memgraph::logging::EmitSessionTraceEvent(hint);
-  }
-  // Per-query signal: count once even if the plan has several qualifying scans.
+  EmitPlanHints(hints, notifications);
+  // Per-query signal: count once even if the plan has several qualifying scans. Counted here
+  // (before AccessorCompliance below) so it reflects every query the planner produced an
+  // unindexed scan for, even one later rejected for a read-only-tx mismatch.
   if (hints.has_unindexed_scan) {
-    (*current_db.db_acc_)->metric_handles()->unindexed_scan_queries.Increment(1.0);
+    (*current_db.db_acc_)->metric_handles()->unindexed_scan_queries.Increment();
   }
 
   if (memgraph::logging::IsSessionTraceEnabled()) {
@@ -3725,10 +3734,8 @@ PreparedQuery PrepareExplainQuery(ParsedQuery parsed_query, std::vector<Notifica
                                              interpreter.query_planner_context());
 
   auto hints = plan::ProvidePlanHints(&cypher_query_plan->plan(), cypher_query_plan->symbol_table());
-  for (const auto &hint : hints.hints) {
-    notifications->emplace_back(SeverityLevel::INFO, NotificationCode::PLAN_HINTING, hint);
-    memgraph::logging::EmitSessionTraceEvent(hint);
-  }
+  // EXPLAIN does not execute the query, so it must not increment the unindexed-scan counter.
+  EmitPlanHints(hints, notifications);
 
   std::stringstream printed_plan;
   plan::PrettyPrint(*dba, &cypher_query_plan->plan(), &printed_plan);
@@ -3841,10 +3848,9 @@ PreparedQuery PrepareProfileQuery(ParsedQuery parsed_query, bool in_explicit_tra
   PrepareCaching(cypher_query_plan->ast_storage(), frame_change_collector);
 
   auto hints = plan::ProvidePlanHints(&cypher_query_plan->plan(), cypher_query_plan->symbol_table());
-  for (const auto &hint : hints.hints) {
-    notifications->emplace_back(SeverityLevel::INFO, NotificationCode::PLAN_HINTING, hint);
-    memgraph::logging::EmitSessionTraceEvent(hint);
-  }
+  // PROFILE is a diagnostic run, not a production execution, so it must not increment the
+  // unindexed-scan counter.
+  EmitPlanHints(hints, notifications);
   AccessorCompliance(*cypher_query_plan, *dba);
   const auto rw_type = cypher_query_plan->rw_type();
 

--- a/src/query/plan/hint_provider.cpp
+++ b/src/query/plan/hint_provider.cpp
@@ -20,7 +20,7 @@ PlanHintsResult ProvidePlanHints(const LogicalOperator *plan_root, const SymbolT
 
   return PlanHintsResult{
       .hints = plan_hinter.take_hints(),
-      .has_no_index_lookup = plan_hinter.has_no_index_lookup(),
+      .has_unindexed_scan = plan_hinter.has_unindexed_scan(),
   };
 }
 

--- a/src/query/plan/hint_provider.cpp
+++ b/src/query/plan/hint_provider.cpp
@@ -20,7 +20,7 @@ PlanHintsResult ProvidePlanHints(const LogicalOperator *plan_root, const SymbolT
 
   return PlanHintsResult{
       .hints = plan_hinter.take_hints(),
-      .no_index_lookup_count = plan_hinter.no_index_lookup_count(),
+      .has_no_index_lookup = plan_hinter.has_no_index_lookup(),
   };
 }
 

--- a/src/query/plan/hint_provider.cpp
+++ b/src/query/plan/hint_provider.cpp
@@ -14,26 +14,24 @@
 namespace memgraph::query::plan {
 
 namespace {
-// Maps a scan to the sequential scan type whose hint logic applies. Parallel-execution plans
-// rewrite `Filter -> Scan*` into `Filter -> ScanChunk -> ParallelMerge -> ScanParallel*`, so the
-// real scan semantics live in the `ScanParallel*` below the chunk (see parallel_rewrite.hpp).
+// Parallel execution rewrites `Filter -> Scan*` into `Filter -> ScanChunk -> ParallelMerge -> ScanParallel*`;
+// map back to the sequential scan type whose hint logic applies (see parallel_rewrite.hpp).
 const utils::TypeInfo &EffectiveScanType(const ScanAll &scan) {
   const auto &type = scan.GetTypeInfo();
   // Sequential plans (incl. ScanChunkByEdge, whose type differs) use their own scan type directly.
   if (type != ScanChunk::kType) {
     return type;
   }
+  // ScanChunk/ParallelMerge ctors guarantee this chain; assert rather than silently misclassify.
   const auto *parallel_merge = scan.input().get();
-  if (parallel_merge == nullptr) return type;
+  DMG_ASSERT(parallel_merge != nullptr, "ScanChunk input must be a ParallelMerge");
   const auto *parallel_scan = parallel_merge->input().get();
-  if (parallel_scan == nullptr) return type;
+  DMG_ASSERT(parallel_scan != nullptr, "ParallelMerge input must be a ScanParallel");
 
   const auto &parallel_type = parallel_scan->GetTypeInfo();
   if (parallel_type == ScanParallel::kType) return ScanAll::kType;
   if (parallel_type == ScanParallelByLabel::kType) return ScanAllByLabel::kType;
-  // Anything else (index-backed scans like ScanParallelByLabelProperties, and full edge scans
-  // like ScanParallelByEdge whose hints are out of scope) keeps its own type, so the logic below
-  // emits no missing-index hint or count for it.
+  // Anything else is an index-backed scan (e.g. ScanParallelByLabelProperties): keep its type, no hint/count.
   return parallel_type;
 }
 }  // namespace
@@ -79,13 +77,11 @@ void PlanHintsProvider::HintIndexUsage(Filter &op) {
       has_unindexed_scan_ = true;
       return;
     }
-    // Property-only filter with no label: no node index can serve a label-less filter,
-    // so there is nothing to suggest and nothing to count.
+    // Label-less property filter: no node index can serve it, so no hint and no count.
     return;
   }
 
-  // Label index already used; suboptimal-index hint, not a missing-index scan -> does not
-  // increment the unindexed-scan counter.
+  // Label index already used: suboptimal-index hint only, not an unindexed scan -> no count.
   if (scan_type == ScanAllByLabel::kType && !filtered_properties.empty()) {
     hints_.push_back(fmt::format(
         "Label index will be used on symbol `{0}` although there is also a filter on properties {1}. Consider "

--- a/src/query/plan/hint_provider.cpp
+++ b/src/query/plan/hint_provider.cpp
@@ -14,8 +14,9 @@
 namespace memgraph::query::plan {
 
 namespace {
-// Parallel execution rewrites `Filter -> Scan*` into `Filter -> ScanChunk -> ParallelMerge -> ScanParallel*`;
-// map back to the sequential scan type whose hint logic applies (see parallel_rewrite.hpp).
+// Parallel execution may rewrite a `Scan*` into `ScanChunk -> ParallelMerge -> ScanParallel*`
+// (edge scans use ScanChunkByEdge -> ... -> ScanParallelByEdge, handled below). For a vertex
+// ScanChunk, recover the scan type whose hint logic applies (see parallel_rewrite.hpp).
 const utils::TypeInfo &EffectiveScanType(const ScanAll &scan) {
   const auto &type = scan.GetTypeInfo();
   // Non-ScanChunk scans (incl. ScanChunkByEdge, the edge parallel rewrite, whose type differs) use

--- a/src/query/plan/hint_provider.cpp
+++ b/src/query/plan/hint_provider.cpp
@@ -19,7 +19,7 @@ PlanHintsResult ProvidePlanHints(const LogicalOperator *plan_root, const SymbolT
   const_cast<LogicalOperator *>(plan_root)->Accept(plan_hinter);
 
   return PlanHintsResult{
-      .hints = std::move(plan_hinter.hints()),
+      .hints = plan_hinter.take_hints(),
       .no_index_lookup_count = plan_hinter.no_index_lookup_count(),
   };
 }

--- a/src/query/plan/hint_provider.cpp
+++ b/src/query/plan/hint_provider.cpp
@@ -18,15 +18,17 @@ namespace {
 // map back to the sequential scan type whose hint logic applies (see parallel_rewrite.hpp).
 const utils::TypeInfo &EffectiveScanType(const ScanAll &scan) {
   const auto &type = scan.GetTypeInfo();
-  // Sequential plans (incl. ScanChunkByEdge, whose type differs) use their own scan type directly.
+  // Non-ScanChunk scans (incl. ScanChunkByEdge, the edge parallel rewrite, whose type differs) use
+  // their own scan type directly.
   if (type != ScanChunk::kType) {
     return type;
   }
-  // ScanChunk/ParallelMerge ctors guarantee this chain; assert rather than silently misclassify.
+  // Guard each hop; on an unexpected shape fall back to `type` (matches no hint branch) rather than
+  // misclassify or null-deref in release.
   const auto *parallel_merge = scan.input().get();
-  DMG_ASSERT(parallel_merge != nullptr, "ScanChunk input must be a ParallelMerge");
+  if (parallel_merge == nullptr || parallel_merge->GetTypeInfo() != ParallelMerge::kType) return type;
   const auto *parallel_scan = parallel_merge->input().get();
-  DMG_ASSERT(parallel_scan != nullptr, "ParallelMerge input must be a ScanParallel");
+  if (parallel_scan == nullptr) return type;
 
   const auto &parallel_type = parallel_scan->GetTypeInfo();
   if (parallel_type == ScanParallel::kType) return ScanAll::kType;

--- a/src/query/plan/hint_provider.cpp
+++ b/src/query/plan/hint_provider.cpp
@@ -13,6 +13,89 @@
 
 namespace memgraph::query::plan {
 
+namespace {
+// Maps a scan to the sequential scan type whose hint logic applies. Parallel-execution plans
+// rewrite `Filter -> Scan*` into `Filter -> ScanChunk -> ParallelMerge -> ScanParallel*`, so the
+// real scan semantics live in the `ScanParallel*` below the chunk (see parallel_rewrite.hpp).
+const utils::TypeInfo &EffectiveScanType(const ScanAll &scan) {
+  const auto &type = scan.GetTypeInfo();
+  // Sequential plans (incl. ScanChunkByEdge, whose type differs) use their own scan type directly.
+  if (type != ScanChunk::kType) {
+    return type;
+  }
+  const auto *parallel_merge = scan.input().get();
+  if (parallel_merge == nullptr) return type;
+  const auto *parallel_scan = parallel_merge->input().get();
+  if (parallel_scan == nullptr) return type;
+
+  const auto &parallel_type = parallel_scan->GetTypeInfo();
+  if (parallel_type == ScanParallel::kType) return ScanAll::kType;
+  if (parallel_type == ScanParallelByLabel::kType) return ScanAllByLabel::kType;
+  // Anything else (index-backed scans like ScanParallelByLabelProperties, and full edge scans
+  // like ScanParallelByEdge whose hints are out of scope) keeps its own type, so the logic below
+  // emits no missing-index hint or count for it.
+  return parallel_type;
+}
+}  // namespace
+
+void PlanHintsProvider::HintIndexUsage(Filter &op) {
+  auto *scan_operator = dynamic_cast<ScanAll *>(op.input().get());
+  if (scan_operator == nullptr) {
+    return;
+  }
+
+  auto const scan_symbol = scan_operator->output_symbol_;
+  auto const &scan_type = EffectiveScanType(*scan_operator);
+
+  Filters filters;
+  filters.CollectFilterExpression(op.expression_, symbol_table_);
+  const std::string filtered_labels = ExtractAndJoin(filters.FilteredLabels(scan_symbol),
+                                                     [](const auto &item) { return fmt::format(":{0}", item.name); });
+  const std::string filtered_properties =
+      ExtractAndJoin(filters.FilteredProperties(scan_symbol), std::mem_fn(&PropertyIxPath::AsPathString));
+  if (filtered_labels.empty() && filtered_properties.empty()) {
+    return;
+  }
+
+  if (scan_type == ScanAll::kType) {
+    if (!filtered_labels.empty() && !filtered_properties.empty()) {
+      hints_.push_back(
+          fmt::format("Sequential scan will be used on symbol `{0}` although there is a filter on labels {1} and "
+                      "properties {2}. Consider "
+                      "creating a label-property index.",
+                      scan_symbol.name(),
+                      filtered_labels,
+                      filtered_properties));
+      has_unindexed_scan_ = true;
+      return;
+    }
+
+    if (!filtered_labels.empty()) {
+      hints_.push_back(
+          fmt::format("Sequential scan will be used on symbol `{0}` although there is a filter on labels {1}. Consider "
+                      "creating a label index.",
+                      scan_symbol.name(),
+                      filtered_labels));
+      has_unindexed_scan_ = true;
+      return;
+    }
+    // Property-only filter with no label: no node index can serve a label-less filter,
+    // so there is nothing to suggest and nothing to count.
+    return;
+  }
+
+  // Label index already used; suboptimal-index hint, not a missing-index scan -> does not
+  // increment the unindexed-scan counter.
+  if (scan_type == ScanAllByLabel::kType && !filtered_properties.empty()) {
+    hints_.push_back(fmt::format(
+        "Label index will be used on symbol `{0}` although there is also a filter on properties {1}. Consider "
+        "creating a label-property index.",
+        scan_symbol.name(),
+        filtered_properties));
+    return;
+  }
+}
+
 PlanHintsResult ProvidePlanHints(const LogicalOperator *plan_root, const SymbolTable &symbol_table) {
   PlanHintsProvider plan_hinter(symbol_table);
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)

--- a/src/query/plan/hint_provider.cpp
+++ b/src/query/plan/hint_provider.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Memgraph Ltd.
+// Copyright 2026 Memgraph Ltd.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
@@ -13,12 +13,15 @@
 
 namespace memgraph::query::plan {
 
-std::vector<std::string> ProvidePlanHints(const LogicalOperator *plan_root, const SymbolTable &symbol_table) {
+PlanHintsResult ProvidePlanHints(const LogicalOperator *plan_root, const SymbolTable &symbol_table) {
   PlanHintsProvider plan_hinter(symbol_table);
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   const_cast<LogicalOperator *>(plan_root)->Accept(plan_hinter);
 
-  return plan_hinter.hints();
+  return PlanHintsResult{
+      .hints = std::move(plan_hinter.hints()),
+      .no_index_lookup_count = plan_hinter.no_index_lookup_count(),
+  };
 }
 
 }  // namespace memgraph::query::plan

--- a/src/query/plan/hint_provider.cpp
+++ b/src/query/plan/hint_provider.cpp
@@ -60,24 +60,22 @@ void PlanHintsProvider::HintIndexUsage(Filter &op) {
 
   if (scan_type == ScanAll::kType) {
     if (!filtered_labels.empty() && !filtered_properties.empty()) {
-      hints_.push_back(
+      AddUnindexedScanHint(
           fmt::format("Sequential scan will be used on symbol `{0}` although there is a filter on labels {1} and "
                       "properties {2}. Consider "
                       "creating a label-property index.",
                       scan_symbol.name(),
                       filtered_labels,
                       filtered_properties));
-      has_unindexed_scan_ = true;
       return;
     }
 
     if (!filtered_labels.empty()) {
-      hints_.push_back(
+      AddUnindexedScanHint(
           fmt::format("Sequential scan will be used on symbol `{0}` although there is a filter on labels {1}. Consider "
                       "creating a label index.",
                       scan_symbol.name(),
                       filtered_labels));
-      has_unindexed_scan_ = true;
       return;
     }
     // Label-less property filter: no node index can serve it, so no hint and no count.

--- a/src/query/plan/hint_provider.hpp
+++ b/src/query/plan/hint_provider.hpp
@@ -30,8 +30,8 @@ namespace memgraph::query::plan {
 
 struct PlanHintsResult {
   std::vector<std::string> hints;
-  // Number of ScanAll+Filter pairs where an index could have served the scan
-  // (per-operator, not per-query — a plan with N qualifying pairs increments by N).
+  // Per-operator count of ScanAll+Filter pairs an index could have served; the
+  // query metric counts once when this is > 0.
   std::size_t no_index_lookup_count{0};
 };
 
@@ -41,7 +41,7 @@ class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
  public:
   explicit PlanHintsProvider(const SymbolTable &symbol_table) : symbol_table_(symbol_table) {}
 
-  std::vector<std::string> &hints() { return hints_; }
+  std::vector<std::string> take_hints() { return std::move(hints_); }
 
   std::size_t no_index_lookup_count() const { return no_index_lookup_count_; }
 
@@ -428,6 +428,7 @@ class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
       return;
     }
 
+    // Label index already used; suboptimal-index hint, not a missing-index scan -> no count.
     if (scan_type == ScanAllByLabel::kType && !filtered_properties.empty()) {
       hints_.push_back(fmt::format(
           "Label index will be used on symbol `{0}` although there is also a filter on properties {1}. Consider "

--- a/src/query/plan/hint_provider.hpp
+++ b/src/query/plan/hint_provider.hpp
@@ -37,11 +37,11 @@ struct PlanHintsResult {
 [[nodiscard]] PlanHintsResult ProvidePlanHints(const LogicalOperator *plan_root, const SymbolTable &symbol_table);
 
 class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
-  // Accessors are valid only post-traversal; ProvidePlanHints owns the construct -> Accept -> read lifecycle.
-  friend PlanHintsResult ProvidePlanHints(const LogicalOperator *plan_root, const SymbolTable &symbol_table);
-
  public:
   explicit PlanHintsProvider(const SymbolTable &symbol_table) : symbol_table_(symbol_table) {}
+
+  // Single-use: constructed, Accept-ed once, then read. take_hints() moves hints_ out, so reuse is a bug.
+  PlanHintsProvider(PlanHintsProvider &&) = delete;
 
   using HierarchicalLogicalOperatorVisitor::PostVisit;
   using HierarchicalLogicalOperatorVisitor::PreVisit;
@@ -377,6 +377,9 @@ class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
   bool PostVisit(RemoveNestedProperty & /*op*/) override { return true; }
 
  private:
+  // ProvidePlanHints owns the construct -> Accept -> read lifecycle; these accessors are valid only post-traversal.
+  friend PlanHintsResult ProvidePlanHints(const LogicalOperator *plan_root, const SymbolTable &symbol_table);
+
   const SymbolTable &symbol_table_;
   std::vector<std::string> hints_;
   bool has_unindexed_scan_{false};
@@ -387,7 +390,15 @@ class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
 
   bool DefaultPreVisit() override { LOG_FATAL("Operator not implemented for providing plan hints!"); }
 
-  // Records a missing-/suboptimal-index hint for a Filter and sets has_unindexed_scan_ accordingly.
+  // A missing-index hint always coincides with an unindexed scan: keep the two in lockstep here so a
+  // ScanAll branch can't push a hint without also being counted (the suboptimal case uses hints_ directly).
+  void AddUnindexedScanHint(std::string hint) {
+    hints_.push_back(std::move(hint));
+    has_unindexed_scan_ = true;
+  }
+
+  // Records a missing- or suboptimal-index hint for a Filter. Marks has_unindexed_scan_ (via
+  // AddUnindexedScanHint) only for the missing-index cases (ScanAll + label/label-property).
   void HintIndexUsage(Filter &op);
 
   template <typename Func>

--- a/src/query/plan/hint_provider.hpp
+++ b/src/query/plan/hint_provider.hpp
@@ -30,7 +30,7 @@ namespace memgraph::query::plan {
 
 struct PlanHintsResult {
   std::vector<std::string> hints;
-  // True if the plan has a ScanAll+Filter a label or label-property index could have served.
+  // True if the plan has a label/label-property-filtered node scan that a matching index could have served.
   bool has_unindexed_scan{false};
 };
 

--- a/src/query/plan/hint_provider.hpp
+++ b/src/query/plan/hint_provider.hpp
@@ -30,16 +30,14 @@ namespace memgraph::query::plan {
 
 struct PlanHintsResult {
   std::vector<std::string> hints;
-  // True if the plan has any ScanAll+Filter an index could have served.
-  // NOTE: add more boolean signals sparingly; beyond a handful, switch to a bitset/enum-flag field.
+  // True if the plan has a ScanAll+Filter a label or label-property index could have served.
   bool has_unindexed_scan{false};
 };
 
 [[nodiscard]] PlanHintsResult ProvidePlanHints(const LogicalOperator *plan_root, const SymbolTable &symbol_table);
 
 class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
-  // Result accessors are only valid after a full traversal; expose them solely through
-  // ProvidePlanHints, which owns the construct -> Accept -> read lifecycle.
+  // Accessors are valid only post-traversal; ProvidePlanHints owns the construct -> Accept -> read lifecycle.
   friend PlanHintsResult ProvidePlanHints(const LogicalOperator *plan_root, const SymbolTable &symbol_table);
 
  public:
@@ -389,9 +387,7 @@ class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
 
   bool DefaultPreVisit() override { LOG_FATAL("Operator not implemented for providing plan hints!"); }
 
-  // Records a missing-/suboptimal-index hint for a Filter and flags has_unindexed_scan_.
-  // Defined out-of-line in hint_provider.cpp. See EffectiveScanType there for the
-  // parallel-execution plan handling.
+  // Records a missing-/suboptimal-index hint for a Filter and sets has_unindexed_scan_ accordingly.
   void HintIndexUsage(Filter &op);
 
   template <typename Func>

--- a/src/query/plan/hint_provider.hpp
+++ b/src/query/plan/hint_provider.hpp
@@ -30,9 +30,8 @@ namespace memgraph::query::plan {
 
 struct PlanHintsResult {
   std::vector<std::string> hints;
-  // Per-operator count of ScanAll+Filter pairs an index could have served; the
-  // query metric counts once when this is > 0.
-  std::size_t no_index_lookup_count{0};
+  // True if the plan has any ScanAll+Filter an index could have served.
+  bool has_no_index_lookup{false};
 };
 
 PlanHintsResult ProvidePlanHints(const LogicalOperator *plan_root, const SymbolTable &symbol_table);
@@ -43,7 +42,7 @@ class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
 
   std::vector<std::string> take_hints() { return std::move(hints_); }
 
-  std::size_t no_index_lookup_count() const { return no_index_lookup_count_; }
+  bool has_no_index_lookup() const { return has_no_index_lookup_; }
 
   using HierarchicalLogicalOperatorVisitor::PostVisit;
   using HierarchicalLogicalOperatorVisitor::PreVisit;
@@ -381,7 +380,7 @@ class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
  private:
   const SymbolTable &symbol_table_;
   std::vector<std::string> hints_;
-  std::size_t no_index_lookup_count_{0};
+  bool has_no_index_lookup_{false};
 
   bool DefaultPreVisit() override { LOG_FATAL("Operator not implemented for providing plan hints!"); }
 
@@ -412,7 +411,7 @@ class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
                         scan_symbol.name(),
                         filtered_labels,
                         filtered_properties));
-        ++no_index_lookup_count_;
+        has_no_index_lookup_ = true;
         return;
       }
 
@@ -422,7 +421,7 @@ class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
             "creating a label index.",
             scan_symbol.name(),
             filtered_labels));
-        ++no_index_lookup_count_;
+        has_no_index_lookup_ = true;
         return;
       }
       return;

--- a/src/query/plan/hint_provider.hpp
+++ b/src/query/plan/hint_provider.hpp
@@ -31,7 +31,7 @@ namespace memgraph::query::plan {
 struct PlanHintsResult {
   std::vector<std::string> hints;
   // True if the plan has any ScanAll+Filter an index could have served.
-  bool has_no_index_lookup{false};
+  bool has_unindexed_scan{false};
 };
 
 PlanHintsResult ProvidePlanHints(const LogicalOperator *plan_root, const SymbolTable &symbol_table);
@@ -42,7 +42,7 @@ class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
 
   std::vector<std::string> take_hints() { return std::move(hints_); }
 
-  bool has_no_index_lookup() const { return has_no_index_lookup_; }
+  bool has_unindexed_scan() const { return has_unindexed_scan_; }
 
   using HierarchicalLogicalOperatorVisitor::PostVisit;
   using HierarchicalLogicalOperatorVisitor::PreVisit;
@@ -380,7 +380,7 @@ class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
  private:
   const SymbolTable &symbol_table_;
   std::vector<std::string> hints_;
-  bool has_no_index_lookup_{false};
+  bool has_unindexed_scan_{false};
 
   bool DefaultPreVisit() override { LOG_FATAL("Operator not implemented for providing plan hints!"); }
 
@@ -411,7 +411,7 @@ class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
                         scan_symbol.name(),
                         filtered_labels,
                         filtered_properties));
-        has_no_index_lookup_ = true;
+        has_unindexed_scan_ = true;
         return;
       }
 
@@ -421,7 +421,7 @@ class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
             "creating a label index.",
             scan_symbol.name(),
             filtered_labels));
-        has_no_index_lookup_ = true;
+        has_unindexed_scan_ = true;
         return;
       }
       return;

--- a/src/query/plan/hint_provider.hpp
+++ b/src/query/plan/hint_provider.hpp
@@ -37,12 +37,12 @@ struct PlanHintsResult {
 PlanHintsResult ProvidePlanHints(const LogicalOperator *plan_root, const SymbolTable &symbol_table);
 
 class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
+  // Result accessors are only valid after a full traversal; expose them solely through
+  // ProvidePlanHints, which owns the construct -> Accept -> read lifecycle.
+  friend PlanHintsResult ProvidePlanHints(const LogicalOperator *plan_root, const SymbolTable &symbol_table);
+
  public:
   explicit PlanHintsProvider(const SymbolTable &symbol_table) : symbol_table_(symbol_table) {}
-
-  std::vector<std::string> take_hints() { return std::move(hints_); }
-
-  bool has_unindexed_scan() const { return has_unindexed_scan_; }
 
   using HierarchicalLogicalOperatorVisitor::PostVisit;
   using HierarchicalLogicalOperatorVisitor::PreVisit;
@@ -382,15 +382,43 @@ class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
   std::vector<std::string> hints_;
   bool has_unindexed_scan_{false};
 
+  [[nodiscard]] std::vector<std::string> take_hints() { return std::move(hints_); }
+
+  [[nodiscard]] bool has_unindexed_scan() const { return has_unindexed_scan_; }
+
   bool DefaultPreVisit() override { LOG_FATAL("Operator not implemented for providing plan hints!"); }
 
+  // Resolves the logical scan type to reason about. Parallel-execution plans rewrite a
+  // `Filter -> Scan*` into `Filter -> ScanChunk -> ParallelMerge -> ScanParallel*`, so the
+  // real scan semantics live in the `ScanParallel*` below the chunk. Map those back to the
+  // equivalent sequential scan type so the hint logic below treats both plan shapes alike.
+  // For non-parallel plans this is just the scan's own type.
+  static const utils::TypeInfo &EffectiveScanType(const ScanAll &scan) {
+    const auto &type = scan.GetTypeInfo();
+    if (type != ScanChunk::kType) {
+      return type;
+    }
+    const auto *parallel_merge = scan.input().get();
+    if (parallel_merge == nullptr) return type;
+    const auto *parallel_scan = parallel_merge->input().get();
+    if (parallel_scan == nullptr) return type;
+
+    const auto &parallel_type = parallel_scan->GetTypeInfo();
+    if (parallel_type == ScanParallel::kType) return ScanAll::kType;
+    if (parallel_type == ScanParallelByLabel::kType) return ScanAllByLabel::kType;
+    // Index-backed parallel scans (label-properties, edge variants) already use an index;
+    // leave their type as-is so no missing-index hint or count fires.
+    return parallel_type;
+  }
+
   void HintIndexUsage(Filter &op) {
-    if (auto *maybe_scan_operator = dynamic_cast<ScanAll *>(op.input().get()); !maybe_scan_operator) {
+    auto *scan_operator = dynamic_cast<ScanAll *>(op.input().get());
+    if (scan_operator == nullptr) {
       return;
     }
 
-    auto const scan_symbol = dynamic_cast<ScanAll *>(op.input().get())->output_symbol_;
-    auto const scan_type = op.input()->GetTypeInfo();
+    auto const scan_symbol = scan_operator->output_symbol_;
+    auto const &scan_type = EffectiveScanType(*scan_operator);
 
     Filters filters;
     filters.CollectFilterExpression(op.expression_, symbol_table_);
@@ -424,10 +452,13 @@ class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
         has_unindexed_scan_ = true;
         return;
       }
+      // Property-only filter with no label: no node index can serve a label-less filter,
+      // so there is nothing to suggest and nothing to count.
       return;
     }
 
-    // Label index already used; suboptimal-index hint, not a missing-index scan -> no count.
+    // Label index already used; suboptimal-index hint, not a missing-index scan -> does not
+    // increment the unindexed-scan counter.
     if (scan_type == ScanAllByLabel::kType && !filtered_properties.empty()) {
       hints_.push_back(fmt::format(
           "Label index will be used on symbol `{0}` although there is also a filter on properties {1}. Consider "

--- a/src/query/plan/hint_provider.hpp
+++ b/src/query/plan/hint_provider.hpp
@@ -31,10 +31,11 @@ namespace memgraph::query::plan {
 struct PlanHintsResult {
   std::vector<std::string> hints;
   // True if the plan has any ScanAll+Filter an index could have served.
+  // NOTE: add more boolean signals sparingly; beyond a handful, switch to a bitset/enum-flag field.
   bool has_unindexed_scan{false};
 };
 
-PlanHintsResult ProvidePlanHints(const LogicalOperator *plan_root, const SymbolTable &symbol_table);
+[[nodiscard]] PlanHintsResult ProvidePlanHints(const LogicalOperator *plan_root, const SymbolTable &symbol_table);
 
 class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
   // Result accessors are only valid after a full traversal; expose them solely through
@@ -388,86 +389,10 @@ class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
 
   bool DefaultPreVisit() override { LOG_FATAL("Operator not implemented for providing plan hints!"); }
 
-  // Resolves the logical scan type to reason about. Parallel-execution plans rewrite a
-  // `Filter -> Scan*` into `Filter -> ScanChunk -> ParallelMerge -> ScanParallel*`, so the
-  // real scan semantics live in the `ScanParallel*` below the chunk. Map those back to the
-  // equivalent sequential scan type so the hint logic below treats both plan shapes alike.
-  // For non-parallel plans this is just the scan's own type.
-  static const utils::TypeInfo &EffectiveScanType(const ScanAll &scan) {
-    const auto &type = scan.GetTypeInfo();
-    if (type != ScanChunk::kType) {
-      return type;
-    }
-    const auto *parallel_merge = scan.input().get();
-    if (parallel_merge == nullptr) return type;
-    const auto *parallel_scan = parallel_merge->input().get();
-    if (parallel_scan == nullptr) return type;
-
-    const auto &parallel_type = parallel_scan->GetTypeInfo();
-    if (parallel_type == ScanParallel::kType) return ScanAll::kType;
-    if (parallel_type == ScanParallelByLabel::kType) return ScanAllByLabel::kType;
-    // Index-backed parallel scans (label-properties, edge variants) already use an index;
-    // leave their type as-is so no missing-index hint or count fires.
-    return parallel_type;
-  }
-
-  void HintIndexUsage(Filter &op) {
-    auto *scan_operator = dynamic_cast<ScanAll *>(op.input().get());
-    if (scan_operator == nullptr) {
-      return;
-    }
-
-    auto const scan_symbol = scan_operator->output_symbol_;
-    auto const &scan_type = EffectiveScanType(*scan_operator);
-
-    Filters filters;
-    filters.CollectFilterExpression(op.expression_, symbol_table_);
-    const std::string filtered_labels = ExtractAndJoin(filters.FilteredLabels(scan_symbol),
-                                                       [](const auto &item) { return fmt::format(":{0}", item.name); });
-    const std::string filtered_properties =
-        ExtractAndJoin(filters.FilteredProperties(scan_symbol), std::mem_fn(&PropertyIxPath::AsPathString));
-    if (filtered_labels.empty() && filtered_properties.empty()) {
-      return;
-    }
-
-    if (scan_type == ScanAll::kType) {
-      if (!filtered_labels.empty() && !filtered_properties.empty()) {
-        hints_.push_back(
-            fmt::format("Sequential scan will be used on symbol `{0}` although there is a filter on labels {1} and "
-                        "properties {2}. Consider "
-                        "creating a label-property index.",
-                        scan_symbol.name(),
-                        filtered_labels,
-                        filtered_properties));
-        has_unindexed_scan_ = true;
-        return;
-      }
-
-      if (!filtered_labels.empty()) {
-        hints_.push_back(fmt::format(
-            "Sequential scan will be used on symbol `{0}` although there is a filter on labels {1}. Consider "
-            "creating a label index.",
-            scan_symbol.name(),
-            filtered_labels));
-        has_unindexed_scan_ = true;
-        return;
-      }
-      // Property-only filter with no label: no node index can serve a label-less filter,
-      // so there is nothing to suggest and nothing to count.
-      return;
-    }
-
-    // Label index already used; suboptimal-index hint, not a missing-index scan -> does not
-    // increment the unindexed-scan counter.
-    if (scan_type == ScanAllByLabel::kType && !filtered_properties.empty()) {
-      hints_.push_back(fmt::format(
-          "Label index will be used on symbol `{0}` although there is also a filter on properties {1}. Consider "
-          "creating a label-property index.",
-          scan_symbol.name(),
-          filtered_properties));
-      return;
-    }
-  }
+  // Records a missing-/suboptimal-index hint for a Filter and flags has_unindexed_scan_.
+  // Defined out-of-line in hint_provider.cpp. See EffectiveScanType there for the
+  // parallel-execution plan handling.
+  void HintIndexUsage(Filter &op);
 
   template <typename Func>
   std::string ExtractAndJoin(auto &&collection, Func &&projection) {

--- a/src/query/plan/hint_provider.hpp
+++ b/src/query/plan/hint_provider.hpp
@@ -28,13 +28,22 @@
 
 namespace memgraph::query::plan {
 
-std::vector<std::string> ProvidePlanHints(const LogicalOperator *plan_root, const SymbolTable &symbol_table);
+struct PlanHintsResult {
+  std::vector<std::string> hints;
+  // Number of ScanAll+Filter pairs where an index could have served the scan
+  // (per-operator, not per-query — a plan with N qualifying pairs increments by N).
+  std::size_t no_index_lookup_count{0};
+};
+
+PlanHintsResult ProvidePlanHints(const LogicalOperator *plan_root, const SymbolTable &symbol_table);
 
 class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
  public:
   explicit PlanHintsProvider(const SymbolTable &symbol_table) : symbol_table_(symbol_table) {}
 
   std::vector<std::string> &hints() { return hints_; }
+
+  std::size_t no_index_lookup_count() const { return no_index_lookup_count_; }
 
   using HierarchicalLogicalOperatorVisitor::PostVisit;
   using HierarchicalLogicalOperatorVisitor::PreVisit;
@@ -372,6 +381,7 @@ class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
  private:
   const SymbolTable &symbol_table_;
   std::vector<std::string> hints_;
+  std::size_t no_index_lookup_count_{0};
 
   bool DefaultPreVisit() override { LOG_FATAL("Operator not implemented for providing plan hints!"); }
 
@@ -402,6 +412,7 @@ class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
                         scan_symbol.name(),
                         filtered_labels,
                         filtered_properties));
+        ++no_index_lookup_count_;
         return;
       }
 
@@ -411,6 +422,7 @@ class PlanHintsProvider final : public HierarchicalLogicalOperatorVisitor {
             "creating a label index.",
             scan_symbol.name(),
             filtered_labels));
+        ++no_index_lookup_count_;
         return;
       }
       return;

--- a/tests/e2e/show_metrics/show_metrics.py
+++ b/tests/e2e/show_metrics/show_metrics.py
@@ -212,7 +212,7 @@ def test_all_show_metrics_info_values_are_present(memgraph):
         {"name": "UnionOperator", "type": "Operator", "metric type": "Counter"},
         {"name": "UnwindOperator", "type": "Operator", "metric type": "Counter"},
         # Query
-        {"name": "QueryNoIndexLookup", "type": "Query", "metric type": "Counter"},
+        {"name": "UnindexedScanQueries", "type": "Query", "metric type": "Counter"},
         {"name": "QueryExecutionLatency_us_50p", "type": "Query", "metric type": "Histogram"},
         {"name": "QueryExecutionLatency_us_90p", "type": "Query", "metric type": "Histogram"},
         {"name": "QueryExecutionLatency_us_99p", "type": "Query", "metric type": "Histogram"},

--- a/tests/e2e/show_metrics/show_metrics.py
+++ b/tests/e2e/show_metrics/show_metrics.py
@@ -212,6 +212,7 @@ def test_all_show_metrics_info_values_are_present(memgraph):
         {"name": "UnionOperator", "type": "Operator", "metric type": "Counter"},
         {"name": "UnwindOperator", "type": "Operator", "metric type": "Counter"},
         # Query
+        {"name": "QueryNoIndexLookup", "type": "Query", "metric type": "Counter"},
         {"name": "QueryExecutionLatency_us_50p", "type": "Query", "metric type": "Histogram"},
         {"name": "QueryExecutionLatency_us_90p", "type": "Query", "metric type": "Histogram"},
         {"name": "QueryExecutionLatency_us_99p", "type": "Query", "metric type": "Histogram"},

--- a/tests/e2e/show_metrics/show_metrics_openmetrics_values.py
+++ b/tests/e2e/show_metrics/show_metrics_openmetrics_values.py
@@ -293,7 +293,7 @@ def test_openmetrics_per_db_transaction_counters(populated_databases):
 
 
 def test_unindexed_scan_queries_counter():
-    """Task 2: count queries whose plan did a ScanAll+Filter an index could have served.
+    """Count queries whose plan did a ScanAll+Filter an index could have served.
 
     Uses a fresh label (Unindexed) so populated_databases' indexes don't apply.
     EXPLAIN/PROFILE must not advance the counter; counting is per-query, so a query
@@ -307,25 +307,29 @@ def test_unindexed_scan_queries_counter():
     def counter():
         return om_get(parse_openmetrics(scrape_openmetrics()), "memgraph_unindexed_scan_queries_total", "memgraph") or 0
 
-    baseline = counter()
+    # `expected` tracks the running count; each step bumps it only when it should count, so the
+    # assertions stay correct if steps are reordered or inserted.
+    expected = counter()
 
     execute(cursor, "MATCH (n:Unindexed) WHERE n.name = 'x' RETURN n")
-    assert counter() == baseline + 1
+    expected += 1
+    assert counter() == expected
 
     execute(cursor, "MATCH (n:Unindexed) WHERE n.name = 'x' RETURN n")
-    assert counter() == baseline + 2
+    expected += 1
+    assert counter() == expected
 
     # EXPLAIN/PROFILE must not advance the counter.
     execute(cursor, "EXPLAIN MATCH (n:Unindexed) WHERE n.name = 'x' RETURN n")
-    assert counter() == baseline + 2
+    assert counter() == expected
     execute(cursor, "PROFILE MATCH (n:Unindexed) WHERE n.name = 'x' RETURN n")
-    assert counter() == baseline + 2
+    assert counter() == expected
 
     # Creating the matching index stops further increments.
     execute(cursor, "CREATE INDEX ON :Unindexed(name)")
     try:
         execute(cursor, "MATCH (n:Unindexed) WHERE n.name = 'x' RETURN n")
-        assert counter() == baseline + 2
+        assert counter() == expected
     finally:
         execute(cursor, "DROP INDEX ON :Unindexed(name)")
 
@@ -336,18 +340,20 @@ def test_unindexed_scan_queries_counter():
         "UNION ALL "
         "MATCH (m:UnindexedB) WHERE m.v = 1 RETURN m.v AS v",
     )
-    assert counter() == baseline + 3
+    expected += 1
+    assert counter() == expected
 
     # Parallel execution rewrites the scan into ScanChunk -> ParallelMerge -> ScanParallel;
     # an unindexed parallel scan must still be counted (+1).
     execute(cursor, "USING PARALLEL EXECUTION MATCH (n:Unindexed) WHERE n.name = 'x' RETURN count(n)")
-    assert counter() == baseline + 4
+    expected += 1
+    assert counter() == expected
 
     # The same parallel query backed by an index must NOT advance the counter.
     execute(cursor, "CREATE INDEX ON :Unindexed(name)")
     try:
         execute(cursor, "USING PARALLEL EXECUTION MATCH (n:Unindexed) WHERE n.name = 'x' RETURN count(n)")
-        assert counter() == baseline + 4
+        assert counter() == expected
     finally:
         execute(cursor, "DROP INDEX ON :Unindexed(name)")
 

--- a/tests/e2e/show_metrics/show_metrics_openmetrics_values.py
+++ b/tests/e2e/show_metrics/show_metrics_openmetrics_values.py
@@ -293,11 +293,11 @@ def test_openmetrics_per_db_transaction_counters(populated_databases):
 
 
 def test_query_no_index_lookup_counter():
-    """Task 2: count ScanAll+Filter queries that could have used an index.
+    """Task 2: count queries whose plan did a ScanAll+Filter an index could have served.
 
     Uses a fresh label (Unindexed) so populated_databases' indexes don't apply.
-    EXPLAIN must not advance the counter; per-operator counting means a query with
-    N qualifying ScanAll+Filter pairs bumps by N.
+    EXPLAIN/PROFILE must not advance the counter; counting is per-query, so a query
+    with several qualifying ScanAll+Filter pairs bumps by 1.
     """
     conn = mgclient.connect(host="localhost", port=7687)
     conn.autocommit = True
@@ -315,8 +315,10 @@ def test_query_no_index_lookup_counter():
     execute(cursor, "MATCH (n:Unindexed) WHERE n.name = 'x' RETURN n")
     assert counter() == baseline + 2
 
-    # EXPLAIN must not advance the counter.
+    # EXPLAIN/PROFILE must not advance the counter.
     execute(cursor, "EXPLAIN MATCH (n:Unindexed) WHERE n.name = 'x' RETURN n")
+    assert counter() == baseline + 2
+    execute(cursor, "PROFILE MATCH (n:Unindexed) WHERE n.name = 'x' RETURN n")
     assert counter() == baseline + 2
 
     # Creating the matching index stops further increments.
@@ -327,14 +329,14 @@ def test_query_no_index_lookup_counter():
     finally:
         execute(cursor, "DROP INDEX ON :Unindexed(name)")
 
-    # Two qualifying ScanAll+Filter pairs via UNION → +2 (per-operator).
+    # Two qualifying ScanAll+Filter pairs in one query (UNION) → +1 (per-query).
     execute(
         cursor,
         "MATCH (n:UnindexedA) WHERE n.v = 1 RETURN n.v AS v "
         "UNION ALL "
         "MATCH (m:UnindexedB) WHERE m.v = 1 RETURN m.v AS v",
     )
-    assert counter() == baseline + 4
+    assert counter() == baseline + 3
 
     conn.close()
 

--- a/tests/e2e/show_metrics/show_metrics_openmetrics_values.py
+++ b/tests/e2e/show_metrics/show_metrics_openmetrics_values.py
@@ -118,7 +118,7 @@ EXPECTED_OPENMETRICS_PER_DB_FAMILIES = {
     "write_queries_total",
     "read_write_queries_total",
     # Query / planner signals
-    "query_no_index_lookup_total",
+    "unindexed_scan_queries_total",
     # TTL
     "deleted_nodes_total",
     "deleted_edges_total",
@@ -292,7 +292,7 @@ def test_openmetrics_per_db_transaction_counters(populated_databases):
     assert om_get(m, "memgraph_committed_transactions_total", "db2") > 0
 
 
-def test_query_no_index_lookup_counter():
+def test_unindexed_scan_queries_counter():
     """Task 2: count queries whose plan did a ScanAll+Filter an index could have served.
 
     Uses a fresh label (Unindexed) so populated_databases' indexes don't apply.
@@ -305,7 +305,7 @@ def test_query_no_index_lookup_counter():
     execute(cursor, "USE DATABASE memgraph")
 
     def counter():
-        return om_get(parse_openmetrics(scrape_openmetrics()), "memgraph_query_no_index_lookup_total", "memgraph") or 0
+        return om_get(parse_openmetrics(scrape_openmetrics()), "memgraph_unindexed_scan_queries_total", "memgraph") or 0
 
     baseline = counter()
 

--- a/tests/e2e/show_metrics/show_metrics_openmetrics_values.py
+++ b/tests/e2e/show_metrics/show_metrics_openmetrics_values.py
@@ -117,6 +117,8 @@ EXPECTED_OPENMETRICS_PER_DB_FAMILIES = {
     "read_queries_total",
     "write_queries_total",
     "read_write_queries_total",
+    # Query / planner signals
+    "query_no_index_lookup_total",
     # TTL
     "deleted_nodes_total",
     "deleted_edges_total",
@@ -288,6 +290,53 @@ def test_openmetrics_per_db_transaction_counters(populated_databases):
     m = parse_openmetrics(scrape_openmetrics())
     assert om_get(m, "memgraph_committed_transactions_total", "memgraph") > 0
     assert om_get(m, "memgraph_committed_transactions_total", "db2") > 0
+
+
+def test_query_no_index_lookup_counter():
+    """Task 2: count ScanAll+Filter queries that could have used an index.
+
+    Uses a fresh label (Unindexed) so populated_databases' indexes don't apply.
+    EXPLAIN must not advance the counter; per-operator counting means a query with
+    N qualifying ScanAll+Filter pairs bumps by N.
+    """
+    conn = mgclient.connect(host="localhost", port=7687)
+    conn.autocommit = True
+    cursor = conn.cursor()
+    execute(cursor, "USE DATABASE memgraph")
+
+    def counter():
+        return om_get(parse_openmetrics(scrape_openmetrics()), "memgraph_query_no_index_lookup_total", "memgraph") or 0
+
+    baseline = counter()
+
+    execute(cursor, "MATCH (n:Unindexed) WHERE n.name = 'x' RETURN n")
+    assert counter() == baseline + 1
+
+    execute(cursor, "MATCH (n:Unindexed) WHERE n.name = 'x' RETURN n")
+    assert counter() == baseline + 2
+
+    # EXPLAIN must not advance the counter.
+    execute(cursor, "EXPLAIN MATCH (n:Unindexed) WHERE n.name = 'x' RETURN n")
+    assert counter() == baseline + 2
+
+    # Creating the matching index stops further increments.
+    execute(cursor, "CREATE INDEX ON :Unindexed(name)")
+    try:
+        execute(cursor, "MATCH (n:Unindexed) WHERE n.name = 'x' RETURN n")
+        assert counter() == baseline + 2
+    finally:
+        execute(cursor, "DROP INDEX ON :Unindexed(name)")
+
+    # Two qualifying ScanAll+Filter pairs via UNION → +2 (per-operator).
+    execute(
+        cursor,
+        "MATCH (n:UnindexedA) WHERE n.v = 1 RETURN n.v AS v "
+        "UNION ALL "
+        "MATCH (m:UnindexedB) WHERE m.v = 1 RETURN m.v AS v",
+    )
+    assert counter() == baseline + 4
+
+    conn.close()
 
 
 if __name__ == "__main__":

--- a/tests/e2e/show_metrics/show_metrics_openmetrics_values.py
+++ b/tests/e2e/show_metrics/show_metrics_openmetrics_values.py
@@ -338,6 +338,19 @@ def test_unindexed_scan_queries_counter():
     )
     assert counter() == baseline + 3
 
+    # Parallel execution rewrites the scan into ScanChunk -> ParallelMerge -> ScanParallel;
+    # an unindexed parallel scan must still be counted (+1).
+    execute(cursor, "USING PARALLEL EXECUTION MATCH (n:Unindexed) WHERE n.name = 'x' RETURN count(n)")
+    assert counter() == baseline + 4
+
+    # The same parallel query backed by an index must NOT advance the counter.
+    execute(cursor, "CREATE INDEX ON :Unindexed(name)")
+    try:
+        execute(cursor, "USING PARALLEL EXECUTION MATCH (n:Unindexed) WHERE n.name = 'x' RETURN count(n)")
+        assert counter() == baseline + 4
+    finally:
+        execute(cursor, "DROP INDEX ON :Unindexed(name)")
+
     conn.close()
 
 

--- a/tests/unit/query_hint_provider.cpp
+++ b/tests/unit/query_hint_provider.cpp
@@ -69,6 +69,14 @@ class HintProviderSuite : public ::testing::Test {
 
     return label_ixs;
   }
+
+  // Builds the chain the parallel-execution rewrite produces for a scan whose output is
+  // `node_symbol`: ScanChunk -> ParallelMerge -> `parallel_scan`.
+  std::shared_ptr<LogicalOperator> WrapInParallelChunk(std::shared_ptr<ScanParallel> parallel_scan, Symbol node_symbol,
+                                                       Symbol state_symbol) {
+    auto parallel_merge = std::make_shared<ParallelMerge>(std::move(parallel_scan));
+    return std::make_shared<ScanChunk>(parallel_merge, node_symbol, view, state_symbol);
+  }
 };
 
 TEST_F(HintProviderSuite, HintWhenFilteringByLabel) {
@@ -180,20 +188,12 @@ TEST_F(HintProviderSuite, DontHintOrCountWhenFilteringByPropertyOnlyOnSequential
   VerifyHintMessages(filter.get(), expected_messages, false);
 }
 
-// Builds the operator chain produced by the parallel-execution rewrite for a scan whose
-// output is `node_symbol`: Filter -> ScanChunk -> ParallelMerge -> `parallel_scan`.
-std::shared_ptr<LogicalOperator> WrapInParallelChunk(std::shared_ptr<ScanParallel> parallel_scan, Symbol node_symbol,
-                                                     Symbol state_symbol, View view) {
-  auto parallel_merge = std::make_shared<ParallelMerge>(std::move(parallel_scan));
-  return std::make_shared<ScanChunk>(parallel_merge, node_symbol, view, state_symbol);
-}
-
 TEST_F(HintProviderSuite, HintWhenFilteringByLabelOnParallelScan) {
   // Parallel-execution rewrite of an unindexed `ScanAll`: the counter must still fire.
   auto scan_all = MakeScanAll(storage, symbol_table, "n");
   auto state_symbol = NextSymbol();
   auto parallel_scan = std::make_shared<ScanParallel>(std::make_shared<Once>(), view, 2, state_symbol);
-  auto scan_chunk = WrapInParallelChunk(parallel_scan, scan_all.sym_, state_symbol, view);
+  auto scan_chunk = WrapInParallelChunk(parallel_scan, scan_all.sym_, state_symbol);
 
   auto *filter_expr = storage.template Create<LabelsTest>(scan_all.node_->identifier_, GetLabelIx({label}));
   auto filter = std::make_shared<Filter>(scan_chunk, pattern_filters_, filter_expr);
@@ -211,7 +211,7 @@ TEST_F(HintProviderSuite, DontCountParallelLabelScanWithPropertyFilter) {
   auto scan_all = MakeScanAll(storage, symbol_table, "n");
   auto state_symbol = NextSymbol();
   auto parallel_scan = std::make_shared<ScanParallelByLabel>(std::make_shared<Once>(), view, 2, state_symbol, label);
-  auto scan_chunk = WrapInParallelChunk(parallel_scan, scan_all.sym_, state_symbol, view);
+  auto scan_chunk = WrapInParallelChunk(parallel_scan, scan_all.sym_, state_symbol);
 
   auto *filter_expr = EQ(PROPERTY_LOOKUP(*dba, scan_all.node_->identifier_, property), LITERAL(42));
   auto filter = std::make_shared<Filter>(scan_chunk, pattern_filters_, filter_expr);
@@ -220,6 +220,53 @@ TEST_F(HintProviderSuite, DontCountParallelLabelScanWithPropertyFilter) {
       "Label index will be used on symbol `n` although there is also a filter on properties property. "
       "Consider "
       "creating a label-property index."};
+
+  VerifyHintMessages(filter.get(), expected_messages, false);
+}
+
+TEST_F(HintProviderSuite, DontHintOrCountWhenFilteringByPropertyOnlyOnParallelScan) {
+  // Parallel-execution rewrite of an unindexed `ScanAll` with a label-less property filter:
+  // no node index can serve it, so (like the sequential case) no hint and no count.
+  auto scan_all = MakeScanAll(storage, symbol_table, "n");
+  auto state_symbol = NextSymbol();
+  auto parallel_scan = std::make_shared<ScanParallel>(std::make_shared<Once>(), view, 2, state_symbol);
+  auto scan_chunk = WrapInParallelChunk(parallel_scan, scan_all.sym_, state_symbol);
+
+  auto *filter_expr = EQ(PROPERTY_LOOKUP(*dba, scan_all.node_->identifier_, property), LITERAL(42));
+  auto filter = std::make_shared<Filter>(scan_chunk, pattern_filters_, filter_expr);
+
+  const std::vector<std::string> expected_messages{};
+
+  VerifyHintMessages(filter.get(), expected_messages, false);
+}
+
+TEST_F(HintProviderSuite, DontHintOrCountParallelEdgeScan) {
+  // Parallel-execution rewrite of an edge scan (ScanChunkByEdge -> ParallelMerge -> ScanParallelByEdge).
+  // Edge-scan hints are out of scope: EffectiveScanType must leave its type untouched so that, even
+  // with a property filter present, no missing-index hint or count fires.
+  auto scan_all = MakeScanAll(storage, symbol_table, "e");  // `e` is the edge output symbol
+  auto edge_symbol = scan_all.sym_;
+  auto node1_symbol = NextSymbol();
+  auto node2_symbol = NextSymbol();
+  auto state_symbol = NextSymbol();
+  const auto direction = EdgeAtom::Direction::BOTH;
+
+  auto parallel_scan = std::make_shared<ScanParallelByEdge>(
+      std::make_shared<Once>(), view, 2, state_symbol, edge_symbol, node1_symbol, node2_symbol, direction);
+  auto parallel_merge = std::make_shared<ParallelMerge>(std::move(parallel_scan));
+  auto scan_chunk = std::make_shared<ScanChunkByEdge>(parallel_merge,
+                                                      edge_symbol,
+                                                      node1_symbol,
+                                                      node2_symbol,
+                                                      direction,
+                                                      std::vector<memgraph::storage::EdgeTypeId>{},
+                                                      view,
+                                                      state_symbol);
+
+  auto *filter_expr = EQ(PROPERTY_LOOKUP(*dba, scan_all.node_->identifier_, property), LITERAL(42));
+  auto filter = std::make_shared<Filter>(scan_chunk, pattern_filters_, filter_expr);
+
+  const std::vector<std::string> expected_messages{};
 
   VerifyHintMessages(filter.get(), expected_messages, false);
 }

--- a/tests/unit/query_hint_provider.cpp
+++ b/tests/unit/query_hint_provider.cpp
@@ -167,3 +167,59 @@ TEST_F(HintProviderSuite, DoubleHintWhenCartesianInFilters) {
 
   VerifyHintMessages(cartesian.get(), expected_messages, true);
 }
+
+TEST_F(HintProviderSuite, DontHintOrCountWhenFilteringByPropertyOnlyOnSequentialScan) {
+  // A label-less property filter cannot be served by any node index (node indices require a
+  // label), so there is nothing to suggest and nothing to count.
+  auto scan_all = MakeScanAll(storage, symbol_table, "n");
+  auto *filter_expr = EQ(PROPERTY_LOOKUP(*dba, scan_all.node_->identifier_, property), LITERAL(42));
+  auto filter = std::make_shared<Filter>(scan_all.op_, pattern_filters_, filter_expr);
+
+  const std::vector<std::string> expected_messages{};
+
+  VerifyHintMessages(filter.get(), expected_messages, false);
+}
+
+// Builds the operator chain produced by the parallel-execution rewrite for a scan whose
+// output is `node_symbol`: Filter -> ScanChunk -> ParallelMerge -> `parallel_scan`.
+std::shared_ptr<LogicalOperator> WrapInParallelChunk(std::shared_ptr<ScanParallel> parallel_scan, Symbol node_symbol,
+                                                     Symbol state_symbol, View view) {
+  auto parallel_merge = std::make_shared<ParallelMerge>(std::move(parallel_scan));
+  return std::make_shared<ScanChunk>(parallel_merge, node_symbol, view, state_symbol);
+}
+
+TEST_F(HintProviderSuite, HintWhenFilteringByLabelOnParallelScan) {
+  // Parallel-execution rewrite of an unindexed `ScanAll`: the counter must still fire.
+  auto scan_all = MakeScanAll(storage, symbol_table, "n");
+  auto state_symbol = NextSymbol();
+  auto parallel_scan = std::make_shared<ScanParallel>(std::make_shared<Once>(), view, 2, state_symbol);
+  auto scan_chunk = WrapInParallelChunk(parallel_scan, scan_all.sym_, state_symbol, view);
+
+  auto *filter_expr = storage.template Create<LabelsTest>(scan_all.node_->identifier_, GetLabelIx({label}));
+  auto filter = std::make_shared<Filter>(scan_chunk, pattern_filters_, filter_expr);
+
+  const std::vector<std::string> expected_messages{
+      "Sequential scan will be used on symbol `n` although there is a filter on labels :label. Consider "
+      "creating a label index."};
+
+  VerifyHintMessages(filter.get(), expected_messages, true);
+}
+
+TEST_F(HintProviderSuite, DontCountParallelLabelScanWithPropertyFilter) {
+  // Parallel-execution rewrite of a `ScanAllByLabel`: a label index is already used, so this
+  // is a suboptimal-index hint, not a missing-index scan -> no count.
+  auto scan_all = MakeScanAll(storage, symbol_table, "n");
+  auto state_symbol = NextSymbol();
+  auto parallel_scan = std::make_shared<ScanParallelByLabel>(std::make_shared<Once>(), view, 2, state_symbol, label);
+  auto scan_chunk = WrapInParallelChunk(parallel_scan, scan_all.sym_, state_symbol, view);
+
+  auto *filter_expr = EQ(PROPERTY_LOOKUP(*dba, scan_all.node_->identifier_, property), LITERAL(42));
+  auto filter = std::make_shared<Filter>(scan_chunk, pattern_filters_, filter_expr);
+
+  const std::vector<std::string> expected_messages{
+      "Label index will be used on symbol `n` although there is also a filter on properties property. "
+      "Consider "
+      "creating a label-property index."};
+
+  VerifyHintMessages(filter.get(), expected_messages, false);
+}

--- a/tests/unit/query_hint_provider.cpp
+++ b/tests/unit/query_hint_provider.cpp
@@ -45,11 +45,13 @@ class HintProviderSuite : public ::testing::Test {
 
   Symbol NextSymbol() { return symbol_table.CreateSymbol("Symbol" + std::to_string(symbol_count++), true); }
 
-  void VerifyHintMessages(LogicalOperator *plan, const std::vector<std::string> &expected_messages) {
+  void VerifyHintMessages(LogicalOperator *plan, const std::vector<std::string> &expected_messages,
+                          std::size_t expected_no_index_lookup_count) {
     auto const result = ProvidePlanHints(plan, symbol_table);
     auto const &messages = result.hints;
 
     ASSERT_EQ(expected_messages.size(), messages.size());
+    ASSERT_EQ(expected_no_index_lookup_count, result.no_index_lookup_count);
 
     for (size_t i = 0; i < messages.size(); i++) {
       const auto &expected_message = expected_messages[i];
@@ -79,7 +81,7 @@ TEST_F(HintProviderSuite, HintWhenFilteringByLabel) {
       "Sequential scan will be used on symbol `n` although there is a filter on labels :label. Consider "
       "creating a label index."};
 
-  VerifyHintMessages(filter.get(), expected_messages);
+  VerifyHintMessages(filter.get(), expected_messages, 1);
 }
 
 TEST_F(HintProviderSuite, DontHintWhenLabelOperatorPresent) {
@@ -88,7 +90,7 @@ TEST_F(HintProviderSuite, DontHintWhenLabelOperatorPresent) {
 
   const std::vector<std::string> expected_messages{};
 
-  VerifyHintMessages(produce.get(), expected_messages);
+  VerifyHintMessages(produce.get(), expected_messages, 0);
 }
 
 TEST_F(HintProviderSuite, HintWhenFilteringByLabelAndProperty) {
@@ -104,7 +106,7 @@ TEST_F(HintProviderSuite, HintWhenFilteringByLabelAndProperty) {
       "Consider "
       "creating a label-property index."};
 
-  VerifyHintMessages(filter.get(), expected_messages);
+  VerifyHintMessages(filter.get(), expected_messages, 1);
 }
 
 TEST_F(HintProviderSuite, DontHintWhenLabelPropertyOperatorPresent) {
@@ -114,7 +116,7 @@ TEST_F(HintProviderSuite, DontHintWhenLabelPropertyOperatorPresent) {
 
   const std::vector<std::string> expected_messages{};
 
-  VerifyHintMessages(produce.get(), expected_messages);
+  VerifyHintMessages(produce.get(), expected_messages, 0);
 }
 
 TEST_F(HintProviderSuite, DontHintWhenLabelPropertyOperatorPresentAndAdditionalPropertyFilterPresent) {
@@ -126,7 +128,7 @@ TEST_F(HintProviderSuite, DontHintWhenLabelPropertyOperatorPresentAndAdditionalP
   auto filter = std::make_shared<Filter>(scan_all_by_label_prop_value.op_, pattern_filters_, filter_expr);
   const std::vector<std::string> expected_messages{};
 
-  VerifyHintMessages(filter.get(), expected_messages);
+  VerifyHintMessages(filter.get(), expected_messages, 0);
 }
 
 TEST_F(HintProviderSuite, HintWhenLabelOperatorPresentButFilteringAlsoByProperty) {
@@ -140,7 +142,7 @@ TEST_F(HintProviderSuite, HintWhenLabelOperatorPresentButFilteringAlsoByProperty
       "Consider "
       "creating a label-property index."};
 
-  VerifyHintMessages(filter.get(), expected_messages);
+  VerifyHintMessages(filter.get(), expected_messages, 0);
 }
 
 TEST_F(HintProviderSuite, DoubleHintWhenCartesianInFilters) {
@@ -163,5 +165,5 @@ TEST_F(HintProviderSuite, DoubleHintWhenCartesianInFilters) {
       "Sequential scan will be used on symbol `m` although there is a filter on labels :label. Consider "
       "creating a label index."};
 
-  VerifyHintMessages(cartesian.get(), expected_messages);
+  VerifyHintMessages(cartesian.get(), expected_messages, 2);
 }

--- a/tests/unit/query_hint_provider.cpp
+++ b/tests/unit/query_hint_provider.cpp
@@ -46,12 +46,12 @@ class HintProviderSuite : public ::testing::Test {
   Symbol NextSymbol() { return symbol_table.CreateSymbol("Symbol" + std::to_string(symbol_count++), true); }
 
   void VerifyHintMessages(LogicalOperator *plan, const std::vector<std::string> &expected_messages,
-                          bool expected_has_no_index_lookup) {
+                          bool expected_has_unindexed_scan) {
     auto const result = ProvidePlanHints(plan, symbol_table);
     auto const &messages = result.hints;
 
     ASSERT_EQ(expected_messages.size(), messages.size());
-    ASSERT_EQ(expected_has_no_index_lookup, result.has_no_index_lookup);
+    ASSERT_EQ(expected_has_unindexed_scan, result.has_unindexed_scan);
 
     for (size_t i = 0; i < messages.size(); i++) {
       const auto &expected_message = expected_messages[i];

--- a/tests/unit/query_hint_provider.cpp
+++ b/tests/unit/query_hint_provider.cpp
@@ -46,7 +46,8 @@ class HintProviderSuite : public ::testing::Test {
   Symbol NextSymbol() { return symbol_table.CreateSymbol("Symbol" + std::to_string(symbol_count++), true); }
 
   void VerifyHintMessages(LogicalOperator *plan, const std::vector<std::string> &expected_messages) {
-    auto messages = ProvidePlanHints(plan, symbol_table);
+    auto const result = ProvidePlanHints(plan, symbol_table);
+    auto const &messages = result.hints;
 
     ASSERT_EQ(expected_messages.size(), messages.size());
 

--- a/tests/unit/query_hint_provider.cpp
+++ b/tests/unit/query_hint_provider.cpp
@@ -224,6 +224,29 @@ TEST_F(HintProviderSuite, DontCountParallelLabelScanWithPropertyFilter) {
   VerifyHintMessages(filter.get(), expected_messages, false);
 }
 
+TEST_F(HintProviderSuite, DontHintOrCountParallelLabelPropertyScanWithPropertyFilter) {
+  // Parallel-execution rewrite of a `ScanAllByLabelProperties`: a label-property index is already in
+  // use, so EffectiveScanType returns its own type and HintIndexUsage emits no hint and no count.
+  auto scan_all = MakeScanAll(storage, symbol_table, "n");
+  auto state_symbol = NextSymbol();
+  auto parallel_scan =
+      std::make_shared<ScanParallelByLabelProperties>(std::make_shared<Once>(),
+                                                      view,
+                                                      2,
+                                                      state_symbol,
+                                                      label,
+                                                      std::vector{memgraph::storage::PropertyPath{property}},
+                                                      std::vector{ExpressionRange::Equal(LITERAL(42))});
+  auto scan_chunk = WrapInParallelChunk(parallel_scan, scan_all.sym_, state_symbol);
+
+  auto *filter_expr = EQ(PROPERTY_LOOKUP(*dba, scan_all.node_->identifier_, property), LITERAL(42));
+  auto filter = std::make_shared<Filter>(scan_chunk, pattern_filters_, filter_expr);
+
+  const std::vector<std::string> expected_messages{};
+
+  VerifyHintMessages(filter.get(), expected_messages, false);
+}
+
 TEST_F(HintProviderSuite, DontHintOrCountWhenFilteringByPropertyOnlyOnParallelScan) {
   // Parallel-execution rewrite of an unindexed `ScanAll` with a label-less property filter:
   // no node index can serve it, so (like the sequential case) no hint and no count.

--- a/tests/unit/query_hint_provider.cpp
+++ b/tests/unit/query_hint_provider.cpp
@@ -46,12 +46,12 @@ class HintProviderSuite : public ::testing::Test {
   Symbol NextSymbol() { return symbol_table.CreateSymbol("Symbol" + std::to_string(symbol_count++), true); }
 
   void VerifyHintMessages(LogicalOperator *plan, const std::vector<std::string> &expected_messages,
-                          std::size_t expected_no_index_lookup_count) {
+                          bool expected_has_no_index_lookup) {
     auto const result = ProvidePlanHints(plan, symbol_table);
     auto const &messages = result.hints;
 
     ASSERT_EQ(expected_messages.size(), messages.size());
-    ASSERT_EQ(expected_no_index_lookup_count, result.no_index_lookup_count);
+    ASSERT_EQ(expected_has_no_index_lookup, result.has_no_index_lookup);
 
     for (size_t i = 0; i < messages.size(); i++) {
       const auto &expected_message = expected_messages[i];
@@ -81,7 +81,7 @@ TEST_F(HintProviderSuite, HintWhenFilteringByLabel) {
       "Sequential scan will be used on symbol `n` although there is a filter on labels :label. Consider "
       "creating a label index."};
 
-  VerifyHintMessages(filter.get(), expected_messages, 1);
+  VerifyHintMessages(filter.get(), expected_messages, true);
 }
 
 TEST_F(HintProviderSuite, DontHintWhenLabelOperatorPresent) {
@@ -90,7 +90,7 @@ TEST_F(HintProviderSuite, DontHintWhenLabelOperatorPresent) {
 
   const std::vector<std::string> expected_messages{};
 
-  VerifyHintMessages(produce.get(), expected_messages, 0);
+  VerifyHintMessages(produce.get(), expected_messages, false);
 }
 
 TEST_F(HintProviderSuite, HintWhenFilteringByLabelAndProperty) {
@@ -106,7 +106,7 @@ TEST_F(HintProviderSuite, HintWhenFilteringByLabelAndProperty) {
       "Consider "
       "creating a label-property index."};
 
-  VerifyHintMessages(filter.get(), expected_messages, 1);
+  VerifyHintMessages(filter.get(), expected_messages, true);
 }
 
 TEST_F(HintProviderSuite, DontHintWhenLabelPropertyOperatorPresent) {
@@ -116,7 +116,7 @@ TEST_F(HintProviderSuite, DontHintWhenLabelPropertyOperatorPresent) {
 
   const std::vector<std::string> expected_messages{};
 
-  VerifyHintMessages(produce.get(), expected_messages, 0);
+  VerifyHintMessages(produce.get(), expected_messages, false);
 }
 
 TEST_F(HintProviderSuite, DontHintWhenLabelPropertyOperatorPresentAndAdditionalPropertyFilterPresent) {
@@ -128,7 +128,7 @@ TEST_F(HintProviderSuite, DontHintWhenLabelPropertyOperatorPresentAndAdditionalP
   auto filter = std::make_shared<Filter>(scan_all_by_label_prop_value.op_, pattern_filters_, filter_expr);
   const std::vector<std::string> expected_messages{};
 
-  VerifyHintMessages(filter.get(), expected_messages, 0);
+  VerifyHintMessages(filter.get(), expected_messages, false);
 }
 
 TEST_F(HintProviderSuite, HintWhenLabelOperatorPresentButFilteringAlsoByProperty) {
@@ -142,7 +142,7 @@ TEST_F(HintProviderSuite, HintWhenLabelOperatorPresentButFilteringAlsoByProperty
       "Consider "
       "creating a label-property index."};
 
-  VerifyHintMessages(filter.get(), expected_messages, 0);
+  VerifyHintMessages(filter.get(), expected_messages, false);
 }
 
 TEST_F(HintProviderSuite, DoubleHintWhenCartesianInFilters) {
@@ -165,5 +165,5 @@ TEST_F(HintProviderSuite, DoubleHintWhenCartesianInFilters) {
       "Sequential scan will be used on symbol `m` although there is a filter on labels :label. Consider "
       "creating a label index."};
 
-  VerifyHintMessages(cartesian.get(), expected_messages, 2);
+  VerifyHintMessages(cartesian.get(), expected_messages, true);
 }


### PR DESCRIPTION
Adds a per-database metric `memgraph_unindexed_scan_queries_total{database,uuid}` that counts query executions whose plan does a `ScanAll`+`Filter` an index could have served.

**What it does**
Surfaces, as an aggregable metric, how often queries run a full scan + filter when an index could have served the scan — previously only emitted as a per-query planner hint notification. Exposed via OpenMetrics and `SHOW METRICS INFO` (row `UnindexedScanQueries`).

**How**
The plan-hint provider already detects this case at plan time; it now also reports a `has_unindexed_scan` bool through `PlanHintsResult`. The interpreter increments the counter once per qualifying query at the regular-execution site only (EXPLAIN/PROFILE do not count). Counting is per-query: a query with several qualifying scans bumps the counter by 1, so `rate(unindexed)/rate(queries)` is a stable ratio. Wired through the existing per-database `DatabaseMetricHandles` machinery (Colin's per-tenant pattern).

**Why**
Operators had no fleet-level signal for missing-index workloads — only a per-query notification. This gives a canary ("is this happening / is the rate growing?") across tenants. It is intentionally a per-query occurrence signal, not a cost signal (see follow-ups for slow-query enrichment / scan amplification). The legacy JSON metrics endpoint is being deprecated, so the counter is OpenMetrics + `SHOW METRICS INFO` only.
