### PR TITLE
fix: Handle whitespace between `$` and parameter name in query stripper

### DIFF
--- a/src/query/frontend/stripped.cpp
+++ b/src/query/frontend/stripped.cpp
@@ -485,13 +485,18 @@ int StrippedQuery::MatchParameter(int start) const {
   int len = original_.size();
   if (start + 1 == len) return 0;
   if (original_[start] != '$') return 0;
+  // ANTLR skips whitespace between '$' and the parameter name/number,
+  // so the stripper must do the same to stay in sync.
+  int ws = MatchWhitespaceAndComments(start + 1);
+  int after_ws = start + 1 + ws;
+  if (after_ws >= len) return 0;
   int max_len = 0;
-  max_len = std::max(max_len, MatchUnescapedName(start + 1));
-  max_len = std::max(max_len, MatchEscapedName(start + 1));
-  max_len = std::max(max_len, MatchKeyword(start + 1));
-  max_len = std::max(max_len, MatchDecimalInt(start + 1));
+  max_len = std::max(max_len, MatchUnescapedName(after_ws));
+  max_len = std::max(max_len, MatchEscapedName(after_ws));
+  max_len = std::max(max_len, MatchKeyword(after_ws));
+  max_len = std::max(max_len, MatchDecimalInt(after_ws));
   if (max_len == 0) return 0;
-  return 1 + max_len;
+  return 1 + ws + max_len;
 }
 
 int StrippedQuery::MatchEscapedName(int start) const {

--- a/src/query/frontend/stripped.cpp
+++ b/src/query/frontend/stripped.cpp
@@ -78,7 +78,12 @@ StrippedQuery::StrippedQuery(std::string query) : original_(std::move(query)) {
       }
       throw LexingException("Invalid query because of a wrong token.");
     }
-    tokens.emplace_back(token, original_.substr(i, len));
+    if (token == Token::PARAMETER) {
+      auto ws = MatchWhitespaceAndComments(i + 1);
+      tokens.emplace_back(token, "$" + original_.substr(i + 1 + ws, len - 1 - ws));
+    } else {
+      tokens.emplace_back(token, original_.substr(i, len));
+    }
     i += len;
 
     // If we notice execute, we possibly create a trigger which has defined statements.

--- a/src/query/frontend/stripped.cpp
+++ b/src/query/frontend/stripped.cpp
@@ -492,8 +492,8 @@ int StrippedQuery::MatchParameter(int start) const {
   if (original_[start] != '$') return 0;
   // ANTLR skips whitespace between '$' and the parameter name/number,
   // so the stripper must do the same to stay in sync.
-  int ws = MatchWhitespaceAndComments(start + 1);
-  int after_ws = start + 1 + ws;
+  int const ws = MatchWhitespaceAndComments(start + 1);
+  int const after_ws = start + 1 + ws;
   if (after_ws >= len) return 0;
   int max_len = 0;
   max_len = std::max(max_len, MatchUnescapedName(after_ws));

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -704,8 +704,10 @@ TYPED_TEST(InterpreterTest, ParametersAsPropertyMap) {
   }
 }
 
-TYPED_TEST(InterpreterTest, DollarSpaceNumberDoesNotCrash) {
-  ASSERT_THROW(this->Interpret("RETURN $ 1"), memgraph::query::UnprovidedParameterError);
+TYPED_TEST(InterpreterTest, WhitespaceBetweenDollarAndParameterName) {
+  auto stream = this->Interpret("RETURN $ 1", {{"1", memgraph::storage::ExternalPropertyValue(42)}});
+  ASSERT_EQ(stream.GetResults().size(), 1U);
+  ASSERT_EQ(stream.GetResults()[0][0].ValueInt(), 42);
 }
 
 // Test bfs end to end.

--- a/tests/unit/interpreter.cpp
+++ b/tests/unit/interpreter.cpp
@@ -704,6 +704,10 @@ TYPED_TEST(InterpreterTest, ParametersAsPropertyMap) {
   }
 }
 
+TYPED_TEST(InterpreterTest, DollarSpaceNumberDoesNotCrash) {
+  ASSERT_THROW(this->Interpret("RETURN $ 1"), memgraph::query::UnprovidedParameterError);
+}
+
 // Test bfs end to end.
 TYPED_TEST(InterpreterTest, Bfs) {
   srand(0);


### PR DESCRIPTION
Fix misalignment between the ANTLR parser and query stripper: the former removes whitespace after a $, whilst the latter didn't. So `$ 1` would be treated as a parameter lookup by the ANTLR parser for a parameter that the stripped did not registered. This results in an assertion and server crash.

