### PR TITLE
Feature (Defunct Recovery / 2) - feat(query): report defunct/ready status in SHOW DATABASES and SHOW STORAGE INFO

### DIFF
--- a/specs/issues/01-walking-skeleton-flag-defunct-gate.md
+++ b/specs/issues/01-walking-skeleton-flag-defunct-gate.md
@@ -31,10 +31,16 @@ The end-to-end spine of the feature, exercised through the single
   overwrites the corrupt files). WAL is never written because commits are
   rejected.
 - A broad, fail-closed query gate: any query that would operate on a defunct
-  current database throws the verbatim exception below. Allowlist: `RECOVER
-  SNAPSHOT`, `REPAIR DATABASE`, and meta queries (`USE DATABASE`, `SHOW
-  DATABASES`, `SHOW DATABASE`, `SHOW STORAGE INFO`). `RECOVER SNAPSHOT` requires
-  UNIQUE access and must be explicitly exempted.
+  current database throws the verbatim exception below. Allowlist: the cure query
+  `RECOVER SNAPSHOT` plus read-only meta / session / info queries that never touch
+  the tenant graph — `RecoverSnapshotQuery`, `DatabaseInfoQuery`,
+  `SystemInfoQuery`, `ReplicationInfoQuery`, `ShowConfigQuery`,
+  `ShowQueryCallableMappingsQuery`, `SettingQuery`, `VersionQuery`,
+  `UseDatabaseQuery`, `MultiDatabaseQuery`, `ShowDatabaseQuery`,
+  `ShowDatabasesQuery`, `ShowMemoryInfoQuery`, `SessionTraceQuery`,
+  `SessionSettingQuery`. (`REPAIR DATABASE` joins the allowlist when that query
+  lands in a later slice.) `RECOVER SNAPSHOT` requires UNIQUE access and must be
+  explicitly exempted.
 
 Exception text (exact):
 > Database is in the defunct state because the recovery process failed. Please recover your database using the RECOVER SNAPSHOT query or REPAIR DATABASE query + run your import queries. If you have a backup of the whole data directory, please replace the current data directory with the backup one and restart the process.

--- a/specs/storage-allow-recovery-failure.md
+++ b/specs/storage-allow-recovery-failure.md
@@ -185,9 +185,17 @@ keeps today's fatal behavior.
   path).
 - The thrown error is exactly:
   > `Database is in the defunct state because the recovery process failed. Please recover your database using the RECOVER SNAPSHOT query or REPAIR DATABASE query + run your import queries. If you have a backup of the whole data directory, please replace the current data directory with the backup one and restart the process.`
-- **Allowlist** (permitted against a defunct current database): `RECOVER SNAPSHOT`,
-  `REPAIR DATABASE`, and meta queries that do not touch the tenant graph
-  (`USE DATABASE`, `SHOW DATABASES`, `SHOW DATABASE`, `SHOW STORAGE INFO`).
+- **Allowlist** (permitted against a defunct current database): the cure queries
+  `RECOVER SNAPSHOT` and `REPAIR DATABASE`, plus read-only meta / session / info
+  queries that never touch the tenant graph. The implemented set is the union of:
+  `RecoverSnapshotQuery`, `DatabaseInfoQuery`, `SystemInfoQuery`,
+  `ReplicationInfoQuery`, `ShowConfigQuery`, `ShowQueryCallableMappingsQuery`,
+  `SettingQuery`, `VersionQuery`, `UseDatabaseQuery`, `MultiDatabaseQuery`,
+  `ShowDatabaseQuery`, `ShowDatabasesQuery`, `ShowMemoryInfoQuery`,
+  `SessionTraceQuery`, `SessionSettingQuery`. (`REPAIR DATABASE` joins this list
+  when that query is added in a later slice.) Everything else — Cypher, DDL,
+  `CREATE SNAPSHOT` — is rejected. The gate is fail-closed: a query type not on
+  the allowlist is rejected by default.
 - Note: `RECOVER SNAPSHOT` requires `UNIQUE` storage access, so it is explicitly
   exempted rather than relying on "no accessor ⇒ allowed".
 

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -8034,7 +8034,7 @@ PreparedQuery PrepareShowDatabasesQuery(ParsedQuery parsed_query, InterpreterCon
       for (const auto &name : all) {
         auto db_name = TypedValue(name);
         auto st = status_of(db_name.ValueString());
-        status.push_back({std::move(db_name), TypedValue(std::move(st))});
+        status.push_back({std::move(db_name), TypedValue(st)});
       }
 
       std::erase_if(status, [&](auto const &row) {

--- a/src/query/interpreter.cpp
+++ b/src/query/interpreter.cpp
@@ -7264,6 +7264,7 @@ PreparedQuery PrepareSystemInfoQuery(ParsedQuery parsed_query, bool in_explicit_
                TypedValue(tenant_limit > 0 ? utils::GetReadableSize(static_cast<double>(tenant_limit))
                                            : std::string("unlimited"))},
               {TypedValue("storage_isolation_level"), TypedValue(IsolationLevelToString(storage->GetIsolationLevel()))},
+              {TypedValue("status"), TypedValue(storage->IsDefunct() ? "defunct" : "ready")},
           };
           return std::pair{results, QueryHandlerResult::NOTHING};
         };
@@ -8013,16 +8014,27 @@ PreparedQuery PrepareShowDatabasesQuery(ParsedQuery parsed_query, InterpreterCon
   AuthQueryHandler *auth = interpreter_context->auth;
 
   Callback callback;
-  callback.header = {"Name"};
+  callback.header = {"Name", "Status"};
   callback.fn =
       [auth, db_handler, user_or_role = std::move(user_or_role)]() mutable -> std::vector<std::vector<TypedValue>> {
     std::vector<std::vector<TypedValue>> status;
+    // A database that failed durability recovery comes up defunct (see
+    // --storage-allow-recovery-failure); report that so operators can spot it.
+    auto status_of = [db_handler](std::string_view name) -> std::string {
+      try {
+        return db_handler->Get(name)->storage()->IsDefunct() ? "defunct" : "ready";
+      } catch (...) {
+        return "ready";
+      }
+    };
     auto gen_status = [&]<typename T, typename K>(T all, K denied) {
       Sort(all);
 
       status.reserve(all.size());
       for (const auto &name : all) {
-        status.push_back({TypedValue(name)});
+        auto db_name = TypedValue(name);
+        auto st = status_of(db_name.ValueString());
+        status.push_back({std::move(db_name), TypedValue(std::move(st))});
       }
 
       std::erase_if(status, [&](auto const &row) {

--- a/tests/e2e/durability/CMakeLists.txt
+++ b/tests/e2e/durability/CMakeLists.txt
@@ -15,6 +15,8 @@ copy_e2e_python_files(durability indices_not_persisted_analytical.py)
 copy_e2e_python_files(durability parameters_durability.py)
 copy_e2e_python_files(durability tenant_profile_durability.py)
 copy_e2e_python_files(durability recovery_failure_defunct.py)
+copy_e2e_python_files(durability recovery_failure_status.py)
+
 
 
 copy_e2e_python_files_from_parent_folder(durability ".." memgraph.py)

--- a/tests/e2e/durability/common.py
+++ b/tests/e2e/durability/common.py
@@ -9,6 +9,7 @@
 # by the Apache License, Version 2.0, included in the file
 # licenses/APL.txt.
 
+import os
 import typing
 
 import mgclient
@@ -37,3 +38,26 @@ def connect(**kwargs) -> mgclient.Connection:
     connection = mgclient.connect(**kwargs)
     connection.autocommit = True
     return connection
+
+
+def corrupt_snapshots(full_data_directory):
+    """Corrupt the data (vertex/edge/index) region of every snapshot while preserving the
+    offsets block at the start and the metadata section at the end. This keeps the file
+    readable by ReadSnapshotInfo (so it is selected for recovery) but makes LoadSnapshot
+    fail, which is the "no usable snapshot" path that yields a defunct database."""
+    snapshot_dir = os.path.join(full_data_directory, "snapshots")
+    files = [
+        os.path.join(snapshot_dir, f) for f in os.listdir(snapshot_dir) if os.path.isfile(os.path.join(snapshot_dir, f))
+    ]
+    assert files, "Expected at least one snapshot to corrupt"
+    head_keep = 1024  # magic + version + SECTION_OFFSETS
+    tail_keep = 4096  # SECTION_METADATA (uuid/epoch/counts) lives near the end
+    for path in files:
+        size = os.path.getsize(path)
+        start = min(head_keep, size)
+        end = max(start, size - tail_keep)
+        assert end > start, f"Snapshot {path} too small ({size} bytes) to corrupt safely"
+        with open(path, "r+b") as fh:
+            fh.seek(start)
+            fh.write(b"\xff" * (end - start))
+    return files

--- a/tests/e2e/durability/recovery_failure_defunct.py
+++ b/tests/e2e/durability/recovery_failure_defunct.py
@@ -35,7 +35,13 @@ def test_name(request):
 
 
 def corrupt_snapshots(full_data_directory):
-    """Corrupts random section of the snapshot."""
+    """Corrupts each snapshot from a random offset through the end of the file.
+
+    Overwriting through EOF always destroys the trailing section-offset table that
+    snapshot recovery reads first, so recovery is guaranteed to fail. (A bounded
+    random span could land on payload bytes - e.g. an integer property value - and
+    still parse, since the snapshot format has no whole-file checksum.)
+    """
     snapshot_dir = os.path.join(full_data_directory, "snapshots")
     files = [
         os.path.join(snapshot_dir, f) for f in os.listdir(snapshot_dir) if os.path.isfile(os.path.join(snapshot_dir, f))
@@ -44,14 +50,10 @@ def corrupt_snapshots(full_data_directory):
 
     for path in files:
         size = os.path.getsize(path)
-        a = random.randint(0, size - 1)
-        b = random.randint(0, size - 1)
-        start = min(a, b)
-        end = max(a, b)
-        assert end > start, f"Snapshot {path} too small ({size} bytes) to corrupt safely"
+        start = random.randint(0, size - 1)
         with open(path, "r+b") as fh:
             fh.seek(start)
-            fh.write(b"\xff" * (end - start))
+            fh.write(b"\xff" * (size - start))
     return files
 
 

--- a/tests/e2e/durability/recovery_failure_defunct.py
+++ b/tests/e2e/durability/recovery_failure_defunct.py
@@ -10,12 +10,11 @@
 # licenses/APL.txt.
 
 import os
-import random
 import sys
 
 import interactive_mg_runner
 import pytest
-from common import connect, execute_and_fetch_all, get_data_path, get_logs_path
+from common import connect, corrupt_snapshots, execute_and_fetch_all, get_data_path, get_logs_path
 
 interactive_mg_runner.SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 interactive_mg_runner.PROJECT_DIR = os.path.normpath(
@@ -32,29 +31,6 @@ DEFUNCT_ERROR = "Database is in the defunct state because the recovery process f
 @pytest.fixture
 def test_name(request):
     return request.node.name
-
-
-def corrupt_snapshots(full_data_directory):
-    """Corrupts each snapshot from a random offset through the end of the file.
-
-    Overwriting through EOF always destroys the trailing section-offset table that
-    snapshot recovery reads first, so recovery is guaranteed to fail. (A bounded
-    random span could land on payload bytes - e.g. an integer property value - and
-    still parse, since the snapshot format has no whole-file checksum.)
-    """
-    snapshot_dir = os.path.join(full_data_directory, "snapshots")
-    files = [
-        os.path.join(snapshot_dir, f) for f in os.listdir(snapshot_dir) if os.path.isfile(os.path.join(snapshot_dir, f))
-    ]
-    assert files, "Expected at least one snapshot to corrupt"
-
-    for path in files:
-        size = os.path.getsize(path)
-        start = random.randint(0, size - 1)
-        with open(path, "r+b") as fh:
-            fh.seek(start)
-            fh.write(b"\xff" * (size - start))
-    return files
 
 
 def test_defunct_on_corrupt_snapshot(test_name):

--- a/tests/e2e/durability/recovery_failure_status.py
+++ b/tests/e2e/durability/recovery_failure_status.py
@@ -15,7 +15,7 @@ import sys
 
 import interactive_mg_runner
 import pytest
-from common import connect, execute_and_fetch_all, get_data_path
+from common import connect, corrupt_snapshots, execute_and_fetch_all, get_data_path
 
 interactive_mg_runner.SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 interactive_mg_runner.PROJECT_DIR = os.path.normpath(
@@ -37,28 +37,6 @@ def cleanup_instances():
     interactive_mg_runner.kill_all()
 
 
-def corrupt_snapshots(base_directory):
-    """Corrupt a chunk inside the vertex-data region of every snapshot under
-    base_directory/snapshots, leaving the offsets header (start) and the metadata
-    section (end) intact. ReadSnapshotInfo still recognizes the file (so it is
-    selected for recovery) but LoadSnapshot fails reading vertices -> the "no usable
-    snapshot" path, which yields a defunct database."""
-    snapshot_dir = os.path.join(base_directory, "snapshots")
-    files = [
-        os.path.join(snapshot_dir, f) for f in os.listdir(snapshot_dir) if os.path.isfile(os.path.join(snapshot_dir, f))
-    ]
-    assert files, "Expected at least one snapshot to corrupt"
-    for path in files:
-        size = os.path.getsize(path)
-        start = min(1024, size // 4)
-        end = min(start + 16384, max(start + 1, size // 2))
-        assert end > start, f"Snapshot {path} too small ({size} bytes) to corrupt safely"
-        with open(path, "r+b") as fh:
-            fh.seek(start)
-            fh.write(b"\xff" * (end - start))
-    return files
-
-
 def storage_info(cursor):
     rows = execute_and_fetch_all(cursor, "SHOW STORAGE INFO ON CURRENT DATABASE")
     return {row[0]: row[1] for row in rows}
@@ -66,7 +44,7 @@ def storage_info(cursor):
 
 def test_storage_info_reports_ready_then_defunct(test_name):
     """SHOW STORAGE INFO reports status=ready for a healthy database and status=defunct
-    after recovery fails (Community-compatible: uses only the default database)."""
+    after recovery fails."""
     data_directory = get_data_path("recovery_failure_status", test_name)
     full_data_directory = os.path.join(interactive_mg_runner.BUILD_DIR, "e2e", "data", data_directory)
     shutil.rmtree(full_data_directory, ignore_errors=True)
@@ -100,7 +78,7 @@ def test_storage_info_reports_ready_then_defunct(test_name):
 
 
 def test_show_databases_reports_status(test_name):
-    """SHOW DATABASES (Enterprise) shows a Status column: defunct for a tenant whose
+    """SHOW DATABASES shows a Status column: defunct for a tenant whose
     recovery failed, ready for a healthy tenant."""
     data_directory = get_data_path("recovery_failure_status", test_name)
     full_data_directory = os.path.join(interactive_mg_runner.BUILD_DIR, "e2e", "data", data_directory)
@@ -117,13 +95,7 @@ def test_show_databases_reports_status(test_name):
     interactive_mg_runner.start(instances, "default")
     connection = connect(host="localhost", port=7687)
     cursor = connection.cursor()
-    try:
-        execute_and_fetch_all(cursor, "CREATE DATABASE broken_db")
-    except Exception as e:
-        if "enterprise" in str(e).lower() or "not supported" in str(e).lower():
-            interactive_mg_runner.kill_all()
-            pytest.skip("SHOW DATABASES / multitenancy requires an enterprise license")
-        raise
+    execute_and_fetch_all(cursor, "CREATE DATABASE broken_db")
 
     # Populate and snapshot the tenant so it has durability to corrupt.
     execute_and_fetch_all(cursor, "USE DATABASE broken_db")

--- a/tests/e2e/durability/recovery_failure_status.py
+++ b/tests/e2e/durability/recovery_failure_status.py
@@ -1,0 +1,157 @@
+# Copyright 2026 Memgraph Ltd.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt; by using this file, you agree to be bound by the terms of the Business Source
+# License, and you may not use this file except in compliance with the Business Source License.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+import os
+import shutil
+import sys
+
+import interactive_mg_runner
+import pytest
+from common import connect, execute_and_fetch_all, get_data_path
+
+interactive_mg_runner.SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+interactive_mg_runner.PROJECT_DIR = os.path.normpath(
+    os.path.join(interactive_mg_runner.SCRIPT_DIR, "..", "..", "..", "..")
+)
+interactive_mg_runner.BUILD_DIR = os.path.normpath(os.path.join(interactive_mg_runner.PROJECT_DIR, "build"))
+interactive_mg_runner.MEMGRAPH_BINARY = os.path.normpath(os.path.join(interactive_mg_runner.BUILD_DIR, "memgraph"))
+
+
+@pytest.fixture
+def test_name(request):
+    return request.node.name
+
+
+@pytest.fixture(autouse=True)
+def cleanup_instances():
+    interactive_mg_runner.kill_all()
+    yield
+    interactive_mg_runner.kill_all()
+
+
+def corrupt_snapshots(base_directory):
+    """Corrupt a chunk inside the vertex-data region of every snapshot under
+    base_directory/snapshots, leaving the offsets header (start) and the metadata
+    section (end) intact. ReadSnapshotInfo still recognizes the file (so it is
+    selected for recovery) but LoadSnapshot fails reading vertices -> the "no usable
+    snapshot" path, which yields a defunct database."""
+    snapshot_dir = os.path.join(base_directory, "snapshots")
+    files = [
+        os.path.join(snapshot_dir, f) for f in os.listdir(snapshot_dir) if os.path.isfile(os.path.join(snapshot_dir, f))
+    ]
+    assert files, "Expected at least one snapshot to corrupt"
+    for path in files:
+        size = os.path.getsize(path)
+        start = min(1024, size // 4)
+        end = min(start + 16384, max(start + 1, size // 2))
+        assert end > start, f"Snapshot {path} too small ({size} bytes) to corrupt safely"
+        with open(path, "r+b") as fh:
+            fh.seek(start)
+            fh.write(b"\xff" * (end - start))
+    return files
+
+
+def storage_info(cursor):
+    rows = execute_and_fetch_all(cursor, "SHOW STORAGE INFO ON CURRENT DATABASE")
+    return {row[0]: row[1] for row in rows}
+
+
+def test_storage_info_reports_ready_then_defunct(test_name):
+    """SHOW STORAGE INFO reports status=ready for a healthy database and status=defunct
+    after recovery fails (Community-compatible: uses only the default database)."""
+    data_directory = get_data_path("recovery_failure_status", test_name)
+    full_data_directory = os.path.join(interactive_mg_runner.BUILD_DIR, "e2e", "data", data_directory)
+    shutil.rmtree(full_data_directory, ignore_errors=True)
+
+    instances = {
+        "default": {
+            # WAL disabled so the snapshot is the only durability: corrupting it makes
+            # recovery fail at the "no usable snapshot" path (covered by this slice).
+            "args": ["--log-level=TRACE", "--data-recovery-on-startup=true", "--storage-wal-enabled=false"],
+            "log_file": "recovery_failure_status.log",
+            "data_directory": data_directory,
+        }
+    }
+
+    # Healthy instance: status must be "ready".
+    interactive_mg_runner.start(instances, "default")
+    cursor = connect(host="localhost", port=7687).cursor()
+    execute_and_fetch_all(cursor, "UNWIND range(1, 5000) AS i CREATE (:Node {id: i})")
+    execute_and_fetch_all(cursor, "CREATE SNAPSHOT")
+    assert storage_info(cursor)["status"] == "ready"
+    interactive_mg_runner.kill_all()
+
+    # Corrupt the snapshot and restart with the recovery-failure flag.
+    corrupt_snapshots(full_data_directory)
+    instances["default"]["args"].append("--storage-allow-recovery-failure=true")
+    interactive_mg_runner.start(instances, "default")
+
+    cursor = connect(host="localhost", port=7687).cursor()
+    assert storage_info(cursor)["status"] == "defunct"
+    interactive_mg_runner.stop_all()
+
+
+def test_show_databases_reports_status(test_name):
+    """SHOW DATABASES (Enterprise) shows a Status column: defunct for a tenant whose
+    recovery failed, ready for a healthy tenant."""
+    data_directory = get_data_path("recovery_failure_status", test_name)
+    full_data_directory = os.path.join(interactive_mg_runner.BUILD_DIR, "e2e", "data", data_directory)
+    shutil.rmtree(full_data_directory, ignore_errors=True)
+
+    instances = {
+        "default": {
+            "args": ["--log-level=TRACE", "--data-recovery-on-startup=true", "--storage-wal-enabled=false"],
+            "log_file": "recovery_failure_status_mt.log",
+            "data_directory": data_directory,
+        }
+    }
+
+    interactive_mg_runner.start(instances, "default")
+    connection = connect(host="localhost", port=7687)
+    cursor = connection.cursor()
+    try:
+        execute_and_fetch_all(cursor, "CREATE DATABASE broken_db")
+    except Exception as e:
+        if "enterprise" in str(e).lower() or "not supported" in str(e).lower():
+            interactive_mg_runner.kill_all()
+            pytest.skip("SHOW DATABASES / multitenancy requires an enterprise license")
+        raise
+
+    # Populate and snapshot the tenant so it has durability to corrupt.
+    execute_and_fetch_all(cursor, "USE DATABASE broken_db")
+    execute_and_fetch_all(cursor, "UNWIND range(1, 5000) AS i CREATE (:Node {id: i})")
+    execute_and_fetch_all(cursor, "CREATE SNAPSHOT")
+    interactive_mg_runner.kill_all()
+
+    # Corrupt the tenant's snapshot (each tenant lives under databases/<uuid>/).
+    databases_dir = os.path.join(full_data_directory, "databases")
+    tenant_dirs = [
+        os.path.join(databases_dir, d)
+        for d in os.listdir(databases_dir)
+        if d not in ("memgraph", ".durability")
+        and not d.startswith(".")
+        and os.path.isdir(os.path.join(databases_dir, d))
+    ]
+    assert tenant_dirs, "Expected a tenant directory to corrupt"
+    corrupt_snapshots(tenant_dirs[0])
+
+    instances["default"]["args"].append("--storage-allow-recovery-failure=true")
+    interactive_mg_runner.start(instances, "default")
+
+    cursor = connect(host="localhost", port=7687).cursor()
+    rows = {row[0]: row[1] for row in execute_and_fetch_all(cursor, "SHOW DATABASES")}
+    assert rows.get("broken_db") == "defunct"
+    assert rows.get("memgraph") == "ready"
+    interactive_mg_runner.stop_all()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-rA"]))

--- a/tests/e2e/durability/workloads.yaml
+++ b/tests/e2e/durability/workloads.yaml
@@ -8,6 +8,9 @@ workloads:
   - name: "Recovery failure defunct"
     binary: "tests/e2e/pytest_runner.sh"
     args: ["durability/recovery_failure_defunct.py"]
+  - name: "Recovery failure status reporting"
+    binary: "tests/e2e/pytest_runner.sh"
+    args: ["durability/recovery_failure_status.py"]
   - name: "Periodic snapshot"
     binary: "tests/e2e/pytest_runner.sh"
     args: ["durability/periodic_snapshot.py"]

--- a/tests/e2e/fine_grained_access/show_db.py
+++ b/tests/e2e/fine_grained_access/show_db.py
@@ -23,19 +23,25 @@ def test_show_databases_w_user():
     user3_connection = common.connect(username="user3", password="test")
 
     assert common.execute_and_fetch_all(admin_connection.cursor(), "SHOW DATABASES") == [
-        ("db1",),
-        ("db2",),
-        ("memgraph",),
+        ("db1", "ready"),
+        ("db2", "ready"),
+        ("memgraph", "ready"),
     ]
     assert common.execute_and_fetch_all(admin_connection.cursor(), "SHOW DATABASE") == [("memgraph",)]
 
-    assert common.execute_and_fetch_all(user_connection.cursor(), "SHOW DATABASES") == [("db1",), ("memgraph",)]
+    assert common.execute_and_fetch_all(user_connection.cursor(), "SHOW DATABASES") == [
+        ("db1", "ready"),
+        ("memgraph", "ready"),
+    ]
     assert common.execute_and_fetch_all(user_connection.cursor(), "SHOW DATABASE") == [("memgraph",)]
 
-    assert common.execute_and_fetch_all(user2_connection.cursor(), "SHOW DATABASES") == [("db2",)]
+    assert common.execute_and_fetch_all(user2_connection.cursor(), "SHOW DATABASES") == [("db2", "ready")]
     assert common.execute_and_fetch_all(user2_connection.cursor(), "SHOW DATABASE") == [("db2",)]
 
-    assert common.execute_and_fetch_all(user3_connection.cursor(), "SHOW DATABASES") == [("db1",), ("db2",)]
+    assert common.execute_and_fetch_all(user3_connection.cursor(), "SHOW DATABASES") == [
+        ("db1", "ready"),
+        ("db2", "ready"),
+    ]
     assert common.execute_and_fetch_all(user3_connection.cursor(), "SHOW DATABASE") == [("db1",)]
 
 

--- a/tests/e2e/system_replication/multitenancy.py
+++ b/tests/e2e/system_replication/multitenancy.py
@@ -1772,9 +1772,9 @@ def test_rename_database_replication(connection, test_name):
     main_cursor = connection(BOLT_PORTS["main"], "main").cursor()
     replica_cursor = connection(BOLT_PORTS["replica_1"], "replica_1").cursor()
     results = execute_and_fetch_all(main_cursor, "SHOW DATABASES")
-    assert results == [("memgraph",), ("renamed_test_db",)]
+    assert results == [("memgraph", "ready"), ("renamed_test_db", "ready")]
     results = execute_and_fetch_all(replica_cursor, "SHOW DATABASES")
-    assert results == [("memgraph",), ("renamed_test_db",)]
+    assert results == [("memgraph", "ready"), ("renamed_test_db", "ready")]
 
 
 def test_rename_database_concurrent_access(connection, test_name):


### PR DESCRIPTION
## Summary

Slice 2 of the **defunct tenants on recovery failure** feature (spec: `specs/storage-allow-recovery-failure.md`, issue: `specs/issues/02-status-reporting.md`). Builds on slice 1 (PR #4284).

Surfaces a tenant's defunct/ready state through the two operator-facing queries:

- **`SHOW DATABASES`** gains a second column, `Status` (`ready` / `defunct`). Each database is resolved via the dbms handler and reports `defunct` when its storage `IsDefunct()`. Names that can't be resolved degrade to `ready` rather than breaking the listing.
- **`SHOW STORAGE INFO`** (per-database, i.e. `ON CURRENT DATABASE` / `ON DATABASE <name>`) gains an always-present `status` row (`ready` / `defunct`). This is a non-breaking addition to the existing key/value output.
