### PR TITLE
feat: MAGE RPM build

### DIFF
--- a/.github/workflows/build_rc.yml
+++ b/.github/workflows/build_rc.yml
@@ -259,7 +259,7 @@ jobs:
       build_docker_image: ${{ matrix.build_docker_image }}
       os: ${{ matrix.os || 'ubuntu-24.04' }}
       memgraph_download_link: >-
-        ${{ startsWith(matrix.os, 'centos') && format(
+        ${{ startsWith(matrix.os || 'ubuntu-24.04', 'centos') && format(
           'https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/memgraph{0}/{1}/{2}/memgraph-{3}_1-1.x86_64.rpm',
           inputs.mock && '-mock-rc' || '',
           needs.PrepareReleaseBranch.outputs.tag_name,
@@ -295,8 +295,8 @@ jobs:
       upload_debug_symbols: true
       run_tests: true
       package_mage: "default"
-      generate_sbom: ${{ matrix.build_arch == 'amd' && !matrix.malloc && !matrix.cuda && !matrix.cugraph && !startsWith(matrix.os, 'centos') }}
-      build_offline_installer: ${{ matrix.build_arch == 'amd' && !matrix.malloc && !matrix.cuda && !matrix.cugraph && !startsWith(matrix.os, 'centos') }}
+      generate_sbom: ${{ matrix.build_arch == 'amd' && !matrix.malloc && !matrix.cuda && !matrix.cugraph && !startsWith(matrix.os || 'ubuntu-24.04', 'centos') }}
+      build_offline_installer: ${{ matrix.build_arch == 'amd' && !matrix.malloc && !matrix.cuda && !matrix.cugraph && !startsWith(matrix.os || 'ubuntu-24.04', 'centos') }}
       ref: ${{ needs.PrepareReleaseBranch.outputs.tag_name }}
       version: ${{ inputs.version }}
     secrets: inherit

--- a/.github/workflows/build_rc.yml
+++ b/.github/workflows/build_rc.yml
@@ -294,7 +294,7 @@ jobs:
       run_smoke_tests: ${{ !matrix.cugraph }}
       upload_debug_symbols: true
       run_tests: true
-      package_deb: "default"
+      package_mage: "default"
       generate_sbom: ${{ matrix.build_arch == 'amd' && !matrix.malloc && !matrix.cuda && !matrix.cugraph && !startsWith(matrix.os, 'centos') }}
       build_offline_installer: ${{ matrix.build_arch == 'amd' && !matrix.malloc && !matrix.cuda && !matrix.cugraph && !startsWith(matrix.os, 'centos') }}
       ref: ${{ needs.PrepareReleaseBranch.outputs.tag_name }}

--- a/.github/workflows/build_rc.yml
+++ b/.github/workflows/build_rc.yml
@@ -241,12 +241,31 @@ jobs:
             cuda: false
             malloc: false
             cugraph: true
+          - build_arch: "amd"
+            build_docker_image: "none"
+            cuda: false
+            malloc: false
+            cugraph: false
+            os: "centos-9"
+          - build_arch: "amd"
+            build_docker_image: "none"
+            cuda: false
+            malloc: false
+            cugraph: false
+            os: "centos-10"
     with:
       arch: ${{ matrix.build_arch }}
       build_type: RelWithDebInfo
       build_docker_image: ${{ matrix.build_docker_image }}
+      os: ${{ matrix.os || 'ubuntu-24.04' }}
       memgraph_download_link: >-
-        ${{ format(
+        ${{ startsWith(matrix.os, 'centos') && format(
+          'https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/memgraph{0}/{1}/{2}/memgraph-{3}_1-1.x86_64.rpm',
+          inputs.mock && '-mock-rc' || '',
+          needs.PrepareReleaseBranch.outputs.tag_name,
+          matrix.os,
+          inputs.version
+        ) || format(
           'https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/memgraph{0}/{1}/ubuntu-24.04{2}{3}/memgraph_{4}-1_{5}.deb',
           inputs.mock && '-mock-rc' || '',
           needs.PrepareReleaseBranch.outputs.tag_name,
@@ -276,8 +295,8 @@ jobs:
       upload_debug_symbols: true
       run_tests: true
       package_deb: "default"
-      generate_sbom: ${{ matrix.build_arch == 'amd' && !matrix.malloc && !matrix.cuda && !matrix.cugraph }}
-      build_offline_installer: ${{ matrix.build_arch == 'amd' && !matrix.malloc && !matrix.cuda && !matrix.cugraph }}
+      generate_sbom: ${{ matrix.build_arch == 'amd' && !matrix.malloc && !matrix.cuda && !matrix.cugraph && !startsWith(matrix.os, 'centos') }}
+      build_offline_installer: ${{ matrix.build_arch == 'amd' && !matrix.malloc && !matrix.cuda && !matrix.cugraph && !startsWith(matrix.os, 'centos') }}
       ref: ${{ needs.PrepareReleaseBranch.outputs.tag_name }}
       version: ${{ inputs.version }}
     secrets: inherit

--- a/.github/workflows/build_rc.yml
+++ b/.github/workflows/build_rc.yml
@@ -216,31 +216,37 @@ jobs:
             malloc: false
             cuda: false
             cugraph: false
+            os: "ubuntu-24.04"
           - build_arch: "arm"
             build_docker_image: "both"
             malloc: false
             cuda: false
             cugraph: false
+            os: "ubuntu-24.04"
           - build_arch: "amd"
             build_docker_image: "both"
             malloc: true
             cuda: false
             cugraph: false
+            os: "ubuntu-24.04"
           - build_arch: "arm"
             build_docker_image: "debug"
             malloc: true
             cuda: false
             cugraph: false
+            os: "ubuntu-24.04"
           - build_arch: "amd"
             build_docker_image: "debug"
             cuda: true
             malloc: false
             cugraph: false
+            os: "ubuntu-24.04"
           - build_arch: "amd"
             build_docker_image: "debug"
             cuda: false
             malloc: false
             cugraph: true
+            os: "ubuntu-24.04"
           - build_arch: "amd"
             build_docker_image: "none"
             cuda: false
@@ -257,9 +263,9 @@ jobs:
       arch: ${{ matrix.build_arch }}
       build_type: RelWithDebInfo
       build_docker_image: ${{ matrix.build_docker_image }}
-      os: ${{ matrix.os || 'ubuntu-24.04' }}
+      os: ${{ matrix.os }}
       memgraph_download_link: >-
-        ${{ startsWith(matrix.os || 'ubuntu-24.04', 'centos') && format(
+        ${{ startsWith(matrix.os, 'centos') && format(
           'https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/memgraph{0}/{1}/{2}/memgraph-{3}_1-1.x86_64.rpm',
           inputs.mock && '-mock-rc' || '',
           needs.PrepareReleaseBranch.outputs.tag_name,
@@ -295,8 +301,8 @@ jobs:
       upload_debug_symbols: true
       run_tests: true
       package_mage: "default"
-      generate_sbom: ${{ matrix.build_arch == 'amd' && !matrix.malloc && !matrix.cuda && !matrix.cugraph && !startsWith(matrix.os || 'ubuntu-24.04', 'centos') }}
-      build_offline_installer: ${{ matrix.build_arch == 'amd' && !matrix.malloc && !matrix.cuda && !matrix.cugraph && !startsWith(matrix.os || 'ubuntu-24.04', 'centos') }}
+      generate_sbom: ${{ matrix.build_arch == 'amd' && !matrix.malloc && !matrix.cuda && !matrix.cugraph && !startsWith(matrix.os, 'centos') }}
+      build_offline_installer: ${{ matrix.build_arch == 'amd' && !matrix.malloc && !matrix.cuda && !matrix.cugraph && !startsWith(matrix.os, 'centos') }}
       ref: ${{ needs.PrepareReleaseBranch.outputs.tag_name }}
       version: ${{ inputs.version }}
     secrets: inherit

--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -219,31 +219,37 @@ jobs:
             malloc: false
             cuda: false
             cugraph: false
+            os: "ubuntu-24.04"
           - build_arch: "arm"
             build_docker_image: "both"
             malloc: false
             cuda: false
             cugraph: false
+            os: "ubuntu-24.04"
           - build_arch: "amd"
             build_docker_image: "both"
             malloc: true
             cuda: false
             cugraph: false
+            os: "ubuntu-24.04"
           - build_arch: "arm"
             build_docker_image: "debug"
             malloc: true
             cuda: false
             cugraph: false
+            os: "ubuntu-24.04"
           - build_arch: "amd"
             build_docker_image: "debug"
             cuda: true
             malloc: false
             cugraph: false
+            os: "ubuntu-24.04"
           - build_arch: "amd"
             build_docker_image: "debug"
             cuda: false
             malloc: false
             cugraph: true
+            os: "ubuntu-24.04"
           - build_arch: "amd"
             build_docker_image: "none"
             cuda: false
@@ -261,9 +267,9 @@ jobs:
       build_type: RelWithDebInfo
       build_docker_image: ${{ matrix.build_docker_image }}
       daily_build: true
-      os: ${{ matrix.os || 'ubuntu-24.04' }}
+      os: ${{ matrix.os }}
       memgraph_download_link: >-
-        ${{ startsWith(matrix.os || 'ubuntu-24.04', 'centos') && format(
+        ${{ startsWith(matrix.os, 'centos') && format(
           'https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/daily-build/memgraph{0}/{1}/{2}/memgraph-{3}-1.x86_64.rpm',
           inputs.mock && '_mock' || '',
           needs.CurrentDateJob.outputs.current_date,
@@ -300,7 +306,7 @@ jobs:
       run_tests: true
       package_mage: "default"
       upload_debug_symbols: true
-      generate_sbom: ${{ matrix.build_arch == 'amd' && !matrix.malloc && !matrix.cuda && !matrix.cugraph && !startsWith(matrix.os || 'ubuntu-24.04', 'centos') }}
+      generate_sbom: ${{ matrix.build_arch == 'amd' && !matrix.malloc && !matrix.cuda && !matrix.cugraph && !startsWith(matrix.os, 'centos') }}
     secrets: inherit
 
   AggregateMAGEBuildTests:

--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -298,7 +298,7 @@ jobs:
       malloc: ${{ matrix.malloc }}
       run_smoke_tests: ${{ !matrix.cugraph && !inputs.skip_smoke_tests }}
       run_tests: true
-      package_deb: "default"
+      package_mage: "default"
       upload_debug_symbols: true
       generate_sbom: ${{ matrix.build_arch == 'amd' && !matrix.malloc && !matrix.cuda && !matrix.cugraph && !startsWith(matrix.os, 'centos') }}
     secrets: inherit

--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -183,6 +183,7 @@ jobs:
     outputs:
       memgraph_version: ${{ steps.version.outputs.memgraph_version }}
       memgraph_version_url: ${{ steps.version.outputs.memgraph_version_url }}
+      memgraph_version_rpm: ${{ steps.version.outputs.memgraph_version_rpm }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -196,10 +197,13 @@ jobs:
           # for download links; memgraph_version stays raw for any filename matching.
           version="$(tools/ci/get_master_package_version.sh)"
           version_url="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$version")"
+          version_rpm="$(tools/ci/get_master_package_version.sh rpm)"
           echo "Resolved memgraph version: $version"
           echo "URL-safe version: $version_url"
+          echo "RPM version: $version_rpm"
           echo "memgraph_version=$version" >> $GITHUB_OUTPUT
           echo "memgraph_version_url=$version_url" >> $GITHUB_OUTPUT
+          echo "memgraph_version_rpm=$version_rpm" >> $GITHUB_OUTPUT
 
   BuildAndTestMAGE:
     if: ${{ (github.event_name == 'schedule' && always()) || (github.event_name == 'workflow_dispatch' && !inputs.skip_mage) }}
@@ -240,13 +244,32 @@ jobs:
             cuda: false
             malloc: false
             cugraph: true
+          - build_arch: "amd"
+            build_docker_image: "none"
+            cuda: false
+            malloc: false
+            cugraph: false
+            os: "centos-9"
+          - build_arch: "amd"
+            build_docker_image: "none"
+            cuda: false
+            malloc: false
+            cugraph: false
+            os: "centos-10"
     with:
       arch: ${{ matrix.build_arch }}
       build_type: RelWithDebInfo
       build_docker_image: ${{ matrix.build_docker_image }}
       daily_build: true
+      os: ${{ matrix.os || 'ubuntu-24.04' }}
       memgraph_download_link: >-
-        ${{ format(
+        ${{ startsWith(matrix.os, 'centos') && format(
+          'https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/daily-build/memgraph{0}/{1}/{2}/memgraph-{3}-1.x86_64.rpm',
+          inputs.mock && '_mock' || '',
+          needs.CurrentDateJob.outputs.current_date,
+          matrix.os,
+          needs.MemgraphVersionSetup.outputs.memgraph_version_rpm
+        ) || format(
           'https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/daily-build/memgraph{0}/{1}/ubuntu-24.04{2}{3}/memgraph_{4}-1_{5}.deb',
           inputs.mock && '_mock' || '',
           needs.CurrentDateJob.outputs.current_date,
@@ -277,7 +300,7 @@ jobs:
       run_tests: true
       package_deb: "default"
       upload_debug_symbols: true
-      generate_sbom: ${{ matrix.build_arch == 'amd' && !matrix.malloc && !matrix.cuda && !matrix.cugraph }}
+      generate_sbom: ${{ matrix.build_arch == 'amd' && !matrix.malloc && !matrix.cuda && !matrix.cugraph && !startsWith(matrix.os, 'centos') }}
     secrets: inherit
 
   AggregateMAGEBuildTests:

--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -263,7 +263,7 @@ jobs:
       daily_build: true
       os: ${{ matrix.os || 'ubuntu-24.04' }}
       memgraph_download_link: >-
-        ${{ startsWith(matrix.os, 'centos') && format(
+        ${{ startsWith(matrix.os || 'ubuntu-24.04', 'centos') && format(
           'https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/daily-build/memgraph{0}/{1}/{2}/memgraph-{3}-1.x86_64.rpm',
           inputs.mock && '_mock' || '',
           needs.CurrentDateJob.outputs.current_date,
@@ -300,7 +300,7 @@ jobs:
       run_tests: true
       package_mage: "default"
       upload_debug_symbols: true
-      generate_sbom: ${{ matrix.build_arch == 'amd' && !matrix.malloc && !matrix.cuda && !matrix.cugraph && !startsWith(matrix.os, 'centos') }}
+      generate_sbom: ${{ matrix.build_arch == 'amd' && !matrix.malloc && !matrix.cuda && !matrix.cugraph && !startsWith(matrix.os || 'ubuntu-24.04', 'centos') }}
     secrets: inherit
 
   AggregateMAGEBuildTests:

--- a/.github/workflows/diff_mage.yml
+++ b/.github/workflows/diff_mage.yml
@@ -124,6 +124,7 @@ jobs:
     with:
       arch: amd
       build_type: RelWithDebInfo
+      build_docker_image: debug
       push_to_github: false
       push_to_s3: false
       run_tests: true

--- a/.github/workflows/package_mage.yaml
+++ b/.github/workflows/package_mage.yaml
@@ -61,7 +61,13 @@ on:
         default: ubuntu-24.04
         options:
           - ubuntu-24.04
+          - ubuntu-22.04
+          - debian-12
+          - debian-13
+          - fedora-42
           - centos-9
+          - centos-10
+          - rocky-10
 
   workflow_call:
     inputs:

--- a/.github/workflows/package_mage.yaml
+++ b/.github/workflows/package_mage.yaml
@@ -163,7 +163,7 @@ jobs:
       malloc: ${{ matrix.malloc == 'true' }}
       run_smoke_tests: ${{ matrix.run_smoke_tests == 'true' }}
       run_tests: ${{ matrix.run_tests == 'true' }}
-      package_deb: ${{ matrix.package_deb }}
+      package_mage: ${{ matrix.package_mage }}
       generate_sbom: ${{ matrix.generate_sbom == 'true' }}
       build_offline_installer: ${{ inputs.build_offline_installer == true }}
       ref: ${{ matrix.ref }}

--- a/.github/workflows/package_mage.yaml
+++ b/.github/workflows/package_mage.yaml
@@ -59,15 +59,12 @@ on:
         type: choice
         description: Target OS
         default: ubuntu-24.04
+        # Only Python-3.12 distros are currently supported (MAGE's deps are
+        # cp312-only); see tools/ci/package_mage_setup.py for the full note.
         options:
           - ubuntu-24.04
-          - ubuntu-22.04
-          - debian-12
-          - debian-13
-          - fedora-42
           - centos-9
           - centos-10
-          - rocky-10
 
   workflow_call:
     inputs:
@@ -145,7 +142,7 @@ jobs:
 
       - name: Set up package execution
         id: setup
-        run: python3 tools/ci/package_mage_setup.py --gh-context-path "$GH_CONTEXT_FILE_NAME"  #TODO: handle Linux distro
+        run: python3 tools/ci/package_mage_setup.py --gh-context-path "$GH_CONTEXT_FILE_NAME"
 
 
   BuildMage:

--- a/.github/workflows/package_mage.yaml
+++ b/.github/workflows/package_mage.yaml
@@ -157,6 +157,10 @@ jobs:
     with:
       arch: ${{ matrix.arch }}
       build_type: RelWithDebInfo
+      # All matrix values come from tools/ci/package_mage_setup.py — the workflow
+      # just passes them through. build_docker_image defaults to 'none' (rpm
+      # distros publish no MAGE image; PR builds set 'debug' for ubuntu there).
+      build_docker_image: ${{ matrix.build_docker_image || 'none' }}
       memgraph_download_link: ${{ matrix.memgraph_download_link }}
       s3_dest_dir: ${{ matrix.s3_dest_dir }}
       cuda: ${{ matrix.cuda == 'true' }}

--- a/.github/workflows/package_mage.yaml
+++ b/.github/workflows/package_mage.yaml
@@ -55,6 +55,13 @@ on:
         type: string
         description: "Branch or tag to build"
         default: ''
+      os:
+        type: choice
+        description: Target OS
+        default: ubuntu-24.04
+        options:
+          - ubuntu-24.04
+          - centos-9
 
   workflow_call:
     inputs:
@@ -106,6 +113,10 @@ on:
         type: string
         description: "Branch or tag to build"
         default: ''
+      os:
+        type: string
+        description: Target OS
+        default: ubuntu-24.04
 
 
 jobs:
@@ -128,7 +139,7 @@ jobs:
 
       - name: Set up package execution
         id: setup
-        run: python3 tools/ci/package_mage_setup.py --gh-context-path "$GH_CONTEXT_FILE_NAME"
+        run: python3 tools/ci/package_mage_setup.py --gh-context-path "$GH_CONTEXT_FILE_NAME"  #TODO: handle Linux distro
 
 
   BuildMage:
@@ -156,4 +167,5 @@ jobs:
       generate_sbom: ${{ matrix.generate_sbom == 'true' }}
       build_offline_installer: ${{ inputs.build_offline_installer == true }}
       ref: ${{ matrix.ref }}
+      os: ${{ matrix.os }}
     secrets: inherit

--- a/.github/workflows/promote_rc_release.yml
+++ b/.github/workflows/promote_rc_release.yml
@@ -562,6 +562,28 @@ jobs:
           aws s3 cp "s3://${rc_bucket}/${mage_rc_dir}/" "s3://${release_bucket}/${mage_release_dir}/ubuntu-24.04/" --recursive --exclude "*" --include "memgraph-mage*_${RELEASE_VERSION}-1_*.deb"
           echo "Copied Ubuntu 24.04 MAGE packages (main + debuginfo) to s3://${release_bucket}/${mage_release_dir}/ubuntu-24.04/"
 
+      - name: Promote MAGE rpm packages to release bucket
+        if: ${{ matrix.image_ext == '' }}
+        run: |
+          # MAGE rpms are stored flat in the RC dir with the distro encoded in
+          # the filename (memgraph-mage*-1.<distro>.<arch>.rpm — main + debuginfo).
+          # Promote each distro's rpms into the matching per-distro subdir of the
+          # release bucket, mirroring the ubuntu-24.04 deb layout above. Extend
+          # the list as new distros are enabled for MAGE.
+          for os in centos-9 centos-10; do
+            dst="s3://${release_bucket}/${mage_release_dir}/${os}/"
+            existing=$(aws s3 ls "$dst" 2>/dev/null | awk '/memgraph-mage.*\.rpm/ {print}')
+            if [[ -n "${existing}" && "$FORCE_PROMOTE" != "true" ]]; then
+              echo "MAGE rpm packages already exist under ${dst}"
+              echo "Set force_promote to true to override existing release!"
+              exit 1
+            fi
+            # --recursive copy is a no-op when a distro produced no rpm (e.g. only
+            # centos-9 was built), so missing distros are skipped gracefully.
+            aws s3 cp "s3://${rc_bucket}/${mage_rc_dir}/" "${dst}" --recursive --exclude "*" --include "memgraph-mage*-1.${os}.*.rpm"
+            echo "Copied ${os} MAGE rpms (main + debuginfo) to ${dst}"
+          done
+
       - name: Setup offline installer paths
         run: |
           offline_run_amd="memgraph-mage-offline-${RELEASE_VERSION}-amd64${{ matrix.image_ext }}.run"

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -204,13 +204,20 @@ jobs:
           fi
           echo "using wheel path: WHEEL_PATH=${WHEEL_PATH}"
           echo "MAGE_WHEEL_PATH=${WHEEL_PATH}" >> $GITHUB_ENV
-          if curl --silent --fail "http://mgdeps-cache:8000/wheels/$WHEEL_PATH/" -o /dev/null; then
-            echo "mgdeps-cache is reachable :D"
-            echo "CACHE_PRESENT=true" >> $GITHUB_ENV
-          else
-            echo "mgdeps-cache is NOT reachable"
-            echo "CACHE_PRESENT=false" >> $GITHUB_ENV
-          fi
+          # TEMPORARY: force the mgdeps-cache off so the build pulls the new
+          # wheels from the S3 "wheels-staging" prefix (via install_python_requirements.sh
+          # --staging, default true) instead of the cached copies. Revert to the
+          # curl reachability check below once the staging wheels are promoted
+          # to the usual "wheels" prefix.
+          echo "mgdeps-cache disabled (temporary: using S3 wheels-staging)"
+          echo "CACHE_PRESENT=false" >> $GITHUB_ENV
+          # if curl --silent --fail "http://mgdeps-cache:8000/wheels/$WHEEL_PATH/" -o /dev/null; then
+          #   echo "mgdeps-cache is reachable :D"
+          #   echo "CACHE_PRESENT=true" >> $GITHUB_ENV
+          # else
+          #   echo "mgdeps-cache is NOT reachable"
+          #   echo "CACHE_PRESENT=false" >> $GITHUB_ENV
+          # fi
 
       - name: Get Memgraph version
         run: |

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -512,7 +512,7 @@ jobs:
           rm -rf "$DBG_DIR"
 
       - name: Build DEB package in MGBUILD container
-        if: ${{ (inputs.push_to_github || inputs.push_to_s3) && env.PACKAGE_MAGE == 'true' && startsWith(inputs.os, 'debian-') || startsWith(inputs.os, 'ubuntu-') }}
+        if: ${{ (inputs.push_to_github || inputs.push_to_s3) && env.PACKAGE_MAGE == 'true' && (startsWith(inputs.os, 'debian-') || startsWith(inputs.os, 'ubuntu-')) }}
         run: |
           PACKAGE_ARGS="${{ inputs.malloc && '--malloc' || '' }}${{ inputs.cuda && ' --cuda' || '' }}"
           ./release/package/mgbuild.sh \
@@ -534,7 +534,7 @@ jobs:
         # RPM counterpart of the DEB step above, gated on the rpm-based distros.
         # The push-to-GitHub/S3 artifact steps for *.rpm already exist further
         # down; this step is what actually produces output/memgraph-mage*.rpm.
-        if: ${{ (inputs.push_to_github || inputs.push_to_s3) && env.PACKAGE_MAGE == 'true' && startsWith(inputs.os, 'fedora-') || startsWith(inputs.os, 'centos-') || startsWith(inputs.os, 'rocky-') }}
+        if: ${{ (inputs.push_to_github || inputs.push_to_s3) && env.PACKAGE_MAGE == 'true' && (startsWith(inputs.os, 'fedora-') || startsWith(inputs.os, 'centos-') || startsWith(inputs.os, 'rocky-')) }}
         run: |
           PACKAGE_ARGS="${{ inputs.malloc && '--malloc' || '' }}${{ inputs.cuda && ' --cuda' || '' }}"
           ./release/package/mgbuild.sh \
@@ -1017,7 +1017,7 @@ jobs:
           path: "mage/mage.tar.gz"
 
       - name: Push DEB package to GitHub
-        if: ${{ inputs.push_to_github && env.PACKAGE_MAGE == 'true' && startsWith(inputs.os, 'debian-') || startsWith(inputs.os, 'ubuntu-') }}
+        if: ${{ inputs.push_to_github && env.PACKAGE_MAGE == 'true' && (startsWith(inputs.os, 'debian-') || startsWith(inputs.os, 'ubuntu-')) }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: "${{ env.ARTIFACT_NAME }}-deb"

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -62,7 +62,7 @@ on:
         type: boolean
         description: "Run tests"
         default: false
-      package_deb:
+      package_mage:
         type: string
         description: "Build deb package (true|false|default)"
         # default is build only for Release/RelWithDebInfo + amd64/arm64 (other combinations are not actually different)
@@ -91,11 +91,15 @@ on:
         type: boolean
         description: "Selects the daily/master PR-style version (<tag>+pr<pr>~<commit>) instead of using release/get_version.py."
         default: false
+      os:
+        type: string
+        description: Target distro
+        default: ubuntu-24.04
 
 run-name: "Build and test MAGE"
 
 env:
-  OS: "${{ inputs.arch == 'arm' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}"
+  OS: "${{ inputs.os }}${{ inputs.arch == 'arm' && '-arm' || '' }}"
   ARCH: "${{ inputs.arch }}"
   DOCKER_REPOSITORY_NAME: memgraph/memgraph-mage
   BUILD_TYPE: "${{ inputs.build_type }}"
@@ -169,27 +173,27 @@ jobs:
         run: |
           ./tools/ci/pull-e2e-docker-images.sh &
 
-      - name: Check package deb build
+      - name: Check package DEB/RPM build
         env:
-          INPUT_PACKAGE_DEB: "${{ inputs.package_deb }}"
+          INPUT_PACKAGE_MAGE: "${{ inputs.package_mage }}"
         run: |
-          if [[ "$INPUT_PACKAGE_DEB" == "true" ]]; then
-            package_deb=true
-          elif [[ "$INPUT_PACKAGE_DEB" == "false" ]]; then
-            package_deb=false
+          if [[ "$INPUT_PACKAGE_MAGE" == "true" ]]; then
+            package_mage=true
+          elif [[ "$INPUT_PACKAGE_MAGE" == "false" ]]; then
+            package_mage=false
           else
             if [[ "$MALLOC" == true ]]; then
-              package_deb=false
+              package_mage=false
             else
-              package_deb=true
+              package_mage=true
             fi
           fi
-          if [[ "$package_deb" == true ]]; then
-            echo "Building deb package"
+          if [[ "$package_mage" == true ]]; then
+            echo "Building DEB/RPM package"
           else
-            echo "Not building deb package"
+            echo "Not building DEB/RPM package"
           fi
-          echo "PACKAGE_DEB=${package_deb}" >> $GITHUB_ENV
+          echo "PACKAGE_MAGE=${package_mage}" >> $GITHUB_ENV
 
       - name: Check mgdeps-cache availability
         run: |
@@ -484,7 +488,7 @@ jobs:
           rm -rf "$DBG_DIR"
 
       - name: Build DEB package in MGBUILD container
-        if: ${{ (inputs.push_to_github || inputs.push_to_s3) && env.PACKAGE_DEB == 'true' }}
+        if: ${{ (inputs.push_to_github || inputs.push_to_s3) && env.PACKAGE_MAGE == 'true' && startsWith(inputs.os, 'debian-') || startsWith(inputs.os, 'ubuntu-') }}
         run: |
           PACKAGE_ARGS="${{ inputs.malloc && '--malloc' || '' }}${{ inputs.cuda && ' --cuda' || '' }}"
           ./release/package/mgbuild.sh \
@@ -503,7 +507,7 @@ jobs:
           echo "DEB_DEBUGINFO_PACKAGE=${DEB_DEBUGINFO_PACKAGE}" >> $GITHUB_ENV
 
       - name: Build offline installer (.run) for Ubuntu 24.04
-        if: ${{ inputs.build_offline_installer && env.PACKAGE_DEB == 'true' }}
+        if: ${{ inputs.build_offline_installer && env.PACKAGE_MAGE == 'true' && startsWith(inputs.os, 'debian-') || startsWith(inputs.os, 'ubuntu-') }}
         run: |
           SUFFIX=""
           [[ "$MALLOC" == "true" ]]               && SUFFIX="${SUFFIX}-malloc"
@@ -593,7 +597,7 @@ jobs:
           stop --remove
 
       - name: "Build image (prod)"
-        if: ${{ env.BUILD_DOCKER_IMAGE == 'prod' || env.BUILD_DOCKER_IMAGE == 'both' }}
+        if: ${{ (env.BUILD_DOCKER_IMAGE == 'prod' || env.BUILD_DOCKER_IMAGE == 'both') && startsWith(inputs.os, 'debian-') || startsWith(inputs.os, 'ubuntu-') }}
         run: |
           ./release/package/mgbuild.sh \
             --toolchain $TOOLCHAIN \
@@ -611,7 +615,7 @@ jobs:
             --package-flavour prod
 
       - name: "Build image (debug)"
-        if: ${{ env.BUILD_DOCKER_IMAGE == 'debug' || env.BUILD_DOCKER_IMAGE == 'both' }}
+        if: ${{ (env.BUILD_DOCKER_IMAGE == 'debug' || env.BUILD_DOCKER_IMAGE == 'both') && startsWith(inputs.os, 'debian-') || startsWith(inputs.os, 'ubuntu-') }}
         run: |
           ./release/package/mgbuild.sh \
             --toolchain $TOOLCHAIN \
@@ -919,11 +923,18 @@ jobs:
           path: "mage/mage.tar.gz"
 
       - name: Push DEB package to GitHub
-        if: ${{ inputs.push_to_github && env.PACKAGE_DEB == 'true' }}
+        if: ${{ inputs.push_to_github && env.PACKAGE_MAGE == 'true' && startsWith(inputs.os, 'debian-') || startsWith(inputs.os, 'ubuntu-') }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: "${{ env.ARTIFACT_NAME }}-deb"
           path: "output/memgraph-mage*.deb"
+
+      - name: Push RPM package to GitHub
+        if: ${{ inputs.push_to_github && env.PACKAGE_MAGE == 'true' && startsWith(inputs.os, 'fedora-') || startsWith(inputs.os, 'centos-') || startsWith(inputs.os, 'rocky-') }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        with:
+          name: "${{ env.ARTIFACT_NAME }}-deb"
+          path: "output/memgraph-mage*.rpm"
 
       - name: Push docker image to GitHub
         if: ${{ inputs.push_to_github && env.BUILD_DOCKER_IMAGE != 'none' }}

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -564,7 +564,7 @@ jobs:
           echo "RPM_DEBUGINFO_PACKAGE=${RPM_DEBUGINFO_PACKAGE}" >> $GITHUB_ENV
 
       - name: Build offline installer (.run) for Ubuntu 24.04
-        if: ${{ inputs.build_offline_installer && env.PACKAGE_MAGE == 'true' && startsWith(inputs.os, 'debian-') || startsWith(inputs.os, 'ubuntu-') }}
+        if: ${{ inputs.build_offline_installer && env.PACKAGE_MAGE == 'true' && inputs.os = 'ubuntu-24.04' && inputs.arch = 'amd' }}
         run: |
           SUFFIX=""
           [[ "$MALLOC" == "true" ]]               && SUFFIX="${SUFFIX}-malloc"
@@ -654,7 +654,7 @@ jobs:
           stop --remove
 
       - name: "Build image (prod)"
-        if: ${{ (env.BUILD_DOCKER_IMAGE == 'prod' || env.BUILD_DOCKER_IMAGE == 'both') && startsWith(inputs.os, 'debian-') || startsWith(inputs.os, 'ubuntu-') }}
+        if: ${{ (env.BUILD_DOCKER_IMAGE == 'prod' || env.BUILD_DOCKER_IMAGE == 'both') && inputs.os = 'ubuntu24.04' }}
         run: |
           ./release/package/mgbuild.sh \
             --toolchain $TOOLCHAIN \
@@ -672,7 +672,7 @@ jobs:
             --package-flavour prod
 
       - name: "Build image (debug)"
-        if: ${{ (env.BUILD_DOCKER_IMAGE == 'debug' || env.BUILD_DOCKER_IMAGE == 'both') && startsWith(inputs.os, 'debian-') || startsWith(inputs.os, 'ubuntu-') }}
+        if: ${{ (env.BUILD_DOCKER_IMAGE == 'debug' || env.BUILD_DOCKER_IMAGE == 'both') && inputs.os = 'ubuntu24.04' }}
         run: |
           ./release/package/mgbuild.sh \
             --toolchain $TOOLCHAIN \

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -654,7 +654,7 @@ jobs:
           stop --remove
 
       - name: "Build image (prod)"
-        if: ${{ (env.BUILD_DOCKER_IMAGE == 'prod' || env.BUILD_DOCKER_IMAGE == 'both') && inputs.os = 'ubuntu24.04' }}
+        if: ${{ (env.BUILD_DOCKER_IMAGE == 'prod' || env.BUILD_DOCKER_IMAGE == 'both') && inputs.os == 'ubuntu24.04' }}
         run: |
           ./release/package/mgbuild.sh \
             --toolchain $TOOLCHAIN \
@@ -672,7 +672,7 @@ jobs:
             --package-flavour prod
 
       - name: "Build image (debug)"
-        if: ${{ (env.BUILD_DOCKER_IMAGE == 'debug' || env.BUILD_DOCKER_IMAGE == 'both') && inputs.os = 'ubuntu24.04' }}
+        if: ${{ (env.BUILD_DOCKER_IMAGE == 'debug' || env.BUILD_DOCKER_IMAGE == 'both') && inputs.os == 'ubuntu24.04' }}
         run: |
           ./release/package/mgbuild.sh \
             --toolchain $TOOLCHAIN \

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -506,6 +506,30 @@ jobs:
           DEB_DEBUGINFO_PACKAGE="$(ls output/memgraph-mage-debuginfo_*.deb 2>/dev/null | head -n 1 || true)"
           echo "DEB_DEBUGINFO_PACKAGE=${DEB_DEBUGINFO_PACKAGE}" >> $GITHUB_ENV
 
+      - name: Build RPM package in MGBUILD container
+        # RPM counterpart of the DEB step above, gated on the rpm-based distros.
+        # The push-to-GitHub/S3 artifact steps for *.rpm already exist further
+        # down; this step is what actually produces output/memgraph-mage*.rpm.
+        if: ${{ (inputs.push_to_github || inputs.push_to_s3) && env.PACKAGE_MAGE == 'true' && startsWith(inputs.os, 'fedora-') || startsWith(inputs.os, 'centos-') || startsWith(inputs.os, 'rocky-') }}
+        run: |
+          PACKAGE_ARGS="${{ inputs.malloc && '--malloc' || '' }}${{ inputs.cuda && ' --cuda' || '' }}"
+          ./release/package/mgbuild.sh \
+            --toolchain $TOOLCHAIN \
+            --os "$OS" \
+            --arch $ARCH \
+            --build-type $BUILD_TYPE \
+            --cugraph $CUGRAPH \
+            package-mage-rpm \
+            --version $MEMGRAPH_VERSION \
+            $PACKAGE_ARGS
+
+          # memgraph-mage-[0-9]* matches the main package; excludes the
+          # memgraph-mage-debuginfo-*.rpm sidecar package.
+          RPM_PACKAGE="$(ls output/memgraph-mage-[0-9]*.rpm | head -n 1)"
+          echo "RPM_PACKAGE=${RPM_PACKAGE}" >> $GITHUB_ENV
+          RPM_DEBUGINFO_PACKAGE="$(ls output/memgraph-mage-debuginfo-*.rpm 2>/dev/null | head -n 1 || true)"
+          echo "RPM_DEBUGINFO_PACKAGE=${RPM_DEBUGINFO_PACKAGE}" >> $GITHUB_ENV
+
       - name: Build offline installer (.run) for Ubuntu 24.04
         if: ${{ inputs.build_offline_installer && env.PACKAGE_MAGE == 'true' && startsWith(inputs.os, 'debian-') || startsWith(inputs.os, 'ubuntu-') }}
         run: |
@@ -933,7 +957,7 @@ jobs:
         if: ${{ inputs.push_to_github && env.PACKAGE_MAGE == 'true' && startsWith(inputs.os, 'fedora-') || startsWith(inputs.os, 'centos-') || startsWith(inputs.os, 'rocky-') }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
-          name: "${{ env.ARTIFACT_NAME }}-deb"
+          name: "${{ env.ARTIFACT_NAME }}-rpm"
           path: "output/memgraph-mage*.rpm"
 
       - name: Push docker image to GitHub

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -385,6 +385,20 @@ jobs:
           copy \
           --sbom
 
+      - name: Build Query Modules in MGBUILD container
+        run: |
+          SPLIT_DEBUG_ARG=""
+          if [[ "$SPLIT_DEBUG" == "true" ]]; then
+            SPLIT_DEBUG_ARG="--split-debug"
+          fi
+          ./release/package/mgbuild.sh \
+          --toolchain $TOOLCHAIN \
+          --os "$OS" \
+          --arch $ARCH \
+          --build-type $BUILD_TYPE \
+          --cugraph $CUGRAPH \
+          build-mage $SPLIT_DEBUG_ARG
+
       - name: "Build heaptrack"
         if: ${{ inputs.build_type == 'RelWithDebInfo' && (env.BUILD_DOCKER_IMAGE == 'debug' || env.BUILD_DOCKER_IMAGE == 'both') }}
         run: |
@@ -442,20 +456,6 @@ jobs:
             --build-type $BUILD_TYPE \
             --cugraph $CUGRAPH \
             build-gssapi
-
-      - name: Build Query Modules in MGBUILD container
-        run: |
-          SPLIT_DEBUG_ARG=""
-          if [[ "$SPLIT_DEBUG" == "true" ]]; then
-            SPLIT_DEBUG_ARG="--split-debug"
-          fi
-          ./release/package/mgbuild.sh \
-          --toolchain $TOOLCHAIN \
-          --os "$OS" \
-          --arch $ARCH \
-          --build-type $BUILD_TYPE \
-          --cugraph $CUGRAPH \
-          build-mage $SPLIT_DEBUG_ARG
 
       - name: Upload debug symbols
         if: ${{ inputs.upload_debug_symbols && env.SPLIT_DEBUG == 'true' }}

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -564,7 +564,7 @@ jobs:
           echo "RPM_DEBUGINFO_PACKAGE=${RPM_DEBUGINFO_PACKAGE}" >> $GITHUB_ENV
 
       - name: Build offline installer (.run) for Ubuntu 24.04
-        if: ${{ inputs.build_offline_installer && env.PACKAGE_MAGE == 'true' && inputs.os = 'ubuntu-24.04' && inputs.arch = 'amd' }}
+        if: ${{ inputs.build_offline_installer && env.PACKAGE_MAGE == 'true' && inputs.os == 'ubuntu-24.04' && inputs.arch == 'amd' }}
         run: |
           SUFFIX=""
           [[ "$MALLOC" == "true" ]]               && SUFFIX="${SUFFIX}-malloc"

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -356,7 +356,7 @@ jobs:
           # of the prod deb. Stage the companion sidecar deb when either
           # docker variant needs it; the relwithdebinfo Dockerfile target
           # consumes it from mage/memgraph-debuginfo.deb.
-          if [[ "$BUILD_DOCKER_IMAGE" == "debug" || "$BUILD_DOCKER_IMAGE" == "both" ]]; then
+          if [[ "$BUILD_DOCKER_IMAGE" == "debug" || "$BUILD_DOCKER_IMAGE" == "both" && "$OS" == ubuntu-* ]]; then
             debuginfo_deb=$(ls -1 "$MG_PACKAGE_ARTIFACT_DIR"/memgraph-debuginfo_*.deb 2>/dev/null | head -n 1)
             if [[ -z "$debuginfo_deb" ]]; then
               echo "Error: building the relwithdebinfo MAGE docker image requires a memgraph-debuginfo deb in $MG_PACKAGE_ARTIFACT_DIR" >&2

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -262,7 +262,14 @@ jobs:
       - name: Download Memgraph package
         if: ${{ inputs.memgraph_download_link != '' }}
         run: |
-          wget -O mage/memgraph.deb "$MEMGRAPH_DOWNLOAD_LINK"
+          # rpm distros need the base package staged as mage/memgraph.rpm for the
+          # centos-9 smoke image; deb distros keep mage/memgraph.deb for the
+          # docker build / offline installer.
+          if [[ "$OS" == ubuntu-* || "$OS" == debian-* ]]; then
+            wget -O mage/memgraph.deb "$MEMGRAPH_DOWNLOAD_LINK"
+          else
+            wget -O mage/memgraph.rpm "$MEMGRAPH_DOWNLOAD_LINK"
+          fi
           echo "Memgraph package downloaded"
           if [[ -n "$MEMGRAPH_DEBUGINFO_DOWNLOAD_LINK" ]]; then
             wget -O mage/memgraph-debuginfo.deb "$MEMGRAPH_DEBUGINFO_DOWNLOAD_LINK"
@@ -371,6 +378,16 @@ jobs:
                 exit 1
               fi
               mv -v "$debuginfo_deb" mage/memgraph-debuginfo.deb
+            fi
+          else
+            # rpm distros: stage the base memgraph rpm as mage/memgraph.rpm for
+            # the centos-9 smoke image (Dockerfile.centos-9). Copy rather than
+            # move so the package stays in $MG_PACKAGE_ARTIFACT_DIR. The base
+            # rpm is memgraph-<version>... ; the -debuginfo rpm is excluded by
+            # the [0-9] after the dash.
+            base_rpm=$(ls -1 "$MG_PACKAGE_ARTIFACT_DIR"/memgraph-[0-9]*.rpm 2>/dev/null | head -n 1)
+            if [[ -n "$base_rpm" ]]; then
+              cp -v "$base_rpm" mage/memgraph.rpm
             fi
           fi
 
@@ -665,6 +682,27 @@ jobs:
             --cuda $CUDA \
             --package-flavour debug
 
+      - name: "Build centos-9 smoke image"
+        # centos-9 publishes no MAGE docker image; build a throwaway local image
+        # from the rpms (base memgraph + memgraph-mage) so the Docker smoke-test
+        # framework can exercise the rpm install path. Never pushed. The base
+        # memgraph rpm was staged to mage/memgraph.rpm by the Copy/Download step;
+        # the memgraph-mage rpm comes from the Build RPM package step.
+        if: ${{ inputs.run_smoke_tests && inputs.os == 'centos-9' && !inputs.cugraph && !inputs.cuda }}
+        run: |
+          set -euo pipefail
+          if [[ ! -f mage/memgraph.rpm ]]; then
+            echo "Error: mage/memgraph.rpm not staged — cannot build centos-9 smoke image" >&2
+            exit 1
+          fi
+          mage_rpm="$(ls -t output/memgraph-mage-[0-9]*.rpm | head -n 1)"
+          cp -v "$mage_rpm" mage/memgraph-mage.rpm
+          # BuildKit required: Dockerfile.centos-9 uses RUN --mount=type=bind.
+          DOCKER_BUILDKIT=1 docker build \
+            -f mage/Dockerfile.centos-9 \
+            -t "${DOCKER_REPOSITORY_NAME}:${PROD_IMAGE_TAG}-centos-9" \
+            mage
+
       - name: "Bolt smoke test (prod)"
         if: ${{ !inputs.cugraph && !inputs.cuda && (env.BUILD_DOCKER_IMAGE == 'prod' || env.BUILD_DOCKER_IMAGE == 'both') }}
         run: |
@@ -947,6 +985,21 @@ jobs:
             test-mage smoke \
             --next-image "${DOCKER_REPOSITORY_NAME}:${DEBUG_IMAGE_TAG}" \
             --last-image "${DOCKER_REPOSITORY_NAME}:${LAST_DEBUG_VERSION}"
+
+      - name: "Run Docker smoke tests (centos-9)"
+        # Smoke the freshly-built centos-9 rpm image (next) against the usual
+        # published prod image (last) — there is no prior centos-9 image to diff
+        # against, so the standard prod image stands in as the baseline.
+        if: ${{ inputs.run_smoke_tests && inputs.os == 'centos-9' && !inputs.cugraph && !inputs.cuda }}
+        run: |
+          docker pull "${DOCKER_REPOSITORY_NAME}:${LAST_PROD_VERSION}"
+          ./release/package/mgbuild.sh \
+            --toolchain $TOOLCHAIN \
+            --os $OS \
+            --arch $ARCH \
+            test-mage smoke \
+            --next-image "${DOCKER_REPOSITORY_NAME}:${PROD_IMAGE_TAG}-centos-9" \
+            --last-image "${DOCKER_REPOSITORY_NAME}:${LAST_PROD_VERSION}"
 
       - name: Push query module archive to GitHub
         if: ${{ inputs.push_to_github }}

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -351,19 +351,27 @@ jobs:
           --package \
           --dest-dir $MG_PACKAGE_ARTIFACT_DIR
 
-          mv -v "$MG_PACKAGE_ARTIFACT_DIR"/memgraph_*.deb mage/memgraph.deb
-          # Debug-flavoured docker images install memgraph-debuginfo on top
-          # of the prod deb. Stage the companion sidecar deb when either
-          # docker variant needs it; the relwithdebinfo Dockerfile target
-          # consumes it from mage/memgraph-debuginfo.deb.
-          if [[ ("$BUILD_DOCKER_IMAGE" == "debug" || "$BUILD_DOCKER_IMAGE" == "both") && "$OS" == ubuntu-* ]]; then
-            debuginfo_deb=$(ls -1 "$MG_PACKAGE_ARTIFACT_DIR"/memgraph-debuginfo_*.deb 2>/dev/null | head -n 1)
-            if [[ -z "$debuginfo_deb" ]]; then
-              echo "Error: building the relwithdebinfo MAGE docker image requires a memgraph-debuginfo deb in $MG_PACKAGE_ARTIFACT_DIR" >&2
-              echo "       (memgraph must build with --split-debug — should always be true under RelWithDebInfo)" >&2
-              exit 1
+          # Stage the base memgraph package as mage/memgraph.deb for the
+          # downstream MAGE docker build and the offline installer. Both only
+          # run on deb-based distros; on rpm distros (centos/fedora/rocky) the
+          # base package is an .rpm and isn't consumed here — package-mage-rpm
+          # only declares `Requires: memgraph`, it doesn't bundle it — so skip
+          # this staging entirely rather than failing on a missing *.deb glob.
+          if [[ "$OS" == ubuntu-* || "$OS" == debian-* ]]; then
+            mv -v "$MG_PACKAGE_ARTIFACT_DIR"/memgraph_*.deb mage/memgraph.deb
+            # Debug-flavoured docker images install memgraph-debuginfo on top
+            # of the prod deb. Stage the companion sidecar deb when either
+            # docker variant needs it; the relwithdebinfo Dockerfile target
+            # consumes it from mage/memgraph-debuginfo.deb.
+            if [[ ("$BUILD_DOCKER_IMAGE" == "debug" || "$BUILD_DOCKER_IMAGE" == "both") && "$OS" == ubuntu-* ]]; then
+              debuginfo_deb=$(ls -1 "$MG_PACKAGE_ARTIFACT_DIR"/memgraph-debuginfo_*.deb 2>/dev/null | head -n 1)
+              if [[ -z "$debuginfo_deb" ]]; then
+                echo "Error: building the relwithdebinfo MAGE docker image requires a memgraph-debuginfo deb in $MG_PACKAGE_ARTIFACT_DIR" >&2
+                echo "       (memgraph must build with --split-debug — should always be true under RelWithDebInfo)" >&2
+                exit 1
+              fi
+              mv -v "$debuginfo_deb" mage/memgraph-debuginfo.deb
             fi
-            mv -v "$debuginfo_deb" mage/memgraph-debuginfo.deb
           fi
 
       - name: "Copy SBOM"

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -371,7 +371,7 @@ jobs:
             # of the prod deb. Stage the companion sidecar deb when either
             # docker variant needs it; the relwithdebinfo Dockerfile target
             # consumes it from mage/memgraph-debuginfo.deb.
-            if [[ ("$BUILD_DOCKER_IMAGE" == "debug" || "$BUILD_DOCKER_IMAGE" == "both") && "$OS" == "ubuntu-24.04" ]]; then
+            if [[ ("$BUILD_DOCKER_IMAGE" == "debug" || "$BUILD_DOCKER_IMAGE" == "both") && "$OS" == ubuntu-24.04* ]]; then
               debuginfo_deb=$(ls -1 "$MG_PACKAGE_ARTIFACT_DIR"/memgraph-debuginfo_*.deb 2>/dev/null | head -n 1)
               if [[ -z "$debuginfo_deb" ]]; then
                 echo "Error: building the relwithdebinfo MAGE docker image requires a memgraph-debuginfo deb in $MG_PACKAGE_ARTIFACT_DIR" >&2
@@ -512,7 +512,7 @@ jobs:
           rm -rf "$DBG_DIR"
 
       - name: Build DEB package in MGBUILD container
-        if: ${{ (inputs.push_to_github || inputs.push_to_s3) && env.PACKAGE_MAGE == 'true' && (startsWith(inputs.os, 'debian-') || startsWith(inputs.os, 'ubuntu-')) }}
+        if: ${{ env.PACKAGE_MAGE == 'true' && (startsWith(inputs.os, 'debian-') || startsWith(inputs.os, 'ubuntu-')) }}
         run: |
           PACKAGE_ARGS="${{ inputs.malloc && '--malloc' || '' }}${{ inputs.cuda && ' --cuda' || '' }}"
           ./release/package/mgbuild.sh \
@@ -531,10 +531,7 @@ jobs:
           echo "DEB_DEBUGINFO_PACKAGE=${DEB_DEBUGINFO_PACKAGE}" >> $GITHUB_ENV
 
       - name: Build RPM package in MGBUILD container
-        # RPM counterpart of the DEB step above, gated on the rpm-based distros.
-        # The push-to-GitHub/S3 artifact steps for *.rpm already exist further
-        # down; this step is what actually produces output/memgraph-mage*.rpm.
-        if: ${{ (inputs.push_to_github || inputs.push_to_s3) && env.PACKAGE_MAGE == 'true' && (startsWith(inputs.os, 'fedora-') || startsWith(inputs.os, 'centos-') || startsWith(inputs.os, 'rocky-')) }}
+        if: ${{ env.PACKAGE_MAGE == 'true' && (startsWith(inputs.os, 'fedora-') || startsWith(inputs.os, 'centos-') || startsWith(inputs.os, 'rocky-')) }}
         run: |
           PACKAGE_ARGS="${{ inputs.malloc && '--malloc' || '' }}${{ inputs.cuda && ' --cuda' || '' }}"
           ./release/package/mgbuild.sh \

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -408,6 +408,7 @@ jobs:
           --dest-dir "$(pwd)/mage"
 
       - name: "Build OpenSSL"
+        if: ${{ inputs.build_docker_image != 'none' }}
         run: |
           # This step is necessary so that we can build custom packages of OpenSSL and libssl3 for
           # the Docker images. These packages will be installed by apt, and as long as the remote

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -364,18 +364,14 @@ jobs:
           --dest-dir $MG_PACKAGE_ARTIFACT_DIR
 
           # Stage the base memgraph package as mage/memgraph.deb for the
-          # downstream MAGE docker build and the offline installer. Both only
-          # run on deb-based distros; on rpm distros (centos/fedora/rocky) the
-          # base package is an .rpm and isn't consumed here — package-mage-rpm
-          # only declares `Requires: memgraph`, it doesn't bundle it — so skip
-          # this staging entirely rather than failing on a missing *.deb glob.
+          # downstream MAGE docker build and the offline installer.
           if [[ "$OS" == ubuntu-* || "$OS" == debian-* ]]; then
             mv -v "$MG_PACKAGE_ARTIFACT_DIR"/memgraph_*.deb mage/memgraph.deb
             # Debug-flavoured docker images install memgraph-debuginfo on top
             # of the prod deb. Stage the companion sidecar deb when either
             # docker variant needs it; the relwithdebinfo Dockerfile target
             # consumes it from mage/memgraph-debuginfo.deb.
-            if [[ ("$BUILD_DOCKER_IMAGE" == "debug" || "$BUILD_DOCKER_IMAGE" == "both") && "$OS" == ubuntu-* ]]; then
+            if [[ ("$BUILD_DOCKER_IMAGE" == "debug" || "$BUILD_DOCKER_IMAGE" == "both") && "$OS" == "ubuntu-24.04" ]]; then
               debuginfo_deb=$(ls -1 "$MG_PACKAGE_ARTIFACT_DIR"/memgraph-debuginfo_*.deb 2>/dev/null | head -n 1)
               if [[ -z "$debuginfo_deb" ]]; then
                 echo "Error: building the relwithdebinfo MAGE docker image requires a memgraph-debuginfo deb in $MG_PACKAGE_ARTIFACT_DIR" >&2
@@ -386,10 +382,7 @@ jobs:
             fi
           else
             # rpm distros: stage the base memgraph rpm as mage/memgraph.rpm for
-            # the centos-9 smoke image (Dockerfile.centos-9). Copy rather than
-            # move so the package stays in $MG_PACKAGE_ARTIFACT_DIR. The base
-            # rpm is memgraph-<version>... ; the -debuginfo rpm is excluded by
-            # the [0-9] after the dash.
+            # the rpm smoke image (Dockerfile.rpm).
             base_rpm=$(ls -1 "$MG_PACKAGE_ARTIFACT_DIR"/memgraph-[0-9]*.rpm 2>/dev/null | head -n 1)
             if [[ -n "$base_rpm" ]]; then
               cp -v "$base_rpm" mage/memgraph.rpm
@@ -687,25 +680,35 @@ jobs:
             --cuda $CUDA \
             --package-flavour debug
 
-      - name: "Build centos-9 smoke image"
-        # centos-9 publishes no MAGE docker image; build a throwaway local image
+      - name: "Build rpm smoke image"
+        # rpm distros publish no MAGE docker image; build a throwaway local image
         # from the rpms (base memgraph + memgraph-mage) so the Docker smoke-test
         # framework can exercise the rpm install path. Never pushed. The base
         # memgraph rpm was staged to mage/memgraph.rpm by the Copy/Download step;
         # the memgraph-mage rpm comes from the Build RPM package step.
-        if: ${{ inputs.run_smoke_tests && inputs.os == 'centos-9' && !inputs.cugraph && !inputs.cuda }}
+        if: ${{ inputs.run_smoke_tests && startsWith(inputs.os, 'centos') && !inputs.cugraph && !inputs.cuda }}
         run: |
           set -euo pipefail
+          # Map the distro to its base image and the python version the modules
+          # need. PY_VERSION empty => distro-default python3; centos-9 ships 3.9
+          # but memgraph there embeds 3.12, so it needs an explicit 3.12.
+          case "$OS" in
+            centos-9)  base_image="quay.io/centos/centos:stream9";  py_version="3.12" ;;
+            centos-10) base_image="quay.io/centos/centos:stream10"; py_version="" ;;
+            *) echo "Error: no rpm smoke base-image mapping for OS '$OS'" >&2; exit 1 ;;
+          esac
           if [[ ! -f mage/memgraph.rpm ]]; then
-            echo "Error: mage/memgraph.rpm not staged — cannot build centos-9 smoke image" >&2
+            echo "Error: mage/memgraph.rpm not staged — cannot build rpm smoke image" >&2
             exit 1
           fi
           mage_rpm="$(ls -t output/memgraph-mage-[0-9]*.rpm | head -n 1)"
           cp -v "$mage_rpm" mage/memgraph-mage.rpm
-          # BuildKit required: Dockerfile.centos-9 uses RUN --mount=type=bind.
+          # BuildKit required: Dockerfile.rpm uses RUN --mount=type=bind.
           DOCKER_BUILDKIT=1 docker build \
-            -f mage/Dockerfile.centos-9 \
-            -t "${DOCKER_REPOSITORY_NAME}:${PROD_IMAGE_TAG}-centos-9" \
+            -f mage/Dockerfile.rpm \
+            --build-arg BASE_IMAGE="$base_image" \
+            --build-arg PY_VERSION="$py_version" \
+            -t "${DOCKER_REPOSITORY_NAME}:${PROD_IMAGE_TAG}-${OS}" \
             mage
 
       - name: "Bolt smoke test (prod)"
@@ -991,11 +994,11 @@ jobs:
             --next-image "${DOCKER_REPOSITORY_NAME}:${DEBUG_IMAGE_TAG}" \
             --last-image "${DOCKER_REPOSITORY_NAME}:${LAST_DEBUG_VERSION}"
 
-      - name: "Run Docker smoke tests (centos-9)"
-        # Smoke the freshly-built centos-9 rpm image (next) against the usual
-        # published prod image (last) — there is no prior centos-9 image to diff
-        # against, so the standard prod image stands in as the baseline.
-        if: ${{ inputs.run_smoke_tests && inputs.os == 'centos-9' && !inputs.cugraph && !inputs.cuda }}
+      - name: "Run Docker smoke tests (rpm)"
+        # Smoke the freshly-built rpm image (next) against the usual published
+        # prod image (last) — there is no prior rpm image to diff against, so the
+        # standard prod image stands in as the baseline.
+        if: ${{ inputs.run_smoke_tests && startsWith(inputs.os, 'centos') && !inputs.cugraph && !inputs.cuda }}
         run: |
           docker pull "${DOCKER_REPOSITORY_NAME}:${LAST_PROD_VERSION}"
           ./release/package/mgbuild.sh \
@@ -1003,7 +1006,7 @@ jobs:
             --os $OS \
             --arch $ARCH \
             test-mage smoke \
-            --next-image "${DOCKER_REPOSITORY_NAME}:${PROD_IMAGE_TAG}-centos-9" \
+            --next-image "${DOCKER_REPOSITORY_NAME}:${PROD_IMAGE_TAG}-${OS}" \
             --last-image "${DOCKER_REPOSITORY_NAME}:${LAST_PROD_VERSION}"
 
       - name: Push query module archive to GitHub

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -202,22 +202,20 @@ jobs:
             echo "Using wheels build for CUDA"
             WHEEL_PATH="cuda-13.0/${WHEEL_PATH}"
           fi
+          # Wheels live under a dated prefix wheels/<date>/<arch>/ (portable
+          # manylinux builds). Keep WHEELS_DATE in sync with the one in
+          # mage/install_python_requirements.sh.
+          WHEELS_DATE="2026-06-25"
+          WHEEL_PATH="${WHEELS_DATE}/${WHEEL_PATH}"
           echo "using wheel path: WHEEL_PATH=${WHEEL_PATH}"
           echo "MAGE_WHEEL_PATH=${WHEEL_PATH}" >> $GITHUB_ENV
-          # TEMPORARY: force the mgdeps-cache off so the build pulls the new
-          # wheels from the S3 "wheels-staging" prefix (via install_python_requirements.sh
-          # --staging, default true) instead of the cached copies. Revert to the
-          # curl reachability check below once the staging wheels are promoted
-          # to the usual "wheels" prefix.
-          echo "mgdeps-cache disabled (temporary: using S3 wheels-staging)"
-          echo "CACHE_PRESENT=false" >> $GITHUB_ENV
-          # if curl --silent --fail "http://mgdeps-cache:8000/wheels/$WHEEL_PATH/" -o /dev/null; then
-          #   echo "mgdeps-cache is reachable :D"
-          #   echo "CACHE_PRESENT=true" >> $GITHUB_ENV
-          # else
-          #   echo "mgdeps-cache is NOT reachable"
-          #   echo "CACHE_PRESENT=false" >> $GITHUB_ENV
-          # fi
+          if curl --silent --fail "http://mgdeps-cache:8000/wheels/$WHEEL_PATH/" -o /dev/null; then
+            echo "mgdeps-cache is reachable :D"
+            echo "CACHE_PRESENT=true" >> $GITHUB_ENV
+          else
+            echo "mgdeps-cache is NOT reachable"
+            echo "CACHE_PRESENT=false" >> $GITHUB_ENV
+          fi
 
       - name: Get Memgraph version
         run: |

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -654,7 +654,7 @@ jobs:
           stop --remove
 
       - name: "Build image (prod)"
-        if: ${{ (env.BUILD_DOCKER_IMAGE == 'prod' || env.BUILD_DOCKER_IMAGE == 'both') && inputs.os == 'ubuntu24.04' }}
+        if: ${{ (env.BUILD_DOCKER_IMAGE == 'prod' || env.BUILD_DOCKER_IMAGE == 'both') && inputs.os == 'ubuntu-24.04' }}
         run: |
           ./release/package/mgbuild.sh \
             --toolchain $TOOLCHAIN \
@@ -672,7 +672,7 @@ jobs:
             --package-flavour prod
 
       - name: "Build image (debug)"
-        if: ${{ (env.BUILD_DOCKER_IMAGE == 'debug' || env.BUILD_DOCKER_IMAGE == 'both') && inputs.os == 'ubuntu24.04' }}
+        if: ${{ (env.BUILD_DOCKER_IMAGE == 'debug' || env.BUILD_DOCKER_IMAGE == 'both') && inputs.os == 'ubuntu-24.04' }}
         run: |
           ./release/package/mgbuild.sh \
             --toolchain $TOOLCHAIN \

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -356,7 +356,7 @@ jobs:
           # of the prod deb. Stage the companion sidecar deb when either
           # docker variant needs it; the relwithdebinfo Dockerfile target
           # consumes it from mage/memgraph-debuginfo.deb.
-          if [[ "$BUILD_DOCKER_IMAGE" == "debug" || "$BUILD_DOCKER_IMAGE" == "both" && "$OS" == ubuntu-* ]]; then
+          if [[ ("$BUILD_DOCKER_IMAGE" == "debug" || "$BUILD_DOCKER_IMAGE" == "both") && "$OS" == ubuntu-* ]]; then
             debuginfo_deb=$(ls -1 "$MG_PACKAGE_ARTIFACT_DIR"/memgraph-debuginfo_*.deb 2>/dev/null | head -n 1)
             if [[ -z "$debuginfo_deb" ]]; then
               echo "Error: building the relwithdebinfo MAGE docker image requires a memgraph-debuginfo deb in $MG_PACKAGE_ARTIFACT_DIR" >&2

--- a/environment/os/centos-9.sh
+++ b/environment/os/centos-9.sh
@@ -57,7 +57,13 @@ MEMGRAPH_BUILD_DEPS=(
     wget # for downloading libs
     libuuid-devel java-11-openjdk # required by antlr
     readline-devel # for memgraph console
-    python3-devel # for query modules
+    # MAGE's query-module python deps (torch/PyG/DGL wheels) are python 3.12
+    # only, so memgraph embeds python 3.12 here (built with
+    # -DMG_PYTHON_VERSION=3.12) rather than the distro-default 3.9. Needs the
+    # 3.12 dev headers/libs to link against, plus the interpreter + pip to
+    # install the module deps at package time.
+    python3.12-devel python3.12 python3.12-pip # for query modules
+    python3-devel # for build tooling that still targets the system python
     openssl-devel
     libseccomp-devel
     python3 python3-pip python3-virtualenv nmap-ncat # for qa, macro_benchmark and stress tests
@@ -82,6 +88,7 @@ MEMGRAPH_TEST_DEPS="${MEMGRAPH_BUILD_DEPS[*]}"
 
 MEMGRAPH_RUN_DEPS=(
     logrotate openssl python3 libseccomp
+    python3.12 # embedded interpreter for query modules (see MEMGRAPH_BUILD_DEPS)
     krb5-libs # runtime for python gssapi (kerberos auth module)
 )
 

--- a/mage/Dockerfile.centos-9
+++ b/mage/Dockerfile.centos-9
@@ -17,7 +17,9 @@ USER root
 # installed under 3.12. Stage the 3.12 interpreter/pip plus the build deps the
 # full requirements install needs — gssapi (kerberos auth module) has no PyPI
 # wheel and is compiled from source, needing gcc + krb5-devel + the 3.12 dev
-# headers.
+# headers. unixODBC provides libodbc.so.2, which pyodbc (imported by the
+# cross_database module) loads at runtime — the prod/debug images install the
+# equivalent via install_runtime_requirements.sh.
 #
 # Then install the base memgraph package and the MAGE package together so dnf
 # orders them (memgraph first, since memgraph-mage Requires it) and resolves the
@@ -31,7 +33,8 @@ RUN --mount=type=bind,source=./memgraph.rpm,target=/packages/memgraph.rpm,ro \
     --mount=type=bind,source=./memgraph-mage.rpm,target=/packages/memgraph-mage.rpm,ro \
   export PIP_BREAK_SYSTEM_PACKAGES=1 && \
   dnf install -y --setopt=tsflags='' \
-    python3.12 python3.12-pip python3.12-devel gcc gcc-c++ krb5-devel && \
+    python3.12 python3.12-pip python3.12-devel gcc gcc-c++ krb5-devel \
+    unixODBC && \
   dnf install -y --setopt=tsflags='' \
     /packages/memgraph.rpm /packages/memgraph-mage.rpm && \
   dnf clean all && rm -rf /var/cache/dnf

--- a/mage/Dockerfile.centos-9
+++ b/mage/Dockerfile.centos-9
@@ -1,0 +1,42 @@
+# Minimal CentOS Stream 9 image for running MAGE smoke tests against the RPM
+# packages. This is NOT a production image and is never published — it exists
+# only so the smoke-test framework (which drives a Docker image) can exercise
+# the memgraph + memgraph-mage RPMs on an rpm-based distro. The build context
+# is the mage/ directory, mirroring Dockerfile.release.
+#
+# Expects two RPMs staged into the build context under fixed names (as
+# Dockerfile.release does with ./memgraph.deb):
+#   ./memgraph.rpm        - the base memgraph package
+#   ./memgraph-mage.rpm   - the MAGE query-modules package built by build-rpm.sh
+FROM quay.io/centos/centos:stream9 AS base
+
+USER root
+
+# Install the base memgraph package and the MAGE package together so dnf orders
+# them (memgraph first, since memgraph-mage Requires it) and resolves the C/C++
+# runtime deps (libgomp, libatomic, openssl, python3, ...) from the stream9
+# repos. --setopt=tsflags='' keeps memgraph's license docs, which the CentOS
+# minimal image otherwise strips via the default tsflags=nodocs.
+#
+# The memgraph-mage %post runs install_python_requirements.sh, which installs
+# the full MAGE python requirements. That is required, not optional: one of the
+# smoke checks asserts every query module loaded, which fails if any module's
+# python deps are missing. Letting %post run is also the faithful install path —
+# it exercises exactly what a user's `dnf install` does.
+RUN --mount=type=bind,source=./memgraph.rpm,target=/packages/memgraph.rpm,ro \
+    --mount=type=bind,source=./memgraph-mage.rpm,target=/packages/memgraph-mage.rpm,ro \
+  export PIP_BREAK_SYSTEM_PACKAGES=1 && \
+  dnf install -y --setopt=tsflags='' \
+    /packages/memgraph.rpm /packages/memgraph-mage.rpm && \
+  dnf clean all && rm -rf /var/cache/dnf
+
+# query_modules holds the MAGE .so files; memgraph's embedded loader needs them
+# on the library path so inter-module symbols resolve.
+ENV LD_LIBRARY_PATH=/usr/lib/memgraph/query_modules
+
+USER memgraph
+WORKDIR /usr/lib/memgraph
+EXPOSE 7687
+
+ENTRYPOINT ["/usr/lib/memgraph/memgraph"]
+CMD [""]

--- a/mage/Dockerfile.centos-9
+++ b/mage/Dockerfile.centos-9
@@ -12,20 +12,26 @@ FROM quay.io/centos/centos:stream9 AS base
 
 USER root
 
-# Install the base memgraph package and the MAGE package together so dnf orders
-# them (memgraph first, since memgraph-mage Requires it) and resolves the C/C++
-# runtime deps (libgomp, libatomic, openssl, python3, ...) from the stream9
-# repos. --setopt=tsflags='' keeps memgraph's license docs, which the CentOS
-# minimal image otherwise strips via the default tsflags=nodocs.
+# memgraph here embeds python 3.12 (built with -DMG_PYTHON_VERSION=3.12, since
+# CentOS Stream 9's default python3 is 3.9), so the query-module deps must be
+# installed under 3.12. Stage the 3.12 interpreter/pip plus the build deps the
+# full requirements install needs — gssapi (kerberos auth module) has no PyPI
+# wheel and is compiled from source, needing gcc + krb5-devel + the 3.12 dev
+# headers.
 #
-# The memgraph-mage %post runs install_python_requirements.sh, which installs
-# the full MAGE python requirements. That is required, not optional: one of the
-# smoke checks asserts every query module loaded, which fails if any module's
-# python deps are missing. Letting %post run is also the faithful install path —
-# it exercises exactly what a user's `dnf install` does.
+# Then install the base memgraph package and the MAGE package together so dnf
+# orders them (memgraph first, since memgraph-mage Requires it) and resolves the
+# remaining C/C++ runtime deps (libgomp, libatomic, openssl, ...). The
+# memgraph-mage %post runs install_python_requirements.sh (auto-selecting
+# python3.12) to install the full MAGE python requirements — required, not
+# optional: one of the smoke checks asserts every query module loaded, which
+# fails if any module's python deps are missing. --setopt=tsflags='' keeps
+# memgraph's license docs, which the CentOS minimal image otherwise strips.
 RUN --mount=type=bind,source=./memgraph.rpm,target=/packages/memgraph.rpm,ro \
     --mount=type=bind,source=./memgraph-mage.rpm,target=/packages/memgraph-mage.rpm,ro \
   export PIP_BREAK_SYSTEM_PACKAGES=1 && \
+  dnf install -y --setopt=tsflags='' \
+    python3.12 python3.12-pip python3.12-devel gcc gcc-c++ krb5-devel && \
   dnf install -y --setopt=tsflags='' \
     /packages/memgraph.rpm /packages/memgraph-mage.rpm && \
   dnf clean all && rm -rf /var/cache/dnf

--- a/mage/Dockerfile.rpm
+++ b/mage/Dockerfile.rpm
@@ -21,26 +21,11 @@ FROM ${BASE_IMAGE} AS base
 
 USER root
 
-# Install the python interpreter the query modules need, plus the build deps the
-# full requirements install pulls in: gssapi (kerberos auth module) has no PyPI
-# wheel and is compiled from source, needing gcc + krb5-devel + the python dev
-# headers; unixODBC provides libodbc.so.2, which pyodbc (imported by the
-# cross_database module) loads at runtime — the prod/debug images install the
-# equivalent via install_runtime_requirements.sh.
-#
 # PY_VERSION selects which python packages to install: empty -> the distro
 # default python3; set -> an explicit pythonX.Y (e.g. 3.12 on CentOS Stream 9,
 # whose default python3 is 3.9). install_python_requirements.sh (run by the
 # memgraph-mage %post) independently prefers python3.12 when present, so the
 # interpreter it installs deps into matches the one memgraph embeds.
-#
-# Then install the base memgraph package and the MAGE package together so dnf
-# orders them (memgraph first, since memgraph-mage Requires it) and resolves the
-# remaining C/C++ runtime deps (libgomp, libatomic, openssl, ...). The
-# memgraph-mage %post installs the full MAGE python requirements — required, not
-# optional: one of the smoke checks asserts every query module loaded, which
-# fails if any module's python deps are missing. --setopt=tsflags='' keeps
-# memgraph's license docs, which the minimal rpm base images otherwise strip.
 ARG PY_VERSION=""
 RUN --mount=type=bind,source=./memgraph.rpm,target=/packages/memgraph.rpm,ro \
     --mount=type=bind,source=./memgraph-mage.rpm,target=/packages/memgraph-mage.rpm,ro \

--- a/mage/Dockerfile.rpm
+++ b/mage/Dockerfile.rpm
@@ -1,40 +1,57 @@
-# Minimal CentOS Stream 9 image for running MAGE smoke tests against the RPM
+# Minimal rpm-distro image for running MAGE smoke tests against the RPM
 # packages. This is NOT a production image and is never published — it exists
 # only so the smoke-test framework (which drives a Docker image) can exercise
 # the memgraph + memgraph-mage RPMs on an rpm-based distro. The build context
 # is the mage/ directory, mirroring Dockerfile.release.
 #
+# Generic across rpm distros via build args:
+#   BASE_IMAGE  - the distro base image (e.g. quay.io/centos/centos:stream9,
+#                 quay.io/centos/centos:stream10, rockylinux/rockylinux:10).
+#   PY_VERSION  - the python the modules need. Leave empty to use the distro
+#                 default (python3), or set it (e.g. "3.12") to install an
+#                 explicit pythonX.Y — CentOS Stream 9 defaults python3 to 3.9
+#                 but memgraph there embeds 3.12.
+#
 # Expects two RPMs staged into the build context under fixed names (as
 # Dockerfile.release does with ./memgraph.deb):
 #   ./memgraph.rpm        - the base memgraph package
 #   ./memgraph-mage.rpm   - the MAGE query-modules package built by build-rpm.sh
-FROM quay.io/centos/centos:stream9 AS base
+ARG BASE_IMAGE=quay.io/centos/centos:stream9
+FROM ${BASE_IMAGE} AS base
 
 USER root
 
-# memgraph here embeds python 3.12 (built with -DMG_PYTHON_VERSION=3.12, since
-# CentOS Stream 9's default python3 is 3.9), so the query-module deps must be
-# installed under 3.12. Stage the 3.12 interpreter/pip plus the build deps the
-# full requirements install needs — gssapi (kerberos auth module) has no PyPI
-# wheel and is compiled from source, needing gcc + krb5-devel + the 3.12 dev
-# headers. unixODBC provides libodbc.so.2, which pyodbc (imported by the
+# Install the python interpreter the query modules need, plus the build deps the
+# full requirements install pulls in: gssapi (kerberos auth module) has no PyPI
+# wheel and is compiled from source, needing gcc + krb5-devel + the python dev
+# headers; unixODBC provides libodbc.so.2, which pyodbc (imported by the
 # cross_database module) loads at runtime — the prod/debug images install the
 # equivalent via install_runtime_requirements.sh.
+#
+# PY_VERSION selects which python packages to install: empty -> the distro
+# default python3; set -> an explicit pythonX.Y (e.g. 3.12 on CentOS Stream 9,
+# whose default python3 is 3.9). install_python_requirements.sh (run by the
+# memgraph-mage %post) independently prefers python3.12 when present, so the
+# interpreter it installs deps into matches the one memgraph embeds.
 #
 # Then install the base memgraph package and the MAGE package together so dnf
 # orders them (memgraph first, since memgraph-mage Requires it) and resolves the
 # remaining C/C++ runtime deps (libgomp, libatomic, openssl, ...). The
-# memgraph-mage %post runs install_python_requirements.sh (auto-selecting
-# python3.12) to install the full MAGE python requirements — required, not
+# memgraph-mage %post installs the full MAGE python requirements — required, not
 # optional: one of the smoke checks asserts every query module loaded, which
 # fails if any module's python deps are missing. --setopt=tsflags='' keeps
-# memgraph's license docs, which the CentOS minimal image otherwise strips.
+# memgraph's license docs, which the minimal rpm base images otherwise strip.
+ARG PY_VERSION=""
 RUN --mount=type=bind,source=./memgraph.rpm,target=/packages/memgraph.rpm,ro \
     --mount=type=bind,source=./memgraph-mage.rpm,target=/packages/memgraph-mage.rpm,ro \
   export PIP_BREAK_SYSTEM_PACKAGES=1 && \
+  if [ -n "$PY_VERSION" ]; then \
+    py_pkgs="python${PY_VERSION} python${PY_VERSION}-pip python${PY_VERSION}-devel"; \
+  else \
+    py_pkgs="python3 python3-pip python3-devel"; \
+  fi && \
   dnf install -y --setopt=tsflags='' \
-    python3.12 python3.12-pip python3.12-devel gcc gcc-c++ krb5-devel \
-    unixODBC && \
+    $py_pkgs gcc gcc-c++ krb5-devel unixODBC && \
   dnf install -y --setopt=tsflags='' \
     /packages/memgraph.rpm /packages/memgraph-mage.rpm && \
   dnf clean all && rm -rf /var/cache/dnf

--- a/mage/cpp/CMakeLists.txt
+++ b/mage/cpp/CMakeLists.txt
@@ -44,6 +44,14 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO
 set(CMAKE_CXX_FLAGS_RELEASE "-O2 -funsafe-math-optimizations -fvect-cost-model=dynamic -DNDEBUG")
 set(CMAKE_SHARED_LIBRARY_PREFIX "")
 
+# Emit a GNU build-id in every module. The memgraph toolchain's linker does not
+# add one by default (unlike Debian/Ubuntu's system ld), so without this the
+# query-module .so files — and thus the split-debug .debug sidecars — carry no
+# build-id and can't be indexed for the debuginfod-layout symbol upload. Mirrors
+# add_link_options(LINKER:--build-id) in the top-level memgraph CMakeLists.
+# Must precede target definitions so it applies to every module.
+add_link_options(LINKER:--build-id)
+
 find_package(Threads REQUIRED)
 include(ExternalProject)
 

--- a/mage/cpp/CMakeLists.txt
+++ b/mage/cpp/CMakeLists.txt
@@ -44,12 +44,7 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO
 set(CMAKE_CXX_FLAGS_RELEASE "-O2 -funsafe-math-optimizations -fvect-cost-model=dynamic -DNDEBUG")
 set(CMAKE_SHARED_LIBRARY_PREFIX "")
 
-# Emit a GNU build-id in every module. The memgraph toolchain's linker does not
-# add one by default (unlike Debian/Ubuntu's system ld), so without this the
-# query-module .so files — and thus the split-debug .debug sidecars — carry no
-# build-id and can't be indexed for the debuginfod-layout symbol upload. Mirrors
-# add_link_options(LINKER:--build-id) in the top-level memgraph CMakeLists.
-# Must precede target definitions so it applies to every module.
+# Emit a GNU build-id in every module.
 add_link_options(LINKER:--build-id)
 
 find_package(Threads REQUIRED)

--- a/mage/install_python_requirements.sh
+++ b/mage/install_python_requirements.sh
@@ -51,6 +51,22 @@ if [[ "$CUDA" == true && "$ARCH" != "amd64" ]]; then
   exit 1
 fi
 
+# MAGE's pinned GNN wheels (torch/PyG/DGL below) are all cp312, and memgraph
+# embeds python 3.12 to match. Most distros already default `python3` to 3.12,
+# but some don't (e.g. CentOS Stream 9 ships 3.9 as python3 and memgraph is
+# built against an explicitly-installed python3.12). Prefer python3.12 when
+# present so the deps land in the interpreter memgraph actually loads; otherwise
+# fall back to python3. Override with PYTHON=<interpreter> if needed.
+PYTHON="${PYTHON:-}"
+if [[ -z "$PYTHON" ]]; then
+  if command -v python3.12 >/dev/null 2>&1; then
+    PYTHON=python3.12
+  else
+    PYTHON=python3
+  fi
+fi
+echo "Installing MAGE python requirements with: $PYTHON ($($PYTHON --version 2>&1))"
+
 export PIP_BREAK_SYSTEM_PACKAGES=1
 export PIP_DEFAULT_TIMEOUT=120
 export PIP_RETRIES=8
@@ -64,20 +80,20 @@ if [ "$CI" = true ]; then
   # take torch from the wheel house if the cache is present
   if [ "$CACHE_PRESENT" = "true" ]; then
     echo "Installing torch from wheel cache"
-    python3 -m pip install --no-cache-dir --no-index --find-links=$WHEEL_CACHE_DIR torch
+    $PYTHON -m pip install --no-cache-dir --no-index --find-links=$WHEEL_CACHE_DIR torch
   fi
 
   # for building the docker image
-  python3 -m pip install --no-cache-dir -r "/tmp/${requirements_file}"
-  python3 -m pip install --no-cache-dir -r /tmp/auth_module-requirements.txt
+  $PYTHON -m pip install --no-cache-dir -r "/tmp/${requirements_file}"
+  $PYTHON -m pip install --no-cache-dir -r /tmp/auth_module-requirements.txt
 elif [[ "$DEB_PACKAGE" == "true" ]]; then
   # for installing python deps during deb package installation
-  python3 -m pip install --no-cache-dir -r "/usr/lib/memgraph/mage-requirements.txt"
-  python3 -m pip install --no-cache-dir -r "/usr/lib/memgraph/auth_module/requirements.txt"
+  $PYTHON -m pip install --no-cache-dir -r "/usr/lib/memgraph/mage-requirements.txt"
+  $PYTHON -m pip install --no-cache-dir -r "/usr/lib/memgraph/auth_module/requirements.txt"
 else
   # for installing locally, from within the memgraph repo, under the mage directory
-  python3 -m pip install --no-cache-dir -r "$(pwd)/python/${requirements_file}"
-  python3 -m pip install --no-cache-dir -r "$(pwd)/../src/auth/reference_modules/requirements.txt"
+  $PYTHON -m pip install --no-cache-dir -r "$(pwd)/python/${requirements_file}"
+  $PYTHON -m pip install --no-cache-dir -r "$(pwd)/../src/auth/reference_modules/requirements.txt"
 fi
 
 # custom package links TODO(matt): use official binaries when available
@@ -115,32 +131,32 @@ fi
 if [ "$ARCH" = "arm64" ]; then
   if [ "$CACHE_PRESENT" = "true" ]; then
     echo "Using cached torch packages"
-    python3 -m pip install --no-index --find-links=$WHEEL_CACHE_DIR torch-sparse torch-cluster torch-spline-conv torch-geometric torch-scatter dgl
+    $PYTHON -m pip install --no-index --find-links=$WHEEL_CACHE_DIR torch-sparse torch-cluster torch-spline-conv torch-geometric torch-scatter dgl
   else
     # Attempt to install from S3 first, if that fails, fallback to pulling from PyG and building from source, if necessary
     {
-      python3 -m pip install --no-cache-dir $TORCH_SPARSE $TORCH_CLUSTER $TORCH_SPLINE_CONV $TORCH_GEOMETRIC $TORCH_SCATTER
+      $PYTHON -m pip install --no-cache-dir $TORCH_SPARSE $TORCH_CLUSTER $TORCH_SPLINE_CONV $TORCH_GEOMETRIC $TORCH_SCATTER
     } || {
-      python3 -m pip install --no-cache-dir torch-sparse torch-cluster torch-spline-conv torch-geometric torch-scatter -f https://data.pyg.org/whl/torch-2.9.0+cpu.html
+      $PYTHON -m pip install --no-cache-dir torch-sparse torch-cluster torch-spline-conv torch-geometric torch-scatter -f https://data.pyg.org/whl/torch-2.9.0+cpu.html
     }
-    python3 -m pip install --no-cache-dir "$DGL"
+    $PYTHON -m pip install --no-cache-dir "$DGL"
   fi
 else
   if [ "$CACHE_PRESENT" = "true" ]; then
       echo "Using cached torch packages"
-      python3 -m pip install --no-index --find-links=$WHEEL_CACHE_DIR torch-sparse torch-cluster torch-spline-conv torch-geometric torch-scatter dgl
+      $PYTHON -m pip install --no-index --find-links=$WHEEL_CACHE_DIR torch-sparse torch-cluster torch-spline-conv torch-geometric torch-scatter dgl
   else
     # Attempt to install from S3 first, if that fails, fallback to pulling from PyG and building from source, if necessary
     {
-      python3 -m pip install --no-cache-dir $TORCH_SPARSE $TORCH_CLUSTER $TORCH_SPLINE_CONV $TORCH_GEOMETRIC $TORCH_SCATTER
+      $PYTHON -m pip install --no-cache-dir $TORCH_SPARSE $TORCH_CLUSTER $TORCH_SPLINE_CONV $TORCH_GEOMETRIC $TORCH_SCATTER
     } || {
       if [[ "$CUDA" == true ]]; then
-        python3 -m pip install --no-cache-dir torch-sparse torch-cluster torch-spline-conv torch-geometric torch-scatter -f https://data.pyg.org/whl/torch-2.9.0+cu130.html
+        $PYTHON -m pip install --no-cache-dir torch-sparse torch-cluster torch-spline-conv torch-geometric torch-scatter -f https://data.pyg.org/whl/torch-2.9.0+cu130.html
       else
-        python3 -m pip install --no-cache-dir torch-sparse torch-cluster torch-spline-conv torch-geometric torch-scatter -f https://data.pyg.org/whl/torch-2.9.0+cpu.html
+        $PYTHON -m pip install --no-cache-dir torch-sparse torch-cluster torch-spline-conv torch-geometric torch-scatter -f https://data.pyg.org/whl/torch-2.9.0+cpu.html
       fi
     }
-    python3 -m pip install --no-cache-dir "$DGL"
+    $PYTHON -m pip install --no-cache-dir "$DGL"
   fi
 fi
 rm -fr /home/memgraph/.cache/pip

--- a/mage/install_python_requirements.sh
+++ b/mage/install_python_requirements.sh
@@ -9,6 +9,11 @@ CUDA_VERSION=13.0
 ARCH=amd64
 WHEEL_CACHE_DIR="$(pwd)/wheels"
 DEB_PACKAGE=false
+# Pull the custom torch/PyG/DGL wheels from the S3 "wheels-staging" prefix
+# rather than the usual "wheels" prefix. Defaults to true so the RPM %post
+# (which calls this script without extra flags) uses the staging wheels too.
+# Set --staging false to go back to the promoted "wheels" prefix.
+STAGING=true
 while [[ $# -gt 0 ]]; do
   case $1 in
     --ci)
@@ -17,6 +22,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --cache-present)
       CACHE_PRESENT=$2
+      shift 2
+      ;;
+    --staging)
+      STAGING=$2
       shift 2
       ;;
     --cuda)
@@ -105,20 +114,46 @@ fi
 # to agree on which version to fetch — there's no upstream registry to derive
 # a single answer from. Any version bump here must be mirrored there and vice
 # versa.
-BASE_URL="https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/wheels"
+S3_HOST="https://s3.eu-west-1.amazonaws.com/deps.memgraph.io"
+# pyg_lib only exists in the staging wheelhouse; stays empty for the promoted
+# "wheels" prefix so the install commands below simply omit it.
+PYG_LIB=""
 if [[ "$ARCH" == "arm64" ]]; then
-  BASE_URL="${BASE_URL}/arm64"
+  # wheels-staging is amd64-only — there are no arm64 staging wheels — so arm64
+  # always uses the promoted "wheels" prefix and its linux_aarch64 filenames.
+  if [[ "$STAGING" == true ]]; then
+    echo "Note: wheels-staging has no arm64 build; using the 'wheels' prefix for arm64."
+  fi
+  BASE_URL="$S3_HOST/wheels/arm64"
   TORCH_CLUSTER="$BASE_URL/torch_cluster-1.6.3-cp312-cp312-linux_aarch64.whl"
   TORCH_GEOMETRIC="$BASE_URL/torch_geometric-2.8.0-py3-none-any.whl"
   TORCH_SCATTER="$BASE_URL/torch_scatter-2.1.2-cp312-cp312-linux_aarch64.whl"
   TORCH_SPARSE="$BASE_URL/torch_sparse-0.6.18-cp312-cp312-linux_aarch64.whl"
   TORCH_SPLINE_CONV="$BASE_URL/torch_spline_conv-1.2.2-cp312-cp312-linux_aarch64.whl"
   DGL="$BASE_URL/dgl-2.5-cp312-cp312-linux_aarch64.whl"
-else
+elif [[ "$STAGING" == true ]]; then
+  # amd64 staging wheelhouse: portable manylinux_2_34 wheels that load on both
+  # Ubuntu and CentOS Stream 9. Filenames/versions differ from the promoted
+  # prefix (torch_geometric bumped to 2.9.0, pyg_lib added). cuda wheels live
+  # under cuda-<ver>/amd64.
   if [[ "$CUDA" == true ]]; then
-    BASE_URL="${BASE_URL}/cuda-${CUDA_VERSION}"
+    BASE_URL="$S3_HOST/wheels-staging/cuda-${CUDA_VERSION}/amd64"
   else
-    BASE_URL="${BASE_URL}/amd64"
+    BASE_URL="$S3_HOST/wheels-staging/amd64"
+  fi
+  TORCH_CLUSTER="$BASE_URL/torch_cluster-1.6.3-cp312-cp312-manylinux_2_34_x86_64.whl"
+  TORCH_GEOMETRIC="$BASE_URL/torch_geometric-2.9.0-py3-none-any.whl"
+  TORCH_SCATTER="$BASE_URL/torch_scatter-2.1.2-cp312-cp312-manylinux_2_34_x86_64.whl"
+  TORCH_SPARSE="$BASE_URL/torch_sparse-0.6.18-cp312-cp312-manylinux_2_34_x86_64.whl"
+  TORCH_SPLINE_CONV="$BASE_URL/torch_spline_conv-1.2.2-cp312-cp312-manylinux_2_34_x86_64.whl"
+  DGL="$BASE_URL/dgl-2.5-cp312-cp312-manylinux_2_34_x86_64.whl"
+  PYG_LIB="$BASE_URL/pyg_lib-0.8.0-cp312-cp312-manylinux_2_34_x86_64.whl"
+else
+  # amd64 promoted "wheels" prefix (original behaviour, linux_x86_64 filenames).
+  if [[ "$CUDA" == true ]]; then
+    BASE_URL="$S3_HOST/wheels/cuda-${CUDA_VERSION}"
+  else
+    BASE_URL="$S3_HOST/wheels/amd64"
   fi
   TORCH_CLUSTER="$BASE_URL/torch_cluster-1.6.3-cp312-cp312-linux_x86_64.whl"
   TORCH_GEOMETRIC="$BASE_URL/torch_geometric-2.8.0-py3-none-any.whl"
@@ -148,7 +183,8 @@ else
   else
     # Attempt to install from S3 first, if that fails, fallback to pulling from PyG and building from source, if necessary
     {
-      $PYTHON -m pip install --no-cache-dir $TORCH_SPARSE $TORCH_CLUSTER $TORCH_SPLINE_CONV $TORCH_GEOMETRIC $TORCH_SCATTER
+      # $PYG_LIB is set only for the staging wheelhouse; empty (omitted) otherwise.
+      $PYTHON -m pip install --no-cache-dir $TORCH_SPARSE $TORCH_CLUSTER $TORCH_SPLINE_CONV $TORCH_GEOMETRIC $TORCH_SCATTER $PYG_LIB
     } || {
       if [[ "$CUDA" == true ]]; then
         $PYTHON -m pip install --no-cache-dir torch-sparse torch-cluster torch-spline-conv torch-geometric torch-scatter -f https://data.pyg.org/whl/torch-2.9.0+cu130.html

--- a/mage/install_python_requirements.sh
+++ b/mage/install_python_requirements.sh
@@ -9,11 +9,6 @@ CUDA_VERSION=13.0
 ARCH=amd64
 WHEEL_CACHE_DIR="$(pwd)/wheels"
 DEB_PACKAGE=false
-# Pull the custom torch/PyG/DGL wheels from the S3 "wheels-staging" prefix
-# rather than the usual "wheels" prefix. Defaults to true so the RPM %post
-# (which calls this script without extra flags) uses the staging wheels too.
-# Set --staging false to go back to the promoted "wheels" prefix.
-STAGING=true
 while [[ $# -gt 0 ]]; do
   case $1 in
     --ci)
@@ -22,10 +17,6 @@ while [[ $# -gt 0 ]]; do
       ;;
     --cache-present)
       CACHE_PRESENT=$2
-      shift 2
-      ;;
-    --staging)
-      STAGING=$2
       shift 2
       ;;
     --cuda)
@@ -114,54 +105,29 @@ fi
 # to agree on which version to fetch — there's no upstream registry to derive
 # a single answer from. Any version bump here must be mirrored there and vice
 # versa.
+#
+# Wheels are portable manylinux_2_34 builds (load on both Ubuntu and CentOS
+# Stream 9) hosted under a dated prefix wheels/<date>/<arch>/; bump WHEELS_DATE
+# when a new set is published. cuda wheels live under cuda-<ver>/amd64.
 S3_HOST="https://s3.eu-west-1.amazonaws.com/deps.memgraph.io"
-# pyg_lib only exists in the staging wheelhouse; stays empty for the promoted
-# "wheels" prefix so the install commands below simply omit it.
-PYG_LIB=""
+WHEELS_DATE="2026-06-25"
 if [[ "$ARCH" == "arm64" ]]; then
-  # wheels-staging is amd64-only — there are no arm64 staging wheels — so arm64
-  # always uses the promoted "wheels" prefix and its linux_aarch64 filenames.
-  if [[ "$STAGING" == true ]]; then
-    echo "Note: wheels-staging has no arm64 build; using the 'wheels' prefix for arm64."
-  fi
-  BASE_URL="$S3_HOST/wheels/arm64"
-  TORCH_CLUSTER="$BASE_URL/torch_cluster-1.6.3-cp312-cp312-linux_aarch64.whl"
-  TORCH_GEOMETRIC="$BASE_URL/torch_geometric-2.8.0-py3-none-any.whl"
-  TORCH_SCATTER="$BASE_URL/torch_scatter-2.1.2-cp312-cp312-linux_aarch64.whl"
-  TORCH_SPARSE="$BASE_URL/torch_sparse-0.6.18-cp312-cp312-linux_aarch64.whl"
-  TORCH_SPLINE_CONV="$BASE_URL/torch_spline_conv-1.2.2-cp312-cp312-linux_aarch64.whl"
-  DGL="$BASE_URL/dgl-2.5-cp312-cp312-linux_aarch64.whl"
-elif [[ "$STAGING" == true ]]; then
-  # amd64 staging wheelhouse: portable manylinux_2_34 wheels that load on both
-  # Ubuntu and CentOS Stream 9. Filenames/versions differ from the promoted
-  # prefix (torch_geometric bumped to 2.9.0, pyg_lib added). cuda wheels live
-  # under cuda-<ver>/amd64.
-  if [[ "$CUDA" == true ]]; then
-    BASE_URL="$S3_HOST/wheels-staging/cuda-${CUDA_VERSION}/amd64"
-  else
-    BASE_URL="$S3_HOST/wheels-staging/amd64"
-  fi
-  TORCH_CLUSTER="$BASE_URL/torch_cluster-1.6.3-cp312-cp312-manylinux_2_34_x86_64.whl"
-  TORCH_GEOMETRIC="$BASE_URL/torch_geometric-2.9.0-py3-none-any.whl"
-  TORCH_SCATTER="$BASE_URL/torch_scatter-2.1.2-cp312-cp312-manylinux_2_34_x86_64.whl"
-  TORCH_SPARSE="$BASE_URL/torch_sparse-0.6.18-cp312-cp312-manylinux_2_34_x86_64.whl"
-  TORCH_SPLINE_CONV="$BASE_URL/torch_spline_conv-1.2.2-cp312-cp312-manylinux_2_34_x86_64.whl"
-  DGL="$BASE_URL/dgl-2.5-cp312-cp312-manylinux_2_34_x86_64.whl"
-  PYG_LIB="$BASE_URL/pyg_lib-0.8.0-cp312-cp312-manylinux_2_34_x86_64.whl"
+  BASE_URL="$S3_HOST/wheels/${WHEELS_DATE}/arm64"
+  PLAT="manylinux_2_34_aarch64"
+elif [[ "$CUDA" == true ]]; then
+  BASE_URL="$S3_HOST/wheels/${WHEELS_DATE}/cuda-${CUDA_VERSION}/amd64"
+  PLAT="manylinux_2_34_x86_64"
 else
-  # amd64 promoted "wheels" prefix (original behaviour, linux_x86_64 filenames).
-  if [[ "$CUDA" == true ]]; then
-    BASE_URL="$S3_HOST/wheels/cuda-${CUDA_VERSION}"
-  else
-    BASE_URL="$S3_HOST/wheels/amd64"
-  fi
-  TORCH_CLUSTER="$BASE_URL/torch_cluster-1.6.3-cp312-cp312-linux_x86_64.whl"
-  TORCH_GEOMETRIC="$BASE_URL/torch_geometric-2.8.0-py3-none-any.whl"
-  TORCH_SCATTER="$BASE_URL/torch_scatter-2.1.2-cp312-cp312-linux_x86_64.whl"
-  TORCH_SPARSE="$BASE_URL/torch_sparse-0.6.18-cp312-cp312-linux_x86_64.whl"
-  TORCH_SPLINE_CONV="$BASE_URL/torch_spline_conv-1.2.2-cp312-cp312-linux_x86_64.whl"
-  DGL="$BASE_URL/dgl-2.5-cp312-cp312-linux_x86_64.whl"
+  BASE_URL="$S3_HOST/wheels/${WHEELS_DATE}/amd64"
+  PLAT="manylinux_2_34_x86_64"
 fi
+TORCH_CLUSTER="$BASE_URL/torch_cluster-1.6.3-cp312-cp312-${PLAT}.whl"
+TORCH_GEOMETRIC="$BASE_URL/torch_geometric-2.9.0-py3-none-any.whl"
+TORCH_SCATTER="$BASE_URL/torch_scatter-2.1.2-cp312-cp312-${PLAT}.whl"
+TORCH_SPARSE="$BASE_URL/torch_sparse-0.6.18-cp312-cp312-${PLAT}.whl"
+TORCH_SPLINE_CONV="$BASE_URL/torch_spline_conv-1.2.2-cp312-cp312-${PLAT}.whl"
+DGL="$BASE_URL/dgl-2.5-cp312-cp312-${PLAT}.whl"
+PYG_LIB="$BASE_URL/pyg_lib-0.8.0-cp312-cp312-${PLAT}.whl"
 
 if [ "$ARCH" = "arm64" ]; then
   if [ "$CACHE_PRESENT" = "true" ]; then
@@ -170,7 +136,7 @@ if [ "$ARCH" = "arm64" ]; then
   else
     # Attempt to install from S3 first, if that fails, fallback to pulling from PyG and building from source, if necessary
     {
-      $PYTHON -m pip install --no-cache-dir $TORCH_SPARSE $TORCH_CLUSTER $TORCH_SPLINE_CONV $TORCH_GEOMETRIC $TORCH_SCATTER
+      $PYTHON -m pip install --no-cache-dir $TORCH_SPARSE $TORCH_CLUSTER $TORCH_SPLINE_CONV $TORCH_GEOMETRIC $TORCH_SCATTER $PYG_LIB
     } || {
       $PYTHON -m pip install --no-cache-dir torch-sparse torch-cluster torch-spline-conv torch-geometric torch-scatter -f https://data.pyg.org/whl/torch-2.9.0+cpu.html
     }
@@ -183,7 +149,6 @@ else
   else
     # Attempt to install from S3 first, if that fails, fallback to pulling from PyG and building from source, if necessary
     {
-      # $PYG_LIB is set only for the staging wheelhouse; empty (omitted) otherwise.
       $PYTHON -m pip install --no-cache-dir $TORCH_SPARSE $TORCH_CLUSTER $TORCH_SPLINE_CONV $TORCH_GEOMETRIC $TORCH_SCATTER $PYG_LIB
     } || {
       if [[ "$CUDA" == true ]]; then

--- a/mage/tests/smoke-release-testing/check_container_logs.sh
+++ b/mage/tests/smoke-release-testing/check_container_logs.sh
@@ -9,9 +9,6 @@ check_container_logs() {
     if echo "$logs" | grep -q "\[error\]"; then
         echo "Error(s) found in container logs:"
         echo "$logs" | grep "\[error\]"
-        # Dump the full log too — the [error] line alone often omits the cause
-        # (e.g. the Python traceback / missing-dependency detail that precedes a
-        # failed query-module load), so print everything for diagnosis.
         echo "----- full memgraph log (memgraph_next_data) -----"
         echo "$logs"
         echo "----- end memgraph log -----"

--- a/mage/tests/smoke-release-testing/check_container_logs.sh
+++ b/mage/tests/smoke-release-testing/check_container_logs.sh
@@ -9,6 +9,12 @@ check_container_logs() {
     if echo "$logs" | grep -q "\[error\]"; then
         echo "Error(s) found in container logs:"
         echo "$logs" | grep "\[error\]"
+        # Dump the full log too — the [error] line alone often omits the cause
+        # (e.g. the Python traceback / missing-dependency detail that precedes a
+        # failed query-module load), so print everything for diagnosis.
+        echo "----- full memgraph log (memgraph_next_data) -----"
+        echo "$logs"
+        echo "----- end memgraph log -----"
         exit 1
     else
         echo "No errors found in container logs"

--- a/release/CMakeLists.txt
+++ b/release/CMakeLists.txt
@@ -81,8 +81,18 @@ It aims to deliver developers the speed, simplicity and scale required to build
 the next generation of applications driver by real-time connected data.")
 
 # Add `openssl` package to dependencies list. Used to generate SSL certificates.
-# We also depend on `python3` because we embed it in Memgraph.
-set(CPACK_RPM_MEMGRAPH_PACKAGE_REQUIRES "openssl >= 1.0.0, curl >= 7.29.0, python3 >= 3.5.0, logrotate")
+# We also depend on `python3` because we embed it in Memgraph. `libatomic` is a
+# runtime dependency of the binary; since CPACK_RPM_PACKAGE_AUTOREQ is off
+# (above), soname deps aren't auto-detected and must be listed explicitly.
+set(CPACK_RPM_MEMGRAPH_PACKAGE_REQUIRES "openssl >= 1.0.0, curl >= 7.29.0, python3 >= 3.5.0, logrotate, libatomic")
+
+# When memgraph is built against an explicit Python (currently CentOS Stream 9,
+# where it embeds python 3.12 instead of the distro-default 3.9 — see
+# -DMG_PYTHON_VERSION), require that interpreter's package so the embedded
+# libpython is present and the MAGE %post (which runs python<ver> -m pip) works.
+if(NOT "${MG_PYTHON_VERSION}" STREQUAL "")
+    set(CPACK_RPM_MEMGRAPH_PACKAGE_REQUIRES "${CPACK_RPM_MEMGRAPH_PACKAGE_REQUIRES}, python${MG_PYTHON_VERSION}")
+endif()
 
 # Configure CPack to build mgconsole using the unified install script
 set(CPACK_INSTALL_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/install_mgconsole.cmake")

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -1995,7 +1995,7 @@ package_mage_rpm() {
   echo -e "${GREEN_BOLD}Packaging MAGE RPM package${RESET}"
   docker exec -i -u root $build_container bash -c "command -v rpmbuild >/dev/null 2>&1 || (dnf install -y rpm-build || yum install -y rpm-build)"
 
-  docker exec -i -u mg $build_container bash -c "cd /home/mg/memgraph/tools/ci/mage-build/package && ./build-rpm.sh '${rpm_arch}' '${pkg_arch}' $build_type $version $malloc $cuda $cugraph"
+  docker exec -i -u mg $build_container bash -c "cd /home/mg/memgraph/tools/ci/mage-build/package && ./build-rpm.sh '${rpm_arch}' '${pkg_arch}' $build_type $version $malloc $cuda $cugraph '${os}'"
 
   mkdir -pv output
   for path in $(docker exec -i -u mg $build_container bash -c "ls /home/mg/memgraph/tools/ci/mage-build/package/memgraph-mage*.rpm"); do

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -745,6 +745,7 @@ build_memgraph () {
   # (see environment/os/centos-9.sh and install_python_requirements.sh).
   # find_package(Python3 3.12 EXACT) needs the 3.12 dev package; install it here
   # in case the prebuilt mgbuild image predates the centos-9.sh change.
+  # TODO(matt): Remove in Toolchain v8
   if [[ "$os" == centos-9* ]]; then
     docker exec -u root "$build_container" bash -c "rpm -q python3.12-devel >/dev/null 2>&1 || dnf install -y python3.12 python3.12-devel python3.12-pip"
     additional_options="$additional_options -DMG_PYTHON_VERSION=3.12"
@@ -1024,8 +1025,7 @@ package_smoke_image() {
   # numpy 1.26.4 / scipy 1.13.0 have no prebuilt wheels for Python 3.13, and
   # the source builds fail inside the smoke image (no compiler/headers).
   # Distros that ship Python 3.13 as the default (debian-13, fedora-41+) need
-  # numpy 2.1.0 / scipy 1.15.0. (centos-9 builds memgraph against python 3.12,
-  # not its distro-default 3.9, so it uses the default versions here.)
+  # numpy 2.1.0 / scipy 1.15.0.
   local numpy_version="1.26.4"
   local scipy_version="1.13.0"
   local networkx_version="3.4.2"

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -739,6 +739,17 @@ build_memgraph () {
     additional_options="$additional_options -DMG_SPLIT_DEBUG=ON"
   fi
 
+  # MAGE's query-module python deps (torch/PyG/DGL) ship only as cp312 wheels,
+  # but CentOS Stream 9's default python3 is 3.9. Build memgraph against python
+  # 3.12 so the interpreter it embeds matches the deps installed at package time
+  # (see environment/os/centos-9.sh and install_python_requirements.sh).
+  # find_package(Python3 3.12 EXACT) needs the 3.12 dev package; install it here
+  # in case the prebuilt mgbuild image predates the centos-9.sh change.
+  if [[ "$os" == centos-9* ]]; then
+    docker exec -u root "$build_container" bash -c "rpm -q python3.12-devel >/dev/null 2>&1 || dnf install -y python3.12 python3.12-devel python3.12-pip"
+    additional_options="$additional_options -DMG_PYTHON_VERSION=3.12"
+  fi
+
   if [[ -n "$additional_options" ]]; then
     echo "Adding additional CMake options: $additional_options"
   fi
@@ -2251,10 +2262,19 @@ test_mage() {
       fi
       docker cp mage/python/$requirements_file $build_container:/tmp/$requirements_file
       docker cp src/auth/reference_modules/requirements.txt $build_container:/tmp/auth_module-requirements.txt
+      # MAGE's deps are cp312 and memgraph embeds python 3.12, so the python
+      # test phase must run under 3.12. CentOS Stream 9 defaults python3 to 3.9,
+      # so install and use python3.12 there; other distros already ship 3.12 as
+      # python3. install_python_requirements.sh honours PYTHON=<interpreter>.
+      local pybin="python3"
+      if [[ "$os" == centos-9* ]]; then
+        pybin="python3.12"
+        docker exec -i -u root $build_container bash -c "rpm -q python3.12-pip >/dev/null 2>&1 || dnf install -y python3.12 python3.12-pip python3.12-devel"
+      fi
       docker exec -i -u mg $build_container bash -c "cd \$HOME/memgraph/mage/ && \
-        ./install_python_requirements.sh --ci --cache-present $cache_present --cuda $cuda --arch ${arch}64 && \
-        pip install -r \$HOME/memgraph/mage/python/tests/requirements.txt --break-system-packages"
-      docker exec -i -u mg $build_container bash -c "cd \$HOME/memgraph/mage/python/ && python3 -m pytest ."
+        PYTHON=$pybin ./install_python_requirements.sh --ci --cache-present $cache_present --cuda $cuda --arch ${arch}64 && \
+        $pybin -m pip install -r \$HOME/memgraph/mage/python/tests/requirements.txt --break-system-packages"
+      docker exec -i -u mg $build_container bash -c "cd \$HOME/memgraph/mage/python/ && $pybin -m pytest ."
     ;;
     e2e)
       shift 1

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -94,6 +94,7 @@ print_help () {
   echo -e "  package-docker [OPTIONS]           Create memgraph docker image and pack it as .tar.gz"
   echo -e "  package-smoke-image [OPTIONS]      Build a Docker image with the .deb/.rpm package installed (for smoke tests)"
   echo -e "  package-mage-deb [OPTIONS]         Create MAGE DEB package"
+  echo -e "  package-mage-rpm [OPTIONS]         Create MAGE RPM package"
   echo -e "  package-mage-docker [OPTIONS]      Create MAGE docker image"
   echo -e "  package-mage-offline-installer [OPTIONS]  Build a self-contained .run installer for Memgraph + MAGE on Ubuntu 24.04"
   echo -e "  pull                               Pull mgbuild image from dockerhub"
@@ -174,6 +175,12 @@ print_help () {
   echo -e "                                This directory should contain the memgraph package."
   echo -e "  --keep-image-loaded bool      Keep built Docker image loaded after packaging (default false)."
   echo -e "  --package-flavour string        Docker package flavour: 'prod' or 'debug' (default 'prod'). 'debug' requires --build-type RelWithDebInfo and produces an image with source and debug tooling."
+
+  echo -e "\npackage-mage-deb / package-mage-rpm options:"
+  echo -e "  --version string              Memgraph version embedded in the package (required)"
+  echo -e "  --malloc                      Variant flag — affects the output filename only"
+  echo -e "  --cuda                        CUDA variant (uses requirements-gpu.txt; implied by global --cugraph)"
+  echo -e "                                Arch and build-type come from the global --arch / --build-type flags."
 
   echo -e "\npackage-mage-docker options:"
   echo -e "  --docker-repository-name str  Docker repository name (default \"memgraph/memgraph-mage\")"
@@ -1906,6 +1913,62 @@ package_mage_deb() {
   done
 }
 
+package_mage_rpm() {
+
+  local version=""
+  local malloc=false
+  local cuda=false
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --version)
+        version=$2
+        shift 2
+      ;;
+      --malloc)
+        malloc=true
+        shift 1
+      ;;
+      --cuda)
+        cuda=true
+        shift 1
+      ;;
+      *)
+        echo "Error: Unknown flag '$1'"
+        print_help
+        exit 1
+      ;;
+    esac
+  done
+
+  if [[ "$cugraph" = true ]]; then
+    cuda=true
+  fi
+
+  # RPM uses different arch spellings than dpkg. rpm_arch is the package
+  # BuildArch (x86_64/aarch64); pkg_arch (amd64/arm64) is what the postinst
+  # forwards to install_python_requirements.sh, matching the DEB path.
+  local rpm_arch pkg_arch
+  case "$arch" in
+    amd) rpm_arch="x86_64";  pkg_arch="amd64" ;;
+    arm) rpm_arch="aarch64"; pkg_arch="arm64" ;;
+    *)
+      echo -e "${RED_BOLD}Error: package_mage_rpm: unsupported arch '$arch' (expected amd or arm)${RESET}"
+      exit 1
+    ;;
+  esac
+
+  echo -e "${GREEN_BOLD}Packaging MAGE RPM package${RESET}"
+  docker exec -i -u root $build_container bash -c "command -v rpmbuild >/dev/null 2>&1 || (dnf install -y rpm-build || yum install -y rpm-build)"
+
+  docker exec -i -u mg $build_container bash -c "cd /home/mg/memgraph/tools/ci/mage-build/package && ./build-rpm.sh '${rpm_arch}' '${pkg_arch}' $build_type $version $malloc $cuda $cugraph"
+
+  mkdir -pv output
+  for path in $(docker exec -i -u mg $build_container bash -c "ls /home/mg/memgraph/tools/ci/mage-build/package/memgraph-mage*.rpm"); do
+    docker cp $build_container:$path output/
+    echo "Package: $path"
+  done
+}
+
 
 package_mage_docker() {
 
@@ -3009,6 +3072,9 @@ case $command in
     ;;
     package-mage-deb)
       package_mage_deb $@
+    ;;
+    package-mage-rpm)
+      package_mage_rpm $@
     ;;
     package-mage-docker)
       package_mage_docker $@

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -1024,8 +1024,8 @@ package_smoke_image() {
   # numpy 1.26.4 / scipy 1.13.0 have no prebuilt wheels for Python 3.13, and
   # the source builds fail inside the smoke image (no compiler/headers).
   # Distros that ship Python 3.13 as the default (debian-13, fedora-41+) need
-  # numpy 2.1.0 / scipy 1.15.0. networkx 3.4 requires Python 3.10+, so
-  # centos-9 (Python 3.9) needs to stay on 3.2.1.
+  # numpy 2.1.0 / scipy 1.15.0. (centos-9 builds memgraph against python 3.12,
+  # not its distro-default 3.9, so it uses the default versions here.)
   local numpy_version="1.26.4"
   local scipy_version="1.13.0"
   local networkx_version="3.4.2"
@@ -1034,7 +1034,7 @@ package_smoke_image() {
     ubuntu-22.04*) base_image="ubuntu:22.04"; pkg_format="deb"; libpython_pkg="libpython3.10" ;;
     debian-12*)    base_image="debian:12";    pkg_format="deb"; libpython_pkg="libpython3.11" ;;
     debian-13*)    base_image="debian:13";    pkg_format="deb"; libpython_pkg="libpython3.13"; numpy_version="2.1.0"; scipy_version="1.15.0" ;;
-    centos-9*)     base_image="quay.io/centos/centos:stream9";  pkg_format="rpm"; networkx_version="3.2.1" ;;
+    centos-9*)     base_image="quay.io/centos/centos:stream9";  pkg_format="rpm" ;;
     centos-10*)    base_image="quay.io/centos/centos:stream10"; pkg_format="rpm" ;;
     rocky-10*)     base_image="rockylinux/rockylinux:10";  pkg_format="rpm" ;;
     fedora-42*)    base_image="fedora:42"; pkg_format="rpm"; numpy_version="2.1.0"; scipy_version="1.15.0" ;;
@@ -1100,9 +1100,22 @@ gssapi==1.11.1 numpy==${numpy_version} scipy==${scipy_version} networkx==${netwo
     # /etc/dnf/dnf.conf, which strips memgraph's license files in
     # /usr/share/doc/memgraph/. Override on the dnf install line so the
     # smoke license check passes.
+    #
+    # By default the deps go to the distro python3 via pip3. CentOS Stream 9 is
+    # the exception: memgraph there embeds python 3.12 (built with
+    # MG_PYTHON_VERSION=3.12), not the distro-default 3.9, so its bundled query
+    # modules import from python3.12's site-packages — install the deps with
+    # python3.12's pip, not pip3 (which would be 3.9 and thus invisible to
+    # memgraph).
+    local rpm_python_pkgs="python3-libs python3-pip"
+    local pip_cmd="pip3"
+    if [[ "$os" == centos-9* ]]; then
+      rpm_python_pkgs="python3.12 python3.12-pip"
+      pip_cmd="python3.12 -m pip"
+    fi
     install_cmd="export PIP_BREAK_SYSTEM_PACKAGES=1 && \
-      dnf install -y --setopt=tsflags='' xmlsec1 libseccomp libatomic python3-libs python3-pip krb5-libs /pkg/$package_name && \
-      pip3 install --no-cache-dir ${pip_find_links} ${pip_packages} && \
+      dnf install -y --setopt=tsflags='' xmlsec1 libseccomp libatomic ${rpm_python_pkgs} krb5-libs /pkg/$package_name && \
+      ${pip_cmd} install --no-cache-dir ${pip_find_links} ${pip_packages} && \
       dnf clean all"
   fi
 

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -1884,9 +1884,9 @@ build_mage() {
   # (e.g. -fvect-cost-model) are GCC-specific, so we use the toolchain gcc, not
   # its clang. CC/CXX propagate into build.sh's `python3 setup` → cmake, which
   # honours them on a fresh configure (CI containers start clean).
-  local TOOLCHAIN_ROOT="/opt/toolchain-${toolchain_version}"
-  local EXPORT_MAGE_COMPILER="export CC=${TOOLCHAIN_ROOT}/bin/gcc CXX=${TOOLCHAIN_ROOT}/bin/g++"
-  docker exec -i $build_container bash -c "$ACTIVATE_TOOLCHAIN && $EXPORT_MAGE_COMPILER && cd /home/mg/memgraph/mage && ../tools/ci/mage-build/build.sh ${build_args[*]}"
+  local toolchain_root="/opt/toolchain-${toolchain_version}"
+  local export_mage_compiler="export CC=${toolchain_root}/bin/gcc CXX=${toolchain_root}/bin/g++"
+  docker exec -i $build_container bash -c "$ACTIVATE_TOOLCHAIN && $export_mage_compiler && cd /home/mg/memgraph/mage && ../tools/ci/mage-build/build.sh ${build_args[*]}"
   if [[ "$config_only" = true ]]; then
     echo -e "${GREEN_BOLD}Configuration done successfully${RESET}"
     exit 0
@@ -1987,7 +1987,7 @@ package_mage_rpm() {
     amd) rpm_arch="x86_64";  pkg_arch="amd64" ;;
     arm) rpm_arch="aarch64"; pkg_arch="arm64" ;;
     *)
-      echo -e "${RED_BOLD}Error: package_mage_rpm: unsupported arch '$arch' (expected amd or arm)${RESET}"
+      echo -e "${RED_BOLD}Error: package_mage_rpm: unsupported arch '$arch' (expected amd or arm)${RESET}" >&2
       exit 1
     ;;
   esac

--- a/release/package/mgbuild.sh
+++ b/release/package/mgbuild.sh
@@ -1851,7 +1851,18 @@ build_mage() {
     build_args+=("--split-debug")
   fi
 
-  docker exec -i $build_container bash -c "$ACTIVATE_TOOLCHAIN && cd /home/mg/memgraph/mage && ../tools/ci/mage-build/build.sh ${build_args[*]}"
+  # Pin the C/C++ compiler to the toolchain's gcc/g++. The toolchain's
+  # `activate` only prepends its bin dir to PATH and adds -isystem flags; it
+  # does not set CC/CXX, and it ships gcc/g++ (no `c++` symlink). So CMake's
+  # default compiler search falls through to the system /usr/bin/c++ — fine on
+  # Ubuntu (GCC 13, has <format>) but broken on RPM distros like centos-9 (GCC
+  # 11, no <format>, so mgp.hpp's #include <format> fails). MAGE's C++ flags
+  # (e.g. -fvect-cost-model) are GCC-specific, so we use the toolchain gcc, not
+  # its clang. CC/CXX propagate into build.sh's `python3 setup` → cmake, which
+  # honours them on a fresh configure (CI containers start clean).
+  local TOOLCHAIN_ROOT="/opt/toolchain-${toolchain_version}"
+  local EXPORT_MAGE_COMPILER="export CC=${TOOLCHAIN_ROOT}/bin/gcc CXX=${TOOLCHAIN_ROOT}/bin/g++"
+  docker exec -i $build_container bash -c "$ACTIVATE_TOOLCHAIN && $EXPORT_MAGE_COMPILER && cd /home/mg/memgraph/mage && ../tools/ci/mage-build/build.sh ${build_args[*]}"
   if [[ "$config_only" = true ]]; then
     echo -e "${GREEN_BOLD}Configuration done successfully${RESET}"
     exit 0

--- a/release/rpm/rpmlintrc
+++ b/release/rpm/rpmlintrc
@@ -18,3 +18,8 @@ except:
 
 # skip signing
 addFilter("E: no-signature")
+
+# libatomic is required explicitly because CPACK_RPM_PACKAGE_AUTOREQ is off
+# (see release/CMakeLists.txt), so soname deps are not auto-generated. The dep
+# is intentional and resolves fine; only rpmlint objects to the lib package name.
+addFilter("E: explicit-lib-dependency libatomic")

--- a/release/rpm/rpmlintrc_centos10
+++ b/release/rpm/rpmlintrc_centos10
@@ -9,3 +9,7 @@ addFilter("E: incorrect-fsf-address")
 addFilter("E: no-signature")
 addFilter("E: no-packager-tag")
 addFilter("E: no-group-tag")
+# libatomic is required explicitly because CPACK_RPM_PACKAGE_AUTOREQ is off
+# (see release/CMakeLists.txt), so soname deps are not auto-generated. The dep
+# is intentional and resolves fine; only rpmlint objects to the lib package name.
+addFilter("E: explicit-lib-dependency libatomic")

--- a/release/rpm/rpmlintrc_fedora
+++ b/release/rpm/rpmlintrc_fedora
@@ -4,3 +4,8 @@
 addFilter("E: logrotate-log-dir-not-packaged")
 
 addFilter("E: incorrect-fsf-address")
+
+# libatomic is required explicitly because CPACK_RPM_PACKAGE_AUTOREQ is off
+# (see release/CMakeLists.txt), so soname deps are not auto-generated. The dep
+# is intentional and resolves fine; only rpmlint objects to the lib package name.
+addFilter("E: explicit-lib-dependency libatomic")

--- a/release/rpm/rpmlintrc_rocky
+++ b/release/rpm/rpmlintrc_rocky
@@ -33,3 +33,8 @@ addFilter("W: dangerous-command-in-%post")
 
 # gethostbyname is pulled in transitively; no IPv6 regression
 addFilter("W: binary-or-shlib-calls-gethostbyname")
+
+# libatomic is required explicitly because CPACK_RPM_PACKAGE_AUTOREQ is off
+# (see release/CMakeLists.txt), so soname deps are not auto-generated. The dep
+# is intentional and resolves fine; only rpmlint objects to the lib package name.
+addFilter("E: explicit-lib-dependency libatomic")

--- a/tools/ci/build-gssapi.sh
+++ b/tools/ci/build-gssapi.sh
@@ -8,7 +8,23 @@ set -euo pipefail
 
 GSSAPI_VERSION="1.11.1"
 
+# Build the wheel with the same interpreter memgraph embeds so its ABI tag
+# matches where it gets installed. Most distros default python3 to that version,
+# but CentOS Stream 9 ships 3.9 as python3 while memgraph is built against an
+# explicitly-installed python3.12 — so prefer python3.12 when present (otherwise
+# the wheel would be cp39 and rejected by the 3.12 install). Override with
+# PYTHON=<interpreter> if needed. Mirrors mage/install_python_requirements.sh.
+PYTHON="${PYTHON:-}"
+if [[ -z "$PYTHON" ]]; then
+  if command -v python3.12 >/dev/null 2>&1; then
+    PYTHON=python3.12
+  else
+    PYTHON=python3
+  fi
+fi
+echo "Building gssapi wheel with: $PYTHON ($($PYTHON --version 2>&1))"
+
 rm -rf gssapi
 mkdir -p gssapi/dist
 cd gssapi
-pip3 wheel --no-deps --no-cache-dir --no-binary=gssapi "gssapi==${GSSAPI_VERSION}" -w dist/
+$PYTHON -m pip wheel --no-deps --no-cache-dir --no-binary=gssapi "gssapi==${GSSAPI_VERSION}" -w dist/

--- a/tools/ci/mage-build/package/build-rpm.sh
+++ b/tools/ci/mage-build/package/build-rpm.sh
@@ -13,12 +13,26 @@ VERSION=$4
 MALLOC=$5
 CUDA=$6
 CUGRAPH=$7
-PACKAGE_DIR=${8:-$HOME/mage.tar.gz}
+OS=$8              # target distro, e.g. centos-9 / centos-10 — encoded in the filename
+PACKAGE_DIR=${9:-$HOME/mage.tar.gz}
+
+if [[ -z "$OS" ]]; then
+    echo "Error: build-rpm.sh requires the target OS as the 8th argument (e.g. centos-9)"
+    exit 1
+fi
 
 # The RPM Version field must not contain '-' (it delimits version-release), so
 # normalise it to '.', then strip anything preceding the version number.
 CLEAN_VERSION=$(echo "$VERSION" | sed 's/-/./g')
 CLEAN_VERSION=$(echo "$CLEAN_VERSION" | sed 's/^[^0-9]*//')
+
+# Encode the target distro in the output filename (in the dist-tag slot, e.g.
+# "centos-9") so per-distro rpms are distinguishable: they otherwise share
+# name-version-release.arch and would collide in the flat MAGE S3 prefix. We use
+# the distro name rather than rpm's %{?dist} tag because the tag is generation-
+# based (centos-10 and rocky-10 are both ".el10") and wouldn't disambiguate
+# same-generation vendors. This only renames the file; the rpm's internal
+# Release still carries %{?dist}.
 
 # Variant suffix, encoded in the output filename only (the package Name stays
 # memgraph-mage), matching build-deb.sh's PACKAGE_NAME convention.
@@ -33,8 +47,8 @@ elif [[ "$CUDA" == true ]]; then
     NAME_SUFFIX="${NAME_SUFFIX}-cuda"
 fi
 
-PACKAGE_NAME="memgraph-mage-${CLEAN_VERSION}-1.${ARCH}${NAME_SUFFIX}.rpm"
-DEBUGINFO_PACKAGE_NAME="memgraph-mage-debuginfo-${CLEAN_VERSION}-1.${ARCH}${NAME_SUFFIX}.rpm"
+PACKAGE_NAME="memgraph-mage-${CLEAN_VERSION}-1.${OS}.${ARCH}${NAME_SUFFIX}.rpm"
+DEBUGINFO_PACKAGE_NAME="memgraph-mage-debuginfo-${CLEAN_VERSION}-1.${OS}.${ARCH}${NAME_SUFFIX}.rpm"
 
 echo "Building package: $PACKAGE_NAME"
 

--- a/tools/ci/mage-build/package/build-rpm.sh
+++ b/tools/ci/mage-build/package/build-rpm.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 # stages the payload, renders rpm/memgraph-mage.spec.in, and runs rpmbuild.
 
 SCRIPT_DIR=$(dirname $(realpath $0))
+# Resolve the mage/ source dir relative to this script (SCRIPT_DIR is
+# tools/ci/mage-build/package) so it works regardless of the caller's CWD.
+MAGE_DIR=$(realpath "$SCRIPT_DIR/../../../../mage")
 
 ARCH=$1            # rpm arch: x86_64 / aarch64
 PKG_ARCH=$2        # dpkg-style arch passed to install_python_requirements.sh: amd64 / arm64
@@ -62,11 +65,11 @@ mkdir -pv "$TOPDIR"/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 mkdir -pv "$STAGE_ROOT/usr/lib/memgraph/query_modules"
 
 if [[ "$CUDA" == true ]]; then
-    cp -v ../../../../mage/python/requirements-gpu.txt "$STAGE_ROOT/usr/lib/memgraph/mage-requirements.txt"
+    cp -v "$MAGE_DIR/python/requirements-gpu.txt" "$STAGE_ROOT/usr/lib/memgraph/mage-requirements.txt"
 else
-    cp -v ../../../../mage/python/requirements.txt "$STAGE_ROOT/usr/lib/memgraph/mage-requirements.txt"
+    cp -v "$MAGE_DIR/python/requirements.txt" "$STAGE_ROOT/usr/lib/memgraph/mage-requirements.txt"
 fi
-cp ../../../../mage/install_python_requirements.sh "$STAGE_ROOT/usr/lib/memgraph/install_python_requirements.sh"
+cp "$MAGE_DIR/install_python_requirements.sh" "$STAGE_ROOT/usr/lib/memgraph/install_python_requirements.sh"
 
 tar -xvzf "$PACKAGE_DIR" -C "$STAGE_ROOT/usr/lib/memgraph/"
 

--- a/tools/ci/mage-build/package/build-rpm.sh
+++ b/tools/ci/mage-build/package/build-rpm.sh
@@ -20,7 +20,7 @@ OS=$8              # target distro, e.g. centos-9 / centos-10 — encoded in the
 PACKAGE_DIR=${9:-$HOME/mage.tar.gz}
 
 if [[ -z "$OS" ]]; then
-    echo "Error: build-rpm.sh requires the target OS as the 8th argument (e.g. centos-9)"
+    echo "Error: build-rpm.sh requires the target OS as the 8th argument (e.g. centos-9)" >&2
     exit 1
 fi
 

--- a/tools/ci/mage-build/package/build-rpm.sh
+++ b/tools/ci/mage-build/package/build-rpm.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+set -euo pipefail
+
+# Builds installable rpm package(s) for MAGE. RPM counterpart of build-deb.sh:
+# stages the payload, renders rpm/memgraph-mage.spec.in, and runs rpmbuild.
+
+SCRIPT_DIR=$(dirname $(realpath $0))
+
+ARCH=$1            # rpm arch: x86_64 / aarch64
+PKG_ARCH=$2        # dpkg-style arch passed to install_python_requirements.sh: amd64 / arm64
+BUILD_TYPE=$3
+VERSION=$4
+MALLOC=$5
+CUDA=$6
+CUGRAPH=$7
+PACKAGE_DIR=${8:-$HOME/mage.tar.gz}
+
+# The RPM Version field must not contain '-' (it delimits version-release), so
+# normalise it to '.', then strip anything preceding the version number.
+CLEAN_VERSION=$(echo "$VERSION" | sed 's/-/./g')
+CLEAN_VERSION=$(echo "$CLEAN_VERSION" | sed 's/^[^0-9]*//')
+
+# Variant suffix, encoded in the output filename only (the package Name stays
+# memgraph-mage), matching build-deb.sh's PACKAGE_NAME convention.
+NAME_SUFFIX=""
+if [[ "$MALLOC" == true ]]; then
+    NAME_SUFFIX="${NAME_SUFFIX}-malloc"
+fi
+if [[ "$CUGRAPH" == true ]]; then
+    NAME_SUFFIX="${NAME_SUFFIX}-cugraph"
+    CUDA=true
+elif [[ "$CUDA" == true ]]; then
+    NAME_SUFFIX="${NAME_SUFFIX}-cuda"
+fi
+
+PACKAGE_NAME="memgraph-mage-${CLEAN_VERSION}-1.${ARCH}${NAME_SUFFIX}.rpm"
+DEBUGINFO_PACKAGE_NAME="memgraph-mage-debuginfo-${CLEAN_VERSION}-1.${ARCH}${NAME_SUFFIX}.rpm"
+
+echo "Building package: $PACKAGE_NAME"
+
+# Fresh rpmbuild tree under the package dir; STAGE_ROOT is the payload tree
+# rooted at "/" that the spec's %install copies into the buildroot.
+TOPDIR="$SCRIPT_DIR/rpmbuild"
+STAGE_ROOT="$SCRIPT_DIR/build-rpm-root"
+DEBUGINFO_STAGE_ROOT="$SCRIPT_DIR/build-rpm-debuginfo-root"
+rm -rf "$TOPDIR" "$STAGE_ROOT" "$DEBUGINFO_STAGE_ROOT"
+mkdir -pv "$TOPDIR"/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+mkdir -pv "$STAGE_ROOT/usr/lib/memgraph/query_modules"
+
+if [[ "$CUDA" == true ]]; then
+    cp -v ../../../../mage/python/requirements-gpu.txt "$STAGE_ROOT/usr/lib/memgraph/mage-requirements.txt"
+else
+    cp -v ../../../../mage/python/requirements.txt "$STAGE_ROOT/usr/lib/memgraph/mage-requirements.txt"
+fi
+cp ../../../../mage/install_python_requirements.sh "$STAGE_ROOT/usr/lib/memgraph/install_python_requirements.sh"
+
+tar -xvzf "$PACKAGE_DIR" -C "$STAGE_ROOT/usr/lib/memgraph/"
+
+# Detect the split-debug sidecar tarball produced alongside mage.tar.gz by
+# compress-query-modules.sh. Read the listing into a variable before grepping:
+# `tar -tzf … | grep -q` lets grep close the pipe early and the resulting
+# SIGPIPE on tar is fatal under `set -o pipefail`. (Same dance as build-deb.sh.)
+DEBUG_PACKAGE_DIR="$(dirname "$PACKAGE_DIR")/mage-debug.tar.gz"
+echo "build-rpm.sh: user=$(id -un) HOME=${HOME:-} PACKAGE_DIR=$PACKAGE_DIR"
+ls -la "$(dirname "$PACKAGE_DIR")"/*.tar.gz 2>&1 || true
+
+HAS_DEBUGINFO=false
+if [[ -f "$DEBUG_PACKAGE_DIR" ]]; then
+    debug_listing="$(tar -tzf "$DEBUG_PACKAGE_DIR" 2>/dev/null || true)"
+    if grep -qm1 '\.debug$' <<<"$debug_listing"; then
+        HAS_DEBUGINFO=true
+    fi
+fi
+
+WITH_DEBUGINFO=0
+if [[ "$HAS_DEBUGINFO" == "true" ]]; then
+    WITH_DEBUGINFO=1
+    mkdir -pv "$DEBUGINFO_STAGE_ROOT/usr/lib/memgraph/query_modules"
+    tar -xvzf "$DEBUG_PACKAGE_DIR" -C "$DEBUGINFO_STAGE_ROOT/usr/lib/memgraph"
+else
+    # No sidecars: build-mage ran without --split-debug (optional for MAGE, as
+    # it is for Memgraph). The spec drops the debuginfo subpackage when
+    # with_debuginfo is 0.
+    echo "::warning::No .debug sidecars at $DEBUG_PACKAGE_DIR — skipping memgraph-mage-debuginfo rpm ($BUILD_TYPE build)."
+fi
+
+# Render the spec from the template.
+SPEC="$TOPDIR/SPECS/memgraph-mage.spec"
+cp "$SCRIPT_DIR/rpm/memgraph-mage.spec.in" "$SPEC"
+sed -i "s/@VERSION@/$CLEAN_VERSION/g" "$SPEC"
+sed -i "s/@ARCH@/$ARCH/g" "$SPEC"
+sed -i "s/@PKG_ARCH@/$PKG_ARCH/g" "$SPEC"
+sed -i "s/@CUDA@/$CUDA/g" "$SPEC"
+sed -i "s/@WITH_DEBUGINFO@/$WITH_DEBUGINFO/g" "$SPEC"
+
+rpmbuild -bb \
+    --define "_topdir $TOPDIR" \
+    --define "stage_root $STAGE_ROOT" \
+    --define "debug_stage_root $DEBUGINFO_STAGE_ROOT" \
+    --target "$ARCH" \
+    "$SPEC"
+
+# rpmbuild drops the artefacts under RPMS/<arch>/; rename them to the variant
+# filenames build-rpm.sh promises (parallel to build-deb.sh's final mv).
+built_main="$(ls "$TOPDIR"/RPMS/*/memgraph-mage-[0-9]*.rpm | grep -v -- '-debuginfo' | head -n 1)"
+mv "$built_main" "$SCRIPT_DIR/$PACKAGE_NAME"
+echo "Package: $SCRIPT_DIR/$PACKAGE_NAME"
+
+if [[ "$HAS_DEBUGINFO" == "true" ]]; then
+    built_debuginfo="$(ls "$TOPDIR"/RPMS/*/memgraph-mage-debuginfo-*.rpm | head -n 1)"
+    mv "$built_debuginfo" "$SCRIPT_DIR/$DEBUGINFO_PACKAGE_NAME"
+    echo "Package: $SCRIPT_DIR/$DEBUGINFO_PACKAGE_NAME"
+fi

--- a/tools/ci/mage-build/package/rpm/memgraph-mage.spec.in
+++ b/tools/ci/mage-build/package/rpm/memgraph-mage.spec.in
@@ -1,0 +1,113 @@
+# -*- rpm-spec -*-
+#
+# Hand-written specfile for the MAGE query-modules RPM. This is the RPM
+# counterpart of the DEB packaging under ../debian/ and is rendered + driven by
+# ../build-rpm.sh (the analogue of build-deb.sh).
+#
+# build-rpm.sh pre-stages the payload into %{stage_root} (and, when split-debug
+# sidecars exist, into %{debug_stage_root}); this spec only re-homes those trees
+# into the buildroot and declares file ownership. The @TOKEN@ placeholders are
+# filled in by sed in build-rpm.sh before rpmbuild runs.
+
+# Ship the query-module .so files exactly as build-mage produced them. With
+# --split-debug they are already stripped and accompanied by .debug sidecars
+# (shipped by the debuginfo subpackage below), so suppress rpmbuild's own strip
+# / debuginfo extraction — the same intent as `override_dh_dwz:` in the DEB
+# rules. Without this, brp-strip would re-strip the .so files and the separate
+# .debug sidecars would either be regenerated or have their DWARF removed.
+%global debug_package %{nil}
+%global __os_install_post %{nil}
+%define __strip /bin/true
+%global _build_id_links none
+
+# Set to 1 by build-rpm.sh when mage-debug.tar.gz carried .debug sidecars.
+%global with_debuginfo @WITH_DEBUGINFO@
+
+Name:           memgraph-mage
+Version:        @VERSION@
+Release:        1%{?dist}
+Summary:        Extra query modules for Memgraph
+License:        BSL-1.1
+Vendor:         Memgraph Ltd.
+URL:            https://memgraph.com
+BuildArch:      @ARCH@
+# Mirror the DEB control's Depends as closely as the RPM world allows. The
+# library sonames are resolved automatically on most distros, but memgraph and
+# the python tooling are named explicitly so a bare `dnf install` pulls them in.
+Requires:       memgraph
+Requires:       libcurl, openssl, python3, python3-pip, python3-setuptools, libgomp, libatomic
+
+%description
+Additional query modules for Memgraph, installed under
+/usr/lib/memgraph/query_modules/.
+
+%if %{with_debuginfo}
+%package debuginfo
+Summary:        Debug symbols for memgraph-mage
+Requires:       memgraph-mage = %{version}-%{release}
+
+%description debuginfo
+Sidecar .debug files for the MAGE query modules, produced by
+objcopy --only-keep-debug at build time. Install alongside
+memgraph-mage for symbolicated stack traces; gdb auto-locates
+each .debug file via .gnu_debuglink next to the corresponding .so.
+%endif
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}
+# %{stage_root} / %{debug_stage_root} are absolute trees rooted at "/", so
+# copying their contents into the buildroot reproduces the install layout.
+cp -a %{stage_root}/. %{buildroot}/
+%if %{with_debuginfo}
+cp -a %{debug_stage_root}/. %{buildroot}/
+%endif
+
+# Generate the %files lists by walking the staged buildroot. The .debug
+# sidecars and the rest of the payload share /usr/lib/memgraph/query_modules/,
+# so we split them by name into two -f filelists rather than owning the
+# directory (which memgraph already owns) from either subpackage.
+cd %{buildroot}
+find . -mindepth 1 \( -type f -o -type l \) ! -name '*.debug' | sed 's,^\.,,' > %{_builddir}/mage_main_files.txt
+%if %{with_debuginfo}
+find . -type f -name '*.debug' | sed 's,^\.,,' > %{_builddir}/mage_debuginfo_files.txt
+%endif
+
+%post
+# Mirror of debian/postinst's `configure` step.
+CUDA=@CUDA@
+ARCH=@PKG_ARCH@
+# install_python_requirements.sh fetches torch/PyG/DGL wheels from the network.
+# During an offline install the wheels are already on disk and the call fails,
+# but the deps are present, so tolerate failure when MEMGRAPH_OFFLINE_INSTALL=1
+# (set by the .run installer). For a normal dnf/rpm install the failure stays
+# hard so a genuine network/pip error doesn't silently leave MAGE broken.
+if ! su - memgraph -c "/usr/lib/memgraph/install_python_requirements.sh --deb-package --cuda $CUDA --arch $ARCH"; then
+    if [ "${MEMGRAPH_OFFLINE_INSTALL:-}" = "1" ]; then
+        echo "WARNING: install_python_requirements.sh exited non-zero." >&2
+        echo "         Tolerated because MEMGRAPH_OFFLINE_INSTALL=1 — the python deps" >&2
+        echo "         were installed by the offline installer's wheel pass." >&2
+    else
+        echo "ERROR: install_python_requirements.sh failed." >&2
+        echo "       Check network connectivity and pip configuration, then retry." >&2
+        exit 1
+    fi
+fi
+# Only restart memgraph if systemd is actually running (absent in containers,
+# chroots, and minimal images); otherwise `systemctl` fails the scriptlet.
+if [ -d /run/systemd/system ]; then
+    systemctl restart memgraph.service
+fi
+exit 0
+
+%files -f %{_builddir}/mage_main_files.txt
+%defattr(-,root,root,-)
+
+%if %{with_debuginfo}
+%files debuginfo -f %{_builddir}/mage_debuginfo_files.txt
+%defattr(-,root,root,-)
+%endif
+
+%changelog
+* Thu Jun 01 2025 Matt James <matthew.james@memgraph.io> - @VERSION@-1
+- Release v@VERSION@.

--- a/tools/ci/mage-build/package/rpm/memgraph-mage.spec.in
+++ b/tools/ci/mage-build/package/rpm/memgraph-mage.spec.in
@@ -26,6 +26,15 @@
 # so our hand-rolled subpackage below is actually built.
 %global _debuginfo_subpackages 0
 
+# memgraph bundles its toolchain libstdc++ under /usr/lib/memgraph, and the
+# query modules (built with that newer toolchain) load it rather than the
+# distro's system libstdc++. So drop the auto-generated libstdc++ Requires:
+# the toolchain's GLIBCXX symbols (e.g. GLIBCXX_3.4.34) aren't provided by the
+# system libstdc++ on older distros (e.g. centos-10), and demanding them would
+# make the package uninstallable. The runtime lib comes from the memgraph
+# package (which memgraph-mage Requires), not the system one.
+%global __requires_exclude ^libstdc\\+\\+\\.so
+
 # Set to 1 by build-rpm.sh when mage-debug.tar.gz carried .debug sidecars.
 %global with_debuginfo @WITH_DEBUGINFO@
 

--- a/tools/ci/mage-build/package/rpm/memgraph-mage.spec.in
+++ b/tools/ci/mage-build/package/rpm/memgraph-mage.spec.in
@@ -42,6 +42,9 @@ BuildArch:      @ARCH@
 # the python tooling are named explicitly so a bare `dnf install` pulls them in.
 Requires:       memgraph
 Requires:       libcurl, openssl, python3, python3-pip, python3-setuptools, libgomp, libatomic
+# %post runs `su - memgraph -c ...`; su lives in util-linux, which is absent
+# from minimal rpm base images (e.g. centos-10's), so declare it explicitly.
+Requires:       util-linux
 # On CentOS Stream 9 memgraph embeds python 3.12 (built with MG_PYTHON_VERSION=3.12)
 # rather than the distro-default 3.9, so the query modules and the %post pip
 # install need the 3.12 interpreter + pip. python3.12-pip pulls python3.12, but

--- a/tools/ci/mage-build/package/rpm/memgraph-mage.spec.in
+++ b/tools/ci/mage-build/package/rpm/memgraph-mage.spec.in
@@ -42,6 +42,13 @@ BuildArch:      @ARCH@
 # the python tooling are named explicitly so a bare `dnf install` pulls them in.
 Requires:       memgraph
 Requires:       libcurl, openssl, python3, python3-pip, python3-setuptools, libgomp, libatomic
+# On CentOS Stream 9 memgraph embeds python 3.12 (built with MG_PYTHON_VERSION=3.12)
+# rather than the distro-default 3.9, so the query modules and the %post pip
+# install need the 3.12 interpreter + pip. python3.12-pip pulls python3.12, but
+# both are named for clarity.
+%if 0%{?rhel} == 9
+Requires:       python3.12, python3.12-pip
+%endif
 
 %description
 Additional query modules for Memgraph, installed under

--- a/tools/ci/mage-build/package/rpm/memgraph-mage.spec.in
+++ b/tools/ci/mage-build/package/rpm/memgraph-mage.spec.in
@@ -98,7 +98,14 @@ ARCH=@PKG_ARCH@
 # but the deps are present, so tolerate failure when MEMGRAPH_OFFLINE_INSTALL=1
 # (set by the .run installer). For a normal dnf/rpm install the failure stays
 # hard so a genuine network/pip error doesn't silently leave MAGE broken.
-if ! su - memgraph -c "/usr/lib/memgraph/install_python_requirements.sh --deb-package --cuda $CUDA --arch $ARCH"; then
+#
+# Use runuser, not su: su's PAM stack pulls in system-auth/postlogin, which on
+# minimal images (e.g. centos-10) isn't configured yet when this %post runs in
+# the same dnf transaction (authselect's scriptlet runs after ours), giving
+# "su: cannot open session: Permission denied". runuser's PAM config is minimal
+# (pam_rootok, pam_systemd optional) so it works regardless. -l gives memgraph's
+# login env (HOME=/var/lib/memgraph) so pip --user lands where memgraph reads it.
+if ! runuser -l memgraph -c "/usr/lib/memgraph/install_python_requirements.sh --deb-package --cuda $CUDA --arch $ARCH"; then
     if [ "${MEMGRAPH_OFFLINE_INSTALL:-}" = "1" ]; then
         echo "WARNING: install_python_requirements.sh exited non-zero." >&2
         echo "         Tolerated because MEMGRAPH_OFFLINE_INSTALL=1 — the python deps" >&2

--- a/tools/ci/mage-build/package/rpm/memgraph-mage.spec.in
+++ b/tools/ci/mage-build/package/rpm/memgraph-mage.spec.in
@@ -4,10 +4,10 @@
 # counterpart of the DEB packaging under ../debian/ and is rendered + driven by
 # ../build-rpm.sh (the analogue of build-deb.sh).
 #
-# build-rpm.sh pre-stages the payload into %{stage_root} (and, when split-debug
-# sidecars exist, into %{debug_stage_root}); this spec only re-homes those trees
-# into the buildroot and declares file ownership. The @TOKEN@ placeholders are
-# filled in by sed in build-rpm.sh before rpmbuild runs.
+# build-rpm.sh pre-stages the payload into the stage_root macro (and, when
+# split-debug sidecars exist, into debug_stage_root); this spec only re-homes
+# those trees into the buildroot and declares file ownership. The @TOKEN@
+# placeholders are filled in by sed in build-rpm.sh before rpmbuild runs.
 
 # Ship the query-module .so files exactly as build-mage produced them. With
 # --split-debug they are already stripped and accompanied by .debug sidecars
@@ -19,6 +19,12 @@
 %global __os_install_post %{nil}
 %define __strip /bin/true
 %global _build_id_links none
+# rpm reserves the "<name>-debuginfo" subpackage name for its own automatic
+# debuginfo machinery: a manually-declared `%package debuginfo` is silently
+# dropped (its files then fail the unpackaged-files check) even with
+# debug_package disabled. Turning off _debuginfo_subpackages releases the name
+# so our hand-rolled subpackage below is actually built.
+%global _debuginfo_subpackages 0
 
 # Set to 1 by build-rpm.sh when mage-debug.tar.gz carried .debug sidecars.
 %global with_debuginfo @WITH_DEBUGINFO@
@@ -109,5 +115,5 @@ exit 0
 %endif
 
 %changelog
-* Thu Jun 01 2025 Matt James <matthew.james@memgraph.io> - @VERSION@-1
+* Sun Jun 01 2025 Matt James <matthew.james@memgraph.io> - @VERSION@-1
 - Release v@VERSION@.

--- a/tools/ci/package_mage_setup.py
+++ b/tools/ci/package_mage_setup.py
@@ -111,6 +111,15 @@ class PackageMageSetup:
                 "cugraph": build["cugraph"],
                 "malloc": build["malloc"],
                 "os": build["os"],
+                # PR builds produce a debug MAGE image so the docker smoke + e2e
+                # tests have something to run against. Only ubuntu-24.04 publishes
+                # a MAGE image; rpm distros build none (smoke-tested via the rpm
+                # smoke image) and cugraph can't be smoke/e2e-tested in CI (GPU),
+                # so it gets no image either — run_smoke_tests stays true but is a
+                # no-op without an image.
+                "build_docker_image": (
+                    "debug" if (build["os"] == "ubuntu-24.04" and build["cugraph"] != "true") else "none"
+                ),
             }
             out.update(default_args)
             return out

--- a/tools/ci/package_mage_setup.py
+++ b/tools/ci/package_mage_setup.py
@@ -90,6 +90,7 @@ class PackageMageSetup:
             "package_deb": "default",
             "generate_sbom": "false",
             "ref": "",
+            "os": "ubuntu-24.04",
         }
         if f"CI -package=mage-{package}" in pr_labels:
             print(f'Found label for "{package}"')
@@ -115,7 +116,7 @@ class PackageMageSetup:
         return None
 
     def _check_workflow_input(self) -> bool:
-        if self.workflow_inputs.get(f"matrix_build") == "true":
+        if self.workflow_inputs.get("matrix_build") == "true":
             return MATRIX_BUILDS
         # GitHub passes workflow_dispatch/workflow_call inputs as strings
         # ("true"/"false"); keep the fallbacks as strings too so the matrix
@@ -134,6 +135,7 @@ class PackageMageSetup:
                 "package_deb": self.workflow_inputs.get("package_deb", "default"),
                 "generate_sbom": self.workflow_inputs.get("generate_sbom", "false"),
                 "ref": self.workflow_inputs.get("ref", ""),
+                "os": self.workflow_inputs("os", "ubuntu-24.04"),
             }
         ]
 
@@ -185,6 +187,7 @@ def print_package_suite(package_suite: dict) -> None:
         print(f"Package deb: {build.get('package_deb')}")
         print(f"Generate SBOM: {build.get('generate_sbom')}")
         print(f"Ref: {build.get('ref')}")
+        print(f"OS: {build.get('os')}")
 
     build_packages = "true" if len(package_suite) > 0 else "false"
     set_output("build_packages", build_packages)

--- a/tools/ci/package_mage_setup.py
+++ b/tools/ci/package_mage_setup.py
@@ -90,7 +90,6 @@ class PackageMageSetup:
             "package_mage": "default",
             "generate_sbom": "false",
             "ref": "",
-            "os": "ubuntu-24.04",
         }
         if f"CI -package=mage-{package}" in pr_labels:
             print(f'Found label for "{package}"')

--- a/tools/ci/package_mage_setup.py
+++ b/tools/ci/package_mage_setup.py
@@ -3,45 +3,77 @@ import json
 import os
 import sys
 
-PR_BUILDS = ["amd", "arm", "cuda", "cugraph", "centos-9"]
-
-# Matrix values are emitted as JSON and consumed by package_mage.yaml via
-# `${{ matrix.X == 'true' }}` comparisons. GitHub Actions coerces operands to
-# numbers when comparing across types, so a Python bool `True` round-tripped
-# through json.dumps as JSON `true` does NOT equal the string `'true'`. Keep
-# every boolean-flavoured field as a string here so the workflow comparisons
-# resolve correctly.
-MATRIX_BUILDS = [
+# Single source of truth for the OS/arch (+ flavour) combinations MAGE can be
+# packaged for. Mirrors the Memgraph build matrix in
+# .github/workflows/build_rc.yml — arm is only listed where Memgraph builds it
+# (ubuntu-24.04, debian-12, debian-13, fedora-42).
+#
+# `label` is the PR-label suffix: apply `CI -package=mage-<label>` to a PR to
+# trigger that build. ubuntu-24.04 is the primary target, so its amd/arm builds
+# keep the short "amd"/"arm" labels and the cuda/cugraph/malloc flavour builds
+# (all ubuntu-24.04 amd) keep their flavour labels; every other distro uses an
+# "<os>"/"<os>-arm" label.
+#
+# Boolean-flavoured fields (cuda/cugraph/malloc) are emitted as JSON and consumed
+# by package_mage.yaml via `${{ matrix.X == 'true' }}` comparisons. GitHub
+# Actions coerces operands to numbers when comparing across types, so a Python
+# bool `True` round-tripped through json.dumps as JSON `true` does NOT equal the
+# string `'true'`. Keep them as strings here so the workflow comparisons resolve.
+SUPPORTED_BUILDS = [
+    {"label": "amd", "os": "ubuntu-24.04", "arch": "amd", "cuda": "false", "cugraph": "false", "malloc": "false"},
+    {"label": "arm", "os": "ubuntu-24.04", "arch": "arm", "cuda": "false", "cugraph": "false", "malloc": "false"},
+    {"label": "cuda", "os": "ubuntu-24.04", "arch": "amd", "cuda": "true", "cugraph": "false", "malloc": "false"},
+    {"label": "cugraph", "os": "ubuntu-24.04", "arch": "amd", "cuda": "false", "cugraph": "true", "malloc": "false"},
+    {"label": "malloc", "os": "ubuntu-24.04", "arch": "amd", "cuda": "false", "cugraph": "false", "malloc": "true"},
     {
+        "label": "ubuntu-22.04",
+        "os": "ubuntu-22.04",
         "arch": "amd",
         "cuda": "false",
         "cugraph": "false",
         "malloc": "false",
     },
+    {"label": "debian-12", "os": "debian-12", "arch": "amd", "cuda": "false", "cugraph": "false", "malloc": "false"},
     {
+        "label": "debian-12-arm",
+        "os": "debian-12",
         "arch": "arm",
         "cuda": "false",
         "cugraph": "false",
         "malloc": "false",
     },
+    {"label": "debian-13", "os": "debian-13", "arch": "amd", "cuda": "false", "cugraph": "false", "malloc": "false"},
     {
-        "arch": "amd",
-        "cuda": "true",
+        "label": "debian-13-arm",
+        "os": "debian-13",
+        "arch": "arm",
+        "cuda": "false",
         "cugraph": "false",
         "malloc": "false",
     },
+    {"label": "fedora-42", "os": "fedora-42", "arch": "amd", "cuda": "false", "cugraph": "false", "malloc": "false"},
     {
-        "arch": "amd",
+        "label": "fedora-42-arm",
+        "os": "fedora-42",
+        "arch": "arm",
         "cuda": "false",
         "cugraph": "false",
-        "malloc": "true",
-    },
-    {
-        "arch": "amd",
-        "cuda": "false",
-        "cugraph": "true",
         "malloc": "false",
     },
+    {"label": "centos-9", "os": "centos-9", "arch": "amd", "cuda": "false", "cugraph": "false", "malloc": "false"},
+    {"label": "centos-10", "os": "centos-10", "arch": "amd", "cuda": "false", "cugraph": "false", "malloc": "false"},
+    {"label": "rocky-10", "os": "rocky-10", "arch": "amd", "cuda": "false", "cugraph": "false", "malloc": "false"},
+]
+
+# matrix_build (workflow_dispatch) builds the original ubuntu-24.04 flavour set
+# (amd, arm, cuda, cugraph, malloc) plus centos-9. Selected from SUPPORTED_BUILDS
+# by label, minus the PR-label key. The remaining distros are still reachable via
+# single-OS workflow_dispatch selection or their PR labels.
+MATRIX_BUILD_LABELS = {"amd", "arm", "cuda", "cugraph", "malloc", "centos-9"}
+MATRIX_BUILDS = [
+    {k: v for k, v in build.items() if k != "label"}
+    for build in SUPPORTED_BUILDS
+    if build["label"] in MATRIX_BUILD_LABELS
 ]
 
 
@@ -79,9 +111,8 @@ class PackageMageSetup:
     def get_package_suite(self) -> dict:
         return self._package_suite
 
-    def _check_pr_label(self, package: str, pr_labels: list) -> dict | None:
+    def _check_pr_label(self, build: dict, pr_labels: list) -> dict | None:
         default_args = {
-            "malloc": "false",
             "memgraph_download_link": "",
             "push_to_s3": "false",
             "s3_dest_dir": "mage-unofficial",
@@ -91,13 +122,15 @@ class PackageMageSetup:
             "generate_sbom": "false",
             "ref": "",
         }
-        if f"CI -package=mage-{package}" in pr_labels:
-            print(f'Found label for "{package}"')
+        label = build["label"]
+        if f"CI -package=mage-{label}" in pr_labels:
+            print(f'Found label for "{label}"')
             out = {
-                "arch": "arm" if package == "arm" else "amd",
-                "cuda": "true" if package == "cuda" else "false",
-                "cugraph": "true" if package == "cugraph" else "false",
-                "os": "centos-9" if package == "centos-9" else "ubuntu-24.04",
+                "arch": build["arch"],
+                "cuda": build["cuda"],
+                "cugraph": build["cugraph"],
+                "malloc": build["malloc"],
+                "os": build["os"],
             }
             out.update(default_args)
             return out
@@ -105,10 +138,10 @@ class PackageMageSetup:
 
     def _setup_pull_request(self) -> None:
         pr_labels = self._get_pr_labels()
-        for package in PR_BUILDS:
-            build = self._check_pr_label(package, pr_labels)
-            if build:
-                self._package_suite.append(build)
+        for build in SUPPORTED_BUILDS:
+            result = self._check_pr_label(build, pr_labels)
+            if result:
+                self._package_suite.append(result)
 
     def get_workflow_inputs(self) -> dict:
         if self._get_event_name() in ["workflow_dispatch", "workflow_call"]:

--- a/tools/ci/package_mage_setup.py
+++ b/tools/ci/package_mage_setup.py
@@ -3,7 +3,7 @@ import json
 import os
 import sys
 
-PR_BUILDS = ["amd", "arm", "cuda", "cugraph"]
+PR_BUILDS = ["amd", "arm", "cuda", "cugraph", "centos-9"]
 
 # Matrix values are emitted as JSON and consumed by package_mage.yaml via
 # `${{ matrix.X == 'true' }}` comparisons. GitHub Actions coerces operands to
@@ -98,13 +98,7 @@ class PackageMageSetup:
                 "arch": "arm" if package == "arm" else "amd",
                 "cuda": "true" if package == "cuda" else "false",
                 "cugraph": "true" if package == "cugraph" else "false",
-            }
-            out.update(default_args)
-            return out
-        if "CI -package=mage-centos-9" in pr_labels:
-            print("Found label for CentOS 9")
-            out = {
-                "arch": "x86",
+                "centos-9": "true" if package == "centos-9" else "false",
             }
             out.update(default_args)
             return out

--- a/tools/ci/package_mage_setup.py
+++ b/tools/ci/package_mage_setup.py
@@ -79,7 +79,7 @@ class PackageMageSetup:
     def get_package_suite(self) -> dict:
         return self._package_suite
 
-    def _check_pr_label(self, package: str, pr_labels: list) -> bool:
+    def _check_pr_label(self, package: str, pr_labels: list) -> dict | None:
         default_args = {
             "malloc": "false",
             "memgraph_download_link": "",
@@ -87,7 +87,7 @@ class PackageMageSetup:
             "s3_dest_dir": "mage-unofficial",
             "run_smoke_tests": "true",
             "run_tests": "true",
-            "package_deb": "default",
+            "package_mage": "default",
             "generate_sbom": "false",
             "ref": "",
             "os": "ubuntu-24.04",
@@ -98,6 +98,13 @@ class PackageMageSetup:
                 "arch": "arm" if package == "arm" else "amd",
                 "cuda": "true" if package == "cuda" else "false",
                 "cugraph": "true" if package == "cugraph" else "false",
+            }
+            out.update(default_args)
+            return out
+        if "CI -package=mage-centos-9" in pr_labels:
+            print("Found label for CentOS 9")
+            out = {
+                "arch": "x86",
             }
             out.update(default_args)
             return out
@@ -115,7 +122,7 @@ class PackageMageSetup:
             return self._gh_context.get("event").get("inputs")
         return None
 
-    def _check_workflow_input(self) -> bool:
+    def _check_workflow_input(self) -> list:
         if self.workflow_inputs.get("matrix_build") == "true":
             return MATRIX_BUILDS
         # GitHub passes workflow_dispatch/workflow_call inputs as strings
@@ -132,10 +139,10 @@ class PackageMageSetup:
                 "s3_dest_dir": self.workflow_inputs.get("s3_dest_dir", "mage-unofficial"),
                 "run_smoke_tests": self.workflow_inputs.get("run_smoke_tests", "false"),
                 "run_tests": self.workflow_inputs.get("run_tests", "false"),
-                "package_deb": self.workflow_inputs.get("package_deb", "default"),
+                "package_mage": self.workflow_inputs.get("package_mage", "default"),
                 "generate_sbom": self.workflow_inputs.get("generate_sbom", "false"),
                 "ref": self.workflow_inputs.get("ref", ""),
-                "os": self.workflow_inputs("os", "ubuntu-24.04"),
+                "os": self.workflow_inputs.get("os", "ubuntu-24.04"),
             }
         ]
 
@@ -184,7 +191,7 @@ def print_package_suite(package_suite: dict) -> None:
         print(f"S3 dest dir: {build.get('s3_dest_dir')}")
         print(f"Run smoke tests: {build.get('run_smoke_tests')}")
         print(f"Run tests: {build.get('run_tests')}")
-        print(f"Package deb: {build.get('package_deb')}")
+        print(f"Package MAGE: {build.get('package_mage')}")
         print(f"Generate SBOM: {build.get('generate_sbom')}")
         print(f"Ref: {build.get('ref')}")
         print(f"OS: {build.get('os')}")

--- a/tools/ci/package_mage_setup.py
+++ b/tools/ci/package_mage_setup.py
@@ -98,7 +98,7 @@ class PackageMageSetup:
                 "arch": "arm" if package == "arm" else "amd",
                 "cuda": "true" if package == "cuda" else "false",
                 "cugraph": "true" if package == "cugraph" else "false",
-                "centos-9": "true" if package == "centos-9" else "false",
+                "os": "centos-9" if package == "centos-9" else "ubuntu-24.04",
             }
             out.update(default_args)
             return out

--- a/tools/ci/package_mage_setup.py
+++ b/tools/ci/package_mage_setup.py
@@ -4,9 +4,15 @@ import os
 import sys
 
 # Single source of truth for the OS/arch (+ flavour) combinations MAGE can be
-# packaged for. Mirrors the Memgraph build matrix in
-# .github/workflows/build_rc.yml — arm is only listed where Memgraph builds it
-# (ubuntu-24.04, debian-12, debian-13, fedora-42).
+# packaged for.
+#
+# IMPORTANT: MAGE's python query-module dependencies (torch/PyG/DGL wheels) are
+# currently cp312-only, so MAGE only works on distros whose embedded Python is
+# 3.12 — ubuntu-24.04, centos-9 (built explicitly against python3.12), and
+# centos-10 (ships 3.12 by default). The other distros Memgraph builds on
+# (ubuntu-22.04 → 3.10, debian-12 → 3.11, debian-13/fedora-42 → 3.13) are
+# commented out below; re-enabling them would require MAGE to support those
+# Python versions (i.e. additional cp310/cp311/cp313 wheel builds).
 #
 # `label` is the PR-label suffix: apply `CI -package=mage-<label>` to a PR to
 # trigger that build. ubuntu-24.04 is the primary target, so its amd/arm builds
@@ -25,44 +31,18 @@ SUPPORTED_BUILDS = [
     {"label": "cuda", "os": "ubuntu-24.04", "arch": "amd", "cuda": "true", "cugraph": "false", "malloc": "false"},
     {"label": "cugraph", "os": "ubuntu-24.04", "arch": "amd", "cuda": "false", "cugraph": "true", "malloc": "false"},
     {"label": "malloc", "os": "ubuntu-24.04", "arch": "amd", "cuda": "false", "cugraph": "false", "malloc": "true"},
-    {
-        "label": "ubuntu-22.04",
-        "os": "ubuntu-22.04",
-        "arch": "amd",
-        "cuda": "false",
-        "cugraph": "false",
-        "malloc": "false",
-    },
-    {"label": "debian-12", "os": "debian-12", "arch": "amd", "cuda": "false", "cugraph": "false", "malloc": "false"},
-    {
-        "label": "debian-12-arm",
-        "os": "debian-12",
-        "arch": "arm",
-        "cuda": "false",
-        "cugraph": "false",
-        "malloc": "false",
-    },
-    {"label": "debian-13", "os": "debian-13", "arch": "amd", "cuda": "false", "cugraph": "false", "malloc": "false"},
-    {
-        "label": "debian-13-arm",
-        "os": "debian-13",
-        "arch": "arm",
-        "cuda": "false",
-        "cugraph": "false",
-        "malloc": "false",
-    },
-    {"label": "fedora-42", "os": "fedora-42", "arch": "amd", "cuda": "false", "cugraph": "false", "malloc": "false"},
-    {
-        "label": "fedora-42-arm",
-        "os": "fedora-42",
-        "arch": "arm",
-        "cuda": "false",
-        "cugraph": "false",
-        "malloc": "false",
-    },
     {"label": "centos-9", "os": "centos-9", "arch": "amd", "cuda": "false", "cugraph": "false", "malloc": "false"},
     {"label": "centos-10", "os": "centos-10", "arch": "amd", "cuda": "false", "cugraph": "false", "malloc": "false"},
-    {"label": "rocky-10", "os": "rocky-10", "arch": "amd", "cuda": "false", "cugraph": "false", "malloc": "false"},
+    # Disabled until MAGE supports Python versions other than 3.12 (see note above).
+    # These mirror the rest of the Memgraph build matrix in build_rc.yml:
+    # {"label": "ubuntu-22.04",  "os": "ubuntu-22.04", "arch": "amd", "cuda": "false", "cugraph": "false", "malloc": "false"},  # Python 3.10
+    # {"label": "debian-12",     "os": "debian-12",    "arch": "amd", "cuda": "false", "cugraph": "false", "malloc": "false"},  # Python 3.11
+    # {"label": "debian-12-arm", "os": "debian-12",    "arch": "arm", "cuda": "false", "cugraph": "false", "malloc": "false"},  # Python 3.11
+    # {"label": "debian-13",     "os": "debian-13",    "arch": "amd", "cuda": "false", "cugraph": "false", "malloc": "false"},  # Python 3.13
+    # {"label": "debian-13-arm", "os": "debian-13",    "arch": "arm", "cuda": "false", "cugraph": "false", "malloc": "false"},  # Python 3.13
+    # {"label": "fedora-42",     "os": "fedora-42",    "arch": "amd", "cuda": "false", "cugraph": "false", "malloc": "false"},  # Python 3.13
+    # {"label": "fedora-42-arm", "os": "fedora-42",    "arch": "arm", "cuda": "false", "cugraph": "false", "malloc": "false"},  # Python 3.13
+    # {"label": "rocky-10",      "os": "rocky-10",     "arch": "amd", "cuda": "false", "cugraph": "false", "malloc": "false"},  # Python 3.12, not yet validated
 ]
 
 # matrix_build (workflow_dispatch) builds the original ubuntu-24.04 flavour set


### PR DESCRIPTION
Adds RPM builds of MAGE for CentOS 9 and CentOS 10 to daily and RC builds.

Key changes:
- The MAGE Python dependencies are all built specifically for Python 3.12 - so for CentOS 9, which uses Python 3.9 by default, we now force Memgraph to link against Python 3.12. 
- In order to have GLIBC compatibility, a new set of `manylinux` packages (GLIBC `>= 2.34`) are built using: https://github.com/memgraph/infra/pull/527. 
- The new packages are stored in S3 and are now versioned by the date on which they are built being part of their prefix, in this case the prefix is `wheels/2026-06-25/`.
- Added smoke tests for the CentOS MAGE packages using `Dockerfile.rpm`. 
- Smoke tests also print the Memgraph logs now when an `[error]` is detected.


